### PR TITLE
topgun/k8s: ensure garden configuration can be properly set for the worker pods

### DIFF
--- a/cmd/concourse/worker_linux.go
+++ b/cmd/concourse/worker_linux.go
@@ -98,7 +98,7 @@ func (cmd *WorkerCommand) gdnRunner(logger lager.Logger) (ifrit.Runner, error) {
 	gdnFlags := []string{}
 
 	if cmd.Garden.GardenConfig.Path() != "" {
-		gdnFlags = append(gdnFlags, "-config", cmd.Garden.GardenConfig.Path())
+		gdnFlags = append(gdnFlags, "--config", cmd.Garden.GardenConfig.Path())
 	}
 
 	gdnServerFlags := []string{

--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Baggageclaim Drivers", func() {
 			waitAllPodsInNamespaceToBeReady(namespace)
 
 			By("Creating the web proxy")
-			proxySession, atcEndpoint = startPortForwarding(namespace, releaseName+"-web", "8080")
+			proxySession, atcEndpoint = startPortForwarding(namespace, "service/" + releaseName+"-web", "8080")
 
 			By("Logging in")
 			fly.Login("test", "test", atcEndpoint)

--- a/topgun/k8s/ephemeral_worker_test.go
+++ b/topgun/k8s/ephemeral_worker_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Ephemeral workers", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, releaseName+"-web", "8080")
+		proxySession, atcEndpoint = startPortForwarding(namespace, "service/" + releaseName+"-web", "8080")
 
 		By("Logging in")
 		fly.Login("test", "test", atcEndpoint)

--- a/topgun/k8s/garden_config_test.go
+++ b/topgun/k8s/garden_config_test.go
@@ -1,0 +1,115 @@
+package k8s_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/onsi/gomega/gexec"
+
+	. "github.com/concourse/concourse/topgun"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Garden Config", func() {
+	var (
+		proxySession        *gexec.Session
+		releaseName         string
+		namespace           string
+		gardenEndpoint      string
+		helmDeployTestFlags []string
+	)
+
+	type gardenCap struct {
+		MaxContainers int `json:"max_containers"`
+	}
+
+	BeforeEach(func() {
+		releaseName = fmt.Sprintf("topgun-gc-%d-%d", GinkgoRandomSeed(), GinkgoParallelNode())
+		namespace = releaseName
+		Run(nil, "kubectl", "create", "namespace", namespace)
+	})
+
+	JustBeforeEach(func() {
+		deployConcourseChart(releaseName, helmDeployTestFlags...)
+
+		waitAllPodsInNamespaceToBeReady(namespace)
+
+		pods := getPods(namespace, "--selector=app="+releaseName+"-worker")
+		Expect(pods).To(HaveLen(1))
+
+		By("Creating the worker-garden proxy")
+		proxySession, gardenEndpoint = startPortForwarding(namespace, "pod/"+pods[0].Metadata.Name, "7777")
+	})
+
+	AfterEach(func() {
+// 		helmDestroy(releaseName)
+// 		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
+		Wait(proxySession.Interrupt())
+	})
+
+	getMaxContainers := func() int {
+		req, err := http.NewRequest("GET", gardenEndpoint+"/capacity", nil)
+
+		Expect(err).ToNot(HaveOccurred())
+
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		defer resp.Body.Close()
+
+		gardenCapObject := gardenCap{}
+
+		err = json.NewDecoder(resp.Body).Decode(&gardenCapObject)
+		Expect(err).ToNot(HaveOccurred())
+
+		return gardenCapObject.MaxContainers
+	}
+
+	FContext("passing a config map location to the worker to be used by gdn", func() {
+		BeforeEach(func() {
+			helmDeployTestFlags = []string{
+				`--set=worker.replicas=1`,
+				`--set=worker.additionalVolumes[0].name=garden-config`,
+				`--set=worker.additionalVolumes[0].configMap.name=garden-config`,
+				`--set=worker.additionalVolumeMounts[0].name=garden-config`,
+				`--set=worker.additionalVolumeMounts[0].mountPath=/foo`,
+				`--set=concourse.worker.garden.config=/foo/garden-config.ini`,
+			}
+
+			configMapCreationArgs := []string{
+				"create",
+				"configmap",
+				"garden-config",
+				"--namespace=" + namespace,
+				`--from-literal=garden-config.ini=
+[limits]
+max-containers = 100
+`,
+			}
+
+			Run(nil, "kubectl", configMapCreationArgs...)
+
+		})
+
+		It("returns the configure number of max containers", func() {
+			Expect(getMaxContainers()).To(Equal(100))
+		})
+	})
+
+	Context("passing the CONCOURSE_GARDEN_ env vars to the gdn server", func() {
+		BeforeEach(func() {
+			helmDeployTestFlags = []string{
+				`--set=worker.replicas=1`,
+				`--set=worker.env[0].name=CONCOURSE_GARDEN_MAX_CONTAINERS`,
+				`--set=worker.env[0].value="100"`,
+			}
+		})
+
+		It("returns the configure number of max containers", func() {
+			Expect(getMaxContainers()).To(Equal(100))
+		})
+	})
+
+})

