### PR TITLE
Fly prints the unpause-pipeline command after creating a pipeline

### DIFF
--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -2,6 +2,7 @@ package setpipelinehelpers
 
 import (
 	"fmt"
+	"github.com/concourse/concourse/fly/rc"
 	"net/url"
 	"os"
 
@@ -19,6 +20,7 @@ import (
 type ATCConfig struct {
 	PipelineName     string
 	Team             concourse.Team
+	TargetName       rc.TargetName
 	Target           string
 	SkipInteraction  bool
 	CheckCredentials bool
@@ -93,6 +95,10 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 	return nil
 }
 
+func (atcConfig ATCConfig) UnpausePipelineCommand() string {
+	return fmt.Sprintf("fly -t %s unpause-pipeline -p %s", atcConfig.TargetName, atcConfig.PipelineName)
+}
+
 func (atcConfig ATCConfig) showPipelineUpdateResult(created bool, updated bool) {
 	if updated {
 		fmt.Println("configuration updated")
@@ -112,7 +118,8 @@ func (atcConfig ATCConfig) showPipelineUpdateResult(created bool, updated bool) 
 		fmt.Printf("you can view your pipeline here: %s\n", targetURL.ResolveReference(pipelineURL))
 		fmt.Println("")
 		fmt.Println("the pipeline is currently paused. to unpause, either:")
-		fmt.Println("  - run the unpause-pipeline command")
+		fmt.Println("  - run the unpause-pipeline command:")
+		fmt.Println("    " + atcConfig.UnpausePipelineCommand())
 		fmt.Println("  - click play next to the pipeline in the web ui")
 	} else {
 		panic("Something really went wrong!")

--- a/fly/commands/internal/setpipelinehelpers/atc_config_test.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config_test.go
@@ -24,3 +24,13 @@ var _ = Describe("ATC Config", func() {
 	})
 
 })
+
+var _ = Describe("UnpausePipelineCommand", func() {
+	It("uses the right target and pipeline name", func() {
+		atcConfig := ATCConfig{
+			TargetName:   "my-target",
+			PipelineName: "my-pipeline",
+		}
+		Expect(atcConfig.UnpausePipelineCommand()).To(Equal("fly -t my-target unpause-pipeline -p my-pipeline"))
+	})
+})

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -52,6 +52,7 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 	atcConfig := setpipelinehelpers.ATCConfig{
 		Team:             target.Team(),
 		PipelineName:     pipelineName,
+		TargetName:       Fly.Target,
 		Target:           target.Client().URL(),
 		SkipInteraction:  command.SkipInteractive,
 		CheckCredentials: command.CheckCredentials,

--- a/fly/integration/set_pipeline_test.go
+++ b/fly/integration/set_pipeline_test.go
@@ -1027,7 +1027,8 @@ this is super secure
 							Eventually(sess).Should(gbytes.Say(fmt.Sprintf("you can view your pipeline here: %s", pipelineURL)))
 
 							Eventually(sess).Should(gbytes.Say("the pipeline is currently paused. to unpause, either:"))
-							Eventually(sess).Should(gbytes.Say("  - run the unpause-pipeline command"))
+							Eventually(sess).Should(gbytes.Say("  - run the unpause-pipeline command:"))
+							Eventually(sess).Should(gbytes.Say("    fly -t " + targetName + " unpause-pipeline -p awesome-pipeline"))
 							Eventually(sess).Should(gbytes.Say("  - click play next to the pipeline in the web ui"))
 
 							<-sess.Exited


### PR DESCRIPTION
This makes it easier to unpause newly-set pipelines.