### PR TITLE
Provide example for `external_url` property.

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -38,10 +38,11 @@ properties:
 
   external_url:
     description: |
-      Externally reachable URL of the ATCs, e.g. `https://ci.concourse.ci`. Required for OAuth.
+      Externally reachable URL of the ATCs. Required for OAuth.
 
       Typically this is the URL that you as a user would use to reach your CI.
       For multiple ATCs it would go to some sort of load balancer.
+    example: https://ci.concourse.ci
 
   peer_url:
     description: |

--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -38,7 +38,7 @@ properties:
 
   external_url:
     description: |
-      Externally reachable URL of the ATCs. Required for OAuth.
+      Externally reachable URL of the ATCs, e.g. `https://ci.concourse.ci`. Required for OAuth.
 
       Typically this is the URL that you as a user would use to reach your CI.
       For multiple ATCs it would go to some sort of load balancer.


### PR DESCRIPTION
When we upgraded and added this property, we did not include the protocol. This caused the basic auth login page to generate invalid links.