### PR TITLE
ci: add attempts to yarn steps in pr's pipeline

### DIFF
--- a/ci/pipelines/prs.yml
+++ b/ci/pipelines/prs.yml
@@ -65,14 +65,17 @@ jobs:
     file: concourse-pr/ci/tasks/check-migration-order.yml
     tags: [pr]
   - task: yarn-analyse
+    attempts: 3
     file: concourse-pr/ci/tasks/yarn-analyse.yml
     input_mapping: {concourse: concourse-pr}
     tags: [pr]
   - task: yarn-test
+    attempts: 3
     file: concourse-pr/ci/tasks/yarn-test.yml
     input_mapping: {concourse: concourse-pr}
     tags: [pr]
   - task: unit
+    attempts: 3
     timeout: 1h
     file: concourse-pr/ci/tasks/unit.yml
     input_mapping: {concourse: built-concourse}
@@ -107,6 +110,7 @@ jobs:
     inputs: [concourse-pr]
     params: {path: concourse-pr, status: pending, context: testflight}
   - task: yarn-build
+    attempts: 3
     file: concourse-pr/ci/tasks/yarn-build.yml
     input_mapping: {concourse: concourse-pr}
     tags: [pr]
@@ -148,6 +152,7 @@ jobs:
     params: {path: concourse-pr, status: pending, context: watsjs}
     tags: [pr]
   - task: yarn-build
+    attempts: 3
     file: concourse-pr/ci/tasks/yarn-build.yml
     input_mapping: {concourse: concourse-pr}
     tags: [pr]


### PR DESCRIPTION
These tests sometimes fail due to network flakiness when
the package manager fails to download certain packages.

Adding attempts here will save us time from manually
kicking off the jobs again for specific PR's.
