### PR TITLE
Fix list containers endpoint

### DIFF
--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -120,11 +120,19 @@ func (t *team) Containers(
 	logger lager.Logger,
 ) ([]Container, error) {
 	rows, err := selectContainers("c").
+		Join("workers w ON c.worker_name = w.name").
 		Join("resource_config_check_sessions rccs ON rccs.id = c.resource_config_check_session_id").
 		Join("resources r ON r.resource_config_id = rccs.resource_config_id").
 		Join("pipelines p ON p.id = r.pipeline_id").
 		Where(sq.Eq{
 			"p.team_id": t.id,
+		}).
+		Where(sq.Or{
+			sq.Eq{
+				"w.team_id": t.id,
+			}, sq.Eq{
+				"w.team_id": nil,
+			},
 		}).
 		Distinct().
 		RunWith(t.conn).
@@ -140,11 +148,19 @@ func (t *team) Containers(
 	}
 
 	rows, err = selectContainers("c").
+		Join("workers w ON c.worker_name = w.name").
 		Join("resource_config_check_sessions rccs ON rccs.id = c.resource_config_check_session_id").
 		Join("resource_types rt ON rt.resource_config_id = rccs.resource_config_id").
 		Join("pipelines p ON p.id = rt.pipeline_id").
 		Where(sq.Eq{
 			"p.team_id": t.id,
+		}).
+		Where(sq.Or{
+			sq.Eq{
+				"w.team_id": t.id,
+			}, sq.Eq{
+				"w.team_id": nil,
+			},
 		}).
 		Distinct().
 		RunWith(t.conn).

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -415,52 +415,241 @@ var _ = Describe("Team", func() {
 			firstContainerCreating db.CreatingContainer
 		)
 
-		BeforeEach(func() {
-			fakeVariablesFactory = new(credsfakes.FakeVariablesFactory)
-			variables = template.StaticVariables{}
-			fakeVariablesFactory.NewVariablesReturns(variables)
+		Context("when there is a task container and a check container", func() {
+			BeforeEach(func() {
+				fakeVariablesFactory = new(credsfakes.FakeVariablesFactory)
+				variables = template.StaticVariables{}
+				fakeVariablesFactory.NewVariablesReturns(variables)
 
-			job, found, err := defaultPipeline.Job("some-job")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+				job, found, err := defaultPipeline.Job("some-job")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
 
-			build, err := job.CreateBuild()
-			Expect(err).ToNot(HaveOccurred())
+				build, err := job.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
 
-			firstContainerCreating, err = defaultWorker.CreateContainer(db.NewBuildStepContainerOwner(build.ID(), atc.PlanID("some-job"), defaultTeam.ID()), db.ContainerMetadata{Type: "task", StepName: "some-task"})
-			Expect(err).ToNot(HaveOccurred())
+				firstContainerCreating, err = defaultWorker.CreateContainer(db.NewBuildStepContainerOwner(build.ID(), atc.PlanID("some-job"), defaultTeam.ID()), db.ContainerMetadata{Type: "task", StepName: "some-task"})
+				Expect(err).ToNot(HaveOccurred())
 
-			expiries := db.ContainerOwnerExpiries{
-				GraceTime: 2 * time.Minute,
-				Min:       5 * time.Minute,
-				Max:       1 * time.Hour,
-			}
+				expiries := db.ContainerOwnerExpiries{
+					GraceTime: 2 * time.Minute,
+					Min:       5 * time.Minute,
+					Max:       1 * time.Hour,
+				}
 
-			pipelineResourceTypes, err := defaultPipeline.ResourceTypes()
-			Expect(err).ToNot(HaveOccurred())
+				pipelineResourceTypes, err := defaultPipeline.ResourceTypes()
+				Expect(err).ToNot(HaveOccurred())
 
-			resourceConfigScope, err = defaultResource.SetResourceConfig(logger, defaultResource.Source(), creds.NewVersionedResourceTypes(variables, pipelineResourceTypes.Deserialize()))
-			Expect(err).ToNot(HaveOccurred())
+				resourceConfigScope, err = defaultResource.SetResourceConfig(logger, defaultResource.Source(), creds.NewVersionedResourceTypes(variables, pipelineResourceTypes.Deserialize()))
+				Expect(err).ToNot(HaveOccurred())
 
-			resourceContainer, err = defaultWorker.CreateContainer(
-				db.NewResourceConfigCheckSessionContainerOwner(resourceConfigScope.ResourceConfig(), expiries),
-				db.ContainerMetadata{},
-			)
-			Expect(err).ToNot(HaveOccurred())
+				resourceContainer, err = defaultWorker.CreateContainer(
+					db.NewResourceConfigCheckSessionContainerOwner(resourceConfigScope.ResourceConfig(), expiries),
+					db.ContainerMetadata{},
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("finds all the containers", func() {
+				containers, err := defaultTeam.Containers(logger)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(containers).To(HaveLen(2))
+				Expect(containers).To(ConsistOf(firstContainerCreating, resourceContainer))
+			})
+
+			It("does not find containers for other teams", func() {
+				containers, err := otherTeam.Containers(logger)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(containers).To(BeEmpty())
+			})
+
 		})
 
-		It("finds all the containers", func() {
-			containers, err := defaultTeam.Containers(logger)
-			Expect(err).ToNot(HaveOccurred())
+		Context("when there is a check container on a team worker", func() {
+			var resourceContainer db.Container
 
-			Expect(containers).To(HaveLen(2))
-			Expect(containers).To(ConsistOf(firstContainerCreating, resourceContainer))
+			BeforeEach(func() {
+				atcWorker := atc.Worker{
+					ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+					Name:            "default-team-worker",
+					GardenAddr:      "3.4.5.6:7777",
+					BaggageclaimURL: "7.8.9.10:7878",
+					Team:            defaultTeam.Name(),
+				}
+
+				worker, err := defaultTeam.SaveWorker(atcWorker, 0)
+				Expect(err).ToNot(HaveOccurred())
+
+				expiries := db.ContainerOwnerExpiries{
+					GraceTime: 2 * time.Minute,
+					Min:       5 * time.Minute,
+					Max:       1 * time.Hour,
+				}
+
+				resourceConfigScope, err = defaultResource.SetResourceConfig(logger, defaultResource.Source(), creds.VersionedResourceTypes{})
+				Expect(err).ToNot(HaveOccurred())
+
+				resourceContainer, err = worker.CreateContainer(
+					db.NewResourceConfigCheckSessionContainerOwner(resourceConfigScope.ResourceConfig(), expiries),
+					db.ContainerMetadata{
+						Type: "check",
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("finds the container", func() {
+				containers, err := defaultTeam.Containers(logger)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(containers).To(HaveLen(1))
+				Expect(containers).To(ConsistOf(resourceContainer))
+			})
+
+			Context("when there is another check container with the same resource config on a different team worker", func() {
+				var (
+					resource2Container db.Container
+					otherTeam          db.Team
+					err                error
+				)
+
+				BeforeEach(func() {
+					otherTeam, err = teamFactory.CreateTeam(atc.Team{Name: "other-team"})
+					Expect(err).NotTo(HaveOccurred())
+
+					otherPipeline, _, err := otherTeam.SavePipeline("other-pipeline", atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+							},
+						},
+						Resources: atc.ResourceConfigs{
+							{
+								Name: "some-resource",
+								Type: "some-base-resource-type",
+								Source: atc.Source{
+									"some": "source",
+								},
+							},
+						},
+						ResourceTypes: atc.ResourceTypes{
+							{
+								Name: "some-type",
+								Type: "some-base-resource-type",
+								Source: atc.Source{
+									"some-type": "source",
+								},
+							},
+						},
+					}, db.ConfigVersion(0), db.PipelineUnpaused)
+					Expect(err).NotTo(HaveOccurred())
+
+					otherResource, found, err := otherPipeline.Resource("some-resource")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(found).To(BeTrue())
+
+					atcWorker := atc.Worker{
+						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+						Name:            "other-team-worker",
+						GardenAddr:      "4.5.6.7:7777",
+						BaggageclaimURL: "8.9.10.11:7878",
+						Team:            otherTeam.Name(),
+					}
+
+					worker, err := otherTeam.SaveWorker(atcWorker, 0)
+					Expect(err).ToNot(HaveOccurred())
+
+					expiries := db.ContainerOwnerExpiries{
+						GraceTime: 2 * time.Minute,
+						Min:       5 * time.Minute,
+						Max:       1 * time.Hour,
+					}
+
+					resourceConfigScope, err = otherResource.SetResourceConfig(logger, otherResource.Source(), creds.VersionedResourceTypes{})
+					Expect(err).ToNot(HaveOccurred())
+
+					resource2Container, err = worker.CreateContainer(
+						db.NewResourceConfigCheckSessionContainerOwner(resourceConfigScope.ResourceConfig(), expiries),
+						db.ContainerMetadata{
+							Type: "check",
+						},
+					)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("returns the container only from the team", func() {
+					containers, err := otherTeam.Containers(logger)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(containers).To(HaveLen(1))
+					Expect(containers).To(ConsistOf(resource2Container))
+				})
+			})
+
+			Context("when there is a check container with the same resource config on a global worker", func() {
+				var (
+					globalResourceContainer db.Container
+				)
+
+				BeforeEach(func() {
+					expiries := db.ContainerOwnerExpiries{
+						GraceTime: 2 * time.Minute,
+						Min:       5 * time.Minute,
+						Max:       1 * time.Hour,
+					}
+
+					resourceConfigScope, err := defaultResource.SetResourceConfig(logger, defaultResource.Source(), creds.VersionedResourceTypes{})
+					Expect(err).ToNot(HaveOccurred())
+
+					globalResourceContainer, err = defaultWorker.CreateContainer(
+						db.NewResourceConfigCheckSessionContainerOwner(resourceConfigScope.ResourceConfig(), expiries),
+						db.ContainerMetadata{
+							Type: "check",
+						},
+					)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("returns the container only from the team worker and global worker", func() {
+					containers, err := defaultTeam.Containers(logger)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(containers).To(HaveLen(2))
+					Expect(containers).To(ConsistOf(resourceContainer, globalResourceContainer))
+				})
+			})
 		})
 
-		It("does not find containers for other teams", func() {
-			containers, err := otherTeam.Containers(logger)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(containers).To(BeEmpty())
+		Context("when there is a check container for a resource type", func() {
+			var resourceContainer db.Container
+
+			BeforeEach(func() {
+				expiries := db.ContainerOwnerExpiries{
+					GraceTime: 2 * time.Minute,
+					Min:       5 * time.Minute,
+					Max:       1 * time.Hour,
+				}
+
+				resourceConfigScope, err := defaultResourceType.SetResourceConfig(logger, defaultResourceType.Source(), creds.VersionedResourceTypes{})
+				Expect(err).ToNot(HaveOccurred())
+
+				resourceContainer, err = defaultWorker.CreateContainer(
+					db.NewResourceConfigCheckSessionContainerOwner(resourceConfigScope.ResourceConfig(), expiries),
+					db.ContainerMetadata{
+						Type: "check",
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("finds the container", func() {
+				containers, err := defaultTeam.Containers(logger)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(containers).To(HaveLen(1))
+				Expect(containers).To(ConsistOf(resourceContainer))
+			})
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/circonus-labs/circonus-gometrics v2.2.1+incompatible // indirect
 	github.com/circonus-labs/circonusllhist v0.0.0-20180430145027-5eb751da55c6 // indirect
 	github.com/cloudfoundry/bosh-cli v5.4.0+incompatible
-	github.com/cloudfoundry/bosh-utils v0.0.0-20180919212956-15c556314b68 // indirect
+	github.com/cloudfoundry/bosh-utils v0.0.0-20181224171034-c2cf699102bd // indirect
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
 	github.com/concourse/baggageclaim v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/cloudfoundry/bosh-cli v5.4.0+incompatible h1:KpT2PBB7nP1QnK8guXeZ/D2k
 github.com/cloudfoundry/bosh-cli v5.4.0+incompatible/go.mod h1:rzIB+e1sn7wQL/TJ54bl/FemPKRhXby5BIMS3tLuWFM=
 github.com/cloudfoundry/bosh-utils v0.0.0-20180919212956-15c556314b68 h1:ITkZdbjPpKp2fZ+ceXsEgNTRqyDM4xTRWSa+ulko3z0=
 github.com/cloudfoundry/bosh-utils v0.0.0-20180919212956-15c556314b68/go.mod h1:JCrKwetZGjxbfq1U139TZuXDBfdGLtjOEAfxMWKV/QM=
+github.com/cloudfoundry/bosh-utils v0.0.0-20181224171034-c2cf699102bd h1:MoLE+6GJml+nqHFXKXQSQsmRieKgyyttAYDUIK2YNfY=
+github.com/cloudfoundry/bosh-utils v0.0.0-20181224171034-c2cf699102bd/go.mod h1:JCrKwetZGjxbfq1U139TZuXDBfdGLtjOEAfxMWKV/QM=
 github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e h1:FQdRViaoDphGRfgrotl2QGsX1gbloe57dbGBS5CG6KY=
 github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e/go.mod h1:PXmcacyJB/pJjSxEl15IU6rEIKXrhZQRzsr0UTkgNNs=
 github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 h1:9j2KbUEQn5E7MEV3enSrkJTrBC0iDbosW5gXX+Z+dLE=


### PR DESCRIPTION
Fixes the bug where the list containers api endpoint would return check
containers that belonged to a worker that you are not authorized to see
(for example, a worker scoped to a different team).
