### PR TITLE
only update resource version metadata if the new value is not null

### DIFF
--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -271,7 +271,8 @@ func saveResourceVersion(tx Tx, r ResourceConfigScope, version atc.Version, meta
 	err = tx.QueryRow(`
 		INSERT INTO resource_config_versions (resource_config_scope_id, version, version_md5, metadata)
 		SELECT $1, $2, md5($3), $4
-		ON CONFLICT (resource_config_scope_id, version_md5) DO UPDATE SET metadata = $4
+		ON CONFLICT (resource_config_scope_id, version_md5)
+		DO UPDATE SET metadata = COALESCE(NULLIF(excluded.metadata, 'null'::jsonb), resource_config_versions.metadata)
 		RETURNING check_order
 		`, r.ID(), string(versionJSON), string(versionJSON), string(metadataJSON)).Scan(&checkOrder)
 	if err != nil {

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -873,6 +873,34 @@ var _ = Describe("Resource", func() {
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
+					Expect(historyPage[0].Metadata).To(Equal([]atc.MetadataField{{Name: "name1", Value: "value1"}}))
+				})
+
+				It("maintains existing metadata after same version is saved with no metadata", func() {
+					resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
+					Expect(err).ToNot(HaveOccurred())
+
+					err = resourceScope.SaveVersions([]atc.Version{resourceVersions[9].Version})
+					Expect(err).ToNot(HaveOccurred())
+
+					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(len(historyPage)).To(Equal(1))
+					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
+					Expect(historyPage[0].Metadata).To(Equal([]atc.MetadataField{{Name: "name1", Value: "value1"}}))
+				})
+
+				It("updates metadata after same version is saved with different metadata", func() {
+					newMetadata := []db.ResourceConfigMetadataField{{Name: "name-new", Value: "value-new"}}
+					_, err := resource.SaveUncheckedVersion(atc.Version(resourceVersions[9].Version), newMetadata, resourceScope.ResourceConfig(), atc.VersionedResourceTypes{})
+
+					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(len(historyPage)).To(Equal(1))
+					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
+					Expect(historyPage[0].Metadata).To(Equal([]atc.MetadataField{{Name: "name-new", Value: "value-new"}}))
 				})
 			})
 


### PR DESCRIPTION
fixes #4005 