### PR TITLE
topgun: don't depend on slow build tracker

### DIFF
--- a/topgun/atc_shutdown_test.go
+++ b/topgun/atc_shutdown_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("[#137641079] ATC Shutting down", func() {
+var _ = Describe("ATC Shutting down", func() {
 	Context("with two atcs available", func() {
 		var atcs []boshInstance
 		var atc0URL string
@@ -22,7 +22,6 @@ var _ = Describe("[#137641079] ATC Shutting down", func() {
 				"deployments/concourse.yml",
 				"-o", "operations/web-instances.yml",
 				"-v", "web_instances=2",
-				"-o", "operations/slow-tracking.yml",
 			)
 
 			waitForRunningWorker()
@@ -36,6 +35,7 @@ var _ = Describe("[#137641079] ATC Shutting down", func() {
 
 		Context("when one of the ATCS is stopped", func() {
 			var stopSession *gexec.Session
+
 			BeforeEach(func() {
 				By("stopping one of the web instances")
 				stopSession = spawnBosh("stop", atcs[1].Name)
@@ -69,64 +69,49 @@ var _ = Describe("[#137641079] ATC Shutting down", func() {
 					waitForRunningWorker()
 				})
 			})
+		})
 
-			Describe("tracking builds previously tracked by shutdown ATC", func() {
-				var buildID string
+		Describe("tracking builds previously tracked by shutdown ATC", func() {
+			var buildID string
 
-				BeforeEach(func() {
-					By("executing a task")
-					buildSession := fly.Start("execute", "-c", "tasks/wait.yml")
-					Eventually(buildSession).Should(gbytes.Say("executing build"))
+			BeforeEach(func() {
+				By("executing a task")
+				buildSession := fly.Start("execute", "-c", "tasks/wait.yml")
+				Eventually(buildSession).Should(gbytes.Say("executing build"))
 
-					buildRegex := regexp.MustCompile(`executing build (\d+)`)
-					matches := buildRegex.FindSubmatch(buildSession.Out.Contents())
-					buildID = string(matches[1])
+				buildRegex := regexp.MustCompile(`executing build (\d+)`)
+				matches := buildRegex.FindSubmatch(buildSession.Out.Contents())
+				buildID = string(matches[1])
 
-					Eventually(buildSession).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
+				Eventually(buildSession).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
+			})
 
-					By("starting the stopped web instance")
-					startSession := spawnBosh("start", atcs[1].Name)
-					<-startSession.Exited
-					Eventually(startSession).Should(gexec.Exit(0))
-
-					fly.Login(atcUsername, atcPassword, atc1URL)
+			Context("when the web node tracking the build shuts down", func() {
+				JustBeforeEach(func() {
+					By("restarting both web nodes")
+					bosh("restart", atcs[0].Group)
 				})
 
-				AfterEach(func() {
-					restartSession := spawnBosh("start", atcs[0].Name)
-					<-restartSession.Exited
-					Eventually(restartSession).Should(gexec.Exit(0))
-				})
+				It("continues tracking the build progress", func() {
+					By("waiting for another web node to attach to process")
+					watchSession := fly.Start("watch", "-b", buildID)
+					Eventually(watchSession).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
+					time.Sleep(10 * time.Second)
 
-				Context("when the atc tracking the build shuts down", func() {
-					JustBeforeEach(func() {
-						By("stopping the first web instance")
-						landSession := spawnBosh("stop", atcs[0].Name)
-						<-landSession.Exited
-						Eventually(landSession).Should(gexec.Exit(0))
-					})
+					By("hijacking the build to tell it to finish")
+					hijackSession := fly.Start(
+						"hijack",
+						"-b", buildID,
+						"-s", "one-off",
+						"touch", "/tmp/stop-waiting",
+					)
+					<-hijackSession.Exited
+					Expect(hijackSession.ExitCode()).To(Equal(0))
 
-					It("continues tracking the build progress", func() {
-						By("waiting for another atc to attach to process")
-						watchSession := fly.Start("watch", "-b", buildID)
-						Eventually(watchSession).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
-						time.Sleep(10 * time.Second)
-
-						By("hijacking the build to tell it to finish")
-						hijackSession := fly.Start(
-							"hijack",
-							"-b", buildID,
-							"-s", "one-off",
-							"touch", "/tmp/stop-waiting",
-						)
-						<-hijackSession.Exited
-						Expect(hijackSession.ExitCode()).To(Equal(0))
-
-						By("waiting for the build to exit")
-						Eventually(watchSession, 1*time.Minute).Should(gbytes.Say("done"))
-						<-watchSession.Exited
-						Expect(watchSession.ExitCode()).To(Equal(0))
-					})
+					By("waiting for the build to exit")
+					Eventually(watchSession, 1*time.Minute).Should(gbytes.Say("done"))
+					<-watchSession.Exited
+					Expect(watchSession.ExitCode()).To(Equal(0))
 				})
 			})
 		})

--- a/topgun/fly.go
+++ b/topgun/fly.go
@@ -120,7 +120,7 @@ func (f *Fly) GetUserRole(teamName string) []string {
 	var teamsInfo RoleInfo = RoleInfo{}
 
 	sess := f.Start("userinfo", "--json")
-	<- sess.Exited
+	<-sess.Exited
 	Expect(sess.ExitCode()).To(BeZero())
 
 	err := json.Unmarshal(sess.Out.Contents(), &teamsInfo)

--- a/topgun/operations/slow-tracking.yml
+++ b/topgun/operations/slow-tracking.yml
@@ -1,3 +1,0 @@
-- type: replace
-  path: /instance_groups/name=web/jobs/name=web/properties/build_tracker_interval?
-  value: 5m


### PR DESCRIPTION
it's not super clear why that was necessary, and now the test fails
because fly executed builds aren't immediately run by the node that the
execute ran against. in any case, this should be testable by just
restarting the `web` nodes.

Signed-off-by: Alex Suraci <suraci.alex@gmail.com>