### PR TITLE
Revert role sorting

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -39,21 +39,17 @@ func (a *access) IsAuthorized(team string) bool {
 	return false
 }
 
-func CompareRoles(role1, role2 string) bool {
-	switch role1 {
+func (a *access) HasPermission(role string) bool {
+	switch requiredRoles[a.action] {
 	case "owner":
-		return true
+		return role == "owner"
 	case "member":
-		return role2 != "owner"
+		return role == "owner" || role == "member"
 	case "viewer":
-		return role2 == "viewer"
+		return role == "owner" || role == "member" || role == "viewer"
 	default:
 		return false
 	}
-}
-
-func (a *access) HasPermission(role string) bool {
-	return CompareRoles(role, requiredRoles[a.action])
 }
 
 func (a *access) IsAdmin() bool {

--- a/atc/api/accessor/accessor_test.go
+++ b/atc/api/accessor/accessor_test.go
@@ -335,6 +335,10 @@ var _ = Describe("Accessor", func() {
 
 			Expect(access.IsAuthorized("some-team")).To(Equal(authorized))
 		},
+		Entry("owner :: table has no entry", "some-role", "owner", false),
+		Entry("member :: table has no entry", "some-role", "member", false),
+		Entry("viewer :: table has no entry", "some-role", "viewer", false),
+
 		Entry("owner :: "+atc.SaveConfig, atc.SaveConfig, "owner", true),
 		Entry("member :: "+atc.SaveConfig, atc.SaveConfig, "member", true),
 		Entry("viewer :: "+atc.SaveConfig, atc.SaveConfig, "viewer", false),

--- a/fly/commands/teams.go
+++ b/fly/commands/teams.go
@@ -7,7 +7,6 @@ import (
 
 	"strings"
 
-	"github.com/concourse/concourse/atc/api/accessor"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
@@ -98,21 +97,7 @@ func (command *TeamsCommand) Execute([]string) error {
 		}
 	}
 
-	if command.Details {
-		roleComparator := func(i, j int) bool {
-			role1 := getRoleFromTableRow(table.Data[i])
-			role2 := getRoleFromTableRow(table.Data[j])
-			return !accessor.CompareRoles(role2, role1)
-		}
-
-		sort.SliceStable(table.Data, roleComparator)
-	} else {
-		sort.Sort(table.Data)
-	}
+	sort.Sort(table.Data)
 
 	return table.Render(os.Stdout, Fly.PrintTableHeaders)
-}
-
-func getRoleFromTableRow(row ui.TableRow) string {
-	return strings.Split(row[0].Contents, "/")[1]
 }

--- a/fly/commands/teams.go
+++ b/fly/commands/teams.go
@@ -100,18 +100,9 @@ func (command *TeamsCommand) Execute([]string) error {
 
 	if command.Details {
 		roleComparator := func(i, j int) bool {
-			team1, role1 := getRoleFromTableRow(table.Data[i])
-			team2, role2 := getRoleFromTableRow(table.Data[j])
-
-			if team1 < team2 {
-				return true
-			}
-
-			if team1 == team2 && accessor.CompareRoles(role1, role2) {
-				return true
-			}
-
-			return false
+			role1 := getRoleFromTableRow(table.Data[i])
+			role2 := getRoleFromTableRow(table.Data[j])
+			return !accessor.CompareRoles(role2, role1)
 		}
 
 		sort.SliceStable(table.Data, roleComparator)
@@ -122,8 +113,6 @@ func (command *TeamsCommand) Execute([]string) error {
 	return table.Render(os.Stdout, Fly.PrintTableHeaders)
 }
 
-func getRoleFromTableRow(row ui.TableRow) (string, string) {
-	team := strings.Split(row[0].Contents, "/")[0]
-	role := strings.Split(row[0].Contents, "/")[1]
-	return team, role
+func getRoleFromTableRow(row ui.TableRow) string {
+	return strings.Split(row[0].Contents, "/")[1]
 }

--- a/fly/integration/teams_test.go
+++ b/fly/integration/teams_test.go
@@ -174,12 +174,12 @@ var _ = Describe("Fly CLI", func() {
 							{Contents: "auth", Color: color.New(color.Bold)},
 						},
 						Data: []ui.TableRow{
+							{{Contents: "main/owner"}, {Contents: "all"}, {Contents: "none"}},
 							{{Contents: "a-team/owner"}, {Contents: "none"}, {Contents: "github:github-org"}},
-							{{Contents: "b-team/member"}, {Contents: "github:github-user"}, {Contents: "none"}},
 							{{Contents: "c-team/owner"}, {Contents: "github:github-user"}, {Contents: "github:github-org"}},
+							{{Contents: "b-team/member"}, {Contents: "github:github-user"}, {Contents: "none"}},
 							{{Contents: "c-team/member"}, {Contents: "github:github-user"}, {Contents: "github:github-org"}},
 							{{Contents: "c-team/viewer"}, {Contents: "github:github-user"}, {Contents: "github:github-org"}},
-							{{Contents: "main/owner"}, {Contents: "all"}, {Contents: "none"}},
 						},
 					}))
 				})

--- a/fly/integration/teams_test.go
+++ b/fly/integration/teams_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Fly CLI", func() {
 					flyCmd.Args = append(flyCmd.Args, "--details")
 				})
 
