### PR TITLE
web: Discover cluster name by API call instead of template injection

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -48,7 +48,6 @@ import (
 	"github.com/concourse/concourse/skymarshal/skycmd"
 	"github.com/concourse/concourse/skymarshal/storage"
 	"github.com/concourse/concourse/web"
-	"github.com/concourse/concourse/web/indexhandler"
 	"github.com/concourse/flag"
 	"github.com/concourse/retryhttp"
 	"github.com/cppforlife/go-semi-semantic/version"
@@ -611,7 +610,6 @@ func (cmd *RunCommand) constructAPIMembers(
 		return nil, err
 	}
 
-	indexhandler.ClusterName = cmd.Server.ClusterName
 	webHandler, err := webHandler(logger)
 	if err != nil {
 		return nil, err

--- a/atc/integration/configuration_test.go
+++ b/atc/integration/configuration_test.go
@@ -61,22 +61,6 @@ var _ = Describe("ATC Integration Test", func() {
 		})
 	})
 
-	Context("when cluster name is specified", func() {
-		BeforeEach(func() {
-			cmd.Server.ClusterName = "foobar"
-		})
-
-		It("renders cluster name into HTML template", func() {
-			resp, err := http.Get(atcURL)
-			Expect(err).NotTo(HaveOccurred())
-
-			bodyBytes, err := ioutil.ReadAll(resp.Body)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(200))
-			Expect(string(bodyBytes)).To(ContainSubstring("foobar"))
-		})
-	})
-
 	It("set default team and config auth for the main team", func() {
 		client := webLogin(atcURL, "test", "test")
 

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -41,7 +41,6 @@ type alias Flags =
     , notFoundImgSrc : String
     , csrfToken : Concourse.CSRFToken
     , authToken : String
-    , clusterName : String
     , pipelineRunningKeyframes : String
     }
 
@@ -63,7 +62,7 @@ init flags url =
         session =
             { userState = UserStateUnknown
             , hovered = Nothing
-            , clusterName = flags.clusterName
+            , clusterName = ""
             , turbulenceImgSrc = flags.turbulenceImgSrc
             , notFoundImgSrc = flags.notFoundImgSrc
             , csrfToken = flags.csrfToken
@@ -97,7 +96,7 @@ init flags url =
                 ]
     in
     ( model
-    , [ FetchUser, GetScreenSize, LoadSideBarState ]
+    , [ FetchUser, GetScreenSize, LoadSideBarState, FetchClusterInfo ]
         ++ handleTokenEffect
         ++ subEffects
     )
@@ -195,6 +194,16 @@ handleCallback callback model =
 
                 newSession =
                     { session | userState = UserStateLoggedOut }
+            in
+            subpageHandleCallback callback ( { model | session = newSession }, [] )
+
+        ClusterInfoFetched (Ok { clusterName }) ->
+            let
+                session =
+                    model.session
+
+                newSession =
+                    { session | clusterName = clusterName }
             in
             subpageHandleCallback callback ( { model | session = newSession }, [] )
 

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -16,7 +16,7 @@ module Concourse exposing
     , BuildStep(..)
     , CSRFToken
     , Cause
-    , ConcourseVersion
+    , ClusterInfo
     , HookedPlan
     , Job
     , JobBuildIdentifier
@@ -523,13 +523,17 @@ decodeBuildStepTimeout =
 -- Info
 
 
-type alias ConcourseVersion =
-    String
+type alias ClusterInfo =
+    { version : String
+    , clusterName : String
+    }
 
 
-decodeInfo : Json.Decode.Decoder ConcourseVersion
+decodeInfo : Json.Decode.Decoder ClusterInfo
 decodeInfo =
-    Json.Decode.field "version" Json.Decode.string
+    Json.Decode.succeed ClusterInfo
+        |> andMap (Json.Decode.field "version" Json.Decode.string)
+        |> andMap (defaultTo "" <| Json.Decode.field "cluster_name" Json.Decode.string)
 
 
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -77,7 +77,6 @@ type alias Flags =
     { turbulencePath : String
     , searchType : Routes.SearchType
     , pipelineRunningKeyframes : String
-    , clusterName : String
     }
 
 
@@ -101,7 +100,6 @@ init flags =
       , query = Routes.extractQuery flags.searchType
       , isUserMenuExpanded = False
       , dropdown = Hidden
-      , clusterName = flags.clusterName
       }
     , [ FetchData
       , PinTeamNames Message.Effects.stickyHeaderConfig
@@ -491,7 +489,7 @@ topBar session model =
         [ Html.div [ style "display" "flex", style "align-items" "center" ]
             [ SideBar.hamburgerMenu session
             , Html.a (href "/" :: Views.Styles.concourseLogo) []
-            , clusterName model
+            , clusterNameView session
             ]
         ]
             ++ (let
@@ -518,11 +516,11 @@ topBar session model =
                )
 
 
-clusterName : Model -> Html Message
-clusterName model =
+clusterNameView : Session -> Html Message
+clusterNameView session =
     Html.div
         Styles.clusterName
-        [ Html.text model.clusterName ]
+        [ Html.text session.clusterName ]
 
 
 dashboardView :

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -30,7 +30,6 @@ type alias Model =
             , userState : UserState.UserState
             , highDensity : Bool
             , query : String
-            , clusterName : String
             }
         )
 

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -33,7 +33,7 @@ type Callback
     | BuildResourcesFetched (Fetched ( Int, Concourse.BuildResources ))
     | ResourceFetched (Fetched Concourse.Resource)
     | VersionedResourcesFetched (Fetched ( Maybe Page, Paginated Concourse.VersionedResource ))
