### PR TITLE
use position fixed so tooltips can 'float' outside the container

### DIFF
--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -856,6 +856,8 @@ viewDurationTooltip minit mstart mfinish tooltip =
                 [ Html.div
                     [ style "position" "inherit"
                     , style "margin-left" "-500px"
+                    , style "display" "flex"
+                    , style "justify-content" "flex-end"
                     ]
                     [ Html.div
                         Styles.durationTooltip

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -187,9 +187,8 @@ stepStatusIcon =
 
 firstOccurrenceTooltip : List (Html.Attribute msg)
 firstOccurrenceTooltip =
-    [ style "position" "absolute"
-    , style "left" "0"
-    , style "bottom" "100%"
+    [ style "position" "fixed"
+    , style "transform" "translate(0, -100%)"
     , style "background-color" Colors.tooltipBackground
     , style "padding" "5px"
     , style "z-index" "100"
@@ -214,9 +213,8 @@ firstOccurrenceTooltipArrow =
 
 durationTooltip : List (Html.Attribute msg)
 durationTooltip =
-    [ style "position" "absolute"
-    , style "right" "0"
-    , style "bottom" "100%"
+    [ style "position" "fixed"
+    , style "transform" "translate(0, -100%)"
     , style "background-color" Colors.tooltipBackground
     , style "padding" "5px"
     , style "z-index" "100"

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1508,7 +1508,7 @@ all =
                             [ attribute <|
                                 Attr.attribute "aria-label" "Trigger Build"
                             ]
-                , test """page contents lay out vertically, filling available 
+                , test """page contents lay out vertically, filling available
                           space without scrolling horizontally""" <|
                     givenHistoryAndDetailsFetched
                         >> Tuple.first
@@ -2755,14 +2755,11 @@ all =
                                 [ style "position" "relative"
                                 , containing
                                     [ containing [ text "new version" ]
-                                    , style "position" "absolute"
-                                    , style "left" "0"
-                                    , style "bottom" "100%"
+                                    , style "position" "fixed"
                                     , style "background-color" tooltipGreyHex
                                     , style "padding" "5px"
                                     , style "z-index" "100"
                                     , style "width" "6em"
-                                    , style "pointer-events" "none"
                                     , style "cursor" "default"
                                     , style "user-select" "none"
                                     , style "-ms-user-select" "none"
@@ -2770,6 +2767,12 @@ all =
                                     , style "-khtml-user-select" "none"
                                     , style "-webkit-user-select" "none"
                                     , style "-webkit-touch-callout" "none"
+                                    , style "transform" "translate(0, -100%)"
+                                    , style "background-color" Colors.tooltipBackground
+                                    , style "padding" "5px"
+                                    , style "z-index" "100"
+                                    , style "width" "6em"
+                                    , style "pointer-events" "none"
                                     ]
                                 , containing
                                     [ style "width" "0"


### PR DESCRIPTION
fixes #3921 and also the same bug in the duration tooltip on the right hand side of steps.

before and after:

<img width="316" alt="duration-current" src="https://user-images.githubusercontent.com/176209/62292120-8a7e4500-b45d-11e9-857f-5bd1212c1087.png"> <img width="313" alt="duration-updated" src="https://user-images.githubusercontent.com/176209/62292124-8ce09f00-b45d-11e9-8b4c-04b289a04a37.png">

<img width="213" alt="first-occurrence-current" src="https://user-images.githubusercontent.com/176209/62291923-12178400-b45d-11e9-8400-e8ccd1916867.png"> <img width="234" alt="first-occurrence-updated" src="https://user-images.githubusercontent.com/176209/62291954-20fe3680-b45d-11e9-80c8-d0d3554b2606.png">
