### PR TITLE
WIP: keepalive worker ssh connections

### DIFF
--- a/tsa/tsacmd/server.go
+++ b/tsa/tsacmd/server.go
@@ -121,6 +121,18 @@ func (server *server) Serve(listener net.Listener) error {
 			"remote": conn.RemoteAddr().String(),
 		})
 
+		if tc, ok := conn.(*net.TCPConn); ok {
+			err := tc.SetKeepAlive(true)
+			if err != nil {
+				logger.Error("failed-to-set-tcp-keepalive", err)
+			}
+
+			err = tc.SetKeepAlivePeriod(15 * time.Second)
+			if err != nil {
+				logger.Error("failed-to-set-tcp-keepalive-period", err)
+			}
+		}
+
 		go server.handshake(logger, conn)
 	}
 }

--- a/tsa/tsacmd/server_runner.go
+++ b/tsa/tsacmd/server_runner.go
@@ -26,17 +26,16 @@ func (runner serverRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) 
 
 	close(ready)
 
-	exited := make(chan struct{})
+	exited := make(chan error)
 
 	go func() {
-		defer close(exited)
-		runner.server.Serve(listener)
+		exited <- runner.server.Serve(listener)
 	}()
 
 	for {
 		select {
-		case <-exited:
-			return nil
+		case err := <-exited:
+			return err
 		case <-signals:
 			listener.Close()
 		}


### PR DESCRIPTION
note: i haven't tested this out with a failing worker yet. it would be nice to have topgun coverage for this sort of thing where we can simulate a hard shutdown. maybe we should try it out before merging?

i also snuck in a cleanup of the `.Accept` loop which is technically unrelated but the bare `return` on any error felt a bit scary in light of possible 'max open files' errors (which would previously cause the TSA to exit).

for the future: we should probably move to https://github.com/gliderlabs/ssh when we have time. once we're using that we can set idle timeout instead, which feels a *little* more intuitive (this is the only place where we have the *server* set tcpkeepalives, usually it's done via the dialer). an idle timeout should be sufficient since we can set it based on the heartbeat interval, which should keep the connection alive.