### PR TITLE
Add --handle option to hijack(intercept)

### DIFF
--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -2,11 +2,11 @@
 package concoursefakes
 
 import (
-	io "io"
-	sync "sync"
+	"io"
+	"sync"
 
-	atc "github.com/concourse/concourse/atc"
-	concourse "github.com/concourse/concourse/go-concourse/concourse"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type FakeTeam struct {
@@ -290,6 +290,19 @@ type FakeTeam struct {
 	}
 	getArtifactReturnsOnCall map[int]struct {
 		result1 io.ReadCloser
+		result2 error
+	}
+	GetContainerStub        func(string) (atc.Container, error)
+	getContainerMutex       sync.RWMutex
+	getContainerArgsForCall []struct {
+		arg1 string
+	}
+	getContainerReturns struct {
+		result1 atc.Container
+		result2 error
+	}
+	getContainerReturnsOnCall map[int]struct {
+		result1 atc.Container
 		result2 error
 	}
 	HidePipelineStub        func(string) (bool, error)
@@ -1873,6 +1886,69 @@ func (fake *FakeTeam) GetArtifactReturnsOnCall(i int, result1 io.ReadCloser, res
 	}{result1, result2}
 }
 
+func (fake *FakeTeam) GetContainer(arg1 string) (atc.Container, error) {
+	fake.getContainerMutex.Lock()
+	ret, specificReturn := fake.getContainerReturnsOnCall[len(fake.getContainerArgsForCall)]
+	fake.getContainerArgsForCall = append(fake.getContainerArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetContainer", []interface{}{arg1})
+	fake.getContainerMutex.Unlock()
+	if fake.GetContainerStub != nil {
+		return fake.GetContainerStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getContainerReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTeam) GetContainerCallCount() int {
+	fake.getContainerMutex.RLock()
+	defer fake.getContainerMutex.RUnlock()
+	return len(fake.getContainerArgsForCall)
+}
+
+func (fake *FakeTeam) GetContainerCalls(stub func(string) (atc.Container, error)) {
+	fake.getContainerMutex.Lock()
+	defer fake.getContainerMutex.Unlock()
+	fake.GetContainerStub = stub
+}
+
+func (fake *FakeTeam) GetContainerArgsForCall(i int) string {
+	fake.getContainerMutex.RLock()
+	defer fake.getContainerMutex.RUnlock()
+	argsForCall := fake.getContainerArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTeam) GetContainerReturns(result1 atc.Container, result2 error) {
+	fake.getContainerMutex.Lock()
+	defer fake.getContainerMutex.Unlock()
+	fake.GetContainerStub = nil
+	fake.getContainerReturns = struct {
+		result1 atc.Container
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTeam) GetContainerReturnsOnCall(i int, result1 atc.Container, result2 error) {
+	fake.getContainerMutex.Lock()
+	defer fake.getContainerMutex.Unlock()
+	fake.GetContainerStub = nil
+	if fake.getContainerReturnsOnCall == nil {
+		fake.getContainerReturnsOnCall = make(map[int]struct {
+			result1 atc.Container
+			result2 error
+		})
+	}
+	fake.getContainerReturnsOnCall[i] = struct {
+		result1 atc.Container
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTeam) HidePipeline(arg1 string) (bool, error) {
 	fake.hidePipelineMutex.Lock()
 	ret, specificReturn := fake.hidePipelineReturnsOnCall[len(fake.hidePipelineArgsForCall)]
@@ -3393,6 +3469,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.exposePipelineMutex.RUnlock()
 	fake.getArtifactMutex.RLock()
 	defer fake.getArtifactMutex.RUnlock()
+	fake.getContainerMutex.RLock()
+	defer fake.getContainerMutex.RUnlock()
 	fake.hidePipelineMutex.RLock()
 	defer fake.hidePipelineMutex.RUnlock()
 	fake.jobMutex.RLock()

--- a/go-concourse/concourse/containers.go
+++ b/go-concourse/concourse/containers.go
@@ -27,3 +27,21 @@ func (team *team) ListContainers(queryList map[string]string) ([]atc.Container, 
 	})
 	return containers, err
 }
+
+func (team *team) GetContainer(handle string) (atc.Container, error) {
+	var container atc.Container
+
+	params := rata.Params{
+		"id":        handle,
+		"team_name": team.name,
+	}
+
+	err := team.connection.Send(internal.Request{
+		RequestName: atc.GetContainer,
+		Params:      params,
+	}, &internal.Response{
+		Result: &container,
+	})
+
+	return container, err
+}

--- a/go-concourse/concourse/containers_test.go
+++ b/go-concourse/concourse/containers_test.go
@@ -81,4 +81,31 @@ var _ = Describe("ATC Handler Containers", func() {
 			})
 		})
 	})
+
+	Describe("GetContainer", func() {
+		Context("when passed a container handle", func() {
+			var expectedContainer atc.Container
+			BeforeEach(func() {
+				expectedURL := "/api/v1/teams/some-team/containers/myid-1"
+
+				expectedContainer = atc.Container{
+					ID:               "myid-1",
+					PipelineName:     "mypipeline-1",
+					WorkingDirectory: "/tmp/build/some-guid",
+				}
+
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", expectedURL),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedContainer),
+					),
+				)
+			})
+			It("should return the associated container", func() {
+				containers, err := team.GetContainer("myid-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(containers).To(Equal(expectedContainer))
+			})
+		})
+	})
 })

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -56,6 +56,7 @@ type Team interface {
 	BuildsWithVersionAsOutput(pipelineName string, resourceName string, resourceVersionID int) ([]atc.Build, bool, error)
 
 	ListContainers(queryList map[string]string) ([]atc.Container, error)
+	GetContainer(id string) (atc.Container, error)
 	ListVolumes() ([]atc.Volume, error)
 	CreateBuild(plan atc.Plan) (atc.Build, error)
 	Builds(page Page) ([]atc.Build, Pagination, error)


### PR DESCRIPTION
Fix for this [issue](https://github.com/concourse/concourse/issues/1081).

Couldn't think of a short hand for handle since `-h` is reserved for `help` and `i` is aliased to `intercept`. Open to suggestions for this!  