### PR TITLE
[topgun/k8s] Add test that uses real btrfs disk

### DIFF
--- a/topgun/pipelines/pipeline-that-fails.yml
+++ b/topgun/pipelines/pipeline-that-fails.yml
@@ -1,0 +1,12 @@
+---
+jobs:
+  - name: simple-job
+    plan:
+      - task: simple-task
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: {repository: busybox}
+          run:
+            path: false


### PR DESCRIPTION
Test to ensure real btrfs disk is cleaned up properly in the helm chart: https://github.com/helm/charts/issues/13284

The `initContainer` script in the helm chart should clean up the btrfs disk properly. If it does then this test passes.

### Blocked
A PR in helm/charts needs to be merged first, otherwise this test will fail.... forever....: ~~https://github.com/helm/charts/pull/12398~~
https://github.com/helm/charts/pull/14941

CC @pivotal-bin-ju 