### PR TITLE
ci: Add ops file to prod

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -688,6 +688,7 @@ jobs:
       trigger: true
     - get: gcp-windows-stemcell
     - get: bbr-sdk-release
+    - get: prod
   - put: prod-deployment
     params:
       manifest: cbd/cluster/concourse.yml
@@ -726,6 +727,7 @@ jobs:
       - cbd/cluster/operations/syslog-drainer.yml
       - cbd/cluster/operations/worker-rebalancing.yml
       - cbd/cluster/operations/enable-global-resources.yml
+      - prod/prod/ops.yml
       vars_files:
       - cbd/versions.yml
       vars:


### PR DESCRIPTION
- added an ops file to `concourse/prod` that adds procstat to web and
worker.
- this commits adds the use of the ops file.

depends on: concourse/prod#6
