### PR TITLE
flight-school needs an `image_resource` early on

### DIFF
--- a/docs/tutorials/flight-school.any
+++ b/docs/tutorials/flight-school.any
@@ -110,10 +110,7 @@ the \reference{installing}{installation guide} before coming back here.
 
   image_resource:
     type: docker-image
-    source:
-      repository: ruby
-      tag: 2.3.0
-  }
+    source: { repository: busybox }
 
   inputs:
   - name: flight-school
@@ -140,7 +137,7 @@ the \reference{installing}{installation guide} before coming back here.
   100 40960    0 40960    0     0   662k      0 --:--:-- --:--:-- --:--:--  800k
   initializing
   running flight-school/ci/test.sh
-  proc_starter: ExecAsUser: system: program 'flight-school/ci/test.sh' was not found in $PATH: exec: "flight-school/ci/test.sh": stat flight-school/ci/test.sh: no such file or directory
+  exec failed: exec: "./flight-school/ci/test.sh": stat ./flight-school/ci/test.sh: no such file or directory
   failed
   }
 
@@ -180,7 +177,7 @@ the \reference{installing}{installation guide} before coming back here.
   100 40960    0 40960    0     0   662k      0 --:--:-- --:--:-- --:--:--  800k
   initializing
   running flight-school/ci/test.sh
-  proc_starter: ExecAsUser: system: program 'flight-school/ci/test.sh' was not found in $PATH: exec: "flight-school/ci/test.sh": permission denied
+  exec failed: exec: "./flight-school/ci/test.sh": permission denied
   failed
   }
 
@@ -201,7 +198,7 @@ the \reference{installing}{installation guide} before coming back here.
   100 40960    0 40960    0     0   662k      0 --:--:-- --:--:-- --:--:--  800k
   initializing
   running flight-school/ci/test.sh
-  proc_starter: ExecAsUser: system: exec of flight-school/ci/test.sh: no such file or directory
+  exec failed: no such file or directory
   failed
   }
 

--- a/docs/tutorials/flight-school.any
+++ b/docs/tutorials/flight-school.any
@@ -108,6 +108,13 @@ the \reference{installing}{installation guide} before coming back here.
   \codeblock{yaml}{
   platform: linux
 
+  image_resource:
+    type: docker-image
+    source:
+      repository: ruby
+      tag: 2.3.0
+  }
+
   inputs:
   - name: flight-school
 


### PR DESCRIPTION
With the switch to Garden runC the `build.xml`, without adding an `image_resource` early on, fails with this error:

```
$ fly -t lite execute -c build.yml
targeting http://192.168.100.4:8080

executing build 219
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 40960    0 40960    0     0  13.4M      0 --:--:-- --:--:-- --:--:-- 19.5M
initializing
volume graph is disabled
errored
```