### PR TITLE
POC for fly curl

### DIFF
--- a/fly/commands/curl.go
+++ b/fly/commands/curl.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/concourse/concourse/fly/commands/internal/curler"
+	"github.com/concourse/concourse/fly/rc"
+	"github.com/pkg/errors"
+	"strings"
+)
+
+type CurlCommand struct {
+}
+
+func (command *CurlCommand) validate(args []string) error {
+	if len(args) != 1 {
+		return errors.New("please provide a path you wish to curl")
+	}
+
+	if !strings.HasPrefix(args[0], "/api") {
+		return errors.New("path must start with /api")
+	}
+	return nil
+}
+
+func (command *CurlCommand) Execute(args []string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	if err := target.Validate(); err != nil {
+		return err
+	}
+
+	if err := command.validate(args); err != nil {
+		return err
+	}
+
+	curl := curler.New(target.Client().HTTPClient(), target.URL())
+
+	body, respHeaders, err := curl.It(args[0])
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(respHeaders))
+	fmt.Println(string(body))
+
+
+	return nil
+}

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -69,6 +69,8 @@ type FlyCommand struct {
 	Workers     WorkersCommand     `command:"workers" alias:"ws" description:"List the registered workers"`
 	LandWorker  LandWorkerCommand  `command:"land-worker" alias:"lw" description:"Land a worker"`
 	PruneWorker PruneWorkerCommand `command:"prune-worker" alias:"pw" description:"Prune a stalled, landing, landed, or retiring worker"`
+
+	Curl CurlCommand `command:"curl" alias:"c" description:"Executes a request to the targeted API endpoint"`
 }
 
 var Fly FlyCommand

--- a/fly/commands/internal/curler/curler.go
+++ b/fly/commands/internal/curler/curler.go
@@ -1,0 +1,50 @@
+package curler
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"path"
+)
+
+type Curler struct {
+	httpClient   *http.Client
+	concourseURL string
+}
+
+func New(httpClient *http.Client, concourseURL string) Curler {
+	return Curler{
+		httpClient:   httpClient,
+		concourseURL: concourseURL,
+	}
+}
+
+func (c Curler) It(apiPath string) (body []byte, respHeaders []byte, err error) {
+	url, err := url.Parse(c.concourseURL)
+	if err != nil {
+		return
+	}
+
+	url.Path = path.Join(url.Path, apiPath)
+	req, err := http.NewRequest("GET", url.String(), nil)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != 200 {
+		err = errors.New(resp.Status)
+		return
+	}
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	respHeaders, err = httputil.DumpResponse(resp, false)
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/peterhellberg/link v1.0.0
+	github.com/pkg/errors v0.8.0
 	github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5
 	github.com/prometheus/client_golang v0.9.0-pre1
 	github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735 // indirect


### PR DESCRIPTION
Howdie!

Sometimes we do stuff that maybe we should not. Stuff like programatically disable a resources version or doing other things with side effects that are not exposed via the fly cli. We maintain a fairly large Concourse cluster with ~550 pipelines so sometimes we just need to get our hands dirty.

For these cases it would be super neat to be able to

```
fly -t ${CONCOURSE_TEAM} curl -XPUT /api/v1/teams/${CONCOURSE_TEAM}/pipelines/${PIPELINE_NAME}/resources/version/versions/${ID}/disable
```

instead of doing janky bash/curl stuff

```
AUTH="Authorization: Bearer$(grep 'value: ' ~/.flyrc | cut -d: -f2)"
VERSION_URL="${CONCOURSE_URL}/api/v1/teams/${CONCOURSE_TEAM}/pipelines/${PIPELINE_NAME}/resources/version/versions"
curl -sSH "${AUTH}" -X PUT ${VERSION_URL}/${ID}/disable
```

Here is a untested POC that can do GET's. If this is something you would merge let me know and we can test and properly implement the functionality.

```
$ pwd
/Users/sjo4473/src/concourse/fly
$ go run main.go -t myTeam curl /api/v1/teams/myTeam/pipelines
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Connection: keep-alive
Content-Type: application/json
Date: Wed, 16 Jan 2019 12:44:08 GMT
Server: nginx/1.15.6
Strict-Transport-Security: max-age=15724800; includeSubDomains
Vary: Accept-Encoding
X-Concourse-Version: 4.2.2
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Xss-Protection: 1; mode=block


[{"id":738,"name":"myPipeline","paused":true,"public":false,"team_name":"myTeam"},......
```