### PR TITLE
fly : #2944 ability to sync without having `-t`

### DIFF
--- a/fly/commands/sync.go
+++ b/fly/commands/sync.go
@@ -17,21 +17,25 @@ import (
 
 type SyncCommand struct {
 	Force  bool   `long:"force" short:"f" description:"Sync even if versions already match."`
-	ATCURL string `short:"c" long:"concourse-url" description:"Concourse URL to authenticate with"`
+	ATCURL string `long:"concourse-url" short:"c" description:"Concourse URL to sync with"`
 }
 
 func (command *SyncCommand) Execute(args []string) error {
 	var target rc.Target
 	var err error
 
-	target, err = rc.NewUnauthenticatedTarget(
-		"dummy",
-		command.ATCURL,
-		"",
-		false,
-		"",
-		Fly.Verbose,
-	)
+	if Fly.Target != "" {
+		target, err = rc.LoadTarget(Fly.Target, Fly.Verbose)
+	} else {
+		target, err = rc.NewUnauthenticatedTarget(
+			"dummy",
+			command.ATCURL,
+			"",
+			false,
+			"",
+			Fly.Verbose,
+		)
+	}
 	if err != nil {
 		return err
 	}

--- a/fly/commands/sync.go
+++ b/fly/commands/sync.go
@@ -16,14 +16,26 @@ import (
 )
 
 type SyncCommand struct {
-	Force bool `long:"force" short:"f" description:"Sync even if versions already match."`
+	Force  bool   `long:"force" short:"f" description:"Sync even if versions already match."`
+	ATCURL string `short:"c" long:"concourse-url" description:"Concourse URL to authenticate with"`
 }
 
 func (command *SyncCommand) Execute(args []string) error {
-	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	var target rc.Target
+	var err error
+
+	target, err = rc.NewUnauthenticatedTarget(
+		"dummy",
+		command.ATCURL,
+		"",
+		false,
+		"",
+		Fly.Verbose,
+	)
 	if err != nil {
 		return err
 	}
+
 	info, err := target.Client().GetInfo()
 	if err != nil {
 		return err

--- a/fly/integration/sync_test.go
+++ b/fly/integration/sync_test.go
@@ -61,17 +61,9 @@ var _ = Describe("Syncing", func() {
 
 			flyVersion = fmt.Sprintf("%d.%d.%d", major, minor, patch+1)
 		})
+
 		It("downloads and replaces the currently running executable", func() {
-			flyCmd := exec.Command(flyPath, "-t", targetName, "sync")
-
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-
-			<-sess.Exited
-			Expect(sess.ExitCode()).To(Equal(0))
-
-			expected := []byte("this will totally execute")
-			expectBinaryToMatch(flyPath, expected[:8])
+			downloadAndReplaceExecutable(flyPath,"sync", "-c", atcServer.URL())
 		})
 
 		Context("When the user running sync doesn't have write permissions for the target directory", func() {
@@ -93,7 +85,7 @@ var _ = Describe("Syncing", func() {
 
 				expectedBinary := readBinary(flyPath)
 
-				flyCmd := exec.Command(flyPath, "-t", targetName, "sync")
+				flyCmd := exec.Command(flyPath, "sync", "-c", atcServer.URL())
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -114,7 +106,7 @@ var _ = Describe("Syncing", func() {
 		It("informs the user, and doesn't download/replace the executable", func() {
 			expectedBinary := readBinary(flyPath)
 
-			flyCmd := exec.Command(flyPath, "-t", targetName, "sync")
+			flyCmd := exec.Command(flyPath,"sync", "-c", atcServer.URL())
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -127,6 +119,19 @@ var _ = Describe("Syncing", func() {
 		})
 	})
 })
+
+func downloadAndReplaceExecutable(flyPath string, arg ...string) {
+	flyCmd := exec.Command(flyPath, arg...)
+
+	sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+
+	<-sess.Exited
+	Expect(sess.ExitCode()).To(Equal(0))
+
+	expected := []byte("this will totally execute")
+	expectBinaryToMatch(flyPath, expected[:8])
+}
 
 func readBinary(path string) []byte {
 	expectedBinary, err := ioutil.ReadFile(flyPath)

--- a/fly/integration/sync_test.go
+++ b/fly/integration/sync_test.go
@@ -62,8 +62,12 @@ var _ = Describe("Syncing", func() {
 			flyVersion = fmt.Sprintf("%d.%d.%d", major, minor, patch+1)
 		})
 
-		It("downloads and replaces the currently running executable", func() {
-			downloadAndReplaceExecutable(flyPath,"sync", "-c", atcServer.URL())
+		It("downloads and replaces the currently running executable with target", func() {
+			downloadAndReplaceExecutable(flyPath, "-t", targetName, "sync")
+		})
+
+		It("downloads and replaces the currently running executable with target URL", func() {
+			downloadAndReplaceExecutable(flyPath, "sync", "-c", atcServer.URL())
 		})
 
 		Context("When the user running sync doesn't have write permissions for the target directory", func() {
@@ -106,7 +110,7 @@ var _ = Describe("Syncing", func() {
 		It("informs the user, and doesn't download/replace the executable", func() {
 			expectedBinary := readBinary(flyPath)
 
-			flyCmd := exec.Command(flyPath,"sync", "-c", atcServer.URL())
+			flyCmd := exec.Command(flyPath, "sync", "-c", atcServer.URL())
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- removed any need for the `-t` flag
- added a new flag `-c` to specify the URL to sync t to specify the URL to sync to

Able to run `fly -t target sync -c concourse-url`