### PR TITLE
fix typo in usage of put

### DIFF
--- a/docs/steps/try.any
+++ b/docs/steps/try.any
@@ -21,7 +21,8 @@
     on_success:
       try:
         put: test-logs
-        from: run-tests/*.log
+        params:
+          from: run-tests/*.log
   - task: do-something-else
     config: # ...
   }


### PR DESCRIPTION
I believe a `params:` is missing here since `from:` isn't documented in the put step - https://concourse.ci/put-step.html