### PR TITLE
ci: moving the bbr job to the atc

### DIFF
--- a/ci/pipelines/concourse.yml
+++ b/ci/pipelines/concourse.yml
@@ -769,7 +769,7 @@ jobs:
       - cbd/cluster/operations/windows-worker.yml
       - cbd/cluster/operations/telegraf-postgres.yml
       - cbd/cluster/operations/syslog_forwarder.yml
-      - cbd/cluster/operations/backup-atc.yml
+      - cbd/cluster/operations/backup-atc-colocated-web.yml
       - cbd/cluster/operations/task-limits.yml
       - cbd/cluster/operations/windows-worker-network.yml
       - cbd/cluster/operations/syslog-drainer.yml


### PR DESCRIPTION
- the reason behind that is that the bosh link for the posrtgres db
(`concourse_db`) is provided by the web job and not the db job.
cc: @cirocosta 