### PR TITLE
Modify migration to delete instead of truncate

### DIFF
--- a/atc/db/migration/migrations/1537546150_global_resource_version_history.up.sql
+++ b/atc/db/migration/migrations/1537546150_global_resource_version_history.up.sql
@@ -90,7 +90,7 @@ BEGIN;
   ALTER TABLE worker_resource_config_check_sessions
     DROP COLUMN team_id;
 
-  TRUNCATE TABLE worker_resource_config_check_sessions CASCADE;
+  DELETE FROM worker_resource_config_check_sessions;
 
   CREATE UNIQUE INDEX worker_resource_config_check_sessions_uniq
   ON worker_resource_config_check_sessions (resource_config_check_session_id, worker_base_resource_type_id);


### PR DESCRIPTION
oops.

This is because truncate with cascade for worker resource config check
sessions will result in postgres deleting all rows in the container and
volumes table. Delete all rows will not truncate those tables and will
just set the worker resource config check session ids to null.