### PR TITLE
Add path prefix into the template file

### DIFF
--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -228,6 +228,9 @@ case $1 in
       <% p("vault.auth.params").each do |k, v| %> \
       --vault-auth-param <%= esc("#{k}=#{v.to_json}") %> \
       <% end %> \
+      <% if_p("vault.path_prefix") do %> \
+      --vault-path-prefix <%= esc(p("vault.path_prefix")) %> \
+      <% end %> \
       <% end %> \
       1>>$LOG_DIR/atc.stdout.log \
       2>>$LOG_DIR/atc.stderr.log


### PR DESCRIPTION
We modified the atc_ctl script manually and restarted with monit to validate this fix works as expected.

fixes #1355

Signed-off-by: Steve Katen <steve.katen@rackspace.com>