### PR TITLE
Make Concourse v1.1.0 compatible with bosh-init

### DIFF
--- a/jobs/tsa/spec
+++ b/jobs/tsa/spec
@@ -78,3 +78,9 @@ properties:
     description: |
       Environment name to specify for errors emitted to Yeller.
     default: ""
+
+  atc.url:
+    description: |
+      ATC API endpoint to which workers will be advertised.
+      If not specified, it will be autodiscovered via BOSH links.
+    default: "http://127.0.0.1:8080"

--- a/jobs/tsa/templates/tsa_ctl.erb
+++ b/jobs/tsa/templates/tsa_ctl.erb
@@ -10,7 +10,20 @@ set -e
     Shellwords.shellescape(x)
   end
 
-  atc = link("atc")
+  if !spec.address or spec.address == ""
+    peer_ip = "127.0.0.1"
+  else
+    peer_ip = spec.address
+  end
+
+  atc_url = nil
+  if_link("atc") do |atc|
+    atc.instances.each do |instance|
+      atc_url = "http://#{instance.address}:#{atc.p("bind_port")}"
+    end
+  end
+  atc_url ||= "#{p("atc.url")}"
+
 %>
 
 RUN_DIR=/var/vcap/sys/run/tsa
@@ -51,10 +64,8 @@ EOF
 
     # TODO: TSA should support multiple ATCs
     exec chpst -u vcap:vcap /var/vcap/packages/tsa/bin/tsa \
-      <% atc.instances.each do |instance| %> \
-      --atc-url <%= "http://#{instance.address}:#{atc.p("bind_port")}" %> \
-      <% end %> \
-      --peer-ip <%= spec.address %> \
+      --atc-url <%= atc_url %> \
+      --peer-ip <%= peer_ip %> \
       --bind-port <%= p("bind_port") %> \
       <% if p("host_key") != "" %> \
       --host-key /var/vcap/jobs/tsa/config/host_key \


### PR DESCRIPTION
## Why

We want to be able to deploy Concourse v1.1.0 with bosh-init. bosh-init does not support the `link()` method and `spec.address` used in the TSA template file.

## What

Use of the `link()` method and `spec.address` is now conditional. This was tested using bosh-init v0.0.87, as that stubs the `if_link()` method to always return false. 

**Note:** This stub method is available in bosh-init from v0.0.82.

Required adding explicit property `tsa_atc_address` and testing for `spec.address` as it is not available in bosh-init.

## How to review

* Deploy Concourse v1.1.0+ using bosh and bosh-init
* Test template renders correctly
* Test Concourse still works

