### PR TITLE
web: fix call stack crash

### DIFF
--- a/web/elm/src/Build/Output.elm
+++ b/web/elm/src/Build/Output.elm
@@ -3,6 +3,7 @@ module Build.Output exposing
     , handleEventsMsg
     , handleStepTreeMsg
     , init
+    , parseMsg
     , planAndResourcesFetched
     , subscribeToEvents
     , view

--- a/web/elm/src/Concourse/BuildEvents.elm
+++ b/web/elm/src/Concourse/BuildEvents.elm
@@ -86,15 +86,23 @@ parseEvents evs =
     parseEventsFromIndex evs (Array.initialize (Array.length evs) (\_ -> End)) 0
 
 
-parseEventsFromIndex : Array.Array ES.Event -> Array.Array BuildEvent -> Int -> Result String (Array.Array BuildEvent)
+parseEventsFromIndex :
+    Array.Array ES.Event
+    -> Array.Array BuildEvent
+    -> Int
+    -> Result String (Array.Array BuildEvent)
 parseEventsFromIndex evs acc i =
     case Array.get i evs of
         Nothing ->
             Ok acc
 
         Just ev ->
-            parseEvent ev
-                |> Result.andThen (\ev -> parseEventsFromIndex evs (Array.set i ev acc) (i + 1))
+            case parseEvent ev of
+                Ok ev ->
+                    parseEventsFromIndex evs (Array.set i ev acc) (i + 1)
+
+                Err err ->
+                    Err err
 
 
 parseEvent : ES.Event -> Result String BuildEvent

--- a/web/elm/src/Native/EventSource.js
+++ b/web/elm/src/Native/EventSource.js
@@ -4,6 +4,14 @@ var _concourse$atc$Native_EventSource = function() {
       var source = new EventSource(url);
       var buffer = [];
 
+      function flush() {
+        if (buffer.length > 0) {
+          var elmBuffer = _elm_lang$core$Native_Array.fromJSArray(buffer);
+          _elm_lang$core$Native_Scheduler.rawSpawn(settings.onEvent(elmBuffer));
+          buffer = [];
+        }
+      }
+
       function dispatchEvent(event) {
         var ev = {
           data: event.data
@@ -22,6 +30,9 @@ var _concourse$atc$Native_EventSource = function() {
         }
 
         buffer.push(ev);
+        if (buffer.length > 1000) {
+          flush();
+        }
       };
 
       source.onmessage = function(event) {
@@ -42,13 +53,7 @@ var _concourse$atc$Native_EventSource = function() {
         _elm_lang$core$Native_Scheduler.rawSpawn(settings.onError(_elm_lang$core$Native_Utils.Tuple0));
       };
 
-      setInterval(function() {
-        if (buffer.length > 0) {
-          var elmBuffer = _elm_lang$core$Native_Array.fromJSArray(buffer);
-          _elm_lang$core$Native_Scheduler.rawSpawn(settings.onEvent(elmBuffer));
-          buffer = [];
-        }
-      }, 200);
+      setInterval(flush, 200);
     });
   }
 

--- a/web/elm/tests/BuildEventsTests.elm
+++ b/web/elm/tests/BuildEventsTests.elm
@@ -1,0 +1,56 @@
+module BuildEventsTests exposing (all)
+
+import Array
+import Build.Models
+import Build.Msgs
+import Build.Output
+import EventSource
+import Expect
+import Json.Encode
+import Test exposing (Test, test)
+
+
+eventData : String
+eventData =
+    Json.Encode.encode 0 <|
+        Json.Encode.object
+            [ ( "data"
+              , Json.Encode.object
+                    [ ( "origin"
+                      , Json.Encode.object
+                            [ ( "source", Json.Encode.string "stdout" )
+                            , ( "id", Json.Encode.string "stepid" )
+                            ]
+                      )
+                    , ( "payload", Json.Encode.string "log message" )
+                    ]
+              )
+            , ( "event", Json.Encode.string "log" )
+            ]
+
+
+all : Test
+all =
+    test "parseMsg can handle many events, i.e. should use tail recursion" <|
+        \_ ->
+            Build.Output.parseMsg
+                (EventSource.Events <|
+                    Array.fromList <|
+                        List.repeat 3000
+                            { lastEventId = Nothing
+                            , name = Just "event"
+                            , data = eventData
+                            }
+                )
+                |> Expect.equal
+                    (Build.Msgs.Events <|
+                        Ok <|
+                            Array.fromList <|
+                                List.repeat
+                                    3000
+                                <|
+                                    Build.Models.Log
+                                        { source = "stdout", id = "stepid" }
+                                        "log message"
+                                        Nothing
+                    )


### PR DESCRIPTION
Fixes #3235

I'd like to mention that the new regression test is pretty implementation-obsessed (indeed it exposes the `parseMsg` function which should otherwise be encapsulated). However, if we move forward with https://github.com/concourse/concourse/issues/3229 I believe we should be able to convert it to a more realistic 'integration-ey' test.

The new test only confirms that the underlying Elm code is resilient to receiving huge batches of events at once (and indeed does highlight the [exact source of the bug](https://github.com/concourse/concourse/commit/618c8113a9beb0102dd526f1facceb8b1684994b#diff-40f2536660c0f4a834dee118f978eb1eR133) where a function failed to be tail-recursive), but I've also made a change to the `EventSource` module to throttle the flow of events into Elm a bit more precisely -- this part is not directly tested.

In terms of benchmarking, I'd like to see if we can demonstrate the build page's performance properties on a lower level (i.e. micro-benchmarking a single update-view loop a la [elm-benchmark](https://package.elm-lang.org/packages/BrianHicks/elm-benchmark/latest/)) before committing to a behemoth performance regression test.