### PR TITLE
ci: Add worker-rebalancing to prod deployment

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -803,6 +803,7 @@ jobs:
       - cbd/cluster/operations/windows-worker-network.yml
       - cbd/cluster/operations/debug-concourse.yml
       - cbd/cluster/operations/syslog-drainer.yml
+      - cbd/cluster/operations/worker-rebalancing.yml
       vars_files:
       - cbd/versions.yml
       vars:
@@ -831,6 +832,7 @@ jobs:
         default_task_memory_limit: 5GB
         default_task_cpu_limit: 1024
         container_placement_strategy: "least-build-containers"
+        worker_rebalance_interval: 30m
 
 
 - name: push-docs


### PR DESCRIPTION
Hey,

This PR is intended to configure the worker rebalancing interval as introduced in the corresponding concourse-bosh-deployment PR: https://github.com/concourse/concourse-bosh-deployment/pull/135 .

This is my first time updating a bosh deployment; please let me know if I missed something :grin: 

Thanks!

--

*ps.: the pipeline has *not* been "set" yet under `ci`.*