### PR TITLE
Update ci pipeline k8s - Run smoke and topgun in parallel with the k8s-check-helm-params task

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -306,33 +306,6 @@ jobs:
     image: unit-image
     file: concourse/ci/tasks/downgrade-test.yml
 
-- name: k8s-check-helm-params
-  public: true
-  max_in_flight: 1
-  plan:
-  - aggregate:
-    - get: concourse
-      passed: [build-rc-image]
-      trigger: true
-    - get: concourse-rc-image
-      passed: [build-rc-image]
-      trigger: true
-    - get: version
-      passed: [build-rc-image]
-      trigger: true
-    - get: unit-image
-      passed: [build-rc-image]
-      trigger: true
-    - get: linux-rc
-      passed: [build-rc-image]
-      trigger: true
-    - get: charts
-      trigger: true
-  - task: check-params
-    file: concourse/ci/tasks/check-distribution-env.yml
-    image: unit-image
-    input_mapping: {distribution: charts}
-    params: {DISTRIBUTION: helm}
 
 - name: k8s-smoke
   public: true
@@ -340,20 +313,19 @@ jobs:
   plan:
   - aggregate:
     - get: concourse
-      passed: [k8s-check-helm-params]
+      passed: [build-rc-image]
       trigger: true
     - get: concourse-rc-image
-      passed: [k8s-check-helm-params]
+      passed: [build-rc-image]
       params: {format: oci}
       trigger: true
     - get: version
-      passed: [k8s-check-helm-params]
+      passed: [build-rc-image]
       trigger: true
     - get: charts
-      passed: [k8s-check-helm-params]
       trigger: true
     - get: unit-image
-      passed: [k8s-check-helm-params]
+      passed: [build-rc-image]
   - try:
       task: try-delete
       image: unit-image
@@ -413,6 +385,33 @@ jobs:
       KUBE_CONFIG: ((kube_config))
       CONCOURSE_IMAGE_NAME: concourse/concourse-rc
 
+- name: k8s-check-helm-params
+  public: true
+  max_in_flight: 1
+  plan:
+  - aggregate:
+    - get: concourse
+      passed: [build-rc-image]
+      trigger: true
+    - get: concourse-rc-image
+      passed: [build-rc-image]
+      trigger: true
+    - get: version
+      passed: [build-rc-image]
+      trigger: true
+    - get: unit-image
+      passed: [build-rc-image]
+      trigger: true
+    - get: linux-rc
+      passed: [build-rc-image]
+      trigger: true
+    - get: charts
+      trigger: true
+  - task: check-params
+    file: concourse/ci/tasks/check-distribution-env.yml
+    image: unit-image
+    input_mapping: {distribution: charts}
+    params: {DISTRIBUTION: helm}
 - name: rc
   public: true
   serial_groups: [version]
@@ -846,12 +845,14 @@ jobs:
     passed:
     - build-rc
     - k8s-topgun
+    - k8s-check-helm-params
     - bosh-smoke
     - bosh-topgun
   - get: unit-image
     passed:
     - build-rc
     - k8s-topgun
+    - k8s-check-helm-params
     - bosh-smoke
     - bosh-topgun
   - get: final-version
@@ -860,6 +861,7 @@ jobs:
     passed:
     - build-rc
     - k8s-topgun
+    - k8s-check-helm-params
     - bosh-smoke
     - bosh-topgun
   - get: linux-rc
@@ -869,7 +871,7 @@ jobs:
   - get: darwin-rc
     passed: [build-rc]
   - get: concourse-rc-image
-    passed: [k8s-topgun]
+    passed: [k8s-topgun, k8s-check-helm-params]
   - get: concourse-release
     passed: [bosh-smoke, bosh-topgun]
   - get: bpm-release

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -298,20 +298,19 @@ jobs:
   plan:
   - aggregate:
     - get: concourse
-      passed: [k8s-check-helm-params]
+      passed: [build-rc-image]
       trigger: true
     - get: concourse-rc-image
-      passed: [k8s-check-helm-params]
+      passed: [build-rc-image]
       params: {format: oci}
       trigger: true
     - get: version
-      passed: [k8s-check-helm-params]
+      passed: [build-rc-image]
       trigger: true
     - get: charts
-      passed: [k8s-check-helm-params]
       trigger: true
     - get: unit-image
-      passed: [k8s-check-helm-params]
+      passed: [build-rc-image]
   - try:
       task: try-delete
       image: unit-image
@@ -706,12 +705,14 @@ jobs:
     passed:
     - build-rc
     - k8s-topgun
+    - k8s-check-helm-params
     - bosh-smoke
     - bosh-topgun
   - get: unit-image
     passed:
     - build-rc
     - k8s-topgun
+    - k8s-check-helm-params
     - bosh-smoke
     - bosh-topgun
   - get: final-version
@@ -720,6 +721,7 @@ jobs:
     passed:
     - build-rc
     - k8s-topgun
+    - k8s-check-helm-params
     - bosh-smoke
     - bosh-topgun
   - get: linux-rc
@@ -729,7 +731,7 @@ jobs:
   - get: darwin-rc
     passed: [build-rc]
   - get: concourse-rc-image
-    passed: [k8s-topgun]
+    passed: [k8s-topgun, k8s-check-helm-params]
   - get: concourse-release
     passed: [bosh-smoke, bosh-topgun]
   - get: bpm-release


### PR DESCRIPTION
Currently, the K8s section of the pipeline is blocked on `check-params` failing.
While, this is a useful signal that needs to be addressed prior to shipping, it shouldn't block running smoke & topgun tests, as those could be worked on independently of params changes.

Hence, the PR switches the ordering of the jobs from;

`k8s-check-helm-params` => `k8s-smoke` => `k8s-topgun`

to 

`k8s-smoke` => `k8s-topgun` => `k8s-check-helm-params` 
