### PR TITLE
ci: rename rc files to final versions

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -868,8 +868,8 @@ jobs:
       passed: [shipit]
     - get: darwin-rc
       passed: [shipit]
-  - task: extract-fly-assets
-    file: concourse/ci/tasks/extract-fly-assets.yml
+  - task: prep-release-assets
+    file: concourse/ci/tasks/prep-release-assets.yml
     image: unit-image
   - task: build-release-notes
     file: concourse/ci/tasks/build-release-notes.yml
@@ -882,9 +882,9 @@ jobs:
       name: release-notes/release-name
       body: release-notes/notes.md
       globs:
-      - linux-rc/*.tgz
-      - darwin-rc/*.tgz
-      - windows-rc/*.zip
+      - concourse-linux/*.tgz
+      - concourse-windows/*.zip
+      - concourse-darwin/*.tgz
       - fly-linux/fly-linux-*.tgz
       - fly-windows/fly-windows-*.zip
       - fly-darwin/fly-darwin-*.tgz

--- a/ci/tasks/prep-release-assets.yml
+++ b/ci/tasks/prep-release-assets.yml
@@ -7,12 +7,18 @@ image_resource:
 
 inputs:
 - name: concourse
+- name: version
 - name: linux-rc
+- name: windows-rc
+- name: darwin-rc
 
 outputs:
+- name: concourse-linux
+- name: concourse-windows
+- name: concourse-darwin
 - name: fly-linux
 - name: fly-windows
 - name: fly-darwin
 
 run:
-  path: concourse/ci/tasks/scripts/extract-fly-assets
+  path: concourse/ci/tasks/scripts/prep-release-assets

--- a/ci/tasks/scripts/extract-fly-assets
+++ b/ci/tasks/scripts/extract-fly-assets
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e -u -x
-
-tar -zxf linux-rc/*.tgz concourse/fly-assets --strip-components=2
-
-mv fly-linux-*.tgz   fly-linux/
-mv fly-windows-*.zip fly-windows/
-mv fly-darwin-*.tgz  fly-darwin/

--- a/ci/tasks/scripts/prep-release-assets
+++ b/ci/tasks/scripts/prep-release-assets
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e -u -x
+
+version=$(cat version/version)
+
+mv linux-rc/*.tgz   concourse-linux/concourse-${version}-linux-amd64.tgz
+mv windows-rc/*.zip concourse-windows/concourse-${version}-windows-amd64.zip
+mv darwin-rc/*.tgz  concourse-darwin/concourse-${version}-darwin-amd64.tgz
+
+tar -zxf concourse-linux/*.tgz concourse/fly-assets --strip-components=2
+
+mv fly-linux-*.tgz   fly-linux/
+mv fly-windows-*.zip fly-windows/
+mv fly-darwin-*.tgz  fly-darwin/


### PR DESCRIPTION
this way release assets don't have -rc.XXX in their filenames

fwiw: manually verified this task to expedite merging