### PR TITLE
Allow to specify Riemann tags

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -284,3 +284,11 @@ properties:
     description: |
       An optional prefix for emitted Riemann services
     default: ""
+
+  riemann.tags:
+    description: |
+      An optional list of tags in key: value format
+    default: {}
+    example:
+      env: dev
+      foo: bar

--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -156,6 +156,9 @@ case $1 in
       --metrics-host-name <%= name %>-<%= index %> \
       --metrics-attribute <%= esc("bosh-deployment:#{spec.deployment}") %> \
       --metrics-attribute <%= esc("bosh-job:#{name}") %> \
+      <% p("riemann.tags").each do |k,v| %> \
+      --metrics-attribute <%= esc(k) %>:<%= esc(v) %> \
+      <% end %> \
       1>>$LOG_DIR/atc.stdout.log \
       2>>$LOG_DIR/atc.stderr.log
 


### PR DESCRIPTION
## What

This PR allows user to specify custom Rieman taggs so they can be used for metrics filtering. 
 
Tags should be a dictionary under Riemann key in ATC properties. 

```
  - name: atc
    properties:
      riemann:
        tags:
          foo: bar
```
## Why

We like to use disposable environments with one Concourse per env. Each concourse uses Riemann to send metrics to Datadog shared account. It's much easier to filter metrics if tags are set properly. 

