### PR TITLE
Aligned long flag of get-team with other

### DIFF
--- a/fly/commands/get_team.go
+++ b/fly/commands/get_team.go
@@ -14,8 +14,8 @@ import (
 )
 
 type GetTeamCommand struct {
-	Team string `short:"n" long:"team" required:"true" description:"Get configuration of this team"`
-	JSON bool   `short:"j" long:"json" description:"Print command result as JSON"`
+	TeamName string `short:"n" long:"team-name" required:"true" description:"Get configuration of this team"`
+	JSON     bool   `short:"j" long:"json" description:"Print command result as JSON"`
 }
 
 func (command *GetTeamCommand) Execute(args []string) error {
@@ -28,7 +28,7 @@ func (command *GetTeamCommand) Execute(args []string) error {
 		return err
 	}
 
-	team, found, err := target.Team().Team(command.Team)
+	team, found, err := target.Team().Team(command.TeamName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
long flag for the team name in `get-team` was different from others.

e.g. 
`set-team`'s long flag (`team-name`)
https://github.com/concourse/concourse/blob/c16d62872e4ae2055efe2a27cf4a9903d9d009f5/fly/commands/set_team.go#L27

`login`'s long flag (`team-name`)
https://github.com/concourse/concourse/blob/c16d62872e4ae2055efe2a27cf4a9903d9d009f5/fly/commands/login.go#L29