### PR TITLE
atc/worker/: Add log to check if container lock is used

### DIFF
--- a/atc/worker/container_provider.go
+++ b/atc/worker/container_provider.go
@@ -171,6 +171,7 @@ func (p *containerProvider) FindOrCreateContainer(
 
 			if !acquired {
 				time.Sleep(creatingContainerRetryDelay)
+				logger.Debug(fmt.Sprintf("did-not-acquire-creating-container-lock-%d", creatingContainer.ID()))
 				continue
 			}
 

--- a/atc/worker/container_provider.go
+++ b/atc/worker/container_provider.go
@@ -171,7 +171,7 @@ func (p *containerProvider) FindOrCreateContainer(
 
 			if !acquired {
 				time.Sleep(creatingContainerRetryDelay)
-				logger.Debug(fmt.Sprintf("did-not-acquire-creating-container-lock-%d", creatingContainer.ID()))
+				logger.Debug("did-not-acquire-creating-container-lock", lager.Data{"containerID": creatingContainer.ID()})
 				continue
 			}
 


### PR DESCRIPTION
Add log line to check if container locks are ever not acquired in containerProvider. We are using this as a metric to decide if we need to keep container locking since FindOrCreateContainer is always called within other held locks.

Signed-off-by: Divya Dadlani <ddadlani@pivotal.io>
Co-authored-by: Krishna Mannem <kmannem@pivotal.io>