### PR TITLE
web: fix lazy-rendering on build page

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -482,7 +482,9 @@ viewBuildOutput : Session -> Build.Models.CurrentOutput -> Html Message
 viewBuildOutput session output =
     case output of
         Output o ->
-            Build.Output.Output.view session o
+            Build.Output.Output.view
+                { timeZone = session.timeZone, hovered = session.hovered }
+                o
 
         Cancelled ->
             Html.div

--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -1,25 +1,772 @@
 module Benchmarks exposing (main)
 
+import Ansi.Log
+import Application.Models exposing (Session)
+import Array
 import Benchmark
 import Benchmark.Runner exposing (BenchmarkProgram, program)
+import Build.Build as Build
+import Build.Models exposing (CurrentOutput(..))
+import Build.Output.Models
+import Build.Output.Output
+import Build.StepTree.Models as STModels
+import Build.Styles
 import Concourse
 import Concourse.BuildStatus
 import Dashboard.DashboardPreview as DP
+import DateFormat
 import Dict exposing (Dict)
 import HoverState
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, class, classList, href)
+import Html.Attributes
+    exposing
+        ( attribute
+        , class
+        , classList
+        , href
+        , id
+        , style
+        , tabindex
+        , title
+        )
+import Html.Events exposing (onBlur, onFocus, onMouseEnter, onMouseLeave)
+import Html.Lazy
+import Login.Login as Login
+import Maybe.Extra
+import Message.Message exposing (DomID(..), Message(..))
+import RemoteData
 import Routes
+import ScreenSize
+import Set
+import SideBar.SideBar as SideBar
+import StrictEvents exposing (onLeftClick, onMouseWheel, onScroll)
+import Time
+import UserState
+import Views.BuildDuration as BuildDuration
+import Views.Icon as Icon
+import Views.LoadingIndicator as LoadingIndicator
+import Views.NotAuthorized as NotAuthorized
+import Views.Spinner as Spinner
+import Views.Styles
+import Views.TopBar as TopBar
 
 
 main : BenchmarkProgram
 main =
     program <|
