### PR TITLE
jobs.worker.gate.atc.username --> jobs.web.properties.tsa.atc.username

### DIFF
--- a/docs/deploying/bosh.scrbl
+++ b/docs/deploying/bosh.scrbl
@@ -170,8 +170,8 @@ values:
   }
 
   @item{
-    @code{jobs.worker.gate.atc.username},
-    @code{jobs.worker.gate.atc.password}: Basic auth credentials to use when
+    @code{jobs.web.properties.tsa.atc.username},
+    @code{jobs.web.properties.tsa.atc.password}: Basic auth credentials to use when
     registering the worker. These must be specified if basic auth is
     configured, otherwise no workers will be available.
 


### PR DESCRIPTION
I'm not 100% sure this is right, this is what I have in my environment, and it's working. It's also following the convention found here: https://github.com/concourse/concourse/blob/master/manifests/aws-vpc.yml