### PR TITLE
Teach Prometheus metric emitter to include job names in `builds_finished`

### DIFF
--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -117,7 +117,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Name:      "finished",
 			Help:      "Count of builds finished across various dimensions.",
 		},
-		[]string{"team", "pipeline", "status"},
+		[]string{"team", "pipeline", "job", "status"},
 	)
 	prometheus.MustRegister(buildsFinishedVec)
 	buildDurationsVec := prometheus.NewHistogramVec(
@@ -323,12 +323,18 @@ func (emitter *PrometheusEmitter) buildFinishedMetrics(logger lager.Logger, even
 		return
 	}
 
+	job, exists := event.Attributes["job"]
+	if !exists {
+		logger.Error("failed-to-find-job-in-event", fmt.Errorf("expected job to exist in event.Attributes"))
+		return
+	}
+
 	buildStatus, exists := event.Attributes["build_status"]
 	if !exists {
 		logger.Error("failed-to-find-build_status-in-event", fmt.Errorf("expected build_status to exist in event.Attributes"))
 		return
 	}
-	emitter.buildsFinishedVec.WithLabelValues(team, pipeline, buildStatus).Inc()
+	emitter.buildsFinishedVec.WithLabelValues(team, pipeline, job, buildStatus).Inc()
 
 	// concourse_builds_(aborted|succeeded|failed|errored)_total
 	switch buildStatus {


### PR DESCRIPTION
concourse#2584 notes that it's difficult/impossible to use the Prometheus metric emitter's output to monitor specific jobs.

This PR goes some way towards addressing that by including a build's job name, alongside its team, pipeline and status, in the existing "builds_finished" counter.

This will increase the number of lines output by the Prometheus emitter by, at most, the `#jobs-in-each-pipeline`, replacing a single metric value with multiple values, labelled with job names.

For example, before this change, the Prometheus `/metrics` endpoint exposes the following:

```
concourse_builds_finished{pipeline="a-pipeline",status="failed",team="main"} 3
```

And after:

```
concourse_builds_finished{job="job-1",pipeline="a-pipeline",status="failed",team="main"} 1
concourse_builds_finished{job="job-2",pipeline="a-pipeline",status="failed",team="main"} 1
concourse_builds_finished{job="job-3",pipeline="a-pipeline",status="failed",team="main"} 1
```

This should not affect existing consumers, as folks using Prometheus's PromQL endpoints will have these metrics aggregated without grouping by the new label, resulting in counters which look the same before and after this change. They'll have the **ability** to slice'n'dice their data by an extra dimension, but it won't happen unless they explicitly choose.

(This has been unit tested, and tested with a `testflight` run against a local `docker-compose`'d instance, as per the contributing docs. This PR doesn't introduce tests as *nothing* in the emitter space is tested, and adding an entire test harness for that subsystem seems somewhat onerous for a minor feature addition which uses existing code and structures.)