### PR TITLE
topgun/k8s: reduce even more the flakiness of worker_lifecycle test

### DIFF
--- a/topgun/k8s/worker_lifecycle_test.go
+++ b/topgun/k8s/worker_lifecycle_test.go
@@ -104,9 +104,12 @@ var _ = Describe("Worker lifecycle", func() {
 					Should(HaveLen(0))
 
 				By("seeing that the build succeeded")
-				startSession := fly.Start("builds", "-j", "some-pipeline/simple-job")
-				<-startSession.Exited
-				Expect(startSession.Out).To(gbytes.Say("succeeded"))
+				Eventually(func() *gbytes.Buffer {
+					startSession := fly.Start("builds", "-j", "some-pipeline/simple-job")
+					<-startSession.Exited
+					return startSession.Out
+				}, 1*time.Minute, 5*time.Second).
+					Should(gbytes.Say("succeeded"))
 			})
 		})
 

--- a/topgun/k8s/worker_lifecycle_test.go
+++ b/topgun/k8s/worker_lifecycle_test.go
@@ -104,12 +104,7 @@ var _ = Describe("Worker lifecycle", func() {
 					Should(HaveLen(0))
 
 				By("seeing that the build succeeded")
-				Eventually(func() *gbytes.Buffer {
-					startSession := fly.Start("builds", "-j", "some-pipeline/simple-job")
-					<-startSession.Exited
-					return startSession.Out
-				}, 1*time.Minute, 5*time.Second).
-					Should(gbytes.Say("succeeded"))
+				fly.Run("watch", "-j", "some-pipeline/simple-job")
 			})
 		})
 
@@ -129,7 +124,7 @@ var _ = Describe("Worker lifecycle", func() {
 				By("seeing that the worker disappeared")
 				startSession := fly.Start("watch", "-j", "some-pipeline/simple-job")
 				<-startSession.Exited
-				Expect(startSession.Out).To(gbytes.Say("disappeared"))
+				Expect(startSession.Out).To(gbytes.Say("errored"))
 			})
 		})
 	})


### PR DESCRIPTION
We were previously not accounting for the fact that it might take a
little while for the build to be marked as succeeded.

That race used to make our tests fail quite a good amount of times.
