### PR TITLE
Fly command: warns if no stalled workers are present.

### DIFF
--- a/fly/commands/prune_worker.go
+++ b/fly/commands/prune_worker.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/fly/ui"
 )
 
 type PruneWorkerCommand struct {
@@ -44,7 +45,7 @@ func (command *PruneWorkerCommand) Execute(args []string) error {
 			}
 		}
 		if workersNames == nil {
-			displayhelpers.Failf("No stalled worker found.")
+			fmt.Printf(ui.WarningColor("WARNING: No stalled workers found.\n"))
 		}
 	}
 


### PR DESCRIPTION
Executing `fly prune-worker --all-stalled` should not return an error if no stalled workers are present to be more friendly toward automated systems.
Prints instead a warning and exits gracefully.

**More context**: when I've proposed #3248 I didn't realize that, if there are no stalled workers, fly exits with a return code of 1. This makes it unfriendly toward an automated system (eg a Concourse job) that only cares that no stalled workers are present.