### PR TITLE
ci: fix check-migration-order script

### DIFF
--- a/ci/pipelines/prs.yml
+++ b/ci/pipelines/prs.yml
@@ -60,6 +60,10 @@ jobs:
     inputs: [concourse-pr]
     params: {path: concourse-pr, status: pending, context: unit}
     tags: [pr]
+  - task: check-migration-order
+    timeout: 5m
+    file: concourse-pr/ci/tasks/check-migration-order.yml
+    tags: [pr]
   - task: yarn-test
     file: concourse-pr/ci/tasks/yarn-test.yml
     input_mapping: {concourse: concourse-pr}
@@ -68,10 +72,6 @@ jobs:
     timeout: 1h
     file: concourse-pr/ci/tasks/unit.yml
     input_mapping: {concourse: built-concourse}
-    tags: [pr]
-  - task: check-migration-order
-    timeout: 5m
-    file: concourse-pr/ci/tasks/check-migration-order.yml
     tags: [pr]
 
 - name: testflight

--- a/ci/tasks/scripts/check-migration-order
+++ b/ci/tasks/scripts/check-migration-order
@@ -24,7 +24,7 @@ new_on_pr=$(comm -13 "$migrations_on_master" "$actual_pr_migrations")
 
 expected_pr_migrations=$(mktemp)
 sort -n "$migrations_on_master" >> "$expected_pr_migrations"
-echo "$new_on_pr" >> "$expected_pr_migrations"
+echo -n "$new_on_pr" >> "$expected_pr_migrations"
 
 # we use `-n` here and not above because comm requires its
 # inputs to be *lexically* sorted but our test is about


### PR DESCRIPTION
For context, this error sucks: https://ci.concourse-ci.org/teams/main/pipelines/prs/jobs/unit/builds/504#L5c5c72ab:1:4

I don't really know why we didn't see this problem when testing with `fly execute` before... Anyway it works when I test it with `fly execute` against prod now.