### PR TITLE
atc/db: add cleanup migration removing unused types and column

### DIFF
--- a/atc/db/migration/migrations/1548260637_cleanup_unused_objects.down.sql
+++ b/atc/db/migration/migrations/1548260637_cleanup_unused_objects.down.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+  CREATE TYPE container_state_old AS ENUM (
+      'creating',
+      'created',
+      'destroying'
+  );
+
+  CREATE TYPE volume_state_old AS ENUM (
+      'creating',
+      'created',
+      'destroying'
+  );
+
+  ALTER TABLE containers ADD COLUMN best_if_used_by timestamp with time zone;
+COMMIT;

--- a/atc/db/migration/migrations/1548260637_cleanup_unused_objects.up.sql
+++ b/atc/db/migration/migrations/1548260637_cleanup_unused_objects.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+  DROP TYPE volume_state_old;
+  DROP TYPE container_state_old;
+  ALTER TABLE containers DROP COLUMN best_if_used_by;
+COMMIT;


### PR DESCRIPTION
Remove `best_if_used_by` column from `containers` table
Remove `volume_state_old` and `container_state_old` custom enum types

Signed-off-by: Divya Dadlani <ddadlani@pivotal.io>
Co-authored-by: Krishna Mannem <kmannem@pivotal.io>