### PR TITLE
topgun/k8s: refactor tests to support targeting PKS

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -1,6 +1,8 @@
 package k8s_test
 
 import (
+	"time"
+
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -52,6 +54,11 @@ func baggageclaimWorks(driver string, selectorFlags ...string) {
 
 			By("Logging in")
 			fly.Login("test", "test", atcEndpoint)
+
+			Eventually(func() []Worker {
+				return getRunningWorkers(fly.GetWorkers())
+			}, 2*time.Minute, 10*time.Second).
+				ShouldNot(HaveLen(0))
 
 			By("Setting and triggering a dumb pipeline")
 			fly.Run("set-pipeline", "-n", "-c", "../pipelines/get-task.yml", "-p", "some-pipeline")

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -286,3 +286,29 @@ func cleanup(releaseName, namespace string, proxySession *gexec.Session) {
 		Wait(proxySession.Interrupt())
 	}
 }
+
+func onPks(f func()) {
+	Context("PKS", func() {
+
+		BeforeEach(func() {
+			if Environment.K8sEngine != "PKS" {
+				Skip("not running on PKS")
+			}
+		})
+
+		f()
+	})
+}
+
+func onGke(f func()) {
+	Context("GKE", func() {
+
+		BeforeEach(func() {
+			if Environment.K8sEngine != "GKE" {
+				Skip("not running on GKE")
+			}
+		})
+
+		f()
+	})
+}

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -36,6 +36,7 @@ type environment struct {
 	ConcourseImageName   string `env:"CONCOURSE_IMAGE_NAME,required"`
 	ConcourseImageTag    string `env:"CONCOURSE_IMAGE_TAG"`
 	FlyPath              string `env:"FLY_PATH"`
+	K8sEngine            string `env:"K8S_ENGINE"`
 }
 
 var (

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -36,7 +36,7 @@ type environment struct {
 	ConcourseImageName   string `env:"CONCOURSE_IMAGE_NAME,required"`
 	ConcourseImageTag    string `env:"CONCOURSE_IMAGE_TAG"`
 	FlyPath              string `env:"FLY_PATH"`
-	K8sEngine            string `env:"K8S_ENGINE"`
+	K8sEngine            string `env:"K8S_ENGINE" envDefault:"GKE"`
 }
 
 var (


### PR DESCRIPTION
Hey,

@taylorsilva and I started working on making the tests that currently fail on PKS (https://github.com/concourse/concourse/issues/4098#issuecomment-508549862) possible to run there.

Our approach is to conditionally `Skip()` based on the Kubernetes IAAS set (through environment variables). Trying to just fit another `if` in the current tests revealed that the code would become hard to reason about, so we started refactoring them:

- [x] `baggageclaim_drivers_test.go`
- [x] `container_limits_test.go`

Thanks!