### PR TITLE
Update prod deployment

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -801,6 +801,7 @@ jobs:
       - cbd/cluster/operations/enable-global-resources.yml
       - cbd/cluster/operations/x-frame-options-unset.yml
       - cbd/cluster/operations/worker-volume-sweeper-max-in-flight.yml
+      - cbd/cluster/operations/vault-shared-path.yml
       - prod/prod/ops.yml
       vars_files:
       - cbd/versions.yml
@@ -833,6 +834,7 @@ jobs:
         container_placement_strategy: "fewest-build-containers"
         worker_rebalance_interval: 30m
         volume_sweeper_max_in_flight: 1
+        vault_shared_path: "shared"
 
 - name: bosh-wings-deploy
   serial: true

--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -800,6 +800,7 @@ jobs:
       - cbd/cluster/operations/worker-rebalancing.yml
       - cbd/cluster/operations/enable-global-resources.yml
       - cbd/cluster/operations/x-frame-options-unset.yml
+      - cbd/cluster/operations/worker-volume-sweeper-max-in-flight.yml
       - prod/prod/ops.yml
       vars_files:
       - cbd/versions.yml
@@ -831,6 +832,7 @@ jobs:
         default_task_cpu_limit: 1024
         container_placement_strategy: "fewest-build-containers"
         worker_rebalance_interval: 30m
+        volume_sweeper_max_in_flight: 1
 
 - name: bosh-wings-deploy
   serial: true


### PR DESCRIPTION
There are two issues in this PR. Each commit represents one issue. Let me know if this should be split into two PR's.

### Issue 1
https://github.com/pivotal-cf/concourse-support/issues/69
This is setting `volume_sweeper_max_in_flight` to 1. The default is 5 and the runtime team thinks this is currently the root cause of the issues we're seeing with prod. We have some logs that appear to support this theory.

### Issue 2
https://github.com/pivotal-cf/concourse-support/issues/70
We're moving secrets shared between the release pipelines into a shared path in vault. This commit is telling concourse where the shared path is. 
Secrets that aren't shared between release pipelines will remain in their pipeline specific paths.