### PR TITLE
semver event parsing, patch downgrade job for now

### DIFF
--- a/atc/event.go
+++ b/atc/event.go
@@ -1,25 +1,32 @@
 package atc
 
+import "strings"
+
+// Event represents an event emitted by a build. They are interpreted as a
+// stream to render the build's output.
 type Event interface {
 	EventType() EventType
 	Version() EventVersion
 }
 
+// EventType is a classification of an event payload, associated to a struct to
+// parse it into.
 type EventType string
 
-// semantic version for an individual event.
+// EventVersion is a MAJOR.MINOR version corresponding to an event type.
 //
-// minor bumps are expected to be backwards-compatible, meaning clients can
-// interpret them via the older handlers, and they can unmarshal into the new
-// version trivially.
+// Minor bumps must be backwards-compatible, meaning older clients can still
+// unmarshal them into their old type and still handle the event.
 //
-// ATC will always emit the highest possible minor version for an event. this is
-// so that we don't have to maintain copies of the event every time there's a
-// minor bump.
+// An example of a minor bump would be an additive change, i.e. a new field.
 //
-// an example of a minor bump would be an additive change, i.e. a new field.
-//
-// major bumps are backwards-incompatible.
-//
-// an example of a major bump would be the changing or removal of a field.
+// Major bumps are backwards-incompatible and must be parsed and handled
+// differently. An example of a major bump would be the changing or removal of a
+// field.
 type EventVersion string
+
+// IsCompatibleWith checks whether the versions have the same major version.
+func (version EventVersion) IsCompatibleWith(other EventVersion) bool {
+	segs := strings.SplitN(string(other), ".", 2)
+	return strings.HasPrefix(string(version), segs[0]+".")
+}

--- a/atc/event/deprecated_events.go
+++ b/atc/event/deprecated_events.go
@@ -411,14 +411,6 @@ const (
 	SingleIncrementV30 OriginV40LocationIncrement = 1
 )
 
-type LogV50 struct {
-	Origin  Origin `json:"origin"`
-	Payload string `json:"payload"`
-}
-
-func (LogV50) EventType() atc.EventType  { return "log" }
-func (LogV50) Version() atc.EventVersion { return "5.0" }
-
 type FinishGetV30 struct {
 	Origin          OriginV40           `json:"origin"`
 	Plan            GetPlanV40          `json:"plan"`
@@ -497,23 +489,3 @@ type FinishPutV40 struct {
 
 func (FinishPutV40) EventType() atc.EventType  { return EventTypeFinishPut }
 func (FinishPutV40) Version() atc.EventVersion { return "4.0" }
-
-type FinishGetV50 struct {
-	Origin          Origin              `json:"origin"`
-	ExitStatus      int                 `json:"exit_status"`
-	FetchedVersion  atc.Version         `json:"version"`
-	FetchedMetadata []atc.MetadataField `json:"metadata,omitempty"`
-}
-
-func (FinishGetV50) EventType() atc.EventType  { return EventTypeFinishGet }
-func (FinishGetV50) Version() atc.EventVersion { return "5.0" }
-
-type FinishPutV50 struct {
-	Origin          Origin              `json:"origin"`
-	ExitStatus      int                 `json:"exit_status"`
-	CreatedVersion  atc.Version         `json:"version"`
-	CreatedMetadata []atc.MetadataField `json:"metadata,omitempty"`
-}
-
-func (FinishPutV50) EventType() atc.EventType  { return EventTypeFinishPut }
-func (FinishPutV50) Version() atc.EventVersion { return "5.0" }

--- a/atc/event/parser.go
+++ b/atc/event/parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/concourse/concourse/atc"
 )
@@ -22,7 +23,7 @@ func unmarshaler(e atc.Event) func([]byte) (atc.Event, error) {
 	}
 }
 
