### PR TITLE
k8s/topgun: test k8s credential management caching

### DIFF
--- a/topgun/k8s/kubernetes_creds_mgmt_test.go
+++ b/topgun/k8s/kubernetes_creds_mgmt_test.go
@@ -26,7 +26,9 @@ var _ = Describe("Kubernetes credential management", func() {
 
 	JustBeforeEach(func() {
 
-		deployConcourseChart(releaseName, append([]string{"--set=worker.replicas=1"}, extraArgs...)...)
+		deployConcourseChart(releaseName, append([]string{
+			"--set=worker.replicas=1",
+		}, extraArgs...)...)
 
 		waitAllPodsInNamespaceToBeReady(namespace)
 
@@ -71,6 +73,7 @@ var _ = Describe("Kubernetes credential management", func() {
 	})
 
 	Context("Consuming per-team k8s secrets", func() {
+
 		JustBeforeEach(func() {
 			// ((foo)) --> bar
 			createCredentialSecret(releaseName, "foo", "main", map[string]string{"value": "bar"})
@@ -78,23 +81,40 @@ var _ = Describe("Kubernetes credential management", func() {
 			// ((caz.baz)) --> zaz
 			createCredentialSecret(releaseName, "caz", "main", map[string]string{"baz": "zaz"})
 
-			fly.Run("set-pipeline", "-n", "-c", "../pipelines/minimal-credential-management.yml", "-p", "pipeline")
-			session := fly.Start("get-pipeline", "-p", "pipeline")
-			Wait(session)
-
-			Expect(string(session.Out.Contents())).ToNot(ContainSubstring("bar"))
-			Expect(string(session.Out.Contents())).ToNot(ContainSubstring("zaz"))
+			fly.Run("set-pipeline", "-n",
+				"-c", "../pipelines/minimal-credential-management.yml",
+				"-p", "pipeline",
+			)
 
 			fly.Run("unpause-pipeline", "-p", "pipeline")
+
 		})
 
-		Context("using the default namespace created by the chart", func() {
-			It("Gets credentials set by consuming k8s secrets", func() {
-				session := fly.Start("trigger-job", "-j", "pipeline/unit", "-w")
-				Wait(session)
+		var runsBuildWithCredentialsResolved = func() {
+			session := fly.Start("trigger-job", "-j", "pipeline/unit", "-w")
+			Wait(session)
 
-				Expect(string(session.Out.Contents())).To(ContainSubstring("bar"))
-				Expect(string(session.Out.Contents())).To(ContainSubstring("zaz"))
+			Expect(string(session.Out.Contents())).To(ContainSubstring("bar"))
+			Expect(string(session.Out.Contents())).To(ContainSubstring("zaz"))
+		}
+
+		Context("using the default namespace created by the chart", func() {
+			It("succeeds", runsBuildWithCredentialsResolved)
+		})
+
+		Context("with caching enabled", func() {
+			BeforeEach(func() {
+				extraArgs = []string{
+					"--set=concourse.web.secretCacheEnabled=true",
+					"--set=concourse.web.secretCacheDuration=600",
+				}
+			})
+
+			It("gets cached credentials", func() {
+				runsBuildWithCredentialsResolved()
+				deleteSecret(releaseName, "main", "foo")
+				deleteSecret(releaseName, "main", "caz")
+				runsBuildWithCredentialsResolved()
 			})
 		})
 
@@ -106,13 +126,7 @@ var _ = Describe("Kubernetes credential management", func() {
 				}
 			})
 
-			It("Gets credentials set by consuming k8s secrets", func() {
-				session := fly.Start("trigger-job", "-j", "pipeline/unit", "-w")
-				Wait(session)
-
-				Expect(string(session.Out.Contents())).To(ContainSubstring("bar"))
-				Expect(string(session.Out.Contents())).To(ContainSubstring("zaz"))
-			})
+			It("succeeds", runsBuildWithCredentialsResolved)
 
 			AfterEach(func() {
 				Run(nil, "kubectl", "delete", "namespace", releaseName+"-main", "--wait=false")
@@ -125,6 +139,10 @@ var _ = Describe("Kubernetes credential management", func() {
 	})
 
 })
+
+func deleteSecret(releaseName, team, secretName string) {
+	Run(nil, "kubectl", "--namespace="+releaseName+"-main", "delete", "secret", secretName)
+}
 
 func createCredentialSecret(releaseName, secretName, team string, kv map[string]string) {
 	args := []string{


### PR DESCRIPTION
With the introduction of cache secret lookups (see [1]), we updated the
helm chart to account for the fact that those can be configured (see
[2]).

This commit adds a test that validates that the caching occurs by
triggering the pipeline two times:

1. having the secret there in the namespace, and another
2. not having the secret in the namespace - just in-memory (cached).

[1]: https://github.com/concourse/concourse/pull/3628
[2]: https://github.com/helm/charts/pull/13295/commits/d9eef448812f0efcb3e8f6e7f52c7d83216c3075

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>