### PR TITLE
Rename last_checked and last_check_finished

### DIFF
--- a/atc/api/present/resource.go
+++ b/atc/api/present/resource.go
@@ -32,8 +32,8 @@ func Resource(resource db.Resource, showCheckError bool, teamName string) atc.Re
 		PinComment:      resource.PinComment(),
 	}
 
-	if !resource.LastChecked().IsZero() {
-		atcResource.LastChecked = resource.LastChecked().Unix()
+	if !resource.LastCheckStartTime().IsZero() {
+		atcResource.LastChecked = resource.LastCheckStartTime().Unix()
 	}
 
 	if resource.ConfigPinnedVersion() != nil {

--- a/atc/api/present/resource.go
+++ b/atc/api/present/resource.go
@@ -32,8 +32,8 @@ func Resource(resource db.Resource, showCheckError bool, teamName string) atc.Re
 		PinComment:      resource.PinComment(),
 	}
 
-	if !resource.LastCheckStartTime().IsZero() {
-		atcResource.LastChecked = resource.LastCheckStartTime().Unix()
+	if !resource.LastCheckEndTime().IsZero() {
+		atcResource.LastChecked = resource.LastCheckEndTime().Unix()
 	}
 
 	if resource.ConfigPinnedVersion() != nil {

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Resources API", func() {
 				resource1.TeamNameReturns("some-team")
 				resource1.NameReturns("resource-1")
 				resource1.TypeReturns("type-1")
-				resource1.LastCheckedReturns(time.Unix(1513364881, 0))
+				resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
 
 				resource2 := new(dbfakes.FakeResource)
 				resource2.IDReturns(2)
@@ -187,7 +187,7 @@ var _ = Describe("Resources API", func() {
 				resource1.PipelineNameReturns("a-pipeline")
 				resource1.NameReturns("resource-1")
 				resource1.TypeReturns("type-1")
-				resource1.LastCheckedReturns(time.Unix(1513364881, 0))
+				resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
 
 				resource2 := new(dbfakes.FakeResource)
 				resource2.IDReturns(2)
@@ -926,7 +926,7 @@ var _ = Describe("Resources API", func() {
 					resource1.PipelineNameReturns("a-pipeline")
 					resource1.NameReturns("resource-1")
 					resource1.TypeReturns("type-1")
-					resource1.LastCheckedReturns(time.Unix(1513364881, 0))
+					resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
 
 					fakePipeline.ResourceReturns(resource1, true, nil)
 				})
@@ -996,7 +996,7 @@ var _ = Describe("Resources API", func() {
 						resource1.PipelineNameReturns("a-pipeline")
 						resource1.NameReturns("resource-1")
 						resource1.TypeReturns("type-1")
-						resource1.LastCheckedReturns(time.Unix(1513364881, 0))
+						resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
 						resource1.ConfigPinnedVersionReturns(atc.Version{"version": "v1"})
 
 						fakePipeline.ResourceReturns(resource1, true, nil)
@@ -1035,7 +1035,7 @@ var _ = Describe("Resources API", func() {
 						resource1.PipelineNameReturns("a-pipeline")
 						resource1.NameReturns("resource-1")
 						resource1.TypeReturns("type-1")
-						resource1.LastCheckedReturns(time.Unix(1513364881, 0))
+						resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
 						resource1.APIPinnedVersionReturns(atc.Version{"version": "v1"})
 
 						fakePipeline.ResourceReturns(resource1, true, nil)
@@ -1071,7 +1071,7 @@ var _ = Describe("Resources API", func() {
 						resource1.PipelineNameReturns("a-pipeline")
 						resource1.NameReturns("resource-1")
 						resource1.TypeReturns("type-1")
-						resource1.LastCheckedReturns(time.Unix(1513364881, 0))
+						resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
 						resource1.APIPinnedVersionReturns(atc.Version{"version": "v1"})
 						resource1.PinCommentReturns("a pin comment")
 						fakePipeline.ResourceReturns(resource1, true, nil)
@@ -1122,7 +1122,7 @@ var _ = Describe("Resources API", func() {
 					resource1.PipelineNameReturns("a-pipeline")
 					resource1.NameReturns("resource-1")
 					resource1.TypeReturns("type-1")
-					resource1.LastCheckedReturns(time.Unix(1513364881, 0))
+					resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
 
 					fakePipeline.ResourceReturns(resource1, true, nil)
 				})

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Resources API", func() {
 				resource1.TeamNameReturns("some-team")
 				resource1.NameReturns("resource-1")
 				resource1.TypeReturns("type-1")
-				resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
+				resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
 
 				resource2 := new(dbfakes.FakeResource)
 				resource2.IDReturns(2)
@@ -187,7 +187,7 @@ var _ = Describe("Resources API", func() {
 				resource1.PipelineNameReturns("a-pipeline")
 				resource1.NameReturns("resource-1")
 				resource1.TypeReturns("type-1")
-				resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
+				resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
 
 				resource2 := new(dbfakes.FakeResource)
 				resource2.IDReturns(2)
@@ -926,7 +926,7 @@ var _ = Describe("Resources API", func() {
 					resource1.PipelineNameReturns("a-pipeline")
 					resource1.NameReturns("resource-1")
 					resource1.TypeReturns("type-1")
-					resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
+					resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
 
 					fakePipeline.ResourceReturns(resource1, true, nil)
 				})
@@ -996,7 +996,7 @@ var _ = Describe("Resources API", func() {
 						resource1.PipelineNameReturns("a-pipeline")
 						resource1.NameReturns("resource-1")
 						resource1.TypeReturns("type-1")
-						resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
+						resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
 						resource1.ConfigPinnedVersionReturns(atc.Version{"version": "v1"})
 
 						fakePipeline.ResourceReturns(resource1, true, nil)
@@ -1035,7 +1035,7 @@ var _ = Describe("Resources API", func() {
 						resource1.PipelineNameReturns("a-pipeline")
 						resource1.NameReturns("resource-1")
 						resource1.TypeReturns("type-1")
-						resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
+						resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
 						resource1.APIPinnedVersionReturns(atc.Version{"version": "v1"})
 
 						fakePipeline.ResourceReturns(resource1, true, nil)
@@ -1071,7 +1071,7 @@ var _ = Describe("Resources API", func() {
 						resource1.PipelineNameReturns("a-pipeline")
 						resource1.NameReturns("resource-1")
 						resource1.TypeReturns("type-1")
-						resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
+						resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
 						resource1.APIPinnedVersionReturns(atc.Version{"version": "v1"})
 						resource1.PinCommentReturns("a pin comment")
 						fakePipeline.ResourceReturns(resource1, true, nil)
@@ -1122,7 +1122,7 @@ var _ = Describe("Resources API", func() {
 					resource1.PipelineNameReturns("a-pipeline")
 					resource1.NameReturns("resource-1")
 					resource1.TypeReturns("type-1")
-					resource1.LastCheckStartTimeReturns(time.Unix(1513364881, 0))
+					resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
 
 					fakePipeline.ResourceReturns(resource1, true, nil)
 				})

--- a/atc/db/dbfakes/fake_build.go
+++ b/atc/db/dbfakes/fake_build.go
@@ -2,15 +2,15 @@
 package dbfakes
 
 import (
-	"encoding/json"
-	"sync"
-	"time"
+	json "encoding/json"
+	sync "sync"
+	time "time"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/creds"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/db/lock"
+	lager "code.cloudfoundry.org/lager"
+	atc "github.com/concourse/concourse/atc"
+	creds "github.com/concourse/concourse/atc/creds"
+	db "github.com/concourse/concourse/atc/db"
+	lock "github.com/concourse/concourse/atc/db/lock"
 )
 
 type FakeBuild struct {

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -2,13 +2,13 @@
 package dbfakes
 
 import (
-	"sync"
-	"time"
+	sync "sync"
+	time "time"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/creds"
-	"github.com/concourse/concourse/atc/db"
+	lager "code.cloudfoundry.org/lager"
+	atc "github.com/concourse/concourse/atc"
+	creds "github.com/concourse/concourse/atc/creds"
+	db "github.com/concourse/concourse/atc/db"
 )
 
 type FakeResource struct {
@@ -114,24 +114,24 @@ type FakeResource struct {
 	iDReturnsOnCall map[int]struct {
 		result1 int
 	}
-	LastCheckFinishedStub        func() time.Time
-	lastCheckFinishedMutex       sync.RWMutex
-	lastCheckFinishedArgsForCall []struct {
+	LastCheckEndTimeStub        func() time.Time
+	lastCheckEndTimeMutex       sync.RWMutex
+	lastCheckEndTimeArgsForCall []struct {
 	}
-	lastCheckFinishedReturns struct {
+	lastCheckEndTimeReturns struct {
 		result1 time.Time
 	}
-	lastCheckFinishedReturnsOnCall map[int]struct {
+	lastCheckEndTimeReturnsOnCall map[int]struct {
 		result1 time.Time
 	}
-	LastCheckedStub        func() time.Time
-	lastCheckedMutex       sync.RWMutex
-	lastCheckedArgsForCall []struct {
+	LastCheckStartTimeStub        func() time.Time
+	lastCheckStartTimeMutex       sync.RWMutex
+	lastCheckStartTimeArgsForCall []struct {
 	}
-	lastCheckedReturns struct {
+	lastCheckStartTimeReturns struct {
 		result1 time.Time
 	}
-	lastCheckedReturnsOnCall map[int]struct {
+	lastCheckStartTimeReturnsOnCall map[int]struct {
 		result1 time.Time
 	}
 	NameStub        func() string
@@ -912,106 +912,106 @@ func (fake *FakeResource) IDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResource) LastCheckFinished() time.Time {
-	fake.lastCheckFinishedMutex.Lock()
-	ret, specificReturn := fake.lastCheckFinishedReturnsOnCall[len(fake.lastCheckFinishedArgsForCall)]
-	fake.lastCheckFinishedArgsForCall = append(fake.lastCheckFinishedArgsForCall, struct {
+func (fake *FakeResource) LastCheckEndTime() time.Time {
+	fake.lastCheckEndTimeMutex.Lock()
+	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
+	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
 	}{})
-	fake.recordInvocation("LastCheckFinished", []interface{}{})
-	fake.lastCheckFinishedMutex.Unlock()
-	if fake.LastCheckFinishedStub != nil {
-		return fake.LastCheckFinishedStub()
+	fake.recordInvocation("LastCheckEndTime", []interface{}{})
+	fake.lastCheckEndTimeMutex.Unlock()
+	if fake.LastCheckEndTimeStub != nil {
+		return fake.LastCheckEndTimeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastCheckFinishedReturns
+	fakeReturns := fake.lastCheckEndTimeReturns
 	return fakeReturns.result1
 }
 
-func (fake *FakeResource) LastCheckFinishedCallCount() int {
-	fake.lastCheckFinishedMutex.RLock()
-	defer fake.lastCheckFinishedMutex.RUnlock()
-	return len(fake.lastCheckFinishedArgsForCall)
+func (fake *FakeResource) LastCheckEndTimeCallCount() int {
+	fake.lastCheckEndTimeMutex.RLock()
+	defer fake.lastCheckEndTimeMutex.RUnlock()
+	return len(fake.lastCheckEndTimeArgsForCall)
 }
 
-func (fake *FakeResource) LastCheckFinishedCalls(stub func() time.Time) {
-	fake.lastCheckFinishedMutex.Lock()
-	defer fake.lastCheckFinishedMutex.Unlock()
-	fake.LastCheckFinishedStub = stub
+func (fake *FakeResource) LastCheckEndTimeCalls(stub func() time.Time) {
+	fake.lastCheckEndTimeMutex.Lock()
+	defer fake.lastCheckEndTimeMutex.Unlock()
+	fake.LastCheckEndTimeStub = stub
 }
 
-func (fake *FakeResource) LastCheckFinishedReturns(result1 time.Time) {
-	fake.lastCheckFinishedMutex.Lock()
-	defer fake.lastCheckFinishedMutex.Unlock()
-	fake.LastCheckFinishedStub = nil
-	fake.lastCheckFinishedReturns = struct {
+func (fake *FakeResource) LastCheckEndTimeReturns(result1 time.Time) {
+	fake.lastCheckEndTimeMutex.Lock()
+	defer fake.lastCheckEndTimeMutex.Unlock()
+	fake.LastCheckEndTimeStub = nil
+	fake.lastCheckEndTimeReturns = struct {
 		result1 time.Time
 	}{result1}
 }
 
-func (fake *FakeResource) LastCheckFinishedReturnsOnCall(i int, result1 time.Time) {
-	fake.lastCheckFinishedMutex.Lock()
-	defer fake.lastCheckFinishedMutex.Unlock()
-	fake.LastCheckFinishedStub = nil
-	if fake.lastCheckFinishedReturnsOnCall == nil {
-		fake.lastCheckFinishedReturnsOnCall = make(map[int]struct {
+func (fake *FakeResource) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time) {
+	fake.lastCheckEndTimeMutex.Lock()
+	defer fake.lastCheckEndTimeMutex.Unlock()
+	fake.LastCheckEndTimeStub = nil
+	if fake.lastCheckEndTimeReturnsOnCall == nil {
+		fake.lastCheckEndTimeReturnsOnCall = make(map[int]struct {
 			result1 time.Time
 		})
 	}
-	fake.lastCheckFinishedReturnsOnCall[i] = struct {
+	fake.lastCheckEndTimeReturnsOnCall[i] = struct {
 		result1 time.Time
 	}{result1}
 }
 
-func (fake *FakeResource) LastChecked() time.Time {
-	fake.lastCheckedMutex.Lock()
-	ret, specificReturn := fake.lastCheckedReturnsOnCall[len(fake.lastCheckedArgsForCall)]
-	fake.lastCheckedArgsForCall = append(fake.lastCheckedArgsForCall, struct {
+func (fake *FakeResource) LastCheckStartTime() time.Time {
+	fake.lastCheckStartTimeMutex.Lock()
+	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
+	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
 	}{})
-	fake.recordInvocation("LastChecked", []interface{}{})
-	fake.lastCheckedMutex.Unlock()
-	if fake.LastCheckedStub != nil {
-		return fake.LastCheckedStub()
+	fake.recordInvocation("LastCheckStartTime", []interface{}{})
+	fake.lastCheckStartTimeMutex.Unlock()
+	if fake.LastCheckStartTimeStub != nil {
+		return fake.LastCheckStartTimeStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastCheckedReturns
+	fakeReturns := fake.lastCheckStartTimeReturns
 	return fakeReturns.result1
 }
 
-func (fake *FakeResource) LastCheckedCallCount() int {
-	fake.lastCheckedMutex.RLock()
-	defer fake.lastCheckedMutex.RUnlock()
-	return len(fake.lastCheckedArgsForCall)
+func (fake *FakeResource) LastCheckStartTimeCallCount() int {
+	fake.lastCheckStartTimeMutex.RLock()
+	defer fake.lastCheckStartTimeMutex.RUnlock()
+	return len(fake.lastCheckStartTimeArgsForCall)
 }
 
-func (fake *FakeResource) LastCheckedCalls(stub func() time.Time) {
-	fake.lastCheckedMutex.Lock()
-	defer fake.lastCheckedMutex.Unlock()
-	fake.LastCheckedStub = stub
+func (fake *FakeResource) LastCheckStartTimeCalls(stub func() time.Time) {
+	fake.lastCheckStartTimeMutex.Lock()
+	defer fake.lastCheckStartTimeMutex.Unlock()
+	fake.LastCheckStartTimeStub = stub
 }
 
-func (fake *FakeResource) LastCheckedReturns(result1 time.Time) {
-	fake.lastCheckedMutex.Lock()
-	defer fake.lastCheckedMutex.Unlock()
-	fake.LastCheckedStub = nil
-	fake.lastCheckedReturns = struct {
+func (fake *FakeResource) LastCheckStartTimeReturns(result1 time.Time) {
+	fake.lastCheckStartTimeMutex.Lock()
+	defer fake.lastCheckStartTimeMutex.Unlock()
+	fake.LastCheckStartTimeStub = nil
+	fake.lastCheckStartTimeReturns = struct {
 		result1 time.Time
 	}{result1}
 }
 
-func (fake *FakeResource) LastCheckedReturnsOnCall(i int, result1 time.Time) {
-	fake.lastCheckedMutex.Lock()
-	defer fake.lastCheckedMutex.Unlock()
-	fake.LastCheckedStub = nil
-	if fake.lastCheckedReturnsOnCall == nil {
-		fake.lastCheckedReturnsOnCall = make(map[int]struct {
+func (fake *FakeResource) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time) {
+	fake.lastCheckStartTimeMutex.Lock()
+	defer fake.lastCheckStartTimeMutex.Unlock()
+	fake.LastCheckStartTimeStub = nil
+	if fake.lastCheckStartTimeReturnsOnCall == nil {
+		fake.lastCheckStartTimeReturnsOnCall = make(map[int]struct {
 			result1 time.Time
 		})
 	}
-	fake.lastCheckedReturnsOnCall[i] = struct {
+	fake.lastCheckStartTimeReturnsOnCall[i] = struct {
 		result1 time.Time
 	}{result1}
 }
@@ -2216,10 +2216,10 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.enableVersionMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
-	fake.lastCheckFinishedMutex.RLock()
-	defer fake.lastCheckFinishedMutex.RUnlock()
-	fake.lastCheckedMutex.RLock()
-	defer fake.lastCheckedMutex.RUnlock()
+	fake.lastCheckEndTimeMutex.RLock()
+	defer fake.lastCheckEndTimeMutex.RUnlock()
+	fake.lastCheckStartTimeMutex.RLock()
+	defer fake.lastCheckStartTimeMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
 	fake.pinCommentMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_config_scope.go
+++ b/atc/db/dbfakes/fake_resource_config_scope.go
@@ -2,13 +2,13 @@
 package dbfakes
 
 import (
-	"sync"
-	"time"
+	sync "sync"
+	time "time"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/db/lock"
+	lager "code.cloudfoundry.org/lager"
+	atc "github.com/concourse/concourse/atc"
+	db "github.com/concourse/concourse/atc/db"
+	lock "github.com/concourse/concourse/atc/db/lock"
 )
 
 type FakeResourceConfigScope struct {
@@ -119,29 +119,29 @@ type FakeResourceConfigScope struct {
 	setCheckErrorReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UpdateLastCheckFinishedStub        func() (bool, error)
-	updateLastCheckFinishedMutex       sync.RWMutex
-	updateLastCheckFinishedArgsForCall []struct {
+	UpdateLastCheckEndTimeStub        func() (bool, error)
+	updateLastCheckEndTimeMutex       sync.RWMutex
+	updateLastCheckEndTimeArgsForCall []struct {
 	}
-	updateLastCheckFinishedReturns struct {
+	updateLastCheckEndTimeReturns struct {
 		result1 bool
 		result2 error
 	}
-	updateLastCheckFinishedReturnsOnCall map[int]struct {
+	updateLastCheckEndTimeReturnsOnCall map[int]struct {
 		result1 bool
 		result2 error
 	}
-	UpdateLastCheckedStub        func(time.Duration, bool) (bool, error)
-	updateLastCheckedMutex       sync.RWMutex
-	updateLastCheckedArgsForCall []struct {
+	UpdateLastCheckStartTimeStub        func(time.Duration, bool) (bool, error)
+	updateLastCheckStartTimeMutex       sync.RWMutex
+	updateLastCheckStartTimeArgsForCall []struct {
 		arg1 time.Duration
 		arg2 bool
 	}
-	updateLastCheckedReturns struct {
+	updateLastCheckStartTimeReturns struct {
 		result1 bool
 		result2 error
 	}
-	updateLastCheckedReturnsOnCall map[int]struct {
+	updateLastCheckStartTimeReturnsOnCall map[int]struct {
 		result1 bool
 		result2 error
 	}
@@ -673,120 +673,120 @@ func (fake *FakeResourceConfigScope) SetCheckErrorReturnsOnCall(i int, result1 e
 	}{result1}
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckFinished() (bool, error) {
-	fake.updateLastCheckFinishedMutex.Lock()
-	ret, specificReturn := fake.updateLastCheckFinishedReturnsOnCall[len(fake.updateLastCheckFinishedArgsForCall)]
-	fake.updateLastCheckFinishedArgsForCall = append(fake.updateLastCheckFinishedArgsForCall, struct {
+func (fake *FakeResourceConfigScope) UpdateLastCheckEndTime() (bool, error) {
+	fake.updateLastCheckEndTimeMutex.Lock()
+	ret, specificReturn := fake.updateLastCheckEndTimeReturnsOnCall[len(fake.updateLastCheckEndTimeArgsForCall)]
+	fake.updateLastCheckEndTimeArgsForCall = append(fake.updateLastCheckEndTimeArgsForCall, struct {
 	}{})
-	fake.recordInvocation("UpdateLastCheckFinished", []interface{}{})
-	fake.updateLastCheckFinishedMutex.Unlock()
-	if fake.UpdateLastCheckFinishedStub != nil {
-		return fake.UpdateLastCheckFinishedStub()
+	fake.recordInvocation("UpdateLastCheckEndTime", []interface{}{})
+	fake.updateLastCheckEndTimeMutex.Unlock()
+	if fake.UpdateLastCheckEndTimeStub != nil {
+		return fake.UpdateLastCheckEndTimeStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateLastCheckFinishedReturns
+	fakeReturns := fake.updateLastCheckEndTimeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckFinishedCallCount() int {
-	fake.updateLastCheckFinishedMutex.RLock()
-	defer fake.updateLastCheckFinishedMutex.RUnlock()
-	return len(fake.updateLastCheckFinishedArgsForCall)
+func (fake *FakeResourceConfigScope) UpdateLastCheckEndTimeCallCount() int {
+	fake.updateLastCheckEndTimeMutex.RLock()
+	defer fake.updateLastCheckEndTimeMutex.RUnlock()
+	return len(fake.updateLastCheckEndTimeArgsForCall)
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckFinishedCalls(stub func() (bool, error)) {
-	fake.updateLastCheckFinishedMutex.Lock()
-	defer fake.updateLastCheckFinishedMutex.Unlock()
-	fake.UpdateLastCheckFinishedStub = stub
+func (fake *FakeResourceConfigScope) UpdateLastCheckEndTimeCalls(stub func() (bool, error)) {
+	fake.updateLastCheckEndTimeMutex.Lock()
+	defer fake.updateLastCheckEndTimeMutex.Unlock()
+	fake.UpdateLastCheckEndTimeStub = stub
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckFinishedReturns(result1 bool, result2 error) {
-	fake.updateLastCheckFinishedMutex.Lock()
-	defer fake.updateLastCheckFinishedMutex.Unlock()
-	fake.UpdateLastCheckFinishedStub = nil
-	fake.updateLastCheckFinishedReturns = struct {
+func (fake *FakeResourceConfigScope) UpdateLastCheckEndTimeReturns(result1 bool, result2 error) {
+	fake.updateLastCheckEndTimeMutex.Lock()
+	defer fake.updateLastCheckEndTimeMutex.Unlock()
+	fake.UpdateLastCheckEndTimeStub = nil
+	fake.updateLastCheckEndTimeReturns = struct {
 		result1 bool
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckFinishedReturnsOnCall(i int, result1 bool, result2 error) {
-	fake.updateLastCheckFinishedMutex.Lock()
-	defer fake.updateLastCheckFinishedMutex.Unlock()
-	fake.UpdateLastCheckFinishedStub = nil
-	if fake.updateLastCheckFinishedReturnsOnCall == nil {
-		fake.updateLastCheckFinishedReturnsOnCall = make(map[int]struct {
+func (fake *FakeResourceConfigScope) UpdateLastCheckEndTimeReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.updateLastCheckEndTimeMutex.Lock()
+	defer fake.updateLastCheckEndTimeMutex.Unlock()
+	fake.UpdateLastCheckEndTimeStub = nil
+	if fake.updateLastCheckEndTimeReturnsOnCall == nil {
+		fake.updateLastCheckEndTimeReturnsOnCall = make(map[int]struct {
 			result1 bool
 			result2 error
 		})
 	}
-	fake.updateLastCheckFinishedReturnsOnCall[i] = struct {
+	fake.updateLastCheckEndTimeReturnsOnCall[i] = struct {
 		result1 bool
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastChecked(arg1 time.Duration, arg2 bool) (bool, error) {
-	fake.updateLastCheckedMutex.Lock()
-	ret, specificReturn := fake.updateLastCheckedReturnsOnCall[len(fake.updateLastCheckedArgsForCall)]
-	fake.updateLastCheckedArgsForCall = append(fake.updateLastCheckedArgsForCall, struct {
+func (fake *FakeResourceConfigScope) UpdateLastCheckStartTime(arg1 time.Duration, arg2 bool) (bool, error) {
+	fake.updateLastCheckStartTimeMutex.Lock()
+	ret, specificReturn := fake.updateLastCheckStartTimeReturnsOnCall[len(fake.updateLastCheckStartTimeArgsForCall)]
+	fake.updateLastCheckStartTimeArgsForCall = append(fake.updateLastCheckStartTimeArgsForCall, struct {
 		arg1 time.Duration
 		arg2 bool
 	}{arg1, arg2})
-	fake.recordInvocation("UpdateLastChecked", []interface{}{arg1, arg2})
-	fake.updateLastCheckedMutex.Unlock()
-	if fake.UpdateLastCheckedStub != nil {
-		return fake.UpdateLastCheckedStub(arg1, arg2)
+	fake.recordInvocation("UpdateLastCheckStartTime", []interface{}{arg1, arg2})
+	fake.updateLastCheckStartTimeMutex.Unlock()
+	if fake.UpdateLastCheckStartTimeStub != nil {
+		return fake.UpdateLastCheckStartTimeStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateLastCheckedReturns
+	fakeReturns := fake.updateLastCheckStartTimeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckedCallCount() int {
-	fake.updateLastCheckedMutex.RLock()
-	defer fake.updateLastCheckedMutex.RUnlock()
-	return len(fake.updateLastCheckedArgsForCall)
+func (fake *FakeResourceConfigScope) UpdateLastCheckStartTimeCallCount() int {
+	fake.updateLastCheckStartTimeMutex.RLock()
+	defer fake.updateLastCheckStartTimeMutex.RUnlock()
+	return len(fake.updateLastCheckStartTimeArgsForCall)
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckedCalls(stub func(time.Duration, bool) (bool, error)) {
-	fake.updateLastCheckedMutex.Lock()
-	defer fake.updateLastCheckedMutex.Unlock()
-	fake.UpdateLastCheckedStub = stub
+func (fake *FakeResourceConfigScope) UpdateLastCheckStartTimeCalls(stub func(time.Duration, bool) (bool, error)) {
+	fake.updateLastCheckStartTimeMutex.Lock()
+	defer fake.updateLastCheckStartTimeMutex.Unlock()
+	fake.UpdateLastCheckStartTimeStub = stub
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckedArgsForCall(i int) (time.Duration, bool) {
-	fake.updateLastCheckedMutex.RLock()
-	defer fake.updateLastCheckedMutex.RUnlock()
-	argsForCall := fake.updateLastCheckedArgsForCall[i]
+func (fake *FakeResourceConfigScope) UpdateLastCheckStartTimeArgsForCall(i int) (time.Duration, bool) {
+	fake.updateLastCheckStartTimeMutex.RLock()
+	defer fake.updateLastCheckStartTimeMutex.RUnlock()
+	argsForCall := fake.updateLastCheckStartTimeArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckedReturns(result1 bool, result2 error) {
-	fake.updateLastCheckedMutex.Lock()
-	defer fake.updateLastCheckedMutex.Unlock()
-	fake.UpdateLastCheckedStub = nil
-	fake.updateLastCheckedReturns = struct {
+func (fake *FakeResourceConfigScope) UpdateLastCheckStartTimeReturns(result1 bool, result2 error) {
+	fake.updateLastCheckStartTimeMutex.Lock()
+	defer fake.updateLastCheckStartTimeMutex.Unlock()
+	fake.UpdateLastCheckStartTimeStub = nil
+	fake.updateLastCheckStartTimeReturns = struct {
 		result1 bool
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckedReturnsOnCall(i int, result1 bool, result2 error) {
-	fake.updateLastCheckedMutex.Lock()
-	defer fake.updateLastCheckedMutex.Unlock()
-	fake.UpdateLastCheckedStub = nil
-	if fake.updateLastCheckedReturnsOnCall == nil {
-		fake.updateLastCheckedReturnsOnCall = make(map[int]struct {
+func (fake *FakeResourceConfigScope) UpdateLastCheckStartTimeReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.updateLastCheckStartTimeMutex.Lock()
+	defer fake.updateLastCheckStartTimeMutex.Unlock()
+	fake.UpdateLastCheckStartTimeStub = nil
+	if fake.updateLastCheckStartTimeReturnsOnCall == nil {
+		fake.updateLastCheckStartTimeReturnsOnCall = make(map[int]struct {
 			result1 bool
 			result2 error
 		})
 	}
-	fake.updateLastCheckedReturnsOnCall[i] = struct {
+	fake.updateLastCheckStartTimeReturnsOnCall[i] = struct {
 		result1 bool
 		result2 error
 	}{result1, result2}
@@ -813,10 +813,10 @@ func (fake *FakeResourceConfigScope) Invocations() map[string][][]interface{} {
 	defer fake.saveVersionsMutex.RUnlock()
 	fake.setCheckErrorMutex.RLock()
 	defer fake.setCheckErrorMutex.RUnlock()
-	fake.updateLastCheckFinishedMutex.RLock()
-	defer fake.updateLastCheckFinishedMutex.RUnlock()
-	fake.updateLastCheckedMutex.RLock()
-	defer fake.updateLastCheckedMutex.RUnlock()
+	fake.updateLastCheckEndTimeMutex.RLock()
+	defer fake.updateLastCheckEndTimeMutex.RUnlock()
+	fake.updateLastCheckStartTimeMutex.RLock()
+	defer fake.updateLastCheckStartTimeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/atc/db/migration/migrations/1554128419_rename_resource_config_scope_last_checked.down.sql
+++ b/atc/db/migration/migrations/1554128419_rename_resource_config_scope_last_checked.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+  ALTER TABLE resource_config_scopes RENAME COLUMN last_check_start_time TO last_checked;
+  ALTER TABLE resource_config_scopes RENAME COLUMN last_check_end_time TO last_check_finished;
+COMMIT;

--- a/atc/db/migration/migrations/1554128419_rename_resource_config_scope_last_checked.up.sql
+++ b/atc/db/migration/migrations/1554128419_rename_resource_config_scope_last_checked.up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+  ALTER TABLE resource_config_scopes RENAME COLUMN last_checked TO last_check_start_time;
+  ALTER TABLE resource_config_scopes RENAME COLUMN last_check_finished TO last_check_end_time;
+COMMIT;

--- a/atc/db/migration/migrations/1554133547_drop_cache_invalidator.down.sql
+++ b/atc/db/migration/migrations/1554133547_drop_cache_invalidator.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+  CREATE TABLE cache_invalidator (
+      last_invalidated timestamp without time zone DEFAULT '1970-01-01 00:00:00'::timestamp without time zone NOT NULL
+  );
+COMMIT;

--- a/atc/db/migration/migrations/1554133547_drop_cache_invalidator.up.sql
+++ b/atc/db/migration/migrations/1554133547_drop_cache_invalidator.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  DROP TABLE cache_invalidator;
+COMMIT;

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -37,12 +37,12 @@ type ResourceConfigScope interface {
 		interval time.Duration,
 	) (lock.Lock, bool, error)
 
-	UpdateLastChecked(
+	UpdateLastCheckStartTime(
 		interval time.Duration,
 		immediate bool,
 	) (bool, error)
 
-	UpdateLastCheckFinished() (bool, error)
+	UpdateLastCheckEndTime() (bool, error)
 }
 
 type resourceConfigScope struct {
@@ -189,7 +189,7 @@ func (r *resourceConfigScope) AcquireResourceCheckingLock(
 	)
 }
 
-func (r *resourceConfigScope) UpdateLastChecked(
+func (r *resourceConfigScope) UpdateLastCheckStartTime(
 	interval time.Duration,
 	immediate bool,
 ) (bool, error) {
@@ -204,13 +204,13 @@ func (r *resourceConfigScope) UpdateLastChecked(
 
 	condition := ""
 	if !immediate {
-		condition = "AND now() - last_checked > ($2 || ' SECONDS')::INTERVAL"
+		condition = "AND now() - last_check_start_time > ($2 || ' SECONDS')::INTERVAL"
 		params = append(params, interval.Seconds())
 	}
 
 	updated, err := checkIfRowsUpdated(tx, `
 			UPDATE resource_config_scopes
-			SET last_checked = now()
+			SET last_check_start_time = now()
 			WHERE id = $1
 		`+condition, params...)
 	if err != nil {
@@ -229,7 +229,7 @@ func (r *resourceConfigScope) UpdateLastChecked(
 	return true, nil
 }
 
-func (r *resourceConfigScope) UpdateLastCheckFinished() (bool, error) {
+func (r *resourceConfigScope) UpdateLastCheckEndTime() (bool, error) {
 	tx, err := r.conn.Begin()
 	if err != nil {
 		return false, err
@@ -239,7 +239,7 @@ func (r *resourceConfigScope) UpdateLastCheckFinished() (bool, error) {
 
 	updated, err := checkIfRowsUpdated(tx, `
 			UPDATE resource_config_scopes
-			SET last_check_finished = now()
+			SET last_check_end_time = now()
 			WHERE id = $1
 		`, r.id)
 	if err != nil {

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Resource Config Scope", func() {
 		})
 	})
 
-	Describe("UpdateLastChecked", func() {
+	Describe("UpdateLastCheckStartTime", func() {
 		var (
 			someResource        db.Resource
 			resourceConfigScope db.ResourceConfigScope
@@ -211,14 +211,14 @@ var _ = Describe("Resource Config Scope", func() {
 
 		Context("when there has not been a check", func() {
 			It("should update the last checked", func() {
-				updated, err := resourceConfigScope.UpdateLastChecked(1*time.Second, false)
+				updated, err := resourceConfigScope.UpdateLastCheckStartTime(1*time.Second, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updated).To(BeTrue())
 			})
 
 			Context("when immediate", func() {
 				It("should update the last checked", func() {
-					updated, err := resourceConfigScope.UpdateLastChecked(1*time.Second, true)
+					updated, err := resourceConfigScope.UpdateLastCheckStartTime(1*time.Second, true)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(updated).To(BeTrue())
 				})
@@ -229,14 +229,14 @@ var _ = Describe("Resource Config Scope", func() {
 			interval := 1 * time.Second
 
 			BeforeEach(func() {
-				updated, err := resourceConfigScope.UpdateLastChecked(interval, false)
+				updated, err := resourceConfigScope.UpdateLastCheckStartTime(interval, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updated).To(BeTrue())
 			})
 
 			Context("when not immediate", func() {
 				It("does not update the last checked until the interval has elapsed", func() {
-					updated, err := resourceConfigScope.UpdateLastChecked(interval, false)
+					updated, err := resourceConfigScope.UpdateLastCheckStartTime(interval, false)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(updated).To(BeFalse())
 				})
@@ -247,7 +247,7 @@ var _ = Describe("Resource Config Scope", func() {
 					})
 
 					It("updates the last checked", func() {
-						updated, err := resourceConfigScope.UpdateLastChecked(interval, false)
+						updated, err := resourceConfigScope.UpdateLastCheckStartTime(interval, false)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(updated).To(BeTrue())
 					})
@@ -256,7 +256,7 @@ var _ = Describe("Resource Config Scope", func() {
 
 			Context("when it is immediate", func() {
 				It("updates the last checked", func() {
-					updated, err := resourceConfigScope.UpdateLastChecked(1*time.Second, true)
+					updated, err := resourceConfigScope.UpdateLastCheckStartTime(1*time.Second, true)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(updated).To(BeTrue())
 				})
@@ -264,7 +264,7 @@ var _ = Describe("Resource Config Scope", func() {
 		})
 	})
 
-	Describe("UpdateLastCheckFinished", func() {
+	Describe("UpdateLastCheckEndTime", func() {
 		var (
 			someResource        db.Resource
 			resourceConfigScope db.ResourceConfigScope
@@ -290,12 +290,12 @@ var _ = Describe("Resource Config Scope", func() {
 		})
 
 		It("should update last check finished", func() {
-			updated, err := resourceConfigScope.UpdateLastCheckFinished()
+			updated, err := resourceConfigScope.UpdateLastCheckEndTime()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated).To(BeTrue())
 
 			someResource.Reload()
-			Expect(someResource.LastCheckFinished()).To(BeTemporally("~", time.Now(), 100*time.Millisecond))
+			Expect(someResource.LastCheckEndTime()).To(BeTemporally("~", time.Now(), 100*time.Millisecond))
 		})
 	})
 

--- a/atc/radar/resource_scanner.go
+++ b/atc/radar/resource_scanner.go
@@ -221,7 +221,7 @@ func (scanner *resourceScanner) scan(logger lager.Logger, resourceName string, f
 
 		defer lock.Release()
 
-		updated, err := resourceConfigScope.UpdateLastChecked(interval, mustComplete)
+		updated, err := resourceConfigScope.UpdateLastCheckStartTime(interval, mustComplete)
 		if err != nil {
 			return interval, err
 		}
@@ -398,7 +398,7 @@ func (scanner *resourceScanner) check(
 		}
 	}
 
-	updated, err := resourceConfigScope.UpdateLastCheckFinished()
+	updated, err := resourceConfigScope.UpdateLastCheckEndTime()
 	if err != nil {
 		return err
 	}

--- a/atc/radar/resource_scanner_test.go
+++ b/atc/radar/resource_scanner_test.go
@@ -199,7 +199,7 @@ var _ = Describe("ResourceScanner", func() {
 
 			Context("when the last checked is not able to be updated", func() {
 				BeforeEach(func() {
-					fakeResourceConfigScope.UpdateLastCheckedReturns(false, nil)
+					fakeResourceConfigScope.UpdateLastCheckStartTimeReturns(false, nil)
 				})
 
 				It("does not check", func() {
@@ -214,7 +214,7 @@ var _ = Describe("ResourceScanner", func() {
 
 			Context("when the last checked fails to update", func() {
 				BeforeEach(func() {
-					fakeResourceConfigScope.UpdateLastCheckedReturns(false, errors.New("woops"))
+					fakeResourceConfigScope.UpdateLastCheckStartTimeReturns(false, errors.New("woops"))
 				})
 
 				It("does not check", func() {
@@ -229,7 +229,7 @@ var _ = Describe("ResourceScanner", func() {
 
 			Context("when the last checked is updated", func() {
 				BeforeEach(func() {
-					fakeResourceConfigScope.UpdateLastCheckedReturns(true, nil)
+					fakeResourceConfigScope.UpdateLastCheckStartTimeReturns(true, nil)
 				})
 
 				It("checks immediately", func() {
@@ -296,12 +296,12 @@ var _ = Describe("ResourceScanner", func() {
 
 					It("leases for the configured interval", func() {
 						Expect(fakeResourceConfigScope.AcquireResourceCheckingLockCallCount()).To(Equal(1))
-						Expect(fakeResourceConfigScope.UpdateLastCheckedCallCount()).To(Equal(1))
+						Expect(fakeResourceConfigScope.UpdateLastCheckStartTimeCallCount()).To(Equal(1))
 
 						_, leaseInterval := fakeResourceConfigScope.AcquireResourceCheckingLockArgsForCall(0)
 						Expect(leaseInterval).To(Equal(10 * time.Millisecond))
 
-						leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckedArgsForCall(0)
+						leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(0)
 						Expect(leaseInterval).To(Equal(10 * time.Millisecond))
 						Expect(immediate).To(BeFalse())
 
@@ -333,12 +333,12 @@ var _ = Describe("ResourceScanner", func() {
 
 				It("grabs a periodic resource checking lock before checking, breaks lock after done", func() {
 					Expect(fakeResourceConfigScope.AcquireResourceCheckingLockCallCount()).To(Equal(1))
-					Expect(fakeResourceConfigScope.UpdateLastCheckedCallCount()).To(Equal(1))
+					Expect(fakeResourceConfigScope.UpdateLastCheckStartTimeCallCount()).To(Equal(1))
 
 					_, leaseInterval := fakeResourceConfigScope.AcquireResourceCheckingLockArgsForCall(0)
 					Expect(leaseInterval).To(Equal(interval))
 
-					leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckedArgsForCall(0)
+					leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(0)
 					Expect(leaseInterval).To(Equal(interval))
 					Expect(immediate).To(BeFalse())
 
@@ -612,7 +612,7 @@ var _ = Describe("ResourceScanner", func() {
 		Context("if the lock can be acquired and last checked updated", func() {
 			BeforeEach(func() {
 				fakeResourceConfigScope.AcquireResourceCheckingLockReturns(fakeLock, true, nil)
-				fakeResourceConfigScope.UpdateLastCheckedReturns(true, nil)
+				fakeResourceConfigScope.UpdateLastCheckStartTimeReturns(true, nil)
 			})
 
 			Context("Parent resource has no version and check fails", func() {
@@ -721,12 +721,12 @@ var _ = Describe("ResourceScanner", func() {
 
 			It("grabs an immediate resource checking lock before checking, breaks lock after done", func() {
 				Expect(fakeResourceConfigScope.AcquireResourceCheckingLockCallCount()).To(Equal(1))
-				Expect(fakeResourceConfigScope.UpdateLastCheckedCallCount()).To(Equal(1))
+				Expect(fakeResourceConfigScope.UpdateLastCheckStartTimeCallCount()).To(Equal(1))
 
 				_, leaseInterval := fakeResourceConfigScope.AcquireResourceCheckingLockArgsForCall(0)
 				Expect(leaseInterval).To(Equal(interval))
 
-				leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckedArgsForCall(0)
+				leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(0)
 				Expect(leaseInterval).To(Equal(interval))
 				Expect(immediate).To(BeTrue())
 
@@ -783,12 +783,12 @@ var _ = Describe("ResourceScanner", func() {
 
 				It("leases for the configured interval", func() {
 					Expect(fakeResourceConfigScope.AcquireResourceCheckingLockCallCount()).To(Equal(1))
-					Expect(fakeResourceConfigScope.UpdateLastCheckedCallCount()).To(Equal(1))
+					Expect(fakeResourceConfigScope.UpdateLastCheckStartTimeCallCount()).To(Equal(1))
 
 					_, leaseInterval := fakeResourceConfigScope.AcquireResourceCheckingLockArgsForCall(0)
 					Expect(leaseInterval).To(Equal(10 * time.Millisecond))
 
-					leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckedArgsForCall(0)
+					leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(0)
 					Expect(leaseInterval).To(Equal(10 * time.Millisecond))
 					Expect(immediate).To(BeTrue())
 
@@ -993,7 +993,7 @@ var _ = Describe("ResourceScanner", func() {
 				})
 
 				It("updates last check finished", func() {
-					Expect(fakeResourceConfigScope.UpdateLastCheckFinishedCallCount()).To(Equal(1))
+					Expect(fakeResourceConfigScope.UpdateLastCheckEndTimeCallCount()).To(Equal(1))
 				})
 
 				Context("when saving fails", func() {
@@ -1002,7 +1002,7 @@ var _ = Describe("ResourceScanner", func() {
 					})
 
 					It("does not update last check finished", func() {
-						Expect(fakeResourceConfigScope.UpdateLastCheckFinishedCallCount()).To(BeZero())
+						Expect(fakeResourceConfigScope.UpdateLastCheckEndTimeCallCount()).To(BeZero())
 					})
 				})
 			})
@@ -1015,7 +1015,7 @@ var _ = Describe("ResourceScanner", func() {
 				})
 
 				It("updates last check finished", func() {
-					Expect(fakeResourceConfigScope.UpdateLastCheckFinishedCallCount()).To(Equal(1))
+					Expect(fakeResourceConfigScope.UpdateLastCheckEndTimeCallCount()).To(Equal(1))
 				})
 			})
 
@@ -1087,7 +1087,7 @@ var _ = Describe("ResourceScanner", func() {
 		Context("if the lock can be acquired and last checked updated", func() {
 			BeforeEach(func() {
 				fakeResourceConfigScope.AcquireResourceCheckingLockReturns(fakeLock, true, nil)
-				fakeResourceConfigScope.UpdateLastCheckedReturns(true, nil)
+				fakeResourceConfigScope.UpdateLastCheckStartTimeReturns(true, nil)
 			})
 
 			Context("when fromVersion is nil", func() {

--- a/atc/radar/resource_type_scanner.go
+++ b/atc/radar/resource_type_scanner.go
@@ -168,7 +168,7 @@ func (scanner *resourceTypeScanner) scan(logger lager.Logger, resourceTypeName s
 
 		defer lock.Release()
 
-		updated, err := resourceConfigScope.UpdateLastChecked(interval, mustComplete)
+		updated, err := resourceConfigScope.UpdateLastCheckStartTime(interval, mustComplete)
 		if err != nil {
 			lockLogger.Error("failed-to-get-update-last-checked", err, lager.Data{
 				"resource-type":      resourceTypeName,

--- a/atc/radar/resource_type_scanner_test.go
+++ b/atc/radar/resource_type_scanner_test.go
@@ -156,7 +156,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 
 			Context("when the last checked was not updated", func() {
 				BeforeEach(func() {
-					fakeResourceConfigScope.UpdateLastCheckedReturns(false, nil)
+					fakeResourceConfigScope.UpdateLastCheckStartTimeReturns(false, nil)
 				})
 
 				It("does not check", func() {
@@ -171,7 +171,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 
 			Context("when the last checked was updated", func() {
 				BeforeEach(func() {
-					fakeResourceConfigScope.UpdateLastCheckedReturns(true, nil)
+					fakeResourceConfigScope.UpdateLastCheckStartTimeReturns(true, nil)
 				})
 
 				It("checks immediately", func() {
@@ -279,12 +279,12 @@ var _ = Describe("ResourceTypeScanner", func() {
 
 					It("leases for the configured interval", func() {
 						Expect(fakeResourceConfigScope.AcquireResourceCheckingLockCallCount()).To(Equal(1))
-						Expect(fakeResourceConfigScope.UpdateLastCheckedCallCount()).To(Equal(1))
+						Expect(fakeResourceConfigScope.UpdateLastCheckStartTimeCallCount()).To(Equal(1))
 
 						_, leaseInterval := fakeResourceConfigScope.AcquireResourceCheckingLockArgsForCall(0)
 						Expect(leaseInterval).To(Equal(10 * time.Millisecond))
 
-						leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckedArgsForCall(0)
+						leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(0)
 						Expect(leaseInterval).To(Equal(10 * time.Millisecond))
 						Expect(immediate).To(BeFalse())
 
@@ -316,12 +316,12 @@ var _ = Describe("ResourceTypeScanner", func() {
 
 				It("grabs a periodic resource checking lock before checking, breaks lock after done", func() {
 					Expect(fakeResourceConfigScope.AcquireResourceCheckingLockCallCount()).To(Equal(1))
-					Expect(fakeResourceConfigScope.UpdateLastCheckedCallCount()).To(Equal(1))
+					Expect(fakeResourceConfigScope.UpdateLastCheckStartTimeCallCount()).To(Equal(1))
 
 					_, leaseInterval := fakeResourceConfigScope.AcquireResourceCheckingLockArgsForCall(0)
 					Expect(leaseInterval).To(Equal(interval))
 
-					leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckedArgsForCall(0)
+					leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(0)
 					Expect(leaseInterval).To(Equal(interval))
 					Expect(immediate).To(BeFalse())
 
@@ -460,7 +460,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 		Context("when the lock can be acquired and last checked is updated", func() {
 			BeforeEach(func() {
 				fakeResourceConfigScope.AcquireResourceCheckingLockReturns(fakeLock, true, nil)
-				fakeResourceConfigScope.UpdateLastCheckedReturns(true, nil)
+				fakeResourceConfigScope.UpdateLastCheckStartTimeReturns(true, nil)
 			})
 
 			It("checks immediately", func() {
@@ -633,12 +633,12 @@ var _ = Describe("ResourceTypeScanner", func() {
 
 			It("grabs an immediate resource checking lock before checking, breaks lock after done", func() {
 				Expect(fakeResourceConfigScope.AcquireResourceCheckingLockCallCount()).To(Equal(1))
-				Expect(fakeResourceConfigScope.UpdateLastCheckedCallCount()).To(Equal(1))
+				Expect(fakeResourceConfigScope.UpdateLastCheckStartTimeCallCount()).To(Equal(1))
 
 				_, leaseInterval := fakeResourceConfigScope.AcquireResourceCheckingLockArgsForCall(0)
 				Expect(leaseInterval).To(Equal(interval))
 
-				leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckedArgsForCall(0)
+				leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(0)
 				Expect(leaseInterval).To(Equal(interval))
 				Expect(immediate).To(BeTrue())
 
@@ -812,7 +812,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 					results <- true
 					close(results)
 
-					fakeResourceConfigScope.UpdateLastCheckedStub = func(interval time.Duration, immediate bool) (bool, error) {
+					fakeResourceConfigScope.UpdateLastCheckStartTimeStub = func(interval time.Duration, immediate bool) (bool, error) {
 						if <-results {
 							return true, nil
 						} else {
@@ -825,17 +825,17 @@ var _ = Describe("ResourceTypeScanner", func() {
 
 				It("retries every second until it is", func() {
 					Expect(fakeResourceConfigScope.AcquireResourceCheckingLockCallCount()).To(Equal(3))
-					Expect(fakeResourceConfigScope.UpdateLastCheckedCallCount()).To(Equal(3))
+					Expect(fakeResourceConfigScope.UpdateLastCheckStartTimeCallCount()).To(Equal(3))
 
-					leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckedArgsForCall(0)
+					leaseInterval, immediate := fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(0)
 					Expect(leaseInterval).To(Equal(interval))
 					Expect(immediate).To(BeTrue())
 
-					leaseInterval, immediate = fakeResourceConfigScope.UpdateLastCheckedArgsForCall(1)
+					leaseInterval, immediate = fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(1)
 					Expect(leaseInterval).To(Equal(interval))
 					Expect(immediate).To(BeTrue())
 
-					leaseInterval, immediate = fakeResourceConfigScope.UpdateLastCheckedArgsForCall(2)
+					leaseInterval, immediate = fakeResourceConfigScope.UpdateLastCheckStartTimeArgsForCall(2)
 					Expect(leaseInterval).To(Equal(interval))
 					Expect(immediate).To(BeTrue())
 
@@ -893,7 +893,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 		Context("if the lock can be acquired", func() {
 			BeforeEach(func() {
 				fakeResourceConfigScope.AcquireResourceCheckingLockReturns(fakeLock, true, nil)
-				fakeResourceConfigScope.UpdateLastCheckedReturns(true, nil)
+				fakeResourceConfigScope.UpdateLastCheckStartTimeReturns(true, nil)
 				fakeResourceConfigVersion := new(dbfakes.FakeResourceConfigVersion)
 				fakeResourceConfigVersion.IDReturns(1)
 				fakeResourceConfigVersion.VersionReturns(db.Version{"custom": "version"})

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -106,7 +106,7 @@ func (s *buildStarter) tryStartNextPendingBuild(
 				continue
 			}
 
-			if resource.LastCheckFinished().Before(nextPendingBuild.CreateTime()) {
+			if resource.LastCheckEndTime().Before(nextPendingBuild.CreateTime()) {
 				return false, nil
 			}
 		}

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -113,7 +113,7 @@ var _ = Describe("BuildStarter", func() {
 				Context("when some of the resources are checked before build create time", func() {
 					BeforeEach(func() {
 						createdBuild.CreateTimeReturns(time.Now())
-						resource.LastCheckFinishedReturns(time.Now().Add(-time.Minute))
+						resource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute))
 					})
 
 					It("does not save the next input mapping", func() {
@@ -145,12 +145,12 @@ var _ = Describe("BuildStarter", func() {
 
 						createdBuild.CreateTimeReturns(time.Now())
 
-						resource.LastCheckFinishedReturns(time.Now().Add(time.Minute))
+						resource.LastCheckEndTimeReturns(time.Now().Add(time.Minute))
 
 						otherResource := new(dbfakes.FakeResource)
 						otherResource.NameReturns("other-resource")
 						otherResource.CurrentPinnedVersionReturns(atc.Version{"some": "version"})
-						otherResource.LastCheckFinishedReturns(time.Now().Add(-time.Minute))
+						otherResource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute))
 
 						resources = db.Resources{resource, otherResource}
 					})


### PR DESCRIPTION
- `last_checked` -> `last_check_start_time`
- `last_check_finished` -> `last_check_end_time`
- API returns `last_check_end_time`
- also drops `cache_invalidator` table since it's not used

fixes #3587 