### PR TITLE
web: refactored the build folder to be better structured

### DIFF
--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -14,11 +14,11 @@ import Build.Models as Models
         ( BuildPageType(..)
         , Hoverable(..)
         , Model
-        , OutputModel
         )
 import Build.Msgs exposing (Msg(..), fromBuildMessage)
-import Build.Output
-import Build.StepTree as StepTree
+import Build.Output.Models exposing (OutputModel)
+import Build.Output.Output
+import Build.StepTree.StepTree as StepTree
 import Build.Styles as Styles
 import BuildDuration
 import Callback exposing (Callback(..))
@@ -136,7 +136,7 @@ subscriptions model =
         |> RemoteData.toMaybe
         |> Maybe.andThen .output
         |> Maybe.andThen .events
-        |> Maybe.map Build.Output.subscribeToEvents
+        |> Maybe.map Build.Output.Output.subscribeToEvents
         |> WhenPresent
     ]
 
@@ -254,7 +254,7 @@ handleCallbackWithoutTopBar action model =
                 ( model, [] )
 
         PlanAndResourcesFetched buildId result ->
-            updateOutput (Build.Output.planAndResourcesFetched buildId result) model
+            updateOutput (Build.Output.Output.planAndResourcesFetched buildId result) model
 
         BuildHistoryFetched (Err err) ->
             flip always (Debug.log "failed to fetch build history" err) <|
@@ -300,7 +300,7 @@ updateWithoutTopBar action model =
                     { model | hoveredElement = state, hoveredCounter = 0 }
             in
             updateOutput
-                (Build.Output.handleStepTreeMsg <|
+                (Build.Output.Output.handleStepTreeMsg <|
                     StepTree.updateTooltip newModel
                 )
                 newModel
@@ -317,26 +317,26 @@ updateWithoutTopBar action model =
             ( model, [ DoAbortBuild buildId model.csrfToken ] )
 
         BuildEventsMsg action ->
-            updateOutput (Build.Output.handleEventsMsg action) model
+            updateOutput (Build.Output.Output.handleEventsMsg action) model
 
         ToggleStep id ->
             updateOutput
-                (Build.Output.handleStepTreeMsg <| StepTree.toggleStep id)
+                (Build.Output.Output.handleStepTreeMsg <| StepTree.toggleStep id)
                 model
 
         SwitchTab id tab ->
             updateOutput
-                (Build.Output.handleStepTreeMsg <| StepTree.switchTab id tab)
+                (Build.Output.Output.handleStepTreeMsg <| StepTree.switchTab id tab)
                 model
 
         SetHighlight id line ->
             updateOutput
-                (Build.Output.handleStepTreeMsg <| StepTree.setHighlight id line)
+                (Build.Output.Output.handleStepTreeMsg <| StepTree.setHighlight id line)
                 model
 
         ExtendHighlight id line ->
             updateOutput
-                (Build.Output.handleStepTreeMsg <| StepTree.extendHighlight id line)
+                (Build.Output.Output.handleStepTreeMsg <| StepTree.extendHighlight id line)
                 model
 
         RevealCurrentBuildInHistory ->
@@ -358,7 +358,7 @@ updateWithoutTopBar action model =
                     }
             in
             updateOutput
