### PR TITLE
web: remove dependence on elm/regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build-debug": "yarn run build-less && yarn run build-elm-debug",
     "test": "cd web/elm && elm-test",
     "build-less": "lessc --clean-css=--advanced web/assets/css/main.less web/public/main.css",
-    "build-elm": "cd web/elm && elm make --output ../public/elm.js src/Main.elm && uglifyjs < ../public/elm.js > ../public/elm.min.js",
+    "build-elm": "cd web/elm && elm make --optimize --output ../public/elm.js src/Main.elm && uglifyjs < ../public/elm.js > ../public/elm.min.js",
     "build-elm-debug": "cd web/elm && elm make --output ../public/elm.js src/Main.elm && uglifyjs < ../public/elm.js > ../public/elm.min.js",
     "watch": "chokidar -i elm-stuff 'web/elm/src/**/*.elm' 'web/assets/css/*.less' -c 'yarn run build-debug' --initial",
     "update-mdi-svg": "./hack/update-mdi-svg \"node_modules/@mdi/svg/svg\" > web/public/mdi-svg.js && uglifyjs < web/public/mdi-svg.js > web/public/mdi-svg.min.js"

--- a/web/elm/elm.json
+++ b/web/elm/elm.json
@@ -14,7 +14,6 @@
             "elm/http": "1.0.0",
             "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
-            "elm/regex": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
@@ -34,6 +33,7 @@
             "avh4/elm-fifo": "1.0.4",
             "elm/virtual-dom": "1.0.2",
             "rtfeldman/elm-hex": "1.0.0",
+            "elm/regex": "1.0.0",
             "rtfeldman/elm-iso8601-date-strings": "1.1.2"
         }
     },

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -860,6 +860,6 @@ customDecoder decoder toResult =
                     Json.Decode.succeed b
 
                 Err err ->
-                    Json.Decode.fail <| Debug.toString err
+                    Json.Decode.fail <| Json.Decode.errorToString err
         )
         decoder

--- a/web/elm/src/Concourse/BuildEvents.elm
+++ b/web/elm/src/Concourse/BuildEvents.elm
@@ -43,12 +43,17 @@ decodeBuildEventEnvelope =
                                 Json.Decode.field "data" Json.Decode.string
                                     |> Json.Decode.andThen
                                         (\rawEvent ->
-                                            case Json.Decode.decodeString decodeBuildEvent rawEvent of
+                                            case
+                                                Json.Decode.decodeString
+                                                    decodeBuildEvent
+                                                    rawEvent
+                                            of
                                                 Ok event ->
                                                     Json.Decode.succeed event
 
                                                 Err err ->
-                                                    Json.Decode.fail <| Debug.toString err
+                                                    Json.Decode.fail <|
+                                                        Json.Decode.errorToString err
                                         )
                     )
     in

--- a/web/elm/src/Network/Build.elm
+++ b/web/elm/src/Network/Build.elm
@@ -35,10 +35,22 @@ abort buildId csrfToken =
             }
 
 
-fetchJobBuilds : Concourse.JobIdentifier -> Maybe Page -> Task Http.Error (Paginated Concourse.Build)
+fetchJobBuilds :
+    Concourse.JobIdentifier
+    -> Maybe Page
+    -> Task Http.Error (Paginated Concourse.Build)
 fetchJobBuilds job page =
     let
-        url =
-            "/api/v1/teams/" ++ job.teamName ++ "/pipelines/" ++ job.pipelineName ++ "/jobs/" ++ job.jobName ++ "/builds"
+        segments =
+            [ "api"
+            , "v1"
+            , "teams"
+            , job.teamName
+            , "pipelines"
+            , job.pipelineName
+            , "jobs"
+            , job.jobName
+            , "builds"
+            ]
     in
-    Network.Pagination.fetch Concourse.decodeBuild url page
+    Network.Pagination.fetch Concourse.decodeBuild segments page

--- a/web/elm/src/Network/Pagination.elm
+++ b/web/elm/src/Network/Pagination.elm
@@ -1,199 +1,139 @@
 module Network.Pagination exposing (fetch, parseLinks)
 
-import Concourse.Pagination exposing (Direction(..), Page, Paginated, Pagination)
+import Concourse.Pagination
+    exposing
+        ( Direction(..)
+        , Page
+        , Paginated
+        , Pagination
+        )
 import Dict exposing (Dict)
 import Http
 import Json.Decode
