### PR TITLE
atc: return non-zero array instead of null for pipelines with no jobs

### DIFF
--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -983,6 +983,7 @@ var _ = Describe("Jobs API", func() {
 					})
 				})
 			})
+
 			Context("when authorized", func() {
 				BeforeEach(func() {
 					fakeaccess.IsAuthorizedReturns(true)
@@ -1078,6 +1079,19 @@ var _ = Describe("Jobs API", func() {
 								"groups": []
 							}
 						]`))
+				})
+
+				Context("when there are no jobs in dashboard", func() {
+					BeforeEach(func() {
+						dashboardResponse = db.Dashboard{}
+						fakePipeline.DashboardReturns(dashboardResponse, nil)
+					})
+					It("should return an empty array", func() {
+						body, err := ioutil.ReadAll(response.Body)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(body).To(MatchJSON(`[]`))
+					})
 				})
 
 				Context("when manual triggering of a job is disabled", func() {

--- a/atc/api/jobserver/list.go
+++ b/atc/api/jobserver/list.go
@@ -13,7 +13,7 @@ func (s *Server) ListJobs(pipeline db.Pipeline) http.Handler {
 	logger := s.logger.Session("list-jobs")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var jobs []atc.Job
+		jobs := []atc.Job{}
 
 		dashboard, err := pipeline.Dashboard()
 


### PR DESCRIPTION
Fix for this issue: [1112](https://github.com/concourse/concourse/issues/1112). 

**FYI**: Original issue references `pipeline.yml` to only have a resource declared. Seems like that isn't applicable anymore since the user will get an error `"resource 'resourceName' is not used"`. Reproduce this issue by having only a `resource_types` in the `pipeline.yml`. 