### PR TITLE
use github notion on build history start/finish timestamp

### DIFF
--- a/web/elm/src/BuildDuration.elm
+++ b/web/elm/src/BuildDuration.elm
@@ -17,10 +17,10 @@ view duration now =
                 [ pendingLabel "pending" ]
 
             ( Just startedAt, Nothing ) ->
-                [ labeledRelativeDate "started" now startedAt ]
+                [ labeledDate "started" now startedAt ]
 
             ( Nothing, Just finishedAt ) ->
-                [ labeledRelativeDate "finished" now finishedAt ]
+                [ labeledDate "finished" now finishedAt ]
 
             ( Just startedAt, Just finishedAt ) ->
                 let
@@ -28,8 +28,8 @@ view duration now =
                         -- https://github.com/elm-lang/elm-compiler/issues/1223
                         Duration.between (Date.toTime startedAt) (Date.toTime finishedAt)
                 in
-                [ labeledVerboseDate "started" startedAt
-                , labeledVerboseDate "finished" finishedAt
+                [ labeledDate "started" now startedAt
+                , labeledDate "finished" now finishedAt
                 , labeledDuration "duration" durationElmIssue
                 ]
 
@@ -38,29 +38,32 @@ show : Time.Time -> Concourse.BuildDuration -> String
 show now =
     .startedAt >> Maybe.map (Date.toTime >> flip Duration.between now >> Duration.format) >> Maybe.withDefault ""
 
-labeledVerboseDate : String -> Date -> Html a
-labeledVerboseDate label date =
-    let verboseDate =
-                    Date.Format.format "%b %d %Y %I:%M:%S %p" date
-    in
-    Html.tr []
-        [ Html.td [ class "dict-key" ] [ Html.text label ]
-        , Html.td
-            [ title verboseDate, class "dict-value" ]
-            [ Html.span [] [ Html.text verboseDate ] ]
-        ]
 
-labeledRelativeDate : String -> Time -> Date -> Html a
-labeledRelativeDate label now date =
+labeledDate: String -> Time -> Date -> Html a
+labeledDate label now date =
     let
         ago =
             Duration.between (Date.toTime date) now
+        oneDay =
+            toFloat 3600 * 24 * 1000
+        verboseDate =
+            Date.Format.format "%b %d %Y %I:%M:%S %p" date
+        relativeDate =
+            Duration.format ago ++ " ago"
     in
-    Html.tr []
+    if ago < oneDay then
+        Html.tr []
         [ Html.td [ class "dict-key" ] [ Html.text label ]
         , Html.td
-            [ title (Date.Format.format "%b %d %Y %I:%M:%S %p" date), class "dict-value" ]
-            [ Html.span [] [ Html.text (Duration.format ago ++ " ago") ] ]
+            [ title verboseDate, class "dict-value" ]
+            [ Html.span [] [ Html.text relativeDate ] ]
+        ]
+    else
+        Html.tr []
+        [ Html.td [ class "dict-key" ] [ Html.text label ]
+        , Html.td
+            [ title relativeDate, class "dict-value" ]
+            [ Html.span [] [ Html.text verboseDate ] ]
         ]
 
 


### PR DESCRIPTION
Signed-off-by: Twiknight <Twiknight@outlook.com>

Improve the timestamp display on build history according to https://github.com/concourse/concourse/issues/3321#issuecomment-464639912

Now if a time (any of started/finished) is
1. more than 24hrs ago -> show verbose date ( `"%b %d %Y %I:%M:%S %p"`), and use relative date (`sometime ago`) as tooltip
2. less than 24hrs ago -> show relative date and use verbose date as tooltip.

following is an example
<img width="526" alt="screen shot 2019-02-20 at 11 07 03 am" src="https://user-images.githubusercontent.com/11556597/53063664-d5378080-34ff-11e9-9cf3-f96a566f9e7b.png">

