### PR TITLE
Added auth-duration as a configurable parameter to the atc job

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -92,6 +92,11 @@ properties:
       Log database queries. Log level is debug, so requires development mode.
     default: false
 
+  auth_duration:
+    description: |
+      Specifies how long authentication tokens are valid for.
+    default: 24h
+
   basic_auth_username:
     description: |
       Username for HTTP basic auth.

--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -152,6 +152,7 @@ case $1 in
       --metrics-host-name <%= name %>-<%= index %> \
       --metrics-attribute <%= esc("bosh-deployment:#{spec.deployment}") %> \
       --metrics-attribute <%= esc("bosh-job:#{name}") %> \
+      --auth-duration <%= esc(p("auth_duration")) %> \
       1>>$LOG_DIR/atc.stdout.log \
       2>>$LOG_DIR/atc.stderr.log
 


### PR DESCRIPTION
Took the new `--auth-duration` flag in `v2.1.0` and made it configurable in the BOSH release