### PR TITLE
Add support for vmware_fusion provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "hashicorp/precise64"
 
   config.vm.network "forwarded_port", guest: 8080, host: 8080 # atc
   config.vm.network "forwarded_port", guest: 5637, host: 5637 # glider
@@ -9,6 +8,11 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 4096
     v.cpus = 2
+  end
+  
+  config.vm.provider "vmware_fusion" do |v, override|
+    v.vmx["memsize"] = 4096    
+    v.vmx["numvcpus"] = 2
   end
 
   config.vm.provision "bosh" do |c|


### PR DESCRIPTION
- The old precise64 box does not work with vmware_fusion
- The new one is from vagrantcloud.com and should work with both providers, it also does not need an explicit box url
