### PR TITLE
web: Mac cli link now goes to 'darwin' rather than 'osx'

### DIFF
--- a/web/elm/src/Concourse/Cli.elm
+++ b/web/elm/src/Concourse/Cli.elm
@@ -1,12 +1,76 @@
-module Concourse.Cli exposing (downloadUrl, Cli(..))
+module Concourse.Cli exposing (Cli, clis, downloadUrl, iconUrl, id, label)
 
 
-downloadUrl : String -> String -> String
-downloadUrl arch platform =
-    "/api/v1/cli?arch=" ++ arch ++ "&platform=" ++ platform
+clis : List Cli
+clis =
+    [ OSX, Windows, Linux ]
 
 
 type Cli
     = OSX
     | Windows
     | Linux
+
+
+downloadUrl : Cli -> String
+downloadUrl cli =
+    let
+        platformName =
+            case cli of
+                OSX ->
+                    "darwin"
+
+                Windows ->
+                    "windows"
+
+                Linux ->
+                    "linux"
+    in
+    "/api/v1/cli?arch=amd64&platform=" ++ platformName
+
+
+iconUrl : Cli -> String
+iconUrl cli =
+    let
+        imageName =
+            case cli of
+                OSX ->
+                    "apple"
+
+                Windows ->
+                    "windows"
+
+                Linux ->
+                    "linux"
+    in
+    "url(/public/images/" ++ imageName ++ "-logo.svg)"
+
+
+label : Cli -> String
+label cli =
+    let
+        platformName =
+            case cli of
+                OSX ->
+                    "OS X"
+
+                Windows ->
+                    "Windows"
+
+                Linux ->
+                    "Linux"
+    in
+    "Download " ++ platformName ++ " CLI"
+
+
+id : Cli -> String
+id cli =
+    case cli of
+        OSX ->
+            "osx"
+
+        Windows ->
+            "windows"
+
+        Linux ->
+            "linux"

--- a/web/elm/src/Dashboard.elm
+++ b/web/elm/src/Dashboard.elm
@@ -718,29 +718,17 @@ welcomeCard { hoveredTopCliIcon, groups, userState } =
         noPipelines =
             List.isEmpty (groups |> List.concatMap .pipelines)
 
-        cliIcon : Cli.Cli -> Maybe Cli.Cli -> Html Msg
-        cliIcon cli hoveredTopCliIcon =
-            let
-                ( cliName, ariaText, icon ) =
-                    case cli of
-                        Cli.OSX ->
-                            ( "osx", "OS X", "apple" )
-
-                        Cli.Windows ->
-                            ( "windows", "Windows", "windows" )
-
-                        Cli.Linux ->
-                            ( "linux", "Linux", "linux" )
-            in
+        cliIcon : Maybe Cli.Cli -> Cli.Cli -> Html Msg
+        cliIcon hoveredTopCliIcon cli =
             Html.a
-                [ href (Cli.downloadUrl "amd64" cliName)
-                , attribute "aria-label" <| "Download " ++ ariaText ++ " CLI"
+                [ href (Cli.downloadUrl cli)
+                , attribute "aria-label" <| Cli.label cli
                 , style <|
                     Styles.topCliIcon
                         { hovered = hoveredTopCliIcon == Just cli
-                        , image = icon ++ "-logo.svg"
+                        , cli = cli
                         }
-                , id <| "top-cli-" ++ cliName
+                , id <| "top-cli-" ++ Cli.id cli
                 , onMouseEnter <| TopCliHover <| Just cli
                 , onMouseLeave <| TopCliHover Nothing
                 ]
@@ -763,13 +751,12 @@ welcomeCard { hoveredTopCliIcon, groups, userState } =
                         , ( "align-items", "center" )
                         ]
                     ]
+                  <|
                     [ Html.div
                         [ style [ ( "margin-right", "10px" ) ] ]
                         [ Html.text Text.cliInstructions ]
-                    , cliIcon Cli.OSX hoveredTopCliIcon
-                    , cliIcon Cli.Windows hoveredTopCliIcon
-                    , cliIcon Cli.Linux hoveredTopCliIcon
                     ]
+                        ++ List.map (cliIcon hoveredTopCliIcon) Cli.clis
                 , Html.div
                     []
                     [ Html.text Text.setPipelineInstructions ]

