### PR TITLE
Add `fly completion` as a command

### DIFF
--- a/fly/commands/completion.go
+++ b/fly/commands/completion.go
@@ -3,11 +3,8 @@ package commands
 import "fmt"
 
 type CompletionCommand struct {
-	Bash BashCompletionCommand `command:"bash"`
-	// TODO: support more shells
+	Shell string `long:"shell" required:"true" choice:"bash"` // add more choices later
 }
-
-type BashCompletionCommand struct {}
 
 // credits:
 // https://godoc.org/github.com/jessevdk/go-flags#hdr-Completion
@@ -21,7 +18,7 @@ const bashCompletionSnippet = `_fly_compl() {
 complete -F _fly_compl fly
 `
 
-func (*BashCompletionCommand) Execute([]string) error {
+func (*CompletionCommand) Execute([]string) error {
 	_, err := fmt.Print(bashCompletionSnippet)
 	return err
 }

--- a/fly/commands/completion.go
+++ b/fly/commands/completion.go
@@ -3,7 +3,7 @@ package commands
 import "fmt"
 
 type CompletionCommand struct {
-	Shell string `long:"shell" required:"true" choice:"bash"` // add more choices later
+	Shell string `long:"shell" required:"true" choice:"bash" choice:"zsh"` // add more choices later
 }
 
 // credits:
@@ -18,7 +18,21 @@ const bashCompletionSnippet = `_fly_compl() {
 complete -F _fly_compl fly
 `
 
-func (*CompletionCommand) Execute([]string) error {
-	_, err := fmt.Print(bashCompletionSnippet)
-	return err
+// initial implemenation just using bashcompinit
+const zshCompletionSnippet = `autoload -Uz compinit && compinit
+autoload -Uz bashcompinit && bashcompinit
+` + bashCompletionSnippet
+
+func (command *CompletionCommand) Execute([]string) error {
+	switch command.Shell {
+	case "bash":
+		_, err := fmt.Print(bashCompletionSnippet)
+		return err
+	case "zsh":
+		_, err := fmt.Print(zshCompletionSnippet)
+		return err
+	default:
+		// this should be unreachable
+		return fmt.Errorf("unknown shell %s", command.Shell)
+	}
 }

--- a/fly/commands/completion.go
+++ b/fly/commands/completion.go
@@ -1,0 +1,27 @@
+package commands
+
+import "fmt"
+
+type CompletionCommand struct {
+	Bash BashCompletionCommand `command:"bash"`
+	// TODO: support more shells
+}
+
+type BashCompletionCommand struct {}
+
+// credits:
+// https://godoc.org/github.com/jessevdk/go-flags#hdr-Completion
+// https://github.com/concourse/concourse/issues/1309#issuecomment-452893900
+const bashCompletionSnippet = `_fly_compl() {
+	args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+	local IFS=$'\n'
+	COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
+	return 0
+}
+complete -F _fly_compl fly
+`
+
+func (*BashCompletionCommand) Execute([]string) error {
+	_, err := fmt.Print(bashCompletionSnippet)
+	return err
+}

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -74,6 +74,8 @@ type FlyCommand struct {
 	PruneWorker PruneWorkerCommand `command:"prune-worker" alias:"pw" description:"Prune a stalled, landing, landed, or retiring worker"`
 
 	Curl CurlCommand `command:"curl" alias:"c" description:"curl the api"`
+
+	Completion CompletionCommand `command:"completion" description:"generate shell completion code"`
 }
 
 var Fly FlyCommand


### PR DESCRIPTION
As mentioned in #1309, users have to add a snippet to their .bashrc to enable autocompletion. This PR packages the snippet into the `fly` CLI, so the `.bashrc` entry can be reduced to one-line:
```
source <(fly completion bash)
```
Or using the `/etc/bash_completion.d` directory:
```
fly completion bash > /etc/bash_completion.d/fly
```
