### PR TITLE
Team name jQuery selector fix

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -110,7 +110,7 @@
         var pipelineName = pipelineInfo[0];
         var pipelineTeamName = pipelineInfo[1];
 
-        var team = $('#' + pipelineTeamName);
+        var team = $('div[id="' + pipelineTeamName + '"]');
         var title = team.find('.dashboard-pipeline[data-pipeline-name="' + pipelineName + '"]').find('.dashboard-pipeline-name');
 
         if(title.get(0).offsetWidth < title.get(0).scrollWidth){


### PR DESCRIPTION
## What this PR does

In reference to https://github.com/concourse/concourse/issues/2872#issuecomment-444931397 a quick fix of jQuery selector.

Having this will allow to use `.` in team names.