### PR TITLE
fly curl command

### DIFF
--- a/fly/commands/curl.go
+++ b/fly/commands/curl.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/concourse/concourse/fly/rc"
+	"io/ioutil"
+	"net/http/httputil"
+	"os"
+)
+
+type CurlCommand struct {
+	Method        string   `short:"X" description:"method" default:"GET"`
+	OutputHeaders bool     `short:"I" description:"output response headers"`
+	Headers       []string `short:"H" description:"HTTP Header"`
+	Body          string   `short:"d" description:"Body"`
+}
+
+func (command *CurlCommand) Execute(args []string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("path required")
+	}
+
+	cr := CurlRequest{
+		Host:    target.URL(),
+		Path:    args[0],
+		Method:  command.Method,
+		Headers: command.Headers,
+		Body:    command.Body,
+	}
+
+	req, err := cr.CreateHttpRequest()
+	if err != nil {
+		return err
+	}
+
+	res, err := target.Client().HTTPClient().Do(req)
+	if err != nil {
+		return err
+	}
+
+	resBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return fmt.Errorf("%s\n%s", res.Status, resBody)
+	}
+
+	if command.OutputHeaders {
+		headers, err := httputil.DumpResponse(res, false)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stdout, string(headers))
+		return nil
+	}
+
+	fmt.Fprintln(os.Stdout, string(resBody))
+	return nil
+}

--- a/fly/commands/curl_request.go
+++ b/fly/commands/curl_request.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+)
+
+type CurlRequest struct {
+	Host    string
+	Path    string
+	Method  string
+	Headers []string
+	Body    string
+}
+
+func (r CurlRequest) CreateHttpRequest() (*http.Request, error) {
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+
+	url, err := url.Parse(r.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyReader, err := r.createBodyReader()
+	if err != nil {
+		return nil, err
+	}
+
+	url.Path = path.Join(url.Path, r.Path)
+	req, err := http.NewRequest(r.Method, url.String(), bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, h := range r.Headers {
+		parts := strings.SplitN(h, ":", 2)
+		req.Header.Set(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+	}
+
+	return req, nil
+}
+
+func (r CurlRequest) createBodyReader() (io.Reader, error) {
+	if strings.HasPrefix(r.Body, "@") {
+		path := r.Body[1:]
+		return os.Open(strings.TrimSpace(path))
+	}
+	return strings.NewReader(r.Body), nil
+}
+
+func (r CurlRequest) validate() error {
+	for _, h := range r.Headers {
+		if !strings.Contains(h, ":") {
+			return invalidHeaderError(h)
+		}
+	}
+	return nil
+}
+
+func invalidHeaderError(value string) error {
+	return fmt.Errorf("invalid header: %s", value)
+}

--- a/fly/commands/curl_request_test.go
+++ b/fly/commands/curl_request_test.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+)
+
+var _ = Describe("CurlRequest", func() {
+
+	It("creates an http request", func() {
+		requester := CurlRequest{
+			Host:   "concourse.foo.com/",
+			Path:   "/some/path",
+			Method: "PUT",
+			Headers: []string{
+				"foo: bar:baz",
+				"Accept-Encoding: application/json",
+			},
+			Body: "body-text",
+		}
+
+		r, err := requester.CreateHttpRequest()
+
+		Expect(err).To(BeNil())
+		Expect(r.URL.Path).To(Equal("concourse.foo.com/some/path"))
+		Expect(r.Method).To(Equal("PUT"))
+		Expect(r.Header.Get("foo")).To(Equal("bar:baz"))
+		Expect(r.Header.Get("Accept-Encoding")).To(Equal("application/json"))
+
+		body, err := ioutil.ReadAll(r.Body)
+		Expect(string(body)).To(Equal("body-text"))
+	})
+
+	It("errors with invalid header", func() {
+		requester := CurlRequest{
+			Host:   "concourse.foo.com/",
+			Path:   "/some/path",
+			Method: "PUT",
+			Headers: []string{
+				"foo",
+			},
+		}
+
+		_, err := requester.CreateHttpRequest()
+		Expect(err).To(Equal(invalidHeaderError(requester.Headers[0])))
+	})
+
+	It("reads body from file", func() {
+		f, _ := ioutil.TempFile("", "tempy-temp")
+		defer os.Remove(f.Name())
+
+		expectedContent := "Waka waka hazznah"
+		f.Write([]byte(expectedContent))
+
+		requester := CurlRequest{
+			Host:   "concourse.foo.com/",
+			Path:   "/some/path",
+			Method: "PUT",
+			Headers: []string{
+				"foo: bar:baz",
+				"Accept-Encoding: application/json",
+			},
+			Body: fmt.Sprintf("@%s", f.Name()),
+		}
+
+		r, err := requester.CreateHttpRequest()
+
+		Expect(err).To(BeNil())
+		Expect(r.URL.Path).To(Equal("concourse.foo.com/some/path"))
+		Expect(r.Method).To(Equal("PUT"))
+		Expect(r.Header.Get("foo")).To(Equal("bar:baz"))
+		Expect(r.Header.Get("Accept-Encoding")).To(Equal("application/json"))
+
+		body, err := ioutil.ReadAll(r.Body)
+		Expect(string(body)).To(Equal(expectedContent))
+	})
+
+	It("returns error if filepath in body doesnt exist", func() {
+		badPath := "/tmp/this/will/most/likely/never/exist/i/hope"
+
+		requester := CurlRequest{
+			Host:   "concourse.foo.com/",
+			Path:   "/some/path",
+			Method: "PUT",
+			Headers: []string{
+				"foo: bar:baz",
+				"Accept-Encoding: application/json",
+			},
+			Body: fmt.Sprintf("@%s", badPath),
+		}
+
+		_, err := requester.CreateHttpRequest()
+
+		Expect(err).To(HaveOccurred())
+		Expect((err.(*os.PathError)).Path).To(Equal(badPath))
+	})
+
+})

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -69,6 +69,8 @@ type FlyCommand struct {
 	Workers     WorkersCommand     `command:"workers" alias:"ws" description:"List the registered workers"`
 	LandWorker  LandWorkerCommand  `command:"land-worker" alias:"lw" description:"Land a worker"`
 	PruneWorker PruneWorkerCommand `command:"prune-worker" alias:"pw" description:"Prune a stalled, landing, landed, or retiring worker"`
+
+	Curl CurlCommand `command:"curl" description:"Curl the API"`
 }
 
 var Fly FlyCommand


### PR DESCRIPTION
Hi, this adds the `fly curl` command, as discussed here: https://github.com/concourse/concourse/pull/3056

```fly curl PATH [-I] [-X METHOD] [-H HEADER] [-d DATA]```

Examples:
```
fly curl /api/v1/pipelines
fly curl /api/v1/teams/myteam/pipelines/mypipeline/config -X PUT -D @pipeline.yml -H 'application/yaml'
```

Options:
```
-X  HTTP method
-H  Custom headers to include in the request, flag can be specified multiple times
-d  HTTP data to include in the request body, or '@' followed by a file name to read the data from
-I  Output response headers
```

