### PR TITLE
ci: add task to ensure PRs add migrations in the right order

### DIFF
--- a/ci/pipelines/prs.yml
+++ b/ci/pipelines/prs.yml
@@ -10,6 +10,11 @@ resource_types:
 
 
 resources:
+- name: concourse-master
+  type: git
+  source:
+    repository: https://github.com/concourse/concourse.git
+
 - name: concourse-pr
   type: pull-request
   source:
@@ -49,6 +54,8 @@ jobs:
     trigger: true
     version: every
     tags: [pr]
+  - get: concourse-master
+    tags: [pr]
   - put: concourse-pr
     inputs: [concourse-pr]
     params: {path: concourse-pr, status: pending, context: unit}
@@ -61,6 +68,10 @@ jobs:
     timeout: 1h
     file: concourse-pr/ci/tasks/unit.yml
     input_mapping: {concourse: built-concourse}
+    tags: [pr]
+  - task: check-migration-order
+    timeout: 5m
+    file: concourse-pr/ci/tasks/check-migration-order.yml
     tags: [pr]
 
 - name: testflight

--- a/ci/tasks/check-migration-order.yml
+++ b/ci/tasks/check-migration-order.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+inputs:
+- name: concourse-pr
+- name: concourse-master
+
+run:
+  path: concourse-pr/ci/tasks/scripts/check-migration-order

--- a/ci/tasks/scripts/check-migration-order
+++ b/ci/tasks/scripts/check-migration-order
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+migrations_path=atc/db/migration/migrations/
+master_dir=concourse-master/$migrations_path
+pr_dir=concourse-pr/$migrations_path
+
+migrations_on_master=$(mktemp)
+find $master_dir -name '[0-9]*' -exec basename {} \; |
+  sort > "$migrations_on_master"
+
+actual_pr_migrations=$(mktemp)
+find $pr_dir -name '[0-9]*' -exec basename {} \; |
+  sort > "$actual_pr_migrations"
+
+unique_to_master=$(comm -23 "$migrations_on_master" "$actual_pr_migrations")
+[ -z "$unique_to_master" ] || {
+  echo "pr removed migrations:"
+  echo "$unique_to_master"
+  echo "and prs cannot remove migrations."
+  exit 1
+}
+
+new_on_pr=$(comm -13 "$migrations_on_master" "$actual_pr_migrations")
+
+expected_pr_migrations=$(mktemp)
+sort -n "$migrations_on_master" >> "$expected_pr_migrations"
+echo "$new_on_pr" >> "$expected_pr_migrations"
+
+# we use `-n` here and not above because comm requires its
+# inputs to be *lexically* sorted but our test is about
+# numerical sorting.
+diff "$expected_pr_migrations" <(sort -n "$actual_pr_migrations") >/dev/null || {
+  echo "pr added migrations:"
+  echo "$new_on_pr"
+  echo "out of order with master."
+  echo "new migrations in a pr must be strictly newer than those on master."
+  exit 1
+}


### PR DESCRIPTION
Born out of a retro action item: 
If two PRs add migrations and one is merged before the other, there is a possibility that the PR with the newer migration version is merged first and the migration library doesn't run the older version when the second PR is merged. 

We determined that adding a CI task for PRs was the easiest way to detect this issue as early as possible. This task asserts that any new migrations have later versions than any migrations on master.