### PR TITLE
atc: Adds missing worker state metric to prometheus emitter

### DIFF
--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -452,7 +452,7 @@ func (event WorkersState) Emit(logger lager.Logger) {
 				Value: numericState,
 				State: eventState,
 				Attributes: map[string]string{
-					"name":         workerName,
+					"worker":       workerName,
 					"worker_state": string(workerState),
 				},
 			},


### PR DESCRIPTION
This PR adds a missing metric that was added before (worker state).

In the case of `prometheus`, it gets named as `concourse_worker_info`,
where `state` is just a label that we can use to aggregate on while
still having per-worker information (which can be further increased
later).

concourse/concourse#2499

With the feature in:

```sh
curl --silent localhost:9391/metrics | ag concourse_workers_info
# HELP concourse_workers_info Per-worker information
# TYPE concourse_workers_info gauge
concourse_workers_info{info="running",worker="ffbbd436b4a5"} 1
```

This way we're able to perform:


*ps.: tests were previously added in https://github.com/concourse/concourse/commit/ff2e45ff73cdf6cf3a9c3158420b1a00dd47a7a6, the issue where the metric (under `metrics.go`) was created.*

cc @YoussB 