### PR TITLE
Fix ca_cert templates

### DIFF
--- a/jobs/atc/templates/cf_ca_cert.erb
+++ b/jobs/atc/templates/cf_ca_cert.erb
@@ -1,1 +1,1 @@
-<%= p("cf.ca_cert", "") %>
+<%= p("cf_auth.ca_cert.certificate", "") %>

--- a/jobs/atc/templates/github_ca_cert.erb
+++ b/jobs/atc/templates/github_ca_cert.erb
@@ -1,1 +1,1 @@
-<%= p("github.ca_cert", "") %>
+<%= p("github_auth.ca_cert.certificate", "") %>

--- a/jobs/atc/templates/oauth_ca_cert.erb
+++ b/jobs/atc/templates/oauth_ca_cert.erb
@@ -1,1 +1,1 @@
-<%= p("oauth.ca_cert", "") %>
+<%= p("generic_oauth.ca_cert.certificate", "") %>

--- a/jobs/atc/templates/oidc_ca_cert.erb
+++ b/jobs/atc/templates/oidc_ca_cert.erb
@@ -1,1 +1,1 @@
-<%= p("oidc.ca_cert", "") %>
+<%= p("generic_oidc.ca_cert.certificate", "") %>


### PR DESCRIPTION
Spec was declaring certificates for authentication as `<auth_system>_auth.ca_cert` but all templates doesn't use prefix `_auth` to retrieve certificate.

In addition, `<auth_system>_auth.ca_cert` are typed as `certificate` so `<auth_system>_auth.ca_cert.certificate` in template seems to be necessary.

For the moment, it is impossible to set `ca_cert` on `cf_auth` for example. When setting `cf_auth.ca_cert`, atc can't start and give this kind of error:

```
server: Failed to open connector cf: failed to open connector: failed to create connector cf: no certs found in root CA file "/var/vcap/jobs/atc/config/cf_ca_cert
```

This PR rewrite key to find in template as `<auth_system>_auth.ca_cert.certificate`.