### PR TITLE
fix task variable lookup order

### DIFF
--- a/atc/exec/garden_factory.go
+++ b/atc/exec/garden_factory.go
@@ -150,13 +150,13 @@ func (factory *gardenFactory) Task(
 		// external task - construct a source which reads it from file
 		taskConfigSource = FileConfigSource{ConfigPath: plan.Task.ConfigPath}
 
-		// use 'vars' from the pipeline + cred mgr variables for interpolation
+		// for interpolation - use 'vars' from the pipeline, and then fill remaining with cred mgr variables
 		taskVars = []boshtemplate.Variables{boshtemplate.StaticVariables(plan.Task.Vars), credMgrVariables}
 	} else {
 		// embedded task - first we take it
 		taskConfigSource = StaticConfigSource{Config: plan.Task.Config}
 
-		// use just cred mgr variables for interpolation
+		// for interpolation - use just cred mgr variables
 		taskVars = []boshtemplate.Variables{credMgrVariables}
 	}
 

--- a/atc/template/template_resolver.go
+++ b/atc/template/template_resolver.go
@@ -54,9 +54,10 @@ func (resolver TemplateResolver) resolve(expectAllKeys bool) ([]byte, error) {
 
 func (resolver TemplateResolver) ResolveDeprecated(allowEmpty bool) ([]byte, error) {
 	vars := boshtemplate.StaticVariables{}
-	for _, variable := range resolver.params {
-		// ideally we should deprecate old-style template parameters and remove this all together
-		if staticVar, ok := variable.(boshtemplate.StaticVariables); ok {
+	// TODO: old-style template parameters require very careful handling and reverse
+	// order processing. we should eventually drop their support
+	for i := len(resolver.params) - 1; i >= 0; i-- {
+		if staticVar, ok := resolver.params[i].(boshtemplate.StaticVariables); ok {
 			for k, v := range staticVar {
 				vars[k] = v
 			}

--- a/atc/template/template_resolver.go
+++ b/atc/template/template_resolver.go
@@ -15,6 +15,9 @@ type TemplateResolver struct {
 	params        []boshtemplate.Variables
 }
 
+// Creates a template resolver, given a configPayload and a slice of param sources. If more than
+// one param source is specified, they will be tried for variable lookup in the provided order.
+// See implementation of boshtemplate.NewMultiVars for details.
 func NewTemplateResolver(configPayload []byte, params []boshtemplate.Variables) TemplateResolver {
 	return TemplateResolver{
 		configPayload: configPayload,
@@ -42,18 +45,10 @@ func (resolver TemplateResolver) Resolve(expectAllKeys bool, allowEmptyInOldStyl
 
 func (resolver TemplateResolver) resolve(expectAllKeys bool) ([]byte, error) {
 	tpl := boshtemplate.NewTemplate(resolver.configPayload)
-
-	vars := []boshtemplate.Variables{}
-	for i := len(resolver.params) - 1; i >= 0; i-- {
-		vars = append(vars, resolver.params[i])
-	}
-
-	bytes, err := tpl.Evaluate(boshtemplate.NewMultiVars(vars), nil, boshtemplate.EvaluateOpts{ExpectAllKeys: expectAllKeys})
-
+	bytes, err := tpl.Evaluate(boshtemplate.NewMultiVars(resolver.params), nil, boshtemplate.EvaluateOpts{ExpectAllKeys: expectAllKeys})
 	if err != nil {
 		return nil, err
 	}
-
 	return bytes, nil
 }
 

--- a/atc/template/template_resolver_test.go
+++ b/atc/template/template_resolver_test.go
@@ -156,8 +156,6 @@ secret:
     private_key: some-private-key-override
 
 env: some-env-override
-
-env-tags: ["speedy-override"]
 `)
 				err := yaml.Unmarshal(paramPayload2, &staticVars2)
 				Expect(err).NotTo(HaveOccurred())
@@ -208,7 +206,7 @@ jobs:
   plan:
   - get: my-repo
   - task: build-thing-on-env
-    tags: ["speedy-override"]
+    tags: ["speedy"]
 `,
 				)))
 


### PR DESCRIPTION
hey @vito

I've been testing task vars and was writing blog post on external tasks today. Found some oddness, which we need to fix. You actually mentioned this before, being unsure about the right order of passing params to the templating engine.

The current behavior is --- cred mgr first and then task vars. The problem with that approach is that it issues a lot of unnecessary lookups to cred mgrs, even though vars are specified (i.e. you specify a var and don't even expect Concourse to reach out to cred mgr, but it still goes there)

After thinking more about this, I think the behavior should be the opposite. If vars are specified, we should take a variable from there (it makes total sense. if it's specified explicitly, then take it! it overrides anything else). If it's not in vars, then we should defer lookup to cred manager.

This turned out to be a somewhat easy fix:
* now, the order in which you pass params, is the order in which they are taken
* there is only one place where we create an array of two values and it's `[]boshtemplate.Variables{boshtemplate.StaticVariables(plan.Task.Vars), credMgrVariables}`. the semantics makes total sense here
* added a comment to NewTemplateResolver() to clarify the interface, and added unit test which checks the order
* the only part of the code which still does processing of variables in reverse order is old style templates. and this code will hopefully be dropped sooner rather than later, along with support for old style templates...