### PR TITLE
topgun: refactor and fix creds/encryption tests

### DIFF
--- a/ci/tasks/topgun.yml
+++ b/ci/tasks/topgun.yml
@@ -6,9 +6,6 @@ image_resource:
   source: {repository: concourse/unit}
 
 params:
-  AWS_ACCESS_KEY_ID:
-  AWS_REGION:
-  AWS_SECRET_ACCESS_KEY:
   BOSH_CA_CERT:
   BOSH_CLIENT:
   BOSH_CLIENT_SECRET:
@@ -18,6 +15,9 @@ params:
   BOSH_USER:
   SKIP:
   TOPGUN_NETWORK_OFFSET:
+  AWS_REGION:
+  AWS_ACCESS_KEY_ID:
+  AWS_SECRET_ACCESS_KEY:
 
 inputs:
 - name: bbr

--- a/topgun/aws_ssm_test.go
+++ b/topgun/aws_ssm_test.go
@@ -1,94 +1,34 @@
 package topgun_test
 
 import (
-	"bytes"
 	"encoding/json"
-	"os"
-	"os/exec"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-/*
-	These tests assume that the parameters are already present in AWS. So require only GetParameter creadentials.
-	To initialize test paramters in AWS, execute following commands:
-
-	aws ssm put-parameter --type String --name "/concourse-topgun/main/pipeline-ssm-test/resource_type_repository" --value "concourse/time-resource"
-	aws ssm put-parameter --type String --name "/concourse-topgun/main/pipeline-ssm-test/time_resource_interval" --value "10m"
-	aws ssm put-parameter --type String --name "/concourse-topgun/main/pipeline-ssm-test/image_resource_repository" --value "busybox"
-	aws ssm put-parameter --type SecureString --name "/concourse-topgun/main/pipeline-ssm-test/job_secret/username" --value "Hello"
-	aws ssm put-parameter --type SecureString --name "/concourse-topgun/main/pipeline-ssm-test/job_secret/password" --value "World"
-	aws ssm put-parameter --type SecureString --name "/concourse-topgun/main/team_secret" --value "Sauce"
-	aws ssm put-parameter --type SecureString --name "/concourse-topgun/main/task_secret" --value "Hiii"
-	aws ssm put-parameter --type SecureString --name "/concourse-topgun/main/image_resource_repository" --value "busybox"
-*/
 var _ = Describe("AWS SSM", func() {
-	const pipeline = "pipeline-ssm-test"
-
-	getPipeline := func() *gexec.Session {
-		session := fly.Start("get-pipeline", "-p", pipeline)
-		<-session.Exited
-		Expect(session.ExitCode()).To(Equal(0))
-		return session
-	}
-
-	pgDump := func() *gexec.Session {
-		dump := exec.Command("pg_dump", "-U", "atc", "-h", dbInstance.IP, "atc")
-		dump.Env = append(os.Environ(), "PGPASSWORD=dummy-password")
-		dump.Stdin = bytes.NewBufferString("dummy-password\n")
-		session, err := gexec.Start(dump, GinkgoWriter, GinkgoWriter)
-		Expect(err).ToNot(HaveOccurred())
-		<-session.Exited
-		Expect(session.ExitCode()).To(Equal(0))
-		return session
-	}
-
+	var ssmAPI *ssm.SSM
 	var awsRegion string
 	var awsCreds credentials.Value
 
 	BeforeEach(func() {
 		awsSession, err := session.NewSession()
 		if err != nil {
-			Skip("Can not create AWS session")
+			Skip("can not create AWS session")
 		}
-		ssmApi := ssm.New(awsSession)
-		awsRegion = *ssmApi.Config.Region
-		awsCreds, err = ssmApi.Config.Credentials.Get()
+
+		ssmAPI = ssm.New(awsSession)
+		awsRegion = *ssmAPI.Config.Region
+		awsCreds, err = ssmAPI.Config.Credentials.Get()
 		if err != nil {
-			Skip("Can not retrive AWS credentials")
-		}
-		// Verify that all secret values are present in SSM parameter store
-		var secrets = map[string]string{
-			"/concourse-topgun/main/pipeline-ssm-test/resource_type_repository":  "concourse/time-resource",
-			"/concourse-topgun/main/pipeline-ssm-test/time_resource_interval":    "10m",
-			"/concourse-topgun/main/pipeline-ssm-test/job_secret/username":       "Hello",
-			"/concourse-topgun/main/pipeline-ssm-test/job_secret/password":       "World",
-			"/concourse-topgun/main/pipeline-ssm-test/image_resource_repository": "busybox",
-			"/concourse-topgun/main/team_secret":                                 "Sauce",
-			"/concourse-topgun/main/task_secret":                                 "Hiii",
-			"/concourse-topgun/main/image_resource_repository":                   "busybox",
-		}
-		names := make([]*string, 0, len(secrets))
-		for n := range secrets {
-			names = append(names, aws.String(n))
-		}
-		result, err := ssmApi.GetParameters(&ssm.GetParametersInput{Names: names, WithDecryption: aws.Bool(true)})
-		Expect(err).To(BeNil())
-		Expect(result.InvalidParameters).To(BeEmpty())
-		for _, p := range result.Parameters {
-			Expect(p).ToNot(BeNil())
-			Expect(p.Name).ToNot(BeNil())
-			Expect(p.Value).ToNot(BeNil())
-			Expect(secrets).To(HaveKeyWithValue(*p.Name, *p.Value))
+			Skip("can not retrive AWS credentials")
 		}
 	})
 
@@ -124,19 +64,19 @@ var _ = Describe("AWS SSM", func() {
 			}
 
 			var (
-				atcUrl         string
+				atcURL         string
 				parsedResponse responseSkeleton
 			)
 
 			BeforeEach(func() {
-				atcUrl = "http://" + JobInstance("web").IP + ":8080"
+				atcURL = "http://" + JobInstance("web").IP + ":8080"
 			})
 
 			JustBeforeEach(func() {
-				token, err := FetchToken(atcUrl, atcUsername, atcPassword)
+				token, err := FetchToken(atcURL, atcUsername, atcPassword)
 				Expect(err).ToNot(HaveOccurred())
 
-				body, err := RequestCredsInfo(atcUrl, token.AccessToken)
+				body, err := RequestCredsInfo(atcURL, token.AccessToken)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(body, &parsedResponse)
@@ -152,76 +92,42 @@ var _ = Describe("AWS SSM", func() {
 			})
 		})
 
-		Context("with a pipeline build", func() {
-			BeforeEach(func() {
-				By("setting a pipeline that contains ssm secrets")
-				fly.Run("set-pipeline", "-n", "-c", "pipelines/credential-management.yml", "-p", pipeline)
+		testCredentialManagement(func() {
+			secrets := map[string]string{
+				"/concourse-topgun/main/team_secret":                              "some_team_secret",
+				"/concourse-topgun/main/pipeline-creds-test/assertion_script":     assertionScript,
+				"/concourse-topgun/main/pipeline-creds-test/canary":               "some_canary",
+				"/concourse-topgun/main/pipeline-creds-test/resource_type_secret": "some_resource_type_secret",
+				"/concourse-topgun/main/pipeline-creds-test/resource_secret":      "some_resource_secret",
+				"/concourse-topgun/main/pipeline-creds-test/job_secret/username":  "some_username",
+				"/concourse-topgun/main/pipeline-creds-test/job_secret/password":  "some_password",
+				"/concourse-topgun/main/pipeline-creds-test/resource_version":     "some_exposed_version_secret",
+			}
 
-				By("getting the pipeline config")
-				session := getPipeline()
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("concourse/time-resource"))
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("10m"))
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("Hello/World"))
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("Sauce"))
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("busybox"))
-
-				By("unpausing the pipeline")
-				fly.Run("unpause-pipeline", "-p", pipeline)
-			})
-			It("parameterizes via SSM and leaves the pipeline uninterpolated", func() {
-				By("triggering job")
-				watch := fly.Start("trigger-job", "-w", "-j", pipeline+"/job-with-custom-input")
-				Wait(watch)
-				Expect(watch).To(gbytes.Say("GET SECRET: GET-Hello/GET-World"))
-				Expect(watch).To(gbytes.Say("PUT SECRET: PUT-Hello/PUT-World"))
-				Expect(watch).To(gbytes.Say("GET SECRET: PUT-GET-Hello/PUT-GET-World"))
-				Expect(watch).To(gbytes.Say("SECRET: Hello/World"))
-				Expect(watch).To(gbytes.Say("TEAM SECRET: Sauce"))
-
-				By("taking a dump")
-				session := pgDump()
-				Expect(session).ToNot(gbytes.Say("concourse/time-resource"))
-				Expect(session).ToNot(gbytes.Say("10m"))
-				Expect(session).To(gbytes.Say("Hello/World")) // build echoed it; nothing we can do
-				Expect(session).To(gbytes.Say("Sauce"))       // build echoed it; nothing we can do
-				Expect(session).ToNot(gbytes.Say("busybox"))
-			})
-			Context("when the job's inputs are used for a one-off build", func() {
-				It("parameterizes the values using the job's pipeline scope", func() {
-					By("triggering job to populate its inputs")
-					watch := fly.Start("trigger-job", "-w", "-j", "pipeline-ssm-test/job-with-input")
-					Wait(watch)
-					Expect(watch).To(gbytes.Say("GET SECRET: GET-Hello/GET-World"))
-					Expect(watch).To(gbytes.Say("PUT SECRET: PUT-Hello/PUT-World"))
-					Expect(watch).To(gbytes.Say("GET SECRET: PUT-GET-Hello/PUT-GET-World"))
-					Expect(watch).To(gbytes.Say("SECRET: Hello/World"))
-					Expect(watch).To(gbytes.Say("TEAM SECRET: Sauce"))
-
-					By("executing a task that parameterizes image_resource")
-					watch = fly.Start("execute", "-c", "tasks/credential-management-with-job-inputs.yml", "-j", "pipeline-ssm-test/job-with-input")
-					Wait(watch)
-					Expect(watch).To(gbytes.Say("./some-resource/input"))
-
-					By("taking a dump")
-					session := pgDump()
-					Expect(session).ToNot(gbytes.Say("concourse/time-resource"))
-					Expect(session).ToNot(gbytes.Say("10m"))
-					Expect(session).To(gbytes.Say("./some-resource/input")) // build echoed it; nothing we can do
+			for name, value := range secrets {
+				_, err := ssmAPI.PutParameter(&ssm.PutParameterInput{
+					Name:      aws.String(name),
+					Value:     aws.String(value),
+					Type:      aws.String("SecureString"),
+					Overwrite: aws.Bool(true),
 				})
-			})
-			Context("with a one-off build", func() {
-				It("parameterizes image_resource and params in a task config", func() {
-					By("executing a task that parameterizes image_resource")
-					watch := fly.Start("execute", "-c", "tasks/credential-management.yml")
-					Wait(watch)
-					Expect(watch).To(gbytes.Say("SECRET: Hiii"))
+				Expect(err).To(BeNil())
+			}
+		}, func() {
+			secrets := map[string]string{
+				"/concourse-topgun/main/team_secret":      "some_team_secret",
+				"/concourse-topgun/main/resource_version": "some_exposed_version_secret",
+			}
 
-					By("taking a dump")
-					session := pgDump()
-					Expect(session).ToNot(gbytes.Say("concourse/time-resource"))
-					Expect(session).To(gbytes.Say("Hiii")) // build echoed it; nothing we can do
+			for name, value := range secrets {
+				_, err := ssmAPI.PutParameter(&ssm.PutParameterInput{
+					Name:      aws.String(name),
+					Value:     aws.String(value),
+					Type:      aws.String("SecureString"),
+					Overwrite: aws.Bool(true),
 				})
-			})
+				Expect(err).To(BeNil())
+			}
 		})
 	})
 })

--- a/topgun/bbr_test.go
+++ b/topgun/bbr_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
@@ -15,6 +16,9 @@ var _ = Describe("BBR", func() {
 	var atc0URL string
 
 	BeforeEach(func() {
+		if !strings.Contains(string(bosh("releases").Out.Contents()), "backup-and-restore-sdk") {
+			Skip("backup-and-restore-sdk release not uploaded")
+		}
 
 		Deploy(
 			"deployments/concourse.yml",

--- a/topgun/credhub_test.go
+++ b/topgun/credhub_test.go
@@ -12,15 +12,12 @@ import (
 	"io/ioutil"
 	"math/big"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"code.cloudfoundry.org/credhub-cli/credhub"
 	"code.cloudfoundry.org/credhub-cli/credhub/credentials/values"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 	yaml "gopkg.in/yaml.v2"
 
 	. "github.com/concourse/concourse/topgun"
@@ -29,24 +26,6 @@ import (
 )
 
 var _ = Describe("Credhub", func() {
-	pgDump := func() *gexec.Session {
-		dump := exec.Command("pg_dump", "-U", "atc", "-h", dbInstance.IP, "atc")
-		dump.Env = append(os.Environ(), "PGPASSWORD=dummy-password")
-		dump.Stdin = bytes.NewBufferString("dummy-password\n")
-		session, err := gexec.Start(dump, GinkgoWriter, GinkgoWriter)
-		Expect(err).ToNot(HaveOccurred())
-		<-session.Exited
-		Expect(session.ExitCode()).To(Equal(0))
-		return session
-	}
-
-	getPipeline := func() *gexec.Session {
-		session := fly.Start("get-pipeline", "-p", "pipeline-credhub-test")
-		<-session.Exited
-		Expect(session.ExitCode()).To(Equal(0))
-		return session
-	}
-
 	BeforeEach(func() {
 		if !strings.Contains(string(bosh("releases").Out.Contents()), "credhub") {
 			Skip("credhub release not uploaded")
@@ -118,7 +97,7 @@ var _ = Describe("Credhub", func() {
 		Describe("/api/v1/info/creds", func() {
 			type responseSkeleton struct {
 				CredHub struct {
-					Url     string   `json:"url"`
+					URL     string   `json:"url"`
 					CACerts []string `json:"ca_certs"`
 					Health  struct {
 						Error    string `json:"error"`
@@ -128,24 +107,24 @@ var _ = Describe("Credhub", func() {
 						Method string `json:"method"`
 					} `json:"health"`
 					PathPrefix  string `json:"path_prefix"`
-					UAAClientId string `json:"uaa_client_id"`
+					UAAClientID string `json:"uaa_client_id"`
 				} `json:"credhub"`
 			}
 
 			var (
-				atcUrl         string
+				atcURL         string
 				parsedResponse responseSkeleton
 			)
 
 			BeforeEach(func() {
-				atcUrl = "http://" + JobInstance("web").IP + ":8080"
+				atcURL = "http://" + JobInstance("web").IP + ":8080"
 			})
 
 			JustBeforeEach(func() {
-				token, err := FetchToken(atcUrl, atcUsername, atcPassword)
+				token, err := FetchToken(atcURL, atcUsername, atcPassword)
 				Expect(err).ToNot(HaveOccurred())
 
-				body, err := RequestCredsInfo(atcUrl, token.AccessToken)
+				body, err := RequestCredsInfo(atcURL, token.AccessToken)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = json.Unmarshal(body, &parsedResponse)
@@ -153,104 +132,43 @@ var _ = Describe("Credhub", func() {
 			})
 
 			It("contains credhub config", func() {
-				Expect(parsedResponse.CredHub.Url).To(Equal("https://" + credhubInstance.IP + ":8844"))
+				Expect(parsedResponse.CredHub.URL).To(Equal("https://" + credhubInstance.IP + ":8844"))
 				Expect(parsedResponse.CredHub.Health.Response).ToNot(BeNil())
 				Expect(parsedResponse.CredHub.Health.Response.Status).To(Equal("UP"))
 				Expect(parsedResponse.CredHub.Health.Error).To(BeEmpty())
 			})
 		})
 
-		Context("with a pipeline build", func() {
-			BeforeEach(func() {
-				_, err := credhubClient.SetValue("/concourse/main/pipeline-credhub-test/resource_type_repository", values.Value("concourse/time-resource"))
-				Expect(err).ToNot(HaveOccurred())
+		testCredentialManagement(func() {
+			_, err := credhubClient.SetValue("/concourse/main/team_secret", values.Value("some_team_secret"))
+			Expect(err).ToNot(HaveOccurred())
 
-				credhubClient.SetValue("/concourse/main/pipeline-credhub-test/time_resource_interval", values.Value("10m"))
-				credhubClient.SetUser("/concourse/main/pipeline-credhub-test/job_secret", values.User{
-					Username: "Hello",
-					Password: "World",
-				})
-				credhubClient.SetValue("/concourse/main/team_secret", values.Value("Sauce"))
-				credhubClient.SetValue("/concourse/main/pipeline-credhub-test/image_resource_repository", values.Value("busybox"))
+			_, err = credhubClient.SetValue("/concourse/main/pipeline-creds-test/assertion_script", values.Value(assertionScript))
+			Expect(err).ToNot(HaveOccurred())
 
-				By("setting a pipeline that contains credhub secrets")
-				fly.Run("set-pipeline", "-n", "-c", "pipelines/credential-management.yml", "-p", "pipeline-credhub-test")
+			_, err = credhubClient.SetValue("/concourse/main/pipeline-creds-test/canary", values.Value("some_canary"))
+			Expect(err).ToNot(HaveOccurred())
 
-				By("getting the pipeline config")
-				session := getPipeline()
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("concourse/time-resource"))
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("10m"))
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("Hello/World"))
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("Sauce"))
-				Expect(string(session.Out.Contents())).ToNot(ContainSubstring("busybox"))
+			_, err = credhubClient.SetValue("/concourse/main/pipeline-creds-test/resource_type_secret", values.Value("some_resource_type_secret"))
+			Expect(err).ToNot(HaveOccurred())
 
-				By("unpausing the pipeline")
-				fly.Run("unpause-pipeline", "-p", "pipeline-credhub-test")
+			_, err = credhubClient.SetValue("/concourse/main/pipeline-creds-test/resource_secret", values.Value("some_resource_secret"))
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = credhubClient.SetUser("/concourse/main/pipeline-creds-test/job_secret", values.User{
+				Username: "some_username",
+				Password: "some_password",
 			})
+			Expect(err).ToNot(HaveOccurred())
 
-			It("parameterizes via Credhub and leaves the pipeline uninterpolated", func() {
-				By("triggering job")
-				watch := fly.Start("trigger-job", "-w", "-j", "pipeline-credhub-test/job-with-custom-input")
-				Wait(watch)
-				Expect(watch).To(gbytes.Say("GET SECRET: GET-Hello/GET-World"))
-				Expect(watch).To(gbytes.Say("PUT SECRET: PUT-Hello/PUT-World"))
-				Expect(watch).To(gbytes.Say("GET SECRET: PUT-GET-Hello/PUT-GET-World"))
-				Expect(watch).To(gbytes.Say("SECRET: Hello/World"))
-				Expect(watch).To(gbytes.Say("TEAM SECRET: Sauce"))
+			_, err = credhubClient.SetValue("/concourse/main/pipeline-creds-test/resource_version", values.Value("some_exposed_version_secret"))
+			Expect(err).ToNot(HaveOccurred())
+		}, func() {
+			_, err := credhubClient.SetValue("/concourse/main/team_secret", values.Value("some_team_secret"))
+			Expect(err).ToNot(HaveOccurred())
 
-				By("taking a dump")
-				session := pgDump()
-				Expect(session).ToNot(gbytes.Say("concourse/time-resource"))
-				Expect(session).ToNot(gbytes.Say("10m"))
-				Expect(session).To(gbytes.Say("Hello/World")) // build echoed it; nothing we can do
-				Expect(session).To(gbytes.Say("Sauce"))       // build echoed it; nothing we can do
-				Expect(session).ToNot(gbytes.Say("busybox"))
-			})
-
-			Context("when the job's inputs are used for a one-off build", func() {
-				It("parameterizes the values using the job's pipeline scope", func() {
-					By("triggering job to populate its inputs")
-					watch := fly.Start("trigger-job", "-w", "-j", "pipeline-credhub-test/job-with-input")
-					Wait(watch)
-					Expect(watch).To(gbytes.Say("GET SECRET: GET-Hello/GET-World"))
-					Expect(watch).To(gbytes.Say("PUT SECRET: PUT-Hello/PUT-World"))
-					Expect(watch).To(gbytes.Say("GET SECRET: PUT-GET-Hello/PUT-GET-World"))
-					Expect(watch).To(gbytes.Say("SECRET: Hello/World"))
-					Expect(watch).To(gbytes.Say("TEAM SECRET: Sauce"))
-
-					By("executing a task that parameterizes image_resource")
-					watch = fly.Start("execute", "-c", "tasks/credential-management-with-job-inputs.yml", "-j", "pipeline-credhub-test/job-with-input")
-					Wait(watch)
-					Expect(watch).To(gbytes.Say("./some-resource/input"))
-
-					By("taking a dump")
-					session := pgDump()
-					Expect(session).ToNot(gbytes.Say("concourse/time-resource"))
-					Expect(session).ToNot(gbytes.Say("10m"))
-					Expect(session).To(gbytes.Say("./some-resource/input")) // build echoed it; nothing we can do
-				})
-			})
-		})
-
-		Context("with a one-off build", func() {
-			BeforeEach(func() {
-				_, err := credhubClient.SetValue("/concourse/main/task_secret", values.Value("Hiii"))
-				Expect(err).ToNot(HaveOccurred())
-
-				credhubClient.SetValue("/concourse/main/image_resource_repository", values.Value("busybox"))
-			})
-
-			It("parameterizes image_resource and params in a task config", func() {
-				By("executing a task that parameterizes image_resource")
-				watch := fly.Start("execute", "-c", "tasks/credential-management.yml")
-				Wait(watch)
-				Expect(watch).To(gbytes.Say("SECRET: Hiii"))
-
-				By("taking a dump")
-				session := pgDump()
-				Expect(session).ToNot(gbytes.Say("concourse/time-resource"))
-				Expect(session).To(gbytes.Say("Hiii")) // build echoed it; nothing we can do
-			})
+			_, err = credhubClient.SetValue("/concourse/main/resource_version", values.Value("some_exposed_version_secret"))
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/topgun/creds_test.go
+++ b/topgun/creds_test.go
@@ -1,0 +1,130 @@
+package topgun_test
+
+import (
+	"github.com/onsi/gomega/gbytes"
+
+	. "github.com/concourse/concourse/topgun"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const assertionScript = `#!/bin/sh
+
+test "$SECRET_USERNAME" = "some_username"
+test "$SECRET_PASSWORD" = "some_password"
+test "$TEAM_SECRET" = "some_team_secret"
+
+test "$MIRRORED_VERSION" = "some_exposed_version_secret"
+
+test "$(cat some-resource/resource_secret)" = "some_resource_secret"
+test "$(cat custom-resource/custom_resource_secret)" = "some_resource_secret"
+test "$(cat params-in-get/username)" = "get_some_username"
+test "$(cat params-in-get/password)" = "get_some_password"
+test "$(cat params-in-put/version)" = "some_exposed_version_secret"
+test "$(cat params-in-put/username)" = "put_get_some_username"
+test "$(cat params-in-put/password)" = "put_get_some_password"
+
+# note: don't assert against canary/canary, since that's used for
+# testing that the credential isn't visible in 'get-pipeline'
+
+echo all credentials matched expected values
+`
+
+func testCredentialManagement(
+	pipelineSetup func(),
+	oneOffSetup func(),
+) {
+	Context("with a pipeline build", func() {
+		BeforeEach(func() {
+			pipelineSetup()
+
+			By("setting a pipeline that uses vars for secrets")
+			fly.Run("set-pipeline", "-n", "-c", "pipelines/credential-management.yml", "-p", "pipeline-creds-test")
+
+			By("getting the pipeline config")
+			session := fly.Start("get-pipeline", "-p", "pipeline-creds-test")
+			<-session.Exited
+			Expect(session.ExitCode()).To(Equal(0))
+			Expect(string(session.Out.Contents())).ToNot(ContainSubstring("some_canary"))
+			Expect(string(session.Out.Contents())).To(ContainSubstring("((resource_type_secret))"))
+			Expect(string(session.Out.Contents())).To(ContainSubstring("((resource_secret))"))
+			Expect(string(session.Out.Contents())).To(ContainSubstring("((job_secret.username))"))
+			Expect(string(session.Out.Contents())).To(ContainSubstring("((job_secret.password))"))
+			Expect(string(session.Out.Contents())).To(ContainSubstring("((resource_version))"))
+			Expect(string(session.Out.Contents())).To(ContainSubstring("((team_secret))"))
+
+			By("unpausing the pipeline")
+			fly.Run("unpause-pipeline", "-p", "pipeline-creds-test")
+		})
+
+		It("parameterizes via Vault and leaves the pipeline uninterpolated", func() {
+			By("triggering job")
+			watch := fly.Start("trigger-job", "-w", "-j", "pipeline-creds-test/some-job")
+			Wait(watch)
+			Expect(watch).To(gbytes.Say("all credentials matched expected values"))
+
+			By("taking a dump")
+			session := pgDump()
+			Expect(session).ToNot(gbytes.Say("some_resource_type_secret"))
+			Expect(session).ToNot(gbytes.Say("some_resource_secret"))
+			Expect(session).ToNot(gbytes.Say("some_username"))
+			Expect(session).ToNot(gbytes.Say("some_password"))
+			Expect(session).ToNot(gbytes.Say("some_team_secret"))
+
+			// versions aren't protected
+			Expect(session).To(gbytes.Say("some_exposed_version_secret"))
+		})
+
+		Context("when the job's inputs are used for a one-off build", func() {
+			It("parameterizes the values using the job's pipeline scope", func() {
+				By("triggering job to populate its inputs")
+				watch := fly.Start("trigger-job", "-w", "-j", "pipeline-creds-test/some-job")
+				Wait(watch)
+				Expect(watch).To(gbytes.Say("all credentials matched expected values"))
+
+				By("executing a task that parameterizes image_resource and uses a pipeline resource with credentials")
+				watch = fly.StartWithEnv(
+					[]string{
+						"EXPECTED_RESOURCE_SECRET=some_resource_secret",
+						"EXPECTED_RESOURCE_VERSION_SECRET=some_exposed_version_secret",
+					},
+					"execute",
+					"-c", "tasks/credential-management-with-job-inputs.yml",
+					"-j", "pipeline-creds-test/some-job",
+				)
+				Wait(watch)
+				Expect(watch).To(gbytes.Say("all credentials matched expected values"))
+
+				By("taking a dump")
+				session := pgDump()
+				Expect(session).ToNot(gbytes.Say("some_resource_secret"))
+
+				// versions aren't protected
+				Expect(session).To(gbytes.Say("some_exposed_version_secret"))
+			})
+		})
+	})
+
+	Context("with a one-off build", func() {
+		BeforeEach(oneOffSetup)
+
+		It("parameterizes image_resource and params in a task config", func() {
+			watch := fly.StartWithEnv(
+				[]string{
+					"EXPECTED_TEAM_SECRET=some_team_secret",
+					"EXPECTED_RESOURCE_VERSION_SECRET=some_exposed_version_secret",
+				},
+				"execute", "-c", "tasks/credential-management.yml",
+			)
+			Wait(watch)
+			Expect(watch).To(gbytes.Say("all credentials matched expected values"))
+
+			By("taking a dump")
+			session := pgDump()
+			Expect(session).ToNot(gbytes.Say("some_team_secret"))
+
+			// versions aren't protected
+			Expect(session).To(gbytes.Say("some_exposed_version_secret"))
+		})
+	})
+}

--- a/topgun/exec.go
+++ b/topgun/exec.go
@@ -51,4 +51,3 @@ func Run(env []string, command string, argv ...string) *gexec.Session {
 	Wait(session)
 	return session
 }
-

--- a/topgun/fly.go
+++ b/topgun/fly.go
@@ -64,6 +64,10 @@ func (f *Fly) Start(argv ...string) *gexec.Session {
 	return Start([]string{"HOME=" + f.Home}, f.Bin, append([]string{"-t", f.Target}, argv...)...)
 }
 
+func (f *Fly) StartWithEnv(env []string, argv ...string) *gexec.Session {
+	return Start(append([]string{"HOME=" + f.Home}, env...), f.Bin, append([]string{"-t", f.Target}, argv...)...)
+}
+
 func (f *Fly) SpawnInteractive(stdin io.Reader, argv ...string) *gexec.Session {
 	return SpawnInteractive(stdin, []string{"HOME=" + f.Home}, f.Bin, append([]string{"-t", f.Target}, argv...)...)
 }

--- a/topgun/k8s/kubernetes_creds_mgmt_test.go
+++ b/topgun/k8s/kubernetes_creds_mgmt_test.go
@@ -120,4 +120,3 @@ func createCredentialSecret(releaseName, secretName, team string, kv map[string]
 
 	Wait(Start(nil, "kubectl", args...))
 }
-

--- a/topgun/pipelines/credential-management.yml
+++ b/topgun/pipelines/credential-management.yml
@@ -1,88 +1,60 @@
 resource_types:
-- name: smuggler
-  type: registry-image
-  source:
-    repository: redfactorlabs/concourse-smuggler-resource
-    tag: ubuntu-14.04
-
 - name: custom-resource-type
-  type: registry-image
+  type: mock
   source:
-    repository: ((resource_type_repository))
+    mirror_self: true
+    create_files:
+      resource_type_secret: ((resource_type_secret))
 
 resources:
+- name: some-resource
+  type: mock
+  source:
+    create_files:
+      resource_secret: ((resource_secret))
+
 - name: custom-resource
   type: custom-resource-type
   source:
-    interval: ((time_resource_interval))
+    create_files:
+      custom_resource_secret: ((resource_secret))
 
-- name: some-resource
-  type: time
+- name: canary
+  type: mock
   source:
-    interval: ((time_resource_interval))
-
-- name: my_smuggler_resource
-  type: smuggler
-  source:
-    commands:
-      check: 'echo version > ${SMUGGLER_OUTPUT_DIR}/versions'
-      in: 'echo GET SECRET: $SMUGGLER_SECRET_USERNAME/$SMUGGLER_SECRET_PASSWORD'
-      out: 'echo PUT SECRET: $SMUGGLER_SECRET_USERNAME/$SMUGGLER_SECRET_PASSWORD; echo new-version > ${SMUGGLER_OUTPUT_DIR}/versions'
+    create_files:
+      # this is just here so we can assert in 'get-pipeline' that this value
+      # isn't interpolated on save
+      canary: ((canary))
 
 jobs:
-- name: job-with-input
+- name: some-job
   plan:
   - get: some-resource
-  - get: my_smuggler_resource
-    params:
-      smuggler_params:
-        SECRET_USERNAME: GET-((job_secret.username))
-        SECRET_PASSWORD: GET-((job_secret.password))
-  - put: my_smuggler_resource
-    params:
-      smuggler_params:
-        SECRET_USERNAME: PUT-((job_secret.username))
-        SECRET_PASSWORD: PUT-((job_secret.password))
-    get_params:
-      smuggler_params:
-        SECRET_USERNAME: PUT-GET-((job_secret.username))
-        SECRET_PASSWORD: PUT-GET-((job_secret.password))
-  - task: simple-task
-    params:
-      SECRET_USERNAME: ((job_secret.username))
-      SECRET_PASSWORD: ((job_secret.password))
-      TEAM_SECRET: ((team_secret))
-    config:
-      platform: linux
 
-      image_resource:
-        type: registry-image
-        source: {repository: ((image_resource_repository))}
-
-      params:
-        SECRET:
-
-      run:
-        path: sh
-        args: ['-c', 'echo TASK SECRET: $SECRET_USERNAME/$SECRET_PASSWORD, TEAM SECRET: $TEAM_SECRET']
-
-- name: job-with-custom-input
-  plan:
   - get: custom-resource
-  - get: my_smuggler_resource
+
+  - get: params-in-get
+    resource: some-resource
     params:
-      smuggler_params:
-        SECRET_USERNAME: GET-((job_secret.username))
-        SECRET_PASSWORD: GET-((job_secret.password))
-  - put: my_smuggler_resource
+      create_files_via_params:
+        username: get_((job_secret.username))
+        password: get_((job_secret.password))
+
+  - put: params-in-put
+    resource: some-resource
     params:
-      smuggler_params:
-        SECRET_USERNAME: PUT-((job_secret.username))
-        SECRET_PASSWORD: PUT-((job_secret.password))
+      version: ((resource_version))
     get_params:
-      smuggler_params:
-        SECRET_USERNAME: PUT-GET-((job_secret.username))
-        SECRET_PASSWORD: PUT-GET-((job_secret.password))
+      create_files_via_params:
+        username: put_get_((job_secret.username))
+        password: put_get_((job_secret.password))
+
+  - get: canary
+    params:
+      create_files_via_params:
+        assert.sh: ((assertion_script))
+
   - task: simple-task
     params:
       SECRET_USERNAME: ((job_secret.username))
@@ -92,12 +64,24 @@ jobs:
       platform: linux
 
       image_resource:
-        type: registry-image
-        source: {repository: ((image_resource_repository))}
+        type: mock
+        source:
+          mirror_self: true
+          force_version: ((resource_version))
 
       params:
         SECRET:
 
+      inputs:
+      - name: canary
+      - name: some-resource
+      - name: custom-resource
+      - name: params-in-get
+      - name: params-in-put
+
       run:
         path: sh
-        args: ['-c', 'echo TASK SECRET: $SECRET_USERNAME/$SECRET_PASSWORD, TEAM SECRET: $TEAM_SECRET']
+
+        # has to be executed as a file, otherwise 'fly watch' prints the
+        # command
+        args: [canary/assert.sh]

--- a/topgun/pipelines/secrets.yml
+++ b/topgun/pipelines/secrets.yml
@@ -1,20 +1,17 @@
 resource_types:
 - name: fake-resource-type
-  type: registry-image
+  type: mock
   source:
-    repository: concourse/time-resource
+    mirror_self: true
+    create_files:
+      resource_type_secret: resource_type_secret
 
 resources:
 - name: fake-resource
   type: fake-resource-type
   source:
-    interval: 1s
-    private_key: |
-      -----BEGIN RSA PRIVATE KEY-----
-      MIIEowIBAAKCAQEAtCS10/f7W7lkQaSgD/mVeaSOvSF9ql4hf/zfMwfVGgHWjj+W
-      resource_secret
-      DWiJL+OFeg9kawcUL6hQ8JeXPhlImG6RTUffma9+iGQyyBMCGd1l
-      -----END RSA PRIVATE KEY-----
+    create_files:
+      resource_secret: resource_secret
 
 jobs:
 - name: simple-job
@@ -27,8 +24,11 @@ jobs:
       platform: linux
 
       image_resource:
-        type: registry-image
-        source: {repository: busybox}
+        type: mock
+        source:
+          mirror_self: true
+          create_files:
+            resource_type_secret: image_resource_secret
 
       params:
         SECRET:

--- a/topgun/suite_test.go
+++ b/topgun/suite_test.go
@@ -1,12 +1,14 @@
 package topgun_test
 
 import (
+	"bytes"
 	"crypto/tls"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -547,4 +549,15 @@ dance:
 
 		break dance
 	}
+}
+
+func pgDump() *gexec.Session {
+	dump := exec.Command("pg_dump", "-U", "atc", "-h", dbInstance.IP, "atc")
+	dump.Env = append(os.Environ(), "PGPASSWORD=dummy-password")
+	dump.Stdin = bytes.NewBufferString("dummy-password\n")
+	session, err := gexec.Start(dump, nil, GinkgoWriter)
+	Expect(err).ToNot(HaveOccurred())
+	<-session.Exited
+	Expect(session.ExitCode()).To(Equal(0))
+	return session
 }

--- a/topgun/tasks/credential-management-with-job-inputs.yml
+++ b/topgun/tasks/credential-management-with-job-inputs.yml
@@ -2,12 +2,27 @@
 platform: linux
 
 image_resource:
-  type: registry-image
-  source: {repository: ((image_resource_repository))}
+  type: mock
+  source:
+    mirror_self: true
+    force_version: ((resource_version))
 
 inputs:
 - name: some-resource
 
+params:
+  EXPECTED_RESOURCE_SECRET:
+  EXPECTED_RESOURCE_VERSION_SECRET:
+
 run:
-  path: find
-  args: ['.']
+  path: sh
+  args:
+  - -ec
+  - |
+    # test image_resource secret
+    test "$MIRRORED_VERSION" = "$EXPECTED_RESOURCE_VERSION_SECRET"
+
+    # test input secret from job (secret is scoped to job's pipeline with execute -j)
+    test "$(cat some-resource/resource_secret)" = "$EXPECTED_RESOURCE_SECRET"
+
+    echo all credentials matched expected values

--- a/topgun/tasks/credential-management.yml
+++ b/topgun/tasks/credential-management.yml
@@ -2,12 +2,25 @@
 platform: linux
 
 image_resource:
-  type: registry-image
-  source: {repository: ((image_resource_repository))}
+  type: mock
+  source:
+    mirror_self: true
+    force_version: ((resource_version))
 
 params:
-  SECRET: ((task_secret))
+  TEAM_SECRET: ((team_secret))
+  EXPECTED_TEAM_SECRET:
+  EXPECTED_RESOURCE_VERSION_SECRET:
 
 run:
   path: sh
-  args: ['-c', 'echo SECRET: $SECRET']
+  args:
+  - -ec
+  - |
+    # test image_resource secret
+    test "$MIRRORED_VERSION" = "$EXPECTED_RESOURCE_VERSION_SECRET"
+
+    # test team-scoped secret via params
+    test "$TEAM_SECRET" = "$EXPECTED_TEAM_SECRET"
+
+    echo all credentials matched expected values


### PR DESCRIPTION
* centralize on one shared example (in creds_test.go)
* switch from smuggler to mock resource, make assertions and credential values clearer
* change AWS SSM suite to set up its own variables, rather than depending on things being set up beforehand
  * note: this means it needs PutParameter access, though this should be fine since it's limited to a /concourse-topgun/* namespace anyway