### PR TITLE
new view for a specific version of a resource

### DIFF
--- a/atc/api/builds_test.go
+++ b/atc/api/builds_test.go
@@ -685,12 +685,14 @@ var _ = Describe("Builds API", func() {
 						Expect(body).To(MatchJSON(`{
 							"inputs": [
 								{
+									"id": 0,
 									"name": "input1",
 									"version": {"version": "value1"},
 									"pipeline_id": 42,
 									"first_occurrence": true
 								},
 								{
+									"id": 0,
 									"name": "input2",
 									"version": {"version": "value2"},
 									"pipeline_id": 42,
@@ -699,10 +701,12 @@ var _ = Describe("Builds API", func() {
 							],
 							"outputs": [
 								{
+									"id": 0,
 									"name": "myresource3",
 									"version": {"version": "value3"}
 								},
 								{
+									"id": 0,
 									"name": "myresource4",
 									"version": {"version": "value4"}
 								}

--- a/atc/api/present/public_build_input.go
+++ b/atc/api/present/public_build_input.go
@@ -7,7 +7,7 @@ import (
 
 func PublicBuildInput(input db.BuildInput, pipelineID int) atc.PublicBuildInput {
 	return atc.PublicBuildInput{
-		ID:              input.ID,
+		ID:              input.VersionID,
 		Name:            input.Name,
 		Version:         atc.Version(input.Version),
 		PipelineID:      pipelineID,
@@ -17,7 +17,7 @@ func PublicBuildInput(input db.BuildInput, pipelineID int) atc.PublicBuildInput 
 
 func PublicBuildOutput(output db.BuildOutput) atc.PublicBuildOutput {
 	return atc.PublicBuildOutput{
-		ID:      output.ID,
+		ID:      output.VersionID,
 		Name:    output.Name,
 		Version: atc.Version(output.Version),
 	}

--- a/atc/api/present/public_build_input.go
+++ b/atc/api/present/public_build_input.go
@@ -7,6 +7,7 @@ import (
 
 func PublicBuildInput(input db.BuildInput, pipelineID int) atc.PublicBuildInput {
 	return atc.PublicBuildInput{
+		ID:              input.ID,
 		Name:            input.Name,
 		Version:         atc.Version(input.Version),
 		PipelineID:      pipelineID,
@@ -16,6 +17,7 @@ func PublicBuildInput(input db.BuildInput, pipelineID int) atc.PublicBuildInput 
 
 func PublicBuildOutput(output db.BuildOutput) atc.PublicBuildOutput {
 	return atc.PublicBuildOutput{
+		ID:      output.ID,
 		Name:    output.Name,
 		Version: atc.Version(output.Version),
 	}

--- a/atc/build_inputs_outputs.go
+++ b/atc/build_inputs_outputs.go
@@ -6,6 +6,7 @@ type BuildInputsOutputs struct {
 }
 
 type PublicBuildInput struct {
+	ID              int     `json:"id"`
 	Name            string  `json:"name"`
 	Version         Version `json:"version"`
 	PipelineID      int     `json:"pipeline_id"`
@@ -13,6 +14,7 @@ type PublicBuildInput struct {
 }
 
 type PublicBuildOutput struct {
+	ID	    int     `json:"id"`
 	Name    string  `json:"name"`
 	Version Version `json:"version"`
 }

--- a/atc/build_inputs_outputs.go
+++ b/atc/build_inputs_outputs.go
@@ -14,7 +14,7 @@ type PublicBuildInput struct {
 }
 
 type PublicBuildOutput struct {
-	ID	    int     `json:"id"`
+	ID      int     `json:"id"`
 	Name    string  `json:"name"`
 	Version Version `json:"version"`
 }

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -579,13 +579,14 @@ var _ = Describe("Build", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(inputs).To(ConsistOf([]db.BuildInput{
-				{Name: "some-input", Version: atc.Version{"ver": "1"}, ResourceID: resource1.ID(), FirstOccurrence: true},
+				{Name: "some-input", Version: atc.Version{"ver": "1"}, ResourceID: resource1.ID(), FirstOccurrence: true, VersionID: 1},
 			}))
 
 			Expect(outputs).To(ConsistOf([]db.BuildOutput{
 				{
-					Name:    "some-output-name",
-					Version: atc.Version{"ver": "2"},
+					Name:      "some-output-name",
+					Version:   atc.Version{"ver": "2"},
+					VersionID: 4,
 				},
 			}))
 		})

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -333,26 +333,27 @@ setStepFinish mtime tree =
     StepTree.map (\step -> { step | finish = mtime }) tree
 
 
-view : Session -> OutputModel -> Html Message
-view session { steps, state } =
-    Html.div [ class "steps" ] [ viewStepTree session steps state ]
+view : Maybe Concourse.JobIdentifier -> Session -> OutputModel -> Html Message
+view currentJob session { steps, state } =
+    Html.div [ class "steps" ] [ viewStepTree currentJob session steps state ]
 
 
 viewStepTree :
-    Session
+    Maybe Concourse.JobIdentifier
+    -> Session
     -> Maybe StepTreeModel
     -> OutputState
     -> Html Message
-viewStepTree session steps state =
+viewStepTree currentJob session steps state =
     case ( state, steps ) of
         ( StepsLoading, _ ) ->
             LoadingIndicator.view
 
         ( StepsLiveUpdating, Just root ) ->
-            Build.StepTree.StepTree.view session root
+            Build.StepTree.StepTree.view currentJob session root
 
         ( StepsComplete, Just root ) ->
-            Build.StepTree.StepTree.view session root
+            Build.StepTree.StepTree.view currentJob session root
 
         ( _, Nothing ) ->
             Html.div [] []

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -69,6 +69,7 @@ type alias Step =
     , error : Maybe String
     , expanded : Maybe Bool
     , version : Maybe Version
+    , versionId : Maybe Int
     , metadata : List MetadataField
     , firstOccurrence : Bool
     , timestamps : Dict Int Time.Posix

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -286,12 +286,14 @@ type alias BuildResourcesInput =
     { name : String
     , version : Version
     , firstOccurrence : Bool
+    , versionId : Int
     }
 
 
 type alias BuildResourcesOutput =
     { name : String
     , version : Version
+    , versionId : Int
     }
 
 
@@ -308,6 +310,7 @@ decodeResourcesInput =
         |> andMap (Json.Decode.field "name" Json.Decode.string)
         |> andMap (Json.Decode.field "version" decodeVersion)
         |> andMap (Json.Decode.field "first_occurrence" Json.Decode.bool)
+        |> andMap (Json.Decode.field "id" Json.Decode.int)
 
 
 decodeResourcesOutput : Json.Decode.Decoder BuildResourcesOutput
@@ -315,6 +318,7 @@ decodeResourcesOutput =
     Json.Decode.succeed BuildResourcesOutput
         |> andMap (Json.Decode.field "name" Json.Decode.string)
         |> andMap (Json.Decode.field "version" <| Json.Decode.dict Json.Decode.string)
+        |> andMap (Json.Decode.field "id" Json.Decode.int)
 
 
 

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -33,6 +33,7 @@ type Callback
     | BuildResourcesFetched (Fetched ( Int, Concourse.BuildResources ))
     | ResourceFetched (Fetched Concourse.Resource)
     | VersionedResourcesFetched (Fetched ( Maybe Page, Paginated Concourse.VersionedResource ))
+    | VersionedResourceFetched (Fetched Concourse.VersionedResource)
     | VersionFetched (Fetched String)
     | PausedToggled (Fetched ())
     | InputToFetched (Fetched ( VersionId, List Concourse.Build ))

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -103,6 +103,7 @@ type Effect
     | FetchJobBuilds Concourse.JobIdentifier (Maybe Page)
     | FetchResource Concourse.ResourceIdentifier
     | FetchVersionedResources Concourse.ResourceIdentifier (Maybe Page)
+    | FetchResourceVersion Concourse.VersionedResourceIdentifier
     | FetchResources Concourse.PipelineIdentifier
     | FetchBuildResources Concourse.BuildId
     | FetchPipeline Concourse.PipelineIdentifier
@@ -195,6 +196,10 @@ runEffect effect key csrfToken =
             Network.Resource.fetchVersionedResources id paging
                 |> Task.map (\b -> ( paging, b ))
                 |> Task.attempt VersionedResourcesFetched
+
+        FetchResourceVersion id ->
+            Network.Resource.fetchVersionedResource id
+                |> Task.attempt VersionedResourceFetched
 
         FetchResources id ->
             Network.Resource.fetchResourcesRaw id

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -226,7 +226,7 @@ handleCallback callback session ( model, effects ) =
               }
                 |> updatePinnedVersion resource
             , effects
-                ++ (RenderSvgIcon "arrow-right"
+                ++ (RenderSvgIcon "pound"
                         :: (case resource.icon of
                                 Just icon ->
                                     [ RenderSvgIcon icon ]
@@ -1466,13 +1466,13 @@ viewDetailsButton { versionID, pinState } =
             ]
             [ Svg.svg
                 [ SvgAttributes.viewBox "0 0 24 24"
-                , style "height" "20px"
-                , style "width" "20px"
-                , style "margin-left" "2px"
-                , style "margin-top" "2px"
+                , style "height" "16px"
+                , style "width" "16px"
+                , style "margin-left" "4px"
+                , style "margin-top" "4px"
                 , SvgAttributes.fill "white"
                 ]
-                [ Svg.use [ SvgAttributes.xlinkHref "#arrow-right-svg-icon" ] []
+                [ Svg.use [ SvgAttributes.xlinkHref "#pound-svg-icon" ] []
                 ]
             ]
         ]

--- a/web/elm/src/ResourceVersion/Models.elm
+++ b/web/elm/src/ResourceVersion/Models.elm
@@ -1,6 +1,5 @@
 module ResourceVersion.Models exposing
-    ( CheckStatus(..)
-    , Model
+    ( Model
     , PageError(..)
     , PinnedVersion
     , Version
@@ -19,18 +18,9 @@ type PageError
     | NotFound
 
 
-type CheckStatus
-    = CheckingSuccessfully
-    | CurrentlyChecking
-    | FailingToCheck
-
-
 type alias Model =
     Login.Model
         { pageStatus : Result PageError ()
-        , checkStatus : CheckStatus
-        , checkError : String
-        , checkSetupError : String
         , lastChecked : Maybe Time.Posix
         , pinnedVersion : PinnedVersion
         , now : Maybe Time.Posix

--- a/web/elm/src/ResourceVersion/Models.elm
+++ b/web/elm/src/ResourceVersion/Models.elm
@@ -1,0 +1,69 @@
+module ResourceVersion.Models exposing
+    ( CheckStatus(..)
+    , Model
+    , PageError(..)
+    , PinnedVersion
+    , Version
+    , VersionEnabledState(..)
+    , VersionId
+    )
+
+import Concourse
+import Login.Login as Login
+import Pinned exposing (CommentState, ResourcePinState)
+import Time
+
+
+type PageError
+    = Empty
+    | NotFound
+
+
+type CheckStatus
+    = CheckingSuccessfully
+    | CurrentlyChecking
+    | FailingToCheck
+
+
+type alias Model =
+    Login.Model
+        { pageStatus : Result PageError ()
+        , checkStatus : CheckStatus
+        , checkError : String
+        , checkSetupError : String
+        , lastChecked : Maybe Time.Posix
+        , pinnedVersion : PinnedVersion
+        , now : Maybe Time.Posix
+        , resourceVersionIdentifier : Concourse.VersionedResourceIdentifier
+        , version : Maybe Version
+        , pinCommentLoading : Bool
+        , textAreaFocused : Bool
+        , icon : Maybe String
+        , timeZone : Time.Zone
+        }
+
+
+type alias PinnedVersion =
+    ResourcePinState Concourse.Version VersionId CommentState
+
+
+type VersionEnabledState
+    = Enabled
+    | Changing
+    | Disabled
+
+
+type alias VersionId =
+    Concourse.VersionedResourceIdentifier
+
+
+type alias Version =
+    { id : VersionId
+    , version : Concourse.Version
+    , metadata : Concourse.Metadata
+    , enabled : VersionEnabledState
+    , expanded : Bool
+    , inputTo : List Concourse.Build
+    , outputOf : List Concourse.Build
+    , showTooltip : Bool
+    }

--- a/web/elm/src/ResourceVersion/ResourceVersion.elm
+++ b/web/elm/src/ResourceVersion/ResourceVersion.elm
@@ -206,14 +206,12 @@ handleCallback callback session ( model, effects ) =
               }
                 |> updatePinnedVersion resource
             , effects
-                ++ (RenderSvgIcon "arrow-right"
-                        :: (case resource.icon of
-                                Just icon ->
-                                    [ RenderSvgIcon icon ]
+                ++ (case resource.icon of
+                        Just icon ->
+                            [ RenderSvgIcon icon ]
 
-                                Nothing ->
-                                    []
-                           )
+                        Nothing ->
+                            []
                    )
             )
 

--- a/web/elm/src/ResourceVersion/Styles.elm
+++ b/web/elm/src/ResourceVersion/Styles.elm
@@ -1,4 +1,4 @@
-module Resource.Styles exposing
+module ResourceVersion.Styles exposing
     ( body
     , checkBarStatus
     , checkButton
@@ -32,7 +32,7 @@ import Colors
 import Html
 import Html.Attributes exposing (style)
 import Pinned
-import Resource.Models as Models
+import ResourceVersion.Models as Models
 
 
 headerHeight : Int

--- a/web/elm/src/ResourceVersion/Styles.elm
+++ b/web/elm/src/ResourceVersion/Styles.elm
@@ -1,9 +1,5 @@
 module ResourceVersion.Styles exposing
     ( body
-    , checkBarStatus
-    , checkButton
-    , checkButtonIcon
-    , checkStatusIcon
     , commentBar
     , commentBarContent
     , commentBarHeader
@@ -18,7 +14,6 @@ module ResourceVersion.Styles exposing
     , headerHeight
     , headerLastCheckedSection
     , headerResourceName
-    , pagination
     , pinBar
     , pinBarTooltip
     , pinButton
@@ -96,11 +91,6 @@ pinBarTooltip =
     , style "padding" "5px"
     , style "z-index" "2"
     ]
-
-
-checkStatusIcon : List (Html.Attribute msg)
-checkStatusIcon =
-    [ style "background-size" "14px 14px" ]
 
 
 versionButton : Pinned.VersionPinState -> List (Html.Attribute msg)
@@ -341,51 +331,4 @@ body =
     [ style "padding" "10px"
     , style "overflow-y" "auto"
     , style "flex-grow" "1"
-    ]
-
-
-pagination : List (Html.Attribute msg)
-pagination =
-    [ style "display" "flex"
-    , style "align-items" "stretch"
-    ]
-
-
-checkBarStatus : List (Html.Attribute msg)
-checkBarStatus =
-    [ style "display" "flex"
-    , style "justify-content" "space-between"
-    , style "align-items" "center"
-    , style "flex-grow" "1"
-    , style "height" "28px"
-    , style "background" Colors.sectionHeader
-    , style "padding-left" "5px"
-    ]
-
-
-checkButton : Bool -> List (Html.Attribute msg)
-checkButton isClickable =
-    [ style "height" "28px"
-    , style "width" "28px"
-    , style "background-color" Colors.sectionHeader
-    , style "margin-right" "5px"
-    , style "cursor" <|
-        if isClickable then
-            "pointer"
-
-        else
-            "default"
-    ]
-
-
-checkButtonIcon : Bool -> List (Html.Attribute msg)
-checkButtonIcon isHighlighted =
-    [ style "margin" "4px"
-    , style "background-size" "contain"
-    , style "opacity" <|
-        if isHighlighted then
-            "1"
-
-        else
-            "0.5"
     ]

--- a/web/elm/src/Views/Styles.elm
+++ b/web/elm/src/Views/Styles.elm
@@ -45,6 +45,12 @@ pageBelowTopBar route =
                     , style "display" "flex"
                     ]
 
+                Routes.ResourceVersion _ ->
+                    [ style "box-sizing" "border-box"
+                    , style "height" "100%"
+                    , style "display" "flex"
+                    ]
+
                 Routes.Pipeline _ ->
                     [ style "box-sizing" "border-box"
                     , style "height" "100%"

--- a/web/elm/src/Views/TopBar.elm
+++ b/web/elm/src/Views/TopBar.elm
@@ -50,7 +50,20 @@ breadcrumbs route =
                     , pipelineName = id.pipelineName
                     }
                 , breadcrumbSeparator
-                , resourceBreadcrumb id.resourceName
+                , resourceBreadcrumb id
+                ]
+
+            Routes.ResourceVersion id ->
+                [ pipelineBreadcumb
+                    { teamName = id.teamName
+                    , pipelineName = id.pipelineName
+                    }
+                , breadcrumbSeparator
+                , resourceBreadcrumb
+                    { teamName = id.teamName
+                    , pipelineName = id.pipelineName
+                    , resourceName = id.resourceName
+                    }
                 ]
 
             Routes.Job { id } ->
@@ -102,11 +115,17 @@ jobBreadcrumb jobName =
         (breadcrumbComponent "job" jobName)
 
 
-resourceBreadcrumb : String -> Html Message
-resourceBreadcrumb resourceName =
-    Html.li
-        (id "breadcrumb-resource" :: Styles.breadcrumbItem False)
-        (breadcrumbComponent "resource" resourceName)
+resourceBreadcrumb : Concourse.ResourceIdentifier -> Html Message
+resourceBreadcrumb resourceId =
+    Html.a
+        ([ id "breadcrumb-resource"
+         , href <|
+            Routes.toString <|
+                Routes.Resource { id = resourceId, page = Nothing }
+         ]
+            ++ Styles.breadcrumbItem True
+        )
+        (breadcrumbComponent "resource" resourceId.resourceName)
 
 
 decodeName : String -> String

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -2415,14 +2415,17 @@ all =
                                                 [ { name = "step"
                                                   , version = version
                                                   , firstOccurrence = True
+                                                  , versionId = 1
                                                   }
                                                 , { name = "step2"
                                                   , version = version
                                                   , firstOccurrence = True
+                                                  , versionId = 2
                                                   }
                                                 , { name = "step3"
                                                   , version = version
                                                   , firstOccurrence = False
+                                                  , versionId = 3
                                                   }
                                                 ]
                                           , outputs = []

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -909,11 +909,13 @@ all =
                             { name = "some-input"
                             , version = Dict.fromList [ ( "version", "v1" ) ]
                             , firstOccurrence = True
+                            , versionId = 1
                             }
 
                         buildOutput =
                             { name = "some-resource"
                             , version = Dict.fromList [ ( "version", "v2" ) ]
+                            , versionId = 2
                             }
                     in
                     let

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -2212,7 +2212,7 @@ all =
                             (Query.children []
                                 >> Query.first
                                 >> Query.children []
-                                >> Query.index 2
+                                >> Query.index 3
                                 >> Query.has
                                     [ style "display" "flex"
                                     , style "align-items" "center"
@@ -2224,7 +2224,7 @@ all =
                             (Query.children []
                                 >> Query.first
                                 >> Query.children []
-                                >> Query.index 2
+                                >> Query.index 3
                                 >> Query.has
                                     [ style "flex-grow" "1" ]
                             )
@@ -2234,7 +2234,7 @@ all =
                             (Query.children []
                                 >> Query.first
                                 >> Query.children []
-                                >> Query.index 2
+                                >> Query.index 3
                                 >> Query.has
                                     [ style "cursor" "pointer" ]
                             )
@@ -2244,7 +2244,7 @@ all =
                             (Query.children []
                                 >> Query.first
                                 >> Query.children []
-                                >> Query.index 2
+                                >> Query.index 3
                                 >> Query.has
                                     [ style "padding-left" "10px" ]
                             )

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -57,6 +57,7 @@ someVersionedStep version id name state =
     , error = Nothing
     , expanded = Nothing
     , version = version
+    , versionId = Nothing
     , metadata = []
     , firstOccurrence = False
     , timestamps = Dict.empty


### PR DESCRIPTION
related to #3734 

New view that display all informations related to a specific version of a resource. It's a copy / paste of the resource view, but it will display only one version and it's expanded by default:
<img width="1043" alt="resource version" src="https://user-images.githubusercontent.com/8672791/58387466-ce447080-800e-11e9-8cb3-2065562d11d6.png">

This screen can be reached by clicking the `#` in the resource view:
<img width="1043" alt="resource" src="https://user-images.githubusercontent.com/8672791/58387467-dd2b2300-800e-11e9-8da1-712e21beafd8.png">

Or the `#` in the build view on a  resource:
<img width="1043" alt="build" src="https://user-images.githubusercontent.com/8672791/58387472-f0d68980-800e-11e9-8ce2-fb1f04154889.png">

For me, the main utility is to be able to go from build -> resource version -> other builds that are using the same version of this resource

Other information that could be interesting to display on this view:
- the logs that produce this version, but I think that would be a bigger change to get the logs 
- anything else ? I'm open to suggestions.

If the view is OK I think there should be more work done for code deduplication between resource view and resource version view, but I didn't want to go into that before discussing what goes where