### PR TITLE
Fix issue #3164: Squishing of build-step output

### DIFF
--- a/web/assets/css/production.less
+++ b/web/assets/css/production.less
@@ -233,8 +233,7 @@ li.prep-status {
 }
 
 .step-body .dictionary {
-  table-layout: fixed;
-  width: 50%;
+  max-width: 50%;
 }
 
 .dict-key {
@@ -246,6 +245,7 @@ li.prep-status {
 .dict-value {
   padding: 0;
   margin: 0;
+  word-break: break-all;
 }
 
 .resource-check-status .header {

--- a/web/assets/css/production.less
+++ b/web/assets/css/production.less
@@ -232,6 +232,11 @@ li.prep-status {
   line-height: 28px;
 }
 
+.step-body .dictionary {
+  table-layout: fixed;
+  width: 50%;
+}
+
 .dict-key {
   text-align: right;
   padding: 0 10px 0 0;


### PR DESCRIPTION
I don't know too much about css, but I believe this fixes issue #3164 where metadata could squish the build output when too long.

![screen shot 2019-02-01 at 14 33 08](https://user-images.githubusercontent.com/8777079/52129019-6799e200-262e-11e9-9c9d-7f4af1f304d2.png)

Notice that `message` is aligned in the middle. Not sure if that is the desired look or not.
