### PR TITLE
Expose token_signing_key option

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -17,12 +17,12 @@ templates:
   vault_client_cert.erb: config/vault_client_cert
   vault_client_key.erb: config/vault_client_key
   credhub_ca_cert.erb: config/credhub_ca_cert
+  token_signing_key.erb: config/token_signing_key
 
 packages:
   - pid_utils
   - atc
   - fly
-  - generated_signing_key
 
 consumes:
 - name: db
@@ -474,3 +474,17 @@ properties:
     description: |
       Client secret for CredHub authorization.
     default: ""
+
+  token_signing_key:
+     description: |
+       PEM RSA private key used for minting ATC tokens.
+       Must be specified, bosh can auto-generate (type rsa), see sample manifest.yml.
+     example:
+       private_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          ...
+          -----END RSA PRIVATE KEY-----
+       public_key: |
+          -----BEGIN PUBLIC KEY-----
+          ...
+          -----END PUBLIC KEY-----

--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -13,7 +13,7 @@ set -e
 
 RUN_DIR=/var/vcap/sys/run/atc
 LOG_DIR=/var/vcap/sys/log/atc
-SIGNING_KEY=/var/vcap/packages/generated_signing_key/id_rsa
+SIGNING_KEY=/var/vcap/jobs/atc/config/token_signing_key
 PIDFILE=$RUN_DIR/atc.pid
 CF_CA_CERT=/var/vcap/jobs/atc/config/cf_ca_cert
 POSTGRESQL_CA_CERT=/var/vcap/jobs/atc/config/postgres_ca_cert

--- a/jobs/atc/templates/token_signing_key.erb
+++ b/jobs/atc/templates/token_signing_key.erb
@@ -1,0 +1,1 @@
+<%= p("token_signing_key.private_key", "") %>

--- a/jobs/groundcrew/spec
+++ b/jobs/groundcrew/spec
@@ -14,10 +14,11 @@ templates:
   private_key.erb: config/private_key
   worker.json.erb: config/worker.json
 
+  tsa_host_key.pub.erb: config/tsa_host_key.pub
+  worker_key.erb: config/worker_key
+
 packages:
   - pid_utils
-  - generated_tsa_host_key
-  - generated_worker_key
   - resource_discovery
   - groundcrew
   - worker_version
@@ -157,3 +158,26 @@ properties:
     description: |
       Environment name you wish to group errors under in yeller.
     default: ""
+
+  tsa_host_key:
+     description: |
+       Must be specified, bosh can auto-generate (type ssh), see sample manifest.yml.
+       Only public key portion is needed here.
+     example:
+       private_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          ...
+          -----END RSA PRIVATE KEY-----
+       public_key: |
+          ssh-rsa ...
+
+  worker_key:
+     description: |
+       Must be specified, bosh can auto-generate (type ssh), see sample manifest.yml.
+     example:
+       private_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          ...
+          -----END RSA PRIVATE KEY-----
+       public_key: |
+          ssh-rsa ...

--- a/jobs/groundcrew/templates/beacon_ctl.erb
+++ b/jobs/groundcrew/templates/beacon_ctl.erb
@@ -28,6 +28,9 @@ RUN_DIR=/var/vcap/sys/run/groundcrew
 LOG_DIR=/var/vcap/sys/log/groundcrew
 PIDFILE=$RUN_DIR/beacon.pid
 
