### PR TITLE
atc: fix syslog leaking goroutines

### DIFF
--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -104,7 +104,7 @@ func (d *drainer) drainBuild(logger lager.Logger, build db.Build, syslog *Syslog
 
 			err = syslog.Write(d.hostname, tag, time.Unix(log.Time, 0), payload)
 			if err != nil {
-				logger.Error("failed-to-write-to-server", err, lager.Data{"tag": tag})
+				logger.Error("failed-to-write-to-server", err)
 				return err
 			}
 		}

--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/event"
@@ -49,51 +50,66 @@ func (d *drainer) Run(ctx context.Context) error {
 			logger.Error("Syslog drainer connecting to server error.", err)
 			return err
 		}
-		defer syslog.Close()
+
+		// ignore any errors coming from syslog.Close()
+		defer db.Close(syslog)
 
 		for _, build := range builds {
-			events, err := build.Events(0)
+			err := d.drainBuild(logger, build, syslog)
 			if err != nil {
-				logger.Error("Syslog drainer getting build events error.", err)
-				return err
-			}
-
-			for {
-				ev, err := events.Next()
-				if err != nil {
-					if err == db.ErrEndOfBuildEventStream {
-						break
-					}
-					logger.Error("Syslog drainer getting next event error.", err)
-					return err
-				}
-
-				if ev.Event == "log" {
-					var log event.Log
-
-					err := json.Unmarshal(*ev.Data, &log)
-					if err != nil {
-						logger.Error("Syslog drainer unmarshalling log error.", err)
-						return err
-					}
-
-					payload := log.Payload
-					tag := build.TeamName() + "/" + build.PipelineName() + "/" + build.JobName() + "/" + build.Name() + "/" + string(log.Origin.ID)
-
-					err = syslog.Write(d.hostname, tag, time.Unix(log.Time, 0), payload)
-					if err != nil {
-						logger.Error("Syslog drainer sending to server error.", err)
-						return err
-					}
-				}
-			}
-
-			err = build.SetDrained(true)
-			if err != nil {
-				logger.Error("Syslog drainer setting drained on build error.", err)
 				return err
 			}
 		}
 	}
+	return nil
+}
+
+func (d *drainer) drainBuild(logger lager.Logger, build db.Build, syslog *Syslog) error {
+	events, err := build.Events(0)
+	if err != nil {
+		logger.Error("Syslog drainer getting build events error.", err)
+		return err
+	}
+
+	// ignore any errors coming from events.Close()
+	defer db.Close(events)
+
+	for {
+		ev, err := events.Next()
+		if err != nil {
+			if err == db.ErrEndOfBuildEventStream {
+				break
+			}
+			logger.Error("Syslog drainer getting next event error.", err)
+			return err
+		}
+
+		if ev.Event == "log" {
+			var log event.Log
+
+			err := json.Unmarshal(*ev.Data, &log)
+			if err != nil {
+				logger.Error("Syslog drainer unmarshalling log error.", err)
+				return err
+			}
+
+			payload := log.Payload
+			tag := build.TeamName() + "/" + build.PipelineName() + "/" + build.JobName() + "/" + build.Name() + "/" + string(log.Origin.ID)
+
+
+			err = syslog.Write(d.hostname, tag, time.Unix(log.Time, 0), payload)
+			if err != nil {
+				logger.Error("Syslog drainer sending to server error.", err)
+				return err
+			}
+		}
+	}
+
+	err = build.SetDrained(true)
+	if err != nil {
+		logger.Error("Syslog drainer setting drained on build error.", err)
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
fixes #3207 

`Build.Events()` spawns off a goroutine to do stuff with the db and needs to be closed.