### PR TITLE
Pass vm_type + network name into single-vm.yml as variables

### DIFF
--- a/manifests/single-vm.yml
+++ b/manifests/single-vm.yml
@@ -12,6 +12,7 @@ releases:
 instance_groups:
 - name: concourse
   instances: 1
+  azs: [z1]
   networks:
   - name: ((network_name))
     static_ips: [&web-ip ((web_ip))]

--- a/manifests/single-vm.yml
+++ b/manifests/single-vm.yml
@@ -13,10 +13,10 @@ instance_groups:
 - name: concourse
   instances: 1
   networks:
-  - name: testflight
+  - name: ((network_name))
     static_ips: [&web-ip ((web_ip))]
   persistent_disk: 10240
-  vm_type: testflight
+  vm_type: ((vm_type))
   stemcell: trusty
   jobs:
   - release: concourse


### PR DESCRIPTION
`testflight` is not a common vm_type/network name for anyone's cloud-config