### PR TITLE
[bugfix] Do not trigger Garden error when asking for container property.

### DIFF
--- a/atc/resource/resource_get_test.go
+++ b/atc/resource/resource_get_test.go
@@ -152,20 +152,13 @@ var _ = Describe("Resource Get", func() {
 
 		Context("when a result is already present on the container", func() {
 			BeforeEach(func() {
-				fakeContainer.PropertyStub = func(name string) (string, error) {
-					switch name {
-					case "concourse:resource-result":
-						return `{
-						"version": {"some": "new-version"},
-						"metadata": [
-							{"name": "a", "value":"a-value"},
-							{"name": "b","value": "b-value"}
-						]
-					}`, nil
-					default:
-						return "", errors.New("unstubbed property: " + name)
-					}
-				}
+				fakeContainer.PropertiesReturns(garden.Properties{"concourse:resource-result": `{
+					"version": {"some": "new-version"},
+					"metadata": [
+						{"name": "a", "value":"a-value"},
+						{"name": "b","value": "b-value"}
+					]
+				}`}, nil)
 			})
 
 			It("exits successfully", func() {
@@ -188,9 +181,7 @@ var _ = Describe("Resource Get", func() {
 
 		Context("when /in has already been spawned", func() {
 			BeforeEach(func() {
-				fakeContainer.PropertyStub = func(name string) (string, error) {
-					return "", errors.New("unstubbed property: " + name)
-				}
+				fakeContainer.PropertiesReturns(nil, nil)
 			})
 
 			It("reattaches to it", func() {
@@ -294,13 +285,7 @@ var _ = Describe("Resource Get", func() {
 
 		Context("when /in has not yet been spawned", func() {
 			BeforeEach(func() {
-				fakeContainer.PropertyStub = func(name string) (string, error) {
-					switch name {
-					default:
-						return "", errors.New("unstubbed property: " + name)
-					}
-				}
-
+				fakeContainer.PropertiesReturns(nil, nil)
 				attachInError = errors.New("not found")
 			})
 

--- a/atc/resource/resource_put_test.go
+++ b/atc/resource/resource_put_test.go
@@ -103,20 +103,13 @@ var _ = Describe("Resource Put", func() {
 
 		Context("when a result is already present on the container", func() {
 			BeforeEach(func() {
-				fakeContainer.PropertyStub = func(name string) (string, error) {
-					switch name {
-					case "concourse:resource-result":
-						return `{
-						"version": {"some": "new-version"},
-						"metadata": [
-							{"name": "a", "value":"a-value"},
-							{"name": "b","value": "b-value"}
-						]
-					}`, nil
-					default:
-						return "", errors.New("unstubbed property: " + name)
-					}
-				}
+				fakeContainer.PropertiesReturns(garden.Properties{"concourse:resource-result": `{
+					"version": {"some": "new-version"},
+					"metadata": [
+						{"name": "a", "value":"a-value"},
+						{"name": "b","value": "b-value"}
+					]
+				}`}, nil)
 			})
 
 			It("exits successfully", func() {
@@ -140,9 +133,7 @@ var _ = Describe("Resource Put", func() {
 
 		Context("when /out has already been spawned", func() {
 			BeforeEach(func() {
-				fakeContainer.PropertyStub = func(name string) (string, error) {
-					return "", errors.New("unstubbed property: " + name)
-				}
+				fakeContainer.PropertiesReturns(nil, nil)
 			})
 
 			It("reattaches to it", func() {
@@ -233,13 +224,7 @@ var _ = Describe("Resource Put", func() {
 
 		Context("when /out has not yet been spawned", func() {
 			BeforeEach(func() {
-				fakeContainer.PropertyStub = func(name string) (string, error) {
-					switch name {
-					default:
-						return "", errors.New("unstubbed property: " + name)
-					}
-				}
-
+				fakeContainer.PropertiesReturns(nil, nil)
 				attachOutError = errors.New("not-found")
 			})
 

--- a/atc/resource/run_script.go
+++ b/atc/resource/run_script.go
@@ -52,9 +52,10 @@ func (resource *resource) runScript(
 	}
 
 	if recoverable {
-		result, err := resource.container.Property(resourceResultPropertyName)
-		if err == nil {
-			return json.Unmarshal([]byte(result), &output)
+		result, _ := resource.container.Properties()
+		code := result[resourceResultPropertyName]
+		if code != "" {
+			return json.Unmarshal([]byte(code), &output)
 		}
 	}
 

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -161,16 +161,18 @@ func (client *client) RunTaskStep(
 	}
 
 	// container already exited
-	exitStatusProp, err := container.Property(taskExitStatusPropertyName)
-	if err == nil {
-		logger.Info("already-exited", lager.Data{"status": exitStatusProp})
+	exitStatusProp, _ := container.Properties()
+	code := exitStatusProp[taskExitStatusPropertyName]
+	if code != "" {
+		logger.Info("already-exited", lager.Data{"status": taskExitStatusPropertyName})
 
-		status, err := strconv.Atoi(exitStatusProp)
+		status, err := strconv.Atoi(code)
 		if err != nil {
 			return TaskResult{-1, []VolumeMount{}, err}
 		}
 
 		return TaskResult{Status: status, VolumeMounts: container.VolumeMounts(), Err: nil}
+
 	}
 
 	processIO := garden.ProcessIO{

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -303,6 +303,7 @@ var _ = Describe("Client", func() {
 				Dir:  "/some/dir",
 			}
 			fakeContainer = new(workerfakes.FakeContainer)
+			fakeContainer.PropertiesReturns(garden.Properties{"concourse:exit-status": "0"}, nil)
 
 			fakeWorker = new(workerfakes.FakeWorker)
 			fakeWorker.NameReturns("some-worker")
@@ -332,7 +333,7 @@ var _ = Describe("Client", func() {
 		Context("choosing a worker", func() {
 			BeforeEach(func() {
 				// later fakes are uninitialized
-				fakeContainer.PropertyReturns("3", nil)
+				fakeContainer.PropertiesReturns(garden.Properties{"concourse:exit-status": "3"}, nil)
 			})
 
 			It("chooses a worker", func() {
@@ -347,6 +348,7 @@ var _ = Describe("Client", func() {
 
 					fakeContainer := new(workerfakes.FakeContainer)
 					fakeWorker.FindOrCreateContainerReturns(fakeContainer, nil)
+					fakeContainer.PropertiesReturns(garden.Properties{"concourse:exit-status": "0"}, nil)
 
 					fakeStrategy.ModifiesActiveTasksReturns(true)
 				})
@@ -385,12 +387,7 @@ var _ = Describe("Client", func() {
 
 		Context("found a container that has already exited", func() {
 			BeforeEach(func() {
-				fakeContainer.PropertyStub = func(prop string) (result string, err error) {
-					if prop == "concourse:exit-status" {
-						return "8", nil
-					}
-					return "", errors.New("unhandled property")
-				}
+				fakeContainer.PropertiesReturns(garden.Properties{"concourse:exit-status": "8"}, nil)
 			})
 
 			It("does not attach to any process", func() {
@@ -485,7 +482,7 @@ var _ = Describe("Client", func() {
 
 			BeforeEach(func() {
 				fakeProcess = new(gardenfakes.FakeProcess)
-				fakeContainer.PropertyReturns("", errors.New("not exited"))
+				fakeContainer.PropertiesReturns(garden.Properties{}, nil)
 
 				// for testing volume mounts being returned
 				fakeVolume1 = new(workerfakes.FakeVolume)
@@ -863,7 +860,7 @@ var _ = Describe("Client", func() {
 
 					Context("when saving the exit status succeeds", func() {
 						BeforeEach(func() {
-							fakeContainer.SetPropertyReturns(nil)
+							fakeContainer.PropertiesReturns(garden.Properties{"concourse:exit-status": "0"}, nil)
 						})
 
 						It("returns successfully", func() {


### PR DESCRIPTION
When querying Garden for a property that does not exist, Garden
logs an error message. This error message pollutes the Worker
logs as it doesn't really indicate that something wrong has
been going on.

By querying all properties and checking if the interested one
is among them we obtain the same result while avoiding Garden
to log an error.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>