### PR TITLE
fixed momentum scrolling on ios

### DIFF
--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -55,7 +55,10 @@ header status =
 
 body : List (Html.Attribute msg)
 body =
-    [ style "overflow-y" "auto", style "outline" "none" ]
+    [ style "overflow-y" "auto"
+    , style "outline" "none"
+    , style "-webkit-overflow-scrolling" "touch"
+    ]
 
 
 historyItem : Concourse.BuildStatus -> List (Html.Attribute msg)

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -79,6 +79,7 @@ content highDensity =
     , style "height" "100%"
     , style "width" "100%"
     , style "box-sizing" "border-box"
+    , style "-webkit-overflow-scrolling" "touch"
     , style "flex-direction" <|
         if highDensity then
             "column"

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -31,6 +31,7 @@ sideBar =
     , style "flex-shrink" "0"
     , style "padding-right" "10px"
     , style "box-sizing" "border-box"
+    , style "-webkit-overflow-scrolling" "touch"
     ]
 
 

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1262,6 +1262,12 @@ all =
                     >> Common.queryView
                     >> Query.find [ id "build-body" ]
                     >> Query.has [ style "overflow-y" "auto" ]
+            , test "build body has momentum based scroll enabled" <|
+                givenBuildFetched
+                    >> Tuple.first
+                    >> Common.queryView
+                    >> Query.find [ id "build-body" ]
+                    >> Query.has [ style "-webkit-overflow-scrolling" "touch" ]
             , test "fetches build history and job details after build is fetched" <|
                 givenBuildFetched
                     >> Tuple.second

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -996,6 +996,17 @@ all =
                         |> Query.find teamHeaderSelector
                         |> Query.find [ containing [ text "OWNER" ] ]
                         |> Query.has [ style "margin-bottom" "" ]
+            , test "has momentum based scrolling" <|
+                \_ ->
+                    whenOnDashboard { highDensity = True }
+                        |> givenDataAndUser
+                            (apiData [ ( "team", [ "pipeline" ] ) ])
+                            (userWithRoles [])
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find [ id "page-below-top-bar" ]
+                        |> Query.find [ class "dashboard" ]
+                        |> Query.has [ style "-webkit-overflow-scrolling" "touch" ]
             ]
         , describe "pipeline cards" <|
             let

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -217,6 +217,10 @@ hasSideBar iAmLookingAtThePage =
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheSideBar
                 >> then_ iSeeItFillsHeight
+        , test "sidebar has momentum based scrolling" <|
+            given iHaveAnOpenSideBar_
+                >> when iAmLookingAtTheSideBar
+                >> then_ itHasMomentumScrolling
         , test "sidebar does not shrink" <|
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheSideBar
@@ -1083,6 +1087,10 @@ iSeeItScrollsIndependently =
 
 iSeeItFillsHeight =
     Query.has [ style "height" "100%", style "box-sizing" "border-box" ]
+
+
+itHasMomentumScrolling =
+    Query.has [ style "-webkit-overflow-scrolling" "touch" ]
 
 
 iSeeItDoesNotShrink =


### PR DESCRIPTION
fixes #3956

### Release Note
```tex
\note{fix}{
  A fix to a regression found recently involving 
  \link{momentum based scrolling}{https://github.com/concourse/concourse/issues/3956}
  on build pages on iOS browsers. 
  Fix was also applied to the sidebar and the dashboard.
}
```