### PR TITLE
add pagerduty resource type

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -133,6 +133,8 @@ before using it!
     \hyperlink{https://github.com/mdomke/concourse-devpi-resource}{Devpi Server: PyPI mirror and package server}
   }{
     \hyperlink{https://github.com/danrspencer/jira-resource}{Jira Integration}
+  }{
+    \hyperlink{https://github.com/FidelityInternational/concourse-pagerduty-notification-resource}{pagerduty Notifications}
   }
 
   \section{Adding to this list}{


### PR DESCRIPTION
Support teams like to know when a concourse job fails, a common tool used is pagerduty hence having a pagerduty notifications resource is extremely useful.

Example:
```
jobs:
- name: health-check
  public: true
  serial: true
  plan:
  - get: pipeline
    trigger: true
  - get: every-2-minutes
    trigger: true
  - task: test
    file: pipeline/tasks/test.yml
    params:
      CONCOURSE_URL: {{concourse-url}}
    on_failure:
      put: pagerduty-alert
      params:
        description: {{description}}
        incident_key: {{incident_key}}
```