### PR TITLE
`add_local_users` passwords can be plain text

### DIFF
--- a/jobs/atc/spec
+++ b/jobs/atc/spec
@@ -163,12 +163,13 @@ properties:
 
   add_local_users:
     description: |
-      List of local concourse users to add with their bcrypted passwords.
-      bcrypted password must have a strength of 10 or higher or the user will not be able to login
+      List of username:password combinations for all your local users. The password can be bcrypted.
+      Bcrypted password must have a strength of 10 or higher or the user will not be able to login.
     default: []
     example:
     - some-user:$2a$10$sKZelZprWWcBAWbp28rB1uFef0Ybxsiqh05uo.H8EIm0sWc6IZGJu
     - some-other-user:$2a$10$.YIYH.5EWQcCvfE49xH/.OhIhGFiNtn.tQq.4pznpcrqZvoLxuKeC
+    - some-plaintext-user:a-plaintext-password
 
   github_auth.client_id:
     description: |


### PR DESCRIPTION
The v4.1.0 release notes (https://concourse-ci.org/download.html#v410) say that local users can have plaintext passwords specified, but the BOSH release spec text doesn't reflect that - it *only* mentions bcrypt'd hashes.

The CLI help text *does* reflect this, which is presumably what the v4.1.0 release notes were referring to:

```
$ ./concourse_darwin_amd64 web --help 2>&1 | grep -m1 add-local-user
          --add-local-user=USERNAME:PASSWORD                            List of username:password combinations for all your local users. The password can be bcrypted - if
```

This commit brings those 2 texts (mostly) into line by updating the atc spec description and making it clear that `user:plaintext-pass` tuples are acceptable.

Realted: concourse/concourse-bosh-release#1