### PR TITLE
Check if session-signing-key is nil

### DIFF
--- a/cmd/concourse/concourse_suite_test.go
+++ b/cmd/concourse/concourse_suite_test.go
@@ -15,12 +15,16 @@ func TestConcourse(t *testing.T) {
 
 var concoursePath string
 
-var _ = BeforeSuite(func() {
-	var err error
-	concoursePath, err = gexec.Build("github.com/concourse/concourse/cmd/concourse")
+var _ = SynchronizedBeforeSuite(func() []byte {
+	buildPath, err := gexec.Build("github.com/concourse/concourse/cmd/concourse")
 	Expect(err).NotTo(HaveOccurred())
+	return []byte(buildPath)
+}, func(data []byte) {
+	concoursePath = string(data)
 })
 
-var _ = AfterSuite(func() {
+var _ = SynchronizedAfterSuite(func() {
+	// other nodes don't need to do any clean up, as it's already taken care of by the first node
+}, func() {
 	gexec.CleanupBuildArtifacts()
 })

--- a/cmd/concourse/concourse_suite_test.go
+++ b/cmd/concourse/concourse_suite_test.go
@@ -3,6 +3,7 @@ package main_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 
 	"testing"
 )
@@ -11,3 +12,15 @@ func TestConcourse(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Concourse Suite")
 }
+
+var concoursePath string
+
+var _ = BeforeSuite(func() {
+	var err error
+	concoursePath, err = gexec.Build("github.com/concourse/concourse/cmd/concourse")
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	gexec.CleanupBuildArtifacts()
+})

--- a/cmd/concourse/concourse_test.go
+++ b/cmd/concourse/concourse_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Web Command", func() {
 
 		Context("but no session signing key is provided", func() {
 			It("should fail due to missing db credentials", func() {
-				Eventually(concourseRunner.Buffer()).Should(gbytes.Say("dial tcp 127.0.0.1:5432: connect: connection refused"))
+				Eventually(concourseRunner.Buffer(), "10s", "2s").Should(gbytes.Say("dial tcp 127.0.0.1:5432: connect: connection refused"))
 			})
 		})
 
@@ -98,10 +98,13 @@ var _ = Describe("Web Command", func() {
 					"--postgres-port", strconv.Itoa(5433+GinkgoParallelNode()),
 					"--main-team-local-user", "test",
 					"--add-local-user", "test:test",
+					"--debug-bind-port", strconv.Itoa(8000+GinkgoParallelNode()),
+					"--bind-port", strconv.Itoa(8080+GinkgoParallelNode()),
+					"--tsa-bind-port", strconv.Itoa(2222+GinkgoParallelNode()),
 				)
 			})
 
-			var _ = AfterEach(func() {
+			AfterEach(func() {
 				postgresRunner.DropTestDB()
 
 				dbProcess.Signal(os.Interrupt)
@@ -110,11 +113,11 @@ var _ = Describe("Web Command", func() {
 			})
 
 			It("ATC should start up", func() {
-				Eventually(concourseRunner.Buffer(), "10s", "2s").Should(gbytes.Say("atc.listening"))
+				Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("atc.listening"))
 			})
 
 			It("TSA should start up", func() {
-				Eventually(concourseRunner.Buffer(), "10s", "2s").Should(gbytes.Say("tsa.listening"))
+				Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("tsa.listening"))
 			})
 
 		})

--- a/cmd/concourse/concourse_test.go
+++ b/cmd/concourse/concourse_test.go
@@ -1,0 +1,152 @@
+package main_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/concourse/concourse/atc/postgresrunner"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/tedsuo/ifrit"
+	"github.com/tedsuo/ifrit/ginkgomon"
+	"golang.org/x/crypto/ssh"
+)
+
+var _ = Describe("Web Command", func() {
+
+	var (
+		args           []string
+		hostKeyFile    string
+		hostPubKeyFile string
+
+		concourseProcess ifrit.Process
+		concourseRunner  *ginkgomon.Runner
+	)
+
+	BeforeEach(func() {
+		args = []string{"web"}
+	})
+
+	JustBeforeEach(func() {
+		concourseCommand := exec.Command(
+			concoursePath,
+			args...,
+		)
+
+		concourseRunner = ginkgomon.New(ginkgomon.Config{
+			Command:       concourseCommand,
+			Name:          "tsa",
+			StartCheck:    "atc.cmd.start",
+			AnsiColorCode: "32m",
+		})
+
+		concourseProcess = ginkgomon.Invoke(concourseRunner)
+
+		// workaround to avoid panic due to registering http handlers multiple times
+		http.DefaultServeMux = new(http.ServeMux)
+	})
+
+	JustAfterEach(func() {
+		ginkgomon.Interrupt(concourseProcess)
+		<-concourseProcess.Wait()
+	})
+
+	Context("when --tsa-host-key is specified", func() {
+		BeforeEach(func() {
+			hostKeyFile, hostPubKeyFile, _, _ = generateSSHKeypair()
+			args = append(args, "--tsa-host-key", hostKeyFile)
+		})
+
+		AfterEach(func() {
+			os.Remove(hostKeyFile)
+			os.Remove(hostPubKeyFile)
+			os.Remove(filepath.Dir(hostPubKeyFile))
+		})
+
+		Context("but no session signing key is provided", func() {
+			It("should fail due to missing db credentials", func() {
+				Eventually(concourseRunner.Buffer()).Should(gbytes.Say("dial tcp 127.0.0.1:5432: connect: connection refused"))
+			})
+		})
+
+		Context("and all other required flags are provided", func() {
+
+			var (
+				postgresRunner postgresrunner.Runner
+				dbProcess      ifrit.Process
+			)
+
+			BeforeEach(func() {
+				postgresRunner = postgresrunner.Runner{
+					Port: 5433 + GinkgoParallelNode(),
+				}
+				dbProcess = ifrit.Invoke(postgresRunner)
+				postgresRunner.CreateTestDB()
+
+				args = append(args, "--postgres-user", "postgres",
+					"--postgres-database", "testdb",
+					"--postgres-port", strconv.Itoa(5433+GinkgoParallelNode()),
+					"--main-team-local-user", "test",
+					"--add-local-user", "test:test",
+				)
+			})
+
+			var _ = AfterEach(func() {
+				postgresRunner.DropTestDB()
+
+				dbProcess.Signal(os.Interrupt)
+				err := <-dbProcess.Wait()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("ATC should start up", func() {
+				Eventually(concourseRunner.Buffer(), "10s", "2s").Should(gbytes.Say("atc.listening"))
+			})
+
+			It("TSA should start up", func() {
+				Eventually(concourseRunner.Buffer(), "10s", "2s").Should(gbytes.Say("tsa.listening"))
+			})
+
+		})
+	})
+})
+
+func generateSSHKeypair() (string, string, *rsa.PrivateKey, ssh.PublicKey) {
+	path, err := ioutil.TempDir("", "tsa-key")
+	Expect(err).NotTo(HaveOccurred())
+
+	privateKeyPath := filepath.Join(path, "id_rsa")
+	publicKeyPath := privateKeyPath + ".pub"
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).NotTo(HaveOccurred())
+
+	privateKeyBytes := pem.EncodeToMemory(&pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	publicKeyRsa, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	Expect(err).NotTo(HaveOccurred())
+
+	publicKeyBytes := ssh.MarshalAuthorizedKey(publicKeyRsa)
+
+	err = ioutil.WriteFile(privateKeyPath, privateKeyBytes, 0600)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ioutil.WriteFile(publicKeyPath, publicKeyBytes, 0600)
+	Expect(err).NotTo(HaveOccurred())
+
+	return privateKeyPath, publicKeyPath, privateKey, publicKeyRsa
+}

--- a/cmd/concourse/web.go
+++ b/cmd/concourse/web.go
@@ -73,8 +73,8 @@ func (cmd *WebCommand) populateTSAFlagsFromATCFlags() error {
 	cmd.TSACommand.SessionSigningKey = cmd.RunCommand.Auth.AuthFlags.SigningKey
 	cmd.TSACommand.PeerAddress = cmd.PeerAddress
 
-	if cmd.RunCommand.Auth.AuthFlags.SigningKey.PrivateKey == nil &&
-		cmd.TSACommand.SessionSigningKey.PrivateKey == nil {
+	if (cmd.RunCommand.Auth.AuthFlags.SigningKey == nil || cmd.RunCommand.Auth.AuthFlags.SigningKey.PrivateKey == nil) &&
+		(cmd.TSACommand.SessionSigningKey == nil || cmd.TSACommand.SessionSigningKey.PrivateKey == nil) {
 		signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
 		if err != nil {
 			return fmt.Errorf("failed to generate session signing key: %s", err)


### PR DESCRIPTION
Fixes #3847 to see if `--session-signing-key` is specified.

I set up a test to check for this specific case, as well as a check for a minimal set of valid parameters.  Any suggestions on these tests?  I wasn't sure how best to approach it.  The `generateSSHKeypair` was copied from [here](https://github.com/concourse/concourse/blob/master/tsa/cmd/tsa/suite_test.go#L197) - not sure if there's a shared test package that I can move it to? 