### PR TITLE
Reference cloudfoundry-community slack resource in docs

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -74,7 +74,7 @@ before using it!
   }
 
   \list{
-    \hyperlink{https://github.com/Nopik/slack-notification-resource}{Slack notifications}
+    \hyperlink{https://github.com/cloudfoundry-community/slack-notification-resource}{Slack notifications}
   }{
     \hyperlink{https://github.com/jtarchie/pullrequest-resource}{Pull Requests}
   }{


### PR DESCRIPTION
- existing docs point to resource that does not work with newer versions of concourse and is not maintained