### PR TITLE
Add in_parallel step

### DIFF
--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -339,6 +339,7 @@ func saveConfigRequestUnmarshaler(r *http.Request) (atc.Config, db.PipelinePause
 			atc.SanitizeDecodeHook,
 			atc.VersionConfigDecodeHook,
 			atc.InputsConfigDecodeHook,
+			atc.InParallelConfigDecodeHook,
 			atc.ContainerLimitsDecodeHook,
 		),
 	}

--- a/atc/config.go
+++ b/atc/config.go
@@ -308,6 +308,13 @@ type PlanConfig struct {
 	// corresponds to an Aggregate plan, keyed by the name of each sub-plan
 	Aggregate *PlanSequence `yaml:"aggregate,omitempty" json:"aggregate,omitempty" mapstructure:"aggregate"`
 
+	// a nested chain of steps to run in parallel
+	Parallel *PlanSequence `yaml:"in_parallel,omitempty" json:"in_parallel,omitempty" mapstructure:"in_parallel"`
+	// limit parallelism for a Parallel plan
+	MaxInParallel int `yaml:"max_in_parallel,omitempty" json:"max_in_parallel,omitempty" mapstructure:"max_in_parallel"`
+	// cancel a parallel step on first error
+	FailFast bool `yaml:"fail_fast,omitempty" json:"fail_fast,omitempty" mapstructure:"fail_fast"`
+
 	// corresponds to Get and Put resource plans, respectively
 	// name of 'input', e.g. bosh-stemcell
 	Get string `yaml:"get,omitempty" json:"get,omitempty" mapstructure:"get"`

--- a/atc/config.go
+++ b/atc/config.go
@@ -292,6 +292,12 @@ func (c InputsConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal("")
 }
 
+type InParallelConfig struct {
+	Steps    PlanSequence `yaml:"steps,omitempty" json:"steps" mapstructure:"steps"`
+	Limit    int          `yaml:"limit,omitempty" json:"limit,omitempty" mapstructure:"limit"`
+	FailFast bool         `yaml:"fail_fast,omitempty" json:"fail_fast,omitempty" mapstructure:"fail_fast"`
+}
+
 // A PlanConfig is a flattened set of configuration corresponding to
 // a particular Plan, where Source and Version are populated lazily.
 type PlanConfig struct {
@@ -309,11 +315,7 @@ type PlanConfig struct {
 	Aggregate *PlanSequence `yaml:"aggregate,omitempty" json:"aggregate,omitempty" mapstructure:"aggregate"`
 
 	// a nested chain of steps to run in parallel
-	Parallel *PlanSequence `yaml:"in_parallel,omitempty" json:"in_parallel,omitempty" mapstructure:"in_parallel"`
-	// limit parallelism for a Parallel plan
-	MaxInParallel int `yaml:"max_in_parallel,omitempty" json:"max_in_parallel,omitempty" mapstructure:"max_in_parallel"`
-	// cancel a parallel step on first error
-	FailFast bool `yaml:"fail_fast,omitempty" json:"fail_fast,omitempty" mapstructure:"fail_fast"`
+	InParallel *InParallelConfig `yaml:"in_parallel,omitempty" json:"in_parallel,omitempty" mapstructure:"in_parallel"`
 
 	// corresponds to Get and Put resource plans, respectively
 	// name of 'input', e.g. bosh-stemcell

--- a/atc/decode_hook.go
+++ b/atc/decode_hook.go
@@ -203,6 +203,29 @@ var InputsConfigDecodeHook = func(
 	return data, nil
 }
 
+var InParallelConfigDecodeHook = func(
+	srcType reflect.Type,
+	dstType reflect.Type,
+	data interface{},
+) (interface{}, error) {
+	if dstType != reflect.TypeOf(InParallelConfig{}) {
+		return data, nil
+	}
+
+	if srcType.Kind() != reflect.Slice {
+		return data, nil
+	}
+
+	steps, ok := data.([]interface{})
+	if !ok {
+		return data, nil
+	}
+
+	return map[string]interface{}{
+		"steps": steps,
+	}, nil
+}
+
 func sanitize(root interface{}) (interface{}, error) {
 	switch rootVal := root.(type) {
 	case map[interface{}]interface{}:

--- a/atc/engine/build_step.go
+++ b/atc/engine/build_step.go
@@ -21,6 +21,20 @@ func (build *execBuild) buildAggregateStep(logger lager.Logger, plan atc.Plan) e
 	return agg
 }
 
+func (build *execBuild) buildParallelStep(logger lager.Logger, plan atc.Plan) exec.Step {
+	logger = logger.Session("parallel")
+
+	var steps []exec.Step
+
+	for _, innerPlan := range plan.Parallel.Steps {
+		innerPlan.Attempts = plan.Attempts
+		step := build.buildStep(logger, innerPlan)
+		steps = append(steps, step)
+	}
+
+	return exec.Parallel(steps, plan.Parallel.MaxInParallel, plan.Parallel.FailFast)
+}
+
 func (build *execBuild) buildDoStep(logger lager.Logger, plan atc.Plan) exec.Step {
 	logger = logger.Session("do")
 

--- a/atc/engine/build_step.go
+++ b/atc/engine/build_step.go
@@ -32,7 +32,7 @@ func (build *execBuild) buildParallelStep(logger lager.Logger, plan atc.Plan) ex
 		steps = append(steps, step)
 	}
 
-	return exec.Parallel(steps, plan.InParallel.MaxInParallel, plan.InParallel.FailFast)
+	return exec.InParallel(steps, plan.InParallel.Limit, plan.InParallel.FailFast)
 }
 
 func (build *execBuild) buildDoStep(logger lager.Logger, plan atc.Plan) exec.Step {

--- a/atc/engine/build_step.go
+++ b/atc/engine/build_step.go
@@ -26,13 +26,13 @@ func (build *execBuild) buildParallelStep(logger lager.Logger, plan atc.Plan) ex
 
 	var steps []exec.Step
 
-	for _, innerPlan := range plan.Parallel.Steps {
+	for _, innerPlan := range plan.InParallel.Steps {
 		innerPlan.Attempts = plan.Attempts
 		step := build.buildStep(logger, innerPlan)
 		steps = append(steps, step)
 	}
 
-	return exec.Parallel(steps, plan.Parallel.MaxInParallel, plan.Parallel.FailFast)
+	return exec.Parallel(steps, plan.InParallel.MaxInParallel, plan.InParallel.FailFast)
 }
 
 func (build *execBuild) buildDoStep(logger lager.Logger, plan atc.Plan) exec.Step {

--- a/atc/engine/exec_engine.go
+++ b/atc/engine/exec_engine.go
@@ -179,7 +179,7 @@ func (build *execBuild) buildStep(logger lager.Logger, plan atc.Plan) exec.Step 
 		return build.buildAggregateStep(logger, plan)
 	}
 
-	if plan.Parallel != nil {
+	if plan.InParallel != nil {
 		return build.buildParallelStep(logger, plan)
 	}
 

--- a/atc/engine/exec_engine.go
+++ b/atc/engine/exec_engine.go
@@ -179,6 +179,10 @@ func (build *execBuild) buildStep(logger lager.Logger, plan atc.Plan) exec.Step 
 		return build.buildAggregateStep(logger, plan)
 	}
 
+	if plan.Parallel != nil {
+		return build.buildParallelStep(logger, plan)
+	}
+
 	if plan.Do != nil {
 		return build.buildDoStep(logger, plan)
 	}

--- a/atc/engine/exec_engine_hooks_test.go
+++ b/atc/engine/exec_engine_hooks_test.go
@@ -464,8 +464,8 @@ var _ = Describe("Exec Engine With Hooks", func() {
 								}),
 							}),
 						},
-						MaxInParallel: 1,
-						FailFast:      true,
+						Limit:    1,
+						FailFast: true,
 					}),
 					Next: planFactory.NewPlan(atc.GetPlan{
 						Name: "some-unused-step",

--- a/atc/engine/exec_engine_hooks_test.go
+++ b/atc/engine/exec_engine_hooks_test.go
@@ -448,7 +448,7 @@ var _ = Describe("Exec Engine With Hooks", func() {
 
 			It("only run the failure hooks", func() {
 				plan := planFactory.NewPlan(atc.OnSuccessPlan{
-					Step: planFactory.NewPlan(atc.ParallelPlan{
+					Step: planFactory.NewPlan(atc.InParallelPlan{
 						Steps: []atc.Plan{
 							planFactory.NewPlan(atc.TaskPlan{
 								Name:   "some-resource",

--- a/atc/engine/exec_engine_hooks_test.go
+++ b/atc/engine/exec_engine_hooks_test.go
@@ -437,5 +437,53 @@ var _ = Describe("Exec Engine With Hooks", func() {
 				Expect(outputStep.RunCallCount()).To(Equal(0))
 			})
 		})
+
+		Context("when a step in the parallel fails the step fails", func() {
+			var planFactory atc.PlanFactory
+
+			BeforeEach(func() {
+				planFactory = atc.NewPlanFactory(123)
+				inputStep.SucceededReturns(false)
+			})
+
+			It("only run the failure hooks", func() {
+				plan := planFactory.NewPlan(atc.OnSuccessPlan{
+					Step: planFactory.NewPlan(atc.ParallelPlan{
+						Steps: []atc.Plan{
+							planFactory.NewPlan(atc.TaskPlan{
+								Name:   "some-resource",
+								Config: &atc.TaskConfig{},
+							}),
+							planFactory.NewPlan(atc.OnFailurePlan{
+								Step: planFactory.NewPlan(atc.GetPlan{
+									Name: "some-input",
+								}),
+								Next: planFactory.NewPlan(atc.TaskPlan{
+									Name:   "some-resource",
+									Config: &atc.TaskConfig{},
+								}),
+							}),
+						},
+						MaxInParallel: 1,
+						FailFast:      true,
+					}),
+					Next: planFactory.NewPlan(atc.GetPlan{
+						Name: "some-unused-step",
+					}),
+				})
+
+				build, err := execEngine.CreateBuild(logger, build, plan)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				build.Resume(logger)
+
+				Expect(inputStep.RunCallCount()).To(Equal(1))
+
+				Expect(taskStep.RunCallCount()).To(Equal(2))
+
+				Expect(outputStep.RunCallCount()).To(Equal(0))
+			})
+		})
 	})
 })

--- a/atc/engine/exec_engine_test.go
+++ b/atc/engine/exec_engine_test.go
@@ -175,11 +175,97 @@ var _ = Describe("ExecEngine", func() {
 			})
 		})
 
+		Describe("with a putget in a parallel", func() {
+			var (
+				putPlan               atc.Plan
+				dependentGetPlan      atc.Plan
+				otherPutPlan          atc.Plan
+				otherDependentGetPlan atc.Plan
+			)
+
+			BeforeEach(func() {
+				putPlan = planFactory.NewPlan(atc.PutPlan{
+					Name:     "some-put",
+					Resource: "some-output-resource",
+					Type:     "put",
+					Source:   atc.Source{"some": "source"},
+					Params:   atc.Params{"some": "params"},
+				})
+
+				otherPutPlan = planFactory.NewPlan(atc.PutPlan{
+					Name:     "some-put-2",
+					Resource: "some-output-resource-2",
+					Type:     "put",
+					Source:   atc.Source{"some": "source-2"},
+					Params:   atc.Params{"some": "params-2"},
+				})
+
+				outputPlan = planFactory.NewPlan(atc.ParallelPlan{
+					Steps: []atc.Plan{
+						planFactory.NewPlan(atc.OnSuccessPlan{
+							Step: putPlan,
+							Next: dependentGetPlan,
+						}),
+						planFactory.NewPlan(atc.OnSuccessPlan{
+							Step: otherPutPlan,
+							Next: otherDependentGetPlan,
+						}),
+					},
+					MaxInParallel: 1,
+					FailFast:      true,
+				})
+			})
+
+			Context("constructing outputs", func() {
+				It("constructs the put correctly", func() {
+					var err error
+					build, err = execEngine.CreateBuild(logger, dbBuild, outputPlan)
+					Expect(err).NotTo(HaveOccurred())
+
+					build.Resume(logger)
+					Expect(fakeFactory.PutCallCount()).To(Equal(2))
+
+					logger, plan, build, stepMetadata, containerMetadata, _ := fakeFactory.PutArgsForCall(0)
+					Expect(logger).NotTo(BeNil())
+					Expect(build).To(Equal(dbBuild))
+					Expect(plan).To(Equal(putPlan))
+					Expect(stepMetadata).To(Equal(expectedMetadata))
+					Expect(containerMetadata).To(Equal(db.ContainerMetadata{
+						Type:         db.ContainerTypePut,
+						StepName:     "some-put",
+						PipelineID:   expectedPipelineID,
+						PipelineName: "some-pipeline",
+						JobID:        expectedJobID,
+						JobName:      "some-job",
+						BuildID:      expectedBuildID,
+						BuildName:    "42",
+					}))
+
+					logger, plan, build, stepMetadata, containerMetadata, _ = fakeFactory.PutArgsForCall(1)
+					Expect(logger).NotTo(BeNil())
+					Expect(build).To(Equal(dbBuild))
+					Expect(plan).To(Equal(otherPutPlan))
+					Expect(stepMetadata).To(Equal(expectedMetadata))
+					Expect(containerMetadata).To(Equal(db.ContainerMetadata{
+						Type:         db.ContainerTypePut,
+						StepName:     "some-put-2",
+						PipelineID:   expectedPipelineID,
+						PipelineName: "some-pipeline",
+						JobID:        expectedJobID,
+						JobName:      "some-job",
+						BuildID:      expectedBuildID,
+						BuildName:    "42",
+					}))
+				})
+			})
+		})
+
 		Context("with a retry plan", func() {
 			var (
 				getPlan       atc.Plan
 				taskPlan      atc.Plan
 				aggregatePlan atc.Plan
+				parallelPlan  atc.Plan
 				doPlan        atc.Plan
 				timeoutPlan   atc.Plan
 				retryPlan     atc.Plan
@@ -209,7 +295,13 @@ var _ = Describe("ExecEngine", func() {
 
 				aggregatePlan = planFactory.NewPlan(atc.AggregatePlan{retryPlanTwo})
 
-				doPlan = planFactory.NewPlan(atc.DoPlan{aggregatePlan})
+				parallelPlan = planFactory.NewPlan(atc.ParallelPlan{
+					Steps:         []atc.Plan{aggregatePlan},
+					MaxInParallel: 1,
+					FailFast:      true,
+				})
+
+				doPlan = planFactory.NewPlan(atc.DoPlan{parallelPlan})
 
 				timeoutPlan = planFactory.NewPlan(atc.TimeoutPlan{
 					Step:     doPlan,

--- a/atc/engine/exec_engine_test.go
+++ b/atc/engine/exec_engine_test.go
@@ -211,8 +211,8 @@ var _ = Describe("ExecEngine", func() {
 							Next: otherDependentGetPlan,
 						}),
 					},
-					MaxInParallel: 1,
-					FailFast:      true,
+					Limit:    1,
+					FailFast: true,
 				})
 			})
 
@@ -296,9 +296,9 @@ var _ = Describe("ExecEngine", func() {
 				aggregatePlan = planFactory.NewPlan(atc.AggregatePlan{retryPlanTwo})
 
 				parallelPlan = planFactory.NewPlan(atc.InParallelPlan{
-					Steps:         []atc.Plan{aggregatePlan},
-					MaxInParallel: 1,
-					FailFast:      true,
+					Steps:    []atc.Plan{aggregatePlan},
+					Limit:    1,
+					FailFast: true,
 				})
 
 				doPlan = planFactory.NewPlan(atc.DoPlan{parallelPlan})

--- a/atc/engine/exec_engine_test.go
+++ b/atc/engine/exec_engine_test.go
@@ -200,7 +200,7 @@ var _ = Describe("ExecEngine", func() {
 					Params:   atc.Params{"some": "params-2"},
 				})
 
-				outputPlan = planFactory.NewPlan(atc.ParallelPlan{
+				outputPlan = planFactory.NewPlan(atc.InParallelPlan{
 					Steps: []atc.Plan{
 						planFactory.NewPlan(atc.OnSuccessPlan{
 							Step: putPlan,
@@ -295,7 +295,7 @@ var _ = Describe("ExecEngine", func() {
 
 				aggregatePlan = planFactory.NewPlan(atc.AggregatePlan{retryPlanTwo})
 
-				parallelPlan = planFactory.NewPlan(atc.ParallelPlan{
+				parallelPlan = planFactory.NewPlan(atc.InParallelPlan{
 					Steps:         []atc.Plan{aggregatePlan},
 					MaxInParallel: 1,
 					FailFast:      true,

--- a/atc/exec/in_parallel.go
+++ b/atc/exec/in_parallel.go
@@ -77,7 +77,10 @@ func (step InParallelStep) Run(ctx context.Context, state RunState) error {
 
 	var errorMessages []string
 	for err := range errs {
-		if err != nil {
+		if err != nil && err != context.Canceled {
+			// The Run context being cancelled only means that one or more steps failed, not
+			// in_parallel itself. If we return context.Canceled error messages the step will
+			// be marked as errored instead of failed, and therefore they should be ignored.
 			errorMessages = append(errorMessages, err.Error())
 		}
 	}

--- a/atc/exec/in_parallel.go
+++ b/atc/exec/in_parallel.go
@@ -13,7 +13,7 @@ type InParallelStep struct {
 	failFast bool
 }
 
-// InParallel constructs a ParallelStep.
+// InParallel constructs an InParallelStep.
 func InParallel(steps []Step, limit int, failFast bool) InParallelStep {
 	if limit < 1 {
 		limit = len(steps)

--- a/atc/exec/in_parallel.go
+++ b/atc/exec/in_parallel.go
@@ -7,22 +7,22 @@ import (
 	"sync"
 )
 
-// ParallelStep is a step of steps to run in parallel.
-type ParallelStep struct {
-	steps         []Step
-	maxInParallel int
-	failFast      bool
+// InParallelStep is a step of steps to run in parallel.
+type InParallelStep struct {
+	steps    []Step
+	limit    int
+	failFast bool
 }
 
-// Parallel constructs a ParallelStep.
-func Parallel(steps []Step, maxInParallel int, failFast bool) ParallelStep {
-	if maxInParallel < 1 {
-		maxInParallel = len(steps)
+// InParallel constructs a ParallelStep.
+func InParallel(steps []Step, limit int, failFast bool) InParallelStep {
+	if limit < 1 {
+		limit = len(steps)
 	}
-	return ParallelStep{
-		steps:         steps,
-		maxInParallel: maxInParallel,
-		failFast:      failFast,
+	return InParallelStep{
+		steps:    steps,
+		limit:    limit,
+		failFast: failFast,
 	}
 }
 
@@ -36,11 +36,11 @@ func Parallel(steps []Step, maxInParallel int, failFast bool) ParallelStep {
 // Cancelling a parallel step means that any outstanding steps will not be scheduled to run.
 // After all steps finish, their errors (if any) will be collected and returned as a
 // single error.
-func (step ParallelStep) Run(ctx context.Context, state RunState) error {
+func (step InParallelStep) Run(ctx context.Context, state RunState) error {
 	var (
 		wg   sync.WaitGroup
 		errs = make(chan error, len(step.steps))
-		sem  = make(chan bool, step.maxInParallel)
+		sem  = make(chan bool, step.limit)
 	)
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -90,7 +90,7 @@ func (step ParallelStep) Run(ctx context.Context, state RunState) error {
 }
 
 // Succeeded is true if all of the steps' Succeeded is true
-func (step ParallelStep) Succeeded() bool {
+func (step InParallelStep) Succeeded() bool {
 	succeeded := true
 
 	for _, step := range step.steps {

--- a/atc/exec/in_parallel_test.go
+++ b/atc/exec/in_parallel_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Parallel", func() {
 	})
 
 	Describe("executing each step", func() {
-		Context("when not limited by maxInParallel", func() {
+		Context("when not constrained by parallel limit", func() {
 			BeforeEach(func() {
 				wg := new(sync.WaitGroup)
 				wg.Add(2)
@@ -90,7 +90,7 @@ var _ = Describe("Parallel", func() {
 			})
 		})
 
-		Context("when maxInParallel is 1", func() {
+		Context("when parallel limit is 1", func() {
 			BeforeEach(func() {
 				step = InParallel(fakeSteps, 1, false)
 				ch := make(chan struct{}, 1)

--- a/atc/exec/in_parallel_test.go
+++ b/atc/exec/in_parallel_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Parallel", func() {
 		fakeStepB = new(execfakes.FakeStep)
 		fakeSteps = []Step{fakeStepA, fakeStepB}
 
-		step = Parallel(fakeSteps, len(fakeSteps), false)
+		step = InParallel(fakeSteps, len(fakeSteps), false)
 
 		repo = artifact.NewRepository()
 		state = new(execfakes.FakeRunState)
@@ -92,7 +92,7 @@ var _ = Describe("Parallel", func() {
 
 		Context("when maxInParallel is 1", func() {
 			BeforeEach(func() {
-				step = Parallel(fakeSteps, 1, false)
+				step = InParallel(fakeSteps, 1, false)
 				ch := make(chan struct{}, 1)
 
 				fakeStepA.RunStub = func(context.Context, RunState) error {
@@ -151,7 +151,7 @@ var _ = Describe("Parallel", func() {
 
 		Context("when there are steps pending execution", func() {
 			BeforeEach(func() {
-				step = Parallel(fakeSteps, 1, false)
+				step = InParallel(fakeSteps, 1, false)
 
 				fakeStepA.RunStub = func(context.Context, RunState) error {
 					cancel()
@@ -187,7 +187,7 @@ var _ = Describe("Parallel", func() {
 
 		Context("and fail fast is false", func() {
 			BeforeEach(func() {
-				step = Parallel(fakeSteps, 1, false)
+				step = InParallel(fakeSteps, 1, false)
 			})
 			It("lets all steps finish before exiting", func() {
 				Expect(fakeStepA.RunCallCount()).To(Equal(1))
@@ -201,7 +201,7 @@ var _ = Describe("Parallel", func() {
 
 		Context("and fail fast is true", func() {
 			BeforeEach(func() {
-				step = Parallel(fakeSteps, 1, true)
+				step = InParallel(fakeSteps, 1, true)
 			})
 			It("it cancels remaining steps", func() {
 				Expect(fakeStepA.RunCallCount()).To(Equal(1))
@@ -250,7 +250,7 @@ var _ = Describe("Parallel", func() {
 
 		Context("when there are no steps", func() {
 			BeforeEach(func() {
-				step = ParallelStep{}
+				step = InParallelStep{}
 			})
 
 			It("returns true", func() {

--- a/atc/exec/parallel_test.go
+++ b/atc/exec/parallel_test.go
@@ -1,0 +1,261 @@
+package exec_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	. "github.com/concourse/concourse/atc/exec"
+	"github.com/concourse/concourse/atc/exec/artifact"
+	"github.com/concourse/concourse/atc/exec/execfakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Parallel", func() {
+	var (
+		ctx    context.Context
+		cancel func()
+
+		fakeStepA *execfakes.FakeStep
+		fakeStepB *execfakes.FakeStep
+		fakeSteps []Step
+
+		repo  *artifact.Repository
+		state *execfakes.FakeRunState
+
+		step    Step
+		stepErr error
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+
+		fakeStepA = new(execfakes.FakeStep)
+		fakeStepB = new(execfakes.FakeStep)
+		fakeSteps = []Step{fakeStepA, fakeStepB}
+
+		step = Parallel(fakeSteps, len(fakeSteps), false)
+
+		repo = artifact.NewRepository()
+		state = new(execfakes.FakeRunState)
+		state.ArtifactsReturns(repo)
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	JustBeforeEach(func() {
+		stepErr = step.Run(ctx, state)
+	})
+
+	It("succeeds", func() {
+		Expect(stepErr).ToNot(HaveOccurred())
+	})
+
+	It("passes the artifact repo to all steps", func() {
+		Expect(fakeStepA.RunCallCount()).To(Equal(1))
+		_, repo := fakeStepA.RunArgsForCall(0)
+		Expect(repo).To(Equal(repo))
+
+		Expect(fakeStepB.RunCallCount()).To(Equal(1))
+		_, repo = fakeStepB.RunArgsForCall(0)
+		Expect(repo).To(Equal(repo))
+	})
+
+	Describe("executing each step", func() {
+		Context("when not limited by maxInParallel", func() {
+			BeforeEach(func() {
+				wg := new(sync.WaitGroup)
+				wg.Add(2)
+
+				fakeStepA.RunStub = func(context.Context, RunState) error {
+					wg.Done()
+					wg.Wait()
+					return nil
+				}
+
+				fakeStepB.RunStub = func(context.Context, RunState) error {
+					wg.Done()
+					wg.Wait()
+					return nil
+				}
+			})
+
+			It("happens concurrently", func() {
+				Expect(fakeStepA.RunCallCount()).To(Equal(1))
+				Expect(fakeStepB.RunCallCount()).To(Equal(1))
+			})
+		})
+
+		Context("when maxInParallel is 1", func() {
+			BeforeEach(func() {
+				step = Parallel(fakeSteps, 1, false)
+				ch := make(chan struct{}, 1)
+
+				fakeStepA.RunStub = func(context.Context, RunState) error {
+					time.Sleep(10 * time.Millisecond)
+					ch <- struct{}{}
+					return nil
+				}
+
+				fakeStepB.RunStub = func(context.Context, RunState) error {
+					defer GinkgoRecover()
+
+					select {
+					case <-ch:
+					default:
+						Fail("step B started before step A could complete")
+					}
+					return nil
+				}
+			})
+
+			It("happens sequentially", func() {
+				Expect(fakeStepA.RunCallCount()).To(Equal(1))
+				Expect(fakeStepB.RunCallCount()).To(Equal(1))
+			})
+		})
+	})
+
+	Describe("canceling", func() {
+		BeforeEach(func() {
+			wg := new(sync.WaitGroup)
+			wg.Add(2)
+
+			fakeStepA.RunStub = func(context.Context, RunState) error {
+				wg.Done()
+				return nil
+			}
+
+			fakeStepB.RunStub = func(context.Context, RunState) error {
+				wg.Done()
+				wg.Wait()
+				cancel()
+				return nil
+			}
+		})
+
+		It("cancels each substep", func() {
+			ctx, _ := fakeStepA.RunArgsForCall(0)
+			Expect(ctx.Err()).To(Equal(context.Canceled))
+			ctx, _ = fakeStepB.RunArgsForCall(0)
+			Expect(ctx.Err()).To(Equal(context.Canceled))
+		})
+
+		It("returns ctx.Err()", func() {
+			Expect(stepErr).To(Equal(context.Canceled))
+		})
+
+		Context("when there are steps pending execution", func() {
+			BeforeEach(func() {
+				step = Parallel(fakeSteps, 1, false)
+
+				fakeStepA.RunStub = func(context.Context, RunState) error {
+					cancel()
+					return nil
+				}
+
+				fakeStepB.RunStub = func(context.Context, RunState) error {
+					return nil
+				}
+			})
+
+			It("returns ctx.Err()", func() {
+				Expect(stepErr).To(Equal(context.Canceled))
+			})
+
+			It("does not execute the remaining steps", func() {
+				ctx, _ := fakeStepA.RunArgsForCall(0)
+				Expect(ctx.Err()).To(Equal(context.Canceled))
+				Expect(fakeStepB.RunCallCount()).To(Equal(0))
+			})
+
+		})
+	})
+
+	Context("when steps fail", func() {
+		disasterA := errors.New("nope A")
+		disasterB := errors.New("nope B")
+
+		BeforeEach(func() {
+			fakeStepA.RunReturns(disasterA)
+			fakeStepB.RunReturns(disasterB)
+		})
+
+		Context("and fail fast is false", func() {
+			BeforeEach(func() {
+				step = Parallel(fakeSteps, 1, false)
+			})
+			It("lets all steps finish before exiting", func() {
+				Expect(fakeStepA.RunCallCount()).To(Equal(1))
+				Expect(fakeStepB.RunCallCount()).To(Equal(1))
+			})
+			It("exits with an error including the original message", func() {
+				Expect(stepErr.Error()).To(ContainSubstring("nope A"))
+				Expect(stepErr.Error()).To(ContainSubstring("nope B"))
+			})
+		})
+
+		Context("and fail fast is true", func() {
+			BeforeEach(func() {
+				step = Parallel(fakeSteps, 1, true)
+			})
+			It("it cancels remaining steps", func() {
+				Expect(fakeStepA.RunCallCount()).To(Equal(1))
+				Expect(fakeStepB.RunCallCount()).To(Equal(0))
+			})
+			It("exits with an error including the message from the failed steps", func() {
+				Expect(stepErr.Error()).To(ContainSubstring("nope A"))
+				Expect(stepErr.Error()).NotTo(ContainSubstring("nope B"))
+			})
+		})
+	})
+
+	Describe("Succeeded", func() {
+		Context("when all steps are successful", func() {
+			BeforeEach(func() {
+				fakeStepA.SucceededReturns(true)
+				fakeStepB.SucceededReturns(true)
+			})
+
+			It("yields true", func() {
+				Expect(step.Succeeded()).To(BeTrue())
+			})
+		})
+
+		Context("and some steps are not successful", func() {
+			BeforeEach(func() {
+				fakeStepA.SucceededReturns(true)
+				fakeStepB.SucceededReturns(false)
+			})
+
+			It("yields false", func() {
+				Expect(step.Succeeded()).To(BeFalse())
+			})
+		})
+
+		Context("when no steps indicate success", func() {
+			BeforeEach(func() {
+				fakeStepA.SucceededReturns(false)
+				fakeStepB.SucceededReturns(false)
+			})
+
+			It("returns false", func() {
+				Expect(step.Succeeded()).To(BeFalse())
+			})
+		})
+
+		Context("when there are no steps", func() {
+			BeforeEach(func() {
+				step = ParallelStep{}
+			})
+
+			It("returns true", func() {
+				Expect(step.Succeeded()).To(BeTrue())
+			})
+		})
+	})
+})

--- a/atc/job_config.go
+++ b/atc/job_config.go
@@ -100,8 +100,8 @@ func collectPlans(plan PlanConfig) []PlanConfig {
 		}
 	}
 
-	if plan.Parallel != nil {
-		for _, p := range *plan.Parallel {
+	if plan.InParallel != nil {
+		for _, p := range plan.InParallel.Steps {
 			plans = append(plans, collectPlans(p)...)
 		}
 	}

--- a/atc/job_config.go
+++ b/atc/job_config.go
@@ -100,6 +100,12 @@ func collectPlans(plan PlanConfig) []PlanConfig {
 		}
 	}
 
+	if plan.Parallel != nil {
+		for _, p := range *plan.Parallel {
+			plans = append(plans, collectPlans(p)...)
+		}
+	}
+
 	return append(plans, plan)
 }
 

--- a/atc/job_config_test.go
+++ b/atc/job_config_test.go
@@ -561,14 +561,16 @@ var _ = Describe("JobConfig", func() {
 				BeforeEach(func() {
 					jobConfig.Plan = atc.PlanSequence{
 						{
-							Parallel: &atc.PlanSequence{
-								{Get: "a"},
-								{Put: "y"},
-								{Get: "b", Resource: "some-resource", Passed: []string{"x"}},
-								{Get: "c", Trigger: true},
+							InParallel: &atc.InParallelConfig{
+								Steps: atc.PlanSequence{
+									{Get: "a"},
+									{Put: "y"},
+									{Get: "b", Resource: "some-resource", Passed: []string{"x"}},
+									{Get: "c", Trigger: true},
+								},
+								Limit:    1,
+								FailFast: true,
 							},
-							MaxInParallel: 1,
-							FailFast:      true,
 						},
 					}
 				})
@@ -600,18 +602,22 @@ var _ = Describe("JobConfig", func() {
 				BeforeEach(func() {
 					jobConfig.Plan = atc.PlanSequence{
 						{
-							Parallel: &atc.PlanSequence{
-								{
-									Parallel: &atc.PlanSequence{
-										{Get: "a"},
+							InParallel: &atc.InParallelConfig{
+								Steps: atc.PlanSequence{
+									{
+										InParallel: &atc.InParallelConfig{
+											Steps: atc.PlanSequence{
+												{Get: "a"},
+											},
+											Limit: 1,
+										},
 									},
-									MaxInParallel: 1,
+									{Get: "b", Resource: "some-resource", Passed: []string{"x"}},
+									{Get: "c", Trigger: true},
 								},
-								{Get: "b", Resource: "some-resource", Passed: []string{"x"}},
-								{Get: "c", Trigger: true},
+								Limit:    2,
+								FailFast: true,
 							},
-							MaxInParallel: 2,
-							FailFast:      true,
 						},
 					}
 				})
@@ -687,8 +693,10 @@ var _ = Describe("JobConfig", func() {
 						{
 							Aggregate: &atc.PlanSequence{
 								{
-									Parallel: &atc.PlanSequence{
-										{Put: "a"},
+									InParallel: &atc.InParallelConfig{
+										Steps: atc.PlanSequence{
+											{Put: "a"},
+										},
 									},
 								},
 								{Put: "b", Resource: "some-resource"},

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -4,20 +4,20 @@ type Plan struct {
 	ID       PlanID `json:"id"`
 	Attempts []int  `json:"attempts,omitempty"`
 
-	Aggregate *AggregatePlan `json:"aggregate,omitempty"`
-	Parallel  *ParallelPlan  `json:"parallel,omitempty"`
-	Do        *DoPlan        `json:"do,omitempty"`
-	Get       *GetPlan       `json:"get,omitempty"`
-	Put       *PutPlan       `json:"put,omitempty"`
-	Task      *TaskPlan      `json:"task,omitempty"`
-	OnAbort   *OnAbortPlan   `json:"on_abort,omitempty"`
-	OnError   *OnErrorPlan   `json:"on_error,omitempty"`
-	Ensure    *EnsurePlan    `json:"ensure,omitempty"`
-	OnSuccess *OnSuccessPlan `json:"on_success,omitempty"`
-	OnFailure *OnFailurePlan `json:"on_failure,omitempty"`
-	Try       *TryPlan       `json:"try,omitempty"`
-	Timeout   *TimeoutPlan   `json:"timeout,omitempty"`
-	Retry     *RetryPlan     `json:"retry,omitempty"`
+	Aggregate  *AggregatePlan  `json:"aggregate,omitempty"`
+	InParallel *InParallelPlan `json:"in_parallel,omitempty"`
+	Do         *DoPlan         `json:"do,omitempty"`
+	Get        *GetPlan        `json:"get,omitempty"`
+	Put        *PutPlan        `json:"put,omitempty"`
+	Task       *TaskPlan       `json:"task,omitempty"`
+	OnAbort    *OnAbortPlan    `json:"on_abort,omitempty"`
+	OnError    *OnErrorPlan    `json:"on_error,omitempty"`
+	Ensure     *EnsurePlan     `json:"ensure,omitempty"`
+	OnSuccess  *OnSuccessPlan  `json:"on_success,omitempty"`
+	OnFailure  *OnFailurePlan  `json:"on_failure,omitempty"`
+	Try        *TryPlan        `json:"try,omitempty"`
+	Timeout    *TimeoutPlan    `json:"timeout,omitempty"`
+	Retry      *RetryPlan      `json:"retry,omitempty"`
 
 	// used for 'fly execute'
 	ArtifactInput  *ArtifactInputPlan  `json:"artifact_input,omitempty"`
@@ -74,7 +74,7 @@ type TryPlan struct {
 
 type AggregatePlan []Plan
 
-type ParallelPlan struct {
+type InParallelPlan struct {
 	Steps         []Plan `json:"steps"`
 	MaxInParallel int    `json:"max_in_parallel,omitempty"`
 	FailFast      bool   `json:"fail_fast,omitempty"`

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -75,9 +75,9 @@ type TryPlan struct {
 type AggregatePlan []Plan
 
 type InParallelPlan struct {
-	Steps         []Plan `json:"steps"`
-	MaxInParallel int    `json:"max_in_parallel,omitempty"`
-	FailFast      bool   `json:"fail_fast,omitempty"`
+	Steps    []Plan `json:"steps"`
+	Limit    int    `json:"limit,omitempty"`
+	FailFast bool   `json:"fail_fast,omitempty"`
 }
 
 type DoPlan []Plan

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -5,6 +5,7 @@ type Plan struct {
 	Attempts []int  `json:"attempts,omitempty"`
 
 	Aggregate *AggregatePlan `json:"aggregate,omitempty"`
+	Parallel  *ParallelPlan  `json:"parallel,omitempty"`
 	Do        *DoPlan        `json:"do,omitempty"`
 	Get       *GetPlan       `json:"get,omitempty"`
 	Put       *PutPlan       `json:"put,omitempty"`
@@ -72,6 +73,12 @@ type TryPlan struct {
 }
 
 type AggregatePlan []Plan
+
+type ParallelPlan struct {
+	Steps         []Plan `json:"steps"`
+	MaxInParallel int    `json:"max_in_parallel,omitempty"`
+	FailFast      bool   `json:"fail_fast,omitempty"`
+}
 
 type DoPlan []Plan
 

--- a/atc/plan_factory.go
+++ b/atc/plan_factory.go
@@ -27,8 +27,8 @@ func (factory PlanFactory) NewPlan(step Step) Plan {
 	switch t := step.(type) {
 	case AggregatePlan:
 		plan.Aggregate = &t
-	case ParallelPlan:
-		plan.Parallel = &t
+	case InParallelPlan:
+		plan.InParallel = &t
 	case DoPlan:
 		plan.Do = &t
 	case GetPlan:

--- a/atc/plan_factory.go
+++ b/atc/plan_factory.go
@@ -27,6 +27,8 @@ func (factory PlanFactory) NewPlan(step Step) Plan {
 	switch t := step.(type) {
 	case AggregatePlan:
 		plan.Aggregate = &t
+	case ParallelPlan:
+		plan.Parallel = &t
 	case DoPlan:
 		plan.Do = &t
 	case GetPlan:

--- a/atc/public_plan.go
+++ b/atc/public_plan.go
@@ -7,7 +7,7 @@ func (plan Plan) Public() *json.RawMessage {
 		ID PlanID `json:"id"`
 
 		Aggregate      *json.RawMessage `json:"aggregate,omitempty"`
-		Parallel       *json.RawMessage `json:"in_parallel,omitempty"`
+		InParallel     *json.RawMessage `json:"in_parallel,omitempty"`
 		Do             *json.RawMessage `json:"do,omitempty"`
 		Get            *json.RawMessage `json:"get,omitempty"`
 		Put            *json.RawMessage `json:"put,omitempty"`
@@ -31,8 +31,8 @@ func (plan Plan) Public() *json.RawMessage {
 		public.Aggregate = plan.Aggregate.Public()
 	}
 
-	if plan.Parallel != nil {
-		public.Parallel = plan.Parallel.Public()
+	if plan.InParallel != nil {
+		public.InParallel = plan.InParallel.Public()
 	}
 
 	if plan.Do != nil {
@@ -108,7 +108,7 @@ func (plan AggregatePlan) Public() *json.RawMessage {
 	return enc(public)
 }
 
-func (plan ParallelPlan) Public() *json.RawMessage {
+func (plan InParallelPlan) Public() *json.RawMessage {
 	steps := make([]*json.RawMessage, len(plan.Steps))
 
 	for i := 0; i < len(plan.Steps); i++ {

--- a/atc/public_plan.go
+++ b/atc/public_plan.go
@@ -116,13 +116,13 @@ func (plan InParallelPlan) Public() *json.RawMessage {
 	}
 
 	return enc(struct {
-		Steps         []*json.RawMessage `json:"steps"`
-		MaxInParallel int                `json:"max_in_parallel,omitempty"`
-		FailFast      bool               `json:"fail_fast,omitempty"`
+		Steps    []*json.RawMessage `json:"steps"`
+		Limit    int                `json:"limit,omitempty"`
+		FailFast bool               `json:"fail_fast,omitempty"`
 	}{
-		Steps:         steps,
-		MaxInParallel: plan.MaxInParallel,
-		FailFast:      plan.FailFast,
+		Steps:    steps,
+		Limit:    plan.Limit,
+		FailFast: plan.FailFast,
 	})
 }
 

--- a/atc/public_plan.go
+++ b/atc/public_plan.go
@@ -7,6 +7,7 @@ func (plan Plan) Public() *json.RawMessage {
 		ID PlanID `json:"id"`
 
 		Aggregate      *json.RawMessage `json:"aggregate,omitempty"`
+		Parallel       *json.RawMessage `json:"in_parallel,omitempty"`
 		Do             *json.RawMessage `json:"do,omitempty"`
 		Get            *json.RawMessage `json:"get,omitempty"`
 		Put            *json.RawMessage `json:"put,omitempty"`
@@ -28,6 +29,10 @@ func (plan Plan) Public() *json.RawMessage {
 
 	if plan.Aggregate != nil {
 		public.Aggregate = plan.Aggregate.Public()
+	}
+
+	if plan.Parallel != nil {
+		public.Parallel = plan.Parallel.Public()
 	}
 
 	if plan.Do != nil {
@@ -101,6 +106,24 @@ func (plan AggregatePlan) Public() *json.RawMessage {
 	}
 
 	return enc(public)
+}
+
+func (plan ParallelPlan) Public() *json.RawMessage {
+	steps := make([]*json.RawMessage, len(plan.Steps))
+
+	for i := 0; i < len(plan.Steps); i++ {
+		steps[i] = plan.Steps[i].Public()
+	}
+
+	return enc(struct {
+		Steps         []*json.RawMessage `json:"steps"`
+		MaxInParallel int                `json:"max_in_parallel,omitempty"`
+		FailFast      bool               `json:"fail_fast,omitempty"`
+	}{
+		Steps:         steps,
+		MaxInParallel: plan.MaxInParallel,
+		FailFast:      plan.FailFast,
+	})
 }
 
 func (plan DoPlan) Public() *json.RawMessage {

--- a/atc/public_plan_test.go
+++ b/atc/public_plan_test.go
@@ -321,6 +321,25 @@ var _ = Describe("Plan", func() {
 							},
 						},
 					},
+					atc.Plan{
+						ID: "36",
+						Parallel: &atc.ParallelPlan{
+							MaxInParallel: 1,
+							FailFast:      true,
+							Steps: []atc.Plan{
+								atc.Plan{
+									ID: "37",
+									Task: &atc.TaskPlan{
+										Name:       "name",
+										ConfigPath: "some/config/path.yml",
+										Config: &atc.TaskConfig{
+											Params: map[string]string{"some": "secret"},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			}
 
@@ -556,6 +575,22 @@ var _ = Describe("Plan", func() {
           }
         }
       }
+		},
+		{
+			"id": "36",
+			"in_parallel": {
+				"steps": [
+					{
+						"id": "37",
+						"task": {
+							"name": "name",
+							"privileged": false
+						}
+					}
+				],
+				"max_in_parallel": 1,
+				"fail_fast": true
+			}
 		}
   ]
 }

--- a/atc/public_plan_test.go
+++ b/atc/public_plan_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Plan", func() {
 					},
 					atc.Plan{
 						ID: "36",
-						Parallel: &atc.ParallelPlan{
+						InParallel: &atc.InParallelPlan{
 							MaxInParallel: 1,
 							FailFast:      true,
 							Steps: []atc.Plan{

--- a/atc/public_plan_test.go
+++ b/atc/public_plan_test.go
@@ -324,8 +324,8 @@ var _ = Describe("Plan", func() {
 					atc.Plan{
 						ID: "36",
 						InParallel: &atc.InParallelPlan{
-							MaxInParallel: 1,
-							FailFast:      true,
+							Limit:    1,
+							FailFast: true,
 							Steps: []atc.Plan{
 								atc.Plan{
 									ID: "37",
@@ -588,7 +588,7 @@ var _ = Describe("Plan", func() {
 						}
 					}
 				],
-				"max_in_parallel": 1,
+				"limit": 1,
 				"fail_fast": true
 			}
 		}

--- a/atc/scheduler/factory/build_factory.go
+++ b/atc/scheduler/factory/build_factory.go
@@ -278,10 +278,10 @@ func (factory *buildFactory) constructUnhookedPlan(
 
 		plan = factory.planFactory.NewPlan(aggregate)
 
-	case planConfig.Parallel != nil:
+	case planConfig.InParallel != nil:
 		var steps []atc.Plan
 
-		for _, planConfig := range *planConfig.Parallel {
+		for _, planConfig := range planConfig.InParallel.Steps {
 			step, err := factory.constructPlanFromConfig(
 				planConfig,
 				resources,
@@ -296,9 +296,9 @@ func (factory *buildFactory) constructUnhookedPlan(
 		}
 
 		plan = factory.planFactory.NewPlan(atc.InParallelPlan{
-			Steps:         steps,
-			MaxInParallel: planConfig.MaxInParallel,
-			FailFast:      planConfig.FailFast,
+			Steps:    steps,
+			Limit:    planConfig.InParallel.Limit,
+			FailFast: planConfig.InParallel.FailFast,
 		})
 	}
 

--- a/atc/scheduler/factory/build_factory.go
+++ b/atc/scheduler/factory/build_factory.go
@@ -277,6 +277,29 @@ func (factory *buildFactory) constructUnhookedPlan(
 		}
 
 		plan = factory.planFactory.NewPlan(aggregate)
+
+	case planConfig.Parallel != nil:
+		var steps []atc.Plan
+
+		for _, planConfig := range *planConfig.Parallel {
+			step, err := factory.constructPlanFromConfig(
+				planConfig,
+				resources,
+				resourceTypes,
+				inputs,
+			)
+			if err != nil {
+				return atc.Plan{}, err
+			}
+
+			steps = append(steps, step)
+		}
+
+		plan = factory.planFactory.NewPlan(atc.ParallelPlan{
+			Steps:         steps,
+			MaxInParallel: planConfig.MaxInParallel,
+			FailFast:      planConfig.FailFast,
+		})
 	}
 
 	if planConfig.Timeout != "" {

--- a/atc/scheduler/factory/build_factory.go
+++ b/atc/scheduler/factory/build_factory.go
@@ -295,7 +295,7 @@ func (factory *buildFactory) constructUnhookedPlan(
 			steps = append(steps, step)
 		}
 
-		plan = factory.planFactory.NewPlan(atc.ParallelPlan{
+		plan = factory.planFactory.NewPlan(atc.InParallelPlan{
 			Steps:         steps,
 			MaxInParallel: planConfig.MaxInParallel,
 			FailFast:      planConfig.FailFast,

--- a/atc/scheduler/factory/factory_parallel_test.go
+++ b/atc/scheduler/factory/factory_parallel_test.go
@@ -1,0 +1,83 @@
+package factory_test
+
+import (
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/scheduler/factory"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Factory Parallel", func() {
+	var (
+		buildFactory factory.BuildFactory
+
+		resources           atc.ResourceConfigs
+		resourceTypes       atc.VersionedResourceTypes
+		actualPlanFactory   atc.PlanFactory
+		expectedPlanFactory atc.PlanFactory
+	)
+
+	BeforeEach(func() {
+		actualPlanFactory = atc.NewPlanFactory(123)
+		expectedPlanFactory = atc.NewPlanFactory(123)
+
+		buildFactory = factory.NewBuildFactory(42, actualPlanFactory)
+
+		resources = atc.ResourceConfigs{
+			{
+				Name:   "some-resource",
+				Type:   "git",
+				Source: atc.Source{"uri": "git://some-resource"},
+			},
+		}
+
+		resourceTypes = atc.VersionedResourceTypes{
+			{
+				ResourceType: atc.ResourceType{
+					Name:   "some-custom-resource",
+					Type:   "registry-image",
+					Source: atc.Source{"some": "custom-source"},
+				},
+				Version: atc.Version{"some": "version"},
+			},
+		}
+	})
+
+	Context("when I have a parallel step", func() {
+		It("returns the correct plan", func() {
+			actual, err := buildFactory.Create(atc.JobConfig{
+				Plan: atc.PlanSequence{
+					{
+						Parallel: &atc.PlanSequence{
+							{
+								Task: "some thing",
+							},
+							{
+								Task: "some other thing",
+							},
+						},
+						MaxInParallel: 1,
+						FailFast:      true,
+					},
+				},
+			}, resources, resourceTypes, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			expected := expectedPlanFactory.NewPlan(atc.ParallelPlan{
+				Steps: []atc.Plan{
+					expectedPlanFactory.NewPlan(atc.TaskPlan{
+						Name:                   "some thing",
+						VersionedResourceTypes: resourceTypes,
+					}),
+					expectedPlanFactory.NewPlan(atc.TaskPlan{
+						Name:                   "some other thing",
+						VersionedResourceTypes: resourceTypes,
+					}),
+				},
+				MaxInParallel: 1,
+				FailFast:      true,
+			})
+			Expect(actual).To(Equal(expected))
+		})
+	})
+})

--- a/atc/scheduler/factory/factory_parallel_test.go
+++ b/atc/scheduler/factory/factory_parallel_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Factory Parallel", func() {
 			}, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			expected := expectedPlanFactory.NewPlan(atc.ParallelPlan{
+			expected := expectedPlanFactory.NewPlan(atc.InParallelPlan{
 				Steps: []atc.Plan{
 					expectedPlanFactory.NewPlan(atc.TaskPlan{
 						Name:                   "some thing",

--- a/atc/scheduler/factory/factory_parallel_test.go
+++ b/atc/scheduler/factory/factory_parallel_test.go
@@ -48,16 +48,18 @@ var _ = Describe("Factory Parallel", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
-						Parallel: &atc.PlanSequence{
-							{
-								Task: "some thing",
+						InParallel: &atc.InParallelConfig{
+							Steps: atc.PlanSequence{
+								{
+									Task: "some thing",
+								},
+								{
+									Task: "some other thing",
+								},
 							},
-							{
-								Task: "some other thing",
-							},
+							Limit:    1,
+							FailFast: true,
 						},
-						MaxInParallel: 1,
-						FailFast:      true,
 					},
 				},
 			}, resources, resourceTypes, nil)
@@ -74,8 +76,8 @@ var _ = Describe("Factory Parallel", func() {
 						VersionedResourceTypes: resourceTypes,
 					}),
 				},
-				MaxInParallel: 1,
-				FailFast:      true,
+				Limit:    1,
+				FailFast: true,
 			})
 			Expect(actual).To(Equal(expected))
 		})

--- a/atc/scheduler/factory/factory_put_test.go
+++ b/atc/scheduler/factory/factory_put_test.go
@@ -297,16 +297,18 @@ var _ = Describe("Factory Put", func() {
 				input = atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
-							Parallel: &atc.PlanSequence{
-								{
-									Task: "some thing",
+							InParallel: &atc.InParallelConfig{
+								Steps: atc.PlanSequence{
+									{
+										Task: "some thing",
+									},
+									{
+										Put: "some-resource",
+									},
 								},
-								{
-									Put: "some-resource",
-								},
+								Limit:    1,
+								FailFast: true,
 							},
-							MaxInParallel: 1,
-							FailFast:      true,
 						},
 					},
 				}
@@ -346,8 +348,8 @@ var _ = Describe("Factory Put", func() {
 							}),
 						}),
 					},
-					MaxInParallel: 1,
-					FailFast:      true,
+					Limit:    1,
+					FailFast: true,
 				})
 				Expect(actual).To(testhelpers.MatchPlan(expected))
 			})

--- a/atc/scheduler/factory/factory_put_test.go
+++ b/atc/scheduler/factory/factory_put_test.go
@@ -326,7 +326,7 @@ var _ = Describe("Factory Put", func() {
 					VersionedResourceTypes: resourceTypes,
 				})
 
-				expected := expectedPlanFactory.NewPlan(atc.ParallelPlan{
+				expected := expectedPlanFactory.NewPlan(atc.InParallelPlan{
 					Steps: []atc.Plan{
 						expectedPlanFactory.NewPlan(atc.TaskPlan{
 							Name:                   "some thing",

--- a/atc/testhelpers/match_plan_matcher.go
+++ b/atc/testhelpers/match_plan_matcher.go
@@ -92,6 +92,13 @@ func stripIDs(plan atc.Plan) (atc.Plan, []string) {
 		}
 	}
 
+	if plan.Parallel != nil {
+		for i, p := range plan.Parallel.Steps {
+			plan.Parallel.Steps[i], subIDs = stripIDs(p)
+			ids = append(ids, subIDs...)
+		}
+	}
+
 	if plan.Do != nil {
 		for i, p := range *plan.Do {
 			(*plan.Do)[i], subIDs = stripIDs(p)

--- a/atc/testhelpers/match_plan_matcher.go
+++ b/atc/testhelpers/match_plan_matcher.go
@@ -92,9 +92,9 @@ func stripIDs(plan atc.Plan) (atc.Plan, []string) {
 		}
 	}
 
-	if plan.Parallel != nil {
-		for i, p := range plan.Parallel.Steps {
-			plan.Parallel.Steps[i], subIDs = stripIDs(p)
+	if plan.InParallel != nil {
+		for i, p := range plan.InParallel.Steps {
+			plan.InParallel.Steps[i], subIDs = stripIDs(p)
 			ids = append(ids, subIDs...)
 		}
 	}

--- a/atc/validate.go
+++ b/atc/validate.go
@@ -334,6 +334,10 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]ConfigWarning
 		foundTypes.Find("aggregate")
 	}
 
+	if plan.Parallel != nil {
+		foundTypes.Find("parallel")
+	}
+
 	if plan.Try != nil {
 		foundTypes.Find("try")
 	}
@@ -357,6 +361,14 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]ConfigWarning
 	case plan.Aggregate != nil:
 		for i, plan := range *plan.Aggregate {
 			subIdentifier := fmt.Sprintf("%s.aggregate[%d]", identifier, i)
+			planWarnings, planErrMessages := validatePlan(c, subIdentifier, plan)
+			warnings = append(warnings, planWarnings...)
+			errorMessages = append(errorMessages, planErrMessages...)
+		}
+
+	case plan.Parallel != nil:
+		for i, plan := range *plan.Parallel {
+			subIdentifier := fmt.Sprintf("%s.parallel[%d]", identifier, i)
 			planWarnings, planErrMessages := validatePlan(c, subIdentifier, plan)
 			warnings = append(warnings, planWarnings...)
 			errorMessages = append(errorMessages, planErrMessages...)

--- a/atc/validate.go
+++ b/atc/validate.go
@@ -334,7 +334,7 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]ConfigWarning
 		foundTypes.Find("aggregate")
 	}
 
-	if plan.Parallel != nil {
+	if plan.InParallel != nil {
 		foundTypes.Find("parallel")
 	}
 
@@ -366,8 +366,8 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]ConfigWarning
 			errorMessages = append(errorMessages, planErrMessages...)
 		}
 
-	case plan.Parallel != nil:
-		for i, plan := range *plan.Parallel {
+	case plan.InParallel != nil:
+		for i, plan := range plan.InParallel.Steps {
 			subIdentifier := fmt.Sprintf("%s.parallel[%d]", identifier, i)
 			planWarnings, planErrMessages := validatePlan(c, subIdentifier, plan)
 			warnings = append(warnings, planWarnings...)

--- a/atc/validate.go
+++ b/atc/validate.go
@@ -359,6 +359,10 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]ConfigWarning
 		}
 
 	case plan.Aggregate != nil:
+		warnings = append(warnings, ConfigWarning{
+			Type:    "pipeline",
+			Message: identifier + " : aggregate is deprecated and will be removed in a future version",
+		})
 		for i, plan := range *plan.Aggregate {
 			subIdentifier := fmt.Sprintf("%s.aggregate[%d]", identifier, i)
 			planWarnings, planErrMessages := validatePlan(c, subIdentifier, plan)
@@ -368,7 +372,7 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]ConfigWarning
 
 	case plan.InParallel != nil:
 		for i, plan := range plan.InParallel.Steps {
-			subIdentifier := fmt.Sprintf("%s.parallel[%d]", identifier, i)
+			subIdentifier := fmt.Sprintf("%s.in_parallel[%d]", identifier, i)
 			planWarnings, planErrMessages := validatePlan(c, subIdentifier, plan)
 			warnings = append(warnings, planWarnings...)
 			errorMessages = append(errorMessages, planErrMessages...)

--- a/atc/validate_test.go
+++ b/atc/validate_test.go
@@ -308,13 +308,15 @@ var _ = Describe("ValidateConfig", func() {
 								},
 							},
 							{
-								Parallel: &PlanSequence{
-									{
-										Get: "parallel",
+								InParallel: &InParallelConfig{
+									Steps: PlanSequence{
+										{
+											Get: "parallel",
+										},
 									},
+									Limit:    1,
+									FailFast: true,
 								},
-								MaxInParallel: 1,
-								FailFast:      true,
 							},
 							{
 								Task:           "some-task",
@@ -571,13 +573,15 @@ var _ = Describe("ValidateConfig", func() {
 					Get: "some-resource",
 				})
 				job.Plan = append(job.Plan, PlanConfig{
-					Parallel: &PlanSequence{
-						{
-							Get: "some-resource",
+					InParallel: &InParallelConfig{
+						Steps: PlanSequence{
+							{
+								Get: "some-resource",
+							},
 						},
+						Limit:    1,
+						FailFast: true,
 					},
-					MaxInParallel: 1,
-					FailFast:      true,
 				})
 
 				config.Jobs = append(config.Jobs, job)
@@ -595,12 +599,12 @@ var _ = Describe("ValidateConfig", func() {
 				Context("when it's not just Get and Put", func() {
 					BeforeEach(func() {
 						job.Plan = append(job.Plan, PlanConfig{
-							Get:       "some-resource",
-							Put:       "some-resource",
-							Task:      "some-resource",
-							Do:        &PlanSequence{},
-							Aggregate: &PlanSequence{},
-							Parallel:  &PlanSequence{},
+							Get:        "some-resource",
+							Put:        "some-resource",
+							Task:       "some-resource",
+							Do:         &PlanSequence{},
+							Aggregate:  &PlanSequence{},
+							InParallel: &InParallelConfig{},
 						})
 
 						config.Jobs = append(config.Jobs, job)
@@ -616,12 +620,12 @@ var _ = Describe("ValidateConfig", func() {
 				Context("when it's just Get and Put (this was valid at one point)", func() {
 					BeforeEach(func() {
 						job.Plan = append(job.Plan, PlanConfig{
-							Get:       "some-resource",
-							Put:       "some-resource",
-							Task:      "",
-							Do:        nil,
-							Aggregate: nil,
-							Parallel:  nil,
+							Get:        "some-resource",
+							Put:        "some-resource",
+							Task:       "",
+							Do:         nil,
+							Aggregate:  nil,
+							InParallel: nil,
 						})
 
 						config.Jobs = append(config.Jobs, job)

--- a/examples/hello-world-every-minute.yml
+++ b/examples/hello-world-every-minute.yml
@@ -30,25 +30,26 @@ jobs:
     - get: every-minute
       trigger: true
     - in_parallel:
-      - task: echo1
-        config: *config
-      - task: echo2
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: busybox
-          run:
-            path: /bin/sh
-            args:
-              - -cex
-              - |
-                sleep 5
-                eccho
-      - task: echo3
-        config: *config
-      - task: echo4
-        config: *config
-      max_in_parallel: 3
-      fail_fast: true
+        limit: 3
+        steps:
+        - task: echo1
+          config: *config
+        - task: echo2
+          config:
+            platform: linux
+            image_resource:
+              type: registry-image
+              source:
+                repository: busybox
+            run:
+              path: /bin/sh
+              args:
+                - -cex
+                - |
+                  sleep 5
+                  eccho
+        - task: echo3
+          config: *config
+        - task: echo4
+          config: *config
+        fail_fast: true

--- a/examples/hello-world-every-minute.yml
+++ b/examples/hello-world-every-minute.yml
@@ -10,13 +10,29 @@ resources:
     source:
       interval: 1m
 
+config: &config
+  platform: linux
+  image_resource:
+    type: registry-image
+    source:
+      repository: busybox
+  run:
+    path: /bin/sh
+    args:
+      - -cex
+      - |
+        sleep 10
+        echo hello world
+
 jobs:
-  - name: hello-world
-    public: true
+  - name: test-parallel
     plan:
-      - get: every-minute
-        trigger: true
-      - task: echo
+    - get: every-minute
+      trigger: true
+    - in_parallel:
+      - task: echo1
+        config: *config
+      - task: echo2
         config:
           platform: linux
           image_resource:
@@ -24,6 +40,15 @@ jobs:
             source:
               repository: busybox
           run:
-            path: echo
+            path: /bin/sh
             args:
-              - hello world
+              - -cex
+              - |
+                sleep 5
+                eccho
+      - task: echo3
+        config: *config
+      - task: echo4
+        config: *config
+      max_in_parallel: 3
+      fail_fast: true

--- a/web/assets/css/modules.less
+++ b/web/assets/css/modules.less
@@ -85,6 +85,11 @@
   border-left: 1px solid @base06;
 }
 
+.parallel {
+  margin-left: -1px;
+  border-left: 1px solid @base06;
+}
+
 .children {
   margin-left: 1em;
 }

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -45,6 +45,7 @@ type StepTree
     | ArtifactOutput Step
     | Put Step
     | Aggregate (Array StepTree)
+    | InParallel (Array StepTree)
     | Do (Array StepTree)
     | OnSuccess HookedStep
     | OnFailure HookedStep
@@ -260,6 +261,9 @@ getMultiStepIndex idx tree =
                 Aggregate trees ->
                     trees
 
+                InParallel trees ->
+                    trees
+
                 Do trees ->
                     trees
 
@@ -284,6 +288,9 @@ setMultiStepIndex idx update tree =
     case tree of
         Aggregate trees ->
             Aggregate (Array.set idx (update (getMultiStepIndex idx tree)) trees)
+
+        InParallel trees ->
+            InParallel (Array.set idx (update (getMultiStepIndex idx tree)) trees)
 
         Do trees ->
             Do (Array.set idx (update (getMultiStepIndex idx tree)) trees)
@@ -325,6 +332,9 @@ finishTree root =
 
         Aggregate trees ->
             Aggregate (Array.map finishTree trees)
+
+        InParallel trees ->
+            InParallel (Array.map finishTree trees)
 
         Do trees ->
             Do (Array.map finishTree trees)

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -83,6 +83,9 @@ init hl resources buildPlan =
         Concourse.BuildStepAggregate plans ->
             initMultiStep hl resources buildPlan.id Aggregate plans
 
+        Concourse.BuildStepInParallel plans ->
+            initMultiStep hl resources buildPlan.id InParallel plans
+
         Concourse.BuildStepDo plans ->
             initMultiStep hl resources buildPlan.id Do plans
 
@@ -232,6 +235,9 @@ treeIsActive : StepTree -> Bool
 treeIsActive stepTree =
     case stepTree of
         Aggregate trees ->
+            List.any treeIsActive (Array.toList trees)
+
+        InParallel trees ->
             List.any treeIsActive (Array.toList trees)
 
         Do trees ->
@@ -446,6 +452,10 @@ viewTree timeZone model tree =
 
         Aggregate steps ->
             Html.div [ class "aggregate" ]
+                (Array.toList <| Array.map (viewSeq timeZone model) steps)
+
+        InParallel steps ->
+            Html.div [ class "parallel" ]
                 (Array.toList <| Array.map (viewSeq timeZone model) steps)
 
         Do steps ->

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -355,6 +355,7 @@ type alias HookedPlan =
     , hook : BuildPlan
     }
 
+
 decodeBuildPlan : Json.Decode.Decoder BuildPlan
 decodeBuildPlan =
     Json.Decode.at [ "plan" ] <|
@@ -406,7 +407,6 @@ decodeBuildPlan_ =
             )
 
 
-
 decodeBuildStepTask : Json.Decode.Decoder BuildStep
 decodeBuildStepTask =
     Json.Decode.succeed BuildStepTask
@@ -443,10 +443,12 @@ decodeBuildStepAggregate =
     Json.Decode.succeed BuildStepAggregate
         |> andMap (Json.Decode.array (lazy (\_ -> decodeBuildPlan_)))
 
+
 decodeBuildStepInParallel : Json.Decode.Decoder BuildStep
 decodeBuildStepInParallel =
     Json.Decode.succeed BuildStepInParallel
-        |> andMap (Json.Decode.field "steps" <| Json.Decode.array ( lazy (\_ -> decodeBuildPlan_)))
+        |> andMap (Json.Decode.field "steps" <| Json.Decode.array (lazy (\_ -> decodeBuildPlan_)))
+
 
 decodeBuildStepDo : Json.Decode.Decoder BuildStep
 decodeBuildStepDo =

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -338,6 +338,7 @@ type BuildStep
     | BuildStepArtifactOutput StepName
     | BuildStepPut StepName
     | BuildStepAggregate (Array BuildPlan)
+    | BuildStepInParallel (Array BuildPlan)
     | BuildStepDo (Array BuildPlan)
     | BuildStepOnSuccess HookedPlan
     | BuildStepOnFailure HookedPlan
@@ -353,7 +354,6 @@ type alias HookedPlan =
     { step : BuildPlan
     , hook : BuildPlan
     }
-
 
 decodeBuildPlan : Json.Decode.Decoder BuildPlan
 decodeBuildPlan =
@@ -382,6 +382,8 @@ decodeBuildPlan_ =
                     lazy (\_ -> decodeBuildStepGet)
                 , Json.Decode.field "aggregate" <|
                     lazy (\_ -> decodeBuildStepAggregate)
+                , Json.Decode.field "in_parallel" <|
+                    lazy (\_ -> decodeBuildStepInParallel)
                 , Json.Decode.field "do" <|
                     lazy (\_ -> decodeBuildStepDo)
                 , Json.Decode.field "on_success" <|
@@ -402,6 +404,7 @@ decodeBuildPlan_ =
                     lazy (\_ -> decodeBuildStepTimeout)
                 ]
             )
+
 
 
 decodeBuildStepTask : Json.Decode.Decoder BuildStep
@@ -440,6 +443,10 @@ decodeBuildStepAggregate =
     Json.Decode.succeed BuildStepAggregate
         |> andMap (Json.Decode.array (lazy (\_ -> decodeBuildPlan_)))
 
+decodeBuildStepInParallel : Json.Decode.Decoder BuildStep
+decodeBuildStepInParallel =
+    Json.Decode.succeed BuildStepInParallel
+        |> andMap (Json.Decode.field "steps" <| Json.Decode.array ( lazy (\_ -> decodeBuildPlan_)))
 
 decodeBuildStepDo : Json.Decode.Decoder BuildStep
 decodeBuildStepDo =

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -2,6 +2,8 @@ module StepTreeTests exposing
     ( all
     , initAggregate
     , initAggregateNested
+    , initParallel
+    , initParallelNested
     , initEnsure
     , initGet
     , initOnFailure
@@ -31,6 +33,8 @@ all =
         , initPut
         , initAggregate
         , initAggregateNested
+        , initInParallel
+        , initInParallelNested
         , initOnSuccess
         , initOnFailure
         , initEnsure
@@ -247,6 +251,115 @@ initAggregateNested =
                         [ Models.Task (someStep "task-a-id" "task-a" Models.StepStatePending)
                         , Models.Task (someStep "task-b-id" "task-b" Models.StepStatePending)
                         , Models.Aggregate
+                            << Array.fromList
+                          <|
+                            [ Models.Task (someStep "task-c-id" "task-c" Models.StepStateSucceeded)
+                            , Models.Task (someStep "task-d-id" "task-d" Models.StepStatePending)
+                            ]
+                        ]
+                    )
+        ]
+
+
+initInParallel : Test
+initInParallel =
+    let
+        { tree, foci } =
+            StepTree.init Routes.HighlightNothing
+                emptyResources
+                { id = "parallel-id"
+                , step =
+                    BuildStepInParallel
+                        << Array.fromList
+                    <|
+                        [ { id = "task-a-id", step = BuildStepTask "task-a" }
+                        , { id = "task-b-id", step = BuildStepTask "task-b" }
+                        ]
+                }
+    in
+    describe "init with Parallel"
+        [ test "the tree" <|
+            \_ ->
+                Expect.equal
+                    (Models.Parallel
+                        << Array.fromList
+                     <|
+                        [ Models.Task (someStep "task-a-id" "task-a" Models.StepStatePending)
+                        , Models.Task (someStep "task-b-id" "task-b" Models.StepStatePending)
+                        ]
+                    )
+                    tree
+        , test "using the focus" <|
+            \_ ->
+                assertFocus "task-a-id"
+                    foci
+                    tree
+                    (\s -> { s | state = Models.StepStateSucceeded })
+                    (Models.Parallel
+                        << Array.fromList
+                     <|
+                        [ Models.Task (someStep "task-a-id" "task-a" Models.StepStateSucceeded)
+                        , Models.Task (someStep "task-b-id" "task-b" Models.StepStatePending)
+                        ]
+                    )
+        ]
+
+
+initInParallelNested : Test
+initInParallelNested =
+    let
+        { tree, foci } =
+            StepTree.init Routes.HighlightNothing
+                emptyResources
+                { id = "parallel-id"
+                , step =
+                    BuildStepInParallel
+                        << Array.fromList
+                    <|
+                        [ { id = "task-a-id", step = BuildStepTask "task-a" }
+                        , { id = "task-b-id", step = BuildStepTask "task-b" }
+                        , { id = "nested-parallel-id"
+                          , step =
+                                BuildStepInParallel
+                                    << Array.fromList
+                                <|
+                                    [ { id = "task-c-id", step = BuildStepTask "task-c" }
+                                    , { id = "task-d-id", step = BuildStepTask "task-d" }
+                                    ]
+                          }
+                        ]
+                }
+    in
+    describe "init with Parallel nested"
+        [ test "the tree" <|
+            \_ ->
+                Expect.equal
+                    (Models.InParallel
+                        << Array.fromList
+                     <|
+                        [ Models.Task (someStep "task-a-id" "task-a" Models.StepStatePending)
+                        , Models.Task (someStep "task-b-id" "task-b" Models.StepStatePending)
+                        , Models.InParallel
+                            << Array.fromList
+                          <|
+                            [ Models.Task (someStep "task-c-id" "task-c" Models.StepStatePending)
+                            , Models.Task (someStep "task-d-id" "task-d" Models.StepStatePending)
+                            ]
+                        ]
+                    )
+                    tree
+        , test "using the focuses for nested elements" <|
+            \_ ->
+                assertFocus "task-c-id"
+                    foci
+                    tree
+                    (\s -> { s | state = Models.StepStateSucceeded })
+                    (Models.InParallel
+                        << Array.fromList
+                     <|
+                        [ Models.Task (someStep "task-a-id" "task-a" Models.StepStatePending)
+                        , Models.Task (someStep "task-b-id" "task-b" Models.StepStatePending)
+                        , Models.InParallel
                             << Array.fromList
                           <|
                             [ Models.Task (someStep "task-c-id" "task-c" Models.StepStateSucceeded)

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -2,10 +2,10 @@ module StepTreeTests exposing
     ( all
     , initAggregate
     , initAggregateNested
-    , initParallel
-    , initParallelNested
     , initEnsure
     , initGet
+    , initInParallel
+    , initInParallelNested
     , initOnFailure
     , initOnSuccess
     , initPut
@@ -281,7 +281,7 @@ initInParallel =
         [ test "the tree" <|
             \_ ->
                 Expect.equal
-                    (Models.Parallel
+                    (Models.InParallel
                         << Array.fromList
                      <|
                         [ Models.Task (someStep "task-a-id" "task-a" Models.StepStatePending)
@@ -295,7 +295,7 @@ initInParallel =
                     foci
                     tree
                     (\s -> { s | state = Models.StepStateSucceeded })
-                    (Models.Parallel
+                    (Models.InParallel
                         << Array.fromList
                      <|
                         [ Models.Task (someStep "task-a-id" "task-a" Models.StepStateSucceeded)


### PR DESCRIPTION
Closes #2628 by adding support for the following:

```yaml
jobs:
  - name: example
    plan:
    - get: every-minute
      trigger: true
    - in_parallel:
        limit: 1
        fail_fast: true
        steps:
        - task: echo
          config:
           ...
        - task: echo
          config:
            ...
```

InParallel ensures that `limit` steps are running at any one time and until all steps are complete. If `limit` is not specified, the default behavior is identical to an `aggregate` step and runs everything at once. Setting `limit` to 1 makes it behave like `do`. When cancelling a job, `in_parallel` will not schedule (`Run()`) the pending tasks and instead return the `ctx.Err()` as soon as possible. When setting `fail_fast`, `in_parallel` will abort all currently running tasks and refrain from scheduling pending tasks.

### Todo

- [ ] Revert changes to `examples/hello-world-every-minute.yml`.
- [x] Submit a PR to [concourse/docs](https://github.com/concourse/docs).
- [ ] Decide on YAML structure and naming (questions in [this comment](https://github.com/concourse/concourse/issues/2628#issuecomment-475908990)).

PS: Sorry for the big PR, but `parallel` is essentially a copy/paste of `aggregate` with very slight modifications. Was originally thinking I could refactor so both used the same underlying implementation, but I think that would only allow us to reuse the code in `exec` which does not have that big of an impact on the diff.