### PR TITLE
atc: Return empty array instead of null

### DIFF
--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -232,6 +232,19 @@ var _ = Describe("Jobs API", func() {
 			})
 		})
 
+		Context("when there are no visible jobs", func() {
+			BeforeEach(func() {
+				dbJobFactory.VisibleJobsReturns(nil, nil)
+			})
+
+			It("returns empty array", func() {
+				body, err := ioutil.ReadAll(response.Body)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(body).To(MatchJSON(`[]`))
+			})
+		})
+
 		Context("when not authenticated", func() {
 			It("populates job factory with no team names", func() {
 				Expect(dbJobFactory.VisibleJobsCallCount()).To(Equal(1))

--- a/atc/api/jobserver/list_all.go
+++ b/atc/api/jobserver/list_all.go
@@ -21,7 +21,7 @@ func (s *Server) ListAllJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var jobs []atc.Job
+	jobs := []atc.Job{}
 
 	for _, job := range dashboard {
 		jobs = append(

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -135,6 +135,19 @@ var _ = Describe("Resources API", func() {
 				})
 			})
 
+			Context("when there are no visible resources", func() {
+				BeforeEach(func() {
+					dbResourceFactory.VisibleResourcesReturns(nil, nil)
+				})
+
+				It("returns empty array", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(body).To(MatchJSON(`[]`))
+				})
+			})
+
 			Context("when not authenticated", func() {
 				It("populates resource factory with no team names", func() {
 					Expect(dbResourceFactory.VisibleResourcesCallCount()).To(Equal(1))

--- a/atc/api/resourceserver/list_all.go
+++ b/atc/api/resourceserver/list_all.go
@@ -21,7 +21,7 @@ func (s *Server) ListAllResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var resources []atc.Resource
+	resources := []atc.Resource{}
 
 	for _, resource := range dbResources {
 		resources = append(


### PR DESCRIPTION
Fix for [#2555]. 

Always creating an empty slice instead of zero-length slice.