### PR TITLE
ci: run property checks against linux-rc

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -280,20 +280,21 @@ jobs:
   plan:
   - aggregate:
     - get: concourse
-      passed: [dev-image]
+      passed: [bin-smoke]
       trigger: true
-    - get: dev-image
-      passed: [dev-image]
+    - get: unit-image
+      passed: [bin-smoke]
       trigger: true
-    - get: helm-chart
-      resource: charts
+    - get: linux-rc
+      passed: [bin-smoke]
+      trigger: true
+    - get: charts
       trigger: true
   - task: check-params
     file: concourse/ci/tasks/check-distribution-env.yml
-    image: dev-image
-    input_mapping: {distribution: helm-chart}
+    image: unit-image
+    input_mapping: {distribution: charts}
     params: {DISTRIBUTION: helm}
-
 
 - name: k8s-topgun
   public: true
@@ -511,13 +512,16 @@ jobs:
     - get: concourse
       passed: [bin-smoke]
       trigger: true
-    - get: dev-image
+    - get: unit-image
+      passed: [bin-smoke]
+      trigger: true
+    - get: linux-rc
       passed: [bin-smoke]
       trigger: true
     - get: concourse-release-repo
-  - task: check-params
+  - task: check-props
     file: concourse/ci/tasks/check-distribution-env.yml
-    image: dev-image
+    image: unit-image
     input_mapping: {distribution: concourse-release-repo}
     params: {DISTRIBUTION: bosh}
 

--- a/ci/tasks/check-distribution-env.yml
+++ b/ci/tasks/check-distribution-env.yml
@@ -3,10 +3,11 @@ platform: linux
 
 image_resource:
   type: registry-image
-  source: {repository: concourse/dev}
+  source: {repository: concourse/unit}
 
 inputs:
 - name: concourse
+- name: linux-rc
 - name: distribution
 
 params:

--- a/ci/tasks/scripts/check-distribution-env/diff
+++ b/ci/tasks/scripts/check-distribution-env/diff
@@ -9,6 +9,7 @@
 set -e -u
 
 distro_dir=$PWD/distribution
+linux_rc=$PWD/linux-rc
 distro_scripts=$(dirname $0)/$DISTRIBUTION
 
 main() {
@@ -31,8 +32,10 @@ get_distribution_variables() {
 }
 
 get_concourse_variables() {
+  tar -zxf $linux_rc/concourse-*.tgz -C $linux_rc
+
   for subcommand in web worker; do
-    concourse $subcommand --help 2>&1 |
+    $linux_rc/concourse/bin/concourse $subcommand --help 2>&1 |
       grep -o '\[\$.*\]' |
       tr -d \[\]\$
   done | filter_list ignored-in-concourse


### PR DESCRIPTION
rather than threading dev-image through bin-smoke (which doesn't need it), we'll run property checks against the built RC which comes out of it