-import Maybe.Extra
-import Regex exposing (Regex)
+import List.Extra
+import Maybe.Extra exposing (orElse)
+import Parser
+    exposing
+        ( (|.)
+        , (|=)
+        , Parser
+        , backtrackable
+        , chompWhile
+        , getChompedString
+        , keyword
+        , map
+        , oneOf
+        , run
+        , spaces
+        , succeed
+        , symbol
+        )
 import String
 import Task exposing (Task)
+import Url
+import Url.Builder
+import Url.Parser exposing (parse, query)
+import Url.Parser.Query as Query
 
 
-fetch : Json.Decode.Decoder a -> String -> Maybe Page -> Task Http.Error (Paginated a)
-fetch decode url page =
+fetch :
+    Json.Decode.Decoder a
+    -> List String
+    -> Maybe Page
+    -> Task Http.Error (Paginated a)
+fetch decoder segments p =
     Http.toTask <|
         Http.request
             { method = "GET"
             , headers = []
-            , url = addParams url page
+            , url = Url.Builder.relative segments (params p)
             , body = Http.emptyBody
-            , expect = Http.expectStringResponse (parsePagination decode)
+            , expect = Http.expectStringResponse (parsePagination decoder)
             , timeout = Nothing
             , withCredentials = False
             }
 
 
-addParams : String -> Maybe Page -> String
-addParams url page =
-    let
-        ( baseURL, query ) =
-            extractQuery url
-    in
-    setQuery baseURL (Dict.union query (toQuery page))
+params : Maybe Page -> List Url.Builder.QueryParameter
+params p =
+    case p of
+        Just { direction, limit } ->
+            [ Url.Builder.int "limit" limit
+            , case direction of
+                Since since ->
+                    Url.Builder.int "since" since
+
+                Until until ->
+                    Url.Builder.int "limit" until
+
+                From from ->
+                    Url.Builder.int "limit" from
+
+                To to ->
+                    Url.Builder.int "limit" to
+            ]
+
+        Nothing ->
+            []
 
 
-parseParams : String -> Maybe Page
-parseParams =
-    fromQuery << Tuple.second << extractQuery
-
-
-extractQuery : String -> ( String, Dict String String )
-extractQuery url =
-    case String.split "?" url of
-        baseURL :: query :: _ ->
-            ( baseURL, parseQuery query )
-
-        _ ->
-            ( url, Dict.empty )
-
-
-setQuery : String -> Dict String String -> String
-setQuery baseURL query =
-    let
-        params =
-            String.join "&" <|
-                List.map (\( k, v ) -> k ++ "=" ++ v) (Dict.toList query)
-    in
-    if params == "" then
-        baseURL
-
-    else
-        baseURL ++ "?" ++ params
-
-
-parsePagination : Json.Decode.Decoder a -> Http.Response String -> Result String (Paginated a)
-parsePagination decode response =
-    let
-        pagination =
-            parseLinks response
-
-        decoded =
-            Json.Decode.decodeString (Json.Decode.list decode) response.body
-    in
-    case decoded of
-        Err err ->
-            Err <| Debug.toString err
-
-        Ok content ->
-            Ok { content = content, pagination = pagination }
+parsePagination :
+    Json.Decode.Decoder a
+    -> Http.Response String
+    -> Result String (Paginated a)
+parsePagination decoder response =
+    response.body
+        |> Json.Decode.decodeString (Json.Decode.list decoder)
+        |> Result.mapError Json.Decode.errorToString
+        |> Result.map
+            (\content ->
+                { content = content, pagination = parseLinks response }
+            )
 
 
 parseLinks : Http.Response String -> Pagination
-parseLinks response =
-    case Dict.get "link" <| keysToLower response.headers of
-        Nothing ->
-            Pagination Nothing Nothing
-
-        Just commaSeparatedCraziness ->
-            let
-                headers =
-                    String.split ", " commaSeparatedCraziness
-
-                parsed =
-                    Dict.fromList <| List.filterMap parseLinkTuple headers
-            in
-            Pagination
-                (Dict.get previousRel parsed |> Maybe.andThen parseParams)
-                (Dict.get nextRel parsed |> Maybe.andThen parseParams)
+parseLinks =
+    .headers
+        >> Dict.toList
+        >> List.Extra.find (Tuple.first >> String.toLower >> (==) "link")
+        >> Maybe.map Tuple.second
+        >> Maybe.andThen (run pagination >> Result.toMaybe)
+        >> Maybe.withDefault { previousPage = Nothing, nextPage = Nothing }
 
 
-fromQuery : Dict String String -> Maybe Page
-fromQuery query =
+pagination : Parser Pagination
+pagination =
     let
