### PR TITLE
ci: wait for deployment rollout in k8s-deployment

### DIFF
--- a/ci/tasks/scripts/k8s-deploy
+++ b/ci/tasks/scripts/k8s-deploy
@@ -62,6 +62,11 @@ run_helm_deploy() {
     --set "worker.replicas=1" \
     $RELEASE_NAME \
     $chart
+
+  kubectl \
+    --namespace "$RELEASE_NAME" \
+    rollout status deployment \
+    "$RELEASE_NAME-web"
 }
 
 main "$@"


### PR DESCRIPTION
Previously, it could happen that `web` didn't have its deployment fully
complete, which used to make `port-forward` fail quite consistently.

By leveraging `rollout status` we can wait for the underlying pods to
get to a `READY` state (instead of plain `RUN`) before moving forward.

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>