-    | VersionFetched (Fetched String)
+    | ClusterInfoFetched (Fetched Concourse.ClusterInfo)
     | PausedToggled (Fetched ())
     | InputToFetched (Fetched ( VersionId, List Concourse.Build ))
     | OutputOfFetched (Fetched ( VersionId, List Concourse.Build ))

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -106,7 +106,7 @@ type Effect
     | FetchResources Concourse.PipelineIdentifier
     | FetchBuildResources Concourse.BuildId
     | FetchPipeline Concourse.PipelineIdentifier
-    | FetchVersion
+    | FetchClusterInfo
     | FetchInputTo Concourse.VersionedResourceIdentifier
     | FetchOutputOf Concourse.VersionedResourceIdentifier
     | FetchData
@@ -209,9 +209,9 @@ runEffect effect key csrfToken =
             Network.Pipeline.fetchPipeline id
                 |> Task.attempt PipelineFetched
 
-        FetchVersion ->
+        FetchClusterInfo ->
             Network.Info.fetch
-                |> Task.attempt VersionFetched
+                |> Task.attempt ClusterInfoFetched
 
         FetchInputTo id ->
             Network.Resource.fetchInputTo id

--- a/web/elm/src/Network/DashboardAPIData.elm
+++ b/web/elm/src/Network/DashboardAPIData.elm
@@ -29,7 +29,7 @@ remoteData =
                                                 (\resources ->
                                                     Network.Info.fetch
                                                         |> Task.andThen
-                                                            (\version ->
+                                                            (\clusterInfo ->
                                                                 Network.User.fetchUser
                                                                     |> Task.map Just
                                                                     |> Task.onError
@@ -42,7 +42,7 @@ remoteData =
                                                                                 , jobs = jobs
                                                                                 , resources = resources
                                                                                 , user = user
-                                                                                , version = version
+                                                                                , version = clusterInfo.version
                                                                                 }
                                                                         )
                                                             )

--- a/web/elm/src/Network/Info.elm
+++ b/web/elm/src/Network/Info.elm
@@ -5,6 +5,6 @@ import Http
 import Task exposing (Task)
 
 
-fetch : Task Http.Error Concourse.ConcourseVersion
+fetch : Task Http.Error Concourse.ClusterInfo
 fetch =
     Http.toTask <| Http.get "/api/v1/info" Concourse.decodeInfo

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -105,7 +105,7 @@ init flags =
     in
     ( model
     , [ FetchPipeline flags.pipelineLocator
-      , FetchVersion
+      , FetchClusterInfo
       , ResetPipelineFocus
       , FetchPipelines
       ]
@@ -255,7 +255,7 @@ handleCallback callback ( model, effects ) =
                         , effects
                         )
 
