### PR TITLE
Fix documentation

### DIFF
--- a/docs/setting-up/installing.any
+++ b/docs/setting-up/installing.any
@@ -198,7 +198,7 @@ Concourse's ideals, buckle up and head over to \reference{clusters-with-bosh}.
         --session-signing-key session_signing_key \\
         --tsa-host-key host_key \\
         --tsa-authorized-keys authorized_worker_keys \\
-        --postgres-data-source postgres://user:pass@10.0.32.0/concourse \\
+        --postgres-data-source postgres://user:pass@10.0.32.0/atc \\
         --external-url https://ci.example.com \\
         --peer-url http://10.0.16.10:8080
       }
@@ -212,7 +212,7 @@ Concourse's ideals, buckle up and head over to \reference{clusters-with-bosh}.
         --session-signing-key session_signing_key \\
         --tsa-host-key host_key \\
         --tsa-authorized-keys authorized_worker_keys \\
-        --postgres-data-source postgres://user:pass@10.0.32.0/concourse \\
+        --postgres-data-source postgres://user:pass@10.0.32.0/atc \\
         --external-url https://ci.example.com \\
         --peer-url http://10.0.16.11:8080
       }


### PR DESCRIPTION
According to [the comment in ATC source codes](https://github.com/concourse/atc/blob/master/atccmd/command.go#L60), `postgres://user:pass@10.0.32.0/concourse` is wrong for the parameter of `--postgres-data-source` option.

The end of the parameter strings should be `atc`, not `concourse`.