### PR TITLE
Add timeouts to SSH tunnel so we can reconnect when it fails.

### DIFF
--- a/jobs/groundcrew/templates/beacon_ctl.erb
+++ b/jobs/groundcrew/templates/beacon_ctl.erb
@@ -74,6 +74,9 @@ case $1 in
         -i /var/vcap/packages/generated_worker_key/id_rsa \
         <% end %> \
         -o UserKnownHostsFile=${KNOWN_HOSTS_FILE} \
+        -o ConnectTimeout=30 \
+        -o ServerAliveInterval=10 \
+        -o ServerAliveCountMax=3 \
         <% if p("groundcrew.garden.forward_address", nil) %> \
           -R0.0.0.0:7777:<%= p("groundcrew.garden.forward_address") %> \
           <% if p("groundcrew.baggageclaim.forward_address", nil) %> \


### PR DESCRIPTION
After conversation with @vito yesterday we added timeouts so that workers can reconnect when their connection fails.