### PR TITLE
topgun/k8s: refactoring + disabling of persistence in tests

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Baggageclaim Drivers", func() {
 				"--set=concourse.web.kubernetes.enabled=false",
 				"--set=concourse.worker.baggageclaim.driver=" + c.Driver,
 				"--set=image=" + Environment.ConcourseImageName,
+				"--set=persistence.enabled=false",
 				"--set=postgresql.persistence.enabled=false",
 				"--set=web.livenessProbe.failureThreshold=3",
 				"--set=web.livenessProbe.initialDelaySeconds=3",

--- a/topgun/k8s/ephemeral_worker_test.go
+++ b/topgun/k8s/ephemeral_worker_test.go
@@ -27,8 +27,10 @@ var _ = Describe("Ephemeral workers", func() {
 			// TODO: https://github.com/concourse/concourse/issues/2827
 			"--set=concourse.web.gc.interval=300ms",
 			"--set=concourse.web.tsa.heartbeatInterval=300ms",
+			"--set=concourse.worker.baggageclaim.driver=overlay",
+			"--set=persistence.enabled=false",
 			"--set=worker.replicas=1",
-			"--set=concourse.worker.baggageclaim.driver=overlay")
+		)
 
 		waitAllPodsInNamespaceToBeReady(namespace)
 

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -225,7 +225,7 @@ func deletePods(namespace string, flags ...string) []string {
 
 func startPortForwarding(namespace, service, port string) (*gexec.Session, string) {
 	session := Start(nil, "kubectl", "port-forward", "--namespace="+namespace, "service/"+service, ":"+port)
-	Eventually(session.Out).Should(gbytes.Say("Forwarding"))
+	Eventually(session.Out, 5*time.Second).Should(gbytes.Say("Forwarding"))
 
 	address := regexp.MustCompile(`127\.0\.0\.1:[0-9]+`).
 		FindStringSubmatch(string(session.Out.Contents()))

--- a/topgun/k8s/kubernetes_creds_mgmt_test.go
+++ b/topgun/k8s/kubernetes_creds_mgmt_test.go
@@ -26,7 +26,10 @@ var _ = Describe("Kubernetes credential management", func() {
 		releaseName = fmt.Sprintf("topgun-k8s-cm-%d-%d", GinkgoRandomSeed(), GinkgoParallelNode())
 		namespace = releaseName
 
-		deployConcourseChart(releaseName, "--set=worker.replicas=1")
+		deployConcourseChart(releaseName,
+			"--set=worker.replicas=1",
+			"--set=persistence.enabled=false",
+		)
 
 		waitAllPodsInNamespaceToBeReady(namespace)
 

--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -60,11 +60,13 @@ var _ = Describe("Prometheus integration", func() {
 		prometheusReleaseName = releaseName + "-prom"
 
 		deployConcourseChart(releaseName,
+			"--set=concourse.web.prometheus.enabled=true",
+			"--set=concourse.worker.baggageclaim.driver=detect",
+			"--set=concourse.worker.ephemeral=true",
+			"--set=persistence.enabled=false",
 			"--set=prometheus.enabled=true",
 			"--set=worker.replicas=1",
-			"--set=concourse.worker.ephemeral=true",
-			"--set=concourse.web.prometheus.enabled=true",
-			"--set=concourse.worker.baggageclaim.driver=detect")
+		)
 
 		helmDeploy(prometheusReleaseName,
 			namespace,

--- a/topgun/k8s/rebalance_test.go
+++ b/topgun/k8s/rebalance_test.go
@@ -25,7 +25,6 @@ var _ = Describe("Worker Rebalancing", func() {
 		namespace = releaseName
 
 		deployConcourseChart(releaseName,
-			"--set=concourse.worker.baggageclaim.driver=detect",
 			"--set=concourse.worker.ephemeral=true",
 			"--set=concourse.worker.rebalanceInterval=5s",
 			"--set=persistence.enabled=false",

--- a/topgun/k8s/rebalance_test.go
+++ b/topgun/k8s/rebalance_test.go
@@ -25,11 +25,13 @@ var _ = Describe("Worker Rebalancing", func() {
 		namespace = releaseName
 
 		deployConcourseChart(releaseName,
+			"--set=concourse.worker.baggageclaim.driver=detect",
 			"--set=concourse.worker.ephemeral=true",
-			"--set=worker.replicas=1",
-			"--set=web.replicas=2",
 			"--set=concourse.worker.rebalanceInterval=5s",
-			"--set=concourse.worker.baggageclaim.driver=detect")
+			"--set=persistence.enabled=false",
+			"--set=web.replicas=2",
+			"--set=worker.replicas=1",
+		)
 
 		waitAllPodsInNamespaceToBeReady(namespace)
 


### PR DESCRIPTION
Hey,

This PR is just about a quick refactoring regarding our k8s tests.

I noticed that in our tests we didn't have the `persistence.enabled` set up to be false, and we could leverage the `deployConcourseChart` in `baggageclaim_drivers_test` as there are no big specifics tunings there that can't be done with `deployConcourseChart`.

This PR also deals with the fact that some times the port forwarding might take some time to get set up, so it increases the `Eventually` timeout for such thing so that we might be able to have some less flakiness there.

Thanks!

---

Update: before merging - with two other PRs having been merged before this, it'd be good to have those tests updated to not use persistence as well as they're not testing lifecycle that requires persistence.

