### PR TITLE
fly: ux tweaks for team commands

### DIFF
--- a/fly/commands/set_team.go
+++ b/fly/commands/set_team.go
@@ -52,36 +52,38 @@ func (command *SetTeamCommand) Execute([]string) error {
 	}
 	sort.Strings(roles)
 
-	fmt.Println("Team Name:", command.TeamName)
+	fmt.Println("setting team:", ui.Embolden("%s", command.TeamName))
 
 	for _, role := range roles {
 		authUsers := authRoles[role]["users"]
 		authGroups := authRoles[role]["groups"]
 
-		fmt.Printf("\nUsers (%s):\n", role)
+		fmt.Println()
+		fmt.Printf("role %s:\n", ui.Embolden(role))
+		fmt.Printf("  users:\n")
 		if len(authUsers) > 0 {
 			for _, user := range authUsers {
-				fmt.Println("-", user)
+				fmt.Printf("  - %s\n", user)
 			}
 		} else {
-			fmt.Println("- none")
+			fmt.Printf("    %s\n", ui.OffColor.Sprint("none"))
 		}
 
-		fmt.Printf("\nGroups (%s):\n", role)
+		fmt.Println()
+		fmt.Printf("  groups:\n")
 		if len(authGroups) > 0 {
 			for _, group := range authGroups {
-				fmt.Println("-", group)
+				fmt.Printf("  - %s\n", group)
 			}
 		} else {
-			fmt.Println("- none")
+			fmt.Printf("    %s\n", ui.OffColor.Sprint("none"))
 		}
-
 	}
 
 	confirm := true
 	if !command.SkipInteractive {
 		confirm = false
-		err = interact.NewInteraction("\napply configuration?").Resolve(&confirm)
+		err = interact.NewInteraction("\napply team configuration?").Resolve(&confirm)
 		if err != nil {
 			return err
 		}

--- a/fly/commands/teams.go
+++ b/fly/commands/teams.go
@@ -42,15 +42,17 @@ func (command *TeamsCommand) Execute([]string) error {
 		return nil
 	}
 
-	headers := ui.TableRow{
-		{Contents: "name", Color: color.New(color.Bold)},
-	}
-
+	var headers ui.TableRow
 	if command.Details {
-		headers = append(headers,
-			ui.TableCell{Contents: "users", Color: color.New(color.Bold)},
-			ui.TableCell{Contents: "groups", Color: color.New(color.Bold)},
-		)
+		headers = ui.TableRow{
+			{Contents: "name/role", Color: color.New(color.Bold)},
+			{Contents: "users", Color: color.New(color.Bold)},
+			{Contents: "groups", Color: color.New(color.Bold)},
+		}
+	} else {
+		headers = ui.TableRow{
+			{Contents: "name", Color: color.New(color.Bold)},
+		}
 	}
 
 	table := ui.Table{Headers: headers}

--- a/fly/integration/set_team_test.go
+++ b/fly/integration/set_team_test.go
@@ -74,22 +74,25 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(member\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role member:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- local:some-member"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(member\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- local:some-owner"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(viewer\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role viewer:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- local:some-viewer"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(viewer\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
 					Eventually(sess).Should(gexec.Exit(1))
 				})
@@ -104,21 +107,24 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(member\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role member:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- github:some-user"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(member\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- github:some-other-org"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(viewer\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role viewer:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- github:some-github-user"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(viewer\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- github:some-org:some-team"))
 
 					Eventually(sess).Should(gexec.Exit(1))
@@ -134,21 +140,24 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(member\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role member:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-member"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(member\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-admin"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-org"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(viewer\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(viewer\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role viewer:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-org:some-space"))
 
 					Eventually(sess).Should(gexec.Exit(1))
@@ -164,21 +173,24 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(member\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role member:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- ldap:some-user"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(member\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- ldap:some-admin"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- ldap:some-other-group"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(viewer\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(viewer\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role viewer:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- ldap:some-group"))
 
 					Eventually(sess).Should(gexec.Exit(1))
@@ -194,21 +206,24 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(member\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role member:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- oauth:some-user"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(member\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- oauth:some-admin"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- oauth:some-other-group"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(viewer\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(viewer\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role viewer:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- oauth:some-group"))
 
 					Eventually(sess).Should(gexec.Exit(1))
