### PR TITLE
docs: improve docker-compose instructions

### DIFF
--- a/docs/setting-up/installing.any
+++ b/docs/setting-up/installing.any
@@ -300,6 +300,7 @@ a tool that meshes well with Concourse's ideals, buckle up and head over to
       depends_on: [concourse-db]
       ports: ["8080:8080"]
       volumes: ["./keys/web:/concourse-keys"]
+      restart: unless-stopped # required so that it retries until conocurse-db comes up
       environment:
         CONCOURSE_BASIC_AUTH_USERNAME: concourse
         CONCOURSE_BASIC_AUTH_PASSWORD: changeme


### PR DESCRIPTION
When starting the docker-compose file, the web container typically starts faster than postgres and exits with a db connection error. Adding `restart: unless-stopped` will restart the web container until it becomes healthy (after postgres is up) and is the easiest way to handle this scenario. 

See also https://stackoverflow.com/questions/31746182/docker-compose-wait-for-container-x-before-starting-y