### PR TITLE
ci: bring back `concourse-rc` image to the pipeline [#3000]

### DIFF
--- a/ci/dockerfiles/rc/Dockerfile
+++ b/ci/dockerfiles/rc/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:bionic
+
+
+ENV \
+  CONCOURSE_RESOURCE_TYPES=/concourse-resource-types \
+  CONCOURSE_WORK_DIR=/worker-state \
+  CONCOURSE_GARDEN_DNS_PROXY_ENABLE=true
+
+
+RUN apt update && apt install -y \
+    ca-certificates \
+    btrfs-tools \
+    dumb-init \
+    iproute2
+
+
+ADD ./rc/bin/concourse /usr/local/bin
+ADD ./rc/bin/gdn /usr/local/bin
+ADD ./rc/resource-types /concourse-resource-types
+ADD ./rc/fly-assets /
+
+
+ENTRYPOINT ["dumb-init", "/usr/local/bin/concourse"]
+

--- a/ci/dockerfiles/rc/Dockerfile
+++ b/ci/dockerfiles/rc/Dockerfile
@@ -24,9 +24,6 @@ ENV CONCOURSE_WORKER_GARDEN_DNS_PROXY_ENABLE  true
 ENV CONCOURSE_WORK_DIR                /worker-state
 ENV CONCOURSE_WORKER_WORK_DIR         /worker-state
 
-# location for base resource types
-ENV CONCOURSE_RESOURCE_TYPES          /usr/local/concourse/resource-types
-
 # volume for non-aufs/etc. mount for baggageclaim's driver
 VOLUME /worker-state
 

--- a/ci/dockerfiles/rc/Dockerfile
+++ b/ci/dockerfiles/rc/Dockerfile
@@ -1,24 +1,42 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic AS ubuntu
+
+FROM ubuntu AS assets
+COPY ./rc/*.tgz /tmp
+RUN tar xzf /tmp/*tgz -C /usr/local
 
 
-ENV \
-  CONCOURSE_RESOURCE_TYPES=/concourse-resource-types \
-  CONCOURSE_WORK_DIR=/worker-state \
-  CONCOURSE_GARDEN_DNS_PROXY_ENABLE=true
+FROM ubuntu
 
+# 'web' keys
+ENV CONCOURSE_SESSION_SIGNING_KEY     /concourse-keys/session_signing_key
+ENV CONCOURSE_TSA_AUTHORIZED_KEYS     /concourse-keys/authorized_worker_keys
+ENV CONCOURSE_TSA_HOST_KEY            /concourse-keys/tsa_host_key
+
+# 'worker' keys
+ENV CONCOURSE_TSA_PUBLIC_KEY          /concourse-keys/tsa_host_key.pub
+ENV CONCOURSE_TSA_WORKER_PRIVATE_KEY  /concourse-keys/worker_key
+
+# enable DNS proxy to support Docker's 127.x.x.x DNS server
+ENV CONCOURSE_GARDEN_DNS_PROXY_ENABLE         true
+ENV CONCOURSE_WORKER_GARDEN_DNS_PROXY_ENABLE  true
+
+# auto-wire work dir for 'worker' and 'quickstart'
+ENV CONCOURSE_WORK_DIR                /worker-state
+ENV CONCOURSE_WORKER_WORK_DIR         /worker-state
+
+# location for base resource types
+ENV CONCOURSE_RESOURCE_TYPES          /usr/local/concourse/resource-types
+
+# volume for non-aufs/etc. mount for baggageclaim's driver
+VOLUME /worker-state
 
 RUN apt update && apt install -y \
-    ca-certificates \
     btrfs-tools \
+    ca-certificates \
     dumb-init \
     iproute2
 
-
-ADD ./rc/bin/concourse /usr/local/bin
-ADD ./rc/bin/gdn /usr/local/bin
-ADD ./rc/resource-types /concourse-resource-types
-ADD ./rc/fly-assets /
+COPY --from=assets /usr/local/concourse /usr/local/concourse
 
 
-ENTRYPOINT ["dumb-init", "/usr/local/bin/concourse"]
-
+ENTRYPOINT ["dumb-init", "/usr/local/concourse/bin/concourse"]

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -37,6 +37,7 @@ groups:
   - unit
   - lint
   - dev-image
+  - rc-image
   - testflight
   - watsjs
   - rc
@@ -234,17 +235,17 @@ jobs:
   plan:
   - aggregate:
     - get: concourse
-      passed: [watsjs, testflight]
+      passed: [rc-image]
       trigger: true
     - get: k8s-dev-image
       passed: [k8s-dev-image]
       trigger: true
-    - get: dev-image
-      passed: [watsjs, testflight]
+    - get: rc-image
+      trigger: true
+      passed: [rc-image]
       params: {format: oci}
     - get: unit-image
-      passed: [watsjs, testflight]
-      trigger: true
+      passed: [rc-image]
     - get: charts
       trigger: true
   - task: terraform-k8s-smoke
@@ -259,8 +260,8 @@ jobs:
     params:
      KUBE_CONFIG: ((kube_config))
      RELEASE_NAME: concourse-smoke
-     CONCOURSE_IMAGE: concourse/dev
-    input_mapping: {endpoint-info: outputs, image-info: dev-image}
+     CONCOURSE_IMAGE: concourse/concourse-rc
+    input_mapping: {endpoint-info: outputs, image-info: rc-image}
     image: k8s-dev-image
   - task: smoke
     image: unit-image
@@ -296,10 +297,13 @@ jobs:
     - get: concourse
       passed: [k8s-smoke]
       trigger: true
-    - get: dev-image
+    - get: rc-image
       passed: [k8s-smoke]
+      trigger: true
       params: {format: oci}
     - get: k8s-dev-image
+      passed: [k8s-smoke]
+      trigger: true
     - get: charts
       trigger: true
       passed: [k8s-smoke]
@@ -308,7 +312,7 @@ jobs:
     image: k8s-dev-image
     params:
      KUBE_CONFIG: ((kube_config))
-     CONCOURSE_IMAGE_NAME: concourse/dev
+     CONCOURSE_IMAGE_NAME: concourse/concourse-rc
 
 - name: k8s-dev-image
   public: true
@@ -407,6 +411,28 @@ jobs:
     - put: darwin-rc
       params: {file: concourse-darwin/concourse-*.tgz}
       inputs: [concourse-darwin]
+
+- name: rc-image
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: linux-rc
+      trigger: true
+      passed: [ build-rc ]
+    - get: unit-image
+      passed: [ build-rc ]
+    - get: concourse
+      passed: [ build-rc ]
+    - get: builder
+  - task: build
+    image: builder
+    privileged: true
+    file: concourse/ci/tasks/rc-image.yml
+  - put: rc-image
+    params: {image: image/image.tar}
+    get_params: {format: oci}
+
 
 - name: bin-smoke
   public: true
@@ -931,6 +957,13 @@ resources:
   type: registry-image
   source:
     repository: concourse/dev
+    username: ((docker.username))
+    password: ((docker.password))
+
+- name: rc-image
+  type: registry-image
+  source:
+    repository: concourse/concourse-rc
     username: ((docker.username))
     password: ((docker.password))
 

--- a/ci/tasks/rc-image.yml
+++ b/ci/tasks/rc-image.yml
@@ -1,0 +1,27 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/builder}
+
+inputs:
+- name: concourse
+- name: linux-rc
+  path: rc
+
+outputs:
+- name: image
+
+params:
+  DOCKERFILE: concourse/ci/dockerfiles/rc/Dockerfile
+  REPOSITORY: concourse/concourse-rc
+  CONTEXT: .
+
+run:
+  path: /bin/bash
+  args:
+    - -ce
+    - |
+      tar xzf ./rc/concourse-*.tgz --strip-components=1 --directory=rc
+      build

--- a/ci/tasks/rc-image.yml
+++ b/ci/tasks/rc-image.yml
@@ -19,9 +19,4 @@ params:
   CONTEXT: .
 
 run:
-  path: /bin/bash
-  args:
-    - -ce
-    - |
-      tar xzf ./rc/concourse-*.tgz --strip-components=1 --directory=rc
-      build
+  path: build


### PR DESCRIPTION
Hey, 

This PR is intended to address the need for having an RC image being built in the pipeline (#3000) so that k8s-smoke, k8s-topgun, and hush-house can use that instead of `dev`.

#### Testing

To test it out, I used `fly execute` with the local changes, which seem to indicate that everything is working:

```sh
# Execute the `rc-image` task consuming some inputs from
# the bin-smoke job (which has similar inputs as `rc-image`).
fly -t ci \
  execute \
  -c ./ci/tasks/rc-image.yml \
  --input=concourse=./ \
  --inputs-from=concourse/bin-smoke \
  -p
```

ps.: when testing I included an extra `img login && img push cirocosta/concourse` so I could manually test the final artifact (the image) in k8s.

#### Image tag

if I understood correctly, [`registry-image`](https://github.com/concourse/registry-image-resource) seems to not support dynamic tag versioning right now (see https://github.com/concourse/registry-image-resource/issues/7  for some discussions around support for tagging built images), so the pipeline is default'ing to have the image being pushed to `concourse/concourse-rc:latest`.

#### How it looks

If you're wondering how the pipeline looks after the changes, check out below.

1. With develop & k8s & bosh:

![first](https://user-images.githubusercontent.com/3574444/51073763-db565980-1643-11e9-9795-1d6a087be716.png)

2. With develop & k8s:

![second](https://user-images.githubusercontent.com/3574444/51073764-db565980-1643-11e9-9bd7-aed97cbec06e.png)

Please let me know if I missed anything,

Thx!