### PR TITLE
Create .flyrc with 0600 permissions instead of 0777

### DIFF
--- a/fly/rc/targets.go
+++ b/fly/rc/targets.go
@@ -157,7 +157,7 @@ func writeTargets(configFileLocation string, targetsToWrite *targetDetailsYAML) 
 		return err
 	}
 
-	err = ioutil.WriteFile(configFileLocation, yamlBytes, os.ModePerm)
+	err = ioutil.WriteFile(configFileLocation, yamlBytes, os.FileMode(0600))
 	if err != nil {
 		return err
 	}

--- a/fly/rc/targets_test.go
+++ b/fly/rc/targets_test.go
@@ -70,7 +70,8 @@ var _ = Describe("Targets", func() {
 
 			Describe("when the file exists with 0755 permissions", func() {
 				BeforeEach(func() {
-					ioutil.WriteFile(flyrc, []byte{}, 0755)
+					err := ioutil.WriteFile(flyrc, []byte{}, 0755)
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("preserves those permissions", func() {

--- a/fly/rc/targets_test.go
+++ b/fly/rc/targets_test.go
@@ -59,6 +59,30 @@ var _ = Describe("Targets", func() {
 	})
 
 	Describe("SaveTarget", func() {
+		Context("when managing .flyrc", func() {
+			It("creates any new file with 0600 permissions", func() {
+				err := rc.SaveTarget("foo", "url", false, "main", nil, "")
+				Expect(err).ToNot(HaveOccurred())
+				fi, statErr := os.Stat(flyrc)
+				Expect(statErr).To(BeNil())
+				Expect(fi.Mode().Perm()).To(Equal(os.FileMode(0600)))
+			})
+
+			Describe("when the file exists with 0755 permissions", func() {
+				BeforeEach(func() {
+					ioutil.WriteFile(flyrc, []byte{}, 0755)
+				})
+
+				It("preserves those permissions", func() {
+					err := rc.SaveTarget("foo", "url", false, "main", nil, "")
+					Expect(err).ToNot(HaveOccurred())
+					fi, statErr := os.Stat(flyrc)
+					Expect(statErr).To(BeNil())
+					Expect(fi.Mode().Perm()).To(Equal(os.FileMode(0755)))
+				})
+			})
+		})
+
 		Describe("CA Cert Flag", func() {
 			Describe("when 'ca_cert' is not set in the flyrc", func() {
 				var targetName rc.TargetName


### PR DESCRIPTION
Fixes #2822

Previously, the `fly` command line tool would create its `.flyrc` file using default permissions `rwxrwxrwx` (0777), or fewer subject to the active `umask`, with 0755 being typical.  This is undesirable since the file is not actually executable, and also contains authentication information that should not be exposed to other users. Now, we will default to `rw-------` (0600). Due to the way that the underlying `open` syscall works, existing `.flyrc` files will retain their existing permissions: this only applies to newly created ones.

Signed-off-by: Alexander Gurney <alexander_gurney@cable.comcast.com>