### PR TITLE
topgun/k8s: refactors and fix rand number generator

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -16,12 +16,7 @@ var _ = Describe("Baggageclaim Drivers", func() {
 	)
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
-		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-
-		if proxySession != nil {
-			Wait(proxySession.Interrupt())
-		}
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 	type Case struct {

--- a/topgun/k8s/container_limits_test.go
+++ b/topgun/k8s/container_limits_test.go
@@ -47,9 +47,7 @@ var _ = Describe("Container Limits", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
-		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-		Wait(proxySession.Interrupt())
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 	Context("using cos as NodeImage", func() {

--- a/topgun/k8s/ephemeral_worker_test.go
+++ b/topgun/k8s/ephemeral_worker_test.go
@@ -43,9 +43,7 @@ var _ = Describe("Ephemeral workers", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
-		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-		Wait(proxySession.Interrupt())
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 	It("Gets properly cleaned when getting removed and then put back on", func() {

--- a/topgun/k8s/external_worker_test.go
+++ b/topgun/k8s/external_worker_test.go
@@ -71,9 +71,7 @@ var _ = Describe("team external workers", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
-		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-		Wait(proxySession.Interrupt())
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 })

--- a/topgun/k8s/garden_config_test.go
+++ b/topgun/k8s/garden_config_test.go
@@ -40,9 +40,7 @@ var _ = Describe("Garden Config", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
-		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-		Wait(proxySession.Interrupt())
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 	getMaxContainers := func() int {

--- a/topgun/k8s/https_web_tls_termination_test.go
+++ b/topgun/k8s/https_web_tls_termination_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -37,9 +36,7 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 
 		})
 		AfterEach(func() {
-			helmDestroy(releaseName)
-			Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-			Wait(proxySession.Interrupt())
+			cleanup(releaseName, namespace, proxySession)
 		})
 
 		Context("configure helm chart for tls termination at web", func() {

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -98,7 +98,7 @@ var _ = BeforeEach(func() {
 })
 
 func setReleaseNameAndNamespace(description string) {
-	releaseName = fmt.Sprintf("topgun-"+description+"-%d-%d", rand.Int(), GinkgoParallelNode())
+	releaseName = fmt.Sprintf("topgun-"+description+"-%d-%d", rand.Int31n(1000000), GinkgoParallelNode())
 	namespace = releaseName
 }
 
@@ -275,4 +275,13 @@ func getRunningWorkers(workers []Worker) (running []Worker) {
 		}
 	}
 	return
+}
+
+func cleanup(releaseName, namespace string, proxySession *gexec.Session) {
+	helmDestroy(releaseName)
+	Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
+
+	if proxySession != nil {
+		Wait(proxySession.Interrupt())
+	}
 }

--- a/topgun/k8s/kubernetes_creds_mgmt_test.go
+++ b/topgun/k8s/kubernetes_creds_mgmt_test.go
@@ -121,9 +121,7 @@ var _ = Describe("Kubernetes credential management", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
-		Wait(proxySession.Interrupt())
-		Run(nil, "kubectl", "delete", "namespace", namespace)
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 })

--- a/topgun/k8s/mainteam_role_test.go
+++ b/topgun/k8s/mainteam_role_test.go
@@ -39,9 +39,7 @@ var _ = Describe("Main team role config", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
-		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-		Wait(proxySession.Interrupt())
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 	Context("Adding team role config yaml to web", func() {

--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/onsi/gomega/gexec"
 
-	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -78,10 +77,8 @@ var _ = Describe("Prometheus integration", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
 		helmDestroy(prometheusReleaseName)
-		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-		Wait(proxySession.Interrupt())
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 	It("Is able to retrieve concourse metrics", func() {

--- a/topgun/k8s/rebalance_test.go
+++ b/topgun/k8s/rebalance_test.go
@@ -43,9 +43,7 @@ var _ = Describe("Worker Rebalancing", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
-		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-		Wait(proxySession.Interrupt())
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 	It("eventually has worker connecting to each web nodes over a period of time", func() {


### PR DESCRIPTION
Hey,

This PR:

- moves the cleanup code to a separate function, and
- updates the random number generator to generate smaller numbers as this was affecting the creation of internal k8s resources with names larger than 63 characters long.

fixes: #3710

cc @YoussB
