### PR TITLE
downgrade_db.erb uses esc function that is not defined

### DIFF
--- a/jobs/atc/templates/downgrade_db.erb
+++ b/jobs/atc/templates/downgrade_db.erb
@@ -2,6 +2,13 @@
 # vim: set ft=sh
 
 set -e
+<%
+  require "shellwords"
+
+  def esc(x)
+    Shellwords.shellescape(x)
+  end
+%>
 
 <%
   postgres_host = ""


### PR DESCRIPTION
esc function is not available to to downgrade_db.erb, adding that function.

Opened issue - https://github.com/concourse/concourse/issues/2029