### PR TITLE
web: moved userState out of the resource page model

### DIFF
--- a/web/elm/src/Resource/Models.elm
+++ b/web/elm/src/Resource/Models.elm
@@ -63,7 +63,6 @@ type alias Model =
     , pinIconHover : Bool
     , route : Routes.Route
     , pipeline : Maybe Concourse.Pipeline
-    , userState : UserState
     , userMenuVisible : Bool
     , pinnedResources : List ( String, Concourse.Version )
     , showPinIconDropDown : Bool

--- a/web/elm/src/Resource/Msgs.elm
+++ b/web/elm/src/Resource/Msgs.elm
@@ -6,6 +6,7 @@ import Resource.Models as Models
 import Routes
 import Time exposing (Time)
 import TopBar.Msgs
+import UserState exposing (UserState)
 
 
 type Msg
@@ -21,8 +22,8 @@ type Msg
     | ToggleVersion Models.VersionToggleAction Models.VersionId
     | PinIconHover Bool
     | Hover Models.Hoverable
-    | Check
-    | TopBarMsg TopBar.Msgs.Msg
+    | CheckRequested Bool
+    | TopBarMsg UserState TopBar.Msgs.Msg
     | EditComment String
     | SaveComment String
     | FocusTextArea

--- a/web/elm/src/SubPage.elm
+++ b/web/elm/src/SubPage.elm
@@ -29,6 +29,7 @@ import String
 import SubPage.Msgs exposing (Msg(..))
 import Subscription exposing (Subscription)
 import UpdateMsg exposing (UpdateMsg)
+import UserState exposing (UserState)
 
 
 type Model
@@ -309,8 +310,8 @@ urlUpdate route model =
             ( model, [] )
 
 
-view : Model -> Html Msg
-view mdl =
+view : UserState -> Model -> Html Msg
+view userState mdl =
     case mdl of
         BuildModel model ->
             Build.view model
@@ -325,7 +326,7 @@ view mdl =
                 |> Html.map PipelineMsg
 
         ResourceModel model ->
-            Resource.view model
+            Resource.view userState model
                 |> HS.toUnstyled
                 |> Html.map ResourceMsg
 

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -159,15 +159,11 @@ all =
                                     , userName = "test"
                                     , name = "test"
                                     , email = "test"
-                                    , teams =
-                                        Dict.fromList
-                                            [ ( teamName, [ "member" ] )
-                                            ]
+                                    , teams = Dict.fromList [ ( teamName, [ "member" ] ) ]
                                     }
                             )
                         |> Tuple.first
-                        |> handleCallback
-                            (Callback.LoggedOut (Ok ()))
+                        |> handleCallback (Callback.LoggedOut (Ok ()))
             in
             [ test "updates top bar state" <|
                 loggingOut
@@ -2487,12 +2483,12 @@ all =
                             |> Query.children []
                             |> Query.first
                             |> Event.simulate Event.click
-                            |> Event.expect (resourceMsg Resource.Msgs.Check)
+                            |> Event.expect (resourceMsg (Resource.Msgs.CheckRequested False))
                 , test "Check msg redirects to login" <|
                     \_ ->
                         init
                             |> givenResourceIsNotPinned
-                            |> update Resource.Msgs.Check
+                            |> update (Resource.Msgs.CheckRequested False)
                             |> Tuple.second
                             |> Expect.equal
                                 [ ( Effects.SubPage 1
@@ -2503,7 +2499,7 @@ all =
                     \_ ->
                         init
                             |> givenResourceIsNotPinned
-                            |> update Resource.Msgs.Check
+                            |> update (Resource.Msgs.CheckRequested False)
                             |> Tuple.first
                             |> checkBar
                             |> Query.find [ tag "h3" ]
@@ -2576,13 +2572,13 @@ all =
                             |> Query.children []
                             |> Query.first
                             |> Event.simulate Event.click
-                            |> Event.expect (resourceMsg Resource.Msgs.Check)
+                            |> Event.expect (resourceMsg (Resource.Msgs.CheckRequested True))
                 , test "Check msg has CheckResource side effect" <|
                     \_ ->
                         init
                             |> givenResourceIsNotPinned
                             |> givenUserIsAuthorized
-                            |> update Resource.Msgs.Check
+                            |> update (Resource.Msgs.CheckRequested True)
                             |> Tuple.second
                             |> Expect.equal
                                 [ ( Effects.SubPage 1
@@ -2600,8 +2596,7 @@ all =
                         givenCheckInProgress =
                             givenResourceIsNotPinned
                                 >> givenUserIsAuthorized
-                                >> Layout.update
-                                    (resourceMsg Resource.Msgs.Check)
+                                >> Layout.update (resourceMsg (Resource.Msgs.CheckRequested True))
                                 >> Tuple.first
                     in
                     [ test "check bar text says 'currently checking'" <|
@@ -2703,7 +2698,7 @@ all =
                         init
                             |> givenResourceIsNotPinned
                             |> givenUserIsAuthorized
-                            |> Layout.update (resourceMsg Resource.Msgs.Check)
+                            |> Layout.update (resourceMsg (Resource.Msgs.CheckRequested True))
                             |> Tuple.first
                             |> handleCallback (Callback.Checked <| Ok ())
                             |> Tuple.first
@@ -2731,7 +2726,7 @@ all =
                         init
                             |> givenResourceIsNotPinned
                             |> givenUserIsAuthorized
-                            |> update Resource.Msgs.Check
+                            |> update (Resource.Msgs.CheckRequested True)
                             |> Tuple.first
                             |> handleCallback (Callback.Checked <| Ok ())
                             |> Tuple.second
@@ -2757,7 +2752,7 @@ all =
                         init
                             |> givenResourceIsNotPinned
                             |> givenUserIsAuthorized
-                            |> update Resource.Msgs.Check
+                            |> update (Resource.Msgs.CheckRequested True)
                             |> Tuple.first
                             |> handleCallback
                                 (Callback.Checked <|
@@ -2793,7 +2788,7 @@ all =
                         init
                             |> givenResourceIsNotPinned
                             |> givenUserIsAuthorized
-                            |> update Resource.Msgs.Check
+                            |> update (Resource.Msgs.CheckRequested True)
                             |> Tuple.first
                             |> handleCallback
                                 (Callback.Checked <|
@@ -2823,7 +2818,7 @@ all =
                         init
                             |> givenResourceIsNotPinned
                             |> givenUserIsAuthorized
-                            |> update Resource.Msgs.Check
+                            |> update (Resource.Msgs.CheckRequested True)
                             |> Tuple.first
                             |> handleCallback
                                 (Callback.Checked <|


### PR DESCRIPTION
This pr is basically to stage the changes from NewTopBar and thus make merging easier. It's not a big deal on its own, and indeed has some messes in it - the gross tupling-untupling for the top bar in Resource and the handling of user fetches in Layout, specifically. Both of these will go away with the newTopBar PR.