### PR TITLE
[topgun/k8s] Add test for one-off builds using secrets

### DIFF
--- a/topgun/tasks/simple-secret.yml
+++ b/topgun/tasks/simple-secret.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: busybox
+run:
+  path: sh
+  args:
+    - -c
+    - echo "((some-secret))"


### PR DESCRIPTION
Fixes: https://github.com/concourse/concourse/issues/3809
Added some test coverage for one-off builds running against a helm deployed concourse that is using Kubernetes credential management.

CC @pivotal-bin-ju 