### PR TITLE
Generalising url option to fly commands

### DIFF
--- a/fly/commands/abort_build.go
+++ b/fly/commands/abort_build.go
@@ -9,8 +9,8 @@ import (
 )
 
 type AbortBuildCommand struct {
-	Job   flaghelpers.JobFlag `short:"j" long:"job" value-name:"PIPELINE/JOB"   description:"Name of a job to cancel"`
-	Build string              `short:"b" long:"build" required:"true" description:"If job is specified: build number to cancel. If job not specified: build id"`
+	Job   flaghelpers.JobFlag `short:"j" long:"job" value-name:"PIPELINE/JOB" env:"JOB"   description:"Name of a job to cancel"`
+	Build string              `short:"b" long:"build" required:"true"         env:"BUILD" description:"If job is specified: build number to cancel. If job not specified: build id"`
 }
 
 func (command *AbortBuildCommand) Execute([]string) error {

--- a/fly/commands/abort_build.go
+++ b/fly/commands/abort_build.go
@@ -19,11 +19,6 @@ func (command *AbortBuildCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	var build atc.Build
 	var exists bool
 	if command.Job.PipelineName == "" && command.Job.JobName == "" {

--- a/fly/commands/abort_build.go
+++ b/fly/commands/abort_build.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type AbortBuildCommand struct {
@@ -15,7 +14,7 @@ type AbortBuildCommand struct {
 }
 
 func (command *AbortBuildCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/builds.go
+++ b/fly/commands/builds.go
@@ -19,15 +19,15 @@ const timeDateLayout = "2006-01-02@15:04:05-0700"
 const inputTimeLayout = "2006-01-02 15:04:05"
 
 type BuildsCommand struct {
-	AllTeams    bool                     `short:"a" long:"all-teams"                     description:"Show builds for the all teams that user has access to"`
-	Count       int                      `short:"c" long:"count" default:"50"            description:"Number of builds you want to limit the return to"`
-	CurrentTeam bool                     `          long:"current-team"                  description:"Show builds for the currently targeted team"`
-	Job         flaghelpers.JobFlag      `short:"j" long:"job" value-name:"PIPELINE/JOB" description:"Name of a job to get builds for"`
-	Json        bool                     `          long:"json"                          description:"Print command result as JSON"`
-	Pipeline    flaghelpers.PipelineFlag `short:"p" long:"pipeline" env:"PIPELINE"       description:"Name of a pipeline to get builds for"`
-	Teams       []string                 `short:"n" long:"team"                          description:"Show builds for these teams"`
-	Since       string                   `          long:"since"                         description:"Start of the range to filter builds"`
-	Until       string                   `          long:"until"                         description:"End of the range to filter builds"`
+	AllTeams    bool                     `short:"a" long:"all-teams"                               description:"Show builds for the all teams that user has access to"`
+	Count       int                      `short:"c" long:"count" default:"50"                      description:"Number of builds you want to limit the return to"`
+	CurrentTeam bool                     `          long:"current-team"                            description:"Show builds for the currently targeted team"`
+	Job         flaghelpers.JobFlag      `short:"j" long:"job" value-name:"PIPELINE/JOB" env:"JOB" description:"Name of a job to get builds for"`
+	Json        bool                     `          long:"json"                                    description:"Print command result as JSON"`
+	Pipeline    flaghelpers.PipelineFlag `short:"p" long:"pipeline" env:"PIPELINE"                 description:"Name of a pipeline to get builds for"`
+	Teams       []string                 `short:"n" long:"team"                                    description:"Show builds for these teams"`
+	Since       string                   `          long:"since"                                   description:"Start of the range to filter builds"`
+	Until       string                   `          long:"until"                                   description:"End of the range to filter builds"`
 }
 
 func (command *BuildsCommand) Execute([]string) error {

--- a/fly/commands/builds.go
+++ b/fly/commands/builds.go
@@ -36,11 +36,6 @@ func (command *BuildsCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	var (
 		timeSince time.Time
 		timeUntil time.Time

--- a/fly/commands/builds.go
+++ b/fly/commands/builds.go
@@ -20,15 +20,15 @@ const timeDateLayout = "2006-01-02@15:04:05-0700"
 const inputTimeLayout = "2006-01-02 15:04:05"
 
 type BuildsCommand struct {
-	AllTeams    bool                     `short:"a" long:"all-teams" description:"Show builds for the all teams that user has access to"`
-	Count       int                      `short:"c" long:"count" default:"50" description:"Number of builds you want to limit the return to"`
-	CurrentTeam bool                     `long:"current-team" description:"Show builds for the currently targeted team"`
+	AllTeams    bool                     `short:"a" long:"all-teams"                     description:"Show builds for the all teams that user has access to"`
+	Count       int                      `short:"c" long:"count" default:"50"            description:"Number of builds you want to limit the return to"`
+	CurrentTeam bool                     `          long:"current-team"                  description:"Show builds for the currently targeted team"`
 	Job         flaghelpers.JobFlag      `short:"j" long:"job" value-name:"PIPELINE/JOB" description:"Name of a job to get builds for"`
-	Json        bool                     `long:"json" description:"Print command result as JSON"`
-	Pipeline    flaghelpers.PipelineFlag `short:"p" long:"pipeline" description:"Name of a pipeline to get builds for"`
-	Teams       []string                 `short:"n"  long:"team" description:"Show builds for these teams"`
-	Since       string                   `long:"since" description:"Start of the range to filter builds"`
-	Until       string                   `long:"until" description:"End of the range to filter builds"`
+	Json        bool                     `          long:"json"                          description:"Print command result as JSON"`
+	Pipeline    flaghelpers.PipelineFlag `short:"p" long:"pipeline" env:"PIPELINE"       description:"Name of a pipeline to get builds for"`
+	Teams       []string                 `short:"n" long:"team"                          description:"Show builds for these teams"`
+	Since       string                   `          long:"since"                         description:"Start of the range to filter builds"`
+	Until       string                   `          long:"until"                         description:"End of the range to filter builds"`
 }
 
 func (command *BuildsCommand) Execute([]string) error {

--- a/fly/commands/builds.go
+++ b/fly/commands/builds.go
@@ -25,7 +25,7 @@ type BuildsCommand struct {
 	Job         flaghelpers.JobFlag      `short:"j" long:"job" value-name:"PIPELINE/JOB" env:"JOB" description:"Name of a job to get builds for"`
 	Json        bool                     `          long:"json"                                    description:"Print command result as JSON"`
 	Pipeline    flaghelpers.PipelineFlag `short:"p" long:"pipeline" env:"PIPELINE"                 description:"Name of a pipeline to get builds for"`
-	Teams       []string                 `short:"n" long:"team"                                    description:"Show builds for these teams"`
+	Teams       []string                 `short:"n" long:"team" env:"TEAM"                         description:"Show builds for these teams"`
 	Since       string                   `          long:"since"                                   description:"Start of the range to filter builds"`
 	Until       string                   `          long:"until"                                   description:"End of the range to filter builds"`
 }

--- a/fly/commands/builds.go
+++ b/fly/commands/builds.go
@@ -10,7 +10,6 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/fatih/color"
@@ -32,7 +31,7 @@ type BuildsCommand struct {
 }
 
 func (command *BuildsCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/check_resource.go
+++ b/fly/commands/check_resource.go
@@ -8,8 +8,8 @@ import (
 )
 
 type CheckResourceCommand struct {
-	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to check version for"`
-	Version  *atc.Version             `short:"f" long:"from"                     value-name:"VERSION"           description:"Version of the resource to check from, e.g. ref:abcd or path:thing-1.2.3.tgz"`
+	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" env:"RESOURCE" description:"Name of a resource to check version for"`
+	Version  *atc.Version             `short:"f" long:"from"                     value-name:"VERSION"                          description:"Version of the resource to check from, e.g. ref:abcd or path:thing-1.2.3.tgz"`
 }
 
 func (command *CheckResourceCommand) Execute(args []string) error {

--- a/fly/commands/check_resource.go
+++ b/fly/commands/check_resource.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type CheckResourceCommand struct {
@@ -14,7 +13,7 @@ type CheckResourceCommand struct {
 }
 
 func (command *CheckResourceCommand) Execute(args []string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/check_resource.go
+++ b/fly/commands/check_resource.go
@@ -18,11 +18,6 @@ func (command *CheckResourceCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	var version atc.Version
 	if command.Version != nil {
 		version = *command.Version

--- a/fly/commands/check_resource_type.go
+++ b/fly/commands/check_resource_type.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type CheckResourceTypeCommand struct {
@@ -14,7 +13,7 @@ type CheckResourceTypeCommand struct {
 }
 
 func (command *CheckResourceTypeCommand) Execute(args []string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/check_resource_type.go
+++ b/fly/commands/check_resource_type.go
@@ -8,8 +8,8 @@ import (
 )
 
 type CheckResourceTypeCommand struct {
-	ResourceType flaghelpers.ResourceFlag `short:"r" long:"resource-type" required:"true" value-name:"PIPELINE/RESOURCE-TYPE" description:"Name of a resource-type to check"`
-	Version      *atc.Version             `short:"f" long:"from"                     value-name:"VERSION"           description:"Version of the resource type to check from, e.g. digest:sha256@..."`
+	ResourceType flaghelpers.ResourceFlag `short:"r" long:"resource-type" required:"true" value-name:"PIPELINE/RESOURCE-TYPE" env:"RESOURCE_TYPE" description:"Name of a resource-type to check"`
+	Version      *atc.Version             `short:"f" long:"from"                          value-name:"VERSION"                                    description:"Version of the resource type to check from, e.g. digest:sha256@..."`
 }
 
 func (command *CheckResourceTypeCommand) Execute(args []string) error {

--- a/fly/commands/check_resource_type.go
+++ b/fly/commands/check_resource_type.go
@@ -18,11 +18,6 @@ func (command *CheckResourceTypeCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	var version atc.Version
 	if command.Version != nil {
 		version = *command.Version

--- a/fly/commands/checklist.go
+++ b/fly/commands/checklist.go
@@ -27,11 +27,6 @@ func (command *ChecklistCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	pipelineName := string(command.Pipeline)
 
 	config, _, _, err := target.Team().PipelineConfig(pipelineName)

--- a/fly/commands/checklist.go
+++ b/fly/commands/checklist.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type ChecklistCommand struct {
@@ -23,7 +22,7 @@ func (command *ChecklistCommand) Execute([]string) error {
 		return err
 	}
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/checklist.go
+++ b/fly/commands/checklist.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ChecklistCommand struct {
-	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"The pipeline from which to generate the Checkfile"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" env:"PIPELINE" description:"The pipeline from which to generate the Checkfile"`
 }
 
 func (command *ChecklistCommand) Validate() error {

--- a/fly/commands/clear_task_cache.go
+++ b/fly/commands/clear_task_cache.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/vito/go-interact/interact"
 )
 
@@ -16,7 +15,7 @@ type ClearTaskCacheCommand struct {
 }
 
 func (command *ClearTaskCacheCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/clear_task_cache.go
+++ b/fly/commands/clear_task_cache.go
@@ -8,10 +8,10 @@ import (
 )
 
 type ClearTaskCacheCommand struct {
-	Job             flaghelpers.JobFlag `short:"j" long:"job"  required:"true"  description:"Job to clear cache from"`
-	StepName        string              `short:"s" long:"step"  required:"true" description:"Step name to clear cache from"`
-	CachePath       string              `short:"c" long:"cache-path"  default:"" description:"Cache directory to clear out"`
-	SkipInteractive bool                `short:"n"  long:"non-interactive"          description:"Destroy the task cache(s) without confirmation"`
+	Job             flaghelpers.JobFlag `short:"j" long:"job" required:"true" env:"JOB" description:"Job to clear cache from"`
+	StepName        string              `short:"s" long:"step" required:"true"          description:"Step name to clear cache from"`
+	CachePath       string              `short:"c" long:"cache-path"  default:""        description:"Cache directory to clear out"`
+	SkipInteractive bool                `short:"n"  long:"non-interactive"              description:"Destroy the task cache(s) without confirmation"`
 }
 
 func (command *ClearTaskCacheCommand) Execute([]string) error {

--- a/fly/commands/clear_task_cache.go
+++ b/fly/commands/clear_task_cache.go
@@ -20,11 +20,6 @@ func (command *ClearTaskCacheCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	warningMsg := fmt.Sprintf("!!! this will remove the task cache(s) for `%s/%s`, task step `%s`",
 		command.Job.PipelineName, command.Job.JobName, command.StepName)
 	if len(command.CachePath) > 0 {

--- a/fly/commands/containers.go
+++ b/fly/commands/containers.go
@@ -20,11 +20,6 @@ func (command *ContainersCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	containers, err := target.Team().ListContainers(map[string]string{})
 	if err != nil {
 		return err

--- a/fly/commands/containers.go
+++ b/fly/commands/containers.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
@@ -16,7 +15,7 @@ type ContainersCommand struct {
 }
 
 func (command *ContainersCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/curl.go
+++ b/fly/commands/curl.go
@@ -23,11 +23,6 @@ func (command *CurlCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	fullUrl, err := command.makeFullUrl(target.URL(), command.Args.Path)
 	if err != nil {
 		return err

--- a/fly/commands/curl.go
+++ b/fly/commands/curl.go
@@ -18,7 +18,7 @@ type CurlCommand struct {
 }
 
 func (command *CurlCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/destroy_pipeline.go
+++ b/fly/commands/destroy_pipeline.go
@@ -28,11 +28,6 @@ func (command *DestroyPipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	pipelineName := string(command.Pipeline)
 	fmt.Printf("!!! this will remove all data for pipeline `%s`\n\n", pipelineName)
 

--- a/fly/commands/destroy_pipeline.go
+++ b/fly/commands/destroy_pipeline.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/vito/go-interact/interact"
 
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
@@ -24,7 +23,7 @@ func (command *DestroyPipelineCommand) Execute(args []string) error {
 		return err
 
 	}
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/destroy_pipeline.go
+++ b/fly/commands/destroy_pipeline.go
@@ -10,8 +10,8 @@ import (
 )
 
 type DestroyPipelineCommand struct {
-	Pipeline        flaghelpers.PipelineFlag `short:"p"  long:"pipeline" required:"true" description:"Pipeline to destroy"`
-	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Destroy the pipeline without confirmation"`
+	Pipeline        flaghelpers.PipelineFlag `short:"p"  long:"pipeline" required:"true" env:"PIPELINE" description:"Pipeline to destroy"`
+	SkipInteractive bool                     `short:"n"  long:"non-interactive"                         description:"Destroy the pipeline without confirmation"`
 }
 
 func (command *DestroyPipelineCommand) Validate() error {

--- a/fly/commands/destroy_team.go
+++ b/fly/commands/destroy_team.go
@@ -21,11 +21,6 @@ func (command *DestroyTeamCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	teamName := command.TeamName
 	fmt.Printf("!!! this will remove all data for team `%s`\n\n", teamName)
 

--- a/fly/commands/destroy_team.go
+++ b/fly/commands/destroy_team.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/vito/go-interact/interact"
@@ -17,7 +16,7 @@ type DestroyTeamCommand struct {
 }
 
 func (command *DestroyTeamCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -43,11 +43,6 @@ func (command *ExecuteCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	taskConfig, err := command.CreateTaskConfig(args)
 	if err != nil {
 		return err

--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -16,7 +16,6 @@ import (
 	"github.com/concourse/concourse/fly/commands/internal/templatehelpers"
 	"github.com/concourse/concourse/fly/config"
 	"github.com/concourse/concourse/fly/eventstream"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/concourse/concourse/fly/ui/progress"
 	"github.com/concourse/concourse/go-concourse/concourse"
@@ -39,7 +38,7 @@ type ExecuteCommand struct {
 }
 
 func (command *ExecuteCommand) Execute(args []string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/expose_pipeline.go
+++ b/fly/commands/expose_pipeline.go
@@ -28,11 +28,6 @@ func (command *ExposePipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	found, err := target.Team().ExposePipeline(pipelineName)
 	if err != nil {
 		return err

--- a/fly/commands/expose_pipeline.go
+++ b/fly/commands/expose_pipeline.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ExposePipelineCommand struct {
-	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Pipeline to expose"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" env:"PIPELINE" description:"Pipeline to expose"`
 }
 
 func (command *ExposePipelineCommand) Validate() error {

--- a/fly/commands/expose_pipeline.go
+++ b/fly/commands/expose_pipeline.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type ExposePipelineCommand struct {
@@ -24,7 +23,7 @@ func (command *ExposePipelineCommand) Execute(args []string) error {
 
 	pipelineName := string(command.Pipeline)
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -1,6 +1,11 @@
 package commands
 
-import "github.com/concourse/concourse/fly/rc"
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/concourse/concourse/fly/rc"
+)
 
 type FlyCommand struct {
 	Help HelpCommand `command:"help" description:"Print this help message"`
@@ -9,6 +14,8 @@ type FlyCommand struct {
 	Targets      TargetsCommand      `command:"targets" alias:"ts" description:"List saved targets"`
 	DeleteTarget DeleteTargetCommand `command:"delete-target" alias:"dtg" description:"Delete target"`
 	EditTarget   EditTargetCommand   `command:"edit-target" alias:"etg" description:"Edit a target"`
+
+	Url string `short:"u" long:"url" description:"URL for the team, pipeline, job, build, or container to target"`
 
 	Version func() `short:"v" long:"version" description:"Print the version of Fly and exit"`
 
@@ -77,3 +84,38 @@ type FlyCommand struct {
 }
 
 var Fly FlyCommand
+
+func (fly *FlyCommand) RetrieveTarget() (rc.Target, error) {
+	var (
+		target rc.Target
+		name   rc.TargetName
+		err    error
+	)
+
+	if fly.Target == "" && fly.Url != "" {
+		u, err := url.Parse(fly.Url)
+		if err != nil {
+			return nil, err
+		}
+		urlMap := parseUrlPath(u.Path)
+		target, name, err = rc.LoadTargetFromURL(fmt.Sprintf("%s://%s", u.Scheme, u.Host), urlMap["teams"], fly.Verbose)
+		if err != nil {
+			return nil, err
+		}
+		fly.Target = name
+	} else {
+		target, err = rc.LoadTarget(fly.Target, fly.Verbose)
+		name = fly.Target
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return target, nil
+
+}

--- a/fly/commands/get_pipeline.go
+++ b/fly/commands/get_pipeline.go
@@ -38,11 +38,6 @@ func (command *GetPipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	config, _, found, err := target.Team().PipelineConfig(pipelineName)
 	if err != nil {
 		return err

--- a/fly/commands/get_pipeline.go
+++ b/fly/commands/get_pipeline.go
@@ -11,14 +11,13 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/mattn/go-isatty"
 )
 
 type GetPipelineCommand struct {
-	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Get configuration of this pipeline"`
-	JSON     bool                     `short:"j" long:"json"                     description:"Print config as json instead of yaml"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" env:"PIPELINE" description:"Get configuration of this pipeline"`
+	JSON     bool                     `short:"j" long:"json"                                    description:"Print config as json instead of yaml"`
 }
 
 func (command *GetPipelineCommand) Validate() error {
@@ -34,7 +33,7 @@ func (command *GetPipelineCommand) Execute(args []string) error {
 	asJSON := command.JSON
 	pipelineName := string(command.Pipeline)
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/hide_pipeline.go
+++ b/fly/commands/hide_pipeline.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type HidePipelineCommand struct {
@@ -24,7 +23,7 @@ func (command *HidePipelineCommand) Execute(args []string) error {
 
 	pipelineName := string(command.Pipeline)
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/hide_pipeline.go
+++ b/fly/commands/hide_pipeline.go
@@ -9,7 +9,7 @@ import (
 )
 
 type HidePipelineCommand struct {
-	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Pipeline to hide"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" env:"PIPELINE" description:"Pipeline to hide"`
 }
 
 func (command *HidePipelineCommand) Validate() error {

--- a/fly/commands/hide_pipeline.go
+++ b/fly/commands/hide_pipeline.go
@@ -28,11 +28,6 @@ func (command *HidePipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	found, err := target.Team().HidePipeline(pipelineName)
 	if err != nil {
 		return err

--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -40,10 +40,6 @@ func (command *HijackCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
 	var chosenContainer atc.Container
 
 	if command.Handle != "" {

--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -22,13 +22,13 @@ import (
 )
 
 type HijackCommand struct {
-	Job            flaghelpers.JobFlag      `short:"j" long:"job"   value-name:"PIPELINE/JOB"   description:"Name of a job to hijack"`
-	Handle         string                   `          long:"handle"                            description:"Handle id of a job to hijack"`
-	Check          flaghelpers.ResourceFlag `short:"c" long:"check" value-name:"PIPELINE/CHECK" description:"Name of a resource's checking container to hijack"`
-	Build          string                   `short:"b" long:"build"                             description:"Build number within the job, or global build ID"`
-	StepName       string                   `short:"s" long:"step"                              description:"Name of step to hijack (e.g. build, unit, resource name)"`
-	StepType       string                   `          long:"step-type"                         description:"Type of step to hijack (e.g. get, put, task)"`
-	Attempt        string                   `short:"a" long:"attempt" value-name:"N[,N,...]"    description:"Attempt number of step to hijack."`
+	Job            flaghelpers.JobFlag      `short:"j" long:"job"   value-name:"PIPELINE/JOB" env:"JOB" description:"Name of a job to hijack"`
+	Handle         string                   `          long:"handle"                                    description:"Handle id of a job to hijack"`
+	Check          flaghelpers.ResourceFlag `short:"c" long:"check" value-name:"PIPELINE/CHECK"         description:"Name of a resource's checking container to hijack"`
+	Build          string                   `short:"b" long:"build"                                     description:"Build number within the job, or global build ID"`
+	StepName       string                   `short:"s" long:"step"                                      description:"Name of step to hijack (e.g. build, unit, resource name)"`
+	StepType       string                   `          long:"step-type"                                 description:"Type of step to hijack (e.g. get, put, task)"`
+	Attempt        string                   `short:"a" long:"attempt" value-name:"N[,N,...]"            description:"Attempt number of step to hijack."`
 	PositionalArgs struct {
 		Command []string `positional-arg-name:"command" description:"The command to run in the container (default: bash)"`
 	} `positional-args:"yes"`

--- a/fly/commands/jobs.go
+++ b/fly/commands/jobs.go
@@ -23,11 +23,6 @@ func (command *JobsCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	var headers []string
 	var jobs []atc.Job
 

--- a/fly/commands/jobs.go
+++ b/fly/commands/jobs.go
@@ -5,18 +5,19 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
 
 type JobsCommand struct {
-	Pipeline string `short:"p" long:"pipeline" required:"true" description:"Get jobs in this pipeline"`
-	Json     bool   `long:"json" description:"Print command result as JSON"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" env:"PIPELINE" description:"Get jobs in this pipeline"`
+	Json     bool                     `long:"json"                                              description:"Print command result as JSON"`
 }
 
 func (command *JobsCommand) Execute([]string) error {
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 
 	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
 	if err != nil {

--- a/fly/commands/jobs.go
+++ b/fly/commands/jobs.go
@@ -6,7 +6,6 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
@@ -19,7 +18,7 @@ type JobsCommand struct {
 func (command *JobsCommand) Execute([]string) error {
 	pipelineName := string(command.Pipeline)
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/land_worker.go
+++ b/fly/commands/land_worker.go
@@ -2,8 +2,6 @@ package commands
 
 import (
 	"fmt"
-
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type LandWorkerCommand struct {
@@ -13,7 +11,7 @@ type LandWorkerCommand struct {
 func (command *LandWorkerCommand) Execute(args []string) error {
 	workerName := command.Worker
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/land_worker.go
+++ b/fly/commands/land_worker.go
@@ -16,11 +16,6 @@ func (command *LandWorkerCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	err = target.Client().LandWorker(workerName)
 	if err != nil {
 		return err

--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 var ErrMissingPipelineName = errors.New("Need to specify atleast one pipeline name")
@@ -30,7 +29,7 @@ func (command *OrderPipelinesCommand) Validate() ([]string, error) {
 }
 
 func (command *OrderPipelinesCommand) Execute(args []string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -34,11 +34,6 @@ func (command *OrderPipelinesCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	pipelines, err := command.Validate()
 	if err != nil {
 		return err

--- a/fly/commands/pause_job.go
+++ b/fly/commands/pause_job.go
@@ -16,11 +16,6 @@ func (command *PauseJobCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	found, err := target.Team().PauseJob(command.Job.PipelineName, command.Job.JobName)
 	if err != nil {
 		return err

--- a/fly/commands/pause_job.go
+++ b/fly/commands/pause_job.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type PauseJobCommand struct {
@@ -12,7 +11,7 @@ type PauseJobCommand struct {
 }
 
 func (command *PauseJobCommand) Execute(args []string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/pause_job.go
+++ b/fly/commands/pause_job.go
@@ -7,7 +7,7 @@ import (
 )
 
 type PauseJobCommand struct {
-	Job flaghelpers.JobFlag `short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" description:"Name of a job to pause"`
+	Job flaghelpers.JobFlag `short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" env:"JOB" description:"Name of a job to pause"`
 }
 
 func (command *PauseJobCommand) Execute(args []string) error {

--- a/fly/commands/pause_pipeline.go
+++ b/fly/commands/pause_pipeline.go
@@ -28,11 +28,6 @@ func (command *PausePipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	found, err := target.Team().PausePipeline(pipelineName)
 	if err != nil {
 		return err

--- a/fly/commands/pause_pipeline.go
+++ b/fly/commands/pause_pipeline.go
@@ -9,7 +9,7 @@ import (
 )
 
 type PausePipelineCommand struct {
-	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline" required:"true" description:"Pipeline to pause"`
+	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline" required:"true" env:"PIPELINE" description:"Pipeline to pause"`
 }
 
 func (command *PausePipelineCommand) Validate() error {

--- a/fly/commands/pause_pipeline.go
+++ b/fly/commands/pause_pipeline.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type PausePipelineCommand struct {
@@ -24,7 +23,7 @@ func (command *PausePipelineCommand) Execute(args []string) error {
 
 	pipelineName := string(command.Pipeline)
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/pipelines.go
+++ b/fly/commands/pipelines.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
@@ -16,7 +15,7 @@ type PipelinesCommand struct {
 }
 
 func (command *PipelinesCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/pipelines.go
+++ b/fly/commands/pipelines.go
@@ -20,11 +20,6 @@ func (command *PipelinesCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	var headers []string
 	var pipelines []atc.Pipeline
 

--- a/fly/commands/prune_worker.go
+++ b/fly/commands/prune_worker.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 )
 

--- a/fly/commands/prune_worker.go
+++ b/fly/commands/prune_worker.go
@@ -29,11 +29,6 @@ func (command *PruneWorkerCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	if command.AllStalled {
 		workers, err := target.Client().ListWorkers()
 		if err != nil {

--- a/fly/commands/prune_worker.go
+++ b/fly/commands/prune_worker.go
@@ -24,7 +24,7 @@ func (command *PruneWorkerCommand) Execute(args []string) error {
 		workersNames = append(workersNames, command.Worker)
 	}
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/rename_pipeline.go
+++ b/fly/commands/rename_pipeline.go
@@ -9,8 +9,8 @@ import (
 )
 
 type RenamePipelineCommand struct {
-	Pipeline flaghelpers.PipelineFlag `short:"o"  long:"old-name" required:"true"  description:"Pipeline to rename"`
-	Name     flaghelpers.PipelineFlag `short:"n"  long:"new-name" required:"true"  description:"Name to set as pipeline name"`
+	Pipeline flaghelpers.PipelineFlag `short:"o" long:"old-name" required:"true" env:"PIPELINE" description:"Pipeline to rename"`
+	Name     flaghelpers.PipelineFlag `short:"n" long:"new-name" required:"true"                description:"Name to set as pipeline name"`
 }
 
 func (command *RenamePipelineCommand) Validate() error {

--- a/fly/commands/rename_pipeline.go
+++ b/fly/commands/rename_pipeline.go
@@ -32,11 +32,6 @@ func (command *RenamePipelineCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	oldName := string(command.Pipeline)
 	newName := string(command.Name)
 

--- a/fly/commands/rename_pipeline.go
+++ b/fly/commands/rename_pipeline.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type RenamePipelineCommand struct {
@@ -28,7 +27,7 @@ func (command *RenamePipelineCommand) Execute([]string) error {
 		return err
 	}
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/rename_team.go
+++ b/fly/commands/rename_team.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type RenameTeamCommand struct {
@@ -13,7 +12,7 @@ type RenameTeamCommand struct {
 }
 
 func (command *RenameTeamCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/rename_team.go
+++ b/fly/commands/rename_team.go
@@ -17,11 +17,6 @@ func (command *RenameTeamCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	found, err := target.Team().RenameTeam(command.TeamName, command.NewTeamName)
 	if err != nil {
 		return err

--- a/fly/commands/resource_versions.go
+++ b/fly/commands/resource_versions.go
@@ -14,9 +14,9 @@ import (
 )
 
 type ResourceVersionsCommand struct {
-	Count    int                      `short:"c" long:"count" default:"50" description:"Number of builds you want to limit the return to"`
-	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to get versions for"`
-	Json     bool                     `long:"json" description:"Print command result as JSON"`
+	Count    int                      `short:"c" long:"count" default:"50"                                                     description:"Number of builds you want to limit the return to"`
+	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" env:"RESOURCE" description:"Name of a resource to get versions for"`
+	Json     bool                     `          long:"json"                                                                   description:"Print command result as JSON"`
 }
 
 func (command *ResourceVersionsCommand) Execute([]string) error {

--- a/fly/commands/resource_versions.go
+++ b/fly/commands/resource_versions.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/fatih/color"
@@ -21,7 +20,7 @@ type ResourceVersionsCommand struct {
 }
 
 func (command *ResourceVersionsCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/resource_versions.go
+++ b/fly/commands/resource_versions.go
@@ -25,11 +25,6 @@ func (command *ResourceVersionsCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	page := concourse.Page{Limit: command.Count}
 
 	team := target.Team()

--- a/fly/commands/resources.go
+++ b/fly/commands/resources.go
@@ -23,11 +23,6 @@ func (command *ResourcesCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	var headers []string
 	var resources []atc.Resource
 

--- a/fly/commands/resources.go
+++ b/fly/commands/resources.go
@@ -12,7 +12,7 @@ import (
 
 type ResourcesCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" env:"PIPELINE" description:"Get resources in this pipeline"`
-	Json     bool                     `long:"json"                                              description:"Print command result as JSON"`
+	Json     bool                     `          long:"json"                                    description:"Print command result as JSON"`
 }
 
 func (command *ResourcesCommand) Execute([]string) error {

--- a/fly/commands/resources.go
+++ b/fly/commands/resources.go
@@ -6,7 +6,6 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
@@ -19,7 +18,7 @@ type ResourcesCommand struct {
 func (command *ResourcesCommand) Execute([]string) error {
 	pipelineName := string(command.Pipeline)
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/resources.go
+++ b/fly/commands/resources.go
@@ -5,18 +5,19 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
 
 type ResourcesCommand struct {
-	Pipeline string `short:"p" long:"pipeline" required:"true" description:"Get resources in this pipeline"`
-	Json     bool   `long:"json" description:"Print command result as JSON"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" env:"PIPELINE" description:"Get resources in this pipeline"`
+	Json     bool                     `long:"json"                                              description:"Print command result as JSON"`
 }
 
 func (command *ResourcesCommand) Execute([]string) error {
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 
 	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
 	if err != nil {

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -5,7 +5,6 @@ import (
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/commands/internal/setpipelinehelpers"
 	"github.com/concourse/concourse/fly/commands/internal/templatehelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/mgutz/ansi"
 )
 
@@ -37,7 +36,7 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 	templateVariablesFiles := command.VarsFrom
 	pipelineName := string(command.Pipeline)
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -41,11 +41,6 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	ansi.DisableColors(command.DisableAnsiColor)
 
 	atcConfig := setpipelinehelpers.ATCConfig{

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -15,8 +15,8 @@ type SetPipelineCommand struct {
 
 	CheckCredentials bool `long:"check-creds"  description:"Validate credential variables against credential manager"`
 
-	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline"  required:"true"  description:"Pipeline to configure"`
-	Config   atc.PathFlag             `short:"c"  long:"config"    required:"true"  description:"Pipeline configuration file"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" env:"PIPELINE" description:"Pipeline to configure"`
+	Config   atc.PathFlag             `short:"c" long:"config"   required:"true"                description:"Pipeline configuration file"`
 
 	Var     []flaghelpers.VariablePairFlag     `short:"v"  long:"var"       value-name:"[NAME=STRING]"  description:"Specify a string value to set for a variable in the pipeline"`
 	YAMLVar []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"  value-name:"[NAME=YAML]"    description:"Specify a YAML value to set for a variable in the pipeline"`

--- a/fly/commands/set_team.go
+++ b/fly/commands/set_team.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/concourse/concourse/skymarshal/skycmd"
 	"github.com/jessevdk/go-flags"
@@ -30,7 +29,7 @@ type SetTeamCommand struct {
 }
 
 func (command *SetTeamCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/set_team.go
+++ b/fly/commands/set_team.go
@@ -34,11 +34,6 @@ func (command *SetTeamCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	authRoles, err := command.AuthFlags.Format()
 	if err != nil {
 		command.ErrorAuthNotConfigured(err)

--- a/fly/commands/status.go
+++ b/fly/commands/status.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
 type StatusCommand struct{}
 
 func (c *StatusCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/status.go
+++ b/fly/commands/status.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/rc"
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
 type StatusCommand struct{}
 
 func (c *StatusCommand) Execute([]string) error {
-	target, err := Fly.RetrieveTarget()
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
 	if err != nil {
 		return err
 	}

--- a/fly/commands/sync.go
+++ b/fly/commands/sync.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/concourse/concourse"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 )
 
@@ -20,7 +19,7 @@ type SyncCommand struct {
 }
 
 func (command *SyncCommand) Execute(args []string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/teams.go
+++ b/fly/commands/teams.go
@@ -23,11 +23,6 @@ func (command *TeamsCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	teams, err := target.Client().ListTeams()
 	if err != nil {
 		return err

--- a/fly/commands/teams.go
+++ b/fly/commands/teams.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
@@ -19,7 +18,7 @@ type TeamsCommand struct {
 }
 
 func (command *TeamsCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/trigger_job.go
+++ b/fly/commands/trigger_job.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/eventstream"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 )
 
@@ -20,7 +19,7 @@ type TriggerJobCommand struct {
 func (command *TriggerJobCommand) Execute(args []string) error {
 	pipelineName, jobName := command.Job.PipelineName, command.Job.JobName
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/trigger_job.go
+++ b/fly/commands/trigger_job.go
@@ -12,8 +12,8 @@ import (
 )
 
 type TriggerJobCommand struct {
-	Job   flaghelpers.JobFlag `short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" description:"Name of a job to trigger"`
-	Watch bool                `short:"w" long:"watch" description:"Start watching the build output"`
+	Job   flaghelpers.JobFlag `short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" env:"JOB" description:"Name of a job to trigger"`
+	Watch bool                `short:"w" long:"watch"                                                   description:"Start watching the build output"`
 }
 
 func (command *TriggerJobCommand) Execute(args []string) error {

--- a/fly/commands/trigger_job.go
+++ b/fly/commands/trigger_job.go
@@ -24,11 +24,6 @@ func (command *TriggerJobCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	build, err := target.Team().CreateJobBuild(pipelineName, jobName)
 	if err != nil {
 		return err

--- a/fly/commands/unpause_job.go
+++ b/fly/commands/unpause_job.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type UnpauseJobCommand struct {
@@ -12,7 +11,7 @@ type UnpauseJobCommand struct {
 }
 
 func (command *UnpauseJobCommand) Execute(args []string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/unpause_job.go
+++ b/fly/commands/unpause_job.go
@@ -16,11 +16,6 @@ func (command *UnpauseJobCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	found, err := target.Team().UnpauseJob(command.Job.PipelineName, command.Job.JobName)
 	if err != nil {
 		return err

--- a/fly/commands/unpause_job.go
+++ b/fly/commands/unpause_job.go
@@ -7,7 +7,7 @@ import (
 )
 
 type UnpauseJobCommand struct {
-	Job flaghelpers.JobFlag `short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" description:"Name of a job to unpause"`
+	Job flaghelpers.JobFlag `short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" env:"JOB" description:"Name of a job to unpause"`
 }
 
 func (command *UnpauseJobCommand) Execute(args []string) error {

--- a/fly/commands/unpause_pipeline.go
+++ b/fly/commands/unpause_pipeline.go
@@ -28,11 +28,6 @@ func (command *UnpausePipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	found, err := target.Team().UnpausePipeline(pipelineName)
 	if err != nil {
 		return err

--- a/fly/commands/unpause_pipeline.go
+++ b/fly/commands/unpause_pipeline.go
@@ -9,7 +9,7 @@ import (
 )
 
 type UnpausePipelineCommand struct {
-	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Pipeline to unpause"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" env:"PIPELINE" description:"Pipeline to unpause"`
 }
 
 func (command *UnpausePipelineCommand) Validate() error {

--- a/fly/commands/unpause_pipeline.go
+++ b/fly/commands/unpause_pipeline.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type UnpausePipelineCommand struct {
@@ -24,7 +23,7 @@ func (command *UnpausePipelineCommand) Execute(args []string) error {
 
 	pipelineName := string(command.Pipeline)
 
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/url_setup.go
+++ b/fly/commands/url_setup.go
@@ -35,7 +35,7 @@ func (options *UrlSetupOptions) SetInEnvironment() error {
 		if os.Getenv("RESOURCE") == "" && urlMap["pipelines"] != "" && urlMap["resources"] != "" {
 			os.Setenv("RESOURCE", urlMap["pipelines"]+"/"+urlMap["resources"])
 		}
-		if os.Getenv("RESOURCE_TYPE") == "" && urlMap["pipelines"] != ""  && urlMap["resource-types"] != "" {
+		if os.Getenv("RESOURCE_TYPE") == "" && urlMap["pipelines"] != "" && urlMap["resource-types"] != "" {
 			os.Setenv("RESOURCE_TYPE", urlMap["pipelines"]+"/"+urlMap["resource-types"])
 		}
 	}

--- a/fly/commands/url_setup.go
+++ b/fly/commands/url_setup.go
@@ -20,11 +20,23 @@ func (options *UrlSetupOptions) SetInEnvironment() error {
 		}
 		urlMap := parseUrlPath(u.Path)
 
+		if os.Getenv("TEAM") == "" && urlMap["teams"] != "" {
+			os.Setenv("TEAM", urlMap["teams"])
+		}
 		if os.Getenv("PIPELINE") == "" && urlMap["pipelines"] != "" {
 			os.Setenv("PIPELINE", urlMap["pipelines"])
 		}
 		if os.Getenv("JOB") == "" && urlMap["pipelines"] != "" && urlMap["jobs"] != "" {
 			os.Setenv("JOB", urlMap["pipelines"]+"/"+urlMap["jobs"])
+		}
+		if os.Getenv("BUILD") == "" && urlMap["builds"] != "" {
+			os.Setenv("BUILD", urlMap["builds"])
+		}
+		if os.Getenv("RESOURCE") == "" && urlMap["pipelines"] != "" && urlMap["resources"] != "" {
+			os.Setenv("RESOURCE", urlMap["pipelines"]+"/"+urlMap["resources"])
+		}
+		if os.Getenv("RESOURCE_TYPE") == "" && urlMap["pipelines"] != ""  && urlMap["resource-types"] != "" {
+			os.Setenv("RESOURCE_TYPE", urlMap["pipelines"]+"/"+urlMap["resource-types"])
 		}
 	}
 

--- a/fly/commands/url_setup.go
+++ b/fly/commands/url_setup.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"net/url"
+	"os"
+	"strings"
+)
+
+type UrlSetupOptions struct {
+	Url     string        `short:"u" long:"url" description:"URL for the team, pipeline, job, build, or container to target"`
+}
+
+var UrlSetup UrlSetupOptions
+
+func (options *UrlSetupOptions) SetInEnvironment() error {
+	if options.Url != "" {
+		u, err := url.Parse(options.Url)
+		if err != nil {
+			return err
+		}
+		urlMap := parseUrlPath(u.Path)
+
+		if os.Getenv("PIPELINE") == "" && urlMap["pipelines"] != "" {
+			os.Setenv("PIPELINE", urlMap["pipelines"])
+		}
+	}
+
+	return nil
+}
+
+func parseUrlPath(urlPath string) map[string]string {
+	pathWithoutFirstSlash := strings.Replace(urlPath, "/", "", 1)
+	urlComponents := strings.Split(pathWithoutFirstSlash, "/")
+	urlMap := make(map[string]string)
+
+	for i := 0; i < len(urlComponents)/2; i++ {
+		keyIndex := i * 2
+		valueIndex := keyIndex + 1
+		urlMap[urlComponents[keyIndex]] = urlComponents[valueIndex]
+	}
+
+	return urlMap
+}

--- a/fly/commands/url_setup.go
+++ b/fly/commands/url_setup.go
@@ -7,7 +7,7 @@ import (
 )
 
 type UrlSetupOptions struct {
-	Url     string        `short:"u" long:"url" description:"URL for the team, pipeline, job, build, or container to target"`
+	Url string `short:"u" long:"url" description:"URL for the team, pipeline, job, build, or container to target"`
 }
 
 var UrlSetup UrlSetupOptions

--- a/fly/commands/url_setup.go
+++ b/fly/commands/url_setup.go
@@ -23,6 +23,9 @@ func (options *UrlSetupOptions) SetInEnvironment() error {
 		if os.Getenv("PIPELINE") == "" && urlMap["pipelines"] != "" {
 			os.Setenv("PIPELINE", urlMap["pipelines"])
 		}
+		if os.Getenv("JOB") == "" && urlMap["pipelines"] != "" && urlMap["jobs"] != "" {
+			os.Setenv("JOB", urlMap["pipelines"]+"/"+urlMap["jobs"])
+		}
 	}
 
 	return nil

--- a/fly/commands/url_setup_test.go
+++ b/fly/commands/url_setup_test.go
@@ -1,0 +1,92 @@
+package commands
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("URL parsing", func() {
+	BeforeEach(func() {
+		os.Setenv("TEAM", "")
+		os.Setenv("PIPELINE", "")
+		os.Setenv("JOB", "")
+		os.Setenv("BUILD", "")
+		os.Setenv("RESOURCE", "")
+		os.Setenv("RESOURCE_TYPE", "")
+	})
+
+	It("set all environment variables for a pipeline", func() {
+		setup := UrlSetupOptions{"https://localhost:8080/teams/main/pipelines/my_pipeline"}
+
+		setup.SetInEnvironment()
+		Expect(os.Getenv("TEAM")).To(Equal("main"))
+		Expect(os.Getenv("PIPELINE")).To(Equal("my_pipeline"))
+		Expect(os.Getenv("JOB")).To(Equal(""))
+		Expect(os.Getenv("BUILD")).To(Equal(""))
+		Expect(os.Getenv("RESOURCE")).To(Equal(""))
+		Expect(os.Getenv("RESOURCE_TYPE")).To(Equal(""))
+	})
+
+	It("set all environment variables for a job", func() {
+		setup := UrlSetupOptions{"https://localhost:8080/teams/main/pipelines/my_pipeline/jobs/my_job"}
+
+		setup.SetInEnvironment()
+		Expect(os.Getenv("TEAM")).To(Equal("main"))
+		Expect(os.Getenv("PIPELINE")).To(Equal("my_pipeline"))
+		Expect(os.Getenv("JOB")).To(Equal("my_pipeline/my_job"))
+		Expect(os.Getenv("BUILD")).To(Equal(""))
+		Expect(os.Getenv("RESOURCE")).To(Equal(""))
+		Expect(os.Getenv("RESOURCE_TYPE")).To(Equal(""))
+	})
+
+	It("set all environment variables for a build", func() {
+		setup := UrlSetupOptions{"https://localhost:8080/teams/main/pipelines/my_pipeline/jobs/my_job/builds/1"}
+
+		setup.SetInEnvironment()
+		Expect(os.Getenv("TEAM")).To(Equal("main"))
+		Expect(os.Getenv("PIPELINE")).To(Equal("my_pipeline"))
+		Expect(os.Getenv("JOB")).To(Equal("my_pipeline/my_job"))
+		Expect(os.Getenv("BUILD")).To(Equal("1"))
+		Expect(os.Getenv("RESOURCE")).To(Equal(""))
+		Expect(os.Getenv("RESOURCE_TYPE")).To(Equal(""))
+	})
+
+	It("set all environment variables for a resource", func() {
+		setup := UrlSetupOptions{"https://localhost:8080/teams/main/pipelines/my_pipeline/resources/my_resource"}
+
+		setup.SetInEnvironment()
+		Expect(os.Getenv("TEAM")).To(Equal("main"))
+		Expect(os.Getenv("PIPELINE")).To(Equal("my_pipeline"))
+		Expect(os.Getenv("JOB")).To(Equal(""))
+		Expect(os.Getenv("BUILD")).To(Equal(""))
+		Expect(os.Getenv("RESOURCE")).To(Equal("my_pipeline/my_resource"))
+		Expect(os.Getenv("RESOURCE_TYPE")).To(Equal(""))
+	})
+
+	It("set all environment variables for a resource", func() {
+		setup := UrlSetupOptions{"https://localhost:8080/teams/main/pipelines/my_pipeline/resource-types/my_resource_type"}
+
+		setup.SetInEnvironment()
+		Expect(os.Getenv("TEAM")).To(Equal("main"))
+		Expect(os.Getenv("PIPELINE")).To(Equal("my_pipeline"))
+		Expect(os.Getenv("JOB")).To(Equal(""))
+		Expect(os.Getenv("BUILD")).To(Equal(""))
+		Expect(os.Getenv("RESOURCE")).To(Equal(""))
+		Expect(os.Getenv("RESOURCE_TYPE")).To(Equal("my_pipeline/my_resource_type"))
+	})
+
+	It("set all environment variables for a build by direct url", func() {
+		setup := UrlSetupOptions{"https://localhost:8080/builds/1"}
+
+		setup.SetInEnvironment()
+		Expect(os.Getenv("TEAM")).To(Equal(""))
+		Expect(os.Getenv("PIPELINE")).To(Equal(""))
+		Expect(os.Getenv("JOB")).To(Equal(""))
+		Expect(os.Getenv("BUILD")).To(Equal("1"))
+		Expect(os.Getenv("RESOURCE")).To(Equal(""))
+		Expect(os.Getenv("RESOURCE_TYPE")).To(Equal(""))
+	})
+
+})

--- a/fly/commands/userinfo.go
+++ b/fly/commands/userinfo.go
@@ -20,11 +20,6 @@ func (command *UserinfoCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	userinfo, err := target.Client().UserInfo()
 	if err != nil {
 		return err

--- a/fly/commands/userinfo.go
+++ b/fly/commands/userinfo.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
@@ -16,7 +15,7 @@ type UserinfoCommand struct {
 }
 
 func (command *UserinfoCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/volumes.go
+++ b/fly/commands/volumes.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
@@ -20,7 +19,7 @@ type VolumesCommand struct {
 }
 
 func (command *VolumesCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/volumes.go
+++ b/fly/commands/volumes.go
@@ -24,11 +24,6 @@ func (command *VolumesCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	volumes, err := target.Team().ListVolumes()
 	if err != nil {
 		return err

--- a/fly/commands/watch.go
+++ b/fly/commands/watch.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/eventstream"
-	"github.com/concourse/concourse/fly/rc"
 )
 
 type WatchCommand struct {
@@ -17,7 +16,7 @@ type WatchCommand struct {
 }
 
 func (command *WatchCommand) Execute(args []string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/watch.go
+++ b/fly/commands/watch.go
@@ -21,11 +21,6 @@ func (command *WatchCommand) Execute(args []string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	var buildId int
 	client := target.Client()
 	if command.Job.JobName != "" || command.Build == "" {

--- a/fly/commands/watch.go
+++ b/fly/commands/watch.go
@@ -10,9 +10,9 @@ import (
 )
 
 type WatchCommand struct {
-	Job       flaghelpers.JobFlag `short:"j" long:"job"         value-name:"PIPELINE/JOB"  description:"Watches builds of the given job"`
-	Build     string              `short:"b" long:"build"                                  description:"Watches a specific build"`
-	Timestamp bool                `short:"t" long:"timestamps"                             description:"Print with local timestamp"`
+	Job       flaghelpers.JobFlag `short:"j" long:"job"         value-name:"PIPELINE/JOB" env:"JOB" description:"Watches builds of the given job"`
+	Build     string              `short:"b" long:"build"                                           description:"Watches a specific build"`
+	Timestamp bool                `short:"t" long:"timestamps"                                      description:"Print with local timestamp"`
 }
 
 func (command *WatchCommand) Execute(args []string) error {

--- a/fly/commands/workers.go
+++ b/fly/commands/workers.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
-	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
 )
@@ -20,7 +19,7 @@ type WorkersCommand struct {
 }
 
 func (command *WorkersCommand) Execute([]string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	target, err := Fly.RetrieveTarget()
 	if err != nil {
 		return err
 	}

--- a/fly/commands/workers.go
+++ b/fly/commands/workers.go
@@ -24,11 +24,6 @@ func (command *WorkersCommand) Execute([]string) error {
 		return err
 	}
 
-	err = target.Validate()
-	if err != nil {
-		return err
-	}
-
 	workers, err := target.Client().ListWorkers()
 	if err != nil {
 		return err

--- a/fly/integration/sync_test.go
+++ b/fly/integration/sync_test.go
@@ -51,7 +51,12 @@ var _ = Describe("Syncing", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 
-		atcServer.AppendHandlers(cliHandler())
+		atcServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/api/v1/info"),
+				ghttp.RespondWithJSONEncoded(200, map[string]interface{}{"version": atcVersion, "worker_version": "test"}),
+			), cliHandler(),
+		)
 	})
 
 	Context("When versions mismatch between fly + atc", func() {

--- a/fly/main.go
+++ b/fly/main.go
@@ -12,7 +12,17 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
+func UrlSetupUnknownOptionHandler(option string, arg flags.SplitArgument, args []string) ([]string, error) {
+	// just ignore additional arguments during url setup
+	return args, nil
+}
+
 func main() {
+	url_setup_parser := flags.NewParser(&commands.UrlSetup, flags.None)
+	url_setup_parser.UnknownOptionHandler = UrlSetupUnknownOptionHandler
+	url_setup_parser.Parse()
+	commands.UrlSetup.SetInEnvironment()
+
 	parser := flags.NewParser(&commands.Fly, flags.HelpFlag|flags.PassDoubleDash)
 	parser.NamespaceDelimiter = "-"
 

--- a/fly/main.go
+++ b/fly/main.go
@@ -18,10 +18,13 @@ func UrlSetupUnknownOptionHandler(option string, arg flags.SplitArgument, args [
 }
 
 func main() {
-	url_setup_parser := flags.NewParser(&commands.UrlSetup, flags.None)
-	url_setup_parser.UnknownOptionHandler = UrlSetupUnknownOptionHandler
-	url_setup_parser.Parse()
-	commands.UrlSetup.SetInEnvironment()
+	// do not look for completion on url
+	if (os.Getenv("GO_FLAGS_COMPLETION") != "1") {
+		url_setup_parser := flags.NewParser(&commands.UrlSetup, flags.None)
+		url_setup_parser.UnknownOptionHandler = UrlSetupUnknownOptionHandler
+		url_setup_parser.Parse()
+		commands.UrlSetup.SetInEnvironment()
+	}
 
 	parser := flags.NewParser(&commands.Fly, flags.HelpFlag|flags.PassDoubleDash)
 	parser.NamespaceDelimiter = "-"

--- a/fly/main.go
+++ b/fly/main.go
@@ -19,7 +19,7 @@ func UrlSetupUnknownOptionHandler(option string, arg flags.SplitArgument, args [
 
 func main() {
 	// do not look for completion on url
-	if (os.Getenv("GO_FLAGS_COMPLETION") != "1") {
+	if os.Getenv("GO_FLAGS_COMPLETION") != "1" {
 		url_setup_parser := flags.NewParser(&commands.UrlSetup, flags.None)
 		url_setup_parser.UnknownOptionHandler = UrlSetupUnknownOptionHandler
 		url_setup_parser.Parse()


### PR DESCRIPTION
for #3660 

This is the smallest change I could think of use an url in all command generically.
What is happening:
- a light options parser, `UrlSetup`, is declared parsing just the url. If the url is present, it will be split in it's components and they will be added as environment variables if they are not already present
- the method to get the target either from the target option or the url has been moved from `HijackCommand` to `Fly`
- the `url` parameter has been moved from `HijackCommand` to `Fly`
- now a command only has to specify that it can take a parameter by an environment variable and it will be loaded from the url if the url has the information. 
- to get the target from the url instead of just the parameter, it's just a different method call

load order is url overloaded by environment variable overloaded by dedicated flag.

See [here](https://github.com/concourse/concourse/pull/3683/files#diff-aab25ef5684fe04b55e132c3bff60622) for all the changes to do to `get-pipeline` for it to work with an url

The only side effect is that pipeline can now also be specified by an environment variable, which I think is a good thing.

`get-pipeline` now can be called (pipeline is `test`, target is `test`, team is `main`):
```
fly -t test get-pipeline -p test
fly get-pipeline -u http://concourse_web_1:8080/teams/main/pipelines/test
fly get-pipeline -u http://concourse_web_1:8080/teams/main/ -p test
PIPELINE=test fly get-pipeline -u http://concourse_web_1:8080/teams/main/
PIPELINE=test fly -t test get-pipeline
```
and if none is specified, it will still give the correct error message:
```
fly -t test get-pipeline
error: the required flag `-p, --pipeline' was not specified
```