### PR TITLE
cmd/smoke: fix garden -config flag, add coverage in bin-smoke

### DIFF
--- a/ci/deployments/smoke/garden/garden.ini
+++ b/ci/deployments/smoke/garden/garden.ini
@@ -1,0 +1,3 @@
+[server]
+dns-server = 8.8.8.8
+dns-server = 8.8.4.4

--- a/ci/deployments/smoke/smoke.tf
+++ b/ci/deployments/smoke/smoke.tf
@@ -164,6 +164,11 @@ resource "null_resource" "rerun" {
     source = "systemd/smoke-worker.conf"
   }
 
+  provisioner "file" {
+    destination = "/etc/concourse/garden.ini"
+    source = "garden/garden.ini"
+  }
+
   provisioner "remote-exec" {
     inline = [
       "set -e -x",

--- a/ci/deployments/smoke/systemd/smoke-worker.conf
+++ b/ci/deployments/smoke/systemd/smoke-worker.conf
@@ -2,3 +2,4 @@
 Environment=CONCOURSE_WORK_DIR=/etc/concourse/work-dir
 Environment=CONCOURSE_TSA_PUBLIC_KEY=/etc/concourse/host_key.pub
 Environment=CONCOURSE_TSA_WORKER_PRIVATE_KEY=/etc/concourse/worker_key
+Environment=CONCOURSE_GARDEN_CONFIG=/etc/concourse/garden.ini

--- a/web/wats/fixtures/smoke-internet-pipeline.yml
+++ b/web/wats/fixtures/smoke-internet-pipeline.yml
@@ -1,0 +1,18 @@
+---
+resources:
+- name: some-image
+  type: registry-image
+  source: {repository: alpine}
+
+jobs:
+- name: use-the-internet
+  plan:
+  - get: some-image
+  - task: hello
+    image: some-image
+    config:
+      platform: linux
+
+      run:
+        path: echo
+        args: ["Hello, world!"]

--- a/web/wats/test/smoke.js
+++ b/web/wats/test/smoke.js
@@ -41,3 +41,11 @@ test('running one-off builds', async t => {
   var result = await t.context.fly.run('execute -c fixtures/smoke-task.yml -i some-input=fixtures/some-input');
   t.regex(result.stdout, /Hello, world!/);
 });
+
+test('reaching the internet', async t => {
+  await t.context.fly.run('set-pipeline -n -p some-pipeline -c fixtures/smoke-internet-pipeline.yml');
+  await t.context.fly.run('unpause-pipeline -p some-pipeline');
+
+  var result = await t.context.fly.run('trigger-job -j some-pipeline/use-the-internet -w');
+  t.regex(result.stdout, /Hello, world!/);
+});


### PR DESCRIPTION
This fixes `--garden-config`/`$CONCOURSE_GARDEN_CONFIG` - previously it would fail because `gdn` accepts `-config`, not `--config`.

Added test coverage to `bin-smoke` that covers usage of this flag and tests network connectivity.