### PR TITLE
make it clear that you need 10 or bcrypt strength

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -161,7 +161,8 @@ properties:
 
   add_local_users:
     description: |
-      List of local concourse users to add with their bcrypted passwords
+      List of local concourse users to add with their bcrypted passwords.
+      bcrypted password must have a strength of 10 or higher or the user will not be able to login
     default: []
     example:
     - some-user:$2a$10$sKZelZprWWcBAWbp28rB1uFef0Ybxsiqh05uo.H8EIm0sWc6IZGJu


### PR DESCRIPTION
I got an error when i created a password with a strength lower then 10 in the atc logs. This will make it clear that 10 or higher is required