### PR TITLE
atc: fix syslog drainer leaking connections

### DIFF
--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -8,10 +8,7 @@ import (
 	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/event"
-	//sl "github.com/papertrail/remote_syslog2/syslog"
 )
-
-const ServerPollingInterval = 5 * time.Second
 
 //go:generate counterfeiter . Drainer
 

--- a/atc/syslog/drainer_test.go
+++ b/atc/syslog/drainer_test.go
@@ -2,104 +2,15 @@ package syslog_test
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
-	"io/ioutil"
-	"net"
-	"os"
-	"strconv"
-	"sync"
-	"time"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/square/certstrap/pkix"
-
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/event"
 	"github.com/concourse/concourse/atc/syslog"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"strconv"
 )
-
-type testServer struct {
-	Addr     string
-	Messages chan string
-
-	ln     net.Listener
-	closed bool
-	wg     *sync.WaitGroup
-}
-
-func newTestServer(cert *tls.Certificate) *testServer {
-	server := &testServer{
-		Messages: make(chan string, 20),
-
-		wg: new(sync.WaitGroup),
-	}
-
-	server.ListenTCP(cert)
-
-	server.wg.Add(1)
-	go server.ServeTCP()
-
-	return server
-}
-
-func (server *testServer) ListenTCP(cert *tls.Certificate) net.Listener {
-	var ln net.Listener
-
-	var err error
-	if cert != nil {
-		config := &tls.Config{
-			Certificates: []tls.Certificate{*cert},
-		}
-		server.ln, err = tls.Listen("tcp", "127.0.0.1:0", config)
-		Expect(err).NotTo(HaveOccurred())
-	} else {
-		server.ln, err = net.Listen("tcp", "[::]:0")
-		Expect(err).NotTo(HaveOccurred())
-	}
-
-	Expect(err).NotTo(HaveOccurred())
-
-	server.Addr = server.ln.Addr().String()
-
-	return ln
-}
-
-func (server *testServer) ServeTCP() {
-	defer server.wg.Done()
-	defer GinkgoRecover()
-
-	for {
-		conn, err := server.ln.Accept()
-		if server.closed {
-			return
-		}
-
-		Expect(err).NotTo(HaveOccurred())
-
-		time.Sleep(100 * time.Millisecond)
-
-		buf := make([]byte, 1024)
-		n, err := conn.Read(buf)
-
-		// expect bad certificate from 'bad cert' test
-		if err != nil && err.Error() == "remote error: tls: bad certificate" {
-			continue
-		}
-
-		Expect(err).NotTo(HaveOccurred())
-
-		server.Messages <- string(buf[0:n])
-	}
-}
-
-func (server *testServer) Close() {
-	server.closed = true
-	server.ln.Close()
-	server.wg.Wait()
-}
 
 func newFakeBuild(id int) db.Build {
 	fakeEventSource := new(dbfakes.FakeEventSource)
@@ -143,69 +54,6 @@ var _ = Describe("Drainer", func() {
 	})
 
 	Context("when there are builds that have not been drained", func() {
-		Context("when tls is enabled", func() {
-			var caFilePath string
-
-			BeforeEach(func() {
-				key, err := pkix.CreateRSAKey(1024)
-				Expect(err).NotTo(HaveOccurred())
-
-				ca, err := pkix.CreateCertificateAuthority(key, "", time.Now().Add(time.Hour), "Acme Co", "", "", "", "")
-				Expect(err).NotTo(HaveOccurred())
-
-				req, err := pkix.CreateCertificateSigningRequest(key, "", []net.IP{net.IPv4(127, 0, 0, 1)}, nil, "Acme Co", "", "", "", "")
-				Expect(err).NotTo(HaveOccurred())
-
-				cert, err := pkix.CreateCertificateHost(ca, key, req, time.Now().Add(time.Hour))
-				Expect(err).NotTo(HaveOccurred())
-
-				keyPEM, err := key.ExportPrivate()
-				Expect(err).NotTo(HaveOccurred())
-
-				caPEM, err := ca.Export()
-				Expect(err).NotTo(HaveOccurred())
-
-				certPEM, err := cert.Export()
-				Expect(err).NotTo(HaveOccurred())
-
-				tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
-				Expect(err).NotTo(HaveOccurred())
-
-				caFile, err := ioutil.TempFile("", "ca")
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = caFile.Write(caPEM)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = caFile.Close()
-				Expect(err).NotTo(HaveOccurred())
-
-				caFilePath = caFile.Name()
-
-				server = newTestServer(&tlsCert)
-			})
-
-			AfterEach(func() {
-				err := os.RemoveAll(caFilePath)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("connects to remote server given correct cert", func() {
-				testDrainer := syslog.NewDrainer("tls", server.Addr, "test", []string{caFilePath}, fakeBuildFactory)
-
-				err := testDrainer.Run(context.TODO())
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("fails connects to remote server given incorrect cert", func() {
-				testDrainer := syslog.NewDrainer("tls", server.Addr, "test", []string{"testdata/incorrect-cert.pem"}, fakeBuildFactory)
-
-				err := testDrainer.Run(context.TODO())
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("x509: certificate signed by unknown authority"))
-			})
-		})
-
 		Context("when tls is not set", func() {
 			BeforeEach(func() {
 				server = newTestServer(nil)
@@ -223,5 +71,6 @@ var _ = Describe("Drainer", func() {
 				Expect(got).NotTo(ContainSubstring("build 345 status"))
 			}, 0.2)
 		})
+
 	})
 })

--- a/atc/syslog/syslog.go
+++ b/atc/syslog/syslog.go
@@ -1,0 +1,95 @@
+package syslog
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	sl "github.com/racksec/srslog"
+	"io/ioutil"
+	"strings"
+	"time"
+)
+
+const rfc5424time = "2006-01-02T15:04:05.999999Z07:00"
+const priority = sl.LOG_USER | sl.LOG_INFO
+
+type Syslog struct {
+	writer *sl.Writer
+	closed bool
+}
+
+func Dial(transport, address string, caCerts []string) (*Syslog, error) {
+	var (
+		syslog *sl.Writer
+		config *tls.Config = nil
+	)
+
+	if transport == "tls" {
+		certpool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, cert := range caCerts {
+			content, err := ioutil.ReadFile(cert)
+			if err != nil {
+				return nil, err
+			}
+
+			ok := certpool.AppendCertsFromPEM(content)
+			if !ok {
+				return nil, errors.New("syslog drainer certificate error")
+			}
+		}
+		// srslog uses "tcp+tls" to specify "tls" connections
+		transport = "tcp+tls"
+
+		config = &tls.Config{
+			RootCAs: certpool,
+		}
+	}
+
+	syslog, err := sl.DialWithTLSConfig(transport, address, priority, "", config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Syslog{
+		writer: syslog,
+		closed: false,
+	}, nil
+}
+
+func (s *Syslog) Write(hostname, tag string, ts time.Time, msg string) error {
+	if s.closed {
+		return errors.New("connection already closed")
+	}
+
+	s.writer.SetFormatter(getSyslogFormatter(hostname, ts, tag))
+	_, err := s.writer.Write([]byte(msg))
+	return err
+}
+
+func (s *Syslog) Close() error {
+	if s.closed {
+		return errors.New("connection already closed")
+	}
+
+	s.closed = true
+	return s.writer.Close()
+}
+
+// generate custom formatter based on hostname and tag
+func getSyslogFormatter(hostname string, ts time.Time, tag string) sl.Formatter {
+	return func(priority sl.Priority, _, _, content string) string {
+		// strip whitespaces
+		s := strings.Replace(content, "\n", " ", -1)
+		s = strings.Replace(s, "\r", " ", -1)
+		s = strings.Replace(s, "\x00", " ", -1)
+
+		msg := fmt.Sprintf("<%d>1 %s %s %s - - - %s\n",
+			priority, ts.Format(rfc5424time), hostname, tag, s)
+		return msg
+	}
+}

--- a/atc/syslog/syslog_suite_test.go
+++ b/atc/syslog/syslog_suite_test.go
@@ -1,8 +1,13 @@
 package syslog_test
 
 import (
+	"crypto/tls"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"io"
+	"net"
+	"sync"
+	"time"
 
 	"testing"
 )
@@ -11,3 +16,89 @@ func TestSyslog(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Syslog Suite")
 }
+
+type testServer struct {
+	Addr     string
+	Messages chan string
+
+	ln     net.Listener
+	closed bool
+	wg     *sync.WaitGroup
+}
+
+func newTestServer(cert *tls.Certificate) *testServer {
+	server := &testServer{
+		Messages: make(chan string, 20),
+
+		wg:    new(sync.WaitGroup),
+	}
+
+	server.ListenTCP(cert)
+
+	server.wg.Add(1)
+	go server.ServeTCP()
+
+	return server
+}
+
+func (server *testServer) ListenTCP(cert *tls.Certificate) net.Listener {
+	var ln net.Listener
+
+	var err error
+	if cert != nil {
+		config := &tls.Config{
+			Certificates: []tls.Certificate{*cert},
+		}
+		server.ln, err = tls.Listen("tcp", "127.0.0.1:0", config)
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		server.ln, err = net.Listen("tcp", "[::]:0")
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	Expect(err).NotTo(HaveOccurred())
+
+	server.Addr = server.ln.Addr().String()
+
+	return ln
+}
+
+func (server *testServer) ServeTCP() {
+	defer server.wg.Done()
+	defer GinkgoRecover()
+
+	for {
+		conn, err := server.ln.Accept()
+		if server.closed {
+			return
+		}
+
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(100 * time.Millisecond)
+
+		buf := make([]byte, 1024)
+		n, err := conn.Read(buf)
+
+		// expect bad certificate from 'bad cert' test
+		if err != nil && err.Error() == "remote error: tls: bad certificate" {
+			continue
+		}
+
+		// expect no message from 'open and close' tests
+		if err != nil && err == io.EOF {
+			continue
+		}
+
+		Expect(err).NotTo(HaveOccurred())
+
+		server.Messages <- string(buf[0:n])
+	}
+}
+
+func (server *testServer) Close() {
+	server.closed = true
+	server.ln.Close()
+	server.wg.Wait()
+}
+

--- a/atc/syslog/syslog_test.go
+++ b/atc/syslog/syslog_test.go
@@ -1,0 +1,152 @@
+package syslog_test
+
+import (
+	"crypto/tls"
+	"github.com/concourse/concourse/atc/syslog"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/square/certstrap/pkix"
+	"io/ioutil"
+	"net"
+	"os"
+	"time"
+)
+
+var _ = Describe("Syslog", func() {
+	var server *testServer
+	const (
+		hostname = "hostname"
+		tag = "tag"
+		message = "build 123 log"
+	)
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	Context("when the address is valid tcp server", func() {
+		Context("when tls is enabled", func() {
+			var caFilePath string
+
+			BeforeEach(func() {
+				key, err := pkix.CreateRSAKey(1024)
+				Expect(err).NotTo(HaveOccurred())
+
+				ca, err := pkix.CreateCertificateAuthority(key, "", time.Now().Add(time.Hour), "Acme Co", "", "", "", "")
+				Expect(err).NotTo(HaveOccurred())
+
+				req, err := pkix.CreateCertificateSigningRequest(key, "", []net.IP{net.IPv4(127, 0, 0, 1)}, nil, "Acme Co", "", "", "", "")
+				Expect(err).NotTo(HaveOccurred())
+
+				cert, err := pkix.CreateCertificateHost(ca, key, req, time.Now().Add(time.Hour))
+				Expect(err).NotTo(HaveOccurred())
+
+				keyPEM, err := key.ExportPrivate()
+				Expect(err).NotTo(HaveOccurred())
+
+				caPEM, err := ca.Export()
+				Expect(err).NotTo(HaveOccurred())
+
+				certPEM, err := cert.Export()
+				Expect(err).NotTo(HaveOccurred())
+
+				tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+				Expect(err).NotTo(HaveOccurred())
+
+				caFile, err := ioutil.TempFile("", "ca")
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = caFile.Write(caPEM)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = caFile.Close()
+				Expect(err).NotTo(HaveOccurred())
+
+				caFilePath = caFile.Name()
+
+				server = newTestServer(&tlsCert)
+			})
+
+			AfterEach(func() {
+				err := os.RemoveAll(caFilePath)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("connects and writes to server given correct cert", func() {
+				sl, err := syslog.Dial("tls", server.Addr, []string{caFilePath})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = sl.Write(hostname, tag, time.Now(), message)
+				Expect(err).NotTo(HaveOccurred())
+
+				got := <-server.Messages
+				Expect(got).To(ContainSubstring(message))
+				Expect(got).NotTo(ContainSubstring("build 123 status"))
+
+				err = sl.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}, 0.2)
+
+			It("fails connects to server given incorrect cert", func() {
+				_, err := syslog.Dial("tls", server.Addr, []string{"testdata/incorrect-cert.pem"})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("x509: certificate signed by unknown authority"))
+			}, 0.2)
+		})
+
+		Context("when tls is not set", func() {
+			BeforeEach(func() {
+				server = newTestServer(nil)
+			})
+
+			It("connects and writes to server", func() {
+				sl, err := syslog.Dial("tcp", server.Addr, []string{})
+				sl.Write(hostname, tag, time.Now(), message)
+				Expect(err).NotTo(HaveOccurred())
+
+				got := <-server.Messages
+				Expect(got).To(ContainSubstring(message))
+				Expect(got).NotTo(ContainSubstring("build 123 status"))
+
+				err = sl.Close()
+				Expect(err).NotTo(HaveOccurred())
+			}, 0.2)
+		})
+
+		Context("after the connection is closed", func() {
+			var (
+				sl  *syslog.Syslog
+				err error
+			)
+
+			BeforeEach(func() {
+				server = newTestServer(nil)
+				sl, err = syslog.Dial("tcp", server.Addr, []string{})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = sl.Close()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("subsequent ops will error", func() {
+				err = sl.Write(hostname, tag, time.Now(), message)
+				Expect(err.Error()).To(ContainSubstring("connection already closed"))
+
+				err = sl.Close()
+				Expect(err.Error()).To(ContainSubstring("connection already closed"))
+			})
+		})
+	})
+
+	Context("when the address is invalid", func() {
+		BeforeEach(func() {
+			server = newTestServer(nil)
+		})
+
+		It("errors", func() {
+			_, err := syslog.Dial("tcp", "bad.address", []string{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+})

--- a/atc/syslog/syslogfakes/fake_drainer.go
+++ b/atc/syslog/syslogfakes/fake_drainer.go
@@ -2,10 +2,10 @@
 package syslogfakes
 
 import (
-	context "context"
-	sync "sync"
+	"context"
+	"sync"
 
-	syslog "github.com/concourse/concourse/atc/syslog"
+	"github.com/concourse/concourse/atc/syslog"
 )
 
 type FakeDrainer struct {

--- a/go.mod
+++ b/go.mod
@@ -132,7 +132,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/ory/dockertest v3.3.2+incompatible // indirect
-	github.com/papertrail/remote_syslog2 v0.0.0-20170912230402-5bae4a1ac1c2
 	github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
@@ -140,6 +139,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5
 	github.com/prometheus/client_golang v0.9.2
+	github.com/racksec/srslog v0.0.0-20180709174129-a4725f04ec91
 	github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,7 +117,6 @@ github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3C
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/emicklei/go-restful v2.8.0+incompatible h1:wN8GCRDPGHguIynsnBartv5GUgGUg1LAU7+xnSn1j7Q=
 github.com/emicklei/go-restful v2.8.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/evandigby/go-msgpack v0.0.0-20180728010727-b3f48f4eda2a/go.mod h1:NMtcr9ZZILO5qKl54Ny2dWuXzQXs4OEhSH+nK4lY7Yg=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.0.0 h1:BrX964Rv5uQ3wwS+KRUAJCBBw5PQmgJfJ6v4yly5QwU=
@@ -200,7 +199,6 @@ github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxB
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-memdb v0.0.0-20180223233045-1289e7fffe71 h1:yxxFgVz31vFoKKTtRUNbXLNe4GFnbLKqg+0N7yG42L8=
 github.com/hashicorp/go-memdb v0.0.0-20180223233045-1289e7fffe71/go.mod h1:kbfItVoBJwCfKXDXN4YoAXjxcFVZ7MRrJzyTX6H4giE=
-github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v0.5.3 h1:zKjpN5BK/P5lMYrLmBHdBULWbJ0XpYR+7NGzqkZzoD4=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
@@ -324,8 +322,6 @@ github.com/opencontainers/runc v0.1.1 h1:GlxAyO6x8rfZYN9Tt0Kti5a/cP41iuiO2yYT0IJ
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/ory/dockertest v3.3.2+incompatible h1:uO+NcwH6GuFof/Uz8yzjNi1g0sGT5SLAJbdBvD8bUYc=
 github.com/ory/dockertest v3.3.2+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
-github.com/papertrail/remote_syslog2 v0.0.0-20170912230402-5bae4a1ac1c2 h1:jyEKV+Fvg1mgmvjp10Ybcia7Odslj+r7MTcZgl+/LNw=
-github.com/papertrail/remote_syslog2 v0.0.0-20170912230402-5bae4a1ac1c2/go.mod h1:bKQTGf39M2hRwOZCSh/I+LoV6PUW857XAAwzYQKqeBw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5QCWA8o6BtfL6mDH5rQgM4/fX3avOs=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
@@ -360,6 +356,8 @@ github.com/prometheus/procfs v0.0.0-20170216223256-a1dba9ce8bae h1:nbLP9B5vU3a/0
 github.com/prometheus/procfs v0.0.0-20170216223256-a1dba9ce8bae/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nLJdBg+pBmGgkJlSaKC2KaQmTCk1XDtE=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/racksec/srslog v0.0.0-20180709174129-a4725f04ec91 h1:3hihQaxFTzBL1t5bTYaPhEwL4rxD3zjSgu4afGzgQqI=
+github.com/racksec/srslog v0.0.0-20180709174129-a4725f04ec91/go.mod h1:eTUUVgGNb+mCsEJeJnwl/Kaaem9IXKa1ZZL5zN4fTag=
 github.com/russellhaering/goxmldsig v0.0.0-20170324122954-eaac44c63fe0 h1:jhWWGMYDGjj/PmvsUkFkhlvBhOR0y8ZJW7OY/21F8FY=
 github.com/russellhaering/goxmldsig v0.0.0-20170324122954-eaac44c63fe0/go.mod h1:Oz4y6ImuOQZxynhbSXk7btjEfNBtGlj2dcaOvXl2FSM=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735 h1:7YvPJVmEeFHR1Tj9sZEYsmarJEQfMVYpd/Vyy/A8dqE=


### PR DESCRIPTION
Fixes #3132 
### dependency changes:
Changed syslog library from [remote_syslog2](https://github.com/papertrail/remote_syslog2) to [srslog](https://github.com/RackSec/srslog).

* remote_syslog2 writes asynchronously and retries on failed writes, however it had no error checking for failed initial connects. The repo does not appear to be very active so submitting PR's might take too long
* srslog is synchronous and offers more low level interfacing, so more power to us


### atc/syslog:
* separated `drainer.go` into `drainer.go` and `syslog.go`. 
* `syslog` is responsible for interacting with the remote server 
* `drainer` is responsible for fetching build logs and calling the syslog interface