### PR TITLE
atc: info API yields the external URL and cluster name

### DIFF
--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -32,6 +32,7 @@ var (
 	sink *lager.ReconfigurableSink
 
 	externalURL = "https://example.com"
+	clusterName = "Test Cluster"
 
 	fakeWorkerClient        *workerfakes.FakeClient
 	fakeVolumeRepository    *dbfakes.FakeVolumeRepository
@@ -152,6 +153,7 @@ var _ = BeforeEach(func() {
 		logger,
 
 		externalURL,
+		clusterName,
 
 		wrappa.NewAPIAuthWrappa(
 			checkPipelineAccessHandlerFactory,

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -34,6 +34,7 @@ func NewHandler(
 	logger lager.Logger,
 
 	externalURL string,
+	clusterName string,
 
 	wrapper wrappa.Wrappa,
 
@@ -89,7 +90,7 @@ func NewHandler(
 	containerServer := containerserver.NewServer(logger, workerClient, secretManager, interceptTimeoutFactory, containerRepository, destroyer)
 	volumesServer := volumeserver.NewServer(logger, volumeRepository, destroyer)
 	teamServer := teamserver.NewServer(logger, dbTeamFactory, externalURL)
-	infoServer := infoserver.NewServer(logger, version, workerVersion, credsManagers)
+	infoServer := infoserver.NewServer(logger, version, workerVersion, externalURL, clusterName, credsManagers)
 	artifactServer := artifactserver.NewServer(logger, workerClient)
 
 	handlers := map[string]http.Handler{

--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -63,7 +63,9 @@ var _ = Describe("Pipelines API", func() {
 
 			Expect(body).To(MatchJSON(`{
 				"version": "1.2.3",
-				"worker_version": "4.5.6"
+				"worker_version": "4.5.6",
+				"external_url": "https://example.com",
+				"cluster_name": "Test Cluster"
 			}`))
 		})
 	})

--- a/atc/api/infoserver/info.go
+++ b/atc/api/infoserver/info.go
@@ -11,7 +11,10 @@ func (s *Server) Info(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.Session("info")
 
 	w.Header().Set("Content-Type", "application/json")
-	err := json.NewEncoder(w).Encode(atc.Info{Version: s.version, WorkerVersion: s.workerVersion})
+	err := json.NewEncoder(w).Encode(atc.Info{Version: s.version,
+		WorkerVersion: s.workerVersion,
+		ExternalURL: s.externalURL,
+		ClusterName: s.clusterName})
 	if err != nil {
 		logger.Error("failed-to-encode-info", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/infoserver/server.go
+++ b/atc/api/infoserver/server.go
@@ -9,6 +9,8 @@ type Server struct {
 	logger        lager.Logger
 	version       string
 	workerVersion string
+	externalURL   string
+	clusterName   string
 	credsManagers creds.Managers
 }
 
@@ -16,12 +18,16 @@ func NewServer(
 	logger lager.Logger,
 	version string,
 	workerVersion string,
+	externalURL string,
+	clusterName string,
 	credsManagers creds.Managers,
 ) *Server {
 	return &Server{
 		logger:        logger,
 		version:       version,
 		workerVersion: workerVersion,
+		externalURL:   externalURL,
+		clusterName:   clusterName,
 		credsManagers: credsManagers,
 	}
 }

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1301,6 +1301,7 @@ func (cmd *RunCommand) constructAPIHandler(
 	return api.NewHandler(
 		logger,
 		cmd.ExternalURL.String(),
+		cmd.Server.ClusterName,
 		apiWrapper,
 
 		teamFactory,

--- a/atc/info.go
+++ b/atc/info.go
@@ -3,4 +3,6 @@ package atc
 type Info struct {
 	Version       string `json:"version"`
 	WorkerVersion string `json:"worker_version"`
+	ExternalURL   string `json:"external_url,omitempty"`
+	ClusterName   string `json:"cluster_name,omitempty"`
 }


### PR DESCRIPTION
The `/api/v1/info` path, in addition to giving the server and worker versions, now also gives the "external URL" - the canonical entry point for the installation. This is useful in cases where the API is accessed by IP address, through a proxy, etc., and we want to find out the proper URL instead. It also now gives the user-facing cluster name, if one is configured, which might in the future be picked up by fly or other clients (see #1077).

This PR doesn't currently have any consumers of this information, but it seems probably useful for it to show up in `fly targets` listings, at least. I'm not sure if the right thing is to display the external URL alongside the configured target URL, or if instead we should be _replacing_ whatever the user specified with whatever the cluster reports in `/info` (e.g., I login with `-c http://10.20.30.40`, that cluster says its external URL is `https://ci.example.com`, and the latter is what gets saved in `.flyrc`). Likewise, I could imagine something like using the cluster name as a default target name (e.g. I could login without specifying `-t`, the cluster says its name is `dev`, so that's saved as target `dev`), but it's not obvious to me whether that's a good idea.
