### PR TITLE
Add mkdir for /var/vcap/data/baggageclaim

### DIFF
--- a/jobs/baggageclaim/templates/baggageclaim_ctl.erb
+++ b/jobs/baggageclaim/templates/baggageclaim_ctl.erb
@@ -30,6 +30,7 @@ case $1 in
     chown -R vcap:vcap $LOG_DIR
 
     umask 0022
+    mkdir -p /var/vcap/data/baggageclaim
     chmod +rx /var/vcap/data/baggageclaim
 
     OVERLAYS_DIR=/var/vcap/data/baggageclaim/overlays


### PR DESCRIPTION
Fixes error where baggaeclaim will not start and
baggageclaim_ctl.log has error `chmod: cannot access
 '/var/vcap/data/baggageclaim': No such file or directory`