### PR TITLE
atc: add type column to resources

### DIFF
--- a/atc/db/migration/migrations/1561558376_add_type_to_resources.down.sql
+++ b/atc/db/migration/migrations/1561558376_add_type_to_resources.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE resources DROP COLUMN type;
+COMMIT;

--- a/atc/db/migration/migrations/1561558376_add_type_to_resources.up.go
+++ b/atc/db/migration/migrations/1561558376_add_type_to_resources.up.go
@@ -1,0 +1,73 @@
+package migrations
+
+import (
+	"database/sql"
+	"encoding/json"
+)
+
+func (self *migrations) Up_1561558376() error {
+	type resource struct {
+		id     int
+		config string
+		nonce  sql.NullString
+	}
+
+	tx, err := self.DB.Begin()
+	if err != nil {
+		return err
+	}
+
+	defer tx.Rollback()
+
+	_, err = tx.Exec("ALTER TABLE resources ADD COLUMN type text")
+	if err != nil {
+		return err
+	}
+
+	rows, err := tx.Query("SELECT id, config, nonce FROM resources")
+	if err != nil {
+		return err
+	}
+
+	resources := []resource{}
+	for rows.Next() {
+
+		resource := resource{}
+		if err = rows.Scan(&resource.id, &resource.config, &resource.nonce); err != nil {
+			return err
+		}
+
+		resources = append(resources, resource)
+	}
+
+	for _, resource := range resources {
+
+		var noncense *string
+		if resource.nonce.Valid {
+			noncense = &resource.nonce.String
+		}
+
+		decrypted, err := self.Strategy.Decrypt(resource.config, noncense)
+		if err != nil {
+			return err
+		}
+
+		var payload map[string]interface{}
+		err = json.Unmarshal(decrypted, &payload)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Exec("UPDATE resources SET type = $1 WHERE id = $2", payload["type"], resource.id)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = tx.Exec("ALTER TABLE resources ALTER COLUMN type SET NOT NULL")
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -61,7 +61,7 @@ type Resource interface {
 	Reload() (bool, error)
 }
 
-var resourcesQuery = psql.Select("r.id, r.name, r.config, r.check_error, rs.last_check_start_time, rs.last_check_end_time, r.pipeline_id, r.nonce, r.resource_config_id, r.resource_config_scope_id, p.name, t.name, rs.check_error, rp.version, rp.comment_text").
+var resourcesQuery = psql.Select("r.id, r.name, r.type, r.config, r.check_error, rs.last_check_start_time, rs.last_check_end_time, r.pipeline_id, r.nonce, r.resource_config_id, r.resource_config_scope_id, p.name, t.name, rs.check_error, rp.version, rp.comment_text").
 	From("resources r").
 	Join("pipelines p ON p.id = r.pipeline_id").
 	Join("teams t ON t.id = p.team_id").
@@ -635,7 +635,7 @@ func scanResource(r *resource, row scannable) error {
 		lastCheckStartTime, lastCheckEndTime                                        pq.NullTime
 	)
 
-	err := row.Scan(&r.id, &r.name, &configBlob, &checkErr, &lastCheckStartTime, &lastCheckEndTime, &r.pipelineID, &nonce, &rcID, &rcScopeID, &r.pipelineName, &r.teamName, &rcsCheckErr, &apiPinnedVersion, &pinComment)
+	err := row.Scan(&r.id, &r.name, &r.type_, &configBlob, &checkErr, &lastCheckStartTime, &lastCheckEndTime, &r.pipelineID, &nonce, &rcID, &rcScopeID, &r.pipelineName, &r.teamName, &rcsCheckErr, &apiPinnedVersion, &pinComment)
 	if err != nil {
 		return err
 	}
@@ -662,7 +662,6 @@ func scanResource(r *resource, row scannable) error {
 	}
 
 	r.public = config.Public
-	r.type_ = config.Type
 	r.source = config.Source
 	r.checkEvery = config.CheckEvery
 	r.checkTimeout = config.CheckTimeout

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -1065,9 +1065,9 @@ func (t *team) saveResource(tx Tx, resource atc.ResourceConfig, pipelineID int) 
 
 	updated, err := checkIfRowsUpdated(tx, `
 		UPDATE resources
-		SET config = $3, active = true, nonce = $4
+		SET config = $3, active = true, nonce = $4, type = $5
 		WHERE name = $1 AND pipeline_id = $2
-	`, resource.Name, pipelineID, encryptedPayload, nonce)
+	`, resource.Name, pipelineID, encryptedPayload, nonce, resource.Type)
 	if err != nil {
 		return err
 	}
@@ -1092,9 +1092,9 @@ func (t *team) saveResource(tx Tx, resource atc.ResourceConfig, pipelineID int) 
 	}
 
 	_, err = tx.Exec(`
-		INSERT INTO resources (name, pipeline_id, config, active, nonce)
-		VALUES ($1, $2, $3, true, $4)
-	`, resource.Name, pipelineID, encryptedPayload, nonce)
+		INSERT INTO resources (name, pipeline_id, config, active, nonce, type)
+		VALUES ($1, $2, $3, true, $4, $5)
+	`, resource.Name, pipelineID, encryptedPayload, nonce, resource.Type)
 
 	return swallowUniqueViolation(err)
 }


### PR DESCRIPTION
This is so that we can join on parent `resource_types`. 

Considering the `resource_types` table already has a type column, this also makes things more consistent between the two.