### PR TITLE
build both alpine and ubuntu resources

### DIFF
--- a/ci/dockerfiles/dev/Dockerfile
+++ b/ci/dockerfiles/dev/Dockerfile
@@ -26,20 +26,20 @@ COPY fly-windows/fly-*.zip /usr/local/concourse/fly-assets
 COPY fly-darwin/fly-*.tgz /usr/local/concourse/fly-assets
 
 # add and extract resource types
-COPY bosh-io-release-resource/bosh-io-release-resource-*.tgz    /concourse-resource-types/bosh-io-release.tgz
-COPY bosh-io-stemcell-resource/bosh-io-stemcell-resource-*.tgz  /concourse-resource-types/bosh-io-stemcell.tgz
-COPY cf-resource/cf-resource-*.tgz                              /concourse-resource-types/cf.tgz
-COPY docker-image-resource/docker-image-resource-*.tgz          /concourse-resource-types/docker-image.tgz
-COPY git-resource/git-resource-*.tgz                            /concourse-resource-types/git.tgz
-COPY github-release-resource/github-release-resource-*.tgz      /concourse-resource-types/github-release.tgz
-COPY hg-resource/hg-resource-*.tgz                              /concourse-resource-types/hg.tgz
-COPY mock-resource/mock-resource-*.tgz                          /concourse-resource-types/mock.tgz
-COPY pool-resource/pool-resource-*.tgz                          /concourse-resource-types/pool.tgz
-COPY registry-image-resource/registry-image-resource-*.tgz      /concourse-resource-types/registry-image.tgz
-COPY s3-resource/s3-resource-*.tgz                              /concourse-resource-types/s3.tgz
-COPY semver-resource/semver-resource-*.tgz                      /concourse-resource-types/semver.tgz
-COPY time-resource/time-resource-*.tgz                          /concourse-resource-types/time.tgz
-COPY tracker-resource/tracker-resource-*.tgz                    /concourse-resource-types/tracker.tgz
+COPY bosh-io-release-resource/bosh-io-release-resource-*alpine.tgz    /concourse-resource-types/bosh-io-release.tgz
+COPY bosh-io-stemcell-resource/bosh-io-stemcell-resource-*alpine.tgz  /concourse-resource-types/bosh-io-stemcell.tgz
+COPY cf-resource/cf-resource-*alpine.tgz                              /concourse-resource-types/cf.tgz
+COPY docker-image-resource/docker-image-resource-*alpine.tgz          /concourse-resource-types/docker-image.tgz
+COPY git-resource/git-resource-*alpine.tgz                            /concourse-resource-types/git.tgz
+COPY github-release-resource/github-release-resource-*alpine.tgz      /concourse-resource-types/github-release.tgz
+COPY hg-resource/hg-resource-*alpine.tgz                              /concourse-resource-types/hg.tgz
+COPY mock-resource/mock-resource-*alpine.tgz                          /concourse-resource-types/mock.tgz
+COPY pool-resource/pool-resource-*alpine.tgz                          /concourse-resource-types/pool.tgz
+COPY registry-image-resource/registry-image-resource-*alpine.tgz      /concourse-resource-types/registry-image.tgz
+COPY s3-resource/s3-resource-*alpine.tgz                              /concourse-resource-types/s3.tgz
+COPY semver-resource/semver-resource-*alpine.tgz                      /concourse-resource-types/semver.tgz
+COPY time-resource/time-resource-*alpine.tgz                          /concourse-resource-types/time.tgz
+COPY tracker-resource/tracker-resource-*alpine.tgz                    /concourse-resource-types/tracker.tgz
 RUN set -e; \
       for tgz in /concourse-resource-types/*.tgz; do \
         file=$(basename $tgz); \

--- a/ci/pipelines/resources/template.jsonnet
+++ b/ci/pipelines/resources/template.jsonnet
@@ -389,7 +389,7 @@ local publish_job(bump) = {
       ]
     },
     {
-      name: "prs",
+      name: "prs-alpine",
       serial: true,
       public: true,
       plan: [
@@ -412,6 +412,7 @@ local publish_job(bump) = {
           resource: "resource-pr",
           params: {
             path: "resource-pr",
+            context: "status-alpine",
             status: "pending"
           },
           get_params: {fetch_merge: true}
@@ -421,13 +422,14 @@ local publish_job(bump) = {
           params: {
             load_base: "alpine-edge",
             tag: resource+"-resource/.git/id",
-            tag_prefix: "pr-",
+            tag_prefix: "pr-alpine-",
             dockerfile: resource+"-resource/dockerfiles/alpine/Dockerfile",
           } + build_params,
           on_failure: {
             put: "resource-pr",
             params: {
               path: "resource-pr",
+              context: "status-alpine",
               status: "failure"
             }
           },
@@ -435,6 +437,63 @@ local publish_job(bump) = {
             put: "resource-pr",
             params: {
               path: "resource-pr",
+              context: "status-alpine",
+              status: "success"
+            }
+          }
+        }
+      ]
+    },
+    {
+      name: "prs-ubuntu",
+      serial: true,
+      public: true,
+      plan: [
+        {
+          aggregate: [
+            {
+              get: "resource-pr",
+              trigger: true,
+              version: "every"
+            },
+            {
+              get: "ubuntu-bionic",
+              params: {save: true},
+              trigger: true
+            },
+          ] + extra_gets
+        },
+        {
+          put: resource+"-resource",
+          resource: "resource-pr",
+          params: {
+            path: "resource-pr",
+            context: "status-ubuntu",
+            status: "pending"
+          },
+          get_params: {fetch_merge: true}
+        },
+        {
+          put: "resource-image-dev-ubuntu",
+          params: {
+            load_base: "ubuntu-bionic",
+            tag: resource+"-resource/.git/id",
+            tag_prefix: "pr-ubuntu-",
+            dockerfile: resource+"-resource/dockerfiles/ubuntu/Dockerfile",
+          } + build_params,
+          on_failure: {
+            put: "resource-pr",
+            params: {
+              path: "resource-pr",
+              context: "status-ubuntu",
+              status: "failure"
+            }
+          },
+          on_success: {
+            put: "resource-pr",
+            params: {
+              path: "resource-pr",
+              context: "status-ubuntu",
               status: "success"
             }
           }

--- a/ci/pipelines/resources/template.jsonnet
+++ b/ci/pipelines/resources/template.jsonnet
@@ -177,10 +177,17 @@ local publish_job(bump) = {
     {
       aggregate: [
         {
-          put: "resource-image-latest",
+          put: "resource-image-alpine",
           params: {
             load: "resource-image-dev-alpine",
-            additional_tags: "docker/tags"
+            additional_tags: "docker/tags",
+            tag_as_latest: true
+          }
+        },
+        {
+          put: "resource-image-ubuntu",
+          params: {
+            load: "resource-image-dev-ubuntu",
           }
         },
         {
@@ -288,11 +295,21 @@ local publish_job(bump) = {
       }
     },
     {
-      name: "resource-image-latest",
+      name: "resource-image-alpine",
       type: "docker-image",
       source: {
         repository: "concourse/"+resource+"-resource",
-        tag: "latest",
+        tag: "alpine",
+        username: "((docker.username))",
+        password: "((docker.password))"
+      }
+    },
+    {
+      name: "resource-image-ubuntu",
+      type: "docker-image",
+      source: {
+        repository: "concourse/"+resource+"-resource",
+        tag: "ubuntu",
         username: "((docker.username))",
         password: "((docker.password))"
       }


### PR DESCRIPTION
Part of concourse/concourse#3266
Requires all resource repos to have a `dockerfiles/alpine/Dockerfile` and `dockerfiles/ubuntu/Dockerfile`

This will modify the resource pipelines to build both the `alpine` and `ubuntu` image when releasing to GitHub.

- the image with the `latest` tag on docker hub will remain alpine
- PR images will also remain alpine
- the GitHub release now has an extra tar, `resource-1.0.0-ubuntu.tgz` (the existing one will be renamed `resource-1.0.0-alpine.tgz`)
- builds will also be triggered on new releases of `ubuntu:bionic` docker image (similar to how it's currently triggered on new releases of `alpine:edge`