### PR TITLE
return VersionResult from PutStep

### DIFF
--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -1,10 +1,9 @@
 package exec
 
 import (
-	"context"
-
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
+	"context"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
@@ -172,7 +171,7 @@ func (step *PutStep) Run(ctx context.Context, state RunState) error {
 	step.delegate.Starting(logger)
 
 	putResource := step.resourceFactory.NewResourceForContainer(container)
-	versionedSource, err := putResource.Put(
+	versionResult, err := putResource.Put(
 		ctx,
 		resource.IOConfig{
 			Stdout: step.delegate.Stdout(),
@@ -194,8 +193,8 @@ func (step *PutStep) Run(ctx context.Context, state RunState) error {
 	}
 
 	versionInfo := VersionInfo{
-		Version:  versionedSource.Version(),
-		Metadata: versionedSource.Metadata(),
+		Version:  versionResult.Version,
+		Metadata: versionResult.Metadata,
 	}
 
 	if step.plan.Resource != "" {

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -166,9 +166,9 @@ var _ = Describe("PutStep", func() {
 
 		Context("when the tracker can initialize the resource", func() {
 			var (
-				fakeResource        *resourcefakes.FakeResource
-				fakeResourceConfig  *dbfakes.FakeResourceConfig
-				fakeVersionedSource *resourcefakes.FakeVersionedSource
+				fakeResource       *resourcefakes.FakeResource
+				fakeResourceConfig *dbfakes.FakeResourceConfig
+				fakeVersionResult  resource.VersionResult
 			)
 
 			BeforeEach(func() {
@@ -177,15 +177,16 @@ var _ = Describe("PutStep", func() {
 
 				fakeResourceConfigFactory.FindOrCreateResourceConfigReturns(fakeResourceConfig, nil)
 
-				fakeVersionedSource = new(resourcefakes.FakeVersionedSource)
-				fakeVersionedSource.VersionReturns(atc.Version{"some": "version"})
-				fakeVersionedSource.MetadataReturns([]atc.MetadataField{{Name: "some", Value: "metadata"}})
+				fakeVersionResult = resource.VersionResult{
+					Version: atc.Version{"some": "version"},
+					Metadata: []atc.MetadataField{{Name: "some", Value: "metadata"}},
+				}
 
 				fakeWorker.NameReturns("some-worker")
 				fakePool.FindOrChooseWorkerForContainerReturns(fakeWorker, nil)
 
 				fakeResource = new(resourcefakes.FakeResource)
-				fakeResource.PutReturns(fakeVersionedSource, nil)
+				fakeResource.PutReturns(fakeVersionResult, nil)
 				fakeResourceFactory.NewResourceForContainerReturns(fakeResource)
 			})
 
@@ -331,7 +332,7 @@ var _ = Describe("PutStep", func() {
 
 			Context("when performing the put exits unsuccessfully", func() {
 				BeforeEach(func() {
-					fakeResource.PutReturns(nil, resource.ErrResourceScriptFailed{
+					fakeResource.PutReturns(resource.VersionResult{}, resource.ErrResourceScriptFailed{
 						ExitStatus: 42,
 					})
 				})
@@ -356,7 +357,7 @@ var _ = Describe("PutStep", func() {
 				disaster := errors.New("oh no")
 
 				BeforeEach(func() {
-					fakeResource.PutReturns(nil, disaster)
+					fakeResource.PutReturns(resource.VersionResult{}, disaster)
 				})
 
 				It("does not finish the step via the delegate", func() {

--- a/atc/resource/resource.go
+++ b/atc/resource/resource.go
@@ -14,7 +14,7 @@ import (
 
 type Resource interface {
 	Get(context.Context, worker.Volume, IOConfig, atc.Source, atc.Params, atc.Version) (VersionedSource, error)
-	Put(context.Context, IOConfig, atc.Source, atc.Params) (VersionedSource, error)
+	Put(context.Context, IOConfig, atc.Source, atc.Params) (VersionResult, error)
 	Check(context.Context, atc.Source, atc.Version) ([]atc.Version, error)
 }
 

--- a/atc/resource/resource_get.go
+++ b/atc/resource/resource_get.go
@@ -21,7 +21,7 @@ func (resource *resource) Get(
 	params atc.Params,
 	version atc.Version,
 ) (VersionedSource, error) {
-	var vr versionResult
+	var vr VersionResult
 
 	err := resource.runScript(
 		ctx,

--- a/atc/resource/resource_put.go
+++ b/atc/resource/resource_put.go
@@ -16,13 +16,10 @@ func (resource *resource) Put(
 	ioConfig IOConfig,
 	source atc.Source,
 	params atc.Params,
-) (VersionedSource, error) {
+) (VersionResult, error) {
 	resourceDir := ResourcesDir("put")
 
-	vs := &putVersionedSource{
-		container:   resource.container,
-		resourceDir: resourceDir,
-	}
+	vr := &VersionResult{}
 
 	err := resource.runScript(
 		ctx,
@@ -32,13 +29,13 @@ func (resource *resource) Put(
 			Params: params,
 			Source: source,
 		},
-		&vs.versionResult,
+		&vr,
 		ioConfig.Stderr,
 		true,
 	)
 	if err != nil {
-		return nil, err
+		return VersionResult{}, err
 	}
 
-	return vs, nil
+	return *vr, nil
 }

--- a/atc/resource/resourcefakes/fake_resource.go
+++ b/atc/resource/resourcefakes/fake_resource.go
@@ -44,7 +44,7 @@ type FakeResource struct {
 		result1 resource.VersionedSource
 		result2 error
 	}
-	PutStub        func(context.Context, resource.IOConfig, atc.Source, atc.Params) (resource.VersionedSource, error)
+	PutStub        func(context.Context, resource.IOConfig, atc.Source, atc.Params) (resource.VersionResult, error)
 	putMutex       sync.RWMutex
 	putArgsForCall []struct {
 		arg1 context.Context
@@ -53,11 +53,11 @@ type FakeResource struct {
 		arg4 atc.Params
 	}
 	putReturns struct {
-		result1 resource.VersionedSource
+		result1 resource.VersionResult
 		result2 error
 	}
 	putReturnsOnCall map[int]struct {
-		result1 resource.VersionedSource
+		result1 resource.VersionResult
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -197,7 +197,7 @@ func (fake *FakeResource) GetReturnsOnCall(i int, result1 resource.VersionedSour
 	}{result1, result2}
 }
 
-func (fake *FakeResource) Put(arg1 context.Context, arg2 resource.IOConfig, arg3 atc.Source, arg4 atc.Params) (resource.VersionedSource, error) {
+func (fake *FakeResource) Put(arg1 context.Context, arg2 resource.IOConfig, arg3 atc.Source, arg4 atc.Params) (resource.VersionResult, error) {
 	fake.putMutex.Lock()
 	ret, specificReturn := fake.putReturnsOnCall[len(fake.putArgsForCall)]
 	fake.putArgsForCall = append(fake.putArgsForCall, struct {
@@ -224,7 +224,7 @@ func (fake *FakeResource) PutCallCount() int {
 	return len(fake.putArgsForCall)
 }
 
-func (fake *FakeResource) PutCalls(stub func(context.Context, resource.IOConfig, atc.Source, atc.Params) (resource.VersionedSource, error)) {
+func (fake *FakeResource) PutCalls(stub func(context.Context, resource.IOConfig, atc.Source, atc.Params) (resource.VersionResult, error)) {
 	fake.putMutex.Lock()
 	defer fake.putMutex.Unlock()
 	fake.PutStub = stub
@@ -237,28 +237,28 @@ func (fake *FakeResource) PutArgsForCall(i int) (context.Context, resource.IOCon
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeResource) PutReturns(result1 resource.VersionedSource, result2 error) {
+func (fake *FakeResource) PutReturns(result1 resource.VersionResult, result2 error) {
 	fake.putMutex.Lock()
 	defer fake.putMutex.Unlock()
 	fake.PutStub = nil
 	fake.putReturns = struct {
-		result1 resource.VersionedSource
+		result1 resource.VersionResult
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeResource) PutReturnsOnCall(i int, result1 resource.VersionedSource, result2 error) {
+func (fake *FakeResource) PutReturnsOnCall(i int, result1 resource.VersionResult, result2 error) {
 	fake.putMutex.Lock()
 	defer fake.putMutex.Unlock()
 	fake.PutStub = nil
 	if fake.putReturnsOnCall == nil {
 		fake.putReturnsOnCall = make(map[int]struct {
-			result1 resource.VersionedSource
+			result1 resource.VersionResult
 			result2 error
 		})
 	}
 	fake.putReturnsOnCall[i] = struct {
-		result1 resource.VersionedSource
+		result1 resource.VersionResult
 		result2 error
 	}{result1, result2}
 }

--- a/atc/resource/versioned_source.go
+++ b/atc/resource/versioned_source.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"path"
 
-	"code.cloudfoundry.org/garden"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/worker"
 )
@@ -21,44 +20,10 @@ type VersionedSource interface {
 	Volume() worker.Volume
 }
 
-type versionResult struct {
+type VersionResult struct {
 	Version atc.Version `json:"version"`
 
 	Metadata []atc.MetadataField `json:"metadata,omitempty"`
-}
-
-type putVersionedSource struct {
-	versionResult versionResult
-
-	container garden.Container
-
-	resourceDir string
-}
-
-func (vs *putVersionedSource) Version() atc.Version {
-	return vs.versionResult.Version
-}
-
-func (vs *putVersionedSource) Metadata() []atc.MetadataField {
-	return vs.versionResult.Metadata
-}
-
-func (vs *putVersionedSource) StreamOut(src string) (io.ReadCloser, error) {
-	return vs.container.StreamOut(garden.StreamOutSpec{
-		// don't use path.Join; it strips trailing slashes
-		Path: vs.resourceDir + "/" + src,
-	})
-}
-
-func (vs *putVersionedSource) Volume() worker.Volume {
-	return nil
-}
-
-func (vs *putVersionedSource) StreamIn(dst string, src io.Reader) error {
-	return vs.container.StreamIn(garden.StreamInSpec{
-		Path:      path.Join(vs.resourceDir, dst),
-		TarStream: src,
-	})
 }
 
 func NewGetVersionedSource(volume worker.Volume, version atc.Version, metadata []atc.MetadataField) VersionedSource {
@@ -66,7 +31,7 @@ func NewGetVersionedSource(volume worker.Volume, version atc.Version, metadata [
 		volume:      volume,
 		resourceDir: ResourcesDir("get"),
 
-		versionResult: versionResult{
+		versionResult: VersionResult{
 			Version:  version,
 			Metadata: metadata,
 		},
@@ -74,7 +39,7 @@ func NewGetVersionedSource(volume worker.Volume, version atc.Version, metadata [
 }
 
 type getVersionedSource struct {
-	versionResult versionResult
+	versionResult VersionResult
 
 	volume      worker.Volume
 	resourceDir string


### PR DESCRIPTION
We used to return a `VersionedSource` from the PutStep, which had `StreamIn` and `StreamOut` implemented using streaming from the container rather than from a volume. We don't really call this anywhere though. Let's get rid of it.

The motivation to do so comes from our refactor in #4052 for which we are trying to invert the dependency between a `Resource` and a `Container` (i.e. a `Resource` should create a container and not be passed one in the constructor)

Signed-off-by: Nader Ziada <nziada@pivotal.io>