### PR TITLE
atc: invalidate pipelines with duplicate groups

### DIFF
--- a/atc/validate.go
+++ b/atc/validate.go
@@ -56,11 +56,21 @@ func validateGroups(c Config) error {
 	errorMessages := []string{}
 
 	jobsGrouped := make(map[string]bool)
+	groupNames := make(map[string]int)
+
 	for _, job := range c.Jobs {
 		jobsGrouped[job.Name] = false
 	}
 
 	for _, group := range c.Groups {
+
+		if val, ok := groupNames[group.Name]; ok {
+			groupNames[group.Name] = val + 1
+
+		} else {
+			groupNames[group.Name] = 1
+		}
+
 		for _, job := range group.Jobs {
 			_, exists := c.Jobs.Lookup(job)
 			if !exists {
@@ -77,6 +87,13 @@ func validateGroups(c Config) error {
 				errorMessages = append(errorMessages,
 					fmt.Sprintf("group '%s' has unknown resource '%s'", group.Name, resource))
 			}
+		}
+	}
+
+	for groupName, groupCount := range groupNames {
+		if groupCount > 1 {
+			errorMessages = append(errorMessages,
+				fmt.Sprintf("group '%s' appears %d times. Duplicate names are not allowed.", groupName, groupCount))
 		}
 	}
 

--- a/atc/validate_test.go
+++ b/atc/validate_test.go
@@ -142,6 +142,41 @@ var _ = Describe("ValidateConfig", func() {
 			})
 
 		})
+
+		Context("when the groups have two duplicate names", func() {
+			BeforeEach(func() {
+				config.Groups = append(config.Groups, GroupConfig{
+					Name: "some-group",
+				})
+			})
+
+			It("returns an error", func() {
+				Expect(errorMessages).To(HaveLen(1))
+				Expect(errorMessages[0]).To(ContainSubstring("invalid groups:"))
+				Expect(errorMessages[0]).To(ContainSubstring("'some-group' appears 2 times. Duplicate names are not allowed."))
+			})
+		})
+
+		Context("when the groups have four duplicate names", func() {
+			BeforeEach(func() {
+				config.Groups = append(config.Groups, GroupConfig{
+					Name: "some-group",
+				}, GroupConfig{
+					Name: "some-group",
+				}, GroupConfig{
+					Name: "some-group",
+				})
+			})
+
+			It("returns an error", func() {
+				Expect(errorMessages).To(HaveLen(1))
+				errorMessage := strings.Trim(errorMessages[0], "\n")
+				errorLines := strings.Split(errorMessage, "\n")
+				Expect(errorLines).To(HaveLen(2))
+				Expect(errorLines[0]).To(ContainSubstring("invalid groups:"))
+				Expect(errorLines[1]).To(ContainSubstring("group 'some-group' appears 4 times. Duplicate names are not allowed."))
+			})
+		})
 	})
 
 	Describe("invalid resources", func() {


### PR DESCRIPTION
Fixes #3651