### PR TITLE
Cleanup unused anchor

### DIFF
--- a/manifests/bosh-lite.yml
+++ b/manifests/bosh-lite.yml
@@ -15,7 +15,7 @@ jobs:
     resource_pool: concourse
     networks:
       - name: concourse
-        static_ips: &web-ips [&web-ip 10.244.8.2]
+        static_ips: &web-ips [10.244.8.2]
     persistent_disk: 1024 # for consul
     templates:
       - {release: concourse, name: consul-agent}


### PR DESCRIPTION
&web-ip is not used so can be removed,
same as https://github.com/concourse/concourse/pull/24 but now on the right branch.