### PR TITLE
Adds ./hack/trace script

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -126,6 +126,25 @@ container as a shared volume, so changes to the `.js`/`.css` assets will
 automatically propagate without needing a restart.
 
 
+### Debugging with dlv
+
+With concourse already running, during local development is possible to attach
+[`dlv`](https://github.com/derekparker/delve) to either the `web` or `worker` instance,
+allowing you to set breakpoints and inspect the current state of either one of those.
+
+To trace a running web instance:
+
+```sh
+./hack/trace web
+```
+
+To trace a running worker instance:
+
+```sh
+./hack/trace worker
+```
+
+
 ## Connecting to Postgres
 
 If you want to poke around the database, you can connect to the `db` node using

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV CONCOURSE_TSA_WORKER_PRIVATE_KEY /concourse-keys/worker_key
 # build Concourse
 COPY . /src
 WORKDIR /src
-RUN go build -o /usr/local/bin/concourse github.com/concourse/concourse/bin/cmd/concourse
+RUN go build -gcflags=all="-N -l" -o /usr/local/bin/concourse github.com/concourse/concourse/bin/cmd/concourse
 
 # override /src with a volume so we get live-updated packr stuff
 VOLUME /src

--- a/ci/dockerfiles/dev/Dockerfile
+++ b/ci/dockerfiles/dev/Dockerfile
@@ -43,7 +43,7 @@ COPY concourse /src
 RUN cd /src && \
       go mod download && \
       go install github.com/gobuffalo/packr/packr && \
-      packr build -o /usr/local/bin/concourse github.com/concourse/concourse/bin/cmd/concourse && \
+      packr build -gcflags=all="-N -l" -o /usr/local/bin/concourse github.com/concourse/concourse/bin/cmd/concourse && \
       rm -rf /src
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/concourse"]

--- a/hack/dlv/Dockerfile
+++ b/hack/dlv/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang
+
+RUN go get -u -v github.com/derekparker/delve/cmd/dlv

--- a/hack/trace
+++ b/hack/trace
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -o errexit
+
+readonly DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+container_name=""
+
+case $1 in
+web)
+  container_name="concourse_web_1"
+  ;;
+
+worker)
+  container_name="concourse_web_1"
+  ;;
+
+*)
+  echo "Usage: trace (web|worker)"
+  exit 1
+  ;;
+esac
+
+tracee_pid=$(docker exec $container_name pidof concourse)
+
+docker build --tag dlv ./dlv
+
+docker run \
+  --interactive \
+  --pid=container:$container_name \
+  --privileged \
+  --rm \
+  --tty \
+  --volume $DIR/..:/src \
+  dlv \
+  dlv attach $tracee_pid


### PR DESCRIPTION
Hey,

from the commit message:

```
The commit introduces the script `./hack/trace` whose
goal is to make debugging a running `web` or `worker` instance
possible through the use of [dlv][1].

It updates `Dockerfile` and `ci/Dockerfile` in order to not make
use of the default optimizations so that `dlv` can leverage the
most of the running process.

The script is capable to attach to either a worker or a web instance
by sharing the PID namespace of those. It can also display the source
code of the lines that match a given trace/breakpoint by having the
source code mounted as a volume in the expected locations.
```

One great enablement of using something like `dlv` during development is the ability to not need to stop a process and add `print`s everywhere - attach a break/tracepoint and there you go. 

Regarding the code itself, given that the Dockerfile under the root and `ci` are meant for development/testing only, I guess having those extra flags are not a problem, or am I wrong regarding that?

wdyt?

thx!

[1]: https://github.com/derekparker/delve


---

<img width="1770" alt="screen shot 2018-11-07 at 9 28 16 pm" src="https://user-images.githubusercontent.com/3574444/48200582-95240780-e32d-11e8-9d94-a40c66aafac7.png">