-        VersionFetched (Ok version) ->
+        ClusterInfoFetched (Ok { version }) ->
             ( { model
                 | concourseVersion = version
                 , experiencingTurbulence = False
@@ -263,7 +263,7 @@ handleCallback callback ( model, effects ) =
             , effects
             )
 
-        VersionFetched (Err _) ->
+        ClusterInfoFetched (Err _) ->
             ( { model | experiencingTurbulence = True }, effects )
 
         PipelinesFetched (Err _) ->
@@ -306,7 +306,7 @@ handleDelivery delivery ( model, effects ) =
             )
 
         ClockTicked OneMinute _ ->
-            ( model, effects ++ [ FetchVersion ] )
+            ( model, effects ++ [ FetchClusterInfo ] )
 
         _ ->
             ( model, effects )

--- a/web/elm/src/SubPage/SubPage.elm
+++ b/web/elm/src/SubPage/SubPage.elm
@@ -90,7 +90,6 @@ init session route =
                 { turbulencePath = session.turbulenceImgSrc
                 , searchType = searchType
                 , pipelineRunningKeyframes = session.pipelineRunningKeyframes
-                , clusterName = session.clusterName
                 }
                 |> Tuple.mapFirst DashboardModel
 

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -57,7 +57,6 @@ all =
                 , notFoundImgSrc = ""
                 , csrfToken = csrfToken
                 , authToken = ""
-                , clusterName = ""
                 , pipelineRunningKeyframes = ""
                 }
 
@@ -1148,7 +1147,6 @@ all =
                     , notFoundImgSrc = "notfound.svg"
                     , csrfToken = "csrf_token"
                     , authToken = ""
-                    , clusterName = ""
                     , pipelineRunningKeyframes = "pipeline-running"
                     }
                     { protocol = Url.Http
@@ -1175,7 +1173,6 @@ all =
                     , notFoundImgSrc = "notfound.svg"
                     , csrfToken = "csrf_token"
                     , authToken = ""
-                    , clusterName = ""
                     , pipelineRunningKeyframes = "pipeline-running"
                     }
                     { protocol = Url.Http

--- a/web/elm/tests/Common.elm
+++ b/web/elm/tests/Common.elm
@@ -70,7 +70,6 @@ init path =
         , notFoundImgSrc = "notfound.svg"
         , csrfToken = "csrf_token"
         , authToken = ""
-        , clusterName = ""
         , pipelineRunningKeyframes = "pipeline-running"
         }
         { protocol = Url.Http
@@ -102,7 +101,6 @@ iOpenTheBuildPage _ =
         , csrfToken = ""
         , authToken = ""
         , pipelineRunningKeyframes = ""
-        , clusterName = ""
         }
         { protocol = Url.Http
         , host = ""

--- a/web/elm/tests/FlySuccessTests.elm
+++ b/web/elm/tests/FlySuccessTests.elm
@@ -60,7 +60,6 @@ flags =
     , notFoundImgSrc = ""
     , csrfToken = ""
     , authToken = authToken
-    , clusterName = ""
     , pipelineRunningKeyframes = ""
     }
 

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -102,7 +102,6 @@ all =
                     , notFoundImgSrc = ""
                     , csrfToken = csrfToken
                     , authToken = ""
-                    , clusterName = ""
                     , pipelineRunningKeyframes = ""
                     }
 
@@ -157,7 +156,6 @@ all =
                             , notFoundImgSrc = "notfound.svg"
                             , csrfToken = "csrf_token"
                             , authToken = ""
-                            , clusterName = ""
                             , pipelineRunningKeyframes = "pipeline-running"
                             }
                             { protocol = Url.Http
@@ -178,7 +176,6 @@ all =
                             , csrfToken = ""
                             , authToken = ""
                             , pipelineRunningKeyframes = ""
-                            , clusterName = ""
                             }
                             { protocol = Url.Http
                             , host = ""

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -53,7 +53,6 @@ flags =
     , notFoundImgSrc = ""
     , csrfToken = csrfToken
     , authToken = ""
-    , clusterName = ""
     , pipelineRunningKeyframes = ""
     }
 
@@ -279,7 +278,6 @@ all =
                     , csrfToken = csrfToken
                     , authToken = ""
                     , pipelineRunningKeyframes = ""
