### PR TITLE
Support generic oauth ca cert.

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -19,6 +19,7 @@ templates:
   credhub_ca_cert.erb: config/credhub_ca_cert
   credhub_client_cert.erb: config/credhub_client_cert
   credhub_client_key.erb: config/credhub_client_key
+  generic_oauth_ca_cert.erb: config/generic_oauth_ca_cert
   token_signing_key.erb: config/token_signing_key
   downgrade_db.erb: bin/experimental_downgrade_db
 
@@ -263,6 +264,9 @@ properties:
   generic_oauth.display_name:
     description: Name of the authentication method to be displayed on the Web UI
     default: ""
+
+  generic_oauth.ca_cert:
+    description: The CA certificate for the Generic OAuth provider's endpoints.
 
   intercept_idle_timeout:
     description: Length of time for a intercepted session to be idle before terminating, in Go duration format.

--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -16,6 +16,7 @@ LOG_DIR=/var/vcap/sys/log/atc
 SIGNING_KEY=/var/vcap/jobs/atc/config/token_signing_key
 PIDFILE=$RUN_DIR/atc.pid
 CF_CA_CERT=/var/vcap/jobs/atc/config/cf_ca_cert
+GENERIC_OAUTH_CA_CERT=/var/vcap/jobs/atc/config/generic_oauth_ca_cert
 POSTGRESQL_CA_CERT=/var/vcap/jobs/atc/config/postgres_ca_cert
 POSTGRESQL_CLIENT_CERT=/var/vcap/jobs/atc/config/postgres_client_cert
 POSTGRESQL_CLIENT_KEY=/var/vcap/jobs/atc/config/postgres_client_key
@@ -185,6 +186,9 @@ case $1 in
       <% end %> \
       --generic-oauth-token-url <%= esc(p("generic_oauth.token_url")) %> \
       --generic-oauth-display-name <%= esc(p("generic_oauth.display_name")) %> \
+      <% if_p("generic_oauth.ca_cert") do %> \
+      --generic-oauth-ca-cert $GENERIC_OAUTH_CA_CERT \
+      <% end %> \
       --session-signing-key $SIGNING_KEY \
       <% if_p("intercept_idle_timeout") do |timeout| %> \
 	      --intercept-idle-timeout <%= esc(timeout) %> \

--- a/jobs/atc/templates/generic_oauth_ca_cert.erb
+++ b/jobs/atc/templates/generic_oauth_ca_cert.erb
@@ -1,0 +1,1 @@
+<%= p("generic_oauth.ca_cert", "") %>


### PR DESCRIPTION
PR for issue: https://github.com/concourse/concourse/issues/1914

Adds support for setting the generic oauth ca cert via bosh property.