### PR TITLE
Add cookie secure flag.

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -53,6 +53,10 @@ properties:
       Port on which the ATC should listen for HTTP traffic.
     default: 8080
 
+  cookie_secure:
+    description: Set secure flag on auth cookies
+    default: false
+
   tls_bind_port:
     description: |
       Port on which the ATC should listen for HTTPS traffic.

--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -98,6 +98,9 @@ case $1 in
     exec chpst -u vcap:vcap /var/vcap/packages/atc/bin/atc \
       --bind-ip <%= p("bind_ip") %> \
       --bind-port <%= p("bind_port") %> \
+      <% if p("cookie_secure") %> \
+      --cookie-secure \
+      <% end %> \
       <% if_p("tls_bind_port", "tls_cert", "tls_key") do |port, _, _| %> \
       --tls-bind-port <%= port %> \
       --tls-cert /var/vcap/jobs/atc/config/tls_cert \


### PR DESCRIPTION
Goes with https://github.com/concourse/skymarshal/pull/1 and https://github.com/concourse/atc/pull/249; see patch to skymarshal for details.