-                    , clusterName = ""
                     }
                     { protocol = Url.Http
                     , host = ""
@@ -391,7 +389,7 @@ all =
                                 )
                             )
                         |> Tuple.second
-                        |> Expect.equal [ Effects.FetchVersion ]
+                        |> Expect.equal [ Effects.FetchClusterInfo ]
             , describe "Legend" <|
                 let
                     clockTick =

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -213,7 +213,6 @@ all =
                     , notFoundImgSrc = "notfound.svg"
                     , csrfToken = "csrf_token"
                     , authToken = ""
-                    , clusterName = ""
                     , pipelineRunningKeyframes = "pipeline-running"
                     }
                     { protocol = Url.Http
@@ -3137,7 +3136,6 @@ flags =
     , notFoundImgSrc = ""
     , csrfToken = csrfToken
     , authToken = ""
-    , clusterName = ""
     , pipelineRunningKeyframes = ""
     }
 

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -833,7 +833,6 @@ iVisitTheDashboard _ =
         , csrfToken = ""
         , authToken = ""
         , pipelineRunningKeyframes = ""
-        , clusterName = ""
         }
         { protocol = Url.Http
         , host = ""
@@ -1274,7 +1273,6 @@ iOpenedThePipelinePage _ =
         , csrfToken = ""
         , authToken = ""
         , pipelineRunningKeyframes = ""
-        , clusterName = ""
         }
         { protocol = Url.Http
         , host = ""
@@ -1750,7 +1748,6 @@ iOpenTheJobPage _ =
         , csrfToken = ""
         , authToken = ""
         , pipelineRunningKeyframes = ""
-        , clusterName = ""
         }
         { protocol = Url.Http
         , host = ""
@@ -1768,7 +1765,6 @@ iOpenTheResourcePage _ =
         , csrfToken = ""
         , authToken = ""
         , pipelineRunningKeyframes = ""
-        , clusterName = ""
         }
         { protocol = Url.Http
         , host = ""

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -124,7 +124,6 @@ flags =
     , notFoundImgSrc = ""
     , csrfToken = ""
     , authToken = ""
-    , clusterName = ""
     , pipelineRunningKeyframes = ""
     }
 

--- a/web/indexhandler/handler.go
+++ b/web/indexhandler/handler.go
@@ -9,12 +9,9 @@ import (
 	"github.com/gobuffalo/packr"
 )
 
-var ClusterName = ""
-
 type templateData struct {
 	CSRFToken   string
 	AuthToken   string
-	ClusterName string
 }
 
 type handler struct {
@@ -65,7 +62,6 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := h.template.Execute(w, templateData{
 		CSRFToken:   csrfToken,
 		AuthToken:   authToken,
-		ClusterName: ClusterName,
 	})
 
 	if err != nil {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -84,7 +84,6 @@
           notFoundImgSrc: {{asset "images/parachute-error-404.svg"}},
           csrfToken: {{ .CSRFToken }},
           authToken: {{ .AuthToken }},
-          clusterName: {{ .ClusterName }},
           pipelineRunningKeyframes: "pipeline-running"
         }
       });

--- a/web/wats/test/dashboard.js
+++ b/web/wats/test/dashboard.js
@@ -100,3 +100,10 @@ test('auto-refreshes to reflect state changes', showsPipelineState, async t => {
   let newBackground = await t.context.web.computedStyle(newBanner, 'backgroundColor');
   t.deepEqual(color(newBackground), palette.red);
 });
+
+test('picks up cluster name from configuration', async t => {
+  await t.context.web.page.goto(t.context.web.route('/'));
+  const clusterName = await t.context.web.page.$eval(`#top-bar-app > div:nth-child(1)`, el => el.innerText);
+
+  t.is(clusterName, 'dev');
+});


### PR DESCRIPTION
When the web UI displayed the cluster name before, it did so because of server-side templating. Instead, we can now retrieve it dynamically from the `/info` API call, storing it in the session. This reduces the necessary plumbing around propagating the value, and we lose a lot of `clusterName = ""` test boilerplate.

The `FetchVersion` effect, which invoked the `/info` path, is now called `FetchClusterInfo` because we are interested in more of that API's data; some more things are renamed in order to match.

Fixes #3909.

Signed-off-by: Alexander Gurney <alexander_gurney@cable.comcast.com>