### PR TITLE
`image_resource` `tag` should be a string

### DIFF
--- a/docs/running-tasks.any
+++ b/docs/running-tasks.any
@@ -28,7 +28,7 @@ Once you've figured out your tasks's configuration, you can reuse it for a
     type: docker-image
     source:
       repository: ubuntu
-      tag: 14.04
+      tag: '14.04'
 
   inputs:
   - name: my-repo


### PR DESCRIPTION
When running the provided example using Concourse v0.72.1, I got the following error:

```
resource script '/opt/resource/check []' failed: exit status 1

stderr:
failed to read request: json: cannot unmarshal number into Go value of type string

errored
```

This changes the value in the example YAML to be a string rather than a number, which fixes the issue.