### PR TITLE
fixed build log timestamps being off by one

### DIFF
--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -620,30 +620,34 @@ viewTimestampedLine { timestamps, highlight, id, lineNo, line, timeZone } =
                     hlId == id && lineNo >= hlLine1 && lineNo <= hlLine2
 
         ts =
-            Dict.get lineNo timestamps
+            Dict.get (lineNo - 1) timestamps
     in
-    Html.tr
-        [ classList
-            [ ( "timestamped-line", True )
-            , ( "highlighted-line", highlighted )
-            ]
-        , Html.Attributes.id <| id ++ ":" ++ String.fromInt lineNo
-        ]
-        [ viewTimestamp
-            { id = id
-            , line = lineNo
-            , date = ts
-            , timeZone = timeZone
-            }
-        , viewLine line
-        ]
+    case line of
+        ( [], _ ) ->
+            Html.text ""
+
+        _ ->
+            Html.tr
+                [ classList
+                    [ ( "timestamped-line", True )
+                    , ( "highlighted-line", highlighted )
+                    ]
+                , Html.Attributes.id <| id ++ ":" ++ String.fromInt lineNo
+                ]
+                [ viewTimestamp
+                    { id = id
+                    , line = lineNo
+                    , date = ts
+                    , timeZone = timeZone
+                    }
+                , viewLine line
+                ]
 
 
 viewLine : Ansi.Log.Line -> Html Message
 viewLine line =
     Html.td [ class "timestamped-content" ]
-        [ Ansi.Log.viewLine line
-        ]
+        [ Ansi.Log.viewLine line ]
 
 
 viewTimestamp :


### PR DESCRIPTION
fixes #3942 

This PR kept the first-build-log-line-id to be 1, as it was before.

# Release Note
```tex
\note{fix}{
  Fixed a bug where the 
  \link{timestamps}{https://github.com/concourse/concourse/issues/3942}
  on build logs were off by one.
}
```