### PR TITLE
Permanent unique version history for base types

### DIFF
--- a/atc/db/base_resource_type.go
+++ b/atc/db/base_resource_type.go
@@ -73,7 +73,7 @@ func (brt BaseResourceType) create(tx Tx, unique bool) (*UsedBaseResourceType, e
 		Suffix(`
 			ON CONFLICT (name) DO UPDATE SET
 				name = EXCLUDED.name,
-				unique_version_history = EXCLUDED.unique_version_history
+				unique_version_history = EXCLUDED.unique_version_history OR base_resource_types.unique_version_history
 			RETURNING id, unique_version_history
 		`).
 		RunWith(tx).

--- a/atc/db/worker_resource_type_test.go
+++ b/atc/db/worker_resource_type_test.go
@@ -56,22 +56,45 @@ var _ = Describe("WorkerResourceType", func() {
 		})
 
 		Context("when the base resource type becomes unique", func() {
+			var uniqueUsedWorkerResourceType *db.UsedWorkerResourceType
+
 			BeforeEach(func() {
 				unique = true
-			})
 
-			It("creates the base resource type with unique history", func() {
 				tx, err := dbConn.Begin()
 				Expect(err).ToNot(HaveOccurred())
 
-				uniqueUsedWorkerResourceType, err := wrt.FindOrCreate(tx, unique)
+				uniqueUsedWorkerResourceType, err = wrt.FindOrCreate(tx, unique)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = tx.Commit()
 				Expect(err).ToNot(HaveOccurred())
+			})
 
+			It("creates the base resource type with unique history", func() {
 				Expect(uniqueUsedWorkerResourceType).ToNot(Equal(usedWorkerResourceType))
 				Expect(uniqueUsedWorkerResourceType.UsedBaseResourceType.UniqueVersionHistory).To(BeTrue())
+			})
+
+			Context("when the base resource type is saved again as not unique", func() {
+				var anotherUniqueUWRT *db.UsedWorkerResourceType
+
+				BeforeEach(func() {
+					unique = false
+
+					tx, err := dbConn.Begin()
+					Expect(err).ToNot(HaveOccurred())
+
+					anotherUniqueUWRT, err = wrt.FindOrCreate(tx, unique)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = tx.Commit()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("stays as unique history", func() {
+					Expect(anotherUniqueUWRT.UsedBaseResourceType.UniqueVersionHistory).To(BeTrue())
+				})
 			})
 		})
 	})

--- a/versions.go
+++ b/versions.go
@@ -11,4 +11,4 @@ var Version = "0.0.0-dev"
 //
 // New features that are otherwise backwards-compatible should result in a
 // minor version bump.
-var WorkerVersion = "2.2"
+var WorkerVersion = "2.1"


### PR DESCRIPTION
If one worker registers with a unique base resource type, that base type gets persisted as unique permanatly.