### PR TITLE
Add option to increase ATC open files limit

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -452,3 +452,9 @@ properties:
       information about the user. The only metric collected is the version of
       concourse.
     default: false
+
+  atc.open_files_limit:
+    description: |
+      Set ATC (build scheduler & web interface) open files limit.
+      In high contention environments, the default limit is known to cause 'too many open files' errors.
+    default: 1024

--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -90,6 +90,8 @@ case $1 in
 
     setcap cap_net_bind_service=+ep /var/vcap/packages/atc/bin/atc
 
+    ulimit -n <%= p("atc.open_files_limit") %>
+
     exec chpst -u vcap:vcap /var/vcap/packages/atc/bin/atc \
       --bind-ip <%= p("bind_ip") %> \
       --bind-port <%= p("bind_port") %> \


### PR DESCRIPTION
The default 1024 open files limit is known to cause 'too many open files' errors

We don't want to change the default ATC open files limit for everyone,
we're simply adding the option to pick a better value when required.
Having measured and understood our very specific case, 10240 was
determined to be adequate for us. We hope that you will also measure and
understand the optimal value for your use-case.

re concourse/concourse#1201

[#150434196]