### PR TITLE
Retain job history

### DIFF
--- a/atc/job_config.go
+++ b/atc/job_config.go
@@ -1,8 +1,9 @@
 package atc
 
 type JobConfig struct {
-	Name   string `yaml:"name" json:"name" mapstructure:"name"`
-	Public bool   `yaml:"public,omitempty" json:"public,omitempty" mapstructure:"public"`
+	Name    string `yaml:"name" json:"name" mapstructure:"name"`
+	OldName string `yaml:"old_name,omitempty" json:"old_name,omitempty" mapstructure:"old_name"`
+	Public  bool   `yaml:"public,omitempty" json:"public,omitempty" mapstructure:"public"`
 
 	DisableManualTrigger bool     `yaml:"disable_manual_trigger,omitempty" json:"disable_manual_trigger,omitempty" mapstructure:"disable_manual_trigger"`
 	Serial               bool     `yaml:"serial,omitempty" json:"serial,omitempty" mapstructure:"serial"`

--- a/testflight/fixtures/rename-simple.yml
+++ b/testflight/fixtures/rename-simple.yml
@@ -1,0 +1,14 @@
+---
+jobs:
+- name: rename-simple
+  old_name: simple
+  plan:
+  - task: simple-task
+    config:
+      platform: linux
+      image_resource:
+        type: mock
+        source: {mirror_self: true}
+      run:
+        path: echo
+        args: ["Hello, world!"]

--- a/testflight/rename_job_test.go
+++ b/testflight/rename_job_test.go
@@ -1,0 +1,24 @@
+package testflight_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("Renaming a job", func() {
+	BeforeEach(func() {
+		setAndUnpausePipeline("fixtures/simple.yml")
+	})
+
+	It("retains job history", func() {
+		fly("trigger-job", "-j", inPipeline("simple"), "-w")
+		build := fly("builds", "-p", pipelineName)
+		Expect(build).To(gbytes.Say(pipelineName+"/simple"))
+
+		setPipeline("fixtures/rename-simple.yml")
+
+		build = fly("builds", "-p", pipelineName)
+		Expect(build).To(gbytes.Say(pipelineName+"/rename-simple"))
+	})
+})


### PR DESCRIPTION
Added functionality to update name of a job without losing history in response to issue [#1128](https://github.com/concourse/concourse/issues/1128). 
Also removing non active jobs to prevent wrong job history associated to a job. 

How it works:
Add `old_name` to config file where `old_name` is the current job name and update `name` field to new name. 