@@ -224,22 +239,25 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(member\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(member\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role member:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- github:some-org"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- local:some-admin"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(viewer\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("role viewer:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- local:some-viewer"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(viewer\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
 					Eventually(sess).Should(gexec.Exit(1))
 				})
@@ -263,7 +281,7 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+					Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 					yes(stdin)
 
 					Eventually(sess).Should(gexec.Exit(0))
@@ -278,7 +296,7 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+					Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 					no(stdin)
 
 					Eventually(sess.Err).Should(gbytes.Say("bailing out"))
@@ -334,7 +352,7 @@ var _ = Describe("Fly CLI", func() {
 				sess, err := gexec.Start(flyCmd, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+				Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 				yes(stdin)
 
 				Eventually(sess).Should(gexec.Exit(0))
@@ -347,7 +365,7 @@ var _ = Describe("Fly CLI", func() {
 				sess, err := gexec.Start(flyCmd, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+				Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 				yes(stdin)
 
 				Eventually(sess.Out).Should(gbytes.Say("team created"))
@@ -403,7 +421,7 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+					Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 					yes(stdin)
 
 					Eventually(sess.Err).Should(gbytes.Say("sorry bro"))
@@ -455,31 +473,12 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- local:brock-samson"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
-
-					Eventually(sess).Should(gexec.Exit(1))
-				})
-			})
-
-			Context("Setting github auth", func() {
-				BeforeEach(func() {
-					cmdParams = []string{"--github-org", "my-org", "--github-team", "samson-org:samson-team", "--github-user", "samsonite"}
-				})
-
-				It("shows the users and groups configured for github", func() {
-					sess, err := gexec.Start(flyCmd, nil, nil)
-					Expect(err).ToNot(HaveOccurred())
-
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- github:samsonite"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- github:my-org"))
-					Eventually(sess.Out).Should(gbytes.Say("- github:samson-org:samson-team"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
 
 					Eventually(sess).Should(gexec.Exit(1))
 				})
@@ -494,10 +493,11 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:my-username"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:myorg-1"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:myorg-2:myspace"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:myspace-guid"))
@@ -515,10 +515,11 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
 					Eventually(sess.Out).Should(gbytes.Say("- ldap:my-username"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- ldap:my-group"))
 
 					Eventually(sess).Should(gexec.Exit(1))
@@ -536,10 +537,11 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- oauth:cool-scope-name"))
 
 					Eventually(sess).Should(gexec.Exit(1))
@@ -555,10 +557,11 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess.Out).Should(gbytes.Say("Team Name: venture"))
-					Eventually(sess.Out).Should(gbytes.Say("Users \\(owner\\):"))
-					Eventually(sess.Out).Should(gbytes.Say("- none"))
-					Eventually(sess.Out).Should(gbytes.Say("Groups \\(owner\\):"))
+					Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
+					Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+					Eventually(sess.Out).Should(gbytes.Say("users:"))
+					Eventually(sess.Out).Should(gbytes.Say("none"))
+					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- github:samson-org:samson-team"))
 
 					Eventually(sess).Should(gexec.Exit(1))
@@ -583,7 +586,7 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+					Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 					yes(stdin)
 
 					Eventually(sess).Should(gexec.Exit(0))
@@ -598,7 +601,7 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+					Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 					no(stdin)
 
 					Eventually(sess.Err).Should(gbytes.Say("bailing out"))
@@ -650,7 +653,7 @@ var _ = Describe("Fly CLI", func() {
 				sess, err := gexec.Start(flyCmd, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+				Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 				yes(stdin)
 
 				Eventually(sess).Should(gexec.Exit(0))
@@ -663,7 +666,7 @@ var _ = Describe("Fly CLI", func() {
 				sess, err := gexec.Start(flyCmd, nil, nil)
 				Expect(err).ToNot(HaveOccurred())
 
-				Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+				Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 				yes(stdin)
 
 				Eventually(sess.Out).Should(gbytes.Say("team created"))
@@ -704,7 +707,7 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, nil, nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+					Eventually(sess).Should(gbytes.Say(`apply team configuration\? \[yN\]: `))
 					yes(stdin)
 
 					Eventually(sess.Err).Should(gbytes.Say("sorry bro"))

--- a/fly/integration/teams_test.go
+++ b/fly/integration/teams_test.go
@@ -169,10 +169,6 @@ var _ = Describe("Fly CLI", func() {
 
 					Eventually(sess).Should(gexec.Exit(0))
 					Expect(sess.Out).To(PrintTable(ui.Table{
-						Headers: ui.TableRow{
-							{Contents: "name", Color: color.New(color.Bold)},
-							{Contents: "auth", Color: color.New(color.Bold)},
-						},
 						Data: []ui.TableRow{
 							{{Contents: "a-team/owner"}, {Contents: "none"}, {Contents: "github:github-org"}},
 							{{Contents: "b-team/member"}, {Contents: "github:github-user"}, {Contents: "none"}},


### PR DESCRIPTION
new output looks like this:

```
~/w/concourse (fly-team-ux-tweaks) $ fly -t ci set-team -n resources --github-team concourse:pivotal
setting team: resources

role owner:
  users:
    none

  groups:
  - github:concourse:pivotal

apply team configuration? [yN]: 
```