### PR TITLE
Update resource-types.any

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -147,6 +147,8 @@ before using it!
   }{
     \hyperlink{https://github.com/mrsixw/concourse-rsync-resource}{Rsync}
   }{
+    \hyperlink{https://github.com/chemist/rsync-resource}{Rsync: rsyncd, for local net}
+  }{
     \hyperlink{https://github.com/cf-platform-eng/concourse-pypi-resource}{PyPI Packages}
   }{
     \hyperlink{https://github.com/mdomke/concourse-devpi-resource}{Devpi Server: PyPI mirror and package server}


### PR DESCRIPTION
I wrote other type of rsync resource.
It does not use ssh, it uses rsyncd.