### PR TITLE
Improve bbr topgun tests

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -703,8 +703,6 @@ jobs:
       trigger: true
     - get: postgres-release
       trigger: true
-    - get: postgres-bbr-compatible-release
-      trigger: true
     - get: bpm-release
       trigger: true
     - get: backup-and-restore-sdk-release
@@ -1407,13 +1405,6 @@ resources:
   icon: *release-icon
   source:
     repository: cloudfoundry/postgres-release
-
-- name: postgres-bbr-compatible-release
-  type: bosh-io-release
-  icon: *release-icon
-  source:
-    repository: cloudfoundry/postgres-release
-    regexp: 31
 
 - name: bpm-release
   type: bosh-io-release

--- a/ci/pipelines/release.yml
+++ b/ci/pipelines/release.yml
@@ -616,8 +616,6 @@ jobs:
       trigger: true
     - get: postgres-release
       trigger: true
-    - get: postgres-bbr-compatible-release
-      trigger: true
     - get: bpm-release
       trigger: true
     - get: backup-and-restore-sdk-release
@@ -1071,13 +1069,6 @@ resources:
   type: bosh-io-release
   icon: *release-icon
   source: {repository: cloudfoundry/postgres-release}
-
-- name: postgres-bbr-compatible-release
-  type: bosh-io-release
-  icon: *release-icon
-  source:
-    repository: cloudfoundry/postgres-release
-    regexp: 31
 
 - name: bpm-release
   type: bosh-io-release

--- a/ci/tasks/scripts/topgun
+++ b/ci/tasks/scripts/topgun
@@ -20,7 +20,6 @@ export STEMCELL_VERSION="$(cat stemcell/version)"
 bosh upload-release concourse-release/*.tgz
 bosh upload-release bpm-release/*.tgz
 bosh upload-release postgres-release/*.tgz
-bosh upload-release postgres-bbr-compatible-release/*.tgz
 bosh upload-release vault-release/*.tgz
 bosh upload-release credhub-release/*.tgz
 bosh upload-release backup-and-restore-sdk-release/*.tgz

--- a/ci/tasks/topgun.yml
+++ b/ci/tasks/topgun.yml
@@ -26,7 +26,6 @@ inputs:
 - name: concourse
 - name: concourse-release
 - name: credhub-release
-- name: postgres-bbr-compatible-release
 - name: postgres-release
 - name: stemcell
 - name: vault-release

--- a/topgun/operations/bbr.yml
+++ b/topgun/operations/bbr.yml
@@ -5,10 +5,6 @@
     version: ((backup_and_restore_sdk_release_version))
 
 - type: replace
-  path: /releases/name=postgres/version
-  value: 31
-
-- type: replace
   path: /instance_groups/name=db/jobs/-
   value:
     name: database-backup-restorer


### PR DESCRIPTION
After investigating using bbr in #2332, the use case we are confident in supporting for db restore is a clean deployment with the same version of concourse release and postgres release. We updated the tests to reflect this:

- Unpinned Postgres version for bbr
- Added test case for data consistence while the restore is failed.
- Refined the backup and restore process, delete the concourse deployment before restore