### PR TITLE
add time for FinishGet and FinishPut events

### DIFF
--- a/atc/engine/builder/delegate_factory.go
+++ b/atc/engine/builder/delegate_factory.go
@@ -41,6 +41,7 @@ func NewGetDelegate(build db.Build, planID atc.PlanID, clock clock.Clock) exec.G
 
 		eventOrigin: event.Origin{ID: event.OriginID(planID)},
 		build:       build,
+		clock:       clock,
 	}
 }
 
@@ -49,6 +50,7 @@ type getDelegate struct {
 
 	build       db.Build
 	eventOrigin event.Origin
+	clock       clock.Clock
 }
 
 func (d *getDelegate) Initializing(logger lager.Logger) {
@@ -80,6 +82,7 @@ func (d *getDelegate) Starting(logger lager.Logger) {
 func (d *getDelegate) Finished(logger lager.Logger, exitStatus exec.ExitStatus, info exec.VersionInfo) {
 	err := d.build.SaveEvent(event.FinishGet{
 		Origin:          d.eventOrigin,
+		Time:            d.clock.Now().Unix(),
 		ExitStatus:      int(exitStatus),
 		FetchedVersion:  info.Version,
 		FetchedMetadata: info.Metadata,
@@ -98,6 +101,7 @@ func NewPutDelegate(build db.Build, planID atc.PlanID, clock clock.Clock) exec.P
 
 		eventOrigin: event.Origin{ID: event.OriginID(planID)},
 		build:       build,
+		clock:       clock,
 	}
 }
 
@@ -106,6 +110,7 @@ type putDelegate struct {
 
 	build       db.Build
 	eventOrigin event.Origin
+	clock       clock.Clock
 }
 
 func (d *putDelegate) Initializing(logger lager.Logger) {
@@ -137,6 +142,7 @@ func (d *putDelegate) Starting(logger lager.Logger) {
 func (d *putDelegate) Finished(logger lager.Logger, exitStatus exec.ExitStatus, info exec.VersionInfo) {
 	err := d.build.SaveEvent(event.FinishPut{
 		Origin:          d.eventOrigin,
+		Time:            d.clock.Now().Unix(),
 		ExitStatus:      int(exitStatus),
 		CreatedVersion:  info.Version,
 		CreatedMetadata: info.Metadata,

--- a/atc/engine/builder/delegate_factory_test.go
+++ b/atc/engine/builder/delegate_factory_test.go
@@ -57,6 +57,7 @@ var _ = Describe("DelegateFactory", func() {
 				Expect(fakeBuild.SaveEventCallCount()).To(Equal(1))
 				Expect(fakeBuild.SaveEventArgsForCall(0)).To(Equal(event.FinishGet{
 					Origin:          event.Origin{ID: event.OriginID("some-plan-id")},
+					Time:            123456789,
 					ExitStatus:      int(exitStatus),
 					FetchedVersion:  info.Version,
 					FetchedMetadata: info.Metadata,
@@ -90,6 +91,7 @@ var _ = Describe("DelegateFactory", func() {
 				Expect(fakeBuild.SaveEventCallCount()).To(Equal(1))
 				Expect(fakeBuild.SaveEventArgsForCall(0)).To(Equal(event.FinishPut{
 					Origin:          event.Origin{ID: event.OriginID("some-plan-id")},
+					Time:            123456789,
 					ExitStatus:      int(exitStatus),
 					CreatedVersion:  info.Version,
 					CreatedMetadata: info.Metadata,


### PR DESCRIPTION
fixes #3835 

The timestamps were lost on events `FinishGet` and `FinishPut` during a refactor.