### PR TITLE
fix hack/db script

### DIFF
--- a/hack/db
+++ b/hack/db
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if command -qs pgcli; then
-  pgcli -h localhost -p 6543 -U dev concourse
+if which pgcli >/dev/null; then
+  PGPASSWORD=dev pgcli -h localhost -p 6543 -U dev concourse
 else
-  psql -h localhost -p 6543 -U dev concourse
+  PGPASSWORD=dev psql -h localhost -p 6543 -U dev concourse
 fi


### PR DESCRIPTION
realized we're not familiar enough with `command` for it to be a useful choice, especially when almost everybody is on systems that have the more familiar `which` anyway. Plus we need to use a password now.