### PR TITLE
atc: fix growing stack on process reattach

### DIFF
--- a/atc/worker/retryable_garden_connection.go
+++ b/atc/worker/retryable_garden_connection.go
@@ -28,7 +28,7 @@ func (conn *RetryableConnection) Run(handle string, processSpec garden.ProcessSp
 		Process: innerProcess,
 
 		rehydrate: func() (garden.Process, error) {
-			return conn.Attach(handle, innerProcess.ID(), processIO)
+			return conn.Connection.Attach(handle, innerProcess.ID(), processIO)
 		},
 	}, nil
 }
@@ -43,7 +43,7 @@ func (conn *RetryableConnection) Attach(handle string, processID string, process
 		Process: innerProcess,
 
 		rehydrate: func() (garden.Process, error) {
-			return conn.Attach(handle, processID, processIO)
+			return conn.Connection.Attach(handle, processID, processIO)
 		},
 	}, nil
 }


### PR DESCRIPTION
saw some pretty funky dumps on prod that showed huge call stacks of `.Wait` - this should fix it

this should return a non-retryable process, otherwise the `.Wait` calls will recurse each time the process is rehydrated