### PR TITLE
atc: Adds http response status code field to http response time metric

### DIFF
--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -176,7 +176,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Name:      "duration_seconds",
 			Help:      "Response time in seconds",
 		},
-		[]string{"method", "route"},
+		[]string{"method", "route", "status"},
 	)
 	prometheus.MustRegister(httpRequestsDuration)
 
@@ -450,13 +450,19 @@ func (emitter *PrometheusEmitter) httpResponseTimeMetrics(logger lager.Logger, e
 		return
 	}
 
+	status, exists := event.Attributes["status"]
+	if !exists {
+		logger.Error("failed-to-find-status-in-event", fmt.Errorf("expected status to exist in event.Attributes"))
+		return
+	}
+
 	responseTime, ok := event.Value.(float64)
 	if !ok {
 		logger.Error("http-response-time-event-value-type-mismatch", fmt.Errorf("expected event.Value to be a float64"))
 		return
 	}
 
-	emitter.httpRequestsDuration.WithLabelValues(method, route).Observe(responseTime / 1000)
+	emitter.httpRequestsDuration.WithLabelValues(method, route, status).Observe(responseTime / 1000)
 }
 
 func (emitter *PrometheusEmitter) schedulingMetrics(logger lager.Logger, event metric.Event) {

--- a/atc/metric/http_test.go
+++ b/atc/metric/http_test.go
@@ -1,0 +1,106 @@
+package metric_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/metric"
+	"github.com/concourse/concourse/atc/metric/metricfakes"
+
+	. "github.com/concourse/concourse/atc/metric"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func noopHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/success":
+		return
+	case "/failure":
+		w.WriteHeader(500)
+		return
+	}
+
+	w.WriteHeader(404)
+	return
+}
+
+var dummyLogger = lager.NewLogger("dont care")
+
+var _ = Describe("MetricsHandler", func() {
+	var (
+		ts      *httptest.Server
+		emitter *metricfakes.FakeEmitter
+	)
+
+	BeforeEach(func() {
+		emitterFactory := &metricfakes.FakeEmitterFactory{}
+		emitter = &metricfakes.FakeEmitter{}
+
+		metric.RegisterEmitter(emitterFactory)
+		emitterFactory.IsConfiguredReturns(true)
+		emitterFactory.NewEmitterReturns(emitter, nil)
+
+		metric.Initialize(dummyLogger, "test", map[string]string{})
+
+		ts = httptest.NewServer(
+			WrapHandler(dummyLogger, "ApiEndpoint", http.HandlerFunc(noopHandler)))
+	})
+
+	AfterEach(func() {
+		ts.Close()
+		metric.Deinitialize(dummyLogger)
+	})
+
+	Context("when serving requests", func() {
+		var (
+			endpoint = "/"
+			event    metric.Event
+		)
+
+		JustBeforeEach(func() {
+			res, err := http.Get(ts.URL + endpoint)
+			Expect(err).ToNot(HaveOccurred())
+			res.Body.Close()
+
+			Eventually(emitter.EmitCallCount).Should(BeNumerically("==", 1))
+			_, event = emitter.EmitArgsForCall(0)
+		})
+
+		It("captures request and response properties", func() {
+			Expect(event.Attributes).To(HaveKeyWithValue("status", "404"))
+			Expect(event.Attributes).To(HaveKeyWithValue("method", "GET"))
+			Expect(event.Attributes).To(HaveKeyWithValue("route", "ApiEndpoint"))
+			Expect(event.Attributes).To(HaveKeyWithValue("path", "/"))
+		})
+
+		Context("to endpoint that returns success statuses", func() {
+			BeforeEach(func() {
+				endpoint = "/success"
+			})
+
+			It("captures error code", func() {
+				Expect(event.Attributes).To(HaveKeyWithValue("status", "200"))
+			})
+
+			It("captures route", func() {
+				Expect(event.Attributes).To(HaveKeyWithValue("path", "/success"))
+			})
+		})
+
+		Context("to faulty endpoint", func() {
+			BeforeEach(func() {
+				endpoint = "/failure"
+			})
+
+			It("captures error code", func() {
+				Expect(event.Attributes).To(HaveKeyWithValue("status", "500"))
+			})
+
+			It("captures route", func() {
+				Expect(event.Attributes).To(HaveKeyWithValue("path", "/failure"))
+			})
+		})
+	})
+})

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -357,10 +357,11 @@ func ms(duration time.Duration) float64 {
 }
 
 type HTTPResponseTime struct {
-	Route    string
-	Path     string
-	Method   string
-	Duration time.Duration
+	Route      string
+	Path       string
+	Method     string
+	StatusCode int
+	Duration   time.Duration
 }
 
 func (event HTTPResponseTime) Emit(logger lager.Logger) {
@@ -384,6 +385,7 @@ func (event HTTPResponseTime) Emit(logger lager.Logger) {
 				"route":  event.Route,
 				"path":   event.Path,
 				"method": event.Method,
+				"status": strconv.Itoa(event.StatusCode),
 			},
 		},
 	)

--- a/atc/metric/periodic_test.go
+++ b/atc/metric/periodic_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/metric"
 	"github.com/concourse/concourse/atc/metric/metricfakes"
+	"github.com/tedsuo/ifrit"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"github.com/tedsuo/ifrit"
 )
 
 var _ = Describe("Periodic emission of metrics", func() {
@@ -42,6 +43,7 @@ var _ = Describe("Periodic emission of metrics", func() {
 	AfterEach(func() {
 		process.Signal(os.Interrupt)
 		<-process.Wait()
+		metric.Deinitialize(nil)
 	})
 
 	It("emits database queries", func() {

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/fatih/gomodifytags v0.0.0-20180914191908-141225bf62b6 // indirect
 	github.com/fatih/motion v0.0.0-20180408211639-218875ebe238 // indirect
 	github.com/fatih/structs v1.0.0 // indirect
+	github.com/felixge/httpsnoop v1.0.0
 	github.com/felixge/tcpkeepalive v0.0.0-20160804073959-5bb0b2dea91e
 	github.com/go-ldap/ldap v2.5.1+incompatible // indirect
 	github.com/go-openapi/jsonpointer v0.0.0-20180825180259-52eb3d4b47c6 // indirect


### PR DESCRIPTION
Covering concourse/concourse#2745, this PR is about adding an extra tag to the fields of `HTTPResponseTime` so that we can also aggregate based on specific HTTP status codes of our interest. 