### PR TITLE
topgun/k8s: clean up for worker_lifecycle and reduce case flakiness.

### DIFF
--- a/topgun/k8s/worker_lifecycle_test.go
+++ b/topgun/k8s/worker_lifecycle_test.go
@@ -27,9 +27,7 @@ var _ = Describe("Worker lifecycle", func() {
 	}
 
 	AfterEach(func() {
-		helmDestroy(releaseName)
-		Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
-		Wait(proxySession.Interrupt())
+		cleanup(releaseName, namespace, proxySession)
 	})
 
 	DescribeTable("retiring a worker",


### PR DESCRIPTION
- clean up even when test fails
- added 2 sleeps to reduce the flakiness as temporary solution

fixes #3749

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>
Co-authored-by: Bin Ju <bju@pivotal.io>