### PR TITLE
Detect Docker for Mac

### DIFF
--- a/dev/util/docker
+++ b/dev/util/docker
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-if [ -z "$DOCKER_HOST" ]; then
+if [[ $(docker version --format "{{.Server.KernelVersion}}") == *-moby ]]; then
+  # running Docker for Mac, no auth required
+  exec docker "$@"
+elif [ -z "$DOCKER_HOST" ]; then
   # assume locally running Docker on linux
   exec sudo docker "$@"
 else


### PR DESCRIPTION
Detect the presence of Docker for Mac. In this case, no `sudo` is needed.