### PR TITLE
fix flaky atc test

### DIFF
--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -226,37 +226,36 @@ var _ = Describe("Resource Config Scope", func() {
 		})
 
 		Context("when there has been a check recently", func() {
+			interval := 1 * time.Second
+
 			BeforeEach(func() {
-				updated, err := resourceConfigScope.UpdateLastChecked(1*time.Second, false)
+				updated, err := resourceConfigScope.UpdateLastChecked(interval, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updated).To(BeTrue())
 			})
 
 			Context("when not immediate", func() {
-				It("does not update the last checked", func() {
-					updated, err := resourceConfigScope.UpdateLastChecked(1*time.Second, false)
+				It("does not update the last checked until the interval has elapsed", func() {
+					updated, err := resourceConfigScope.UpdateLastChecked(interval, false)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(updated).To(BeFalse())
 				})
 
-				It("updates the last checked and stops others from periodically updating at the same time", func() {
-					Consistently(func() bool {
-						updated, err := resourceConfigScope.UpdateLastChecked(1*time.Second, false)
+				Context("when the interval has elapsed", func() {
+					BeforeEach(func() {
+						time.Sleep(interval)
+					})
+
+					It("updates the last checked", func() {
+						updated, err := resourceConfigScope.UpdateLastChecked(interval, false)
 						Expect(err).ToNot(HaveOccurred())
-
-						return updated
-					}, time.Second, 100*time.Millisecond).Should(BeFalse())
-
-					time.Sleep(time.Second)
-
-					updated, err := resourceConfigScope.UpdateLastChecked(1*time.Second, false)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(updated).To(BeTrue())
+						Expect(updated).To(BeTrue())
+					})
 				})
 			})
 
 			Context("when it is immediate", func() {
-				It("updates the last checked and stops others from updating too", func() {
+				It("updates the last checked", func() {
 					updated, err := resourceConfigScope.UpdateLastChecked(1*time.Second, true)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(updated).To(BeTrue())


### PR DESCRIPTION
this was too sensitive to timing boundaries and would fail on a slower/overloaded system