--- a/web/elm/src/Dashboard/Footer.elm
+++ b/web/elm/src/Dashboard/Footer.elm
@@ -159,14 +159,12 @@ concourseInfo { version, hoveredCliIcon } =
     [ Html.div [ id "concourse-info", style Styles.info ]
         [ Html.div [ style Styles.infoItem ]
             [ Html.text <| "version: v" ++ version ]
-        , Html.div [ style Styles.infoItem ]
+        , Html.div [ style Styles.infoItem ] <|
             [ Html.span
                 [ style [ ( "margin-right", "10px" ) ] ]
                 [ Html.text "cli: " ]
-            , cliIcon Cli.OSX hoveredCliIcon
-            , cliIcon Cli.Windows hoveredCliIcon
-            , cliIcon Cli.Linux hoveredCliIcon
             ]
+                ++ List.map (cliIcon hoveredCliIcon) Cli.clis
         ]
     ]
 
@@ -226,65 +224,18 @@ legendSeparator screenSize =
             ]
 
 
-cliIcon : Cli.Cli -> Maybe Cli.Cli -> Html Msg
-cliIcon cli =
-    case cli of
-        Cli.OSX ->
-            cliIconOSX
-
-        Cli.Windows ->
-            cliIconWindows
-
-        Cli.Linux ->
-            cliIconLinux
-
-
-cliIconOSX : Maybe Cli.Cli -> Html Msg
-cliIconOSX hoveredCliIcon =
+cliIcon : Maybe Cli.Cli -> Cli.Cli -> Html Msg
+cliIcon hoveredCliIcon cli =
     Html.a
-        [ href (Cli.downloadUrl "amd64" "osx")
-        , attribute "aria-label" <| "Download OS X CLI"
+        [ href (Cli.downloadUrl cli)
+        , attribute "aria-label" <| Cli.label cli
         , style <|
             Styles.infoCliIcon
-                { hovered = hoveredCliIcon == Just Cli.OSX
-                , image = "apple"
+                { hovered = hoveredCliIcon == Just cli
+                , cli = cli
                 }
-        , id <| "cli-osx"
-        , onMouseEnter <| CliHover <| Just Cli.OSX
-        , onMouseLeave <| CliHover Nothing
-        ]
-        []
-
-
-cliIconWindows : Maybe Cli.Cli -> Html Msg
-cliIconWindows hoveredCliIcon =
-    Html.a
-        [ href (Cli.downloadUrl "amd64" "windows")
-        , attribute "aria-label" <| "Download Windows CLI"
-        , style <|
-            Styles.infoCliIcon
-                { hovered = hoveredCliIcon == Just Cli.Windows
-                , image = "windows"
-                }
-        , id <| "cli-windows"
-        , onMouseEnter <| CliHover <| Just Cli.Windows
-        , onMouseLeave <| CliHover Nothing
-        ]
-        []
-
-
-cliIconLinux : Maybe Cli.Cli -> Html Msg
-cliIconLinux hoveredCliIcon =
-    Html.a
-        [ href (Cli.downloadUrl "amd64" "linux")
-        , attribute "aria-label" <| "Download Linux CLI"
-        , style <|
-            Styles.infoCliIcon
-                { hovered = hoveredCliIcon == Just Cli.Linux
-                , image = "linux"
-                }
-        , id <| "cli-linux"
-        , onMouseEnter <| CliHover <| Just Cli.Linux
+        , id <| "cli-" ++ Cli.id cli
+        , onMouseEnter <| CliHover <| Just cli
         , onMouseLeave <| CliHover Nothing
         ]
         []

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -36,6 +36,7 @@ module Dashboard.Styles exposing
     )
 
 import Colors
+import Concourse.Cli as Cli
 import Concourse.PipelineStatus exposing (PipelineStatus(..))
 import ScreenSize
 
@@ -413,12 +414,12 @@ infoItem =
     ]
 
 
-infoCliIcon : { hovered : Bool, image : String } -> List ( String, String )
-infoCliIcon { hovered, image } =
+infoCliIcon : { hovered : Bool, cli : Cli.Cli } -> List ( String, String )
+infoCliIcon { hovered, cli } =
     [ ( "margin-right", "10px" )
     , ( "width", "20px" )
     , ( "height", "20px" )
-    , ( "background-image", "url(/public/images/" ++ image ++ "-logo.svg)" )
+    , ( "background-image", Cli.iconUrl cli )
     , ( "background-repeat", "no-repeat" )
     , ( "background-position", "50% 50%" )
     , ( "background-size", "contain" )
@@ -432,8 +433,8 @@ infoCliIcon { hovered, image } =
     ]
 
 
-topCliIcon : { hovered : Bool, image : String } -> List ( String, String )
-topCliIcon { hovered, image } =
+topCliIcon : { hovered : Bool, cli : Cli.Cli } -> List ( String, String )
+topCliIcon { hovered, cli } =
     [ ( "opacity"
       , if hovered then
             "1"
@@ -441,7 +442,7 @@ topCliIcon { hovered, image } =
         else
             "0.5"
       )
-    , ( "background-image", "url(/public/images/" ++ image ++ ")" )
+    , ( "background-image", Cli.iconUrl cli )
     , ( "background-position", "50% 50%" )
     , ( "background-repeat", "no-repeat" )
     , ( "width", "32px" )
@@ -512,13 +513,14 @@ asciiArt =
     , ( "z-index", "1" )
     ]
 
