### PR TITLE
ci: bump prod resources

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -724,8 +724,8 @@ jobs:
       - cbd/versions.yml
       vars:
         deployment_name: concourse-prod
-        web_instances: 2
-        worker_instances: 5
+        web_instances: 3
+        worker_instances: 8
         external_url: "https://ci.concourse-ci.org"
         web_vm_type: web
         db_vm_type: database


### PR DESCRIPTION
Temporarily bumping the production resources so we can get the extra
hotfix pipelines running smoothly.

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>
Co-authored-by: Topher Bullock <cbullock@pivotal.io>