### PR TITLE
topgun/k8s: remove flakiness from worker-lifecycle test

### DIFF
--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -279,7 +279,7 @@ func getRunningWorkers(workers []Worker) (running []Worker) {
 
 func cleanup(releaseName, namespace string, proxySession *gexec.Session) {
 	helmDestroy(releaseName)
-	Wait(Start(nil, "kubectl", "delete", "namespace", namespace, "--wait=false"))
+	Run(nil, "kubectl", "delete", "namespace", namespace, "--wait=false")
 
 	if proxySession != nil {
 		Wait(proxySession.Interrupt())


### PR DESCRIPTION
Hey,

By ensuring that we're able to rely less and less on time, this commit
addresses the concerns in https://github.com/concourse/concourse/issues/3795.

The idea here is to control the timing by explicitly writing to the file that the pipeline waits forever one.

Thus, the two cases come down to:

```
gracefully:
	set pipeline

	trigger job async

	wait for a task container to appear 
		(instead of waiting for `started`)

	start scale down to 0 replicas 
		(instead of killing the pod)

	see that the worker is retiring

	allow the task to finish
		(by writing to a file, instead of waiting for some time)

	see that build succeeded
	
	see that there are no more workers


ungracefully:
	set pipeline

	trigger job async

	wait for a task container to appear 
		(instead of waiting for `started`)

	start scale down to 0 replicas 
		(instead of killing the pod)

	see that there are no more workers

	see that the task was interrupted right away
```

Thanks!

---

closes #3795