-        Benchmark.compare "view"
-            "with uncertainty metric"
-            (\_ -> DP.view HoverState.NoHover sampleJobs)
-            "straight recursion"
-            (\_ -> view sampleJobs)
+        Benchmark.describe "benchmark suite"
+            [ Benchmark.compare "DashboardPreview.view"
+                "current"
+                (\_ -> DP.view HoverState.NoHover sampleJobs)
+                "old"
+                (\_ -> dashboardPreviewView sampleJobs)
+            , Benchmark.compare "Build.view"
+                "current"
+                (\_ -> Build.view sampleSession sampleModel)
+                "old"
+                (\_ -> buildView sampleSession sampleModel)
+            ]
+
+
+bodyId : String
+bodyId =
+    "build-body"
+
+
+historyId : String
+historyId =
+    "builds"
+
+
+buildView : Session -> Build.Models.Model -> Html Message
+buildView session model =
+    let
+        route =
+            case model.page of
+                Build.Models.OneOffBuildPage buildId ->
+                    Routes.OneOffBuild
+                        { id = buildId
+                        , highlight = model.highlight
+                        }
+
+                Build.Models.JobBuildPage buildId ->
+                    Routes.Build
+                        { id = buildId
+                        , highlight = model.highlight
+                        }
+    in
+    Html.div
+        (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
+        [ Html.div
+            (id "top-bar-app" :: Views.Styles.topBar False)
+            [ SideBar.hamburgerMenu session
+            , TopBar.concourseLogo
+            , breadcrumbs model
+            , Login.view session.userState model False
+            ]
+        , Html.div
+            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
+            [ SideBar.view
+                { expandedTeams = session.expandedTeams
+                , pipelines = session.pipelines
+                , hovered = session.hovered
+                , isSideBarOpen = session.isSideBarOpen
+                , screenSize = session.screenSize
+                }
+                (currentJob model
+                    |> Maybe.map
+                        (\j ->
+                            { pipelineName = j.pipelineName
+                            , teamName = j.teamName
+                            }
+                        )
+                )
+            , viewBuildPage session model
+            ]
+        ]
+
+
+viewBuildPage : Session -> Build.Models.Model -> Html Message
+viewBuildPage session model =
+    case model.currentBuild |> RemoteData.toMaybe of
+        Just currentBuild ->
+            Html.div
+                [ class "with-fixed-header"
+                , attribute "data-build-name" currentBuild.build.name
+                , style "flex-grow" "1"
+                , style "display" "flex"
+                , style "flex-direction" "column"
+                , style "overflow" "hidden"
+                ]
+                [ viewBuildHeader session model currentBuild.build
+                , body
+                    session
+                    { currentBuild = currentBuild
+                    , authorized = model.authorized
+                    , showHelp = model.showHelp
+                    }
+                ]
+
+        _ ->
+            LoadingIndicator.view
+
+
+currentJob : Build.Models.Model -> Maybe Concourse.JobIdentifier
+currentJob =
+    .currentBuild
+        >> RemoteData.toMaybe
+        >> Maybe.map .build
+        >> Maybe.andThen .job
+
+
+breadcrumbs : Build.Models.Model -> Html Message
+breadcrumbs model =
+    case ( currentJob model, model.page ) of
+        ( Just jobId, _ ) ->
+            TopBar.breadcrumbs <|
+                Routes.Job
+                    { id = jobId
+                    , page = Nothing
+                    }
+
+        ( _, Build.Models.JobBuildPage buildId ) ->
+            TopBar.breadcrumbs <|
+                Routes.Build
+                    { id = buildId
+                    , highlight = model.highlight
+                    }
+
+        _ ->
+            Html.text ""
+
+
+body :
+    Session
+    ->
+        { currentBuild : Build.Models.CurrentBuild
+        , authorized : Bool
+        , showHelp : Bool
+        }
+    -> Html Message
+body session { currentBuild, authorized, showHelp } =
+    Html.div
+        ([ class "scrollable-body build-body"
+         , id bodyId
+         , tabindex 0
+         , onScroll Scrolled
+         ]
+            ++ Build.Styles.body
+        )
+    <|
+        if authorized then
+            [ viewBuildPrep currentBuild.prep
+            , Html.Lazy.lazy2 viewBuildOutput session currentBuild.output
+            , keyboardHelp showHelp
+            ]
+                ++ tombstone session.timeZone currentBuild
+
+        else
+            [ NotAuthorized.view ]
+
+
+viewBuildHeader :
+    Session
+    -> Build.Models.Model
+    -> Concourse.Build
+    -> Html Message
+viewBuildHeader session model build =
+    let
+        triggerButton =
+            case currentJob model of
+                Just _ ->
+                    let
+                        buttonDisabled =
+                            model.disableManualTrigger
+
+                        buttonHovered =
+                            HoverState.isHovered
+                                TriggerBuildButton
+                                session.hovered
+                    in
+                    Html.button
+                        ([ attribute "role" "button"
+                         , attribute "tabindex" "0"
+                         , attribute "aria-label" "Trigger Build"
+                         , attribute "title" "Trigger Build"
+                         , onLeftClick <| Click TriggerBuildButton
+                         , onMouseEnter <| Hover <| Just TriggerBuildButton
+                         , onFocus <| Hover <| Just TriggerBuildButton
+                         , onMouseLeave <| Hover Nothing
+                         , onBlur <| Hover Nothing
+                         ]
+                            ++ Build.Styles.triggerButton
+                                buttonDisabled
+                                buttonHovered
+                                build.status
+                        )
+                    <|
+                        [ Icon.icon
+                            { sizePx = 40
+                            , image = "ic-add-circle-outline-white.svg"
+                            }
+                            []
+                        ]
+                            ++ (if buttonDisabled && buttonHovered then
+                                    [ Html.div
+                                        Build.Styles.triggerTooltip
+                                        [ Html.text <|
+                                            "manual triggering disabled "
+                                                ++ "in job config"
+                                        ]
+                                    ]
+
+                                else
+                                    []
+                               )
+
+                Nothing ->
+                    Html.text ""
+
+        abortHovered =
+            HoverState.isHovered AbortBuildButton session.hovered
+
+        abortButton =
+            if Concourse.BuildStatus.isRunning build.status then
+                Html.button
+                    ([ onLeftClick (Click <| AbortBuildButton)
+                     , attribute "role" "button"
+                     , attribute "tabindex" "0"
+                     , attribute "aria-label" "Abort Build"
+                     , attribute "title" "Abort Build"
+                     , onMouseEnter <| Hover <| Just AbortBuildButton
+                     , onFocus <| Hover <| Just AbortBuildButton
+                     , onMouseLeave <| Hover Nothing
+                     , onBlur <| Hover Nothing
+                     ]
+                        ++ Build.Styles.abortButton abortHovered
+                    )
+                    [ Icon.icon
+                        { sizePx = 40
+                        , image = "ic-abort-circle-outline-white.svg"
+                        }
+                        []
+                    ]
+
+            else
+                Html.text ""
+
+        buildTitle =
+            case build.job of
+                Just jobId ->
+                    let
+                        jobRoute =
+                            Routes.Job { id = jobId, page = Nothing }
+                    in
+                    Html.a
+                        [ href <| Routes.toString jobRoute ]
+                        [ Html.span [ class "build-name" ] [ Html.text jobId.jobName ]
+                        , Html.text (" #" ++ build.name)
+                        ]
+
+                _ ->
+                    Html.text ("build #" ++ String.fromInt build.id)
+    in
+    Html.div [ class "fixed-header" ]
+        [ Html.div
+            ([ id "build-header"
+             , class "build-header"
+             ]
+                ++ Build.Styles.header build.status
+            )
+            [ Html.div []
+                [ Html.h1 [] [ buildTitle ]
+                , case model.now of
+                    Just n ->
+                        BuildDuration.view session.timeZone build.duration n
+
+                    Nothing ->
+                        Html.text ""
+                ]
+            , Html.div
+                [ style "display" "flex" ]
+                [ abortButton, triggerButton ]
+            ]
+        , Html.div
+            [ onMouseWheel ScrollBuilds ]
+            [ lazyViewHistory build model.history ]
+        ]
+
+
+tombstone : Time.Zone -> Build.Models.CurrentBuild -> List (Html Message)
+tombstone timeZone currentBuild =
+    let
+        build =
+            currentBuild.build
+
+        maybeBirthDate =
+            Maybe.Extra.or build.duration.startedAt build.duration.finishedAt
+    in
+    case ( maybeBirthDate, build.reapTime ) of
+        ( Just birthDate, Just reapTime ) ->
+            [ Html.div
+                [ class "tombstone" ]
+                [ Html.div [ class "heading" ] [ Html.text "RIP" ]
+                , Html.div
+                    [ class "job-name" ]
+                    [ Html.text <|
+                        Maybe.withDefault
+                            "one-off build"
+                        <|
+                            Maybe.map .jobName build.job
+                    ]
+                , Html.div
+                    [ class "build-name" ]
+                    [ Html.text <|
+                        "build #"
+                            ++ (case build.job of
+                                    Nothing ->
+                                        String.fromInt build.id
+
+                                    Just _ ->
+                                        build.name
+                               )
+                    ]
+                , Html.div
+                    [ class "date" ]
+                    [ Html.text <|
+                        mmDDYY timeZone birthDate
+                            ++ "-"
+                            ++ mmDDYY timeZone reapTime
+                    ]
+                , Html.div
+                    [ class "epitaph" ]
+                    [ Html.text <|
+                        case build.status of
+                            Concourse.BuildStatusSucceeded ->
+                                "It passed, and now it has passed on."
+
+                            Concourse.BuildStatusFailed ->
+                                "It failed, and now has been forgotten."
+
+                            Concourse.BuildStatusErrored ->
+                                "It errored, but has found forgiveness."
+
+                            Concourse.BuildStatusAborted ->
+                                "It was never given a chance."
+
+                            _ ->
+                                "I'm not dead yet."
+                    ]
+                ]
+            , Html.div
+                [ class "explanation" ]
+                [ Html.text "This log has been "
+                , Html.a
+                    [ Html.Attributes.href "https://concourse-ci.org/jobs.html#job-build-log-retention" ]
+                    [ Html.text "reaped." ]
+                ]
+            ]
+
+        _ ->
+            []
+
+
+keyboardHelp : Bool -> Html Message
+keyboardHelp showHelp =
+    Html.div
+        [ classList
+            [ ( "keyboard-help", True )
+            , ( "hidden", not showHelp )
+            ]
+        ]
+        [ Html.div
+            [ class "help-title" ]
+            [ Html.text "keyboard shortcuts" ]
+        , Html.div
+            [ class "help-line" ]
+            [ Html.div
+                [ class "keys" ]
+                [ Html.span [ class "key" ] [ Html.text "h" ]
+                , Html.span [ class "key" ] [ Html.text "l" ]
+                ]
+            , Html.text "previous/next build"
+            ]
+        , Html.div
+            [ class "help-line" ]
+            [ Html.div
+                [ class "keys" ]
+                [ Html.span [ class "key" ] [ Html.text "j" ]
+                , Html.span [ class "key" ] [ Html.text "k" ]
+                ]
+            , Html.text "scroll down/up"
+            ]
+        , Html.div
+            [ class "help-line" ]
+            [ Html.div
+                [ class "keys" ]
+                [ Html.span [ class "key" ] [ Html.text "T" ] ]
+            , Html.text "trigger a new build"
+            ]
+        , Html.div
+            [ class "help-line" ]
+            [ Html.div
+                [ class "keys" ]
+                [ Html.span [ class "key" ] [ Html.text "A" ] ]
+            , Html.text "abort build"
+            ]
+        , Html.div
+            [ class "help-line" ]
+            [ Html.div
+                [ class "keys" ]
+                [ Html.span [ class "key" ] [ Html.text "gg" ] ]
+            , Html.text "scroll to the top"
+            ]
+        , Html.div
+            [ class "help-line" ]
+            [ Html.div
+                [ class "keys" ]
+                [ Html.span [ class "key" ] [ Html.text "G" ] ]
+            , Html.text "scroll to the bottom"
+            ]
+        , Html.div
+            [ class "help-line" ]
+            [ Html.div
+                [ class "keys" ]
+                [ Html.span [ class "key" ] [ Html.text "?" ] ]
+            , Html.text "hide/show help"
+            ]
+        ]
+
+
+viewBuildOutput : Session -> Build.Models.CurrentOutput -> Html Message
+viewBuildOutput session output =
+    case output of
+        Output o ->
+            Build.Output.Output.view session o
+
+        Cancelled ->
+            Html.div
+                Build.Styles.errorLog
+                [ Html.text "build cancelled" ]
+
+        Empty ->
+            Html.div [] []
+
+
+viewBuildPrep : Maybe Concourse.BuildPrep -> Html Message
+viewBuildPrep buildPrep =
+    case buildPrep of
+        Just prep ->
+            Html.div [ class "build-step" ]
+                [ Html.div
+                    [ class "header"
+                    , style "display" "flex"
+                    , style "align-items" "center"
+                    ]
+                    [ Icon.icon
+                        { sizePx = 15, image = "ic-cogs.svg" }
+                        [ style "margin" "6.5px"
+                        , style "margin-right" "0.5px"
+                        , style "background-size" "contain"
+                        ]
+                    , Html.h3 [] [ Html.text "preparing build" ]
+                    ]
+                , Html.div []
+                    [ Html.ul [ class "prep-status-list" ]
+                        ([ viewBuildPrepLi "checking pipeline is not paused" prep.pausedPipeline Dict.empty
+                         , viewBuildPrepLi "checking job is not paused" prep.pausedJob Dict.empty
+                         ]
+                            ++ viewBuildPrepInputs prep.inputs
+                            ++ [ viewBuildPrepLi "waiting for a suitable set of input versions" prep.inputsSatisfied prep.missingInputReasons
+                               , viewBuildPrepLi "checking max-in-flight is not reached" prep.maxRunningBuilds Dict.empty
+                               ]
+                        )
+                    ]
+                ]
+
+        Nothing ->
+            Html.div [] []
+
+
+lazyViewHistory : Concourse.Build -> List Concourse.Build -> Html Message
+lazyViewHistory currentBuild builds =
+    Html.Lazy.lazy2 viewHistory currentBuild builds
+
+
+viewHistory : Concourse.Build -> List Concourse.Build -> Html Message
+viewHistory currentBuild builds =
+    Html.ul [ id historyId ]
+        (List.map (viewHistoryItem currentBuild) builds)
+
+
+viewHistoryItem : Concourse.Build -> Concourse.Build -> Html Message
+viewHistoryItem currentBuild build =
+    Html.li
+        ([ classList [ ( "current", build.id == currentBuild.id ) ]
+         , id <| String.fromInt build.id
+         ]
+            ++ Build.Styles.historyItem build.status
+        )
+        [ Html.a
+            [ onLeftClick <| Click <| BuildTab build
+            , href <| Routes.toString <| Routes.buildRoute build
+            ]
+            [ Html.text build.name ]
+        ]
+
+
+mmDDYY : Time.Zone -> Time.Posix -> String
+mmDDYY =
+    DateFormat.format
+        [ DateFormat.monthFixed
+        , DateFormat.text "/"
+        , DateFormat.dayOfMonthFixed
+        , DateFormat.text "/"
+        , DateFormat.yearNumberLastTwo
+        ]
+
+
+viewBuildPrepLi :
+    String
+    -> Concourse.BuildPrepStatus
+    -> Dict String String
+    -> Html Message
+viewBuildPrepLi text status details =
+    Html.li
+        [ classList
+            [ ( "prep-status", True )
+            , ( "inactive", status == Concourse.BuildPrepStatusUnknown )
+            ]
+        ]
+        [ Html.div
+            [ style "align-items" "center"
+            , style "display" "flex"
+            ]
+            [ viewBuildPrepStatus status
+            , Html.span []
+                [ Html.text text ]
+            ]
+        , viewBuildPrepDetails details
+        ]
+
+
+viewBuildPrepInputs : Dict String Concourse.BuildPrepStatus -> List (Html Message)
+viewBuildPrepInputs inputs =
+    List.map viewBuildPrepInput (Dict.toList inputs)
+
+
+viewBuildPrepInput : ( String, Concourse.BuildPrepStatus ) -> Html Message
+viewBuildPrepInput ( name, status ) =
+    viewBuildPrepLi ("discovering any new versions of " ++ name) status Dict.empty
+
+
+viewBuildPrepDetails : Dict String String -> Html Message
+viewBuildPrepDetails details =
+    Html.ul [ class "details" ]
+        (List.map viewDetailItem (Dict.toList details))
+
+
+viewBuildPrepStatus : Concourse.BuildPrepStatus -> Html Message
+viewBuildPrepStatus status =
+    case status of
+        Concourse.BuildPrepStatusUnknown ->
+            Html.div
+                [ title "thinking..." ]
+                [ Spinner.spinner
+                    { sizePx = 12
+                    , margin = "0 5px 0 0"
+                    }
+                ]
+
+        Concourse.BuildPrepStatusBlocking ->
+            Html.div
+                [ title "blocking" ]
+                [ Spinner.spinner
+                    { sizePx = 12
+                    , margin = "0 5px 0 0"
+                    }
+                ]
+
+        Concourse.BuildPrepStatusNotBlocking ->
+            Icon.icon
+                { sizePx = 12
+                , image = "ic-not-blocking-check.svg"
+                }
+                [ style "margin-right" "5px"
+                , style "background-size" "contain"
+                , title "not blocking"
+                ]
+
+
+viewDetailItem : ( String, String ) -> Html Message
+viewDetailItem ( name, status ) =
+    Html.li []
+        [ Html.text (name ++ " - " ++ status) ]
+
+
+sampleSession : Session
+sampleSession =
+    { authToken = ""
+    , clusterName = ""
+    , csrfToken = ""
+    , expandedTeams = Set.empty
+    , hovered = HoverState.NoHover
+    , isSideBarOpen = False
+    , notFoundImgSrc = ""
+    , pipelineRunningKeyframes = ""
+    , pipelines = RemoteData.NotAsked
+    , screenSize = ScreenSize.Desktop
+    , timeZone = Time.utc
+    , turbulenceImgSrc = ""
+    , userState = UserState.UserStateLoggedOut
+    }
+
+
+sampleModel : Build.Models.Model
+sampleModel =
+    { page = Build.Models.OneOffBuildPage 0
+    , now = Nothing
+    , disableManualTrigger = False
+    , history = []
+    , nextPage = Nothing
+    , currentBuild =
+        RemoteData.Success
+            { build =
+                { id = 0
+                , name = "0"
+                , job = Nothing
+                , status = Concourse.BuildStatusStarted
+                , duration =
+                    { startedAt = Nothing
+                    , finishedAt = Nothing
+                    }
+                , reapTime = Nothing
+                }
+            , prep = Nothing
+            , output =
+                Build.Models.Output
+                    { steps = steps
+                    , state = Build.Output.Models.StepsLiveUpdating
+                    , eventSourceOpened = True
+                    , eventStreamUrlPath = Nothing
+                    , highlight = Routes.HighlightNothing
+                    }
+            }
+    , browsingIndex = 0
+    , autoScroll = True
+    , previousKeyPress = Nothing
+    , shiftDown = False
+    , previousTriggerBuildByKey = False
+    , showHelp = False
+    , highlight = Routes.HighlightNothing
+    , hoveredCounter = 0
+    , fetchingHistory = False
+    , scrolledToCurrentBuild = True
+    , authorized = True
+    , isUserMenuExpanded = False
+    }
+
+
+ansiLogStyle : Ansi.Log.Style
+ansiLogStyle =
+    { foreground = Nothing
+    , background = Nothing
+    , bold = False
+    , faint = False
+    , italic = False
+    , underline = False
+    , blink = False
+    , inverted = False
+    , fraktur = False
+    , framed = False
+    }
+
+
+position : Ansi.Log.CursorPosition
+position =
+    { row = 0
+    , column = 0
+    }
+
+
+log : Ansi.Log.Model
+log =
+    { lineDiscipline = Ansi.Log.Cooked
+    , lines = Array.empty
+    , position = position
+    , savedPosition = Nothing
+    , style = ansiLogStyle
+    , remainder = ""
+    }
+
+
+tree : STModels.StepTree
+tree =
+    STModels.Task
+        { id = "stepid"
+        , name = "task_step"
+        , state = STModels.StepStateRunning
+        , log = log
+        , error = Nothing
+        , expanded = True
+        , version = Nothing
+        , metadata = []
+        , firstOccurrence = False
+        , timestamps = Dict.empty
+        , initialize = Nothing
+        , start = Nothing
+        , finish = Nothing
+        }
+
+
+steps : Maybe STModels.StepTreeModel
+steps =
+    Just
+        { tree = tree
+        , foci = Dict.empty
+        , highlight = Routes.HighlightNothing
+        , tooltip = Nothing
+        }
 
 
 sampleJob : String -> List String -> Concourse.Job
@@ -60,8 +807,8 @@ pipelineId =
     { pipelineName = "pipeline", teamName = "team" }
 
 
-view : List Concourse.Job -> Html msg
-view jobs =
+dashboardPreviewView : List Concourse.Job -> Html msg
+dashboardPreviewView jobs =
     let
         groups =
             jobGroups jobs

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -8,7 +8,6 @@ module Build.Output.Output exposing
     )
 
 import Ansi.Log
