### PR TITLE
add more optimizations in the elm compiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build-debug": "yarn run build-less && yarn run build-elm-debug",
     "test": "cd web/elm && elm-test",
     "build-less": "lessc --clean-css=--advanced web/assets/css/main.less web/public/main.css",
-    "build-elm": "cd web/elm && elm make --optimize --output ../public/elm.js src/Main.elm && uglifyjs < ../public/elm.js > ../public/elm.min.js",
+    "build-elm": "cd web/elm && elm make --optimize --output ../public/elm.js src/Main.elm && uglifyjs ../public/elm.js --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output=../public/elm.min.js",
     "build-elm-debug": "cd web/elm && elm make --output ../public/elm.js src/Main.elm && uglifyjs < ../public/elm.js > ../public/elm.min.js",
     "watch": "chokidar -i elm-stuff 'web/elm/src/**/*.elm' 'web/assets/css/*.less' -c 'yarn run build-debug' --initial",
     "update-mdi-svg": "./hack/update-mdi-svg \"node_modules/@mdi/svg/svg\" > web/public/mdi-svg.js && uglifyjs < web/public/mdi-svg.js > web/public/mdi-svg.min.js",


### PR DESCRIPTION
This follows this documentation from the elm website:
https://elm-lang.org/0.19.0/optimize

The minified js (elm.min.js) goes from around 600k to 200k

Signed-off-by: Michiel Stigter <michiel.stigter@springer.com>