### PR TITLE
Enable to print specified team config (fly get-team)

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -193,6 +193,7 @@ var requiredRoles = map[string]string{
 	atc.ListDestroyingVolumes:         "viewer",
 	atc.ReportWorkerVolumes:           "member",
 	atc.ListTeams:                     "viewer",
+	atc.GetTeam:                       "viewer",
 	atc.SetTeam:                       "owner",
 	atc.RenameTeam:                    "owner",
 	atc.DestroyTeam:                   "owner",

--- a/atc/api/accessor/accessor_test.go
+++ b/atc/api/accessor/accessor_test.go
@@ -634,6 +634,10 @@ var _ = Describe("Accessor", func() {
 		Entry("member :: "+atc.ListTeams, atc.ListTeams, "member", true),
 		Entry("viewer :: "+atc.ListTeams, atc.ListTeams, "viewer", true),
 
+		Entry("owner :: "+atc.GetTeam, atc.GetTeam, "owner", true),
+		Entry("member :: "+atc.GetTeam, atc.GetTeam, "member", true),
+		Entry("viewer :: "+atc.GetTeam, atc.GetTeam, "viewer", true),
+
 		Entry("owner :: "+atc.SetTeam, atc.SetTeam, "owner", true),
 		Entry("member :: "+atc.SetTeam, atc.SetTeam, "member", false),
 		Entry("viewer :: "+atc.SetTeam, atc.SetTeam, "viewer", false),

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -184,6 +184,7 @@ func NewHandler(
 		atc.ReportWorkerVolumes:   http.HandlerFunc(volumesServer.ReportWorkerVolumes),
 
 		atc.ListTeams:      http.HandlerFunc(teamServer.ListTeams),
+		atc.GetTeam:        http.HandlerFunc(teamServer.GetTeam),
 		atc.SetTeam:        http.HandlerFunc(teamServer.SetTeam),
 		atc.RenameTeam:     http.HandlerFunc(teamServer.RenameTeam),
 		atc.DestroyTeam:    http.HandlerFunc(teamServer.DestroyTeam),

--- a/atc/api/teamserver/get.go
+++ b/atc/api/teamserver/get.go
@@ -3,9 +3,7 @@ package teamserver
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/accessor"
@@ -33,7 +31,6 @@ func (s *Server) GetTeam(w http.ResponseWriter, r *http.Request) {
 	acc := accessor.GetAccessor(r)
 	var presentedTeam atc.Team
 
-	fmt.Fprintf(os.Stderr, "ADMIN: %#v\n", acc.IsAdmin())
 	if acc.IsAdmin() || acc.IsAuthorized(team.Name()) {
 		presentedTeam = present.Team(team)
 	} else {

--- a/atc/api/teamserver/get.go
+++ b/atc/api/teamserver/get.go
@@ -1,0 +1,52 @@
+package teamserver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/api/accessor"
+	"github.com/concourse/concourse/atc/api/present"
+)
+
+func (s *Server) GetTeam(w http.ResponseWriter, r *http.Request) {
+	hLog := s.logger.Session("get-team")
+
+	hLog.Debug("getting-team")
+
+	teamName := r.FormValue(":team_name")
+	team, found, err := s.teamFactory.FindTeam(teamName)
+	if err != nil {
+		hLog.Error("failed-to-get-team", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !found {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	acc := accessor.GetAccessor(r)
+	var presentedTeam atc.Team
+
+	fmt.Fprintf(os.Stderr, "ADMIN: %#v\n", acc.IsAdmin())
+	if acc.IsAdmin() || acc.IsAuthorized(team.Name()) {
+		presentedTeam = present.Team(team)
+	} else {
+		hLog.Error("unauthorized", errors.New("not authorized to "+team.Name()))
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(presentedTeam); err != nil {
+		hLog.Error("failed-to-encode-team", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	return
+}

--- a/atc/routes.go
+++ b/atc/routes.go
@@ -93,6 +93,7 @@ const (
 	ReportWorkerVolumes   = "ReportWorkerVolumes"
 
 	ListTeams      = "ListTeams"
+	GetTeam        = "GetTeam"
 	SetTeam        = "SetTeam"
 	RenameTeam     = "RenameTeam"
 	DestroyTeam    = "DestroyTeam"
@@ -199,6 +200,7 @@ var Routes = rata.Routes([]rata.Route{
 	{Path: "/api/v1/volumes/report", Method: "PUT", Name: ReportWorkerVolumes},
 
 	{Path: "/api/v1/teams", Method: "GET", Name: ListTeams},
+	{Path: "/api/v1/teams/:team_name", Method: "GET", Name: GetTeam},
 	{Path: "/api/v1/teams/:team_name", Method: "PUT", Name: SetTeam},
 	{Path: "/api/v1/teams/:team_name/rename", Method: "PUT", Name: RenameTeam},
 	{Path: "/api/v1/teams/:team_name", Method: "DELETE", Name: DestroyTeam},

--- a/atc/wrappa/api_auth_wrappa.go
+++ b/atc/wrappa/api_auth_wrappa.go
@@ -102,6 +102,7 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.RegisterWorker,
 			atc.HeartbeatWorker,
 			atc.DeleteWorker,
+			atc.GetTeam,
 			atc.SetTeam,
 			atc.ListTeamBuilds,
 			atc.RenameTeam,

--- a/atc/wrappa/api_auth_wrappa_test.go
+++ b/atc/wrappa/api_auth_wrappa_test.go
@@ -202,6 +202,7 @@ var _ = Describe("APIAuthWrappa", func() {
 				atc.RegisterWorker:  authenticated(inputHandlers[atc.RegisterWorker]),
 				atc.HeartbeatWorker: authenticated(inputHandlers[atc.HeartbeatWorker]),
 				atc.DeleteWorker:    authenticated(inputHandlers[atc.DeleteWorker]),
+				atc.GetTeam:         authenticated(inputHandlers[atc.GetTeam]),
 				atc.SetTeam:         authenticated(inputHandlers[atc.SetTeam]),
 				atc.RenameTeam:      authenticated(inputHandlers[atc.RenameTeam]),
 				atc.DestroyTeam:     authenticated(inputHandlers[atc.DestroyTeam]),

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -24,6 +24,7 @@ type FlyCommand struct {
 	Userinfo UserinfoCommand `command:"userinfo" description:"User information"`
 
 	Teams       TeamsCommand       `command:"teams" alias:"t" description:"List the configured teams"`
+	GetTeam     GetTeamCommand     `command:"get-team"  alias:"gt" description:"Show team configuration"`
 	SetTeam     SetTeamCommand     `command:"set-team"  alias:"st" description:"Create or modify a team to have the given credentials"`
 	RenameTeam  RenameTeamCommand  `command:"rename-team"   alias:"rt" description:"Rename a team"`
 	DestroyTeam DestroyTeamCommand `command:"destroy-team"  alias:"dt" description:"Destroy a team and delete all of its data"`

--- a/fly/commands/get_pipeline.go
+++ b/fly/commands/get_pipeline.go
@@ -53,10 +53,10 @@ func (command *GetPipelineCommand) Execute(args []string) error {
 		return errors.New("pipeline not found")
 	}
 
-	return dump(config, asJSON)
+	return dumpPipeline(config, asJSON)
 }
 
-func dump(config atc.Config, asJSON bool) error {
+func dumpPipeline(config atc.Config, asJSON bool) error {
 	var payload []byte
 	var err error
 	if asJSON {

--- a/fly/commands/get_pipeline.go
+++ b/fly/commands/get_pipeline.go
@@ -53,10 +53,10 @@ func (command *GetPipelineCommand) Execute(args []string) error {
 		return errors.New("pipeline not found")
 	}
 
-	return dumpPipeline(config, asJSON)
+	return dump(config, asJSON)
 }
 
-func dumpPipeline(config atc.Config, asJSON bool) error {
+func dump(config atc.Config, asJSON bool) error {
 	var payload []byte
 	var err error
 	if asJSON {

--- a/fly/commands/get_team.go
+++ b/fly/commands/get_team.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/rc"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type GetTeamCommand struct {
+	Team string `short:"n" long:"team" required:"true" description:"Get configuration of this team"`
+	JSON bool   `short:"j" long:"json" description:"Print config as json instead of yaml"`
+}
+
+func (command *GetTeamCommand) Execute(args []string) error {
+	asJSON := command.JSON
+	teamName := command.Team
+
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	if err := target.Validate(); err != nil {
+		return err
+	}
+
+	config, found, err := target.Team().Config(teamName)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return errors.New("team not found")
+	}
+
+	return dumpTeam(config, asJSON)
+}
+
+func dumpTeam(config atc.Team, asJSON bool) error {
+	var payload []byte
+	var err error
+	if asJSON {
+		payload, err = json.Marshal(config)
+	} else {
+		payload, err = yaml.Marshal(config)
+	}
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Printf("%s", payload)
+
+	return err
+}

--- a/fly/commands/get_team.go
+++ b/fly/commands/get_team.go
@@ -28,7 +28,7 @@ func (command *GetTeamCommand) Execute(args []string) error {
 		return err
 	}
 
-	config, found, err := target.Team().Config(teamName)
+	config, found, err := target.Team().Team(teamName)
 	if err != nil {
 		return err
 	}

--- a/fly/integration/get_team_test.go
+++ b/fly/integration/get_team_test.go
@@ -1,0 +1,104 @@
+package integration_test
+
+import (
+	"net/http"
+	"os/exec"
+
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/tedsuo/rata"
+	"gopkg.in/yaml.v2"
+)
+
+var _ = Describe("GetPipeline", func() {
+	var (
+		team atc.Team
+	)
+
+	BeforeEach(func() {
+		team = atc.Team{
+			ID:   1,
+			Name: "myTeam",
+			Auth: atc.TeamAuth{
+				"owner": map[string][]string{
+					"groups": {}, "users": {"local:username"},
+				},
+			},
+		}
+
+		Context("when not specifying a team name", func() {
+			It("fails and says you should give a team name", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "get-team")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
+
+				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("n", "team") + "' was not specified"))
+			})
+		})
+
+		Context("when specifying a team name", func() {
+			var path string
+			BeforeEach(func() {
+				var err error
+				path, err = atc.Routes.CreatePathForRoute(atc.GetTeam, rata.Params{"team_name": "myTeam"})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Context("and team is not found", func() {
+				JustBeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", path),
+							ghttp.RespondWithJSONEncoded(http.StatusNotFound, ""),
+						),
+					)
+				})
+
+				It("should print team not found error", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "get-team", "-n", "myTeam")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(1))
+				})
+			})
+
+			Context("when atc returns team config", func() {
+				BeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", path),
+							ghttp.RespondWithJSONEncoded(200, team),
+						),
+					)
+				})
+
+				It("prints the config as yaml to stdout", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "get-team", "myTeam")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(0))
+
+					var printedConfig atc.Team
+					err = yaml.Unmarshal(sess.Out.Contents(), &printedConfig)
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(printedConfig).To(Equal(team))
+				})
+			})
+		})
+	})
+})

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -121,6 +121,21 @@ type FakeTeam struct {
 		result1 int64
 		result2 error
 	}
+	ConfigStub        func(string) (atc.Team, bool, error)
+	configMutex       sync.RWMutex
+	configArgsForCall []struct {
+		arg1 string
+	}
+	configReturns struct {
+		result1 atc.Team
+		result2 bool
+		result3 error
+	}
+	configReturnsOnCall map[int]struct {
+		result1 atc.Team
+		result2 bool
+		result3 error
+	}
 	CreateArtifactStub        func(io.Reader) (atc.WorkerArtifact, error)
 	createArtifactMutex       sync.RWMutex
 	createArtifactArgsForCall []struct {
@@ -1103,6 +1118,72 @@ func (fake *FakeTeam) ClearTaskCacheReturnsOnCall(i int, result1 int64, result2 
 		result1 int64
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeTeam) Config(arg1 string) (atc.Team, bool, error) {
+	fake.configMutex.Lock()
+	ret, specificReturn := fake.configReturnsOnCall[len(fake.configArgsForCall)]
+	fake.configArgsForCall = append(fake.configArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("Config", []interface{}{arg1})
+	fake.configMutex.Unlock()
+	if fake.ConfigStub != nil {
+		return fake.ConfigStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.configReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeTeam) ConfigCallCount() int {
+	fake.configMutex.RLock()
+	defer fake.configMutex.RUnlock()
+	return len(fake.configArgsForCall)
+}
+
+func (fake *FakeTeam) ConfigCalls(stub func(string) (atc.Team, bool, error)) {
+	fake.configMutex.Lock()
+	defer fake.configMutex.Unlock()
+	fake.ConfigStub = stub
+}
+
+func (fake *FakeTeam) ConfigArgsForCall(i int) string {
+	fake.configMutex.RLock()
+	defer fake.configMutex.RUnlock()
+	argsForCall := fake.configArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTeam) ConfigReturns(result1 atc.Team, result2 bool, result3 error) {
+	fake.configMutex.Lock()
+	defer fake.configMutex.Unlock()
+	fake.ConfigStub = nil
+	fake.configReturns = struct {
+		result1 atc.Team
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeTeam) ConfigReturnsOnCall(i int, result1 atc.Team, result2 bool, result3 error) {
+	fake.configMutex.Lock()
+	defer fake.configMutex.Unlock()
+	fake.ConfigStub = nil
+	if fake.configReturnsOnCall == nil {
+		fake.configReturnsOnCall = make(map[int]struct {
+			result1 atc.Team
+			result2 bool
+			result3 error
+		})
+	}
+	fake.configReturnsOnCall[i] = struct {
+		result1 atc.Team
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeTeam) CreateArtifact(arg1 io.Reader) (atc.WorkerArtifact, error) {
@@ -3440,6 +3521,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.checkResourceTypeMutex.RUnlock()
 	fake.clearTaskCacheMutex.RLock()
 	defer fake.clearTaskCacheMutex.RUnlock()
+	fake.configMutex.RLock()
+	defer fake.configMutex.RUnlock()
 	fake.createArtifactMutex.RLock()
 	defer fake.createArtifactMutex.RUnlock()
 	fake.createBuildMutex.RLock()

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -121,21 +121,6 @@ type FakeTeam struct {
 		result1 int64
 		result2 error
 	}
-	ConfigStub        func(string) (atc.Team, bool, error)
-	configMutex       sync.RWMutex
-	configArgsForCall []struct {
-		arg1 string
-	}
-	configReturns struct {
-		result1 atc.Team
-		result2 bool
-		result3 error
-	}
-	configReturnsOnCall map[int]struct {
-		result1 atc.Team
-		result2 bool
-		result3 error
-	}
 	CreateArtifactStub        func(io.Reader) (atc.WorkerArtifact, error)
 	createArtifactMutex       sync.RWMutex
 	createArtifactArgsForCall []struct {
@@ -608,6 +593,21 @@ type FakeTeam struct {
 		result2 concourse.Pagination
 		result3 bool
 		result4 error
+	}
+	TeamStub        func(string) (atc.Team, bool, error)
+	teamMutex       sync.RWMutex
+	teamArgsForCall []struct {
+		arg1 string
+	}
+	teamReturns struct {
+		result1 atc.Team
+		result2 bool
+		result3 error
+	}
+	teamReturnsOnCall map[int]struct {
+		result1 atc.Team
+		result2 bool
+		result3 error
 	}
 	UnpauseJobStub        func(string, string) (bool, error)
 	unpauseJobMutex       sync.RWMutex
@@ -1118,72 +1118,6 @@ func (fake *FakeTeam) ClearTaskCacheReturnsOnCall(i int, result1 int64, result2 
 		result1 int64
 		result2 error
 	}{result1, result2}
-}
-
-func (fake *FakeTeam) Config(arg1 string) (atc.Team, bool, error) {
-	fake.configMutex.Lock()
-	ret, specificReturn := fake.configReturnsOnCall[len(fake.configArgsForCall)]
-	fake.configArgsForCall = append(fake.configArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("Config", []interface{}{arg1})
-	fake.configMutex.Unlock()
-	if fake.ConfigStub != nil {
-		return fake.ConfigStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	fakeReturns := fake.configReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakeTeam) ConfigCallCount() int {
-	fake.configMutex.RLock()
-	defer fake.configMutex.RUnlock()
-	return len(fake.configArgsForCall)
-}
-
-func (fake *FakeTeam) ConfigCalls(stub func(string) (atc.Team, bool, error)) {
-	fake.configMutex.Lock()
-	defer fake.configMutex.Unlock()
-	fake.ConfigStub = stub
-}
-
-func (fake *FakeTeam) ConfigArgsForCall(i int) string {
-	fake.configMutex.RLock()
-	defer fake.configMutex.RUnlock()
-	argsForCall := fake.configArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeTeam) ConfigReturns(result1 atc.Team, result2 bool, result3 error) {
-	fake.configMutex.Lock()
-	defer fake.configMutex.Unlock()
-	fake.ConfigStub = nil
-	fake.configReturns = struct {
-		result1 atc.Team
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakeTeam) ConfigReturnsOnCall(i int, result1 atc.Team, result2 bool, result3 error) {
-	fake.configMutex.Lock()
-	defer fake.configMutex.Unlock()
-	fake.ConfigStub = nil
-	if fake.configReturnsOnCall == nil {
-		fake.configReturnsOnCall = make(map[int]struct {
-			result1 atc.Team
-			result2 bool
-			result3 error
-		})
-	}
-	fake.configReturnsOnCall[i] = struct {
-		result1 atc.Team
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
 }
 
 func (fake *FakeTeam) CreateArtifact(arg1 io.Reader) (atc.WorkerArtifact, error) {
@@ -3311,6 +3245,72 @@ func (fake *FakeTeam) ResourceVersionsReturnsOnCall(i int, result1 []atc.Resourc
 	}{result1, result2, result3, result4}
 }
 
+func (fake *FakeTeam) Team(arg1 string) (atc.Team, bool, error) {
+	fake.teamMutex.Lock()
+	ret, specificReturn := fake.teamReturnsOnCall[len(fake.teamArgsForCall)]
+	fake.teamArgsForCall = append(fake.teamArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("Team", []interface{}{arg1})
+	fake.teamMutex.Unlock()
+	if fake.TeamStub != nil {
+		return fake.TeamStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.teamReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeTeam) TeamCallCount() int {
+	fake.teamMutex.RLock()
+	defer fake.teamMutex.RUnlock()
+	return len(fake.teamArgsForCall)
+}
+
+func (fake *FakeTeam) TeamCalls(stub func(string) (atc.Team, bool, error)) {
+	fake.teamMutex.Lock()
+	defer fake.teamMutex.Unlock()
+	fake.TeamStub = stub
+}
+
+func (fake *FakeTeam) TeamArgsForCall(i int) string {
+	fake.teamMutex.RLock()
+	defer fake.teamMutex.RUnlock()
+	argsForCall := fake.teamArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTeam) TeamReturns(result1 atc.Team, result2 bool, result3 error) {
+	fake.teamMutex.Lock()
+	defer fake.teamMutex.Unlock()
+	fake.TeamStub = nil
+	fake.teamReturns = struct {
+		result1 atc.Team
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeTeam) TeamReturnsOnCall(i int, result1 atc.Team, result2 bool, result3 error) {
+	fake.teamMutex.Lock()
+	defer fake.teamMutex.Unlock()
+	fake.TeamStub = nil
+	if fake.teamReturnsOnCall == nil {
+		fake.teamReturnsOnCall = make(map[int]struct {
+			result1 atc.Team
+			result2 bool
+			result3 error
+		})
+	}
+	fake.teamReturnsOnCall[i] = struct {
+		result1 atc.Team
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeTeam) UnpauseJob(arg1 string, arg2 string) (bool, error) {
 	fake.unpauseJobMutex.Lock()
 	ret, specificReturn := fake.unpauseJobReturnsOnCall[len(fake.unpauseJobArgsForCall)]
@@ -3521,8 +3521,6 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.checkResourceTypeMutex.RUnlock()
 	fake.clearTaskCacheMutex.RLock()
 	defer fake.clearTaskCacheMutex.RUnlock()
-	fake.configMutex.RLock()
-	defer fake.configMutex.RUnlock()
 	fake.createArtifactMutex.RLock()
 	defer fake.createArtifactMutex.RUnlock()
 	fake.createBuildMutex.RLock()
@@ -3589,6 +3587,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.resourceMutex.RUnlock()
 	fake.resourceVersionsMutex.RLock()
 	defer fake.resourceVersionsMutex.RUnlock()
+	fake.teamMutex.RLock()
+	defer fake.teamMutex.RUnlock()
 	fake.unpauseJobMutex.RLock()
 	defer fake.unpauseJobMutex.RUnlock()
 	fake.unpausePipelineMutex.RLock()

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -12,6 +12,7 @@ import (
 type Team interface {
 	Name() string
 
+	Config(teamName string) (atc.Team, bool, error)
 	CreateOrUpdate(team atc.Team) (atc.Team, bool, bool, error)
 	RenameTeam(teamName, name string) (bool, error)
 	DestroyTeam(teamName string) error

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -12,7 +12,7 @@ import (
 type Team interface {
 	Name() string
 
-	Config(teamName string) (atc.Team, bool, error)
+	Team(teamName string) (atc.Team, bool, error)
 	CreateOrUpdate(team atc.Team) (atc.Team, bool, bool, error)
 	RenameTeam(teamName, name string) (bool, error)
 	DestroyTeam(teamName string) error

--- a/go-concourse/concourse/teams.go
+++ b/go-concourse/concourse/teams.go
@@ -14,6 +14,27 @@ import (
 
 var ErrDestroyRefused = errors.New("not-permitted-to-destroy-as-requested")
 
+// Config get team configuration with the name given as argument.
+func (team *team) Config(teamName string) (atc.Team, bool, error) {
+	var t atc.Team
+	params := rata.Params{"team_name": teamName}
+	err := team.connection.Send(internal.Request{
+		RequestName: atc.GetTeam,
+		Params:      params,
+	}, &internal.Response{
+		Result: &t,
+	})
+
+	switch err.(type) {
+	case nil:
+		return t, true, nil
+	case internal.ResourceNotFoundError:
+		return atc.Team{}, false, nil
+	default:
+		return atc.Team{}, false, err
+	}
+}
+
 // CreateOrUpdate creates or updates team teamName with the settings provided in passedTeam.
 // passedTeam should reflect the desired state of team's configuration.
 func (team *team) CreateOrUpdate(passedTeam atc.Team) (atc.Team, bool, bool, error) {

--- a/go-concourse/concourse/teams.go
+++ b/go-concourse/concourse/teams.go
@@ -14,8 +14,8 @@ import (
 
 var ErrDestroyRefused = errors.New("not-permitted-to-destroy-as-requested")
 
-// Config get team configuration with the name given as argument.
-func (team *team) Config(teamName string) (atc.Team, bool, error) {
+// Team get team with the name given as argument.
+func (team *team) Team(teamName string) (atc.Team, bool, error) {
 	var t atc.Team
 	params := rata.Params{"team_name": teamName}
 	err := team.connection.Send(internal.Request{

--- a/go-concourse/concourse/teams_test.go
+++ b/go-concourse/concourse/teams_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("ATC Handler Teams", func() {
-	Describe("Config", func() {
+	Describe("Team", func() {
 		var expectedTeam atc.Team
 		teamName := "myTeam"
 		expectedURL := "/api/v1/teams/myTeam"
@@ -40,7 +40,7 @@ var _ = Describe("ATC Handler Teams", func() {
 			})
 
 			It("returns the requested team", func() {
-				team, found, err := team.Config(teamName)
+				team, found, err := team.Team(teamName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(team).To(Equal(expectedTeam))
@@ -58,7 +58,7 @@ var _ = Describe("ATC Handler Teams", func() {
 			})
 
 			It("returns false", func() {
-				_, found, err := team.Config(teamName)
+				_, found, err := team.Team(teamName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeFalse())
 			})
@@ -75,7 +75,7 @@ var _ = Describe("ATC Handler Teams", func() {
 			})
 
 			It("returns false and error", func() {
-				_, found, err := team.Config(teamName)
+				_, found, err := team.Team(teamName)
 				Expect(found).To(BeFalse())
 				Expect(err).To(HaveOccurred())
 			})


### PR DESCRIPTION
fix #3785 

I enabled to print **one** team config.
The team config is as follows.

```yaml                     
id: 2
name: mechanic
auth:
  owner:
    groups: []
    users:
    - local:mechanic
```

Admin users and users who belong to a team can view the team config.
And the viewer or higher authority can view it.

Before, the way to get one team config was below.
(concourseTeam is mechanic)
```
$ fly -t <target> teams -d --json | jq '.[] | if .name == "mechanic" then . else empty end'
{
  "id": 2,
  "name": "mechanic",
  "auth": {
    "owner": {
      "groups": [],
      "users": [
        "local:mechanic"
      ]
    }
  }
}
```

After these changes, the way is below.
```                                           
$ fly -t <target> get-team -n mechanic 
name/role         users                    groups
mechanic /member  local:mechanic   none
```

or

```
$ fly -t <target> get-team -n mechanic --json
{
  "id": 2,
  "name": "mechanic",
  "auth": {
    "owner": {
      "groups": [],
      "users": [
        "local:mechanic"
      ]
    }
  }
}
```

or

```
fly -t <target> curl api/v1/teams/mechanic
{"id":2,"name":"mechanic","auth":{"owner":{"groups":[],"users":["local:mechanic"]}}}
```

### edited
This command's output was changed based on https://github.com/concourse/concourse/pull/3801#discussion_r280564477