+TSA_HOST_PUB_KEY=/var/vcap/jobs/groundcrew/config/tsa_host_key.pub
+WORKER_KEY=/var/vcap/jobs/groundcrew/config/worker_key
+
 source /var/vcap/packages/pid_utils/pid_utils.sh
 
 kill_session_siblings_of() {
@@ -58,7 +61,7 @@ case $1 in
 
     echo $$ > $PIDFILE
 
-    for key in /var/vcap/packages/generated_worker_key/id_rsa \
+    for key in $WORKER_KEY \
                /var/vcap/jobs/groundcrew/config/private_key; do
       chown vcap:vcap $key
       chmod 0400 $key
@@ -69,7 +72,7 @@ case $1 in
     {
       <% tsa_addrs.each do |addr| %>
       echo -n '[<%= addr %>]:<%= tsa_port %> '
-      cat /var/vcap/packages/generated_tsa_host_key/id_rsa.pub
+      cat $TSA_HOST_PUB_KEY
       <% end %>
     } > /var/vcap/jobs/groundcrew/config/generated_tsa_known_hosts
 
@@ -103,7 +106,7 @@ case $1 in
         <% if p("tsa.private_key") != "" %> \
         -i /var/vcap/jobs/groundcrew/config/private_key \
         <% else %> \
-        -i /var/vcap/packages/generated_worker_key/id_rsa \
+        -i $WORKER_KEY \
         <% end %> \
         -o UserKnownHostsFile=${KNOWN_HOSTS_FILE} \
         -o ConnectTimeout=30 \

--- a/jobs/groundcrew/templates/drain.erb
+++ b/jobs/groundcrew/templates/drain.erb
@@ -5,6 +5,9 @@ set -e
 RUN_DIR=/var/vcap/sys/run/groundcrew
 LOG_DIR=/var/vcap/sys/log/groundcrew
 
+TSA_HOST_PUB_KEY=/var/vcap/jobs/groundcrew/config/tsa_host_key.pub
+WORKER_KEY=/var/vcap/jobs/groundcrew/config/worker_key
+
 mkdir -p $RUN_DIR
 chown -R vcap:vcap $RUN_DIR
 
@@ -33,7 +36,7 @@ fi
   end
 %>
 
-for key in /var/vcap/packages/generated_worker_key/id_rsa \
+for key in $WORKER_KEY \
            /var/vcap/jobs/groundcrew/config/private_key; do
   chown vcap:vcap $key
   chmod 0400 $key
@@ -44,7 +47,7 @@ done
 {
   <% tsa_addrs.each do |addr| %>
   echo -n '[<%= addr %>]:<%= tsa_port %> '
-  cat /var/vcap/packages/generated_tsa_host_key/id_rsa.pub
+  cat $TSA_HOST_PUB_KEY
   <% end %>
 } > /var/vcap/jobs/groundcrew/config/generated_tsa_known_hosts
 
@@ -76,7 +79,7 @@ chpst -u vcap:vcap /var/vcap/packages/groundcrew/bin/groundcrew \
   <% if p("tsa.private_key") != "" %> \
   --tsa-ssh-key /var/vcap/jobs/groundcrew/config/private_key \
   <% else %> \
-  --tsa-ssh-key /var/vcap/packages/generated_worker_key/id_rsa \
+  --tsa-ssh-key $WORKER_KEY \
   <% end %> \
   --beacon-pid-file=$RUN_DIR/beacon.pid \
   <% if_p("drain_timeout") do |drain_timeout| %> \

--- a/jobs/groundcrew/templates/tsa_host_key.pub.erb
+++ b/jobs/groundcrew/templates/tsa_host_key.pub.erb
@@ -1,0 +1,1 @@
+<%= p("tsa_host_key.public_key", "") %>

--- a/jobs/groundcrew/templates/worker_key.erb
+++ b/jobs/groundcrew/templates/worker_key.erb
@@ -1,0 +1,1 @@
+<%= p("worker_key.private_key", "") %>

--- a/jobs/tsa/spec
+++ b/jobs/tsa/spec
@@ -7,13 +7,13 @@ description: |
 templates:
   tsa_ctl.erb: bin/tsa_ctl
   host_key.erb: config/host_key
+  token_signing_key.erb: config/token_signing_key
+  tsa_host_key.erb: config/tsa_host_key
+  worker_key.pub.erb: config/worker_key.pub
 
 packages:
   - pid_utils
   - tsa
-  - generated_signing_key
-  - generated_tsa_host_key
-  - generated_worker_key
 
 consumes:
 - name: atc
@@ -98,3 +98,40 @@ properties:
       ATC API endpoints to which workers will be advertised.
       If not specified, they will be autodiscovered via BOSH links.
     default: ["http://127.0.0.1:8080"]
+
+  token_signing_key:
+     description: |
+       PEM RSA private key used for minting ATC tokens.
+       Must be specified, bosh can auto-generate (type rsa), see sample manifest.yml.
+     example:
+       private_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          ...
+          -----END RSA PRIVATE KEY-----
+       public_key: |
+          -----BEGIN PUBLIC KEY-----
+          ...
+          -----END PUBLIC KEY-----
+
+  tsa_host_key:
+     description: |
+       Must be specified, bosh can auto-generate (type ssh), see sample manifest.yml.
+     example:
+       private_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          ...
+          -----END RSA PRIVATE KEY-----
+       public_key: |
+          ssh-rsa ...
+
+  worker_key:
+     description: |
+       Must be specified, bosh can auto-generate (type ssh), see sample manifest.yml.
+       Only public key portion is needed here.
+     example:
+       private_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          ...
+          -----END RSA PRIVATE KEY-----
+       public_key: |
+          ssh-rsa ...

--- a/jobs/tsa/templates/token_signing_key.erb
+++ b/jobs/tsa/templates/token_signing_key.erb
@@ -1,0 +1,1 @@
+<%= p("token_signing_key.private_key", "") %>

--- a/jobs/tsa/templates/tsa_ctl.erb
+++ b/jobs/tsa/templates/tsa_ctl.erb
@@ -42,7 +42,9 @@ set -e
 RUN_DIR=/var/vcap/sys/run/tsa
 LOG_DIR=/var/vcap/sys/log/tsa
 PIDFILE=$RUN_DIR/tsa.pid
-SIGNING_KEY=/var/vcap/packages/generated_signing_key/id_rsa
+SIGNING_KEY=/var/vcap/jobs/tsa/config/token_signing_key
+TSA_HOST_KEY=/var/vcap/jobs/tsa/config/tsa_host_key
+WORKER_PUB_KEY=/var/vcap/jobs/tsa/config/worker_key.pub
 
 source /var/vcap/packages/pid_utils/pid_utils.sh
 
@@ -59,7 +61,7 @@ case $1 in
 
     echo $$ > /var/vcap/sys/run/tsa/tsa.pid
 
-    for key in /var/vcap/packages/generated_tsa_host_key/id_rsa \
+    for key in $TSA_HOST_KEY \
                /var/vcap/jobs/tsa/config/host_key \
                $SIGNING_KEY; do
       chown vcap:vcap $key
@@ -68,7 +70,7 @@ case $1 in
 
     {
 <% if p("authorize_generated_worker_key") %>
-      cat /var/vcap/packages/generated_worker_key/id_rsa.pub
+      cat $WORKER_PUB_KEY
 <% end %>
       cat <<EOF
 <%= p("authorized_keys").join("\n") %>
@@ -92,7 +94,7 @@ EOF
       <% if p("host_key") != "" %> \
       --host-key /var/vcap/jobs/tsa/config/host_key \
       <% else %> \
-      --host-key /var/vcap/packages/generated_tsa_host_key/id_rsa \
+      --host-key $TSA_HOST_KEY \
       <% end %> \
       --authorized-keys /var/vcap/jobs/tsa/config/authorized_keys \
       <% teamAuthorizedKeys.each do |team, keys| %> \

--- a/jobs/tsa/templates/tsa_host_key.erb
+++ b/jobs/tsa/templates/tsa_host_key.erb
@@ -1,0 +1,1 @@
+<%= p("tsa_host_key.private_key", "") %>

--- a/jobs/tsa/templates/worker_key.pub.erb
+++ b/jobs/tsa/templates/worker_key.pub.erb
@@ -1,0 +1,1 @@
+<%= p("worker_key.public_key", "") %>

--- a/manifests/single-vm.yml
+++ b/manifests/single-vm.yml
@@ -1,11 +1,11 @@
 ---
-name: ((deployment_name))
+name: concourse
 
 releases:
 - name: concourse
-  version: ((concourse_version))
+  version: latest
 - name: garden-runc
-  version: ((garden_runc_version))
+  version: latest
 - name: postgres
   version: latest
 
@@ -13,10 +13,11 @@ instance_groups:
 - name: concourse
   instances: 1
   networks:
-  - name: testflight
+  - name: default
     static_ips: [&web-ip ((web_ip))]
+  azs: [z1]
   persistent_disk: 10240
-  vm_type: testflight
+  vm_type: small
   stemcell: trusty
   jobs:
   - release: concourse
@@ -30,13 +31,19 @@ instance_groups:
         database: atc
         role:
           name: atc
-          password: dummy-password
+          password: ((postgres_password))
 
       no_really_i_dont_want_any_auth: true
 
+      token_signing_key: ((token_signing_key))
+
   - release: concourse
     name: tsa
-    properties: {log_level: debug}
+    properties:
+      log_level: debug
+      token_signing_key: ((token_signing_key))
+      tsa_host_key: ((tsa_host_key))
+      worker_key: ((worker_key))
 
   - release: postgres
     name: postgres
@@ -47,15 +54,19 @@ instance_groups:
         - name: atc
         roles:
         - name: atc
-          password: dummy-password
+          password: ((postgres_password))
 
   - release: concourse
     name: groundcrew
-    properties: {drain_timeout: 10m}
+    properties:
+      drain_timeout: 10m
+      tsa_host_key: ((tsa_host_key))
+      worker_key: ((worker_key))
 
   - release: concourse
     name: baggageclaim
-    properties: {log_level: debug}
+    properties:
+      log_level: debug
 
   - release: garden-runc
     name: garden
@@ -64,6 +75,16 @@ instance_groups:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
         allow_host_access: true
+
+variables:
+- name: postgres_password
+  type: password
+- name: token_signing_key
+  type: rsa
+- name: tsa_host_key
+  type: ssh
+- name: worker_key
+  type: ssh
 
 stemcells:
 - alias: trusty

--- a/packages/generated_signing_key/packaging
+++ b/packages/generated_signing_key/packaging
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e -x
-
-ssh-keygen -t rsa -N '' -f ${BOSH_INSTALL_TARGET}/id_rsa

--- a/packages/generated_signing_key/spec
+++ b/packages/generated_signing_key/spec
@@ -1,3 +1,0 @@
----
-name: generated_signing_key
-files: [.boshkeep]

--- a/packages/generated_tsa_host_key/packaging
+++ b/packages/generated_tsa_host_key/packaging
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e -x
-
-ssh-keygen -t rsa -N '' -f ${BOSH_INSTALL_TARGET}/id_rsa

--- a/packages/generated_tsa_host_key/spec
+++ b/packages/generated_tsa_host_key/spec
@@ -1,3 +1,0 @@
----
-name: generated_tsa_host_key
-files: [.boshkeep]

--- a/packages/generated_worker_key/packaging
+++ b/packages/generated_worker_key/packaging
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e -x
-
-ssh-keygen -t rsa -N '' -f ${BOSH_INSTALL_TARGET}/id_rsa

--- a/packages/generated_worker_key/spec
+++ b/packages/generated_worker_key/spec
@@ -1,3 +1,0 @@
----
-name: generated_worker_key
-files: [.boshkeep]


### PR DESCRIPTION
This would be helpful for [issue 1559](https://github.com/concourse/concourse/issues/1559) as it would allow us to generate our own token signing key and pass it through the appropriate jobs using the existing option flags.