### PR TITLE
web: clean up routes

### DIFF
--- a/web/elm/src/Build.elm
+++ b/web/elm/src/Build.elm
@@ -1106,16 +1106,16 @@ viewBuildHeader build { now, job, history, hoveredElement } =
 
         buildTitle =
             case build.job of
-                Just { jobName, teamName, pipelineName } ->
+                Just jobId ->
                     let
                         jobRoute =
-                            Routes.Job { teamName = teamName, pipelineName = pipelineName, jobName = jobName, page = Nothing }
+                            Routes.Job { id = jobId, page = Nothing }
                     in
                     Html.a
                         [ StrictEvents.onLeftClick <| NavTo jobRoute
                         , href <| Routes.toString jobRoute
                         ]
-                        [ Html.span [ class "build-name" ] [ Html.text jobName ]
+                        [ Html.span [ class "build-name" ] [ Html.text jobId.jobName ]
                         , Html.text (" #" ++ build.name)
                         ]
 

--- a/web/elm/src/Build.elm
+++ b/web/elm/src/Build.elm
@@ -1109,7 +1109,7 @@ viewBuildHeader build { now, job, history, hoveredElement } =
                 Just { jobName, teamName, pipelineName } ->
                     let
                         jobRoute =
-                            Routes.Job teamName pipelineName jobName Nothing
+                            Routes.Job { teamName = teamName, pipelineName = pipelineName, jobName = jobName, page = Nothing }
                     in
                     Html.a
                         [ StrictEvents.onLeftClick <| NavTo jobRoute

--- a/web/elm/src/Build.elm
+++ b/web/elm/src/Build.elm
@@ -4,7 +4,6 @@ module Build exposing
     , getUpdateMessage
     , handleCallback
     , init
-    , initJobBuildPage
     , subscriptions
     , update
     , view
@@ -12,10 +11,10 @@ module Build exposing
 
 import Build.Models as Models
     exposing
-        ( Hoverable(..)
+        ( BuildPageType(..)
+        , Hoverable(..)
         , Model
         , OutputModel
-        , Page(..)
         )
 import Build.Msgs exposing (Msg(..), fromBuildMessage)
 import Build.Output
@@ -68,21 +67,6 @@ import UserState exposing (UserState)
 import Views
 
 
-initJobBuildPage :
-    Concourse.TeamName
-    -> Concourse.PipelineName
-    -> Concourse.JobName
-    -> Concourse.BuildName
-    -> Page
-initJobBuildPage teamName pipelineName jobName buildName =
-    JobBuildPage
-        { teamName = teamName
-        , pipelineName = pipelineName
-        , jobName = jobName
-        , buildName = buildName
-        }
-
-
 type StepRenderingState
     = StepsLoading
     | StepsLiveUpdating
@@ -93,7 +77,7 @@ type StepRenderingState
 type alias Flags =
     { csrfToken : String
     , highlight : Routes.Highlight
-    , route : Routes.Route
+    , pageType : BuildPageType
     }
 
 
@@ -102,16 +86,24 @@ type ScrollBehavior
     | NoScroll
 
 
-init : Flags -> Page -> ( Model, List Effect )
-init flags page =
+init : Flags -> ( Model, List Effect )
+init flags =
     let
+        route =
+            case flags.pageType of
+                OneOffBuildPage buildId ->
+                    Routes.OneOffBuild { id = buildId, highlight = flags.highlight }
+
+                JobBuildPage buildId ->
+                    Routes.Build { id = buildId, highlight = flags.highlight }
+
         ( topBar, topBarEffects ) =
-            NewestTopBar.init { route = flags.route }
+            NewestTopBar.init { route = route }
 
         ( model, effects ) =
             changeToBuild
-                page
-                { page = page
+                flags.pageType
+                { page = flags.pageType
                 , now = Nothing
                 , job = Nothing
                 , history = []
@@ -149,7 +141,7 @@ subscriptions model =
     ]
 
 
-changeToBuild : Page -> Model -> ( Model, List Effect )
+changeToBuild : BuildPageType -> Model -> ( Model, List Effect )
 changeToBuild page model =
     if model.browsingIndex > 0 && page == model.page then
         ( model, [] )
@@ -176,7 +168,7 @@ changeToBuild page model =
             , page = page
           }
         , case page of
-            BuildPage buildId ->
+            OneOffBuildPage buildId ->
                 [ FetchBuild 0 newIndex buildId ]
 
             JobBuildPage jbi ->

--- a/web/elm/src/Build/Models.elm
+++ b/web/elm/src/Build/Models.elm
@@ -1,5 +1,6 @@
 module Build.Models exposing
     ( BuildEvent(..)
+    , BuildPageType(..)
     , HookedStep
     , Hoverable(..)
     , MetadataField
@@ -7,7 +8,6 @@ module Build.Models exposing
     , Origin
     , OutputModel
     , OutputState(..)
-    , Page(..)
     , Step
     , StepFocus
     , StepHeaderType(..)
@@ -35,7 +35,7 @@ import Time exposing (Time)
 
 
 type alias Model =
-    { page : Page
+    { page : BuildPageType
     , now : Maybe Time
     , job : Maybe Concourse.Job
     , history : List Concourse.Build
@@ -60,8 +60,8 @@ type alias CurrentBuild =
     }
 
 
-type Page
-    = BuildPage Int
+type BuildPageType
+    = OneOffBuildPage Concourse.BuildId
     | JobBuildPage Concourse.JobBuildIdentifier
 
 

--- a/web/elm/src/Dashboard.elm
+++ b/web/elm/src/Dashboard.elm
@@ -60,10 +60,8 @@ import UserState exposing (UserState)
 type alias Flags =
     { csrfToken : String
     , turbulencePath : String
-    , search : String
-    , highDensity : Bool
+    , searchType : Routes.SearchType
     , pipelineRunningKeyframes : String
-    , route : Routes.Route
     }
 
 
@@ -101,12 +99,12 @@ init : Flags -> ( Model, List Effect )
 init flags =
     let
         ( topBar, topBarEffects ) =
-            NewTopBar.init { route = flags.route }
+            NewTopBar.init { route = Routes.Dashboard { searchType = flags.searchType } }
     in
     ( { state = RemoteData.NotAsked
       , csrfToken = flags.csrfToken
       , turbulencePath = flags.turbulencePath
-      , highDensity = flags.highDensity
+      , highDensity = flags.searchType == Routes.HighDensity
       , hoveredPipeline = Nothing
       , pipelineRunningKeyframes = flags.pipelineRunningKeyframes
       , groups = []

--- a/web/elm/src/FlySuccess.elm
+++ b/web/elm/src/FlySuccess.elm
@@ -43,7 +43,7 @@ init : { authToken : String, flyPort : Maybe Int } -> ( Model, List Effect )
 init { authToken, flyPort } =
     let
         ( topBar, topBarEffects ) =
-            NewestTopBar.init { route = Routes.FlySuccess flyPort }
+            NewestTopBar.init { route = Routes.FlySuccess { flyPort = flyPort } }
     in
     ( { buttonState = Unhovered
       , authToken = authToken

--- a/web/elm/src/Job.elm
+++ b/web/elm/src/Job.elm
@@ -102,15 +102,7 @@ init flags =
             }
 
         ( topBar, topBarEffects ) =
-            NewestTopBar.init
-                { route =
-                    Routes.Job
-                        { teamName = flags.teamName
-                        , pipelineName = flags.pipelineName
-                        , jobName = flags.jobName
-                        , page = flags.paging
-                        }
-                }
+            NewestTopBar.init { route = Routes.Job { id = jobId, page = flags.paging } }
 
         model =
             { jobIdentifier = jobId
@@ -192,10 +184,12 @@ handleCallbackWithoutTopBar callback model =
                     [ NavigateTo <|
                         Routes.toString <|
                             Routes.Build
-                                { teamName = job.teamName
-                                , pipelineName = job.pipelineName
-                                , jobName = job.jobName
-                                , buildName = build.name
+                                { id =
+                                    { teamName = job.teamName
+                                    , pipelineName = job.pipelineName
+                                    , jobName = job.jobName
+                                    , buildName = build.name
+                                    }
                                 , highlight = Routes.HighlightNothing
                                 }
                     ]
@@ -592,12 +586,7 @@ viewPaginationBar model =
             Just page ->
                 let
                     jobRoute =
-                        Routes.Job
-                            { teamName = model.jobIdentifier.teamName
-                            , pipelineName = model.jobIdentifier.pipelineName
-                            , jobName = model.jobIdentifier.jobName
-                            , page = Just page
-                            }
+                        Routes.Job { id = model.jobIdentifier, page = Just page }
                 in
                 Html.div
                     [ style chevronContainer
@@ -635,12 +624,7 @@ viewPaginationBar model =
             Just page ->
                 let
                     jobRoute =
-                        Routes.Job
-                            { teamName = model.jobIdentifier.teamName
-                            , pipelineName = model.jobIdentifier.pipelineName
-                            , jobName = model.jobIdentifier.jobName
-                            , page = Just page
-                            }
+                        Routes.Job { id = model.jobIdentifier, page = Just page }
                 in
                 Html.div
                     [ style chevronContainer

--- a/web/elm/src/Job.elm
+++ b/web/elm/src/Job.elm
@@ -89,7 +89,6 @@ type alias Flags =
     , pipelineName : String
     , paging : Maybe Page
     , csrfToken : String
-    , route : Routes.Route
     }
 
 
@@ -103,7 +102,15 @@ init flags =
             }
 
         ( topBar, topBarEffects ) =
-            NewestTopBar.init { route = flags.route }
+            NewestTopBar.init
+                { route =
+                    Routes.Job
+                        { teamName = flags.teamName
+                        , pipelineName = flags.pipelineName
+                        , jobName = flags.jobName
+                        , page = flags.paging
+                        }
+                }
 
         model =
             { jobIdentifier = jobId
@@ -184,11 +191,13 @@ handleCallbackWithoutTopBar callback model =
                 Just job ->
                     [ NavigateTo <|
                         Routes.toString <|
-                            Routes.Build job.teamName
-                                job.pipelineName
-                                job.jobName
-                                build.name
-                                Routes.HighlightNothing
+                            Routes.Build
+                                { teamName = job.teamName
+                                , pipelineName = job.pipelineName
+                                , jobName = job.jobName
+                                , buildName = build.name
+                                , highlight = Routes.HighlightNothing
+                                }
                     ]
             )
 
@@ -583,10 +592,12 @@ viewPaginationBar model =
             Just page ->
                 let
                     jobRoute =
-                        Routes.Job model.jobIdentifier.teamName
-                            model.jobIdentifier.pipelineName
-                            model.jobIdentifier.jobName
-                            (Just page)
+                        Routes.Job
+                            { teamName = model.jobIdentifier.teamName
+                            , pipelineName = model.jobIdentifier.pipelineName
+                            , jobName = model.jobIdentifier.jobName
+                            , page = Just page
+                            }
                 in
                 Html.div
                     [ style chevronContainer
@@ -624,10 +635,12 @@ viewPaginationBar model =
             Just page ->
                 let
                     jobRoute =
-                        Routes.Job model.jobIdentifier.teamName
-                            model.jobIdentifier.pipelineName
-                            model.jobIdentifier.jobName
-                            (Just page)
+                        Routes.Job
+                            { teamName = model.jobIdentifier.teamName
+                            , pipelineName = model.jobIdentifier.pipelineName
+                            , jobName = model.jobIdentifier.jobName
+                            , page = Just page
+                            }
                 in
                 Html.div
                     [ style chevronContainer

--- a/web/elm/src/Job.elm
+++ b/web/elm/src/Job.elm
@@ -84,9 +84,7 @@ jobBuildsPerPage =
 
 
 type alias Flags =
-    { jobName : String
-    , teamName : String
-    , pipelineName : String
+    { jobId : Concourse.JobIdentifier
     , paging : Maybe Page
     , csrfToken : String
     }
@@ -95,17 +93,11 @@ type alias Flags =
 init : Flags -> ( Model, List Effect )
 init flags =
     let
-        jobId =
-            { jobName = flags.jobName
-            , teamName = flags.teamName
-            , pipelineName = flags.pipelineName
-            }
-
         ( topBar, topBarEffects ) =
-            NewestTopBar.init { route = Routes.Job { id = jobId, page = flags.paging } }
+            NewestTopBar.init { route = Routes.Job { id = flags.jobId, page = flags.paging } }
 
         model =
-            { jobIdentifier = jobId
+            { jobIdentifier = flags.jobId
             , job = RemoteData.NotAsked
             , pausedChanging = False
             , buildsWithResources =
@@ -123,8 +115,8 @@ init flags =
             }
     in
     ( model
-    , [ FetchJob jobId
-      , FetchJobBuilds jobId flags.paging
+    , [ FetchJob flags.jobId
+      , FetchJobBuilds flags.jobId flags.paging
       , GetCurrentTime
       ]
         ++ topBarEffects

--- a/web/elm/src/Layout.elm
+++ b/web/elm/src/Layout.elm
@@ -362,16 +362,16 @@ subscriptions model =
 routeMatchesModel : Routes.Route -> Model -> Bool
 routeMatchesModel route model =
     case ( route, model.subModel ) of
-        ( Routes.Pipeline _ _ _, SubPage.PipelineModel _ ) ->
+        ( Routes.Pipeline _, SubPage.PipelineModel _ ) ->
             True
 
-        ( Routes.Resource _ _ _ _, SubPage.ResourceModel _ ) ->
+        ( Routes.Resource _, SubPage.ResourceModel _ ) ->
             True
 
-        ( Routes.Build _ _ _ _ _, SubPage.BuildModel _ ) ->
+        ( Routes.Build _, SubPage.BuildModel _ ) ->
             True
 
-        ( Routes.Job _ _ _ _, SubPage.JobModel _ ) ->
+        ( Routes.Job _, SubPage.JobModel _ ) ->
             True
 
         ( Routes.Dashboard _, SubPage.DashboardModel _ ) ->

--- a/web/elm/src/NewestTopBar.elm
+++ b/web/elm/src/NewestTopBar.elm
@@ -629,25 +629,25 @@ viewConcourseLogo =
 viewBreadcrumbs : Routes.Route -> List (Html Msg)
 viewBreadcrumbs route =
     case route of
-        Routes.Pipeline { teamName, pipelineName } ->
-            [ viewPipelineBreadcrumb { teamName = teamName, pipelineName = pipelineName } ]
+        Routes.Pipeline { id } ->
+            [ viewPipelineBreadcrumb { teamName = id.teamName, pipelineName = id.pipelineName } ]
 
-        Routes.Build { teamName, pipelineName, jobName } ->
-            [ viewPipelineBreadcrumb { teamName = teamName, pipelineName = pipelineName }
+        Routes.Build { id } ->
+            [ viewPipelineBreadcrumb { teamName = id.teamName, pipelineName = id.pipelineName }
             , viewBreadcrumbSeparator
-            , viewJobBreadcrumb jobName
+            , viewJobBreadcrumb id.jobName
             ]
 
-        Routes.Resource { teamName, pipelineName, resourceName } ->
-            [ viewPipelineBreadcrumb { teamName = teamName, pipelineName = pipelineName }
+        Routes.Resource { id } ->
+            [ viewPipelineBreadcrumb { teamName = id.teamName, pipelineName = id.pipelineName }
             , viewBreadcrumbSeparator
-            , viewResourceBreadcrumb resourceName
+            , viewResourceBreadcrumb id.resourceName
             ]
 
-        Routes.Job { teamName, pipelineName, jobName } ->
-            [ viewPipelineBreadcrumb { teamName = teamName, pipelineName = pipelineName }
+        Routes.Job { id } ->
+            [ viewPipelineBreadcrumb { teamName = id.teamName, pipelineName = id.pipelineName }
             , viewBreadcrumbSeparator
-            , viewJobBreadcrumb jobName
+            , viewJobBreadcrumb id.jobName
             ]
 
         _ ->
@@ -671,19 +671,15 @@ viewBreadcrumbSeparator =
 
 
 viewPipelineBreadcrumb : Concourse.PipelineIdentifier -> Html Msg
-viewPipelineBreadcrumb pipeline =
+viewPipelineBreadcrumb pipelineId =
     Html.li
         [ id "breadcrumb-pipeline", style Styles.breadcrumbItem ]
         [ Html.a
             [ href <|
                 Routes.toString <|
-                    Routes.Pipeline
-                        { teamName = pipeline.teamName
-                        , pipelineName = pipeline.pipelineName
-                        , groups = []
-                        }
+                    Routes.Pipeline { id = pipelineId, groups = [] }
             ]
-            (breadcrumbComponent "pipeline" pipeline.pipelineName)
+            (breadcrumbComponent "pipeline" pipelineId.pipelineName)
         ]
 
 
@@ -772,9 +768,11 @@ viewPinDropdown pinnedResources pipeline model =
                             [ onClick <|
                                 GoToPinnedResource <|
                                     Routes.Resource
-                                        { teamName = pipeline.teamName
-                                        , pipelineName = pipeline.pipelineName
-                                        , resourceName = resourceName
+                                        { id =
+                                            { teamName = pipeline.teamName
+                                            , pipelineName = pipeline.pipelineName
+                                            , resourceName = resourceName
+                                            }
                                         , page = Nothing
                                         }
                             , style Styles.pinDropdownCursor

--- a/web/elm/src/Pipeline.elm
+++ b/web/elm/src/Pipeline.elm
@@ -56,8 +56,7 @@ type alias Model =
 
 
 type alias Flags =
-    { teamName : String
-    , pipelineName : String
+    { pipelineLocator : Concourse.PipelineIdentifier
     , turbulenceImgSrc : String
     , selectedGroups : List String
     }
@@ -66,18 +65,13 @@ type alias Flags =
 init : Flags -> ( Model, List Effect )
 init flags =
     let
-        pipelineLocator =
-            { teamName = flags.teamName
-            , pipelineName = flags.pipelineName
-            }
-
         ( topBar, topBarEffects ) =
-            NewestTopBar.init { route = Routes.Pipeline { id = pipelineLocator, groups = flags.selectedGroups } }
+            NewestTopBar.init { route = Routes.Pipeline { id = flags.pipelineLocator, groups = flags.selectedGroups } }
 
         model =
             { concourseVersion = ""
             , turbulenceImgSrc = flags.turbulenceImgSrc
-            , pipelineLocator = pipelineLocator
+            , pipelineLocator = flags.pipelineLocator
             , pipeline = RemoteData.NotAsked
             , fetchedJobs = Nothing
             , fetchedResources = Nothing
@@ -90,18 +84,12 @@ init flags =
             , topBar = topBar
             }
     in
-    ( model, [ FetchPipeline pipelineLocator, FetchVersion, ResetPipelineFocus ] ++ topBarEffects )
+    ( model, [ FetchPipeline flags.pipelineLocator, FetchVersion, ResetPipelineFocus ] ++ topBarEffects )
 
 
 changeToPipelineAndGroups : Flags -> Model -> ( Model, List Effect )
 changeToPipelineAndGroups flags model =
-    let
-        pid =
-            { teamName = flags.teamName
-            , pipelineName = flags.pipelineName
-            }
-    in
-    if model.pipelineLocator == pid then
+    if model.pipelineLocator == flags.pipelineLocator then
         let
             ( newModel, effects ) =
                 renderIfNeeded { model | selectedGroups = flags.selectedGroups }

--- a/web/elm/src/Pipeline.elm
+++ b/web/elm/src/Pipeline.elm
@@ -60,7 +60,6 @@ type alias Flags =
     , pipelineName : String
     , turbulenceImgSrc : String
     , selectedGroups : List String
-    , route : Routes.Route
     }
 
 
@@ -73,7 +72,14 @@ init flags =
             }
 
         ( topBar, topBarEffects ) =
-            NewestTopBar.init { route = flags.route }
+            NewestTopBar.init
+                { route =
+                    Routes.Pipeline
+                        { pipelineName = flags.pipelineName
+                        , teamName = flags.teamName
+                        , groups = flags.selectedGroups
+                        }
+                }
 
         model =
             { concourseVersion = ""
@@ -436,11 +442,12 @@ viewGroup :
 viewGroup { selectedGroups, pipelineLocator } grp =
     let
         url =
-            Routes.Pipeline
-                pipelineLocator.teamName
-                pipelineLocator.pipelineName
-                []
-                |> Routes.toString
+            Routes.toString <|
+                Routes.Pipeline
+                    { teamName = pipelineLocator.teamName
+                    , pipelineName = pipelineLocator.pipelineName
+                    , groups = []
+                    }
     in
     Html.li
         [ if List.member grp.name selectedGroups then
@@ -598,11 +605,12 @@ getDefaultSelectedGroups pipeline =
 
 getNextUrl : List String -> Model -> String
 getNextUrl newGroups model =
-    Routes.Pipeline
-        model.pipelineLocator.teamName
-        model.pipelineLocator.pipelineName
-        newGroups
-        |> Routes.toString
+    Routes.toString <|
+        Routes.Pipeline
+            { teamName = model.pipelineLocator.teamName
+            , pipelineName = model.pipelineLocator.pipelineName
+            , groups = newGroups
+            }
 
 
 cliIcon : Cli.Cli -> List ( String, String )

--- a/web/elm/src/Pipeline.elm
+++ b/web/elm/src/Pipeline.elm
@@ -72,14 +72,7 @@ init flags =
             }
 
         ( topBar, topBarEffects ) =
-            NewestTopBar.init
-                { route =
-                    Routes.Pipeline
-                        { pipelineName = flags.pipelineName
-                        , teamName = flags.teamName
-                        , groups = flags.selectedGroups
-                        }
-                }
+            NewestTopBar.init { route = Routes.Pipeline { id = pipelineLocator, groups = flags.selectedGroups } }
 
         model =
             { concourseVersion = ""
@@ -443,11 +436,7 @@ viewGroup { selectedGroups, pipelineLocator } grp =
     let
         url =
             Routes.toString <|
-                Routes.Pipeline
-                    { teamName = pipelineLocator.teamName
-                    , pipelineName = pipelineLocator.pipelineName
-                    , groups = []
-                    }
+                Routes.Pipeline { id = pipelineLocator, groups = [] }
     in
     Html.li
         [ if List.member grp.name selectedGroups then
@@ -606,11 +595,7 @@ getDefaultSelectedGroups pipeline =
 getNextUrl : List String -> Model -> String
 getNextUrl newGroups model =
     Routes.toString <|
-        Routes.Pipeline
-            { teamName = model.pipelineLocator.teamName
-            , pipelineName = model.pipelineLocator.pipelineName
-            , groups = newGroups
-            }
+        Routes.Pipeline { id = model.pipelineLocator, groups = newGroups }
 
 
 cliIcon : Cli.Cli -> List ( String, String )

--- a/web/elm/src/Resource.elm
+++ b/web/elm/src/Resource.elm
@@ -97,15 +97,7 @@ init flags =
             }
 
         ( topBar, topBarEffects ) =
-            NewestTopBar.init
-                { route =
-                    Routes.Resource
-                        { teamName = flags.teamName
-                        , pipelineName = flags.pipelineName
-                        , resourceName = flags.resourceName
-                        , page = Nothing
-                        }
-                }
+            NewestTopBar.init { route = Routes.Resource { id = resourceId, page = Nothing } }
 
         model =
             { resourceIdentifier = resourceId
@@ -128,13 +120,7 @@ init flags =
             , csrfToken = flags.csrfToken
             , showPinBarTooltip = False
             , pinIconHover = False
-            , route =
-                Routes.Resource
-                    { teamName = flags.teamName
-                    , pipelineName = flags.pipelineName
-                    , resourceName = flags.resourceName
-                    , page = Nothing
-                    }
+            , route = Routes.Resource { id = resourceId, page = Nothing }
             , pinCommentLoading = False
             , ctrlDown = False
             , textAreaFocused = False
@@ -499,12 +485,7 @@ update action model =
             , [ FetchVersionedResources model.resourceIdentifier <| Just page
               , NavigateTo <|
                     Routes.toString <|
-                        Routes.Resource
-                            { teamName = model.resourceIdentifier.teamName
-                            , pipelineName = model.resourceIdentifier.pipelineName
-                            , resourceName = model.resourceIdentifier.resourceName
-                            , page = Just page
-                            }
+                        Routes.Resource { id = model.resourceIdentifier, page = Just page }
               ]
             )
 
@@ -926,12 +907,7 @@ paginationMenu { versions, resourceIdentifier, hovered } =
                     [ Html.a
                         [ href <|
                             Routes.toString <|
-                                Routes.Resource
-                                    { teamName = resourceIdentifier.teamName
-                                    , pipelineName = resourceIdentifier.pipelineName
-                                    , resourceName = resourceIdentifier.resourceName
-                                    , page = Just page
-                                    }
+                                Routes.Resource { id = resourceIdentifier, page = Just page }
                         , attribute "aria-label" "Previous Page"
                         , style <|
                             chevron
@@ -968,12 +944,7 @@ paginationMenu { versions, resourceIdentifier, hovered } =
                     [ Html.a
                         [ href <|
                             Routes.toString <|
-                                Routes.Resource
-                                    { teamName = resourceIdentifier.teamName
-                                    , pipelineName = resourceIdentifier.pipelineName
-                                    , resourceName = resourceIdentifier.resourceName
-                                    , page = Just page
-                                    }
+                                Routes.Resource { id = resourceIdentifier, page = Just page }
                         , attribute "aria-label" "Next Page"
                         , style <|
                             chevron
@@ -1673,10 +1644,12 @@ viewBuildsByJob buildDict jobName =
                         let
                             link =
                                 Routes.Build
-                                    { teamName = job.teamName
-                                    , pipelineName = job.pipelineName
-                                    , jobName = job.jobName
-                                    , buildName = build.name
+                                    { id =
+                                        { teamName = job.teamName
+                                        , pipelineName = job.pipelineName
+                                        , jobName = job.jobName
+                                        , buildName = build.name
+                                        }
                                     , highlight = Routes.HighlightNothing
                                     }
                         in

--- a/web/elm/src/Resource.elm
+++ b/web/elm/src/Resource.elm
@@ -97,7 +97,15 @@ init flags =
             }
 
         ( topBar, topBarEffects ) =
-            NewestTopBar.init { route = Routes.Resource flags.teamName flags.pipelineName flags.resourceName Nothing }
+            NewestTopBar.init
+                { route =
+                    Routes.Resource
+                        { teamName = flags.teamName
+                        , pipelineName = flags.pipelineName
+                        , resourceName = flags.resourceName
+                        , page = Nothing
+                        }
+                }
 
         model =
             { resourceIdentifier = resourceId
@@ -122,10 +130,11 @@ init flags =
             , pinIconHover = False
             , route =
                 Routes.Resource
-                    flags.teamName
-                    flags.pipelineName
-                    flags.resourceName
-                    Nothing
+                    { teamName = flags.teamName
+                    , pipelineName = flags.pipelineName
+                    , resourceName = flags.resourceName
+                    , page = Nothing
+                    }
             , pinCommentLoading = False
             , ctrlDown = False
             , textAreaFocused = False
@@ -491,10 +500,11 @@ update action model =
               , NavigateTo <|
                     Routes.toString <|
                         Routes.Resource
-                            model.resourceIdentifier.teamName
-                            model.resourceIdentifier.pipelineName
-                            model.resourceIdentifier.resourceName
-                            (Just page)
+                            { teamName = model.resourceIdentifier.teamName
+                            , pipelineName = model.resourceIdentifier.pipelineName
+                            , resourceName = model.resourceIdentifier.resourceName
+                            , page = Just page
+                            }
               ]
             )
 
@@ -916,7 +926,12 @@ paginationMenu { versions, resourceIdentifier, hovered } =
                     [ Html.a
                         [ href <|
                             Routes.toString <|
-                                Routes.Resource resourceIdentifier.teamName resourceIdentifier.pipelineName resourceIdentifier.resourceName (Just page)
+                                Routes.Resource
+                                    { teamName = resourceIdentifier.teamName
+                                    , pipelineName = resourceIdentifier.pipelineName
+                                    , resourceName = resourceIdentifier.resourceName
+                                    , page = Just page
+                                    }
                         , attribute "aria-label" "Previous Page"
                         , style <|
                             chevron
@@ -953,7 +968,12 @@ paginationMenu { versions, resourceIdentifier, hovered } =
                     [ Html.a
                         [ href <|
                             Routes.toString <|
-                                Routes.Resource resourceIdentifier.teamName resourceIdentifier.pipelineName resourceIdentifier.resourceName (Just page)
+                                Routes.Resource
+                                    { teamName = resourceIdentifier.teamName
+                                    , pipelineName = resourceIdentifier.pipelineName
+                                    , resourceName = resourceIdentifier.resourceName
+                                    , page = Just page
+                                    }
                         , attribute "aria-label" "Next Page"
                         , style <|
                             chevron
@@ -1652,7 +1672,13 @@ viewBuildsByJob buildDict jobName =
                     Just job ->
                         let
                             link =
-                                Routes.Build job.teamName job.pipelineName job.jobName build.name Routes.HighlightNothing
+                                Routes.Build
+                                    { teamName = job.teamName
+                                    , pipelineName = job.pipelineName
+                                    , jobName = job.jobName
+                                    , buildName = build.name
+                                    , highlight = Routes.HighlightNothing
+                                    }
                         in
                         Html.li [ class <| Concourse.BuildStatus.show build.status ]
                             [ Html.a

--- a/web/elm/src/Resource/Models.elm
+++ b/web/elm/src/Resource/Models.elm
@@ -45,9 +45,6 @@ type CheckStatus
 
 type alias Model =
     { pageStatus : Result PageError ()
-    , teamName : String
-    , pipelineName : String
-    , name : String
     , checkStatus : CheckStatus
     , checkError : String
     , checkSetupError : String
@@ -62,7 +59,6 @@ type alias Model =
     , showPinBarTooltip : Bool
     , pinIconHover : Bool
     , topBar : NewTopBar.Model.Model
-    , route : Routes.Route
     , pinCommentLoading : Bool
     , ctrlDown : Bool
     , textAreaFocused : Bool

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -24,6 +24,7 @@ import UrlParser
         , (<?>)
         , Parser
         , custom
+        , int
         , intParam
         , map
         , oneOf
@@ -37,7 +38,7 @@ type Route
     = Build { id : Concourse.JobBuildIdentifier, highlight : Highlight }
     | Resource { id : Concourse.ResourceIdentifier, page : Maybe Pagination.Page }
     | Job { id : Concourse.JobIdentifier, page : Maybe Pagination.Page }
-    | OneOffBuild { id : Concourse.BuildName, highlight : Highlight }
+    | OneOffBuild { id : Concourse.BuildId, highlight : Highlight }
     | Pipeline { id : Concourse.PipelineIdentifier, groups : List String }
     | Dashboard { searchType : SearchType }
     | FlySuccess { flyPort : Maybe Int }
@@ -81,7 +82,7 @@ build =
 
 oneOffBuild : Parser ((Highlight -> Route) -> a) a
 oneOffBuild =
-    map (\b h -> OneOffBuild { id = b, highlight = h }) (s "builds" </> string)
+    map (\b h -> OneOffBuild { id = b, highlight = h }) (s "builds" </> int)
 
 
 parsePage : Maybe Int -> Maybe Int -> Maybe Int -> Maybe Pagination.Page
@@ -193,7 +194,7 @@ buildRoute build =
                 }
 
         Nothing ->
-            OneOffBuild { id = Basics.toString build.id, highlight = HighlightNothing }
+            OneOffBuild { id = build.id, highlight = HighlightNothing }
 
 
 jobRoute : Concourse.Job -> Route
@@ -345,7 +346,7 @@ toString route =
 
         OneOffBuild { id, highlight } ->
             "/builds/"
-                ++ id
+                ++ Basics.toString id
                 ++ showHighlight highlight
 
         Pipeline { id, groups } ->

--- a/web/elm/src/SubPage.elm
+++ b/web/elm/src/SubPage.elm
@@ -53,7 +53,7 @@ type alias Flags =
 init : Flags -> Routes.Route -> ( Model, List Effect )
 init flags route =
     case route of
-        Routes.Build teamName pipelineName jobName buildName highlight ->
+        Routes.Build { teamName, pipelineName, jobName, buildName, highlight } ->
             Build.Models.JobBuildPage
                 { teamName = teamName
                 , pipelineName = pipelineName
@@ -67,7 +67,7 @@ init flags route =
                     }
                 |> Tuple.mapFirst BuildModel
 
-        Routes.OneOffBuild buildId highlight ->
+        Routes.OneOffBuild { buildId, highlight } ->
             Build.Models.BuildPage (Result.withDefault 0 (String.toInt buildId))
                 |> Build.init
                     { csrfToken = flags.csrfToken
@@ -76,7 +76,7 @@ init flags route =
                     }
                 |> Tuple.mapFirst BuildModel
 
-        Routes.Resource teamName pipelineName resourceName page ->
+        Routes.Resource { teamName, pipelineName, resourceName, page } ->
             Resource.init
                 { resourceName = resourceName
                 , teamName = teamName
@@ -86,50 +86,35 @@ init flags route =
                 }
                 |> Tuple.mapFirst ResourceModel
 
-        Routes.Job teamName pipelineName jobName page ->
+        Routes.Job { teamName, pipelineName, jobName, page } ->
             Job.init
                 { jobName = jobName
                 , teamName = teamName
                 , pipelineName = pipelineName
                 , paging = page
                 , csrfToken = flags.csrfToken
-                , route = route
                 }
                 |> Tuple.mapFirst JobModel
 
-        Routes.Pipeline teamName pipelineName groups ->
+        Routes.Pipeline { teamName, pipelineName, groups } ->
             Pipeline.init
                 { teamName = teamName
                 , pipelineName = pipelineName
                 , turbulenceImgSrc = flags.turbulencePath
                 , selectedGroups = groups
-                , route = route
                 }
                 |> Tuple.mapFirst PipelineModel
 
-        Routes.Dashboard (Routes.Normal search) ->
+        Routes.Dashboard { searchType } ->
             Dashboard.init
                 { turbulencePath = flags.turbulencePath
                 , csrfToken = flags.csrfToken
-                , search = search |> Maybe.withDefault ""
-                , highDensity = False
+                , searchType = searchType
                 , pipelineRunningKeyframes = flags.pipelineRunningKeyframes
-                , route = route
                 }
                 |> Tuple.mapFirst DashboardModel
 
-        Routes.Dashboard Routes.HighDensity ->
-            Dashboard.init
-                { turbulencePath = flags.turbulencePath
-                , csrfToken = flags.csrfToken
-                , search = ""
-                , highDensity = True
-                , pipelineRunningKeyframes = flags.pipelineRunningKeyframes
-                , route = route
-                }
-                |> Tuple.mapFirst DashboardModel
-
-        Routes.FlySuccess flyPort ->
+        Routes.FlySuccess { flyPort } ->
             FlySuccess.init
                 { authToken = flags.authToken
                 , flyPort = flyPort
@@ -273,18 +258,17 @@ update turbulence notFound csrfToken route msg mdl =
 urlUpdate : Routes.Route -> Model -> ( Model, List Effect )
 urlUpdate route model =
     case ( route, model ) of
-        ( Routes.Pipeline team pipeline groups, PipelineModel mdl ) ->
+        ( Routes.Pipeline { teamName, pipelineName, groups }, PipelineModel mdl ) ->
             Pipeline.changeToPipelineAndGroups
-                { teamName = team
-                , pipelineName = pipeline
+                { teamName = teamName
+                , pipelineName = pipelineName
                 , turbulenceImgSrc = mdl.turbulenceImgSrc
                 , selectedGroups = groups
-                , route = route
                 }
                 mdl
                 |> Tuple.mapFirst PipelineModel
 
-        ( Routes.Resource teamName pipelineName resourceName page, ResourceModel mdl ) ->
+        ( Routes.Resource { teamName, pipelineName, resourceName, page }, ResourceModel mdl ) ->
             Resource.changeToResource
                 { teamName = teamName
                 , pipelineName = pipelineName
@@ -295,19 +279,18 @@ urlUpdate route model =
                 mdl
                 |> Tuple.mapFirst ResourceModel
 
-        ( Routes.Job teamName pipelineName jobName page, JobModel mdl ) ->
+        ( Routes.Job { teamName, pipelineName, jobName, page }, JobModel mdl ) ->
             Job.changeToJob
                 { teamName = teamName
                 , pipelineName = pipelineName
                 , jobName = jobName
                 , paging = page
                 , csrfToken = mdl.csrfToken
-                , route = route
                 }
                 mdl
                 |> Tuple.mapFirst JobModel
 
-        ( Routes.Build teamName pipelineName jobName buildName highlight, BuildModel buildModel ) ->
+        ( Routes.Build { teamName, pipelineName, jobName, buildName, highlight }, BuildModel buildModel ) ->
             Build.changeToBuild
                 (Build.Models.JobBuildPage
                     { teamName = teamName

--- a/web/elm/src/SubPage.elm
+++ b/web/elm/src/SubPage.elm
@@ -53,13 +53,8 @@ type alias Flags =
 init : Flags -> Routes.Route -> ( Model, List Effect )
 init flags route =
     case route of
-        Routes.Build { teamName, pipelineName, jobName, buildName, highlight } ->
-            Build.Models.JobBuildPage
-                { teamName = teamName
-                , pipelineName = pipelineName
-                , jobName = jobName
-                , buildName = buildName
-                }
+        Routes.Build { id, highlight } ->
+            Build.Models.JobBuildPage id
                 |> Build.init
                     { csrfToken = flags.csrfToken
                     , highlight = highlight
@@ -67,8 +62,8 @@ init flags route =
                     }
                 |> Tuple.mapFirst BuildModel
 
-        Routes.OneOffBuild { buildId, highlight } ->
-            Build.Models.BuildPage (Result.withDefault 0 (String.toInt buildId))
+        Routes.OneOffBuild { id, highlight } ->
+            Build.Models.BuildPage (Result.withDefault 0 (String.toInt id))
                 |> Build.init
                     { csrfToken = flags.csrfToken
                     , highlight = highlight
@@ -76,30 +71,30 @@ init flags route =
                     }
                 |> Tuple.mapFirst BuildModel
 
-        Routes.Resource { teamName, pipelineName, resourceName, page } ->
+        Routes.Resource { id, page } ->
             Resource.init
-                { resourceName = resourceName
-                , teamName = teamName
-                , pipelineName = pipelineName
+                { resourceName = id.resourceName
+                , teamName = id.teamName
+                , pipelineName = id.pipelineName
                 , paging = page
                 , csrfToken = flags.csrfToken
                 }
                 |> Tuple.mapFirst ResourceModel
 
-        Routes.Job { teamName, pipelineName, jobName, page } ->
+        Routes.Job { id, page } ->
             Job.init
-                { jobName = jobName
-                , teamName = teamName
-                , pipelineName = pipelineName
+                { jobName = id.jobName
+                , teamName = id.teamName
+                , pipelineName = id.pipelineName
                 , paging = page
                 , csrfToken = flags.csrfToken
                 }
                 |> Tuple.mapFirst JobModel
 
-        Routes.Pipeline { teamName, pipelineName, groups } ->
+        Routes.Pipeline { id, groups } ->
             Pipeline.init
-                { teamName = teamName
-                , pipelineName = pipelineName
+                { teamName = id.teamName
+                , pipelineName = id.pipelineName
                 , turbulenceImgSrc = flags.turbulencePath
                 , selectedGroups = groups
                 }
@@ -258,47 +253,41 @@ update turbulence notFound csrfToken route msg mdl =
 urlUpdate : Routes.Route -> Model -> ( Model, List Effect )
 urlUpdate route model =
     case ( route, model ) of
-        ( Routes.Pipeline { teamName, pipelineName, groups }, PipelineModel mdl ) ->
+        ( Routes.Pipeline { id, groups }, PipelineModel mdl ) ->
             Pipeline.changeToPipelineAndGroups
-                { teamName = teamName
-                , pipelineName = pipelineName
+                { teamName = id.teamName
+                , pipelineName = id.pipelineName
                 , turbulenceImgSrc = mdl.turbulenceImgSrc
                 , selectedGroups = groups
                 }
                 mdl
                 |> Tuple.mapFirst PipelineModel
 
-        ( Routes.Resource { teamName, pipelineName, resourceName, page }, ResourceModel mdl ) ->
+        ( Routes.Resource { id, page }, ResourceModel mdl ) ->
             Resource.changeToResource
-                { teamName = teamName
-                , pipelineName = pipelineName
-                , resourceName = resourceName
+                { teamName = id.teamName
+                , pipelineName = id.pipelineName
+                , resourceName = id.resourceName
                 , paging = page
                 , csrfToken = mdl.csrfToken
                 }
                 mdl
                 |> Tuple.mapFirst ResourceModel
 
-        ( Routes.Job { teamName, pipelineName, jobName, page }, JobModel mdl ) ->
+        ( Routes.Job { id, page }, JobModel mdl ) ->
             Job.changeToJob
-                { teamName = teamName
-                , pipelineName = pipelineName
-                , jobName = jobName
+                { teamName = id.teamName
+                , pipelineName = id.pipelineName
+                , jobName = id.jobName
                 , paging = page
                 , csrfToken = mdl.csrfToken
                 }
                 mdl
                 |> Tuple.mapFirst JobModel
 
-        ( Routes.Build { teamName, pipelineName, jobName, buildName, highlight }, BuildModel buildModel ) ->
+        ( Routes.Build { id, highlight }, BuildModel buildModel ) ->
             Build.changeToBuild
-                (Build.Models.JobBuildPage
-                    { teamName = teamName
-                    , pipelineName = pipelineName
-                    , jobName = jobName
-                    , buildName = buildName
-                    }
-                )
+                (Build.Models.JobBuildPage id)
                 { buildModel | highlight = highlight }
                 |> Tuple.mapFirst BuildModel
 

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -45,7 +45,14 @@ all =
                 Build.init
                     { csrfToken = ""
                     , highlight = Routes.HighlightNothing
-                    , route = Routes.Build "team" "pipeline" "job" "1" Routes.HighlightNothing
+                    , route =
+                        Routes.Build
+                            { teamName = "team"
+                            , pipelineName = "pipeline"
+                            , jobName = "job"
+                            , buildName = "1"
+                            , highlight = Routes.HighlightNothing
+                            }
                     }
                     (Models.JobBuildPage
                         { teamName = "team"

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -48,13 +48,8 @@ all =
                 Build.init
                     { csrfToken = ""
                     , highlight = Routes.HighlightNothing
-                    , route =
-                        Routes.Build
-                            { id = buildId
-                            , highlight = Routes.HighlightNothing
-                            }
+                    , pageType = Models.JobBuildPage buildId
                     }
-                    (Models.JobBuildPage buildId)
 
             theBuild : Concourse.Build
             theBuild =

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -41,26 +41,20 @@ all : Test
 all =
     describe "build page" <|
         let
+            buildId =
+                { teamName = "team", pipelineName = "pipeline", jobName = "job", buildName = "1" }
+
             pageLoad =
                 Build.init
                     { csrfToken = ""
                     , highlight = Routes.HighlightNothing
                     , route =
                         Routes.Build
-                            { teamName = "team"
-                            , pipelineName = "pipeline"
-                            , jobName = "job"
-                            , buildName = "1"
+                            { id = buildId
                             , highlight = Routes.HighlightNothing
                             }
                     }
-                    (Models.JobBuildPage
-                        { teamName = "team"
-                        , pipelineName = "pipeline"
-                        , jobName = "job"
-                        , buildName = "1"
-                        }
-                    )
+                    (Models.JobBuildPage buildId)
 
             theBuild : Concourse.Build
             theBuild =

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -2827,15 +2827,13 @@ whenOnDashboard { highDensity } =
     Dashboard.init
         { csrfToken = ""
         , turbulencePath = ""
-        , search = ""
-        , highDensity = highDensity
         , pipelineRunningKeyframes = pipelineRunningKeyframes
-        , route =
+        , searchType =
             if highDensity then
-                Routes.Dashboard Routes.HighDensity
+                Routes.HighDensity
 
             else
-                Routes.Dashboard (Routes.Normal Nothing)
+                Routes.Normal Nothing
         }
         |> Tuple.first
 

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -87,7 +87,6 @@ all =
                         , pipelineName = "some-pipeline"
                         , paging = Nothing
                         , csrfToken = ""
-                        , route = Routes.Job "some-team" "some-pipeline" "some-job" Nothing
                         }
                         |> Tuple.first
 

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -82,9 +82,7 @@ all =
                 defaultModel : Job.Model
                 defaultModel =
                     Job.init
-                        { jobName = "some-job"
-                        , teamName = "some-team"
-                        , pipelineName = "some-pipeline"
+                        { jobId = someJobInfo
                         , paging = Nothing
                         , csrfToken = ""
                         }

--- a/web/elm/tests/NewestTopBarTests.elm
+++ b/web/elm/tests/NewestTopBarTests.elm
@@ -99,14 +99,14 @@ all : Test
 all =
     describe "NewestTopBar"
         [ rspecStyleDescribe "on init"
-            (NewestTopBar.init { route = Routes.Pipeline "team" "pipeline" [] }
+            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } }
                 |> Tuple.second
             )
             [ it "requests screen size" <|
                 Expect.equal [ Effects.GetScreenSize ]
             ]
         , rspecStyleDescribe "when on pipeline page"
-            (NewestTopBar.init { route = Routes.Pipeline "team" "pipeline" [] }
+            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } }
                 |> Tuple.first
             )
             [ context "when login state unknown"
@@ -248,12 +248,12 @@ all =
                         >> Query.hasNot [ id "logout-button" ]
                 ]
             , it "clicking a pinned resource navigates to the pinned resource page" <|
-                NewestTopBar.update (Msgs.GoToPinnedResource (Routes.Resource "t" "p" "r" Nothing))
+                NewestTopBar.update (Msgs.GoToPinnedResource (Routes.Resource { teamName = "t", pipelineName = "p", resourceName = "r", page = Nothing }))
                     >> Tuple.second
                     >> Expect.equal [ Effects.NavigateTo "/teams/t/pipelines/p/resources/r" ]
             ]
         , rspecStyleDescribe "rendering user menus on clicks"
-            (NewestTopBar.init { route = Routes.Pipeline "team" "pipeline" [] }
+            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } }
                 |> Tuple.first
             )
             [ it "shows user menu when ToggleUserMenu msg is received" <|
@@ -307,7 +307,7 @@ all =
                     >> Query.has [ text "login" ]
             ]
         , rspecStyleDescribe "login component when user is logged out"
-            (NewestTopBar.init { route = Routes.Pipeline "team" "pipeline" [] }
+            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } }
                 |> Tuple.first
                 |> viewNormally
             )
@@ -345,7 +345,7 @@ all =
                         ]
             ]
         , rspecStyleDescribe "when triggering a log in message"
-            (NewestTopBar.init { route = Routes.Pipeline "team" "pipeline" [] })
+            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } })
             [ it "redirects to login page when you click login" <|
                 Tuple.first
                     >> NewestTopBar.update Msgs.LogIn
@@ -353,7 +353,7 @@ all =
                     >> Expect.equal [ Effects.RedirectToLogin ]
             ]
         , rspecStyleDescribe "rendering top bar on build page"
-            (NewestTopBar.init { route = Routes.Build "team" "pipeline" "job" "1" Routes.HighlightNothing }
+            (NewestTopBar.init { route = Routes.Build { teamName = "team", pipelineName = "pipeline", jobName = "job", buildName = "1", highlight = Routes.HighlightNothing } }
                 |> Tuple.first
                 |> viewNormally
             )
@@ -377,7 +377,7 @@ all =
                     >> Query.has [ text "job" ]
             ]
         , rspecStyleDescribe "rendering top bar on resource page"
-            (NewestTopBar.init { route = Routes.Resource "team" "pipeline" "resource" Nothing }
+            (NewestTopBar.init { route = Routes.Resource { teamName = "team", pipelineName = "pipeline", resourceName = "resource", page = Nothing } }
                 |> Tuple.first
                 |> viewNormally
             )
@@ -413,7 +413,7 @@ all =
                         [ text "resource" ]
             ]
         , rspecStyleDescribe "rendering top bar on job page"
-            (NewestTopBar.init { route = Routes.Job "team" "pipeline" "job" Nothing }
+            (NewestTopBar.init { route = Routes.Job { teamName = "team", pipelineName = "pipeline", jobName = "job", page = Nothing } }
                 |> Tuple.first
                 |> viewNormally
             )
@@ -435,7 +435,7 @@ all =
                         ]
             ]
         , rspecStyleDescribe "when checking search bar values"
-            (NewestTopBar.init { route = Routes.Dashboard (Routes.Normal (Just "test")) }
+            (NewestTopBar.init { route = Routes.Dashboard { searchType = Routes.Normal (Just "test") } }
                 |> Tuple.first
             )
             [ it "renders the search bar with the text in the search query" <|
@@ -459,7 +459,7 @@ all =
                     >> Query.has [ style [ ( "opacity", "1" ) ] ]
             ]
         , rspecStyleDescribe "rendering search bar on dashboard page"
-            (NewestTopBar.init { route = Routes.Dashboard (Routes.Normal Nothing) }
+            (NewestTopBar.init { route = Routes.Dashboard { searchType = Routes.Normal Nothing } }
                 |> Tuple.first
             )
             [ context "when desktop sized"
@@ -709,7 +709,7 @@ all =
                 ]
             ]
         , rspecStyleDescribe "when search query is updated"
-            (NewestTopBar.init { route = Routes.Dashboard (Routes.Normal Nothing) }
+            (NewestTopBar.init { route = Routes.Dashboard { searchType = Routes.Normal Nothing } }
                 |> Tuple.first
             )
             [ it "search item is modified" <|
@@ -749,7 +749,7 @@ all =
                     >> Query.count (Expect.equal 0)
             ]
         , rspecStyleDescribe "when search query is `status:`"
-            (NewestTopBar.init { route = Routes.Dashboard (Routes.Normal (Just "status:")) }
+            (NewestTopBar.init { route = Routes.Dashboard { searchType = Routes.Normal (Just "status:") } }
                 |> Tuple.first
             )
             [ it "should display a dropdown of status options when the search bar is focused" <|
@@ -770,7 +770,7 @@ all =
                         ]
             ]
         , rspecStyleDescribe "when the search query is `team:`"
-            (NewestTopBar.init { route = Routes.Dashboard (Routes.Normal (Just "team:")) }
+            (NewestTopBar.init { route = Routes.Dashboard { searchType = Routes.Normal (Just "team:") } }
                 |> Tuple.first
             )
             [ it "when the user is not logged in the dropdown is empty" <|
@@ -842,7 +842,7 @@ all =
                     >> Query.count (Expect.equal 10)
             ]
         , rspecStyleDescribe "dropdown stuff"
-            (NewestTopBar.init { route = Routes.Dashboard (Routes.Normal Nothing) }
+            (NewestTopBar.init { route = Routes.Dashboard { searchType = Routes.Normal Nothing } }
                 |> Tuple.first
             )
             [ context "before receiving FocusMsg"

--- a/web/elm/tests/NewestTopBarTests.elm
+++ b/web/elm/tests/NewestTopBarTests.elm
@@ -99,14 +99,14 @@ all : Test
 all =
     describe "NewestTopBar"
         [ rspecStyleDescribe "on init"
-            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } }
+            (NewestTopBar.init { route = Routes.Pipeline { id = { teamName = "team", pipelineName = "pipeline" }, groups = [] } }
                 |> Tuple.second
             )
             [ it "requests screen size" <|
                 Expect.equal [ Effects.GetScreenSize ]
             ]
         , rspecStyleDescribe "when on pipeline page"
-            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } }
+            (NewestTopBar.init { route = Routes.Pipeline { id = { teamName = "team", pipelineName = "pipeline" }, groups = [] } }
                 |> Tuple.first
             )
             [ context "when login state unknown"
@@ -248,12 +248,12 @@ all =
                         >> Query.hasNot [ id "logout-button" ]
                 ]
             , it "clicking a pinned resource navigates to the pinned resource page" <|
-                NewestTopBar.update (Msgs.GoToPinnedResource (Routes.Resource { teamName = "t", pipelineName = "p", resourceName = "r", page = Nothing }))
+                NewestTopBar.update (Msgs.GoToPinnedResource (Routes.Resource { id = { teamName = "t", pipelineName = "p", resourceName = "r" }, page = Nothing }))
                     >> Tuple.second
                     >> Expect.equal [ Effects.NavigateTo "/teams/t/pipelines/p/resources/r" ]
             ]
         , rspecStyleDescribe "rendering user menus on clicks"
-            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } }
+            (NewestTopBar.init { route = Routes.Pipeline { id = { teamName = "team", pipelineName = "pipeline" }, groups = [] } }
                 |> Tuple.first
             )
             [ it "shows user menu when ToggleUserMenu msg is received" <|
@@ -307,7 +307,7 @@ all =
                     >> Query.has [ text "login" ]
             ]
         , rspecStyleDescribe "login component when user is logged out"
-            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } }
+            (NewestTopBar.init { route = Routes.Pipeline { id = { teamName = "team", pipelineName = "pipeline" }, groups = [] } }
                 |> Tuple.first
                 |> viewNormally
             )
@@ -345,7 +345,7 @@ all =
                         ]
             ]
         , rspecStyleDescribe "when triggering a log in message"
-            (NewestTopBar.init { route = Routes.Pipeline { teamName = "team", pipelineName = "pipeline", groups = [] } })
+            (NewestTopBar.init { route = Routes.Pipeline { id = { teamName = "team", pipelineName = "pipeline" }, groups = [] } })
             [ it "redirects to login page when you click login" <|
                 Tuple.first
                     >> NewestTopBar.update Msgs.LogIn
@@ -353,7 +353,7 @@ all =
                     >> Expect.equal [ Effects.RedirectToLogin ]
             ]
         , rspecStyleDescribe "rendering top bar on build page"
-            (NewestTopBar.init { route = Routes.Build { teamName = "team", pipelineName = "pipeline", jobName = "job", buildName = "1", highlight = Routes.HighlightNothing } }
+            (NewestTopBar.init { route = Routes.Build { id = { teamName = "team", pipelineName = "pipeline", jobName = "job", buildName = "1" }, highlight = Routes.HighlightNothing } }
                 |> Tuple.first
                 |> viewNormally
             )
@@ -377,7 +377,7 @@ all =
                     >> Query.has [ text "job" ]
             ]
         , rspecStyleDescribe "rendering top bar on resource page"
-            (NewestTopBar.init { route = Routes.Resource { teamName = "team", pipelineName = "pipeline", resourceName = "resource", page = Nothing } }
+            (NewestTopBar.init { route = Routes.Resource { id = { teamName = "team", pipelineName = "pipeline", resourceName = "resource" }, page = Nothing } }
                 |> Tuple.first
                 |> viewNormally
             )
@@ -413,7 +413,7 @@ all =
                         [ text "resource" ]
             ]
         , rspecStyleDescribe "rendering top bar on job page"
-            (NewestTopBar.init { route = Routes.Job { teamName = "team", pipelineName = "pipeline", jobName = "job", page = Nothing } }
+            (NewestTopBar.init { route = Routes.Job { id = { teamName = "team", pipelineName = "pipeline", jobName = "job" }, page = Nothing } }
                 |> Tuple.first
                 |> viewNormally
             )

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -95,7 +95,6 @@ all =
                         , pipelineName = "some-pipeline"
                         , turbulenceImgSrc = "some-turbulence-img-src"
                         , selectedGroups = []
-                        , route = Routes.Pipeline "some-team" "some-pipeline" []
                         }
                         |> Tuple.first
             in
@@ -600,7 +599,12 @@ all =
                         >> Event.expect
                             (wrapTopBarMessage <|
                                 NewTopBar.Msgs.GoToPinnedResource <|
-                                    Routes.Resource "team" "pipeline" "resource" Nothing
+                                    Routes.Resource
+                                        { teamName = "team"
+                                        , pipelineName = "pipeline"
+                                        , resourceName = "resource"
+                                        , page = Nothing
+                                        }
                             )
                 , it "TogglePinIconDropdown msg causes dropdown list of pinned resources to disappear" <|
                     givenPinnedResource

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -91,8 +91,10 @@ all =
                 defaultModel : Pipeline.Model
                 defaultModel =
                     Pipeline.init
-                        { teamName = "some-team"
-                        , pipelineName = "some-pipeline"
+                        { pipelineLocator =
+                            { teamName = "some-team"
+                            , pipelineName = "some-pipeline"
+                            }
                         , turbulenceImgSrc = "some-turbulence-img-src"
                         , selectedGroups = []
                         }

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -600,9 +600,11 @@ all =
                             (wrapTopBarMessage <|
                                 NewTopBar.Msgs.GoToPinnedResource <|
                                     Routes.Resource
-                                        { teamName = "team"
-                                        , pipelineName = "pipeline"
-                                        , resourceName = "resource"
+                                        { id =
+                                            { teamName = "team"
+                                            , pipelineName = "pipeline"
+                                            , resourceName = "resource"
+                                            }
                                         , page = Nothing
                                         }
                             )

--- a/web/elm/tests/SubPageTests.elm
+++ b/web/elm/tests/SubPageTests.elm
@@ -61,7 +61,19 @@ all =
                     >> Tuple.first
                     >> .subModel
                     >> Expect.equal
-                        (NotFoundModel { notFoundImgSrc = "notfound.svg", topBar = topBar (Routes.Job "t" "p" "j" Nothing) })
+                        (NotFoundModel
+                            { notFoundImgSrc = "notfound.svg"
+                            , topBar =
+                                topBar
+                                    (Routes.Job
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , jobName = "j"
+                                        , page = Nothing
+                                        }
+                                    )
+                            }
+                        )
             , test "Resource not found" <|
                 init "/teams/t/pipelines/p/resources/r"
                     >> Layout.handleCallback
@@ -70,7 +82,19 @@ all =
                     >> Tuple.first
                     >> .subModel
                     >> Expect.equal
-                        (NotFoundModel { notFoundImgSrc = "notfound.svg", topBar = topBar (Routes.Resource "t" "p" "r" Nothing) })
+                        (NotFoundModel
+                            { notFoundImgSrc = "notfound.svg"
+                            , topBar =
+                                topBar
+                                    (Routes.Resource
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , resourceName = "r"
+                                        , page = Nothing
+                                        }
+                                    )
+                            }
+                        )
             , test "Build not found" <|
                 init "/builds/1"
                     >> Layout.handleCallback
@@ -79,7 +103,17 @@ all =
                     >> Tuple.first
                     >> .subModel
                     >> Expect.equal
-                        (NotFoundModel { notFoundImgSrc = "notfound.svg", topBar = topBar (Routes.OneOffBuild "1" Routes.HighlightNothing) })
+                        (NotFoundModel
+                            { notFoundImgSrc = "notfound.svg"
+                            , topBar =
+                                topBar
+                                    (Routes.OneOffBuild
+                                        { buildId = "1"
+                                        , highlight = Routes.HighlightNothing
+                                        }
+                                    )
+                            }
+                        )
             , test "Pipeline not found" <|
                 init "/teams/t/pipelines/p"
                     >> Layout.handleCallback
@@ -88,7 +122,18 @@ all =
                     >> Tuple.first
                     >> .subModel
                     >> Expect.equal
-                        (NotFoundModel { notFoundImgSrc = "notfound.svg", topBar = topBar (Routes.Pipeline "t" "p" []) })
+                        (NotFoundModel
+                            { notFoundImgSrc = "notfound.svg"
+                            , topBar =
+                                topBar
+                                    (Routes.Pipeline
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , groups = []
+                                        }
+                                    )
+                            }
+                        )
             ]
         ]
 

--- a/web/elm/tests/SubPageTests.elm
+++ b/web/elm/tests/SubPageTests.elm
@@ -112,7 +112,7 @@ all =
                             , topBar =
                                 topBar
                                     (Routes.OneOffBuild
-                                        { id = "1"
+                                        { id = 1
                                         , highlight = Routes.HighlightNothing
                                         }
                                     )

--- a/web/elm/tests/SubPageTests.elm
+++ b/web/elm/tests/SubPageTests.elm
@@ -66,9 +66,11 @@ all =
                             , topBar =
                                 topBar
                                     (Routes.Job
-                                        { teamName = "t"
-                                        , pipelineName = "p"
-                                        , jobName = "j"
+                                        { id =
+                                            { teamName = "t"
+                                            , pipelineName = "p"
+                                            , jobName = "j"
+                                            }
                                         , page = Nothing
                                         }
                                     )
@@ -87,9 +89,11 @@ all =
                             , topBar =
                                 topBar
                                     (Routes.Resource
-                                        { teamName = "t"
-                                        , pipelineName = "p"
-                                        , resourceName = "r"
+                                        { id =
+                                            { teamName = "t"
+                                            , pipelineName = "p"
+                                            , resourceName = "r"
+                                            }
                                         , page = Nothing
                                         }
                                     )
@@ -108,7 +112,7 @@ all =
                             , topBar =
                                 topBar
                                     (Routes.OneOffBuild
-                                        { buildId = "1"
+                                        { id = "1"
                                         , highlight = Routes.HighlightNothing
                                         }
                                     )
@@ -127,8 +131,10 @@ all =
                             , topBar =
                                 topBar
                                     (Routes.Pipeline
-                                        { teamName = "t"
-                                        , pipelineName = "p"
+                                        { id =
+                                            { teamName = "t"
+                                            , pipelineName = "p"
+                                            }
                                         , groups = []
                                         }
                                     )


### PR DESCRIPTION
The route models now use our proper concourse identifiers. This also opens up the door to a nicer set of flags for page creation.

Refactor