### PR TITLE
clearer errors and logging for limit-active-tasks

### DIFF
--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -20,7 +20,7 @@ const (
 	LockTypeVolumeCreating
 	LockTypeContainerCreating
 	LockTypeDatabaseMigration
-	LockTypeTaskStep
+	LockTypeActiveTasks
 )
 
 var ErrLostLock = errors.New("lock was lost while held, possibly due to connection breakage")
@@ -45,16 +45,12 @@ func NewVolumeCreatingLockID(volumeID int) LockID {
 	return LockID{LockTypeVolumeCreating, volumeID}
 }
 
-func NewContainerCreatingLockID() LockID {
-	return LockID{LockTypeContainerCreating}
-}
-
 func NewDatabaseMigrationLockID() LockID {
 	return LockID{LockTypeDatabaseMigration}
 }
 
-func NewTaskStepLockID() LockID {
-	return LockID{LockTypeTaskStep}
+func NewActiveTasksLockID() LockID {
+	return LockID{LockTypeActiveTasks}
 }
 
 //go:generate counterfeiter . LockFactory

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -176,8 +176,6 @@ func (step *TaskStep) Run(ctx context.Context, state RunState) error {
 		config.Limits.Memory = step.defaultLimits.Memory
 	}
 
-
-
 	step.delegate.Initializing(logger, config)
 
 	workerSpec, err := step.workerSpec(logger, resourceTypes, repository, config)


### PR DESCRIPTION
As part of merging in changes from `limit-active-tasks` and refactoring the task step, we accidentally introduced an error in the logs where we tried to decrease the number of active tasks even if we were not using `limit-active-tasks`.

This PR fixes that, as well as cleaning up other logging and naming for better clarity.

Signed-off-by: Denise Yu <dyu@pivotal.io>
Co-authored-by: Divya Dadlani <ddadlani@pivotal.io>