### PR TITLE
Ubuntu bosh release

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -587,6 +587,8 @@ jobs:
       passed: [build-rc]
       trigger: true
     - get: concourse-release-repo
+  - task: ubuntu-image-replace
+    file: concourse/ci/tasks/ubuntu-image-replace.yml
   - task: bump-concourse-blobs
     file: concourse/ci/tasks/bump-concourse-blobs.yml
     image: unit-image

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -587,6 +587,48 @@ jobs:
       passed: [build-rc]
       trigger: true
     - get: concourse-release-repo
+    - get: bosh-io-release-resource
+      passed: [dev-image]
+      trigger: true
+    - get: bosh-io-stemcell-resource
+      passed: [dev-image]
+      trigger: true
+    - get: cf-resource
+      passed: [dev-image]
+      trigger: true
+    - get: docker-image-resource
+      passed: [dev-image]
+      trigger: true
+    - get: git-resource
+      passed: [dev-image]
+      trigger: true
+    - get: github-release-resource
+      passed: [dev-image]
+      trigger: true
+    - get: hg-resource
+      passed: [dev-image]
+      trigger: true
+    - get: pool-resource
+      passed: [dev-image]
+      trigger: true
+    - get: registry-image-resource
+      passed: [dev-image]
+      trigger: true
+    - get: s3-resource
+      passed: [dev-image]
+      trigger: true
+    - get: semver-resource
+      passed: [dev-image]
+      trigger: true
+    - get: time-resource
+      passed: [dev-image]
+      trigger: true
+    - get: tracker-resource
+      passed: [dev-image]
+      trigger: true
+    - get: mock-resource
+      passed: [dev-image]
+      trigger: true
   - task: ubuntu-image-replace
     file: concourse/ci/tasks/ubuntu-image-replace.yml
   - task: bump-concourse-blobs

--- a/ci/tasks/bump-concourse-blobs.yml
+++ b/ci/tasks/bump-concourse-blobs.yml
@@ -10,7 +10,7 @@ inputs:
 - name: concourse
 - name: version
 - name: concourse-release-repo
-- name: linux-rc
+- name: ubuntu-linux-rc
 - name: windows-rc
 
 outputs:

--- a/ci/tasks/scripts/bump-concourse-blobs
+++ b/ci/tasks/scripts/bump-concourse-blobs
@@ -7,6 +7,7 @@ version=$(cat version/version)
 
 git clone concourse-release-repo bumped-concourse-release-repo
 
+# authenticate us to upload to GCS bucket
 export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp.key.json
 cat > $GOOGLE_APPLICATION_CREDENTIALS <<EOF
 $GCP_JSON_KEY
@@ -25,20 +26,11 @@ for blob in $(bosh blobs --column="path"  | grep concourse/); do
   bosh -n remove-blob $blob
 done
 
