### PR TITLE
Support querying resource versions by fields

### DIFF
--- a/atc/api/present/resource_version.go
+++ b/atc/api/present/resource_version.go
@@ -5,7 +5,7 @@ import (
 )
 
 func ResourceVersions(hideMetadata bool, resourceVersions []atc.ResourceVersion) []atc.ResourceVersion {
-	var presented []atc.ResourceVersion
+	presented := []atc.ResourceVersion{}
 
 	for _, resourceVersion := range resourceVersions {
 		if hideMetadata {

--- a/atc/api/resourceserver/versionserver/list.go
+++ b/atc/api/resourceserver/versionserver/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
@@ -24,6 +25,20 @@ func (s *Server) ListResourceVersions(pipeline db.Pipeline) http.Handler {
 			to    int
 			limit int
 		)
+
+		err = r.ParseForm()
+		if err != nil {
+			logger.Error("failed-to-parse-request-form", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		fields := r.Form["filter"]
+		versionFilter := make(atc.Version)
+		for _, field := range fields {
+			vs := strings.SplitN(field, ":", 2)
+			versionFilter[vs[0]] = vs[1]
+		}
 
 		resourceName := r.FormValue(":resource_name")
 		teamName := r.FormValue(":team_name")
@@ -66,7 +81,7 @@ func (s *Server) ListResourceVersions(pipeline db.Pipeline) http.Handler {
 			From:  from,
 			To:    to,
 			Limit: limit,
-		})
+		}, versionFilter)
 		if err != nil {
 			logger.Error("failed-to-get-resource-config-versions", err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -74,6 +89,7 @@ func (s *Server) ListResourceVersions(pipeline db.Pipeline) http.Handler {
 		}
 
 		if !found {
+			logger.Info("resource-versions-not-found", lager.Data{"resource-name": resourceName})
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}

--- a/atc/api/resourceserver/versionserver/list.go
+++ b/atc/api/resourceserver/versionserver/list.go
@@ -37,7 +37,9 @@ func (s *Server) ListResourceVersions(pipeline db.Pipeline) http.Handler {
 		versionFilter := make(atc.Version)
 		for _, field := range fields {
 			vs := strings.SplitN(field, ":", 2)
-			versionFilter[vs[0]] = vs[1]
+			if len(vs) == 2 {
+				versionFilter[vs[0]] = vs[1]
+			}
 		}
 
 		resourceName := r.FormValue(":resource_name")

--- a/atc/api/versions_test.go
+++ b/atc/api/versions_test.go
@@ -230,7 +230,7 @@ var _ = Describe("Versions API", func() {
 					It("does not set defaults for since and until", func() {
 						Expect(fakeResource.VersionsCallCount()).To(Equal(1))
 
-						page := fakeResource.VersionsArgsForCall(0)
+						page, versionFilter := fakeResource.VersionsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
 							Since: 0,
 							Until: 0,
@@ -238,18 +238,19 @@ var _ = Describe("Versions API", func() {
 							To:    0,
 							Limit: 100,
 						}))
+						Expect(versionFilter).To(Equal(atc.Version{}))
 					})
 				})
 
 				Context("when all the params are passed", func() {
 					BeforeEach(func() {
-						queryParams = "?since=2&until=3&from=5&to=7&limit=8"
+						queryParams = "?since=2&until=3&from=5&to=7&limit=8&filter=ref:foo&filter=some-ref:blah"
 					})
 
 					It("passes them through", func() {
 						Expect(fakeResource.VersionsCallCount()).To(Equal(1))
 
-						page := fakeResource.VersionsArgsForCall(0)
+						page, versionFilter := fakeResource.VersionsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
 							Since: 2,
 							Until: 3,
@@ -257,6 +258,57 @@ var _ = Describe("Versions API", func() {
 							To:    7,
 							Limit: 8,
 						}))
+						Expect(versionFilter).To(Equal(atc.Version{
+							"ref":      "foo",
+							"some-ref": "blah",
+						}))
+					})
+				})
+
+				Context("when params includes version filter has special char", func() {
+					Context("space char", func() {
+						BeforeEach(func() {
+							queryParams = "?filter=some%20ref:some%20value"
+						})
+
+						It("passes them through", func() {
+							Expect(fakeResource.VersionsCallCount()).To(Equal(1))
+
+							_, versionFilter := fakeResource.VersionsArgsForCall(0)
+							Expect(versionFilter).To(Equal(atc.Version{
+								"some ref": "some value",
+							}))
+						})
+					})
+
+					Context("% char", func() {
+						BeforeEach(func() {
+							queryParams = "?filter=ref:some%25value"
+						})
+
+						It("passes them through", func() {
+							Expect(fakeResource.VersionsCallCount()).To(Equal(1))
+
+							_, versionFilter := fakeResource.VersionsArgsForCall(0)
+							Expect(versionFilter).To(Equal(atc.Version{
+								"ref": "some%value",
+							}))
+						})
+					})
+
+					Context(": char", func() {
+						BeforeEach(func() {
+							queryParams = "?filter=key%3Awith%3Acolon:abcdef"
+						})
+
+						It("passes them through by splitting on first colon", func() {
+							Expect(fakeResource.VersionsCallCount()).To(Equal(1))
+
+							_, versionFilter := fakeResource.VersionsArgsForCall(0)
+							Expect(versionFilter).To(Equal(atc.Version{
+								"key": "with:colon:abcdef",
+							}))
+						})
 					})
 				})
 
@@ -271,6 +323,7 @@ var _ = Describe("Versions API", func() {
 								Enabled: true,
 								Version: atc.Version{
 									"some": "version",
+									"ref":  "foo",
 								},
 								Metadata: []atc.MetadataField{
 									{
@@ -284,6 +337,7 @@ var _ = Describe("Versions API", func() {
 								Enabled: false,
 								Version: atc.Version{
 									"some": "version",
+									"ref":  "blah",
 								},
 								Metadata: []atc.MetadataField{
 									{
@@ -313,7 +367,7 @@ var _ = Describe("Versions API", func() {
 					{
 						"id": 4,
 						"enabled": true,
-						"version": {"some":"version"},
+						"version": {"some":"version", "ref":"foo"},
 						"metadata": [
 							{
 								"name":"some",
@@ -324,7 +378,7 @@ var _ = Describe("Versions API", func() {
 					{
 						"id":2,
 						"enabled": false,
-						"version": {"some":"version"},
+						"version": {"some":"version", "ref":"blah"},
 						"metadata": [
 							{
 								"name":"some",

--- a/atc/api/versions_test.go
+++ b/atc/api/versions_test.go
@@ -310,6 +310,19 @@ var _ = Describe("Versions API", func() {
 							}))
 						})
 					})
+
+					Context("if there is no : ", func() {
+						BeforeEach(func() {
+							queryParams = "?filter=abcdef"
+						})
+
+						It("set no filter when fetching versions", func() {
+							Expect(fakeResource.VersionsCallCount()).To(Equal(1))
+
+							_, versionFilter := fakeResource.VersionsArgsForCall(0)
+							Expect(versionFilter).To(BeEmpty())
+						})
+					})
 				})
 
 				Context("when getting the versions succeeds", func() {

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -1036,7 +1036,7 @@ var _ = Describe("Build", func() {
 					err = resourceConfig1.SaveVersions([]atc.Version{{"version": "v1"}})
 					Expect(err).NotTo(HaveOccurred())
 
-					versions, _, found, err := resource1.Versions(db.Page{Limit: 1})
+					versions, _, found, err := resource1.Versions(db.Page{Limit: 1}, nil)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(versions).To(HaveLen(1))

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -2,11 +2,11 @@
 package dbfakes
 
 import (
-	"sync"
-	"time"
+	sync "sync"
+	time "time"
 
-	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/db"
+	atc "github.com/concourse/concourse/atc"
+	db "github.com/concourse/concourse/atc/db"
 )
 
 type FakeResource struct {
@@ -376,10 +376,11 @@ type FakeResource struct {
 		result1 bool
 		result2 error
 	}
-	VersionsStub        func(db.Page) ([]atc.ResourceVersion, db.Pagination, bool, error)
+	VersionsStub        func(db.Page, atc.Version) ([]atc.ResourceVersion, db.Pagination, bool, error)
 	versionsMutex       sync.RWMutex
 	versionsArgsForCall []struct {
 		arg1 db.Page
+		arg2 atc.Version
 	}
 	versionsReturns struct {
 		result1 []atc.ResourceVersion
@@ -2270,16 +2271,17 @@ func (fake *FakeResource) UpdateMetadataReturnsOnCall(i int, result1 bool, resul
 	}{result1, result2}
 }
 
-func (fake *FakeResource) Versions(arg1 db.Page) ([]atc.ResourceVersion, db.Pagination, bool, error) {
+func (fake *FakeResource) Versions(arg1 db.Page, arg2 atc.Version) ([]atc.ResourceVersion, db.Pagination, bool, error) {
 	fake.versionsMutex.Lock()
 	ret, specificReturn := fake.versionsReturnsOnCall[len(fake.versionsArgsForCall)]
 	fake.versionsArgsForCall = append(fake.versionsArgsForCall, struct {
 		arg1 db.Page
-	}{arg1})
-	fake.recordInvocation("Versions", []interface{}{arg1})
+		arg2 atc.Version
+	}{arg1, arg2})
+	fake.recordInvocation("Versions", []interface{}{arg1, arg2})
 	fake.versionsMutex.Unlock()
 	if fake.VersionsStub != nil {
-		return fake.VersionsStub(arg1)
+		return fake.VersionsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
@@ -2294,17 +2296,17 @@ func (fake *FakeResource) VersionsCallCount() int {
 	return len(fake.versionsArgsForCall)
 }
 
-func (fake *FakeResource) VersionsCalls(stub func(db.Page) ([]atc.ResourceVersion, db.Pagination, bool, error)) {
+func (fake *FakeResource) VersionsCalls(stub func(db.Page, atc.Version) ([]atc.ResourceVersion, db.Pagination, bool, error)) {
 	fake.versionsMutex.Lock()
 	defer fake.versionsMutex.Unlock()
 	fake.VersionsStub = stub
 }
 
-func (fake *FakeResource) VersionsArgsForCall(i int) db.Page {
+func (fake *FakeResource) VersionsArgsForCall(i int) (db.Page, atc.Version) {
 	fake.versionsMutex.RLock()
 	defer fake.versionsMutex.RUnlock()
 	argsForCall := fake.versionsArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeResource) VersionsReturns(result1 []atc.ResourceVersion, result2 db.Pagination, result3 bool, result4 error) {

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -765,7 +765,7 @@ var _ = Describe("Job", func() {
 			}, resourceConfigScope.ResourceConfig(), atc.VersionedResourceTypes{})
 			Expect(err).NotTo(HaveOccurred())
 
-			reversions, _, found, err := resource.Versions(db.Page{Limit: 3})
+			reversions, _, found, err := resource.Versions(db.Page{Limit: 3}, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 
@@ -945,7 +945,7 @@ var _ = Describe("Job", func() {
 			}, resourceConfigScope.ResourceConfig(), atc.VersionedResourceTypes{})
 			Expect(err).NotTo(HaveOccurred())
 
-			reversions, _, found, err := resource.Versions(db.Page{Limit: 3})
+			reversions, _, found, err := resource.Versions(db.Page{Limit: 3}, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -885,7 +885,7 @@ var _ = Describe("Pipeline", func() {
 				err = build.SaveOutput("some-type", atc.Source{"source-config": "some-value"}, atc.VersionedResourceTypes{}, atc.Version(beforeVR.Version()), nil, "some-output-name", "some-resource")
 				Expect(err).ToNot(HaveOccurred())
 
-				versions, _, found, err := resource.Versions(db.Page{Limit: 10})
+				versions, _, found, err := resource.Versions(db.Page{Limit: 10}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(versions).To(HaveLen(5))

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -726,6 +726,121 @@ var _ = Describe("Resource", func() {
 			resourceScope        db.ResourceConfigScope
 		)
 
+		Context("with version filters", func() {
+			var filter atc.Version
+			var resourceVersions []atc.ResourceVersion
+
+			BeforeEach(func() {
+				setupTx, err := dbConn.Begin()
+				Expect(err).ToNot(HaveOccurred())
+
+				brt := db.BaseResourceType{
+					Name: "git",
+				}
+
+				_, err = brt.FindOrCreate(setupTx, false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(setupTx.Commit()).To(Succeed())
+
+				var found bool
+				resource, found, err = pipeline.Resource("some-other-resource")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
+				Expect(err).ToNot(HaveOccurred())
+
+				originalVersionSlice = []atc.Version{
+					{"ref": "v0", "commit": "v0"},
+					{"ref": "v1", "commit": "v1"},
+					{"ref": "v2", "commit": "v2"},
+				}
+
+				err = resourceScope.SaveVersions(originalVersionSlice)
+				Expect(err).ToNot(HaveOccurred())
+
+				resourceVersions = make([]atc.ResourceVersion, 0)
+
+				for i := 0; i < 3; i++ {
+					rcv, found, err := resourceScope.FindVersion(atc.Version{
+						"ref":    "v" + strconv.Itoa(i),
+						"commit": "v" + strconv.Itoa(i),
+					})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+
+					var metadata []atc.MetadataField
+
+					for _, v := range rcv.Metadata() {
+						metadata = append(metadata, atc.MetadataField(v))
+					}
+
+					resourceVersion := atc.ResourceVersion{
+						ID:       rcv.ID(),
+						Version:  atc.Version(rcv.Version()),
+						Metadata: metadata,
+						Enabled:  true,
+					}
+
+					resourceVersions = append(resourceVersions, resourceVersion)
+				}
+			})
+
+			Context("when filter include one field that matches", func() {
+				BeforeEach(func() {
+					filter = atc.Version{"ref": "v2"}
+				})
+
+				It("return version that matches field filter", func() {
+					result, _, found, err := resource.Versions(db.Page{Limit: 10}, filter)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(len(result)).To(Equal(1))
+					Expect(result[0].Version).To(Equal(resourceVersions[2].Version))
+				})
+			})
+
+			Context("when filter include one field that doesn't match", func() {
+				BeforeEach(func() {
+					filter = atc.Version{"ref": "v20"}
+				})
+
+				It("return no version", func() {
+					result, _, found, err := resource.Versions(db.Page{Limit: 10}, filter)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(len(result)).To(Equal(0))
+				})
+			})
+
+			Context("when filter include two fields that match", func() {
+				BeforeEach(func() {
+					filter = atc.Version{"ref": "v1", "commit": "v1"}
+				})
+
+				It("return version", func() {
+					result, _, found, err := resource.Versions(db.Page{Limit: 10}, filter)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(len(result)).To(Equal(1))
+					Expect(result[0].Version).To(Equal(resourceVersions[1].Version))
+				})
+			})
+
+			Context("when filter include two fields and one of them does not match", func() {
+				BeforeEach(func() {
+					filter = atc.Version{"ref": "v1", "commit": "v2"}
+				})
+
+				It("return no version", func() {
+					result, _, found, err := resource.Versions(db.Page{Limit: 10}, filter)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
+					Expect(len(result)).To(Equal(0))
+				})
+			})
+		})
+
 		Context("when resource has versions created in order of check order", func() {
 			var resourceVersions []atc.ResourceVersion
 
@@ -795,7 +910,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with no since/until", func() {
 				It("returns the first page, with the given limit, and a next page", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 2})
+					historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -808,7 +923,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with a since that places it in the middle of the builds", func() {
 				It("returns the builds, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Since: resourceVersions[6].ID, Limit: 2})
+					historyPage, pagination, found, err := resource.Versions(db.Page{Since: resourceVersions[6].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -821,7 +936,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with a since that places it at the end of the builds", func() {
 				It("returns the builds, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Since: resourceVersions[2].ID, Limit: 2})
+					historyPage, pagination, found, err := resource.Versions(db.Page{Since: resourceVersions[2].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -834,7 +949,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with an until that places it in the middle of the builds", func() {
 				It("returns the builds, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Until: resourceVersions[6].ID, Limit: 2})
+					historyPage, pagination, found, err := resource.Versions(db.Page{Until: resourceVersions[6].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -847,7 +962,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with a until that places it at the beginning of the builds", func() {
 				It("returns the builds, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Until: resourceVersions[7].ID, Limit: 2})
+					historyPage, pagination, found, err := resource.Versions(db.Page{Until: resourceVersions[7].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -868,7 +983,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("returns the metadata in the version history", func() {
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1})
+					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
@@ -913,7 +1028,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("returns a disabled version", func() {
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1})
+					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(ConsistOf([]atc.ResourceVersion{resourceVersions[9]}))
@@ -932,7 +1047,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("returns a version with metadata updated", func() {
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1})
+					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
@@ -1009,7 +1124,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with no since/until", func() {
 				It("returns versions ordered by check order", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 4})
+					historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 4}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(4))
@@ -1024,7 +1139,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with a since", func() {
 				It("returns the builds, with previous/next pages excluding since", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Since: 3, Limit: 2})
+					historyPage, pagination, found, err := resource.Versions(db.Page{Since: 3, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
@@ -1037,7 +1152,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with from", func() {
 				It("returns the builds, with previous/next pages including from", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{From: 2, Limit: 2})
+					historyPage, pagination, found, err := resource.Versions(db.Page{From: 2, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
@@ -1050,7 +1165,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with a until", func() {
 				It("returns the builds, with previous/next pages excluding until", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Until: 1, Limit: 2})
+					historyPage, pagination, found, err := resource.Versions(db.Page{Until: 1, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
@@ -1063,7 +1178,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with to", func() {
 				It("returns the builds, with previous/next pages including to", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{To: 4, Limit: 2})
+					historyPage, pagination, found, err := resource.Versions(db.Page{To: 4, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
@@ -1104,7 +1219,7 @@ var _ = Describe("Resource", func() {
 			})
 
 			It("does not return the version", func() {
-				historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 2})
+				historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 2}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(historyPage).To(BeNil())

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -998,7 +998,7 @@ var _ = Describe("Resource", func() {
 					err = resourceScope.SaveVersions([]atc.Version{resourceVersions[9].Version})
 					Expect(err).ToNot(HaveOccurred())
 
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1})
+					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, atc.Version{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
@@ -1010,7 +1010,7 @@ var _ = Describe("Resource", func() {
 					newMetadata := []db.ResourceConfigMetadataField{{Name: "name-new", Value: "value-new"}}
 					_, err := resource.SaveUncheckedVersion(atc.Version(resourceVersions[9].Version), newMetadata, resourceScope.ResourceConfig(), atc.VersionedResourceTypes{})
 
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1})
+					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, atc.Version{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))

--- a/fly/commands/curl.go
+++ b/fly/commands/curl.go
@@ -2,17 +2,19 @@ package commands
 
 import (
 	"fmt"
-	"github.com/concourse/concourse/fly/rc"
 	"net/url"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/concourse/concourse/fly/rc"
 )
 
 type CurlCommand struct {
 	Args struct {
-		Path string   `positional-arg-name:"PATH" required:"true"`
-		Rest []string `positional-arg-name:"curl flags"`
+		Path  string   `positional-arg-name:"PATH" required:"true"`
+		Query string   `positional-arg-name:"QUERY"`
+		Rest  []string `positional-arg-name:"curl flags"`
 	} `positional-args:"yes"`
 	PrintAndExit bool `long:"print-and-exit" description:"Print curl command and exit"`
 }
@@ -28,7 +30,7 @@ func (command *CurlCommand) Execute([]string) error {
 		return err
 	}
 
-	fullUrl, err := command.makeFullUrl(target.URL(), command.Args.Path)
+	fullUrl, err := command.makeFullUrl(target.URL(), command.Args.Path, command.Args.Query)
 	if err != nil {
 		return err
 	}
@@ -52,12 +54,13 @@ func (command *CurlCommand) Execute([]string) error {
 	return nil
 }
 
-func (command *CurlCommand) makeFullUrl(host, path string) (string, error) {
+func (command *CurlCommand) makeFullUrl(host, path string, query string) (string, error) {
 	u, err := url.Parse(host)
 	if err != nil {
 		return "", err
 	}
 	u.Path = path
+	u.RawQuery = query
 	return u.String(), nil
 }
 

--- a/fly/integration/curl_test.go
+++ b/fly/integration/curl_test.go
@@ -1,0 +1,31 @@
+package integration_test
+
+import (
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Fly CLI", func() {
+	Describe("curl", func() {
+		var (
+			flyCmd *exec.Cmd
+		)
+
+		Context("when providing a query args", func() {
+			It("parse the query params correctly", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "curl", "--print-and-exit", "some-path", "some-query-param=value")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+
+				Expect(string(sess.Out.Contents())).To(ContainSubstring("some-path?some-query-param=value"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
refer to https://github.com/concourse/concourse/issues/3932

a related side work is fixing `fly curl` with query params (since there is no concourse api needed passing query until this one) as before there was no way to pass query and if one using `fly curl /api/v1/path?param=value`, it will encode the `?` and produces a wrong url cause `404 not found`