### PR TITLE
documentation: Clarify interaction between params pipeline vs task.yml

### DIFF
--- a/docs/introduction/concepts.any
+++ b/docs/introduction/concepts.any
@@ -38,6 +38,9 @@ becomes more involved.
 
   To learn more about configuring and running tasks, see
   \reference{running-tasks}.
+
+  To learn more about tasks in the context of jobs and pipelines, see
+  \reference{task-step}.
 }
 
 \section{Resources}{resources}{

--- a/docs/steps/task.any
+++ b/docs/steps/task.any
@@ -89,8 +89,7 @@ plan:
 
 \define-attribute{params: object}{task-params}{
   \italic{Optional.} A map of task parameters to set, overriding those
-  configured in \code{config} or \code{file}. This is useful for passing in
-  credentials or other configuration to the task from the pipeline.
+  configured in \code{config} or \code{file}.
 
   For example:
 
@@ -105,8 +104,48 @@ plan:
       PASSWORD: my-pass
   }
 
+  If this \code{params:} block provides parameters not specified in
+  \code{config:} nor within the \code{file:} task.yml, the params in this
+  build-plan do still get passed in to the container that will run the task.
+
   This is often used in combination with
-  \reference{parameters}{\code{((parameters))}} in the pipeline.
+  \reference{parameters}{\code{((parameters))}} in the pipeline, to pass in
+  credentials or other configuration to the task from the pipeline.
+
+  For example:
+
+  \codeblock{yaml}{
+  plan:
+  - get: my-repo
+  - task: integration
+    file: my-repo/ci/integration.yml
+    params:
+      REMOTE_SERVER: 10.20.30.40:8080
+      USERNAME: ((integration-username))
+      PASSWORD: ((integration-password))
+  }
+
+  Looking into the task.yml, a common pattern is to list the param in the task
+  definition with no value. This indicates that you expect the pipeline to
+  provide the value.
+
+  For example, in the task.yml:
+
+  \codeblock{yaml}{
+  params:
+    FOO: fizzbuzz
+    BAR:
+  }
+
+  And in the pipeline.yml:
+
+  \codeblock{yaml}{
+  params:
+    BAR: qux
+  }
+
+  If the pipeline used this task.yml but did not set \code{BAR}, the value of
+  \code{$BAR} would be set to the empty string in the task container.
 }
 
 \define-attribute{image: string}{task-image}{


### PR DESCRIPTION
- Specifically not referencing pipeline implications in
  `running-tasks.any`
- Note that `\reference{foo}` refers to the `\title{foo}` field of the
  target page, and it's also the same as what you see with `.html` on
  the live site. It doesn't refer to the `*.any` filename

Resubmission of #1186