### PR TITLE
Add smuggler generic resource framework to docs

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -107,6 +107,8 @@ before using it!
     \hyperlink{https://github.com/robdimsdale/concourse-pipeline-resource}{Concourse Pipelines}
   }{
     \hyperlink{https://github.com/hpcloud/hipchat-notification-resource}{HipChat Notifications}
+  }{
+    \hyperlink{https://github.com/redfactorlabs/concourse-smuggler-resource}{Smuggler: generic resource framework}
   }
 
   \section{Adding to this list}{


### PR DESCRIPTION
Add the resource https://github.com/redfactorlabs/concourse-smuggler-resource/ to the list of third party resources.

Although it is not a resource per sé, but a framework to quickly implement resources and lower the entry barrier.