### PR TITLE
Add link to devpi-resource

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -125,6 +125,8 @@ before using it!
     \hyperlink{https://github.com/karunamon/concourse-resource-bitbucket}{Bitbucket Notifications}
   }{
     \hyperlink{https://github.com/ljfranklin/terraform-resource}{Terraform}
+  }{
+    \hyperlink{https://github.com/mdomke/concourse-devpi-resource}{Devpi Server: PyPI mirror and package server}
   }
 
   \section{Adding to this list}{


### PR DESCRIPTION
The [devpi server](http://doc.devpi.net/latest/) is a PyPI mirror and development package server for Python packages. The [concourse-devpi-resource](https://github.com/mdomke/concourse-devpi-resource) allows it to track and upload packages from a devpi server.