### PR TITLE
support parsing old finish-get/finish-put events

### DIFF
--- a/atc/event/deprecated_events.go
+++ b/atc/event/deprecated_events.go
@@ -497,3 +497,23 @@ type FinishPutV40 struct {
 
 func (FinishPutV40) EventType() atc.EventType  { return EventTypeFinishPut }
 func (FinishPutV40) Version() atc.EventVersion { return "4.0" }
+
+type FinishGetV50 struct {
+	Origin          Origin              `json:"origin"`
+	ExitStatus      int                 `json:"exit_status"`
+	FetchedVersion  atc.Version         `json:"version"`
+	FetchedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+}
+
+func (FinishGetV50) EventType() atc.EventType  { return EventTypeFinishGet }
+func (FinishGetV50) Version() atc.EventVersion { return "5.0" }
+
+type FinishPutV50 struct {
+	Origin          Origin              `json:"origin"`
+	ExitStatus      int                 `json:"exit_status"`
+	CreatedVersion  atc.Version         `json:"version"`
+	CreatedMetadata []atc.MetadataField `json:"metadata,omitempty"`
+}
+
+func (FinishPutV50) EventType() atc.EventType  { return EventTypeFinishPut }
+func (FinishPutV50) Version() atc.EventVersion { return "5.0" }

--- a/atc/event/events.go
+++ b/atc/event/events.go
@@ -128,7 +128,7 @@ func (StartGet) Version() atc.EventVersion { return "1.0" }
 
 type FinishGet struct {
 	Origin          Origin              `json:"origin"`
-	Time            int64               `json:"time,omitempty"`
+	Time            int64               `json:"time"`
 	ExitStatus      int                 `json:"exit_status"`
 	FetchedVersion  atc.Version         `json:"version"`
 	FetchedMetadata []atc.MetadataField `json:"metadata,omitempty"`
@@ -155,7 +155,7 @@ func (StartPut) Version() atc.EventVersion { return "1.0" }
 
 type FinishPut struct {
 	Origin          Origin              `json:"origin"`
-	Time            int64               `json:"time,omitempty"`
+	Time            int64               `json:"time"`
 	ExitStatus      int                 `json:"exit_status"`
 	CreatedVersion  atc.Version         `json:"version"`
 	CreatedMetadata []atc.MetadataField `json:"metadata,omitempty"`

--- a/atc/event/parser.go
+++ b/atc/event/parser.go
@@ -82,6 +82,8 @@ func init() {
 	registerEvent(InitializePutV10{})
 	registerEvent(FinishGetV40{})
 	registerEvent(FinishPutV40{})
+	registerEvent(FinishGetV50{})
+	registerEvent(FinishPutV50{})
 }
 
 type Message struct {


### PR DESCRIPTION
these versions are pretty misleading; they're compared via equality and
not actual semver.

follow-up to https://github.com/concourse/concourse/pull/3579 to fix upgrade/downgrade tests