### PR TITLE
Revert "topgun: pend flaky worker landing test"

### DIFF
--- a/topgun/worker_landing_test.go
+++ b/topgun/worker_landing_test.go
@@ -122,20 +122,7 @@ var _ = Describe("Worker landing", func() {
 					preservedContainerID = string(hijackSession.Out.Contents())
 				})
 
-				//TODO: This test, as written, may not be valuable.
-				//      It is failing because sometimes, by the
-				//      time you hijack, there is already a new
-				//      check container scheduled on the worker.
-				//      In this case fly hijack will show a
-				//      prompt to choose a container. Though
-				//      it is logical to only have one check
-				//      container per session, this behaviour
-				//      is not harmful. It's possible this test
-				//      should be revised to test something more
-				//      critical, like task containers not being
-				//      killed or recreated when interrupted by
-				//      a worker restart.
-				XIt("keeps volumes and containers after restart", func() {
+				It("keeps volumes and containers after restart", func() {
 					By("starting the worker back up")
 					waitForLandedWorker()
 					startLandedWorker(landingWorkerInstance)


### PR DESCRIPTION
Reverts concourse/concourse#3981

https://github.com/concourse/concourse/pull/3983 has been merged which should fix it