### PR TITLE
fix coercion of null task params to strings

### DIFF
--- a/atc/task.go
+++ b/atc/task.go
@@ -175,6 +175,10 @@ func (cs *CoercedString) UnmarshalJSON(p []byte) error {
 		return err
 	}
 
+	if raw == nil {
+		*cs = CoercedString("")
+		return nil
+	}
 	switch v := raw.(type) {
 	case string:
 		*cs = CoercedString(v)

--- a/atc/task_test.go
+++ b/atc/task_test.go
@@ -140,6 +140,20 @@ run: {path: a/file}
 					Expect(err).ToNot(HaveOccurred())
 					Expect(config.Params["testParam"]).To(Equal(`{"foo":"bar"}`))
 				})
+
+				It("converts empty values to empty string in params", func() {
+					data := []byte(`
+platform: beos
+
+params:
+  testParam:
+
+run: {path: a/file}
+`)
+					config, err := NewTaskConfig(data)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(config.Params["testParam"]).To(Equal(""))
+				})
 			})
 
 			Context("given a valid task config with numeric params", func() {

--- a/fly/integration/execute_test.go
+++ b/fly/integration/execute_test.go
@@ -71,6 +71,7 @@ params:
   FOO: bar
   BAZ: buzz
   X: 1
+  EMPTY:
 
 run:
   path: find
@@ -106,9 +107,10 @@ run:
 						{Name: "fixture"},
 					},
 					Params: map[string]string{
-						"FOO": "bar",
-						"BAZ": "buzz",
-						"X":   "1",
+						"FOO":   "bar",
+						"BAZ":   "buzz",
+						"X":     "1",
+						"EMPTY": "",
 					},
 					Run: atc.TaskRunConfig{
 						Path: "find",
@@ -586,6 +588,7 @@ params:
   FOO: bar
   BAZ: buzz
   X: 1
+  EMPTY:
 
 run:
   path: find
@@ -675,6 +678,7 @@ params:
   FOO: bar
   BAZ: buzz
   X: 1
+  EMPTY:
 
 run:
   path: find
@@ -776,9 +780,10 @@ run:
 	Context("when parameters are specified in the environment", func() {
 		BeforeEach(func() {
 			(*expectedPlan.Do)[1].Task.Config.Params = map[string]string{
-				"FOO": "newbar",
-				"BAZ": "buzz",
-				"X":   "",
+				"FOO":   "newbar",
+				"BAZ":   "buzz",
+				"X":     "",
+				"EMPTY": "",
 			}
 		})
 


### PR DESCRIPTION
fixes #4205

As I thought, #3505 was the culprit. The fly integration test technically only covers fly's use of this unmarshalling, but I performed another manual test. If you run:

1.
        $ fly -t dev set-pipeline -n -p pipeline -c <(cat <<EOF
        jobs:
        - name: job
          plan:
          - task: create-task
            config:
              platform: linux
              image_resource:
                type: registry-image
                source: {repository: busybox}
              outputs:
              - name: output
              run:
                path: sh
                args:
                - -c
                - |
                  cat > output/task.yml <<EOT
                  platform: linux
                  image_resource:
                    type: registry-image
                    source: {repository: busybox}
                  params:
                    PARAM:
                  run:
                    path: env
                  EOT
          - task: run-task
            file: output/task.yml
        EOF
        )
1. `fly -t dev up -p pipeline`
1. `fly -t dev tj -w -j pipeline/job`

you get the expected output with `PARAM=` instead of `PARAM=null`. This means that the right logic is being invoked on the server side, even when dynamically resolving a task from a file. I think the unit test in `atc/task_test.go` does enough to cover the important logic and this is just a comforting manual acceptance test, not worth adding to the automated suite.