### PR TITLE
Add locking around steps.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -760,6 +760,7 @@ func (cmd *RunCommand) constructBackendMembers(
 		defaultLimits,
 		buildContainerStrategy,
 		resourceFactory,
+		lockFactory,
 	)
 
 	radarSchedulerFactory := pipelines.NewRadarSchedulerFactory(
@@ -1233,6 +1234,7 @@ func (cmd *RunCommand) constructEngine(
 	defaultLimits atc.ContainerLimits,
 	strategy worker.ContainerPlacementStrategy,
 	resourceFactory resource.ResourceFactory,
+	lockFactory lock.LockFactory,
 ) engine.Engine {
 
 	stepFactory := builder.NewStepFactory(
@@ -1245,12 +1247,14 @@ func (cmd *RunCommand) constructEngine(
 		defaultLimits,
 		strategy,
 		resourceFactory,
+		lockFactory,
 	)
 
 	stepBuilder := builder.NewStepBuilder(
 		stepFactory,
 		builder.NewDelegateFactory(),
 		cmd.ExternalURL.String(),
+		lockFactory,
 	)
 
 	return engine.NewEngine(stepBuilder)

--- a/atc/engine/builder/builder.go
+++ b/atc/engine/builder/builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/exec"
 )
 
@@ -15,9 +16,9 @@ const supportedSchema = "exec.v2"
 //go:generate counterfeiter . StepFactory
 
 type StepFactory interface {
-	GetStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.GetDelegate) exec.Step
-	PutStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.PutDelegate) exec.Step
-	TaskStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.TaskDelegate) exec.Step
+	GetStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.GetDelegate, lock.LockFactory) exec.Step
+	PutStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.PutDelegate, lock.LockFactory) exec.Step
+	TaskStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.TaskDelegate, lock.LockFactory) exec.Step
 	ArtifactInputStep(atc.Plan, db.Build, exec.BuildStepDelegate) exec.Step
 	ArtifactOutputStep(atc.Plan, db.Build, exec.BuildStepDelegate) exec.Step
 }
@@ -35,11 +36,13 @@ func NewStepBuilder(
 	stepFactory StepFactory,
 	delegateFactory DelegateFactory,
 	externalURL string,
+	lockFactory lock.LockFactory,
 ) *stepBuilder {
 	return &stepBuilder{
 		stepFactory:     stepFactory,
 		delegateFactory: delegateFactory,
 		externalURL:     externalURL,
+		lockFactory:     lockFactory,
 	}
 }
 
@@ -47,6 +50,7 @@ type stepBuilder struct {
 	stepFactory     StepFactory
 	delegateFactory DelegateFactory
 	externalURL     string
+	lockFactory     lock.LockFactory
 }
 
 func (builder *stepBuilder) BuildStep(build db.Build) (exec.Step, error) {
@@ -256,6 +260,7 @@ func (builder *stepBuilder) buildGetStep(build db.Build, plan atc.Plan) exec.Ste
 		stepMetadata,
 		containerMetadata,
 		builder.delegateFactory.GetDelegate(build, plan.ID),
+		builder.lockFactory,
 	)
 }
 
@@ -278,6 +283,7 @@ func (builder *stepBuilder) buildPutStep(build db.Build, plan atc.Plan) exec.Ste
 		stepMetadata,
 		containerMetadata,
 		builder.delegateFactory.PutDelegate(build, plan.ID),
+		builder.lockFactory,
 	)
 }
 
@@ -300,6 +306,7 @@ func (builder *stepBuilder) buildTaskStep(build db.Build, plan atc.Plan) exec.St
 		stepMetadata,
 		containerMetadata,
 		builder.delegateFactory.TaskDelegate(build, plan.ID),
+		builder.lockFactory,
 	)
 }
 

--- a/atc/engine/builder/builder_test.go
+++ b/atc/engine/builder/builder_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Builder", func() {
 				fakeStepFactory,
 				fakeDelegateFactory,
 				"http://example.com",
+				nil,
 			)
 
 			planFactory = atc.NewPlanFactory(123)
