### PR TITLE
hack: base delve image off concourse:local

### DIFF
--- a/hack/dlv/Dockerfile
+++ b/hack/dlv/Dockerfile
@@ -1,3 +1,5 @@
-FROM golang
+FROM concourse/concourse:local
 
 RUN go get -u -v github.com/derekparker/delve/cmd/dlv
+
+ENTRYPOINT [ "dlv" ]

--- a/hack/trace
+++ b/hack/trace
@@ -30,6 +30,5 @@ docker run \
   --privileged \
   --rm \
   --tty \
-  --mount type=bind,source="$(pwd)",target=/src \
   dlv \
-  dlv attach $trace_pid
+  attach $trace_pid


### PR DESCRIPTION
this allows go modules to be debugged by including them in the container


here's an example of what that debugging the baggageclaim module looks like:
```
> github.com/concourse/baggageclaim/volume/driver.(*OverlayDriver).CreateVolume() /go/pkg/mod/github.com/concourse/baggageclaim@v1.3.3/volume/driver/overlay_linux.go:19 (PC: 0x1d53fe3)
    14:
    15:	func (driver *OverlayDriver) CreateVolume(path string) error {
    16:		layerDir := driver.layerDir(path)
    17:
    18:		err := os.MkdirAll(layerDir, 0755)
=>  19:		if err != nil {
    20:			return err
    21:		}
    22:
    23:		err = os.Mkdir(path, 0755)
    24:		if err != nil {
(dlv)
```