### PR TITLE
adds '--all' to the pause and unpause commands

### DIFF
--- a/fly/commands/pause_pipeline.go
+++ b/fly/commands/pause_pipeline.go
@@ -9,7 +9,8 @@ import (
 )
 
 type PausePipelineCommand struct {
-	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline" required:"true" description:"Pipeline to pause"`
+	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline" description:"Pipeline to pause"`
+	All      bool                     `short:"a"  long:"all"      description:"Pause all pipelines"`
 }
 
 func (command *PausePipelineCommand) Validate() error {
@@ -17,12 +18,18 @@ func (command *PausePipelineCommand) Validate() error {
 }
 
 func (command *PausePipelineCommand) Execute(args []string) error {
+	if string(command.Pipeline) == "" && !command.All {
+		displayhelpers.Failf("Either a pipeline name or --all are required")
+	}
+
+	if string(command.Pipeline) != "" && command.All {
+		displayhelpers.Failf("A pipeline and --all can not both be specified")
+	}
+
 	err := command.Validate()
 	if err != nil {
 		return err
 	}
-
-	pipelineName := string(command.Pipeline)
 
 	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
 	if err != nil {
@@ -34,15 +41,33 @@ func (command *PausePipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	found, err := target.Team().PausePipeline(pipelineName)
-	if err != nil {
-		return err
+	var pipelineNames []string
+	if string(command.Pipeline) != "" {
+		pipelineNames = []string{string(command.Pipeline)}
 	}
 
-	if found {
-		fmt.Printf("paused '%s'\n", pipelineName)
-	} else {
-		displayhelpers.Failf("pipeline '%s' not found\n", pipelineName)
+	if command.All {
+		pipelines, err := target.Team().ListPipelines()
+		if err != nil {
+			return err
+		}
+
+		for _, pipeline := range pipelines {
+			pipelineNames = append(pipelineNames, pipeline.Name)
+		}
+	}
+
+	for _, pipelineName := range pipelineNames {
+		found, err := target.Team().PausePipeline(pipelineName)
+		if err != nil {
+			return err
+		}
+
+		if found {
+			fmt.Printf("paused '%s'\n", pipelineName)
+		} else {
+			displayhelpers.Failf("pipeline '%s' not found\n", pipelineName)
+		}
 	}
 
 	return nil

--- a/fly/integration/pause_pipeline_test.go
+++ b/fly/integration/pause_pipeline_test.go
@@ -81,13 +81,33 @@ var _ = Describe("Fly CLI", func() {
 			})
 		})
 
-		Context("when the pipline name is not specified", func() {
+		Context("when the pipline name or --all is not specified", func() {
 			It("errors", func() {
 				Expect(func() {
 					flyCmd := exec.Command(flyPath, "-t", targetName, "pause-pipeline")
 
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess.Err).Should(gbytes.Say(`Either a pipeline name or --all are required`))
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(1))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(0))
+			})
+		})
+
+		Context("when both the pipline name and --all are specified", func() {
+			It("errors", func() {
+				Expect(func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "pause-pipeline", "-p", "awesome-pipeline", "--all")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess.Err).Should(gbytes.Say(`A pipeline and --all can not both be specified`))
 
 					<-sess.Exited
 					Expect(sess.ExitCode()).To(Equal(1))
@@ -109,6 +129,58 @@ var _ = Describe("Fly CLI", func() {
 
 				Expect(sess.Err).To(gbytes.Say("error: pipeline name cannot contain '/'"))
 			})
+		})
+
+	})
+
+	Context("when the --all flag is passed", func() {
+		var (
+			somePath      string
+			someOtherPath string
+			err           error
+		)
+
+		BeforeEach(func() {
+			somePath, err = atc.Routes.CreatePathForRoute(atc.PausePipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+			Expect(err).NotTo(HaveOccurred())
+
+			someOtherPath, err = atc.Routes.CreatePathForRoute(atc.PausePipeline, rata.Params{"pipeline_name": "more-awesome-pipeline", "team_name": "main"})
+			Expect(err).NotTo(HaveOccurred())
+
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
+					ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
+						{Name: "awesome-pipeline", Paused: false, Public: false},
+						{Name: "more-awesome-pipeline", Paused: true, Public: false},
+					}),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", somePath),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", someOtherPath),
+					ghttp.RespondWith(http.StatusOK, nil),
+				),
+			)
+		})
+
+		It("pauses every pipeline", func() {
+			Expect(func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "pause-pipeline", "--all")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gbytes.Say(`paused 'awesome-pipeline'`))
+				Eventually(sess).Should(gbytes.Say(`paused 'more-awesome-pipeline'`))
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+			}).To(Change(func() int {
+				return len(atcServer.ReceivedRequests())
+			}).By(4))
 		})
 
 	})


### PR DESCRIPTION
- will pause and unpause all pipelines

before making changes to my concourse I like to pause every pipeline so I don't get stuck in a state where a worker starts to drain, and the change can happen more quickly. I wrote some hacky bash to make this happen but I thought it would be nice to add it into fly as a first class feature.

Signed-off-by: Josh Zarrabi <jzarrabi@pivotal.io>