### PR TITLE
Change concourse/lite URL to HTTP

### DIFF
--- a/docs/index.any
+++ b/docs/index.any
@@ -58,7 +58,7 @@
       }
 
       The web server will be running at
-      \hyperlink{https://192.168.100.4:8080}{192.168.100.4:8080}.
+      \hyperlink{http://192.168.100.4:8080}{192.168.100.4:8080}.
     }
 
     \step{1{\newline}min}{Save a .yml file with this example pipeline:}{


### PR DESCRIPTION
As suggested by olefriis in your Slack channel:

> olefriis [8:14 AM]
> Hi there! I'm just starting to read about Concourse and spinning up a
> Vagrant machine following the instructions on http://concourse.ci/ - it's a
> really nice way of getting a demo environment up and running quickly.
>
> [8:14]
> However, the link to the server inside the VM is an https URL, but the
> server is running plain old http.
>
> [8:14]
> ...which means that following the link from the concourse.ci front-page will
> just get me an error.
>
> [8:15]
> (It's in the "The web server will be running at 192.168.100.4:8080." part of
> the Concourse main page.)
>
> [8:16]
> If any of you guys know how to remove that "s" in the link, you'll save a
> lot of people a couple of minutes of frustration