### PR TITLE
mention bindata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,8 @@ to synchronize with multiple PRs in flight. We'll take it from there. If your
 changes involve multiple components, though (`atc` and `fly` for example), be
 sure to let us know in each PR.
 
+### Counterfeiter fakes
+
 When adding / modifying methods to the ATC API, you may need to regenerate
 models and data structures used for testing using Counterfeiter. To do so,
 download and install counterfeiter:
@@ -192,6 +194,14 @@ go generate ./...
 ```
 
 Don't forget to commit the changes made to this repository when committing your other changes.
+
+### go-bindata
+
+There are a few places where non-go assets are converted into generated go source code --
+specifically the database migrations in the ATC repo and web assets in the
+web and skymarshal repos. Before committing, make sure that the relevant `bindata.go` files are
+up to date with any changes made their inputs. Generally the repos have a `generate-bindata` script
+to help you.
 
 # Testing
 


### PR DESCRIPTION
The means of generating bindata is not uniform across all the repos, so I kept the advice pretty general.

For example, in the web repo technically you can run `scripts/generate-bindata`, but in my experience
it is much more common to run `make clean all` (in fact, I wonder whether the build instructions for elm should be mentioned in this document?). At the moment there is no `generate-bindata` in the skymarshal repo, but I think @pivotal-jwinters may be on the case.