### PR TITLE
[POC] Limit tasks per worker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-.DS_Store
-.idea
-*.iml
 node_modules
 *-packr.go
 tags
@@ -13,3 +10,9 @@ ci/deployments/*/.terraform/
 ci/deployments/*/keys/gcp.json
 ci/deployments/*/keys/id_rsa
 ci/deployments/*/keys/id_rsa.pub
+
+# Editors
+.DS_Store
+.idea
+.vscode
+*.iml

--- a/atc/db/migration/migrations/1510262030_initial_schema.up.sql
+++ b/atc/db/migration/migrations/1510262030_initial_schema.up.sql
@@ -179,6 +179,7 @@ BEGIN;
       team_id integer,
       state container_state DEFAULT 'creating'::container_state NOT NULL,
       hijacked boolean DEFAULT false NOT NULL,
+      running_task boolean DEFAULT false NOT NULL,
       discontinued boolean DEFAULT false NOT NULL,
       meta_type text DEFAULT ''::text NOT NULL,
       meta_step_name text DEFAULT ''::text NOT NULL,

--- a/atc/db/worker_factory.go
+++ b/atc/db/worker_factory.go
@@ -342,7 +342,7 @@ func (f *workerFactory) FindWorkersForContainerByOwner(owner ContainerOwner) ([]
 func (f *workerFactory) BuildContainersCountPerWorker() (map[string]int, error) {
 	rows, err := psql.Select("worker_name, COUNT(*)").
 		From("containers").
-		Where("build_id IS NOT NULL").
+		Where("build_id IS NOT NULL AND running_task='true'").
 		GroupBy("worker_name").
 		RunWith(f.conn).
 		Query()

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -270,6 +270,9 @@ func (step *TaskStep) Run(ctx context.Context, state RunState) error {
 	}
 
 	logger.Info("attached")
+	container.SetRunningTask(true)
+	running, err := container.RunningTask()
+	logger.Info(fmt.Sprintf("Process started. Running task? %t", running))
 
 	exited := make(chan struct{})
 	var processStatus int
@@ -277,6 +280,9 @@ func (step *TaskStep) Run(ctx context.Context, state RunState) error {
 
 	go func() {
 		processStatus, processErr = process.Wait()
+		container.SetRunningTask(false)
+		running, err = container.RunningTask()
+		logger.Info(fmt.Sprintf("Process stopped. Running task? %t", running))
 		close(exited)
 	}()
 

--- a/atc/worker/container.go
+++ b/atc/worker/container.go
@@ -22,6 +22,10 @@ type Container interface {
 	WorkerName() string
 
 	MarkAsHijacked() error
+
+	RunningTask() (bool, error)
+
+	SetRunningTask(bool) error
 }
 
 type gardenWorkerContainer struct {
@@ -87,6 +91,14 @@ func (container *gardenWorkerContainer) WorkerName() string {
 
 func (container *gardenWorkerContainer) MarkAsHijacked() error {
 	return container.dbContainer.MarkAsHijacked()
+}
+
+func (container *gardenWorkerContainer) RunningTask() (bool, error) {
+	return container.dbContainer.RunningTask()
+}
+
+func (container *gardenWorkerContainer) SetRunningTask(set bool) error {
+	return container.dbContainer.SetRunningTask(set)
 }
 
 func (container *gardenWorkerContainer) Run(spec garden.ProcessSpec, io garden.ProcessIO) (garden.Process, error) {


### PR DESCRIPTION
This is a POC to attempt fixing #2928.
I have started by using the number of "Build containers" in a worker to evaluate if the worker can accept more tasks. However the lifetime of a container is longer than the lifetime of the task: this is especially evident in cases where a task fails or gets aborted.

To circumvent the above limitation I have added a column to the containers DB table: "running_task" that the task step sets to true when starts and to false when it completes. This allow to schedule tasks on workers that, effectively, are not executing a task.

As a side effect the strategy `fewest-build-containers` is more accurate, in the sense that now it counts the build containers on a worker that are active AND running a task.

With this draft PR I would like some feedback to understand if I am going in an acceptable direction, of course there are still many refinements to do before this could be a real PR, including but not limited to:

- Parametrize the maximum number of active tasks per worker as an option
- Set a limit on the amount of time the task can wait for a free worker
- Take into account the new column in the database migration
- Remove silly debug messages
- Add tests
- Tackle the corner case where tasks scheduled close to one another can still
end up on the same worker? (e.g. a job with in_parallel tasks).

What do you think?