### PR TITLE
Resource type scanner does not loop on acquiring lock

### DIFF
--- a/atc/pipelines/radar_scheduler_factory.go
+++ b/atc/pipelines/radar_scheduler_factory.go
@@ -54,16 +54,6 @@ func (rsf *radarSchedulerFactory) BuildScanRunnerFactory(dbPipeline db.Pipeline,
 
 func (rsf *radarSchedulerFactory) BuildScheduler(pipeline db.Pipeline, externalURL string, variables creds.Variables) scheduler.BuildScheduler {
 
-	resourceTypeScanner := radar.NewResourceTypeScanner(
-		clock.NewClock(),
-		rsf.resourceFactory,
-		rsf.resourceConfigFactory,
-		rsf.resourceTypeCheckingInterval,
-		pipeline,
-		externalURL,
-		variables,
-	)
-
 	scanner := radar.NewResourceScanner(
 		clock.NewClock(),
 		rsf.resourceFactory,
@@ -72,7 +62,6 @@ func (rsf *radarSchedulerFactory) BuildScheduler(pipeline db.Pipeline, externalU
 		pipeline,
 		externalURL,
 		variables,
-		resourceTypeScanner,
 	)
 
 	inputMapper := inputmapper.NewInputMapper(

--- a/atc/radar/scan_runner_factory.go
+++ b/atc/radar/scan_runner_factory.go
@@ -61,7 +61,6 @@ func NewScanRunnerFactory(
 		dbPipeline,
 		externalURL,
 		variables,
-		resourceTypeScanner,
 	)
 	return &scanRunnerFactory{
 		clock:               clock,

--- a/atc/radar/scanner_factory.go
+++ b/atc/radar/scanner_factory.go
@@ -54,16 +54,6 @@ func NewScannerFactory(
 func (f *scannerFactory) NewResourceScanner(dbPipeline db.Pipeline) Scanner {
 	variables := f.variablesFactory.NewVariables(dbPipeline.TeamName(), dbPipeline.Name())
 
-	resourceTypeScanner := NewResourceTypeScanner(
-		clock.NewClock(),
-		f.resourceFactory,
-		f.resourceConfigFactory,
-		f.resourceTypeCheckingInterval,
-		dbPipeline,
-		f.externalURL,
-		variables,
-	)
-
 	return NewResourceScanner(
 		clock.NewClock(),
 		f.resourceFactory,
@@ -72,7 +62,6 @@ func (f *scannerFactory) NewResourceScanner(dbPipeline db.Pipeline) Scanner {
 		dbPipeline,
 		f.externalURL,
 		variables,
-		resourceTypeScanner,
 	)
 }
 


### PR DESCRIPTION
Instead of manually running a resource type scan within the resource
scanner when the resource uses a custom type with not versions, it will
wait on the resource type to receive a version from it's own resource
type scanning interval. This fixes the problem when many resources use
one resource type that has no versions yet, it will start off many scans
which all try to acquire the same lock. Resource type scanning also now
differs from the resource scanner because it does not loop if it fails
to acquire the lock, it will just exit with the error. We are able to do
this because even if global resources is disabled, resource type
versions are still shared within a concourse deployment so there is no
real need for them to pull in their own versions for each pipeline
resource.

[#3241]