### PR TITLE
Added vault cache key to concourse bosh manifest

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -636,6 +636,9 @@ properties:
   vault.url:
     description: |
       Vault server URL to use for parameterizing credentials.
+  vault.cache:
+      description: |
+        Enable Vault cache for secrets lease duration in memory.
   vault.path_prefix:
     description: |
       Path under which to namespace team/pipeline credentials.

--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -637,8 +637,9 @@ properties:
     description: |
       Vault server URL to use for parameterizing credentials.
   vault.cache:
-      description: |
-        Enable Vault cache for secrets lease duration in memory.
+    description: |
+      Enable Vault cache for secrets lease duration in memory.
+    default: false
   vault.path_prefix:
     description: |
       Path under which to namespace team/pipeline credentials.

--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -329,6 +329,9 @@ case $1 in
       <% end %> \
       <% if_p("vault.url") do |url| %> \
       --vault-url <%= esc(url) %> \
+      <% if p("vault.cache") %> \
+      --vault-cache \
+      <% end %> \
       <% if_p("vault.tls.ca_cert") do |ca_cert| %> \
       --vault-ca-cert /var/vcap/jobs/atc/config/vault_ca_cert \
       <% end %> \


### PR DESCRIPTION
Please let me know if there is Test that needs to be updated for this change.
Discord: @fsegui

Note: Concourse does 2 requests per credentials (1) pipeline level (2) team level. If my credential is at team level, concourse will cache it on the (2) request. Then it will still make request (1) every time to vault and not find the credential. After that, It will try (2) and find the cached credential. So --vault-cache will just halve the requests by eliminating (2) request.