### PR TITLE
Use "host_key" as the default TSA host key name

### DIFF
--- a/dev/setup
+++ b/dev/setup
@@ -18,9 +18,9 @@ function keygen() {
   [ -f $1 ] || ssh-keygen -t rsa -f $1 -N ''
 }
 
-keygen ./web/tsa_host_key
+keygen ./web/host_key
 keygen ./web/session_signing_key
 keygen ./worker/worker_key
 
 cp ./worker/worker_key.pub ./web/authorized_worker_keys
-cp ./web/tsa_host_key.pub ./worker
+cp ./web/host_key.pub ./worker

--- a/dev/tsa
+++ b/dev/tsa
@@ -14,7 +14,7 @@ go install github.com/concourse/tsa/cmd/tsa
 
 tsa \
   --atc-url http://127.0.0.1:8080 \
-  --host-key $KEYSDIR/web/tsa_host_key \
+  --host-key $KEYSDIR/web/host_key \
   --peer-ip 127.0.0.1 \
   --authorized-keys $KEYSDIR/web/authorized_worker_keys \
   --session-signing-key $KEYSDIR/web/session_signing_key \

--- a/docs/setting-up/installing.any
+++ b/docs/setting-up/installing.any
@@ -313,13 +313,13 @@ a tool that meshes well with Concourse's ideals, buckle up and head over to
   \codeblock{bash}{
     mkdir -p keys/web keys/worker
 
-    ssh-keygen -t rsa -f ./keys/web/tsa_host_key -N ''
+    ssh-keygen -t rsa -f ./keys/web/host_key -N ''
     ssh-keygen -t rsa -f ./keys/web/session_signing_key -N ''
 
     ssh-keygen -t rsa -f ./keys/worker/worker_key -N ''
 
     cp ./keys/worker/worker_key.pub ./keys/web/authorized_worker_keys
-    cp ./keys/web/tsa_host_key.pub ./keys/worker
+    cp ./keys/web/host_key.pub ./keys/worker
   }
 
   The next thing you'll need is an address that can be used to reach the


### PR DESCRIPTION
The documentation specifies "host_key" so we should be consistent (see https://concourse.ci/binaries.html)

It's also an issue with the Docker container. Don't know where that's created though.

Obvious Fix