-        limit =
-            Maybe.withDefault 0 <|
-                (Dict.get "limit" query |> Maybe.andThen String.toInt)
-
-        until =
-            Maybe.map Until <|
-                (Dict.get "until" query |> Maybe.andThen String.toInt)
-
-        since =
-            Maybe.map Since <|
-                (Dict.get "since" query |> Maybe.andThen String.toInt)
-
-        from =
-            Maybe.map Since <|
-                (Dict.get "from" query |> Maybe.andThen String.toInt)
-
-        to =
-            Maybe.map Since <|
-                (Dict.get "to" query |> Maybe.andThen String.toInt)
+        entry rel =
+            backtrackable <|
+                succeed parsePage
+                    |. symbol "<"
+                    |= getChompedString (chompWhile <| (/=) '>')
+                    |. symbol ">"
+                    |. symbol ";"
+                    |. spaces
+                    |. keyword "rel"
+                    |. symbol "="
+                    |. symbol "\""
+                    |. keyword rel
+                    |. symbol "\""
     in
-    Maybe.map (\direction -> { direction = direction, limit = limit }) <|
-        Maybe.Extra.or until <|
-            Maybe.Extra.or since <|
-                Maybe.Extra.or from to
-
-
-toQuery : Maybe Page -> Dict String String
-toQuery page =
-    case page of
-        Nothing ->
-            Dict.empty
-
-        Just somePage ->
-            let
-                directionParam =
-                    case somePage.direction of
-                        Since id ->
-                            ( "since", String.fromInt id )
-
-                        Until id ->
-                            ( "until", String.fromInt id )
-
-                        From id ->
-                            ( "from", String.fromInt id )
-
-                        To id ->
-                            ( "to", String.fromInt id )
-
-                limitParam =
-                    ( "limit", String.fromInt somePage.limit )
-            in
-            Dict.fromList [ directionParam, limitParam ]
-
-
-parseLinkTuple : String -> Maybe ( String, String )
-parseLinkTuple header =
-    case
-        Maybe.map (\r -> Regex.findAtMost 1 r header) linkHeaderRegex
-            |> Maybe.withDefault []
-    of
-        [] ->
-            Nothing
-
-        { submatches } :: _ ->
-            case submatches of
-                (Just url) :: (Just rel) :: _ ->
-                    Just ( rel, url )
-
-                _ ->
-                    Nothing
-
-
-parseQuery : String -> Dict String String
-parseQuery query =
-    let
-        parseParam p =
-            case String.split "=" p of
-                k :: vs ->
-                    ( k, String.join "=" vs )
-
-                [] ->
-                    ( "", "" )
-    in
-    Dict.fromList <|
-        List.map parseParam <|
-            String.split "&" query
-
-
-keysToLower : Dict String a -> Dict String a
-keysToLower =
-    Dict.toList
-        >> List.map (Tuple.mapFirst String.toLower)
-        >> Dict.fromList
+    oneOf
+        [ succeed (\p n -> { previousPage = p, nextPage = n })
+            |= entry previousRel
+            |. symbol ","
+            |. spaces
+            |= entry nextRel
+        , succeed (\n p -> { previousPage = p, nextPage = n })
+            |= entry nextRel
+            |. symbol ","
+            |. spaces
+            |= entry previousRel
+        , succeed (\p -> { previousPage = p, nextPage = Nothing })
+            |= entry previousRel
+        , succeed (\n -> { previousPage = Nothing, nextPage = n })
+            |= entry nextRel
+        ]
 
 
 previousRel : String
@@ -206,6 +146,29 @@ nextRel =
     "next"
 
 
-linkHeaderRegex : Maybe Regex
-linkHeaderRegex =
-    Regex.fromString ("<([^>]+)>; rel=\"(" ++ previousRel ++ "|" ++ nextRel ++ ")\"")
+parsePage : String -> Maybe Page
+parsePage url =
+    let
+        tryParam param =
+            url
+                |> Url.fromString
+                -- for some reason, the `query` function returns parsers that
+                -- only work when the path is empty. This is probably a bug:
+                -- https://github.com/elm/url/issues/17
+                |> Maybe.map (\u -> { u | path = "" })
+                |> Maybe.andThen (parse <| query <| Query.int param)
+                |> Maybe.withDefault Nothing
+
+        tryDirection dir =
+            tryParam
+                >> Maybe.map
+                    (\n ->
+                        { direction = dir n
+                        , limit = tryParam "limit" |> Maybe.withDefault 0
+                        }
+                    )
+    in
+    tryDirection Until "until"
+        |> orElse (tryDirection Since "since")
+        |> orElse (tryDirection From "from")
+        |> orElse (tryDirection To "to")

