### PR TITLE
Allow beacon and jettison to have 60 seconds to start before timing out

### DIFF
--- a/jobs/groundcrew/monit
+++ b/jobs/groundcrew/monit
@@ -1,11 +1,11 @@
 check process beacon
   with pidfile /var/vcap/sys/run/groundcrew/beacon.pid
-  start program "/var/vcap/jobs/groundcrew/bin/beacon_ctl start"
+  start program "/var/vcap/jobs/groundcrew/bin/beacon_ctl start" with timeout 60 seconds
   stop program "/var/vcap/jobs/groundcrew/bin/beacon_ctl stop"
   group vcap
 
 check process jettison
   with pidfile /var/vcap/sys/run/groundcrew/jettison.pid
-  start program "/var/vcap/jobs/groundcrew/bin/jettison_ctl start"
+  start program "/var/vcap/jobs/groundcrew/bin/jettison_ctl start" with timeout 60 seconds
   stop program "/var/vcap/jobs/groundcrew/bin/jettison_ctl stop"
   group vcap


### PR DESCRIPTION
When deploying Concourse, I always am forced to run `bosh deploy` again because it thinks the workers failed to update.

```
Director task 4396
  Started preparing deployment > Preparing deployment. Done (00:00:00)

  Started preparing package compilation > Finding packages to compile. Done (00:00:00)

  Started updating job web > web/0 (77fab7e0-b22d-4c87-b7a8-2562070e3479) (canary). Done (00:03:25)
  Started updating job worker-aws
  Started updating job worker-aws > worker-aws/0 (8a0de851-f090-45b3-92d7-cdfe9f1df64c) (canary). Failed: `worker-aws/0 (8a0de851-f090-45b3-92d7-cdfe9f1df64c)' is not running after update. Review logs for failed jobs: beacon, jettison, baggageclaim, garden (00:04:32)
```

ssh-ing onto the worker-aws/0 and running `monit summary` will show that all the monit processes are running. Re-running `bosh deploy` will then succeed for worker-aws/0 but fail for worker-aws/1

```
Director task 4400
  Started preparing deployment > Preparing deployment. Done (00:00:00)

  Started preparing package compilation > Finding packages to compile. Done (00:00:00)

  Started updating job worker-aws
  Started updating job worker-aws > worker-aws/0 (8a0de851-f090-45b3-92d7-cdfe9f1df64c) (canary). Done (00:01:39)
Started updating job worker-aws > worker-aws/1 (06b2a5ea-0045-4f17-b21e-6d86675fb616). Failed: `worker-aws/1 (06b2a5ea-0045-4f17-b21e-6d86675fb616)' is not running after update. Review logs for failed jobs: beacon, jettison, baggageclaim, garden (00:05:11)
   Failed updating job worker-aws (00:06:50)
```

Likewise, monit processes are all running on worker-aws/1 and running `bosh deploy` again will allow the worker to be deployed successfully.

This PR allows beacon and jettison to have 60 seconds before timing out (I believe the default is 30 seconds).