### PR TITLE
Don't fetch rows that we won't modify

### DIFF
--- a/atc/db/open.go
+++ b/atc/db/open.go
@@ -129,6 +129,7 @@ func encryptPlaintext(logger lager.Logger, sqlDB *sql.DB, key *encryption.Key) e
 			SELECT id, ` + col + `
 			FROM ` + table + `
 			WHERE nonce IS NULL
+			AND ` + col + ` IS NOT NULL
 		`)
 		if err != nil {
 			return err


### PR DESCRIPTION
We're in the middle of trying to track down a really weird issue whereby `atc` appears to hang on startup, but only when (a) we're on Xenial instead of Trusty, (b) we're in this environment, not our other one and (c) when Postgres SSL verification is enabled.

(The above is irrelevant to this PR, but I share the context in case anyone has some ideas to throw at us...)

Along the way I noticed that our `builds` table has 1.5 million entries, each with a `NULL` `engine_metadata` field.

No point fetching each of these rows upon server start when we skip over them a few lines later if a `NULL` value is found.

Now back to find a solution for our original issue...