### PR TITLE
Update tls & ssh config

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -979,20 +979,8 @@ func (cmd *RunCommand) tlsConfig() (*tls.Config, error) {
 			return nil, err
 		}
 
-		tlsConfig = &tls.Config{
-			Certificates:     []tls.Certificate{cert},
-			MinVersion:       tls.VersionTLS12,
-			CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
-			CipherSuites: []uint16{
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-			},
-			PreferServerCipherSuites: true,
-			NextProtos:               []string{"h2"},
-		}
+		tlsConfig = atc.DefaultTLSConfig()
+		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 	return tlsConfig, nil
 }

--- a/tsa/client.go
+++ b/tsa/client.go
@@ -342,9 +342,7 @@ func (client *Client) dial(ctx context.Context, idleTimeout time.Duration) (*ssh
 	}
 
 	clientConfig := &ssh.ClientConfig{
-		Config: ssh.Config{
-			MACs: AllowedMACs,
-		},
+		Config: atc.DefaultSSHConfig(),
 
 		User: "beacon", // doesn't matter
 

--- a/tsa/constants.go
+++ b/tsa/constants.go
@@ -1,8 +1,0 @@
-package tsa
-
-// CIS recommends a certain set of MAC algorithms to be used in SSH connections. This restricts the set from a more permissive set used by default by Go.
-// See https://infosec.mozilla.org/guidelines/openssh.html and https://www.cisecurity.org/cis-benchmarks/
-var AllowedMACs = []string{
-	"hmac-sha2-256-etm@openssh.com",
-	"hmac-sha2-256",
-}

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/tsa"
 	"github.com/concourse/flag"
 	"github.com/tedsuo/ifrit"
@@ -168,9 +169,7 @@ func (cmd *TSACommand) configureSSHServer(sessionAuthTeam *sessionTeam, authoriz
 	}
 
 	config := &ssh.ServerConfig{
-		Config: ssh.Config{
-			MACs: tsa.AllowedMACs,
-		},
+		Config: atc.DefaultSSHConfig(),
 		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
 			return certChecker.Authenticate(conn, key)
 		},


### PR DESCRIPTION
- move tls & ssh config to a common file
- TLS: restrict cipher suites to a smaller set ( removed CBC )
- TLS: changed priority of tls curves
- SSH: restrict KeyExchange algos to a smaller set ( removed SHA1
variants )
