### PR TITLE
Remove dangerous and unneeded options from UAA example

### DIFF
--- a/docs/lit/using-concourse/teams.lit
+++ b/docs/lit/using-concourse/teams.lit
@@ -213,12 +213,9 @@ as).
           id: my-client-id
           secret: my-client-secret
           scope: cloud_controller.read
-          authorities: cloud_controller.admin
-          authorized-grant-types: "authorization_code,client_credentials,refresh_token"
+          authorized-grant-types: "authorization_code,refresh_token"
           access-token-validity: 3600
           refresh-token-validity: 3600
-          autoapprove: true
-          override: true
           redirect-uri: https://concourse.example.com/auth/uaa/callback
       }}
     }


### PR DESCRIPTION
There is no need, as far as I can tell from reading the code, for Concourse to need a `client_credentials` grant with `cloud_controller.admin`.

Allowing a `client_credentials` grant with `cloud_controller.admin` authority lets Concourse authenticate on its own behalf to UAA to get a token with full access to Cloud Controller (<https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-Security.md#client-tokens>) without a user being present.

Since we always have a user present, who is doing a standard OAuth flow, we shouldn't make the OAuth client more powerful than it needs to be.