### PR TITLE
ci: fix downgrade job

### DIFF
--- a/atc/db/migration/migrations/1537546150_global_resource_version_history.down.go
+++ b/atc/db/migration/migrations/1537546150_global_resource_version_history.down.go
@@ -191,7 +191,7 @@ func (self *migrations) Down_1537546150() error {
 		return err
 	}
 
-	_, err = tx.Exec(`CREATE UNIQUE INDEX resource_caches_resource_config_id_version_params_hash_uniq ON resource_caches (resource_config_id, md5(version), params_hash)`)
+	_, err = tx.Exec(`CREATE UNIQUE INDEX resource_caches_resource_config_id_version_params_hash_key ON resource_caches (resource_config_id, md5(version), params_hash)`)
 	if err != nil {
 		tx.Rollback()
 		return err

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -277,7 +277,7 @@ jobs:
   - task: downgrade-test
     privileged: true
     image: unit-image
-    file: concourse/ci/tasks/upgrade-test.yml
+    file: concourse/ci/tasks/downgrade-test.yml
     params: {DOCKERFILE: ci/dockerfiles/dev-test/Dockerfile}
 
 - name: k8s-check-helm-params


### PR DESCRIPTION
`downgrade` job should run the correct task.

Also fixed an index issue with global resources down migration.