-disableInteraction: List ( String, String )
+
+disableInteraction : List ( String, String )
 disableInteraction =
-    [ ("cursor", "default")
-    , ("user-select", "none")
-    , ("-ms-user-select", "none")
-    , ("-moz-user-select", "none")
-    , ("-khtml-user-select", "none")
-    , ("-webkit-user-select", "none")
-    , ("-webkit-touch-callout", "none")
+    [ ( "cursor", "default" )
+    , ( "user-select", "none" )
+    , ( "-ms-user-select", "none" )
+    , ( "-moz-user-select", "none" )
+    , ( "-khtml-user-select", "none" )
+    , ( "-webkit-user-select", "none" )
+    , ( "-webkit-touch-callout", "none" )
     ]

--- a/web/elm/src/Pipeline.elm
+++ b/web/elm/src/Pipeline.elm
@@ -13,7 +13,7 @@ module Pipeline exposing
 import Char
 import Colors
 import Concourse
-import Concourse.Cli
+import Concourse.Cli as Cli
 import Effects exposing (Callback(..), Effect(..))
 import Html exposing (Html)
 import Html.Attributes exposing (class, height, href, id, src, style, width)
@@ -307,44 +307,19 @@ view model =
                 [ Html.tr []
                     [ Html.td [ class "label" ] [ Html.text "cli:" ]
                     , Html.td []
-                        [ Html.ul [ class "cli-downloads" ]
-                            [ Html.li []
-                                [ Html.a
-                                    [ href <|
-                                        Concourse.Cli.downloadUrl
-                                            "amd64"
-                                            "darwin"
-                                    , ariaLabel "Download OS X CLI"
-                                    , Html.Attributes.style <|
-                                        cliIcon "apple"
-                                    ]
-                                    []
-                                ]
-                            , Html.li []
-                                [ Html.a
-                                    [ href <|
-                                        Concourse.Cli.downloadUrl
-                                            "amd64"
-                                            "windows"
-                                    , ariaLabel "Download Windows CLI"
-                                    , Html.Attributes.style <|
-                                        cliIcon "windows"
-                                    ]
-                                    []
-                                ]
-                            , Html.li []
-                                [ Html.a
-                                    [ href <|
-                                        Concourse.Cli.downloadUrl
-                                            "amd64"
-                                            "linux"
-                                    , ariaLabel "Download Linux CLI"
-                                    , Html.Attributes.style <|
-                                        cliIcon "linux"
-                                    ]
-                                    []
-                                ]
-                            ]
+                        [ Html.ul [ class "cli-downloads" ] <|
+                            List.map
+                                (\cli ->
+                                    Html.li []
+                                        [ Html.a
+                                            [ href <| Cli.downloadUrl cli
+                                            , ariaLabel <| Cli.label cli
+                                            , Html.Attributes.style <| cliIcon cli
+                                            ]
+                                            []
+                                        ]
+                                )
+                                Cli.clis
                         ]
                     ]
                 , Html.tr []
@@ -593,11 +568,11 @@ pipelineIdentifierFromModel model =
             Nothing
 
 
-cliIcon : String -> List ( String, String )
-cliIcon image =
+cliIcon : Cli.Cli -> List ( String, String )
+cliIcon cli =
     [ ( "width", "12px" )
     , ( "height", "12px" )
-    , ( "background-image", "url(/public/images/" ++ image ++ "-logo.svg)" )
+    , ( "background-image", Cli.iconUrl cli )
     , ( "background-repeat", "no-repeat" )
     , ( "background-position", "50% 50%" )
     , ( "background-size", "contain" )

--- a/web/elm/tests/CliTests.elm
+++ b/web/elm/tests/CliTests.elm
@@ -1,0 +1,35 @@
+module CliTests exposing (all)
+
+import Concourse.Cli exposing (..)
+import Expect
+import Test exposing (..)
+
+
+all : Test
+all =
+    describe "cli display functions"
+        [ test "downloadUrl uses the correct architecture and platform name for each os" <|
+            \_ ->
+                List.map downloadUrl clis
+                    |> Expect.equal
+                        [ "/api/v1/cli?arch=amd64&platform=darwin"
+                        , "/api/v1/cli?arch=amd64&platform=windows"
+                        , "/api/v1/cli?arch=amd64&platform=linux"
+                        ]
+        , test "cli-icon returns the icon name for each os" <|
+            \_ ->
+                List.map iconUrl clis
+                    |> Expect.equal
+                        [ "url(/public/images/apple-logo.svg)"
+                        , "url(/public/images/windows-logo.svg)"
+                        , "url(/public/images/linux-logo.svg)"
+                        ]
+        , test "cli label returns the text for each os" <|
+            \_ ->
+                List.map label clis
+                    |> Expect.equal
+                        [ "Download OS X CLI"
+                        , "Download Windows CLI"
+                        , "Download Linux CLI"
+                        ]
+        ]

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -25,6 +25,7 @@ import Effects
 import Expect exposing (Expectation)
 import Html.Attributes as Attr
 import Html.Styled as HS
+import List.Extra
 import RemoteData
 import Test exposing (..)
 import Test.Html.Event as Event
@@ -274,7 +275,7 @@ all =
                                             ]
                                                 ++ iconSelector { size = "32px", image = "apple-logo.svg" }
                                         }
-                                    , mouseEnterMsg = Msgs.TopCliHover <| Just Cli.OSX
+                                    , mouseEnterMsg = Msgs.TopCliHover <| List.Extra.getAt 0 Cli.clis
                                     , mouseLeaveMsg = Msgs.TopCliHover Nothing
                                     , hoveredSelector =
                                         { description = "white apple icon"
@@ -302,7 +303,7 @@ all =
                                             ]
                                                 ++ iconSelector { size = "32px", image = "windows-logo.svg" }
                                         }
-                                    , mouseEnterMsg = Msgs.TopCliHover <| Just Cli.Windows
+                                    , mouseEnterMsg = Msgs.TopCliHover <| List.Extra.getAt 1 Cli.clis
                                     , mouseLeaveMsg = Msgs.TopCliHover Nothing
                                     , hoveredSelector =
                                         { description = "white windows icon"
@@ -330,7 +331,7 @@ all =
                                             ]
                                                 ++ iconSelector { size = "32px", image = "linux-logo.svg" }
                                         }
