### PR TITLE
make channel size for event emit metrics configurable

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -128,6 +128,7 @@ type RunCommand struct {
 		HostName            string            `long:"metrics-host-name" description:"Host string to attach to emitted metrics."`
 		Attributes          map[string]string `long:"metrics-attribute" description:"A key-value attribute to attach to emitted metrics. Can be specified multiple times." value-name:"NAME:VALUE"`
 		CaptureErrorMetrics bool              `long:"capture-error-metrics" description:"Enable capturing of error log metrics"`
+		MetricBufferLimit   int               `long:"metric-buffer-limit" default:"1000" description:"Maximum number of unemitted metrics in buffer"`
 	} `group:"Metrics & Diagnostics"`
 
 	Server struct {
@@ -1110,7 +1111,7 @@ func (cmd *RunCommand) configureMetrics(logger lager.Logger) error {
 		host, _ = os.Hostname()
 	}
 
-	return metric.Initialize(logger.Session("metrics"), host, cmd.Metrics.Attributes)
+	return metric.Initialize(logger.Session("metrics"), host, cmd.Metrics.Attributes, cmd.Metrics.MetricBufferLimit)
 }
 
 func (cmd *RunCommand) constructDBConn(

--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -66,7 +66,7 @@ var (
 	emissions       chan eventEmission
 )
 
-func Initialize(logger lager.Logger, host string, attributes map[string]string) error {
+func Initialize(logger lager.Logger, host string, attributes map[string]string, metricBufferLimit int) error {
 	var (
 		emitterDescriptions []string
 		err                 error
@@ -97,7 +97,7 @@ func Initialize(logger lager.Logger, host string, attributes map[string]string) 
 	emitter = emitter
 	eventHost = host
 	eventAttributes = attributes
-	emissions = make(chan eventEmission, 1000)
+	emissions = make(chan eventEmission, metricBufferLimit)
 
 	go emitLoop()
 

--- a/atc/metric/error_sink_collector_test.go
+++ b/atc/metric/error_sink_collector_test.go
@@ -13,10 +13,12 @@ var _ = Describe("ErrorSinkCollector", func() {
 	var (
 		errorSinkCollector metric.ErrorSinkCollector
 		emitter            *metricfakes.FakeEmitter
+		metricsBufferLimit	int
 	)
 
 	BeforeEach(func() {
 		testLogger := lager.NewLogger("test")
+		metricsBufferLimit = 1000
 
 		errorSinkCollector = metric.NewErrorSinkCollector(testLogger)
 
@@ -25,7 +27,7 @@ var _ = Describe("ErrorSinkCollector", func() {
 		metric.RegisterEmitter(emitterFactory)
 		emitterFactory.IsConfiguredReturns(true)
 		emitterFactory.NewEmitterReturns(emitter, nil)
-		metric.Initialize(testLogger, "test", map[string]string{})
+		metric.Initialize(testLogger, "test", map[string]string{}, metricsBufferLimit)
 	})
 
 	AfterEach(func() {

--- a/atc/metric/http_test.go
+++ b/atc/metric/http_test.go
@@ -32,17 +32,19 @@ var _ = Describe("MetricsHandler", func() {
 	var (
 		ts      *httptest.Server
 		emitter *metricfakes.FakeEmitter
+		metricBufferLimit int
 	)
 
 	BeforeEach(func() {
 		emitterFactory := &metricfakes.FakeEmitterFactory{}
 		emitter = &metricfakes.FakeEmitter{}
+		metricBufferLimit = 1000
 
 		metric.RegisterEmitter(emitterFactory)
 		emitterFactory.IsConfiguredReturns(true)
 		emitterFactory.NewEmitterReturns(emitter, nil)
 
-		metric.Initialize(dummyLogger, "test", map[string]string{})
+		metric.Initialize(dummyLogger, "test", map[string]string{}, metricBufferLimit)
 
 		ts = httptest.NewServer(
 			WrapHandler(dummyLogger, "ApiEndpoint", http.HandlerFunc(noopHandler)))

--- a/atc/metric/periodic_test.go
+++ b/atc/metric/periodic_test.go
@@ -19,6 +19,7 @@ import (
 var _ = Describe("Periodic emission of metrics", func() {
 	var (
 		emitter *metricfakes.FakeEmitter
+		metricsBufferLimit int
 
 		process ifrit.Process
 	)
@@ -26,6 +27,7 @@ var _ = Describe("Periodic emission of metrics", func() {
 	BeforeEach(func() {
 		emitterFactory := &metricfakes.FakeEmitterFactory{}
 		emitter = &metricfakes.FakeEmitter{}
+		metricsBufferLimit = 1000
 
 		metric.RegisterEmitter(emitterFactory)
 		emitterFactory.IsConfiguredReturns(true)
@@ -35,7 +37,7 @@ var _ = Describe("Periodic emission of metrics", func() {
 		b := &dbfakes.FakeConn{}
 		b.NameReturns("B")
 		metric.Databases = []db.Conn{a, b}
-		metric.Initialize(nil, "test", map[string]string{})
+		metric.Initialize(nil, "test", map[string]string{}, metricsBufferLimit)
 
 		process = ifrit.Invoke(metric.PeriodicallyEmit(lager.NewLogger("dont care"), 250*time.Millisecond))
 	})


### PR DESCRIPTION
References #3769 and also relates to #3674 