### PR TITLE
make values starts with https or http clickable in build metadata

### DIFF
--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -42,7 +42,7 @@ import Dict exposing (Dict)
 import DictView
 import Effects exposing (Effect(..))
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, class, classList, href, style)
+import Html.Attributes exposing (attribute, class, classList, href, style, target)
 import Html.Events exposing (onClick, onMouseDown, onMouseEnter, onMouseLeave)
 import Routes exposing (Highlight(..), StepID, showHighlight)
 import Spinner
@@ -574,9 +574,25 @@ viewVersion version =
 
 viewMetadata : List MetadataField -> Html Msg
 viewMetadata =
-    List.map (\{ name, value } -> ( name, Html.pre [] [ Html.text value ] ))
-        >> Dict.fromList
-        >> DictView.view []
+        List.map
+            (\{ name, value } ->
+                ( name
+                , Html.pre []
+                    [ if String.startsWith "http://" value || String.startsWith "https://" value then
+                        Html.a
+                            [ href value
+                            , target "_blank"
+                            , style [ ( "text-decoration-line", "underline" ) ]
+                            ]
+                            [ Html.text value ]
+
+                      else
+                        Html.text value
+                    ]
+                )
+            )
+            >> Dict.fromList
+            >> DictView.view []
 
 
 viewStepState : StepState -> Html Msg


### PR DESCRIPTION
A partial implementation for #429

It makes all strings that looks like a url in area `build -> resource -> metadata` clickable. 

This is very useful when your resource returns information from an external website, for example GitHub or GitLab like below case:

<img width="1907" alt="image" src="https://user-images.githubusercontent.com/11556597/53537863-52897380-3b46-11e9-8b5b-c22c3a013106.png">


- It only handles url-like strings (String starts with "http://" or "https://"), since in elm 0.19 we'll have official url lib, it would be duplication to implement https://tools.ietf.org/html/rfc3986 here 

- It only works in build page with the resource metadata. The reason is, to make all url-like stuff clickable would be larger change that impacts several files and ten more functions. I chose to start with build metadata, where in most cases, you would want a clickable link. When we decide this is a proper way or find a better way, more changes can be applied to the rest parts.

