### PR TITLE
cmd/concourse: fix worker private key flag

### DIFF
--- a/cmd/concourse/quickstart.go
+++ b/cmd/concourse/quickstart.go
@@ -27,6 +27,7 @@ func (cmd QuickstartCommand) lessenRequirements(command *flags.Command) {
 	command.FindOptionByLongName("session-signing-key").Required = false
 	command.FindOptionByLongName("tsa-authorized-keys").Required = false
 	command.FindOptionByLongName("tsa-host-key").Required = false
+	command.FindOptionByLongName("worker-tsa-worker-private-key").Required = false
 }
 
 func (cmd *QuickstartCommand) Execute(args []string) error {

--- a/cmd/concourse/worker_linux.go
+++ b/cmd/concourse/worker_linux.go
@@ -37,7 +37,6 @@ type GardenBackend struct {
 func (cmd WorkerCommand) lessenRequirements(prefix string, command *flags.Command) {
 	// configured as work-dir/volumes
 	command.FindOptionByLongName(prefix + "baggageclaim-volumes").Required = false
-	command.FindOptionByLongName(prefix + "tsa-worker-private-key").Required = false
 }
 
 func (cmd *WorkerCommand) gardenRunner(logger lager.Logger) (atc.Worker, ifrit.Runner, error) {

--- a/cmd/concourse/worker_nonlinux.go
+++ b/cmd/concourse/worker_nonlinux.go
@@ -18,7 +18,6 @@ type Certs struct{}
 func (cmd WorkerCommand) lessenRequirements(prefix string, command *flags.Command) {
 	// created in the work-dir
 	command.FindOptionByLongName(prefix + "baggageclaim-volumes").Required = false
-	command.FindOptionByLongName(prefix + "tsa-worker-private-key").Required = false
 }
 
 func (cmd *WorkerCommand) gardenRunner(logger lager.Logger) (atc.Worker, ifrit.Runner, error) {


### PR DESCRIPTION
this flag should be required for the worker commands, and only optional
in 'quickstart'

Signed-off-by: Alex Suraci <suraci.alex@gmail.com>