### PR TITLE
Restrict access to InternalSecurityGroup.

### DIFF
--- a/manifests/cloudformation.json
+++ b/manifests/cloudformation.json
@@ -154,13 +154,13 @@
         "SecurityGroupEgress": [],
         "SecurityGroupIngress": [
           {
-            "CidrIp": "0.0.0.0/0",
+            "SourceSecurityGroupId": { "Ref": "WebSecurityGroup" },
             "IpProtocol": "tcp",
             "FromPort": "0",
             "ToPort": "65535"
           },
           {
-            "CidrIp": "0.0.0.0/0",
+            "SourceSecurityGroupId": { "Ref": "WebSecurityGroup" },
             "IpProtocol": "udp",
             "FromPort": "0",
             "ToPort": "65535"
@@ -172,6 +172,50 @@
             "ToPort": "-1"
           }
         ]
+      }
+    },
+
+    "InternalSecurityGroupIngressTCPfromBOSH": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {"Ref": "InternalSecurityGroup"},
+        "SourceSecurityGroupId": { "Ref": "BOSHSecurityGroup" },
+        "IpProtocol": "tcp",
+        "FromPort": "0",
+        "ToPort": "65535"
+      }
+    },
+
+    "InternalSecurityGroupIngressUDPfromBOSH": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {"Ref": "InternalSecurityGroup"},
+        "SourceSecurityGroupId": { "Ref": "BOSHSecurityGroup" },
+        "IpProtocol": "udp",
+        "FromPort": "0",
+        "ToPort": "65535"
+      }
+    },
+
+    "InternalSecurityGroupIngressTCPfromSelf": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {"Ref": "InternalSecurityGroup"},
+        "SourceSecurityGroupId": { "Ref": "InternalSecurityGroup" },
+        "IpProtocol": "tcp",
+        "FromPort": "0",
+        "ToPort": "65535"
+      }
+    },
+
+    "InternalSecurityGroupIngressUDPfromSelf": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {"Ref": "InternalSecurityGroup"},
+        "SourceSecurityGroupId": { "Ref": "InternalSecurityGroup" },
+        "IpProtocol": "udp",
+        "FromPort": "0",
+        "ToPort": "65535"
       }
     },
 


### PR DESCRIPTION
As discussed on Slack (https://concourseci.slack.com/archives/general/p1452624733008350) we would like to tighten our security group rules for the internal security group. Further to the discussion, it appears we needed to add access from the WebSecurityGroup as well as those mentioned.

Allow only the following sources to connect to InternalSecurityGroup on tcp and udp: InternalSecurityGroup, WebSecurityGroup, BOSHSecurityGroup.

The current configuration (InternalSecurityGroup is open to all sources on every port) causes amazon trusted advisor to raise a red warning.

Signed-off-by: Simon Jones <simon@cloudcredo.com>