### PR TITLE
Hide resource metadata for exposed pipeline

### DIFF
--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -57,7 +57,7 @@ func (s *Server) GetCC(w http.ResponseWriter, r *http.Request) {
 	var projects []Project
 
 	for _, pipeline := range pipelines {
-		dashboards, err := pipeline.Dashboard();
+		dashboards, err := pipeline.Dashboard()
 
 		if err != nil {
 			logger.Error("failed-to-get-dashboards", err)

--- a/atc/api/present/resource_version.go
+++ b/atc/api/present/resource_version.go
@@ -1,0 +1,19 @@
+package present
+
+import (
+	"github.com/concourse/concourse/atc"
+)
+
+func ResourceVersions(hideMetadata bool, resourceVersions []atc.ResourceVersion) []atc.ResourceVersion {
+	var presented []atc.ResourceVersion
+
+	for _, resourceVersion := range resourceVersions {
+		if hideMetadata {
+			resourceVersion.Metadata = nil
+		}
+
+		presented = append(presented, resourceVersion)
+	}
+
+	return presented
+}

--- a/atc/api/resourceserver/versionserver/list.go
+++ b/atc/api/resourceserver/versionserver/list.go
@@ -8,6 +8,8 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/api/accessor"
+	"github.com/concourse/concourse/atc/api/present"
 	"github.com/concourse/concourse/atc/db"
 )
 
@@ -87,6 +89,11 @@ func (s *Server) ListResourceVersions(pipeline db.Pipeline) http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 
 		w.WriteHeader(http.StatusOK)
+
+		acc := accessor.GetAccessor(r)
+		hideMetadata := !resource.Public() && !acc.IsAuthenticated()
+
+		versions = present.ResourceVersions(hideMetadata, versions)
 
 		err = json.NewEncoder(w).Encode(versions)
 		if err != nil {

--- a/atc/api/resourceserver/versionserver/list.go
+++ b/atc/api/resourceserver/versionserver/list.go
@@ -91,7 +91,7 @@ func (s *Server) ListResourceVersions(pipeline db.Pipeline) http.Handler {
 		w.WriteHeader(http.StatusOK)
 
 		acc := accessor.GetAccessor(r)
-		hideMetadata := !resource.Public() && !acc.IsAuthenticated()
+		hideMetadata := !resource.Public() && !acc.IsAuthorized(teamName)
 
 		versions = present.ResourceVersions(hideMetadata, versions)
 

--- a/atc/api/versions_test.go
+++ b/atc/api/versions_test.go
@@ -160,26 +160,51 @@ var _ = Describe("Versions API", func() {
 					}
 				]`))
 					})
-
 				})
 
 				Context("when resource is not public", func() {
-					It("returns the json without version metadata", func() {
-						body, err := ioutil.ReadAll(response.Body)
-						Expect(err).NotTo(HaveOccurred())
+					Context("when the user is not authenticated", func() {
+						It("returns the json without version metadata", func() {
+							body, err := ioutil.ReadAll(response.Body)
+							Expect(err).NotTo(HaveOccurred())
 
-						Expect(body).To(MatchJSON(`[
-					{
-						"id": 4,
-						"enabled": true,
-						"version": {"some":"version"}
-					},
-					{
-						"id":2,
-						"enabled": false,
-						"version": {"some":"version"}
-					}
-				]`))
+							Expect(body).To(MatchJSON(`[
+								{
+									"id": 4,
+									"enabled": true,
+									"version": {"some":"version"}
+								},
+								{
+									"id":2,
+									"enabled": false,
+									"version": {"some":"version"}
+								}
+							]`))
+						})
+					})
+
+					Context("when the user is authenticated", func() {
+						BeforeEach(func() {
+							fakeaccess.IsAuthenticatedReturns(true)
+						})
+
+						It("returns the json without version metadata", func() {
+							body, err := ioutil.ReadAll(response.Body)
+							Expect(err).NotTo(HaveOccurred())
+
+							Expect(body).To(MatchJSON(`[
+								{
+									"id": 4,
+									"enabled": true,
+									"version": {"some":"version"}
+								},
+								{
+									"id":2,
+									"enabled": false,
+									"version": {"some":"version"}
+								}
+							]`))
+						})
 					})
 				})
 			})

--- a/atc/build_inputs_outputs.go
+++ b/atc/build_inputs_outputs.go
@@ -19,7 +19,7 @@ type PublicBuildOutput struct {
 
 type ResourceVersion struct {
 	ID       int             `json:"id"`
-	Metadata []MetadataField `json:"metadata"`
+	Metadata []MetadataField `json:"metadata,omitempty"`
 	Version  Version         `json:"version"`
 	Enabled  bool            `json:"enabled"`
 }

--- a/atc/config.go
+++ b/atc/config.go
@@ -52,6 +52,7 @@ func (groups GroupConfigs) Lookup(name string) (GroupConfig, int, bool) {
 
 type ResourceConfig struct {
 	Name         string  `yaml:"name" json:"name" mapstructure:"name"`
+	Public       bool    `yaml:"public,omitempty" json:"public,omitempty" mapstructure:"public"`
 	WebhookToken string  `yaml:"webhook_token,omitempty" json:"webhook_token" mapstructure:"webhook_token"`
 	Type         string  `yaml:"type" json:"type" mapstructure:"type"`
 	Source       Source  `yaml:"source" json:"source" mapstructure:"source"`

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -175,6 +175,16 @@ type FakeResource struct {
 	pipelineNameReturnsOnCall map[int]struct {
 		result1 string
 	}
+	PublicStub        func() bool
+	publicMutex       sync.RWMutex
+	publicArgsForCall []struct {
+	}
+	publicReturns struct {
+		result1 bool
+	}
+	publicReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	ReloadStub        func() (bool, error)
 	reloadMutex       sync.RWMutex
 	reloadArgsForCall []struct {
@@ -1212,6 +1222,58 @@ func (fake *FakeResource) PipelineNameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakeResource) Public() bool {
+	fake.publicMutex.Lock()
+	ret, specificReturn := fake.publicReturnsOnCall[len(fake.publicArgsForCall)]
+	fake.publicArgsForCall = append(fake.publicArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Public", []interface{}{})
+	fake.publicMutex.Unlock()
+	if fake.PublicStub != nil {
+		return fake.PublicStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.publicReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeResource) PublicCallCount() int {
+	fake.publicMutex.RLock()
+	defer fake.publicMutex.RUnlock()
+	return len(fake.publicArgsForCall)
+}
+
+func (fake *FakeResource) PublicCalls(stub func() bool) {
+	fake.publicMutex.Lock()
+	defer fake.publicMutex.Unlock()
+	fake.PublicStub = stub
+}
+
+func (fake *FakeResource) PublicReturns(result1 bool) {
+	fake.publicMutex.Lock()
+	defer fake.publicMutex.Unlock()
+	fake.PublicStub = nil
+	fake.publicReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeResource) PublicReturnsOnCall(i int, result1 bool) {
+	fake.publicMutex.Lock()
+	defer fake.publicMutex.Unlock()
+	fake.PublicStub = nil
+	if fake.publicReturnsOnCall == nil {
+		fake.publicReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.publicReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakeResource) Reload() (bool, error) {
 	fake.reloadMutex.Lock()
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
@@ -2104,6 +2166,8 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.pipelineIDMutex.RUnlock()
 	fake.pipelineNameMutex.RLock()
 	defer fake.pipelineNameMutex.RUnlock()
+	fake.publicMutex.RLock()
+	defer fake.publicMutex.RUnlock()
 	fake.reloadMutex.RLock()
 	defer fake.reloadMutex.RUnlock()
 	fake.resourceConfigIDMutex.RLock()

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -21,6 +21,7 @@ import (
 type Resource interface {
 	ID() int
 	Name() string
+	Public() bool
 	PipelineID() int
 	PipelineName() string
 	TeamName() string
@@ -69,6 +70,7 @@ var resourcesQuery = psql.Select("r.id, r.name, r.config, r.check_error, rs.last
 type resource struct {
 	id                    int
 	name                  string
+	public                bool
 	pipelineID            int
 	pipelineName          string
 	teamName              string
@@ -117,6 +119,7 @@ func (resources Resources) Configs() atc.ResourceConfigs {
 	for _, r := range resources {
 		configs = append(configs, atc.ResourceConfig{
 			Name:         r.Name(),
+			Public:       r.Public(),
 			WebhookToken: r.WebhookToken(),
 			Type:         r.Type(),
 			Source:       r.Source(),
@@ -131,6 +134,7 @@ func (resources Resources) Configs() atc.ResourceConfigs {
 
 func (r *resource) ID() int                          { return r.id }
 func (r *resource) Name() string                     { return r.name }
+func (r *resource) Public() bool                     { return r.public }
 func (r *resource) PipelineID() int                  { return r.pipelineID }
 func (r *resource) PipelineName() string             { return r.pipelineName }
 func (r *resource) TeamName() string                 { return r.teamName }
@@ -614,6 +618,7 @@ func scanResource(r *resource, row scannable) error {
 		return err
 	}
 
+	r.public = config.Public
 	r.type_ = config.Type
 	r.source = config.Source
 	r.checkEvery = config.CheckEvery

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -34,11 +34,13 @@ var _ = Describe("Resource", func() {
 					},
 					{
 						Name:   "some-other-resource",
+						Public: true,
 						Type:   "git",
 						Source: atc.Source{"some": "other-repository"},
 					},
 					{
 						Name:   "some-secret-resource",
+						Public: false,
 						Type:   "git",
 						Source: atc.Source{"some": "((secret-repository))"},
 					},
@@ -1190,6 +1192,50 @@ var _ = Describe("Resource", func() {
 
 			It("should return the config pinned version", func() {
 				Expect(resource.CurrentPinnedVersion()).To(Equal(atc.Version{"ref": "abcdef"}))
+			})
+		})
+	})
+
+	Describe("Public", func() {
+		var (
+			resource db.Resource
+			found    bool
+			err      error
+		)
+
+		Context("when public is not set in the config", func() {
+			BeforeEach(func() {
+				resource, found, err = pipeline.Resource("some-resource")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+
+			It("returns false", func() {
+				Expect(resource.Public()).To(BeFalse())
+			})
+		})
+
+		Context("when public is set to true in the config", func() {
+			BeforeEach(func() {
+				resource, found, err = pipeline.Resource("some-other-resource")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+
+			It("returns true", func() {
+				Expect(resource.Public()).To(BeTrue())
+			})
+		})
+
+		Context("when public is set to false in the config", func() {
+			BeforeEach(func() {
+				resource, found, err = pipeline.Resource("some-secret-resource")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+
+			It("returns false", func() {
+				Expect(resource.Public()).To(BeFalse())
 			})
 		})
 	})

--- a/atc/metric/error_sink_collector_test.go
+++ b/atc/metric/error_sink_collector_test.go
@@ -58,7 +58,7 @@ var _ = Describe("ErrorSinkCollector", func() {
 					log = lager.LogFormat{
 						Message:  "message",
 						LogLevel: lager.ERROR,
-						Error: metric.ErrFailedToEmit,
+						Error:    metric.ErrFailedToEmit,
 					}
 				})
 

--- a/atc/syslog/syslog.go
+++ b/atc/syslog/syslog.go
@@ -19,7 +19,7 @@ type Syslog struct {
 	writer *sl.Writer
 	closed bool
 
-	mu     sync.RWMutex
+	mu sync.RWMutex
 }
 
 func Dial(transport, address string, caCerts []string) (*Syslog, error) {

--- a/atc/syslog/syslog_suite_test.go
+++ b/atc/syslog/syslog_suite_test.go
@@ -31,7 +31,7 @@ func newTestServer(cert *tls.Certificate) *testServer {
 	server := &testServer{
 		Messages: make(chan string, 20),
 
-		wg:    new(sync.WaitGroup),
+		wg: new(sync.WaitGroup),
 	}
 
 	server.ListenTCP(cert)
@@ -109,4 +109,3 @@ func (server *testServer) Close() {
 	server.ln.Close()
 	server.wg.Wait()
 }
-

--- a/atc/syslog/syslog_test.go
+++ b/atc/syslog/syslog_test.go
@@ -16,8 +16,8 @@ var _ = Describe("Syslog", func() {
 	var server *testServer
 	const (
 		hostname = "hostname"
-		tag = "tag"
-		message = "build 123 log"
+		tag      = "tag"
+		message  = "build 123 log"
 	)
 
 	AfterEach(func() {

--- a/fly/integration/resource_versions_test.go
+++ b/fly/integration/resource_versions_test.go
@@ -52,20 +52,17 @@ var _ = Describe("Fly CLI", func() {
                 {
                   "id": 3,
 									"version": {"version":"3","another":"field"},
-									"enabled": true,
-									"metadata": null
+									"enabled": true
                 },
                 {
                   "id": 2,
 									"version": {"version":"2","another":"field"},
-									"enabled": false,
-									"metadata": null
+									"enabled": false
                 },
                 {
                   "id": 1,
 									"version": {"version":"1","another":"field"},
-									"enabled": true,
-									"metadata": null
+									"enabled": true
                 }
               ]`))
 					})

--- a/fly/integration/resources_test.go
+++ b/fly/integration/resources_test.go
@@ -37,9 +37,9 @@ var _ = Describe("Fly CLI", func() {
 		Context("when resources are returned from the API", func() {
 			createResource := func(num int, pinnedVersion atc.Version, resourceType string) atc.Resource {
 				return atc.Resource{
-					Name:   fmt.Sprintf("resource-%d", num),
+					Name:          fmt.Sprintf("resource-%d", num),
 					PinnedVersion: pinnedVersion,
-					Type:   resourceType,
+					Type:          resourceType,
 				}
 			}
 
@@ -51,7 +51,7 @@ var _ = Describe("Fly CLI", func() {
 						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines/pipeline/resources"),
 						ghttp.RespondWithJSONEncoded(200, []atc.Resource{
 							createResource(1, nil, "time"),
-							createResource(2, atc.Version{"some":"version"}, "custom"),
+							createResource(2, atc.Version{"some": "version"}, "custom"),
 						}),
 					),
 				)


### PR DESCRIPTION
* Added `Public` to resource config. Resource metadata is no longer returned in resource versions endpoint when `Public` is set to false or not set and the user is not authenticated.

#1971