### PR TITLE
update typo

### DIFF
--- a/docs/introduction/pipeline-mechanics.any
+++ b/docs/introduction/pipeline-mechanics.any
@@ -11,7 +11,7 @@ Composing the three core \reference{concepts} together results in a
 
 A pipeline is the result of configuring \reference{configuring-jobs} and
 \reference{configuring-resources}. When you configure a pipeline, it takes on a
-life of its own, to continously detect resource versions and schedule jobs over
+life of its own, to continuously detect resource versions and schedule jobs over
 time. The mechanics of this are described below.
 
 \section{Scheduling with Resources}{

--- a/docs/setting-up/worker-pools.any
+++ b/docs/setting-up/worker-pools.any
@@ -136,12 +136,12 @@ added to your workers.
 \section{Registering via the TSA}{registering-via-tsa}{
   Using the \code{/api/v1/workers} API directly is a bit inconvenient. Your
   workers need credentials for the ATC, and must advertise an address that the
-  ATC can reach. The API consumer would also have to continously heartbeat so
+  ATC can reach. The API consumer would also have to continuously heartbeat so
   long as the server it's advertising is healthy.
 
   A typical Concourse installation includes a component called the
   \reference{architecture-tsa}{TSA}. The TSA is used to securely register
-  workers via SSH, and continously health-check and heartbeat them to the ATC.
+  workers via SSH, and continuously health-check and heartbeat them to the ATC.
   These workers can come from any network that can reach the TSA, which is
   usually colocated with the ATC and possibly sitting behind the same load
   balancer (but on a different port, usually \code{2222}).


### PR DESCRIPTION
Is there a way to automate in a pipeline a command line spell checker like `aspell`, etc. for the docs?

Here's one I noticed that can be corrected.

Cheers.