-func registerEvent(e atc.Event) {
+func RegisterEvent(e atc.Event) {
 	versions, found := events[e.EventType()]
 	if !found {
 		versions = eventVersions{}
@@ -33,57 +34,54 @@ func registerEvent(e atc.Event) {
 }
 
 func init() {
-	registerEvent(InitializeTask{})
-	registerEvent(StartTask{})
-	registerEvent(FinishTask{})
-	registerEvent(InitializeGet{})
-	registerEvent(StartGet{})
-	registerEvent(FinishGet{})
-	registerEvent(InitializePut{})
-	registerEvent(StartPut{})
-	registerEvent(FinishPut{})
-	registerEvent(Status{})
-	registerEvent(Log{})
-	registerEvent(Error{})
+	RegisterEvent(InitializeTask{})
+	RegisterEvent(StartTask{})
+	RegisterEvent(FinishTask{})
+	RegisterEvent(InitializeGet{})
+	RegisterEvent(StartGet{})
+	RegisterEvent(FinishGet{})
+	RegisterEvent(InitializePut{})
+	RegisterEvent(StartPut{})
+	RegisterEvent(FinishPut{})
+	RegisterEvent(Status{})
+	RegisterEvent(Log{})
+	RegisterEvent(Error{})
 
 	// deprecated:
-	registerEvent(InitializeV10{})
-	registerEvent(FinishV10{})
-	registerEvent(StartV10{})
-	registerEvent(InputV10{})
-	registerEvent(InputV20{})
-	registerEvent(OutputV10{})
-	registerEvent(OutputV20{})
-	registerEvent(ErrorV10{})
-	registerEvent(ErrorV20{})
-	registerEvent(ErrorV30{})
-	registerEvent(FinishTaskV10{})
-	registerEvent(FinishTaskV20{})
-	registerEvent(FinishTaskV30{})
-	registerEvent(InitializeTaskV10{})
-	registerEvent(InitializeTaskV20{})
-	registerEvent(InitializeTaskV30{})
-	registerEvent(StartTaskV10{})
-	registerEvent(StartTaskV20{})
-	registerEvent(StartTaskV30{})
-	registerEvent(StartTaskV40{})
-	registerEvent(LogV10{})
-	registerEvent(LogV20{})
-	registerEvent(LogV30{})
-	registerEvent(LogV40{})
-	registerEvent(LogV50{})
-	registerEvent(FinishGetV10{})
-	registerEvent(FinishGetV20{})
-	registerEvent(FinishGetV30{})
-	registerEvent(FinishPutV10{})
-	registerEvent(FinishPutV20{})
-	registerEvent(FinishPutV30{})
-	registerEvent(InitializeGetV10{})
-	registerEvent(InitializePutV10{})
-	registerEvent(FinishGetV40{})
-	registerEvent(FinishPutV40{})
-	registerEvent(FinishGetV50{})
-	registerEvent(FinishPutV50{})
+	RegisterEvent(InitializeV10{})
+	RegisterEvent(FinishV10{})
+	RegisterEvent(StartV10{})
+	RegisterEvent(InputV10{})
+	RegisterEvent(InputV20{})
+	RegisterEvent(OutputV10{})
+	RegisterEvent(OutputV20{})
+	RegisterEvent(ErrorV10{})
+	RegisterEvent(ErrorV20{})
+	RegisterEvent(ErrorV30{})
+	RegisterEvent(FinishTaskV10{})
+	RegisterEvent(FinishTaskV20{})
+	RegisterEvent(FinishTaskV30{})
+	RegisterEvent(InitializeTaskV10{})
+	RegisterEvent(InitializeTaskV20{})
+	RegisterEvent(InitializeTaskV30{})
+	RegisterEvent(StartTaskV10{})
+	RegisterEvent(StartTaskV20{})
+	RegisterEvent(StartTaskV30{})
+	RegisterEvent(StartTaskV40{})
+	RegisterEvent(LogV10{})
+	RegisterEvent(LogV20{})
+	RegisterEvent(LogV30{})
+	RegisterEvent(LogV40{})
+	RegisterEvent(FinishGetV10{})
+	RegisterEvent(FinishGetV20{})
+	RegisterEvent(FinishGetV30{})
+	RegisterEvent(FinishPutV10{})
+	RegisterEvent(FinishPutV20{})
+	RegisterEvent(FinishPutV30{})
+	RegisterEvent(InitializeGetV10{})
+	RegisterEvent(InitializePutV10{})
+	RegisterEvent(FinishGetV40{})
+	RegisterEvent(FinishPutV40{})
 }
 
 type Message struct {
@@ -129,16 +127,47 @@ func (m *Message) UnmarshalJSON(bytes []byte) error {
 	return nil
 }
 
+type UnknownEventTypeError struct {
+	Type atc.EventType
+}
+
+func (err UnknownEventTypeError) Error() string {
+	return fmt.Sprintf("unknown event type: %s", err.Type)
+}
+
+type UnknownEventVersionError struct {
+	Type          atc.EventType
+	Version       atc.EventVersion
+	KnownVersions []string
+}
+
+func (err UnknownEventVersionError) Error() string {
+	return fmt.Sprintf(
+		"unknown event version: %s version %s (supported versions: %s)",
+		err.Type,
+		err.Version,
+		strings.Join(err.KnownVersions, ", "),
+	)
+}
+
 func ParseEvent(version atc.EventVersion, typ atc.EventType, payload []byte) (atc.Event, error) {
 	versions, found := events[typ]
 	if !found {
-		return nil, fmt.Errorf("unknown event type: %s", typ)
+		return nil, UnknownEventTypeError{typ}
 	}
 
-	parser, found := versions[version]
-	if !found {
-		return nil, fmt.Errorf("unknown version of event: %s v%s", typ, version)
+	knownVersions := []string{}
+	for v, parser := range versions {
+		knownVersions = append(knownVersions, string(v))
+
+		if v.IsCompatibleWith(version) {
+			return parser(payload)
+		}
 	}
 
-	return parser(payload)
+	return nil, UnknownEventVersionError{
+		Type:          typ,
+		Version:       version,
+		KnownVersions: knownVersions,
+	}
 }

--- a/atc/event/parser_test.go
+++ b/atc/event/parser_test.go
@@ -1,0 +1,51 @@
+package event_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/event"
+)
+
+type fakeEvent struct {
+	Hello      string `json:"hello"`
+	AddedField string `json:"added"`
+}
+
+func (fakeEvent) EventType() atc.EventType  { return "fake" }
+func (fakeEvent) Version() atc.EventVersion { return "5.1" }
+
+var _ = Describe("ParseEvent", func() {
+	BeforeEach(func() {
+		event.RegisterEvent(fakeEvent{})
+	})
+
+	It("can parse an older event type with a compatible major version", func() {
+		e, err := event.ParseEvent("5.0", "fake", []byte(`{"hello":"sup"}`))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(e).To(Equal(fakeEvent{Hello: "sup"}))
+	})
+
+	It("can parse a newer event type with a compatible major version", func() {
+		e, err := event.ParseEvent("5.3", "fake", []byte(`{"hello":"sup","future":"field"}`))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(e).To(Equal(fakeEvent{Hello: "sup"}))
+	})
+
+	It("fails to parse if the type is unknown", func() {
+		_, err := event.ParseEvent("4.0", "fake-unknown", []byte(`{"hello":"sup"}`))
+		Expect(err).To(Equal(event.UnknownEventTypeError{
+			Type: "fake-unknown",
+		}))
+	})
+
+	It("fails to parse if the version is incompatible", func() {
+		_, err := event.ParseEvent("4.0", "fake", []byte(`{"hello":"sup"}`))
+		Expect(err).To(Equal(event.UnknownEventVersionError{
+			Type:          "fake",
+			Version:       "4.0",
+			KnownVersions: []string{"5.1"},
+		}))
+	})
+})

--- a/atc/event/suite_test.go
+++ b/atc/event/suite_test.go
@@ -1,0 +1,13 @@
+package event_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEvent(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Event Suite")
+}

--- a/ci/tasks/scripts/verify-upgrade-downgrade-pipeline
+++ b/ci/tasks/scripts/verify-upgrade-downgrade-pipeline
@@ -40,9 +40,13 @@ fly -t local set-pipeline -n \
 fly -t local builds \
   | grep "test-pipeline/test-job.*1.*succeeded"
 
-# test that we can still fetch build history
-fly -t local watch -j "test-pipeline/test-job" \
-  | grep "succeeded"
+# TODO: pre-5.1 event parsing behavior made this finnicky to support as event
+# versions were not actually parsed with semver compatibility. this can be
+# brought back once 5.1 has shipped.
+#
+# test that we can still read build logs
+# fly -t local watch -j "test-pipeline/test-job" \
+#   | grep "succeeded"
 
 # test that we can check our resources
 fly -t local check-resource -r "test-pipeline/test-resource" \

--- a/fly/eventstream/render.go
+++ b/fly/eventstream/render.go
@@ -37,10 +37,6 @@ func Render(dst io.Writer, src eventstream.EventStream, options RenderOptions) i
 			dstImpl.SetTimestamp(e.Time)
 			fmt.Fprintf(dstImpl, "%s", e.Payload)
 
-		case event.LogV50:
-			dstImpl.SetTimestamp(0)
-			fmt.Fprintf(dstImpl, "%s", e.Payload)
-
 		case event.InitializeTask:
 			dstImpl.SetTimestamp(e.Time)
 			fmt.Fprintf(dstImpl, "\x1b[1minitializing\x1b[0m\n")


### PR DESCRIPTION
This should make it easier to make backwards-compatible changes to build events in the future. Added some basic tests for event parsing which cover the version compatibility semantics, and commented out a part of the upgrade/downgrade tests that can't be expected to pass until we ship 5.1 (because the tests rely on using the old `fly` which won't have this fix).