### PR TITLE
fix retire worker using tsa-team-authorized-keys only

### DIFF
--- a/worker/retire/retire_runner.go
+++ b/worker/retire/retire_runner.go
@@ -14,6 +14,7 @@ type RetireWorkerCommand struct {
 	TSA worker.TSAConfig `group:"TSA Configuration" namespace:"tsa" required:"true"`
 
 	WorkerName string `long:"name" required:"true" description:"The name of the worker you wish to retire."`
+	WorkerTeam string `long:"team" description:"The team name of the worker you wish to retire."`
 }
 
 func (cmd *RetireWorkerCommand) Execute(args []string) error {
@@ -22,6 +23,7 @@ func (cmd *RetireWorkerCommand) Execute(args []string) error {
 
 	client := cmd.TSA.Client(atc.Worker{
 		Name: cmd.WorkerName,
+		Team: cmd.WorkerTeam,
 	})
 
 	return client.Retire(lagerctx.NewContext(context.Background(), logger))


### PR DESCRIPTION
Fix issue : Not able to retire worker using tsa-team-authorized-keys only #3549

Before the patch :

```
root@01993a002c30:/src# concourse retire-worker --name $HOSTNAME
{"timestamp":"2019-05-28T12:02:56.757975470Z","level":"error","source":"retire-worker","message":"retire-worker.run.command-failed","data":{"command":"retire-worker","error":"Process exited with status 1","session":"2"}}
Process exited with status 1

{"timestamp":"2019-05-28T12:02:56.594409936Z","level":"debug","source":"atc","message":"atc.build-tracker.track.start","data":{"session":"16.27"}}
{"timestamp":"2019-05-28T12:02:56.597415009Z","level":"debug","source":"atc","message":"atc.build-tracker.track.done","data":{"session":"16.27"}}
{"timestamp":"2019-05-28T12:02:56.757792903Z","level":"error","source":"tsa","message":"tsa.connection.channel.exited-with-error","data":{"error":"key is authorized for team foo, but worker is global","remote":"172.18.0.4:60902","session":"27.1"}}
```

After the patch :

```
root@01993a002c30:/src# concourse retire-worker --name $HOSTNAME --team foo
{"timestamp":"2019-05-28T12:03:39.303142352Z","level":"debug","source":"retire-worker","message":"retire-worker.run.command-exited","data":{"command":"retire-worker","session":"2"}}

{"timestamp":"2019-05-28T12:05:01.499302164Z","level":"info","source":"tsa","message":"tsa.connection.channel.command.start","data":{"command":"retire-worker","remote":"172.18.0.4:32838","session":"46.1.1"}}
{"timestamp":"2019-05-28T12:05:01.516087207Z","level":"info","source":"tsa","message":"tsa.connection.channel.command.end","data":{"command":"retire-worker","remote":"172.18.0.4:32838","session":"46.1.1"}}
```