### PR TITLE
topgun/k8s: external worker test to use separate deployments

### DIFF
--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -138,7 +138,7 @@ func helmDeploy(releaseName, namespace, chartDir string, args ...string) *gexec.
 	return sess
 }
 
-func helmInstallArgs(args ...string) []string{
+func helmInstallArgs(args ...string) []string {
 	helmArgs := []string{
 		"--set=web.livenessProbe.failureThreshold=3",
 		"--set=web.livenessProbe.initialDelaySeconds=3",


### PR DESCRIPTION
- In order to test the worker only and web-only deployments, we updated
the external worker test to use separate deployments so we can be able
to make sure that the worker connects successfully to the ATC.


cc @taylorsilva 