### PR TITLE
Add open build service resource to resource types

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -122,6 +122,8 @@ before using it!
   }{
     \hyperlink{https://github.com/jdub/debian-sources-resource}{Debian/Ubuntu Sources Updates}
   }{
+    \hyperlink{https://github.com/SUSE/open-build-service-resource}{Open Build Service}
+  }{
     \hyperlink{https://github.com/Orange-OpenSource/travis-resource}{Travis-ci}
   }{
     \hyperlink{https://github.com/karunamon/concourse-resource-bitbucket}{Bitbucket Notifications}


### PR DESCRIPTION
We create a resource to control Open Build Service from Concourse. Would it be possible to add it to the resource types page in the documentation?