### PR TITLE
Update README Download Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ declarative config, stateless workers, and reproducible builds.
 
 ## Installation
 
-Concourse is distributed as a single `concourse` binary, available on the [Downloads page](https://concourse-ci.org/download.html).
+Concourse is distributed as a single `concourse` binary, available on the [Releases page](https://github.com/concourse/concourse/releases/latest).
 
 If you want to just kick the tires, jump ahead to the [Quick Start](#quick-start).
 


### PR DESCRIPTION
The original link was pointing to a `404` page. This matches the path on concourse-ci.org.

My first contribution! 👋