### PR TITLE
Bionic golang builder image

### DIFF
--- a/ci/dockerfiles/golang-builder/Dockerfile
+++ b/ci/dockerfiles/golang-builder/Dockerfile
@@ -2,26 +2,19 @@ FROM ubuntu:bionic
 
 # gcc for cgo
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		g++ \
-		gcc \
-		libc6-dev \
-		make \
-		pkg-config \
-                wget \
-                git \
-                ca-certificates \
-	&& rm -rf /var/lib/apt/lists/*
+    build-essential \
+    git \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.11.5
+COPY ./golang-linux/go*.linux-amd64.tar.gz /go.linux-amd64.tgz
 
-RUN set -eux; \
-	url="https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz"; \
-	wget -nv -O - "$url" | tar -C /usr/local -xz; \
-	export PATH="/usr/local/go/bin:$PATH"; \
-	go version
+RUN tar -C /usr/local -xzf /go.linux-amd64.tgz \
+  && rm /go.linux-amd64.tgz
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH

--- a/ci/dockerfiles/golang-builder/Dockerfile
+++ b/ci/dockerfiles/golang-builder/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:bionic
+
+# gcc for cgo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		g++ \
+		gcc \
+		libc6-dev \
+		make \
+		pkg-config \
+                wget \
+                git \
+                ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.11.5
+
+RUN set -eux; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "${dpkgArch##*-}" in \
+		amd64) goRelArch='linux-amd64'; goRelSha256='ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25' ;; \
+		armhf) goRelArch='linux-armv6l'; goRelSha256='b26b53c94923f78955236386fee0725ef4e76b6cb47e0df0ed0c0c4724e7b198' ;; \
+		arm64) goRelArch='linux-arm64'; goRelSha256='6ee9a5714444182a236d3cc4636e74cfc5e24a1bacf0463ac71dcf0e7d4288ed' ;; \
+		i386) goRelArch='linux-386'; goRelSha256='acd8e05f8d3eed406e09bb58eab89de3f0a139d4aef15f74adeed2d2c24cb440' ;; \
+		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='66e83152c68cb35d41f21453377d6a811585c9e01a6ac54b19f7a6e2cbb3d1f5' ;; \
+		s390x) goRelArch='linux-s390x'; goRelSha256='56209e5498c64a8338cd6f0fe0c2e2cbf6857c0acdb10c774894f0cc0d19f413' ;; \
+		*) goRelArch='src'; goRelSha256='bc1ef02bb1668835db1390a2e478dcbccb5dd16911691af9d75184bbe5aa943e'; \
+			echo >&2; echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; echo >&2 ;; \
+	esac; \
+	\
+	url="https://golang.org/dl/go${GOLANG_VERSION}.${goRelArch}.tar.gz"; \
+	wget -O go.tgz "$url" 2>/dev/null; \
+	echo "${goRelSha256} *go.tgz" | sha256sum -c -; \
+	tar -C /usr/local -xzf go.tgz; \
+	rm go.tgz; \
+	\
+	if [ "$goRelArch" = 'src' ]; then \
+		echo >&2; \
+		echo >&2 'error: UNIMPLEMENTED'; \
+		echo >&2 'TODO install golang-any from jessie-backports for GOROOT_BOOTSTRAP (and uninstall after build)'; \
+		echo >&2; \
+		exit 1; \
+	fi; \
+	\
+	export PATH="/usr/local/go/bin:$PATH"; \
+	go version
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH

--- a/ci/dockerfiles/golang-builder/Dockerfile
+++ b/ci/dockerfiles/golang-builder/Dockerfile
@@ -15,33 +15,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV GOLANG_VERSION 1.11.5
 
 RUN set -eux; \
-	\
-	dpkgArch="$(dpkg --print-architecture)"; \
-	case "${dpkgArch##*-}" in \
-		amd64) goRelArch='linux-amd64'; goRelSha256='ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25' ;; \
-		armhf) goRelArch='linux-armv6l'; goRelSha256='b26b53c94923f78955236386fee0725ef4e76b6cb47e0df0ed0c0c4724e7b198' ;; \
-		arm64) goRelArch='linux-arm64'; goRelSha256='6ee9a5714444182a236d3cc4636e74cfc5e24a1bacf0463ac71dcf0e7d4288ed' ;; \
-		i386) goRelArch='linux-386'; goRelSha256='acd8e05f8d3eed406e09bb58eab89de3f0a139d4aef15f74adeed2d2c24cb440' ;; \
-		ppc64el) goRelArch='linux-ppc64le'; goRelSha256='66e83152c68cb35d41f21453377d6a811585c9e01a6ac54b19f7a6e2cbb3d1f5' ;; \
-		s390x) goRelArch='linux-s390x'; goRelSha256='56209e5498c64a8338cd6f0fe0c2e2cbf6857c0acdb10c774894f0cc0d19f413' ;; \
-		*) goRelArch='src'; goRelSha256='bc1ef02bb1668835db1390a2e478dcbccb5dd16911691af9d75184bbe5aa943e'; \
-			echo >&2; echo >&2 "warning: current architecture ($dpkgArch) does not have a corresponding Go binary release; will be building from source"; echo >&2 ;; \
-	esac; \
-	\
-	url="https://golang.org/dl/go${GOLANG_VERSION}.${goRelArch}.tar.gz"; \
+	url="https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz"; \
 	wget -O go.tgz "$url" 2>/dev/null; \
-	echo "${goRelSha256} *go.tgz" | sha256sum -c -; \
 	tar -C /usr/local -xzf go.tgz; \
 	rm go.tgz; \
-	\
-	if [ "$goRelArch" = 'src' ]; then \
-		echo >&2; \
-		echo >&2 'error: UNIMPLEMENTED'; \
-		echo >&2 'TODO install golang-any from jessie-backports for GOROOT_BOOTSTRAP (and uninstall after build)'; \
-		echo >&2; \
-		exit 1; \
-	fi; \
-	\
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 

--- a/ci/dockerfiles/golang-builder/Dockerfile
+++ b/ci/dockerfiles/golang-builder/Dockerfile
@@ -12,13 +12,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                 ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.11.5
+ARG GOLANG_VERSION=1.11.5
 
 RUN set -eux; \
 	url="https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz"; \
-	wget -O go.tgz "$url" 2>/dev/null; \
-	tar -C /usr/local -xzf go.tgz; \
-	rm go.tgz; \
+	wget -nv -O - "$url" | tar -C /usr/local -xz; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -64,6 +64,7 @@ groups:
 - name: images
   jobs:
   - unit-image
+  - golang-builder-image
 
 - name: publish
   jobs:
@@ -104,6 +105,30 @@ jobs:
       caches: [{path: cache}]
       run: {path: build}
   - put: unit-image
+    params: {image: image/image.tar}
+
+- name: golang-builder-image
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      resource: golang-builder-dockerfile
+      trigger: true
+    - get: builder
+  - task: build
+    image: builder
+    privileged: true
+    config:
+      platform: linux
+      params:
+        REPOSITORY: concourse/golang-builder
+        CONTEXT: concourse/ci/dockerfiles/golang-builder
+      inputs: [{name: concourse}]
+      outputs: [{name: image}]
+      caches: [{path: cache}]
+      run: {path: build}
+  - put: golang-builder-image
     params: {image: image/image.tar}
 
 - name: unit
@@ -1033,6 +1058,13 @@ resources:
     branch: master
     paths: [ci/dockerfiles/unit]
 
+- name: golang-builder-dockerfile
+  type: git
+  source:
+    uri: https://github.com/concourse/concourse.git
+    branch: master
+    paths: [ci/dockerfiles/golang-builder]
+
 - name: dev-image
   type: registry-image
   source:
@@ -1058,6 +1090,13 @@ resources:
   type: registry-image
   source:
     repository: concourse/unit
+    username: ((docker.username))
+    password: ((docker.password))
+
+- name: golang-builder-image
+  type: registry-image
+  source:
+    repository: concourse/golang-builder
     username: ((docker.username))
     password: ((docker.password))
 

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -116,18 +116,12 @@ jobs:
       resource: golang-builder-dockerfile
       trigger: true
     - get: builder
+    - get: golang-linux
+      trigger: true
   - task: build
     image: builder
     privileged: true
-    config:
-      platform: linux
-      params:
-        REPOSITORY: concourse/golang-builder
-        CONTEXT: concourse/ci/dockerfiles/golang-builder
-      inputs: [{name: concourse}]
-      outputs: [{name: image}]
-      caches: [{path: cache}]
-      run: {path: build}
+    file: concourse/ci/tasks/build-golang-builder-image.yml
   - put: golang-builder-image
     params: {image: image/image.tar}
 
@@ -1399,6 +1393,13 @@ resources:
     endpoint: storage.googleapis.com
     bucket: golang
     regexp: 'go(\d+\.\d+(\.\d+)?)\.windows-amd64\.msi'
+
+- name: golang-linux
+  type: s3
+  source:
+    endpoint: storage.googleapis.com
+    bucket: golang
+    regexp: 'go(\d+\.\d+(\.\d+)?)\.linux-amd64\.tar\.gz'
 
 - name: concourse-github-release
   type: github-release

--- a/ci/tasks/build-golang-builder-image.yml
+++ b/ci/tasks/build-golang-builder-image.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+
+params:
+  REPOSITORY: concourse/golang-builder
+  DOCKERFILE: concourse/ci/dockerfiles/golang-builder/Dockerfile
+  CONTEXT: .
+
+inputs:
+- name: concourse
+- name: golang-linux
+
+outputs:
+- name: image
+
+caches:
+- path: cache
+
+run:
+  path: build


### PR DESCRIPTION
As part of switching to `ubuntu:bionic` for the resources, we need an intermediate image to build `go` files (we were using `golang:alpine` before).

This adds a new job to build and push the `golang-builder` image to docker-hub under `concourse/golang-builder`

Go version is configured in `ci/dockerfiles/golang-builder/Dockerfile`