### PR TITLE
web: tooltips on pause toggles

### DIFF
--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -19,6 +19,7 @@ import Time
 import UserState exposing (UserState)
 import Views.PauseToggle as PauseToggle
 import Views.Spinner as Spinner
+import Views.Styles
 
 
 pipelineNotSetView : Html Message
@@ -154,14 +155,16 @@ footerView userState pipeline now hovered =
             [ style "display" "flex" ]
           <|
             List.intersperse spacer
-                [ PauseToggle.view "0"
-                    userState
+                [ PauseToggle.view
                     { isPaused =
                         pipeline.status == PipelineStatus.PipelineStatusPaused
                     , pipeline = pipelineId
                     , isToggleHovered =
                         hovered == (Just <| PipelineButton pipelineId)
                     , isToggleLoading = pipeline.isToggleLoading
+                    , tooltipPosition = Views.Styles.Above
+                    , margin = "0"
+                    , userState = userState
                     }
                 , visibilityView
                     { public = pipeline.public

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -427,8 +427,7 @@ view session model =
                     (id "top-bar-pause-toggle"
                         :: (Styles.pauseToggle <| isPaused model.pipeline)
                     )
-                    [ PauseToggle.view "17px"
-                        session.userState
+                    [ PauseToggle.view
                         { pipeline = model.pipelineLocator
                         , isPaused = isPaused model.pipeline
                         , isToggleHovered =
@@ -437,6 +436,9 @@ view session model =
                                         PipelineButton model.pipelineLocator
                                    )
                         , isToggleLoading = model.isToggleLoading
+                        , tooltipPosition = Views.Styles.Below
+                        , margin = "17px"
+                        , userState = session.userState
                         }
                     ]
                 , Login.view session.userState model <| isPaused model.pipeline

--- a/web/elm/src/Views/PauseToggle.elm
+++ b/web/elm/src/Views/PauseToggle.elm
@@ -2,6 +2,7 @@ module Views.PauseToggle exposing (view)
 
 import Concourse
 import Html exposing (Html)
+import Html.Attributes exposing (class)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import Message.Message exposing (DomID(..), Message(..))
 import UserState exposing (UserState(..))
@@ -11,50 +12,61 @@ import Views.Styles as Styles
 
 
 view :
-    String
-    -> UserState
-    ->
-        { a
-            | isPaused : Bool
-            , pipeline : Concourse.PipelineIdentifier
-            , isToggleHovered : Bool
-            , isToggleLoading : Bool
-        }
+    { a
+        | isPaused : Bool
+        , pipeline : Concourse.PipelineIdentifier
+        , isToggleHovered : Bool
+        , isToggleLoading : Bool
+        , margin : String
+        , userState : UserState
+        , tooltipPosition : Styles.TooltipPosition
+    }
     -> Html Message
-view margin userState { isPaused, pipeline, isToggleHovered, isToggleLoading } =
+view params =
     let
         isClickable =
-            UserState.isAnonymous userState
+            UserState.isAnonymous params.userState
                 || UserState.isMember
-                    { teamName = pipeline.teamName
-                    , userState = userState
+                    { teamName = params.pipeline.teamName
+                    , userState = params.userState
                     }
     in
-    if isToggleLoading then
-        Spinner.spinner { sizePx = 20, margin = margin }
+    if params.isToggleLoading then
+        Spinner.spinner { sizePx = 20, margin = params.margin }
 
     else
-        Icon.icon
-            { sizePx = 20
-            , image =
-                if isPaused then
-                    "ic-play-white.svg"
-
-                else
-                    "ic-pause-white.svg"
-            }
-            ([ onMouseEnter <| Hover <| Just <| PipelineButton pipeline
-             , onMouseLeave <| Hover Nothing
-             ]
-                ++ Styles.pauseToggleIcon
-                    { isHovered = isClickable && isToggleHovered
-                    , isClickable = isClickable
-                    , margin = margin
-                    }
+        Html.div
+            (Styles.pauseToggle params.margin
+                ++ [ onMouseEnter <| Hover <| Just <| PipelineButton params.pipeline
+                   , onMouseLeave <| Hover Nothing
+                   , class "pause-toggle"
+                   ]
                 ++ (if isClickable then
-                        [ onClick <| Click <| PipelineButton pipeline ]
+                        [ onClick <| Click <| PipelineButton params.pipeline ]
 
                     else
                         []
                    )
             )
+            [ Icon.icon
+                { sizePx = 20
+                , image =
+                    if params.isPaused then
+                        "ic-play-white.svg"
+
+                    else
+                        "ic-pause-white.svg"
+                }
+                (Styles.pauseToggleIcon
+                    { isHovered = isClickable && params.isToggleHovered
+                    , isClickable = isClickable
+                    }
+                )
+            , if params.isToggleHovered && not isClickable then
+                Html.div
+                    (Styles.pauseToggleTooltip params.tooltipPosition)
+                    [ Html.text "not authorized" ]
+
+              else
+                Html.text ""
+            ]

--- a/web/elm/src/Views/Styles.elm
+++ b/web/elm/src/Views/Styles.elm
@@ -1,12 +1,15 @@
 module Views.Styles exposing
-    ( breadcrumbComponent
+    ( TooltipPosition(..)
+    , breadcrumbComponent
     , breadcrumbContainer
     , breadcrumbItem
     , concourseLogo
     , pageBelowTopBar
     , pageHeaderHeight
     , pageIncludingTopBar
+    , pauseToggle
     , pauseToggleIcon
+    , pauseToggleTooltip
     , topBar
     )
 
@@ -140,16 +143,24 @@ breadcrumbItem clickable =
     ]
 
 
+pauseToggle : String -> List (Html.Attribute msg)
+pauseToggle margin =
+    [ style "position" "relative"
+    , style "margin" margin
+    ]
+
+
 pauseToggleIcon :
     { isHovered : Bool
     , isClickable : Bool
-    , margin : String
     }
     -> List (Html.Attribute msg)
-pauseToggleIcon { isHovered, isClickable, margin } =
-    [ style "margin" margin
-    , style "opacity" <|
-        if isHovered then
+pauseToggleIcon { isHovered, isClickable } =
+    [ style "opacity" <|
+        if not isClickable then
+            "0.2"
+
+        else if isHovered then
             "1"
 
         else
@@ -160,4 +171,30 @@ pauseToggleIcon { isHovered, isClickable, margin } =
 
         else
             "default"
+    ]
+
+
+type TooltipPosition
+    = Above
+    | Below
+
+
+pauseToggleTooltip : TooltipPosition -> List (Html.Attribute msg)
+pauseToggleTooltip ttp =
+    [ style "background-color" "#9b9b9b"
+    , style "position" "absolute"
+    , style
+        (case ttp of
+            Above ->
+                "bottom"
+
+            Below ->
+                "top"
+        )
+        "100%"
+    , style "white-space" "nowrap"
+    , style "padding" "2.5px"
+    , style "margin-bottom" "5px"
+    , style "right" "-150%"
+    , style "z-index" "1"
     ]

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -2732,12 +2732,7 @@ all =
                                     |> Tuple.first
                                     |> Common.queryView
                                     |> Query.find [ class "card-footer" ]
-                                    |> Query.find
-                                        (iconSelector
-                                            { size = "20px"
-                                            , image = "ic-pause-white.svg"
-                                            }
-                                        )
+                                    |> Query.find [ class "pause-toggle" ]
                                     |> Event.simulate Event.click
                                     |> Event.expect
                                         (ApplicationMsgs.Update <|

--- a/web/elm/tests/PauseToggleTests.elm
+++ b/web/elm/tests/PauseToggleTests.elm
@@ -1,0 +1,99 @@
+module PauseToggleTests exposing (all)
+
+import Dict
+import Test exposing (Test, describe, test)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (containing, style, tag, text)
+import UserState exposing (UserState(..))
+import Views.PauseToggle as PauseToggle
+import Views.Styles as Styles
+
+
+all : Test
+all =
+    describe "pause toggle"
+        [ describe "when user is unauthorized" <|
+            let
+                pipeline =
+                    { pipelineName = "pipeline"
+                    , teamName = "team"
+                    }
+
+                userState =
+                    UserStateLoggedIn
+                        { id = "test"
+                        , userName = "test"
+                        , name = "test"
+                        , email = "test"
+                        , teams = Dict.fromList [ ( "team", [ "viewer" ] ) ]
+                        }
+            in
+            [ test "has very low opacity" <|
+                \_ ->
+                    PauseToggle.view
+                        { isPaused = False
+                        , pipeline = pipeline
+                        , isToggleHovered = False
+                        , isToggleLoading = False
+                        , margin = ""
+                        , userState = userState
+                        , tooltipPosition = Styles.Above
+                        }
+                        |> Query.fromHtml
+                        |> Query.has [ style "opacity" "0.2" ]
+            , test "has tooltip above" <|
+                \_ ->
+                    PauseToggle.view
+                        { isPaused = False
+                        , pipeline = pipeline
+                        , isToggleHovered = True
+                        , isToggleLoading = False
+                        , margin = ""
+                        , userState = userState
+                        , tooltipPosition = Styles.Above
+                        }
+                        |> Query.fromHtml
+                        |> Query.has
+                            [ style "position" "relative"
+                            , containing
+                                [ tag "div"
+                                , containing [ text "not authorized" ]
+                                , style "background-color" "#9b9b9b"
+                                , style "position" "absolute"
+                                , style "bottom" "100%"
+                                , style "white-space" "nowrap"
+                                , style "padding" "2.5px"
+                                , style "margin-bottom" "5px"
+                                , style "right" "-150%"
+                                , style "z-index" "1"
+                                ]
+                            ]
+            , test "has tooltip below" <|
+                \_ ->
+                    PauseToggle.view
+                        { isPaused = False
+                        , pipeline = pipeline
+                        , isToggleHovered = True
+                        , isToggleLoading = False
+                        , margin = ""
+                        , userState = userState
+                        , tooltipPosition = Styles.Below
+                        }
+                        |> Query.fromHtml
+                        |> Query.has
+                            [ style "position" "relative"
+                            , containing
+                                [ tag "div"
+                                , containing [ text "not authorized" ]
+                                , style "background-color" "#9b9b9b"
+                                , style "position" "absolute"
+                                , style "top" "100%"
+                                , style "white-space" "nowrap"
+                                , style "padding" "2.5px"
+                                , style "margin-bottom" "5px"
+                                , style "right" "-150%"
+                                , style "z-index" "1"
+                                ]
+                            ]
+            ]
+        ]

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -1450,7 +1450,7 @@ all =
                 , unhoveredSelector =
                     { description = "faded play button with light border"
                     , selector =
-                        [ style "opacity" "0.5"
+                        [ style "opacity" "0.2"
                         , style "margin" "17px"
                         , style "cursor" "default"
                         ]
@@ -1460,16 +1460,24 @@ all =
                                 }
                     }
                 , hoveredSelector =
-                    { description = "faded play button with light border"
+                    { description = "faded play button with tooltip below"
                     , selector =
-                        [ style "margin" "17px"
-                        , style "cursor" "default"
-                        , style "opacity" "0.5"
+                        [ containing
+                            ([ style "cursor" "default"
+                             , style "opacity" "0.2"
+                             ]
+                                ++ iconSelector
+                                    { size = "20px"
+                                    , image = "ic-play-white.svg"
+                                    }
+                            )
+                        , containing
+                            [ style "position" "absolute"
+                            , style "top" "100%"
+                            ]
+                        , style "position" "relative"
+                        , style "margin" "17px"
                         ]
-                            ++ iconSelector
-                                { size = "20px"
-                                , image = "ic-play-white.svg"
-                                }
                     }
                 , hoverable =
                     Msgs.PipelineButton { pipelineName = "p", teamName = "t" }


### PR DESCRIPTION
on dashboard pipeline cards:
<img width="280" alt="Screen Shot 2019-05-08 at 1 05 01 PM" src="https://user-images.githubusercontent.com/22056320/57393925-2f0c2600-7192-11e9-8c6d-0115b3d8b187.png">

on pipeline page:
<img width="217" alt="Screen Shot 2019-05-08 at 1 05 17 PM" src="https://user-images.githubusercontent.com/22056320/57393942-35020700-7192-11e9-8986-c87e822d87de.png">


fixes #2428