### PR TITLE
Make baggageclaim response header timeout configurable

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -290,6 +290,12 @@ properties:
       resource is found. Use Go duration format (1m = 1 minute).
     default: 5m
 
+  baggageclaim_response_header_timeout:
+    description: |
+      How long to wait for Baggageclaim to send the response header. Use Go duration
+      format (1m = 1 minute).
+    default: 10m
+
   postgresql_database:
     description: |
       Name of the database to use from the `postgresql` link.

--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -186,6 +186,7 @@ case $1 in
       --resource-cache-cleanup-interval <%= p("resource_cache_cleanup_interval") %> \
       --gc-interval <%= p("gc_interval") %> \
       --build-tracker-interval <%= p("build_tracker_interval") %> \
+      --baggageclaim-response-header-timeout <%= p("baggageclaim_response_header_timeout") %> \
       --cli-artifacts-dir /var/vcap/packages/fly \
       --yeller-api-key <%= esc(p("yeller.api_key")) %> \
       --yeller-environment <%= esc(p("yeller.environment_name")) %> \


### PR DESCRIPTION
Work around for #1333. This pull request makes the response header timeout for the Baggageclaim client in the Garden worker configurable, since even the generous ten minutes it is currently set to aren't enough sometimes. 