### PR TITLE
topgun/k8s: add test for scaling `web` in and out

### DIFF
--- a/topgun/k8s/web_scaling_test.go
+++ b/topgun/k8s/web_scaling_test.go
@@ -1,0 +1,49 @@
+package k8s_test
+
+import (
+	"strconv"
+	"time"
+
+	. "github.com/concourse/concourse/topgun"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Scaling web instances", func() {
+
+	BeforeEach(func() {
+		setReleaseNameAndNamespace("swi")
+	})
+
+	AfterEach(func() {
+		cleanup(releaseName, namespace, nil)
+	})
+
+	It("succeeds", func() {
+		successfullyDeploysConcourse(1, 1)
+		successfullyDeploysConcourse(0, 1)
+		successfullyDeploysConcourse(2, 1)
+	})
+})
+
+func successfullyDeploysConcourse(webReplicas, workerReplicas int) {
+	deployConcourseChart(releaseName,
+		"--set=web.replicas="+strconv.Itoa(webReplicas),
+		"--set=worker.replicas="+strconv.Itoa(workerReplicas),
+	)
+
+	waitAllPodsInNamespaceToBeReady(namespace)
+
+	By("Creating the web proxy")
+	proxySession, atcEndpoint := startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+	defer proxySession.Interrupt()
+
+	By("Logging in")
+	fly.Login("test", "test", atcEndpoint)
+
+	By("waiting for a running worker")
+	Eventually(func() []Worker {
+		return getRunningWorkers(fly.GetWorkers())
+	}, 2*time.Minute, 10*time.Second).
+		Should(HaveLen(workerReplicas))
+}


### PR DESCRIPTION
Hey,

This PR adds a test for verifying that, using the Helm chart, we're
able to go from 1 to 0 replicas (scaling in), then from 0 to 2 (scaling
out) using the standard helm primitives (updating `replicas` fields).

- closes #2851

Thanks!