### PR TITLE
Use one-off build url for pipeline scoped build created by fly exec

### DIFF
--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -109,22 +109,16 @@ func (command *ExecuteCommand) Execute(args []string) error {
 		if err != nil {
 			return err
 		}
-
-		buildURL, err = url.Parse(fmt.Sprintf("/teams/%s/pipelines/%s/builds/%s", build.TeamName, build.PipelineName, build.Name))
-		if err != nil {
-			return err
-		}
-
 	} else {
 		build, err = target.Team().CreateBuild(plan)
 		if err != nil {
 			return err
 		}
+	}
 
-		buildURL, err = url.Parse(fmt.Sprintf("/builds/%d", build.ID))
-		if err != nil {
-			return err
-		}
+	buildURL, err = url.Parse(fmt.Sprintf("/builds/%d", build.ID))
+	if err != nil {
+		return err
 	}
 
 	fmt.Printf("executing build %d at %s \n", build.ID, clientURL.ResolveReference(buildURL))


### PR DESCRIPTION
Despite it is a normal build or pipeline scoped build, `fly execute` will always output `../builds/:build_id` as build URL 

fixes concourse/concourse#3262
