### PR TITLE
Contributing docs - Artifactory

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -143,7 +143,10 @@ before using it!
     \hyperlink{https://github.com/w32blaster/telegram-notification-resource}{Telegram}
   }{
     \hyperlink{https://github.com/frodenas/gcs-resource}{Google Cloud Storage}
+  }{
+    \hyperlink{https://github.com/mborges-pivotal/artifactory-resource}{Artifactory}
   }
+
 
   \section{Adding to this list}{
     Fork the


### PR DESCRIPTION
The web page I'm editing says to fork and create a PR of this file. It doesn't state which branch to make the change on and I don't see this file on Master. I can only assume contributing-docs is the correct branch. I'm adding a link to the Artifactory resource by Pivotal Services. I find the resource useful and noticed it wasn't listed on this page.