-                                    , mouseEnterMsg = Msgs.TopCliHover <| Just Cli.Linux
+                                    , mouseEnterMsg = Msgs.TopCliHover <| List.Extra.getAt 2 Cli.clis
                                     , mouseLeaveMsg = Msgs.TopCliHover Nothing
                                     , hoveredSelector =
                                         { description = "white linux icon"
@@ -357,19 +358,19 @@ all =
                                 >> Query.has
                                     [ style
                                         [ ( "user-select", "none" )
-                                        , ("-ms-user-select", "none")
-                                        , ("-moz-user-select", "none")
-                                        , ("-khtml-user-select", "none")
-                                        , ("-webkit-user-select", "none")
-                                        , ("-webkit-touch-callout", "none")
+                                        , ( "-ms-user-select", "none" )
+                                        , ( "-moz-user-select", "none" )
+                                        , ( "-khtml-user-select", "none" )
+                                        , ( "-webkit-user-select", "none" )
+                                        , ( "-webkit-touch-callout", "none" )
                                         ]
                                     ]
                         , test "cursor is set to default" <|
                             art
                                 >> Query.has
-                                [ style
-                                    [ ("cursor", "default") ]
-                                ]
+                                    [ style
+                                        [ ( "cursor", "default" ) ]
+                                    ]
                         ]
                     ]
             in
@@ -2595,7 +2596,7 @@ all =
                                         }
                             }
                         , updateFunc = \msg -> Dashboard.update msg >> Tuple.first
-                        , mouseEnterMsg = Msgs.CliHover <| Just Cli.OSX
+                        , mouseEnterMsg = Msgs.CliHover <| List.Extra.getAt 0 Cli.clis
                         , mouseLeaveMsg = Msgs.CliHover Nothing
                         , hoveredSelector =
                             { description = "white apple icon"
@@ -2634,7 +2635,7 @@ all =
                                         }
                             }
                         , updateFunc = \msg -> Dashboard.update msg >> Tuple.first
-                        , mouseEnterMsg = Msgs.CliHover <| Just Cli.Windows
+                        , mouseEnterMsg = Msgs.CliHover <| List.Extra.getAt 1 Cli.clis
                         , mouseLeaveMsg = Msgs.CliHover Nothing
                         , hoveredSelector =
                             { description = "white windows icon"
@@ -2673,7 +2674,7 @@ all =
                                         }
                             }
                         , updateFunc = \msg -> Dashboard.update msg >> Tuple.first
-                        , mouseEnterMsg = Msgs.CliHover <| Just Cli.Linux
+                        , mouseEnterMsg = Msgs.CliHover <| List.Extra.getAt 2 Cli.clis
                         , mouseLeaveMsg = Msgs.CliHover Nothing
                         , hoveredSelector =
                             { description = "white linux icon"


### PR DESCRIPTION
Fixes #3068