### PR TITLE
Add calendar resource

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -141,6 +141,8 @@ before using it!
   }{
     \hyperlink{https://github.com/jpatel-pivotal/google-drive-concourse-resource}{Google Drive}
   }{
+    \hyperlink{https://github.com/henrytk/calendar-resource}{Google Calendar}
+  }{
     \hyperlink{https://github.com/FidelityInternational/concourse-pagerduty-notification-resource}{pagerduty Notifications}
   }{
     \hyperlink{https://github.com/w32blaster/telegram-notification-resource}{Telegram}


### PR DESCRIPTION
This pull request adds a [calendar resource](https://github.com/henrytk/calendar-resource) to the list of third party resources. The resource currently only supports Google Calendars, but could be extended to other providers.