### PR TITLE
Restrict SSH MAC algos to a smaller set

### DIFF
--- a/tsa/client.go
+++ b/tsa/client.go
@@ -342,6 +342,10 @@ func (client *Client) dial(ctx context.Context, idleTimeout time.Duration) (*ssh
 	}
 
 	clientConfig := &ssh.ClientConfig{
+		Config: ssh.Config{
+			MACs: AllowedMACs,
+		},
+
 		User: "beacon", // doesn't matter
 
 		HostKeyCallback: client.checkHostKey,

--- a/tsa/constants.go
+++ b/tsa/constants.go
@@ -1,0 +1,8 @@
+package tsa
+
+// CIS recommends a certain set of MAC algorithms to be used in SSH connections. This restricts the set from a more permissive set used by default by Go.
+// See https://infosec.mozilla.org/guidelines/openssh.html and https://www.cisecurity.org/cis-benchmarks/
+var AllowedMACs = []string{
+	"hmac-sha2-256-etm@openssh.com",
+	"hmac-sha2-256",
+}

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -168,6 +168,9 @@ func (cmd *TSACommand) configureSSHServer(sessionAuthTeam *sessionTeam, authoriz
 	}
 
 	config := &ssh.ServerConfig{
+		Config: ssh.Config{
+			MACs: tsa.AllowedMACs,
+		},
 		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
 			return certChecker.Authenticate(conn, key)
 		},


### PR DESCRIPTION
- go by default allows for some weak algorithms https://github.com/golang/crypto/blob/d864b10871cd4370fe574816b489c819c675ccc7/ssh/common.go#L69
- fixes https://github.com/concourse/concourse-bosh-release/issues/25