### PR TITLE
Adding documentation for the logout command

### DIFF
--- a/docs/using-concourse/fly-cli.any
+++ b/docs/using-concourse/fly-cli.any
@@ -78,7 +78,7 @@ flag. Once you've learned what the commands do, you may want to consult
   \code{example} Concourse instance.
 }
 
-\section{\code{logout}\aux{: Remove authentication and delete Concourse targets}}{fly-out}{
+\section{\code{logout}\aux{: Remove authentication and delete Concourse targets}}{fly-logout}{
   There are cases when you would like to remove all evidence of a particular
   target. This is achieved by the \code{logout} command. There are two variants
   of this command, one to get rid of a specific target, and another to remove

--- a/docs/using-concourse/fly-cli.any
+++ b/docs/using-concourse/fly-cli.any
@@ -78,19 +78,20 @@ flag. Once you've learned what the commands do, you may want to consult
   \code{example} Concourse instance.
 }
 
-\section{\code{login}\aux{: Authenticating with and saving Concourse targets}}{fly-login}{
-
+\section{\code{logout}\aux{: Remove authentication and delete Concourse targets}}{fly-out}{
   There are cases when you would like to remove all evidence of a particular
-  configuration. This is achieve by the \code{logout} command. There are two
-  variants of this command, one to get rid of a specific target, and another
-  to remove all targets from the \code{~/.flyrc} file.
+  target. This is achieved by the \code{logout} command. There are two variants
+  of this command, one to get rid of a specific target, and another to remove
+  all targets from the \code{~/.flyrc} file.
 
   To remove a specific target run:
+
   \codeblock{bash}{
   $ fly -t example logout
   }
 
   To remove all targets run:
+
   \codeblock{bash}{
   $ fly logout -a
   }

--- a/docs/using-concourse/fly-cli.any
+++ b/docs/using-concourse/fly-cli.any
@@ -78,6 +78,27 @@ flag. Once you've learned what the commands do, you may want to consult
   \code{example} Concourse instance.
 }
 
+\section{\code{login}\aux{: Authenticating with and saving Concourse targets}}{fly-login}{
+
+  There are cases when you would like to remove all evidence of a particular
+  configuration. This is achieve by the \code{logout} command. There are two
+  variants of this command, one to get rid of a specific target, and another
+  to remove all targets from the \code{~/.flyrc} file.
+
+  To remove a specific target run:
+  \codeblock{bash}{
+  $ fly -t example logout
+  }
+
+  To remove all targets run:
+  \codeblock{bash}{
+  $ fly logout -a
+  }
+
+  Note: These two variations are mutually exclusive. If the target parameter
+  \code{-t} and all parameter \code{-a} are both specified, an error will occur.
+}
+
 \section{\code{targets}\aux{: List the current targets}}{fly-targets}{
   To see what targets are currently known to \code{fly}, run:
 


### PR DESCRIPTION
As a followup to [Issue 660](https://github.com/concourse/concourse/issues/660) and [Pull request 114](https://github.com/concourse/fly/pull/114). This is the documentation for the `logout` command.