--- a/web/elm/src/Network/Pagination.elm
+++ b/web/elm/src/Network/Pagination.elm
@@ -7,7 +7,7 @@ import Concourse.Pagination
         , Paginated
         , Pagination
         )
-import Dict exposing (Dict)
+import Dict
 import Http
 import Json.Decode
 import List.Extra
@@ -46,7 +46,7 @@ fetch decoder segments p =
         Http.request
             { method = "GET"
             , headers = []
-            , url = Url.Builder.relative segments (params p)
+            , url = Url.Builder.absolute segments (params p)
             , body = Http.emptyBody
             , expect = Http.expectStringResponse (parsePagination decoder)
             , timeout = Nothing

--- a/web/elm/src/Network/Resource.elm
+++ b/web/elm/src/Network/Resource.elm
@@ -63,13 +63,25 @@ fetchVersionedResource vrid =
             ++ String.fromInt vrid.versionID
 
 
-fetchVersionedResources : Concourse.ResourceIdentifier -> Maybe Page -> Task Http.Error (Paginated Concourse.VersionedResource)
+fetchVersionedResources :
+    Concourse.ResourceIdentifier
+    -> Maybe Page
+    -> Task Http.Error (Paginated Concourse.VersionedResource)
 fetchVersionedResources rid page =
     let
-        url =
-            "/api/v1/teams/" ++ rid.teamName ++ "/pipelines/" ++ rid.pipelineName ++ "/resources/" ++ rid.resourceName ++ "/versions"
+        segments =
+            [ "api"
+            , "v1"
+            , "teams"
+            , rid.teamName
+            , "pipelines"
+            , rid.pipelineName
+            , "resources"
+            , rid.resourceName
+            , "versions"
+            ]
     in
-    Network.Pagination.fetch Concourse.decodeVersionedResource url page
+    Network.Pagination.fetch Concourse.decodeVersionedResource segments page
 
 
 enableDisableVersionedResource : Bool -> Concourse.VersionedResourceIdentifier -> Concourse.CSRFToken -> Task Http.Error ()

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -173,8 +173,22 @@ job =
 
 pipeline : Parser (Route -> a) a
 pipeline =
-    map (\t p g -> Pipeline { id = { teamName = t, pipelineName = p }, groups = g })
-        (s "teams" </> string </> s "pipelines" </> string <?> Query.custom "group" identity)
+    map
+        (\t p g ->
+            Pipeline
+                { id =
+                    { teamName = t
+                    , pipelineName = p
+                    }
+                , groups = g
+                }
+        )
+        (s "teams"
+            </> string
+            </> s "pipelines"
+            </> string
+            <?> Query.custom "group" identity
+        )
 
 
 dashboard : Parser (Route -> a) a
@@ -214,7 +228,14 @@ buildRoute b =
 
 jobRoute : Concourse.Job -> Route
 jobRoute j =
-    Job { id = { teamName = j.teamName, pipelineName = j.pipelineName, jobName = j.name }, page = Nothing }
+    Job
+        { id =
+            { teamName = j.teamName
+            , pipelineName = j.pipelineName
+            , jobName = j.name
+            }
+        , page = Nothing
+        }
 
 
 pipelineRoute : { a | name : String, teamName : String } -> Route

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -259,15 +259,15 @@ showHighlight hl =
             ""
 
         HighlightLine id line ->
-            "#L" ++ id ++ ":" ++ Debug.toString line
+            "#L" ++ id ++ ":" ++ String.fromInt line
 
         HighlightRange id line1 line2 ->
             "#L"
                 ++ id
                 ++ ":"
-                ++ Debug.toString line1
+                ++ String.fromInt line1
                 ++ ":"
-                ++ Debug.toString line2
+                ++ String.fromInt line2
 
 
 parseHighlight : Maybe String -> Highlight


### PR DESCRIPTION
* use parser instead of regex
* use url builders instead of building strings by hand

Also, fixes #3622