### PR TITLE
Only check for env variables in the templates dir

### DIFF
--- a/ci/tasks/scripts/check-distribution-env/helm/list-actual
+++ b/ci/tasks/scripts/check-distribution-env/helm/list-actual
@@ -9,6 +9,6 @@ fi
 
 charts=$1
 
-grep -REhv '\s+#\s+' $charts/stable/concourse |
+grep -REhv '\s+#\s+' $charts/stable/concourse/templates |
   grep -Eoh 'name: (([A-Z_])+|http_proxy|https_proxy|no_proxy)' |
   sed -e "s/^name: //"


### PR DESCRIPTION
It was catching other things that had capital letters in them.

For example:
```
+ CONCOURSE_ENABLE_LETS_ENCRYPT
+ CONCOURSE_LETS_ENCRYPT_ACME_URL
- Y
```

What's that `Y` flag?? We don't care!

cc @taylorsilva 