### PR TITLE
Topgun: Add tests for TSA web service nodeport

### DIFF
--- a/topgun/k8s/tsa_node_port_test.go
+++ b/topgun/k8s/tsa_node_port_test.go
@@ -1,0 +1,43 @@
+package k8s_test
+
+import (
+	"time"
+
+	"github.com/onsi/gomega/gexec"
+
+	. "github.com/concourse/concourse/topgun"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TSA Service Node Port", func() {
+
+	var (
+		proxySession *gexec.Session
+	)
+
+	JustBeforeEach(func() {
+		setReleaseNameAndNamespace("tnp")
+
+		deployConcourseChart(releaseName,
+			"--set=web.service.type=NodePort",
+		)
+	})
+
+	It("deployment succeeds", func() {
+		var atcEndpoint string
+
+		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+
+		fly.Login("test", "test", atcEndpoint)
+		Eventually(func() []Worker {
+			return getRunningWorkers(fly.GetWorkers())
+		}, 2*time.Minute, 10*time.Second).
+			ShouldNot(HaveLen(0))
+	})
+
+	AfterEach(func() {
+		cleanup(releaseName, namespace, proxySession)
+	})
+
+})


### PR DESCRIPTION
This PR is related to this github issue: https://github.com/concourse/concourse/issues/4094
- set value for `web.service.type` and `web.service.tsaNodePort` to see if concourse chart can be deployed succesfully

cc: @cirocosta 

We're still waiting for the response from that github issue.