### PR TITLE
Fix formatting of example manifest

### DIFF
--- a/docs/setting-up/installing.any
+++ b/docs/setting-up/installing.any
@@ -331,9 +331,9 @@ Concourse's ideals, buckle up and head over to \reference{clusters-with-bosh}.
         instances: 1
         # replace with a VM type from your BOSH Director's cloud config
         vm_type: REPLACE_ME
-        vm_extensions:
         # replace with a VM extension from your BOSH Director's cloud config that will attach
         # this instance group to your ELB
+        vm_extensions:
         - REPLACE_ME
         stemcell: trusty
         azs: [z1]
@@ -381,9 +381,9 @@ Concourse's ideals, buckle up and head over to \reference{clusters-with-bosh}.
         instances: 1
         # replace with a VM type from your BOSH Director's cloud config
         vm_type: REPLACE_ME
-        vm_extensions:
         # replace with a VM extension from your BOSH Director's cloud config that will attach
         # sufficient ephemeral storage to VMs in this instance group.
+        vm_extensions:
         - REPLACE_ME
         stemcell: trusty
         azs: [z1]

--- a/manifests/concourse.yml
+++ b/manifests/concourse.yml
@@ -20,9 +20,9 @@ instance_groups:
   instances: 1
   # replace with a VM type from your BOSH Director's cloud config
   vm_type: REPLACE_ME
-  vm_extensions:
   # replace with a VM extension from your BOSH Director's cloud config that will attach
   # this instance group to your ELB
+  vm_extensions:
   - REPLACE_ME
   stemcell: trusty
   azs: [z1]
@@ -66,9 +66,9 @@ instance_groups:
   instances: 1
   # replace with a VM type from your BOSH Director's cloud config
   vm_type: REPLACE_ME
-  vm_extensions:
   # replace with a VM extension from your BOSH Director's cloud config that will attach
   # sufficient ephemeral storage to VMs in this instance group.
+  vm_extensions:
   - REPLACE_ME
   stemcell: trusty
   azs: [z1]


### PR DESCRIPTION
Move vm_extension description above the key to follow format of other manifest key descriptions.