### PR TITLE
topgun: increase test coverage for bbr

### DIFF
--- a/topgun/bbr_test.go
+++ b/topgun/bbr_test.go
@@ -12,20 +12,21 @@ import (
 )
 
 var _ = Describe("BBR", func() {
-	var atcs []boshInstance
-	var atc0URL string
+
+	var (
+		atcs       []boshInstance
+		atc0URL    string
+		deployArgs = []string{}
+	)
 
 	BeforeEach(func() {
 		if !strings.Contains(string(bosh("releases").Out.Contents()), "backup-and-restore-sdk") {
 			Skip("backup-and-restore-sdk release not uploaded")
 		}
+	})
 
-		Deploy(
-			"deployments/concourse.yml",
-			"-o", "operations/bbr.yml",
-		)
-
-		waitForRunningWorker()
+	JustBeforeEach(func() {
+		Deploy("deployments/concourse.yml", deployArgs...)
 
 		atcs = JobInstances("web")
 		atc0URL = "http://" + atcs[0].IP + ":8080"
@@ -33,141 +34,183 @@ var _ = Describe("BBR", func() {
 		fly.Login(atcUsername, atcPassword, atc0URL)
 	})
 
-	Context("restoring a deployment with data to a deployment with less data", func() {
-		var tmpDir string
+	Context("using different property providers", func() {
 
 		BeforeEach(func() {
-			var err error
-			tmpDir, err = ioutil.TempDir("", "")
-			Expect(err).NotTo(HaveOccurred())
+			deployArgs = append(deployArgs, "-v", "worker_instances=0")
 		})
 
-		AfterEach(func() {
-			os.RemoveAll(tmpDir)
+		var successfullyExecutesBackup = func() {
+			It("successfully executes backup", func() {
+				Run(nil, "bbr", "deployment", "-d", deploymentName, "backup")
+			})
+		}
+
+		Context("consuming concourse_db links", func() {
+			BeforeEach(func() {
+				deployArgs = append(deployArgs, "-o", "operations/bbr-concourse-link.yml")
+			})
+
+			successfullyExecutesBackup()
 		})
 
-		It("backups and restores", func() {
-			By("creating a new pipeline")
-			fly.Run("set-pipeline", "-n", "-p", "pipeline", "-c", "./pipelines/get-task.yml")
-			pipelines := fly.GetPipelines()
-			Expect(pipelines).ToNot(BeEmpty())
-			Expect(pipelines[0].Name).To(Equal("pipeline"))
+		Context("passing properties", func() {
+			BeforeEach(func() {
+				deployArgs = append(deployArgs, "-o", "operations/bbr-with-properties.yml")
+			})
 
-			By("unpausing the pipeline")
-			fly.Run("unpause-pipeline", "-p", "pipeline")
-
-			By("triggering a build")
-			fly.Run("trigger-job", "-w", "-j", "pipeline/simple-job")
-
-			By("creating a database backup")
-			backupArgs := []string{
-				"deployment",
-				"-d", deploymentName,
-				"backup",
-				"--artifact-path", tmpDir,
-			}
-			Run(nil, "bbr", backupArgs...)
-			entries, err := ioutil.ReadDir(tmpDir)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(entries).To(HaveLen(1))
-
-			By("deleting the deployment")
-			waitForDeploymentLock()
-			bosh("delete-deployment")
-
-			By("creating a new deployment")
-			Deploy(
-				"deployments/concourse.yml",
-				"-o", "operations/bbr.yml",
-			)
-			waitForRunningWorker()
-
-			atcs = JobInstances("web")
-			atc0URL = "http://" + atcs[0].IP + ":8080"
-
-			fly.Login(atcUsername, atcPassword, atc0URL)
-
-			By("restoring the backup")
-			restoreArgs := []string{
-				"deployment",
-				"-d", deploymentName,
-				"restore",
-				"--artifact-path", path.Join(tmpDir, entries[0].Name()),
-			}
-			Run(nil, "bbr", restoreArgs...)
-			pipelines = fly.GetPipelines()
-			Expect(pipelines).ToNot(BeEmpty())
-			Expect(pipelines[0].Name).To(Equal("pipeline"))
+			successfullyExecutesBackup()
 		})
+
 	})
 
-	Context("when restoring fails", func() {
-		var tmpDir string
+	Context("regardless of property provider", func() {
 
 		BeforeEach(func() {
-			var err error
-			tmpDir, err = ioutil.TempDir("", "")
-			Expect(err).NotTo(HaveOccurred())
+			deployArgs = append(deployArgs, "-o", "operations/bbr-with-properties.yml")
 		})
 
-		AfterEach(func() {
-			os.RemoveAll(tmpDir)
+		JustBeforeEach(func() {
+			waitForRunningWorker()
 		})
 
-		It("rolls back the partial restore", func() {
-			By("creating new pipeline")
-			fly.Run("set-pipeline", "-n", "-p", "pipeline", "-c", "./pipelines/get-task.yml")
-			pipelines := fly.GetPipelines()
-			Expect(pipelines).ToNot(BeEmpty())
-			Expect(pipelines[0].Name).To(Equal("pipeline"))
+		Context("restoring a deployment with data to a deployment with less data", func() {
+			var tmpDir string
 
-			By("unpausing the pipeline")
-			fly.Run("unpause-pipeline", "-p", "pipeline")
+			BeforeEach(func() {
+				var err error
+				tmpDir, err = ioutil.TempDir("", "")
+				Expect(err).NotTo(HaveOccurred())
+			})
 
-			By("triggering a build")
-			fly.Run("trigger-job", "-w", "-j", "pipeline/simple-job")
+			AfterEach(func() {
+				os.RemoveAll(tmpDir)
+			})
 
-			By("creating a database backup")
-			backupArgs := []string{
-				"deployment",
-				"-d", deploymentName,
-				"backup",
-				"--artifact-path", tmpDir,
-			}
-			Run(nil, "bbr", backupArgs...)
-			entries, err := ioutil.ReadDir(tmpDir)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(entries).To(HaveLen(1))
+			It("backups and restores", func() {
+				By("creating a new pipeline")
+				fly.Run("set-pipeline", "-n", "-p", "pipeline", "-c", "./pipelines/get-task.yml")
+				pipelines := fly.GetPipelines()
+				Expect(pipelines).ToNot(BeEmpty())
+				Expect(pipelines[0].Name).To(Equal("pipeline"))
 
-			By("creating new pipeline and triggering the new pipeling (this will fail the restore)")
+				By("unpausing the pipeline")
+				fly.Run("unpause-pipeline", "-p", "pipeline")
 
-			fly.Run("set-pipeline", "-n", "-p", "pipeline-2", "-c", "./pipelines/get-task.yml")
-			pipelines = fly.GetPipelines()
-			Expect(pipelines).ToNot(BeEmpty())
-			Expect(pipelines[1].Name).To(Equal("pipeline-2"))
+				By("triggering a build")
+				fly.Run("trigger-job", "-w", "-j", "pipeline/simple-job")
 
-			By("unpausing the pipeline")
-			fly.Run("unpause-pipeline", "-p", "pipeline-2")
+				By("creating a database backup")
+				backupArgs := []string{
+					"deployment",
+					"-d", deploymentName,
+					"backup",
+					"--artifact-path", tmpDir,
+				}
+				Run(nil, "bbr", backupArgs...)
+				entries, err := ioutil.ReadDir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(HaveLen(1))
 
-			By("triggering a build")
-			fly.Run("trigger-job", "-w", "-j", "pipeline-2/simple-job")
+				By("deleting the deployment")
+				waitForDeploymentLock()
+				bosh("delete-deployment")
 
-			By("restoring concourse")
+				By("creating a new deployment")
+				Deploy(
+					"deployments/concourse.yml",
+					"-o", "operations/bbr-with-properties.yml",
+				)
+				waitForRunningWorker()
 
-			restoreArgs := []string{
-				"deployment",
-				"-d", deploymentName,
-				"restore",
-				"--artifact-path", path.Join(tmpDir, entries[0].Name()),
-			}
-			session := Start(nil, "bbr", restoreArgs...)
-			<-session.Exited
-			Expect(session.ExitCode()).To(Equal(1))
+				atcs = JobInstances("web")
+				atc0URL = "http://" + atcs[0].IP + ":8080"
 
-			By("checking pipeline")
-			pipelines = fly.GetPipelines()
-			Expect(pipelines).ToNot(BeEmpty())
-			Expect(len(pipelines)).To(Equal(2))
+				fly.Login(atcUsername, atcPassword, atc0URL)
+
+				By("restoring the backup")
+				restoreArgs := []string{
+					"deployment",
+					"-d", deploymentName,
+					"restore",
+					"--artifact-path", path.Join(tmpDir, entries[0].Name()),
+				}
+				Run(nil, "bbr", restoreArgs...)
+				pipelines = fly.GetPipelines()
+				Expect(pipelines).ToNot(BeEmpty())
+				Expect(pipelines[0].Name).To(Equal("pipeline"))
+			})
 		})
+
+		Context("when restoring fails", func() {
+			var tmpDir string
+
+			BeforeEach(func() {
+				var err error
+				tmpDir, err = ioutil.TempDir("", "")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				os.RemoveAll(tmpDir)
+			})
+
+			It("rolls back the partial restore", func() {
+				By("creating new pipeline")
+				fly.Run("set-pipeline", "-n", "-p", "pipeline", "-c", "./pipelines/get-task.yml")
+				pipelines := fly.GetPipelines()
+				Expect(pipelines).ToNot(BeEmpty())
+				Expect(pipelines[0].Name).To(Equal("pipeline"))
+
+				By("unpausing the pipeline")
+				fly.Run("unpause-pipeline", "-p", "pipeline")
+
+				By("triggering a build")
+				fly.Run("trigger-job", "-w", "-j", "pipeline/simple-job")
+
+				By("creating a database backup")
+				backupArgs := []string{
+					"deployment",
+					"-d", deploymentName,
+					"backup",
+					"--artifact-path", tmpDir,
+				}
+				Run(nil, "bbr", backupArgs...)
+				entries, err := ioutil.ReadDir(tmpDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries).To(HaveLen(1))
+
+				By("creating new pipeline and triggering the new pipeling (this will fail the restore)")
+
+				fly.Run("set-pipeline", "-n", "-p", "pipeline-2", "-c", "./pipelines/get-task.yml")
+				pipelines = fly.GetPipelines()
+				Expect(pipelines).ToNot(BeEmpty())
+				Expect(pipelines[1].Name).To(Equal("pipeline-2"))
+
+				By("unpausing the pipeline")
+				fly.Run("unpause-pipeline", "-p", "pipeline-2")
+
+				By("triggering a build")
+				fly.Run("trigger-job", "-w", "-j", "pipeline-2/simple-job")
+
+				By("restoring concourse")
+
+				restoreArgs := []string{
+					"deployment",
+					"-d", deploymentName,
+					"restore",
+					"--artifact-path", path.Join(tmpDir, entries[0].Name()),
+				}
+				session := Start(nil, "bbr", restoreArgs...)
+				<-session.Exited
+				Expect(session.ExitCode()).To(Equal(1))
+
+				By("checking pipeline")
+				pipelines = fly.GetPipelines()
+				Expect(pipelines).ToNot(BeEmpty())
+				Expect(len(pipelines)).To(Equal(2))
+			})
+		})
+
 	})
 })

--- a/topgun/operations/bbr-concourse-link.yml
+++ b/topgun/operations/bbr-concourse-link.yml
@@ -16,10 +16,3 @@
   value:
     release: concourse
     name: bbr-atcdb
-    properties:
-      postgresql_database: atc
-      postgresql:
-        database: atc
-        role:
-          name: atc
-          password: dummy-password

--- a/topgun/operations/bbr-with-properties.yml
+++ b/topgun/operations/bbr-with-properties.yml
@@ -1,0 +1,29 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/provides?
+  value:
+    concourse_db: nil
+
+- type: replace
+  path: /releases/-
+  value:
+    name: backup-and-restore-sdk
+    version: ((backup_and_restore_sdk_release_version))
+
+- type: replace
+  path: /instance_groups/name=db/jobs/-
+  value:
+    name: database-backup-restorer
+    release: backup-and-restore-sdk
+    properties: {}
+
+- type: replace
+  path: /instance_groups/name=db/jobs/-
+  value:
+    release: concourse
+    name: bbr-atcdb
+    properties:
+      postgresql:
+        database: atc
+        role:
+          name: atc
+          password: dummy-password


### PR DESCRIPTION
Previously, there were no tests covering the use of the link provided by
the Concourse deployment through `concourse_db` - we were relying solely
on the use of properties.

Now, with the introduction of that type of configuration, we needed
tests for it.

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>