### PR TITLE
web: disable ascii art interaction

### DIFF
--- a/web/elm/src/Dashboard.elm
+++ b/web/elm/src/Dashboard.elm
@@ -844,7 +844,7 @@ welcomeCard { hoveredTopCliIcon, groups, userState } =
                     [ Html.text Text.setPipelineInstructions ]
                 ]
                     ++ loginInstruction userState
-            , Html.pre [ style Styles.asciiArt ] [ Html.text Text.asciiArt ]
+            , Html.pre [ style (Styles.asciiArt ++ Styles.disableInteraction) ] [ Html.text Text.asciiArt ]
             ]
         ]
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -2,6 +2,7 @@ module Dashboard.Styles exposing
     ( asciiArt
     , cardBody
     , cardFooter
+    , disableInteraction
     , highDensityIcon
     , highDensityToggle
     , info
@@ -459,12 +460,15 @@ welcomeCard =
     , ( "position", "relative" )
     , ( "overflow", "hidden" )
     , ( "font-weight", "400" )
+    , ( "display", "flex" )
+    , ( "flex-direction", "column" )
     ]
 
 
 welcomeCardBody : List ( String, String )
 welcomeCardBody =
     [ ( "font-size", "16px" )
+    , ( "z-index", "2" )
     ]
 
 
@@ -505,4 +509,16 @@ asciiArt =
     , ( "margin", "0" )
     , ( "white-space", "pre" )
     , ( "color", Colors.asciiArt )
+    , ( "z-index", "1" )
+    ]
+
+disableInteraction: List ( String, String )
+disableInteraction =
+    [ ("cursor", "default")
+    , ("user-select", "none")
+    , ("-ms-user-select", "none")
+    , ("-moz-user-select", "none")
+    , ("-khtml-user-select", "none")
+    , ("-webkit-user-select", "none")
+    , ("-webkit-touch-callout", "none")
     ]

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -345,6 +345,31 @@ all =
                                 ]
                             ]
                         ]
+                    , describe "ascii art" <|
+                        let
+                            art : () -> Query.Single Msgs.Msg
+                            art =
+                                subject >> Query.children [] >> Query.index 2
+                        in
+                        [ test "not selectable for all browsers" <|
+                            art
+                                >> Query.has
+                                    [ style
+                                        [ ( "user-select", "none" )
+                                        , ("-ms-user-select", "none")
+                                        , ("-moz-user-select", "none")
+                                        , ("-khtml-user-select", "none")
+                                        , ("-webkit-user-select", "none")
+                                        , ("-webkit-touch-callout", "none")
+                                        ]
+                                    ]
+                        , test "cursor is set to default" <|
+                            art
+                                >> Query.has
+                                [ style
+                                    [ ("cursor", "default") ]
+                                ]
+                        ]
                     ]
             in
             [ describe "when unauthenticated with no teams" <|


### PR DESCRIPTION
Just think that ascii art not being selectable would be better... wdyt? 
![screen shot 2019-01-11 at 9 55 17 am](https://user-images.githubusercontent.com/14202461/51041055-062ea800-1587-11e9-80f6-e509b2ff07d9.png)
vs.
![screen shot 2019-01-11 at 9 53 38 am](https://user-images.githubusercontent.com/14202461/51040970-d089bf00-1586-11e9-85b9-e9cbdf4c1625.png)
