### PR TITLE
atc: make x-frame-options secure by default

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -129,7 +129,7 @@ type RunCommand struct {
 	} `group:"Metrics & Diagnostics"`
 
 	Server struct {
-		XFrameOptions string `long:"x-frame-options" description:"The value to set for X-Frame-Options. If omitted, the header is not set."`
+		XFrameOptions string `long:"x-frame-options" default:"deny" description:"The value to set for X-Frame-Options."`
 	} `group:"Web Server"`
 
 	LogDBQueries bool `long:"log-db-queries" description:"Log database queries."`

--- a/atc/integration/configuration_test.go
+++ b/atc/integration/configuration_test.go
@@ -73,6 +73,12 @@ var _ = Describe("ATC Integration Test", func() {
 		Expect(string(bodyBytes)).To(ContainSubstring("main"))
 		Expect(string(bodyBytes)).To(ContainSubstring("local:test"))
 	})
+
+	It("X-Frame-Options header prevents clickjacking by default", func() {
+		resp, err := http.Get(atcURL)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Header.Get("x-frame-options")).To(Equal("deny"))
+	})
 })
 
 func webLogin(atcURL, username, password string) http.Client {


### PR DESCRIPTION
fixes #3511