### PR TITLE
Add GitHub Commit Status third-party resource

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -113,6 +113,8 @@ before using it!
     \hyperlink{https://github.com/freelock/matrix-notification-resource}{Matrix Notifications}
   }{
     \hyperlink{https://github.com/redfactorlabs/concourse-smuggler-resource}{Smuggler: generic resource framework}
+  }{
+    \hyperlink{https://github.com/dpb587/github-status-resource}{GitHub Commit Status}
   }
 
   \section{Adding to this list}{


### PR DESCRIPTION
Made a resource to work with branch/PR statuses if you think a reference would be useful to the community.