-                (Build.Output.handleStepTreeMsg <|
+                (Build.Output.Output.handleStepTreeMsg <|
                     StepTree.updateTooltip newModel
                 )
                 newModel
@@ -424,7 +424,7 @@ getScrollBehavior model =
 
 
 updateOutput :
-    (OutputModel -> ( OutputModel, List Effect, Build.Output.OutMsg ))
+    (OutputModel -> ( OutputModel, List Effect, Build.Output.Output.OutMsg ))
     -> Model
     -> ( Model, List Effect )
 updateOutput updater model =
@@ -641,7 +641,7 @@ initBuildOutput : Concourse.Build -> Model -> ( Model, List Effect )
 initBuildOutput build model =
     let
         ( output, outputCmd ) =
-            Build.Output.init { highlight = model.highlight } build
+            Build.Output.Output.init { highlight = model.highlight } build
     in
     ( { model
         | currentBuild =
@@ -885,7 +885,7 @@ viewBuildOutput : Concourse.Build -> Maybe OutputModel -> Html Msg
 viewBuildOutput build output =
     case output of
         Just o ->
-            Build.Output.view build o
+            Build.Output.Output.view build o
 
         Nothing ->
             Html.div [] []
@@ -1177,13 +1177,13 @@ durationTitle date content =
     Html.div [ title (Date.Format.format "%b" date) ] content
 
 
-handleOutMsg : Build.Output.OutMsg -> Model -> ( Model, List Effect )
+handleOutMsg : Build.Output.Output.OutMsg -> Model -> ( Model, List Effect )
 handleOutMsg outMsg model =
     case outMsg of
-        Build.Output.OutNoop ->
+        Build.Output.Output.OutNoop ->
             ( model, [] )
 
-        Build.Output.OutBuildStatus status date ->
+        Build.Output.Output.OutBuildStatus status date ->
             case model.currentBuild |> RemoteData.toMaybe of
                 Nothing ->
                     ( model, [] )

--- a/web/elm/src/Build/Models.elm
+++ b/web/elm/src/Build/Models.elm
@@ -1,33 +1,16 @@
 module Build.Models exposing
-    ( BuildEvent(..)
-    , BuildPageType(..)
-    , HookedStep
+    ( BuildPageType(..)
     , Hoverable(..)
-    , MetadataField
     , Model
-    , Origin
-    , OutputModel
-    , OutputState(..)
-    , Step
-    , StepFocus
     , StepHeaderType(..)
-    , StepName
-    , StepState(..)
-    , StepTree(..)
-    , StepTreeModel
-    , TabFocus(..)
-    , Version
     )
 
-import Ansi.Log
-import Array exposing (Array)
+import Build.Output.Models exposing (OutputModel)
 import Concourse
-import Date exposing (Date)
-import Dict exposing (Dict)
-import TopBar.Model
 import RemoteData exposing (WebData)
 import Routes exposing (Highlight, StepID)
 import Time exposing (Time)
+import TopBar.Model
 
 
 
@@ -75,122 +58,3 @@ type Hoverable
     = Abort
     | Trigger
     | FirstOccurrence StepID
-
-
-
--- Output
-
-
-type alias OutputModel =
-    { steps : Maybe StepTreeModel
-    , errors : Maybe Ansi.Log.Model
-    , state : OutputState
-    , eventSourceOpened : Bool
-    , events : Maybe Int
-    , highlight : Highlight
-    }
-
-
-type OutputState
-    = StepsLoading
-    | StepsLiveUpdating
-    | StepsComplete
-    | NotAuthorized
-
-
-
--- StepTree
-
-
-type alias StepTreeModel =
-    { tree : StepTree
-    , foci : Dict StepID StepFocus
-    , finished : Bool
-    , highlight : Highlight
-    , tooltip : Maybe StepID
-    }
-
-
-type StepTree
-    = Task Step
-    | Get Step
-    | Put Step
-    | Aggregate (Array StepTree)
-    | Do (Array StepTree)
-    | OnSuccess HookedStep
-    | OnFailure HookedStep
-    | OnAbort HookedStep
-    | Ensure HookedStep
-    | Try StepTree
-    | Retry StepID Int TabFocus (Array StepTree)
-    | Timeout StepTree
-
-
-type alias StepFocus =
-    { update : (StepTree -> StepTree) -> StepTree -> StepTree }
-
-
-type alias Step =
-    { id : StepID
-    , name : StepName
-    , state : StepState
-    , log : Ansi.Log.Model
-    , error : Maybe String
-    , expanded : Maybe Bool
-    , version : Maybe Version
-    , metadata : List MetadataField
-    , firstOccurrence : Bool
-    , timestamps : Dict Int Date
-    }
-
-
-type alias StepName =
-    String
-
-
-type StepState
-    = StepStatePending
-    | StepStateRunning
-    | StepStateSucceeded
-    | StepStateFailed
-    | StepStateErrored
-
-
-type alias Version =
-    Dict String String
-
-
-type alias MetadataField =
-    { name : String
-    , value : String
-    }
-
-
-type alias HookedStep =
-    { step : StepTree
-    , hook : StepTree
-    }
-
-
-type TabFocus
-    = Auto
-    | User
-
-
-type BuildEvent
-    = BuildStatus Concourse.BuildStatus Date
-    | Initialize Origin
-    | StartTask Origin
-    | FinishTask Origin Int
-    | FinishGet Origin Int Concourse.Version Concourse.Metadata
-    | FinishPut Origin Int Concourse.Version Concourse.Metadata
-    | Log Origin String (Maybe Date)
-    | Error Origin String
-    | BuildError String
-    | End
-
-
-type alias Origin =
-    { source : String
-    , id : String
-    }

--- a/web/elm/src/Build/Msgs.elm
+++ b/web/elm/src/Build/Msgs.elm
@@ -1,14 +1,15 @@
 module Build.Msgs exposing (EventsMsg(..), Msg(..), fromBuildMessage)
 
 import Array
-import Build.Models exposing (BuildEvent, Hoverable)
+import Build.Models exposing (Hoverable)
+import Build.StepTree.Models exposing (BuildEvent)
 import Concourse
 import Keyboard
-import TopBar.Msgs
 import Routes exposing (StepID)
 import Scroll
 import StrictEvents
 import Time
+import TopBar.Msgs
 
 
 type Msg

--- a/web/elm/src/Build/Output/Models.elm
+++ b/web/elm/src/Build/Output/Models.elm
@@ -1,0 +1,22 @@
+module Build.Output.Models exposing (OutputModel, OutputState(..))
+
+import Ansi.Log
+import Build.StepTree.Models exposing (StepTreeModel)
+import Routes exposing (Highlight)
+
+
+type alias OutputModel =
+    { steps : Maybe StepTreeModel
+    , errors : Maybe Ansi.Log.Model
+    , state : OutputState
+    , eventSourceOpened : Bool
+    , events : Maybe Int
+    , highlight : Highlight
+    }
+
+
+type OutputState
+    = StepsLoading
+    | StepsLiveUpdating
+    | StepsComplete
+    | NotAuthorized

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -1,4 +1,4 @@
-module Build.Output exposing
+module Build.Output.Output exposing
     ( OutMsg(..)
     , handleEventsMsg
     , handleStepTreeMsg
@@ -11,17 +11,16 @@ module Build.Output exposing
 
 import Ansi.Log
 import Array exposing (Array)
-import Build.Models
+import Build.Msgs exposing (EventsMsg(..), Msg(..))
+import Build.Output.Models exposing (OutputModel, OutputState(..))
+import Build.StepTree.Models
     exposing
         ( BuildEvent(..)
-        , OutputModel
-        , OutputState(..)
         , StepState(..)
         , StepTree
         , StepTreeModel
         )
-import Build.Msgs exposing (EventsMsg(..), Msg(..))
-import Build.StepTree as StepTree
+import Build.StepTree.StepTree as StepTree
 import Build.Styles as Styles
 import Concourse
 import Concourse.BuildEvents as BuildEvents

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -1,0 +1,115 @@
+module Build.StepTree.Models exposing
+    ( BuildEvent(..)
+    , HookedStep
+    , MetadataField
+    , Origin
+    , Step
+    , StepFocus
+    , StepName
+    , StepState(..)
+    , StepTree(..)
+    , StepTreeModel
+    , TabFocus(..)
+    , Version
+    )
+
+import Ansi.Log
+import Array exposing (Array)
+import Concourse
+import Date exposing (Date)
+import Dict exposing (Dict)
+import Routes exposing (Highlight, StepID)
+
+
+type alias StepTreeModel =
+    { tree : StepTree
+    , foci : Dict StepID StepFocus
+    , finished : Bool
+    , highlight : Highlight
+    , tooltip : Maybe StepID
+    }
+
+
+type StepTree
+    = Task Step
+    | Get Step
+    | Put Step
+    | Aggregate (Array StepTree)
+    | Do (Array StepTree)
+    | OnSuccess HookedStep
+    | OnFailure HookedStep
+    | OnAbort HookedStep
+    | Ensure HookedStep
+    | Try StepTree
+    | Retry StepID Int TabFocus (Array StepTree)
+    | Timeout StepTree
+
+
+type alias StepFocus =
+    { update : (StepTree -> StepTree) -> StepTree -> StepTree }
+
+
+type alias Step =
+    { id : StepID
+    , name : StepName
+    , state : StepState
+    , log : Ansi.Log.Model
+    , error : Maybe String
+    , expanded : Maybe Bool
+    , version : Maybe Version
+    , metadata : List MetadataField
+    , firstOccurrence : Bool
+    , timestamps : Dict Int Date
+    }
+
+
+type alias StepName =
+    String
+
+
+type StepState
+    = StepStatePending
+    | StepStateRunning
+    | StepStateSucceeded
+    | StepStateFailed
+    | StepStateErrored
+
+
+type alias Version =
+    Dict String String
+
+
+type alias MetadataField =
+    { name : String
+    , value : String
+    }
+
+
+type alias HookedStep =
+    { step : StepTree
+    , hook : StepTree
+    }
+
+
+type TabFocus
+    = Auto
+    | User
+
+
+type BuildEvent
+    = BuildStatus Concourse.BuildStatus Date
+    | Initialize Origin
+    | StartTask Origin
+    | FinishTask Origin Int
+    | FinishGet Origin Int Concourse.Version Concourse.Metadata
+    | FinishPut Origin Int Concourse.Version Concourse.Metadata
+    | Log Origin String (Maybe Date)
+    | Error Origin String
+    | BuildError String
+    | End
+
+
+type alias Origin =
+    { source : String
+    , id : String
+    }

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -1,4 +1,4 @@
-module Build.StepTree exposing
+module Build.StepTree.StepTree exposing
     ( extendHighlight
     , finished
     , init
@@ -13,14 +13,14 @@ module Build.StepTree exposing
 
 import Ansi.Log
 import Array exposing (Array)
-import Build.Models
+import Build.Models exposing (Hoverable(..), StepHeaderType(..))
+import Build.Msgs exposing (Msg(..))
+import Build.StepTree.Models
     exposing
         ( HookedStep
-        , Hoverable(..)
         , MetadataField
         , Step
         , StepFocus
-        , StepHeaderType(..)
         , StepName
         , StepState(..)
         , StepTree(..)
@@ -28,7 +28,6 @@ import Build.Models
         , TabFocus(..)
         , Version
         )
-import Build.Msgs exposing (Msg(..))
 import Build.Styles as Styles
 import Concourse
 import Date exposing (Date)

--- a/web/elm/src/Concourse/BuildEvents.elm
+++ b/web/elm/src/Concourse/BuildEvents.elm
@@ -11,7 +11,7 @@ module Concourse.BuildEvents exposing
     )
 
 import Array exposing (Array)
-import Build.Models exposing (BuildEvent(..), Origin)
+import Build.StepTree.Models exposing (BuildEvent(..), Origin)
 import Concourse
 import Date exposing (Date)
 import Dict exposing (Dict)

--- a/web/elm/tests/BuildEventsTests.elm
+++ b/web/elm/tests/BuildEventsTests.elm
@@ -1,9 +1,9 @@
 module BuildEventsTests exposing (all)
 
 import Array
-import Build.Models
 import Build.Msgs
-import Build.Output
+import Build.Output.Output
+import Build.StepTree.Models
 import EventSource.EventSource as EventSource
 import Expect
 import Json.Encode
@@ -33,7 +33,7 @@ all : Test
 all =
     test "parseMsg can handle many events, i.e. should use tail recursion" <|
         \_ ->
-            Build.Output.parseMsg
+            Build.Output.Output.parseMsg
                 (EventSource.Events <|
                     Array.fromList <|
                         List.repeat 3000
@@ -49,7 +49,7 @@ all =
                                 List.repeat
                                     3000
                                 <|
-                                    Build.Models.Log
+                                    Build.StepTree.Models.Log
                                         { source = "stdout", id = "stepid" }
                                         "log message"
                                         Nothing

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -6,6 +6,7 @@ import Array
 import Build.Build as Build
 import Build.Models as Models
 import Build.Msgs
+import Build.StepTree.Models as TreeModels
 import Callback
 import Char
 import Concourse exposing (BuildPrepStatus(..))
@@ -226,11 +227,11 @@ all =
                                     Build.Msgs.Events <|
                                         Ok <|
                                             Array.fromList
-                                                [ Models.StartTask
+                                                [ TreeModels.StartTask
                                                     { source = "stdout"
                                                     , id = "stepid"
                                                     }
-                                                , Models.Log
+                                                , TreeModels.Log
                                                     { source = "stdout"
                                                     , id = "stepid"
                                                     }
@@ -1208,7 +1209,7 @@ all =
                                 Build.Msgs.Events <|
                                     Ok <|
                                         Array.fromList
-                                            [ Models.FinishGet
+                                            [ TreeModels.FinishGet
                                                 { source = "stdout", id = "plan" }
                                                 0
                                                 Dict.empty
@@ -1237,7 +1238,7 @@ all =
                                 Build.Msgs.Events <|
                                     Ok <|
                                         Array.fromList
-                                            [ Models.FinishGet
+                                            [ TreeModels.FinishGet
                                                 { source = "stdout", id = "plan" }
                                                 0
                                                 (Dict.fromList [ ( "version", "v3.1.4" ) ])
@@ -1258,7 +1259,7 @@ all =
                                 Build.Msgs.Events <|
                                     Ok <|
                                         Array.fromList
-                                            [ Models.StartTask
+                                            [ TreeModels.StartTask
                                                 { source = "stdout"
                                                 , id = "plan"
                                                 }
@@ -1286,7 +1287,7 @@ all =
                                 Build.Msgs.Events <|
                                     Ok <|
                                         Array.fromList
-                                            [ Models.FinishGet
+                                            [ TreeModels.FinishGet
                                                 { source = "stdout", id = "plan" }
                                                 1
                                                 Dict.empty
@@ -1315,7 +1316,7 @@ all =
                                 Build.Msgs.Events <|
                                     Ok <|
                                         Array.fromList
-                                            [ Models.Error
+                                            [ TreeModels.Error
                                                 { source = "stderr", id = "plan" }
                                                 "error message"
                                             ]
@@ -1349,7 +1350,7 @@ all =
                                     Build.Msgs.Events <|
                                         Ok <|
                                             Array.fromList
-                                                [ Models.BuildError
+                                                [ TreeModels.BuildError
                                                     "error message"
                                                 ]
                                 )

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -14,8 +14,8 @@ module StepTreeTests exposing
 
 import Ansi.Log
 import Array
-import Build.Models as Models
-import Build.StepTree as StepTree
+import Build.StepTree.Models as Models
+import Build.StepTree.StepTree as StepTree
 import Concourse exposing (BuildStep(..), HookedPlan)
 import Dict
 import Expect exposing (..)


### PR DESCRIPTION
Build.Models is huge and bloaty. We already have a divided Dashboard file, Build is the next largest. It should be moved into subfolders too, IMO.

Pure code movement, no code changes, let alone feature work.