### PR TITLE
Set a darker background on highlighted-line

### DIFF
--- a/web/assets/css/build.less
+++ b/web/assets/css/build.less
@@ -70,7 +70,7 @@
   }
 
   &.highlighted-line {
-    background: @base02;
+    background: @base01;
 
     .timestamp {
       color: @base0A;


### PR DESCRIPTION
Darken `.highlighted-line` a bit, switching from `@base02` (`#3d3c3c`) to `@base01` (`#2a2929`) which helps highlight the highlighted-line(s) pop a bit more:

### Before
![before](https://user-images.githubusercontent.com/25628/57736361-ab60a680-7675-11e9-93c9-e91394747d50.png)

### After
![after](https://user-images.githubusercontent.com/25628/57736362-ad2a6a00-7675-11e9-8826-87b9aab50ff7.png)








Addresses https://github.com/concourse/concourse/issues/3805