### PR TITLE
ci: fix bin-smoke provisioning

### DIFF
--- a/ci/deployments/smoke/smoke.tf
+++ b/ci/deployments/smoke/smoke.tf
@@ -166,6 +166,8 @@ resource "null_resource" "rerun" {
     inline = [
       "set -e -x",
 
+      "export PATH=/usr/local/concourse/bin:$PATH",
+
       "concourse generate-key -t rsa -f /etc/concourse/session_signing_key",
       "concourse generate-key -t ssh -f /etc/concourse/host_key",
       "concourse generate-key -t ssh -f /etc/concourse/worker_key",


### PR DESCRIPTION
verified this via 'fly execute' this time:

    env \
        GCP_PROJECT=cf-concourse-production \
        GCP_KEY="((concourse_smoke_gcp_key))" \
        SSH_KEY="((concourse_smoke_ssh_key))" \
        DEPLOYMENT=smoke \
      fly -t ci execute -c ci/tasks/terraform-smoke.yml \
        -j concourse/bin-smoke -i concourse=.