### PR TITLE
Fix --vault-path-prefix flag name

### DIFF
--- a/docs/lit/setting-up/credential-management.lit
+++ b/docs/lit/setting-up/credential-management.lit
@@ -120,7 +120,7 @@ are not present, the action will error.
     }
 
     The leading \code{/concourse} can be changed by specifying
-    \code{--vault-prefix}.
+    \code{--vault-path-prefix}.
 
     If the action is being run in the context of a pipeline (e.g. a
     \code{check} or a step in a build of a job), the ATC will first look in the


### PR DESCRIPTION
The documentation uses the wrong (old?) version of the flag name. In the current version of Concourse, it seems to have been renamed. We update the documentation so that people are not trying to use the wrong flag name.