### PR TITLE
fix quickstart to ignore --worker-tsa-worker-private-key flag

### DIFF
--- a/cmd/concourse/worker_linux.go
+++ b/cmd/concourse/worker_linux.go
@@ -37,6 +37,7 @@ type GardenBackend struct {
 func (cmd WorkerCommand) lessenRequirements(prefix string, command *flags.Command) {
 	// configured as work-dir/volumes
 	command.FindOptionByLongName(prefix + "baggageclaim-volumes").Required = false
+	command.FindOptionByLongName(prefix + "tsa-worker-private-key").Required = false
 }
 
 func (cmd *WorkerCommand) gardenRunner(logger lager.Logger) (atc.Worker, ifrit.Runner, error) {

--- a/cmd/concourse/worker_nonlinux.go
+++ b/cmd/concourse/worker_nonlinux.go
@@ -18,6 +18,7 @@ type Certs struct{}
 func (cmd WorkerCommand) lessenRequirements(prefix string, command *flags.Command) {
 	// created in the work-dir
 	command.FindOptionByLongName(prefix + "baggageclaim-volumes").Required = false
+	command.FindOptionByLongName(prefix + "tsa-worker-private-key").Required = false
 }
 
 func (cmd *WorkerCommand) gardenRunner(logger lager.Logger) (atc.Worker, ifrit.Runner, error) {


### PR DESCRIPTION
set this flag to `required` false when running `concourse quickstart`

Signed-off-by: Rui Yang <ryang@pivotal.io>