-				It("lists them to the user, ordered by roles level and name", func() {
+				It("lists them to the user, ordered by name", func() {
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -174,12 +174,12 @@ var _ = Describe("Fly CLI", func() {
 							{Contents: "auth", Color: color.New(color.Bold)},
 						},
 						Data: []ui.TableRow{
-							{{Contents: "main/owner"}, {Contents: "all"}, {Contents: "none"}},
 							{{Contents: "a-team/owner"}, {Contents: "none"}, {Contents: "github:github-org"}},
-							{{Contents: "c-team/owner"}, {Contents: "github:github-user"}, {Contents: "github:github-org"}},
 							{{Contents: "b-team/member"}, {Contents: "github:github-user"}, {Contents: "none"}},
 							{{Contents: "c-team/member"}, {Contents: "github:github-user"}, {Contents: "github:github-org"}},
+							{{Contents: "c-team/owner"}, {Contents: "github:github-user"}, {Contents: "github:github-org"}},
 							{{Contents: "c-team/viewer"}, {Contents: "github:github-user"}, {Contents: "github:github-org"}},
+							{{Contents: "main/owner"}, {Contents: "all"}, {Contents: "none"}},
 						},
 					}))
 				})

--- a/skymarshal/token/issuer.go
+++ b/skymarshal/token/issuer.go
@@ -2,11 +2,9 @@ package token
 
 import (
 	"errors"
-	"sort"
 	"strings"
 	"time"
 
-	"github.com/concourse/concourse/atc/api/accessor"
 	"github.com/concourse/concourse/atc/db"
 	"golang.org/x/oauth2"
 )
@@ -106,13 +104,9 @@ func (i *issuer) Issue(verifiedClaims *VerifiedClaims) (*oauth2.Token, error) {
 
 	teams := map[string][]string{}
 	for team, roles := range teamSet {
-		for role := range roles {
+		for role, _ := range roles {
 			teams[team] = append(teams[team], role)
 		}
-		roleComparator := func(i, j int) bool {
-			return accessor.CompareRoles(teams[team][i], teams[team][j])
-		}
-		sort.Slice(teams[team], roleComparator)
 	}
 
 	if len(teams) == 0 {

--- a/skymarshal/token/issuer_test.go
+++ b/skymarshal/token/issuer_test.go
@@ -362,12 +362,11 @@ var _ = Describe("Token Issuer", func() {
 						})
 					})
 
-					It("calls generate with expected team claims, with roles in descending order", func() {
+					It("calls generate with expected team claims", func() {
 						AssertIssueToken()
 						claims := fakeGenerator.GenerateArgsForCall(0)
-						teams := claims["teams"].(map[string][]string)
-						Expect(teams["fake-team-1"]).To(Equal([]string{"owner", "member", "viewer"}))
 						Expect(claims["is_admin"]).To(BeFalse())
+						Expect(claims["teams"]).To(HaveKeyWithValue("fake-team-1", ConsistOf("owner", "member", "viewer")))
 					})
 
 					AssertTokenClaims()


### PR DESCRIPTION
This reverts the role sorting.

It introduced a bug where any new handlers that weren't part of the accessor map would default to being granted access in the `accessor.HasPermission` method call. We want the default behaviour in this case to restrict access for unknown handlers.

We also added a new test to cover the case where the action doesn't exist in the role map.