### PR TITLE
ci: update k8s-smoke to use deployment instead of svc in port-forwarding

### DIFF
--- a/ci/tasks/scripts/k8s-deploy
+++ b/ci/tasks/scripts/k8s-deploy
@@ -49,12 +49,16 @@ run_helm_deploy() {
     --namespace "$RELEASE_NAME" \
     --set "concourse.web.auth.mainTeam.localUser=admin" \
     --set "concourse.web.kubernetes.enabled=false" \
-    --set "concourse.worker.baggageclaim.driver=overlay" \
+    --set "concourse.worker.baggageclaim.driver=naive" \
     --set "image=$CONCOURSE_IMAGE" \
     --set "imageDigest=$CONCOURSE_DIGEST" \
     --set "persistence.enabled=false" \
     --set "postgresql.persistence.enabled=false" \
     --set "secrets.localUsers=admin:admin\,guest:guest" \
+    --set "web.livenessProbe.failureThreshold=3" \
+    --set "web.livenessProbe.initialDelaySeconds=3" \
+    --set "web.livenessProbe.periodSeconds=3" \
+    --set "web.livenessProbe.timeoutSeconds=3" \
     --set "worker.replicas=1" \
     $RELEASE_NAME \
     $chart

--- a/ci/tasks/scripts/k8s-smoke
+++ b/ci/tasks/scripts/k8s-smoke
@@ -28,7 +28,11 @@ eventually_populate_kube_config() {
 }
 
 forward_atc_port () {
-  kubectl port-forward --namespace $RELEASE_NAME service/$RELEASE_NAME-web 8080:8080 &
+  kubectl port-forward \
+    --namespace $RELEASE_NAME \
+    deployment/$RELEASE_NAME-web \
+    --pod-running-timeout=5m \
+    8080:8080 &
 }
 
 run_test () {


### PR DESCRIPTION
Previously we were using `service` for port-forwarding the deployed
`web` instances to the network namespace used by the `k8s-smoke` task.

As services allow the routing to occur only after the underlying pods
get ready, this means that we need to wait for the readinessProbe to
return positive values.

By switching that to `deployment`, we'd be shortcutting that and going
straight to the `web` pods from the deployment, avoiding those failures
like https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-smoke/builds/980#L5c79f272:70:98
