### PR TITLE
use elm/url to determine url when display URL metadata

### DIFF
--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -45,6 +45,7 @@ import Message.Message exposing (Hoverable(..), Message(..))
 import Routes exposing (Highlight(..), StepID, showHighlight)
 import StrictEvents
 import Time
+import Url exposing (fromString)
 import Views.DictView as DictView
 import Views.Icon as Icon
 import Views.Spinner as Spinner
@@ -596,16 +597,17 @@ viewMetadata =
         (\{ name, value } ->
             ( name
             , Html.pre []
-                [ if String.startsWith "http://" value || String.startsWith "https://" value then
-                    Html.a
-                        [ href value
-                        , target "_blank"
-                        , style "text-decoration-line" "underline"
-                        ]
-                        [ Html.text value ]
+                [ case fromString value of
+                    Just _ ->
+                        Html.a
+                            [ href value
+                            , target "_blank"
+                            , style "text-decoration-line" "underline"
+                            ]
+                            [ Html.text value ]
 
-                  else
-                    Html.text value
+                    Nothing ->
+                        Html.text value
                 ]
             )
         )

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -2330,6 +2330,9 @@ all =
                     plainText =
                         "plain-text"
 
+                    invalidURLText =
+                        "https:// is secure!"
+
                     metadataView =
                         Application.init
                             { turbulenceImgSrc = ""
@@ -2445,6 +2448,18 @@ all =
                                 , style "text-decoration-line" "underline"
                                 , attribute <| Attr.target "_blank"
                                 , attribute <| Attr.href plainText
+                                ]
+                , test "should not show hyperlink if metadata is malformed URL" <|
+                    \_ ->
+                        metadataView
+                            |> Query.find
+                                [ containing [ text invalidURLText ]
+                                ]
+                            |> Query.hasNot
+                                [ tag "a"
+                                , style "text-decoration-line" "underline"
+                                , attribute <| Attr.target "_blank"
+                                , attribute <| Attr.href invalidURLText
                                 ]
                 ]
             ]


### PR DESCRIPTION
Signed-off-by: Twiknight <Twiknight@outlook.com>

This is a follow up of my previous patch on URLs:  https://github.com/concourse/concourse/pull/3398

Since we are now elm:0.19, naive `startsWith` should be replaced a real url parser.

After the change, URL-like non-URLs will not be displayed as hyperlink.