### PR TITLE
Bump garden linux to 0.117.0

### DIFF
--- a/manifests/vagrant-bosh.yml
+++ b/manifests/vagrant-bosh.yml
@@ -18,8 +18,8 @@ releases:
     url: dir+bosh://.
     version: latest
   - name: garden-linux
-    url: https://s3.amazonaws.com/garden-linux-release/releases/garden-linux-0.34.0.tgz
-    version: 0.34.0
+    url: https://s3.amazonaws.com/garden-linux-release/releases/garden-linux-0.117.0.tgz
+    version: 0.117.0
 
 networks:
   - name: concourse


### PR DESCRIPTION
New installation via vagrant-bosh plugin using garden linux 0.34 fails to run Diego Inigo tests with http response 500.