### PR TITLE
web: add 'yarn format' to format Elm code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,6 +275,11 @@ unused imports and variables, potential optimizations, etc. Powered by
 it will run a server at `localhost:3000` which allows for easier browsing, and
 even some automated fixes!
 
+### Elm formatting
+
+Run `yarn format` to format the elm code according to the official Elm Style
+Guide. Powered by [elm-format](https://github.com/avh4/elm-format).
+
 ### Running the acceptance tests (`testflight`)
 
 The `testflight` package contains tests that run against a real live Concourse.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "uglify-js": "^3.3.22"
   },
   "scripts": {
+    "format": "elm-format --elm-version=0.18 web/elm --yes",
     "analyse": "cd web/elm && elm-analyse",
     "build": "yarn run build-less && yarn run build-elm",
     "build-debug": "yarn run build-less && yarn run build-elm-debug",

--- a/web/elm/src/Build/Models.elm
+++ b/web/elm/src/Build/Models.elm
@@ -24,10 +24,10 @@ import Array exposing (Array)
 import Concourse
 import Date exposing (Date)
 import Dict exposing (Dict)
-import TopBar.Model
 import RemoteData exposing (WebData)
 import Routes exposing (Highlight, StepID)
 import Time exposing (Time)
+import TopBar.Model
 
 
 

--- a/web/elm/src/Build/Msgs.elm
+++ b/web/elm/src/Build/Msgs.elm
@@ -4,11 +4,11 @@ import Array
 import Build.Models exposing (BuildEvent, Hoverable)
 import Concourse
 import Keyboard
-import TopBar.Msgs
 import Routes exposing (StepID)
 import Scroll
 import StrictEvents
 import Time
+import TopBar.Msgs
 
 
 type Msg

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -48,10 +48,10 @@ import Json.Decode
 import List.Extra
 import Maybe.Extra
 import Monocle.Optional
-import TopBar.Styles as NTBS
 import Ordering exposing (Ordering)
 import Set
 import Time exposing (Time)
+import TopBar.Styles as NTBS
 
 
 type alias Group =

--- a/web/elm/src/Dashboard/Msgs.elm
+++ b/web/elm/src/Dashboard/Msgs.elm
@@ -3,8 +3,8 @@ module Dashboard.Msgs exposing (Msg(..), fromDashboardMsg)
 import Concourse.Cli as Cli
 import Dashboard.Models as Models
 import Keyboard
-import TopBar.Msgs as NTB
 import Time
+import TopBar.Msgs as NTB
 import Window
 
 

--- a/web/elm/src/Job/Msgs.elm
+++ b/web/elm/src/Job/Msgs.elm
@@ -1,8 +1,8 @@
 module Job.Msgs exposing (Hoverable(..), Msg(..))
 
-import TopBar.Msgs
 import Routes
 import Time exposing (Time)
+import TopBar.Msgs
 
 
 type Msg

--- a/web/elm/src/NotFound.elm
+++ b/web/elm/src/NotFound.elm
@@ -5,11 +5,11 @@ import Effects exposing (Effect)
 import Html exposing (Html)
 import Html.Attributes exposing (class, href, id, src, style)
 import Html.Styled as HS
+import Routes
 import TopBar.Model
 import TopBar.Msgs
 import TopBar.Styles
 import TopBar.TopBar as TopBar
-import Routes
 import UserState exposing (UserState)
 
 

--- a/web/elm/src/Pipeline/Msgs.elm
+++ b/web/elm/src/Pipeline/Msgs.elm
@@ -2,8 +2,8 @@ module Pipeline.Msgs exposing (Msg(..))
 
 import Concourse
 import Keyboard
-import TopBar.Msgs
 import Time exposing (Time)
+import TopBar.Msgs
 
 
 type Msg

--- a/web/elm/src/Resource/Msgs.elm
+++ b/web/elm/src/Resource/Msgs.elm
@@ -2,10 +2,10 @@ module Resource.Msgs exposing (Msg(..))
 
 import Concourse.Pagination exposing (Page, Paginated)
 import Keyboard
-import TopBar.Msgs
 import Resource.Models as Models
 import Routes
 import Time exposing (Time)
+import TopBar.Msgs
 
 
 type Msg

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -27,7 +27,6 @@ import Expect exposing (Expectation)
 import Html.Attributes as Attr
 import Html.Styled as HS
 import List.Extra
-import TopBar.Msgs
 import Routes
 import Test exposing (..)
 import Test.Html.Event as Event
@@ -44,6 +43,7 @@ import Test.Html.Selector
         , text
         )
 import Time exposing (Time)
+import TopBar.Msgs
 import UserState
 
 

--- a/web/elm/tests/SubPageTests.elm
+++ b/web/elm/tests/SubPageTests.elm
@@ -6,12 +6,12 @@ import Dict exposing (Dict)
 import Effects
 import Expect
 import Http
-import TopBar.Model
 import RemoteData
 import Routes
 import ScreenSize
 import SubPage.SubPage exposing (..)
 import Test exposing (..)
+import TopBar.Model
 
 
 notFoundResult : Result Http.Error a


### PR DESCRIPTION
Also ran it across the codebase and it wound up organizing some imports.