### PR TITLE
Support for cc.xml

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -118,6 +118,7 @@ func (a *access) CSRFToken() string {
 var requiredRoles = map[string]string{
 	atc.SaveConfig:                    "member",
 	atc.GetConfig:                     "viewer",
+	atc.GetCC:                         "viewer",
 	atc.GetBuild:                      "viewer",
 	atc.GetBuildPlan:                  "viewer",
 	atc.CreateBuild:                   "member",

--- a/atc/api/accessor/accessor_test.go
+++ b/atc/api/accessor/accessor_test.go
@@ -347,6 +347,10 @@ var _ = Describe("Accessor", func() {
 		Entry("member :: "+atc.GetConfig, atc.GetConfig, "member", true),
 		Entry("viewer :: "+atc.GetConfig, atc.GetConfig, "viewer", true),
 
+		Entry("owner :: "+atc.GetCC, atc.GetCC, "owner", true),
+		Entry("member :: "+atc.GetCC, atc.GetCC, "member", true),
+		Entry("viewer :: "+atc.GetCC, atc.GetCC, "viewer", true),
+
 		Entry("owner :: "+atc.GetBuild, atc.GetBuild, "owner", true),
 		Entry("member :: "+atc.GetBuild, atc.GetBuild, "member", true),
 		Entry("viewer :: "+atc.GetBuild, atc.GetBuild, "viewer", true),

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -37,7 +37,7 @@ var _ = Describe("cc.xml", func() {
 
 		JustBeforeEach(func() {
 			req, err := requestGenerator.CreateRequest(atc.GetCC, rata.Params{
-				"team_name":     "a-team",
+				"team_name": "a-team",
 			}, nil)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -63,8 +63,6 @@ var _ = Describe("cc.xml", func() {
 					var fakePipeline *dbfakes.FakePipeline
 					BeforeEach(func() {
 						fakePipeline = new(dbfakes.FakePipeline)
-						fakePipeline.NameReturns("something-else")
-						fakePipeline.TeamNameReturns("a-team")
 						fakeTeam.PipelinesReturns([]db.Pipeline{
 							fakePipeline,
 						}, nil)
@@ -75,6 +73,8 @@ var _ = Describe("cc.xml", func() {
 						var endTime time.Time
 						BeforeEach(func() {
 							fakeJob = new(dbfakes.FakeJob)
+							fakeJob.PipelineNameReturns("something-else")
+							fakeJob.TeamNameReturns("a-team")
 							fakeJob.NameReturns("some-job")
 
 							fakePipeline.DashboardReturns(db.Dashboard{

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -114,7 +114,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else/some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})
@@ -140,7 +140,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Exception" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Exception" lastBuildTime="2018-11-04T21:26:38Z" name="something-else/some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})
@@ -166,7 +166,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Exception" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Exception" lastBuildTime="2018-11-04T21:26:38Z" name="something-else/some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})
@@ -192,7 +192,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Failure" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Failure" lastBuildTime="2018-11-04T21:26:38Z" name="something-else/some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})
@@ -222,7 +222,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Building" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
+  <Project activity="Building" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else/some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -126,7 +126,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Unknown" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Exception" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -1,10 +1,15 @@
 package api_test
 
 import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/tedsuo/rata"
-	"net/http"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -45,9 +50,135 @@ var _ = Describe("cc.xml", func() {
 				fakeaccess.IsAuthorizedReturns(true)
 			})
 
+			Context("when the team is found", func() {
+				var fakeTeam *dbfakes.FakeTeam
+				BeforeEach(func() {
+					fakeTeam = new(dbfakes.FakeTeam)
+					fakeTeam.NameReturns("a-team")
+					dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+				})
+
+				Context("when a pipeline is found", func() {
+					var fakePipeline *dbfakes.FakePipeline
+					BeforeEach(func() {
+						fakePipeline = new(dbfakes.FakePipeline)
+						fakePipeline.NameReturns("something-else")
+						fakePipeline.ConfigVersionReturns(1)
+						fakePipeline.GroupsReturns(atc.GroupConfigs{
+							{
+								Name:      "some-group",
+								Jobs:      []string{"some-job"},
+							},
+						})
+						fakeTeam.PipelinesReturns([]db.Pipeline{
+							fakePipeline,
+						}, nil)
+					})
+
+					Context("when a job is found", func() {
+						var fakeJob *dbfakes.FakeJob
+						BeforeEach(func() {
+							fakeJob = new(dbfakes.FakeJob)
+							fakeJob.ConfigReturns(atc.JobConfig{
+								Name:   "some-job",
+							})
+
+							fakePipeline.JobsReturns(db.Jobs{fakeJob}, nil)
+						})
+
+						It("returns 200", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusOK))
+						})
+
+						It("returns Content-Type 'application/xml'", func() {
+							Expect(response.Header.Get("Content-Type")).To(Equal("application/xml"))
+						})
+
+						It("returns the CC.xml", func() {
+							body, err := ioutil.ReadAll(response.Body)
+							Expect(err).NotTo(HaveOccurred())
+
+							Expect(body).To(MatchXML(`
+<Projects>
+  <Project name="something-else :: some-job"/>
+</Projects>
+`))
+						})
+					})
+
+					Context("when no job is found", func() {
+						BeforeEach(func() {
+							fakePipeline.JobsReturns(db.Jobs{}, nil)
+						})
+
+						It("returns 200", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusOK))
+						})
+
+						It("returns the CC.xml", func() {
+							body, err := ioutil.ReadAll(response.Body)
+							Expect(err).NotTo(HaveOccurred())
+
+							Expect(body).To(MatchXML("<Projects></Projects>"))
+						})
+					})
+
+					Context("when finding the jobs fails", func() {
+						BeforeEach(func() {
+							fakePipeline.JobsReturns(nil, errors.New("failed"))
+						})
+
+						It("returns 500", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+						})
+					})
+				})
+
+				Context("when no pipeline is found", func() {
+					BeforeEach(func() {
+						fakeTeam.PipelinesReturns([]db.Pipeline{}, nil)
+					})
+
+					It("returns 200", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusOK))
+					})
+
+					It("returns the CC.xml", func() {
+						body, err := ioutil.ReadAll(response.Body)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(body).To(MatchXML("<Projects></Projects>"))
+					})
+				})
+
+				Context("when getting the pipelines fails", func() {
+					BeforeEach(func() {
+						fakeTeam.PipelinesReturns(nil, errors.New("failed"))
+					})
+
+					It("returns 500", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					})
+				})
+			})
+
 			Context("when the team is not found", func() {
+				BeforeEach(func() {
+					dbTeamFactory.FindTeamReturns(nil, false, nil)
+				})
+
 				It("returns 404", func() {
 					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+				})
+			})
+
+			Context("when finding the team fails", func() {
+				BeforeEach(func() {
+					dbTeamFactory.FindTeamReturns(nil, false, errors.New("failed"))
+				})
+
+				It("returns 500", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
 				})
 			})
 		})

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -86,7 +86,7 @@ var _ = Describe("cc.xml", func() {
 							BeforeEach(func() {
 								succeededBuild := new(dbfakes.FakeBuild)
 								succeededBuild.StatusReturns(db.BuildStatusSucceeded)
-								succeededBuild.IDReturns(42)
+								succeededBuild.NameReturns("42")
 								succeededBuild.EndTimeReturns(endTime)
 								fakeJob.FinishedAndNextBuildReturns(succeededBuild, nil, nil)
 							})
@@ -115,7 +115,7 @@ var _ = Describe("cc.xml", func() {
 							BeforeEach(func() {
 								abortedBuild := new(dbfakes.FakeBuild)
 								abortedBuild.StatusReturns(db.BuildStatusAborted)
-								abortedBuild.IDReturns(42)
+								abortedBuild.NameReturns("42")
 								abortedBuild.EndTimeReturns(endTime)
 								fakeJob.FinishedAndNextBuildReturns(abortedBuild, nil, nil)
 							})
@@ -136,7 +136,7 @@ var _ = Describe("cc.xml", func() {
 							BeforeEach(func() {
 								erroredBuild := new(dbfakes.FakeBuild)
 								erroredBuild.StatusReturns(db.BuildStatusErrored)
-								erroredBuild.IDReturns(42)
+								erroredBuild.NameReturns("42")
 								erroredBuild.EndTimeReturns(endTime)
 								fakeJob.FinishedAndNextBuildReturns(erroredBuild, nil, nil)
 							})
@@ -157,7 +157,7 @@ var _ = Describe("cc.xml", func() {
 							BeforeEach(func() {
 								failedBuild := new(dbfakes.FakeBuild)
 								failedBuild.StatusReturns(db.BuildStatusFailed)
-								failedBuild.IDReturns(42)
+								failedBuild.NameReturns("42")
 								failedBuild.EndTimeReturns(endTime)
 								fakeJob.FinishedAndNextBuildReturns(failedBuild, nil, nil)
 							})
@@ -178,7 +178,7 @@ var _ = Describe("cc.xml", func() {
 							BeforeEach(func() {
 								finishedBuild := new(dbfakes.FakeBuild)
 								finishedBuild.StatusReturns(db.BuildStatusSucceeded)
-								finishedBuild.IDReturns(42)
+								finishedBuild.NameReturns("42")
 								finishedBuild.EndTimeReturns(endTime)
 
 								nextBuild := new(dbfakes.FakeBuild)

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -1,0 +1,65 @@
+package api_test
+
+import (
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
+	"github.com/tedsuo/rata"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("cc.xml", func() {
+	var (
+		requestGenerator *rata.RequestGenerator
+		fakeaccess       *accessorfakes.FakeAccess
+	)
+
+	BeforeEach(func() {
+		requestGenerator = rata.NewRequestGenerator(server.URL, atc.Routes)
+
+		fakeaccess = new(accessorfakes.FakeAccess)
+	})
+
+	JustBeforeEach(func() {
+		fakeAccessor.CreateReturns(fakeaccess)
+	})
+
+	Describe("GET /api/v1/teams/:team_name/cc.xml", func() {
+		var response *http.Response
+
+		JustBeforeEach(func() {
+			req, err := requestGenerator.CreateRequest(atc.GetCC, rata.Params{
+				"team_name":     "a-team",
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err = client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when authorized", func() {
+			BeforeEach(func() {
+				fakeaccess.IsAuthenticatedReturns(true)
+				fakeaccess.IsAuthorizedReturns(true)
+			})
+
+			Context("when the team is not found", func() {
+				It("returns 404", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+				})
+			})
+		})
+
+		Context("when not authenticated", func() {
+			BeforeEach(func() {
+				fakeaccess.IsAuthenticatedReturns(false)
+			})
+
+			It("returns 401", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+		})
+	})
+})

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -64,6 +64,7 @@ var _ = Describe("cc.xml", func() {
 					BeforeEach(func() {
 						fakePipeline = new(dbfakes.FakePipeline)
 						fakePipeline.NameReturns("something-else")
+						fakePipeline.TeamNameReturns("a-team")
 						fakeTeam.PipelinesReturns([]db.Pipeline{
 							fakePipeline,
 						}, nil)
@@ -104,7 +105,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})
@@ -125,7 +126,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Unknown" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Unknown" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})
@@ -146,7 +147,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Exception" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Exception" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})
@@ -167,7 +168,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Failure" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Failure" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})
@@ -191,7 +192,7 @@ var _ = Describe("cc.xml", func() {
 
 								Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Building" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job"/>
+  <Project activity="Building" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else :: some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job"/>
 </Projects>
 `))
 							})

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -119,7 +119,7 @@ func (s *Server) buildProject(build db.Build, nextBuild db.Build, pipeline db.Pi
 	projectName := fmt.Sprintf("%s :: %s", pipeline.Name(), job.Name())
 	return Project{
 		Activity:		 activity,
-		LastBuildLabel:  fmt.Sprint(build.ID()),
+		LastBuildLabel:  fmt.Sprint(build.Name()),
 		LastBuildStatus: lastBuildStatus,
 		LastBuildTime:   build.EndTime().Format(time.RFC3339),
 		Name:            projectName,

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 
@@ -13,7 +14,9 @@ import (
 
 type Project struct {
 	Name			string `xml:"name,attr"`
+	LastBuildLabel  string `xml:"lastBuildLabel,attr"`
 	LastBuildStatus	string `xml:"lastBuildStatus,attr"`
+	LastBuildTime   string `xml:"lastBuildTime,attr"`
 }
 
 type ProjectsContainer struct {
@@ -97,7 +100,9 @@ func buildProject(build db.Build, pipeline db.Pipeline, job db.Job) Project {
 
 	projectName := fmt.Sprintf("%s :: %s", pipeline.Name(), job.Config().Name)
 	return Project{
-		Name:            projectName,
+		LastBuildLabel:  fmt.Sprint(build.ID()),
 		LastBuildStatus: lastBuildStatus,
+		LastBuildTime:   build.EndTime().Format(time.RFC3339),
+		Name:            projectName,
 	}
 }

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -17,15 +17,15 @@ import (
 type Project struct {
 	Activity        string `xml:"activity,attr"`
 	LastBuildLabel  string `xml:"lastBuildLabel,attr"`
-	LastBuildStatus	string `xml:"lastBuildStatus,attr"`
+	LastBuildStatus string `xml:"lastBuildStatus,attr"`
 	LastBuildTime   string `xml:"lastBuildTime,attr"`
-	Name			string `xml:"name,attr"`
-	WebUrl			string `xml:"webUrl,attr"`
+	Name            string `xml:"name,attr"`
+	WebUrl          string `xml:"webUrl,attr"`
 }
 
 type ProjectsContainer struct {
-	XMLName   xml.Name `xml:"Projects"`
-	Projects  []Project `xml:"Project"`
+	XMLName  xml.Name  `xml:"Projects"`
+	Projects []Project `xml:"Project"`
 }
 
 func (s *Server) GetCC(w http.ResponseWriter, r *http.Request) {
@@ -118,12 +118,12 @@ func (s *Server) buildProject(build db.Build, nextBuild db.Build, pipeline db.Pi
 
 	projectName := fmt.Sprintf("%s :: %s", pipeline.Name(), job.Name())
 	return Project{
-		Activity:		 activity,
+		Activity:        activity,
 		LastBuildLabel:  fmt.Sprint(build.Name()),
 		LastBuildStatus: lastBuildStatus,
 		LastBuildTime:   build.EndTime().Format(time.RFC3339),
 		Name:            projectName,
-		WebUrl:			 webUrl,
+		WebUrl:          webUrl,
 	}
 }
 

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -65,9 +65,9 @@ func (s *Server) GetCC(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		for _, dashboard := range dashboards {
-			if dashboard.FinishedBuild != nil {
-				projects = append(projects, s.buildProject(dashboard, pipeline))
+		for _, dashboardJob := range dashboards {
+			if dashboardJob.FinishedBuild != nil {
+				projects = append(projects, s.buildProject(dashboardJob))
 			}
 		}
 	}
@@ -82,7 +82,7 @@ func (s *Server) GetCC(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) buildProject(j db.DashboardJob, pipeline db.Pipeline) Project {
+func (s *Server) buildProject(j db.DashboardJob) Project {
 	var lastBuildStatus string
 	switch {
 	case j.FinishedBuild.Status() == db.BuildStatusSucceeded:
@@ -102,14 +102,14 @@ func (s *Server) buildProject(j db.DashboardJob, pipeline db.Pipeline) Project {
 
 	webUrl := s.createWebUrl([]string{
 		"teams",
-		pipeline.TeamName(),
+		j.Job.TeamName(),
 		"pipelines",
-		pipeline.Name(),
+		j.Job.PipelineName(),
 		"jobs",
 		j.Job.Name(),
 	})
 
-	projectName := fmt.Sprintf("%s :: %s", pipeline.Name(), j.Job.Name())
+	projectName := fmt.Sprintf("%s :: %s", j.Job.PipelineName(), j.Job.Name())
 	return Project{
 		Activity:        activity,
 		LastBuildLabel:  fmt.Sprint(j.FinishedBuild.Name()),

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -96,10 +96,8 @@ func (s *Server) buildProject(build db.Build, nextBuild db.Build, pipeline db.Pi
 		lastBuildStatus = "Success"
 	case build.Status() == db.BuildStatusFailed:
 		lastBuildStatus = "Failure"
-	case build.Status() == db.BuildStatusErrored:
-		lastBuildStatus = "Exception"
 	default:
-		lastBuildStatus = "Unknown"
+		lastBuildStatus = "Exception"
 	}
 
 	var activity string

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -109,7 +109,7 @@ func (s *Server) buildProject(j db.DashboardJob) Project {
 		j.Job.Name(),
 	})
 
-	projectName := fmt.Sprintf("%s :: %s", j.Job.PipelineName(), j.Job.Name())
+	projectName := fmt.Sprintf("%s/%s", j.Job.PipelineName(), j.Job.Name())
 	return Project{
 		Activity:        activity,
 		LastBuildLabel:  fmt.Sprint(j.FinishedBuild.Name()),

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -1,6 +1,8 @@
 package ccserver
 
 import (
+	"encoding/xml"
+	"fmt"
 	"net/http"
 
 	"code.cloudfoundry.org/lager"
@@ -8,10 +10,63 @@ import (
 	"github.com/tedsuo/rata"
 )
 
+type Project struct {
+	Name	string `xml:"name,attr"`
+}
+
+type ProjectsContainer struct {
+	XMLName   xml.Name `xml:"Projects"`
+	Projects  []Project `xml:"Project"`
+}
+
 func (s *Server) GetCC(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.Session("get-cc")
 	teamName := rata.Param(r, "team_name")
 
-	logger.Debug("team-not-found", lager.Data{"team": teamName})
-	w.WriteHeader(http.StatusNotFound)
+	team, found, err := s.teamFactory.FindTeam(teamName)
+
+	if err != nil {
+		logger.Error("failed-to-find-team", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !found {
+		logger.Debug("team-not-found", lager.Data{"team": teamName})
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	pipelines, err := team.Pipelines()
+
+	if err != nil {
+		logger.Error("failed-to-get-all-active-pipelines", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	var projects []Project
+
+	for _, pipeline := range pipelines {
+		jobs, err := pipeline.Jobs()
+		if err != nil {
+			logger.Error("failed-to-get-jobs", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		for _, job := range jobs {
+			projectName := fmt.Sprintf("%s :: %s", pipeline.Name(), job.Config().Name)
+			projects = append(projects, Project{Name: projectName})
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	err = xml.NewEncoder(w).Encode(ProjectsContainer{Projects: projects})
+
+	if err != nil {
+		logger.Error("failed-to-serialize-projects", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 }

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -1,0 +1,17 @@
+package ccserver
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/lager"
+
+	"github.com/tedsuo/rata"
+)
+
+func (s *Server) GetCC(w http.ResponseWriter, r *http.Request) {
+	logger := s.logger.Session("get-cc")
+	teamName := rata.Param(r, "team_name")
+
+	logger.Debug("team-not-found", lager.Data{"team": teamName})
+	w.WriteHeader(http.StatusNotFound)
+}

--- a/atc/api/ccserver/server.go
+++ b/atc/api/ccserver/server.go
@@ -2,16 +2,20 @@ package ccserver
 
 import (
 	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/db"
 )
 
 type Server struct {
 	logger           lager.Logger
+	teamFactory      db.TeamFactory
 }
 
 func NewServer(
 	logger lager.Logger,
+	teamFactory db.TeamFactory,
 ) *Server {
 	return &Server{
 		logger:           logger,
+		teamFactory:      teamFactory,
 	}
 }

--- a/atc/api/ccserver/server.go
+++ b/atc/api/ccserver/server.go
@@ -1,0 +1,17 @@
+package ccserver
+
+import (
+	"code.cloudfoundry.org/lager"
+)
+
+type Server struct {
+	logger           lager.Logger
+}
+
+func NewServer(
+	logger lager.Logger,
+) *Server {
+	return &Server{
+		logger:           logger,
+	}
+}

--- a/atc/api/ccserver/server.go
+++ b/atc/api/ccserver/server.go
@@ -8,14 +8,17 @@ import (
 type Server struct {
 	logger           lager.Logger
 	teamFactory      db.TeamFactory
+	externalURL      string
 }
 
 func NewServer(
 	logger lager.Logger,
 	teamFactory db.TeamFactory,
+	externalURL string,
 ) *Server {
 	return &Server{
 		logger:           logger,
 		teamFactory:      teamFactory,
+		externalURL:      externalURL,
 	}
 }

--- a/atc/api/ccserver/server.go
+++ b/atc/api/ccserver/server.go
@@ -6,9 +6,9 @@ import (
 )
 
 type Server struct {
-	logger           lager.Logger
-	teamFactory      db.TeamFactory
-	externalURL      string
+	logger      lager.Logger
+	teamFactory db.TeamFactory
+	externalURL string
 }
 
 func NewServer(
@@ -17,8 +17,8 @@ func NewServer(
 	externalURL string,
 ) *Server {
 	return &Server{
-		logger:           logger,
-		teamFactory:      teamFactory,
-		externalURL:      externalURL,
+		logger:      logger,
+		teamFactory: teamFactory,
+		externalURL: externalURL,
 	}
 }

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/buildserver"
-	"github.com/concourse/concourse/atc/api/cliserver"
 	"github.com/concourse/concourse/atc/api/ccserver"
+	"github.com/concourse/concourse/atc/api/cliserver"
 	"github.com/concourse/concourse/atc/api/configserver"
 	"github.com/concourse/concourse/atc/api/containerserver"
 	"github.com/concourse/concourse/atc/api/infoserver"

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -87,7 +87,7 @@ func NewHandler(
 	versionServer := versionserver.NewServer(logger, externalURL)
 	pipelineServer := pipelineserver.NewServer(logger, dbTeamFactory, dbPipelineFactory, externalURL, engine)
 	configServer := configserver.NewServer(logger, dbTeamFactory, variablesFactory)
-	ccServer := ccserver.NewServer(logger)
+	ccServer := ccserver.NewServer(logger, dbTeamFactory)
 	workerServer := workerserver.NewServer(logger, dbTeamFactory, dbWorkerFactory, workerProvider)
 	logLevelServer := loglevelserver.NewServer(logger, sink)
 	cliServer := cliserver.NewServer(logger, absCLIDownloadsDir)

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -87,7 +87,7 @@ func NewHandler(
 	versionServer := versionserver.NewServer(logger, externalURL)
 	pipelineServer := pipelineserver.NewServer(logger, dbTeamFactory, dbPipelineFactory, externalURL, engine)
 	configServer := configserver.NewServer(logger, dbTeamFactory, variablesFactory)
-	ccServer := ccserver.NewServer(logger, dbTeamFactory)
+	ccServer := ccserver.NewServer(logger, dbTeamFactory, externalURL)
 	workerServer := workerserver.NewServer(logger, dbTeamFactory, dbWorkerFactory, workerProvider)
 	logLevelServer := loglevelserver.NewServer(logger, sink)
 	cliServer := cliserver.NewServer(logger, absCLIDownloadsDir)

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/buildserver"
 	"github.com/concourse/concourse/atc/api/cliserver"
+	"github.com/concourse/concourse/atc/api/ccserver"
 	"github.com/concourse/concourse/atc/api/configserver"
 	"github.com/concourse/concourse/atc/api/containerserver"
 	"github.com/concourse/concourse/atc/api/infoserver"
@@ -86,6 +87,7 @@ func NewHandler(
 	versionServer := versionserver.NewServer(logger, externalURL)
 	pipelineServer := pipelineserver.NewServer(logger, dbTeamFactory, dbPipelineFactory, externalURL, engine)
 	configServer := configserver.NewServer(logger, dbTeamFactory, variablesFactory)
+	ccServer := ccserver.NewServer(logger)
 	workerServer := workerserver.NewServer(logger, dbTeamFactory, dbWorkerFactory, workerProvider)
 	logLevelServer := loglevelserver.NewServer(logger, sink)
 	cliServer := cliserver.NewServer(logger, absCLIDownloadsDir)
@@ -97,6 +99,8 @@ func NewHandler(
 	handlers := map[string]http.Handler{
 		atc.GetConfig:  http.HandlerFunc(configServer.GetConfig),
 		atc.SaveConfig: http.HandlerFunc(configServer.SaveConfig),
+
+		atc.GetCC: http.HandlerFunc(ccServer.GetCC),
 
 		atc.ListBuilds:              http.HandlerFunc(buildServer.ListBuilds),
 		atc.CreateBuild:             teamHandlerFactory.HandlerFor(buildServer.CreateBuild),

--- a/atc/routes.go
+++ b/atc/routes.go
@@ -50,6 +50,8 @@ const (
 	ListBuildsWithVersionAsOutput = "ListBuildsWithVersionAsOutput"
 	GetResourceCausality          = "GetResourceCausality"
 
+	GetCC = "GetCC"
+
 	ListAllPipelines    = "ListAllPipelines"
 	ListPipelines       = "ListPipelines"
 	GetPipeline         = "GetPipeline"
@@ -166,6 +168,8 @@ var Routes = rata.Routes([]rata.Route{
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_config_version_id/input_to", Method: "GET", Name: ListBuildsWithVersionAsInput},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_config_version_id/output_of", Method: "GET", Name: ListBuildsWithVersionAsOutput},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/causality", Method: "GET", Name: GetResourceCausality},
+
+	{Path: "/api/v1/teams/:team_name/cc.xml", Method: "GET", Name: GetCC},
 
 	{Path: "/api/v1/workers", Method: "GET", Name: ListWorkers},
 	{Path: "/api/v1/workers", Method: "POST", Name: RegisterWorker},

--- a/atc/wrappa/api_auth_wrappa.go
+++ b/atc/wrappa/api_auth_wrappa.go
@@ -126,6 +126,7 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.PinResourceVersion,
 			atc.UnpinResource,
 			atc.GetConfig,
+			atc.GetCC,
 			atc.GetVersionsDB,
 			atc.ListJobInputs,
 			atc.OrderPipelines,

--- a/atc/wrappa/api_auth_wrappa_test.go
+++ b/atc/wrappa/api_auth_wrappa_test.go
@@ -223,6 +223,7 @@ var _ = Describe("APIAuthWrappa", func() {
 				atc.PinResourceVersion:     authorized(inputHandlers[atc.PinResourceVersion]),
 				atc.UnpinResource:          authorized(inputHandlers[atc.UnpinResource]),
 				atc.GetConfig:              authorized(inputHandlers[atc.GetConfig]),
+				atc.GetCC:                  authorized(inputHandlers[atc.GetCC]),
 				atc.GetVersionsDB:          authorized(inputHandlers[atc.GetVersionsDB]),
 				atc.ListJobInputs:          authorized(inputHandlers[atc.ListJobInputs]),
 				atc.OrderPipelines:         authorized(inputHandlers[atc.OrderPipelines]),


### PR DESCRIPTION
This PR tries to implement what's being asked for in #438.

Following the documentation in https://github.com/concourse/concourse/blob/master/.github/CONTRIBUTING.md#running-concourse one should yield the following.

Given the token from `~/.flyrc`:
```
$ curl 'http://localhost:8080/api/v1/teams/main/cc.xml' -H 'Authorization: Bearer YOUR_TOKEN'
```
```xml
<Projects>
  <Project activity="Sleeping" lastBuildLabel="5" lastBuildStatus="Success" 
           lastBuildTime="2018-11-05T20:02:57Z" name="example :: hello-world"
           webUrl="http://localhost:8080/teams/main/pipelines/example/jobs/hello-world"></Project>
</Projects>
```

I've assumed that an aborted build shall be marked as failed. Apologies for mixed tabs and spaces, I've trusted GoLand to choose the right thing to do, it might have failed me horribly.

The only way to currently access the endpoint is via a token retrieved from fly AFAIK (see above example). I wonder what Concourse wants to offer other apps when it comes to retrieving a long running session, preferably with easy user login. Currently I would see this as a blocker for integrating this new endpoint in my build monitor tools of choice.