-mkdir temp-linux-rc
-tar -zxf ../linux-rc/concourse-*.tgz -C temp-linux-rc
-cd temp-linux-rc
-for resource in concourse/resource-types/*; do
-  file_size=`ls -lh $resource/rootfs.tgz | awk '{print $5}'`
-  resource_name=`basename $resource`
-  echo "$resource_name\t $file_size"
-done
-cd ..
-
 for blob in ../linux-rc/concourse-*.tgz ../windows-rc/concourse-*.zip; do
   bosh -n add-blob $blob concourse/$(basename $blob)
 done
 
+# Upload blobs to GCS bucket
 bosh -n upload-blobs
 
 git add -A

--- a/ci/tasks/scripts/bump-concourse-blobs
+++ b/ci/tasks/scripts/bump-concourse-blobs
@@ -25,6 +25,16 @@ for blob in $(bosh blobs --column="path"  | grep concourse/); do
   bosh -n remove-blob $blob
 done
 
+mkdir temp-linux-rc
+tar -zxf ../linux-rc/concourse-*.tgz -C temp-linux-rc
+cd temp-linux-rc
+for resource in concourse/resource-types/*; do
+  file_size=`ls -lh $resource/rootfs.tgz | awk '{print $5}'`
+  resource_name=`basename $resource`
+  echo "$resource_name\t $file_size"
+done
+cd ..
+
 for blob in ../linux-rc/concourse-*.tgz ../windows-rc/concourse-*.zip; do
   bosh -n add-blob $blob concourse/$(basename $blob)
 done

--- a/ci/tasks/scripts/bump-concourse-blobs
+++ b/ci/tasks/scripts/bump-concourse-blobs
@@ -13,25 +13,25 @@ cat > $GOOGLE_APPLICATION_CREDENTIALS <<EOF
 $GCP_JSON_KEY
 EOF
 
-cd bumped-concourse-release-repo/
+pushd bumped-concourse-release-repo/
+  # work-around Go BOSH CLI trying to rename blobs downloaded into ~/.root/tmp
+  # into release dir, which is invalid cross-device link
+  export HOME=$PWD
 
-# work-around Go BOSH CLI trying to rename blobs downloaded into ~/.root/tmp
-# into release dir, which is invalid cross-device link
-export HOME=$PWD
+  git config --global user.email "concourseteam+concourse-github-bot@gmail.com"
+  git config --global user.name "Concourse Bot"
 
-git config --global user.email "concourseteam+concourse-github-bot@gmail.com"
-git config --global user.name "Concourse Bot"
+  for blob in $(bosh blobs --column="path"  | grep concourse/); do
+    bosh -n remove-blob $blob
+  done
 
-for blob in $(bosh blobs --column="path"  | grep concourse/); do
-  bosh -n remove-blob $blob
-done
+  for blob in ../ubuntu-linux-rc/concourse-*.tgz ../windows-rc/concourse-*.zip; do
+    bosh -n add-blob $blob concourse/$(basename $blob)
+  done
 
-for blob in ../linux-rc/concourse-*.tgz ../windows-rc/concourse-*.zip; do
-  bosh -n add-blob $blob concourse/$(basename $blob)
-done
+  # Upload blobs to GCS bucket
+  bosh -n upload-blobs
 
-# Upload blobs to GCS bucket
-bosh -n upload-blobs
-
-git add -A
-git commit -m "bump concourse to $version"
+  git add -A
+  git commit -m "bump concourse to $version"
+popd

--- a/ci/tasks/scripts/ubuntu-replace-resource-types
+++ b/ci/tasks/scripts/ubuntu-replace-resource-types
@@ -1,26 +1,24 @@
 #!/bin/bash
 set -e -x
-# resource files in ../linux-rc/concourse-*.tgz  ../windows-rc/concourse-*.zip
-# tar -zxf to untar those resource
 
-## alpine version concourse tgz package
-mkdir concourse-alpine
+# alpine version concourse tgz package
+mkdir -p concourse-alpine
 
-concourse_file_name=`ls linux-rc/concourse-*.tgz`
-echo "concourse file name: $concourse_file_name"
+concourse_file_name=$(ls linux-rc/concourse-*.tgz)
+
 tar -zxf $concourse_file_name -C concourse-alpine
 
-## unzip resource 1 and replace alpine rootfs.tgz with ubuntu
+# iterate all directories of resource-types in concourse alpine tgz file
+# replace alpine version of rootfs.tgz with ubuntu version
 for res in concourse-alpine/concourse/resource-types/*; do
   resource_name=$(basename $res)
   rm -rf concourse-alpine/concourse/resource-types/$resource_name/*
   tar -zxf resources/$resource_name/*-ubuntu.tgz -C concourse-alpine/concourse/resource-types/$resource_name/
   echo "replaced $resource_name"
 done
-## pack the concourse release again
+
+# pack the concourse for linux release again
 rm $concourse_file_name
 pushd concourse-alpine
   tar -czf ../$concourse_file_name *
 popd
-# find ./concourse-alpine -name "*"
-tar -tzf $concourse_file_name

--- a/ci/tasks/scripts/ubuntu-replace-resource-types
+++ b/ci/tasks/scripts/ubuntu-replace-resource-types
@@ -2,23 +2,22 @@
 set -e -x
 
 # alpine version concourse tgz package
-mkdir -p concourse-alpine
+mkdir -p tarball-contents
 
-concourse_file_name=$(ls linux-rc/concourse-*.tgz)
+concourse_file_path=$(ls linux-rc/concourse-*.tgz)
 
-tar -zxf $concourse_file_name -C concourse-alpine
+tar -zxf $concourse_file_path -C tarball-contents
 
 # iterate all directories of resource-types in concourse alpine tgz file
 # replace alpine version of rootfs.tgz with ubuntu version
-for res in concourse-alpine/concourse/resource-types/*; do
+for res in tarball-contents/concourse/resource-types/*; do
   resource_name=$(basename $res)
-  rm -rf concourse-alpine/concourse/resource-types/$resource_name/*
-  tar -zxf resources/$resource_name/*-ubuntu.tgz -C concourse-alpine/concourse/resource-types/$resource_name/
+  rm -rf tarball-contents/concourse/resource-types/$resource_name/*
+  tar -zxf resources/$resource_name/*-ubuntu.tgz -C tarball-contents/concourse/resource-types/$resource_name/
   echo "replaced $resource_name"
 done
 
 # pack the concourse for linux release again
-rm $concourse_file_name
-pushd concourse-alpine
-  tar -czf ../$concourse_file_name *
+pushd tarball-contents
+tar -czf ../ubuntu-linux-rc/$(basename $concourse_file_path) *
 popd

--- a/ci/tasks/scripts/ubuntu-replace-resource-types
+++ b/ci/tasks/scripts/ubuntu-replace-resource-types
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e -x
+# resource files in ../linux-rc/concourse-*.tgz  ../windows-rc/concourse-*.zip
+# tar -zxf to untar those resource
+
+## alpine version concourse tgz package
+mkdir concourse-alpine
+
+concourse_file_name=`ls linux-rc/concourse-*.tgz`
+echo "concourse file name: $concourse_file_name"
+tar -zxf $concourse_file_name -C concourse-alpine
+
+## unzip resource 1 and replace alpine rootfs.tgz with ubuntu
+for res in concourse-alpine/concourse/resource-types/*; do
+  resource_name=$(basename $res)
+  rm -rf concourse-alpine/concourse/resource-types/$resource_name/*
+  tar -zxf resources/$resource_name/*-ubuntu.tgz -C concourse-alpine/concourse/resource-types/$resource_name/
+  echo "replaced $resource_name"
+done
+## pack the concourse release again
+rm $concourse_file_name
+pushd concourse-alpine
+  tar -czf ../$concourse_file_name *
+popd
+# find ./concourse-alpine -name "*"
+tar -tzf $concourse_file_name

--- a/ci/tasks/ubuntu-image-replace.yml
+++ b/ci/tasks/ubuntu-image-replace.yml
@@ -39,7 +39,7 @@ inputs:
 - name: linux-rc
 
 outputs:
-- name: linux-rc
+- name: ubuntu-linux-rc
 
 run:
   path: concourse/ci/tasks/scripts/ubuntu-replace-resource-types

--- a/ci/tasks/ubuntu-image-replace.yml
+++ b/ci/tasks/ubuntu-image-replace.yml
@@ -8,7 +8,6 @@ image_resource:
 
 inputs:
 - name: concourse
-
 - name: bosh-io-release-resource
   path: resources/bosh-io-release
 - name: bosh-io-stemcell-resource
@@ -37,18 +36,10 @@ inputs:
   path: resources/time
 - name: tracker-resource
   path: resources/tracker
-
-- name: linux-rc  # download using `gsutil`, put `linux-rc`
-
-
-# fly execute \
-#   -i concourse=./ \
-#   -i linux-rc=linux-rc \
-#   -i bosh-io-release-resource=bosh-io-release-resource
-
+- name: linux-rc
 
 outputs:
-- name: ubuntu-resources-image
+- name: linux-rc
 
 run:
   path: concourse/ci/tasks/scripts/ubuntu-replace-resource-types

--- a/ci/tasks/ubuntu-image-replace.yml
+++ b/ci/tasks/ubuntu-image-replace.yml
@@ -1,0 +1,54 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: concourse/unit
+
+inputs:
+- name: concourse
+
+- name: bosh-io-release-resource
+  path: resources/bosh-io-release
+- name: bosh-io-stemcell-resource
+  path: resources/bosh-io-stemcell
+- name: cf-resource
+  path: resources/cf
+- name: docker-image-resource
+  path: resources/docker-image
+- name: git-resource
+  path: resources/git
+- name: github-release-resource
+  path: resources/github-release
+- name: hg-resource
+  path: resources/hg
+- name: mock-resource
+  path: resources/mock
+- name: pool-resource
+  path: resources/pool
+- name: registry-image-resource
+  path: resources/registry-image
+- name: s3-resource
+  path: resources/s3
+- name: semver-resource
+  path: resources/semver
+- name: time-resource
+  path: resources/time
+- name: tracker-resource
+  path: resources/tracker
+
+- name: linux-rc  # download using `gsutil`, put `linux-rc`
+
+
+# fly execute \
+#   -i concourse=./ \
+#   -i linux-rc=linux-rc \
+#   -i bosh-io-release-resource=bosh-io-release-resource
+
+
+outputs:
+- name: ubuntu-resources-image
+
+run:
+  path: concourse/ci/tasks/scripts/ubuntu-replace-resource-types


### PR DESCRIPTION
We added a step in the job `bosh-bump` to replace `alpine` rootfs with `ubuntu` rootfs in the concourse linux-rc.
Link to a private note with more details is here: https://github.com/orgs/concourse/projects/33#card-19512105