### PR TITLE
web: broke dependency loop in routes-newtopbar-build

### DIFF
--- a/web/elm/src/Build.elm
+++ b/web/elm/src/Build.elm
@@ -81,7 +81,7 @@ type StepRenderingState
 
 type alias Flags =
     { csrfToken : String
-    , highlight : Models.Highlight
+    , highlight : Routes.Highlight
     }
 
 

--- a/web/elm/src/Build/Models.elm
+++ b/web/elm/src/Build/Models.elm
@@ -1,6 +1,5 @@
 module Build.Models exposing
-    ( Highlight(..)
-    , HookedStep
+    ( HookedStep
     , MetadataField
     , Model
     , OutputModel
@@ -19,11 +18,12 @@ module Build.Models exposing
 
 import Ansi.Log
 import Array exposing (Array)
-import Build.Msgs exposing (Hoverable, Msg, StepID)
+import Build.Msgs exposing (Hoverable, Msg)
 import Concourse
 import Date exposing (Date)
 import Dict exposing (Dict)
 import RemoteData exposing (WebData)
+import Routes exposing (Highlight(..), StepID)
 import Subscription exposing (Subscription)
 import Time exposing (Time)
 
@@ -119,12 +119,6 @@ type StepTree
 
 type alias StepFocus =
     { update : (StepTree -> StepTree) -> StepTree -> StepTree }
-
-
-type Highlight
-    = HighlightNothing
-    | HighlightLine StepID Int
-    | HighlightRange StepID Int Int
 
 
 type alias Step =

--- a/web/elm/src/Build/Msgs.elm
+++ b/web/elm/src/Build/Msgs.elm
@@ -1,8 +1,9 @@
-module Build.Msgs exposing (Hoverable(..), Msg(..), StepID)
+module Build.Msgs exposing (Hoverable(..), Msg(..))
 
 import Concourse
 import Concourse.BuildEvents
 import Keyboard
+import Routes exposing (StepID)
 import Scroll
 import StrictEvents
 import Time
@@ -27,10 +28,6 @@ type Msg
     | SetHighlight String Int
     | ExtendHighlight String Int
     | ScrollDown
-
-
-type alias StepID =
-    String
 
 
 type Hoverable

--- a/web/elm/src/Build/Output.elm
+++ b/web/elm/src/Build/Output.elm
@@ -17,7 +17,7 @@ import Build.Models
         , StepTree
         , StepTreeModel
         )
-import Build.Msgs exposing (Msg(..), StepID)
+import Build.Msgs exposing (Msg(..))
 import Build.StepTree as StepTree
 import Build.Styles as Styles
 import Concourse
@@ -40,6 +40,7 @@ import Html.Attributes
 import Http
 import LoadingIndicator
 import NotAuthorized
+import Routes exposing (StepID)
 import Subscription exposing (Subscription(..))
 
 
@@ -49,7 +50,7 @@ type OutMsg
 
 
 type alias Flags =
-    { highlight : Build.Models.Highlight }
+    { highlight : Routes.Highlight }
 
 
 init : Flags -> Concourse.Build -> ( OutputModel, List Effect )

--- a/web/elm/src/Build/StepTree.elm
+++ b/web/elm/src/Build/StepTree.elm
@@ -15,8 +15,7 @@ import Ansi.Log
 import Array exposing (Array)
 import Build.Models
     exposing
-        ( Highlight(..)
-        , HookedStep
+        ( HookedStep
         , MetadataField
         , Step
         , StepFocus
@@ -28,7 +27,7 @@ import Build.Models
         , TabFocus(..)
         , Version
         )
-import Build.Msgs exposing (Hoverable(..), Msg(..), StepID)
+import Build.Msgs exposing (Hoverable(..), Msg(..))
 import Build.Styles as Styles
 import Concourse
 import Date exposing (Date)
@@ -40,7 +39,7 @@ import Effects exposing (Effect(..))
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, class, classList, href, style)
 import Html.Events exposing (onClick, onMouseDown, onMouseEnter, onMouseLeave)
-import Routes exposing (showHighlight)
+import Routes exposing (Highlight(..), StepID, showHighlight)
 import Spinner
 import StrictEvents
 

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -1,6 +1,8 @@
 module Routes exposing
-    ( Route(..)
+    ( Highlight(..)
+    , Route(..)
     , SearchType(..)
+    , StepID
     , buildRoute
     , dashboardRoute
     , jobRoute
@@ -11,7 +13,6 @@ module Routes exposing
     , tokenToFlyRoute
     )
 
-import Build.Models exposing (Highlight(..))
 import Concourse
 import Concourse.Pagination as Pagination exposing (Direction(..))
 import Navigation exposing (Location)
@@ -44,6 +45,16 @@ type Route
 type SearchType
     = HighDensity
     | Normal (Maybe String)
+
+
+type Highlight
+    = HighlightNothing
+    | HighlightLine StepID Int
+    | HighlightRange StepID Int Int
+
+
+type alias StepID =
+    String
 
 
 

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -19,6 +19,7 @@ import Expect
 import Html.Attributes as Attr
 import Layout
 import Msgs
+import Routes
 import SubPage.Msgs
 import Test exposing (..)
 import Test.Html.Event as Event
@@ -42,7 +43,7 @@ all =
             pageLoad =
                 Build.init
                     { csrfToken = ""
-                    , highlight = Models.HighlightNothing
+                    , highlight = Routes.HighlightNothing
                     }
                     (Models.JobBuildPage
                         { teamName = "team"

--- a/web/elm/tests/NewestTopBarTests.elm
+++ b/web/elm/tests/NewestTopBarTests.elm
@@ -337,7 +337,7 @@ all =
                     >> Expect.equal [ Effects.RedirectToLogin ]
             ]
         , rspecStyleDescribe "rendering top bar on build page"
-            (NewestTopBar.init { route = Routes.Build "team" "pipeline" "job" "1" Build.Models.HighlightNothing }
+            (NewestTopBar.init { route = Routes.Build "team" "pipeline" "job" "1" Routes.HighlightNothing }
                 |> Tuple.first
                 |> NewestTopBar.view
                 |> toUnstyled

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -20,6 +20,7 @@ import Build.StepTree as StepTree
 import Concourse exposing (BuildStep(..), HookedPlan)
 import Dict
 import Expect exposing (..)
+import Routes
 import Test exposing (..)
 
 
@@ -39,12 +40,12 @@ all =
         ]
 
 
-someStep : Msgs.StepID -> Models.StepName -> Models.StepState -> Models.Step
+someStep : Routes.StepID -> Models.StepName -> Models.StepState -> Models.Step
 someStep =
     someVersionedStep Nothing
 
 
-someVersionedStep : Maybe Models.Version -> Msgs.StepID -> Models.StepName -> Models.StepState -> Models.Step
+someVersionedStep : Maybe Models.Version -> Routes.StepID -> Models.StepName -> Models.StepState -> Models.Step
 someVersionedStep version id name state =
     { id = id
     , name = name
@@ -68,7 +69,7 @@ initTask : Test
 initTask =
     let
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "some-id"
                 , step = BuildStepTask "some-name"
@@ -97,7 +98,7 @@ initGet =
             Dict.fromList [ ( "some", "version" ) ]
 
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "some-id"
                 , step = BuildStepGet "some-name" (Just version)
@@ -123,7 +124,7 @@ initPut : Test
 initPut =
     let
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "some-id"
                 , step = BuildStepPut "some-name"
@@ -149,7 +150,7 @@ initAggregate : Test
 initAggregate =
     let
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "aggregate-id"
                 , step =
@@ -193,7 +194,7 @@ initAggregateNested : Test
 initAggregateNested =
     let
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "aggregate-id"
                 , step =
@@ -258,7 +259,7 @@ initOnSuccess : Test
 initOnSuccess =
     let
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =
@@ -307,7 +308,7 @@ initOnFailure : Test
 initOnFailure =
     let
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =
@@ -356,7 +357,7 @@ initEnsure : Test
 initEnsure =
     let
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =
@@ -405,7 +406,7 @@ initTry : Test
 initTry =
     let
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =
@@ -436,7 +437,7 @@ initTimeout : Test
 initTimeout =
     let
         { tree, foci, finished } =
-            StepTree.init Models.HighlightNothing
+            StepTree.init Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =
@@ -479,7 +480,13 @@ updateStep f tree =
             tree
 
 
-assertFocus : Msgs.StepID -> Dict.Dict Msgs.StepID Models.StepFocus -> Models.StepTree -> (Models.Step -> Models.Step) -> Models.StepTree -> Expectation
+assertFocus :
+    Routes.StepID
+    -> Dict.Dict Routes.StepID Models.StepFocus
+    -> Models.StepTree
+    -> (Models.Step -> Models.Step)
+    -> Models.StepTree
+    -> Expectation
 assertFocus id foci tree update expected =
     case Dict.get id foci of
         Nothing ->


### PR DESCRIPTION
We need Highlight and StepID from Build.Models for the Routes models, but once we put the topbar into the build page Build.Models will depend on Routes! Moving them up to Routes solves the issue.

I kinda want to get this out separately so it can be reviewed as its own change, if @pivotal-jamie-klassen thinks of better places it could go or whatever.

This is a pure refactor; there are no meaningful code changes.