### PR TITLE
Stop always skipping TLS verification for credential managers

### DIFF
--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -223,7 +223,9 @@ case $1 in
       <% if_p("credhub.tls.ca_cert") do |ca_cert| %> \
       --credhub-ca-cert /var/vcap/jobs/atc/config/credhub_ca_cert \
       <% end %> \
-      --credhub-insecure-skip-verify <%= esc p("credhub.tls.insecure_skip_verify") %> \
+      <% if p("credhub.tls.insecure_skip_verify") %> \
+      --credhub-insecure-skip-verify \
+      <% end %> \
       --credhub-client-id <%= esc p("credhub.client_id") %> \
       --credhub-client-secret <%= esc p("credhub.client_secret") %> \
       --credhub-path-prefix <%= esc p("credhub.path_prefix") %> \
@@ -234,7 +236,9 @@ case $1 in
       --vault-ca-cert /var/vcap/jobs/atc/config/vault_ca_cert \
       <% end %> \
       --vault-server-name <%= esc(p("vault.tls.server_name")) %> \
-      --vault-insecure-skip-verify <%= p("vault.tls.insecure_skip_verify") %> \
+      <% if p("vault.tls.insecure_skip_verify") %> \
+      --vault-insecure-skip-verify \
+      <% end %> \
       <% if_p("vault.tls.client_cert") do %> \
       --vault-client-cert /var/vcap/jobs/atc/config/vault_client_cert \
       --vault-client-key /var/vcap/jobs/atc/config/vault_client_key \


### PR DESCRIPTION
Previous code incorrectly passed a boolean value to a boolean flag.

This is wrong because the flag parser silently ignores values for boolean flags, and simply sets the value to true.

(I have a separate ATC PR to return an error when an unrecognized positional argument like this is received).

As such all bosh deployments of atc are skipping TLS verification whether you want it or not for CredHub and Vault.

There's a good chance this change will break existing installations that thought they were verifying TLS, but really weren't, and may not be configured correctly to do so.