### PR TITLE
feat[exec]: enable on_failure to access failed resource

### DIFF
--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -464,6 +464,35 @@ var _ = Describe("GetStep", func() {
 			It("is not successful", func() {
 				Expect(getStep.Succeeded()).To(BeFalse())
 			})
+
+			Context("when registerUponFailure is true", func() {
+				JustBeforeEach(func() {
+					plan := atc.Plan{
+						ID:  atc.PlanID(planID),
+						Get: getPlan,
+					}
+
+					getStep = exec.NewGetStep(
+						plan.ID,
+						*plan.Get,
+						stepMetadata,
+						containerMetadata,
+						fakeSecretManager,
+						fakeResourceFetcher,
+						fakeResourceCacheFactory,
+						fakeStrategy,
+						fakePool,
+						fakeDelegate,
+					)
+					getStep.(*exec.GetStep).SetRegisterUponFailure(true)
+
+					stepErr = getStep.Run(ctx, state)
+				})
+
+				It("should still register resource", func() {
+					Expect(state.ArtifactsCallCount()).To(Equal(1))
+				})
+			})
 		})
 	})
 

--- a/atc/exec/on_failure_test.go
+++ b/atc/exec/on_failure_test.go
@@ -3,6 +3,13 @@ package exec_test
 import (
 	"context"
 	"errors"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/creds/credsfakes"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbfakes"
+	"github.com/concourse/concourse/atc/resource"
+	"github.com/concourse/concourse/atc/resource/resourcefakes"
+	"github.com/concourse/concourse/atc/worker/workerfakes"
 
 	"github.com/concourse/concourse/atc/exec"
 	"github.com/concourse/concourse/atc/exec/artifact"
@@ -142,6 +149,186 @@ var _ = Describe("On Failure Step", func() {
 
 			It("returns true", func() {
 				Expect(onFailureStep.Succeeded()).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("updateGetStep", func() {
+		var getStep exec.Step
+
+		BeforeEach(func() {
+			//testLogger := lagertest.NewTestLogger("get-action-test")
+			ctx, cancel = context.WithCancel(context.Background())
+
+			//fakeWorker := new(workerfakes.FakeWorker)
+			fakeResourceFetcher := new(resourcefakes.FakeFetcher)
+			fakePool := new(workerfakes.FakePool)
+			fakeStrategy := new(workerfakes.FakeContainerPlacementStrategy)
+			fakeResourceCacheFactory := new(dbfakes.FakeResourceCacheFactory)
+
+			fakeSecretManager := new(credsfakes.FakeSecrets)
+			fakeSecretManager.GetReturns("super-secret-source", nil, true, nil)
+
+			artifactRepository := artifact.NewRepository()
+			state = new(execfakes.FakeRunState)
+			state.ArtifactsReturns(artifactRepository)
+
+			fakeVersionedSource := new(resourcefakes.FakeVersionedSource)
+			fakeResourceFetcher.FetchReturns(fakeVersionedSource, nil)
+
+			fakeDelegate := new(execfakes.FakeGetDelegate)
+
+			uninterpolatedResourceTypes := atc.VersionedResourceTypes{
+				{
+					ResourceType: atc.ResourceType{
+						Name:   "custom-resource",
+						Type:   "custom-type",
+						Source: atc.Source{"some-custom": "((source-param))"},
+					},
+					Version: atc.Version{"some-custom": "version"},
+				},
+			}
+
+			containerMetadata := db.ContainerMetadata{
+				WorkingDirectory: resource.ResourcesDir("get"),
+				PipelineID:       4567,
+				Type:             db.ContainerTypeGet,
+				StepName:         "some-step",
+			}
+
+			stepMetadata := exec.StepMetadata{
+				TeamID:       123,
+				TeamName:     "some-team",
+				BuildID:      42,
+				BuildName:    "some-build",
+				PipelineID:   4567,
+				PipelineName: "some-pipeline",
+			}
+
+			getPlan := &atc.GetPlan{
+				Name:                   "some-name",
+				Type:                   "some-resource-type",
+				Source:                 atc.Source{"some": "((source-param))"},
+				Params:                 atc.Params{"some-param": "some-value"},
+				Tags:                   []string{"some", "tags"},
+				Version:                &atc.Version{"some-version": "some-value"},
+				VersionedResourceTypes: uninterpolatedResourceTypes,
+			}
+
+			plan := atc.Plan{
+				ID:  atc.PlanID(67),
+				Get: getPlan,
+			}
+
+			getStep = exec.NewGetStep(
+				plan.ID,
+				*plan.Get,
+				stepMetadata,
+				containerMetadata,
+				fakeSecretManager,
+				fakeResourceFetcher,
+				fakeResourceCacheFactory,
+				fakeStrategy,
+				fakePool,
+				fakeDelegate,
+			)
+
+
+		})
+
+		Context("GetStep", func() {
+			BeforeEach(func() {
+				onFailureStep = exec.OnFailure(getStep, hook)
+				onFailureStep.Run(ctx, state)
+			})
+
+			It("Should set registerUponFailure of GetStep", func() {
+				Expect(getStep.(*exec.GetStep).GetRegisterUponFailure()).To(BeTrue())
+			})
+		})
+
+		Context("AggregateStep", func() {
+			BeforeEach(func() {
+				aggregateStep := exec.AggregateStep{getStep}
+				onFailureStep = exec.OnFailure(aggregateStep, hook)
+				onFailureStep.Run(ctx, state)
+			})
+
+			It("Should set registerUponFailure of GetStep", func() {
+				Expect(getStep.(*exec.GetStep).GetRegisterUponFailure()).To(BeTrue())
+			})
+		})
+
+		Context("InParallelStep", func() {
+			BeforeEach(func() {
+				inParallelStep := exec.InParallel([]exec.Step{getStep}, 5, true)
+				onFailureStep = exec.OnFailure(inParallelStep, hook)
+				onFailureStep.Run(ctx, state)
+			})
+
+			It("Should set registerUponFailure of GetStep", func() {
+				Expect(getStep.(*exec.GetStep).GetRegisterUponFailure()).To(BeTrue())
+			})
+		})
+
+		Context("LogErrorStep", func() {
+			BeforeEach(func() {
+				fakeDelegate := new(execfakes.FakeGetDelegate)
+				logErrorStep := exec.LogError(getStep, fakeDelegate)
+				onFailureStep = exec.OnFailure(logErrorStep, hook)
+				onFailureStep.Run(ctx, state)
+			})
+
+			It("Should set registerUponFailure of GetStep", func() {
+				Expect(getStep.(*exec.GetStep).GetRegisterUponFailure()).To(BeTrue())
+			})
+		})
+
+		Context("OnSuccessStep-1", func() {
+			BeforeEach(func() {
+				onSuccessStep := exec.OnSuccess(getStep, hook)
+				onFailureStep = exec.OnFailure(onSuccessStep, hook)
+				onFailureStep.Run(ctx, state)
+			})
+
+			It("Should set registerUponFailure of GetStep", func() {
+				Expect(getStep.(*exec.GetStep).GetRegisterUponFailure()).To(BeTrue())
+			})
+		})
+
+		Context("OnSuccessStep-2", func() {
+			BeforeEach(func() {
+				onSuccessStep := exec.OnSuccess(hook, getStep)
+				onFailureStep = exec.OnFailure(onSuccessStep, hook)
+				onFailureStep.Run(ctx, state)
+			})
+
+			It("Should set registerUponFailure of GetStep", func() {
+				Expect(getStep.(*exec.GetStep).GetRegisterUponFailure()).To(BeTrue())
+			})
+		})
+
+		Context("TimeoutStep", func() {
+			BeforeEach(func() {
+				timeoutStep := exec.Timeout(getStep, "5m")
+				onFailureStep = exec.OnFailure(timeoutStep, hook)
+				onFailureStep.Run(ctx, state)
+			})
+
+			It("Should set registerUponFailure of GetStep", func() {
+				Expect(getStep.(*exec.GetStep).GetRegisterUponFailure()).To(BeTrue())
+			})
+		})
+
+		Context("TryStep", func() {
+			BeforeEach(func() {
+				tryStep := exec.Try(getStep)
+				onFailureStep = exec.OnFailure(tryStep, hook)
+				onFailureStep.Run(ctx, state)
+			})
+
+			It("Should set registerUponFailure of GetStep", func() {
+				Expect(getStep.(*exec.GetStep).GetRegisterUponFailure()).To(BeTrue())
 			})
 		})
 	})

--- a/atc/resource/fetcher.go
+++ b/atc/resource/fetcher.go
@@ -83,7 +83,7 @@ func (f *fetcher) Fetch(
 				if err == ErrFailedToGetLock {
 					break
 				}
-				return nil, err
+				return versionedSource, err
 			}
 
 			return versionedSource, nil

--- a/atc/resource/resource_get.go
+++ b/atc/resource/resource_get.go
@@ -33,7 +33,9 @@ func (resource *resource) Get(
 		true,
 	)
 	if err != nil {
-		return nil, err
+		vs := NewGetVersionedSource(volume, version, []atc.MetadataField{})
+		version["_err"] = err.Error()
+		return vs, err
 	}
 
 	return NewGetVersionedSource(volume, vr.Version, vr.Metadata), nil

--- a/atc/resource/resource_instance_fetch_source.go
+++ b/atc/resource/resource_instance_fetch_source.go
@@ -172,25 +172,25 @@ func (s *resourceInstanceFetchSource) Create(ctx context.Context) (VersionedSour
 	)
 	if err != nil {
 		sLog.Error("failed-to-fetch-resource", err)
-		return nil, err
+		return versionedSource, err
 	}
 
 	err = volume.SetPrivileged(false)
 	if err != nil {
 		sLog.Error("failed-to-set-volume-unprivileged", err)
-		return nil, err
+		return versionedSource, err
 	}
 
 	err = volume.InitializeResourceCache(s.resourceInstance.ResourceCache())
 	if err != nil {
 		sLog.Error("failed-to-initialize-cache", err)
-		return nil, err
+		return versionedSource, err
 	}
 
 	err = s.dbResourceCacheFactory.UpdateResourceCacheMetadata(s.resourceInstance.ResourceCache(), versionedSource.Metadata())
 	if err != nil {
 		s.logger.Error("failed-to-update-resource-cache-metadata", err, lager.Data{"resource-cache": s.resourceInstance.ResourceCache()})
-		return nil, err
+		return versionedSource, err
 	}
 
 	return versionedSource, nil

--- a/atc/resource/resource_instance_fetch_source_test.go
+++ b/atc/resource/resource_instance_fetch_source_test.go
@@ -169,6 +169,7 @@ var _ = Describe("ResourceInstanceFetchSource", func() {
 
 		BeforeEach(func() {
 			fakeResourceInstance.ResourceTypeReturns(resource.ResourceType("fake-resource-type"))
+			fakeResourceInstance.VersionReturns(atc.Version{"v": "1"})
 		})
 
 		JustBeforeEach(func() {


### PR DESCRIPTION
Without this feature, when a put/get follows an on_failure step, if put/get fails, on_failure will have no access to the failed resource, so that on_failure step has no idea why it failed. This feature enables on_failure to access the failed resource.

Signed-off-by: Chao Li <chaol@vmware.com>