### PR TITLE
Colorized diff output for Windows terminal.

### DIFF
--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -312,7 +312,9 @@ func (atcConfig ATCConfig) showHelpfulMessage(created bool, updated bool) {
 func diff(existingConfig atc.Config, newConfig atc.Config) bool {
 	var diffExists bool
 
-	indent := gexec.NewPrefixedWriter("  ", os.Stdout)
+	stdout, _ := ui.ForTTY(os.Stdout)
+
+	indent := gexec.NewPrefixedWriter("  ", stdout)
 
 	groupDiffs := groupDiffIndices(GroupIndex(existingConfig.Groups), GroupIndex(newConfig.Groups))
 	if len(groupDiffs) > 0 {


### PR DESCRIPTION
This fixes the colorization of the diff output on Windows. Note, it only solves the problem in a cmd shell. It would be desirable to support color in Powershell Core windows as well.