### PR TITLE
ci: fix `try` step and input_mapping in k8s-smoke

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -314,15 +314,16 @@ jobs:
     - get: charts
       trigger: true
   - try:
-    task: delete
-    image: unit-image
-    file: concourse/ci/tasks/k8s-delete.yml
-    params:
-     KUBE_CONFIG: ((kube_config))
-     RELEASE_NAME: concourse-smoke
-     CONCOURSE_IMAGE: concourse/concourse-rc
+      task: try-delete
+      image: unit-image
+      file: concourse/ci/tasks/k8s-delete.yml
+      params:
+       KUBE_CONFIG: ((kube_config))
+       RELEASE_NAME: concourse-smoke
+       CONCOURSE_IMAGE: concourse/concourse-rc
   - task: deploy
     image: unit-image
+    input_mapping: {image-info: rc-image}
     file: concourse/ci/tasks/k8s-deploy.yml
     params:
       KUBE_CONFIG: ((kube_config))


### PR DESCRIPTION
Previously the `try` step didn't have the right indentation, making
`concourse` think that the step was just a `task`, not a `try` of a
`task.`

We also missed leaving the `input_mapping` for `image-info` when
removing the mapping for `endpoint-info`.

Signed-off-by: Bishoy Youssef <byoussef@pivotal.io>
Co-authored-by: Ciro S. Costa <cscosta@pivotal.io>