### PR TITLE
fix file permission when uploading local input during fly execute

### DIFF
--- a/atc/api/artifactserver/create.go
+++ b/atc/api/artifactserver/create.go
@@ -20,11 +20,16 @@ func (s *Server) CreateArtifact(team db.Team) http.Handler {
 		// which we can lookup in the checksum field
 		// that way we don't have to create another volume.
 
-		spec := worker.VolumeSpec{
+		workerSpec := worker.WorkerSpec{
+			TeamID:   team.ID(),
+			Platform: r.FormValue("platform"),
+		}
+
+		volumeSpec := worker.VolumeSpec{
 			Strategy: baggageclaim.EmptyStrategy{},
 		}
 
-		volume, err := s.workerClient.CreateVolume(hLog, spec, team.ID(), db.VolumeTypeArtifact)
+		volume, err := s.workerClient.CreateVolume(hLog, volumeSpec, workerSpec, db.VolumeTypeArtifact)
 		if err != nil {
 			hLog.Error("failed-to-create-volume", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -10,7 +10,7 @@ import (
 type Client interface {
 	FindContainer(logger lager.Logger, teamID int, handle string) (Container, bool, error)
 	FindVolume(logger lager.Logger, teamID int, handle string) (Volume, bool, error)
-	CreateVolume(logger lager.Logger, spec VolumeSpec, teamID int, volumeType db.VolumeType) (Volume, error)
+	CreateVolume(logger lager.Logger, vSpec VolumeSpec, wSpec WorkerSpec, volumeType db.VolumeType) (Volume, error)
 }
 
 func NewClient(pool Pool, provider WorkerProvider) *client {
@@ -59,11 +59,11 @@ func (client *client) FindVolume(logger lager.Logger, teamID int, handle string)
 	return worker.LookupVolume(logger, handle)
 }
 
-func (client *client) CreateVolume(logger lager.Logger, spec VolumeSpec, teamID int, volumeType db.VolumeType) (Volume, error) {
-	worker, err := client.pool.FindOrChooseWorker(logger, WorkerSpec{TeamID: teamID})
+func (client *client) CreateVolume(logger lager.Logger, volumeSpec VolumeSpec, workerSpec WorkerSpec, volumeType db.VolumeType) (Volume, error) {
+	worker, err := client.pool.FindOrChooseWorker(logger, workerSpec)
 	if err != nil {
 		return nil, err
 	}
 
-	return worker.CreateVolume(logger, spec, teamID, volumeType)
+	return worker.CreateVolume(logger, volumeSpec, workerSpec.TeamID, volumeType)
 }

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -151,6 +151,7 @@ var _ = Describe("Client", func() {
 		var (
 			fakeWorker *workerfakes.FakeWorker
 			volumeSpec worker.VolumeSpec
+			workerSpec worker.WorkerSpec
 			volumeType db.VolumeType
 			err        error
 		)
@@ -160,11 +161,15 @@ var _ = Describe("Client", func() {
 				Strategy: baggageclaim.EmptyStrategy{},
 			}
 
+			workerSpec = worker.WorkerSpec{
+				TeamID: 1,
+			}
+
 			volumeType = db.VolumeTypeArtifact
 		})
 
 		JustBeforeEach(func() {
-			_, err = client.CreateVolume(logger, volumeSpec, 1, volumeType)
+			_, err = client.CreateVolume(logger, volumeSpec, workerSpec, volumeType)
 		})
 
 		Context("when no workers can be found", func() {

--- a/atc/worker/workerfakes/fake_client.go
+++ b/atc/worker/workerfakes/fake_client.go
@@ -2,20 +2,20 @@
 package workerfakes
 
 import (
-	sync "sync"
+	"sync"
 
-	lager "code.cloudfoundry.org/lager"
-	db "github.com/concourse/concourse/atc/db"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeClient struct {
-	CreateVolumeStub        func(lager.Logger, worker.VolumeSpec, int, db.VolumeType) (worker.Volume, error)
+	CreateVolumeStub        func(lager.Logger, worker.VolumeSpec, worker.WorkerSpec, db.VolumeType) (worker.Volume, error)
 	createVolumeMutex       sync.RWMutex
 	createVolumeArgsForCall []struct {
 		arg1 lager.Logger
 		arg2 worker.VolumeSpec
-		arg3 int
+		arg3 worker.WorkerSpec
 		arg4 db.VolumeType
 	}
 	createVolumeReturns struct {
@@ -64,13 +64,13 @@ type FakeClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClient) CreateVolume(arg1 lager.Logger, arg2 worker.VolumeSpec, arg3 int, arg4 db.VolumeType) (worker.Volume, error) {
+func (fake *FakeClient) CreateVolume(arg1 lager.Logger, arg2 worker.VolumeSpec, arg3 worker.WorkerSpec, arg4 db.VolumeType) (worker.Volume, error) {
 	fake.createVolumeMutex.Lock()
 	ret, specificReturn := fake.createVolumeReturnsOnCall[len(fake.createVolumeArgsForCall)]
 	fake.createVolumeArgsForCall = append(fake.createVolumeArgsForCall, struct {
 		arg1 lager.Logger
 		arg2 worker.VolumeSpec
-		arg3 int
+		arg3 worker.WorkerSpec
 		arg4 db.VolumeType
 	}{arg1, arg2, arg3, arg4})
 	fake.recordInvocation("CreateVolume", []interface{}{arg1, arg2, arg3, arg4})
@@ -91,7 +91,13 @@ func (fake *FakeClient) CreateVolumeCallCount() int {
 	return len(fake.createVolumeArgsForCall)
 }
 
-func (fake *FakeClient) CreateVolumeArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, db.VolumeType) {
+func (fake *FakeClient) CreateVolumeCalls(stub func(lager.Logger, worker.VolumeSpec, worker.WorkerSpec, db.VolumeType) (worker.Volume, error)) {
+	fake.createVolumeMutex.Lock()
+	defer fake.createVolumeMutex.Unlock()
+	fake.CreateVolumeStub = stub
+}
+
+func (fake *FakeClient) CreateVolumeArgsForCall(i int) (lager.Logger, worker.VolumeSpec, worker.WorkerSpec, db.VolumeType) {
 	fake.createVolumeMutex.RLock()
 	defer fake.createVolumeMutex.RUnlock()
 	argsForCall := fake.createVolumeArgsForCall[i]
@@ -99,6 +105,8 @@ func (fake *FakeClient) CreateVolumeArgsForCall(i int) (lager.Logger, worker.Vol
 }
 
 func (fake *FakeClient) CreateVolumeReturns(result1 worker.Volume, result2 error) {
+	fake.createVolumeMutex.Lock()
+	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	fake.createVolumeReturns = struct {
 		result1 worker.Volume
@@ -107,6 +115,8 @@ func (fake *FakeClient) CreateVolumeReturns(result1 worker.Volume, result2 error
 }
 
 func (fake *FakeClient) CreateVolumeReturnsOnCall(i int, result1 worker.Volume, result2 error) {
+	fake.createVolumeMutex.Lock()
+	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	if fake.createVolumeReturnsOnCall == nil {
 		fake.createVolumeReturnsOnCall = make(map[int]struct {
@@ -146,6 +156,12 @@ func (fake *FakeClient) FindContainerCallCount() int {
 	return len(fake.findContainerArgsForCall)
 }
 
+func (fake *FakeClient) FindContainerCalls(stub func(lager.Logger, int, string) (worker.Container, bool, error)) {
+	fake.findContainerMutex.Lock()
+	defer fake.findContainerMutex.Unlock()
+	fake.FindContainerStub = stub
+}
+
 func (fake *FakeClient) FindContainerArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findContainerMutex.RLock()
 	defer fake.findContainerMutex.RUnlock()
@@ -154,6 +170,8 @@ func (fake *FakeClient) FindContainerArgsForCall(i int) (lager.Logger, int, stri
 }
 
 func (fake *FakeClient) FindContainerReturns(result1 worker.Container, result2 bool, result3 error) {
+	fake.findContainerMutex.Lock()
+	defer fake.findContainerMutex.Unlock()
 	fake.FindContainerStub = nil
 	fake.findContainerReturns = struct {
 		result1 worker.Container
@@ -163,6 +181,8 @@ func (fake *FakeClient) FindContainerReturns(result1 worker.Container, result2 b
 }
 
 func (fake *FakeClient) FindContainerReturnsOnCall(i int, result1 worker.Container, result2 bool, result3 error) {
+	fake.findContainerMutex.Lock()
+	defer fake.findContainerMutex.Unlock()
 	fake.FindContainerStub = nil
 	if fake.findContainerReturnsOnCall == nil {
 		fake.findContainerReturnsOnCall = make(map[int]struct {
@@ -204,6 +224,12 @@ func (fake *FakeClient) FindVolumeCallCount() int {
 	return len(fake.findVolumeArgsForCall)
 }
 
+func (fake *FakeClient) FindVolumeCalls(stub func(lager.Logger, int, string) (worker.Volume, bool, error)) {
+	fake.findVolumeMutex.Lock()
+	defer fake.findVolumeMutex.Unlock()
+	fake.FindVolumeStub = stub
+}
+
 func (fake *FakeClient) FindVolumeArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findVolumeMutex.RLock()
 	defer fake.findVolumeMutex.RUnlock()
@@ -212,6 +238,8 @@ func (fake *FakeClient) FindVolumeArgsForCall(i int) (lager.Logger, int, string)
 }
 
 func (fake *FakeClient) FindVolumeReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeMutex.Lock()
+	defer fake.findVolumeMutex.Unlock()
 	fake.FindVolumeStub = nil
 	fake.findVolumeReturns = struct {
 		result1 worker.Volume
@@ -221,6 +249,8 @@ func (fake *FakeClient) FindVolumeReturns(result1 worker.Volume, result2 bool, r
 }
 
 func (fake *FakeClient) FindVolumeReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeMutex.Lock()
+	defer fake.findVolumeMutex.Unlock()
 	fake.FindVolumeStub = nil
 	if fake.findVolumeReturnsOnCall == nil {
 		fake.findVolumeReturnsOnCall = make(map[int]struct {

--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -65,6 +65,7 @@ func (command *ExecuteCommand) Execute(args []string) error {
 		command.Image,
 		command.InputsFrom,
 		command.IncludeIgnored,
+		taskConfig.Platform,
 	)
 	if err != nil {
 		return err

--- a/fly/commands/internal/executehelpers/inputs.go
+++ b/fly/commands/internal/executehelpers/inputs.go
@@ -30,6 +30,7 @@ func DetermineInputs(
 	jobInputImage string,
 	inputsFrom flaghelpers.JobFlag,
 	includeIgnored bool,
+	platform string,
 ) ([]Input, map[string]string, *atc.ImageResource, error) {
 	inputMappings := ConvertInputMappings(userInputMappings)
 
@@ -55,7 +56,7 @@ func DetermineInputs(
 		})
 	}
 
-	inputsFromLocal, err := GenerateLocalInputs(fact, team, localInputMappings, includeIgnored)
+	inputsFromLocal, err := GenerateLocalInputs(fact, team, localInputMappings, includeIgnored, platform)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -138,6 +139,7 @@ func GenerateLocalInputs(
 	team concourse.Team,
 	inputMappings []flaghelpers.InputPairFlag,
 	includeIgnored bool,
+	platform string,
 ) (map[string]Input, error) {
 	inputs := map[string]Input{}
 
@@ -150,7 +152,7 @@ func GenerateLocalInputs(
 		path := mapping.Path
 
 		prog.Go("uploading "+name, func(bar *mpb.Bar) error {
-			artifact, err := Upload(bar, team, path, includeIgnored)
+			artifact, err := Upload(bar, team, path, includeIgnored, platform)
 			if err != nil {
 				return err
 			}

--- a/fly/commands/internal/executehelpers/uploads.go
+++ b/fly/commands/internal/executehelpers/uploads.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vbauerster/mpb/v4"
 )
 
-func Upload(bar *mpb.Bar, team concourse.Team, path string, includeIgnored bool) (atc.WorkerArtifact, error) {
+func Upload(bar *mpb.Bar, team concourse.Team, path string, includeIgnored bool, platform string) (atc.WorkerArtifact, error) {
 	files := getFiles(path, includeIgnored)
 
 	archiveStream, archiveWriter := io.Pipe()
@@ -22,7 +22,7 @@ func Upload(bar *mpb.Bar, team concourse.Team, path string, includeIgnored bool)
 		archiveWriter.CloseWithError(tarfs.Compress(zstd.NewWriter(archiveWriter), path, files...))
 	}()
 
-	return team.CreateArtifact(bar.ProxyReader(archiveStream))
+	return team.CreateArtifact(bar.ProxyReader(archiveStream), platform)
 }
 
 func getFiles(dir string, includeIgnored bool) []string {

--- a/fly/integration/execute_multiple_inputs_test.go
+++ b/fly/integration/execute_multiple_inputs_test.go
@@ -131,6 +131,8 @@ run:
 		atcServer.RouteToHandler("POST", "/api/v1/teams/main/artifacts",
 			ghttp.CombineHandlers(
 				func(w http.ResponseWriter, req *http.Request) {
+					Expect(req.FormValue("platform")).To(Equal("some-platform"))
+
 					tr := tar.NewReader(zstd.NewReader(req.Body))
 
 					hdr, err := tr.Next()

--- a/fly/integration/execute_overriding_inputs_test.go
+++ b/fly/integration/execute_overriding_inputs_test.go
@@ -164,6 +164,8 @@ run:
 				func(w http.ResponseWriter, req *http.Request) {
 					close(uploading)
 
+					Expect(req.FormValue("platform")).To(Equal("some-platform"))
+
 					tr := tar.NewReader(zstd.NewReader(req.Body))
 
 					hdr, err := tr.Next()

--- a/fly/integration/execute_test.go
+++ b/fly/integration/execute_test.go
@@ -419,6 +419,8 @@ run: {}
 							func(w http.ResponseWriter, req *http.Request) {
 								close(uploading)
 
+								Expect(req.FormValue("platform")).To(Equal("some-platform"))
+
 								tr := tar.NewReader(zstd.NewReader(req.Body))
 
 								var matchFound = false

--- a/fly/integration/execute_with_outputs_test.go
+++ b/fly/integration/execute_with_outputs_test.go
@@ -145,6 +145,8 @@ run:
 		atcServer.RouteToHandler("POST", "/api/v1/teams/main/artifacts",
 			ghttp.CombineHandlers(
 				func(w http.ResponseWriter, req *http.Request) {
+					Expect(req.FormValue("platform")).To(Equal("some-platform"))
+
 					tr := tar.NewReader(zstd.NewReader(req.Body))
 
 					hdr, err := tr.Next()

--- a/go-concourse/concourse/artifacts.go
+++ b/go-concourse/concourse/artifacts.go
@@ -3,6 +3,7 @@ package concourse
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/concourse/concourse/atc"
@@ -10,7 +11,7 @@ import (
 	"github.com/tedsuo/rata"
 )
 
-func (team *team) CreateArtifact(src io.Reader) (atc.WorkerArtifact, error) {
+func (team *team) CreateArtifact(src io.Reader, platform string) (atc.WorkerArtifact, error) {
 	var artifact atc.WorkerArtifact
 
 	params := rata.Params{
@@ -21,6 +22,7 @@ func (team *team) CreateArtifact(src io.Reader) (atc.WorkerArtifact, error) {
 		Header:      http.Header{"Content-Type": {"application/octet-stream"}},
 		RequestName: atc.CreateArtifact,
 		Params:      params,
+		Query:       url.Values{"platform": {platform}},
 		Body:        src,
 	}, &internal.Response{
 		Result: &artifact,

--- a/go-concourse/concourse/artifacts_test.go
+++ b/go-concourse/concourse/artifacts_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Artifacts", func() {
 			})
 
 			It("errors", func() {
-				_, err := team.CreateArtifact(bytes.NewBufferString("some-contents"))
+				_, err := team.CreateArtifact(bytes.NewBufferString("some-contents"), "some-platform")
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -45,7 +45,7 @@ var _ = Describe("Artifacts", func() {
 			})
 
 			It("returns json", func() {
-				artifact, err := team.CreateArtifact(bytes.NewBufferString("some-contents"))
+				artifact, err := team.CreateArtifact(bytes.NewBufferString("some-contents"), "some-platform")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(artifact.ID).To(Equal(17))
 			})

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -2,11 +2,11 @@
 package concoursefakes
 
 import (
-	"io"
-	"sync"
+	io "io"
+	sync "sync"
 
-	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/go-concourse/concourse"
+	atc "github.com/concourse/concourse/atc"
+	concourse "github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type FakeTeam struct {
@@ -121,10 +121,11 @@ type FakeTeam struct {
 		result1 int64
 		result2 error
 	}
-	CreateArtifactStub        func(io.Reader) (atc.WorkerArtifact, error)
+	CreateArtifactStub        func(io.Reader, string) (atc.WorkerArtifact, error)
 	createArtifactMutex       sync.RWMutex
 	createArtifactArgsForCall []struct {
 		arg1 io.Reader
+		arg2 string
 	}
 	createArtifactReturns struct {
 		result1 atc.WorkerArtifact
@@ -1120,16 +1121,17 @@ func (fake *FakeTeam) ClearTaskCacheReturnsOnCall(i int, result1 int64, result2 
 	}{result1, result2}
 }
 
-func (fake *FakeTeam) CreateArtifact(arg1 io.Reader) (atc.WorkerArtifact, error) {
+func (fake *FakeTeam) CreateArtifact(arg1 io.Reader, arg2 string) (atc.WorkerArtifact, error) {
 	fake.createArtifactMutex.Lock()
 	ret, specificReturn := fake.createArtifactReturnsOnCall[len(fake.createArtifactArgsForCall)]
 	fake.createArtifactArgsForCall = append(fake.createArtifactArgsForCall, struct {
 		arg1 io.Reader
-	}{arg1})
-	fake.recordInvocation("CreateArtifact", []interface{}{arg1})
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("CreateArtifact", []interface{}{arg1, arg2})
 	fake.createArtifactMutex.Unlock()
 	if fake.CreateArtifactStub != nil {
-		return fake.CreateArtifactStub(arg1)
+		return fake.CreateArtifactStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1144,17 +1146,17 @@ func (fake *FakeTeam) CreateArtifactCallCount() int {
 	return len(fake.createArtifactArgsForCall)
 }
 
-func (fake *FakeTeam) CreateArtifactCalls(stub func(io.Reader) (atc.WorkerArtifact, error)) {
+func (fake *FakeTeam) CreateArtifactCalls(stub func(io.Reader, string) (atc.WorkerArtifact, error)) {
 	fake.createArtifactMutex.Lock()
 	defer fake.createArtifactMutex.Unlock()
 	fake.CreateArtifactStub = stub
 }
 
-func (fake *FakeTeam) CreateArtifactArgsForCall(i int) io.Reader {
+func (fake *FakeTeam) CreateArtifactArgsForCall(i int) (io.Reader, string) {
 	fake.createArtifactMutex.RLock()
 	defer fake.createArtifactMutex.RUnlock()
 	argsForCall := fake.createArtifactArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeTeam) CreateArtifactReturns(result1 atc.WorkerArtifact, result2 error) {

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -63,7 +63,7 @@ type Team interface {
 	Builds(page Page) ([]atc.Build, Pagination, error)
 	OrderingPipelines(pipelineNames []string) error
 
-	CreateArtifact(io.Reader) (atc.WorkerArtifact, error)
+	CreateArtifact(io.Reader, string) (atc.WorkerArtifact, error)
 	GetArtifact(int) (io.ReadCloser, error)
 }
 


### PR DESCRIPTION
concourse/concourse#3803

when uploading local inputs for fly execute it will send "platform" of task config to create artifact endpoint. Then it will include platform info in worker spec for choosing a worker for artifact volume initializing.