-import Application.Models exposing (Session)
 import Array
 import Build.Output.Models exposing (OutputModel, OutputState(..))
 import Build.StepTree.Models as StepTree
@@ -23,6 +22,7 @@ import Build.StepTree.StepTree
 import Concourse
 import Concourse.BuildStatus
 import Dict
+import HoverState
 import Html exposing (Html)
 import Html.Attributes exposing (class)
 import Message.Effects exposing (Effect(..))
@@ -333,13 +333,16 @@ setStepFinish mtime tree =
     StepTree.map (\step -> { step | finish = mtime }) tree
 
 
-view : Session -> OutputModel -> Html Message
+view :
+    { timeZone : Time.Zone, hovered : HoverState.HoverState }
+    -> OutputModel
+    -> Html Message
 view session { steps, state } =
     Html.div [ class "steps" ] [ viewStepTree session steps state ]
 
 
 viewStepTree :
-    Session
+    { timeZone : Time.Zone, hovered : HoverState.HoverState }
     -> Maybe StepTreeModel
     -> OutputState
     -> Html Message

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -10,7 +10,6 @@ module Build.StepTree.StepTree exposing
     )
 
 import Ansi.Log
-import Application.Models exposing (Session)
 import Array exposing (Array)
 import Build.Models exposing (StepHeaderType(..))
 import Build.StepTree.Models
