### PR TITLE
Change `fly targets` to not error and bail

### DIFF
--- a/fly/commands/targets.go
+++ b/fly/commands/targets.go
@@ -1,12 +1,12 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"strconv"
 	"time"
 
-	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/dgrijalva/jwt-go"
@@ -31,7 +31,7 @@ func (command *TargetsCommand) Execute([]string) error {
 	}
 
 	for targetName, targetValues := range flyYAML.Targets {
-		expirationTime := GetExpirationFromString(targetValues.Token)
+		expirationTime := getExpirationFromString(targetValues.Token)
 
 		row := ui.TableRow{
 			{Contents: string(targetName)},
@@ -48,7 +48,7 @@ func (command *TargetsCommand) Execute([]string) error {
 	return table.Render(os.Stdout, Fly.PrintTableHeaders)
 }
 
-func GetExpirationFromString(token *rc.TargetToken) string {
+func getExpirationFromString(token *rc.TargetToken) string {
 	if token == nil || token.Type == "" || token.Value == "" {
 		return "n/a"
 	}
@@ -58,8 +58,7 @@ func GetExpirationFromString(token *rc.TargetToken) string {
 	})
 
 	if err != nil && err.Error() != jwt.ErrInvalidKeyType.Error() {
-		displayhelpers.FailWithErrorf("please login again.\n\ntoken validation failed with error ", err)
-		return "n/a"
+		return fmt.Sprintf("n/a: %s", err)
 	}
 
 	claims := parsedToken.Claims.(jwt.MapClaims)

--- a/fly/integration/targets_test.go
+++ b/fly/integration/targets_test.go
@@ -81,13 +81,13 @@ var _ = Describe("Fly CLI", func() {
 				flyrcFixture = "./fixtures/flyrc-badtoken.yml"
 			})
 
-			It("shows an error message", func() {
+			It("shows error message from jwt parsing library but does not fail", func() {
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(sess).Should(gexec.Exit(1))
+				Eventually(sess).Should(gexec.Exit(0))
 
-				Expect(sess.Err).To(gbytes.Say("token validation failed"))
+				Expect(sess).Should(gbytes.Say("n/a: token contains an invalid number of segments"))
 			})
 		})
 


### PR DESCRIPTION
* #4181 fixed the segfault, but introduced exiting 1
  if any targets had an expired or invalid token in .flyrc
* Append error message inline to display after "n/a" for each target

Signed-off-by: Sameer Vohra <svohra@pivotal.io>
Co-authored-by: Sameer Vohra <svohra@pivotal.io>