### PR TITLE
Clarify use of from flag in check-resource CLI command

### DIFF
--- a/docs/using-concourse/fly-cli.any
+++ b/docs/using-concourse/fly-cli.any
@@ -425,6 +425,10 @@ flag. Once you've learned what the commands do, you may want to consult
   This can be useful for collecting versions that are older than the current
   ones, given that a newly configured resource will only start from the latest
   version.
+
+  Note the \code{ref:} prefix is resource-dependent. For example, the
+  \italic{bosh-io-release} resource might use \code{version:11.2} in place of
+  \code{ref:abcdef}.
 }
 
 \section{\code{builds}\aux{: Showing build history}}{fly-builds}{


### PR DESCRIPTION
- We were initially confused when the `ref:` prefix didn't work with the
  bosh-io-release resource
- Our goal was to point out that the prefix is resource-dependent

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>