### PR TITLE
Add support for newer AWS region on CloudFormation template

### DIFF
--- a/manifests/cloudformation.json
+++ b/manifests/cloudformation.json
@@ -63,6 +63,7 @@
       "ap-southeast-1": { "AMI": "ami-f22772a0" },
       "ap-southeast-2": { "AMI": "ami-3bae3201" },
       "ap-northeast-1": { "AMI": "ami-cd43d9cc" },
+      "ap-northeast-2": { "AMI": "ami-4118d72f" },
       "sa-east-1":      { "AMI": "ami-d78325ca" }
     }
   },

--- a/manifests/cloudformation.json
+++ b/manifests/cloudformation.json
@@ -56,15 +56,16 @@
 
   "Mappings": {
     "AWSNATAMI" : {
-      "us-east-1":      { "AMI": "ami-ad227cc4" },
-      "us-west-1":      { "AMI": "ami-d69aad93" },
-      "us-west-2":      { "AMI": "ami-f032acc0" },
-      "eu-west-1":      { "AMI": "ami-f3e30084" },
-      "ap-southeast-1": { "AMI": "ami-f22772a0" },
-      "ap-southeast-2": { "AMI": "ami-3bae3201" },
-      "ap-northeast-1": { "AMI": "ami-cd43d9cc" },
+      "us-east-1":      { "AMI": "ami-68115b02" },
+      "us-west-1":      { "AMI": "ami-ef1a718f" },
+      "us-west-2":      { "AMI": "ami-77a4b816" },
+      "eu-west-1":      { "AMI": "ami-c0993ab3" },
+      "eu-central-1":   { "AMI": "ami-0b322e67" },
+      "ap-southeast-1": { "AMI": "ami-e2fc3f81" },
+      "ap-southeast-2": { "AMI": "ami-e3217a80" },
+      "ap-northeast-1": { "AMI": "ami-f885ae96" },
       "ap-northeast-2": { "AMI": "ami-4118d72f" },
-      "sa-east-1":      { "AMI": "ami-d78325ca" }
+      "sa-east-1":      { "AMI": "ami-8631b5ea" }
     }
   },
 

--- a/manifests/cloudformation.json
+++ b/manifests/cloudformation.json
@@ -264,7 +264,7 @@
     "NATInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
-        "InstanceType": "m3.medium",
+        "InstanceType": "m4.large",
         "SubnetId": { "Ref": "BOSHSubnet" },
         "ImageId" : {
           "Fn::FindInMap": ["AWSNATAMI", { "Ref" : "AWS::Region" }, "AMI"]


### PR DESCRIPTION
#### New region support

I modified CloudFormation template to support newer AWS region. I added support for two missing regions:

- EU (Frankfurt) region
- Asia Pacific (Seoul) region

#### Change NAT AMIs to use HVM virtualization type 

I changed NAT AMIs to use HVM Virtualization Types, since PV(Paravirtual) virtualization type is not supported in new regions.

#### Change instance type

I changed instance type to `m4.large` since M3 type is not supported in new regions. Since it's almost twice expensive compared to existing `m3.medium`, I thought about using cheaper instance type like `t2.medium`, but since it doesn't have a consistent performance I decided to use standard M4 instance type instead. Feel free to modify it to another instance type.