### PR TITLE
Introduce a global max-in-flight limit

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -533,8 +533,8 @@ func (cmd *RunCommand) constructAPIMembers(
 		cmd.ResourceTypeCheckingInterval,
 		cmd.ResourceCheckingInterval,
 		engine,
+		dbWorkerFactory,
 	)
-
 	radarScannerFactory := radar.NewScannerFactory(
 		resourceFactory,
 		dbResourceConfigCheckSessionFactory,
@@ -729,6 +729,7 @@ func (cmd *RunCommand) constructBackendMembers(
 		cmd.ResourceTypeCheckingInterval,
 		cmd.ResourceCheckingInterval,
 		engine,
+		dbWorkerFactory,
 	)
 	dbWorkerLifecycle := db.NewWorkerLifecycle(dbConn)
 	dbResourceCacheLifecycle := db.NewResourceCacheLifecycle(dbConn)


### PR DESCRIPTION
Essentially, this commit is intended to prevent Concourse from scheduling builds when workers are under heavy load. By doing so it should be possible to reduce the number of deployed workers.

Deliberately excluded features that can be added in future:

* Configurability for setting of container limit and utilisation limit.
* Having workers declare their own container limits or utilisation.
* Scaling utilisation limits according to worker pool size (larger pools can have higher utilisation while retaining safety; variability falls as the workloads are pooled)
* Giving yes/no according to job size -- ie allowing smaller jobs through if there is still room.
