### PR TITLE
Enable cert generation using Let's Encrypt

### DIFF
--- a/atc/atccmd/cert_cache.go
+++ b/atc/atccmd/cert_cache.go
@@ -1,0 +1,62 @@
+package atccmd
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/encryption"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+type dbCache struct {
+	get, put, delete *sql.Stmt
+	es               encryption.Strategy
+}
+
+func newDbCache(conn db.Conn) (autocert.Cache, error) {
+	c := new(dbCache)
+	c.es = conn.EncryptionStrategy()
+	var err error
+	c.get, err = conn.Prepare("SELECT cert, nonce FROM cert_cache WHERE domain = $1")
+	if err != nil {
+		return nil, err
+	}
+	c.put, err = conn.Prepare("INSERT INTO cert_cache (domain, cert, nonce) VALUES ($1, $2, $3)")
+	if err != nil {
+		return nil, err
+	}
+	c.delete, err = conn.Prepare("DELETE FROM cert_cache WHERE domain = $1")
+	return c, err
+}
+
+func (c *dbCache) Get(ctx context.Context, domain string) ([]byte, error) {
+	var ciphertext string
+	var nonce sql.NullString
+	err := c.get.QueryRowContext(ctx, domain).Scan(&ciphertext, &nonce)
+	if err == sql.ErrNoRows {
+		err = autocert.ErrCacheMiss
+	}
+	if err != nil {
+		return nil, err
+	}
+	var noncense *string
+	if nonce.Valid {
+		noncense = &nonce.String
+	}
+	return c.es.Decrypt(ciphertext, noncense)
+}
+
+func (c *dbCache) Put(ctx context.Context, domain string, cert []byte) error {
+	ciphertext, nonce, err := c.es.Encrypt(cert)
+	if err != nil {
+		return err
+	}
+	_, err = c.put.ExecContext(ctx, domain, ciphertext, nonce)
+	return err
+}
+
+func (c *dbCache) Delete(ctx context.Context, domain string) error {
+	_, err := c.delete.ExecContext(ctx, domain)
+	return err
+}

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1006,7 +1006,7 @@ func (cmd *RunCommand) tlsConfig(logger lager.Logger, dbConn db.Conn) (*tls.Conf
 	if cmd.isTLSEnabled() {
 		tlsLogger := logger.Session("tls-enabled")
 		if cmd.EnableAutocert {
-			tlsLogger.Info("starting autocert manager")
+			tlsLogger.Debug("using-autocert-manager")
 
 			cache, err := newDbCache(dbConn)
 			if err != nil {
@@ -1017,12 +1017,11 @@ func (cmd *RunCommand) tlsConfig(logger lager.Logger, dbConn db.Conn) (*tls.Conf
 				Cache:      cache,
 				HostPolicy: autocert.HostWhitelist(cmd.ExternalURL.URL.Hostname()),
 				Client:     &acme.Client{DirectoryURL: cmd.ACMEURL.URL.String()},
-				ForceRSA:   true,
 			}
 			tlsConfig.NextProtos = append(tlsConfig.NextProtos, acme.ALPNProto)
 			tlsConfig.GetCertificate = m.GetCertificate
 		} else {
-			tlsLogger.Info("configuring tls using provided certs")
+			tlsLogger.Debug("loading-tls-certs")
 			cert, err := tls.LoadX509KeyPair(string(cmd.TLSCert), string(cmd.TLSKey))
 			if err != nil {
 				return nil, err
@@ -1097,12 +1096,6 @@ func (cmd *RunCommand) validate() error {
 			errs = multierror.Append(
 				errs,
 				errors.New("cannot enable autocert if --tls-cert or --tls-key are set"),
-			)
-		}
-		if cmd.TLSBindPort != 443 {
-			errs = multierror.Append(
-				errs,
-				errors.New("cannot enable autocert if external port is not 443"),
 			)
 		}
 	case cmd.TLSCert != "" && cmd.TLSKey != "":

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -58,6 +58,8 @@ import (
 	"github.com/tedsuo/ifrit/grouper"
 	"github.com/tedsuo/ifrit/http_server"
 	"github.com/tedsuo/ifrit/sigmon"
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
 
 	// dynamically registered metric emitters
 	_ "github.com/concourse/concourse/atc/metric/emitter"
@@ -84,9 +86,11 @@ type RunCommand struct {
 	BindIP   flag.IP `long:"bind-ip"   default:"0.0.0.0" description:"IP address on which to listen for web traffic."`
 	BindPort uint16  `long:"bind-port" default:"8080"    description:"Port on which to listen for HTTP traffic."`
 
-	TLSBindPort uint16    `long:"tls-bind-port" description:"Port on which to listen for HTTPS traffic."`
-	TLSCert     flag.File `long:"tls-cert"      description:"File containing an SSL certificate."`
-	TLSKey      flag.File `long:"tls-key"       description:"File containing an RSA private key, used to encrypt HTTPS traffic."`
+	TLSBindPort    uint16    `long:"tls-bind-port" description:"Port on which to listen for HTTPS traffic."`
+	TLSCert        flag.File `long:"tls-cert"      description:"File containing an SSL certificate."`
+	TLSKey         flag.File `long:"tls-key"       description:"File containing an RSA private key, used to encrypt HTTPS traffic."`
+	EnableAutocert bool      `long:"enable-autocert"      description:"Use ACME to obtain an SSL certificate"`
+	ACMEURL        flag.URL  `long:"acme-url" default:"https://acme-v01.api.letsencrypt.org/directory" description:"URL of the ACME CA directory endpoint."`
 
 	ExternalURL flag.URL `long:"external-url" description:"URL used to reach any ATC from the outside world."`
 
@@ -662,7 +666,7 @@ func (cmd *RunCommand) constructAPIMembers(
 	}
 
 	if httpsHandler != nil {
-		tlsConfig, err := cmd.tlsConfig()
+		tlsConfig, err := cmd.tlsConfig(logger, dbConn)
 		if err != nil {
 			return nil, err
 		}
@@ -942,23 +946,24 @@ func (cmd *RunCommand) skyHttpClient() (*http.Client, error) {
 	httpClient := http.DefaultClient
 
 	if cmd.isTLSEnabled() {
-		cert, err := tls.LoadX509KeyPair(string(cmd.TLSCert), string(cmd.TLSKey))
-		if err != nil {
-			return nil, err
-		}
-
-		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
-		if err != nil {
-			return nil, err
-		}
-
 		certpool, err := x509.SystemCertPool()
 		if err != nil {
 			return nil, err
 		}
+		if !cmd.EnableAutocert {
+			cert, err := tls.LoadX509KeyPair(string(cmd.TLSCert), string(cmd.TLSKey))
+			if err != nil {
+				return nil, err
+			}
 
-		certpool.AddCert(x509Cert)
+			x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+			if err != nil {
+				return nil, err
+			}
 
+			certpool.AddCert(x509Cert)
+
+		}
 		httpClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
 				RootCAs: certpool,
@@ -994,17 +999,36 @@ func (tripper mitmRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	return tripper.RoundTripper.RoundTrip(req)
 }
 
-func (cmd *RunCommand) tlsConfig() (*tls.Config, error) {
+func (cmd *RunCommand) tlsConfig(logger lager.Logger, dbConn db.Conn) (*tls.Config, error) {
 	var tlsConfig *tls.Config
+	tlsConfig = atc.DefaultTLSConfig()
 
 	if cmd.isTLSEnabled() {
-		cert, err := tls.LoadX509KeyPair(string(cmd.TLSCert), string(cmd.TLSKey))
-		if err != nil {
-			return nil, err
-		}
+		tlsLogger := logger.Session("tls-enabled")
+		if cmd.EnableAutocert {
+			tlsLogger.Info("starting autocert manager")
 
-		tlsConfig = atc.DefaultTLSConfig()
-		tlsConfig.Certificates = []tls.Certificate{cert}
+			cache, err := newDbCache(dbConn)
+			if err != nil {
+				return nil, err
+			}
+			m := autocert.Manager{
+				Prompt:     autocert.AcceptTOS,
+				Cache:      cache,
+				HostPolicy: autocert.HostWhitelist(cmd.ExternalURL.URL.Hostname()),
+				Client:     &acme.Client{DirectoryURL: cmd.ACMEURL.URL.String()},
+				ForceRSA:   true,
+			}
+			tlsConfig.NextProtos = append(tlsConfig.NextProtos, acme.ALPNProto)
+			tlsConfig.GetCertificate = m.GetCertificate
+		} else {
+			tlsLogger.Info("configuring tls using provided certs")
+			cert, err := tls.LoadX509KeyPair(string(cmd.TLSCert), string(cmd.TLSKey))
+			if err != nil {
+				return nil, err
+			}
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		}
 	}
 	return tlsConfig, nil
 }
@@ -1060,28 +1084,38 @@ func run(runner ifrit.Runner, onReady func(), onExit func()) ifrit.Runner {
 func (cmd *RunCommand) validate() error {
 	var errs *multierror.Error
 
-	tlsFlagCount := 0
-	if cmd.TLSBindPort != 0 {
-		tlsFlagCount++
-	}
-	if cmd.TLSCert != "" {
-		tlsFlagCount++
-	}
-	if cmd.TLSKey != "" {
-		tlsFlagCount++
-	}
-
-	if tlsFlagCount == 3 {
+	switch {
+	case cmd.TLSBindPort == 0:
+		if cmd.TLSCert != "" || cmd.TLSKey != "" || cmd.EnableAutocert {
+			errs = multierror.Append(
+				errs,
+				errors.New("must specify --tls-bind-port to use TLS"),
+			)
+		}
+	case cmd.EnableAutocert:
+		if cmd.TLSCert != "" || cmd.TLSKey != "" {
+			errs = multierror.Append(
+				errs,
+				errors.New("cannot enable autocert if --tls-cert or --tls-key are set"),
+			)
+		}
+		if cmd.TLSBindPort != 443 {
+			errs = multierror.Append(
+				errs,
+				errors.New("cannot enable autocert if external port is not 443"),
+			)
+		}
+	case cmd.TLSCert != "" && cmd.TLSKey != "":
 		if cmd.ExternalURL.URL.Scheme != "https" {
 			errs = multierror.Append(
 				errs,
 				errors.New("must specify HTTPS external-url to use TLS"),
 			)
 		}
-	} else if tlsFlagCount != 0 {
+	default:
 		errs = multierror.Append(
 			errs,
-			errors.New("must specify --tls-bind-port, --tls-cert, --tls-key to use TLS"),
+			errors.New("must specify --tls-cert and --tls-key, or --autocert to use TLS"),
 		)
 	}
 

--- a/atc/config.go
+++ b/atc/config.go
@@ -514,6 +514,9 @@ func DefaultTLSConfig() *tls.Config {
 
 		// Security team recommends a very restricted set of cipher suites
 		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 		},

--- a/atc/db/migration/auto_cert_test.go
+++ b/atc/db/migration/auto_cert_test.go
@@ -1,0 +1,53 @@
+package migration_test
+
+import (
+	"database/sql"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Add Cert Cache Table", func() {
+
+	const postMigrationVersion = 1557237784
+	const preMigrationVersion = 1556724983
+
+	var (
+		db *sql.DB
+	)
+
+	Context("Up", func() {
+		It("successfully creates table cert_cache", func() {
+			db = postgresRunner.OpenDBAtVersion(postMigrationVersion)
+			writeAutoCert(db, "magic-domain", "iamcert", "iamnonce")
+			cert, err := readAutoCert(db, "magic-domain")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cert).To(Equal("iamcert"))
+			db.Close()
+		})
+	})
+
+	Context("Down", func() {
+		It("successfully drops table cert_cache", func() {
+			db = postgresRunner.OpenDBAtVersion(postMigrationVersion)
+			writeAutoCert(db, "magic-domain", "iamcert", "iamnonce")
+			db.Close()
+
+			db = postgresRunner.OpenDBAtVersion(preMigrationVersion)
+			_, err := readAutoCert(db, "magic-domain")
+			Expect(err).To(HaveOccurred())
+			db.Close()
+		})
+	})
+
+})
+
+func readAutoCert(dbConn *sql.DB, domain string) (string, error) {
+	var cert []byte
+	err := dbConn.QueryRow("SELECT cert FROM cert_cache WHERE domain = $1", domain).Scan(&cert)
+	return string(cert), err
+}
+
+func writeAutoCert(dbConn *sql.DB, domain, cert, nonce string) {
+	dbConn.Exec("INSERT INTO cert_cache(domain, cert, nonce) VALUES($1, $2, $3)", domain, cert, nonce)
+}

--- a/atc/db/migration/migrations/1557237784_create_auto_cert_cache.down.sql
+++ b/atc/db/migration/migrations/1557237784_create_auto_cert_cache.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  DROP TABLE cert_cache;
+COMMIT;

--- a/atc/db/migration/migrations/1557237784_create_auto_cert_cache.up.sql
+++ b/atc/db/migration/migrations/1557237784_create_auto_cert_cache.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+  CREATE TABLE cert_cache (
+    "domain" text PRIMARY KEY,
+    "cert" text NOT NULL,
+    "nonce" text
+  );
+COMMIT;

--- a/atc/db/open.go
+++ b/atc/db/open.go
@@ -120,6 +120,7 @@ var encryptedColumns = map[string]string{
 	"jobs":           "config",
 	"resource_types": "config",
 	"builds":         "private_plan",
+	"cert_cache":     "cert",
 }
 
 func encryptPlaintext(logger lager.Logger, sqlDB *sql.DB, key *encryption.Key) error {

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/cloudfoundry/bosh-utils v0.0.0-20181224171034-c2cf699102bd // indirect
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
+	github.com/concourse/atc v4.2.2+incompatible
 	github.com/concourse/baggageclaim v1.4.0
 	github.com/concourse/dex v0.0.0-20190417202333-2202f4ef4172
 	github.com/concourse/flag v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/cloudfoundry/bosh-utils v0.0.0-20181224171034-c2cf699102bd // indirect
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
-	github.com/concourse/atc v4.2.2+incompatible
 	github.com/concourse/baggageclaim v1.4.0
 	github.com/concourse/dex v0.0.0-20190417202333-2202f4ef4172
 	github.com/concourse/flag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 h1:9j2Kb
 github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2/go.mod h1:0a+Ghg38uB86Dx+de84dFSkILTnBHzCpFMRnjHgSzi4=
 github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292 h1:dzj1/xcivGjNPwwifh/dWTczkwcuqsXXFHY1X/TZMtw=
 github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292/go.mod h1:qRiX68mZX1lGBkTWyp3CLcenw9I94W2dLeRvMzcn9N4=
+github.com/concourse/atc v4.2.2+incompatible h1:hMtYBdeytPtIu/QNuHLQTafiHUHxm852dgsUfoIf1Mo=
+github.com/concourse/atc v4.2.2+incompatible/go.mod h1:sB+NvCgZM3gsgFKEec4dRfBAxz8AHrUgol2t4B42wVM=
 github.com/concourse/baggageclaim v1.4.0 h1:pNohKpBWgr9RWvDoEpsi+IhPJ67ZaKt0/o/WLt2hFa4=
 github.com/concourse/baggageclaim v1.4.0/go.mod h1:JXDes0u8KKR4DDDATN1uLTMxNrQlTJcU0FeAtHqSkSg=
 github.com/concourse/dex v0.0.0-20190227205709-0d3a1049c2d9 h1:nOfFldnpftQS6nzLM2p7wvAChsGQ+76VNUwD1xxIics=
@@ -519,6 +521,7 @@ github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa h1:E+gaaifzi2xF65PbDmuKI3PhLWY6G5opMLniFq8vmXA=
 github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa/go.mod h1:2RVY1rIf+2J2o/IM9+vPq9RzmHDSseB7FoXiSNIUsoU=
 github.com/spf13/cobra v0.0.0-20160615143614-bc81c21bd0d8/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v0.0.0-20160610190902-367864438f1b/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=


### PR DESCRIPTION
Instead of passing cert and key to serve over tls, the enable_autocert flag sets up ATC to get a certificate from Let's Encrypt.

Based on [this PR](https://github.com/concourse/atc/pull/199)