### PR TITLE
manually revert changes from PR #3902

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -561,7 +561,7 @@ func (cmd *RunCommand) constructAPIMembers(
 		cmd.BaggageclaimResponseHeaderTimeout,
 	)
 
-	pool := worker.NewPool(clock.NewClock(), lockFactory, workerProvider)
+	pool := worker.NewPool(workerProvider)
 	workerClient := worker.NewClient(pool, workerProvider)
 
 	checkContainerStrategy := worker.NewRandomPlacementStrategy()
@@ -739,7 +739,7 @@ func (cmd *RunCommand) constructBackendMembers(
 		cmd.BaggageclaimResponseHeaderTimeout,
 	)
 
-	pool := worker.NewPool(clock.NewClock(), lockFactory, workerProvider)
+	pool := worker.NewPool(workerProvider)
 	workerClient := worker.NewClient(pool, workerProvider)
 
 	defaultLimits, err := cmd.parseDefaultLimits()

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -183,7 +183,6 @@ func (step *GetStep) Run(ctx context.Context, state RunState) error {
 		logger,
 		resourceInstance.ContainerOwner(),
 		containerSpec,
-		step.containerMetadata,
 		workerSpec,
 		step.strategy,
 	)

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -153,7 +153,7 @@ var _ = Describe("GetStep", func() {
 
 	It("finds or chooses a worker", func() {
 		Expect(fakePool.FindOrChooseWorkerForContainerCallCount()).To(Equal(1))
-		_, _, actualOwner, actualContainerSpec, actualContainerMetadata, actualWorkerSpec, strategy := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
+		_, _, actualOwner, actualContainerSpec, actualWorkerSpec, strategy := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
 		Expect(actualOwner).To(Equal(db.NewBuildStepContainerOwner(stepMetadata.BuildID, atc.PlanID(planID), stepMetadata.TeamID)))
 		Expect(actualContainerSpec).To(Equal(worker.ContainerSpec{
 			ImageSpec: worker.ImageSpec{
@@ -162,7 +162,6 @@ var _ = Describe("GetStep", func() {
 			TeamID: stepMetadata.TeamID,
 			Env:    stepMetadata.Env(),
 		}))
-		Expect(actualContainerMetadata).To(Equal(containerMetadata))
 		Expect(actualWorkerSpec).To(Equal(worker.WorkerSpec{
 			ResourceType:  "some-resource-type",
 			Tags:          atc.Tags{"some", "tags"},

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -145,7 +145,6 @@ func (step *PutStep) Run(ctx context.Context, state RunState) error {
 		logger,
 		owner,
 		containerSpec,
-		step.containerMetadata,
 		workerSpec,
 		step.strategy,
 	)
@@ -162,6 +161,7 @@ func (step *PutStep) Run(ctx context.Context, state RunState) error {
 		logger,
 		step.delegate,
 		owner,
+		step.containerMetadata,
 		containerSpec,
 		resourceTypes,
 	)

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -191,7 +191,7 @@ var _ = Describe("PutStep", func() {
 
 			It("finds/chooses a worker and creates a container with the correct type, session, and sources with no inputs specified (meaning it takes all artifacts)", func() {
 				Expect(fakePool.FindOrChooseWorkerForContainerCallCount()).To(Equal(1))
-				_, _, actualOwner, actualContainerSpec, actualContainerMetadata, actualWorkerSpec, strategy := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
+				_, _, actualOwner, actualContainerSpec, actualWorkerSpec, strategy := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
 				Expect(actualOwner).To(Equal(db.NewBuildStepContainerOwner(42, atc.PlanID(planID), 123)))
 				Expect(actualContainerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 					ResourceType: "some-resource-type",
@@ -201,7 +201,6 @@ var _ = Describe("PutStep", func() {
 				Expect(actualContainerSpec.Env).To(Equal(stepMetadata.Env()))
 				Expect(actualContainerSpec.Dir).To(Equal("/tmp/build/put"))
 				Expect(actualContainerSpec.Inputs).To(HaveLen(3))
-				Expect(actualContainerMetadata).To(Equal(containerMetadata))
 				Expect(actualWorkerSpec).To(Equal(worker.WorkerSpec{
 					TeamID:        123,
 					Tags:          []string{"some", "tags"},
@@ -210,8 +209,9 @@ var _ = Describe("PutStep", func() {
 				}))
 				Expect(strategy).To(Equal(fakeStrategy))
 
-				_, _, delegate, owner, containerSpec, actualResourceTypes := fakeWorker.FindOrCreateContainerArgsForCall(0)
+				_, _, delegate, owner, actualContainerMetadata, containerSpec, actualResourceTypes := fakeWorker.FindOrCreateContainerArgsForCall(0)
 				Expect(owner).To(Equal(db.NewBuildStepContainerOwner(42, atc.PlanID(planID), 123)))
+				Expect(actualContainerMetadata).To(Equal(containerMetadata))
 				Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 					ResourceType: "some-resource-type",
 				}))
@@ -242,7 +242,7 @@ var _ = Describe("PutStep", func() {
 				})
 
 				It("initializes the container with specified inputs", func() {
-					_, _, _, _, containerSpec, _ := fakeWorker.FindOrCreateContainerArgsForCall(0)
+					_, _, _, _, _, containerSpec, _ := fakeWorker.FindOrCreateContainerArgsForCall(0)
 					Expect(containerSpec.Inputs).To(HaveLen(2))
 					Expect([]worker.ArtifactSource{
 						containerSpec.Inputs[0].Source(),

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -195,7 +195,6 @@ func (step *TaskStep) Run(ctx context.Context, state RunState) error {
 		logger,
 		owner,
 		containerSpec,
-		step.containerMetadata,
 		workerSpec,
 		step.strategy,
 	)
@@ -208,6 +207,7 @@ func (step *TaskStep) Run(ctx context.Context, state RunState) error {
 		logger,
 		step.delegate,
 		owner,
+		step.containerMetadata,
 		containerSpec,
 		resourceTypes,
 	)

--- a/atc/radar/resource_scanner.go
+++ b/atc/radar/resource_scanner.go
@@ -326,9 +326,6 @@ func (scanner *resourceScanner) check(
 		logger,
 		owner,
 		containerSpec,
-		db.ContainerMetadata{
-			Type: db.ContainerTypeCheck,
-		},
 		workerSpec,
 		scanner.strategy,
 	)
@@ -345,6 +342,9 @@ func (scanner *resourceScanner) check(
 		logger,
 		worker.NoopImageFetchingDelegate{},
 		owner,
+		db.ContainerMetadata{
+			Type: db.ContainerTypeCheck,
+		},
 		containerSpec,
 		resourceTypes,
 	)

--- a/atc/radar/resource_scanner_test.go
+++ b/atc/radar/resource_scanner_test.go
@@ -238,7 +238,7 @@ var _ = Describe("ResourceScanner", func() {
 					err := fakeDBResource.SetCheckSetupErrorArgsForCall(0)
 					Expect(err).To(BeNil())
 
-					_, _, owner, containerSpec, metadata, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
+					_, _, owner, containerSpec, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
 					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, radar.ContainerExpiries)))
 					Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 						ResourceType: "git",
@@ -250,9 +250,6 @@ var _ = Describe("ResourceScanner", func() {
 						"RESOURCE_PIPELINE_NAME=some-pipeline",
 						"RESOURCE_NAME=some-resource",
 					}))
-					Expect(metadata).To(Equal(db.ContainerMetadata{
-						Type: db.ContainerTypeCheck,
-					}))
 					Expect(workerSpec).To(Equal(worker.WorkerSpec{
 						ResourceType:  "git",
 						Tags:          atc.Tags{"some-tag"},
@@ -260,9 +257,13 @@ var _ = Describe("ResourceScanner", func() {
 						TeamID:        123,
 					}))
 
+					var metadata db.ContainerMetadata
 					Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-					_, _, _, owner, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+					_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
 					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, radar.ContainerExpiries)))
+					Expect(metadata).To(Equal(db.ContainerMetadata{
+						Type: db.ContainerTypeCheck,
+					}))
 					Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 						ResourceType: "git",
 					}))
@@ -660,7 +661,7 @@ var _ = Describe("ResourceScanner", func() {
 				err := fakeDBResource.SetCheckSetupErrorArgsForCall(0)
 				Expect(err).To(BeNil())
 
-				_, _, owner, containerSpec, metadata, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
+				_, _, owner, containerSpec, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
 				Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, radar.ContainerExpiries)))
 				Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 					ResourceType: "git",
@@ -672,9 +673,6 @@ var _ = Describe("ResourceScanner", func() {
 					"RESOURCE_PIPELINE_NAME=some-pipeline",
 					"RESOURCE_NAME=some-resource",
 				}))
-				Expect(metadata).To(Equal(db.ContainerMetadata{
-					Type: db.ContainerTypeCheck,
-				}))
 				Expect(workerSpec).To(Equal(worker.WorkerSpec{
 					ResourceType:  "git",
 					Tags:          atc.Tags{"some-tag"},
@@ -682,8 +680,12 @@ var _ = Describe("ResourceScanner", func() {
 					TeamID:        123,
 				}))
 
-				_, _, _, owner, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+				var metadata db.ContainerMetadata
+				_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
 				Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, radar.ContainerExpiries)))
+				Expect(metadata).To(Equal(db.ContainerMetadata{
+					Type: db.ContainerTypeCheck,
+				}))
 				Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 					ResourceType: "git",
 				}))

--- a/atc/radar/resource_type_scanner.go
+++ b/atc/radar/resource_type_scanner.go
@@ -261,9 +261,6 @@ func (scanner *resourceTypeScanner) check(
 		logger,
 		owner,
 		containerSpec,
-		db.ContainerMetadata{
-			Type: db.ContainerTypeCheck,
-		},
 		workerSpec,
 		scanner.strategy,
 	)
@@ -281,6 +278,9 @@ func (scanner *resourceTypeScanner) check(
 		logger,
 		worker.NoopImageFetchingDelegate{},
 		db.NewResourceConfigCheckSessionContainerOwner(resourceConfigScope.ResourceConfig(), ContainerExpiries),
+		db.ContainerMetadata{
+			Type: db.ContainerTypeCheck,
+		},
 		containerSpec,
 		versionedResourceTypes.Without(savedResourceType.Name()),
 	)

--- a/atc/radar/resource_type_scanner_test.go
+++ b/atc/radar/resource_type_scanner_test.go
@@ -41,6 +41,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 		fakeClock                 *fakeclock.FakeClock
 		interval                  time.Duration
 		variables                 creds.Variables
+		metadata				  db.ContainerMetadata
 
 		fakeResourceType          *dbfakes.FakeResourceType
 		interpolatedResourceTypes atc.VersionedResourceTypes
@@ -186,16 +187,13 @@ var _ = Describe("ResourceTypeScanner", func() {
 					Expect(resourceSource).To(Equal(atc.Source{"custom": "some-secret-sauce"}))
 					Expect(resourceTypes).To(Equal(atc.VersionedResourceTypes{}))
 
-					_, _, owner, containerSpec, metadata, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
+					_, _, owner, containerSpec, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
 					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 					Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 						ResourceType: "registry-image",
 					}))
 					Expect(containerSpec.Tags).To(Equal([]string{"some-tag"}))
 					Expect(containerSpec.TeamID).To(Equal(123))
-					Expect(metadata).To(Equal(db.ContainerMetadata{
-						Type: db.ContainerTypeCheck,
-					}))
 					Expect(workerSpec).To(Equal(worker.WorkerSpec{
 						ResourceType:  "registry-image",
 						Tags:          []string{"some-tag"},
@@ -204,8 +202,11 @@ var _ = Describe("ResourceTypeScanner", func() {
 					}))
 
 					Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-					_, _, _, owner, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+					_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
 					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
+					Expect(metadata).To(Equal(db.ContainerMetadata{
+						Type: db.ContainerTypeCheck,
+					}))
 					Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 						ResourceType: "registry-image",
 					}))
@@ -243,15 +244,12 @@ var _ = Describe("ResourceTypeScanner", func() {
 						err := fakeResourceType.SetCheckSetupErrorArgsForCall(0)
 						Expect(err).To(BeNil())
 
-						_, _, owner, containerSpec, metadata, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
+						_, _, owner, containerSpec, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
 						Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 						Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 							ResourceType: "registry-image",
 						}))
 						Expect(containerSpec.TeamID).To(Equal(123))
-						Expect(metadata).To(Equal(db.ContainerMetadata{
-							Type: db.ContainerTypeCheck,
-						}))
 						Expect(workerSpec).To(Equal(worker.WorkerSpec{
 							ResourceType:  "registry-image",
 							ResourceTypes: interpolatedResourceTypes,
@@ -259,8 +257,11 @@ var _ = Describe("ResourceTypeScanner", func() {
 						}))
 
 						Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-						_, _, _, owner, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+						_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
 						Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
+						Expect(metadata).To(Equal(db.ContainerMetadata{
+							Type: db.ContainerTypeCheck,
+						}))
 						Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 							ResourceType: "registry-image",
 						}))
@@ -469,16 +470,13 @@ var _ = Describe("ResourceTypeScanner", func() {
 				err := fakeResourceType.SetCheckSetupErrorArgsForCall(0)
 				Expect(err).To(BeNil())
 
-				_, _, owner, containerSpec, metadata,  workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
+				_, _, owner, containerSpec, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
 				Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 				Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 					ResourceType: "registry-image",
 				}))
 				Expect(containerSpec.Tags).To(Equal([]string{"some-tag"}))
 				Expect(containerSpec.TeamID).To(Equal(123))
-				Expect(metadata).To(Equal(db.ContainerMetadata{
-					Type: db.ContainerTypeCheck,
-				}))
 				Expect(workerSpec).To(Equal(worker.WorkerSpec{
 					ResourceType:  "registry-image",
 					Tags:          []string{"some-tag"},
@@ -487,8 +485,11 @@ var _ = Describe("ResourceTypeScanner", func() {
 				}))
 
 				Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-				_, _, _, owner, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+				_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
 				Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
+				Expect(metadata).To(Equal(db.ContainerMetadata{
+					Type: db.ContainerTypeCheck,
+				}))
 				Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 					ResourceType: "registry-image",
 				}))
@@ -593,7 +594,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 					Expect(resourceSource).To(Equal(atc.Source{"custom": "some-secret-sauce"}))
 					Expect(resourceTypes).To(Equal(interpolatedResourceTypes))
 
-					_, _,  owner, containerSpec, metadata, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
+					_, _,  owner, containerSpec, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
 					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 					Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 						ResourceType: "registry-image",
@@ -604,13 +605,13 @@ var _ = Describe("ResourceTypeScanner", func() {
 						ResourceTypes: interpolatedResourceTypes,
 						TeamID:        123,
 					}))
+
+					Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
+					_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 					Expect(metadata).To(Equal(db.ContainerMetadata{
 						Type: db.ContainerTypeCheck,
 					}))
-
-					Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-					_, _, _, owner, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
-					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 					Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 						ResourceType: "registry-image",
 					}))

--- a/atc/resource/resource_instance_fetch_source.go
+++ b/atc/resource/resource_instance_fetch_source.go
@@ -130,21 +130,13 @@ func (s *resourceInstanceFetchSource) Create(ctx context.Context) (VersionedSour
 		&worker.CertsVolumeMount{Logger: s.logger},
 	}
 
-	err = s.worker.EnsureDBContainerExists(
-		ctx,
-		s.logger,
-		s.resourceInstance.ContainerOwner(),
-		s.session.Metadata,
-	)
-	if err != nil {
-		return nil, err
-	}
 
 	container, err := s.worker.FindOrCreateContainer(
 		ctx,
 		s.logger,
 		s.imageFetchingDelegate,
 		s.resourceInstance.ContainerOwner(),
+		s.session.Metadata,
 		s.containerSpec,
 		s.resourceTypes,
 	)