@@ -415,7 +414,7 @@ updateTooltip { hovered } { hoveredCounter } model =
 
 
 view :
-    Session
+    { timeZone : Time.Zone, hovered : HoverState.HoverState }
     -> StepTreeModel
     -> Html Message
 view session model =
@@ -423,7 +422,7 @@ view session model =
 
 
 viewTree :
-    Session
+    { timeZone : Time.Zone, hovered : HoverState.HoverState }
     -> StepTreeModel
     -> StepTree
     -> Html Message
@@ -493,7 +492,7 @@ viewTree session model tree =
 
 
 viewTab :
-    Session
+    { timeZone : Time.Zone, hovered : HoverState.HoverState }
     -> StepID
     -> Int
     -> Int
@@ -522,12 +521,12 @@ viewTab { hovered } id currentTab idx step =
         [ Html.text (String.fromInt tab) ]
 
 
-viewSeq : Session -> StepTreeModel -> StepTree -> Html Message
+viewSeq : { timeZone : Time.Zone, hovered : HoverState.HoverState } -> StepTreeModel -> StepTree -> Html Message
 viewSeq session model tree =
     Html.div [ class "seq" ] [ viewTree session model tree ]
 
 
-viewHooked : Session -> String -> StepTreeModel -> StepTree -> StepTree -> Html Message
+viewHooked : { timeZone : Time.Zone, hovered : HoverState.HoverState } -> String -> StepTreeModel -> StepTree -> StepTree -> Html Message
 viewHooked session name model step hook =
     Html.div [ class "hooked" ]
         [ Html.div [ class "step" ] [ viewTree session model step ]
@@ -542,7 +541,7 @@ isActive state =
     state /= StepStatePending && state /= StepStateCancelled
 
 
-viewStep : StepTreeModel -> Session -> Step -> StepHeaderType -> Html Message
+viewStep : StepTreeModel -> { timeZone : Time.Zone, hovered : HoverState.HoverState } -> Step -> StepHeaderType -> Html Message
 viewStep model session { id, name, log, state, error, expanded, version, metadata, timestamps, initialize, start, finish } headerType =
     Html.div
         [ classList


### PR DESCRIPTION
branched off of #4110, please merge it first.

There was a lot of delicate research that went into this PR, documented at
https://github.com/pivotal-jamie-klassen/lazy (in `story.md`). We will probably
publish a technical blog post documenting these findings. Long story short,
it wasn't the map of functions that caused the problem, but some leakiness
in record update syntax in Elm.

fixes #4061