### PR TITLE
Fix regression in k8s credential manager

### DIFF
--- a/atc/creds/kubernetes/kubernetes.go
+++ b/atc/creds/kubernetes/kubernetes.go
@@ -4,7 +4,6 @@ import (
 	"code.cloudfoundry.org/lager"
 	"fmt"
 	"github.com/concourse/concourse/atc/creds"
-	"path"
 	"strings"
 	"time"
 
@@ -24,9 +23,9 @@ type Kubernetes struct {
 func (k Kubernetes) NewSecretLookupPaths(teamName string, pipelineName string) []creds.SecretLookupPath {
 	lookupPaths := []creds.SecretLookupPath{}
 	if len(pipelineName) > 0 {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(k.namespacePrefix, teamName, pipelineName)+"/"))
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(k.namespacePrefix+teamName+":"+pipelineName+"."))
 	}
-	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(k.namespacePrefix, teamName)+"/"))
+	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(k.namespacePrefix+teamName+":"))
 	return lookupPaths
 }
 

--- a/atc/creds/kubernetes/kubernetes_factory.go
+++ b/atc/creds/kubernetes/kubernetes_factory.go
@@ -30,13 +30,3 @@ func (factory *kubernetesFactory) NewSecrets() creds.Secrets {
 		namespacePrefix: factory.namespacePrefix,
 	}
 }
-
-// NewSecretLookupPaths defines how variables will be searched in the underlying secret manager
-func (factory *kubernetesFactory) NewSecretLookupPaths(teamName string, pipelineName string) []creds.SecretLookupPath {
-	lookupPaths := []creds.SecretLookupPath{}
-	if len(pipelineName) > 0 {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(factory.namespacePrefix+teamName+":"+pipelineName+"."))
-	}
-	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(factory.namespacePrefix+teamName+":"))
-	return lookupPaths
-}

--- a/atc/creds/kubernetes/kubernetes_suite_test.go
+++ b/atc/creds/kubernetes/kubernetes_suite_test.go
@@ -1,0 +1,13 @@
+package kubernetes_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestKubernetes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kubernetes Suite")
+}

--- a/atc/creds/kubernetes/kubernetes_test.go
+++ b/atc/creds/kubernetes/kubernetes_test.go
@@ -1,0 +1,35 @@
+package kubernetes_test
+
+import (
+	"github.com/concourse/concourse/atc/creds"
+	"github.com/concourse/concourse/atc/creds/kubernetes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Kubernetes", func() {
+
+	var k creds.Secrets
+
+	JustBeforeEach(func() {
+		factory := kubernetes.NewKubernetesFactory(nil, nil, "namespace")
+		k = factory.NewSecrets()
+	})
+
+	Describe("NewSecretLookupPaths()", func() {
+		It("should transform variable names to kubernetes secret names correctly", func() {
+			pathObjects := k.NewSecretLookupPaths("team", "pipeline")
+			var paths []string
+			for _, p := range pathObjects {
+				path, err := p.VariableToSecretPath("variable")
+				Expect(err).To(BeNil())
+				paths = append(paths, path)
+			}
+
+			Expect(len(paths)).To(BeEquivalentTo(2))
+			Expect(paths).To(ContainElement("namespaceteam:pipeline.variable"))
+			Expect(paths).To(ContainElement("namespaceteam:variable"))
+		})
+
+	})
+})


### PR DESCRIPTION
Fixes #3821

Kubernetes secret manager was one of the two places I was worried about, because it didn't have any unit tests. I was moving methods between SecretsFactory and Secrets, and the right code ended up in a place where it was not being used :(

I moved it to the right place and added a basic unit test, which tests var -> secret name conversion.