--- a/topgun/k8s/garden_config_test.go
+++ b/topgun/k8s/garden_config_test.go
@@ -44,8 +44,8 @@ var _ = Describe("Garden Config", func() {
 	})
 
 	AfterEach(func() {
-// 		helmDestroy(releaseName)
-// 		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
+		helmDestroy(releaseName)
+		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
 		Wait(proxySession.Interrupt())
 	})
 
@@ -67,7 +67,7 @@ var _ = Describe("Garden Config", func() {
 		return gardenCapObject.MaxContainers
 	}
 
-	FContext("passing a config map location to the worker to be used by gdn", func() {
+	Context("passing a config map location to the worker to be used by gdn", func() {
 		BeforeEach(func() {
 			helmDeployTestFlags = []string{
 				`--set=worker.replicas=1`,
@@ -84,9 +84,8 @@ var _ = Describe("Garden Config", func() {
 				"garden-config",
 				"--namespace=" + namespace,
 				`--from-literal=garden-config.ini=
-[limits]
-max-containers = 100
-`,
+[server]
+  max-containers = 100`,
 			}
 
 			Run(nil, "kubectl", configMapCreationArgs...)

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -223,8 +223,9 @@ func deletePods(namespace string, flags ...string) []string {
 	return podNames
 }
 
-func startPortForwarding(namespace, service, port string) (*gexec.Session, string) {
-	session := Start(nil, "kubectl", "port-forward", "--namespace="+namespace, "service/"+service, ":"+port)
+
+func startPortForwarding(namespace, resource, port string) (*gexec.Session, string) {
+	session := Start(nil, "kubectl", "port-forward", "--namespace="+namespace, resource, ":"+port)
 	Eventually(session.Out).Should(gbytes.Say("Forwarding"))
 
 	address := regexp.MustCompile(`127\.0\.0\.1:[0-9]+`).

--- a/topgun/k8s/kubernetes_creds_mgmt_test.go
+++ b/topgun/k8s/kubernetes_creds_mgmt_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Kubernetes credential management", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, releaseName+"-web", "8080")
+		proxySession, atcEndpoint = startPortForwarding(namespace, "service/" + releaseName+"-web", "8080")
 
 		By("Logging in")
 		fly.Login(username, password, atcEndpoint)

--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Prometheus integration", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the prometheus proxy")
-		proxySession, prometheusEndpoint = startPortForwarding(namespace, prometheusReleaseName+"-prometheus-server", "80")
+		proxySession, prometheusEndpoint = startPortForwarding(namespace, "service/" + prometheusReleaseName+"-prometheus-server", "80")
 	})
 
 	AfterEach(func() {

--- a/topgun/k8s/rebalance_test.go
+++ b/topgun/k8s/rebalance_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Worker Rebalancing", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, releaseName+"-web", "8080")
+		proxySession, atcEndpoint = startPortForwarding(namespace, "service/" + releaseName+"-web", "8080")
 
 		By("Logging in")
 		fly.Login("test", "test", atcEndpoint)


### PR DESCRIPTION
This ensures that our 5.x branch can have garden properties passed not only through environment variables as usual, but also ConfigMaps, which can be referenced through `CONCOURSE_GARDEN_CONFIG`.

fixes #3237
fixes #3405