### PR TITLE
[topgun/bosh] Update tests for bosh links

### DIFF
--- a/topgun/operations/bbr-concourse-link.yml
+++ b/topgun/operations/bbr-concourse-link.yml
@@ -1,3 +1,16 @@
+# use non-default credentials to ensure concourse_db bosh links are used
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/role
+  value:
+    name: concourse
+    password: dummy-password
+
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/0
+  value:
+    name: concourse
+    password: dummy-password
+
 - type: replace
   path: /releases/-
   value:

--- a/topgun/operations/bbr-concourse-link.yml
+++ b/topgun/operations/bbr-concourse-link.yml
@@ -1,4 +1,4 @@
-# use non-default credentials to ensure concourse_db bosh links are used
+# use non-default values to ensure concourse_db bosh links are used
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/postgresql/role
   value:
@@ -10,6 +10,23 @@
   value:
     name: concourse
     password: dummy-password
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/database
+  value: atcdb
+
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/databases/0
+  value:
+    name: atcdb
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/port?
+  value: 5433
+
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/port
+  value: 5433
 
 - type: replace
   path: /releases/-

--- a/topgun/operations/bbr-with-properties.yml
+++ b/topgun/operations/bbr-with-properties.yml
@@ -17,13 +17,43 @@
     properties: {}
 
 - type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/role
+  value:
+    name: concourse
+    password: dummy-password
+
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/0
+  value:
+    name: concourse
+    password: dummy-password
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/database
+  value: atcdb
+
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/databases/0
+  value:
+    name: atcdb
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/port?
+  value: 5433
+
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/port
+  value: 5433
+
+- type: replace
   path: /instance_groups/name=db/jobs/-
   value:
     release: concourse
     name: bbr-atcdb
     properties:
       postgresql:
-        database: atc
+        database: atcdb
+        port: 5433
         role:
-          name: atc
+          name: concourse
           password: dummy-password


### PR DESCRIPTION
Change the postgres credentials to be non-default. Existing tests will only pass if the bosh job in our release uses the bosh links correctly.

Blocked by https://github.com/concourse/concourse-bosh-release/pull/41