### PR TITLE
atc: add indexes for build input/output joins

### DIFF
--- a/atc/db/migration/migrations/1551110547_add_indexes_for_versions_db.down.sql
+++ b/atc/db/migration/migrations/1551110547_add_indexes_for_versions_db.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+  DROP INDEX build_resource_config_version_inputs_resource_id_idx;
+  DROP INDEX build_resource_config_version_inputs_build_id_idx;
+
+  DROP INDEX build_resource_config_version_outputs_resource_id_idx;
+  DROP INDEX build_resource_config_version_outputs_build_id_idx;
+COMMIT;

--- a/atc/db/migration/migrations/1551110547_add_indexes_for_versions_db.up.sql
+++ b/atc/db/migration/migrations/1551110547_add_indexes_for_versions_db.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+  CREATE INDEX build_resource_config_version_inputs_resource_id_idx ON build_resource_config_version_inputs (resource_id);
+  CREATE INDEX build_resource_config_version_inputs_build_id_idx ON build_resource_config_version_inputs (build_id);
+
+  CREATE INDEX build_resource_config_version_outputs_resource_id_idx ON build_resource_config_version_outputs (resource_id);
+  CREATE INDEX build_resource_config_version_outputs_build_id_idx ON build_resource_config_version_outputs (build_id);
+COMMIT;


### PR DESCRIPTION
these indexes greatly improve the time taken to load a pipeline's versions db