### PR TITLE
Fix docker-compose install key generation instructions

### DIFF
--- a/docs/setting-up/installing.any
+++ b/docs/setting-up/installing.any
@@ -313,13 +313,13 @@ a tool that meshes well with Concourse's ideals, buckle up and head over to
   \codeblock{bash}{
     mkdir -p keys/web keys/worker
 
-    ssh-keygen -t rsa -f ./keys/web/host_key -N ''
+    ssh-keygen -t rsa -f ./keys/web/tsa_host_key -N ''
     ssh-keygen -t rsa -f ./keys/web/session_signing_key -N ''
 
     ssh-keygen -t rsa -f ./keys/worker/worker_key -N ''
 
     cp ./keys/worker/worker_key.pub ./keys/web/authorized_worker_keys
-    cp ./keys/web/host_key.pub ./keys/worker
+    cp ./keys/web/tsa_host_key.pub ./keys/worker
   }
 
   The next thing you'll need is an address that can be used to reach the


### PR DESCRIPTION
It looks like what's on the [Docker Repository set up](https://concourse.ci/docker-repository.html) page is different from [what's set up in the repository](https://github.com/concourse/concourse-docker/blob/master/generate-keys.sh), and since the output of the script in the repository is what the [Dockerfile uses in the environment variables](https://github.com/concourse/concourse-docker/blob/master/Dockerfile#L11-L18), this reconciles the differences.