### PR TITLE
Remove unecessary PATH modification in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,1 @@
 export GOPATH=$PWD
-export PATH=$PWD/bin:$PATH


### PR DESCRIPTION
The `.envrc` file adds `$GOPATH/bin` to the `$PATH`, but that directory doesn't exist.  I expect this is cargo culted.