### PR TITLE
change garden-linux version in bosh-lite.yml

### DIFF
--- a/manifests/bosh-lite.yml
+++ b/manifests/bosh-lite.yml
@@ -7,7 +7,7 @@ releases:
   - name: concourse
     version: latest
   - name: garden-linux
-    version: latest
+    version: 0.205.0
 
 jobs:
   - name: web


### PR DESCRIPTION
v0.205.0 is the latest working version; latest does not work.