### PR TITLE
ci: release pipeline changes

### DIFF
--- a/ci/deployments/bosh-smoke.yml
+++ b/ci/deployments/bosh-smoke.yml
@@ -1,5 +1,5 @@
 ---
-name: concourse-smoke
+name: ((deployment_name))
 
 releases:
 - name: concourse

--- a/ci/deployments/smoke/smoke.tf
+++ b/ci/deployments/smoke/smoke.tf
@@ -20,12 +20,14 @@ provider "google" {
 
 data "google_compute_zones" "available" {}
 
+resource "random_pet" "smoke" {}
+
 resource "google_compute_address" "smoke" {
-  name = "smoke"
+  name = "smoke-${random_pet.smoke.id}-ip"
 }
 
 resource "google_compute_firewall" "bosh-director" {
-  name    = "allow-smoke-http"
+  name    = "smoke-${random_pet.smoke.id}-allow-http"
   network = "default"
 
   allow {
@@ -37,7 +39,7 @@ resource "google_compute_firewall" "bosh-director" {
 }
 
 resource "google_compute_instance" "smoke" {
-  name = "smoke"
+  name = "smoke-${random_pet.smoke.id}"
   machine_type = "custom-8-8192"
   zone = "${data.google_compute_zones.available.names[0]}"
   tags = ["smoke"]

--- a/ci/overrides/docker-compose.latest.yml
+++ b/ci/overrides/docker-compose.latest.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   web:
-    image: concourse/concourse:latest
+    image: concourse/concourse:${CONCOURSE_LATEST_TAG}
 
   worker:
-    image: concourse/concourse:latest
+    image: concourse/concourse:${CONCOURSE_LATEST_TAG}

--- a/ci/overrides/docker-compose.no-build.yml
+++ b/ci/overrides/docker-compose.no-build.yml
@@ -2,9 +2,9 @@ version: '3'
 
 services:
   web:
-    image: concourse/dev:latest
+    image: concourse/dev:${CONCOURSE_DEV_TAG}
     volumes: ["./keys:/concourse-keys"]
 
   worker:
-    image: concourse/dev:latest
+    image: concourse/dev:${CONCOURSE_DEV_TAG}
     volumes: ["./keys:/concourse-keys"]

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -623,6 +623,8 @@ jobs:
       - bpm-release/*.tgz
       stemcells:
       - gcp-xenial-stemcell/*.tgz
+      vars:
+        deployment_name: concourse-smoke
   - task: discover-bosh-endpoint-info
     file: concourse/ci/tasks/discover-bosh-endpoint-info.yml
     image: unit-image

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -3,6 +3,11 @@ resource_types:
   type: registry-image
   source: {repository: frodenas/gcs-resource}
 
+- name: registry-image
+  type: registry-image
+  # 'dev' tag is needed for 'tag' file creation
+  source: {repository: concourse/registry-image-resource, tag: dev}
+
 - name: bosh-release
   type: registry-image
   source: {repository: dpb587/bosh-release-resource}
@@ -352,9 +357,9 @@ jobs:
       image: unit-image
       file: concourse/ci/tasks/k8s-delete.yml
       params:
-       KUBE_CONFIG: ((kube_config))
-       RELEASE_NAME: concourse-smoke
-       CONCOURSE_IMAGE: concourse/concourse-rc
+        KUBE_CONFIG: ((kube_config))
+        RELEASE_NAME: concourse-smoke
+        CONCOURSE_IMAGE: concourse/concourse-rc
   - task: deploy
     image: unit-image
     input_mapping: {image-info: concourse-rc-image}
@@ -374,9 +379,9 @@ jobs:
     image: unit-image
     file: concourse/ci/tasks/k8s-delete.yml
     params:
-     KUBE_CONFIG: ((kube_config))
-     RELEASE_NAME: concourse-smoke
-     CONCOURSE_IMAGE: concourse/concourse-rc
+      KUBE_CONFIG: ((kube_config))
+      RELEASE_NAME: concourse-smoke
+      CONCOURSE_IMAGE: concourse/concourse-rc
 
 - name: k8s-topgun
   public: true
@@ -403,8 +408,8 @@ jobs:
     file: concourse/ci/tasks/k8s-topgun.yml
     image: unit-image
     params:
-     KUBE_CONFIG: ((kube_config))
-     CONCOURSE_IMAGE_NAME: concourse/concourse-rc
+      KUBE_CONFIG: ((kube_config))
+      CONCOURSE_IMAGE_NAME: concourse/concourse-rc
 
 - name: rc
   public: true

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -79,7 +79,8 @@ groups:
   - publish-binaries
   - publish-image
   - publish-bosh-release
-  - publish-bosh-deployment
+  - promote-cbd
+  - bump-cbd-versions
   - publish-docs
 
 - name: workers
@@ -930,7 +931,7 @@ jobs:
       tarball: concourse-release/*.tgz
       version: version/version
 
-- name: publish-bosh-deployment
+- name: bump-cbd-versions
   serial: true
   plan:
   - aggregate:
@@ -938,25 +939,39 @@ jobs:
       trigger: true
     - get: unit-image
       passed: [shipit]
-    - get: cbd
+    - get: cbd-master
     - get: version
       passed: [shipit]
     - get: bpm-release
       passed: [shipit]
     - get: postgres-release
       passed: [shipit]
-  # TODO: check that boshio version matches given version
   - task: bump-versions
     file: cbd/ci/bump-versions.yml
-    input_mapping: {concourse-bosh-deployment: cbd}
+    input_mapping: {concourse-bosh-deployment: cbd-master}
     image: unit-image
-  - put: cbd
-    params:
-      repository: bumped-repo
-      merge: true
   - put: cbd-master
     params:
       repository: bumped-repo
+      merge: true
+
+- name: promote-cbd
+  serial: true
+  plan:
+  - aggregate:
+    - get: version
+      passed: [shipit]
+      trigger: true
+    - get: cbd
+    - get: unit-image
+      passed: [shipit]
+    - get: bpm-release
+      passed: [shipit]
+    - get: postgres-release
+      passed: [shipit]
+  - put: cbd-master
+    params:
+      repository: cbd
       merge: true
 
 - name: publish-image

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -963,9 +963,9 @@ jobs:
     - get: concourse-rc-image
       passed: [shipit]
       params: {format: oci}
+    - get: latest-version
   - task: docker-semver-tags
     file: concourse/ci/tasks/docker-semver-tags.yml
-    params: {MAJOR: "true"}
   - put: concourse-image
     params:
       image: concourse-rc-image/image.tar
@@ -1412,3 +1412,10 @@ resources:
   type: bosh-io-release
   source:
     repository: concourse/concourse-bosh-release
+
+- name: latest-version
+  type: github-release
+  source:
+    owner: concourse
+    repository: concourse
+    access_token: ((concourse_github_release.access_token))

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -3,10 +3,10 @@ resource_types:
   type: registry-image
   source: {repository: frodenas/gcs-resource}
 
+# needed for 'tag' file creation; can be removed once shipped
 - name: registry-image
   type: registry-image
-  # 'dev' tag is needed for 'tag' file creation
-  source: {repository: concourse/registry-image-resource, tag: dev}
+  source: {repository: concourse/registry-image-resource}
 
 - name: bosh-release
   type: registry-image
@@ -989,6 +989,8 @@ jobs:
     - get: latest-version
   - task: docker-semver-tags
     file: concourse/ci/tasks/docker-semver-tags.yml
+    input_mapping:
+      latest-of-same-major-version: latest-version
   - put: concourse-image
     params:
       image: concourse-rc-image/image.tar

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -81,7 +81,6 @@ groups:
   - publish-bosh-release
   - publish-bosh-deployment
   - publish-docs
-  - patch
 
 - name: workers
   jobs:
@@ -992,16 +991,6 @@ jobs:
     params: {ANALYTICS_ID: ((analytics_id))}
   - put: docs-gh-pages
     params: {repository: built-docs}
-
-- name: patch
-  public: true
-  serial_groups: [version]
-  plan:
-  - get: version
-    passed: [shipit]
-    trigger: true
-  - put: version
-    params: {bump: patch, pre: rc}
 
 - name: merge-cbd
   public: true

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -265,17 +265,18 @@ jobs:
   plan:
   - aggregate:
     - get: concourse
-      passed: [dev-image]
+      passed: [unit, dev-image]
       trigger: true
     - get: dev-image
       passed: [dev-image]
       params: {format: oci}
+      trigger: true
+    - get: unit-image
+      passed: [unit, dev-image]
     - get: concourse-image
       params: {format: oci}
     - get: postgres-image
       params: {format: oci}
-    - get: unit-image
-      passed: [dev-image]
   - task: upgrade-test
     privileged: true
     image: unit-image
@@ -287,17 +288,18 @@ jobs:
   plan:
   - aggregate:
     - get: concourse
-      passed: [dev-image]
+      passed: [unit, dev-image]
       trigger: true
     - get: dev-image
       passed: [dev-image]
       params: {format: oci}
+      trigger: true
+    - get: unit-image
+      passed: [unit, dev-image]
     - get: concourse-image
       params: {format: oci}
     - get: postgres-image
       params: {format: oci}
-    - get: unit-image
-      passed: [dev-image]
   - task: downgrade-test
     privileged: true
     image: unit-image

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -2,6 +2,7 @@
 #
 #   ((release_major)) the MAJOR version, e.g. 5
 #   ((release_minor)) the MAJOR.MINOR version, e.g. 5.1
+#   ((concourse_smoke_deployment_name)) a unique name for the smoke bosh deployment
 #
 # the following git branches need to be created:
 #

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -312,7 +312,7 @@ jobs:
       file: concourse/ci/tasks/k8s-delete.yml
       params:
         KUBE_CONFIG: ((kube_config))
-        RELEASE_NAME: concourse-smoke-patch # TODO can't use release_minor
+        RELEASE_NAME: ((concourse_smoke_deployment_name))
         CONCOURSE_IMAGE: concourse/concourse-rc
   - task: deploy
     image: unit-image
@@ -320,21 +320,21 @@ jobs:
     file: concourse/ci/tasks/k8s-deploy.yml
     params:
       KUBE_CONFIG: ((kube_config))
-      RELEASE_NAME: concourse-smoke-patch # TODO can't use release_minor
+      RELEASE_NAME: ((concourse_smoke_deployment_name))
       CONCOURSE_IMAGE: concourse/concourse-rc
   - task: k8s-smoke
     image: unit-image
     file: concourse/ci/tasks/k8s-smoke.yml
     params:
       KUBE_CONFIG: ((kube_config))
-      RELEASE_NAME: concourse-smoke-patch # TODO can't use release_minor
+      RELEASE_NAME: ((concourse_smoke_deployment_name))
       MAX_TICKS: 180
   - task: delete
     image: unit-image
     file: concourse/ci/tasks/k8s-delete.yml
     params:
       KUBE_CONFIG: ((kube_config))
-      RELEASE_NAME: concourse-smoke-patch # TODO can't use release_minor
+      RELEASE_NAME: ((concourse_smoke_deployment_name))
       CONCOURSE_IMAGE: concourse/concourse-rc
 
 - name: k8s-topgun
@@ -578,7 +578,7 @@ jobs:
       stemcells:
       - gcp-xenial-stemcell/*.tgz
       vars:
-        deployment_name: concourse-smoke-patch # TODO can't use release_minor
+        deployment_name: ((concourse_smoke_deployment_name))
   - task: discover-bosh-endpoint-info
     file: concourse/ci/tasks/discover-bosh-endpoint-info.yml
     image: unit-image
@@ -586,7 +586,7 @@ jobs:
       BOSH_ENVIRONMENT: ((bosh_target))
       BOSH_CLIENT: ((bosh_client.id))
       BOSH_CLIENT_SECRET: ((bosh_client.secret))
-      BOSH_DEPLOYMENT: concourse-smoke-patch # TODO can't use release_minor
+      BOSH_DEPLOYMENT: ((concourse_smoke_deployment_name))
       BOSH_INSTANCE_GROUP: concourse
   - task: smoke
     image: unit-image
@@ -949,7 +949,7 @@ resources:
     target: ((bosh_target))
     client: ((bosh_client.id))
     client_secret: ((bosh_client.secret))
-    deployment: concourse-smoke-patch # TODO can't use release_minor
+    deployment: ((concourse_smoke_deployment_name))
 
 - name: wings-deployment
   type: bosh-deployment

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -1,0 +1,1192 @@
+# the following git branches need to be created:
+#
+#   concourse/concourse                 release/((release_minor)).x
+#   concourse/concourse-bosh-release    release/((release_minor)).x
+#   concourse/concourse-bosh-deployment release/((release_minor)).x
+#
+# everything else will be managed by the pipeline
+
+resource_types:
+- name: gcs
+  type: registry-image
+  source: {repository: frodenas/gcs-resource}
+
+- name: registry-image
+  type: registry-image
+  # 'dev' tag is needed for 'tag' file creation
+  source: {repository: concourse/registry-image-resource, tag: dev}
+
+- name: bosh-release
+  type: registry-image
+  source: {repository: dpb587/bosh-release-resource}
+
+- name: bosh-deployment
+  type: registry-image
+  source: {repository: cloudfoundry/bosh-deployment-resource}
+
+- name: github-release
+  type: registry-image
+  source: {repository: concourse/github-release-resource}
+
+- name: semver
+  type: registry-image
+  source: {repository: concourse/semver-resource}
+
+- name: s3
+  type: registry-image
+  source: {repository: concourse/s3-resource}
+
+- name: bosh-io-release
+  type: registry-image
+  source: {repository: concourse/bosh-io-release-resource}
+
+- name: bosh-io-stemcell
+  type: registry-image
+  source: {repository: concourse/bosh-io-stemcell-resource}
+
+groups:
+- name: develop
+  jobs:
+  - unit
+  - dev-image
+  - testflight
+  - watsjs
+  - rc
+  - build-rc
+  - build-rc-image
+  - bin-smoke
+  - upgrade
+  - downgrade
+
+- name: k8s
+  jobs:
+  - k8s-check-helm-params
+  - k8s-smoke
+  - k8s-topgun
+
+- name: bosh
+  jobs:
+  - bosh-bump
+  - bosh-smoke
+  - bosh-topgun
+  - bosh-wings-deploy
+  - bosh-check-props
+
+- name: publish
+  jobs:
+  - shipit
+  - publish-binaries
+  - publish-image
+  - publish-bosh-release
+  - publish-bosh-deployment
+  - publish-docs
+  - patch
+
+jobs:
+- name: unit
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      trigger: true
+    - get: unit-image
+      trigger: true
+  - task: yarn-test
+    image: unit-image
+    file: concourse/ci/tasks/yarn-test.yml
+  - aggregate:
+    - task: unit
+      image: unit-image
+      file: concourse/ci/tasks/unit.yml
+      input_mapping: {concourse: built-concourse}
+      timeout: 1h
+    - task: fly-darwin
+      file: concourse/ci/tasks/fly-darwin.yml
+      timeout: 1h
+    - task: fly-windows
+      file: concourse/ci/tasks/fly-windows.yml
+      timeout: 1h
+
+- name: dev-image
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      trigger: true
+    - get: unit-image
+      trigger: true
+    - get: gdn
+      trigger: true
+    - get: dumb-init
+      trigger: true
+    - get: bosh-io-release-resource
+      trigger: true
+    - get: bosh-io-stemcell-resource
+      trigger: true
+    - get: cf-resource
+      trigger: true
+    - get: docker-image-resource
+      trigger: true
+    - get: git-resource
+      trigger: true
+    - get: github-release-resource
+      trigger: true
+    - get: hg-resource
+      trigger: true
+    - get: pool-resource
+      trigger: true
+    - get: registry-image-resource
+      trigger: true
+    - get: s3-resource
+      trigger: true
+    - get: semver-resource
+      trigger: true
+    - get: time-resource
+      trigger: true
+    - get: tracker-resource
+      trigger: true
+    - get: mock-resource
+      trigger: true
+    - get: builder
+  - task: yarn-build
+    image: unit-image
+    file: concourse/ci/tasks/yarn-build.yml
+  - aggregate:
+    - task: fly-linux
+      file: concourse/ci/tasks/fly-build-linux.yml
+    - task: fly-windows
+      file: concourse/ci/tasks/fly-build-windows.yml
+    - task: fly-darwin
+      file: concourse/ci/tasks/fly-build-darwin.yml
+  - task: build
+    image: builder
+    privileged: true
+    input_mapping: {concourse: built-concourse}
+    file: concourse/ci/tasks/build-dev-image.yml
+  - put: dev-image
+    params: {image: image/image.tar}
+    get_params: {format: oci}
+
+- name: testflight
+  public: true
+  max_in_flight: 2
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [unit, dev-image]
+      trigger: true
+    - get: dev-image
+      passed: [dev-image]
+      params: {format: oci}
+      trigger: true
+    - get: unit-image
+      passed: [unit, dev-image]
+    - get: postgres-image
+      params: {format: oci}
+  - task: testflight
+    image: unit-image
+    privileged: true
+    timeout: 1h
+    file: concourse/ci/tasks/docker-compose-testflight.yml
+
+- name: watsjs
+  public: true
+  max_in_flight: 2
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [unit, dev-image]
+      trigger: true
+    - get: dev-image
+      passed: [dev-image]
+      params: {format: oci}
+      trigger: true
+    - get: unit-image
+      passed: [unit, dev-image]
+    - get: postgres-image
+      params: {format: oci}
+  - task: watsjs
+    image: unit-image
+    privileged: true
+    timeout: 1h
+    file: concourse/ci/tasks/docker-compose-watsjs.yml
+
+- name: upgrade
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [unit, dev-image]
+      trigger: true
+    - get: dev-image
+      passed: [dev-image]
+      params: {format: oci}
+      trigger: true
+    - get: unit-image
+      passed: [unit, dev-image]
+    - get: concourse-image
+      params: {format: oci}
+    - get: postgres-image
+      params: {format: oci}
+  - task: upgrade-test
+    privileged: true
+    image: unit-image
+    file: concourse/ci/tasks/upgrade-test.yml
+
+- name: downgrade
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [unit, dev-image]
+      trigger: true
+    - get: dev-image
+      passed: [dev-image]
+      params: {format: oci}
+      trigger: true
+    - get: unit-image
+      passed: [unit, dev-image]
+    - get: concourse-image
+      params: {format: oci}
+    - get: postgres-image
+      params: {format: oci}
+  - task: downgrade-test
+    privileged: true
+    image: unit-image
+    file: concourse/ci/tasks/downgrade-test.yml
+
+- name: k8s-check-helm-params
+  public: true
+  max_in_flight: 1
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [build-rc-image]
+      trigger: true
+    - get: concourse-rc-image
+      passed: [build-rc-image]
+      trigger: true
+    - get: version
+      passed: [build-rc-image]
+      trigger: true
+    - get: unit-image
+      passed: [build-rc-image]
+      trigger: true
+    - get: linux-rc
+      passed: [build-rc-image]
+      trigger: true
+    - get: charts
+      trigger: true
+  - task: check-params
+    file: concourse/ci/tasks/check-distribution-env.yml
+    image: unit-image
+    input_mapping: {distribution: charts}
+    params: {DISTRIBUTION: helm}
+
+- name: k8s-smoke
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [k8s-check-helm-params]
+      trigger: true
+    - get: concourse-rc-image
+      passed: [k8s-check-helm-params]
+      params: {format: oci}
+      trigger: true
+    - get: version
+      passed: [k8s-check-helm-params]
+      trigger: true
+    - get: charts
+      passed: [k8s-check-helm-params]
+      trigger: true
+    - get: unit-image
+      passed: [k8s-check-helm-params]
+  - try:
+      task: try-delete
+      image: unit-image
+      file: concourse/ci/tasks/k8s-delete.yml
+      params:
+        KUBE_CONFIG: ((kube_config))
+        RELEASE_NAME: concourse-smoke-patch # TODO can't use release_minor
+        CONCOURSE_IMAGE: concourse/concourse-rc
+  - task: deploy
+    image: unit-image
+    input_mapping: {image-info: concourse-rc-image}
+    file: concourse/ci/tasks/k8s-deploy.yml
+    params:
+      KUBE_CONFIG: ((kube_config))
+      RELEASE_NAME: concourse-smoke-patch # TODO can't use release_minor
+      CONCOURSE_IMAGE: concourse/concourse-rc
+  - task: k8s-smoke
+    image: unit-image
+    file: concourse/ci/tasks/k8s-smoke.yml
+    params:
+      KUBE_CONFIG: ((kube_config))
+      RELEASE_NAME: concourse-smoke-patch # TODO can't use release_minor
+      MAX_TICKS: 180
+  - task: delete
+    image: unit-image
+    file: concourse/ci/tasks/k8s-delete.yml
+    params:
+      KUBE_CONFIG: ((kube_config))
+      RELEASE_NAME: concourse-smoke-patch # TODO can't use release_minor
+      CONCOURSE_IMAGE: concourse/concourse-rc
+
+- name: k8s-topgun
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [k8s-smoke]
+      trigger: true
+    - get: version
+      passed: [k8s-smoke]
+      trigger: true
+    - get: concourse-rc-image
+      passed: [k8s-smoke]
+      trigger: true
+      params: {format: oci}
+    - get: unit-image
+      passed: [k8s-smoke]
+      trigger: true
+    - get: charts
+      trigger: true
+      passed: [k8s-smoke]
+  - task: k8s-topgun
+    file: concourse/ci/tasks/k8s-topgun.yml
+    image: unit-image
+    params:
+      KUBE_CONFIG: ((kube_config))
+      CONCOURSE_IMAGE_NAME: concourse/concourse-rc
+
+- name: rc
+  public: true
+  serial_groups: [version]
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [testflight, watsjs, upgrade, downgrade]
+      trigger: true
+    - get: dev-image
+      trigger: true
+      passed: [testflight, watsjs, upgrade, downgrade]
+    - get: unit-image
+      passed: [testflight, watsjs, upgrade, downgrade]
+      trigger: true
+  - put: version
+    params: {pre: rc}
+
+- name: build-rc
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [rc]
+      trigger: true
+    - get: unit-image
+      passed: [rc]
+      trigger: true
+    - get: dev-image
+      passed: [rc]
+      trigger: true
+    - get: version
+      passed: [rc]
+      trigger: true
+    - get: final-version
+      resource: version
+      passed: [rc]
+      params: {bump: final}
+  - aggregate:
+    - task: fly-linux
+      file: concourse/ci/tasks/fly-build-linux.yml
+    - task: fly-windows
+      file: concourse/ci/tasks/fly-build-windows.yml
+    - task: fly-darwin
+      file: concourse/ci/tasks/fly-build-darwin.yml
+  - task: hoist-linux-dependencies
+    image: dev-image
+    file: concourse/ci/tasks/hoist-linux-dependencies.yml
+  - task: yarn-build
+    image: unit-image
+    file: concourse/ci/tasks/yarn-build.yml
+  - aggregate:
+    - task: concourse-linux
+      image: unit-image
+      file: concourse/ci/tasks/concourse-build-linux.yml
+      input_mapping: {concourse: built-concourse}
+    - task: concourse-windows
+      file: concourse/ci/tasks/concourse-build-windows.yml
+      input_mapping: {concourse: built-concourse}
+    - task: concourse-darwin
+      file: concourse/ci/tasks/concourse-build-darwin.yml
+      input_mapping: {concourse: built-concourse}
+  - aggregate:
+    - put: linux-rc
+      params: {file: concourse-linux/concourse-*.tgz}
+      inputs: [concourse-linux]
+    - put: windows-rc
+      params: {file: concourse-windows/concourse-*.zip}
+      inputs: [concourse-windows]
+    - put: darwin-rc
+      params: {file: concourse-darwin/concourse-*.tgz}
+      inputs: [concourse-darwin]
+
+- name: build-rc-image
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [build-rc]
+      trigger: true
+    - get: version
+      passed: [build-rc]
+      trigger: true
+    - get: linux-rc
+      trigger: true
+      passed: [build-rc]
+    - get: unit-image
+      passed: [build-rc]
+    - get: builder
+  - task: build
+    image: builder
+    privileged: true
+    file: concourse/ci/tasks/build-rc-image.yml
+  - put: concourse-rc-image
+    params:
+      image: image/image.tar
+      additional_tags: version/version
+    get_params: {format: oci}
+
+- name: bin-smoke
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [build-rc]
+      trigger: true
+    - get: version
+      passed: [build-rc]
+      trigger: true
+    - get: linux-rc
+      passed: [build-rc]
+      trigger: true
+    - get: unit-image
+      passed: [build-rc]
+      trigger: true
+  - task: terraform-smoke
+    file: concourse/ci/tasks/terraform-smoke.yml
+    params:
+      GCP_PROJECT: cf-concourse-production
+      GCP_KEY: ((concourse_smoke_gcp_key))
+      SSH_KEY: ((concourse_smoke_ssh_key))
+      DEPLOYMENT: smoke
+  - task: smoke
+    image: unit-image
+    file: concourse/ci/tasks/smoke.yml
+    input_mapping: {endpoint-info: outputs}
+
+- name: bosh-check-props
+  public: true
+  max_in_flight: 1
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [bin-smoke]
+      trigger: true
+    - get: unit-image
+      passed: [bin-smoke]
+      trigger: true
+    - get: version
+      passed: [bin-smoke]
+      trigger: true
+    - get: linux-rc
+      passed: [bin-smoke]
+      trigger: true
+    - get: concourse-release-repo
+  - task: check-props
+    file: concourse/ci/tasks/check-distribution-env.yml
+    image: unit-image
+    input_mapping: {distribution: concourse-release-repo}
+    params: {DISTRIBUTION: bosh}
+
+- name: bosh-bump
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [bosh-check-props]
+      trigger: true
+    - get: unit-image
+      passed: [bosh-check-props]
+      trigger: true
+    - get: version
+      passed: [bosh-check-props]
+      trigger: true
+    - get: linux-rc
+      passed: [build-rc, bosh-check-props]
+      trigger: true
+    - get: windows-rc
+      passed: [build-rc]
+      trigger: true
+    - get: concourse-release-repo
+  - task: bump-concourse-blobs
+    file: concourse/ci/tasks/bump-concourse-blobs.yml
+    image: unit-image
+    params: {GCP_JSON_KEY: ((concourse_artifacts_json_key))}
+  - put: concourse-release-repo
+    params: {repository: bumped-concourse-release-repo}
+
+- name: bosh-smoke
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    # these don't trigger, to ensure that the job gets triggered by
+    # concourse-release, which is unfortunately decoupled from the resource
+    # that we 'put' to.
+    - get: concourse
+      passed: [bosh-bump]
+    - get: unit-image
+      passed: [bosh-bump]
+    - get: version
+      passed: [bosh-bump]
+    - get: concourse-release
+      trigger: true
+    - get: postgres-release
+      trigger: true
+    - get: bpm-release
+      trigger: true
+    - get: gcp-xenial-stemcell
+      trigger: true
+  - put: smoke-deployment
+    params:
+      manifest: concourse/ci/deployments/bosh-smoke.yml
+      releases:
+      - concourse-release/*.tgz
+      - postgres-release/*.tgz
+      - bpm-release/*.tgz
+      stemcells:
+      - gcp-xenial-stemcell/*.tgz
+      vars:
+        deployment_name: concourse-smoke-patch # TODO can't use release_minor
+  - task: discover-bosh-endpoint-info
+    file: concourse/ci/tasks/discover-bosh-endpoint-info.yml
+    image: unit-image
+    params:
+      BOSH_ENVIRONMENT: ((bosh_target))
+      BOSH_CLIENT: ((bosh_client.id))
+      BOSH_CLIENT_SECRET: ((bosh_client.secret))
+      BOSH_DEPLOYMENT: concourse-smoke-patch # TODO can't use release_minor
+      BOSH_INSTANCE_GROUP: concourse
+  - task: smoke
+    image: unit-image
+    file: concourse/ci/tasks/smoke.yml
+
+- name: bosh-topgun
+  public: true
+  serial: true
+  interruptible: true
+  plan:
+  - aggregate:
+    # these don't trigger, to ensure that the job gets triggered by
+    # concourse-release, which is unfortunately decoupled from the resource
+    # that we 'put' to.
+    - get: concourse
+      passed: [bosh-bump]
+    - get: unit-image
+      passed: [bosh-bump]
+    - get: version
+      passed: [bosh-bump]
+    - get: concourse-release
+      trigger: true
+    - get: postgres-release
+      trigger: true
+    - get: postgres-bbr-compatible-release
+      trigger: true
+    - get: bpm-release
+      trigger: true
+    - get: backup-and-restore-sdk-release
+      trigger: true
+    - get: gcp-xenial-stemcell
+      trigger: true
+    - get: vault-release
+      trigger: true
+    - get: credhub-release
+      trigger: true
+    - get: bbr
+      trigger: true
+  - task: bosh-topgun
+    file: concourse/ci/tasks/topgun.yml
+    image: unit-image
+    input_mapping:
+      stemcell: gcp-xenial-stemcell
+    params:
+      DEPLOYMENT_NAME_PREFIX: concourse-topgun-((release_minor))
+      BOSH_ENVIRONMENT: ((bosh_target))
+      BOSH_CA_CERT: ((tmp_bosh_client.ca_cert))
+      BOSH_CLIENT: ((bosh_client.id))
+      BOSH_CLIENT_SECRET: ((bosh_client.secret))
+      BOSH_SSH_KEY: ((topgun_bosh_key))
+      AWS_REGION: ((topgun_aws_ssm.region))
+      AWS_ACCESS_KEY_ID: ((topgun_aws_ssm.access_key_id))
+      AWS_SECRET_ACCESS_KEY: ((topgun_aws_ssm.secret_access_key))
+
+- name: bosh-wings-deploy
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [bosh-smoke, bosh-topgun]
+    - get: version
+      passed: [bosh-smoke, bosh-topgun]
+    - get: concourse-release
+      passed: [bosh-smoke, bosh-topgun]
+    - get: bpm-release
+      passed: [bosh-smoke, bosh-topgun]
+    - get: gcp-xenial-stemcell
+      passed: [bosh-smoke, bosh-topgun]
+    - get: cbd
+    - get: prod
+  - put: wings-deployment
+    params:
+      manifest: cbd/cluster/concourse.yml
+      stemcells:
+      - gcp-xenial-stemcell/*.tgz
+      releases:
+      - concourse-release/*.tgz
+      - bpm-release/*.tgz
+      ops_files:
+      - cbd/cluster/operations/dev-versions.yml
+      - cbd/cluster/operations/debug-concourse.yml
+      - cbd/cluster/operations/privileged-http.yml
+      - cbd/cluster/operations/privileged-https.yml
+      - cbd/cluster/operations/tls.yml
+      - cbd/cluster/operations/web-network-extension.yml
+      - cbd/cluster/operations/scale.yml
+      - cbd/cluster/operations/syslog_forwarder.yml
+      - cbd/cluster/operations/team-authorized-keys.yml
+      - cbd/cluster/operations/storage-driver.yml
+      - cbd/cluster/operations/external-postgres.yml
+      - cbd/cluster/operations/external-postgres-tls.yml
+      - cbd/cluster/operations/influxdb.yml
+      - cbd/cluster/operations/container-placement-strategy.yml
+      - cbd/cluster/operations/github-auth.yml
+      - cbd/cluster/operations/add-local-users.yml
+      - cbd/cluster/operations/worker-rebalancing.yml
+      - cbd/cluster/operations/encryption.yml
+      - cbd/cluster/operations/garden-dns.yml
+      - cbd/cluster/operations/max-in-flight.yml
+      - cbd/cluster/operations/worker-max-in-flight.yml
+      - cbd/cluster/operations/enable-global-resources.yml
+      - prod/wings/ops.yml
+      vars_files:
+      - prod/wings/vars.yml
+
+- name: shipit
+  public: true
+  serial_groups: [version]
+  plan:
+  - get: concourse
+    passed:
+    - build-rc
+    - k8s-topgun
+    - bosh-smoke
+    - bosh-topgun
+  - get: unit-image
+    passed:
+    - build-rc
+    - k8s-topgun
+    - bosh-smoke
+    - bosh-topgun
+  - get: final-version
+    resource: version
+    params: {bump: final}
+    passed:
+    - build-rc
+    - k8s-topgun
+    - bosh-smoke
+    - bosh-topgun
+  - get: linux-rc
+    passed: [build-rc]
+  - get: windows-rc
+    passed: [build-rc]
+  - get: darwin-rc
+    passed: [build-rc]
+  - get: concourse-rc-image
+    passed: [k8s-topgun]
+  - get: concourse-release
+    passed: [bosh-smoke, bosh-topgun]
+  - get: bpm-release
+    passed: [bosh-smoke, bosh-topgun]
+  - get: postgres-release
+    passed: [bosh-smoke, bosh-topgun]
+  - put: version
+    params: {file: final-version/version}
+
+- name: publish-binaries
+  serial: true
+  plan:
+  - aggregate:
+    - get: version
+      passed: [shipit]
+      trigger: true
+    - get: concourse
+      passed: [shipit]
+    - get: unit-image
+      passed: [shipit]
+    - get: linux-rc
+      passed: [shipit]
+    - get: windows-rc
+      passed: [shipit]
+    - get: darwin-rc
+      passed: [shipit]
+  - task: prep-release-assets
+    file: concourse/ci/tasks/prep-release-assets.yml
+    image: unit-image
+  - task: build-release-notes
+    file: concourse/ci/tasks/build-release-notes.yml
+    image: unit-image
+  - put: concourse-github-release
+    params:
+      commitish: concourse/.git/ref
+      tag: version/version
+      tag_prefix: v
+      name: release-notes/release-name
+      body: release-notes/notes.md
+      globs:
+      - concourse-linux/*.tgz
+      - concourse-windows/*.zip
+      - concourse-darwin/*.tgz
+      - fly-linux/fly-*-linux-*.tgz
+      - fly-windows/fly-*-windows-*.zip
+      - fly-darwin/fly-*-darwin-*.tgz
+
+- name: publish-bosh-release
+  serial: true
+  plan:
+  - aggregate:
+    - get: version
+      passed: [shipit]
+      trigger: true
+    - get: concourse-release
+      passed: [shipit]
+  - put: concourse-release-final
+    params:
+      tarball: concourse-release/*.tgz
+      version: version/version
+
+- name: publish-bosh-deployment
+  serial: true
+  plan:
+  - aggregate:
+    - get: concourse-boshio
+      trigger: true
+    - get: unit-image
+      passed: [shipit]
+    - get: cbd
+    - get: version
+      passed: [shipit]
+    - get: bpm-release
+      passed: [shipit]
+    - get: postgres-release
+      passed: [shipit]
+  # TODO: check that boshio version matches given version
+  - task: bump-versions
+    file: cbd/ci/bump-versions.yml
+    input_mapping: {concourse-bosh-deployment: cbd}
+    image: unit-image
+  - put: cbd
+    params:
+      repository: bumped-repo
+      merge: true
+  - put: cbd-master
+    params:
+      repository: bumped-repo
+      merge: true
+
+- name: publish-image
+  serial: true
+  plan:
+  - aggregate:
+    - get: version
+      passed: [shipit]
+      trigger: true
+    - get: concourse
+      passed: [shipit]
+    - get: concourse-rc-image
+      passed: [shipit]
+      params: {format: oci}
+    - get: latest-version
+  - task: docker-semver-tags
+    file: concourse/ci/tasks/docker-semver-tags.yml
+  - put: concourse-image
+    params:
+      image: concourse-rc-image/image.tar
+      additional_tags: tags/tags
+
+- name: publish-docs
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: version
+      passed: [shipit]
+      trigger: true
+    - get: docs
+  - task: build-docs
+    file: docs/ci/build.yml
+    params: {ANALYTICS_ID: ((analytics_id))}
+  - put: docs-gh-pages
+    params: {repository: built-docs}
+
+- name: patch
+  public: true
+  serial_groups: [version]
+  plan:
+  - get: version
+    passed: [shipit]
+    trigger: true
+  - put: version
+    params: {bump: patch, pre: rc}
+
+resources:
+- name: concourse
+  type: git
+  source:
+    uri: https://github.com/concourse/concourse.git
+    branch: release/((release_minor)).x
+
+- name: dev-image
+  type: registry-image
+  source:
+    repository: concourse/dev
+    username: ((docker.username))
+    password: ((docker.password))
+    tag: release-((release_minor))
+
+- name: concourse-rc-image
+  type: registry-image
+  source:
+    repository: concourse/concourse-rc
+    username: ((docker.username))
+    password: ((docker.password))
+    tag: release-((release_minor))
+
+- name: concourse-image
+  type: registry-image
+  source:
+    repository: concourse/concourse
+    username: ((docker.username))
+    password: ((docker.password))
+
+    # avoid tagging as 'latest' in case this is a patch release for an older
+    # version
+    tag: ((release_minor))
+
+- name: version
+  type: semver
+  source:
+    driver: gcs
+    json_key: ((concourse_artifacts_json_key))
+
+    bucket: concourse-artifacts
+    key: version-((release_minor))
+    initial_version: ((release_minor)).1
+
+- name: latest-version
+  type: github-release
+  source:
+    owner: concourse
+    repository: concourse
+    access_token: ((concourse_github_release.access_token))
+
+- name: linux-rc
+  type: gcs
+  source:
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    regexp: rcs/concourse-(.*)-linux-amd64.tgz
+
+- name: windows-rc
+  type: gcs
+  source:
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    regexp: rcs/concourse-(.*)-windows-amd64.zip
+
+- name: darwin-rc
+  type: gcs
+  source:
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    regexp: rcs/concourse-(.*)-darwin-amd64.tgz
+
+- name: docs
+  type: git
+  source:
+    uri: https://github.com/concourse/docs
+    branch: master
+
+- name: docs-gh-pages
+  type: git
+  source:
+    uri: git@github.com:concourse/docs
+    branch: gh-pages
+    private_key: ((docs_deploy_key))
+
+- name: concourse-release
+  type: bosh-release
+  source:
+    uri: https://github.com/concourse/concourse-bosh-release
+    branch: release/((release_minor)).x
+    dev_releases: true
+    private_config: &release_private_config
+      blobstore:
+        provider: gcs
+        options:
+          credentials_source: static
+          json_key: ((concourse_artifacts_json_key))
+
+- name: concourse-release-final
+  type: bosh-release
+  source:
+    uri: git@github.com:concourse/concourse-bosh-release
+    branch: master
+    private_config: *release_private_config
+    private_key: ((concourse_release_deploy_key))
+
+- name: concourse-release-repo
+  type: git
+  source:
+    uri: git@github.com:concourse/concourse-bosh-release
+    branch: release/((release_minor)).x
+    private_key: ((concourse_release_deploy_key))
+
+- name: smoke-deployment
+  type: bosh-deployment
+  source:
+    target: ((bosh_target))
+    client: ((bosh_client.id))
+    client_secret: ((bosh_client.secret))
+    deployment: concourse-smoke-patch # TODO can't use release_minor
+
+- name: wings-deployment
+  type: bosh-deployment
+  source:
+    target: ((bosh_target))
+    client: ((bosh_client.id))
+    client_secret: ((bosh_client.secret))
+    deployment: concourse-wings
+
+- name: cbd
+  type: git
+  source:
+    uri: git@github.com:concourse/concourse-bosh-deployment.git
+    branch: release/((release_minor)).x
+    private_key: ((concourse_deployment_repo_private_key))
+
+- name: cbd-master
+  type: git
+  source:
+    uri: git@github.com:concourse/concourse-bosh-deployment.git
+    branch: master
+    private_key: ((concourse_deployment_repo_private_key))
+
+- name: charts
+  type: git
+  source:
+    uri: https://github.com/helm/charts.git
+    branch: master
+
+- name: prod
+  type: git
+  source:
+    uri: https://github.com/concourse/prod.git
+    branch: master
+
+- name: concourse-github-release
+  type: github-release
+  source:
+    owner: concourse
+    repository: concourse
+    access_token: ((concourse_github_release.access_token))
+
+- name: concourse-boshio
+  type: bosh-io-release
+  source: {repository: concourse/concourse-bosh-release}
+
+- name: unit-image
+  type: registry-image
+  source: {repository: concourse/unit}
+
+- name: builder
+  type: registry-image
+  source: {repository: concourse/builder}
+
+- name: gcp-xenial-stemcell
+  type: bosh-io-stemcell
+  source: {name: bosh-google-kvm-ubuntu-xenial-go_agent}
+
+- name: postgres-image
+  type: registry-image
+  source: {repository: postgres}
+
+- name: dumb-init
+  type: github-release
+  source:
+    owner: Yelp
+    repository: dumb-init
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: bbr
+  type: github-release
+  source:
+    owner: cloudfoundry-incubator
+    repository: bosh-backup-and-restore
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: gdn
+  type: github-release
+  source:
+    owner: cloudfoundry
+    repository: garden-runc-release
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: postgres-release
+  type: bosh-io-release
+  source: {repository: cloudfoundry/postgres-release}
+
+- name: postgres-bbr-compatible-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry/postgres-release
+    regexp: 31
+
+- name: bpm-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry-incubator/bpm-release
+
+- name: vault-release
+  type: bosh-io-release
+  source:
+    repository: vito/vault-boshrelease
+
+- name: credhub-release
+  type: bosh-io-release
+  source: {repository: pivotal-cf/credhub-release}
+  version: {version: 1.9.5}
+
+- name: backup-and-restore-sdk-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry-incubator/backup-and-restore-sdk-release
+
+- name: mock-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: mock-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: bosh-io-release-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: bosh-io-release-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: bosh-io-stemcell-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: bosh-io-stemcell-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: cf-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: cf-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: docker-image-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: docker-image-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: git-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: git-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: github-release-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: github-release-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: hg-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: hg-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: pool-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: pool-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: registry-image-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: registry-image-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: s3-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: s3-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: semver-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: semver-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: time-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: time-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: tracker-resource
+  type: github-release
+  source:
+    owner: concourse
+    repository: tracker-resource
+    access_token: ((concourse_github_dummy.access_token))

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -78,7 +78,6 @@ groups:
   - publish-binaries
   - publish-image
   - publish-bosh-release
-  - publish-bosh-deployment
   - publish-docs
   - patch
 
@@ -786,35 +785,6 @@ jobs:
       tarball: concourse-release/*.tgz
       version: version/version
 
-- name: publish-bosh-deployment
-  serial: true
-  plan:
-  - aggregate:
-    - get: concourse-boshio
-      trigger: true
-    - get: unit-image
-      passed: [shipit]
-    - get: cbd
-    - get: version
-      passed: [shipit]
-    - get: bpm-release
-      passed: [shipit]
-    - get: postgres-release
-      passed: [shipit]
-  # TODO: check that boshio version matches given version
-  - task: bump-versions
-    file: cbd/ci/bump-versions.yml
-    input_mapping: {concourse-bosh-deployment: cbd}
-    image: unit-image
-  - put: cbd
-    params:
-      repository: bumped-repo
-      merge: true
-  - put: cbd-master
-    params:
-      repository: bumped-repo
-      merge: true
-
 - name: publish-image
   serial: true
   plan:
@@ -996,13 +966,6 @@ resources:
     branch: release/((release_minor)).x
     private_key: ((concourse_deployment_repo_private_key))
 
-- name: cbd-master
-  type: git
-  source:
-    uri: git@github.com:concourse/concourse-bosh-deployment.git
-    branch: master
-    private_key: ((concourse_deployment_repo_private_key))
-
 - name: charts
   type: git
   source:
@@ -1021,10 +984,6 @@ resources:
     owner: concourse
     repository: concourse
     access_token: ((concourse_github_release.access_token))
-
-- name: concourse-boshio
-  type: bosh-io-release
-  source: {repository: concourse/concourse-bosh-release}
 
 - name: unit-image
   type: registry-image

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -1,3 +1,8 @@
+# the following vars must be specified:
+#
+#   ((release_major)) the MAJOR version, e.g. 5
+#   ((release_minor)) the MAJOR.MINOR version, e.g. 5.1
+#
 # the following git branches need to be created:
 #
 #   concourse/concourse                 release/((release_minor)).x
@@ -11,10 +16,10 @@ resource_types:
   type: registry-image
   source: {repository: frodenas/gcs-resource}
 
+# needed for 'tag' file creation; can be removed once shipped
 - name: registry-image
   type: registry-image
-  # 'dev' tag is needed for 'tag' file creation
-  source: {repository: concourse/registry-image-resource, tag: dev}
+  source: {repository: concourse/registry-image-resource}
 
 - name: bosh-release
   type: registry-image
@@ -798,6 +803,7 @@ jobs:
       passed: [shipit]
       params: {format: oci}
     - get: latest-version
+    - get: latest-of-same-major-version
   - task: docker-semver-tags
     file: concourse/ci/tasks/docker-semver-tags.yml
   - put: concourse-image
@@ -880,6 +886,14 @@ resources:
     owner: concourse
     repository: concourse
     access_token: ((concourse_github_release.access_token))
+
+- name: latest-of-same-major-version
+  type: github-release
+  source:
+    owner: concourse
+    repository: concourse
+    access_token: ((concourse_github_release.access_token))
+    tag_filter: '^v(((release_major))\.\d+\.\d+)$'
 
 - name: linux-rc
   type: gcs

--- a/ci/tasks/docker-semver-tags.yml
+++ b/ci/tasks/docker-semver-tags.yml
@@ -9,6 +9,7 @@ inputs:
 - name: concourse
 - name: version
 - name: latest-version
+- name: latest-of-same-major-version
 
 outputs:
 - name: tags

--- a/ci/tasks/docker-semver-tags.yml
+++ b/ci/tasks/docker-semver-tags.yml
@@ -6,25 +6,12 @@ image_resource:
   source: {repository: concourse/unit}
 
 inputs:
+- name: concourse
 - name: version
+- name: latest-version
 
 outputs:
 - name: tags
 
-params:
-  MAJOR:
-
 run:
-  path: bash
-  args:
-  - -exc
-  - |
-    version=$(cat version/version)
-    echo $version | cut -d. -f1,2,3 >> tags/tags
-    echo $version | cut -d. -f1,2   >> tags/tags
-
-    if [ "$MAJOR" = "true" ]; then
-      # when pushing a patch for an old version, you won't want to bump the
-      # major tag, so this should be opt-in
-      echo $version | cut -d. -f1   >> tags/tags
-    fi
+  path: concourse/ci/tasks/scripts/docker-semver-tags

--- a/ci/tasks/k8s-topgun.yml
+++ b/ci/tasks/k8s-topgun.yml
@@ -8,7 +8,6 @@ image_resource:
 params:
   CONCOURSE_CHART_DIR:
   CONCOURSE_IMAGE_NAME:
-  CONCOURSE_IMAGE_TAG:
   KUBE_CONFIG:
 
 inputs:

--- a/ci/tasks/scripts/docker-semver-tags
+++ b/ci/tasks/scripts/docker-semver-tags
@@ -3,19 +3,26 @@
 set -e -u
 
 version=$(cat version/version)
+latest_of_same_major_version=$(cat latest-of-same-major-version/version)
 latest_version=$(cat latest-version/version)
 
 major_version=$(echo $version | cut -d. -f1)
 minor_version=$(echo $version | cut -d. -f1,2)
 
 latest_minor_version=$(echo $latest_version | cut -d. -f1,2)
+latest_minor_of_same_major_version=$(echo $latest_of_same_major_version | cut -d. -f1,2)
 
 echo $version       >> tags/tags
 echo $minor_version >> tags/tags
 
-# if the version we're publishing is for the latest minor version, bump the
-# major and latest tags, too
-if [ "$minor_version" = "$latest_minor_version" ]; then
+# if the version we're publishing is for the latest minor version *of our major
+# version*, bump the major tag
+if [ "$minor_version" = "$latest_minor_of_same_major_version" ]; then
   echo $major_version >> tags/tags
-  echo latest         >> tags/tags
+fi
+
+# if the version we're publishing is for the latest minor version, *overall*,
+# bump the latest tag
+if [ "$minor_version" = "$latest_minor_version" ]; then
+  echo latest >> tags/tags
 fi

--- a/ci/tasks/scripts/docker-semver-tags
+++ b/ci/tasks/scripts/docker-semver-tags
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e -u
+
+version=$(cat version/version)
+latest_version=$(cat latest-version/version)
+
+major_version=$(echo $version | cut -d. -f1)
+minor_version=$(echo $version | cut -d. -f1,2)
+
+latest_minor_version=$(echo $latest_version | cut -d. -f1,2)
+
+echo $version       >> tags/tags
+echo $minor_version >> tags/tags
+
+# if the version we're publishing is for the latest minor version, bump the
+# major and latest tags, too
+if [ "$minor_version" = "$latest_minor_version" ]; then
+  echo $major_version >> tags/tags
+  echo latest         >> tags/tags
+fi

--- a/ci/tasks/scripts/downgrade-test
+++ b/ci/tasks/scripts/downgrade-test
@@ -14,6 +14,9 @@ start_docker
 [ -d concourse-image ] && docker load -i concourse-image/image.tar
 [ -d postgres-image ] && docker load -i postgres-image/image.tar
 
+export CONCOURSE_DEV_TAG=$(cat dev-image/tag)
+export CONCOURSE_LATEST_TAG=$(cat concourse-image/tag)
+
 cd concourse
 
 # generate keys for the cluster

--- a/ci/tasks/scripts/generate-keys
+++ b/ci/tasks/scripts/generate-keys
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-docker run -v $PWD/keys:/keys concourse/dev generate-key -t rsa -b 1024 -f /keys/session_signing_key
-docker run -v $PWD/keys:/keys concourse/dev generate-key -t ssh -b 1024 -f /keys/tsa_host_key
-docker run -v $PWD/keys:/keys concourse/dev generate-key -t ssh -b 1024 -f /keys/worker_key
+set -e -u
+
+docker run -v $PWD/keys:/keys concourse/dev:${CONCOURSE_DEV_TAG} generate-key -t rsa -b 1024 -f /keys/session_signing_key
+docker run -v $PWD/keys:/keys concourse/dev:${CONCOURSE_DEV_TAG} generate-key -t ssh -b 1024 -f /keys/tsa_host_key
+docker run -v $PWD/keys:/keys concourse/dev:${CONCOURSE_DEV_TAG} generate-key -t ssh -b 1024 -f /keys/worker_key
+
 cp keys/worker_key.pub keys/authorized_worker_keys

--- a/ci/tasks/scripts/k8s-topgun
+++ b/ci/tasks/scripts/k8s-topgun
@@ -15,6 +15,7 @@ if [ ! -f ~/.kube/config ]; then
 fi
 
 export CONCOURSE_IMAGE_DIGEST="$(cat concourse-rc-image/digest)"
+export CONCOURSE_IMAGE_TAG="$(cat concourse-rc-image/tag)"
 export CHARTS_DIR="$(realpath ./charts)"
 
 cd concourse

--- a/ci/tasks/scripts/upgrade-test
+++ b/ci/tasks/scripts/upgrade-test
@@ -14,6 +14,9 @@ start_docker
 [ -d concourse-image ] && docker load -i concourse-image/image.tar
 [ -d postgres-image ] && docker load -i postgres-image/image.tar
 
+export CONCOURSE_DEV_TAG=$(cat dev-image/tag)
+export CONCOURSE_LATEST_TAG=$(cat concourse-image/tag)
+
 cd concourse
 
 # generate keys for the cluster

--- a/ci/tasks/scripts/with-docker-compose
+++ b/ci/tasks/scripts/with-docker-compose
@@ -9,6 +9,8 @@ start_docker
 [ -d dev-image ] && docker load -i dev-image/image.tar
 [ -d postgres-image ] && docker load -i postgres-image/image.tar
 
+export CONCOURSE_DEV_TAG=$(cat dev-image/tag)
+
 pushd concourse
   if [ "$BUILD" = "true" ]; then
     docker-compose \


### PR DESCRIPTION
These are all the changes that were necessary for 5.0.1. There's also a release template pipeline, which should be re-usable for future minor releases.

Each commit has a little more context in its description. :+1: 