### PR TITLE
CONTRIBUTING: update guide to include instructions regarding topgun/k8s

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,6 +353,28 @@ a screenshot taken at the moment of the failure will be at
 `web/wats/failure.png`.
 
 
+### Running Kubernetes tests
+
+Kubernetes-related testing are all end-to-end, living under `topgun/k8s`. They
+require access to a real Kubernetes cluster with access granted through a 
+properly configured `~/.kube/config` file.
+
+The tests require a few environment variables to be set:
+
+- `CONCOURSE_IMAGE_TAG` or `CONCOURSE_IMAGE_DIGEST`: the tag or digest to use
+when deploying Concourse in the k8s cluster
+- `CONCOURSE_IMAGE_NAME`: the name of the image to use when deploying Concourse
+to the Kubernetes cluster
+- `CHARTS_DIR`: location in the filesystem where a copy of [`the Concourse Helm 
+chart`][concourse-helm-chart] exists.
+
+With those set, go to `topgun/k8s` and run Ginkgo:
+
+```sh
+ginkgo .
+```
+
+
 ### A note on `topgun`
 
 The `topgun/` suite is quite heavyweight and we don't currently expect most
@@ -437,3 +459,4 @@ pushed commits without the signature.
 [style-guide]: https://github.com/concourse/concourse/wiki/Concourse-Go-Style-Guide
 [how-to-fork]: https://help.github.com/articles/fork-a-repo/
 [how-to-pr]: https://help.github.com/articles/creating-a-pull-request-from-a-fork/
+[concourse-helm-chart]: https://github.com/helm/charts/blob/master/stable/concourse/README.md


### PR DESCRIPTION
Hey,

This is a missing piece of documentation that we (those maintaining
topgun/k8s) neglected. As it's a bit more accessible than the
bosh-specific topgun tests, I guess this might matter for contributors
wanting to ensure that k8s-related code works fine (maybe we could even
have people contributing to the coverage as well?)

Please let me know if the phrasing here makes sense.

Thanks!