### PR TITLE
Fixes a bug where the 'not authorized' div covers the sidebar

### DIFF
--- a/web/assets/css/notauthorized.less
+++ b/web/assets/css/notauthorized.less
@@ -1,5 +1,5 @@
 .not-authorized {
-  position: absolute;
+  position: relative;
   top: 0;
   left: 0;
   bottom: 0;


### PR DESCRIPTION
This fixes https://github.com/concourse/concourse/issues/4190