### PR TITLE
Added config params & retry logic for getting secrets. See #2542

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -91,7 +91,7 @@ type RunCommand struct {
 
 	Postgres flag.PostgresConfig `group:"PostgreSQL Configuration" namespace:"postgres"`
 
-	CredentialManagement struct{} `group:"Credential Management"`
+	CredentialManagement creds.CredentialManagementConfig `group:"Credential Management"`
 	CredentialManagers   creds.Managers
 
 	EncryptionKey    flag.Cipher `long:"encryption-key"     description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
@@ -881,7 +881,7 @@ func (cmd *RunCommand) variablesFactory(logger lager.Logger) (creds.VariablesFac
 
 		break
 	}
-	return variablesFactory, nil
+	return creds.NewRetryableVariablesFactory(variablesFactory, cmd.CredentialManagement.RetryConfig), nil
 }
 
 func (cmd *RunCommand) newKey() *encryption.Key {

--- a/atc/creds/manager.go
+++ b/atc/creds/manager.go
@@ -20,6 +20,10 @@ type ManagerFactory interface {
 
 type Managers map[string]Manager
 
+type CredentialManagementConfig struct {
+	RetryConfig SecretRetryConfig
+}
+
 type HealthResponse struct {
 	Response interface{} `json:"response,omitempty"`
 	Error    string      `json:"error,omitempty"`

--- a/atc/creds/retryable_variables_factory.go
+++ b/atc/creds/retryable_variables_factory.go
@@ -1,0 +1,65 @@
+package creds
+
+import (
+	"fmt"
+	"github.com/cloudfoundry/bosh-cli/director/template"
+	"github.com/concourse/retryhttp"
+	"time"
+)
+
+type SecretRetryConfig struct {
+	Attempts int           `long:"secret-retry-attempts" default:"5"  description:"The number of attempts secret will be retried to be fetched, in case a retryable error happens."`
+	Interval time.Duration `long:"secret-retry-interval" default:"1s" description:"The interval between secret retry retrieval attempts."`
+}
+
+type RetryableVariablesFactory struct {
+	factory     VariablesFactory
+	retryConfig SecretRetryConfig
+}
+
+type RetryableVariables struct {
+	variables   Variables
+	retryConfig SecretRetryConfig
+}
+
+func NewRetryableVariablesFactory(factory VariablesFactory, retryConfig SecretRetryConfig) VariablesFactory {
+	return &RetryableVariablesFactory{factory: factory, retryConfig: retryConfig}
+}
+
+func (rvf RetryableVariablesFactory) NewVariables(teamName string, pipelineName string) Variables {
+	return RetryableVariables{variables: rvf.factory.NewVariables(teamName, pipelineName), retryConfig: rvf.retryConfig}
+}
+
+func (rv RetryableVariables) Get(varDef template.VariableDefinition) (interface{}, bool, error) {
+	r := &retryhttp.DefaultRetryer{}
+	for i := 0; i < rv.retryConfig.Attempts-1; i++ {
+		result, exists, err := rv.variables.Get(varDef)
+		if err != nil && r.IsRetryable(err) {
+			time.Sleep(rv.retryConfig.Interval)
+			continue
+		}
+		return result, exists, err
+	}
+	result, exists, err := rv.variables.Get(varDef)
+	if err != nil {
+		err = fmt.Errorf("%s (after %d retries)", err, rv.retryConfig.Attempts)
+	}
+	return result, exists, err
+}
+
+func (rv RetryableVariables) List() ([]template.VariableDefinition, error) {
+	r := &retryhttp.DefaultRetryer{}
+	for i := 0; i < rv.retryConfig.Attempts-1; i++ {
+		result, err := rv.variables.List()
+		if err != nil && r.IsRetryable(err) {
+			time.Sleep(rv.retryConfig.Interval)
+			continue
+		}
+		return result, err
+	}
+	result, err := rv.variables.List()
+	if err != nil {
+		err = fmt.Errorf("%s (after %d retries)", err, rv.retryConfig.Attempts)
+	}
+	return result, err
+}

--- a/atc/creds/retryable_variables_factory_test.go
+++ b/atc/creds/retryable_variables_factory_test.go
@@ -1,0 +1,59 @@
+package creds_test
+
+import (
+	"fmt"
+	"github.com/cloudfoundry/bosh-cli/director/template"
+	"github.com/concourse/concourse/atc/creds"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+type flakyVariables struct {
+	attempt       int
+	numberOfFails int
+}
+
+func (f *flakyVariables) Get(template.VariableDefinition) (interface{}, bool, error) {
+	f.attempt++
+	if f.attempt <= f.numberOfFails {
+		return nil, false, fmt.Errorf("remote error: handshake failure")
+	}
+	return "received value", true, nil
+}
+
+func (f *flakyVariables) List() ([]template.VariableDefinition, error) {
+	return nil, nil
+}
+
+type flakyFactory struct {
+	flakyVariables creds.Variables
+}
+
+func (f *flakyFactory) NewVariables(string, string) creds.Variables {
+	return f.flakyVariables
+}
+
+var _ = Describe("Retryable Variables Factory", func() {
+
+	It("should retry receiving a parameter in case of retryable error", func() {
+		flakyFactory := &flakyFactory{flakyVariables: &flakyVariables{numberOfFails: 3}}
+		factory := creds.NewRetryableVariablesFactory(flakyFactory, creds.SecretRetryConfig{Attempts: 5, Interval: time.Millisecond})
+		varDef := template.VariableDefinition{Name: "somevar"}
+		value, found, err := factory.NewVariables("team", "pipeline").Get(varDef)
+		Expect(value).To(BeEquivalentTo("received value"))
+		Expect(found).To(BeTrue())
+		Expect(err).To(BeNil())
+	})
+
+	It("should not receive a parameter if the number of retryable errors exceeded the number of allowed attempts", func() {
+		flakyFactory := &flakyFactory{flakyVariables: &flakyVariables{numberOfFails: 10}}
+		factory := creds.NewRetryableVariablesFactory(flakyFactory, creds.SecretRetryConfig{Attempts: 5, Interval: time.Millisecond})
+		varDef := template.VariableDefinition{Name: "somevar"}
+		value, found, err := factory.NewVariables("team", "pipeline").Get(varDef)
+		Expect(value).To(BeNil())
+		Expect(found).To(BeFalse())
+		Expect(err).NotTo(BeNil())
+	})
+
+})

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/concourse/dex v0.0.0-20181120155244-024cbea7e753
 	github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c
 	github.com/concourse/go-archive v1.0.0
-	github.com/concourse/retryhttp v0.0.0-20170802173037-937335fd9545
+	github.com/concourse/retryhttp v0.0.0-20181126170240-7ab5e29e634f
 	github.com/containerd/continuity v0.0.0-20180919190352-508d86ade3c2 // indirect
 	github.com/coreos/go-oidc v0.0.0-20170307191026-be73733bb8cc
 	github.com/cosiner/argv v0.0.0-20181111161405-36fdb9e0bb2d // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,9 @@ github.com/concourse/go-archive v0.0.0-20180803203406-784931698f4f h1:Z7s60kZd9k
 github.com/concourse/go-archive v0.0.0-20180803203406-784931698f4f/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv0NFwlpjf5CO8=
 github.com/concourse/go-archive v1.0.0 h1:nRejB54QZL8UwCKR5UlenYqwkEKN1A7khsarI5oRBkY=
 github.com/concourse/go-archive v1.0.0/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv0NFwlpjf5CO8=
-github.com/concourse/retryhttp v0.0.0-20170802173037-937335fd9545 h1:EprZV3ig+v+5sOp0eruDCgrW/nlmyXm4Z8JOF1Unz1o=
 github.com/concourse/retryhttp v0.0.0-20170802173037-937335fd9545/go.mod h1:4+V9YCkKuoV7rg+/No+ZM9FsO3BK4tIJNUiYMI7nki0=
+github.com/concourse/retryhttp v0.0.0-20181126170240-7ab5e29e634f h1:YlKSrd1N2/WnG3ce28g6DOj6oXpZbBjH/3G97qdTZns=
+github.com/concourse/retryhttp v0.0.0-20181126170240-7ab5e29e634f/go.mod h1:4+V9YCkKuoV7rg+/No+ZM9FsO3BK4tIJNUiYMI7nki0=
 github.com/containerd/continuity v0.0.0-20180919190352-508d86ade3c2 h1:oiQ0OCfHdE7YXG94mc3HpKhbaZ8Nk17lw4E+ycI8Zgs=
 github.com/containerd/continuity v0.0.0-20180919190352-508d86ade3c2/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/coreos/etcd v3.2.9+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
- every manager has SecretRetry with retry params (attempts + interval)
- SecretRetry gets passed down to Get() into each cred manager
- Get() now performs a configured number of retries instead of a single
  lookup and fail
- couple of unit tests added for retries (just for ssm, but they are
  all the same)