@@ -149,7 +150,7 @@ var _ = Describe("Builder", func() {
 
 					Context("constructing outputs", func() {
 						It("constructs the put correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.PutStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.PutStepArgsForCall(0)
 							Expect(plan).To(Equal(putPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -163,7 +164,7 @@ var _ = Describe("Builder", func() {
 								BuildName:    "42",
 							}))
 
-							plan, stepMetadata, containerMetadata, _ = fakeStepFactory.PutStepArgsForCall(1)
+							plan, stepMetadata, containerMetadata, _, _ = fakeStepFactory.PutStepArgsForCall(1)
 							Expect(plan).To(Equal(otherPutPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -223,7 +224,7 @@ var _ = Describe("Builder", func() {
 
 					Context("constructing outputs", func() {
 						It("constructs the put correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.PutStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.PutStepArgsForCall(0)
 							Expect(plan).To(Equal(putPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -237,7 +238,7 @@ var _ = Describe("Builder", func() {
 								BuildName:    "42",
 							}))
 
-							plan, stepMetadata, containerMetadata, _ = fakeStepFactory.PutStepArgsForCall(1)
+							plan, stepMetadata, containerMetadata, _, _ = fakeStepFactory.PutStepArgsForCall(1)
 							Expect(plan).To(Equal(otherPutPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -313,7 +314,7 @@ var _ = Describe("Builder", func() {
 					})
 
 					It("constructs the first get correctly", func() {
-						plan, stepMetadata, containerMetadata, _ := fakeStepFactory.GetStepArgsForCall(0)
+						plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.GetStepArgsForCall(0)
 						expectedPlan := getPlan
 						expectedPlan.Attempts = []int{1}
 						Expect(plan).To(Equal(expectedPlan))
@@ -332,7 +333,7 @@ var _ = Describe("Builder", func() {
 					})
 
 					It("constructs the second get correctly", func() {
-						plan, stepMetadata, containerMetadata, _ := fakeStepFactory.GetStepArgsForCall(1)
+						plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.GetStepArgsForCall(1)
 						expectedPlan := getPlan
 						expectedPlan.Attempts = []int{3}
 						Expect(plan).To(Equal(expectedPlan))
@@ -355,7 +356,7 @@ var _ = Describe("Builder", func() {
 					})
 
 					It("constructs nested steps correctly", func() {
-						plan, stepMetadata, containerMetadata, _ := fakeStepFactory.TaskStepArgsForCall(0)
+						plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.TaskStepArgsForCall(0)
 						expectedPlan := taskPlan
 						expectedPlan.Attempts = []int{2, 1}
 						Expect(plan).To(Equal(expectedPlan))
@@ -372,7 +373,7 @@ var _ = Describe("Builder", func() {
 							Attempt:      "2.1",
 						}))
 
-						plan, stepMetadata, containerMetadata, _ = fakeStepFactory.TaskStepArgsForCall(1)
+						plan, stepMetadata, containerMetadata, _, _ = fakeStepFactory.TaskStepArgsForCall(1)
 						expectedPlan = taskPlan
 						expectedPlan.Attempts = []int{2, 2}
 						Expect(plan).To(Equal(expectedPlan))
@@ -442,15 +443,15 @@ var _ = Describe("Builder", func() {
 					It("constructs nested steps correctly", func() {
 						Expect(fakeStepFactory.TaskStepCallCount()).To(Equal(6))
 
-						_, _, containerMetadata, _ := fakeStepFactory.TaskStepArgsForCall(0)
+						_, _, containerMetadata, _, _ := fakeStepFactory.TaskStepArgsForCall(0)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
-						_, _, containerMetadata, _ = fakeStepFactory.TaskStepArgsForCall(1)
+						_, _, containerMetadata, _, _ = fakeStepFactory.TaskStepArgsForCall(1)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
-						_, _, containerMetadata, _ = fakeStepFactory.TaskStepArgsForCall(2)
+						_, _, containerMetadata, _, _ = fakeStepFactory.TaskStepArgsForCall(2)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
-						_, _, containerMetadata, _ = fakeStepFactory.TaskStepArgsForCall(3)
+						_, _, containerMetadata, _, _ = fakeStepFactory.TaskStepArgsForCall(3)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
-						_, _, containerMetadata, _ = fakeStepFactory.TaskStepArgsForCall(4)
+						_, _, containerMetadata, _, _ = fakeStepFactory.TaskStepArgsForCall(4)
 						Expect(containerMetadata.Attempt).To(Equal("1"))
 					})
 				})
@@ -471,7 +472,7 @@ var _ = Describe("Builder", func() {
 						})
 
 						It("constructs inputs correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.GetStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.GetStepArgsForCall(0)
 							Expect(plan).To(Equal(expectedPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -498,7 +499,7 @@ var _ = Describe("Builder", func() {
 						})
 
 						It("constructs tasks correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.TaskStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.TaskStepArgsForCall(0)
 							Expect(plan).To(Equal(expectedPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -547,7 +548,7 @@ var _ = Describe("Builder", func() {
 						})
 
 						It("constructs the put correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.PutStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.PutStepArgsForCall(0)
 							Expect(plan).To(Equal(putPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -563,7 +564,7 @@ var _ = Describe("Builder", func() {
 						})
 
 						It("constructs the dependent get correctly", func() {
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.GetStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.GetStepArgsForCall(0)
 							Expect(plan).To(Equal(dependentGetPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -628,7 +629,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the step correctly", func() {
 							Expect(fakeStepFactory.GetStepCallCount()).To(Equal(1))
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.GetStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.GetStepArgsForCall(0)
 							Expect(plan).To(Equal(inputPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -645,7 +646,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the completion hook correctly", func() {
 							Expect(fakeStepFactory.TaskStepCallCount()).To(Equal(4))
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.TaskStepArgsForCall(2)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.TaskStepArgsForCall(2)
 							Expect(plan).To(Equal(completionTaskPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -662,7 +663,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the failure hook correctly", func() {
 							Expect(fakeStepFactory.TaskStepCallCount()).To(Equal(4))
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.TaskStepArgsForCall(0)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.TaskStepArgsForCall(0)
 							Expect(plan).To(Equal(failureTaskPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -679,7 +680,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the success hook correctly", func() {
 							Expect(fakeStepFactory.TaskStepCallCount()).To(Equal(4))
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.TaskStepArgsForCall(1)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.TaskStepArgsForCall(1)
 							Expect(plan).To(Equal(successTaskPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -696,7 +697,7 @@ var _ = Describe("Builder", func() {
 
 						It("constructs the next step correctly", func() {
 							Expect(fakeStepFactory.TaskStepCallCount()).To(Equal(4))
-							plan, stepMetadata, containerMetadata, _ := fakeStepFactory.TaskStepArgsForCall(3)
+							plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.TaskStepArgsForCall(3)
 							Expect(plan).To(Equal(nextTaskPlan))
 							Expect(stepMetadata).To(Equal(expectedMetadata))
 							Expect(containerMetadata).To(Equal(db.ContainerMetadata{
@@ -728,7 +729,7 @@ var _ = Describe("Builder", func() {
 
 					It("constructs the step correctly", func() {
 						Expect(fakeStepFactory.GetStepCallCount()).To(Equal(1))
-						plan, stepMetadata, containerMetadata, _ := fakeStepFactory.GetStepArgsForCall(0)
+						plan, stepMetadata, containerMetadata, _, _ := fakeStepFactory.GetStepArgsForCall(0)
 						Expect(plan).To(Equal(inputPlan))
 						Expect(stepMetadata).To(Equal(expectedMetadata))
 						Expect(containerMetadata).To(Equal(db.ContainerMetadata{

--- a/atc/engine/builder/builderfakes/fake_step_factory.go
+++ b/atc/engine/builder/builderfakes/fake_step_factory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/engine/builder"
 	"github.com/concourse/concourse/atc/exec"
 )
@@ -37,13 +38,14 @@ type FakeStepFactory struct {
 	artifactOutputStepReturnsOnCall map[int]struct {
 		result1 exec.Step
 	}
-	GetStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.GetDelegate) exec.Step
+	GetStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.GetDelegate, lock.LockFactory) exec.Step
 	getStepMutex       sync.RWMutex
 	getStepArgsForCall []struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
 		arg4 exec.GetDelegate
+		arg5 lock.LockFactory
 	}
 	getStepReturns struct {
 		result1 exec.Step
@@ -51,13 +53,14 @@ type FakeStepFactory struct {
 	getStepReturnsOnCall map[int]struct {
 		result1 exec.Step
 	}
-	PutStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.PutDelegate) exec.Step
+	PutStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.PutDelegate, lock.LockFactory) exec.Step
 	putStepMutex       sync.RWMutex
 	putStepArgsForCall []struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
 		arg4 exec.PutDelegate
+		arg5 lock.LockFactory
 	}
 	putStepReturns struct {
 		result1 exec.Step
@@ -65,13 +68,14 @@ type FakeStepFactory struct {
 	putStepReturnsOnCall map[int]struct {
 		result1 exec.Step
 	}
-	TaskStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.TaskDelegate) exec.Step
+	TaskStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.TaskDelegate, lock.LockFactory) exec.Step
 	taskStepMutex       sync.RWMutex
 	taskStepArgsForCall []struct {
 		arg1 atc.Plan
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
 		arg4 exec.TaskDelegate
+		arg5 lock.LockFactory
 	}
 	taskStepReturns struct {
 		result1 exec.Step
@@ -207,7 +211,7 @@ func (fake *FakeStepFactory) ArtifactOutputStepReturnsOnCall(i int, result1 exec
 	}{result1}
 }
 
-func (fake *FakeStepFactory) GetStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 exec.GetDelegate) exec.Step {
+func (fake *FakeStepFactory) GetStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 exec.GetDelegate, arg5 lock.LockFactory) exec.Step {
 	fake.getStepMutex.Lock()
 	ret, specificReturn := fake.getStepReturnsOnCall[len(fake.getStepArgsForCall)]
 	fake.getStepArgsForCall = append(fake.getStepArgsForCall, struct {
@@ -215,11 +219,12 @@ func (fake *FakeStepFactory) GetStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
 		arg4 exec.GetDelegate
-	}{arg1, arg2, arg3, arg4})
-	fake.recordInvocation("GetStep", []interface{}{arg1, arg2, arg3, arg4})
+		arg5 lock.LockFactory
+	}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("GetStep", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.getStepMutex.Unlock()
 	if fake.GetStepStub != nil {
-		return fake.GetStepStub(arg1, arg2, arg3, arg4)
+		return fake.GetStepStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -234,17 +239,17 @@ func (fake *FakeStepFactory) GetStepCallCount() int {
 	return len(fake.getStepArgsForCall)
 }
 
-func (fake *FakeStepFactory) GetStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.GetDelegate) exec.Step) {
+func (fake *FakeStepFactory) GetStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.GetDelegate, lock.LockFactory) exec.Step) {
 	fake.getStepMutex.Lock()
 	defer fake.getStepMutex.Unlock()
 	fake.GetStepStub = stub
 }
 
-func (fake *FakeStepFactory) GetStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.GetDelegate) {
+func (fake *FakeStepFactory) GetStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.GetDelegate, lock.LockFactory) {
 	fake.getStepMutex.RLock()
 	defer fake.getStepMutex.RUnlock()
 	argsForCall := fake.getStepArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeStepFactory) GetStepReturns(result1 exec.Step) {
@@ -270,7 +275,7 @@ func (fake *FakeStepFactory) GetStepReturnsOnCall(i int, result1 exec.Step) {
 	}{result1}
 }
 
-func (fake *FakeStepFactory) PutStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 exec.PutDelegate) exec.Step {
+func (fake *FakeStepFactory) PutStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 exec.PutDelegate, arg5 lock.LockFactory) exec.Step {
 	fake.putStepMutex.Lock()
 	ret, specificReturn := fake.putStepReturnsOnCall[len(fake.putStepArgsForCall)]
 	fake.putStepArgsForCall = append(fake.putStepArgsForCall, struct {
@@ -278,11 +283,12 @@ func (fake *FakeStepFactory) PutStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
 		arg4 exec.PutDelegate
-	}{arg1, arg2, arg3, arg4})
-	fake.recordInvocation("PutStep", []interface{}{arg1, arg2, arg3, arg4})
+		arg5 lock.LockFactory
+	}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("PutStep", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.putStepMutex.Unlock()
 	if fake.PutStepStub != nil {
-		return fake.PutStepStub(arg1, arg2, arg3, arg4)
+		return fake.PutStepStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -297,17 +303,17 @@ func (fake *FakeStepFactory) PutStepCallCount() int {
 	return len(fake.putStepArgsForCall)
 }
 
-func (fake *FakeStepFactory) PutStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.PutDelegate) exec.Step) {
+func (fake *FakeStepFactory) PutStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.PutDelegate, lock.LockFactory) exec.Step) {
 	fake.putStepMutex.Lock()
 	defer fake.putStepMutex.Unlock()
 	fake.PutStepStub = stub
 }
 
-func (fake *FakeStepFactory) PutStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.PutDelegate) {
+func (fake *FakeStepFactory) PutStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.PutDelegate, lock.LockFactory) {
 	fake.putStepMutex.RLock()
 	defer fake.putStepMutex.RUnlock()
 	argsForCall := fake.putStepArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeStepFactory) PutStepReturns(result1 exec.Step) {
@@ -333,7 +339,7 @@ func (fake *FakeStepFactory) PutStepReturnsOnCall(i int, result1 exec.Step) {
 	}{result1}
 }
 
-func (fake *FakeStepFactory) TaskStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 exec.TaskDelegate) exec.Step {
+func (fake *FakeStepFactory) TaskStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 exec.TaskDelegate, arg5 lock.LockFactory) exec.Step {
 	fake.taskStepMutex.Lock()
 	ret, specificReturn := fake.taskStepReturnsOnCall[len(fake.taskStepArgsForCall)]
 	fake.taskStepArgsForCall = append(fake.taskStepArgsForCall, struct {
@@ -341,11 +347,12 @@ func (fake *FakeStepFactory) TaskStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
 		arg4 exec.TaskDelegate
-	}{arg1, arg2, arg3, arg4})
-	fake.recordInvocation("TaskStep", []interface{}{arg1, arg2, arg3, arg4})
+		arg5 lock.LockFactory
+	}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("TaskStep", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.taskStepMutex.Unlock()
 	if fake.TaskStepStub != nil {
-		return fake.TaskStepStub(arg1, arg2, arg3, arg4)
+		return fake.TaskStepStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -360,17 +367,17 @@ func (fake *FakeStepFactory) TaskStepCallCount() int {
 	return len(fake.taskStepArgsForCall)
 }
 
-func (fake *FakeStepFactory) TaskStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.TaskDelegate) exec.Step) {
+func (fake *FakeStepFactory) TaskStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.TaskDelegate, lock.LockFactory) exec.Step) {
 	fake.taskStepMutex.Lock()
 	defer fake.taskStepMutex.Unlock()
 	fake.TaskStepStub = stub
 }
 
-func (fake *FakeStepFactory) TaskStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.TaskDelegate) {
+func (fake *FakeStepFactory) TaskStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.TaskDelegate, lock.LockFactory) {
 	fake.taskStepMutex.RLock()
 	defer fake.taskStepMutex.RUnlock()
 	argsForCall := fake.taskStepArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeStepFactory) TaskStepReturns(result1 exec.Step) {

--- a/atc/exec/execfakes/fake_get_delegate.go
+++ b/atc/exec/execfakes/fake_get_delegate.go
@@ -41,13 +41,6 @@ type FakeGetDelegate struct {
 	initializingArgsForCall []struct {
 		arg1 lager.Logger
 	}
-	SaveVersionStub        func(lager.Logger, string, exec.VersionInfo)
-	saveVersionMutex       sync.RWMutex
-	saveVersionArgsForCall []struct {
-		arg1 lager.Logger
-		arg2 string
-		arg3 exec.VersionInfo
-	}
 	StartingStub        func(lager.Logger)
 	startingMutex       sync.RWMutex
 	startingArgsForCall []struct {
@@ -240,39 +233,6 @@ func (fake *FakeGetDelegate) InitializingArgsForCall(i int) lager.Logger {
 	return argsForCall.arg1
 }
 
-func (fake *FakeGetDelegate) SaveVersion(arg1 lager.Logger, arg2 string, arg3 exec.VersionInfo) {
-	fake.saveVersionMutex.Lock()
-	fake.saveVersionArgsForCall = append(fake.saveVersionArgsForCall, struct {
-		arg1 lager.Logger
-		arg2 string
-		arg3 exec.VersionInfo
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("SaveVersion", []interface{}{arg1, arg2, arg3})
-	fake.saveVersionMutex.Unlock()
-	if fake.SaveVersionStub != nil {
-		fake.SaveVersionStub(arg1, arg2, arg3)
-	}
-}
-
-func (fake *FakeGetDelegate) SaveVersionCallCount() int {
-	fake.saveVersionMutex.RLock()
-	defer fake.saveVersionMutex.RUnlock()
-	return len(fake.saveVersionArgsForCall)
-}
-
-func (fake *FakeGetDelegate) SaveVersionCalls(stub func(lager.Logger, string, exec.VersionInfo)) {
-	fake.saveVersionMutex.Lock()
-	defer fake.saveVersionMutex.Unlock()
-	fake.SaveVersionStub = stub
-}
-
-func (fake *FakeGetDelegate) SaveVersionArgsForCall(i int) (lager.Logger, string, exec.VersionInfo) {
-	fake.saveVersionMutex.RLock()
-	defer fake.saveVersionMutex.RUnlock()
-	argsForCall := fake.saveVersionArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
 func (fake *FakeGetDelegate) Starting(arg1 lager.Logger) {
 	fake.startingMutex.Lock()
 	fake.startingArgsForCall = append(fake.startingArgsForCall, struct {
@@ -452,8 +412,6 @@ func (fake *FakeGetDelegate) Invocations() map[string][][]interface{} {
 	defer fake.imageVersionDeterminedMutex.RUnlock()
 	fake.initializingMutex.RLock()
 	defer fake.initializingMutex.RUnlock()
-	fake.saveVersionMutex.RLock()
-	defer fake.saveVersionMutex.RUnlock()
 	fake.startingMutex.RLock()
 	defer fake.startingMutex.RUnlock()
 	fake.stderrMutex.RLock()

--- a/atc/radar/resource_scanner.go
+++ b/atc/radar/resource_scanner.go
@@ -347,6 +347,7 @@ func (scanner *resourceScanner) check(
 		},
 		containerSpec,
 		resourceTypes,
+		nil,
 	)
 	if err != nil {
 		// TODO: remove this after ephemeral check containers.

--- a/atc/radar/resource_scanner_test.go
+++ b/atc/radar/resource_scanner_test.go
@@ -259,7 +259,7 @@ var _ = Describe("ResourceScanner", func() {
 
 					var metadata db.ContainerMetadata
 					Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-					_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+					_, _, _, owner, metadata, containerSpec, resourceTypes, _ = fakeWorker.FindOrCreateContainerArgsForCall(0)
 					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, radar.ContainerExpiries)))
 					Expect(metadata).To(Equal(db.ContainerMetadata{
 						Type: db.ContainerTypeCheck,
@@ -681,7 +681,7 @@ var _ = Describe("ResourceScanner", func() {
 				}))
 
 				var metadata db.ContainerMetadata
-				_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+				_, _, _, owner, metadata, containerSpec, resourceTypes, _ = fakeWorker.FindOrCreateContainerArgsForCall(0)
 				Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, radar.ContainerExpiries)))
 				Expect(metadata).To(Equal(db.ContainerMetadata{
 					Type: db.ContainerTypeCheck,

--- a/atc/radar/resource_type_scanner.go
+++ b/atc/radar/resource_type_scanner.go
@@ -283,6 +283,7 @@ func (scanner *resourceTypeScanner) check(
 		},
 		containerSpec,
 		versionedResourceTypes.Without(savedResourceType.Name()),
+		nil,
 	)
 	if err != nil {
 		chkErr := resourceConfigScope.SetCheckError(err)

--- a/atc/radar/resource_type_scanner_test.go
+++ b/atc/radar/resource_type_scanner_test.go
@@ -41,7 +41,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 		fakeClock                 *fakeclock.FakeClock
 		interval                  time.Duration
 		variables                 creds.Variables
-		metadata				  db.ContainerMetadata
+		metadata                  db.ContainerMetadata
 
 		fakeResourceType          *dbfakes.FakeResourceType
 		interpolatedResourceTypes atc.VersionedResourceTypes
@@ -202,7 +202,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 					}))
 
 					Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-					_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+					_, _, _, owner, metadata, containerSpec, resourceTypes, _ = fakeWorker.FindOrCreateContainerArgsForCall(0)
 					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 					Expect(metadata).To(Equal(db.ContainerMetadata{
 						Type: db.ContainerTypeCheck,
@@ -257,7 +257,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 						}))
 
 						Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-						_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+						_, _, _, owner, metadata, containerSpec, resourceTypes, _ = fakeWorker.FindOrCreateContainerArgsForCall(0)
 						Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 						Expect(metadata).To(Equal(db.ContainerMetadata{
 							Type: db.ContainerTypeCheck,
@@ -485,7 +485,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 				}))
 
 				Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-				_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+				_, _, _, owner, metadata, containerSpec, resourceTypes, _ = fakeWorker.FindOrCreateContainerArgsForCall(0)
 				Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 				Expect(metadata).To(Equal(db.ContainerMetadata{
 					Type: db.ContainerTypeCheck,
@@ -594,7 +594,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 					Expect(resourceSource).To(Equal(atc.Source{"custom": "some-secret-sauce"}))
 					Expect(resourceTypes).To(Equal(interpolatedResourceTypes))
 
-					_, _,  owner, containerSpec, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
+					_, _, owner, containerSpec, workerSpec, _ := fakePool.FindOrChooseWorkerForContainerArgsForCall(0)
 					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 					Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 						ResourceType: "registry-image",
@@ -607,7 +607,7 @@ var _ = Describe("ResourceTypeScanner", func() {
 					}))
 
 					Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-					_, _, _, owner, metadata, containerSpec, resourceTypes = fakeWorker.FindOrCreateContainerArgsForCall(0)
+					_, _, _, owner, metadata, containerSpec, resourceTypes, _ = fakeWorker.FindOrCreateContainerArgsForCall(0)
 					Expect(owner).To(Equal(db.NewResourceConfigCheckSessionContainerOwner(fakeResourceConfig, ContainerExpiries)))
 					Expect(metadata).To(Equal(db.ContainerMetadata{
 						Type: db.ContainerTypeCheck,

--- a/atc/resource/fetcher_test.go
+++ b/atc/resource/fetcher_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Fetcher", func() {
 			atc.VersionedResourceTypes{},
 			new(resourcefakes.FakeResourceInstance),
 			fakeBuildStepDelegate,
+			nil,
 		)
 	})
 

--- a/atc/resource/resource_instance_fetch_source.go
+++ b/atc/resource/resource_instance_fetch_source.go
@@ -130,7 +130,6 @@ func (s *resourceInstanceFetchSource) Create(ctx context.Context) (VersionedSour
 		&worker.CertsVolumeMount{Logger: s.logger},
 	}
 
-
 	container, err := s.worker.FindOrCreateContainer(
 		ctx,
 		s.logger,
@@ -139,6 +138,7 @@ func (s *resourceInstanceFetchSource) Create(ctx context.Context) (VersionedSour
 		s.session.Metadata,
 		s.containerSpec,
 		s.resourceTypes,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/atc/resource/resource_instance_fetch_source_test.go
+++ b/atc/resource/resource_instance_fetch_source_test.go
@@ -204,7 +204,7 @@ var _ = Describe("ResourceInstanceFetchSource", func() {
 				Expect(initErr).NotTo(HaveOccurred())
 
 				Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-				_, logger, delegate, owner, actualMetadata, containerSpec, types := fakeWorker.FindOrCreateContainerArgsForCall(0)
+				_, logger, delegate, owner, actualMetadata, containerSpec, types, _ := fakeWorker.FindOrCreateContainerArgsForCall(0)
 				Expect(delegate).To(Equal(fakeDelegate))
 				Expect(owner).To(Equal(db.NewBuildStepContainerOwner(43, atc.PlanID("some-plan-id"), 42)))
 				Expect(actualMetadata).To(Equal(metadata))

--- a/atc/resource/resourcefakes/fake_fetcher.go
+++ b/atc/resource/resourcefakes/fake_fetcher.go
@@ -7,12 +7,13 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/resource"
 	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeFetcher struct {
-	FetchStub        func(context.Context, lager.Logger, resource.Session, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate) (resource.VersionedSource, error)
+	FetchStub        func(context.Context, lager.Logger, resource.Session, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate, lock.Lock) (resource.VersionedSource, error)
 	fetchMutex       sync.RWMutex
 	fetchArgsForCall []struct {
 		arg1 context.Context
@@ -23,6 +24,7 @@ type FakeFetcher struct {
 		arg6 atc.VersionedResourceTypes
 		arg7 resource.ResourceInstance
 		arg8 worker.ImageFetchingDelegate
+		arg9 lock.Lock
 	}
 	fetchReturns struct {
 		result1 resource.VersionedSource
@@ -36,7 +38,7 @@ type FakeFetcher struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeFetcher) Fetch(arg1 context.Context, arg2 lager.Logger, arg3 resource.Session, arg4 worker.Worker, arg5 worker.ContainerSpec, arg6 atc.VersionedResourceTypes, arg7 resource.ResourceInstance, arg8 worker.ImageFetchingDelegate) (resource.VersionedSource, error) {
+func (fake *FakeFetcher) Fetch(arg1 context.Context, arg2 lager.Logger, arg3 resource.Session, arg4 worker.Worker, arg5 worker.ContainerSpec, arg6 atc.VersionedResourceTypes, arg7 resource.ResourceInstance, arg8 worker.ImageFetchingDelegate, arg9 lock.Lock) (resource.VersionedSource, error) {
 	fake.fetchMutex.Lock()
 	ret, specificReturn := fake.fetchReturnsOnCall[len(fake.fetchArgsForCall)]
 	fake.fetchArgsForCall = append(fake.fetchArgsForCall, struct {
@@ -48,11 +50,12 @@ func (fake *FakeFetcher) Fetch(arg1 context.Context, arg2 lager.Logger, arg3 res
 		arg6 atc.VersionedResourceTypes
 		arg7 resource.ResourceInstance
 		arg8 worker.ImageFetchingDelegate
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
-	fake.recordInvocation("Fetch", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
+		arg9 lock.Lock
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9})
+	fake.recordInvocation("Fetch", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9})
 	fake.fetchMutex.Unlock()
 	if fake.FetchStub != nil {
-		return fake.FetchStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+		return fake.FetchStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -67,17 +70,17 @@ func (fake *FakeFetcher) FetchCallCount() int {
 	return len(fake.fetchArgsForCall)
 }
 
-func (fake *FakeFetcher) FetchCalls(stub func(context.Context, lager.Logger, resource.Session, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate) (resource.VersionedSource, error)) {
+func (fake *FakeFetcher) FetchCalls(stub func(context.Context, lager.Logger, resource.Session, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate, lock.Lock) (resource.VersionedSource, error)) {
 	fake.fetchMutex.Lock()
 	defer fake.fetchMutex.Unlock()
 	fake.FetchStub = stub
 }
 
-func (fake *FakeFetcher) FetchArgsForCall(i int) (context.Context, lager.Logger, resource.Session, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate) {
+func (fake *FakeFetcher) FetchArgsForCall(i int) (context.Context, lager.Logger, resource.Session, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate, lock.Lock) {
 	fake.fetchMutex.RLock()
 	defer fake.fetchMutex.RUnlock()
 	argsForCall := fake.fetchArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8, argsForCall.arg9
 }
 
 func (fake *FakeFetcher) FetchReturns(result1 resource.VersionedSource, result2 error) {

--- a/atc/worker/db_worker_provider_test.go
+++ b/atc/worker/db_worker_provider_test.go
@@ -432,6 +432,7 @@ var _ = Describe("DBProvider", func() {
 						db.ContainerMetadata{},
 						containerSpec,
 						nil,
+						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -505,6 +506,7 @@ var _ = Describe("DBProvider", func() {
 						db.NewBuildStepContainerOwner(42, atc.PlanID("some-plan-id"), 1),
 						db.ContainerMetadata{},
 						containerSpec,
+						nil,
 						nil,
 					)
 					Expect(err).NotTo(HaveOccurred())

--- a/atc/worker/image/image_resource_fetcher.go
+++ b/atc/worker/image/image_resource_fetcher.go
@@ -178,6 +178,7 @@ func (i *imageResourceFetcher) Fetch(
 		i.customTypes,
 		resourceInstance,
 		i.imageFetchingDelegate,
+		nil,
 	)
 	if err != nil {
 		logger.Error("failed-to-fetch-image", err)
@@ -238,6 +239,7 @@ func (i *imageResourceFetcher) ensureVersionOfType(
 		},
 		containerSpec,
 		i.customTypes,
+		nil,
 	)
 	if err != nil {
 		return err
@@ -296,6 +298,7 @@ func (i *imageResourceFetcher) getLatestVersion(
 		},
 		resourceSpec,
 		i.customTypes,
+		nil,
 	)
 	if err != nil {
 		return nil, err

--- a/atc/worker/image/image_resource_fetcher_test.go
+++ b/atc/worker/image/image_resource_fetcher_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Image", func() {
 
 					It("checks for the latest version of the resource type", func() {
 						By("find or create a resource container")
-						_, _, _, _, _,  containerSpec, _ := fakeWorker.FindOrCreateContainerArgsForCall(0)
+						_, _, _, _, _, containerSpec, _, _ := fakeWorker.FindOrCreateContainerArgsForCall(0)
 						Expect(containerSpec.ImageSpec.ResourceType).To(Equal("custom-type-a"))
 
 						By("calling the resource type's check script")
@@ -197,7 +197,7 @@ var _ = Describe("Image", func() {
 
 						It("uses the version of the custom type when checking for the original resource", func() {
 							Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(2))
-							_, _, _, _, _, containerSpec, customTypes := fakeWorker.FindOrCreateContainerArgsForCall(1)
+							_, _, _, _, _, containerSpec, customTypes, _ := fakeWorker.FindOrCreateContainerArgsForCall(1)
 							Expect(containerSpec.ImageSpec.ResourceType).To(Equal("custom-type-a"))
 							Expect(customTypes[0].Version).To(Equal(atc.Version{"some": "version"}))
 						})
@@ -269,7 +269,7 @@ var _ = Describe("Image", func() {
 
 								It("created the 'check' resource with the correct session, with the currently fetching type removed from the set", func() {
 									Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-									cctx, _, delegate, owner, metadata, containerSpec, actualCustomTypes := fakeWorker.FindOrCreateContainerArgsForCall(0)
+									cctx, _, delegate, owner, metadata, containerSpec, actualCustomTypes, _ := fakeWorker.FindOrCreateContainerArgsForCall(0)
 									Expect(cctx).To(Equal(ctx))
 									Expect(owner).To(Equal(db.NewImageCheckContainerOwner(fakeCreatingContainer, 123)))
 									Expect(metadata).To(Equal(db.ContainerMetadata{
@@ -310,7 +310,7 @@ var _ = Describe("Image", func() {
 
 							It("created the 'check' resource with the correct session, with the currently fetching type removed from the set", func() {
 								Expect(fakeWorker.FindOrCreateContainerCallCount()).To(Equal(1))
-								cctx, _, delegate, owner, metadata, containerSpec, actualCustomTypes := fakeWorker.FindOrCreateContainerArgsForCall(0)
+								cctx, _, delegate, owner, metadata, containerSpec, actualCustomTypes, _ := fakeWorker.FindOrCreateContainerArgsForCall(0)
 								Expect(cctx).To(Equal(ctx))
 								Expect(owner).To(Equal(db.NewImageCheckContainerOwner(fakeCreatingContainer, 123)))
 								Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
@@ -341,7 +341,7 @@ var _ = Describe("Image", func() {
 
 							It("fetches resource with correct session", func() {
 								Expect(fakeResourceFetcher.FetchCallCount()).To(Equal(1))
-								_, _, session, actualWorker, containerSpec, actualCustomTypes, resourceInstance, delegate := fakeResourceFetcher.FetchArgsForCall(0)
+								_, _, session, actualWorker, containerSpec, actualCustomTypes, resourceInstance, delegate, _ := fakeResourceFetcher.FetchArgsForCall(0)
 								Expect(session).To(Equal(resource.Session{
 									Metadata: db.ContainerMetadata{
 										Type: db.ContainerTypeGet,
@@ -561,7 +561,7 @@ var _ = Describe("Image", func() {
 
 					It("fetches resource with correct session", func() {
 						Expect(fakeResourceFetcher.FetchCallCount()).To(Equal(1))
-						_, _, session, actualWorker, containerSpec, actualCustomTypes, resourceInstance, delegate := fakeResourceFetcher.FetchArgsForCall(0)
+						_, _, session, actualWorker, containerSpec, actualCustomTypes, resourceInstance, delegate, _ := fakeResourceFetcher.FetchArgsForCall(0)
 						Expect(session).To(Equal(resource.Session{
 							Metadata: db.ContainerMetadata{
 								Type: db.ContainerTypeGet,

--- a/atc/worker/worker_test.go
+++ b/atc/worker/worker_test.go
@@ -946,6 +946,7 @@ var _ = Describe("Worker", func() {
 				db.ContainerMetadata{},
 				containerSpec,
 				atcResourceTypes,
+				nil,
 			)
 		})
 		disasterErr := errors.New("disaster")

--- a/atc/worker/workerfakes/fake_artifact_destination.go
+++ b/atc/worker/workerfakes/fake_artifact_destination.go
@@ -2,10 +2,10 @@
 package workerfakes
 
 import (
-	io "io"
-	sync "sync"
+	"io"
+	"sync"
 
-	worker "github.com/concourse/concourse/atc/worker"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeArtifactDestination struct {
@@ -50,6 +50,12 @@ func (fake *FakeArtifactDestination) StreamInCallCount() int {
 	return len(fake.streamInArgsForCall)
 }
 
+func (fake *FakeArtifactDestination) StreamInCalls(stub func(string, io.Reader) error) {
+	fake.streamInMutex.Lock()
+	defer fake.streamInMutex.Unlock()
+	fake.StreamInStub = stub
+}
+
 func (fake *FakeArtifactDestination) StreamInArgsForCall(i int) (string, io.Reader) {
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
@@ -58,6 +64,8 @@ func (fake *FakeArtifactDestination) StreamInArgsForCall(i int) (string, io.Read
 }
 
 func (fake *FakeArtifactDestination) StreamInReturns(result1 error) {
+	fake.streamInMutex.Lock()
+	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	fake.streamInReturns = struct {
 		result1 error
@@ -65,6 +73,8 @@ func (fake *FakeArtifactDestination) StreamInReturns(result1 error) {
 }
 
 func (fake *FakeArtifactDestination) StreamInReturnsOnCall(i int, result1 error) {
+	fake.streamInMutex.Lock()
+	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	if fake.streamInReturnsOnCall == nil {
 		fake.streamInReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_artifact_source.go
+++ b/atc/worker/workerfakes/fake_artifact_source.go
@@ -2,11 +2,11 @@
 package workerfakes
 
 import (
-	io "io"
-	sync "sync"
+	"io"
+	"sync"
 
-	lager "code.cloudfoundry.org/lager"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeArtifactSource struct {
@@ -81,6 +81,12 @@ func (fake *FakeArtifactSource) StreamFileCallCount() int {
 	return len(fake.streamFileArgsForCall)
 }
 
+func (fake *FakeArtifactSource) StreamFileCalls(stub func(lager.Logger, string) (io.ReadCloser, error)) {
+	fake.streamFileMutex.Lock()
+	defer fake.streamFileMutex.Unlock()
+	fake.StreamFileStub = stub
+}
+
 func (fake *FakeArtifactSource) StreamFileArgsForCall(i int) (lager.Logger, string) {
 	fake.streamFileMutex.RLock()
 	defer fake.streamFileMutex.RUnlock()
@@ -89,6 +95,8 @@ func (fake *FakeArtifactSource) StreamFileArgsForCall(i int) (lager.Logger, stri
 }
 
 func (fake *FakeArtifactSource) StreamFileReturns(result1 io.ReadCloser, result2 error) {
+	fake.streamFileMutex.Lock()
+	defer fake.streamFileMutex.Unlock()
 	fake.StreamFileStub = nil
 	fake.streamFileReturns = struct {
 		result1 io.ReadCloser
@@ -97,6 +105,8 @@ func (fake *FakeArtifactSource) StreamFileReturns(result1 io.ReadCloser, result2
 }
 
 func (fake *FakeArtifactSource) StreamFileReturnsOnCall(i int, result1 io.ReadCloser, result2 error) {
+	fake.streamFileMutex.Lock()
+	defer fake.streamFileMutex.Unlock()
 	fake.StreamFileStub = nil
 	if fake.streamFileReturnsOnCall == nil {
 		fake.streamFileReturnsOnCall = make(map[int]struct {
@@ -135,6 +145,12 @@ func (fake *FakeArtifactSource) StreamToCallCount() int {
 	return len(fake.streamToArgsForCall)
 }
 
+func (fake *FakeArtifactSource) StreamToCalls(stub func(lager.Logger, worker.ArtifactDestination) error) {
+	fake.streamToMutex.Lock()
+	defer fake.streamToMutex.Unlock()
+	fake.StreamToStub = stub
+}
+
 func (fake *FakeArtifactSource) StreamToArgsForCall(i int) (lager.Logger, worker.ArtifactDestination) {
 	fake.streamToMutex.RLock()
 	defer fake.streamToMutex.RUnlock()
@@ -143,6 +159,8 @@ func (fake *FakeArtifactSource) StreamToArgsForCall(i int) (lager.Logger, worker
 }
 
 func (fake *FakeArtifactSource) StreamToReturns(result1 error) {
+	fake.streamToMutex.Lock()
+	defer fake.streamToMutex.Unlock()
 	fake.StreamToStub = nil
 	fake.streamToReturns = struct {
 		result1 error
@@ -150,6 +168,8 @@ func (fake *FakeArtifactSource) StreamToReturns(result1 error) {
 }
 
 func (fake *FakeArtifactSource) StreamToReturnsOnCall(i int, result1 error) {
+	fake.streamToMutex.Lock()
+	defer fake.streamToMutex.Unlock()
 	fake.StreamToStub = nil
 	if fake.streamToReturnsOnCall == nil {
 		fake.streamToReturnsOnCall = make(map[int]struct {
@@ -186,6 +206,12 @@ func (fake *FakeArtifactSource) VolumeOnCallCount() int {
 	return len(fake.volumeOnArgsForCall)
 }
 
+func (fake *FakeArtifactSource) VolumeOnCalls(stub func(lager.Logger, worker.Worker) (worker.Volume, bool, error)) {
+	fake.volumeOnMutex.Lock()
+	defer fake.volumeOnMutex.Unlock()
+	fake.VolumeOnStub = stub
+}
+
 func (fake *FakeArtifactSource) VolumeOnArgsForCall(i int) (lager.Logger, worker.Worker) {
 	fake.volumeOnMutex.RLock()
 	defer fake.volumeOnMutex.RUnlock()
@@ -194,6 +220,8 @@ func (fake *FakeArtifactSource) VolumeOnArgsForCall(i int) (lager.Logger, worker
 }
 
 func (fake *FakeArtifactSource) VolumeOnReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.volumeOnMutex.Lock()
+	defer fake.volumeOnMutex.Unlock()
 	fake.VolumeOnStub = nil
 	fake.volumeOnReturns = struct {
 		result1 worker.Volume
@@ -203,6 +231,8 @@ func (fake *FakeArtifactSource) VolumeOnReturns(result1 worker.Volume, result2 b
 }
 
 func (fake *FakeArtifactSource) VolumeOnReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.volumeOnMutex.Lock()
+	defer fake.volumeOnMutex.Unlock()
 	fake.VolumeOnStub = nil
 	if fake.volumeOnReturnsOnCall == nil {
 		fake.volumeOnReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_bind_mount_source.go
+++ b/atc/worker/workerfakes/fake_bind_mount_source.go
@@ -2,10 +2,10 @@
 package workerfakes
 
 import (
-	sync "sync"
+	"sync"
 
-	garden "code.cloudfoundry.org/garden"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/garden"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeBindMountSource struct {
@@ -52,6 +52,12 @@ func (fake *FakeBindMountSource) VolumeOnCallCount() int {
 	return len(fake.volumeOnArgsForCall)
 }
 
+func (fake *FakeBindMountSource) VolumeOnCalls(stub func(worker.Worker) (garden.BindMount, bool, error)) {
+	fake.volumeOnMutex.Lock()
+	defer fake.volumeOnMutex.Unlock()
+	fake.VolumeOnStub = stub
+}
+
 func (fake *FakeBindMountSource) VolumeOnArgsForCall(i int) worker.Worker {
 	fake.volumeOnMutex.RLock()
 	defer fake.volumeOnMutex.RUnlock()
@@ -60,6 +66,8 @@ func (fake *FakeBindMountSource) VolumeOnArgsForCall(i int) worker.Worker {
 }
 
 func (fake *FakeBindMountSource) VolumeOnReturns(result1 garden.BindMount, result2 bool, result3 error) {
+	fake.volumeOnMutex.Lock()
+	defer fake.volumeOnMutex.Unlock()
 	fake.VolumeOnStub = nil
 	fake.volumeOnReturns = struct {
 		result1 garden.BindMount
@@ -69,6 +77,8 @@ func (fake *FakeBindMountSource) VolumeOnReturns(result1 garden.BindMount, resul
 }
 
 func (fake *FakeBindMountSource) VolumeOnReturnsOnCall(i int, result1 garden.BindMount, result2 bool, result3 error) {
+	fake.volumeOnMutex.Lock()
+	defer fake.volumeOnMutex.Unlock()
 	fake.VolumeOnStub = nil
 	if fake.volumeOnReturnsOnCall == nil {
 		fake.volumeOnReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_container.go
+++ b/atc/worker/workerfakes/fake_container.go
@@ -2,12 +2,12 @@
 package workerfakes
 
 import (
-	io "io"
-	sync "sync"
-	time "time"
+	"io"
+	"sync"
+	"time"
 
-	garden "code.cloudfoundry.org/garden"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/garden"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeContainer struct {
@@ -322,6 +322,12 @@ func (fake *FakeContainer) AttachCallCount() int {
 	return len(fake.attachArgsForCall)
 }
 
+func (fake *FakeContainer) AttachCalls(stub func(string, garden.ProcessIO) (garden.Process, error)) {
+	fake.attachMutex.Lock()
+	defer fake.attachMutex.Unlock()
+	fake.AttachStub = stub
+}
+
 func (fake *FakeContainer) AttachArgsForCall(i int) (string, garden.ProcessIO) {
 	fake.attachMutex.RLock()
 	defer fake.attachMutex.RUnlock()
@@ -330,6 +336,8 @@ func (fake *FakeContainer) AttachArgsForCall(i int) (string, garden.ProcessIO) {
 }
 
 func (fake *FakeContainer) AttachReturns(result1 garden.Process, result2 error) {
+	fake.attachMutex.Lock()
+	defer fake.attachMutex.Unlock()
 	fake.AttachStub = nil
 	fake.attachReturns = struct {
 		result1 garden.Process
@@ -338,6 +346,8 @@ func (fake *FakeContainer) AttachReturns(result1 garden.Process, result2 error) 
 }
 
 func (fake *FakeContainer) AttachReturnsOnCall(i int, result1 garden.Process, result2 error) {
+	fake.attachMutex.Lock()
+	defer fake.attachMutex.Unlock()
 	fake.AttachStub = nil
 	if fake.attachReturnsOnCall == nil {
 		fake.attachReturnsOnCall = make(map[int]struct {
@@ -380,6 +390,12 @@ func (fake *FakeContainer) BulkNetOutCallCount() int {
 	return len(fake.bulkNetOutArgsForCall)
 }
 
+func (fake *FakeContainer) BulkNetOutCalls(stub func([]garden.NetOutRule) error) {
+	fake.bulkNetOutMutex.Lock()
+	defer fake.bulkNetOutMutex.Unlock()
+	fake.BulkNetOutStub = stub
+}
+
 func (fake *FakeContainer) BulkNetOutArgsForCall(i int) []garden.NetOutRule {
 	fake.bulkNetOutMutex.RLock()
 	defer fake.bulkNetOutMutex.RUnlock()
@@ -388,6 +404,8 @@ func (fake *FakeContainer) BulkNetOutArgsForCall(i int) []garden.NetOutRule {
 }
 
 func (fake *FakeContainer) BulkNetOutReturns(result1 error) {
+	fake.bulkNetOutMutex.Lock()
+	defer fake.bulkNetOutMutex.Unlock()
 	fake.BulkNetOutStub = nil
 	fake.bulkNetOutReturns = struct {
 		result1 error
@@ -395,6 +413,8 @@ func (fake *FakeContainer) BulkNetOutReturns(result1 error) {
 }
 
 func (fake *FakeContainer) BulkNetOutReturnsOnCall(i int, result1 error) {
+	fake.bulkNetOutMutex.Lock()
+	defer fake.bulkNetOutMutex.Unlock()
 	fake.BulkNetOutStub = nil
 	if fake.bulkNetOutReturnsOnCall == nil {
 		fake.bulkNetOutReturnsOnCall = make(map[int]struct {
@@ -429,7 +449,15 @@ func (fake *FakeContainer) CurrentBandwidthLimitsCallCount() int {
 	return len(fake.currentBandwidthLimitsArgsForCall)
 }
 
+func (fake *FakeContainer) CurrentBandwidthLimitsCalls(stub func() (garden.BandwidthLimits, error)) {
+	fake.currentBandwidthLimitsMutex.Lock()
+	defer fake.currentBandwidthLimitsMutex.Unlock()
+	fake.CurrentBandwidthLimitsStub = stub
+}
+
 func (fake *FakeContainer) CurrentBandwidthLimitsReturns(result1 garden.BandwidthLimits, result2 error) {
+	fake.currentBandwidthLimitsMutex.Lock()
+	defer fake.currentBandwidthLimitsMutex.Unlock()
 	fake.CurrentBandwidthLimitsStub = nil
 	fake.currentBandwidthLimitsReturns = struct {
 		result1 garden.BandwidthLimits
@@ -438,6 +466,8 @@ func (fake *FakeContainer) CurrentBandwidthLimitsReturns(result1 garden.Bandwidt
 }
 
 func (fake *FakeContainer) CurrentBandwidthLimitsReturnsOnCall(i int, result1 garden.BandwidthLimits, result2 error) {
+	fake.currentBandwidthLimitsMutex.Lock()
+	defer fake.currentBandwidthLimitsMutex.Unlock()
 	fake.CurrentBandwidthLimitsStub = nil
 	if fake.currentBandwidthLimitsReturnsOnCall == nil {
 		fake.currentBandwidthLimitsReturnsOnCall = make(map[int]struct {
@@ -474,7 +504,15 @@ func (fake *FakeContainer) CurrentCPULimitsCallCount() int {
 	return len(fake.currentCPULimitsArgsForCall)
 }
 
+func (fake *FakeContainer) CurrentCPULimitsCalls(stub func() (garden.CPULimits, error)) {
+	fake.currentCPULimitsMutex.Lock()
+	defer fake.currentCPULimitsMutex.Unlock()
+	fake.CurrentCPULimitsStub = stub
+}
+
 func (fake *FakeContainer) CurrentCPULimitsReturns(result1 garden.CPULimits, result2 error) {
+	fake.currentCPULimitsMutex.Lock()
+	defer fake.currentCPULimitsMutex.Unlock()
 	fake.CurrentCPULimitsStub = nil
 	fake.currentCPULimitsReturns = struct {
 		result1 garden.CPULimits
@@ -483,6 +521,8 @@ func (fake *FakeContainer) CurrentCPULimitsReturns(result1 garden.CPULimits, res
 }
 
 func (fake *FakeContainer) CurrentCPULimitsReturnsOnCall(i int, result1 garden.CPULimits, result2 error) {
+	fake.currentCPULimitsMutex.Lock()
+	defer fake.currentCPULimitsMutex.Unlock()
 	fake.CurrentCPULimitsStub = nil
 	if fake.currentCPULimitsReturnsOnCall == nil {
 		fake.currentCPULimitsReturnsOnCall = make(map[int]struct {
@@ -519,7 +559,15 @@ func (fake *FakeContainer) CurrentDiskLimitsCallCount() int {
 	return len(fake.currentDiskLimitsArgsForCall)
 }
 
+func (fake *FakeContainer) CurrentDiskLimitsCalls(stub func() (garden.DiskLimits, error)) {
+	fake.currentDiskLimitsMutex.Lock()
+	defer fake.currentDiskLimitsMutex.Unlock()
+	fake.CurrentDiskLimitsStub = stub
+}
+
 func (fake *FakeContainer) CurrentDiskLimitsReturns(result1 garden.DiskLimits, result2 error) {
+	fake.currentDiskLimitsMutex.Lock()
+	defer fake.currentDiskLimitsMutex.Unlock()
 	fake.CurrentDiskLimitsStub = nil
 	fake.currentDiskLimitsReturns = struct {
 		result1 garden.DiskLimits
@@ -528,6 +576,8 @@ func (fake *FakeContainer) CurrentDiskLimitsReturns(result1 garden.DiskLimits, r
 }
 
 func (fake *FakeContainer) CurrentDiskLimitsReturnsOnCall(i int, result1 garden.DiskLimits, result2 error) {
+	fake.currentDiskLimitsMutex.Lock()
+	defer fake.currentDiskLimitsMutex.Unlock()
 	fake.CurrentDiskLimitsStub = nil
 	if fake.currentDiskLimitsReturnsOnCall == nil {
 		fake.currentDiskLimitsReturnsOnCall = make(map[int]struct {
@@ -564,7 +614,15 @@ func (fake *FakeContainer) CurrentMemoryLimitsCallCount() int {
 	return len(fake.currentMemoryLimitsArgsForCall)
 }
 
+func (fake *FakeContainer) CurrentMemoryLimitsCalls(stub func() (garden.MemoryLimits, error)) {
+	fake.currentMemoryLimitsMutex.Lock()
+	defer fake.currentMemoryLimitsMutex.Unlock()
+	fake.CurrentMemoryLimitsStub = stub
+}
+
 func (fake *FakeContainer) CurrentMemoryLimitsReturns(result1 garden.MemoryLimits, result2 error) {
+	fake.currentMemoryLimitsMutex.Lock()
+	defer fake.currentMemoryLimitsMutex.Unlock()
 	fake.CurrentMemoryLimitsStub = nil
 	fake.currentMemoryLimitsReturns = struct {
 		result1 garden.MemoryLimits
@@ -573,6 +631,8 @@ func (fake *FakeContainer) CurrentMemoryLimitsReturns(result1 garden.MemoryLimit
 }
 
 func (fake *FakeContainer) CurrentMemoryLimitsReturnsOnCall(i int, result1 garden.MemoryLimits, result2 error) {
+	fake.currentMemoryLimitsMutex.Lock()
+	defer fake.currentMemoryLimitsMutex.Unlock()
 	fake.CurrentMemoryLimitsStub = nil
 	if fake.currentMemoryLimitsReturnsOnCall == nil {
 		fake.currentMemoryLimitsReturnsOnCall = make(map[int]struct {
@@ -609,7 +669,15 @@ func (fake *FakeContainer) DestroyCallCount() int {
 	return len(fake.destroyArgsForCall)
 }
 
+func (fake *FakeContainer) DestroyCalls(stub func() error) {
+	fake.destroyMutex.Lock()
+	defer fake.destroyMutex.Unlock()
+	fake.DestroyStub = stub
+}
+
 func (fake *FakeContainer) DestroyReturns(result1 error) {
+	fake.destroyMutex.Lock()
+	defer fake.destroyMutex.Unlock()
 	fake.DestroyStub = nil
 	fake.destroyReturns = struct {
 		result1 error
@@ -617,6 +685,8 @@ func (fake *FakeContainer) DestroyReturns(result1 error) {
 }
 
 func (fake *FakeContainer) DestroyReturnsOnCall(i int, result1 error) {
+	fake.destroyMutex.Lock()
+	defer fake.destroyMutex.Unlock()
 	fake.DestroyStub = nil
 	if fake.destroyReturnsOnCall == nil {
 		fake.destroyReturnsOnCall = make(map[int]struct {
@@ -651,7 +721,15 @@ func (fake *FakeContainer) HandleCallCount() int {
 	return len(fake.handleArgsForCall)
 }
 
+func (fake *FakeContainer) HandleCalls(stub func() string) {
+	fake.handleMutex.Lock()
+	defer fake.handleMutex.Unlock()
+	fake.HandleStub = stub
+}
+
 func (fake *FakeContainer) HandleReturns(result1 string) {
+	fake.handleMutex.Lock()
+	defer fake.handleMutex.Unlock()
 	fake.HandleStub = nil
 	fake.handleReturns = struct {
 		result1 string
@@ -659,6 +737,8 @@ func (fake *FakeContainer) HandleReturns(result1 string) {
 }
 
 func (fake *FakeContainer) HandleReturnsOnCall(i int, result1 string) {
+	fake.handleMutex.Lock()
+	defer fake.handleMutex.Unlock()
 	fake.HandleStub = nil
 	if fake.handleReturnsOnCall == nil {
 		fake.handleReturnsOnCall = make(map[int]struct {
@@ -693,7 +773,15 @@ func (fake *FakeContainer) InfoCallCount() int {
 	return len(fake.infoArgsForCall)
 }
 
+func (fake *FakeContainer) InfoCalls(stub func() (garden.ContainerInfo, error)) {
+	fake.infoMutex.Lock()
+	defer fake.infoMutex.Unlock()
+	fake.InfoStub = stub
+}
+
 func (fake *FakeContainer) InfoReturns(result1 garden.ContainerInfo, result2 error) {
+	fake.infoMutex.Lock()
+	defer fake.infoMutex.Unlock()
 	fake.InfoStub = nil
 	fake.infoReturns = struct {
 		result1 garden.ContainerInfo
@@ -702,6 +790,8 @@ func (fake *FakeContainer) InfoReturns(result1 garden.ContainerInfo, result2 err
 }
 
 func (fake *FakeContainer) InfoReturnsOnCall(i int, result1 garden.ContainerInfo, result2 error) {
+	fake.infoMutex.Lock()
+	defer fake.infoMutex.Unlock()
 	fake.InfoStub = nil
 	if fake.infoReturnsOnCall == nil {
 		fake.infoReturnsOnCall = make(map[int]struct {
@@ -738,7 +828,15 @@ func (fake *FakeContainer) MarkAsHijackedCallCount() int {
 	return len(fake.markAsHijackedArgsForCall)
 }
 
+func (fake *FakeContainer) MarkAsHijackedCalls(stub func() error) {
+	fake.markAsHijackedMutex.Lock()
+	defer fake.markAsHijackedMutex.Unlock()
+	fake.MarkAsHijackedStub = stub
+}
+
 func (fake *FakeContainer) MarkAsHijackedReturns(result1 error) {
+	fake.markAsHijackedMutex.Lock()
+	defer fake.markAsHijackedMutex.Unlock()
 	fake.MarkAsHijackedStub = nil
 	fake.markAsHijackedReturns = struct {
 		result1 error
@@ -746,6 +844,8 @@ func (fake *FakeContainer) MarkAsHijackedReturns(result1 error) {
 }
 
 func (fake *FakeContainer) MarkAsHijackedReturnsOnCall(i int, result1 error) {
+	fake.markAsHijackedMutex.Lock()
+	defer fake.markAsHijackedMutex.Unlock()
 	fake.MarkAsHijackedStub = nil
 	if fake.markAsHijackedReturnsOnCall == nil {
 		fake.markAsHijackedReturnsOnCall = make(map[int]struct {
@@ -780,7 +880,15 @@ func (fake *FakeContainer) MetricsCallCount() int {
 	return len(fake.metricsArgsForCall)
 }
 
+func (fake *FakeContainer) MetricsCalls(stub func() (garden.Metrics, error)) {
+	fake.metricsMutex.Lock()
+	defer fake.metricsMutex.Unlock()
+	fake.MetricsStub = stub
+}
+
 func (fake *FakeContainer) MetricsReturns(result1 garden.Metrics, result2 error) {
+	fake.metricsMutex.Lock()
+	defer fake.metricsMutex.Unlock()
 	fake.MetricsStub = nil
 	fake.metricsReturns = struct {
 		result1 garden.Metrics
@@ -789,6 +897,8 @@ func (fake *FakeContainer) MetricsReturns(result1 garden.Metrics, result2 error)
 }
 
 func (fake *FakeContainer) MetricsReturnsOnCall(i int, result1 garden.Metrics, result2 error) {
+	fake.metricsMutex.Lock()
+	defer fake.metricsMutex.Unlock()
 	fake.MetricsStub = nil
 	if fake.metricsReturnsOnCall == nil {
 		fake.metricsReturnsOnCall = make(map[int]struct {
@@ -827,6 +937,12 @@ func (fake *FakeContainer) NetInCallCount() int {
 	return len(fake.netInArgsForCall)
 }
 
+func (fake *FakeContainer) NetInCalls(stub func(uint32, uint32) (uint32, uint32, error)) {
+	fake.netInMutex.Lock()
+	defer fake.netInMutex.Unlock()
+	fake.NetInStub = stub
+}
+
 func (fake *FakeContainer) NetInArgsForCall(i int) (uint32, uint32) {
 	fake.netInMutex.RLock()
 	defer fake.netInMutex.RUnlock()
@@ -835,6 +951,8 @@ func (fake *FakeContainer) NetInArgsForCall(i int) (uint32, uint32) {
 }
 
 func (fake *FakeContainer) NetInReturns(result1 uint32, result2 uint32, result3 error) {
+	fake.netInMutex.Lock()
+	defer fake.netInMutex.Unlock()
 	fake.NetInStub = nil
 	fake.netInReturns = struct {
 		result1 uint32
@@ -844,6 +962,8 @@ func (fake *FakeContainer) NetInReturns(result1 uint32, result2 uint32, result3 
 }
 
 func (fake *FakeContainer) NetInReturnsOnCall(i int, result1 uint32, result2 uint32, result3 error) {
+	fake.netInMutex.Lock()
+	defer fake.netInMutex.Unlock()
 	fake.NetInStub = nil
 	if fake.netInReturnsOnCall == nil {
 		fake.netInReturnsOnCall = make(map[int]struct {
@@ -883,6 +1003,12 @@ func (fake *FakeContainer) NetOutCallCount() int {
 	return len(fake.netOutArgsForCall)
 }
 
+func (fake *FakeContainer) NetOutCalls(stub func(garden.NetOutRule) error) {
+	fake.netOutMutex.Lock()
+	defer fake.netOutMutex.Unlock()
+	fake.NetOutStub = stub
+}
+
 func (fake *FakeContainer) NetOutArgsForCall(i int) garden.NetOutRule {
 	fake.netOutMutex.RLock()
 	defer fake.netOutMutex.RUnlock()
@@ -891,6 +1017,8 @@ func (fake *FakeContainer) NetOutArgsForCall(i int) garden.NetOutRule {
 }
 
 func (fake *FakeContainer) NetOutReturns(result1 error) {
+	fake.netOutMutex.Lock()
+	defer fake.netOutMutex.Unlock()
 	fake.NetOutStub = nil
 	fake.netOutReturns = struct {
 		result1 error
@@ -898,6 +1026,8 @@ func (fake *FakeContainer) NetOutReturns(result1 error) {
 }
 
 func (fake *FakeContainer) NetOutReturnsOnCall(i int, result1 error) {
+	fake.netOutMutex.Lock()
+	defer fake.netOutMutex.Unlock()
 	fake.NetOutStub = nil
 	if fake.netOutReturnsOnCall == nil {
 		fake.netOutReturnsOnCall = make(map[int]struct {
@@ -932,7 +1062,15 @@ func (fake *FakeContainer) PropertiesCallCount() int {
 	return len(fake.propertiesArgsForCall)
 }
 
+func (fake *FakeContainer) PropertiesCalls(stub func() (garden.Properties, error)) {
+	fake.propertiesMutex.Lock()
+	defer fake.propertiesMutex.Unlock()
+	fake.PropertiesStub = stub
+}
+
 func (fake *FakeContainer) PropertiesReturns(result1 garden.Properties, result2 error) {
+	fake.propertiesMutex.Lock()
+	defer fake.propertiesMutex.Unlock()
 	fake.PropertiesStub = nil
 	fake.propertiesReturns = struct {
 		result1 garden.Properties
@@ -941,6 +1079,8 @@ func (fake *FakeContainer) PropertiesReturns(result1 garden.Properties, result2 
 }
 
 func (fake *FakeContainer) PropertiesReturnsOnCall(i int, result1 garden.Properties, result2 error) {
+	fake.propertiesMutex.Lock()
+	defer fake.propertiesMutex.Unlock()
 	fake.PropertiesStub = nil
 	if fake.propertiesReturnsOnCall == nil {
 		fake.propertiesReturnsOnCall = make(map[int]struct {
@@ -978,6 +1118,12 @@ func (fake *FakeContainer) PropertyCallCount() int {
 	return len(fake.propertyArgsForCall)
 }
 
+func (fake *FakeContainer) PropertyCalls(stub func(string) (string, error)) {
+	fake.propertyMutex.Lock()
+	defer fake.propertyMutex.Unlock()
+	fake.PropertyStub = stub
+}
+
 func (fake *FakeContainer) PropertyArgsForCall(i int) string {
 	fake.propertyMutex.RLock()
 	defer fake.propertyMutex.RUnlock()
@@ -986,6 +1132,8 @@ func (fake *FakeContainer) PropertyArgsForCall(i int) string {
 }
 
 func (fake *FakeContainer) PropertyReturns(result1 string, result2 error) {
+	fake.propertyMutex.Lock()
+	defer fake.propertyMutex.Unlock()
 	fake.PropertyStub = nil
 	fake.propertyReturns = struct {
 		result1 string
@@ -994,6 +1142,8 @@ func (fake *FakeContainer) PropertyReturns(result1 string, result2 error) {
 }
 
 func (fake *FakeContainer) PropertyReturnsOnCall(i int, result1 string, result2 error) {
+	fake.propertyMutex.Lock()
+	defer fake.propertyMutex.Unlock()
 	fake.PropertyStub = nil
 	if fake.propertyReturnsOnCall == nil {
 		fake.propertyReturnsOnCall = make(map[int]struct {
@@ -1031,6 +1181,12 @@ func (fake *FakeContainer) RemovePropertyCallCount() int {
 	return len(fake.removePropertyArgsForCall)
 }
 
+func (fake *FakeContainer) RemovePropertyCalls(stub func(string) error) {
+	fake.removePropertyMutex.Lock()
+	defer fake.removePropertyMutex.Unlock()
+	fake.RemovePropertyStub = stub
+}
+
 func (fake *FakeContainer) RemovePropertyArgsForCall(i int) string {
 	fake.removePropertyMutex.RLock()
 	defer fake.removePropertyMutex.RUnlock()
@@ -1039,6 +1195,8 @@ func (fake *FakeContainer) RemovePropertyArgsForCall(i int) string {
 }
 
 func (fake *FakeContainer) RemovePropertyReturns(result1 error) {
+	fake.removePropertyMutex.Lock()
+	defer fake.removePropertyMutex.Unlock()
 	fake.RemovePropertyStub = nil
 	fake.removePropertyReturns = struct {
 		result1 error
@@ -1046,6 +1204,8 @@ func (fake *FakeContainer) RemovePropertyReturns(result1 error) {
 }
 
 func (fake *FakeContainer) RemovePropertyReturnsOnCall(i int, result1 error) {
+	fake.removePropertyMutex.Lock()
+	defer fake.removePropertyMutex.Unlock()
 	fake.RemovePropertyStub = nil
 	if fake.removePropertyReturnsOnCall == nil {
 		fake.removePropertyReturnsOnCall = make(map[int]struct {
@@ -1082,6 +1242,12 @@ func (fake *FakeContainer) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
+func (fake *FakeContainer) RunCalls(stub func(garden.ProcessSpec, garden.ProcessIO) (garden.Process, error)) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
+	fake.RunStub = stub
+}
+
 func (fake *FakeContainer) RunArgsForCall(i int) (garden.ProcessSpec, garden.ProcessIO) {
 	fake.runMutex.RLock()
 	defer fake.runMutex.RUnlock()
@@ -1090,6 +1256,8 @@ func (fake *FakeContainer) RunArgsForCall(i int) (garden.ProcessSpec, garden.Pro
 }
 
 func (fake *FakeContainer) RunReturns(result1 garden.Process, result2 error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	fake.runReturns = struct {
 		result1 garden.Process
@@ -1098,6 +1266,8 @@ func (fake *FakeContainer) RunReturns(result1 garden.Process, result2 error) {
 }
 
 func (fake *FakeContainer) RunReturnsOnCall(i int, result1 garden.Process, result2 error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	if fake.runReturnsOnCall == nil {
 		fake.runReturnsOnCall = make(map[int]struct {
@@ -1135,6 +1305,12 @@ func (fake *FakeContainer) SetGraceTimeCallCount() int {
 	return len(fake.setGraceTimeArgsForCall)
 }
 
+func (fake *FakeContainer) SetGraceTimeCalls(stub func(time.Duration) error) {
+	fake.setGraceTimeMutex.Lock()
+	defer fake.setGraceTimeMutex.Unlock()
+	fake.SetGraceTimeStub = stub
+}
+
 func (fake *FakeContainer) SetGraceTimeArgsForCall(i int) time.Duration {
 	fake.setGraceTimeMutex.RLock()
 	defer fake.setGraceTimeMutex.RUnlock()
@@ -1143,6 +1319,8 @@ func (fake *FakeContainer) SetGraceTimeArgsForCall(i int) time.Duration {
 }
 
 func (fake *FakeContainer) SetGraceTimeReturns(result1 error) {
+	fake.setGraceTimeMutex.Lock()
+	defer fake.setGraceTimeMutex.Unlock()
 	fake.SetGraceTimeStub = nil
 	fake.setGraceTimeReturns = struct {
 		result1 error
@@ -1150,6 +1328,8 @@ func (fake *FakeContainer) SetGraceTimeReturns(result1 error) {
 }
 
 func (fake *FakeContainer) SetGraceTimeReturnsOnCall(i int, result1 error) {
+	fake.setGraceTimeMutex.Lock()
+	defer fake.setGraceTimeMutex.Unlock()
 	fake.SetGraceTimeStub = nil
 	if fake.setGraceTimeReturnsOnCall == nil {
 		fake.setGraceTimeReturnsOnCall = make(map[int]struct {
@@ -1186,6 +1366,12 @@ func (fake *FakeContainer) SetPropertyCallCount() int {
 	return len(fake.setPropertyArgsForCall)
 }
 
+func (fake *FakeContainer) SetPropertyCalls(stub func(string, string) error) {
+	fake.setPropertyMutex.Lock()
+	defer fake.setPropertyMutex.Unlock()
+	fake.SetPropertyStub = stub
+}
+
 func (fake *FakeContainer) SetPropertyArgsForCall(i int) (string, string) {
 	fake.setPropertyMutex.RLock()
 	defer fake.setPropertyMutex.RUnlock()
@@ -1194,6 +1380,8 @@ func (fake *FakeContainer) SetPropertyArgsForCall(i int) (string, string) {
 }
 
 func (fake *FakeContainer) SetPropertyReturns(result1 error) {
+	fake.setPropertyMutex.Lock()
+	defer fake.setPropertyMutex.Unlock()
 	fake.SetPropertyStub = nil
 	fake.setPropertyReturns = struct {
 		result1 error
@@ -1201,6 +1389,8 @@ func (fake *FakeContainer) SetPropertyReturns(result1 error) {
 }
 
 func (fake *FakeContainer) SetPropertyReturnsOnCall(i int, result1 error) {
+	fake.setPropertyMutex.Lock()
+	defer fake.setPropertyMutex.Unlock()
 	fake.SetPropertyStub = nil
 	if fake.setPropertyReturnsOnCall == nil {
 		fake.setPropertyReturnsOnCall = make(map[int]struct {
@@ -1236,6 +1426,12 @@ func (fake *FakeContainer) StopCallCount() int {
 	return len(fake.stopArgsForCall)
 }
 
+func (fake *FakeContainer) StopCalls(stub func(bool) error) {
+	fake.stopMutex.Lock()
+	defer fake.stopMutex.Unlock()
+	fake.StopStub = stub
+}
+
 func (fake *FakeContainer) StopArgsForCall(i int) bool {
 	fake.stopMutex.RLock()
 	defer fake.stopMutex.RUnlock()
@@ -1244,6 +1440,8 @@ func (fake *FakeContainer) StopArgsForCall(i int) bool {
 }
 
 func (fake *FakeContainer) StopReturns(result1 error) {
+	fake.stopMutex.Lock()
+	defer fake.stopMutex.Unlock()
 	fake.StopStub = nil
 	fake.stopReturns = struct {
 		result1 error
@@ -1251,6 +1449,8 @@ func (fake *FakeContainer) StopReturns(result1 error) {
 }
 
 func (fake *FakeContainer) StopReturnsOnCall(i int, result1 error) {
+	fake.stopMutex.Lock()
+	defer fake.stopMutex.Unlock()
 	fake.StopStub = nil
 	if fake.stopReturnsOnCall == nil {
 		fake.stopReturnsOnCall = make(map[int]struct {
@@ -1286,6 +1486,12 @@ func (fake *FakeContainer) StreamInCallCount() int {
 	return len(fake.streamInArgsForCall)
 }
 
+func (fake *FakeContainer) StreamInCalls(stub func(garden.StreamInSpec) error) {
+	fake.streamInMutex.Lock()
+	defer fake.streamInMutex.Unlock()
+	fake.StreamInStub = stub
+}
+
 func (fake *FakeContainer) StreamInArgsForCall(i int) garden.StreamInSpec {
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
@@ -1294,6 +1500,8 @@ func (fake *FakeContainer) StreamInArgsForCall(i int) garden.StreamInSpec {
 }
 
 func (fake *FakeContainer) StreamInReturns(result1 error) {
+	fake.streamInMutex.Lock()
+	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	fake.streamInReturns = struct {
 		result1 error
@@ -1301,6 +1509,8 @@ func (fake *FakeContainer) StreamInReturns(result1 error) {
 }
 
 func (fake *FakeContainer) StreamInReturnsOnCall(i int, result1 error) {
+	fake.streamInMutex.Lock()
+	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	if fake.streamInReturnsOnCall == nil {
 		fake.streamInReturnsOnCall = make(map[int]struct {
@@ -1336,6 +1546,12 @@ func (fake *FakeContainer) StreamOutCallCount() int {
 	return len(fake.streamOutArgsForCall)
 }
 
+func (fake *FakeContainer) StreamOutCalls(stub func(garden.StreamOutSpec) (io.ReadCloser, error)) {
+	fake.streamOutMutex.Lock()
+	defer fake.streamOutMutex.Unlock()
+	fake.StreamOutStub = stub
+}
+
 func (fake *FakeContainer) StreamOutArgsForCall(i int) garden.StreamOutSpec {
 	fake.streamOutMutex.RLock()
 	defer fake.streamOutMutex.RUnlock()
@@ -1344,6 +1560,8 @@ func (fake *FakeContainer) StreamOutArgsForCall(i int) garden.StreamOutSpec {
 }
 
 func (fake *FakeContainer) StreamOutReturns(result1 io.ReadCloser, result2 error) {
+	fake.streamOutMutex.Lock()
+	defer fake.streamOutMutex.Unlock()
 	fake.StreamOutStub = nil
 	fake.streamOutReturns = struct {
 		result1 io.ReadCloser
@@ -1352,6 +1570,8 @@ func (fake *FakeContainer) StreamOutReturns(result1 io.ReadCloser, result2 error
 }
 
 func (fake *FakeContainer) StreamOutReturnsOnCall(i int, result1 io.ReadCloser, result2 error) {
+	fake.streamOutMutex.Lock()
+	defer fake.streamOutMutex.Unlock()
 	fake.StreamOutStub = nil
 	if fake.streamOutReturnsOnCall == nil {
 		fake.streamOutReturnsOnCall = make(map[int]struct {
@@ -1388,7 +1608,15 @@ func (fake *FakeContainer) VolumeMountsCallCount() int {
 	return len(fake.volumeMountsArgsForCall)
 }
 
+func (fake *FakeContainer) VolumeMountsCalls(stub func() []worker.VolumeMount) {
+	fake.volumeMountsMutex.Lock()
+	defer fake.volumeMountsMutex.Unlock()
+	fake.VolumeMountsStub = stub
+}
+
 func (fake *FakeContainer) VolumeMountsReturns(result1 []worker.VolumeMount) {
+	fake.volumeMountsMutex.Lock()
+	defer fake.volumeMountsMutex.Unlock()
 	fake.VolumeMountsStub = nil
 	fake.volumeMountsReturns = struct {
 		result1 []worker.VolumeMount
@@ -1396,6 +1624,8 @@ func (fake *FakeContainer) VolumeMountsReturns(result1 []worker.VolumeMount) {
 }
 
 func (fake *FakeContainer) VolumeMountsReturnsOnCall(i int, result1 []worker.VolumeMount) {
+	fake.volumeMountsMutex.Lock()
+	defer fake.volumeMountsMutex.Unlock()
 	fake.VolumeMountsStub = nil
 	if fake.volumeMountsReturnsOnCall == nil {
 		fake.volumeMountsReturnsOnCall = make(map[int]struct {
@@ -1430,7 +1660,15 @@ func (fake *FakeContainer) WorkerNameCallCount() int {
 	return len(fake.workerNameArgsForCall)
 }
 
+func (fake *FakeContainer) WorkerNameCalls(stub func() string) {
+	fake.workerNameMutex.Lock()
+	defer fake.workerNameMutex.Unlock()
+	fake.WorkerNameStub = stub
+}
+
 func (fake *FakeContainer) WorkerNameReturns(result1 string) {
+	fake.workerNameMutex.Lock()
+	defer fake.workerNameMutex.Unlock()
 	fake.WorkerNameStub = nil
 	fake.workerNameReturns = struct {
 		result1 string
@@ -1438,6 +1676,8 @@ func (fake *FakeContainer) WorkerNameReturns(result1 string) {
 }
 
 func (fake *FakeContainer) WorkerNameReturnsOnCall(i int, result1 string) {
+	fake.workerNameMutex.Lock()
+	defer fake.workerNameMutex.Unlock()
 	fake.WorkerNameStub = nil
 	if fake.workerNameReturnsOnCall == nil {
 		fake.workerNameReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_container_placement_strategy.go
+++ b/atc/worker/workerfakes/fake_container_placement_strategy.go
@@ -2,10 +2,10 @@
 package workerfakes
 
 import (
-	sync "sync"
+	"sync"
 
-	lager "code.cloudfoundry.org/lager"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeContainerPlacementStrategy struct {
@@ -59,6 +59,12 @@ func (fake *FakeContainerPlacementStrategy) ChooseCallCount() int {
 	return len(fake.chooseArgsForCall)
 }
 
+func (fake *FakeContainerPlacementStrategy) ChooseCalls(stub func(lager.Logger, []worker.Worker, worker.ContainerSpec) (worker.Worker, error)) {
+	fake.chooseMutex.Lock()
+	defer fake.chooseMutex.Unlock()
+	fake.ChooseStub = stub
+}
+
 func (fake *FakeContainerPlacementStrategy) ChooseArgsForCall(i int) (lager.Logger, []worker.Worker, worker.ContainerSpec) {
 	fake.chooseMutex.RLock()
 	defer fake.chooseMutex.RUnlock()
@@ -67,6 +73,8 @@ func (fake *FakeContainerPlacementStrategy) ChooseArgsForCall(i int) (lager.Logg
 }
 
 func (fake *FakeContainerPlacementStrategy) ChooseReturns(result1 worker.Worker, result2 error) {
+	fake.chooseMutex.Lock()
+	defer fake.chooseMutex.Unlock()
 	fake.ChooseStub = nil
 	fake.chooseReturns = struct {
 		result1 worker.Worker
@@ -75,6 +83,8 @@ func (fake *FakeContainerPlacementStrategy) ChooseReturns(result1 worker.Worker,
 }
 
 func (fake *FakeContainerPlacementStrategy) ChooseReturnsOnCall(i int, result1 worker.Worker, result2 error) {
+	fake.chooseMutex.Lock()
+	defer fake.chooseMutex.Unlock()
 	fake.ChooseStub = nil
 	if fake.chooseReturnsOnCall == nil {
 		fake.chooseReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_image.go
+++ b/atc/worker/workerfakes/fake_image.go
@@ -2,12 +2,12 @@
 package workerfakes
 
 import (
-	context "context"
-	sync "sync"
+	"context"
+	"sync"
 
-	lager "code.cloudfoundry.org/lager"
-	db "github.com/concourse/concourse/atc/db"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeImage struct {
@@ -56,6 +56,12 @@ func (fake *FakeImage) FetchForContainerCallCount() int {
 	return len(fake.fetchForContainerArgsForCall)
 }
 
+func (fake *FakeImage) FetchForContainerCalls(stub func(context.Context, lager.Logger, db.CreatingContainer) (worker.FetchedImage, error)) {
+	fake.fetchForContainerMutex.Lock()
+	defer fake.fetchForContainerMutex.Unlock()
+	fake.FetchForContainerStub = stub
+}
+
 func (fake *FakeImage) FetchForContainerArgsForCall(i int) (context.Context, lager.Logger, db.CreatingContainer) {
 	fake.fetchForContainerMutex.RLock()
 	defer fake.fetchForContainerMutex.RUnlock()
@@ -64,6 +70,8 @@ func (fake *FakeImage) FetchForContainerArgsForCall(i int) (context.Context, lag
 }
 
 func (fake *FakeImage) FetchForContainerReturns(result1 worker.FetchedImage, result2 error) {
+	fake.fetchForContainerMutex.Lock()
+	defer fake.fetchForContainerMutex.Unlock()
 	fake.FetchForContainerStub = nil
 	fake.fetchForContainerReturns = struct {
 		result1 worker.FetchedImage
@@ -72,6 +80,8 @@ func (fake *FakeImage) FetchForContainerReturns(result1 worker.FetchedImage, res
 }
 
 func (fake *FakeImage) FetchForContainerReturnsOnCall(i int, result1 worker.FetchedImage, result2 error) {
+	fake.fetchForContainerMutex.Lock()
+	defer fake.fetchForContainerMutex.Unlock()
 	fake.FetchForContainerStub = nil
 	if fake.fetchForContainerReturnsOnCall == nil {
 		fake.fetchForContainerReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_image_factory.go
+++ b/atc/worker/workerfakes/fake_image_factory.go
@@ -2,11 +2,11 @@
 package workerfakes
 
 import (
-	sync "sync"
+	"sync"
 
-	lager "code.cloudfoundry.org/lager"
-	atc "github.com/concourse/concourse/atc"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeImageFactory struct {
@@ -63,6 +63,12 @@ func (fake *FakeImageFactory) GetImageCallCount() int {
 	return len(fake.getImageArgsForCall)
 }
 
+func (fake *FakeImageFactory) GetImageCalls(stub func(lager.Logger, worker.Worker, worker.VolumeClient, worker.ImageSpec, int, worker.ImageFetchingDelegate, atc.VersionedResourceTypes) (worker.Image, error)) {
+	fake.getImageMutex.Lock()
+	defer fake.getImageMutex.Unlock()
+	fake.GetImageStub = stub
+}
+
 func (fake *FakeImageFactory) GetImageArgsForCall(i int) (lager.Logger, worker.Worker, worker.VolumeClient, worker.ImageSpec, int, worker.ImageFetchingDelegate, atc.VersionedResourceTypes) {
 	fake.getImageMutex.RLock()
 	defer fake.getImageMutex.RUnlock()
@@ -71,6 +77,8 @@ func (fake *FakeImageFactory) GetImageArgsForCall(i int) (lager.Logger, worker.W
 }
 
 func (fake *FakeImageFactory) GetImageReturns(result1 worker.Image, result2 error) {
+	fake.getImageMutex.Lock()
+	defer fake.getImageMutex.Unlock()
 	fake.GetImageStub = nil
 	fake.getImageReturns = struct {
 		result1 worker.Image
@@ -79,6 +87,8 @@ func (fake *FakeImageFactory) GetImageReturns(result1 worker.Image, result2 erro
 }
 
 func (fake *FakeImageFactory) GetImageReturnsOnCall(i int, result1 worker.Image, result2 error) {
+	fake.getImageMutex.Lock()
+	defer fake.getImageMutex.Unlock()
 	fake.GetImageStub = nil
 	if fake.getImageReturnsOnCall == nil {
 		fake.getImageReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_image_fetching_delegate.go
+++ b/atc/worker/workerfakes/fake_image_fetching_delegate.go
@@ -2,11 +2,11 @@
 package workerfakes
 
 import (
-	io "io"
-	sync "sync"
+	"io"
+	"sync"
 
-	db "github.com/concourse/concourse/atc/db"
-	worker "github.com/concourse/concourse/atc/worker"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeImageFetchingDelegate struct {
@@ -69,6 +69,12 @@ func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedCallCount() int {
 	return len(fake.imageVersionDeterminedArgsForCall)
 }
 
+func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedCalls(stub func(db.UsedResourceCache) error) {
+	fake.imageVersionDeterminedMutex.Lock()
+	defer fake.imageVersionDeterminedMutex.Unlock()
+	fake.ImageVersionDeterminedStub = stub
+}
+
 func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedArgsForCall(i int) db.UsedResourceCache {
 	fake.imageVersionDeterminedMutex.RLock()
 	defer fake.imageVersionDeterminedMutex.RUnlock()
@@ -77,6 +83,8 @@ func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedArgsForCall(i int) 
 }
 
 func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedReturns(result1 error) {
+	fake.imageVersionDeterminedMutex.Lock()
+	defer fake.imageVersionDeterminedMutex.Unlock()
 	fake.ImageVersionDeterminedStub = nil
 	fake.imageVersionDeterminedReturns = struct {
 		result1 error
@@ -84,6 +92,8 @@ func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedReturns(result1 err
 }
 
 func (fake *FakeImageFetchingDelegate) ImageVersionDeterminedReturnsOnCall(i int, result1 error) {
+	fake.imageVersionDeterminedMutex.Lock()
+	defer fake.imageVersionDeterminedMutex.Unlock()
 	fake.ImageVersionDeterminedStub = nil
 	if fake.imageVersionDeterminedReturnsOnCall == nil {
 		fake.imageVersionDeterminedReturnsOnCall = make(map[int]struct {
@@ -118,7 +128,15 @@ func (fake *FakeImageFetchingDelegate) StderrCallCount() int {
 	return len(fake.stderrArgsForCall)
 }
 
+func (fake *FakeImageFetchingDelegate) StderrCalls(stub func() io.Writer) {
+	fake.stderrMutex.Lock()
+	defer fake.stderrMutex.Unlock()
+	fake.StderrStub = stub
+}
+
 func (fake *FakeImageFetchingDelegate) StderrReturns(result1 io.Writer) {
+	fake.stderrMutex.Lock()
+	defer fake.stderrMutex.Unlock()
 	fake.StderrStub = nil
 	fake.stderrReturns = struct {
 		result1 io.Writer
@@ -126,6 +144,8 @@ func (fake *FakeImageFetchingDelegate) StderrReturns(result1 io.Writer) {
 }
 
 func (fake *FakeImageFetchingDelegate) StderrReturnsOnCall(i int, result1 io.Writer) {
+	fake.stderrMutex.Lock()
+	defer fake.stderrMutex.Unlock()
 	fake.StderrStub = nil
 	if fake.stderrReturnsOnCall == nil {
 		fake.stderrReturnsOnCall = make(map[int]struct {
@@ -160,7 +180,15 @@ func (fake *FakeImageFetchingDelegate) StdoutCallCount() int {
 	return len(fake.stdoutArgsForCall)
 }
 
+func (fake *FakeImageFetchingDelegate) StdoutCalls(stub func() io.Writer) {
+	fake.stdoutMutex.Lock()
+	defer fake.stdoutMutex.Unlock()
+	fake.StdoutStub = stub
+}
+
 func (fake *FakeImageFetchingDelegate) StdoutReturns(result1 io.Writer) {
+	fake.stdoutMutex.Lock()
+	defer fake.stdoutMutex.Unlock()
 	fake.StdoutStub = nil
 	fake.stdoutReturns = struct {
 		result1 io.Writer
@@ -168,6 +196,8 @@ func (fake *FakeImageFetchingDelegate) StdoutReturns(result1 io.Writer) {
 }
 
 func (fake *FakeImageFetchingDelegate) StdoutReturnsOnCall(i int, result1 io.Writer) {
+	fake.stdoutMutex.Lock()
+	defer fake.stdoutMutex.Unlock()
 	fake.StdoutStub = nil
 	if fake.stdoutReturnsOnCall == nil {
 		fake.stdoutReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_input_source.go
+++ b/atc/worker/workerfakes/fake_input_source.go
@@ -2,9 +2,9 @@
 package workerfakes
 
 import (
-	sync "sync"
+	"sync"
 
-	worker "github.com/concourse/concourse/atc/worker"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeInputSource struct {
@@ -55,7 +55,15 @@ func (fake *FakeInputSource) DestinationPathCallCount() int {
 	return len(fake.destinationPathArgsForCall)
 }
 
+func (fake *FakeInputSource) DestinationPathCalls(stub func() string) {
+	fake.destinationPathMutex.Lock()
+	defer fake.destinationPathMutex.Unlock()
+	fake.DestinationPathStub = stub
+}
+
 func (fake *FakeInputSource) DestinationPathReturns(result1 string) {
+	fake.destinationPathMutex.Lock()
+	defer fake.destinationPathMutex.Unlock()
 	fake.DestinationPathStub = nil
 	fake.destinationPathReturns = struct {
 		result1 string
@@ -63,6 +71,8 @@ func (fake *FakeInputSource) DestinationPathReturns(result1 string) {
 }
 
 func (fake *FakeInputSource) DestinationPathReturnsOnCall(i int, result1 string) {
+	fake.destinationPathMutex.Lock()
+	defer fake.destinationPathMutex.Unlock()
 	fake.DestinationPathStub = nil
 	if fake.destinationPathReturnsOnCall == nil {
 		fake.destinationPathReturnsOnCall = make(map[int]struct {
@@ -97,7 +107,15 @@ func (fake *FakeInputSource) SourceCallCount() int {
 	return len(fake.sourceArgsForCall)
 }
 
+func (fake *FakeInputSource) SourceCalls(stub func() worker.ArtifactSource) {
+	fake.sourceMutex.Lock()
+	defer fake.sourceMutex.Unlock()
+	fake.SourceStub = stub
+}
+
 func (fake *FakeInputSource) SourceReturns(result1 worker.ArtifactSource) {
+	fake.sourceMutex.Lock()
+	defer fake.sourceMutex.Unlock()
 	fake.SourceStub = nil
 	fake.sourceReturns = struct {
 		result1 worker.ArtifactSource
@@ -105,6 +123,8 @@ func (fake *FakeInputSource) SourceReturns(result1 worker.ArtifactSource) {
 }
 
 func (fake *FakeInputSource) SourceReturnsOnCall(i int, result1 worker.ArtifactSource) {
+	fake.sourceMutex.Lock()
+	defer fake.sourceMutex.Unlock()
 	fake.SourceStub = nil
 	if fake.sourceReturnsOnCall == nil {
 		fake.sourceReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_pool.go
+++ b/atc/worker/workerfakes/fake_pool.go
@@ -2,12 +2,12 @@
 package workerfakes
 
 import (
-	context "context"
-	sync "sync"
+	"context"
+	"sync"
 
-	lager "code.cloudfoundry.org/lager"
-	db "github.com/concourse/concourse/atc/db"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakePool struct {
@@ -72,6 +72,12 @@ func (fake *FakePool) FindOrChooseWorkerCallCount() int {
 	return len(fake.findOrChooseWorkerArgsForCall)
 }
 
+func (fake *FakePool) FindOrChooseWorkerCalls(stub func(lager.Logger, worker.WorkerSpec) (worker.Worker, error)) {
+	fake.findOrChooseWorkerMutex.Lock()
+	defer fake.findOrChooseWorkerMutex.Unlock()
+	fake.FindOrChooseWorkerStub = stub
+}
+
 func (fake *FakePool) FindOrChooseWorkerArgsForCall(i int) (lager.Logger, worker.WorkerSpec) {
 	fake.findOrChooseWorkerMutex.RLock()
 	defer fake.findOrChooseWorkerMutex.RUnlock()
@@ -80,6 +86,8 @@ func (fake *FakePool) FindOrChooseWorkerArgsForCall(i int) (lager.Logger, worker
 }
 
 func (fake *FakePool) FindOrChooseWorkerReturns(result1 worker.Worker, result2 error) {
+	fake.findOrChooseWorkerMutex.Lock()
+	defer fake.findOrChooseWorkerMutex.Unlock()
 	fake.FindOrChooseWorkerStub = nil
 	fake.findOrChooseWorkerReturns = struct {
 		result1 worker.Worker
@@ -88,6 +96,8 @@ func (fake *FakePool) FindOrChooseWorkerReturns(result1 worker.Worker, result2 e
 }
 
 func (fake *FakePool) FindOrChooseWorkerReturnsOnCall(i int, result1 worker.Worker, result2 error) {
+	fake.findOrChooseWorkerMutex.Lock()
+	defer fake.findOrChooseWorkerMutex.Unlock()
 	fake.FindOrChooseWorkerStub = nil
 	if fake.findOrChooseWorkerReturnsOnCall == nil {
 		fake.findOrChooseWorkerReturnsOnCall = make(map[int]struct {
@@ -130,6 +140,12 @@ func (fake *FakePool) FindOrChooseWorkerForContainerCallCount() int {
 	return len(fake.findOrChooseWorkerForContainerArgsForCall)
 }
 
+func (fake *FakePool) FindOrChooseWorkerForContainerCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy) (worker.Worker, error)) {
+	fake.findOrChooseWorkerForContainerMutex.Lock()
+	defer fake.findOrChooseWorkerForContainerMutex.Unlock()
+	fake.FindOrChooseWorkerForContainerStub = stub
+}
+
 func (fake *FakePool) FindOrChooseWorkerForContainerArgsForCall(i int) (context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy) {
 	fake.findOrChooseWorkerForContainerMutex.RLock()
 	defer fake.findOrChooseWorkerForContainerMutex.RUnlock()
@@ -138,6 +154,8 @@ func (fake *FakePool) FindOrChooseWorkerForContainerArgsForCall(i int) (context.
 }
 
 func (fake *FakePool) FindOrChooseWorkerForContainerReturns(result1 worker.Worker, result2 error) {
+	fake.findOrChooseWorkerForContainerMutex.Lock()
+	defer fake.findOrChooseWorkerForContainerMutex.Unlock()
 	fake.FindOrChooseWorkerForContainerStub = nil
 	fake.findOrChooseWorkerForContainerReturns = struct {
 		result1 worker.Worker
@@ -146,6 +164,8 @@ func (fake *FakePool) FindOrChooseWorkerForContainerReturns(result1 worker.Worke
 }
 
 func (fake *FakePool) FindOrChooseWorkerForContainerReturnsOnCall(i int, result1 worker.Worker, result2 error) {
+	fake.findOrChooseWorkerForContainerMutex.Lock()
+	defer fake.findOrChooseWorkerForContainerMutex.Unlock()
 	fake.FindOrChooseWorkerForContainerStub = nil
 	if fake.findOrChooseWorkerForContainerReturnsOnCall == nil {
 		fake.findOrChooseWorkerForContainerReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_volume.go
+++ b/atc/worker/workerfakes/fake_volume.go
@@ -2,13 +2,13 @@
 package workerfakes
 
 import (
-	io "io"
-	sync "sync"
+	"io"
+	"sync"
 
-	lager "code.cloudfoundry.org/lager"
-	baggageclaim "github.com/concourse/baggageclaim"
-	db "github.com/concourse/concourse/atc/db"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/baggageclaim"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeVolume struct {
@@ -203,7 +203,15 @@ func (fake *FakeVolume) COWStrategyCallCount() int {
 	return len(fake.cOWStrategyArgsForCall)
 }
 
+func (fake *FakeVolume) COWStrategyCalls(stub func() baggageclaim.COWStrategy) {
+	fake.cOWStrategyMutex.Lock()
+	defer fake.cOWStrategyMutex.Unlock()
+	fake.COWStrategyStub = stub
+}
+
 func (fake *FakeVolume) COWStrategyReturns(result1 baggageclaim.COWStrategy) {
+	fake.cOWStrategyMutex.Lock()
+	defer fake.cOWStrategyMutex.Unlock()
 	fake.COWStrategyStub = nil
 	fake.cOWStrategyReturns = struct {
 		result1 baggageclaim.COWStrategy
@@ -211,6 +219,8 @@ func (fake *FakeVolume) COWStrategyReturns(result1 baggageclaim.COWStrategy) {
 }
 
 func (fake *FakeVolume) COWStrategyReturnsOnCall(i int, result1 baggageclaim.COWStrategy) {
+	fake.cOWStrategyMutex.Lock()
+	defer fake.cOWStrategyMutex.Unlock()
 	fake.COWStrategyStub = nil
 	if fake.cOWStrategyReturnsOnCall == nil {
 		fake.cOWStrategyReturnsOnCall = make(map[int]struct {
@@ -247,6 +257,12 @@ func (fake *FakeVolume) CreateChildForContainerCallCount() int {
 	return len(fake.createChildForContainerArgsForCall)
 }
 
+func (fake *FakeVolume) CreateChildForContainerCalls(stub func(db.CreatingContainer, string) (db.CreatingVolume, error)) {
+	fake.createChildForContainerMutex.Lock()
+	defer fake.createChildForContainerMutex.Unlock()
+	fake.CreateChildForContainerStub = stub
+}
+
 func (fake *FakeVolume) CreateChildForContainerArgsForCall(i int) (db.CreatingContainer, string) {
 	fake.createChildForContainerMutex.RLock()
 	defer fake.createChildForContainerMutex.RUnlock()
@@ -255,6 +271,8 @@ func (fake *FakeVolume) CreateChildForContainerArgsForCall(i int) (db.CreatingCo
 }
 
 func (fake *FakeVolume) CreateChildForContainerReturns(result1 db.CreatingVolume, result2 error) {
+	fake.createChildForContainerMutex.Lock()
+	defer fake.createChildForContainerMutex.Unlock()
 	fake.CreateChildForContainerStub = nil
 	fake.createChildForContainerReturns = struct {
 		result1 db.CreatingVolume
@@ -263,6 +281,8 @@ func (fake *FakeVolume) CreateChildForContainerReturns(result1 db.CreatingVolume
 }
 
 func (fake *FakeVolume) CreateChildForContainerReturnsOnCall(i int, result1 db.CreatingVolume, result2 error) {
+	fake.createChildForContainerMutex.Lock()
+	defer fake.createChildForContainerMutex.Unlock()
 	fake.CreateChildForContainerStub = nil
 	if fake.createChildForContainerReturnsOnCall == nil {
 		fake.createChildForContainerReturnsOnCall = make(map[int]struct {
@@ -299,7 +319,15 @@ func (fake *FakeVolume) DestroyCallCount() int {
 	return len(fake.destroyArgsForCall)
 }
 
+func (fake *FakeVolume) DestroyCalls(stub func() error) {
+	fake.destroyMutex.Lock()
+	defer fake.destroyMutex.Unlock()
+	fake.DestroyStub = stub
+}
+
 func (fake *FakeVolume) DestroyReturns(result1 error) {
+	fake.destroyMutex.Lock()
+	defer fake.destroyMutex.Unlock()
 	fake.DestroyStub = nil
 	fake.destroyReturns = struct {
 		result1 error
@@ -307,6 +335,8 @@ func (fake *FakeVolume) DestroyReturns(result1 error) {
 }
 
 func (fake *FakeVolume) DestroyReturnsOnCall(i int, result1 error) {
+	fake.destroyMutex.Lock()
+	defer fake.destroyMutex.Unlock()
 	fake.DestroyStub = nil
 	if fake.destroyReturnsOnCall == nil {
 		fake.destroyReturnsOnCall = make(map[int]struct {
@@ -341,7 +371,15 @@ func (fake *FakeVolume) HandleCallCount() int {
 	return len(fake.handleArgsForCall)
 }
 
+func (fake *FakeVolume) HandleCalls(stub func() string) {
+	fake.handleMutex.Lock()
+	defer fake.handleMutex.Unlock()
+	fake.HandleStub = stub
+}
+
 func (fake *FakeVolume) HandleReturns(result1 string) {
+	fake.handleMutex.Lock()
+	defer fake.handleMutex.Unlock()
 	fake.HandleStub = nil
 	fake.handleReturns = struct {
 		result1 string
@@ -349,6 +387,8 @@ func (fake *FakeVolume) HandleReturns(result1 string) {
 }
 
 func (fake *FakeVolume) HandleReturnsOnCall(i int, result1 string) {
+	fake.handleMutex.Lock()
+	defer fake.handleMutex.Unlock()
 	fake.HandleStub = nil
 	if fake.handleReturnsOnCall == nil {
 		fake.handleReturnsOnCall = make(map[int]struct {
@@ -385,6 +425,12 @@ func (fake *FakeVolume) InitializeArtifactCallCount() int {
 	return len(fake.initializeArtifactArgsForCall)
 }
 
+func (fake *FakeVolume) InitializeArtifactCalls(stub func(string, int) (db.WorkerArtifact, error)) {
+	fake.initializeArtifactMutex.Lock()
+	defer fake.initializeArtifactMutex.Unlock()
+	fake.InitializeArtifactStub = stub
+}
+
 func (fake *FakeVolume) InitializeArtifactArgsForCall(i int) (string, int) {
 	fake.initializeArtifactMutex.RLock()
 	defer fake.initializeArtifactMutex.RUnlock()
@@ -393,6 +439,8 @@ func (fake *FakeVolume) InitializeArtifactArgsForCall(i int) (string, int) {
 }
 
 func (fake *FakeVolume) InitializeArtifactReturns(result1 db.WorkerArtifact, result2 error) {
+	fake.initializeArtifactMutex.Lock()
+	defer fake.initializeArtifactMutex.Unlock()
 	fake.InitializeArtifactStub = nil
 	fake.initializeArtifactReturns = struct {
 		result1 db.WorkerArtifact
@@ -401,6 +449,8 @@ func (fake *FakeVolume) InitializeArtifactReturns(result1 db.WorkerArtifact, res
 }
 
 func (fake *FakeVolume) InitializeArtifactReturnsOnCall(i int, result1 db.WorkerArtifact, result2 error) {
+	fake.initializeArtifactMutex.Lock()
+	defer fake.initializeArtifactMutex.Unlock()
 	fake.InitializeArtifactStub = nil
 	if fake.initializeArtifactReturnsOnCall == nil {
 		fake.initializeArtifactReturnsOnCall = make(map[int]struct {
@@ -438,6 +488,12 @@ func (fake *FakeVolume) InitializeResourceCacheCallCount() int {
 	return len(fake.initializeResourceCacheArgsForCall)
 }
 
+func (fake *FakeVolume) InitializeResourceCacheCalls(stub func(db.UsedResourceCache) error) {
+	fake.initializeResourceCacheMutex.Lock()
+	defer fake.initializeResourceCacheMutex.Unlock()
+	fake.InitializeResourceCacheStub = stub
+}
+
 func (fake *FakeVolume) InitializeResourceCacheArgsForCall(i int) db.UsedResourceCache {
 	fake.initializeResourceCacheMutex.RLock()
 	defer fake.initializeResourceCacheMutex.RUnlock()
@@ -446,6 +502,8 @@ func (fake *FakeVolume) InitializeResourceCacheArgsForCall(i int) db.UsedResourc
 }
 
 func (fake *FakeVolume) InitializeResourceCacheReturns(result1 error) {
+	fake.initializeResourceCacheMutex.Lock()
+	defer fake.initializeResourceCacheMutex.Unlock()
 	fake.InitializeResourceCacheStub = nil
 	fake.initializeResourceCacheReturns = struct {
 		result1 error
@@ -453,6 +511,8 @@ func (fake *FakeVolume) InitializeResourceCacheReturns(result1 error) {
 }
 
 func (fake *FakeVolume) InitializeResourceCacheReturnsOnCall(i int, result1 error) {
+	fake.initializeResourceCacheMutex.Lock()
+	defer fake.initializeResourceCacheMutex.Unlock()
 	fake.InitializeResourceCacheStub = nil
 	if fake.initializeResourceCacheReturnsOnCall == nil {
 		fake.initializeResourceCacheReturnsOnCall = make(map[int]struct {
@@ -492,6 +552,12 @@ func (fake *FakeVolume) InitializeTaskCacheCallCount() int {
 	return len(fake.initializeTaskCacheArgsForCall)
 }
 
+func (fake *FakeVolume) InitializeTaskCacheCalls(stub func(lager.Logger, int, string, string, bool) error) {
+	fake.initializeTaskCacheMutex.Lock()
+	defer fake.initializeTaskCacheMutex.Unlock()
+	fake.InitializeTaskCacheStub = stub
+}
+
 func (fake *FakeVolume) InitializeTaskCacheArgsForCall(i int) (lager.Logger, int, string, string, bool) {
 	fake.initializeTaskCacheMutex.RLock()
 	defer fake.initializeTaskCacheMutex.RUnlock()
@@ -500,6 +566,8 @@ func (fake *FakeVolume) InitializeTaskCacheArgsForCall(i int) (lager.Logger, int
 }
 
 func (fake *FakeVolume) InitializeTaskCacheReturns(result1 error) {
+	fake.initializeTaskCacheMutex.Lock()
+	defer fake.initializeTaskCacheMutex.Unlock()
 	fake.InitializeTaskCacheStub = nil
 	fake.initializeTaskCacheReturns = struct {
 		result1 error
@@ -507,6 +575,8 @@ func (fake *FakeVolume) InitializeTaskCacheReturns(result1 error) {
 }
 
 func (fake *FakeVolume) InitializeTaskCacheReturnsOnCall(i int, result1 error) {
+	fake.initializeTaskCacheMutex.Lock()
+	defer fake.initializeTaskCacheMutex.Unlock()
 	fake.InitializeTaskCacheStub = nil
 	if fake.initializeTaskCacheReturnsOnCall == nil {
 		fake.initializeTaskCacheReturnsOnCall = make(map[int]struct {
@@ -541,7 +611,15 @@ func (fake *FakeVolume) PathCallCount() int {
 	return len(fake.pathArgsForCall)
 }
 
+func (fake *FakeVolume) PathCalls(stub func() string) {
+	fake.pathMutex.Lock()
+	defer fake.pathMutex.Unlock()
+	fake.PathStub = stub
+}
+
 func (fake *FakeVolume) PathReturns(result1 string) {
+	fake.pathMutex.Lock()
+	defer fake.pathMutex.Unlock()
 	fake.PathStub = nil
 	fake.pathReturns = struct {
 		result1 string
@@ -549,6 +627,8 @@ func (fake *FakeVolume) PathReturns(result1 string) {
 }
 
 func (fake *FakeVolume) PathReturnsOnCall(i int, result1 string) {
+	fake.pathMutex.Lock()
+	defer fake.pathMutex.Unlock()
 	fake.PathStub = nil
 	if fake.pathReturnsOnCall == nil {
 		fake.pathReturnsOnCall = make(map[int]struct {
@@ -583,7 +663,15 @@ func (fake *FakeVolume) PropertiesCallCount() int {
 	return len(fake.propertiesArgsForCall)
 }
 
+func (fake *FakeVolume) PropertiesCalls(stub func() (baggageclaim.VolumeProperties, error)) {
+	fake.propertiesMutex.Lock()
+	defer fake.propertiesMutex.Unlock()
+	fake.PropertiesStub = stub
+}
+
 func (fake *FakeVolume) PropertiesReturns(result1 baggageclaim.VolumeProperties, result2 error) {
+	fake.propertiesMutex.Lock()
+	defer fake.propertiesMutex.Unlock()
 	fake.PropertiesStub = nil
 	fake.propertiesReturns = struct {
 		result1 baggageclaim.VolumeProperties
@@ -592,6 +680,8 @@ func (fake *FakeVolume) PropertiesReturns(result1 baggageclaim.VolumeProperties,
 }
 
 func (fake *FakeVolume) PropertiesReturnsOnCall(i int, result1 baggageclaim.VolumeProperties, result2 error) {
+	fake.propertiesMutex.Lock()
+	defer fake.propertiesMutex.Unlock()
 	fake.PropertiesStub = nil
 	if fake.propertiesReturnsOnCall == nil {
 		fake.propertiesReturnsOnCall = make(map[int]struct {
@@ -629,6 +719,12 @@ func (fake *FakeVolume) SetPrivilegedCallCount() int {
 	return len(fake.setPrivilegedArgsForCall)
 }
 
+func (fake *FakeVolume) SetPrivilegedCalls(stub func(bool) error) {
+	fake.setPrivilegedMutex.Lock()
+	defer fake.setPrivilegedMutex.Unlock()
+	fake.SetPrivilegedStub = stub
+}
+
 func (fake *FakeVolume) SetPrivilegedArgsForCall(i int) bool {
 	fake.setPrivilegedMutex.RLock()
 	defer fake.setPrivilegedMutex.RUnlock()
@@ -637,6 +733,8 @@ func (fake *FakeVolume) SetPrivilegedArgsForCall(i int) bool {
 }
 
 func (fake *FakeVolume) SetPrivilegedReturns(result1 error) {
+	fake.setPrivilegedMutex.Lock()
+	defer fake.setPrivilegedMutex.Unlock()
 	fake.SetPrivilegedStub = nil
 	fake.setPrivilegedReturns = struct {
 		result1 error
@@ -644,6 +742,8 @@ func (fake *FakeVolume) SetPrivilegedReturns(result1 error) {
 }
 
 func (fake *FakeVolume) SetPrivilegedReturnsOnCall(i int, result1 error) {
+	fake.setPrivilegedMutex.Lock()
+	defer fake.setPrivilegedMutex.Unlock()
 	fake.SetPrivilegedStub = nil
 	if fake.setPrivilegedReturnsOnCall == nil {
 		fake.setPrivilegedReturnsOnCall = make(map[int]struct {
@@ -680,6 +780,12 @@ func (fake *FakeVolume) SetPropertyCallCount() int {
 	return len(fake.setPropertyArgsForCall)
 }
 
+func (fake *FakeVolume) SetPropertyCalls(stub func(string, string) error) {
+	fake.setPropertyMutex.Lock()
+	defer fake.setPropertyMutex.Unlock()
+	fake.SetPropertyStub = stub
+}
+
 func (fake *FakeVolume) SetPropertyArgsForCall(i int) (string, string) {
 	fake.setPropertyMutex.RLock()
 	defer fake.setPropertyMutex.RUnlock()
@@ -688,6 +794,8 @@ func (fake *FakeVolume) SetPropertyArgsForCall(i int) (string, string) {
 }
 
 func (fake *FakeVolume) SetPropertyReturns(result1 error) {
+	fake.setPropertyMutex.Lock()
+	defer fake.setPropertyMutex.Unlock()
 	fake.SetPropertyStub = nil
 	fake.setPropertyReturns = struct {
 		result1 error
@@ -695,6 +803,8 @@ func (fake *FakeVolume) SetPropertyReturns(result1 error) {
 }
 
 func (fake *FakeVolume) SetPropertyReturnsOnCall(i int, result1 error) {
+	fake.setPropertyMutex.Lock()
+	defer fake.setPropertyMutex.Unlock()
 	fake.SetPropertyStub = nil
 	if fake.setPropertyReturnsOnCall == nil {
 		fake.setPropertyReturnsOnCall = make(map[int]struct {
@@ -731,6 +841,12 @@ func (fake *FakeVolume) StreamInCallCount() int {
 	return len(fake.streamInArgsForCall)
 }
 
+func (fake *FakeVolume) StreamInCalls(stub func(string, io.Reader) error) {
+	fake.streamInMutex.Lock()
+	defer fake.streamInMutex.Unlock()
+	fake.StreamInStub = stub
+}
+
 func (fake *FakeVolume) StreamInArgsForCall(i int) (string, io.Reader) {
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
@@ -739,6 +855,8 @@ func (fake *FakeVolume) StreamInArgsForCall(i int) (string, io.Reader) {
 }
 
 func (fake *FakeVolume) StreamInReturns(result1 error) {
+	fake.streamInMutex.Lock()
+	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	fake.streamInReturns = struct {
 		result1 error
@@ -746,6 +864,8 @@ func (fake *FakeVolume) StreamInReturns(result1 error) {
 }
 
 func (fake *FakeVolume) StreamInReturnsOnCall(i int, result1 error) {
+	fake.streamInMutex.Lock()
+	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = nil
 	if fake.streamInReturnsOnCall == nil {
 		fake.streamInReturnsOnCall = make(map[int]struct {
@@ -781,6 +901,12 @@ func (fake *FakeVolume) StreamOutCallCount() int {
 	return len(fake.streamOutArgsForCall)
 }
 
+func (fake *FakeVolume) StreamOutCalls(stub func(string) (io.ReadCloser, error)) {
+	fake.streamOutMutex.Lock()
+	defer fake.streamOutMutex.Unlock()
+	fake.StreamOutStub = stub
+}
+
 func (fake *FakeVolume) StreamOutArgsForCall(i int) string {
 	fake.streamOutMutex.RLock()
 	defer fake.streamOutMutex.RUnlock()
@@ -789,6 +915,8 @@ func (fake *FakeVolume) StreamOutArgsForCall(i int) string {
 }
 
 func (fake *FakeVolume) StreamOutReturns(result1 io.ReadCloser, result2 error) {
+	fake.streamOutMutex.Lock()
+	defer fake.streamOutMutex.Unlock()
 	fake.StreamOutStub = nil
 	fake.streamOutReturns = struct {
 		result1 io.ReadCloser
@@ -797,6 +925,8 @@ func (fake *FakeVolume) StreamOutReturns(result1 io.ReadCloser, result2 error) {
 }
 
 func (fake *FakeVolume) StreamOutReturnsOnCall(i int, result1 io.ReadCloser, result2 error) {
+	fake.streamOutMutex.Lock()
+	defer fake.streamOutMutex.Unlock()
 	fake.StreamOutStub = nil
 	if fake.streamOutReturnsOnCall == nil {
 		fake.streamOutReturnsOnCall = make(map[int]struct {
@@ -833,7 +963,15 @@ func (fake *FakeVolume) WorkerNameCallCount() int {
 	return len(fake.workerNameArgsForCall)
 }
 
+func (fake *FakeVolume) WorkerNameCalls(stub func() string) {
+	fake.workerNameMutex.Lock()
+	defer fake.workerNameMutex.Unlock()
+	fake.WorkerNameStub = stub
+}
+
 func (fake *FakeVolume) WorkerNameReturns(result1 string) {
+	fake.workerNameMutex.Lock()
+	defer fake.workerNameMutex.Unlock()
 	fake.WorkerNameStub = nil
 	fake.workerNameReturns = struct {
 		result1 string
@@ -841,6 +979,8 @@ func (fake *FakeVolume) WorkerNameReturns(result1 string) {
 }
 
 func (fake *FakeVolume) WorkerNameReturnsOnCall(i int, result1 string) {
+	fake.workerNameMutex.Lock()
+	defer fake.workerNameMutex.Unlock()
 	fake.WorkerNameStub = nil
 	if fake.workerNameReturnsOnCall == nil {
 		fake.workerNameReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_volume_client.go
+++ b/atc/worker/workerfakes/fake_volume_client.go
@@ -2,11 +2,11 @@
 package workerfakes
 
 import (
-	sync "sync"
+	"sync"
 
-	lager "code.cloudfoundry.org/lager"
-	db "github.com/concourse/concourse/atc/db"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeVolumeClient struct {
@@ -194,6 +194,12 @@ func (fake *FakeVolumeClient) CreateVolumeCallCount() int {
 	return len(fake.createVolumeArgsForCall)
 }
 
+func (fake *FakeVolumeClient) CreateVolumeCalls(stub func(lager.Logger, worker.VolumeSpec, int, string, db.VolumeType) (worker.Volume, error)) {
+	fake.createVolumeMutex.Lock()
+	defer fake.createVolumeMutex.Unlock()
+	fake.CreateVolumeStub = stub
+}
+
 func (fake *FakeVolumeClient) CreateVolumeArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, string, db.VolumeType) {
 	fake.createVolumeMutex.RLock()
 	defer fake.createVolumeMutex.RUnlock()
@@ -202,6 +208,8 @@ func (fake *FakeVolumeClient) CreateVolumeArgsForCall(i int) (lager.Logger, work
 }
 
 func (fake *FakeVolumeClient) CreateVolumeReturns(result1 worker.Volume, result2 error) {
+	fake.createVolumeMutex.Lock()
+	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	fake.createVolumeReturns = struct {
 		result1 worker.Volume
@@ -210,6 +218,8 @@ func (fake *FakeVolumeClient) CreateVolumeReturns(result1 worker.Volume, result2
 }
 
 func (fake *FakeVolumeClient) CreateVolumeReturnsOnCall(i int, result1 worker.Volume, result2 error) {
+	fake.createVolumeMutex.Lock()
+	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	if fake.createVolumeReturnsOnCall == nil {
 		fake.createVolumeReturnsOnCall = make(map[int]struct {
@@ -252,6 +262,12 @@ func (fake *FakeVolumeClient) CreateVolumeForTaskCacheCallCount() int {
 	return len(fake.createVolumeForTaskCacheArgsForCall)
 }
 
+func (fake *FakeVolumeClient) CreateVolumeForTaskCacheCalls(stub func(lager.Logger, worker.VolumeSpec, int, int, string, string) (worker.Volume, error)) {
+	fake.createVolumeForTaskCacheMutex.Lock()
+	defer fake.createVolumeForTaskCacheMutex.Unlock()
+	fake.CreateVolumeForTaskCacheStub = stub
+}
+
 func (fake *FakeVolumeClient) CreateVolumeForTaskCacheArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, int, string, string) {
 	fake.createVolumeForTaskCacheMutex.RLock()
 	defer fake.createVolumeForTaskCacheMutex.RUnlock()
@@ -260,6 +276,8 @@ func (fake *FakeVolumeClient) CreateVolumeForTaskCacheArgsForCall(i int) (lager.
 }
 
 func (fake *FakeVolumeClient) CreateVolumeForTaskCacheReturns(result1 worker.Volume, result2 error) {
+	fake.createVolumeForTaskCacheMutex.Lock()
+	defer fake.createVolumeForTaskCacheMutex.Unlock()
 	fake.CreateVolumeForTaskCacheStub = nil
 	fake.createVolumeForTaskCacheReturns = struct {
 		result1 worker.Volume
@@ -268,6 +286,8 @@ func (fake *FakeVolumeClient) CreateVolumeForTaskCacheReturns(result1 worker.Vol
 }
 
 func (fake *FakeVolumeClient) CreateVolumeForTaskCacheReturnsOnCall(i int, result1 worker.Volume, result2 error) {
+	fake.createVolumeForTaskCacheMutex.Lock()
+	defer fake.createVolumeForTaskCacheMutex.Unlock()
 	fake.CreateVolumeForTaskCacheStub = nil
 	if fake.createVolumeForTaskCacheReturnsOnCall == nil {
 		fake.createVolumeForTaskCacheReturnsOnCall = make(map[int]struct {
@@ -310,6 +330,12 @@ func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerCallCount() int {
 	return len(fake.findOrCreateCOWVolumeForContainerArgsForCall)
 }
 
+func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerCalls(stub func(lager.Logger, worker.VolumeSpec, db.CreatingContainer, worker.Volume, int, string) (worker.Volume, error)) {
+	fake.findOrCreateCOWVolumeForContainerMutex.Lock()
+	defer fake.findOrCreateCOWVolumeForContainerMutex.Unlock()
+	fake.FindOrCreateCOWVolumeForContainerStub = stub
+}
+
 func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerArgsForCall(i int) (lager.Logger, worker.VolumeSpec, db.CreatingContainer, worker.Volume, int, string) {
 	fake.findOrCreateCOWVolumeForContainerMutex.RLock()
 	defer fake.findOrCreateCOWVolumeForContainerMutex.RUnlock()
@@ -318,6 +344,8 @@ func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerArgsForCall(i int
 }
 
 func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerReturns(result1 worker.Volume, result2 error) {
+	fake.findOrCreateCOWVolumeForContainerMutex.Lock()
+	defer fake.findOrCreateCOWVolumeForContainerMutex.Unlock()
 	fake.FindOrCreateCOWVolumeForContainerStub = nil
 	fake.findOrCreateCOWVolumeForContainerReturns = struct {
 		result1 worker.Volume
@@ -326,6 +354,8 @@ func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerReturns(result1 w
 }
 
 func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainerReturnsOnCall(i int, result1 worker.Volume, result2 error) {
+	fake.findOrCreateCOWVolumeForContainerMutex.Lock()
+	defer fake.findOrCreateCOWVolumeForContainerMutex.Unlock()
 	fake.FindOrCreateCOWVolumeForContainerStub = nil
 	if fake.findOrCreateCOWVolumeForContainerReturnsOnCall == nil {
 		fake.findOrCreateCOWVolumeForContainerReturnsOnCall = make(map[int]struct {
@@ -366,6 +396,12 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeCallCount() i
 	return len(fake.findOrCreateVolumeForBaseResourceTypeArgsForCall)
 }
 
+func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeCalls(stub func(lager.Logger, worker.VolumeSpec, int, string) (worker.Volume, error)) {
+	fake.findOrCreateVolumeForBaseResourceTypeMutex.Lock()
+	defer fake.findOrCreateVolumeForBaseResourceTypeMutex.Unlock()
+	fake.FindOrCreateVolumeForBaseResourceTypeStub = stub
+}
+
 func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, string) {
 	fake.findOrCreateVolumeForBaseResourceTypeMutex.RLock()
 	defer fake.findOrCreateVolumeForBaseResourceTypeMutex.RUnlock()
@@ -374,6 +410,8 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeArgsForCall(i
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeReturns(result1 worker.Volume, result2 error) {
+	fake.findOrCreateVolumeForBaseResourceTypeMutex.Lock()
+	defer fake.findOrCreateVolumeForBaseResourceTypeMutex.Unlock()
 	fake.FindOrCreateVolumeForBaseResourceTypeStub = nil
 	fake.findOrCreateVolumeForBaseResourceTypeReturns = struct {
 		result1 worker.Volume
@@ -382,6 +420,8 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeReturns(resul
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceTypeReturnsOnCall(i int, result1 worker.Volume, result2 error) {
+	fake.findOrCreateVolumeForBaseResourceTypeMutex.Lock()
+	defer fake.findOrCreateVolumeForBaseResourceTypeMutex.Unlock()
 	fake.FindOrCreateVolumeForBaseResourceTypeStub = nil
 	if fake.findOrCreateVolumeForBaseResourceTypeReturnsOnCall == nil {
 		fake.findOrCreateVolumeForBaseResourceTypeReturnsOnCall = make(map[int]struct {
@@ -423,6 +463,12 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerCallCount() int {
 	return len(fake.findOrCreateVolumeForContainerArgsForCall)
 }
 
+func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerCalls(stub func(lager.Logger, worker.VolumeSpec, db.CreatingContainer, int, string) (worker.Volume, error)) {
+	fake.findOrCreateVolumeForContainerMutex.Lock()
+	defer fake.findOrCreateVolumeForContainerMutex.Unlock()
+	fake.FindOrCreateVolumeForContainerStub = stub
+}
+
 func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerArgsForCall(i int) (lager.Logger, worker.VolumeSpec, db.CreatingContainer, int, string) {
 	fake.findOrCreateVolumeForContainerMutex.RLock()
 	defer fake.findOrCreateVolumeForContainerMutex.RUnlock()
@@ -431,6 +477,8 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerArgsForCall(i int) (
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerReturns(result1 worker.Volume, result2 error) {
+	fake.findOrCreateVolumeForContainerMutex.Lock()
+	defer fake.findOrCreateVolumeForContainerMutex.Unlock()
 	fake.FindOrCreateVolumeForContainerStub = nil
 	fake.findOrCreateVolumeForContainerReturns = struct {
 		result1 worker.Volume
@@ -439,6 +487,8 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerReturns(result1 work
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForContainerReturnsOnCall(i int, result1 worker.Volume, result2 error) {
+	fake.findOrCreateVolumeForContainerMutex.Lock()
+	defer fake.findOrCreateVolumeForContainerMutex.Unlock()
 	fake.FindOrCreateVolumeForContainerStub = nil
 	if fake.findOrCreateVolumeForContainerReturnsOnCall == nil {
 		fake.findOrCreateVolumeForContainerReturnsOnCall = make(map[int]struct {
@@ -476,6 +526,12 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsCallCount() int 
 	return len(fake.findOrCreateVolumeForResourceCertsArgsForCall)
 }
 
+func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsCalls(stub func(lager.Logger) (worker.Volume, bool, error)) {
+	fake.findOrCreateVolumeForResourceCertsMutex.Lock()
+	defer fake.findOrCreateVolumeForResourceCertsMutex.Unlock()
+	fake.FindOrCreateVolumeForResourceCertsStub = stub
+}
+
 func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsArgsForCall(i int) lager.Logger {
 	fake.findOrCreateVolumeForResourceCertsMutex.RLock()
 	defer fake.findOrCreateVolumeForResourceCertsMutex.RUnlock()
@@ -484,6 +540,8 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsArgsForCall(i in
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.findOrCreateVolumeForResourceCertsMutex.Lock()
+	defer fake.findOrCreateVolumeForResourceCertsMutex.Unlock()
 	fake.FindOrCreateVolumeForResourceCertsStub = nil
 	fake.findOrCreateVolumeForResourceCertsReturns = struct {
 		result1 worker.Volume
@@ -493,6 +551,8 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsReturns(result1 
 }
 
 func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCertsReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.findOrCreateVolumeForResourceCertsMutex.Lock()
+	defer fake.findOrCreateVolumeForResourceCertsMutex.Unlock()
 	fake.FindOrCreateVolumeForResourceCertsStub = nil
 	if fake.findOrCreateVolumeForResourceCertsReturnsOnCall == nil {
 		fake.findOrCreateVolumeForResourceCertsReturnsOnCall = make(map[int]struct {
@@ -533,6 +593,12 @@ func (fake *FakeVolumeClient) FindVolumeForResourceCacheCallCount() int {
 	return len(fake.findVolumeForResourceCacheArgsForCall)
 }
 
+func (fake *FakeVolumeClient) FindVolumeForResourceCacheCalls(stub func(lager.Logger, db.UsedResourceCache) (worker.Volume, bool, error)) {
+	fake.findVolumeForResourceCacheMutex.Lock()
+	defer fake.findVolumeForResourceCacheMutex.Unlock()
+	fake.FindVolumeForResourceCacheStub = stub
+}
+
 func (fake *FakeVolumeClient) FindVolumeForResourceCacheArgsForCall(i int) (lager.Logger, db.UsedResourceCache) {
 	fake.findVolumeForResourceCacheMutex.RLock()
 	defer fake.findVolumeForResourceCacheMutex.RUnlock()
@@ -541,6 +607,8 @@ func (fake *FakeVolumeClient) FindVolumeForResourceCacheArgsForCall(i int) (lage
 }
 
 func (fake *FakeVolumeClient) FindVolumeForResourceCacheReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeForResourceCacheMutex.Lock()
+	defer fake.findVolumeForResourceCacheMutex.Unlock()
 	fake.FindVolumeForResourceCacheStub = nil
 	fake.findVolumeForResourceCacheReturns = struct {
 		result1 worker.Volume
@@ -550,6 +618,8 @@ func (fake *FakeVolumeClient) FindVolumeForResourceCacheReturns(result1 worker.V
 }
 
 func (fake *FakeVolumeClient) FindVolumeForResourceCacheReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeForResourceCacheMutex.Lock()
+	defer fake.findVolumeForResourceCacheMutex.Unlock()
 	fake.FindVolumeForResourceCacheStub = nil
 	if fake.findVolumeForResourceCacheReturnsOnCall == nil {
 		fake.findVolumeForResourceCacheReturnsOnCall = make(map[int]struct {
@@ -593,6 +663,12 @@ func (fake *FakeVolumeClient) FindVolumeForTaskCacheCallCount() int {
 	return len(fake.findVolumeForTaskCacheArgsForCall)
 }
 
+func (fake *FakeVolumeClient) FindVolumeForTaskCacheCalls(stub func(lager.Logger, int, int, string, string) (worker.Volume, bool, error)) {
+	fake.findVolumeForTaskCacheMutex.Lock()
+	defer fake.findVolumeForTaskCacheMutex.Unlock()
+	fake.FindVolumeForTaskCacheStub = stub
+}
+
 func (fake *FakeVolumeClient) FindVolumeForTaskCacheArgsForCall(i int) (lager.Logger, int, int, string, string) {
 	fake.findVolumeForTaskCacheMutex.RLock()
 	defer fake.findVolumeForTaskCacheMutex.RUnlock()
@@ -601,6 +677,8 @@ func (fake *FakeVolumeClient) FindVolumeForTaskCacheArgsForCall(i int) (lager.Lo
 }
 
 func (fake *FakeVolumeClient) FindVolumeForTaskCacheReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeForTaskCacheMutex.Lock()
+	defer fake.findVolumeForTaskCacheMutex.Unlock()
 	fake.FindVolumeForTaskCacheStub = nil
 	fake.findVolumeForTaskCacheReturns = struct {
 		result1 worker.Volume
@@ -610,6 +688,8 @@ func (fake *FakeVolumeClient) FindVolumeForTaskCacheReturns(result1 worker.Volum
 }
 
 func (fake *FakeVolumeClient) FindVolumeForTaskCacheReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeForTaskCacheMutex.Lock()
+	defer fake.findVolumeForTaskCacheMutex.Unlock()
 	fake.FindVolumeForTaskCacheStub = nil
 	if fake.findVolumeForTaskCacheReturnsOnCall == nil {
 		fake.findVolumeForTaskCacheReturnsOnCall = make(map[int]struct {
@@ -650,6 +730,12 @@ func (fake *FakeVolumeClient) LookupVolumeCallCount() int {
 	return len(fake.lookupVolumeArgsForCall)
 }
 
+func (fake *FakeVolumeClient) LookupVolumeCalls(stub func(lager.Logger, string) (worker.Volume, bool, error)) {
+	fake.lookupVolumeMutex.Lock()
+	defer fake.lookupVolumeMutex.Unlock()
+	fake.LookupVolumeStub = stub
+}
+
 func (fake *FakeVolumeClient) LookupVolumeArgsForCall(i int) (lager.Logger, string) {
 	fake.lookupVolumeMutex.RLock()
 	defer fake.lookupVolumeMutex.RUnlock()
@@ -658,6 +744,8 @@ func (fake *FakeVolumeClient) LookupVolumeArgsForCall(i int) (lager.Logger, stri
 }
 
 func (fake *FakeVolumeClient) LookupVolumeReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.lookupVolumeMutex.Lock()
+	defer fake.lookupVolumeMutex.Unlock()
 	fake.LookupVolumeStub = nil
 	fake.lookupVolumeReturns = struct {
 		result1 worker.Volume
@@ -667,6 +755,8 @@ func (fake *FakeVolumeClient) LookupVolumeReturns(result1 worker.Volume, result2
 }
 
 func (fake *FakeVolumeClient) LookupVolumeReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.lookupVolumeMutex.Lock()
+	defer fake.lookupVolumeMutex.Unlock()
 	fake.LookupVolumeStub = nil
 	if fake.lookupVolumeReturnsOnCall == nil {
 		fake.lookupVolumeReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_worker.go
+++ b/atc/worker/workerfakes/fake_worker.go
@@ -2,16 +2,17 @@
 package workerfakes
 
 import (
-	context "context"
-	sync "sync"
-	time "time"
+	"context"
+	"sync"
+	"time"
 
-	garden "code.cloudfoundry.org/garden"
-	lager "code.cloudfoundry.org/lager"
-	atc "github.com/concourse/concourse/atc"
-	db "github.com/concourse/concourse/atc/db"
-	worker "github.com/concourse/concourse/atc/worker"
-	version "github.com/cppforlife/go-semi-semantic/version"
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/lock"
+	"github.com/concourse/concourse/atc/worker"
+	"github.com/cppforlife/go-semi-semantic/version"
 )
 
 type FakeWorker struct {
@@ -107,7 +108,7 @@ type FakeWorker struct {
 		result2 bool
 		result3 error
 	}
-	FindOrCreateContainerStub        func(context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, db.ContainerMetadata, worker.ContainerSpec, atc.VersionedResourceTypes) (worker.Container, error)
+	FindOrCreateContainerStub        func(context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, db.ContainerMetadata, worker.ContainerSpec, atc.VersionedResourceTypes, lock.Lock) (worker.Container, error)
 	findOrCreateContainerMutex       sync.RWMutex
 	findOrCreateContainerArgsForCall []struct {
 		arg1 context.Context
@@ -117,6 +118,7 @@ type FakeWorker struct {
 		arg5 db.ContainerMetadata
 		arg6 worker.ContainerSpec
 		arg7 atc.VersionedResourceTypes
+		arg8 lock.Lock
 	}
 	findOrCreateContainerReturns struct {
 		result1 worker.Container
@@ -288,7 +290,15 @@ func (fake *FakeWorker) BuildContainersCallCount() int {
 	return len(fake.buildContainersArgsForCall)
 }
 
+func (fake *FakeWorker) BuildContainersCalls(stub func() int) {
+	fake.buildContainersMutex.Lock()
+	defer fake.buildContainersMutex.Unlock()
+	fake.BuildContainersStub = stub
+}
+
 func (fake *FakeWorker) BuildContainersReturns(result1 int) {
+	fake.buildContainersMutex.Lock()
+	defer fake.buildContainersMutex.Unlock()
 	fake.BuildContainersStub = nil
 	fake.buildContainersReturns = struct {
 		result1 int
@@ -296,6 +306,8 @@ func (fake *FakeWorker) BuildContainersReturns(result1 int) {
 }
 
 func (fake *FakeWorker) BuildContainersReturnsOnCall(i int, result1 int) {
+	fake.buildContainersMutex.Lock()
+	defer fake.buildContainersMutex.Unlock()
 	fake.BuildContainersStub = nil
 	if fake.buildContainersReturnsOnCall == nil {
 		fake.buildContainersReturnsOnCall = make(map[int]struct {
@@ -331,6 +343,12 @@ func (fake *FakeWorker) CertsVolumeCallCount() int {
 	return len(fake.certsVolumeArgsForCall)
 }
 
+func (fake *FakeWorker) CertsVolumeCalls(stub func(lager.Logger) (worker.Volume, bool, error)) {
+	fake.certsVolumeMutex.Lock()
+	defer fake.certsVolumeMutex.Unlock()
+	fake.CertsVolumeStub = stub
+}
+
 func (fake *FakeWorker) CertsVolumeArgsForCall(i int) lager.Logger {
 	fake.certsVolumeMutex.RLock()
 	defer fake.certsVolumeMutex.RUnlock()
@@ -339,6 +357,8 @@ func (fake *FakeWorker) CertsVolumeArgsForCall(i int) lager.Logger {
 }
 
 func (fake *FakeWorker) CertsVolumeReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.certsVolumeMutex.Lock()
+	defer fake.certsVolumeMutex.Unlock()
 	fake.CertsVolumeStub = nil
 	fake.certsVolumeReturns = struct {
 		result1 worker.Volume
@@ -348,6 +368,8 @@ func (fake *FakeWorker) CertsVolumeReturns(result1 worker.Volume, result2 bool, 
 }
 
 func (fake *FakeWorker) CertsVolumeReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.certsVolumeMutex.Lock()
+	defer fake.certsVolumeMutex.Unlock()
 	fake.CertsVolumeStub = nil
 	if fake.certsVolumeReturnsOnCall == nil {
 		fake.certsVolumeReturnsOnCall = make(map[int]struct {
@@ -390,6 +412,12 @@ func (fake *FakeWorker) CreateVolumeCallCount() int {
 	return len(fake.createVolumeArgsForCall)
 }
 
+func (fake *FakeWorker) CreateVolumeCalls(stub func(lager.Logger, worker.VolumeSpec, int, db.VolumeType) (worker.Volume, error)) {
+	fake.createVolumeMutex.Lock()
+	defer fake.createVolumeMutex.Unlock()
+	fake.CreateVolumeStub = stub
+}
+
 func (fake *FakeWorker) CreateVolumeArgsForCall(i int) (lager.Logger, worker.VolumeSpec, int, db.VolumeType) {
 	fake.createVolumeMutex.RLock()
 	defer fake.createVolumeMutex.RUnlock()
@@ -398,6 +426,8 @@ func (fake *FakeWorker) CreateVolumeArgsForCall(i int) (lager.Logger, worker.Vol
 }
 
 func (fake *FakeWorker) CreateVolumeReturns(result1 worker.Volume, result2 error) {
+	fake.createVolumeMutex.Lock()
+	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	fake.createVolumeReturns = struct {
 		result1 worker.Volume
@@ -406,6 +436,8 @@ func (fake *FakeWorker) CreateVolumeReturns(result1 worker.Volume, result2 error
 }
 
 func (fake *FakeWorker) CreateVolumeReturnsOnCall(i int, result1 worker.Volume, result2 error) {
+	fake.createVolumeMutex.Lock()
+	defer fake.createVolumeMutex.Unlock()
 	fake.CreateVolumeStub = nil
 	if fake.createVolumeReturnsOnCall == nil {
 		fake.createVolumeReturnsOnCall = make(map[int]struct {
@@ -442,7 +474,15 @@ func (fake *FakeWorker) DescriptionCallCount() int {
 	return len(fake.descriptionArgsForCall)
 }
 
+func (fake *FakeWorker) DescriptionCalls(stub func() string) {
+	fake.descriptionMutex.Lock()
+	defer fake.descriptionMutex.Unlock()
+	fake.DescriptionStub = stub
+}
+
 func (fake *FakeWorker) DescriptionReturns(result1 string) {
+	fake.descriptionMutex.Lock()
+	defer fake.descriptionMutex.Unlock()
 	fake.DescriptionStub = nil
 	fake.descriptionReturns = struct {
 		result1 string
@@ -450,6 +490,8 @@ func (fake *FakeWorker) DescriptionReturns(result1 string) {
 }
 
 func (fake *FakeWorker) DescriptionReturnsOnCall(i int, result1 string) {
+	fake.descriptionMutex.Lock()
+	defer fake.descriptionMutex.Unlock()
 	fake.DescriptionStub = nil
 	if fake.descriptionReturnsOnCall == nil {
 		fake.descriptionReturnsOnCall = make(map[int]struct {
@@ -488,6 +530,12 @@ func (fake *FakeWorker) EnsureDBContainerExistsCallCount() int {
 	return len(fake.ensureDBContainerExistsArgsForCall)
 }
 
+func (fake *FakeWorker) EnsureDBContainerExistsCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, db.ContainerMetadata) error) {
+	fake.ensureDBContainerExistsMutex.Lock()
+	defer fake.ensureDBContainerExistsMutex.Unlock()
+	fake.EnsureDBContainerExistsStub = stub
+}
+
 func (fake *FakeWorker) EnsureDBContainerExistsArgsForCall(i int) (context.Context, lager.Logger, db.ContainerOwner, db.ContainerMetadata) {
 	fake.ensureDBContainerExistsMutex.RLock()
 	defer fake.ensureDBContainerExistsMutex.RUnlock()
@@ -496,6 +544,8 @@ func (fake *FakeWorker) EnsureDBContainerExistsArgsForCall(i int) (context.Conte
 }
 
 func (fake *FakeWorker) EnsureDBContainerExistsReturns(result1 error) {
+	fake.ensureDBContainerExistsMutex.Lock()
+	defer fake.ensureDBContainerExistsMutex.Unlock()
 	fake.EnsureDBContainerExistsStub = nil
 	fake.ensureDBContainerExistsReturns = struct {
 		result1 error
@@ -503,6 +553,8 @@ func (fake *FakeWorker) EnsureDBContainerExistsReturns(result1 error) {
 }
 
 func (fake *FakeWorker) EnsureDBContainerExistsReturnsOnCall(i int, result1 error) {
+	fake.ensureDBContainerExistsMutex.Lock()
+	defer fake.ensureDBContainerExistsMutex.Unlock()
 	fake.EnsureDBContainerExistsStub = nil
 	if fake.ensureDBContainerExistsReturnsOnCall == nil {
 		fake.ensureDBContainerExistsReturnsOnCall = make(map[int]struct {
@@ -537,7 +589,15 @@ func (fake *FakeWorker) EphemeralCallCount() int {
 	return len(fake.ephemeralArgsForCall)
 }
 
+func (fake *FakeWorker) EphemeralCalls(stub func() bool) {
+	fake.ephemeralMutex.Lock()
+	defer fake.ephemeralMutex.Unlock()
+	fake.EphemeralStub = stub
+}
+
 func (fake *FakeWorker) EphemeralReturns(result1 bool) {
+	fake.ephemeralMutex.Lock()
+	defer fake.ephemeralMutex.Unlock()
 	fake.EphemeralStub = nil
 	fake.ephemeralReturns = struct {
 		result1 bool
@@ -545,6 +605,8 @@ func (fake *FakeWorker) EphemeralReturns(result1 bool) {
 }
 
 func (fake *FakeWorker) EphemeralReturnsOnCall(i int, result1 bool) {
+	fake.ephemeralMutex.Lock()
+	defer fake.ephemeralMutex.Unlock()
 	fake.EphemeralStub = nil
 	if fake.ephemeralReturnsOnCall == nil {
 		fake.ephemeralReturnsOnCall = make(map[int]struct {
@@ -582,6 +644,12 @@ func (fake *FakeWorker) FindContainerByHandleCallCount() int {
 	return len(fake.findContainerByHandleArgsForCall)
 }
 
+func (fake *FakeWorker) FindContainerByHandleCalls(stub func(lager.Logger, int, string) (worker.Container, bool, error)) {
+	fake.findContainerByHandleMutex.Lock()
+	defer fake.findContainerByHandleMutex.Unlock()
+	fake.FindContainerByHandleStub = stub
+}
+
 func (fake *FakeWorker) FindContainerByHandleArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findContainerByHandleMutex.RLock()
 	defer fake.findContainerByHandleMutex.RUnlock()
@@ -590,6 +658,8 @@ func (fake *FakeWorker) FindContainerByHandleArgsForCall(i int) (lager.Logger, i
 }
 
 func (fake *FakeWorker) FindContainerByHandleReturns(result1 worker.Container, result2 bool, result3 error) {
+	fake.findContainerByHandleMutex.Lock()
+	defer fake.findContainerByHandleMutex.Unlock()
 	fake.FindContainerByHandleStub = nil
 	fake.findContainerByHandleReturns = struct {
 		result1 worker.Container
@@ -599,6 +669,8 @@ func (fake *FakeWorker) FindContainerByHandleReturns(result1 worker.Container, r
 }
 
 func (fake *FakeWorker) FindContainerByHandleReturnsOnCall(i int, result1 worker.Container, result2 bool, result3 error) {
+	fake.findContainerByHandleMutex.Lock()
+	defer fake.findContainerByHandleMutex.Unlock()
 	fake.FindContainerByHandleStub = nil
 	if fake.findContainerByHandleReturnsOnCall == nil {
 		fake.findContainerByHandleReturnsOnCall = make(map[int]struct {
@@ -614,7 +686,7 @@ func (fake *FakeWorker) FindContainerByHandleReturnsOnCall(i int, result1 worker
 	}{result1, result2, result3}
 }
 
-func (fake *FakeWorker) FindOrCreateContainer(arg1 context.Context, arg2 lager.Logger, arg3 worker.ImageFetchingDelegate, arg4 db.ContainerOwner, arg5 db.ContainerMetadata, arg6 worker.ContainerSpec, arg7 atc.VersionedResourceTypes) (worker.Container, error) {
+func (fake *FakeWorker) FindOrCreateContainer(arg1 context.Context, arg2 lager.Logger, arg3 worker.ImageFetchingDelegate, arg4 db.ContainerOwner, arg5 db.ContainerMetadata, arg6 worker.ContainerSpec, arg7 atc.VersionedResourceTypes, arg8 lock.Lock) (worker.Container, error) {
 	fake.findOrCreateContainerMutex.Lock()
 	ret, specificReturn := fake.findOrCreateContainerReturnsOnCall[len(fake.findOrCreateContainerArgsForCall)]
 	fake.findOrCreateContainerArgsForCall = append(fake.findOrCreateContainerArgsForCall, struct {
@@ -625,11 +697,12 @@ func (fake *FakeWorker) FindOrCreateContainer(arg1 context.Context, arg2 lager.L
 		arg5 db.ContainerMetadata
 		arg6 worker.ContainerSpec
 		arg7 atc.VersionedResourceTypes
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
-	fake.recordInvocation("FindOrCreateContainer", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg8 lock.Lock
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
+	fake.recordInvocation("FindOrCreateContainer", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
 	fake.findOrCreateContainerMutex.Unlock()
 	if fake.FindOrCreateContainerStub != nil {
-		return fake.FindOrCreateContainerStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		return fake.FindOrCreateContainerStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -644,14 +717,22 @@ func (fake *FakeWorker) FindOrCreateContainerCallCount() int {
 	return len(fake.findOrCreateContainerArgsForCall)
 }
 
-func (fake *FakeWorker) FindOrCreateContainerArgsForCall(i int) (context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, db.ContainerMetadata, worker.ContainerSpec, atc.VersionedResourceTypes) {
+func (fake *FakeWorker) FindOrCreateContainerCalls(stub func(context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, db.ContainerMetadata, worker.ContainerSpec, atc.VersionedResourceTypes, lock.Lock) (worker.Container, error)) {
+	fake.findOrCreateContainerMutex.Lock()
+	defer fake.findOrCreateContainerMutex.Unlock()
+	fake.FindOrCreateContainerStub = stub
+}
+
+func (fake *FakeWorker) FindOrCreateContainerArgsForCall(i int) (context.Context, lager.Logger, worker.ImageFetchingDelegate, db.ContainerOwner, db.ContainerMetadata, worker.ContainerSpec, atc.VersionedResourceTypes, lock.Lock) {
 	fake.findOrCreateContainerMutex.RLock()
 	defer fake.findOrCreateContainerMutex.RUnlock()
 	argsForCall := fake.findOrCreateContainerArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8
 }
 
 func (fake *FakeWorker) FindOrCreateContainerReturns(result1 worker.Container, result2 error) {
+	fake.findOrCreateContainerMutex.Lock()
+	defer fake.findOrCreateContainerMutex.Unlock()
 	fake.FindOrCreateContainerStub = nil
 	fake.findOrCreateContainerReturns = struct {
 		result1 worker.Container
@@ -660,6 +741,8 @@ func (fake *FakeWorker) FindOrCreateContainerReturns(result1 worker.Container, r
 }
 
 func (fake *FakeWorker) FindOrCreateContainerReturnsOnCall(i int, result1 worker.Container, result2 error) {
+	fake.findOrCreateContainerMutex.Lock()
+	defer fake.findOrCreateContainerMutex.Unlock()
 	fake.FindOrCreateContainerStub = nil
 	if fake.findOrCreateContainerReturnsOnCall == nil {
 		fake.findOrCreateContainerReturnsOnCall = make(map[int]struct {
@@ -698,6 +781,12 @@ func (fake *FakeWorker) FindVolumeForResourceCacheCallCount() int {
 	return len(fake.findVolumeForResourceCacheArgsForCall)
 }
 
+func (fake *FakeWorker) FindVolumeForResourceCacheCalls(stub func(lager.Logger, db.UsedResourceCache) (worker.Volume, bool, error)) {
+	fake.findVolumeForResourceCacheMutex.Lock()
+	defer fake.findVolumeForResourceCacheMutex.Unlock()
+	fake.FindVolumeForResourceCacheStub = stub
+}
+
 func (fake *FakeWorker) FindVolumeForResourceCacheArgsForCall(i int) (lager.Logger, db.UsedResourceCache) {
 	fake.findVolumeForResourceCacheMutex.RLock()
 	defer fake.findVolumeForResourceCacheMutex.RUnlock()
@@ -706,6 +795,8 @@ func (fake *FakeWorker) FindVolumeForResourceCacheArgsForCall(i int) (lager.Logg
 }
 
 func (fake *FakeWorker) FindVolumeForResourceCacheReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeForResourceCacheMutex.Lock()
+	defer fake.findVolumeForResourceCacheMutex.Unlock()
 	fake.FindVolumeForResourceCacheStub = nil
 	fake.findVolumeForResourceCacheReturns = struct {
 		result1 worker.Volume
@@ -715,6 +806,8 @@ func (fake *FakeWorker) FindVolumeForResourceCacheReturns(result1 worker.Volume,
 }
 
 func (fake *FakeWorker) FindVolumeForResourceCacheReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeForResourceCacheMutex.Lock()
+	defer fake.findVolumeForResourceCacheMutex.Unlock()
 	fake.FindVolumeForResourceCacheStub = nil
 	if fake.findVolumeForResourceCacheReturnsOnCall == nil {
 		fake.findVolumeForResourceCacheReturnsOnCall = make(map[int]struct {
@@ -758,6 +851,12 @@ func (fake *FakeWorker) FindVolumeForTaskCacheCallCount() int {
 	return len(fake.findVolumeForTaskCacheArgsForCall)
 }
 
+func (fake *FakeWorker) FindVolumeForTaskCacheCalls(stub func(lager.Logger, int, int, string, string) (worker.Volume, bool, error)) {
+	fake.findVolumeForTaskCacheMutex.Lock()
+	defer fake.findVolumeForTaskCacheMutex.Unlock()
+	fake.FindVolumeForTaskCacheStub = stub
+}
+
 func (fake *FakeWorker) FindVolumeForTaskCacheArgsForCall(i int) (lager.Logger, int, int, string, string) {
 	fake.findVolumeForTaskCacheMutex.RLock()
 	defer fake.findVolumeForTaskCacheMutex.RUnlock()
@@ -766,6 +865,8 @@ func (fake *FakeWorker) FindVolumeForTaskCacheArgsForCall(i int) (lager.Logger, 
 }
 
 func (fake *FakeWorker) FindVolumeForTaskCacheReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeForTaskCacheMutex.Lock()
+	defer fake.findVolumeForTaskCacheMutex.Unlock()
 	fake.FindVolumeForTaskCacheStub = nil
 	fake.findVolumeForTaskCacheReturns = struct {
 		result1 worker.Volume
@@ -775,6 +876,8 @@ func (fake *FakeWorker) FindVolumeForTaskCacheReturns(result1 worker.Volume, res
 }
 
 func (fake *FakeWorker) FindVolumeForTaskCacheReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.findVolumeForTaskCacheMutex.Lock()
+	defer fake.findVolumeForTaskCacheMutex.Unlock()
 	fake.FindVolumeForTaskCacheStub = nil
 	if fake.findVolumeForTaskCacheReturnsOnCall == nil {
 		fake.findVolumeForTaskCacheReturnsOnCall = make(map[int]struct {
@@ -813,7 +916,15 @@ func (fake *FakeWorker) GardenClientCallCount() int {
 	return len(fake.gardenClientArgsForCall)
 }
 
+func (fake *FakeWorker) GardenClientCalls(stub func() garden.Client) {
+	fake.gardenClientMutex.Lock()
+	defer fake.gardenClientMutex.Unlock()
+	fake.GardenClientStub = stub
+}
+
 func (fake *FakeWorker) GardenClientReturns(result1 garden.Client) {
+	fake.gardenClientMutex.Lock()
+	defer fake.gardenClientMutex.Unlock()
 	fake.GardenClientStub = nil
 	fake.gardenClientReturns = struct {
 		result1 garden.Client
@@ -821,6 +932,8 @@ func (fake *FakeWorker) GardenClientReturns(result1 garden.Client) {
 }
 
 func (fake *FakeWorker) GardenClientReturnsOnCall(i int, result1 garden.Client) {
+	fake.gardenClientMutex.Lock()
+	defer fake.gardenClientMutex.Unlock()
 	fake.GardenClientStub = nil
 	if fake.gardenClientReturnsOnCall == nil {
 		fake.gardenClientReturnsOnCall = make(map[int]struct {
@@ -855,7 +968,15 @@ func (fake *FakeWorker) IsOwnedByTeamCallCount() int {
 	return len(fake.isOwnedByTeamArgsForCall)
 }
 
+func (fake *FakeWorker) IsOwnedByTeamCalls(stub func() bool) {
+	fake.isOwnedByTeamMutex.Lock()
+	defer fake.isOwnedByTeamMutex.Unlock()
+	fake.IsOwnedByTeamStub = stub
+}
+
 func (fake *FakeWorker) IsOwnedByTeamReturns(result1 bool) {
+	fake.isOwnedByTeamMutex.Lock()
+	defer fake.isOwnedByTeamMutex.Unlock()
 	fake.IsOwnedByTeamStub = nil
 	fake.isOwnedByTeamReturns = struct {
 		result1 bool
@@ -863,6 +984,8 @@ func (fake *FakeWorker) IsOwnedByTeamReturns(result1 bool) {
 }
 
 func (fake *FakeWorker) IsOwnedByTeamReturnsOnCall(i int, result1 bool) {
+	fake.isOwnedByTeamMutex.Lock()
+	defer fake.isOwnedByTeamMutex.Unlock()
 	fake.IsOwnedByTeamStub = nil
 	if fake.isOwnedByTeamReturnsOnCall == nil {
 		fake.isOwnedByTeamReturnsOnCall = make(map[int]struct {
@@ -899,6 +1022,12 @@ func (fake *FakeWorker) IsVersionCompatibleCallCount() int {
 	return len(fake.isVersionCompatibleArgsForCall)
 }
 
+func (fake *FakeWorker) IsVersionCompatibleCalls(stub func(lager.Logger, version.Version) bool) {
+	fake.isVersionCompatibleMutex.Lock()
+	defer fake.isVersionCompatibleMutex.Unlock()
+	fake.IsVersionCompatibleStub = stub
+}
+
 func (fake *FakeWorker) IsVersionCompatibleArgsForCall(i int) (lager.Logger, version.Version) {
 	fake.isVersionCompatibleMutex.RLock()
 	defer fake.isVersionCompatibleMutex.RUnlock()
@@ -907,6 +1036,8 @@ func (fake *FakeWorker) IsVersionCompatibleArgsForCall(i int) (lager.Logger, ver
 }
 
 func (fake *FakeWorker) IsVersionCompatibleReturns(result1 bool) {
+	fake.isVersionCompatibleMutex.Lock()
+	defer fake.isVersionCompatibleMutex.Unlock()
 	fake.IsVersionCompatibleStub = nil
 	fake.isVersionCompatibleReturns = struct {
 		result1 bool
@@ -914,6 +1045,8 @@ func (fake *FakeWorker) IsVersionCompatibleReturns(result1 bool) {
 }
 
 func (fake *FakeWorker) IsVersionCompatibleReturnsOnCall(i int, result1 bool) {
+	fake.isVersionCompatibleMutex.Lock()
+	defer fake.isVersionCompatibleMutex.Unlock()
 	fake.IsVersionCompatibleStub = nil
 	if fake.isVersionCompatibleReturnsOnCall == nil {
 		fake.isVersionCompatibleReturnsOnCall = make(map[int]struct {
@@ -950,6 +1083,12 @@ func (fake *FakeWorker) LookupVolumeCallCount() int {
 	return len(fake.lookupVolumeArgsForCall)
 }
 
+func (fake *FakeWorker) LookupVolumeCalls(stub func(lager.Logger, string) (worker.Volume, bool, error)) {
+	fake.lookupVolumeMutex.Lock()
+	defer fake.lookupVolumeMutex.Unlock()
+	fake.LookupVolumeStub = stub
+}
+
 func (fake *FakeWorker) LookupVolumeArgsForCall(i int) (lager.Logger, string) {
 	fake.lookupVolumeMutex.RLock()
 	defer fake.lookupVolumeMutex.RUnlock()
@@ -958,6 +1097,8 @@ func (fake *FakeWorker) LookupVolumeArgsForCall(i int) (lager.Logger, string) {
 }
 
 func (fake *FakeWorker) LookupVolumeReturns(result1 worker.Volume, result2 bool, result3 error) {
+	fake.lookupVolumeMutex.Lock()
+	defer fake.lookupVolumeMutex.Unlock()
 	fake.LookupVolumeStub = nil
 	fake.lookupVolumeReturns = struct {
 		result1 worker.Volume
@@ -967,6 +1108,8 @@ func (fake *FakeWorker) LookupVolumeReturns(result1 worker.Volume, result2 bool,
 }
 
 func (fake *FakeWorker) LookupVolumeReturnsOnCall(i int, result1 worker.Volume, result2 bool, result3 error) {
+	fake.lookupVolumeMutex.Lock()
+	defer fake.lookupVolumeMutex.Unlock()
 	fake.LookupVolumeStub = nil
 	if fake.lookupVolumeReturnsOnCall == nil {
 		fake.lookupVolumeReturnsOnCall = make(map[int]struct {
@@ -1005,7 +1148,15 @@ func (fake *FakeWorker) NameCallCount() int {
 	return len(fake.nameArgsForCall)
 }
 
+func (fake *FakeWorker) NameCalls(stub func() string) {
+	fake.nameMutex.Lock()
+	defer fake.nameMutex.Unlock()
+	fake.NameStub = stub
+}
+
 func (fake *FakeWorker) NameReturns(result1 string) {
+	fake.nameMutex.Lock()
+	defer fake.nameMutex.Unlock()
 	fake.NameStub = nil
 	fake.nameReturns = struct {
 		result1 string
@@ -1013,6 +1164,8 @@ func (fake *FakeWorker) NameReturns(result1 string) {
 }
 
 func (fake *FakeWorker) NameReturnsOnCall(i int, result1 string) {
+	fake.nameMutex.Lock()
+	defer fake.nameMutex.Unlock()
 	fake.NameStub = nil
 	if fake.nameReturnsOnCall == nil {
 		fake.nameReturnsOnCall = make(map[int]struct {
@@ -1047,7 +1200,15 @@ func (fake *FakeWorker) ResourceTypesCallCount() int {
 	return len(fake.resourceTypesArgsForCall)
 }
 
+func (fake *FakeWorker) ResourceTypesCalls(stub func() []atc.WorkerResourceType) {
+	fake.resourceTypesMutex.Lock()
+	defer fake.resourceTypesMutex.Unlock()
+	fake.ResourceTypesStub = stub
+}
+
 func (fake *FakeWorker) ResourceTypesReturns(result1 []atc.WorkerResourceType) {
+	fake.resourceTypesMutex.Lock()
+	defer fake.resourceTypesMutex.Unlock()
 	fake.ResourceTypesStub = nil
 	fake.resourceTypesReturns = struct {
 		result1 []atc.WorkerResourceType
@@ -1055,6 +1216,8 @@ func (fake *FakeWorker) ResourceTypesReturns(result1 []atc.WorkerResourceType) {
 }
 
 func (fake *FakeWorker) ResourceTypesReturnsOnCall(i int, result1 []atc.WorkerResourceType) {
+	fake.resourceTypesMutex.Lock()
+	defer fake.resourceTypesMutex.Unlock()
 	fake.ResourceTypesStub = nil
 	if fake.resourceTypesReturnsOnCall == nil {
 		fake.resourceTypesReturnsOnCall = make(map[int]struct {
@@ -1091,6 +1254,12 @@ func (fake *FakeWorker) SatisfiesCallCount() int {
 	return len(fake.satisfiesArgsForCall)
 }
 
+func (fake *FakeWorker) SatisfiesCalls(stub func(lager.Logger, worker.WorkerSpec) bool) {
+	fake.satisfiesMutex.Lock()
+	defer fake.satisfiesMutex.Unlock()
+	fake.SatisfiesStub = stub
+}
+
 func (fake *FakeWorker) SatisfiesArgsForCall(i int) (lager.Logger, worker.WorkerSpec) {
 	fake.satisfiesMutex.RLock()
 	defer fake.satisfiesMutex.RUnlock()
@@ -1099,6 +1268,8 @@ func (fake *FakeWorker) SatisfiesArgsForCall(i int) (lager.Logger, worker.Worker
 }
 
 func (fake *FakeWorker) SatisfiesReturns(result1 bool) {
+	fake.satisfiesMutex.Lock()
+	defer fake.satisfiesMutex.Unlock()
 	fake.SatisfiesStub = nil
 	fake.satisfiesReturns = struct {
 		result1 bool
@@ -1106,6 +1277,8 @@ func (fake *FakeWorker) SatisfiesReturns(result1 bool) {
 }
 
 func (fake *FakeWorker) SatisfiesReturnsOnCall(i int, result1 bool) {
+	fake.satisfiesMutex.Lock()
+	defer fake.satisfiesMutex.Unlock()
 	fake.SatisfiesStub = nil
 	if fake.satisfiesReturnsOnCall == nil {
 		fake.satisfiesReturnsOnCall = make(map[int]struct {
@@ -1140,7 +1313,15 @@ func (fake *FakeWorker) TagsCallCount() int {
 	return len(fake.tagsArgsForCall)
 }
 
+func (fake *FakeWorker) TagsCalls(stub func() atc.Tags) {
+	fake.tagsMutex.Lock()
+	defer fake.tagsMutex.Unlock()
+	fake.TagsStub = stub
+}
+
 func (fake *FakeWorker) TagsReturns(result1 atc.Tags) {
+	fake.tagsMutex.Lock()
+	defer fake.tagsMutex.Unlock()
 	fake.TagsStub = nil
 	fake.tagsReturns = struct {
 		result1 atc.Tags
@@ -1148,6 +1329,8 @@ func (fake *FakeWorker) TagsReturns(result1 atc.Tags) {
 }
 
 func (fake *FakeWorker) TagsReturnsOnCall(i int, result1 atc.Tags) {
+	fake.tagsMutex.Lock()
+	defer fake.tagsMutex.Unlock()
 	fake.TagsStub = nil
 	if fake.tagsReturnsOnCall == nil {
 		fake.tagsReturnsOnCall = make(map[int]struct {
@@ -1182,7 +1365,15 @@ func (fake *FakeWorker) UptimeCallCount() int {
 	return len(fake.uptimeArgsForCall)
 }
 
+func (fake *FakeWorker) UptimeCalls(stub func() time.Duration) {
+	fake.uptimeMutex.Lock()
+	defer fake.uptimeMutex.Unlock()
+	fake.UptimeStub = stub
+}
+
 func (fake *FakeWorker) UptimeReturns(result1 time.Duration) {
+	fake.uptimeMutex.Lock()
+	defer fake.uptimeMutex.Unlock()
 	fake.UptimeStub = nil
 	fake.uptimeReturns = struct {
 		result1 time.Duration
@@ -1190,6 +1381,8 @@ func (fake *FakeWorker) UptimeReturns(result1 time.Duration) {
 }
 
 func (fake *FakeWorker) UptimeReturnsOnCall(i int, result1 time.Duration) {
+	fake.uptimeMutex.Lock()
+	defer fake.uptimeMutex.Unlock()
 	fake.UptimeStub = nil
 	if fake.uptimeReturnsOnCall == nil {
 		fake.uptimeReturnsOnCall = make(map[int]struct {

--- a/atc/worker/workerfakes/fake_worker_provider.go
+++ b/atc/worker/workerfakes/fake_worker_provider.go
@@ -2,12 +2,12 @@
 package workerfakes
 
 import (
-	sync "sync"
+	"sync"
 
-	clock "code.cloudfoundry.org/clock"
-	lager "code.cloudfoundry.org/lager"
-	db "github.com/concourse/concourse/atc/db"
-	worker "github.com/concourse/concourse/atc/worker"
+	"code.cloudfoundry.org/clock"
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeWorkerProvider struct {
@@ -116,6 +116,12 @@ func (fake *FakeWorkerProvider) FindWorkerForContainerCallCount() int {
 	return len(fake.findWorkerForContainerArgsForCall)
 }
 
+func (fake *FakeWorkerProvider) FindWorkerForContainerCalls(stub func(lager.Logger, int, string) (worker.Worker, bool, error)) {
+	fake.findWorkerForContainerMutex.Lock()
+	defer fake.findWorkerForContainerMutex.Unlock()
+	fake.FindWorkerForContainerStub = stub
+}
+
 func (fake *FakeWorkerProvider) FindWorkerForContainerArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findWorkerForContainerMutex.RLock()
 	defer fake.findWorkerForContainerMutex.RUnlock()
@@ -124,6 +130,8 @@ func (fake *FakeWorkerProvider) FindWorkerForContainerArgsForCall(i int) (lager.
 }
 
 func (fake *FakeWorkerProvider) FindWorkerForContainerReturns(result1 worker.Worker, result2 bool, result3 error) {
+	fake.findWorkerForContainerMutex.Lock()
+	defer fake.findWorkerForContainerMutex.Unlock()
 	fake.FindWorkerForContainerStub = nil
 	fake.findWorkerForContainerReturns = struct {
 		result1 worker.Worker
@@ -133,6 +141,8 @@ func (fake *FakeWorkerProvider) FindWorkerForContainerReturns(result1 worker.Wor
 }
 
 func (fake *FakeWorkerProvider) FindWorkerForContainerReturnsOnCall(i int, result1 worker.Worker, result2 bool, result3 error) {
+	fake.findWorkerForContainerMutex.Lock()
+	defer fake.findWorkerForContainerMutex.Unlock()
 	fake.FindWorkerForContainerStub = nil
 	if fake.findWorkerForContainerReturnsOnCall == nil {
 		fake.findWorkerForContainerReturnsOnCall = make(map[int]struct {
@@ -174,6 +184,12 @@ func (fake *FakeWorkerProvider) FindWorkerForVolumeCallCount() int {
 	return len(fake.findWorkerForVolumeArgsForCall)
 }
 
+func (fake *FakeWorkerProvider) FindWorkerForVolumeCalls(stub func(lager.Logger, int, string) (worker.Worker, bool, error)) {
+	fake.findWorkerForVolumeMutex.Lock()
+	defer fake.findWorkerForVolumeMutex.Unlock()
+	fake.FindWorkerForVolumeStub = stub
+}
+
 func (fake *FakeWorkerProvider) FindWorkerForVolumeArgsForCall(i int) (lager.Logger, int, string) {
 	fake.findWorkerForVolumeMutex.RLock()
 	defer fake.findWorkerForVolumeMutex.RUnlock()
@@ -182,6 +198,8 @@ func (fake *FakeWorkerProvider) FindWorkerForVolumeArgsForCall(i int) (lager.Log
 }
 
 func (fake *FakeWorkerProvider) FindWorkerForVolumeReturns(result1 worker.Worker, result2 bool, result3 error) {
+	fake.findWorkerForVolumeMutex.Lock()
+	defer fake.findWorkerForVolumeMutex.Unlock()
 	fake.FindWorkerForVolumeStub = nil
 	fake.findWorkerForVolumeReturns = struct {
 		result1 worker.Worker
@@ -191,6 +209,8 @@ func (fake *FakeWorkerProvider) FindWorkerForVolumeReturns(result1 worker.Worker
 }
 
 func (fake *FakeWorkerProvider) FindWorkerForVolumeReturnsOnCall(i int, result1 worker.Worker, result2 bool, result3 error) {
+	fake.findWorkerForVolumeMutex.Lock()
+	defer fake.findWorkerForVolumeMutex.Unlock()
 	fake.FindWorkerForVolumeStub = nil
 	if fake.findWorkerForVolumeReturnsOnCall == nil {
 		fake.findWorkerForVolumeReturnsOnCall = make(map[int]struct {
@@ -231,6 +251,12 @@ func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerCallCount() int {
 	return len(fake.findWorkersForContainerByOwnerArgsForCall)
 }
 
+func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerCalls(stub func(lager.Logger, db.ContainerOwner) ([]worker.Worker, error)) {
+	fake.findWorkersForContainerByOwnerMutex.Lock()
+	defer fake.findWorkersForContainerByOwnerMutex.Unlock()
+	fake.FindWorkersForContainerByOwnerStub = stub
+}
+
 func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerArgsForCall(i int) (lager.Logger, db.ContainerOwner) {
 	fake.findWorkersForContainerByOwnerMutex.RLock()
 	defer fake.findWorkersForContainerByOwnerMutex.RUnlock()
@@ -239,6 +265,8 @@ func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerArgsForCall(i int)
 }
 
 func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerReturns(result1 []worker.Worker, result2 error) {
+	fake.findWorkersForContainerByOwnerMutex.Lock()
+	defer fake.findWorkersForContainerByOwnerMutex.Unlock()
 	fake.FindWorkersForContainerByOwnerStub = nil
 	fake.findWorkersForContainerByOwnerReturns = struct {
 		result1 []worker.Worker
@@ -247,6 +275,8 @@ func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerReturns(result1 []
 }
 
 func (fake *FakeWorkerProvider) FindWorkersForContainerByOwnerReturnsOnCall(i int, result1 []worker.Worker, result2 error) {
+	fake.findWorkersForContainerByOwnerMutex.Lock()
+	defer fake.findWorkersForContainerByOwnerMutex.Unlock()
 	fake.FindWorkersForContainerByOwnerStub = nil
 	if fake.findWorkersForContainerByOwnerReturnsOnCall == nil {
 		fake.findWorkersForContainerByOwnerReturnsOnCall = make(map[int]struct {
@@ -287,6 +317,12 @@ func (fake *FakeWorkerProvider) NewGardenWorkerCallCount() int {
 	return len(fake.newGardenWorkerArgsForCall)
 }
 
+func (fake *FakeWorkerProvider) NewGardenWorkerCalls(stub func(lager.Logger, clock.Clock, db.Worker, int) worker.Worker) {
+	fake.newGardenWorkerMutex.Lock()
+	defer fake.newGardenWorkerMutex.Unlock()
+	fake.NewGardenWorkerStub = stub
+}
+
 func (fake *FakeWorkerProvider) NewGardenWorkerArgsForCall(i int) (lager.Logger, clock.Clock, db.Worker, int) {
 	fake.newGardenWorkerMutex.RLock()
 	defer fake.newGardenWorkerMutex.RUnlock()
@@ -295,6 +331,8 @@ func (fake *FakeWorkerProvider) NewGardenWorkerArgsForCall(i int) (lager.Logger,
 }
 
 func (fake *FakeWorkerProvider) NewGardenWorkerReturns(result1 worker.Worker) {
+	fake.newGardenWorkerMutex.Lock()
+	defer fake.newGardenWorkerMutex.Unlock()
 	fake.NewGardenWorkerStub = nil
 	fake.newGardenWorkerReturns = struct {
 		result1 worker.Worker
@@ -302,6 +340,8 @@ func (fake *FakeWorkerProvider) NewGardenWorkerReturns(result1 worker.Worker) {
 }
 
 func (fake *FakeWorkerProvider) NewGardenWorkerReturnsOnCall(i int, result1 worker.Worker) {
+	fake.newGardenWorkerMutex.Lock()
+	defer fake.newGardenWorkerMutex.Unlock()
 	fake.NewGardenWorkerStub = nil
 	if fake.newGardenWorkerReturnsOnCall == nil {
 		fake.newGardenWorkerReturnsOnCall = make(map[int]struct {
@@ -337,6 +377,12 @@ func (fake *FakeWorkerProvider) RunningWorkersCallCount() int {
 	return len(fake.runningWorkersArgsForCall)
 }
 
+func (fake *FakeWorkerProvider) RunningWorkersCalls(stub func(lager.Logger) ([]worker.Worker, error)) {
+	fake.runningWorkersMutex.Lock()
+	defer fake.runningWorkersMutex.Unlock()
+	fake.RunningWorkersStub = stub
+}
+
 func (fake *FakeWorkerProvider) RunningWorkersArgsForCall(i int) lager.Logger {
 	fake.runningWorkersMutex.RLock()
 	defer fake.runningWorkersMutex.RUnlock()
@@ -345,6 +391,8 @@ func (fake *FakeWorkerProvider) RunningWorkersArgsForCall(i int) lager.Logger {
 }
 
 func (fake *FakeWorkerProvider) RunningWorkersReturns(result1 []worker.Worker, result2 error) {
+	fake.runningWorkersMutex.Lock()
+	defer fake.runningWorkersMutex.Unlock()
 	fake.RunningWorkersStub = nil
 	fake.runningWorkersReturns = struct {
 		result1 []worker.Worker
@@ -353,6 +401,8 @@ func (fake *FakeWorkerProvider) RunningWorkersReturns(result1 []worker.Worker, r
 }
 
 func (fake *FakeWorkerProvider) RunningWorkersReturnsOnCall(i int, result1 []worker.Worker, result2 error) {
+	fake.runningWorkersMutex.Lock()
+	defer fake.runningWorkersMutex.Unlock()
 	fake.RunningWorkersStub = nil
 	if fake.runningWorkersReturnsOnCall == nil {
 		fake.runningWorkersReturnsOnCall = make(map[int]struct {


### PR DESCRIPTION
This is my tentative at fixing #3301. Taking a pragmatic way and implementing a lock wherever needed.

All steps chose the worker serially by acquiring the same lock.

The lock is acquired in the task, put and get steps,
each implemented in the relative Run method.

The lock is released by the corresponding method that creates
the Container in the database just after that's done:
either `worker.FindOrCreateContainer` or `fetcher.Fetch`.

Resource_scanner, resource_type_scanner and image_resource_fetcher
do not implement the locking mechanism thus their processing is independent.

The unit tests are adjusted for the addition of the lock.

New test cases are probably required but I'd like to have feedback on the general direction I've taken
before working more on this.

@ddadlani @deniseyu @kcmannem 

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>