### PR TITLE
Fix upgrade/downgrade

### DIFF
--- a/ci/tasks/scripts/create-upgrade-downgrade-pipeline
+++ b/ci/tasks/scripts/create-upgrade-downgrade-pipeline
@@ -20,7 +20,8 @@ echo "logging in..."
 fly -t local login -c "$web_url" -u test -p test
 
 # wait for worker to be available
-until fly -t local workers | grep running; do
+worker=$(docker ps -q --filter name=worker)
+until fly -t local workers | grep "${worker}.*running"; do
   echo "waiting for running worker..."
   sleep 2
 done

--- a/ci/tasks/scripts/downgrade-test
+++ b/ci/tasks/scripts/downgrade-test
@@ -19,7 +19,7 @@ docker-compose up --build -d
 
 ./ci/tasks/scripts/create-upgrade-downgrade-pipeline
 
-downgrade_to=$(docker run concourse/concourse:4.2.2 migrate --current-db-version)
+downgrade_to=$(docker run concourse/concourse:4.2.2 migrate --supported-db-version)
 docker-compose stop web
 docker-compose run web migrate --migrate-db-to-version $downgrade_to
 

--- a/ci/tasks/scripts/downgrade-test
+++ b/ci/tasks/scripts/downgrade-test
@@ -15,16 +15,25 @@ start_docker
 
 cd concourse
 
+# start with rc and set up
 docker-compose up --build -d
-
 ./ci/tasks/scripts/create-upgrade-downgrade-pipeline
 
+# perform down migrations
 downgrade_to=$(docker run concourse/concourse:4.2.2 migrate --supported-db-version)
 docker-compose stop web
 docker-compose run web migrate --migrate-db-to-version $downgrade_to
 
+# downgrade and verify
 docker-compose -f docker-compose-4.2.2.yml up --remove-orphans -d
-
 ./ci/tasks/scripts/verify-upgrade-downgrade-pipeline
 
-./ci/tasks/scripts/watsjs test/smoke.js
+# upgrade back and verify
+docker-compose up --build --remove-orphans -d
+./ci/tasks/scripts/verify-upgrade-downgrade-pipeline
+
+# run smoke tests
+cd web/wats
+stty columns 80 # for better yarn output
+yarn install
+yarn test -v --color test/smoke.js

--- a/ci/tasks/scripts/upgrade-test
+++ b/ci/tasks/scripts/upgrade-test
@@ -15,12 +15,16 @@ start_docker
 
 cd concourse
 
+# start with latest release and set up
 docker-compose -f docker-compose-4.2.2.yml up -d
-
 ./ci/tasks/scripts/create-upgrade-downgrade-pipeline
 
+# upgrade and verify
 docker-compose up --build --remove-orphans -d
-
 ./ci/tasks/scripts/verify-upgrade-downgrade-pipeline
 
-./ci/tasks/scripts/watsjs test/smoke.js
+# run smoke tests
+cd web/wats
+stty columns 80 # for better yarn output
+yarn install
+yarn test -v --color test/smoke.js

--- a/ci/tasks/scripts/verify-upgrade-downgrade-pipeline
+++ b/ci/tasks/scripts/verify-upgrade-downgrade-pipeline
@@ -20,7 +20,8 @@ echo "logging in..."
 fly -t local login -c "$web_url" -u test -p test
 
 # wait for worker to be available
-until fly -t local workers | grep running; do
+worker=$(docker ps -q --filter name=worker)
+until fly -t local workers | grep "${worker}.*running"; do
   echo "waiting for running worker..."
   sleep 2
 done

--- a/ci/tasks/scripts/watsjs
+++ b/ci/tasks/scripts/watsjs
@@ -12,7 +12,7 @@ fi
 
 cd web/wats
 
-# for better yarn output
-stty columns 80
+stty columns 80 # for better yarn output
 yarn install
+
 yarn test -v --color "$@"


### PR DESCRIPTION
fixes #2149, improves the polling for worker to be available (important for worker version bumps), and also uh, makes them work again post-refactor (which was merged quicker to expedite `concourse/dev` fix)

this can be verified with:

```sh
env DOCKERFILE=ci/dockerfiles/dev-test/Dockerfile fly -t ci e -c ci/tasks/upgrade-test.yml -j concourse/watsjs -i concourse=$PWD -p
env DOCKERFILE=ci/dockerfiles/dev-test/Dockerfile fly -t ci e -c ci/tasks/downgrade-test.yml -j concourse/watsjs -i concourse=$PWD -p
```