### PR TITLE
Prevent postgres deadlocking

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -858,11 +858,6 @@ func (b *build) SaveOutput(
 		if err != nil {
 			return err
 		}
-
-		err = bumpCacheIndexForPipelinesUsingResourceConfigScope(tx, resourceConfigScope)
-		if err != nil {
-			return err
-		}
 	}
 
 	_, err = psql.Insert("build_resource_config_version_outputs").
@@ -881,7 +876,17 @@ func (b *build) SaveOutput(
 		return err
 	}
 
-	return tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	err = bumpCacheIndexForPipelinesUsingResourceConfigScope(b.conn, resourceConfigScope.ID())
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (b *build) UseInputs(inputs []BuildInput) error {

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -219,16 +219,16 @@ func (r *resource) SetResourceConfig(logger lager.Logger, source atc.Source, res
 		return nil, err
 	}
 
-	if rowsAffected > 0 {
-		err = bumpCacheIndexForPipelinesUsingResourceConfigScope(tx, resourceConfigScope)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	err = tx.Commit()
 	if err != nil {
 		return nil, err
+	}
+
+	if rowsAffected > 0 {
+		err = bumpCacheIndexForPipelinesUsingResourceConfigScope(r.conn, resourceConfigScope.ID())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return resourceConfigScope, nil

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -91,12 +91,17 @@ func (r *resourceConfigScope) SaveVersions(versions []atc.Version) error {
 		}
 	}
 
-	err = bumpCacheIndexForPipelinesUsingResourceConfigScope(tx, r)
+	err = tx.Commit()
 	if err != nil {
 		return err
 	}
 
-	return tx.Commit()
+	err = bumpCacheIndexForPipelinesUsingResourceConfigScope(r.conn, r.id)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (r *resourceConfigScope) FindVersion(v atc.Version) (ResourceConfigVersion, bool, error) {
@@ -269,13 +274,42 @@ func incrementCheckOrder(tx Tx, r ResourceConfigScope, version string) error {
 	return err
 }
 
-func bumpCacheIndexForPipelinesUsingResourceConfigScope(tx Tx, resourceConfigScope ResourceConfigScope) error {
-	_, err := tx.Exec(`
-		UPDATE pipelines p
-		SET cache_index = cache_index + 1
-		FROM resources r
-		WHERE r.pipeline_id = p.id
-		AND r.resource_config_scope_id = $1
-	`, resourceConfigScope.ID())
-	return err
+func bumpCacheIndexForPipelinesUsingResourceConfigScope(conn Conn, rcsID int) error {
+	rows, err := psql.Select("p.id").
+		From("pipelines p").
+		Join("resources r ON r.pipeline_id = p.id").
+		Where(sq.Eq{
+			"r.resource_config_scope_id": rcsID,
+		}).
+		RunWith(conn).
+		Query()
+	if err != nil {
+		return err
+	}
+
+	var pipelines []int
+	for rows.Next() {
+		var pid int
+		err = rows.Scan(&pid)
+		if err != nil {
+			return err
+		}
+
+		pipelines = append(pipelines, pid)
+	}
+
+	for _, p := range pipelines {
+		_, err := psql.Update("pipelines").
+			Set("cache_index", sq.Expr("cache_index + 1")).
+			Where(sq.Eq{
+				"id": p,
+			}).
+			RunWith(conn).
+			Exec()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
When we update the cache indexes for the all the pipelines that use a
resource config which we found new versions for, postgres can get into a
deadlock when two resource configs try to update the same pipeline's
cache indexes at the same time. By running all the cache index updates
by itself (not in a transaction), we will prevent that from happening.
