### PR TITLE
topgun: make deployment name prefix configurable

### DIFF
--- a/ci/tasks/topgun.yml
+++ b/ci/tasks/topgun.yml
@@ -6,6 +6,7 @@ image_resource:
   source: {repository: concourse/unit}
 
 params:
+  DEPLOYMENT_NAME_PREFIX:
   BOSH_CA_CERT:
   BOSH_CLIENT:
   BOSH_CLIENT_SECRET:

--- a/topgun/suite_test.go
+++ b/topgun/suite_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 var (
+	deploymentNamePrefix string
+
 	fly                       = Fly{}
 	deploymentName, flyTarget string
 	instances                 map[string][]boshInstance
@@ -85,6 +87,11 @@ var _ = BeforeEach(func() {
 
 	logger = lagertest.NewTestLogger("test")
 
+	deploymentNamePrefix = os.Getenv("DEPLOYMENT_NAME_PREFIX")
+	if deploymentNamePrefix == "" {
+		deploymentNamePrefix = "concourse-topgun"
+	}
+
 	concourseReleaseVersion = os.Getenv("CONCOURSE_RELEASE_VERSION")
 	if concourseReleaseVersion == "" {
 		concourseReleaseVersion = "latest"
@@ -121,7 +128,7 @@ var _ = BeforeEach(func() {
 
 	deploymentNumber := GinkgoParallelNode()
 
-	deploymentName = fmt.Sprintf("concourse-topgun-%d", deploymentNumber)
+	deploymentName = fmt.Sprintf("%s-%d", deploymentNamePrefix, deploymentNumber)
 	fly.Target = deploymentName
 
 	var err error


### PR DESCRIPTION
this way release pipelines can run topgun without trampling on other pipelines