### PR TITLE
Add link to RSS resource

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -156,6 +156,8 @@ before using it!
     \hyperlink{https://github.com/everpeace/aws-kms-resource}{AWS Key Management Service}
   }{
     \hyperlink{https://github.com/ckaznocha/marathon-resource}{Marathon}
+  }{
+    \hyperlink{https://github.com/suhlig/concourse-rss-resource}{RSS}
   }
 
   \section{Adding to this list}{


### PR DESCRIPTION
I created a resource for tracking RSS feeds. This PR is to create a link in the docs, pointing to the resource's github page.