### PR TITLE
Add option to prune all stalled workers instead of just one at the time.

### DIFF
--- a/fly/commands/prune_worker.go
+++ b/fly/commands/prune_worker.go
@@ -3,15 +3,25 @@ package commands
 import (
 	"fmt"
 
+	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/rc"
 )
 
 type PruneWorkerCommand struct {
-	Worker string `short:"w"  long:"worker" required:"true" description:"Worker to prune"`
+	Worker     string `short:"w"  long:"worker" description:"Worker to prune"`
+	AllStalled bool   `short:"a" long:"all-stalled" description:"Prune all stalled workers"`
 }
 
 func (command *PruneWorkerCommand) Execute(args []string) error {
-	workerName := command.Worker
+	if command.Worker == "" && !command.AllStalled {
+		displayhelpers.Failf("Either a worker name or --all-stalled are required")
+	}
+
+	var workersNames []string
+
+	if command.Worker != "" {
+		workersNames = append(workersNames, command.Worker)
+	}
 
 	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
 	if err != nil {
@@ -23,12 +33,28 @@ func (command *PruneWorkerCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Client().PruneWorker(workerName)
-	if err != nil {
-		return err
+	if command.AllStalled {
+		workers, err := target.Client().ListWorkers()
+		if err != nil {
+			return err
+		}
+		for _, worker := range workers {
+			if worker.State == "stalled" {
+				workersNames = append(workersNames, worker.Name)
+			}
+		}
+		if workersNames == nil {
+			displayhelpers.Failf("No stalled worker found.")
+		}
 	}
 
-	fmt.Printf("pruned '%s'\n", workerName)
+	for _, workerName := range workersNames {
+		err = target.Client().PruneWorker(workerName)
+		if err != nil {
+			return err
+		}
 
+		fmt.Printf("pruned '%s'\n", workerName)
+	}
 	return nil
 }


### PR DESCRIPTION
I couldn't find any existing test checking the functionality of the existing prune-worker command and thus making a bit hard to add a test for this additional command.
I'm willing to try to add some test if given some general direction.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>