### PR TITLE
smoke: Wait until worker(s) register

### DIFF
--- a/ci/tasks/scripts/smoke
+++ b/ci/tasks/scripts/smoke
@@ -5,7 +5,7 @@ set -e -u
 
 readonly DIR=$(cd $(dirname $0) && pwd)
 
-export MAX_TICKS="${MAX_TICKS:-60}"
+export MAX_TICKS="${MAX_TICKS:-120}"
 export ATC_URL="${ATC_URL:-"http://$(cat endpoint-info/instance_ip):8080"}"
 
 if [ -e endpoint-info/admin_username ]; then
@@ -41,5 +41,7 @@ else
 fi
 
 fly --version
+
+$DIR/wait-worker
 
 $DIR/watsjs test/smoke.js

--- a/ci/tasks/scripts/wait-worker
+++ b/ci/tasks/scripts/wait-worker
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# vim: set ft=sh
+
+set -u
+
+readonly ATC_URL="${ATC_URL:-}"
+readonly MAX_TICKS="${MAX_TICKS:-}"
+readonly TARGET_NAME="wait-worker-"$RANDOM
+
+main() {
+  check_environment_variables
+  create_target
+  try_until_responding
+  echo 'ok!'
+}
+
+check_environment_variables() {
+  if [[ -z $ATC_URL ]]; then
+    echo "ATC_URL environment variable must be specified"
+    exit 1
+  fi
+
+  if [[ -z $ATC_ADMIN_USERNAME ]]; then
+    echo "ATC_ADMIN_USERNAME environment variable must be specified"
+    exit 1
+  fi
+
+  if [[ -z $ATC_ADMIN_PASSWORD ]]; then
+    echo "ATC_ADMIN_PASSWORD environment variable must be specified"
+    exit 1
+  fi
+
+  if [[ -z $MAX_TICKS ]]; then
+    echo "MAX_TICKS environment variable must be specified"
+    exit 1
+  fi
+}
+
+create_target() {
+  fly -t $TARGET_NAME login -c $ATC_URL -u $ATC_ADMIN_USERNAME -p $ATC_ADMIN_PASSWORD
+}
+
+try_until_responding() {
+  local ticks=0
+
+  echo "waiting for a worker to be running"
+
+  until $(fly -t $TARGET_NAME workers | grep 'running' &> /dev/null); do
+    echo -n
+
+    ((ticks++))
+
+    if [[ $ticks -ge $MAX_TICKS ]]; then
+      echo "giving up. :("
+      exit 1
+    fi
+
+    sleep 1
+done
+}
+
+main


### PR DESCRIPTION
- As noticed in many smoke tests (K8s-smoke), the failure is usually due
to the `no workers`.
- Added a `wait-worker` script similar to `wait-atc` that makes sure a
worker is registered before running the test.
- Also, increased the default Max retries to 2 minutes before giving up.

---

Update from @cirocosta: fixes #3501
