### PR TITLE
Add Bitbucket build status resource

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -121,6 +121,8 @@ before using it!
     \hyperlink{https://github.com/jdub/debian-sources-resource}{Debian/Ubuntu Sources Updates}
   }{
     \hyperlink{https://github.com/Orange-OpenSource/travis-resource}{Travis-ci}
+  }{
+    \hyperlink{https://github.com/karunamon/concourse-resource-bitbucket}{Bitbucket Notifications}
   }
 
   \section{Adding to this list}{


### PR DESCRIPTION
This PR adds a link to a new resource to the appropriate docs page, one which notifies Bitbucket (yet another web-based Git service) of build statuses.