### PR TITLE
Add useful information in "implementing resource" doc

### DIFF
--- a/docs/using-concourse/implementing-resources.any
+++ b/docs/using-concourse/implementing-resources.any
@@ -22,6 +22,9 @@ dependencies. For example, the Git resource comes with \code{git} installed.
 All resources must implement all three actions, though the actions can just be
 no-ops (which still must be correctly implemented as detailed below).
 
+Resources can log to the web interface by writting to stderr. 
+Ansi colors are interpreted in the web interface and can be used when writting to stdout and stderr.
+
 \section{\code{check}\aux{: Check for new versions.}}{resource-check}{
   A resource type's \code{check} script is invoked to detect new versions of
   the resource. It is given the configured source and current version on stdin,


### PR DESCRIPTION
When i develop my first resource it was hard to see how I can put trace and how to have colors to the web interface. I had to look on other resource code.
I added these small information in the doc.