### PR TITLE
Fix add_local_users to produce correct output for switch

### DIFF
--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -145,7 +145,7 @@ case $1 in
       --log-db-queries \
       <% end %> \
       <% p("add_local_users").each do |v| %> \
-      --add-local-user <%= esc(v) %> \
+      --add-local-user <%= esc(v.keys[0]) + ":" + esc(v.values[0]) %> \
       <% end %> \
       --auth-duration <%= p("auth_duration") %> \
       --github-client-id <%= esc(p("github_auth.client_id")) %> \


### PR DESCRIPTION
Fixes `add_local_users` in the bosh release. Currently using `add_local_users` results in an error in the `atc.stderr.log` of `server: no connectors specified`. This is caused by a malformed user entry in the atc_ctl template. The current template generates a line like:

```
--add-local-user \{\"concourse\"\=\>\"\$6\$Wbj2fLWp2\$/j4TZfKxDUpUfKIBfpB7ghQPcccNpaa1mX.bptgiednPA9DJpkRQYEdiESziPCvfNSTLVufmD8Marr3W81\"\} \
```

After the patch the line looks like:
```
--add-local-user concourse:\$6\$Wbj2fLWp2\$/j4TZfKxDUpUfKIBfpB7ghQPcccNpaa1mX.bptgiednPA9DJpkRQYEdiESziPCvfNSTLVufmD8Marr3W81
```