### PR TITLE
Fix the `pipeline-operator` tag

### DIFF
--- a/web/elm/src/Dashboard/Group/Tag.elm
+++ b/web/elm/src/Dashboard/Group/Tag.elm
@@ -31,10 +31,10 @@ view : Bool -> Tag -> Html msg
 view isHd t =
     Html.div
         ([ style "border" ("1px solid " ++ Colors.white)
+         , style "display" "inline-block"
          , style "font-size" "0.7em"
-         , style "padding" "0.5em 0"
+         , style "padding" "0.5em"
          , style "line-height" "0.9em"
-         , style "width" "6em"
          , style "text-align" "center"
          , style "letter-spacing" "0.2em"
          ]

--- a/web/elm/tests/TagTests.elm
+++ b/web/elm/tests/TagTests.elm
@@ -35,17 +35,17 @@ all =
         in
         [ fuzz tag "has a white border" <|
             hasStyle [ ( "border", "1px solid " ++ white ) ]
+        , fuzz tag "is an inline-block" <|
+            hasStyle [ ( "display", "inline-block" ) ]
         , fuzz tag "has very small font" <|
             hasStyle [ ( "font-size", "0.7em" ) ]
         , fuzz tag "letters are spaced apart" <|
             hasStyle [ ( "letter-spacing", "0.2em" ) ]
         , fuzz tag "has a bit of padding above and below" <|
             hasStyle
-                [ ( "padding", "0.5em 0" )
+                [ ( "padding", "0.5em" )
                 , ( "line-height", "0.9em" )
                 ]
-        , fuzz tag "has a fixed width of 8 character widths" <|
-            hasStyle [ ( "width", "6em" ) ]
         , fuzz tag "text is horizontally centered in the white box" <|
             hasStyle [ ( "text-align", "center" ) ]
         ]


### PR DESCRIPTION
## What

The tag, is longer than the currently designed box allowing 8 characters
of text. This is not elegant and could look a little better.

This does however mean, all the tags are now not fixed and have variable
width.


### Before

![Screen Shot 2019-07-26 at 16 16 19](https://user-images.githubusercontent.com/2418945/61962390-4accde80-afc1-11e9-89a5-32dcb5955079.png)
![Screen Shot 2019-07-26 at 16 13 23](https://user-images.githubusercontent.com/2418945/61962391-4accde80-afc1-11e9-9cfe-bc48721e8240.png)

### After

![Screen Shot 2019-07-26 at 16 16 27](https://user-images.githubusercontent.com/2418945/61962400-502a2900-afc1-11e9-9b66-4ba7ec2f4f04.png)
![Screen Shot 2019-07-26 at 16 13 29](https://user-images.githubusercontent.com/2418945/61962399-502a2900-afc1-11e9-9478-c17f7d997c89.png)

## How to review

- Sanity check
- Perhaps run it and test it (I've only tested this by fiddling with dev tools)
