### PR TITLE
ci: fix check-migration-order again

### DIFF
--- a/ci/tasks/scripts/check-migration-order
+++ b/ci/tasks/scripts/check-migration-order
@@ -24,7 +24,9 @@ new_on_pr=$(comm -13 "$migrations_on_master" "$actual_pr_migrations")
 
 expected_pr_migrations=$(mktemp)
 sort -n "$migrations_on_master" >> "$expected_pr_migrations"
-echo -n "$new_on_pr" >> "$expected_pr_migrations"
+if [ -n "$new_on_pr" ]; then
+  echo "$new_on_pr" >> "$expected_pr_migrations"
+fi
 
 # we use `-n` here and not above because comm requires its
 # inputs to be *lexically* sorted but our test is about


### PR DESCRIPTION
I'm guessing this failed before when no migrations were added because it would effectively do `echo "" >> $expected_pr_migrations`, adding an erroneous trailing linebreak.

But if migrations are actually added, that linebreak had to be there. So instead just conditionally append `$new_on_pr` with a trailing linebreak.