### PR TITLE
topgun/k8s: add DNS behavior testing

### DIFF
--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -1,0 +1,119 @@
+package k8s_test
+
+import (
+	"github.com/onsi/gomega/gexec"
+	"time"
+
+	. "github.com/concourse/concourse/topgun"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DNS Resolution", func() {
+
+	var (
+		atcEndpoint  string
+		proxySession *gexec.Session
+	)
+
+	BeforeEach(func() {
+		setReleaseNameAndNamespace("dp")
+	})
+
+	var setupDeployment = func(dnsProxyEnable, dnsServer string) {
+		args := []string{
+			`--set=worker.replicas=1`,
+			`--set-string=concourse.worker.garden.dnsProxyEnable=` + dnsProxyEnable,
+		}
+		if dnsServer != "" {
+			args = append(args,
+				`--set=worker.env[0].name=CONCOURSE_GARDEN_DNS_SERVER`,
+				`--set=worker.env[0].value=`+dnsServer)
+		}
+		deployConcourseChart(releaseName, args...)
+		waitAllPodsInNamespaceToBeReady(namespace)
+
+		By("Creating the web proxy")
+		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+
+		By("Logging in")
+		fly.Login("test", "test", atcEndpoint)
+
+		By("waiting for a running worker")
+		Eventually(func() []Worker {
+			return getRunningWorkers(fly.GetWorkers())
+		}, 2*time.Minute, 10*time.Second).
+			ShouldNot(HaveLen(0))
+	}
+
+	var fullAddress = func() string {
+		return releaseName + "-web." + namespace + ".svc.cluster.local:8080/api/v1/info"
+	}
+
+	var shortAddress = func() string {
+		return releaseName + "-web:8080/api/v1/info"
+	}
+
+	AfterEach(func() {
+		cleanup(releaseName, namespace, proxySession)
+	})
+
+	type Case struct {
+		// args
+		enableDnsProxy  string
+		dnsServer       string
+		addressFunction func() string
+
+		// expectations
+		shouldWork bool
+	}
+
+	DescribeTable("different proxy settings",
+		func(c Case) {
+			setupDeployment(c.enableDnsProxy, c.dnsServer)
+
+			sess := fly.Start("execute", "-c", "../tasks/dns-proxy-task.yml", "-v", "url="+c.addressFunction())
+			<-sess.Exited
+
+			if !c.shouldWork {
+				Expect(sess.ExitCode()).ToNot(BeZero())
+				return
+			}
+
+			Expect(sess.ExitCode()).To(BeZero())
+		},
+		Entry("Proxy Enabled, with full service name", Case{
+			enableDnsProxy:  "true",
+			addressFunction: fullAddress,
+			shouldWork:      true,
+		}),
+		Entry("Proxy Enabled, with short service name", Case{
+			enableDnsProxy:  "true",
+			addressFunction: shortAddress,
+			shouldWork:      false,
+		}),
+		Entry("Proxy Disabled, with full service name", Case{
+			enableDnsProxy:  "false",
+			addressFunction: fullAddress,
+			shouldWork:      true,
+		}),
+		Entry("Proxy Disabled, with short service name", Case{
+			enableDnsProxy:  "false",
+			addressFunction: shortAddress,
+			shouldWork:      true,
+		}),
+		Entry("Adding extra dns server, with Proxy Disabled and full address", Case{
+			enableDnsProxy:  "false",
+			dnsServer:       "8.8.8.8",
+			addressFunction: fullAddress,
+			shouldWork:      false,
+		}),
+		Entry("Adding extra dns server, with Proxy Enabled and full address", Case{
+			enableDnsProxy:  "true",
+			dnsServer:       "8.8.8.8",
+			addressFunction: fullAddress,
+			shouldWork:      false,
+		}),
+	)
+})

--- a/topgun/tasks/dns-proxy-task.yml
+++ b/topgun/tasks/dns-proxy-task.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: busybox
+run:
+  path: "wget"
+  args:
+  - "-O-"
+  - "((url))"


### PR DESCRIPTION
Hey,

Here we test the different cases where one is either able (or not) to access other services in a Kubernetes cluster from within garden containers when using the Helm chart.

Please see https://github.com/concourse/concourse/issues/3103 for the details on what are the differences between the scenarios.

closes #3103 

Thanks!