### PR TITLE
web: add red border to failing steps

### DIFF
--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -555,7 +555,7 @@ viewStep model session { id, name, log, state, error, expanded, version, metadat
             ([ class "header"
              , onClick <| Click <| StepHeader id
              ]
-                ++ Styles.stepHeader
+                ++ Styles.stepHeader state
             )
             [ Html.div
                 [ style "display" "flex" ]

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -146,12 +146,15 @@ stepHeader : StepState -> List (Html.Attribute msg)
 stepHeader state =
     [ style "display" "flex"
     , style "justify-content" "space-between"
-    , case state of
-        StepStateFailed ->
-            style "border" "1px solid #C24433"
+    , style "border" <|
+        "1px solid "
+            ++ (case state of
+                    StepStateFailed ->
+                        Colors.failure
 
-        _ ->
-            style "border" "none"
+                    _ ->
+                        Colors.frame
+               )
     ]
 
 

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -19,6 +19,7 @@ module Build.Styles exposing
 
 import Application.Styles
 import Build.Models exposing (StepHeaderType(..))
+import Build.StepTree.Models exposing (StepState(..))
 import Colors
 import Concourse
 import Dashboard.Styles exposing (striped)
@@ -141,10 +142,16 @@ triggerTooltip =
     ]
 
 
-stepHeader : List (Html.Attribute msg)
-stepHeader =
+stepHeader : StepState -> List (Html.Attribute msg)
+stepHeader state =
     [ style "display" "flex"
     , style "justify-content" "space-between"
+    , case state of
+        StepStateFailed ->
+            style "border" "1px solid #C24433"
+
+        _ ->
+            style "border" "none"
     ]
 
 

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -152,7 +152,22 @@ stepHeader state =
                     StepStateFailed ->
                         Colors.failure
 
-                    _ ->
+                    StepStateErrored ->
+                        Colors.error
+
+                    StepStatePending ->
+                        Colors.frame
+
+                    StepStateRunning ->
+                        Colors.frame
+
+                    StepStateInterrupted ->
+                        Colors.frame
+
+                    StepStateCancelled ->
+                        Colors.frame
+
+                    StepStateSucceeded ->
                         Colors.frame
                )
     ]

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -3217,7 +3217,7 @@ all =
                         >> Common.queryView
                         >> Query.find [ class "header" ]
                         >> Query.has
-                            [ style "border" "none" ]
+                            [ style "border" <| "1px solid " ++ Colors.frame ]
                 , test "failing step has a red border" <|
                     fetchPlanWithGetStep
                         >> Application.handleDelivery
@@ -3238,7 +3238,7 @@ all =
                         >> Common.queryView
                         >> Query.find [ class "header" ]
                         >> Query.has
-                            [ style "border" "1px solid #C24433" ]
+                            [ style "border" <| "1px solid " ++ Colors.failure ]
                 , test "network error on first event shows passport officer" <|
                     let
                         imgUrl =

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -3194,6 +3194,51 @@ all =
                                 }
                                 ++ [ style "background-size" "14px 14px" ]
                             )
+                , test "successful step has no border" <|
+                    fetchPlanWithGetStep
+                        >> Application.handleDelivery
+                            (EventsReceived <|
+                                Ok <|
+                                    [ { url =
+                                            eventsUrl
+                                      , data =
+                                            STModels.FinishGet
+                                                { source = "stdout"
+                                                , id = "plan"
+                                                }
+                                                0
+                                                Dict.empty
+                                                []
+                                                Nothing
+                                      }
+                                    ]
+                            )
+                        >> Tuple.first
+                        >> Common.queryView
+                        >> Query.find [ class "header" ]
+                        >> Query.has
+                            [ style "border" "none" ]
+                , test "failing step has a red border" <|
+                    fetchPlanWithGetStep
+                        >> Application.handleDelivery
+                            (EventsReceived <|
+                                Ok <|
+                                    [ { url = eventsUrl
+                                      , data =
+                                            STModels.FinishGet
+                                                { source = "stdout", id = "plan" }
+                                                1
+                                                Dict.empty
+                                                []
+                                                Nothing
+                                      }
+                                    ]
+                            )
+                        >> Tuple.first
+                        >> Common.queryView
+                        >> Query.find [ class "header" ]
+                        >> Query.has
+                            [ style "border" "1px solid #C24433" ]
                 , test "network error on first event shows passport officer" <|
                     let
                         imgUrl =


### PR DESCRIPTION
fixes #4111


# Release Note
```tex
\note{feature}{
  We noticed after \link{PR #4058}{https://github.com/concourse/concourse/pull/4058} 
  (where build steps are collapsed by default) that it wasn't very easy to see failing steps.
  
  Now a failed step has a simple red border around its header and an erroring step has an
  orange border
  \link{#4164}{https://github.com/concourse/concourse/pull/4164} 
}
```