### PR TITLE
fly -h & fly --help exits successfully

### DIFF
--- a/fly/main.go
+++ b/fly/main.go
@@ -71,6 +71,10 @@ func handleError(helpParser *flags.Parser, err error) {
 			helpParser.ParseArgs([]string{"-h"})
 			helpParser.WriteHelp(os.Stdout)
 			os.Exit(0)
+		} else if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+			helpParser.ParseArgs([]string{"-h"})
+			helpParser.WriteHelp(os.Stdout)
+			os.Exit(0)
 		} else {
 			fmt.Fprintf(ui.Stderr, "error: %s\n", err)
 		}

--- a/fly/main.go
+++ b/fly/main.go
@@ -64,21 +64,21 @@ func handleError(helpParser *flags.Parser, err error) {
 			fmt.Fprintln(ui.Stderr, "")
 			fmt.Fprintln(ui.Stderr, "is the targeted Concourse running? better go catch it lol")
 		} else if err == commands.ErrShowHelpMessage {
-			helpParser.ParseArgs([]string{"-h"})
-			helpParser.WriteHelp(os.Stdout)
-			os.Exit(0)
+			showHelp(helpParser)
 		} else if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrCommandRequired {
-			helpParser.ParseArgs([]string{"-h"})
-			helpParser.WriteHelp(os.Stdout)
-			os.Exit(0)
+			showHelp(helpParser)
 		} else if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
-			helpParser.ParseArgs([]string{"-h"})
-			helpParser.WriteHelp(os.Stdout)
-			os.Exit(0)
+			showHelp(helpParser)
 		} else {
 			fmt.Fprintf(ui.Stderr, "error: %s\n", err)
 		}
 
 		os.Exit(1)
 	}
+}
+
+func showHelp(helpParser *flags.Parser) {
+	helpParser.ParseArgs([]string{"-h"})
+	helpParser.WriteHelp(os.Stdout)
+	os.Exit(0)
 }


### PR DESCRIPTION
`fly` cli should show by executing `fly -h` or `fly --help`

```
$ fly help
Usage:
  fly [OPTIONS] <command>

Application Options:
  -t, --target=              Concourse target name
  -v, --version              Print the version of Fly and exit
      --verbose              Print API requests and responses
      --print-table-headers  Print table headers even for redirected output

Help Options:
#### HERE!!
  -h, --help                 Show this help message
```

But these commands end which `exit 1`.
```bash
$ fly -h
$ echo $?
1
$ fly --help
$ echo $?
1
```

And these commands output logs to stderr, so `grep` command, etc can't be used.
```bash
$ fly -h | grep volume
error: Usage:
  fly [OPTIONS] <command>

Application Options:
  -t, --target=              Concourse target name
  -v, --version              Print the version of Fly and exit
      --verbose              Print API requests and responses
      --print-table-headers  Print table headers even for redirected output

Help Options:
  -h, --help                 Show this help message

<snip>
```

I intend to solve the above problems.

#### additional
I just noticed that this pr fixes https://github.com/concourse/concourse/issues/1069