### PR TITLE
fix postgres client cert handling in `atc_ctl.erb`

### DIFF
--- a/jobs/atc/templates/atc_ctl.erb
+++ b/jobs/atc/templates/atc_ctl.erb
@@ -133,7 +133,7 @@ case $1 in
       <% if_p("postgresql.ca_cert") do |_| %> \
       --postgres-ca-cert $POSTGRESQL_CA_CERT \
       <% end %> \
-      <% if_p("postgresql.client_cert", "postgresql.client_key") do |*_| %> \
+      <% if_p("postgresql.client_cert") do |_| %> \
       --postgres-client-cert $POSTGRESQL_CLIENT_CERT \
       --postgres-client-key $POSTGRESQL_CLIENT_KEY \
       <% end %> \


### PR DESCRIPTION
The "--postgresql-client-cert" and "--postgresql-client-key" options should only depend on the `postgresql.client_cert` property, and not on the `postgresql.client_key` property, which was removed in 72fe707.

fixes #2397 

It's not really clear to me how I might add tests to cover use of atc postgres client certs, but since it's been broken for a while perhaps it'd be a good thing. If someone can provide me guidance on how to do so, I'm happy to do some work on it.
