### PR TITLE
Render known_hosts entry

### DIFF
--- a/jobs/groundcrew/templates/known_hosts.erb
+++ b/jobs/groundcrew/templates/known_hosts.erb
@@ -3,14 +3,16 @@
   tsa_port = nil
   tsa_host_public_key = nil
 
+  known_host = ""
   if_p("tsa.host", "tsa.port", "tsa.host_public_key") do |host, port, public_key|
-    "[#{host}]:#{port} #{public_key}"
+    known_host = "[#{host}]:#{port} #{public_key}"
   end.else do
     tsa = link("tsa")
     port = tsa.p("bind_port")
     key = tsa.p("host_key.public_key")
-    tsa.instances.collect do |i|
+    known_host = tsa.instances.collect do |i|
       "[#{i.address}]:#{port} #{key}"
     end.join("\n")
   end
+  known_host
 %>


### PR DESCRIPTION
This fixes the `known_hosts` rendering problem in https://github.com/concourse/concourse/issues/1862.

On [jobs/groundcrew/templates/known_hosts.erb#L7](https://github.com/concourse/concourse/blob/v3.7.0/jobs/groundcrew/templates/known_hosts.erb#L7), the string that is supposed to be rendered by the erb is not within a scope where the erb can see it. We had to add a variable outside the block and set that for it to be brought within scope and rendered correctly.

@oozie and @christianang