### PR TITLE
topgun/k8s: move random seed to release+ns setup

### DIFF
--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -71,8 +71,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	envBytes, err := json.Marshal(parsedEnv)
 	Expect(err).ToNot(HaveOccurred())
 
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	return envBytes
 }, func(data []byte) {
 	err := json.Unmarshal(data, &Environment)
@@ -80,7 +78,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = BeforeEach(func() {
-
 	SetDefaultEventuallyTimeout(30 * time.Second)
 	SetDefaultConsistentlyDuration(30 * time.Second)
 
@@ -98,7 +95,8 @@ var _ = BeforeEach(func() {
 })
 
 func setReleaseNameAndNamespace(description string) {
-	releaseName = fmt.Sprintf("topgun-"+description+"-%d-%d", rand.Int31n(1000000), GinkgoParallelNode())
+	rand.Seed(time.Now().UTC().UnixNano())
+	releaseName = fmt.Sprintf("topgun-"+description+"-%d", rand.Int63n(100000000))
 	namespace = releaseName
 }
 


### PR DESCRIPTION
fixes: #4124

Previously, we had the seed for random being configured only at the
suite level, which lead to us having problems with name colisions.

Now, having it being seeded every time (+ having a bigger random number
size) we need a random name, we're able to better ensure that we won't
have collisions even when running in parallel.
