### PR TITLE
vault: configure a max elapsed time of 0

### DIFF
--- a/atc/creds/vault/reauther.go
+++ b/atc/creds/vault/reauther.go
@@ -83,6 +83,7 @@ func (ra *ReAuther) authLoop() {
 		exp := backoff.NewExponentialBackOff()
 		exp.InitialInterval = ra.base
 		exp.MaxInterval = ra.max
+		exp.MaxElapsedTime = 0
 		exp.Reset()
 
 		for {


### PR DESCRIPTION
turns out there's a default max elapsed time of 15 minutes. this
resulted in `NextBackOff` returning `backoff.Stop`, i.e. 0, leading to a
tight loop of auth attempts after 15 minutes.