### PR TITLE
Add alternative email resource.

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -84,6 +84,8 @@ before using it!
   }{
     \hyperlink{https://github.com/pivotal-cf/email-resource}{Email}
   }{
+    \hyperlink{https://github.com/mdomke/concourse-email-resource}{Email with integrated MTA}
+  }{
     \hyperlink{https://github.com/jamiemonserrate/bintray-resource}{Bintray}
   }{
     \hyperlink{https://github.com/olhtbr/p4-resource}{Perforce}


### PR DESCRIPTION
The original email resource ([pivotal-cf/email-resource](https://github.com/pivotal-cf/email-resource)) didn't include a
MTA and was therefore more complicated to configure and setup as I think
it should be.