### PR TITLE
added shared path for vault credential lookup

### DIFF
--- a/atc/creds/vault/manager.go
+++ b/atc/creds/vault/manager.go
@@ -17,6 +17,7 @@ type VaultManager struct {
 	URL string `long:"url" description:"Vault server address used to access secrets."`
 
 	PathPrefix string `long:"path-prefix" default:"/concourse" description:"Path under which to namespace credential lookup."`
+	SharedPath string `long:"shared-path" description:"Path under which to lookup shared credentials."`
 
 	Cache    bool          `long:"cache" description:"Cache returned secrets for their lease duration in memory"`
 	MaxLease time.Duration `long:"max-lease" description:"If the cache is enabled, and this is set, override secrets lease duration with a maximum value"`
@@ -131,5 +132,5 @@ func (manager VaultManager) NewVariablesFactory(logger lager.Logger) (creds.Vari
 		sr = NewCache(manager.Client, manager.MaxLease)
 	}
 
-	return NewVaultFactory(sr, ra.LoggedIn(), manager.PathPrefix), nil
+	return NewVaultFactory(sr, ra.LoggedIn(), manager.PathPrefix, manager.SharedPath), nil
 }

--- a/atc/creds/vault/manager_test.go
+++ b/atc/creds/vault/manager_test.go
@@ -1,0 +1,59 @@
+package vault_test
+
+import (
+	"github.com/concourse/concourse/atc/creds/vault"
+	"github.com/jessevdk/go-flags"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("VaultManager", func() {
+	var manager vault.VaultManager
+
+	Describe("IsConfigured()", func() {
+		JustBeforeEach(func() {
+			_, err := flags.ParseArgs(&manager, []string{})
+			Expect(err).To(BeNil())
+		})
+
+		It("fails on empty Manager", func() {
+			Expect(manager.IsConfigured()).To(BeFalse())
+		})
+
+		It("passes if URL is set", func() {
+			manager.URL = "http://vault"
+			Expect(manager.IsConfigured()).To(BeTrue())
+		})
+	})
+
+	Describe("Validate()", func() {
+		JustBeforeEach(func() {
+			manager = vault.VaultManager{URL: "http://vault", Auth: vault.AuthConfig{ClientToken: "xxx"}}
+			_, err := flags.ParseArgs(&manager, []string{})
+			Expect(err).To(BeNil())
+			Expect(manager.SharedPath).To(Equal(""))
+			Expect(manager.PathPrefix).To(Equal("/concourse"))
+		})
+
+		It("passes on default parameters", func() {
+			Expect(manager.Validate()).To(BeNil())
+		})
+
+		DescribeTable("passes if all vault credentials are specified",
+			func(backend, clientToken string) {
+				manager.Auth.Backend = backend
+				manager.Auth.ClientToken = clientToken
+				Expect(manager.Validate()).To(BeNil())
+			},
+			Entry("all values", "backend", "clientToken"),
+			Entry("only clientToken", "", "clientToken"),
+		)
+
+		It("fails on missing vault auth credentials", func() {
+			manager.Auth = vault.AuthConfig{}
+			Expect(manager.Validate()).ToNot(BeNil())
+		})
+	})
+})

--- a/atc/creds/vault/vault.go
+++ b/atc/creds/vault/vault.go
@@ -19,6 +19,7 @@ type Vault struct {
 	SecretReader SecretReader
 
 	PathPrefix   string
+	SharedPath   string
 	TeamName     string
 	PipelineName string
 }
@@ -37,6 +38,13 @@ func (v Vault) Get(varDef template.VariableDefinition) (interface{}, bool, error
 
 	if !found {
 		secret, found, err = v.findSecret(v.path(v.TeamName, varDef.Name))
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	if !found && v.SharedPath != "" {
+		secret, found, err = v.findSecret(v.path(v.SharedPath, varDef.Name))
 		if err != nil {
 			return nil, false, err
 		}

--- a/atc/creds/vault/vault_factory.go
+++ b/atc/creds/vault/vault_factory.go
@@ -10,13 +10,15 @@ import (
 type vaultFactory struct {
 	sr       SecretReader
 	prefix   string
+	sharedPath string
 	loggedIn <-chan struct{}
 }
 
-func NewVaultFactory(sr SecretReader, loggedIn <-chan struct{}, prefix string) *vaultFactory {
+func NewVaultFactory(sr SecretReader, loggedIn <-chan struct{}, prefix string, sharedPath string) *vaultFactory {
 	factory := &vaultFactory{
 		sr:       sr,
 		prefix:   prefix,
+		sharedPath: sharedPath,
 		loggedIn: loggedIn,
 	}
 
@@ -34,6 +36,7 @@ func (factory *vaultFactory) NewVariables(teamName string, pipelineName string) 
 	return &Vault{
 		SecretReader: factory.sr,
 		PathPrefix:   factory.prefix,
+		SharedPath:   factory.sharedPath,
 		TeamName:     teamName,
 		PipelineName: pipelineName,
 	}

--- a/atc/creds/vault/vault_suite_test.go
+++ b/atc/creds/vault/vault_suite_test.go
@@ -1,0 +1,13 @@
+package vault_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVault(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Vault Suite")
+}

--- a/atc/creds/vault/vault_test.go
+++ b/atc/creds/vault/vault_test.go
@@ -1,0 +1,125 @@
+package vault_test
+
+import (
+	"github.com/cloudfoundry/bosh-cli/director/template"
+	"github.com/concourse/concourse/atc/creds/vault"
+	vaultapi "github.com/hashicorp/vault/api"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type MockSecret struct {
+	path   string
+	secret *vaultapi.Secret
+}
+
+type MockSecretReader struct {
+	secrets *[]MockSecret
+}
+
+func (msr *MockSecretReader) Read(lookupPath string) (*vaultapi.Secret, error) {
+	Expect(lookupPath).ToNot(BeNil())
+
+	for _, secret := range *msr.secrets {
+		if (lookupPath == secret.path) {
+			return secret.secret, nil
+		}
+	}
+
+	return nil, nil
+}
+
+var _ = Describe("Vault", func() {
+
+	var v *vault.Vault
+	var msr *MockSecretReader
+
+	JustBeforeEach(func() {
+
+		msr = &MockSecretReader{&[]MockSecret{
+			{
+				path: "/concourse/team",
+				secret: &vaultapi.Secret{
+					Data: map[string]interface{}{"foo": "bar"},
+				},
+			}},
+		}
+
+		v = &vault.Vault{
+			SecretReader: msr,
+			PathPrefix:   "/concourse",
+			SharedPath:   "shared",
+			TeamName:     "team",
+			PipelineName: "pipeline",
+		}
+
+	})
+
+	Describe("Get()", func() {
+		It("should get secret from pipeline", func() {
+			v.SecretReader = &MockSecretReader{&[]MockSecret{
+				{
+					path: "/concourse/team/pipeline/foo",
+					secret: &vaultapi.Secret{
+						Data: map[string]interface{}{"value": "bar"},
+					},
+				}},
+			}
+			value, found, err := v.Get(template.VariableDefinition{Name: "foo"})
+			Expect(value).To(BeEquivalentTo("bar"))
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should get secret from team", func() {
+			v.SecretReader = &MockSecretReader{&[]MockSecret{
+				{
+					path: "/concourse/team/foo",
+					secret: &vaultapi.Secret{
+						Data: map[string]interface{}{"value": "bar"},
+					},
+				}},
+			}
+			value, found, err := v.Get(template.VariableDefinition{Name: "foo"})
+			Expect(value).To(BeEquivalentTo("bar"))
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should get secret from shared", func() {
+			v.SecretReader = &MockSecretReader{&[]MockSecret{
+				{
+					path: "/concourse/shared/foo",
+					secret: &vaultapi.Secret{
+						Data: map[string]interface{}{"value": "bar"},
+					},
+				}},
+			}
+			value, found, err := v.Get(template.VariableDefinition{Name: "foo"})
+			Expect(value).To(BeEquivalentTo("bar"))
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should get secret from pipeline even its in shared", func() {
+			v.SecretReader = &MockSecretReader{&[]MockSecret{
+				{
+					path: "/concourse/shared/foo",
+					secret: &vaultapi.Secret{
+						Data: map[string]interface{}{"value": "foo"},
+					},
+				},
+				{
+					path: "/concourse/team/foo",
+					secret: &vaultapi.Secret{
+						Data: map[string]interface{}{"value": "bar"},
+					},
+				}},
+			}
+			value, found, err := v.Get(template.VariableDefinition{Name: "foo"})
+			Expect(value).To(BeEquivalentTo("bar"))
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
We have a lot of shared secrets, that we have to copy into each team folder. Also sometimes we create vault secrets during provisioning, where we are not aware of the available teams in Concourse. 

This PR adds an optional `shared-path` to the vault credential lookup. Existing behaviour of the credential lookup rules stays the same, except that if the path is configured, and credentials are neither found in `/concourse/TEAM_NAME/PIPELINE_NAME/foo_param` or `/concourse/TEAM_NAME/foo_param` it will check the shared path `/concourse/SHARED_PATH/foo_param`.

Resolves: https://github.com/concourse/concourse/issues/2442