### PR TITLE
ci: fix `ATC_URL` in smoke test

### DIFF
--- a/ci/tasks/scripts/smoke
+++ b/ci/tasks/scripts/smoke
@@ -6,7 +6,7 @@ set -e -u
 readonly DIR=$(cd $(dirname $0) && pwd)
 
 export MAX_TICKS="${MAX_TICKS:-60}"
-export ATC_URL="${ATC_URL:-$(cat endpoint-info/instance_ip)}"
+export ATC_URL="${ATC_URL:-"http://$(cat endpoint-info/instance_ip):8080"}"
 
 if [ -e endpoint-info/admin_username ]; then
   export ATC_ADMIN_USERNAME="$(cat endpoint-info/admin_username)"


### PR DESCRIPTION
In a previous commit, `ATC_URL` was set to just use the IP, which is a
problem for the test as it expects the full address, including the
scheme and the port.

tl;dr: https://github.com/concourse/concourse/pull/3380 had a "whoops"