### PR TITLE
windows packages should be compiled on a linux host

### DIFF
--- a/packages/baggageclaim-windows/packaging
+++ b/packages/baggageclaim-windows/packaging
@@ -1,3 +1,5 @@
+. ./exiter.ps1
+
 # vim: set ft=ps1
 
 Write-Host "sleeping"

--- a/packages/houdini-windows/packaging
+++ b/packages/houdini-windows/packaging
@@ -1,3 +1,5 @@
+. ./exiter.ps1
+
 # vim: set ft=ps1
 
 Write-Host "sleeping"

--- a/packages/worker-windows/packaging
+++ b/packages/worker-windows/packaging
@@ -1,3 +1,5 @@
+. ./exiter.ps1
+
 # vim: set ft=ps1
 
 Write-Host "sleeping"

--- a/packages/worker_version-windows/packaging
+++ b/packages/worker_version-windows/packaging
@@ -1,3 +1,5 @@
+. ./exiter.ps1
+
 # vim: set ft=ps1
 
 Copy-Item worker-version/version ${env:BOSH_INSTALL_TARGET}/version

--- a/src/exiter.ps1
+++ b/src/exiter.ps1
@@ -1,0 +1,2 @@
+# this file is here so that bosh export release on linux stemcells is skipped for windows packages
+exit 0


### PR DESCRIPTION
currently there is not exit strategy for windows packages on a linux host.
this will provide this exit strategy.