### PR TITLE
Clarify Vault field name to write for parameters

### DIFF
--- a/docs/lit/setting-up/credential-management.lit
+++ b/docs/lit/setting-up/credential-management.lit
@@ -122,18 +122,9 @@ are not present, the action will error.
     The leading \code{/concourse} can be changed by specifying
     \code{--vault-path-prefix}.
 
-    The actual value of the parameter has to be written under a field
-    named "value". So if you want to make a foo_param value of "BAR"
-    accessible at
-
-    \list{
-      \code{
-        /concourse/TEAM_NAME/PIPELINE_NAME/foo_param
-      }
-    }
-
-    you have to write the key-value pair "value=BAR" to that location
-    in the Vault.
+    Vault credentials are actually key-value, so for `((foo))` Concourse will
+    default to the field name `value`. You can specify the field to grab via
+    `.` syntax, e.g. `((foo.bar))`.
 
     If the action is being run in the context of a pipeline (e.g. a
     \code{check} or a step in a build of a job), the ATC will first look in the

--- a/docs/lit/setting-up/credential-management.lit
+++ b/docs/lit/setting-up/credential-management.lit
@@ -122,6 +122,19 @@ are not present, the action will error.
     The leading \code{/concourse} can be changed by specifying
     \code{--vault-path-prefix}.
 
+    The actual value of the parameter has to be written under a field
+    named "value". So if you want to make a foo_param value of "BAR"
+    accessible at
+
+    \list{
+      \code{
+        /concourse/TEAM_NAME/PIPELINE_NAME/foo_param
+      }
+    }
+
+    you have to write the key-value pair "value=BAR" to that location
+    in the Vault.
+
     If the action is being run in the context of a pipeline (e.g. a
     \code{check} or a step in a build of a job), the ATC will first look in the
     pipeline path. If it's not found there, it will look in the team path. This


### PR DESCRIPTION
I had to look into the code to find out how the parameter has to be written. It's better to clarify it in the docs.

edit: Found the key name to use here:

https://github.com/concourse/atc/blob/3c7785c3aab803fd966d8f604f3b239626d5e3e8/creds/vault/vault.go#L41