### PR TITLE
Improve observability of logs during step run

### DIFF
--- a/atc/engine/builder/delegate_factory.go
+++ b/atc/engine/builder/delegate_factory.go
@@ -61,7 +61,7 @@ func (d *getDelegate) Initializing(logger lager.Logger) {
 		return
 	}
 
-	logger.Debug("initializing")
+	logger.Info("initializing")
 }
 
 func (d *getDelegate) Starting(logger lager.Logger) {
@@ -118,7 +118,7 @@ func (d *putDelegate) Initializing(logger lager.Logger) {
 		return
 	}
 
-	logger.Debug("initializing")
+	logger.Info("initializing")
 }
 
 func (d *putDelegate) Starting(logger lager.Logger) {
@@ -176,7 +176,7 @@ func (d *taskDelegate) Initializing(logger lager.Logger, taskConfig atc.TaskConf
 		return
 	}
 
-	logger.Debug("initializing")
+	logger.Info("initializing")
 }
 
 func (d *taskDelegate) Starting(logger lager.Logger, taskConfig atc.TaskConfig) {

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -153,6 +153,10 @@ func NewGetStep(
 // fetching the resource) is registered under the step's SourceName.
 func (step *GetStep) Run(ctx context.Context, state RunState) error {
 	logger := lagerctx.FromContext(ctx)
+	logger = logger.Session("get-step", lager.Data{
+		"step-name": step.name,
+		"job-id":    step.build.JobID(),
+	})
 
 	step.delegate.Initializing(logger)
 

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -102,6 +102,10 @@ func NewPutStep(
 // script will be interrupted.
 func (step *PutStep) Run(ctx context.Context, state RunState) error {
 	logger := lagerctx.FromContext(ctx)
+	logger = logger.Session("put-step", lager.Data{
+		"step-name": step.name,
+		"job-id":    step.build.JobID(),
+	})
 
 	step.delegate.Initializing(logger)
 

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -153,6 +153,10 @@ func NewTaskStep(
 // name of the task.
 func (action *TaskStep) Run(ctx context.Context, state RunState) error {
 	logger := lagerctx.FromContext(ctx)
+	logger = logger.Session("task-step", lager.Data{
+		"step-name": action.stepName,
+		"job-id":    action.jobID,
+	})
 
 	repository := state.Artifacts()
 


### PR DESCRIPTION
This PR introduces a new logger session for get, put and task steps. It also attaches additional data to the logs to allow the identification of the step that produced a particular log line.

An example output of `docker-compose logs -f | grep get-step-run` while running the `testflight` test suite:
```
web_1     | {"timestamp":"2019-04-25T08:22:11.785874433Z","level":"info","source":"atc","message":"atc.pipelines.scheduler.tick.scheduling.try-start-next-pending-build.get-step-run.initializing","data":{"build-id":436,"build-name":"1","job-id":598,"pipeline":"tf-pipeline-1-320e3b2f-dc15-4d28-794e-0d0e7d709987","session":"17.172.4.3.4.6","step-name":"some-resource","team":"testflight"}}
web_1     | {"timestamp":"2019-04-25T08:22:11.806112779Z","level":"info","source":"atc","message":"atc.pipelines.scheduler.tick.scheduling.try-start-next-pending-build.get-step-run.starting","data":{"build-id":436,"build-name":"1","job-id":598,"pipeline":"tf-pipeline-1-320e3b2f-dc15-4d28-794e-0d0e7d709987","session":"17.172.4.3.4.6","step-name":"some-resource","team":"testflight"}}
web_1     | {"timestamp":"2019-04-25T08:22:11.835793485Z","level":"info","source":"atc","message":"atc.pipelines.scheduler.tick.scheduling.try-start-next-pending-build.get-step-run.finished","data":{"build-id":436,"build-name":"1","exit-status":0,"job-id":598,"pipeline":"tf-pipeline-1-320e3b2f-dc15-4d28-794e-0d0e7d709987","session":"17.172.4.3.4.6","step-name":"some-resource","team":"testflight"}}
```

Events from a particular step can be identified and observed from a single log level.