### PR TITLE
atc: set BUILD_URL and BUILD_URL_SHORT metadata envvars

### DIFF
--- a/atc/engine/step_metadata.go
+++ b/atc/engine/step_metadata.go
@@ -35,5 +35,13 @@ func (metadata StepMetadata) Env() []string {
 		env = append(env, "BUILD_TEAM_NAME="+metadata.TeamName)
 	}
 
+	if metadata.ExternalURL != "" && metadata.TeamName != "" && metadata.PipelineName != "" && metadata.JobName != "" && metadata.BuildName != "" {
+		env = append(env, fmt.Sprintf("BUILD_URL=%s/teams/%s/pipelines/%s/jobs/%s/builds/%s", metadata.ExternalURL, metadata.TeamName, metadata.PipelineName, metadata.JobName, metadata.BuildName))
+	}
+
+	if metadata.ExternalURL != "" && metadata.BuildID != 0 {
+		env = append(env, fmt.Sprintf("BUILD_URL_SHORT=%s/builds/%d", metadata.ExternalURL, metadata.BuildID))
+	}
+
 	return env
 }

--- a/atc/engine/step_metadata_test.go
+++ b/atc/engine/step_metadata_test.go
@@ -24,6 +24,8 @@ var _ = Describe("StepMetadata", func() {
 				"BUILD_NAME=42",
 				"ATC_EXTERNAL_URL=http://www.example.com",
 				"BUILD_TEAM_NAME=some-team",
+				"BUILD_URL=http://www.example.com/teams/some-team/pipelines/some-pipeline-name/jobs/some-job-name/builds/42",
+				"BUILD_URL_SHORT=http://www.example.com/builds/1",
 			}))
 		})
 


### PR DESCRIPTION
One often needs an URL to the Concourse build page, eg. to report a failed build to a Slack channel. It's not hard to construct it from the already existing metadata envvars, but that also means that the code that constructs the URL will encapsulate knowledge about the way Concourse build URLs are formulated (and then changing the URL structure of Concourse build pages would break that code).

This PR adds two new metadata envvars:
* BUILD_URL is the "long" URL (the one that contains the team, pipeline and job name) to the build page
* BUILD_URL_SHORT is the "short" URL (that only contains the BUILD_ID)