### PR TITLE
fix fly execute command

### DIFF
--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -203,7 +203,6 @@ func abortOnSignal(
 	err := client.AbortBuild(strconv.Itoa(build.ID))
 	if err != nil {
 		fmt.Fprintln(ui.Stderr, "failed to abort:", err)
-		os.Exit(2)
 	}
 
 	// if told to terminate again, exit immediately


### PR DESCRIPTION
go routine abortOnSignal is only executed once.

early exit on first signal will make following code never be executed, and the program will be stuck at that point. 