### PR TITLE
Add ORDER BY for resourceTypesQuery and resourcesQuery

### DIFF
--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -453,7 +453,11 @@ func (p *pipeline) Resources() (Resources, error) {
 }
 
 func (p *pipeline) ResourceTypes() (ResourceTypes, error) {
-	rows, err := resourceTypesQuery.Where(sq.Eq{"r.pipeline_id": p.id}).RunWith(p.conn).Query()
+	rows, err := resourceTypesQuery.
+		Where(sq.Eq{"r.pipeline_id": p.id}).
+		OrderBy("r.name").
+		RunWith(p.conn).
+		Query()
 	if err != nil {
 		return nil, err
 	}
@@ -1049,7 +1053,11 @@ func getNewBuildNameForJob(tx Tx, jobName string, pipelineID int) (string, int, 
 }
 
 func resources(pipelineID int, conn Conn, lockFactory lock.LockFactory) (Resources, error) {
-	rows, err := resourcesQuery.Where(sq.Eq{"r.pipeline_id": pipelineID}).RunWith(conn).Query()
+	rows, err := resourcesQuery.
+		Where(sq.Eq{"r.pipeline_id": pipelineID}).
+		OrderBy("r.name").
+		RunWith(conn).
+		Query()
 	if err != nil {
 		return nil, err
 	}

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -2057,6 +2057,41 @@ var _ = Describe("Team", func() {
 			Expect(otherReturnedGroups).To(Equal(updatedConfig.Groups))
 		})
 
+		It("should return sorted resources and resource_types", func() {
+			config.ResourceTypes = append(config.ResourceTypes, atc.ResourceType{
+				Name: "new-resource-type",
+				Type: "new-type",
+				Source: atc.Source{
+					"new-source-config": "new-value",
+				},
+			})
+
+			config.Resources = append(config.Resources, atc.ResourceConfig{
+				Name: "new-resource",
+				Type: "new-type",
+				Source: atc.Source{
+					"new-source-config": "new-value",
+				},
+			})
+
+			pipelineName := "a-pipeline-name"
+
+			pipeline, _, err := team.SavePipeline(pipelineName, config, 0, db.PipelineUnpaused)
+			Expect(err).ToNot(HaveOccurred())
+
+			resourceTypes, err := pipeline.ResourceTypes()
+			Expect(err).ToNot(HaveOccurred())
+			rtConfigs := resourceTypes.Configs()
+			Expect(rtConfigs[0].Name).To(Equal(config.ResourceTypes[1].Name)) // "new-resource-type"
+			Expect(rtConfigs[1].Name).To(Equal(config.ResourceTypes[0].Name)) // "some-resource-type"
+
+			resources, err := pipeline.Resources()
+			Expect(err).ToNot(HaveOccurred())
+			rConfigs := resources.Configs()
+			Expect(rConfigs[0].Name).To(Equal(config.Resources[1].Name)) // "new-resource"
+			Expect(rConfigs[1].Name).To(Equal(config.Resources[0].Name)) // "some-resource"
+		})
+
 		Context("when there are multiple teams", func() {
 			It("can allow pipelines with the same name across teams", func() {
 				teamPipeline, _, err := team.SavePipeline("steve", config, 0, db.PipelineUnpaused)


### PR DESCRIPTION
This adds an `ORDER BY` to the resourceTypesQuery and resourcesQuery so that `fly get-pipeline` will return consistent, sorted configuration. This addresses #2814.

edit: I forgot to mention that I didn't order the other fields of the [config](https://github.com/concourse/concourse/blob/master/atc/api/configserver/get.go#L67-L70), because the pipeline groups are stored as a [single field](https://github.com/concourse/concourse/blob/master/atc/db/pipeline.go#L108) in the database, and the jobs query was already [sorted](https://github.com/concourse/concourse/blob/master/atc/db/pipeline.go#L523).