### PR TITLE
add config for stale and no-response bots

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,10 @@
+daysUntilClose: 14
+
+responseRequiredLabel: needs-more-information
+
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author.
+
+  It will be re-opened when the original author replies. Otherwise, a new issue
+  should be created to continue the conversation. Thank you!

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,27 @@
+only: issues
+
+daysUntilStale: 60
+
+daysUntilClose: 7
+
+exemptLabels:
+- triage
+- help wanted
+- good first issue
+
+staleLabel: wontfix
+
+exemptProjects: true
+
+issues:
+  markComment: |
+    Beep boop! This issue has been idle for long enough that it's time to check
+    in and see if it's still important.
+
+    If it is, what is blocking it? Would anyone be interested in [submitting a
+    PR](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md) or
+    continuing the discussion to help move things forward?
+
+    If no activity is observed within the next week, this issue will be
+    ~~exterminated~~ closed, in accordance with our [stale issue
+    process](https://github.com/concourse/concourse/wiki/How-Issues-are-Managed#staleness).


### PR DESCRIPTION
Trying to have them not sound too stern but also not be too verbose. So the stale bot for example links to the wiki describing our stale issue process.

This, in combination with the new [How Issues are Managed](https://github.com/concourse/concourse/wiki/How-Issues-are-Managed) wiki fixes #3004.