### PR TITLE
atc: clean up PauseResource and UnpauseResource actions

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -162,8 +162,6 @@ var requiredRoles = map[string]string{
 	atc.ListResources:                 "viewer",
 	atc.ListResourceTypes:             "viewer",
 	atc.GetResource:                   "viewer",
-	atc.PauseResource:                 "pipeline-operator",
-	atc.UnpauseResource:               "pipeline-operator",
 	atc.UnpinResource:                 "pipeline-operator",
 	atc.SetPinCommentOnResource:       "pipeline-operator",
 	atc.CheckResource:                 "pipeline-operator",

--- a/atc/api/accessor/accessor_test.go
+++ b/atc/api/accessor/accessor_test.go
@@ -540,16 +540,6 @@ var _ = Describe("Accessor", func() {
 		Entry("pipeline-operator :: "+atc.GetResource, atc.GetResource, "pipeline-operator", true),
 		Entry("viewer :: "+atc.GetResource, atc.GetResource, "viewer", true),
 
-		Entry("owner :: "+atc.PauseResource, atc.PauseResource, "owner", true),
-		Entry("member :: "+atc.PauseResource, atc.PauseResource, "member", true),
-		Entry("pipeline-operator :: "+atc.PauseResource, atc.PauseResource, "pipeline-operator", true),
-		Entry("viewer :: "+atc.PauseResource, atc.PauseResource, "viewer", false),
-
-		Entry("owner :: "+atc.UnpauseResource, atc.UnpauseResource, "owner", true),
-		Entry("member :: "+atc.UnpauseResource, atc.UnpauseResource, "member", true),
-		Entry("pipeline-operator :: "+atc.UnpauseResource, atc.UnpauseResource, "pipeline-operator", true),
-		Entry("viewer :: "+atc.UnpauseResource, atc.UnpauseResource, "viewer", false),
-
 		Entry("owner :: "+atc.CheckResource, atc.CheckResource, "owner", true),
 		Entry("member :: "+atc.CheckResource, atc.CheckResource, "member", true),
 		Entry("pipeline-operator :: "+atc.CheckResource, atc.CheckResource, "pipeline-operator", true),

--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -115,8 +115,6 @@ var loggingLevels = map[string]string{
 	atc.ListResources:                 "EnableResourceAuditLog",
 	atc.ListResourceTypes:             "EnableResourceAuditLog",
 	atc.GetResource:                   "EnableResourceAuditLog",
-	atc.PauseResource:                 "EnableResourceAuditLog",
-	atc.UnpauseResource:               "EnableResourceAuditLog",
 	atc.UnpinResource:                 "EnableResourceAuditLog",
 	atc.SetPinCommentOnResource:       "EnableResourceAuditLog",
 	atc.CheckResource:                 "EnableResourceAuditLog",

--- a/atc/routes.go
+++ b/atc/routes.go
@@ -34,8 +34,6 @@ const (
 	ListResources        = "ListResources"
 	ListResourceTypes    = "ListResourceTypes"
 	GetResource          = "GetResource"
-	PauseResource        = "PauseResource"
-	UnpauseResource      = "UnpauseResource"
 	CheckResource        = "CheckResource"
 	CheckResourceWebHook = "CheckResourceWebHook"
 	CheckResourceType    = "CheckResourceType"


### PR DESCRIPTION
Removed extra references to PauseResource and UnpauseResource since they have no routes any more.