### PR TITLE
concourse/dev: don't preserve /src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV CONCOURSE_TSA_PUBLIC_KEY         /concourse-keys/tsa_host_key.pub
 ENV CONCOURSE_TSA_WORKER_PRIVATE_KEY /concourse-keys/worker_key
 
 # download go modules separately so this doesn't re-run on every change
+WORKDIR /src
 COPY go.mod .
 COPY go.sum .
 RUN grep '^replace' go.mod || go mod download

--- a/ci/dockerfiles/dev/Dockerfile
+++ b/ci/dockerfiles/dev/Dockerfile
@@ -50,12 +50,16 @@ RUN set -e; \
       rm -rf /concourse-resource-types
 
 # install concourse, leaving the module cache populated
+#
+# nuke /src after to ensure dev builds build from a clean slate (otherwise this
+# can cause build failures if e.g. files are removed locally)
 COPY concourse /src
-WORKDIR /src
-RUN go mod download && \
+RUN cd /src && \
+      go mod download && \
       go install github.com/gobuffalo/packr/packr && \
       packr build -gcflags=all="-N -l" -o /usr/local/concourse/bin/concourse \
-        ./bin/cmd/concourse
+        ./bin/cmd/concourse && \
+      rm -rf /src
 
 # volume for non-aufs/etc. mount for baggageclaim's driver
 VOLUME /worker-state


### PR DESCRIPTION
this is causing build failures:

* https://ci.concourse-ci.org/teams/main/pipelines/prs/jobs/testflight/builds/486
* https://ci.concourse-ci.org/teams/main/pipelines/prs/jobs/watsjs/builds/482