### PR TITLE
Reduce size of baggageclaim btrfs image file.

### DIFF
--- a/jobs/baggageclaim/spec
+++ b/jobs/baggageclaim/spec
@@ -37,3 +37,10 @@ properties:
     description: |
       Environment name to specify for errors emitted to Yeller.
     default: ""
+
+  volumes_image_size_mb:
+    description: |
+      The size in megabytes of the volumes image to allocate. This is allocated
+      under /var/vcap/data, so should leave enough space for everything else.
+      Defaults to the filesystem size minus 10Gig.
+    default: -1

--- a/jobs/baggageclaim/templates/baggageclaim_ctl.erb
+++ b/jobs/baggageclaim/templates/baggageclaim_ctl.erb
@@ -30,7 +30,7 @@ case $1 in
     chown -R vcap:vcap $LOG_DIR
 
     IMAGE_PATH=/var/vcap/data/baggageclaim/volumes.img
-    IMAGE_SIZE=$(df -m /var/vcap/data | tail -n1 | awk '{print $2}')
+    IMAGE_SIZE=$(($(df -m /var/vcap/data | tail -n1 | awk '{print $2}') - 10 * 1024))
     mkdir -p $(dirname ${IMAGE_PATH})
 
     VOLUMES_DIR=/var/vcap/data/baggageclaim/volumes

--- a/jobs/baggageclaim/templates/baggageclaim_ctl.erb
+++ b/jobs/baggageclaim/templates/baggageclaim_ctl.erb
@@ -30,7 +30,11 @@ case $1 in
     chown -R vcap:vcap $LOG_DIR
 
     IMAGE_PATH=/var/vcap/data/baggageclaim/volumes.img
+  <% if p('volumes_image_size_mb') > 0 %>
+    IMAGE_SIZE=<%= p('volumes_image_size_mb') %>
+  <% else %>
     IMAGE_SIZE=$(($(df -m /var/vcap/data | tail -n1 | awk '{print $2}') - 10 * 1024))
+  <% end %>
     mkdir -p $(dirname ${IMAGE_PATH})
 
     VOLUMES_DIR=/var/vcap/data/baggageclaim/volumes


### PR DESCRIPTION
This was previously created to be the same size as the `/var/vcap/data`
filesystem. This is a problem because this filesystem is also used by
other things (bosh packages and jobs, garden's graph and depot, logs
etc).

When the btrfs volume starts to get full, this can lead to errors when the
btrfs driver gets a `no space on device` error when writing to the
sparse image file. This in turn causes a kernel error, and the loopback
filesystem gets remounted read-only.

To reduce the likelihood of this, this changes the init script to allocate
10Gig less than the filesystem size. This PR also adds a property to allow
overriding the size for cases when 10Gig of overhead isn't enough.