### PR TITLE
[#4200] prevent reconnect floods to Postgres

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1153,7 +1153,7 @@ func (cmd *RunCommand) configureMetrics(logger lager.Logger) error {
 func (cmd *RunCommand) constructDBConn(
 	driverName string,
 	logger lager.Logger,
-	maxConn int,
+	maxIdleConns int,
 	connectionName string,
 	lockFactory lock.LockFactory,
 ) (db.Conn, error) {
@@ -1172,7 +1172,8 @@ func (cmd *RunCommand) constructDBConn(
 	}
 
 	// Prepare
-	dbConn.SetMaxOpenConns(maxConn)
+	dbConn.SetMaxOpenConns(2 * maxIdleConns)
+	dbConn.SetMaxIdleConns(maxIdleConns)
 
 	return dbConn, nil
 }
@@ -1187,8 +1188,8 @@ func (cmd *RunCommand) constructLockConn(driverName string) (*sql.DB, error) {
 		return nil, err
 	}
 
-	dbConn.SetMaxOpenConns(1)
-	dbConn.SetMaxIdleConns(1)
+	dbConn.SetMaxOpenConns(10)
+	dbConn.SetMaxIdleConns(5)
 	dbConn.SetConnMaxLifetime(0)
 
 	return dbConn, nil

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1190,6 +1190,7 @@ func (cmd *RunCommand) constructLockConn(driverName string) (*sql.DB, error) {
 		return nil, err
 	}
 
+	dbConn.SetMaxOpenConns(1)
 	dbConn.SetMaxIdleConns(1)
 	dbConn.SetConnMaxLifetime(0)
 

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -98,7 +98,7 @@ type RunCommand struct {
 
 	Postgres flag.PostgresConfig `group:"PostgreSQL Configuration" namespace:"postgres"`
 
-	MaxOpenConnections int `long:"max-conns" description:"The maximum number of open connections for a conneciton pool." default:"32"`
+	MaxOpenConnections int `long:"max-conns" description:"The maximum number of open connections for a connection pool." default:"32"`
 
 	CredentialManagement creds.CredentialManagementConfig `group:"Credential Management"`
 	CredentialManagers   creds.Managers


### PR DESCRIPTION
After many profiles, it became clear that at high transaction levels the system was spending substantial amounts of it's time reaping and re-establishing TLS connections in order to grab locks or run queries against Postgres.  

This change resulted in a 30% reduction in CPU for our web processes.  The dominate calls now are around marshaling and un-marshaling JSON.

Signed-off-by: Eric Billingsley <eric@calculi.com>