### PR TITLE
Replace hardcoded vm types with REPLACE_MEs in example manifest

### DIFF
--- a/docs/setting-up/installing.any
+++ b/docs/setting-up/installing.any
@@ -307,9 +307,10 @@ Concourse's ideals, buckle up and head over to \reference{clusters-with-bosh}.
     example manifest is below; you'll want to replace the \code{REPLACE_ME} bits
     with whatever values are appropriate.
 
-    Note that the VM types and network names used in this manifest must be
-    present in your Cloud Config. Consult \reference{prepping-bosh} if you
-    haven't set it up yet.
+    Note that the VM types, VM extensions, persistent disk type, and network names
+    must come from your Cloud Config. Consult \reference{prepping-bosh} if you
+    haven't set it up yet. You can retrieve your Cloud Config by running
+    \code{bosh cloud-config}.
 
     \codeblock{yaml}{
       ---
@@ -332,7 +333,12 @@ Concourse's ideals, buckle up and head over to \reference{clusters-with-bosh}.
       instance_groups:
       - name: web
         instances: 1
-        vm_type: web
+        # replace with a VM type from your BOSH Director's cloud config
+        vm_type: REPLACE_ME
+        vm_extensions:
+        # replace with a VM extension from your BOSH Director's cloud config that will attach
+        # this instance group to your ELB
+        - REPLACE_ME
         stemcell: trusty
         azs: [z1]
         networks: [\{name: private\}]
@@ -354,9 +360,11 @@ Concourse's ideals, buckle up and head over to \reference{clusters-with-bosh}.
 
       - name: db
         instances: 1
-        vm_type: database
+        # replace with a VM type from your BOSH Director's cloud config
+        vm_type: REPLACE_ME
         stemcell: trusty
-        persistent_disk_type: database
+        # replace with a disk type from your BOSH Director's cloud config
+        persistent_disk_type: REPLACE_ME
         azs: [z1]
         networks: [\{name: private\}]
         jobs:
@@ -371,7 +379,12 @@ Concourse's ideals, buckle up and head over to \reference{clusters-with-bosh}.
 
       - name: worker
         instances: 1
-        vm_type: worker
+        # replace with a VM type from your BOSH Director's cloud config
+        vm_type: REPLACE_ME
+        vm_extensions:
+        # replace with a VM extension from your BOSH Director's cloud config that will attach
+        # sufficient ephemeral storage to VMs in this instance group.
+        - REPLACE_ME
         stemcell: trusty
         azs: [z1]
         networks: [\{name: private\}]

--- a/manifests/concourse.yml
+++ b/manifests/concourse.yml
@@ -18,7 +18,12 @@ stemcells:
 instance_groups:
 - name: web
   instances: 1
-  vm_type: web
+  # replace with a VM type from your BOSH Director's cloud config
+  vm_type: REPLACE_ME
+  vm_extensions:
+  # replace with a VM extension from your BOSH Director's cloud config that will attach
+  # this instance group to your ELB
+  - REPLACE_ME
   stemcell: trusty
   azs: [z1]
   networks: [{name: private}]
@@ -40,9 +45,11 @@ instance_groups:
 
 - name: db
   instances: 1
-  vm_type: database
+  # replace with a VM type from your BOSH Director's cloud config
+  vm_type: REPLACE_ME
   stemcell: trusty
-  persistent_disk_type: database
+  # replace with a disk type from your BOSH Director's cloud config
+  persistent_disk_type: REPLACE_ME
   azs: [z1]
   networks: [{name: private}]
   jobs:
@@ -57,7 +64,12 @@ instance_groups:
 
 - name: worker
   instances: 1
-  vm_type: worker
+  # replace with a VM type from your BOSH Director's cloud config
+  vm_type: REPLACE_ME
+  vm_extensions:
+  # replace with a VM extension from your BOSH Director's cloud config that will attach
+  # sufficient ephemeral storage to VMs in this instance group.
+  - REPLACE_ME
   stemcell: trusty
   azs: [z1]
   networks: [{name: private}]


### PR DESCRIPTION
The example BOSH manifest for Concourse hardcodes vm types and does not specify what values the user should change. Since there is no de facto cloud config, we wanted to update the example manifest to accommodate for various cloud configs by using REPLACE_MEs. Then the user can drop in their own values from their own cloud config.

We also added in vm_extensions to notify the user that there needs to be a load balancer on the web vm and an ephemeral disk on the worker vm.

Hopefully this will help educate users on how to populate their manifests when deploying Concourse. Let us know if this looks like it could be merged.

Thanks,
Christian Ang and @kkallday