### PR TITLE
keep fly check resource until it succeed in downgrade/upgrade job

### DIFF
--- a/ci/tasks/scripts/verify-upgrade-downgrade-pipeline
+++ b/ci/tasks/scripts/verify-upgrade-downgrade-pipeline
@@ -45,5 +45,8 @@ fly -t local watch -j "test-pipeline/test-job" \
   | grep "succeeded"
 
 # test that we can check our resources
-fly -t local check-resource -r "test-pipeline/test-resource" \
-  | grep "checked"
+until fly -t local check-resource -r "test-pipeline/test-resource" \
+  | grep "checked"; do
+  echo "waiting for old check conainer expired..."
+  sleep 2
+done


### PR DESCRIPTION
Refer to #3494 

There is a chance that `fly check resource` failed when looking up existing check container on an already-removed worker.

This won't be an issue anymore if https://github.com/concourse/concourse/issues/3079 is done. Since the very first `fly check resource` after downgrade would just spin up a new check container instead of using the old one.