### PR TITLE
Fixing docker composer postgres link

### DIFF
--- a/docs/setting-up/installing.any
+++ b/docs/setting-up/installing.any
@@ -295,8 +295,7 @@ a tool that meshes well with Concourse's ideals, buckle up and head over to
       CONCOURSE_BASIC_AUTH_USERNAME: concourse
       CONCOURSE_BASIC_AUTH_PASSWORD: changeme
       CONCOURSE_EXTERNAL_URL: "$\{CONCOURSE_EXTERNAL_URL\}"
-      CONCOURSE_POSTGRES_DATA_SOURCE: |
-        postgres://concourse:changeme@concourse-db:5432/concourse?sslmode=disable
+      CONCOURSE_POSTGRES_DATA_SOURCE: "postgres://concourse:changeme@concourse-db:5432/concourse?sslmode=disable"
 
   concourse-worker:
     image: concourse/concourse


### PR DESCRIPTION
Seems the postgres connection chain is not pass correctly.

Just putting on the same line with double quote seems to fix the "sslmode is invalid" error