### PR TITLE
[bugfix] Do not increase active_tasks if the container is already present.

### DIFF
--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -353,6 +353,15 @@ var _ = Describe("Client", func() {
 				It("increase the active tasks on the worker", func() {
 					Expect(fakeWorker.IncreaseActiveTasksCallCount()).To(Equal(1))
 				})
+
+				Context("when the container is already present on the worker", func() {
+					BeforeEach(func() {
+						fakePool.ContainerInWorkerReturns(true, nil)
+					})
+					It("does not increase the active tasks on the worker", func() {
+						Expect(fakeWorker.IncreaseActiveTasksCallCount()).To(Equal(0))
+					})
+				})
 			})
 
 			Context("when finding or choosing the worker fails", func() {

--- a/atc/worker/workerfakes/fake_pool.go
+++ b/atc/worker/workerfakes/fake_pool.go
@@ -11,6 +11,22 @@ import (
 )
 
 type FakePool struct {
+	ContainerInWorkerStub        func(lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec) (bool, error)
+	containerInWorkerMutex       sync.RWMutex
+	containerInWorkerArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 db.ContainerOwner
+		arg3 worker.ContainerSpec
+		arg4 worker.WorkerSpec
+	}
+	containerInWorkerReturns struct {
+		result1 bool
+		result2 error
+	}
+	containerInWorkerReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	FindOrChooseWorkerStub        func(lager.Logger, worker.WorkerSpec) (worker.Worker, error)
 	findOrChooseWorkerMutex       sync.RWMutex
 	findOrChooseWorkerArgsForCall []struct {
@@ -45,6 +61,72 @@ type FakePool struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakePool) ContainerInWorker(arg1 lager.Logger, arg2 db.ContainerOwner, arg3 worker.ContainerSpec, arg4 worker.WorkerSpec) (bool, error) {
+	fake.containerInWorkerMutex.Lock()
+	ret, specificReturn := fake.containerInWorkerReturnsOnCall[len(fake.containerInWorkerArgsForCall)]
+	fake.containerInWorkerArgsForCall = append(fake.containerInWorkerArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 db.ContainerOwner
+		arg3 worker.ContainerSpec
+		arg4 worker.WorkerSpec
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("ContainerInWorker", []interface{}{arg1, arg2, arg3, arg4})
+	fake.containerInWorkerMutex.Unlock()
+	if fake.ContainerInWorkerStub != nil {
+		return fake.ContainerInWorkerStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.containerInWorkerReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakePool) ContainerInWorkerCallCount() int {
+	fake.containerInWorkerMutex.RLock()
+	defer fake.containerInWorkerMutex.RUnlock()
+	return len(fake.containerInWorkerArgsForCall)
+}
+
+func (fake *FakePool) ContainerInWorkerCalls(stub func(lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec) (bool, error)) {
+	fake.containerInWorkerMutex.Lock()
+	defer fake.containerInWorkerMutex.Unlock()
+	fake.ContainerInWorkerStub = stub
+}
+
+func (fake *FakePool) ContainerInWorkerArgsForCall(i int) (lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec) {
+	fake.containerInWorkerMutex.RLock()
+	defer fake.containerInWorkerMutex.RUnlock()
+	argsForCall := fake.containerInWorkerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakePool) ContainerInWorkerReturns(result1 bool, result2 error) {
+	fake.containerInWorkerMutex.Lock()
+	defer fake.containerInWorkerMutex.Unlock()
+	fake.ContainerInWorkerStub = nil
+	fake.containerInWorkerReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePool) ContainerInWorkerReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.containerInWorkerMutex.Lock()
+	defer fake.containerInWorkerMutex.Unlock()
+	fake.ContainerInWorkerStub = nil
+	if fake.containerInWorkerReturnsOnCall == nil {
+		fake.containerInWorkerReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.containerInWorkerReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakePool) FindOrChooseWorker(arg1 lager.Logger, arg2 worker.WorkerSpec) (worker.Worker, error) {
@@ -182,6 +264,8 @@ func (fake *FakePool) FindOrChooseWorkerForContainerReturnsOnCall(i int, result1
 func (fake *FakePool) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.containerInWorkerMutex.RLock()
+	defer fake.containerInWorkerMutex.RUnlock()
 	fake.findOrChooseWorkerMutex.RLock()
 	defer fake.findOrChooseWorkerMutex.RUnlock()
 	fake.findOrChooseWorkerForContainerMutex.RLock()


### PR DESCRIPTION
This fixes a bug where the active_tasks counter (used in the limit-active-tasks strategy)
would be increased even if the container running the task is already present in the worker.

The above bug can manifest, for instance, if the ATC restarts.

To detect if a container is already present on a worker a small helper function is added
to Pool and queried it only when usign the limit-active-tasks strategy.

A test case is added to ensure the active_tasks counter is not increased when the container
is already present on the worker.

@xtreme-sameer-vohra first noticed this issue while reviewing #4118.
If this PR is accepted I'll also remove from the docs the warning that workers needs to be restarted to reset the counter.