--- a/atc/resource/resource_instance_fetch_source_test.go
+++ b/atc/resource/resource_instance_fetch_source_test.go
@@ -202,15 +202,12 @@ var _ = Describe("ResourceInstanceFetchSource", func() {
 
 			It("creates container with volume and worker", func() {
 				Expect(initErr).NotTo(HaveOccurred())
-				Expect(fakeWorker.EnsureDBContainerExistsCallCount()).To(Equal(1))
-				_, _, owner, actualMetadata := fakeWorker.EnsureDBContainerExistsArgsForCall(0)
-				Expect(owner).To(Equal(db.NewBuildStepContainerOwner(43, atc.PlanID("some-plan-id"), 42)))
-				Expect(actualMetadata).To(Equal(metadata))
 
 				Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-				_, logger, delegate, owner, containerSpec, types := fakeWorker.FindOrCreateContainerArgsForCall(0)
+				_, logger, delegate, owner, actualMetadata, containerSpec, types := fakeWorker.FindOrCreateContainerArgsForCall(0)
 				Expect(delegate).To(Equal(fakeDelegate))
 				Expect(owner).To(Equal(db.NewBuildStepContainerOwner(43, atc.PlanID("some-plan-id"), 42)))
+				Expect(actualMetadata).To(Equal(metadata))
 				Expect(containerSpec).To(Equal(worker.ContainerSpec{
 					TeamID: 42,
 					Tags:   []string{},

--- a/atc/worker/db_worker_provider_test.go
+++ b/atc/worker/db_worker_provider_test.go
@@ -429,6 +429,7 @@ var _ = Describe("DBProvider", func() {
 						logger,
 						fakeImageFetchingDelegate,
 						db.NewBuildStepContainerOwner(42, atc.PlanID("some-plan-id"), 1),
+						db.ContainerMetadata{},
 						containerSpec,
 						nil,
 					)
@@ -502,6 +503,7 @@ var _ = Describe("DBProvider", func() {
 						logger,
 						fakeImageFetchingDelegate,
 						db.NewBuildStepContainerOwner(42, atc.PlanID("some-plan-id"), 1),
+						db.ContainerMetadata{},
 						containerSpec,
 						nil,
 					)

--- a/atc/worker/image/image_resource_fetcher.go
+++ b/atc/worker/image/image_resource_fetcher.go
@@ -227,23 +227,15 @@ func (i *imageResourceFetcher) ensureVersionOfType(
 	}
 
 	owner := db.NewImageCheckContainerOwner(container, i.teamID)
-	err := i.worker.EnsureDBContainerExists(
-		ctx,
-		logger,
-		owner,
-		db.ContainerMetadata{
-			Type: db.ContainerTypeCheck,
-		},
-	)
-	if err != nil {
-		return err
-	}
 
 	resourceTypeContainer, err := i.worker.FindOrCreateContainer(
 		ctx,
 		logger,
 		worker.NoopImageFetchingDelegate{},
 		owner,
+		db.ContainerMetadata{
+			Type: db.ContainerTypeCheck,
+		},
 		containerSpec,
 		i.customTypes,
 	)
@@ -293,23 +285,15 @@ func (i *imageResourceFetcher) getLatestVersion(
 	}
 
 	owner := db.NewImageCheckContainerOwner(container, i.teamID)
-	err := i.worker.EnsureDBContainerExists(
-		ctx,
-		logger,
-		owner,
-		db.ContainerMetadata{
-			Type: db.ContainerTypeCheck,
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
 
 	imageContainer, err := i.worker.FindOrCreateContainer(
 		ctx,
 		logger,
 		i.imageFetchingDelegate,
 		owner,
+		db.ContainerMetadata{
+			Type: db.ContainerTypeCheck,
+		},
 		resourceSpec,
 		i.customTypes,
 	)

--- a/atc/worker/image/imagefakes/fake_image_resource_fetcher.go
+++ b/atc/worker/image/imagefakes/fake_image_resource_fetcher.go
@@ -2,15 +2,15 @@
 package imagefakes
 
 import (
-	"context"
-	"io"
-	"sync"
+	context "context"
+	io "io"
+	sync "sync"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/worker"
-	"github.com/concourse/concourse/atc/worker/image"
+	lager "code.cloudfoundry.org/lager"
+	atc "github.com/concourse/concourse/atc"
+	db "github.com/concourse/concourse/atc/db"
+	worker "github.com/concourse/concourse/atc/worker"
+	image "github.com/concourse/concourse/atc/worker/image"
 )
 
 type FakeImageResourceFetcher struct {
@@ -65,12 +65,6 @@ func (fake *FakeImageResourceFetcher) FetchCallCount() int {
 	return len(fake.fetchArgsForCall)
 }
 
-func (fake *FakeImageResourceFetcher) FetchCalls(stub func(context.Context, lager.Logger, db.CreatingContainer, bool) (worker.Volume, io.ReadCloser, atc.Version, error)) {
-	fake.fetchMutex.Lock()
-	defer fake.fetchMutex.Unlock()
-	fake.FetchStub = stub
-}
-
 func (fake *FakeImageResourceFetcher) FetchArgsForCall(i int) (context.Context, lager.Logger, db.CreatingContainer, bool) {
 	fake.fetchMutex.RLock()
 	defer fake.fetchMutex.RUnlock()
@@ -79,8 +73,6 @@ func (fake *FakeImageResourceFetcher) FetchArgsForCall(i int) (context.Context, 
 }
 
 func (fake *FakeImageResourceFetcher) FetchReturns(result1 worker.Volume, result2 io.ReadCloser, result3 atc.Version, result4 error) {
-	fake.fetchMutex.Lock()
-	defer fake.fetchMutex.Unlock()
 	fake.FetchStub = nil
 	fake.fetchReturns = struct {
 		result1 worker.Volume
@@ -91,8 +83,6 @@ func (fake *FakeImageResourceFetcher) FetchReturns(result1 worker.Volume, result
 }
 
 func (fake *FakeImageResourceFetcher) FetchReturnsOnCall(i int, result1 worker.Volume, result2 io.ReadCloser, result3 atc.Version, result4 error) {
-	fake.fetchMutex.Lock()
-	defer fake.fetchMutex.Unlock()
 	fake.FetchStub = nil
 	if fake.fetchReturnsOnCall == nil {
 		fake.fetchReturnsOnCall = make(map[int]struct {

--- a/atc/worker/image/imagefakes/fake_image_resource_fetcher_factory.go
+++ b/atc/worker/image/imagefakes/fake_image_resource_fetcher_factory.go
@@ -2,11 +2,11 @@
 package imagefakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/worker"
-	"github.com/concourse/concourse/atc/worker/image"
+	atc "github.com/concourse/concourse/atc"
+	worker "github.com/concourse/concourse/atc/worker"
+	image "github.com/concourse/concourse/atc/worker/image"
 )
 
 type FakeImageResourceFetcherFactory struct {
@@ -59,12 +59,6 @@ func (fake *FakeImageResourceFetcherFactory) NewImageResourceFetcherCallCount() 
 	return len(fake.newImageResourceFetcherArgsForCall)
 }
 
-func (fake *FakeImageResourceFetcherFactory) NewImageResourceFetcherCalls(stub func(worker.Worker, worker.ImageResource, atc.Version, int, atc.VersionedResourceTypes, worker.ImageFetchingDelegate) image.ImageResourceFetcher) {
-	fake.newImageResourceFetcherMutex.Lock()
-	defer fake.newImageResourceFetcherMutex.Unlock()
-	fake.NewImageResourceFetcherStub = stub
-}
-
 func (fake *FakeImageResourceFetcherFactory) NewImageResourceFetcherArgsForCall(i int) (worker.Worker, worker.ImageResource, atc.Version, int, atc.VersionedResourceTypes, worker.ImageFetchingDelegate) {
 	fake.newImageResourceFetcherMutex.RLock()
 	defer fake.newImageResourceFetcherMutex.RUnlock()
@@ -73,8 +67,6 @@ func (fake *FakeImageResourceFetcherFactory) NewImageResourceFetcherArgsForCall(
 }
 
 func (fake *FakeImageResourceFetcherFactory) NewImageResourceFetcherReturns(result1 image.ImageResourceFetcher) {
-	fake.newImageResourceFetcherMutex.Lock()
-	defer fake.newImageResourceFetcherMutex.Unlock()
 	fake.NewImageResourceFetcherStub = nil
 	fake.newImageResourceFetcherReturns = struct {
 		result1 image.ImageResourceFetcher
@@ -82,8 +74,6 @@ func (fake *FakeImageResourceFetcherFactory) NewImageResourceFetcherReturns(resu
 }
 
 func (fake *FakeImageResourceFetcherFactory) NewImageResourceFetcherReturnsOnCall(i int, result1 image.ImageResourceFetcher) {
-	fake.newImageResourceFetcherMutex.Lock()
-	defer fake.newImageResourceFetcherMutex.Unlock()
 	fake.NewImageResourceFetcherStub = nil
 	if fake.newImageResourceFetcherReturnsOnCall == nil {
 		fake.newImageResourceFetcherReturnsOnCall = make(map[int]struct {

--- a/atc/worker/pool_test.go
+++ b/atc/worker/pool_test.go
@@ -9,9 +9,7 @@ import (
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
-	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/db/lock/lockfakes"
 	. "github.com/concourse/concourse/atc/worker"
 	"github.com/concourse/concourse/atc/worker/workerfakes"
@@ -127,7 +125,6 @@ var _ = Describe("Pool", func() {
 				logger,
 				fakeOwner,
 				spec,
-				db.ContainerMetadata{},
 				workerSpec,
 				fakeStrategy,
 			)
@@ -148,50 +145,6 @@ var _ = Describe("Pool", func() {
 				fakeStrategy.ChooseReturns(workerA, nil)
 			})
 
-			Context("fails to acquire the pool lock", func() {
-				BeforeEach(func() {
-					fakeLockFactory.AcquireReturns(nil, false, ErrFailedAcquirePoolLock)
-				})
-
-				It("returns an error", func() {
-					Expect(fakeLockFactory.AcquireCallCount()).To(Equal(1))
-					fakeLockFactory.AcquireReturns(nil, false, ErrFailedAcquirePoolLock)
-					Expect(chooseErr).To(HaveOccurred())
-					Expect(chooseErr.Error()).To(Equal("failed to acquire pool lock"))
-				})
-			})
-
-			Context("lock is held by another", func() {
-				BeforeEach(func() {
-					callCount := 0
-					fakeLockFactory.AcquireStub = func(logger lager.Logger, lockID lock.LockID) (lock.Lock, bool, error) {
-						callCount++
-						go fakeClock.WaitForWatcherAndIncrement(time.Second)
-
-						if callCount < 3 {
-							return nil, false, nil
-						}
-
-						return fakeLock, true, nil
-					}
-				})
-
-				It("retries every second until it is", func() {
-					Expect(fakeLockFactory.AcquireCallCount()).To(Equal(3))
-					Expect(fakeLock.ReleaseCallCount()).To(Equal(1))
-				})
-			})
-
-			Context("lock is not held by anyone", func() {
-				BeforeEach(func() {
-					fakeLockFactory.AcquireReturns(fakeLock, true, nil)
-				})
-
-				It("acquires the lock", func() {
-					Expect(fakeLockFactory.AcquireCallCount()).To(Equal(1))
-					Expect(chooseErr).ToNot(HaveOccurred())
-				})
-			})
 		})
 
 		Context("when workers are found with the container", func() {
@@ -213,10 +166,6 @@ var _ = Describe("Pool", func() {
 				fakeProvider.FindWorkersForContainerByOwnerReturns([]Worker{workerA, workerB, workerC}, nil)
 				fakeProvider.RunningWorkersReturns([]Worker{workerA, workerB, workerC}, nil)
 				fakeStrategy.ChooseReturns(workerA, nil)
-			})
-
-			It("ensures a db container exists", func() {
-				Expect(workerA.EnsureDBContainerExistsCallCount()).To(Equal(1))
 			})
 
 			Context("when one of the workers satisfy the spec", func() {
@@ -319,10 +268,6 @@ var _ = Describe("Pool", func() {
 
 					fakeProvider.RunningWorkersReturns([]Worker{workerA, workerB, workerC}, nil)
 					fakeStrategy.ChooseReturns(workerA, nil)
-				})
-
-				It("ensures a db container exists", func() {
-					Expect(workerA.EnsureDBContainerExistsCallCount()).To(Equal(1))
 				})
 
 				It("checks that the workers satisfy the given worker spec", func() {
@@ -471,9 +416,6 @@ var _ = Describe("Pool", func() {
 						fakeStrategy.ChooseReturns(compatibleWorker, nil)
 					})
 
-					It("ensures a db container exists", func() {
-						Expect(compatibleWorker.EnsureDBContainerExistsCallCount()).To(Equal(1))
-					})
 					It("chooses a worker", func() {
 						Expect(chooseErr).ToNot(HaveOccurred())
 						Expect(fakeStrategy.ChooseCallCount()).To(Equal(1))

--- a/atc/worker/pool_test.go
+++ b/atc/worker/pool_test.go
@@ -3,14 +3,11 @@ package worker_test
 import (
 	"context"
 	"errors"
-	"time"
 
-	"code.cloudfoundry.org/clock/fakeclock"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db/dbfakes"
-	"github.com/concourse/concourse/atc/db/lock/lockfakes"
 	. "github.com/concourse/concourse/atc/worker"
 	"github.com/concourse/concourse/atc/worker/workerfakes"
 	. "github.com/onsi/ginkgo"
@@ -19,20 +16,16 @@ import (
 
 var _ = Describe("Pool", func() {
 	var (
-		fakeClock       *fakeclock.FakeClock
 		logger          *lagertest.TestLogger
 		fakeProvider    *workerfakes.FakeWorkerProvider
-		fakeLockFactory *lockfakes.FakeLockFactory
 		pool            Pool
 	)
 
 	BeforeEach(func() {
 		logger = lagertest.NewTestLogger("test")
 		fakeProvider = new(workerfakes.FakeWorkerProvider)
-		fakeLockFactory = new(lockfakes.FakeLockFactory)
-		fakeClock = fakeclock.NewFakeClock(time.Unix(123, 456))
 
-		pool = NewPool(fakeClock, fakeLockFactory, fakeProvider)
+		pool = NewPool(fakeProvider)
 	})
 
 	Describe("FindOrChooseWorkerForContainer", func() {
@@ -41,7 +34,6 @@ var _ = Describe("Pool", func() {
 			workerSpec    WorkerSpec
 			resourceTypes atc.VersionedResourceTypes
 			fakeOwner     *dbfakes.FakeContainerOwner
-			fakeLock      *lockfakes.FakeLock
 
 			chosenWorker Worker
 			chooseErr    error
@@ -114,9 +106,6 @@ var _ = Describe("Pool", func() {
 
 			compatibleWorker = new(workerfakes.FakeWorker)
 			compatibleWorker.SatisfiesReturns(true)
-
-			fakeLock = new(lockfakes.FakeLock)
-			fakeLockFactory.AcquireReturns(fakeLock, true, nil)
 		})
 
 		JustBeforeEach(func() {

--- a/atc/worker/transport/transportfakes/fake_read_closer.go
+++ b/atc/worker/transport/transportfakes/fake_read_closer.go
@@ -2,9 +2,9 @@
 package transportfakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"github.com/concourse/concourse/atc/worker/transport"
+	transport "github.com/concourse/concourse/atc/worker/transport"
 )
 
 type FakeReadCloser struct {
@@ -58,15 +58,7 @@ func (fake *FakeReadCloser) CloseCallCount() int {
 	return len(fake.closeArgsForCall)
 }
 
-func (fake *FakeReadCloser) CloseCalls(stub func() error) {
-	fake.closeMutex.Lock()
-	defer fake.closeMutex.Unlock()
-	fake.CloseStub = stub
-}
-
 func (fake *FakeReadCloser) CloseReturns(result1 error) {
-	fake.closeMutex.Lock()
-	defer fake.closeMutex.Unlock()
 	fake.CloseStub = nil
 	fake.closeReturns = struct {
 		result1 error
@@ -74,8 +66,6 @@ func (fake *FakeReadCloser) CloseReturns(result1 error) {
 }
 
 func (fake *FakeReadCloser) CloseReturnsOnCall(i int, result1 error) {
-	fake.closeMutex.Lock()
-	defer fake.closeMutex.Unlock()
 	fake.CloseStub = nil
 	if fake.closeReturnsOnCall == nil {
 		fake.closeReturnsOnCall = make(map[int]struct {
@@ -116,12 +106,6 @@ func (fake *FakeReadCloser) ReadCallCount() int {
 	return len(fake.readArgsForCall)
 }
 
-func (fake *FakeReadCloser) ReadCalls(stub func([]byte) (int, error)) {
-	fake.readMutex.Lock()
-	defer fake.readMutex.Unlock()
-	fake.ReadStub = stub
-}
-
 func (fake *FakeReadCloser) ReadArgsForCall(i int) []byte {
 	fake.readMutex.RLock()
 	defer fake.readMutex.RUnlock()
@@ -130,8 +114,6 @@ func (fake *FakeReadCloser) ReadArgsForCall(i int) []byte {
 }
 
 func (fake *FakeReadCloser) ReadReturns(result1 int, result2 error) {
-	fake.readMutex.Lock()
-	defer fake.readMutex.Unlock()
 	fake.ReadStub = nil
 	fake.readReturns = struct {
 		result1 int
@@ -140,8 +122,6 @@ func (fake *FakeReadCloser) ReadReturns(result1 int, result2 error) {
 }
 
 func (fake *FakeReadCloser) ReadReturnsOnCall(i int, result1 int, result2 error) {
-	fake.readMutex.Lock()
-	defer fake.readMutex.Unlock()
 	fake.ReadStub = nil
 	if fake.readReturnsOnCall == nil {
 		fake.readReturnsOnCall = make(map[int]struct {

--- a/atc/worker/transport/transportfakes/fake_request_generator.go
+++ b/atc/worker/transport/transportfakes/fake_request_generator.go
@@ -2,12 +2,12 @@
 package transportfakes
 
 import (
-	"io"
-	"net/http"
-	"sync"
+	io "io"
+	http "net/http"
+	sync "sync"
 
-	"github.com/concourse/concourse/atc/worker/transport"
-	"github.com/tedsuo/rata"
+	transport "github.com/concourse/concourse/atc/worker/transport"
+	rata "github.com/tedsuo/rata"
 )
 
 type FakeRequestGenerator struct {
@@ -56,12 +56,6 @@ func (fake *FakeRequestGenerator) CreateRequestCallCount() int {
 	return len(fake.createRequestArgsForCall)
 }
 
-func (fake *FakeRequestGenerator) CreateRequestCalls(stub func(string, rata.Params, io.Reader) (*http.Request, error)) {
-	fake.createRequestMutex.Lock()
-	defer fake.createRequestMutex.Unlock()
-	fake.CreateRequestStub = stub
-}
-
 func (fake *FakeRequestGenerator) CreateRequestArgsForCall(i int) (string, rata.Params, io.Reader) {
 	fake.createRequestMutex.RLock()
 	defer fake.createRequestMutex.RUnlock()
@@ -70,8 +64,6 @@ func (fake *FakeRequestGenerator) CreateRequestArgsForCall(i int) (string, rata.
 }
 
 func (fake *FakeRequestGenerator) CreateRequestReturns(result1 *http.Request, result2 error) {
-	fake.createRequestMutex.Lock()
-	defer fake.createRequestMutex.Unlock()
 	fake.CreateRequestStub = nil
 	fake.createRequestReturns = struct {
 		result1 *http.Request
@@ -80,8 +72,6 @@ func (fake *FakeRequestGenerator) CreateRequestReturns(result1 *http.Request, re
 }
 
 func (fake *FakeRequestGenerator) CreateRequestReturnsOnCall(i int, result1 *http.Request, result2 error) {
-	fake.createRequestMutex.Lock()
-	defer fake.createRequestMutex.Unlock()
 	fake.CreateRequestStub = nil
 	if fake.createRequestReturnsOnCall == nil {
 		fake.createRequestReturnsOnCall = make(map[int]struct {

--- a/atc/worker/transport/transportfakes/fake_round_tripper.go
+++ b/atc/worker/transport/transportfakes/fake_round_tripper.go
@@ -2,10 +2,10 @@
 package transportfakes
 
 import (
-	"net/http"
-	"sync"
+	http "net/http"
+	sync "sync"
 
-	"github.com/concourse/concourse/atc/worker/transport"
+	transport "github.com/concourse/concourse/atc/worker/transport"
 )
 
 type FakeRoundTripper struct {
@@ -50,12 +50,6 @@ func (fake *FakeRoundTripper) RoundTripCallCount() int {
 	return len(fake.roundTripArgsForCall)
 }
 
-func (fake *FakeRoundTripper) RoundTripCalls(stub func(*http.Request) (*http.Response, error)) {
-	fake.roundTripMutex.Lock()
-	defer fake.roundTripMutex.Unlock()
-	fake.RoundTripStub = stub
-}
-
 func (fake *FakeRoundTripper) RoundTripArgsForCall(i int) *http.Request {
 	fake.roundTripMutex.RLock()
 	defer fake.roundTripMutex.RUnlock()
@@ -64,8 +58,6 @@ func (fake *FakeRoundTripper) RoundTripArgsForCall(i int) *http.Request {
 }
 
 func (fake *FakeRoundTripper) RoundTripReturns(result1 *http.Response, result2 error) {
-	fake.roundTripMutex.Lock()
-	defer fake.roundTripMutex.Unlock()
 	fake.RoundTripStub = nil
 	fake.roundTripReturns = struct {
 		result1 *http.Response
@@ -74,8 +66,6 @@ func (fake *FakeRoundTripper) RoundTripReturns(result1 *http.Response, result2 e
 }
 
 func (fake *FakeRoundTripper) RoundTripReturnsOnCall(i int, result1 *http.Response, result2 error) {
-	fake.roundTripMutex.Lock()
-	defer fake.roundTripMutex.Unlock()
 	fake.RoundTripStub = nil
 	if fake.roundTripReturnsOnCall == nil {
 		fake.roundTripReturnsOnCall = make(map[int]struct {

--- a/atc/worker/transport/transportfakes/fake_transport_db.go
+++ b/atc/worker/transport/transportfakes/fake_transport_db.go
@@ -2,10 +2,10 @@
 package transportfakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/worker/transport"
+	db "github.com/concourse/concourse/atc/db"
+	transport "github.com/concourse/concourse/atc/worker/transport"
 )
 
 type FakeTransportDB struct {
@@ -52,12 +52,6 @@ func (fake *FakeTransportDB) GetWorkerCallCount() int {
 	return len(fake.getWorkerArgsForCall)
 }
 
-func (fake *FakeTransportDB) GetWorkerCalls(stub func(string) (db.Worker, bool, error)) {
-	fake.getWorkerMutex.Lock()
-	defer fake.getWorkerMutex.Unlock()
-	fake.GetWorkerStub = stub
-}
-
 func (fake *FakeTransportDB) GetWorkerArgsForCall(i int) string {
 	fake.getWorkerMutex.RLock()
 	defer fake.getWorkerMutex.RUnlock()
@@ -66,8 +60,6 @@ func (fake *FakeTransportDB) GetWorkerArgsForCall(i int) string {
 }
 
 func (fake *FakeTransportDB) GetWorkerReturns(result1 db.Worker, result2 bool, result3 error) {
-	fake.getWorkerMutex.Lock()
-	defer fake.getWorkerMutex.Unlock()
 	fake.GetWorkerStub = nil
 	fake.getWorkerReturns = struct {
 		result1 db.Worker
@@ -77,8 +69,6 @@ func (fake *FakeTransportDB) GetWorkerReturns(result1 db.Worker, result2 bool, r
 }
 
 func (fake *FakeTransportDB) GetWorkerReturnsOnCall(i int, result1 db.Worker, result2 bool, result3 error) {
-	fake.getWorkerMutex.Lock()
-	defer fake.getWorkerMutex.Unlock()
 	fake.GetWorkerStub = nil
 	if fake.getWorkerReturnsOnCall == nil {
 		fake.getWorkerReturnsOnCall = make(map[int]struct {

--- a/atc/worker/worker.go
+++ b/atc/worker/worker.go
@@ -51,6 +51,7 @@ type Worker interface {
 		lager.Logger,
 		ImageFetchingDelegate,
 		db.ContainerOwner,
+		db.ContainerMetadata,
 		ContainerSpec,
 		atc.VersionedResourceTypes,
 	) (Container, error)
@@ -178,6 +179,7 @@ func (worker *gardenWorker) FindOrCreateContainer(
 	logger lager.Logger,
 	delegate ImageFetchingDelegate,
 	owner db.ContainerOwner,
+	metadata db.ContainerMetadata,
 	containerSpec ContainerSpec,
 	resourceTypes atc.VersionedResourceTypes,
 ) (Container, error) {
@@ -189,6 +191,11 @@ func (worker *gardenWorker) FindOrCreateContainer(
 		containerHandle   string
 		err               error
 	)
+
+	err = worker.EnsureDBContainerExists(ctx, logger, owner, metadata)
+	if err != nil {
+		return nil, err
+	}
 
 	creatingContainer, createdContainer, err = worker.dbWorker.FindContainer(owner)
 	if err != nil {

--- a/atc/worker/worker_test.go
+++ b/atc/worker/worker_test.go
@@ -943,6 +943,7 @@ var _ = Describe("Worker", func() {
 				logger,
 				fakeImageFetchingDelegate,
 				fakeContainerOwner,
+				db.ContainerMetadata{},
 				containerSpec,
 				atcResourceTypes,
 			)

--- a/atc/worker/workerfakes/fake_artifact_destination.go
+++ b/atc/worker/workerfakes/fake_artifact_destination.go
@@ -2,10 +2,10 @@
 package workerfakes
 
 import (
-	"io"
-	"sync"
+	io "io"
+	sync "sync"
 
-	"github.com/concourse/concourse/atc/worker"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeArtifactDestination struct {
@@ -50,12 +50,6 @@ func (fake *FakeArtifactDestination) StreamInCallCount() int {
 	return len(fake.streamInArgsForCall)
 }
 
-func (fake *FakeArtifactDestination) StreamInCalls(stub func(string, io.Reader) error) {
-	fake.streamInMutex.Lock()
-	defer fake.streamInMutex.Unlock()
-	fake.StreamInStub = stub
-}
-
 func (fake *FakeArtifactDestination) StreamInArgsForCall(i int) (string, io.Reader) {
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
@@ -64,8 +58,6 @@ func (fake *FakeArtifactDestination) StreamInArgsForCall(i int) (string, io.Read
 }
 
 func (fake *FakeArtifactDestination) StreamInReturns(result1 error) {
-	fake.streamInMutex.Lock()
-	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	fake.streamInReturns = struct {
 		result1 error
@@ -73,8 +65,6 @@ func (fake *FakeArtifactDestination) StreamInReturns(result1 error) {
 }
 
 func (fake *FakeArtifactDestination) StreamInReturnsOnCall(i int, result1 error) {
-	fake.streamInMutex.Lock()
-	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	if fake.streamInReturnsOnCall == nil {
 		fake.streamInReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_artifact_source.go
+++ b/atc/worker/workerfakes/fake_artifact_source.go
@@ -2,11 +2,11 @@
 package workerfakes
 
 import (
-	"io"
-	"sync"
+	io "io"
+	sync "sync"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc/worker"
+	lager "code.cloudfoundry.org/lager"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeArtifactSource struct {
@@ -81,12 +81,6 @@ func (fake *FakeArtifactSource) StreamFileCallCount() int {
 	return len(fake.streamFileArgsForCall)
 }
 
-func (fake *FakeArtifactSource) StreamFileCalls(stub func(lager.Logger, string) (io.ReadCloser, error)) {
-	fake.streamFileMutex.Lock()
-	defer fake.streamFileMutex.Unlock()
-	fake.StreamFileStub = stub
-}
-
 func (fake *FakeArtifactSource) StreamFileArgsForCall(i int) (lager.Logger, string) {
 	fake.streamFileMutex.RLock()
 	defer fake.streamFileMutex.RUnlock()
@@ -95,8 +89,6 @@ func (fake *FakeArtifactSource) StreamFileArgsForCall(i int) (lager.Logger, stri
 }
 
 func (fake *FakeArtifactSource) StreamFileReturns(result1 io.ReadCloser, result2 error) {
-	fake.streamFileMutex.Lock()
-	defer fake.streamFileMutex.Unlock()
 	fake.StreamFileStub = nil
 	fake.streamFileReturns = struct {
 		result1 io.ReadCloser
@@ -105,8 +97,6 @@ func (fake *FakeArtifactSource) StreamFileReturns(result1 io.ReadCloser, result2
 }
 
 func (fake *FakeArtifactSource) StreamFileReturnsOnCall(i int, result1 io.ReadCloser, result2 error) {
-	fake.streamFileMutex.Lock()
-	defer fake.streamFileMutex.Unlock()
 	fake.StreamFileStub = nil
 	if fake.streamFileReturnsOnCall == nil {
 		fake.streamFileReturnsOnCall = make(map[int]struct {
@@ -145,12 +135,6 @@ func (fake *FakeArtifactSource) StreamToCallCount() int {
 	return len(fake.streamToArgsForCall)
 }
 
-func (fake *FakeArtifactSource) StreamToCalls(stub func(lager.Logger, worker.ArtifactDestination) error) {
-	fake.streamToMutex.Lock()
-	defer fake.streamToMutex.Unlock()
-	fake.StreamToStub = stub
-}
-
 func (fake *FakeArtifactSource) StreamToArgsForCall(i int) (lager.Logger, worker.ArtifactDestination) {
 	fake.streamToMutex.RLock()
 	defer fake.streamToMutex.RUnlock()
@@ -159,8 +143,6 @@ func (fake *FakeArtifactSource) StreamToArgsForCall(i int) (lager.Logger, worker
 }
 
 func (fake *FakeArtifactSource) StreamToReturns(result1 error) {
-	fake.streamToMutex.Lock()
-	defer fake.streamToMutex.Unlock()
 	fake.StreamToStub = nil
 	fake.streamToReturns = struct {
 		result1 error
@@ -168,8 +150,6 @@ func (fake *FakeArtifactSource) StreamToReturns(result1 error) {
 }
 
 func (fake *FakeArtifactSource) StreamToReturnsOnCall(i int, result1 error) {
-	fake.streamToMutex.Lock()
-	defer fake.streamToMutex.Unlock()
 	fake.StreamToStub = nil
 	if fake.streamToReturnsOnCall == nil {
 		fake.streamToReturnsOnCall = make(map[int]struct {
@@ -206,12 +186,6 @@ func (fake *FakeArtifactSource) VolumeOnCallCount() int {
 	return len(fake.volumeOnArgsForCall)
 }
 
-func (fake *FakeArtifactSource) VolumeOnCalls(stub func(lager.Logger, worker.Worker) (worker.Volume, bool, error)) {
-	fake.volumeOnMutex.Lock()
-	defer fake.volumeOnMutex.Unlock()
-	fake.VolumeOnStub = stub
-}
-
 func (fake *FakeArtifactSource) VolumeOnArgsForCall(i int) (lager.Logger, worker.Worker) {
 	fake.volumeOnMutex.RLock()
 	defer fake.volumeOnMutex.RUnlock()
@@ -220,8 +194,6 @@ func (fake *FakeArtifactSource) VolumeOnArgsForCall(i int) (lager.Logger, worker
 }
 
 func (fake *FakeArtifactSource) VolumeOnReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.volumeOnMutex.Lock()
-	defer fake.volumeOnMutex.Unlock()
 	fake.VolumeOnStub = nil
 	fake.volumeOnReturns = struct {
 		result1 worker.Volume
@@ -231,8 +203,6 @@ func (fake *FakeArtifactSource) VolumeOnReturns(result1 worker.Volume, result2 b
 }
 
 func (fake *FakeArtifactSource) VolumeOnReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.volumeOnMutex.Lock()
-	defer fake.volumeOnMutex.Unlock()
 	fake.VolumeOnStub = nil
 	if fake.volumeOnReturnsOnCall == nil {
 		fake.volumeOnReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_bind_mount_source.go
+++ b/atc/worker/workerfakes/fake_bind_mount_source.go
@@ -2,10 +2,10 @@
 package workerfakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"code.cloudfoundry.org/garden"
-	"github.com/concourse/concourse/atc/worker"
+	garden "code.cloudfoundry.org/garden"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeBindMountSource struct {
@@ -52,12 +52,6 @@ func (fake *FakeBindMountSource) VolumeOnCallCount() int {
 	return len(fake.volumeOnArgsForCall)
 }
 
-func (fake *FakeBindMountSource) VolumeOnCalls(stub func(worker.Worker) (garden.BindMount, bool, error)) {
-	fake.volumeOnMutex.Lock()
-	defer fake.volumeOnMutex.Unlock()
-	fake.VolumeOnStub = stub
-}
-
 func (fake *FakeBindMountSource) VolumeOnArgsForCall(i int) worker.Worker {
 	fake.volumeOnMutex.RLock()
 	defer fake.volumeOnMutex.RUnlock()
@@ -66,8 +60,6 @@ func (fake *FakeBindMountSource) VolumeOnArgsForCall(i int) worker.Worker {
 }
 
 func (fake *FakeBindMountSource) VolumeOnReturns(result1 garden.BindMount, result2 bool, result3 error) {
-	fake.volumeOnMutex.Lock()
-	defer fake.volumeOnMutex.Unlock()
 	fake.VolumeOnStub = nil
 	fake.volumeOnReturns = struct {
 		result1 garden.BindMount
@@ -77,8 +69,6 @@ func (fake *FakeBindMountSource) VolumeOnReturns(result1 garden.BindMount, resul
 }
 
 func (fake *FakeBindMountSource) VolumeOnReturnsOnCall(i int, result1 garden.BindMount, result2 bool, result3 error) {
-	fake.volumeOnMutex.Lock()
-	defer fake.volumeOnMutex.Unlock()
 	fake.VolumeOnStub = nil
 	if fake.volumeOnReturnsOnCall == nil {
 		fake.volumeOnReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_client.go
+++ b/atc/worker/workerfakes/fake_client.go
@@ -2,11 +2,11 @@
 package workerfakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/worker"
+	lager "code.cloudfoundry.org/lager"
+	db "github.com/concourse/concourse/atc/db"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeClient struct {
@@ -91,12 +91,6 @@ func (fake *FakeClient) CreateVolumeCallCount() int {
 	return len(fake.createVolumeArgsForCall)
 }
 
-func (fake *FakeClient) CreateVolumeCalls(stub func(lager.Logger, worker.VolumeSpec, int, db.VolumeType) (worker.Volume, error)) {
-	fake.createVolumeMutex.Lock()
-	defer fake.createVolumeMutex.Unlock()
-	fake.CreateVolumeStub = stub
-}
-
 func (fake *FakeClient) CreateVolumeArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, db.VolumeType) {
 	fake.createVolumeMutex.RLock()
 	defer fake.createVolumeMutex.RUnlock()
@@ -105,8 +99,6 @@ func (fake *FakeClient) CreateVolumeArgsForCall(i int) (lager.Logger, worker.Vol
 }
 
 func (fake *FakeClient) CreateVolumeReturns(result1 worker.Volume, result2 error) {
-	fake.createVolumeMutex.Lock()
-	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	fake.createVolumeReturns = struct {
 		result1 worker.Volume
@@ -115,8 +107,6 @@ func (fake *FakeClient) CreateVolumeReturns(result1 worker.Volume, result2 error
 }
 
 func (fake *FakeClient) CreateVolumeReturnsOnCall(i int, result1 worker.Volume, result2 error) {
-	fake.createVolumeMutex.Lock()
-	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	if fake.createVolumeReturnsOnCall == nil {
 		fake.createVolumeReturnsOnCall = make(map[int]struct {
@@ -156,12 +146,6 @@ func (fake *FakeClient) FindContainerCallCount() int {
 	return len(fake.findContainerArgsForCall)
 }
 
-func (fake *FakeClient) FindContainerCalls(stub func(lager.Logger, int, string) (worker.Container, bool, error)) {
-	fake.findContainerMutex.Lock()
-	defer fake.findContainerMutex.Unlock()
-	fake.FindContainerStub = stub
-}
-
 func (fake *FakeClient) FindContainerArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findContainerMutex.RLock()
 	defer fake.findContainerMutex.RUnlock()
@@ -170,8 +154,6 @@ func (fake *FakeClient) FindContainerArgsForCall(i int) (lager.Logger, int, stri
 }
 
 func (fake *FakeClient) FindContainerReturns(result1 worker.Container, result2 bool, result3 error) {
-	fake.findContainerMutex.Lock()
-	defer fake.findContainerMutex.Unlock()
 	fake.FindContainerStub = nil
 	fake.findContainerReturns = struct {
 		result1 worker.Container
@@ -181,8 +163,6 @@ func (fake *FakeClient) FindContainerReturns(result1 worker.Container, result2 b
 }
 
 func (fake *FakeClient) FindContainerReturnsOnCall(i int, result1 worker.Container, result2 bool, result3 error) {
-	fake.findContainerMutex.Lock()
-	defer fake.findContainerMutex.Unlock()
 	fake.FindContainerStub = nil
 	if fake.findContainerReturnsOnCall == nil {
 		fake.findContainerReturnsOnCall = make(map[int]struct {
@@ -224,12 +204,6 @@ func (fake *FakeClient) FindVolumeCallCount() int {
 	return len(fake.findVolumeArgsForCall)
 }
 
-func (fake *FakeClient) FindVolumeCalls(stub func(lager.Logger, int, string) (worker.Volume, bool, error)) {
-	fake.findVolumeMutex.Lock()
-	defer fake.findVolumeMutex.Unlock()
-	fake.FindVolumeStub = stub
-}
-
 func (fake *FakeClient) FindVolumeArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findVolumeMutex.RLock()
 	defer fake.findVolumeMutex.RUnlock()
@@ -238,8 +212,6 @@ func (fake *FakeClient) FindVolumeArgsForCall(i int) (lager.Logger, int, string)
 }
 
 func (fake *FakeClient) FindVolumeReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeMutex.Lock()
-	defer fake.findVolumeMutex.Unlock()
 	fake.FindVolumeStub = nil
 	fake.findVolumeReturns = struct {
 		result1 worker.Volume
@@ -249,8 +221,6 @@ func (fake *FakeClient) FindVolumeReturns(result1 worker.Volume, result2 bool, r
 }
 
 func (fake *FakeClient) FindVolumeReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeMutex.Lock()
-	defer fake.findVolumeMutex.Unlock()
 	fake.FindVolumeStub = nil
 	if fake.findVolumeReturnsOnCall == nil {
 		fake.findVolumeReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_container.go
+++ b/atc/worker/workerfakes/fake_container.go
@@ -2,12 +2,12 @@
 package workerfakes
 
 import (
-	"io"
-	"sync"
-	"time"
+	io "io"
+	sync "sync"
+	time "time"
 
-	"code.cloudfoundry.org/garden"
-	"github.com/concourse/concourse/atc/worker"
+	garden "code.cloudfoundry.org/garden"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeContainer struct {
@@ -322,12 +322,6 @@ func (fake *FakeContainer) AttachCallCount() int {
 	return len(fake.attachArgsForCall)
 }
 
-func (fake *FakeContainer) AttachCalls(stub func(string, garden.ProcessIO) (garden.Process, error)) {
-	fake.attachMutex.Lock()
-	defer fake.attachMutex.Unlock()
-	fake.AttachStub = stub
-}
-
 func (fake *FakeContainer) AttachArgsForCall(i int) (string, garden.ProcessIO) {
 	fake.attachMutex.RLock()
 	defer fake.attachMutex.RUnlock()
@@ -336,8 +330,6 @@ func (fake *FakeContainer) AttachArgsForCall(i int) (string, garden.ProcessIO) {
 }
 
 func (fake *FakeContainer) AttachReturns(result1 garden.Process, result2 error) {
-	fake.attachMutex.Lock()
-	defer fake.attachMutex.Unlock()
 	fake.AttachStub = nil
 	fake.attachReturns = struct {
 		result1 garden.Process
@@ -346,8 +338,6 @@ func (fake *FakeContainer) AttachReturns(result1 garden.Process, result2 error) 
 }
 
 func (fake *FakeContainer) AttachReturnsOnCall(i int, result1 garden.Process, result2 error) {
-	fake.attachMutex.Lock()
-	defer fake.attachMutex.Unlock()
 	fake.AttachStub = nil
 	if fake.attachReturnsOnCall == nil {
 		fake.attachReturnsOnCall = make(map[int]struct {
@@ -390,12 +380,6 @@ func (fake *FakeContainer) BulkNetOutCallCount() int {
 	return len(fake.bulkNetOutArgsForCall)
 }
 
-func (fake *FakeContainer) BulkNetOutCalls(stub func([]garden.NetOutRule) error) {
-	fake.bulkNetOutMutex.Lock()
-	defer fake.bulkNetOutMutex.Unlock()
-	fake.BulkNetOutStub = stub
-}
-
 func (fake *FakeContainer) BulkNetOutArgsForCall(i int) []garden.NetOutRule {
 	fake.bulkNetOutMutex.RLock()
 	defer fake.bulkNetOutMutex.RUnlock()
@@ -404,8 +388,6 @@ func (fake *FakeContainer) BulkNetOutArgsForCall(i int) []garden.NetOutRule {
 }
 
 func (fake *FakeContainer) BulkNetOutReturns(result1 error) {
-	fake.bulkNetOutMutex.Lock()
-	defer fake.bulkNetOutMutex.Unlock()
 	fake.BulkNetOutStub = nil
 	fake.bulkNetOutReturns = struct {
 		result1 error
@@ -413,8 +395,6 @@ func (fake *FakeContainer) BulkNetOutReturns(result1 error) {
 }
 
 func (fake *FakeContainer) BulkNetOutReturnsOnCall(i int, result1 error) {
-	fake.bulkNetOutMutex.Lock()
-	defer fake.bulkNetOutMutex.Unlock()
 	fake.BulkNetOutStub = nil
 	if fake.bulkNetOutReturnsOnCall == nil {
 		fake.bulkNetOutReturnsOnCall = make(map[int]struct {
@@ -449,15 +429,7 @@ func (fake *FakeContainer) CurrentBandwidthLimitsCallCount() int {
 	return len(fake.currentBandwidthLimitsArgsForCall)
 }
 
-func (fake *FakeContainer) CurrentBandwidthLimitsCalls(stub func() (garden.BandwidthLimits, error)) {
-	fake.currentBandwidthLimitsMutex.Lock()
-	defer fake.currentBandwidthLimitsMutex.Unlock()
-	fake.CurrentBandwidthLimitsStub = stub
-}
-
 func (fake *FakeContainer) CurrentBandwidthLimitsReturns(result1 garden.BandwidthLimits, result2 error) {
-	fake.currentBandwidthLimitsMutex.Lock()
-	defer fake.currentBandwidthLimitsMutex.Unlock()
 	fake.CurrentBandwidthLimitsStub = nil
 	fake.currentBandwidthLimitsReturns = struct {
 		result1 garden.BandwidthLimits
@@ -466,8 +438,6 @@ func (fake *FakeContainer) CurrentBandwidthLimitsReturns(result1 garden.Bandwidt
 }
 
 func (fake *FakeContainer) CurrentBandwidthLimitsReturnsOnCall(i int, result1 garden.BandwidthLimits, result2 error) {
-	fake.currentBandwidthLimitsMutex.Lock()
-	defer fake.currentBandwidthLimitsMutex.Unlock()
 	fake.CurrentBandwidthLimitsStub = nil
 	if fake.currentBandwidthLimitsReturnsOnCall == nil {
 		fake.currentBandwidthLimitsReturnsOnCall = make(map[int]struct {
@@ -504,15 +474,7 @@ func (fake *FakeContainer) CurrentCPULimitsCallCount() int {
 	return len(fake.currentCPULimitsArgsForCall)
 }
 
-func (fake *FakeContainer) CurrentCPULimitsCalls(stub func() (garden.CPULimits, error)) {
-	fake.currentCPULimitsMutex.Lock()
-	defer fake.currentCPULimitsMutex.Unlock()
-	fake.CurrentCPULimitsStub = stub
-}
-
 func (fake *FakeContainer) CurrentCPULimitsReturns(result1 garden.CPULimits, result2 error) {
-	fake.currentCPULimitsMutex.Lock()
-	defer fake.currentCPULimitsMutex.Unlock()
 	fake.CurrentCPULimitsStub = nil
 	fake.currentCPULimitsReturns = struct {
 		result1 garden.CPULimits
@@ -521,8 +483,6 @@ func (fake *FakeContainer) CurrentCPULimitsReturns(result1 garden.CPULimits, res
 }
 
 func (fake *FakeContainer) CurrentCPULimitsReturnsOnCall(i int, result1 garden.CPULimits, result2 error) {
-	fake.currentCPULimitsMutex.Lock()
-	defer fake.currentCPULimitsMutex.Unlock()
 	fake.CurrentCPULimitsStub = nil
 	if fake.currentCPULimitsReturnsOnCall == nil {
 		fake.currentCPULimitsReturnsOnCall = make(map[int]struct {
@@ -559,15 +519,7 @@ func (fake *FakeContainer) CurrentDiskLimitsCallCount() int {
 	return len(fake.currentDiskLimitsArgsForCall)
 }
 
-func (fake *FakeContainer) CurrentDiskLimitsCalls(stub func() (garden.DiskLimits, error)) {
-	fake.currentDiskLimitsMutex.Lock()
-	defer fake.currentDiskLimitsMutex.Unlock()
-	fake.CurrentDiskLimitsStub = stub
-}
-
 func (fake *FakeContainer) CurrentDiskLimitsReturns(result1 garden.DiskLimits, result2 error) {
-	fake.currentDiskLimitsMutex.Lock()
-	defer fake.currentDiskLimitsMutex.Unlock()
 	fake.CurrentDiskLimitsStub = nil
 	fake.currentDiskLimitsReturns = struct {
 		result1 garden.DiskLimits
@@ -576,8 +528,6 @@ func (fake *FakeContainer) CurrentDiskLimitsReturns(result1 garden.DiskLimits, r
 }
 
 func (fake *FakeContainer) CurrentDiskLimitsReturnsOnCall(i int, result1 garden.DiskLimits, result2 error) {
-	fake.currentDiskLimitsMutex.Lock()
-	defer fake.currentDiskLimitsMutex.Unlock()
 	fake.CurrentDiskLimitsStub = nil
 	if fake.currentDiskLimitsReturnsOnCall == nil {
 		fake.currentDiskLimitsReturnsOnCall = make(map[int]struct {
@@ -614,15 +564,7 @@ func (fake *FakeContainer) CurrentMemoryLimitsCallCount() int {
 	return len(fake.currentMemoryLimitsArgsForCall)
 }
 
-func (fake *FakeContainer) CurrentMemoryLimitsCalls(stub func() (garden.MemoryLimits, error)) {
-	fake.currentMemoryLimitsMutex.Lock()
-	defer fake.currentMemoryLimitsMutex.Unlock()
-	fake.CurrentMemoryLimitsStub = stub
-}
-
 func (fake *FakeContainer) CurrentMemoryLimitsReturns(result1 garden.MemoryLimits, result2 error) {
-	fake.currentMemoryLimitsMutex.Lock()
-	defer fake.currentMemoryLimitsMutex.Unlock()
 	fake.CurrentMemoryLimitsStub = nil
 	fake.currentMemoryLimitsReturns = struct {
 		result1 garden.MemoryLimits
@@ -631,8 +573,6 @@ func (fake *FakeContainer) CurrentMemoryLimitsReturns(result1 garden.MemoryLimit
 }
 
 func (fake *FakeContainer) CurrentMemoryLimitsReturnsOnCall(i int, result1 garden.MemoryLimits, result2 error) {
-	fake.currentMemoryLimitsMutex.Lock()
-	defer fake.currentMemoryLimitsMutex.Unlock()
 	fake.CurrentMemoryLimitsStub = nil
 	if fake.currentMemoryLimitsReturnsOnCall == nil {
 		fake.currentMemoryLimitsReturnsOnCall = make(map[int]struct {
@@ -669,15 +609,7 @@ func (fake *FakeContainer) DestroyCallCount() int {
 	return len(fake.destroyArgsForCall)
 }
 
-func (fake *FakeContainer) DestroyCalls(stub func() error) {
-	fake.destroyMutex.Lock()
-	defer fake.destroyMutex.Unlock()
-	fake.DestroyStub = stub
-}
-
 func (fake *FakeContainer) DestroyReturns(result1 error) {
-	fake.destroyMutex.Lock()
-	defer fake.destroyMutex.Unlock()
 	fake.DestroyStub = nil
 	fake.destroyReturns = struct {
 		result1 error
@@ -685,8 +617,6 @@ func (fake *FakeContainer) DestroyReturns(result1 error) {
 }
 
 func (fake *FakeContainer) DestroyReturnsOnCall(i int, result1 error) {
-	fake.destroyMutex.Lock()
-	defer fake.destroyMutex.Unlock()
 	fake.DestroyStub = nil
 	if fake.destroyReturnsOnCall == nil {
 		fake.destroyReturnsOnCall = make(map[int]struct {
@@ -721,15 +651,7 @@ func (fake *FakeContainer) HandleCallCount() int {
 	return len(fake.handleArgsForCall)
 }
 
-func (fake *FakeContainer) HandleCalls(stub func() string) {
-	fake.handleMutex.Lock()
-	defer fake.handleMutex.Unlock()
-	fake.HandleStub = stub
-}
-
 func (fake *FakeContainer) HandleReturns(result1 string) {
-	fake.handleMutex.Lock()
-	defer fake.handleMutex.Unlock()
 	fake.HandleStub = nil
 	fake.handleReturns = struct {
 		result1 string
@@ -737,8 +659,6 @@ func (fake *FakeContainer) HandleReturns(result1 string) {
 }
 
 func (fake *FakeContainer) HandleReturnsOnCall(i int, result1 string) {
-	fake.handleMutex.Lock()
-	defer fake.handleMutex.Unlock()
 	fake.HandleStub = nil
 	if fake.handleReturnsOnCall == nil {
 		fake.handleReturnsOnCall = make(map[int]struct {
@@ -773,15 +693,7 @@ func (fake *FakeContainer) InfoCallCount() int {
 	return len(fake.infoArgsForCall)
 }
 
-func (fake *FakeContainer) InfoCalls(stub func() (garden.ContainerInfo, error)) {
-	fake.infoMutex.Lock()
-	defer fake.infoMutex.Unlock()
-	fake.InfoStub = stub
-}
-
 func (fake *FakeContainer) InfoReturns(result1 garden.ContainerInfo, result2 error) {
-	fake.infoMutex.Lock()
-	defer fake.infoMutex.Unlock()
 	fake.InfoStub = nil
 	fake.infoReturns = struct {
 		result1 garden.ContainerInfo
@@ -790,8 +702,6 @@ func (fake *FakeContainer) InfoReturns(result1 garden.ContainerInfo, result2 err
 }
 
 func (fake *FakeContainer) InfoReturnsOnCall(i int, result1 garden.ContainerInfo, result2 error) {
-	fake.infoMutex.Lock()
-	defer fake.infoMutex.Unlock()
 	fake.InfoStub = nil
 	if fake.infoReturnsOnCall == nil {
 		fake.infoReturnsOnCall = make(map[int]struct {
@@ -828,15 +738,7 @@ func (fake *FakeContainer) MarkAsHijackedCallCount() int {
 	return len(fake.markAsHijackedArgsForCall)
 }
 
-func (fake *FakeContainer) MarkAsHijackedCalls(stub func() error) {
-	fake.markAsHijackedMutex.Lock()
-	defer fake.markAsHijackedMutex.Unlock()
-	fake.MarkAsHijackedStub = stub
-}
-
 func (fake *FakeContainer) MarkAsHijackedReturns(result1 error) {
-	fake.markAsHijackedMutex.Lock()
-	defer fake.markAsHijackedMutex.Unlock()
 	fake.MarkAsHijackedStub = nil
 	fake.markAsHijackedReturns = struct {
 		result1 error
@@ -844,8 +746,6 @@ func (fake *FakeContainer) MarkAsHijackedReturns(result1 error) {
 }
 
 func (fake *FakeContainer) MarkAsHijackedReturnsOnCall(i int, result1 error) {
-	fake.markAsHijackedMutex.Lock()
-	defer fake.markAsHijackedMutex.Unlock()
 	fake.MarkAsHijackedStub = nil
 	if fake.markAsHijackedReturnsOnCall == nil {
 		fake.markAsHijackedReturnsOnCall = make(map[int]struct {
@@ -880,15 +780,7 @@ func (fake *FakeContainer) MetricsCallCount() int {
 	return len(fake.metricsArgsForCall)
 }
 
-func (fake *FakeContainer) MetricsCalls(stub func() (garden.Metrics, error)) {
-	fake.metricsMutex.Lock()
-	defer fake.metricsMutex.Unlock()
-	fake.MetricsStub = stub
-}
-
 func (fake *FakeContainer) MetricsReturns(result1 garden.Metrics, result2 error) {
-	fake.metricsMutex.Lock()
-	defer fake.metricsMutex.Unlock()
 	fake.MetricsStub = nil
 	fake.metricsReturns = struct {
 		result1 garden.Metrics
@@ -897,8 +789,6 @@ func (fake *FakeContainer) MetricsReturns(result1 garden.Metrics, result2 error)
 }
 
 func (fake *FakeContainer) MetricsReturnsOnCall(i int, result1 garden.Metrics, result2 error) {
-	fake.metricsMutex.Lock()
-	defer fake.metricsMutex.Unlock()
 	fake.MetricsStub = nil
 	if fake.metricsReturnsOnCall == nil {
 		fake.metricsReturnsOnCall = make(map[int]struct {
@@ -937,12 +827,6 @@ func (fake *FakeContainer) NetInCallCount() int {
 	return len(fake.netInArgsForCall)
 }
 
-func (fake *FakeContainer) NetInCalls(stub func(uint32, uint32) (uint32, uint32, error)) {
-	fake.netInMutex.Lock()
-	defer fake.netInMutex.Unlock()
-	fake.NetInStub = stub
-}
-
 func (fake *FakeContainer) NetInArgsForCall(i int) (uint32, uint32) {
 	fake.netInMutex.RLock()
 	defer fake.netInMutex.RUnlock()
@@ -951,8 +835,6 @@ func (fake *FakeContainer) NetInArgsForCall(i int) (uint32, uint32) {
 }
 
 func (fake *FakeContainer) NetInReturns(result1 uint32, result2 uint32, result3 error) {
-	fake.netInMutex.Lock()
-	defer fake.netInMutex.Unlock()
 	fake.NetInStub = nil
 	fake.netInReturns = struct {
 		result1 uint32
@@ -962,8 +844,6 @@ func (fake *FakeContainer) NetInReturns(result1 uint32, result2 uint32, result3 
 }
 
 func (fake *FakeContainer) NetInReturnsOnCall(i int, result1 uint32, result2 uint32, result3 error) {
-	fake.netInMutex.Lock()
-	defer fake.netInMutex.Unlock()
 	fake.NetInStub = nil
 	if fake.netInReturnsOnCall == nil {
 		fake.netInReturnsOnCall = make(map[int]struct {
@@ -1003,12 +883,6 @@ func (fake *FakeContainer) NetOutCallCount() int {
 	return len(fake.netOutArgsForCall)
 }
 
-func (fake *FakeContainer) NetOutCalls(stub func(garden.NetOutRule) error) {
-	fake.netOutMutex.Lock()
-	defer fake.netOutMutex.Unlock()
-	fake.NetOutStub = stub
-}
-
 func (fake *FakeContainer) NetOutArgsForCall(i int) garden.NetOutRule {
 	fake.netOutMutex.RLock()
 	defer fake.netOutMutex.RUnlock()
@@ -1017,8 +891,6 @@ func (fake *FakeContainer) NetOutArgsForCall(i int) garden.NetOutRule {
 }
 
 func (fake *FakeContainer) NetOutReturns(result1 error) {
-	fake.netOutMutex.Lock()
-	defer fake.netOutMutex.Unlock()
 	fake.NetOutStub = nil
 	fake.netOutReturns = struct {
 		result1 error
@@ -1026,8 +898,6 @@ func (fake *FakeContainer) NetOutReturns(result1 error) {
 }
 
 func (fake *FakeContainer) NetOutReturnsOnCall(i int, result1 error) {
-	fake.netOutMutex.Lock()
-	defer fake.netOutMutex.Unlock()
 	fake.NetOutStub = nil
 	if fake.netOutReturnsOnCall == nil {
 		fake.netOutReturnsOnCall = make(map[int]struct {
@@ -1062,15 +932,7 @@ func (fake *FakeContainer) PropertiesCallCount() int {
 	return len(fake.propertiesArgsForCall)
 }
 
-func (fake *FakeContainer) PropertiesCalls(stub func() (garden.Properties, error)) {
-	fake.propertiesMutex.Lock()
-	defer fake.propertiesMutex.Unlock()
-	fake.PropertiesStub = stub
-}
-
 func (fake *FakeContainer) PropertiesReturns(result1 garden.Properties, result2 error) {
-	fake.propertiesMutex.Lock()
-	defer fake.propertiesMutex.Unlock()
 	fake.PropertiesStub = nil
 	fake.propertiesReturns = struct {
 		result1 garden.Properties
@@ -1079,8 +941,6 @@ func (fake *FakeContainer) PropertiesReturns(result1 garden.Properties, result2 
 }
 
 func (fake *FakeContainer) PropertiesReturnsOnCall(i int, result1 garden.Properties, result2 error) {
-	fake.propertiesMutex.Lock()
-	defer fake.propertiesMutex.Unlock()
 	fake.PropertiesStub = nil
 	if fake.propertiesReturnsOnCall == nil {
 		fake.propertiesReturnsOnCall = make(map[int]struct {
@@ -1118,12 +978,6 @@ func (fake *FakeContainer) PropertyCallCount() int {
 	return len(fake.propertyArgsForCall)
 }
 
-func (fake *FakeContainer) PropertyCalls(stub func(string) (string, error)) {
-	fake.propertyMutex.Lock()
-	defer fake.propertyMutex.Unlock()
-	fake.PropertyStub = stub
-}
-
 func (fake *FakeContainer) PropertyArgsForCall(i int) string {
 	fake.propertyMutex.RLock()
 	defer fake.propertyMutex.RUnlock()
@@ -1132,8 +986,6 @@ func (fake *FakeContainer) PropertyArgsForCall(i int) string {
 }
 
 func (fake *FakeContainer) PropertyReturns(result1 string, result2 error) {
-	fake.propertyMutex.Lock()
-	defer fake.propertyMutex.Unlock()
 	fake.PropertyStub = nil
 	fake.propertyReturns = struct {
 		result1 string
@@ -1142,8 +994,6 @@ func (fake *FakeContainer) PropertyReturns(result1 string, result2 error) {
 }
 
 func (fake *FakeContainer) PropertyReturnsOnCall(i int, result1 string, result2 error) {
-	fake.propertyMutex.Lock()
-	defer fake.propertyMutex.Unlock()
 	fake.PropertyStub = nil
 	if fake.propertyReturnsOnCall == nil {
 		fake.propertyReturnsOnCall = make(map[int]struct {
@@ -1181,12 +1031,6 @@ func (fake *FakeContainer) RemovePropertyCallCount() int {
 	return len(fake.removePropertyArgsForCall)
 }
 
-func (fake *FakeContainer) RemovePropertyCalls(stub func(string) error) {
-	fake.removePropertyMutex.Lock()
-	defer fake.removePropertyMutex.Unlock()
-	fake.RemovePropertyStub = stub
-}
-
 func (fake *FakeContainer) RemovePropertyArgsForCall(i int) string {
 	fake.removePropertyMutex.RLock()
 	defer fake.removePropertyMutex.RUnlock()
@@ -1195,8 +1039,6 @@ func (fake *FakeContainer) RemovePropertyArgsForCall(i int) string {
 }
 
 func (fake *FakeContainer) RemovePropertyReturns(result1 error) {
-	fake.removePropertyMutex.Lock()
-	defer fake.removePropertyMutex.Unlock()
 	fake.RemovePropertyStub = nil
 	fake.removePropertyReturns = struct {
 		result1 error
@@ -1204,8 +1046,6 @@ func (fake *FakeContainer) RemovePropertyReturns(result1 error) {
 }
 
 func (fake *FakeContainer) RemovePropertyReturnsOnCall(i int, result1 error) {
-	fake.removePropertyMutex.Lock()
-	defer fake.removePropertyMutex.Unlock()
 	fake.RemovePropertyStub = nil
 	if fake.removePropertyReturnsOnCall == nil {
 		fake.removePropertyReturnsOnCall = make(map[int]struct {
@@ -1242,12 +1082,6 @@ func (fake *FakeContainer) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
-func (fake *FakeContainer) RunCalls(stub func(garden.ProcessSpec, garden.ProcessIO) (garden.Process, error)) {
-	fake.runMutex.Lock()
-	defer fake.runMutex.Unlock()
-	fake.RunStub = stub
-}
-
 func (fake *FakeContainer) RunArgsForCall(i int) (garden.ProcessSpec, garden.ProcessIO) {
 	fake.runMutex.RLock()
 	defer fake.runMutex.RUnlock()
@@ -1256,8 +1090,6 @@ func (fake *FakeContainer) RunArgsForCall(i int) (garden.ProcessSpec, garden.Pro
 }
 
 func (fake *FakeContainer) RunReturns(result1 garden.Process, result2 error) {
-	fake.runMutex.Lock()
-	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	fake.runReturns = struct {
 		result1 garden.Process
@@ -1266,8 +1098,6 @@ func (fake *FakeContainer) RunReturns(result1 garden.Process, result2 error) {
 }
 
 func (fake *FakeContainer) RunReturnsOnCall(i int, result1 garden.Process, result2 error) {
-	fake.runMutex.Lock()
-	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	if fake.runReturnsOnCall == nil {
 		fake.runReturnsOnCall = make(map[int]struct {
@@ -1305,12 +1135,6 @@ func (fake *FakeContainer) SetGraceTimeCallCount() int {
 	return len(fake.setGraceTimeArgsForCall)
 }
 
-func (fake *FakeContainer) SetGraceTimeCalls(stub func(time.Duration) error) {
-	fake.setGraceTimeMutex.Lock()
-	defer fake.setGraceTimeMutex.Unlock()
-	fake.SetGraceTimeStub = stub
-}
-
 func (fake *FakeContainer) SetGraceTimeArgsForCall(i int) time.Duration {
 	fake.setGraceTimeMutex.RLock()
 	defer fake.setGraceTimeMutex.RUnlock()
@@ -1319,8 +1143,6 @@ func (fake *FakeContainer) SetGraceTimeArgsForCall(i int) time.Duration {
 }
 
 func (fake *FakeContainer) SetGraceTimeReturns(result1 error) {
-	fake.setGraceTimeMutex.Lock()
-	defer fake.setGraceTimeMutex.Unlock()
 	fake.SetGraceTimeStub = nil
 	fake.setGraceTimeReturns = struct {
 		result1 error
@@ -1328,8 +1150,6 @@ func (fake *FakeContainer) SetGraceTimeReturns(result1 error) {
 }
 
 func (fake *FakeContainer) SetGraceTimeReturnsOnCall(i int, result1 error) {
-	fake.setGraceTimeMutex.Lock()
-	defer fake.setGraceTimeMutex.Unlock()
 	fake.SetGraceTimeStub = nil
 	if fake.setGraceTimeReturnsOnCall == nil {
 		fake.setGraceTimeReturnsOnCall = make(map[int]struct {
@@ -1366,12 +1186,6 @@ func (fake *FakeContainer) SetPropertyCallCount() int {
 	return len(fake.setPropertyArgsForCall)
 }
 
-func (fake *FakeContainer) SetPropertyCalls(stub func(string, string) error) {
-	fake.setPropertyMutex.Lock()
-	defer fake.setPropertyMutex.Unlock()
-	fake.SetPropertyStub = stub
-}
-
 func (fake *FakeContainer) SetPropertyArgsForCall(i int) (string, string) {
 	fake.setPropertyMutex.RLock()
 	defer fake.setPropertyMutex.RUnlock()
@@ -1380,8 +1194,6 @@ func (fake *FakeContainer) SetPropertyArgsForCall(i int) (string, string) {
 }
 
 func (fake *FakeContainer) SetPropertyReturns(result1 error) {
-	fake.setPropertyMutex.Lock()
-	defer fake.setPropertyMutex.Unlock()
 	fake.SetPropertyStub = nil
 	fake.setPropertyReturns = struct {
 		result1 error
@@ -1389,8 +1201,6 @@ func (fake *FakeContainer) SetPropertyReturns(result1 error) {
 }
 
 func (fake *FakeContainer) SetPropertyReturnsOnCall(i int, result1 error) {
-	fake.setPropertyMutex.Lock()
-	defer fake.setPropertyMutex.Unlock()
 	fake.SetPropertyStub = nil
 	if fake.setPropertyReturnsOnCall == nil {
 		fake.setPropertyReturnsOnCall = make(map[int]struct {
@@ -1426,12 +1236,6 @@ func (fake *FakeContainer) StopCallCount() int {
 	return len(fake.stopArgsForCall)
 }
 
-func (fake *FakeContainer) StopCalls(stub func(bool) error) {
-	fake.stopMutex.Lock()
-	defer fake.stopMutex.Unlock()
-	fake.StopStub = stub
-}
-
 func (fake *FakeContainer) StopArgsForCall(i int) bool {
 	fake.stopMutex.RLock()
 	defer fake.stopMutex.RUnlock()
@@ -1440,8 +1244,6 @@ func (fake *FakeContainer) StopArgsForCall(i int) bool {
 }
 
 func (fake *FakeContainer) StopReturns(result1 error) {
-	fake.stopMutex.Lock()
-	defer fake.stopMutex.Unlock()
 	fake.StopStub = nil
 	fake.stopReturns = struct {
 		result1 error
@@ -1449,8 +1251,6 @@ func (fake *FakeContainer) StopReturns(result1 error) {
 }
 
 func (fake *FakeContainer) StopReturnsOnCall(i int, result1 error) {
-	fake.stopMutex.Lock()
-	defer fake.stopMutex.Unlock()
 	fake.StopStub = nil
 	if fake.stopReturnsOnCall == nil {
 		fake.stopReturnsOnCall = make(map[int]struct {
@@ -1486,12 +1286,6 @@ func (fake *FakeContainer) StreamInCallCount() int {
 	return len(fake.streamInArgsForCall)
 }
 
-func (fake *FakeContainer) StreamInCalls(stub func(garden.StreamInSpec) error) {
-	fake.streamInMutex.Lock()
-	defer fake.streamInMutex.Unlock()
-	fake.StreamInStub = stub
-}
-
 func (fake *FakeContainer) StreamInArgsForCall(i int) garden.StreamInSpec {
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
@@ -1500,8 +1294,6 @@ func (fake *FakeContainer) StreamInArgsForCall(i int) garden.StreamInSpec {
 }
 
 func (fake *FakeContainer) StreamInReturns(result1 error) {
-	fake.streamInMutex.Lock()
-	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	fake.streamInReturns = struct {
 		result1 error
@@ -1509,8 +1301,6 @@ func (fake *FakeContainer) StreamInReturns(result1 error) {
 }
 
 func (fake *FakeContainer) StreamInReturnsOnCall(i int, result1 error) {
-	fake.streamInMutex.Lock()
-	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	if fake.streamInReturnsOnCall == nil {
 		fake.streamInReturnsOnCall = make(map[int]struct {
@@ -1546,12 +1336,6 @@ func (fake *FakeContainer) StreamOutCallCount() int {
 	return len(fake.streamOutArgsForCall)
 }
 
-func (fake *FakeContainer) StreamOutCalls(stub func(garden.StreamOutSpec) (io.ReadCloser, error)) {
-	fake.streamOutMutex.Lock()
-	defer fake.streamOutMutex.Unlock()
-	fake.StreamOutStub = stub
-}
-
 func (fake *FakeContainer) StreamOutArgsForCall(i int) garden.StreamOutSpec {
 	fake.streamOutMutex.RLock()
 	defer fake.streamOutMutex.RUnlock()
@@ -1560,8 +1344,6 @@ func (fake *FakeContainer) StreamOutArgsForCall(i int) garden.StreamOutSpec {
 }
 
 func (fake *FakeContainer) StreamOutReturns(result1 io.ReadCloser, result2 error) {
-	fake.streamOutMutex.Lock()
-	defer fake.streamOutMutex.Unlock()
 	fake.StreamOutStub = nil
 	fake.streamOutReturns = struct {
 		result1 io.ReadCloser
@@ -1570,8 +1352,6 @@ func (fake *FakeContainer) StreamOutReturns(result1 io.ReadCloser, result2 error
 }
 
 func (fake *FakeContainer) StreamOutReturnsOnCall(i int, result1 io.ReadCloser, result2 error) {
-	fake.streamOutMutex.Lock()
-	defer fake.streamOutMutex.Unlock()
 	fake.StreamOutStub = nil
 	if fake.streamOutReturnsOnCall == nil {
 		fake.streamOutReturnsOnCall = make(map[int]struct {
@@ -1608,15 +1388,7 @@ func (fake *FakeContainer) VolumeMountsCallCount() int {
 	return len(fake.volumeMountsArgsForCall)
 }
 
-func (fake *FakeContainer) VolumeMountsCalls(stub func() []worker.VolumeMount) {
-	fake.volumeMountsMutex.Lock()
-	defer fake.volumeMountsMutex.Unlock()
-	fake.VolumeMountsStub = stub
-}
-
 func (fake *FakeContainer) VolumeMountsReturns(result1 []worker.VolumeMount) {
-	fake.volumeMountsMutex.Lock()
-	defer fake.volumeMountsMutex.Unlock()
 	fake.VolumeMountsStub = nil
 	fake.volumeMountsReturns = struct {
 		result1 []worker.VolumeMount
@@ -1624,8 +1396,6 @@ func (fake *FakeContainer) VolumeMountsReturns(result1 []worker.VolumeMount) {
 }
 
 func (fake *FakeContainer) VolumeMountsReturnsOnCall(i int, result1 []worker.VolumeMount) {
-	fake.volumeMountsMutex.Lock()
-	defer fake.volumeMountsMutex.Unlock()
 	fake.VolumeMountsStub = nil
 	if fake.volumeMountsReturnsOnCall == nil {
 		fake.volumeMountsReturnsOnCall = make(map[int]struct {
@@ -1660,15 +1430,7 @@ func (fake *FakeContainer) WorkerNameCallCount() int {
 	return len(fake.workerNameArgsForCall)
 }
 
-func (fake *FakeContainer) WorkerNameCalls(stub func() string) {
-	fake.workerNameMutex.Lock()
-	defer fake.workerNameMutex.Unlock()
-	fake.WorkerNameStub = stub
-}
-
 func (fake *FakeContainer) WorkerNameReturns(result1 string) {
-	fake.workerNameMutex.Lock()
-	defer fake.workerNameMutex.Unlock()
 	fake.WorkerNameStub = nil
 	fake.workerNameReturns = struct {
 		result1 string
@@ -1676,8 +1438,6 @@ func (fake *FakeContainer) WorkerNameReturns(result1 string) {
 }
 
 func (fake *FakeContainer) WorkerNameReturnsOnCall(i int, result1 string) {
-	fake.workerNameMutex.Lock()
-	defer fake.workerNameMutex.Unlock()
 	fake.WorkerNameStub = nil
 	if fake.workerNameReturnsOnCall == nil {
 		fake.workerNameReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_container_placement_strategy.go
+++ b/atc/worker/workerfakes/fake_container_placement_strategy.go
@@ -2,10 +2,10 @@
 package workerfakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc/worker"
+	lager "code.cloudfoundry.org/lager"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeContainerPlacementStrategy struct {
@@ -59,12 +59,6 @@ func (fake *FakeContainerPlacementStrategy) ChooseCallCount() int {
 	return len(fake.chooseArgsForCall)
 }
 
-func (fake *FakeContainerPlacementStrategy) ChooseCalls(stub func(lager.Logger, []worker.Worker, worker.ContainerSpec) (worker.Worker, error)) {
-	fake.chooseMutex.Lock()
-	defer fake.chooseMutex.Unlock()
-	fake.ChooseStub = stub
-}
-
 func (fake *FakeContainerPlacementStrategy) ChooseArgsForCall(i int) (lager.Logger, []worker.Worker, worker.ContainerSpec) {
 	fake.chooseMutex.RLock()
 	defer fake.chooseMutex.RUnlock()
@@ -73,8 +67,6 @@ func (fake *FakeContainerPlacementStrategy) ChooseArgsForCall(i int) (lager.Logg
 }
 
 func (fake *FakeContainerPlacementStrategy) ChooseReturns(result1 worker.Worker, result2 error) {
-	fake.chooseMutex.Lock()
-	defer fake.chooseMutex.Unlock()
 	fake.ChooseStub = nil
 	fake.chooseReturns = struct {
 		result1 worker.Worker
@@ -83,8 +75,6 @@ func (fake *FakeContainerPlacementStrategy) ChooseReturns(result1 worker.Worker,
 }
 
 func (fake *FakeContainerPlacementStrategy) ChooseReturnsOnCall(i int, result1 worker.Worker, result2 error) {
-	fake.chooseMutex.Lock()
-	defer fake.chooseMutex.Unlock()
 	fake.ChooseStub = nil
 	if fake.chooseReturnsOnCall == nil {
 		fake.chooseReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_image.go
+++ b/atc/worker/workerfakes/fake_image.go
@@ -2,12 +2,12 @@
 package workerfakes
 
 import (
-	"context"
-	"sync"
+	context "context"
+	sync "sync"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/worker"
+	lager "code.cloudfoundry.org/lager"
+	db "github.com/concourse/concourse/atc/db"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeImage struct {
@@ -56,12 +56,6 @@ func (fake *FakeImage) FetchForContainerCallCount() int {
 	return len(fake.fetchForContainerArgsForCall)
 }
 
-func (fake *FakeImage) FetchForContainerCalls(stub func(context.Context, lager.Logger, db.CreatingContainer) (worker.FetchedImage, error)) {
-	fake.fetchForContainerMutex.Lock()
-	defer fake.fetchForContainerMutex.Unlock()
-	fake.FetchForContainerStub = stub
-}
-
 func (fake *FakeImage) FetchForContainerArgsForCall(i int) (context.Context, lager.Logger, db.CreatingContainer) {
 	fake.fetchForContainerMutex.RLock()
 	defer fake.fetchForContainerMutex.RUnlock()
@@ -70,8 +64,6 @@ func (fake *FakeImage) FetchForContainerArgsForCall(i int) (context.Context, lag
 }
 
 func (fake *FakeImage) FetchForContainerReturns(result1 worker.FetchedImage, result2 error) {
-	fake.fetchForContainerMutex.Lock()
-	defer fake.fetchForContainerMutex.Unlock()
 	fake.FetchForContainerStub = nil
 	fake.fetchForContainerReturns = struct {
 		result1 worker.FetchedImage
@@ -80,8 +72,6 @@ func (fake *FakeImage) FetchForContainerReturns(result1 worker.FetchedImage, res
 }
 
 func (fake *FakeImage) FetchForContainerReturnsOnCall(i int, result1 worker.FetchedImage, result2 error) {
-	fake.fetchForContainerMutex.Lock()
-	defer fake.fetchForContainerMutex.Unlock()
 	fake.FetchForContainerStub = nil
 	if fake.fetchForContainerReturnsOnCall == nil {
 		fake.fetchForContainerReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_image_factory.go
+++ b/atc/worker/workerfakes/fake_image_factory.go
@@ -2,11 +2,11 @@
 package workerfakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/worker"
+	lager "code.cloudfoundry.org/lager"
+	atc "github.com/concourse/concourse/atc"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeImageFactory struct {
@@ -63,12 +63,6 @@ func (fake *FakeImageFactory) GetImageCallCount() int {
 	return len(fake.getImageArgsForCall)
 }
 
-func (fake *FakeImageFactory) GetImageCalls(stub func(lager.Logger, worker.Worker, worker.VolumeClient, worker.ImageSpec, int, worker.ImageFetchingDelegate, atc.VersionedResourceTypes) (worker.Image, error)) {
-	fake.getImageMutex.Lock()
-	defer fake.getImageMutex.Unlock()
-	fake.GetImageStub = stub
-}
-
 func (fake *FakeImageFactory) GetImageArgsForCall(i int) (lager.Logger, worker.Worker, worker.VolumeClient, worker.ImageSpec, int, worker.ImageFetchingDelegate, atc.VersionedResourceTypes) {
 	fake.getImageMutex.RLock()
 	defer fake.getImageMutex.RUnlock()
@@ -77,8 +71,6 @@ func (fake *FakeImageFactory) GetImageArgsForCall(i int) (lager.Logger, worker.W
 }
 
 func (fake *FakeImageFactory) GetImageReturns(result1 worker.Image, result2 error) {
-	fake.getImageMutex.Lock()
-	defer fake.getImageMutex.Unlock()
 	fake.GetImageStub = nil
 	fake.getImageReturns = struct {
 		result1 worker.Image
@@ -87,8 +79,6 @@ func (fake *FakeImageFactory) GetImageReturns(result1 worker.Image, result2 erro
 }
 
 func (fake *FakeImageFactory) GetImageReturnsOnCall(i int, result1 worker.Image, result2 error) {
-	fake.getImageMutex.Lock()
-	defer fake.getImageMutex.Unlock()
 	fake.GetImageStub = nil
 	if fake.getImageReturnsOnCall == nil {
 		fake.getImageReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_image_fetching_delegate.go
+++ b/atc/worker/workerfakes/fake_image_fetching_delegate.go
@@ -2,11 +2,11 @@
 package workerfakes
 
 import (
-	"io"
-	"sync"
+	io "io"
+	sync "sync"
 
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/worker"
+	db "github.com/concourse/concourse/atc/db"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeImageFetchingDelegate struct {
@@ -69,12 +69,6 @@ func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedCallCount() int {
 	return len(fake.imageVersionDeterminedArgsForCall)
 }
 
-func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedCalls(stub func(db.UsedResourceCache) error) {
-	fake.imageVersionDeterminedMutex.Lock()
-	defer fake.imageVersionDeterminedMutex.Unlock()
-	fake.ImageVersionDeterminedStub = stub
-}
-
 func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedArgsForCall(i int) db.UsedResourceCache {
 	fake.imageVersionDeterminedMutex.RLock()
 	defer fake.imageVersionDeterminedMutex.RUnlock()
@@ -83,8 +77,6 @@ func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedArgsForCall(i int) 
 }
 
 func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedReturns(result1 error) {
-	fake.imageVersionDeterminedMutex.Lock()
-	defer fake.imageVersionDeterminedMutex.Unlock()
 	fake.ImageVersionDeterminedStub = nil
 	fake.imageVersionDeterminedReturns = struct {
 		result1 error
@@ -92,8 +84,6 @@ func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedReturns(result1 err
 }
 
 func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedReturnsOnCall(i int, result1 error) {
-	fake.imageVersionDeterminedMutex.Lock()
-	defer fake.imageVersionDeterminedMutex.Unlock()
 	fake.ImageVersionDeterminedStub = nil
 	if fake.imageVersionDeterminedReturnsOnCall == nil {
 		fake.imageVersionDeterminedReturnsOnCall = make(map[int]struct {
@@ -128,15 +118,7 @@ func (fake *FakeImageFetchingDelegate) StderrCallCount() int {
 	return len(fake.stderrArgsForCall)
 }
 
-func (fake *FakeImageFetchingDelegate) StderrCalls(stub func() io.Writer) {
-	fake.stderrMutex.Lock()
-	defer fake.stderrMutex.Unlock()
-	fake.StderrStub = stub
-}
-
 func (fake *FakeImageFetchingDelegate) StderrReturns(result1 io.Writer) {
-	fake.stderrMutex.Lock()
-	defer fake.stderrMutex.Unlock()
 	fake.StderrStub = nil
 	fake.stderrReturns = struct {
 		result1 io.Writer
@@ -144,8 +126,6 @@ func (fake *FakeImageFetchingDelegate) StderrReturns(result1 io.Writer) {
 }
 
 func (fake *FakeImageFetchingDelegate) StderrReturnsOnCall(i int, result1 io.Writer) {
-	fake.stderrMutex.Lock()
-	defer fake.stderrMutex.Unlock()
 	fake.StderrStub = nil
 	if fake.stderrReturnsOnCall == nil {
 		fake.stderrReturnsOnCall = make(map[int]struct {
@@ -180,15 +160,7 @@ func (fake *FakeImageFetchingDelegate) StdoutCallCount() int {
 	return len(fake.stdoutArgsForCall)
 }
 
-func (fake *FakeImageFetchingDelegate) StdoutCalls(stub func() io.Writer) {
-	fake.stdoutMutex.Lock()
-	defer fake.stdoutMutex.Unlock()
-	fake.StdoutStub = stub
-}
-
 func (fake *FakeImageFetchingDelegate) StdoutReturns(result1 io.Writer) {
-	fake.stdoutMutex.Lock()
-	defer fake.stdoutMutex.Unlock()
 	fake.StdoutStub = nil
 	fake.stdoutReturns = struct {
 		result1 io.Writer
@@ -196,8 +168,6 @@ func (fake *FakeImageFetchingDelegate) StdoutReturns(result1 io.Writer) {
 }
 
 func (fake *FakeImageFetchingDelegate) StdoutReturnsOnCall(i int, result1 io.Writer) {
-	fake.stdoutMutex.Lock()
-	defer fake.stdoutMutex.Unlock()
 	fake.StdoutStub = nil
 	if fake.stdoutReturnsOnCall == nil {
 		fake.stdoutReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_input_source.go
+++ b/atc/worker/workerfakes/fake_input_source.go
@@ -2,9 +2,9 @@
 package workerfakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"github.com/concourse/concourse/atc/worker"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeInputSource struct {
@@ -55,15 +55,7 @@ func (fake *FakeInputSource) DestinationPathCallCount() int {
 	return len(fake.destinationPathArgsForCall)
 }
 
-func (fake *FakeInputSource) DestinationPathCalls(stub func() string) {
-	fake.destinationPathMutex.Lock()
-	defer fake.destinationPathMutex.Unlock()
-	fake.DestinationPathStub = stub
-}
-
 func (fake *FakeInputSource) DestinationPathReturns(result1 string) {
-	fake.destinationPathMutex.Lock()
-	defer fake.destinationPathMutex.Unlock()
 	fake.DestinationPathStub = nil
 	fake.destinationPathReturns = struct {
 		result1 string
@@ -71,8 +63,6 @@ func (fake *FakeInputSource) DestinationPathReturns(result1 string) {
 }
 
 func (fake *FakeInputSource) DestinationPathReturnsOnCall(i int, result1 string) {
-	fake.destinationPathMutex.Lock()
-	defer fake.destinationPathMutex.Unlock()
 	fake.DestinationPathStub = nil
 	if fake.destinationPathReturnsOnCall == nil {
 		fake.destinationPathReturnsOnCall = make(map[int]struct {
@@ -107,15 +97,7 @@ func (fake *FakeInputSource) SourceCallCount() int {
 	return len(fake.sourceArgsForCall)
 }
 
-func (fake *FakeInputSource) SourceCalls(stub func() worker.ArtifactSource) {
-	fake.sourceMutex.Lock()
-	defer fake.sourceMutex.Unlock()
-	fake.SourceStub = stub
-}
-
 func (fake *FakeInputSource) SourceReturns(result1 worker.ArtifactSource) {
-	fake.sourceMutex.Lock()
-	defer fake.sourceMutex.Unlock()
 	fake.SourceStub = nil
 	fake.sourceReturns = struct {
 		result1 worker.ArtifactSource
@@ -123,8 +105,6 @@ func (fake *FakeInputSource) SourceReturns(result1 worker.ArtifactSource) {
 }
 
 func (fake *FakeInputSource) SourceReturnsOnCall(i int, result1 worker.ArtifactSource) {
-	fake.sourceMutex.Lock()
-	defer fake.sourceMutex.Unlock()
 	fake.SourceStub = nil
 	if fake.sourceReturnsOnCall == nil {
 		fake.sourceReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_pool.go
+++ b/atc/worker/workerfakes/fake_pool.go
@@ -2,13 +2,13 @@
 package workerfakes
 
 import (
-	"context"
-	"sync"
+	context "context"
+	sync "sync"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/db/lock"
-	"github.com/concourse/concourse/atc/worker"
+	lager "code.cloudfoundry.org/lager"
+	db "github.com/concourse/concourse/atc/db"
+	lock "github.com/concourse/concourse/atc/db/lock"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakePool struct {
@@ -41,16 +41,15 @@ type FakePool struct {
 		result1 worker.Worker
 		result2 error
 	}
-	FindOrChooseWorkerForContainerStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, db.ContainerMetadata, worker.WorkerSpec, worker.ContainerPlacementStrategy) (worker.Worker, error)
+	FindOrChooseWorkerForContainerStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy) (worker.Worker, error)
 	findOrChooseWorkerForContainerMutex       sync.RWMutex
 	findOrChooseWorkerForContainerArgsForCall []struct {
 		arg1 context.Context
 		arg2 lager.Logger
 		arg3 db.ContainerOwner
 		arg4 worker.ContainerSpec
-		arg5 db.ContainerMetadata
-		arg6 worker.WorkerSpec
-		arg7 worker.ContainerPlacementStrategy
+		arg5 worker.WorkerSpec
+		arg6 worker.ContainerPlacementStrategy
 	}
 	findOrChooseWorkerForContainerReturns struct {
 		result1 worker.Worker
@@ -88,12 +87,6 @@ func (fake *FakePool) AcquireContainerCreatingLockCallCount() int {
 	return len(fake.acquireContainerCreatingLockArgsForCall)
 }
 
-func (fake *FakePool) AcquireContainerCreatingLockCalls(stub func(lager.Logger) (lock.Lock, bool, error)) {
-	fake.acquireContainerCreatingLockMutex.Lock()
-	defer fake.acquireContainerCreatingLockMutex.Unlock()
-	fake.AcquireContainerCreatingLockStub = stub
-}
-
 func (fake *FakePool) AcquireContainerCreatingLockArgsForCall(i int) lager.Logger {
 	fake.acquireContainerCreatingLockMutex.RLock()
 	defer fake.acquireContainerCreatingLockMutex.RUnlock()
@@ -102,8 +95,6 @@ func (fake *FakePool) AcquireContainerCreatingLockArgsForCall(i int) lager.Logge
 }
 
 func (fake *FakePool) AcquireContainerCreatingLockReturns(result1 lock.Lock, result2 bool, result3 error) {
-	fake.acquireContainerCreatingLockMutex.Lock()
-	defer fake.acquireContainerCreatingLockMutex.Unlock()
 	fake.AcquireContainerCreatingLockStub = nil
 	fake.acquireContainerCreatingLockReturns = struct {
 		result1 lock.Lock
@@ -113,8 +104,6 @@ func (fake *FakePool) AcquireContainerCreatingLockReturns(result1 lock.Lock, res
 }
 
 func (fake *FakePool) AcquireContainerCreatingLockReturnsOnCall(i int, result1 lock.Lock, result2 bool, result3 error) {
-	fake.acquireContainerCreatingLockMutex.Lock()
-	defer fake.acquireContainerCreatingLockMutex.Unlock()
 	fake.AcquireContainerCreatingLockStub = nil
 	if fake.acquireContainerCreatingLockReturnsOnCall == nil {
 		fake.acquireContainerCreatingLockReturnsOnCall = make(map[int]struct {
@@ -155,12 +144,6 @@ func (fake *FakePool) FindOrChooseWorkerCallCount() int {
 	return len(fake.findOrChooseWorkerArgsForCall)
 }
 
-func (fake *FakePool) FindOrChooseWorkerCalls(stub func(lager.Logger, worker.WorkerSpec) (worker.Worker, error)) {
-	fake.findOrChooseWorkerMutex.Lock()
-	defer fake.findOrChooseWorkerMutex.Unlock()
-	fake.FindOrChooseWorkerStub = stub
-}
-
 func (fake *FakePool) FindOrChooseWorkerArgsForCall(i int) (lager.Logger, worker.WorkerSpec) {
 	fake.findOrChooseWorkerMutex.RLock()
 	defer fake.findOrChooseWorkerMutex.RUnlock()
@@ -169,8 +152,6 @@ func (fake *FakePool) FindOrChooseWorkerArgsForCall(i int) (lager.Logger, worker
 }
 
 func (fake *FakePool) FindOrChooseWorkerReturns(result1 worker.Worker, result2 error) {
-	fake.findOrChooseWorkerMutex.Lock()
-	defer fake.findOrChooseWorkerMutex.Unlock()
 	fake.FindOrChooseWorkerStub = nil
 	fake.findOrChooseWorkerReturns = struct {
 		result1 worker.Worker
@@ -179,8 +160,6 @@ func (fake *FakePool) FindOrChooseWorkerReturns(result1 worker.Worker, result2 e
 }
 
 func (fake *FakePool) FindOrChooseWorkerReturnsOnCall(i int, result1 worker.Worker, result2 error) {
-	fake.findOrChooseWorkerMutex.Lock()
-	defer fake.findOrChooseWorkerMutex.Unlock()
 	fake.FindOrChooseWorkerStub = nil
 	if fake.findOrChooseWorkerReturnsOnCall == nil {
 		fake.findOrChooseWorkerReturnsOnCall = make(map[int]struct {
@@ -194,7 +173,7 @@ func (fake *FakePool) FindOrChooseWorkerReturnsOnCall(i int, result1 worker.Work
 	}{result1, result2}
 }
 
-func (fake *FakePool) FindOrChooseWorkerForContainer(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 db.ContainerMetadata, arg6 worker.WorkerSpec, arg7 worker.ContainerPlacementStrategy) (worker.Worker, error) {
+func (fake *FakePool) FindOrChooseWorkerForContainer(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy) (worker.Worker, error) {
 	fake.findOrChooseWorkerForContainerMutex.Lock()
 	ret, specificReturn := fake.findOrChooseWorkerForContainerReturnsOnCall[len(fake.findOrChooseWorkerForContainerArgsForCall)]
 	fake.findOrChooseWorkerForContainerArgsForCall = append(fake.findOrChooseWorkerForContainerArgsForCall, struct {
@@ -202,14 +181,13 @@ func (fake *FakePool) FindOrChooseWorkerForContainer(arg1 context.Context, arg2 
 		arg2 lager.Logger
 		arg3 db.ContainerOwner
 		arg4 worker.ContainerSpec
-		arg5 db.ContainerMetadata
-		arg6 worker.WorkerSpec
-		arg7 worker.ContainerPlacementStrategy
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
-	fake.recordInvocation("FindOrChooseWorkerForContainer", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg5 worker.WorkerSpec
+		arg6 worker.ContainerPlacementStrategy
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.recordInvocation("FindOrChooseWorkerForContainer", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.findOrChooseWorkerForContainerMutex.Unlock()
 	if fake.FindOrChooseWorkerForContainerStub != nil {
-		return fake.FindOrChooseWorkerForContainerStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		return fake.FindOrChooseWorkerForContainerStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -224,22 +202,14 @@ func (fake *FakePool) FindOrChooseWorkerForContainerCallCount() int {
 	return len(fake.findOrChooseWorkerForContainerArgsForCall)
 }
 
-func (fake *FakePool) FindOrChooseWorkerForContainerCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, db.ContainerMetadata, worker.WorkerSpec, worker.ContainerPlacementStrategy) (worker.Worker, error)) {
-	fake.findOrChooseWorkerForContainerMutex.Lock()
-	defer fake.findOrChooseWorkerForContainerMutex.Unlock()
-	fake.FindOrChooseWorkerForContainerStub = stub
-}
-
-func (fake *FakePool) FindOrChooseWorkerForContainerArgsForCall(i int) (context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, db.ContainerMetadata, worker.WorkerSpec, worker.ContainerPlacementStrategy) {
+func (fake *FakePool) FindOrChooseWorkerForContainerArgsForCall(i int) (context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy) {
 	fake.findOrChooseWorkerForContainerMutex.RLock()
 	defer fake.findOrChooseWorkerForContainerMutex.RUnlock()
 	argsForCall := fake.findOrChooseWorkerForContainerArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakePool) FindOrChooseWorkerForContainerReturns(result1 worker.Worker, result2 error) {
-	fake.findOrChooseWorkerForContainerMutex.Lock()
-	defer fake.findOrChooseWorkerForContainerMutex.Unlock()
 	fake.FindOrChooseWorkerForContainerStub = nil
 	fake.findOrChooseWorkerForContainerReturns = struct {
 		result1 worker.Worker
@@ -248,8 +218,6 @@ func (fake *FakePool) FindOrChooseWorkerForContainerReturns(result1 worker.Worke
 }
 
 func (fake *FakePool) FindOrChooseWorkerForContainerReturnsOnCall(i int, result1 worker.Worker, result2 error) {
-	fake.findOrChooseWorkerForContainerMutex.Lock()
-	defer fake.findOrChooseWorkerForContainerMutex.Unlock()
 	fake.FindOrChooseWorkerForContainerStub = nil
 	if fake.findOrChooseWorkerForContainerReturnsOnCall == nil {
 		fake.findOrChooseWorkerForContainerReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_pool.go
+++ b/atc/worker/workerfakes/fake_pool.go
@@ -7,26 +7,10 @@ import (
 
 	lager "code.cloudfoundry.org/lager"
 	db "github.com/concourse/concourse/atc/db"
-	lock "github.com/concourse/concourse/atc/db/lock"
 	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakePool struct {
-	AcquireContainerCreatingLockStub        func(lager.Logger) (lock.Lock, bool, error)
-	acquireContainerCreatingLockMutex       sync.RWMutex
-	acquireContainerCreatingLockArgsForCall []struct {
-		arg1 lager.Logger
-	}
-	acquireContainerCreatingLockReturns struct {
-		result1 lock.Lock
-		result2 bool
-		result3 error
-	}
-	acquireContainerCreatingLockReturnsOnCall map[int]struct {
-		result1 lock.Lock
-		result2 bool
-		result3 error
-	}
 	FindOrChooseWorkerStub        func(lager.Logger, worker.WorkerSpec) (worker.Worker, error)
 	findOrChooseWorkerMutex       sync.RWMutex
 	findOrChooseWorkerArgsForCall []struct {
@@ -61,62 +45,6 @@ type FakePool struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakePool) AcquireContainerCreatingLock(arg1 lager.Logger) (lock.Lock, bool, error) {
-	fake.acquireContainerCreatingLockMutex.Lock()
-	ret, specificReturn := fake.acquireContainerCreatingLockReturnsOnCall[len(fake.acquireContainerCreatingLockArgsForCall)]
-	fake.acquireContainerCreatingLockArgsForCall = append(fake.acquireContainerCreatingLockArgsForCall, struct {
-		arg1 lager.Logger
-	}{arg1})
-	fake.recordInvocation("AcquireContainerCreatingLock", []interface{}{arg1})
-	fake.acquireContainerCreatingLockMutex.Unlock()
-	if fake.AcquireContainerCreatingLockStub != nil {
-		return fake.AcquireContainerCreatingLockStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	fakeReturns := fake.acquireContainerCreatingLockReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakePool) AcquireContainerCreatingLockCallCount() int {
-	fake.acquireContainerCreatingLockMutex.RLock()
-	defer fake.acquireContainerCreatingLockMutex.RUnlock()
-	return len(fake.acquireContainerCreatingLockArgsForCall)
-}
-
-func (fake *FakePool) AcquireContainerCreatingLockArgsForCall(i int) lager.Logger {
-	fake.acquireContainerCreatingLockMutex.RLock()
-	defer fake.acquireContainerCreatingLockMutex.RUnlock()
-	argsForCall := fake.acquireContainerCreatingLockArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakePool) AcquireContainerCreatingLockReturns(result1 lock.Lock, result2 bool, result3 error) {
-	fake.AcquireContainerCreatingLockStub = nil
-	fake.acquireContainerCreatingLockReturns = struct {
-		result1 lock.Lock
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakePool) AcquireContainerCreatingLockReturnsOnCall(i int, result1 lock.Lock, result2 bool, result3 error) {
-	fake.AcquireContainerCreatingLockStub = nil
-	if fake.acquireContainerCreatingLockReturnsOnCall == nil {
-		fake.acquireContainerCreatingLockReturnsOnCall = make(map[int]struct {
-			result1 lock.Lock
-			result2 bool
-			result3 error
-		})
-	}
-	fake.acquireContainerCreatingLockReturnsOnCall[i] = struct {
-		result1 lock.Lock
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
 }
 
 func (fake *FakePool) FindOrChooseWorker(arg1 lager.Logger, arg2 worker.WorkerSpec) (worker.Worker, error) {
@@ -234,8 +162,6 @@ func (fake *FakePool) FindOrChooseWorkerForContainerReturnsOnCall(i int, result1
 func (fake *FakePool) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.acquireContainerCreatingLockMutex.RLock()
-	defer fake.acquireContainerCreatingLockMutex.RUnlock()
 	fake.findOrChooseWorkerMutex.RLock()
 	defer fake.findOrChooseWorkerMutex.RUnlock()
 	fake.findOrChooseWorkerForContainerMutex.RLock()

--- a/atc/worker/workerfakes/fake_volume.go
+++ b/atc/worker/workerfakes/fake_volume.go
@@ -2,13 +2,13 @@
 package workerfakes
 
 import (
-	"io"
-	"sync"
+	io "io"
+	sync "sync"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/baggageclaim"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/worker"
+	lager "code.cloudfoundry.org/lager"
+	baggageclaim "github.com/concourse/baggageclaim"
+	db "github.com/concourse/concourse/atc/db"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeVolume struct {
@@ -203,15 +203,7 @@ func (fake *FakeVolume) COWStrategyCallCount() int {
 	return len(fake.cOWStrategyArgsForCall)
 }
 
-func (fake *FakeVolume) COWStrategyCalls(stub func() baggageclaim.COWStrategy) {
-	fake.cOWStrategyMutex.Lock()
-	defer fake.cOWStrategyMutex.Unlock()
-	fake.COWStrategyStub = stub
-}
-
 func (fake *FakeVolume) COWStrategyReturns(result1 baggageclaim.COWStrategy) {
-	fake.cOWStrategyMutex.Lock()
-	defer fake.cOWStrategyMutex.Unlock()
 	fake.COWStrategyStub = nil
 	fake.cOWStrategyReturns = struct {
 		result1 baggageclaim.COWStrategy
@@ -219,8 +211,6 @@ func (fake *FakeVolume) COWStrategyReturns(result1 baggageclaim.COWStrategy) {
 }
 
 func (fake *FakeVolume) COWStrategyReturnsOnCall(i int, result1 baggageclaim.COWStrategy) {
-	fake.cOWStrategyMutex.Lock()
-	defer fake.cOWStrategyMutex.Unlock()
 	fake.COWStrategyStub = nil
 	if fake.cOWStrategyReturnsOnCall == nil {
 		fake.cOWStrategyReturnsOnCall = make(map[int]struct {
@@ -257,12 +247,6 @@ func (fake *FakeVolume) CreateChildForContainerCallCount() int {
 	return len(fake.createChildForContainerArgsForCall)
 }
 
-func (fake *FakeVolume) CreateChildForContainerCalls(stub func(db.CreatingContainer, string) (db.CreatingVolume, error)) {
-	fake.createChildForContainerMutex.Lock()
-	defer fake.createChildForContainerMutex.Unlock()
-	fake.CreateChildForContainerStub = stub
-}
-
 func (fake *FakeVolume) CreateChildForContainerArgsForCall(i int) (db.CreatingContainer, string) {
 	fake.createChildForContainerMutex.RLock()
 	defer fake.createChildForContainerMutex.RUnlock()
@@ -271,8 +255,6 @@ func (fake *FakeVolume) CreateChildForContainerArgsForCall(i int) (db.CreatingCo
 }
 
 func (fake *FakeVolume) CreateChildForContainerReturns(result1 db.CreatingVolume, result2 error) {
-	fake.createChildForContainerMutex.Lock()
-	defer fake.createChildForContainerMutex.Unlock()
 	fake.CreateChildForContainerStub = nil
 	fake.createChildForContainerReturns = struct {
 		result1 db.CreatingVolume
@@ -281,8 +263,6 @@ func (fake *FakeVolume) CreateChildForContainerReturns(result1 db.CreatingVolume
 }
 
 func (fake *FakeVolume) CreateChildForContainerReturnsOnCall(i int, result1 db.CreatingVolume, result2 error) {
-	fake.createChildForContainerMutex.Lock()
-	defer fake.createChildForContainerMutex.Unlock()
 	fake.CreateChildForContainerStub = nil
 	if fake.createChildForContainerReturnsOnCall == nil {
 		fake.createChildForContainerReturnsOnCall = make(map[int]struct {
@@ -319,15 +299,7 @@ func (fake *FakeVolume) DestroyCallCount() int {
 	return len(fake.destroyArgsForCall)
 }
 
-func (fake *FakeVolume) DestroyCalls(stub func() error) {
-	fake.destroyMutex.Lock()
-	defer fake.destroyMutex.Unlock()
-	fake.DestroyStub = stub
-}
-
 func (fake *FakeVolume) DestroyReturns(result1 error) {
-	fake.destroyMutex.Lock()
-	defer fake.destroyMutex.Unlock()
 	fake.DestroyStub = nil
 	fake.destroyReturns = struct {
 		result1 error
@@ -335,8 +307,6 @@ func (fake *FakeVolume) DestroyReturns(result1 error) {
 }
 
 func (fake *FakeVolume) DestroyReturnsOnCall(i int, result1 error) {
-	fake.destroyMutex.Lock()
-	defer fake.destroyMutex.Unlock()
 	fake.DestroyStub = nil
 	if fake.destroyReturnsOnCall == nil {
 		fake.destroyReturnsOnCall = make(map[int]struct {
@@ -371,15 +341,7 @@ func (fake *FakeVolume) HandleCallCount() int {
 	return len(fake.handleArgsForCall)
 }
 
-func (fake *FakeVolume) HandleCalls(stub func() string) {
-	fake.handleMutex.Lock()
-	defer fake.handleMutex.Unlock()
-	fake.HandleStub = stub
-}
-
 func (fake *FakeVolume) HandleReturns(result1 string) {
-	fake.handleMutex.Lock()
-	defer fake.handleMutex.Unlock()
 	fake.HandleStub = nil
 	fake.handleReturns = struct {
 		result1 string
@@ -387,8 +349,6 @@ func (fake *FakeVolume) HandleReturns(result1 string) {
 }
 
 func (fake *FakeVolume) HandleReturnsOnCall(i int, result1 string) {
-	fake.handleMutex.Lock()
-	defer fake.handleMutex.Unlock()
 	fake.HandleStub = nil
 	if fake.handleReturnsOnCall == nil {
 		fake.handleReturnsOnCall = make(map[int]struct {
@@ -425,12 +385,6 @@ func (fake *FakeVolume) InitializeArtifactCallCount() int {
 	return len(fake.initializeArtifactArgsForCall)
 }
 
-func (fake *FakeVolume) InitializeArtifactCalls(stub func(string, int) (db.WorkerArtifact, error)) {
-	fake.initializeArtifactMutex.Lock()
-	defer fake.initializeArtifactMutex.Unlock()
-	fake.InitializeArtifactStub = stub
-}
-
 func (fake *FakeVolume) InitializeArtifactArgsForCall(i int) (string, int) {
 	fake.initializeArtifactMutex.RLock()
 	defer fake.initializeArtifactMutex.RUnlock()
@@ -439,8 +393,6 @@ func (fake *FakeVolume) InitializeArtifactArgsForCall(i int) (string, int) {
 }
 
 func (fake *FakeVolume) InitializeArtifactReturns(result1 db.WorkerArtifact, result2 error) {
-	fake.initializeArtifactMutex.Lock()
-	defer fake.initializeArtifactMutex.Unlock()
 	fake.InitializeArtifactStub = nil
 	fake.initializeArtifactReturns = struct {
 		result1 db.WorkerArtifact
@@ -449,8 +401,6 @@ func (fake *FakeVolume) InitializeArtifactReturns(result1 db.WorkerArtifact, res
 }
 
 func (fake *FakeVolume) InitializeArtifactReturnsOnCall(i int, result1 db.WorkerArtifact, result2 error) {
-	fake.initializeArtifactMutex.Lock()
-	defer fake.initializeArtifactMutex.Unlock()
 	fake.InitializeArtifactStub = nil
 	if fake.initializeArtifactReturnsOnCall == nil {
 		fake.initializeArtifactReturnsOnCall = make(map[int]struct {
@@ -488,12 +438,6 @@ func (fake *FakeVolume) InitializeResourceCacheCallCount() int {
 	return len(fake.initializeResourceCacheArgsForCall)
 }
 
-func (fake *FakeVolume) InitializeResourceCacheCalls(stub func(db.UsedResourceCache) error) {
-	fake.initializeResourceCacheMutex.Lock()
-	defer fake.initializeResourceCacheMutex.Unlock()
-	fake.InitializeResourceCacheStub = stub
-}
-
 func (fake *FakeVolume) InitializeResourceCacheArgsForCall(i int) db.UsedResourceCache {
 	fake.initializeResourceCacheMutex.RLock()
 	defer fake.initializeResourceCacheMutex.RUnlock()
@@ -502,8 +446,6 @@ func (fake *FakeVolume) InitializeResourceCacheArgsForCall(i int) db.UsedResourc
 }
 
 func (fake *FakeVolume) InitializeResourceCacheReturns(result1 error) {
-	fake.initializeResourceCacheMutex.Lock()
-	defer fake.initializeResourceCacheMutex.Unlock()
 	fake.InitializeResourceCacheStub = nil
 	fake.initializeResourceCacheReturns = struct {
 		result1 error
@@ -511,8 +453,6 @@ func (fake *FakeVolume) InitializeResourceCacheReturns(result1 error) {
 }
 
 func (fake *FakeVolume) InitializeResourceCacheReturnsOnCall(i int, result1 error) {
-	fake.initializeResourceCacheMutex.Lock()
-	defer fake.initializeResourceCacheMutex.Unlock()
 	fake.InitializeResourceCacheStub = nil
 	if fake.initializeResourceCacheReturnsOnCall == nil {
 		fake.initializeResourceCacheReturnsOnCall = make(map[int]struct {
@@ -552,12 +492,6 @@ func (fake *FakeVolume) InitializeTaskCacheCallCount() int {
 	return len(fake.initializeTaskCacheArgsForCall)
 }
 
-func (fake *FakeVolume) InitializeTaskCacheCalls(stub func(lager.Logger, int, string, string, bool) error) {
-	fake.initializeTaskCacheMutex.Lock()
-	defer fake.initializeTaskCacheMutex.Unlock()
-	fake.InitializeTaskCacheStub = stub
-}
-
 func (fake *FakeVolume) InitializeTaskCacheArgsForCall(i int) (lager.Logger, int, string, string, bool) {
 	fake.initializeTaskCacheMutex.RLock()
 	defer fake.initializeTaskCacheMutex.RUnlock()
@@ -566,8 +500,6 @@ func (fake *FakeVolume) InitializeTaskCacheArgsForCall(i int) (lager.Logger, int
 }
 
 func (fake *FakeVolume) InitializeTaskCacheReturns(result1 error) {
-	fake.initializeTaskCacheMutex.Lock()
-	defer fake.initializeTaskCacheMutex.Unlock()
 	fake.InitializeTaskCacheStub = nil
 	fake.initializeTaskCacheReturns = struct {
 		result1 error
@@ -575,8 +507,6 @@ func (fake *FakeVolume) InitializeTaskCacheReturns(result1 error) {
 }
 
 func (fake *FakeVolume) InitializeTaskCacheReturnsOnCall(i int, result1 error) {
-	fake.initializeTaskCacheMutex.Lock()
-	defer fake.initializeTaskCacheMutex.Unlock()
 	fake.InitializeTaskCacheStub = nil
 	if fake.initializeTaskCacheReturnsOnCall == nil {
 		fake.initializeTaskCacheReturnsOnCall = make(map[int]struct {
@@ -611,15 +541,7 @@ func (fake *FakeVolume) PathCallCount() int {
 	return len(fake.pathArgsForCall)
 }
 
-func (fake *FakeVolume) PathCalls(stub func() string) {
-	fake.pathMutex.Lock()
-	defer fake.pathMutex.Unlock()
-	fake.PathStub = stub
-}
-
 func (fake *FakeVolume) PathReturns(result1 string) {
-	fake.pathMutex.Lock()
-	defer fake.pathMutex.Unlock()
 	fake.PathStub = nil
 	fake.pathReturns = struct {
 		result1 string
@@ -627,8 +549,6 @@ func (fake *FakeVolume) PathReturns(result1 string) {
 }
 
 func (fake *FakeVolume) PathReturnsOnCall(i int, result1 string) {
-	fake.pathMutex.Lock()
-	defer fake.pathMutex.Unlock()
 	fake.PathStub = nil
 	if fake.pathReturnsOnCall == nil {
 		fake.pathReturnsOnCall = make(map[int]struct {
@@ -663,15 +583,7 @@ func (fake *FakeVolume) PropertiesCallCount() int {
 	return len(fake.propertiesArgsForCall)
 }
 
-func (fake *FakeVolume) PropertiesCalls(stub func() (baggageclaim.VolumeProperties, error)) {
-	fake.propertiesMutex.Lock()
-	defer fake.propertiesMutex.Unlock()
-	fake.PropertiesStub = stub
-}
-
 func (fake *FakeVolume) PropertiesReturns(result1 baggageclaim.VolumeProperties, result2 error) {
-	fake.propertiesMutex.Lock()
-	defer fake.propertiesMutex.Unlock()
 	fake.PropertiesStub = nil
 	fake.propertiesReturns = struct {
 		result1 baggageclaim.VolumeProperties
@@ -680,8 +592,6 @@ func (fake *FakeVolume) PropertiesReturns(result1 baggageclaim.VolumeProperties,
 }
 
 func (fake *FakeVolume) PropertiesReturnsOnCall(i int, result1 baggageclaim.VolumeProperties, result2 error) {
-	fake.propertiesMutex.Lock()
-	defer fake.propertiesMutex.Unlock()
 	fake.PropertiesStub = nil
 	if fake.propertiesReturnsOnCall == nil {
 		fake.propertiesReturnsOnCall = make(map[int]struct {
@@ -719,12 +629,6 @@ func (fake *FakeVolume) SetPrivilegedCallCount() int {
 	return len(fake.setPrivilegedArgsForCall)
 }
 
-func (fake *FakeVolume) SetPrivilegedCalls(stub func(bool) error) {
-	fake.setPrivilegedMutex.Lock()
-	defer fake.setPrivilegedMutex.Unlock()
-	fake.SetPrivilegedStub = stub
-}
-
 func (fake *FakeVolume) SetPrivilegedArgsForCall(i int) bool {
 	fake.setPrivilegedMutex.RLock()
 	defer fake.setPrivilegedMutex.RUnlock()
@@ -733,8 +637,6 @@ func (fake *FakeVolume) SetPrivilegedArgsForCall(i int) bool {
 }
 
 func (fake *FakeVolume) SetPrivilegedReturns(result1 error) {
-	fake.setPrivilegedMutex.Lock()
-	defer fake.setPrivilegedMutex.Unlock()
 	fake.SetPrivilegedStub = nil
 	fake.setPrivilegedReturns = struct {
 		result1 error
@@ -742,8 +644,6 @@ func (fake *FakeVolume) SetPrivilegedReturns(result1 error) {
 }
 
 func (fake *FakeVolume) SetPrivilegedReturnsOnCall(i int, result1 error) {
-	fake.setPrivilegedMutex.Lock()
-	defer fake.setPrivilegedMutex.Unlock()
 	fake.SetPrivilegedStub = nil
 	if fake.setPrivilegedReturnsOnCall == nil {
 		fake.setPrivilegedReturnsOnCall = make(map[int]struct {
@@ -780,12 +680,6 @@ func (fake *FakeVolume) SetPropertyCallCount() int {
 	return len(fake.setPropertyArgsForCall)
 }
 
-func (fake *FakeVolume) SetPropertyCalls(stub func(string, string) error) {
-	fake.setPropertyMutex.Lock()
-	defer fake.setPropertyMutex.Unlock()
-	fake.SetPropertyStub = stub
-}
-
 func (fake *FakeVolume) SetPropertyArgsForCall(i int) (string, string) {
 	fake.setPropertyMutex.RLock()
 	defer fake.setPropertyMutex.RUnlock()
@@ -794,8 +688,6 @@ func (fake *FakeVolume) SetPropertyArgsForCall(i int) (string, string) {
 }
 
 func (fake *FakeVolume) SetPropertyReturns(result1 error) {
-	fake.setPropertyMutex.Lock()
-	defer fake.setPropertyMutex.Unlock()
 	fake.SetPropertyStub = nil
 	fake.setPropertyReturns = struct {
 		result1 error
@@ -803,8 +695,6 @@ func (fake *FakeVolume) SetPropertyReturns(result1 error) {
 }
 
 func (fake *FakeVolume) SetPropertyReturnsOnCall(i int, result1 error) {
-	fake.setPropertyMutex.Lock()
-	defer fake.setPropertyMutex.Unlock()
 	fake.SetPropertyStub = nil
 	if fake.setPropertyReturnsOnCall == nil {
 		fake.setPropertyReturnsOnCall = make(map[int]struct {
@@ -841,12 +731,6 @@ func (fake *FakeVolume) StreamInCallCount() int {
 	return len(fake.streamInArgsForCall)
 }
 
-func (fake *FakeVolume) StreamInCalls(stub func(string, io.Reader) error) {
-	fake.streamInMutex.Lock()
-	defer fake.streamInMutex.Unlock()
-	fake.StreamInStub = stub
-}
-
 func (fake *FakeVolume) StreamInArgsForCall(i int) (string, io.Reader) {
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
@@ -855,8 +739,6 @@ func (fake *FakeVolume) StreamInArgsForCall(i int) (string, io.Reader) {
 }
 
 func (fake *FakeVolume) StreamInReturns(result1 error) {
-	fake.streamInMutex.Lock()
-	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	fake.streamInReturns = struct {
 		result1 error
@@ -864,8 +746,6 @@ func (fake *FakeVolume) StreamInReturns(result1 error) {
 }
 
 func (fake *FakeVolume) StreamInReturnsOnCall(i int, result1 error) {
-	fake.streamInMutex.Lock()
-	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	if fake.streamInReturnsOnCall == nil {
 		fake.streamInReturnsOnCall = make(map[int]struct {
@@ -901,12 +781,6 @@ func (fake *FakeVolume) StreamOutCallCount() int {
 	return len(fake.streamOutArgsForCall)
 }
 
-func (fake *FakeVolume) StreamOutCalls(stub func(string) (io.ReadCloser, error)) {
-	fake.streamOutMutex.Lock()
-	defer fake.streamOutMutex.Unlock()
-	fake.StreamOutStub = stub
-}
-
 func (fake *FakeVolume) StreamOutArgsForCall(i int) string {
 	fake.streamOutMutex.RLock()
 	defer fake.streamOutMutex.RUnlock()
@@ -915,8 +789,6 @@ func (fake *FakeVolume) StreamOutArgsForCall(i int) string {
 }
 
 func (fake *FakeVolume) StreamOutReturns(result1 io.ReadCloser, result2 error) {
-	fake.streamOutMutex.Lock()
-	defer fake.streamOutMutex.Unlock()
 	fake.StreamOutStub = nil
 	fake.streamOutReturns = struct {
 		result1 io.ReadCloser
@@ -925,8 +797,6 @@ func (fake *FakeVolume) StreamOutReturns(result1 io.ReadCloser, result2 error) {
 }
 
 func (fake *FakeVolume) StreamOutReturnsOnCall(i int, result1 io.ReadCloser, result2 error) {
-	fake.streamOutMutex.Lock()
-	defer fake.streamOutMutex.Unlock()
 	fake.StreamOutStub = nil
 	if fake.streamOutReturnsOnCall == nil {
 		fake.streamOutReturnsOnCall = make(map[int]struct {
@@ -963,15 +833,7 @@ func (fake *FakeVolume) WorkerNameCallCount() int {
 	return len(fake.workerNameArgsForCall)
 }
 
-func (fake *FakeVolume) WorkerNameCalls(stub func() string) {
-	fake.workerNameMutex.Lock()
-	defer fake.workerNameMutex.Unlock()
-	fake.WorkerNameStub = stub
-}
-
 func (fake *FakeVolume) WorkerNameReturns(result1 string) {
-	fake.workerNameMutex.Lock()
-	defer fake.workerNameMutex.Unlock()
 	fake.WorkerNameStub = nil
 	fake.workerNameReturns = struct {
 		result1 string
@@ -979,8 +841,6 @@ func (fake *FakeVolume) WorkerNameReturns(result1 string) {
 }
 
 func (fake *FakeVolume) WorkerNameReturnsOnCall(i int, result1 string) {
-	fake.workerNameMutex.Lock()
-	defer fake.workerNameMutex.Unlock()
 	fake.WorkerNameStub = nil
 	if fake.workerNameReturnsOnCall == nil {
 		fake.workerNameReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_volume_client.go
+++ b/atc/worker/workerfakes/fake_volume_client.go
@@ -2,11 +2,11 @@
 package workerfakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/worker"
+	lager "code.cloudfoundry.org/lager"
+	db "github.com/concourse/concourse/atc/db"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeVolumeClient struct {
@@ -194,12 +194,6 @@ func (fake *FakeVolumeClient) CreateVolumeCallCount() int {
 	return len(fake.createVolumeArgsForCall)
 }
 
-func (fake *FakeVolumeClient) CreateVolumeCalls(stub func(lager.Logger, worker.VolumeSpec, int, string, db.VolumeType) (worker.Volume, error)) {
-	fake.createVolumeMutex.Lock()
-	defer fake.createVolumeMutex.Unlock()
-	fake.CreateVolumeStub = stub
-}
-
 func (fake *FakeVolumeClient) CreateVolumeArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, string, db.VolumeType) {
 	fake.createVolumeMutex.RLock()
 	defer fake.createVolumeMutex.RUnlock()
@@ -208,8 +202,6 @@ func (fake *FakeVolumeClient) CreateVolumeArgsForCall(i int) (lager.Logger, work
 }
 
 func (fake *FakeVolumeClient) CreateVolumeReturns(result1 worker.Volume, result2 error) {
-	fake.createVolumeMutex.Lock()
-	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	fake.createVolumeReturns = struct {
 		result1 worker.Volume
@@ -218,8 +210,6 @@ func (fake *FakeVolumeClient) CreateVolumeReturns(result1 worker.Volume, result2
 }
 
 func (fake *FakeVolumeClient) CreateVolumeReturnsOnCall(i int, result1 worker.Volume, result2 error) {
-	fake.createVolumeMutex.Lock()
-	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	if fake.createVolumeReturnsOnCall == nil {
 		fake.createVolumeReturnsOnCall = make(map[int]struct {
@@ -262,12 +252,6 @@ func (fake *FakeVolumeClient) CreateVolumeForTaskCacheCallCount() int {
 	return len(fake.createVolumeForTaskCacheArgsForCall)
 }
 
-func (fake *FakeVolumeClient) CreateVolumeForTaskCacheCalls(stub func(lager.Logger, worker.VolumeSpec, int, int, string, string) (worker.Volume, error)) {
-	fake.createVolumeForTaskCacheMutex.Lock()
-	defer fake.createVolumeForTaskCacheMutex.Unlock()
-	fake.CreateVolumeForTaskCacheStub = stub
-}
-
 func (fake *FakeVolumeClient) CreateVolumeForTaskCacheArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, int, string, string) {
 	fake.createVolumeForTaskCacheMutex.RLock()
 	defer fake.createVolumeForTaskCacheMutex.RUnlock()
@@ -276,8 +260,6 @@ func (fake *FakeVolumeClient) CreateVolumeForTaskCacheArgsForCall(i int) (lager.
 }
 
 func (fake *FakeVolumeClient) CreateVolumeForTaskCacheReturns(result1 worker.Volume, result2 error) {
-	fake.createVolumeForTaskCacheMutex.Lock()
-	defer fake.createVolumeForTaskCacheMutex.Unlock()
 	fake.CreateVolumeForTaskCacheStub = nil
 	fake.createVolumeForTaskCacheReturns = struct {
 		result1 worker.Volume
@@ -286,8 +268,6 @@ func (fake *FakeVolumeClient) CreateVolumeForTaskCacheReturns(result1 worker.Vol
 }
 
 func (fake *FakeVolumeClient) CreateVolumeForTaskCacheReturnsOnCall(i int, result1 worker.Volume, result2 error) {
-	fake.createVolumeForTaskCacheMutex.Lock()
-	defer fake.createVolumeForTaskCacheMutex.Unlock()
 	fake.CreateVolumeForTaskCacheStub = nil
 	if fake.createVolumeForTaskCacheReturnsOnCall == nil {
 		fake.createVolumeForTaskCacheReturnsOnCall = make(map[int]struct {
@@ -330,12 +310,6 @@ func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerCallCount() int {
 	return len(fake.findOrCreateCOWVolumeForContainerArgsForCall)
 }
 
-func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerCalls(stub func(lager.Logger, worker.VolumeSpec, db.CreatingContainer, worker.Volume, int, string) (worker.Volume, error)) {
-	fake.findOrCreateCOWVolumeForContainerMutex.Lock()
-	defer fake.findOrCreateCOWVolumeForContainerMutex.Unlock()
-	fake.FindOrCreateCOWVolumeForContainerStub = stub
-}
-
 func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerArgsForCall(i int) (lager.Logger, worker.VolumeSpec, db.CreatingContainer, worker.Volume, int, string) {
 	fake.findOrCreateCOWVolumeForContainerMutex.RLock()
 	defer fake.findOrCreateCOWVolumeForContainerMutex.RUnlock()
@@ -344,8 +318,6 @@ func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerArgsForCall(i int
 }
 
 func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerReturns(result1 worker.Volume, result2 error) {
-	fake.findOrCreateCOWVolumeForContainerMutex.Lock()
-	defer fake.findOrCreateCOWVolumeForContainerMutex.Unlock()
 	fake.FindOrCreateCOWVolumeForContainerStub = nil
 	fake.findOrCreateCOWVolumeForContainerReturns = struct {
 		result1 worker.Volume
@@ -354,8 +326,6 @@ func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerReturns(result1 w
 }
 
 func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerReturnsOnCall(i int, result1 worker.Volume, result2 error) {
-	fake.findOrCreateCOWVolumeForContainerMutex.Lock()
-	defer fake.findOrCreateCOWVolumeForContainerMutex.Unlock()
 	fake.FindOrCreateCOWVolumeForContainerStub = nil
 	if fake.findOrCreateCOWVolumeForContainerReturnsOnCall == nil {
 		fake.findOrCreateCOWVolumeForContainerReturnsOnCall = make(map[int]struct {
@@ -396,12 +366,6 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeCallCount() i
 	return len(fake.findOrCreateVolumeForBaseResourceTypeArgsForCall)
 }
 
-func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeCalls(stub func(lager.Logger, worker.VolumeSpec, int, string) (worker.Volume, error)) {
-	fake.findOrCreateVolumeForBaseResourceTypeMutex.Lock()
-	defer fake.findOrCreateVolumeForBaseResourceTypeMutex.Unlock()
-	fake.FindOrCreateVolumeForBaseResourceTypeStub = stub
-}
-
 func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, string) {
 	fake.findOrCreateVolumeForBaseResourceTypeMutex.RLock()
 	defer fake.findOrCreateVolumeForBaseResourceTypeMutex.RUnlock()
@@ -410,8 +374,6 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeArgsForCall(i
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeReturns(result1 worker.Volume, result2 error) {
-	fake.findOrCreateVolumeForBaseResourceTypeMutex.Lock()
-	defer fake.findOrCreateVolumeForBaseResourceTypeMutex.Unlock()
 	fake.FindOrCreateVolumeForBaseResourceTypeStub = nil
 	fake.findOrCreateVolumeForBaseResourceTypeReturns = struct {
 		result1 worker.Volume
@@ -420,8 +382,6 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeReturns(resul
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeReturnsOnCall(i int, result1 worker.Volume, result2 error) {
-	fake.findOrCreateVolumeForBaseResourceTypeMutex.Lock()
-	defer fake.findOrCreateVolumeForBaseResourceTypeMutex.Unlock()
 	fake.FindOrCreateVolumeForBaseResourceTypeStub = nil
 	if fake.findOrCreateVolumeForBaseResourceTypeReturnsOnCall == nil {
 		fake.findOrCreateVolumeForBaseResourceTypeReturnsOnCall = make(map[int]struct {
@@ -463,12 +423,6 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerCallCount() int {
 	return len(fake.findOrCreateVolumeForContainerArgsForCall)
 }
 
-func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerCalls(stub func(lager.Logger, worker.VolumeSpec, db.CreatingContainer, int, string) (worker.Volume, error)) {
-	fake.findOrCreateVolumeForContainerMutex.Lock()
-	defer fake.findOrCreateVolumeForContainerMutex.Unlock()
-	fake.FindOrCreateVolumeForContainerStub = stub
-}
-
 func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerArgsForCall(i int) (lager.Logger, worker.VolumeSpec, db.CreatingContainer, int, string) {
 	fake.findOrCreateVolumeForContainerMutex.RLock()
 	defer fake.findOrCreateVolumeForContainerMutex.RUnlock()
@@ -477,8 +431,6 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerArgsForCall(i int) (
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerReturns(result1 worker.Volume, result2 error) {
-	fake.findOrCreateVolumeForContainerMutex.Lock()
-	defer fake.findOrCreateVolumeForContainerMutex.Unlock()
 	fake.FindOrCreateVolumeForContainerStub = nil
 	fake.findOrCreateVolumeForContainerReturns = struct {
 		result1 worker.Volume
@@ -487,8 +439,6 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerReturns(result1 work
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerReturnsOnCall(i int, result1 worker.Volume, result2 error) {
-	fake.findOrCreateVolumeForContainerMutex.Lock()
-	defer fake.findOrCreateVolumeForContainerMutex.Unlock()
 	fake.FindOrCreateVolumeForContainerStub = nil
 	if fake.findOrCreateVolumeForContainerReturnsOnCall == nil {
 		fake.findOrCreateVolumeForContainerReturnsOnCall = make(map[int]struct {
@@ -526,12 +476,6 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsCallCount() int 
 	return len(fake.findOrCreateVolumeForResourceCertsArgsForCall)
 }
 
-func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsCalls(stub func(lager.Logger) (worker.Volume, bool, error)) {
-	fake.findOrCreateVolumeForResourceCertsMutex.Lock()
-	defer fake.findOrCreateVolumeForResourceCertsMutex.Unlock()
-	fake.FindOrCreateVolumeForResourceCertsStub = stub
-}
-
 func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsArgsForCall(i int) lager.Logger {
 	fake.findOrCreateVolumeForResourceCertsMutex.RLock()
 	defer fake.findOrCreateVolumeForResourceCertsMutex.RUnlock()
@@ -540,8 +484,6 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsArgsForCall(i in
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.findOrCreateVolumeForResourceCertsMutex.Lock()
-	defer fake.findOrCreateVolumeForResourceCertsMutex.Unlock()
 	fake.FindOrCreateVolumeForResourceCertsStub = nil
 	fake.findOrCreateVolumeForResourceCertsReturns = struct {
 		result1 worker.Volume
@@ -551,8 +493,6 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsReturns(result1 
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.findOrCreateVolumeForResourceCertsMutex.Lock()
-	defer fake.findOrCreateVolumeForResourceCertsMutex.Unlock()
 	fake.FindOrCreateVolumeForResourceCertsStub = nil
 	if fake.findOrCreateVolumeForResourceCertsReturnsOnCall == nil {
 		fake.findOrCreateVolumeForResourceCertsReturnsOnCall = make(map[int]struct {
@@ -593,12 +533,6 @@ func (fake *FakeVolumeClient) FindVolumeForResourceCacheCallCount() int {
 	return len(fake.findVolumeForResourceCacheArgsForCall)
 }
 
-func (fake *FakeVolumeClient) FindVolumeForResourceCacheCalls(stub func(lager.Logger, db.UsedResourceCache) (worker.Volume, bool, error)) {
-	fake.findVolumeForResourceCacheMutex.Lock()
-	defer fake.findVolumeForResourceCacheMutex.Unlock()
-	fake.FindVolumeForResourceCacheStub = stub
-}
-
 func (fake *FakeVolumeClient) FindVolumeForResourceCacheArgsForCall(i int) (lager.Logger, db.UsedResourceCache) {
 	fake.findVolumeForResourceCacheMutex.RLock()
 	defer fake.findVolumeForResourceCacheMutex.RUnlock()
@@ -607,8 +541,6 @@ func (fake *FakeVolumeClient) FindVolumeForResourceCacheArgsForCall(i int) (lage
 }
 
 func (fake *FakeVolumeClient) FindVolumeForResourceCacheReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeForResourceCacheMutex.Lock()
-	defer fake.findVolumeForResourceCacheMutex.Unlock()
 	fake.FindVolumeForResourceCacheStub = nil
 	fake.findVolumeForResourceCacheReturns = struct {
 		result1 worker.Volume
@@ -618,8 +550,6 @@ func (fake *FakeVolumeClient) FindVolumeForResourceCacheReturns(result1 worker.V
 }
 
 func (fake *FakeVolumeClient) FindVolumeForResourceCacheReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeForResourceCacheMutex.Lock()
-	defer fake.findVolumeForResourceCacheMutex.Unlock()
 	fake.FindVolumeForResourceCacheStub = nil
 	if fake.findVolumeForResourceCacheReturnsOnCall == nil {
 		fake.findVolumeForResourceCacheReturnsOnCall = make(map[int]struct {
@@ -663,12 +593,6 @@ func (fake *FakeVolumeClient) FindVolumeForTaskCacheCallCount() int {
 	return len(fake.findVolumeForTaskCacheArgsForCall)
 }
 
-func (fake *FakeVolumeClient) FindVolumeForTaskCacheCalls(stub func(lager.Logger, int, int, string, string) (worker.Volume, bool, error)) {
-	fake.findVolumeForTaskCacheMutex.Lock()
-	defer fake.findVolumeForTaskCacheMutex.Unlock()
-	fake.FindVolumeForTaskCacheStub = stub
-}
-
 func (fake *FakeVolumeClient) FindVolumeForTaskCacheArgsForCall(i int) (lager.Logger, int, int, string, string) {
 	fake.findVolumeForTaskCacheMutex.RLock()
 	defer fake.findVolumeForTaskCacheMutex.RUnlock()
@@ -677,8 +601,6 @@ func (fake *FakeVolumeClient) FindVolumeForTaskCacheArgsForCall(i int) (lager.Lo
 }
 
 func (fake *FakeVolumeClient) FindVolumeForTaskCacheReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeForTaskCacheMutex.Lock()
-	defer fake.findVolumeForTaskCacheMutex.Unlock()
 	fake.FindVolumeForTaskCacheStub = nil
 	fake.findVolumeForTaskCacheReturns = struct {
 		result1 worker.Volume
@@ -688,8 +610,6 @@ func (fake *FakeVolumeClient) FindVolumeForTaskCacheReturns(result1 worker.Volum
 }
 
 func (fake *FakeVolumeClient) FindVolumeForTaskCacheReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeForTaskCacheMutex.Lock()
-	defer fake.findVolumeForTaskCacheMutex.Unlock()
 	fake.FindVolumeForTaskCacheStub = nil
 	if fake.findVolumeForTaskCacheReturnsOnCall == nil {
 		fake.findVolumeForTaskCacheReturnsOnCall = make(map[int]struct {
@@ -730,12 +650,6 @@ func (fake *FakeVolumeClient) LookupVolumeCallCount() int {
 	return len(fake.lookupVolumeArgsForCall)
 }
 
-func (fake *FakeVolumeClient) LookupVolumeCalls(stub func(lager.Logger, string) (worker.Volume, bool, error)) {
-	fake.lookupVolumeMutex.Lock()
-	defer fake.lookupVolumeMutex.Unlock()
-	fake.LookupVolumeStub = stub
-}
-
 func (fake *FakeVolumeClient) LookupVolumeArgsForCall(i int) (lager.Logger, string) {
 	fake.lookupVolumeMutex.RLock()
 	defer fake.lookupVolumeMutex.RUnlock()
@@ -744,8 +658,6 @@ func (fake *FakeVolumeClient) LookupVolumeArgsForCall(i int) (lager.Logger, stri
 }
 
 func (fake *FakeVolumeClient) LookupVolumeReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.lookupVolumeMutex.Lock()
-	defer fake.lookupVolumeMutex.Unlock()
 	fake.LookupVolumeStub = nil
 	fake.lookupVolumeReturns = struct {
 		result1 worker.Volume
@@ -755,8 +667,6 @@ func (fake *FakeVolumeClient) LookupVolumeReturns(result1 worker.Volume, result2
 }
 
 func (fake *FakeVolumeClient) LookupVolumeReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.lookupVolumeMutex.Lock()
-	defer fake.lookupVolumeMutex.Unlock()
 	fake.LookupVolumeStub = nil
 	if fake.lookupVolumeReturnsOnCall == nil {
 		fake.lookupVolumeReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_worker.go
+++ b/atc/worker/workerfakes/fake_worker.go
@@ -2,16 +2,16 @@
 package workerfakes
 
 import (
-	"context"
-	"sync"
-	"time"
+	context "context"
+	sync "sync"
+	time "time"
 
-	"code.cloudfoundry.org/garden"
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/worker"
-	"github.com/cppforlife/go-semi-semantic/version"
+	garden "code.cloudfoundry.org/garden"
+	lager "code.cloudfoundry.org/lager"
+	atc "github.com/concourse/concourse/atc"
+	db "github.com/concourse/concourse/atc/db"
+	worker "github.com/concourse/concourse/atc/worker"
+	version "github.com/cppforlife/go-semi-semantic/version"
 )
 
 type FakeWorker struct {
@@ -107,15 +107,16 @@ type FakeWorker struct {
 		result2 bool
 		result3 error
 	}
-	FindOrCreateContainerStub        func(context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, worker.ContainerSpec, atc.VersionedResourceTypes) (worker.Container, error)
+	FindOrCreateContainerStub        func(context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, db.ContainerMetadata, worker.ContainerSpec, atc.VersionedResourceTypes) (worker.Container, error)
 	findOrCreateContainerMutex       sync.RWMutex
 	findOrCreateContainerArgsForCall []struct {
 		arg1 context.Context
 		arg2 lager.Logger
 		arg3 worker.ImageFetchingDelegate
 		arg4 db.ContainerOwner
-		arg5 worker.ContainerSpec
-		arg6 atc.VersionedResourceTypes
+		arg5 db.ContainerMetadata
+		arg6 worker.ContainerSpec
+		arg7 atc.VersionedResourceTypes
 	}
 	findOrCreateContainerReturns struct {
 		result1 worker.Container
@@ -287,15 +288,7 @@ func (fake *FakeWorker) BuildContainersCallCount() int {
 	return len(fake.buildContainersArgsForCall)
 }
 
-func (fake *FakeWorker) BuildContainersCalls(stub func() int) {
-	fake.buildContainersMutex.Lock()
-	defer fake.buildContainersMutex.Unlock()
-	fake.BuildContainersStub = stub
-}
-
 func (fake *FakeWorker) BuildContainersReturns(result1 int) {
-	fake.buildContainersMutex.Lock()
-	defer fake.buildContainersMutex.Unlock()
 	fake.BuildContainersStub = nil
 	fake.buildContainersReturns = struct {
 		result1 int
@@ -303,8 +296,6 @@ func (fake *FakeWorker) BuildContainersReturns(result1 int) {
 }
 
 func (fake *FakeWorker) BuildContainersReturnsOnCall(i int, result1 int) {
-	fake.buildContainersMutex.Lock()
-	defer fake.buildContainersMutex.Unlock()
 	fake.BuildContainersStub = nil
 	if fake.buildContainersReturnsOnCall == nil {
 		fake.buildContainersReturnsOnCall = make(map[int]struct {
@@ -340,12 +331,6 @@ func (fake *FakeWorker) CertsVolumeCallCount() int {
 	return len(fake.certsVolumeArgsForCall)
 }
 
-func (fake *FakeWorker) CertsVolumeCalls(stub func(lager.Logger) (worker.Volume, bool, error)) {
-	fake.certsVolumeMutex.Lock()
-	defer fake.certsVolumeMutex.Unlock()
-	fake.CertsVolumeStub = stub
-}
-
 func (fake *FakeWorker) CertsVolumeArgsForCall(i int) lager.Logger {
 	fake.certsVolumeMutex.RLock()
 	defer fake.certsVolumeMutex.RUnlock()
@@ -354,8 +339,6 @@ func (fake *FakeWorker) CertsVolumeArgsForCall(i int) lager.Logger {
 }
 
 func (fake *FakeWorker) CertsVolumeReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.certsVolumeMutex.Lock()
-	defer fake.certsVolumeMutex.Unlock()
 	fake.CertsVolumeStub = nil
 	fake.certsVolumeReturns = struct {
 		result1 worker.Volume
@@ -365,8 +348,6 @@ func (fake *FakeWorker) CertsVolumeReturns(result1 worker.Volume, result2 bool, 
 }
 
 func (fake *FakeWorker) CertsVolumeReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.certsVolumeMutex.Lock()
-	defer fake.certsVolumeMutex.Unlock()
 	fake.CertsVolumeStub = nil
 	if fake.certsVolumeReturnsOnCall == nil {
 		fake.certsVolumeReturnsOnCall = make(map[int]struct {
@@ -409,12 +390,6 @@ func (fake *FakeWorker) CreateVolumeCallCount() int {
 	return len(fake.createVolumeArgsForCall)
 }
 
-func (fake *FakeWorker) CreateVolumeCalls(stub func(lager.Logger, worker.VolumeSpec, int, db.VolumeType) (worker.Volume, error)) {
-	fake.createVolumeMutex.Lock()
-	defer fake.createVolumeMutex.Unlock()
-	fake.CreateVolumeStub = stub
-}
-
 func (fake *FakeWorker) CreateVolumeArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, db.VolumeType) {
 	fake.createVolumeMutex.RLock()
 	defer fake.createVolumeMutex.RUnlock()
@@ -423,8 +398,6 @@ func (fake *FakeWorker) CreateVolumeArgsForCall(i int) (lager.Logger, worker.Vol
 }
 
 func (fake *FakeWorker) CreateVolumeReturns(result1 worker.Volume, result2 error) {
-	fake.createVolumeMutex.Lock()
-	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	fake.createVolumeReturns = struct {
 		result1 worker.Volume
@@ -433,8 +406,6 @@ func (fake *FakeWorker) CreateVolumeReturns(result1 worker.Volume, result2 error
 }
 
 func (fake *FakeWorker) CreateVolumeReturnsOnCall(i int, result1 worker.Volume, result2 error) {
-	fake.createVolumeMutex.Lock()
-	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	if fake.createVolumeReturnsOnCall == nil {
 		fake.createVolumeReturnsOnCall = make(map[int]struct {
@@ -471,15 +442,7 @@ func (fake *FakeWorker) DescriptionCallCount() int {
 	return len(fake.descriptionArgsForCall)
 }
 
-func (fake *FakeWorker) DescriptionCalls(stub func() string) {
-	fake.descriptionMutex.Lock()
-	defer fake.descriptionMutex.Unlock()
-	fake.DescriptionStub = stub
-}
-
 func (fake *FakeWorker) DescriptionReturns(result1 string) {
-	fake.descriptionMutex.Lock()
-	defer fake.descriptionMutex.Unlock()
 	fake.DescriptionStub = nil
 	fake.descriptionReturns = struct {
 		result1 string
@@ -487,8 +450,6 @@ func (fake *FakeWorker) DescriptionReturns(result1 string) {
 }
 
 func (fake *FakeWorker) DescriptionReturnsOnCall(i int, result1 string) {
-	fake.descriptionMutex.Lock()
-	defer fake.descriptionMutex.Unlock()
 	fake.DescriptionStub = nil
 	if fake.descriptionReturnsOnCall == nil {
 		fake.descriptionReturnsOnCall = make(map[int]struct {
@@ -527,12 +488,6 @@ func (fake *FakeWorker) EnsureDBContainerExistsCallCount() int {
 	return len(fake.ensureDBContainerExistsArgsForCall)
 }
 
-func (fake *FakeWorker) EnsureDBContainerExistsCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, db.ContainerMetadata) error) {
-	fake.ensureDBContainerExistsMutex.Lock()
-	defer fake.ensureDBContainerExistsMutex.Unlock()
-	fake.EnsureDBContainerExistsStub = stub
-}
-
 func (fake *FakeWorker) EnsureDBContainerExistsArgsForCall(i int) (context.Context, lager.Logger, db.ContainerOwner, db.ContainerMetadata) {
 	fake.ensureDBContainerExistsMutex.RLock()
 	defer fake.ensureDBContainerExistsMutex.RUnlock()
@@ -541,8 +496,6 @@ func (fake *FakeWorker) EnsureDBContainerExistsArgsForCall(i int) (context.Conte
 }
 
 func (fake *FakeWorker) EnsureDBContainerExistsReturns(result1 error) {
-	fake.ensureDBContainerExistsMutex.Lock()
-	defer fake.ensureDBContainerExistsMutex.Unlock()
 	fake.EnsureDBContainerExistsStub = nil
 	fake.ensureDBContainerExistsReturns = struct {
 		result1 error
@@ -550,8 +503,6 @@ func (fake *FakeWorker) EnsureDBContainerExistsReturns(result1 error) {
 }
 
 func (fake *FakeWorker) EnsureDBContainerExistsReturnsOnCall(i int, result1 error) {
-	fake.ensureDBContainerExistsMutex.Lock()
-	defer fake.ensureDBContainerExistsMutex.Unlock()
 	fake.EnsureDBContainerExistsStub = nil
 	if fake.ensureDBContainerExistsReturnsOnCall == nil {
 		fake.ensureDBContainerExistsReturnsOnCall = make(map[int]struct {
@@ -586,15 +537,7 @@ func (fake *FakeWorker) EphemeralCallCount() int {
 	return len(fake.ephemeralArgsForCall)
 }
 
-func (fake *FakeWorker) EphemeralCalls(stub func() bool) {
-	fake.ephemeralMutex.Lock()
-	defer fake.ephemeralMutex.Unlock()
-	fake.EphemeralStub = stub
-}
-
 func (fake *FakeWorker) EphemeralReturns(result1 bool) {
-	fake.ephemeralMutex.Lock()
-	defer fake.ephemeralMutex.Unlock()
 	fake.EphemeralStub = nil
 	fake.ephemeralReturns = struct {
 		result1 bool
@@ -602,8 +545,6 @@ func (fake *FakeWorker) EphemeralReturns(result1 bool) {
 }
 
 func (fake *FakeWorker) EphemeralReturnsOnCall(i int, result1 bool) {
-	fake.ephemeralMutex.Lock()
-	defer fake.ephemeralMutex.Unlock()
 	fake.EphemeralStub = nil
 	if fake.ephemeralReturnsOnCall == nil {
 		fake.ephemeralReturnsOnCall = make(map[int]struct {
@@ -641,12 +582,6 @@ func (fake *FakeWorker) FindContainerByHandleCallCount() int {
 	return len(fake.findContainerByHandleArgsForCall)
 }
 
-func (fake *FakeWorker) FindContainerByHandleCalls(stub func(lager.Logger, int, string) (worker.Container, bool, error)) {
-	fake.findContainerByHandleMutex.Lock()
-	defer fake.findContainerByHandleMutex.Unlock()
-	fake.FindContainerByHandleStub = stub
-}
-
 func (fake *FakeWorker) FindContainerByHandleArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findContainerByHandleMutex.RLock()
 	defer fake.findContainerByHandleMutex.RUnlock()
@@ -655,8 +590,6 @@ func (fake *FakeWorker) FindContainerByHandleArgsForCall(i int) (lager.Logger, i
 }
 
 func (fake *FakeWorker) FindContainerByHandleReturns(result1 worker.Container, result2 bool, result3 error) {
-	fake.findContainerByHandleMutex.Lock()
-	defer fake.findContainerByHandleMutex.Unlock()
 	fake.FindContainerByHandleStub = nil
 	fake.findContainerByHandleReturns = struct {
 		result1 worker.Container
@@ -666,8 +599,6 @@ func (fake *FakeWorker) FindContainerByHandleReturns(result1 worker.Container, r
 }
 
 func (fake *FakeWorker) FindContainerByHandleReturnsOnCall(i int, result1 worker.Container, result2 bool, result3 error) {
-	fake.findContainerByHandleMutex.Lock()
-	defer fake.findContainerByHandleMutex.Unlock()
 	fake.FindContainerByHandleStub = nil
 	if fake.findContainerByHandleReturnsOnCall == nil {
 		fake.findContainerByHandleReturnsOnCall = make(map[int]struct {
@@ -683,7 +614,7 @@ func (fake *FakeWorker) FindContainerByHandleReturnsOnCall(i int, result1 worker
 	}{result1, result2, result3}
 }
 
-func (fake *FakeWorker) FindOrCreateContainer(arg1 context.Context, arg2 lager.Logger, arg3 worker.ImageFetchingDelegate, arg4 db.ContainerOwner, arg5 worker.ContainerSpec, arg6 atc.VersionedResourceTypes) (worker.Container, error) {
+func (fake *FakeWorker) FindOrCreateContainer(arg1 context.Context, arg2 lager.Logger, arg3 worker.ImageFetchingDelegate, arg4 db.ContainerOwner, arg5 db.ContainerMetadata, arg6 worker.ContainerSpec, arg7 atc.VersionedResourceTypes) (worker.Container, error) {
 	fake.findOrCreateContainerMutex.Lock()
 	ret, specificReturn := fake.findOrCreateContainerReturnsOnCall[len(fake.findOrCreateContainerArgsForCall)]
 	fake.findOrCreateContainerArgsForCall = append(fake.findOrCreateContainerArgsForCall, struct {
@@ -691,13 +622,14 @@ func (fake *FakeWorker) FindOrCreateContainer(arg1 context.Context, arg2 lager.L
 		arg2 lager.Logger
 		arg3 worker.ImageFetchingDelegate
 		arg4 db.ContainerOwner
-		arg5 worker.ContainerSpec
-		arg6 atc.VersionedResourceTypes
-	}{arg1, arg2, arg3, arg4, arg5, arg6})
-	fake.recordInvocation("FindOrCreateContainer", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
+		arg5 db.ContainerMetadata
+		arg6 worker.ContainerSpec
+		arg7 atc.VersionedResourceTypes
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("FindOrCreateContainer", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	fake.findOrCreateContainerMutex.Unlock()
 	if fake.FindOrCreateContainerStub != nil {
-		return fake.FindOrCreateContainerStub(arg1, arg2, arg3, arg4, arg5, arg6)
+		return fake.FindOrCreateContainerStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -712,22 +644,14 @@ func (fake *FakeWorker) FindOrCreateContainerCallCount() int {
 	return len(fake.findOrCreateContainerArgsForCall)
 }
 
-func (fake *FakeWorker) FindOrCreateContainerCalls(stub func(context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, worker.ContainerSpec, atc.VersionedResourceTypes) (worker.Container, error)) {
-	fake.findOrCreateContainerMutex.Lock()
-	defer fake.findOrCreateContainerMutex.Unlock()
-	fake.FindOrCreateContainerStub = stub
-}
-
-func (fake *FakeWorker) FindOrCreateContainerArgsForCall(i int) (context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, worker.ContainerSpec, atc.VersionedResourceTypes) {
+func (fake *FakeWorker) FindOrCreateContainerArgsForCall(i int) (context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, db.ContainerMetadata, worker.ContainerSpec, atc.VersionedResourceTypes) {
 	fake.findOrCreateContainerMutex.RLock()
 	defer fake.findOrCreateContainerMutex.RUnlock()
 	argsForCall := fake.findOrCreateContainerArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
 }
 
 func (fake *FakeWorker) FindOrCreateContainerReturns(result1 worker.Container, result2 error) {
-	fake.findOrCreateContainerMutex.Lock()
-	defer fake.findOrCreateContainerMutex.Unlock()
 	fake.FindOrCreateContainerStub = nil
 	fake.findOrCreateContainerReturns = struct {
 		result1 worker.Container
@@ -736,8 +660,6 @@ func (fake *FakeWorker) FindOrCreateContainerReturns(result1 worker.Container, r
 }
 
 func (fake *FakeWorker) FindOrCreateContainerReturnsOnCall(i int, result1 worker.Container, result2 error) {
-	fake.findOrCreateContainerMutex.Lock()
-	defer fake.findOrCreateContainerMutex.Unlock()
 	fake.FindOrCreateContainerStub = nil
 	if fake.findOrCreateContainerReturnsOnCall == nil {
 		fake.findOrCreateContainerReturnsOnCall = make(map[int]struct {
@@ -776,12 +698,6 @@ func (fake *FakeWorker) FindVolumeForResourceCacheCallCount() int {
 	return len(fake.findVolumeForResourceCacheArgsForCall)
 }
 
-func (fake *FakeWorker) FindVolumeForResourceCacheCalls(stub func(lager.Logger, db.UsedResourceCache) (worker.Volume, bool, error)) {
-	fake.findVolumeForResourceCacheMutex.Lock()
-	defer fake.findVolumeForResourceCacheMutex.Unlock()
-	fake.FindVolumeForResourceCacheStub = stub
-}
-
 func (fake *FakeWorker) FindVolumeForResourceCacheArgsForCall(i int) (lager.Logger, db.UsedResourceCache) {
 	fake.findVolumeForResourceCacheMutex.RLock()
 	defer fake.findVolumeForResourceCacheMutex.RUnlock()
@@ -790,8 +706,6 @@ func (fake *FakeWorker) FindVolumeForResourceCacheArgsForCall(i int) (lager.Logg
 }
 
 func (fake *FakeWorker) FindVolumeForResourceCacheReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeForResourceCacheMutex.Lock()
-	defer fake.findVolumeForResourceCacheMutex.Unlock()
 	fake.FindVolumeForResourceCacheStub = nil
 	fake.findVolumeForResourceCacheReturns = struct {
 		result1 worker.Volume
@@ -801,8 +715,6 @@ func (fake *FakeWorker) FindVolumeForResourceCacheReturns(result1 worker.Volume,
 }
 
 func (fake *FakeWorker) FindVolumeForResourceCacheReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeForResourceCacheMutex.Lock()
-	defer fake.findVolumeForResourceCacheMutex.Unlock()
 	fake.FindVolumeForResourceCacheStub = nil
 	if fake.findVolumeForResourceCacheReturnsOnCall == nil {
 		fake.findVolumeForResourceCacheReturnsOnCall = make(map[int]struct {
@@ -846,12 +758,6 @@ func (fake *FakeWorker) FindVolumeForTaskCacheCallCount() int {
 	return len(fake.findVolumeForTaskCacheArgsForCall)
 }
 
-func (fake *FakeWorker) FindVolumeForTaskCacheCalls(stub func(lager.Logger, int, int, string, string) (worker.Volume, bool, error)) {
-	fake.findVolumeForTaskCacheMutex.Lock()
-	defer fake.findVolumeForTaskCacheMutex.Unlock()
-	fake.FindVolumeForTaskCacheStub = stub
-}
-
 func (fake *FakeWorker) FindVolumeForTaskCacheArgsForCall(i int) (lager.Logger, int, int, string, string) {
 	fake.findVolumeForTaskCacheMutex.RLock()
 	defer fake.findVolumeForTaskCacheMutex.RUnlock()
@@ -860,8 +766,6 @@ func (fake *FakeWorker) FindVolumeForTaskCacheArgsForCall(i int) (lager.Logger, 
 }
 
 func (fake *FakeWorker) FindVolumeForTaskCacheReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeForTaskCacheMutex.Lock()
-	defer fake.findVolumeForTaskCacheMutex.Unlock()
 	fake.FindVolumeForTaskCacheStub = nil
 	fake.findVolumeForTaskCacheReturns = struct {
 		result1 worker.Volume
@@ -871,8 +775,6 @@ func (fake *FakeWorker) FindVolumeForTaskCacheReturns(result1 worker.Volume, res
 }
 
 func (fake *FakeWorker) FindVolumeForTaskCacheReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.findVolumeForTaskCacheMutex.Lock()
-	defer fake.findVolumeForTaskCacheMutex.Unlock()
 	fake.FindVolumeForTaskCacheStub = nil
 	if fake.findVolumeForTaskCacheReturnsOnCall == nil {
 		fake.findVolumeForTaskCacheReturnsOnCall = make(map[int]struct {
@@ -911,15 +813,7 @@ func (fake *FakeWorker) GardenClientCallCount() int {
 	return len(fake.gardenClientArgsForCall)
 }
 
-func (fake *FakeWorker) GardenClientCalls(stub func() garden.Client) {
-	fake.gardenClientMutex.Lock()
-	defer fake.gardenClientMutex.Unlock()
-	fake.GardenClientStub = stub
-}
-
 func (fake *FakeWorker) GardenClientReturns(result1 garden.Client) {
-	fake.gardenClientMutex.Lock()
-	defer fake.gardenClientMutex.Unlock()
 	fake.GardenClientStub = nil
 	fake.gardenClientReturns = struct {
 		result1 garden.Client
@@ -927,8 +821,6 @@ func (fake *FakeWorker) GardenClientReturns(result1 garden.Client) {
 }
 
 func (fake *FakeWorker) GardenClientReturnsOnCall(i int, result1 garden.Client) {
-	fake.gardenClientMutex.Lock()
-	defer fake.gardenClientMutex.Unlock()
 	fake.GardenClientStub = nil
 	if fake.gardenClientReturnsOnCall == nil {
 		fake.gardenClientReturnsOnCall = make(map[int]struct {
@@ -963,15 +855,7 @@ func (fake *FakeWorker) IsOwnedByTeamCallCount() int {
 	return len(fake.isOwnedByTeamArgsForCall)
 }
 
-func (fake *FakeWorker) IsOwnedByTeamCalls(stub func() bool) {
-	fake.isOwnedByTeamMutex.Lock()
-	defer fake.isOwnedByTeamMutex.Unlock()
-	fake.IsOwnedByTeamStub = stub
-}
-
 func (fake *FakeWorker) IsOwnedByTeamReturns(result1 bool) {
-	fake.isOwnedByTeamMutex.Lock()
-	defer fake.isOwnedByTeamMutex.Unlock()
 	fake.IsOwnedByTeamStub = nil
 	fake.isOwnedByTeamReturns = struct {
 		result1 bool
@@ -979,8 +863,6 @@ func (fake *FakeWorker) IsOwnedByTeamReturns(result1 bool) {
 }
 
 func (fake *FakeWorker) IsOwnedByTeamReturnsOnCall(i int, result1 bool) {
-	fake.isOwnedByTeamMutex.Lock()
-	defer fake.isOwnedByTeamMutex.Unlock()
 	fake.IsOwnedByTeamStub = nil
 	if fake.isOwnedByTeamReturnsOnCall == nil {
 		fake.isOwnedByTeamReturnsOnCall = make(map[int]struct {
@@ -1017,12 +899,6 @@ func (fake *FakeWorker) IsVersionCompatibleCallCount() int {
 	return len(fake.isVersionCompatibleArgsForCall)
 }
 
-func (fake *FakeWorker) IsVersionCompatibleCalls(stub func(lager.Logger, version.Version) bool) {
-	fake.isVersionCompatibleMutex.Lock()
-	defer fake.isVersionCompatibleMutex.Unlock()
-	fake.IsVersionCompatibleStub = stub
-}
-
 func (fake *FakeWorker) IsVersionCompatibleArgsForCall(i int) (lager.Logger, version.Version) {
 	fake.isVersionCompatibleMutex.RLock()
 	defer fake.isVersionCompatibleMutex.RUnlock()
@@ -1031,8 +907,6 @@ func (fake *FakeWorker) IsVersionCompatibleArgsForCall(i int) (lager.Logger, ver
 }
 
 func (fake *FakeWorker) IsVersionCompatibleReturns(result1 bool) {
-	fake.isVersionCompatibleMutex.Lock()
-	defer fake.isVersionCompatibleMutex.Unlock()
 	fake.IsVersionCompatibleStub = nil
 	fake.isVersionCompatibleReturns = struct {
 		result1 bool
@@ -1040,8 +914,6 @@ func (fake *FakeWorker) IsVersionCompatibleReturns(result1 bool) {
 }
 
 func (fake *FakeWorker) IsVersionCompatibleReturnsOnCall(i int, result1 bool) {
-	fake.isVersionCompatibleMutex.Lock()
-	defer fake.isVersionCompatibleMutex.Unlock()
 	fake.IsVersionCompatibleStub = nil
 	if fake.isVersionCompatibleReturnsOnCall == nil {
 		fake.isVersionCompatibleReturnsOnCall = make(map[int]struct {
@@ -1078,12 +950,6 @@ func (fake *FakeWorker) LookupVolumeCallCount() int {
 	return len(fake.lookupVolumeArgsForCall)
 }
 
-func (fake *FakeWorker) LookupVolumeCalls(stub func(lager.Logger, string) (worker.Volume, bool, error)) {
-	fake.lookupVolumeMutex.Lock()
-	defer fake.lookupVolumeMutex.Unlock()
-	fake.LookupVolumeStub = stub
-}
-
 func (fake *FakeWorker) LookupVolumeArgsForCall(i int) (lager.Logger, string) {
 	fake.lookupVolumeMutex.RLock()
 	defer fake.lookupVolumeMutex.RUnlock()
@@ -1092,8 +958,6 @@ func (fake *FakeWorker) LookupVolumeArgsForCall(i int) (lager.Logger, string) {
 }
 
 func (fake *FakeWorker) LookupVolumeReturns(result1 worker.Volume, result2 bool, result3 error) {
-	fake.lookupVolumeMutex.Lock()
-	defer fake.lookupVolumeMutex.Unlock()
 	fake.LookupVolumeStub = nil
 	fake.lookupVolumeReturns = struct {
 		result1 worker.Volume
@@ -1103,8 +967,6 @@ func (fake *FakeWorker) LookupVolumeReturns(result1 worker.Volume, result2 bool,
 }
 
 func (fake *FakeWorker) LookupVolumeReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
-	fake.lookupVolumeMutex.Lock()
-	defer fake.lookupVolumeMutex.Unlock()
 	fake.LookupVolumeStub = nil
 	if fake.lookupVolumeReturnsOnCall == nil {
 		fake.lookupVolumeReturnsOnCall = make(map[int]struct {
@@ -1143,15 +1005,7 @@ func (fake *FakeWorker) NameCallCount() int {
 	return len(fake.nameArgsForCall)
 }
 
-func (fake *FakeWorker) NameCalls(stub func() string) {
-	fake.nameMutex.Lock()
-	defer fake.nameMutex.Unlock()
-	fake.NameStub = stub
-}
-
 func (fake *FakeWorker) NameReturns(result1 string) {
-	fake.nameMutex.Lock()
-	defer fake.nameMutex.Unlock()
 	fake.NameStub = nil
 	fake.nameReturns = struct {
 		result1 string
@@ -1159,8 +1013,6 @@ func (fake *FakeWorker) NameReturns(result1 string) {
 }
 
 func (fake *FakeWorker) NameReturnsOnCall(i int, result1 string) {
-	fake.nameMutex.Lock()
-	defer fake.nameMutex.Unlock()
 	fake.NameStub = nil
 	if fake.nameReturnsOnCall == nil {
 		fake.nameReturnsOnCall = make(map[int]struct {
@@ -1195,15 +1047,7 @@ func (fake *FakeWorker) ResourceTypesCallCount() int {
 	return len(fake.resourceTypesArgsForCall)
 }
 
-func (fake *FakeWorker) ResourceTypesCalls(stub func() []atc.WorkerResourceType) {
-	fake.resourceTypesMutex.Lock()
-	defer fake.resourceTypesMutex.Unlock()
-	fake.ResourceTypesStub = stub
-}
-
 func (fake *FakeWorker) ResourceTypesReturns(result1 []atc.WorkerResourceType) {
-	fake.resourceTypesMutex.Lock()
-	defer fake.resourceTypesMutex.Unlock()
 	fake.ResourceTypesStub = nil
 	fake.resourceTypesReturns = struct {
 		result1 []atc.WorkerResourceType
@@ -1211,8 +1055,6 @@ func (fake *FakeWorker) ResourceTypesReturns(result1 []atc.WorkerResourceType) {
 }
 
 func (fake *FakeWorker) ResourceTypesReturnsOnCall(i int, result1 []atc.WorkerResourceType) {
-	fake.resourceTypesMutex.Lock()
-	defer fake.resourceTypesMutex.Unlock()
 	fake.ResourceTypesStub = nil
 	if fake.resourceTypesReturnsOnCall == nil {
 		fake.resourceTypesReturnsOnCall = make(map[int]struct {
@@ -1249,12 +1091,6 @@ func (fake *FakeWorker) SatisfiesCallCount() int {
 	return len(fake.satisfiesArgsForCall)
 }
 
-func (fake *FakeWorker) SatisfiesCalls(stub func(lager.Logger, worker.WorkerSpec) bool) {
-	fake.satisfiesMutex.Lock()
-	defer fake.satisfiesMutex.Unlock()
-	fake.SatisfiesStub = stub
-}
-
 func (fake *FakeWorker) SatisfiesArgsForCall(i int) (lager.Logger, worker.WorkerSpec) {
 	fake.satisfiesMutex.RLock()
 	defer fake.satisfiesMutex.RUnlock()
@@ -1263,8 +1099,6 @@ func (fake *FakeWorker) SatisfiesArgsForCall(i int) (lager.Logger, worker.Worker
 }
 
 func (fake *FakeWorker) SatisfiesReturns(result1 bool) {
-	fake.satisfiesMutex.Lock()
-	defer fake.satisfiesMutex.Unlock()
 	fake.SatisfiesStub = nil
 	fake.satisfiesReturns = struct {
 		result1 bool
@@ -1272,8 +1106,6 @@ func (fake *FakeWorker) SatisfiesReturns(result1 bool) {
 }
 
 func (fake *FakeWorker) SatisfiesReturnsOnCall(i int, result1 bool) {
-	fake.satisfiesMutex.Lock()
-	defer fake.satisfiesMutex.Unlock()
 	fake.SatisfiesStub = nil
 	if fake.satisfiesReturnsOnCall == nil {
 		fake.satisfiesReturnsOnCall = make(map[int]struct {
@@ -1308,15 +1140,7 @@ func (fake *FakeWorker) TagsCallCount() int {
 	return len(fake.tagsArgsForCall)
 }
 
-func (fake *FakeWorker) TagsCalls(stub func() atc.Tags) {
-	fake.tagsMutex.Lock()
-	defer fake.tagsMutex.Unlock()
-	fake.TagsStub = stub
-}
-
 func (fake *FakeWorker) TagsReturns(result1 atc.Tags) {
-	fake.tagsMutex.Lock()
-	defer fake.tagsMutex.Unlock()
 	fake.TagsStub = nil
 	fake.tagsReturns = struct {
 		result1 atc.Tags
@@ -1324,8 +1148,6 @@ func (fake *FakeWorker) TagsReturns(result1 atc.Tags) {
 }
 
 func (fake *FakeWorker) TagsReturnsOnCall(i int, result1 atc.Tags) {
-	fake.tagsMutex.Lock()
-	defer fake.tagsMutex.Unlock()
 	fake.TagsStub = nil
 	if fake.tagsReturnsOnCall == nil {
 		fake.tagsReturnsOnCall = make(map[int]struct {
@@ -1360,15 +1182,7 @@ func (fake *FakeWorker) UptimeCallCount() int {
 	return len(fake.uptimeArgsForCall)
 }
 
-func (fake *FakeWorker) UptimeCalls(stub func() time.Duration) {
-	fake.uptimeMutex.Lock()
-	defer fake.uptimeMutex.Unlock()
-	fake.UptimeStub = stub
-}
-
 func (fake *FakeWorker) UptimeReturns(result1 time.Duration) {
-	fake.uptimeMutex.Lock()
-	defer fake.uptimeMutex.Unlock()
 	fake.UptimeStub = nil
 	fake.uptimeReturns = struct {
 		result1 time.Duration
@@ -1376,8 +1190,6 @@ func (fake *FakeWorker) UptimeReturns(result1 time.Duration) {
 }
 
 func (fake *FakeWorker) UptimeReturnsOnCall(i int, result1 time.Duration) {
-	fake.uptimeMutex.Lock()
-	defer fake.uptimeMutex.Unlock()
 	fake.UptimeStub = nil
 	if fake.uptimeReturnsOnCall == nil {
 		fake.uptimeReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_worker_provider.go
+++ b/atc/worker/workerfakes/fake_worker_provider.go
@@ -2,12 +2,12 @@
 package workerfakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"code.cloudfoundry.org/clock"
-	"code.cloudfoundry.org/lager"
-	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/worker"
+	clock "code.cloudfoundry.org/clock"
+	lager "code.cloudfoundry.org/lager"
+	db "github.com/concourse/concourse/atc/db"
+	worker "github.com/concourse/concourse/atc/worker"
 )
 
 type FakeWorkerProvider struct {
@@ -116,12 +116,6 @@ func (fake *FakeWorkerProvider) FindWorkerForContainerCallCount() int {
 	return len(fake.findWorkerForContainerArgsForCall)
 }
 
-func (fake *FakeWorkerProvider) FindWorkerForContainerCalls(stub func(lager.Logger, int, string) (worker.Worker, bool, error)) {
-	fake.findWorkerForContainerMutex.Lock()
-	defer fake.findWorkerForContainerMutex.Unlock()
-	fake.FindWorkerForContainerStub = stub
-}
-
 func (fake *FakeWorkerProvider) FindWorkerForContainerArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findWorkerForContainerMutex.RLock()
 	defer fake.findWorkerForContainerMutex.RUnlock()
@@ -130,8 +124,6 @@ func (fake *FakeWorkerProvider) FindWorkerForContainerArgsForCall(i int) (lager.
 }
 
 func (fake *FakeWorkerProvider) FindWorkerForContainerReturns(result1 worker.Worker, result2 bool, result3 error) {
-	fake.findWorkerForContainerMutex.Lock()
-	defer fake.findWorkerForContainerMutex.Unlock()
 	fake.FindWorkerForContainerStub = nil
 	fake.findWorkerForContainerReturns = struct {
 		result1 worker.Worker
@@ -141,8 +133,6 @@ func (fake *FakeWorkerProvider) FindWorkerForContainerReturns(result1 worker.Wor
 }
 
 func (fake *FakeWorkerProvider) FindWorkerForContainerReturnsOnCall(i int, result1 worker.Worker, result2 bool, result3 error) {
-	fake.findWorkerForContainerMutex.Lock()
-	defer fake.findWorkerForContainerMutex.Unlock()
 	fake.FindWorkerForContainerStub = nil
 	if fake.findWorkerForContainerReturnsOnCall == nil {
 		fake.findWorkerForContainerReturnsOnCall = make(map[int]struct {
@@ -184,12 +174,6 @@ func (fake *FakeWorkerProvider) FindWorkerForVolumeCallCount() int {
 	return len(fake.findWorkerForVolumeArgsForCall)
 }
 
-func (fake *FakeWorkerProvider) FindWorkerForVolumeCalls(stub func(lager.Logger, int, string) (worker.Worker, bool, error)) {
-	fake.findWorkerForVolumeMutex.Lock()
-	defer fake.findWorkerForVolumeMutex.Unlock()
-	fake.FindWorkerForVolumeStub = stub
-}
-
 func (fake *FakeWorkerProvider) FindWorkerForVolumeArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findWorkerForVolumeMutex.RLock()
 	defer fake.findWorkerForVolumeMutex.RUnlock()
@@ -198,8 +182,6 @@ func (fake *FakeWorkerProvider) FindWorkerForVolumeArgsForCall(i int) (lager.Log
 }
 
 func (fake *FakeWorkerProvider) FindWorkerForVolumeReturns(result1 worker.Worker, result2 bool, result3 error) {
-	fake.findWorkerForVolumeMutex.Lock()
-	defer fake.findWorkerForVolumeMutex.Unlock()
 	fake.FindWorkerForVolumeStub = nil
 	fake.findWorkerForVolumeReturns = struct {
 		result1 worker.Worker
@@ -209,8 +191,6 @@ func (fake *FakeWorkerProvider) FindWorkerForVolumeReturns(result1 worker.Worker
 }
 
 func (fake *FakeWorkerProvider) FindWorkerForVolumeReturnsOnCall(i int, result1 worker.Worker, result2 bool, result3 error) {
-	fake.findWorkerForVolumeMutex.Lock()
-	defer fake.findWorkerForVolumeMutex.Unlock()
 	fake.FindWorkerForVolumeStub = nil
 	if fake.findWorkerForVolumeReturnsOnCall == nil {
 		fake.findWorkerForVolumeReturnsOnCall = make(map[int]struct {
@@ -251,12 +231,6 @@ func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerCallCount() int {
 	return len(fake.findWorkersForContainerByOwnerArgsForCall)
 }
 
-func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerCalls(stub func(lager.Logger, db.ContainerOwner) ([]worker.Worker, error)) {
-	fake.findWorkersForContainerByOwnerMutex.Lock()
-	defer fake.findWorkersForContainerByOwnerMutex.Unlock()
-	fake.FindWorkersForContainerByOwnerStub = stub
-}
-
 func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerArgsForCall(i int) (lager.Logger, db.ContainerOwner) {
 	fake.findWorkersForContainerByOwnerMutex.RLock()
 	defer fake.findWorkersForContainerByOwnerMutex.RUnlock()
@@ -265,8 +239,6 @@ func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerArgsForCall(i int)
 }
 
 func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerReturns(result1 []worker.Worker, result2 error) {
-	fake.findWorkersForContainerByOwnerMutex.Lock()
-	defer fake.findWorkersForContainerByOwnerMutex.Unlock()
 	fake.FindWorkersForContainerByOwnerStub = nil
 	fake.findWorkersForContainerByOwnerReturns = struct {
 		result1 []worker.Worker
@@ -275,8 +247,6 @@ func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerReturns(result1 []
 }
 
 func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerReturnsOnCall(i int, result1 []worker.Worker, result2 error) {
-	fake.findWorkersForContainerByOwnerMutex.Lock()
-	defer fake.findWorkersForContainerByOwnerMutex.Unlock()
 	fake.FindWorkersForContainerByOwnerStub = nil
 	if fake.findWorkersForContainerByOwnerReturnsOnCall == nil {
 		fake.findWorkersForContainerByOwnerReturnsOnCall = make(map[int]struct {
@@ -317,12 +287,6 @@ func (fake *FakeWorkerProvider) NewGardenWorkerCallCount() int {
 	return len(fake.newGardenWorkerArgsForCall)
 }
 
-func (fake *FakeWorkerProvider) NewGardenWorkerCalls(stub func(lager.Logger, clock.Clock, db.Worker, int) worker.Worker) {
-	fake.newGardenWorkerMutex.Lock()
-	defer fake.newGardenWorkerMutex.Unlock()
-	fake.NewGardenWorkerStub = stub
-}
-
 func (fake *FakeWorkerProvider) NewGardenWorkerArgsForCall(i int) (lager.Logger, clock.Clock, db.Worker, int) {
 	fake.newGardenWorkerMutex.RLock()
 	defer fake.newGardenWorkerMutex.RUnlock()
@@ -331,8 +295,6 @@ func (fake *FakeWorkerProvider) NewGardenWorkerArgsForCall(i int) (lager.Logger,
 }
 
 func (fake *FakeWorkerProvider) NewGardenWorkerReturns(result1 worker.Worker) {
-	fake.newGardenWorkerMutex.Lock()
-	defer fake.newGardenWorkerMutex.Unlock()
 	fake.NewGardenWorkerStub = nil
 	fake.newGardenWorkerReturns = struct {
 		result1 worker.Worker
@@ -340,8 +302,6 @@ func (fake *FakeWorkerProvider) NewGardenWorkerReturns(result1 worker.Worker) {
 }
 
 func (fake *FakeWorkerProvider) NewGardenWorkerReturnsOnCall(i int, result1 worker.Worker) {
-	fake.newGardenWorkerMutex.Lock()
-	defer fake.newGardenWorkerMutex.Unlock()
 	fake.NewGardenWorkerStub = nil
 	if fake.newGardenWorkerReturnsOnCall == nil {
 		fake.newGardenWorkerReturnsOnCall = make(map[int]struct {
@@ -377,12 +337,6 @@ func (fake *FakeWorkerProvider) RunningWorkersCallCount() int {
 	return len(fake.runningWorkersArgsForCall)
 }
 
-func (fake *FakeWorkerProvider) RunningWorkersCalls(stub func(lager.Logger) ([]worker.Worker, error)) {
-	fake.runningWorkersMutex.Lock()
-	defer fake.runningWorkersMutex.Unlock()
-	fake.RunningWorkersStub = stub
-}
-
 func (fake *FakeWorkerProvider) RunningWorkersArgsForCall(i int) lager.Logger {
 	fake.runningWorkersMutex.RLock()
 	defer fake.runningWorkersMutex.RUnlock()
@@ -391,8 +345,6 @@ func (fake *FakeWorkerProvider) RunningWorkersArgsForCall(i int) lager.Logger {
 }
 
 func (fake *FakeWorkerProvider) RunningWorkersReturns(result1 []worker.Worker, result2 error) {
-	fake.runningWorkersMutex.Lock()
-	defer fake.runningWorkersMutex.Unlock()
 	fake.RunningWorkersStub = nil
 	fake.runningWorkersReturns = struct {
 		result1 []worker.Worker
@@ -401,8 +353,6 @@ func (fake *FakeWorkerProvider) RunningWorkersReturns(result1 []worker.Worker, r
 }
 
 func (fake *FakeWorkerProvider) RunningWorkersReturnsOnCall(i int, result1 []worker.Worker, result2 error) {
-	fake.runningWorkersMutex.Lock()
-	defer fake.runningWorkersMutex.Unlock()
 	fake.RunningWorkersStub = nil
 	if fake.runningWorkersReturnsOnCall == nil {
 		fake.runningWorkersReturnsOnCall = make(map[int]struct {

--- a/topgun/pipelines/lots-ata-time-2.yml
+++ b/topgun/pipelines/lots-ata-time-2.yml
@@ -9,127 +9,52 @@ jobs:
   plan:
   - get: timer
     trigger: true
-  - in_parallel:
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
+  - task: exit
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: concourse/dev}
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - |
+          exit 2
 
 - name: exiter2
   plan:
   - get: timer
     trigger: true
-  - in_parallel:
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
+  - task: exit
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: concourse/dev}
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - |
+          exit 2
 
 - name: exiter3
   plan:
   - get: timer
     trigger: true
-  - in_parallel:
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
+  - task: exit
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: concourse/dev}
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - |
+          exit 2
 
 - name: exiter4
   plan:
@@ -177,43 +102,18 @@ jobs:
   plan:
   - get: timer
     trigger: true
-  - in_parallel:
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
+  - task: exit
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: concourse/dev}
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - |
+          exit 2
 
 - name: exiter6
   plan:

--- a/topgun/pipelines/lots-ata-time.yml
+++ b/topgun/pipelines/lots-ata-time.yml
@@ -9,211 +9,86 @@ jobs:
   plan:
   - get: timer
     trigger: true
-  - in_parallel:
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
+  - task: exit
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: concourse/dev}
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - |
+          exit 2
 
 - name: exiter2
   plan:
   - get: timer
     trigger: true
-  - in_parallel:
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
+  - task: exit
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: concourse/dev}
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - |
+          exit 2
 
 - name: exiter3
   plan:
   - get: timer
     trigger: true
-  - in_parallel:
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
+  - task: exit
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: concourse/dev}
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - |
+          exit 2
 
 - name: exiter4
   plan:
   - get: timer
     trigger: true
-  - in_parallel:
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
+  - task: exit
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: concourse/dev}
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - |
+          exit 2
 
 - name: exiter5
   plan:
   - get: timer
     trigger: true
-  - in_parallel:
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
-    - task: exit
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source: {repository: concourse/dev}
-        run:
-          path: /bin/sh
-          args:
-          - -c
-          - |
-            exit 2
+  - task: exit
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: concourse/dev}
+      run:
+        path: /bin/sh
+        args:
+        - -c
+        - |
+          exit 2
 
 - name: exiter6
   plan:


### PR DESCRIPTION
The changes made in PR #3902 (fixing #3301) were not fully correct. The changes caused unused db.CreatingContainers to be created in the case where two identical get steps were run in quick succession. This broke the topgun build (issue #4070).

Since a manual merge was done after #3902 was merged in to master, we decided to manually revert the changes. This PR removes the container creation and locking logic from `pool.FindOrChooseWorkerForContainer` and puts the db.CreatingContainer creation back into `worker.FindOrCreateContainer`.

Fixes #4070 

Signed-off-by: Divya Dadlani <ddadlani@pivotal.io>