### PR TITLE
document -c flag for fly builds command [Obvious Fix]

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "2.3.1", engine: "rbx", engine_version: "3.65"
+ruby "2.3.1", engine: "rbx", engine_version: "3.69"
 
 gem "anatomy", "~> 0.4.0"
 gem "concourse-docs", path: File.expand_path("../concourse-docs", __FILE__)

--- a/docs/using-concourse/fly-cli.any
+++ b/docs/using-concourse/fly-cli.any
@@ -554,10 +554,11 @@ flag. Once you've learned what the commands do, you may want to consult
   This can be useful for periodically monitoring the state of a job. The output
   also works well with tools like \code{awk} and \code{grep}.
 
-  By default the most recent 50 builds are shown. To see more builds, run:
+  By default the most recent 50 builds are shown. To see more builds, use
+  the \code{-c} flag, like so:
 
   \codeblock{bash}{
-  $fly -t example builds -c 100
+  $ fly -t example builds -c 100
   }
 }
 

--- a/docs/using-concourse/fly-cli.any
+++ b/docs/using-concourse/fly-cli.any
@@ -553,6 +553,12 @@ flag. Once you've learned what the commands do, you may want to consult
 
   This can be useful for periodically monitoring the state of a job. The output
   also works well with tools like \code{awk} and \code{grep}.
+
+  By default the most recent 50 builds are shown. To see more builds, run:
+
+  \codeblock{bash}{
+  $fly -t example builds -c 100
+  }
 }
 
 \section{\code{abort-build}\aux{: Aborting a running build of a job}}{fly-abort-build}{


### PR DESCRIPTION
Some users asked how to show more builds in `fly builds`. Seems like this could go in the docs too.