### PR TITLE
change flag of fly builds --team from t to n because t is already used

### DIFF
--- a/fly/commands/builds.go
+++ b/fly/commands/builds.go
@@ -26,7 +26,7 @@ type BuildsCommand struct {
 	Job         flaghelpers.JobFlag      `short:"j" long:"job" value-name:"PIPELINE/JOB" description:"Name of a job to get builds for"`
 	Json        bool                     `long:"json" description:"Print command result as JSON"`
 	Pipeline    flaghelpers.PipelineFlag `short:"p" long:"pipeline" description:"Name of a pipeline to get builds for"`
-	Teams       []string                 `short:"t"  long:"team" description:"Show builds for these teams"`
+	Teams       []string                 `short:"n"  long:"team" description:"Show builds for these teams"`
 	Since       string                   `long:"since" description:"Start of the range to filter builds"`
 	Until       string                   `long:"until" description:"End of the range to filter builds"`
 }


### PR DESCRIPTION
This fixes #3697. 