### PR TITLE
atc/api: Super admin user first steps

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -42,19 +42,23 @@ func (a *access) Claims() jwt.MapClaims {
 }
 
 func (a *access) IsAuthorized(team string) bool {
+	if a.IsAdmin() {
+		return true
+	}
 	for teamName, teamRoles := range a.TeamRoles() {
-		if teamName == team {
-			for _, teamRole := range teamRoles {
-				if a.HasPermission(teamRole) {
-					return true
-				}
+		if teamName != team {
+			continue
+		}
+		for _, teamRole := range teamRoles {
+			if a.hasPermission(teamRole) {
+				return true
 			}
 		}
 	}
 	return false
 }
 
-func (a *access) HasPermission(role string) bool {
+func (a *access) hasPermission(role string) bool {
 	switch requiredRoles[a.action] {
 	case "owner":
 		return role == "owner"

--- a/atc/api/builds_test.go
+++ b/atc/api/builds_test.go
@@ -299,6 +299,27 @@ var _ = Describe("Builds API", func() {
 				fakeAccess.IsAuthenticatedReturns(true)
 			})
 
+			Context("when user has the admin privilege", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAdminReturns(true)
+				})
+
+				It("calls AllBuilds", func() {
+					Expect(dbBuildFactory.AllBuildsCallCount()).To(Equal(1))
+					Expect(dbBuildFactory.VisibleBuildsCallCount()).To(Equal(0))
+				})
+
+				Context("timestamp is provided", func() {
+					BeforeEach(func() {
+						queryParams = "?timestamps=true"
+					})
+					It("calls AllBuildsWithTime", func() {
+						Expect(dbBuildFactory.AllBuildsWithTimeCallCount()).To(Equal(1))
+						Expect(dbBuildFactory.VisibleBuildsWithTimeCallCount()).To(Equal(0))
+					})
+				})
+			})
+
 			Context("when no params are passed", func() {
 				BeforeEach(func() {
 					queryParams = ""

--- a/atc/api/builds_test.go
+++ b/atc/api/builds_test.go
@@ -219,6 +219,17 @@ var _ = Describe("Builds API", func() {
 						Limit: 8,
 					}))
 				})
+
+				Context("timestamp is provided", func() {
+					BeforeEach(func() {
+						queryParams = "?timestamps=true"
+					})
+
+					It("calls AllBuilds", func() {
+						_, page := dbBuildFactory.VisibleBuildsArgsForCall(0)
+						Expect(page.UseDate).To(Equal(true))
+					})
+				})
 			})
 
 			Context("when getting the builds succeeds", func() {
@@ -309,15 +320,6 @@ var _ = Describe("Builds API", func() {
 					Expect(dbBuildFactory.VisibleBuildsCallCount()).To(Equal(0))
 				})
 
-				Context("timestamp is provided", func() {
-					BeforeEach(func() {
-						queryParams = "?timestamps=true"
-					})
-					It("calls AllBuildsWithTime", func() {
-						Expect(dbBuildFactory.AllBuildsWithTimeCallCount()).To(Equal(1))
-						Expect(dbBuildFactory.VisibleBuildsWithTimeCallCount()).To(Equal(0))
-					})
-				})
 			})
 
 			Context("when no params are passed", func() {

--- a/atc/api/buildserver/list.go
+++ b/atc/api/buildserver/list.go
@@ -44,9 +44,17 @@ func (s *Server) ListBuilds(w http.ResponseWriter, r *http.Request) {
 
 	acc := accessor.GetAccessor(r)
 	if timestamps == "" {
-		builds, pagination, err = s.buildFactory.VisibleBuilds(acc.TeamNames(), page)
+		if acc.IsAdmin() {
+			builds, pagination, err =  s.buildFactory.AllBuilds(page)
+		} else {
+			builds, pagination, err = s.buildFactory.VisibleBuilds(acc.TeamNames(), page)
+		}
 	} else {
-		builds, pagination, err = s.buildFactory.VisibleBuildsWithTime(acc.TeamNames(), page)
+		if acc.IsAdmin() {
+			builds, pagination, err = s.buildFactory.AllBuildsWithTime(page)
+		} else {
+			builds, pagination, err = s.buildFactory.VisibleBuildsWithTime(acc.TeamNames(), page)
+		}
 	}
 
 	if err != nil {

--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -251,6 +251,16 @@ var _ = Describe("Jobs API", func() {
 				Expect(dbJobFactory.VisibleJobsCallCount()).To(Equal(1))
 				Expect(dbJobFactory.VisibleJobsArgsForCall(0)).To(ContainElement("some-team"))
 			})
+
+			Context("user has the admin privilege", func() {
+				BeforeEach(func() {
+					fakeaccess.IsAdminReturns(true)
+				})
+
+				It("returns all jobs from public and private pipelines from unauthenticated teams", func() {
+					Expect(dbJobFactory.AllActiveJobsCallCount()).To(Equal(1))
+				})
+			})
 		})
 	})
 

--- a/atc/api/jobserver/list_all.go
+++ b/atc/api/jobserver/list_all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/accessor"
 	"github.com/concourse/concourse/atc/api/present"
+	"github.com/concourse/concourse/atc/db"
 )
 
 func (s *Server) ListAllJobs(w http.ResponseWriter, r *http.Request) {
@@ -14,7 +15,15 @@ func (s *Server) ListAllJobs(w http.ResponseWriter, r *http.Request) {
 
 	acc := accessor.GetAccessor(r)
 
-	dashboard, err := s.jobFactory.VisibleJobs(acc.TeamNames())
+	var dashboard db.Dashboard
+	var err error
+
+	if acc.IsAdmin() {
+		dashboard, err = s.jobFactory.AllActiveJobs()
+	} else {
+		dashboard, err = s.jobFactory.VisibleJobs(acc.TeamNames())
+	}
+
 	if err != nil {
 		logger.Error("failed-to-get-all-visible-jobs", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -172,6 +172,8 @@ var _ = Describe("Pipelines API", func() {
 				body, err := ioutil.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
+				Expect(dbPipelineFactory.VisiblePipelinesCallCount()).To(Equal(1))
+
 				Expect(body).To(MatchJSON(`[
 				{
 					"id": 3,

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -25,9 +25,10 @@ var _ = Describe("Pipelines API", func() {
 		fakeTeam   *dbfakes.FakeTeam
 		fakeaccess *accessorfakes.FakeAccess
 
-		publicPipeline        *dbfakes.FakePipeline
-		anotherPublicPipeline *dbfakes.FakePipeline
-		privatePipeline       *dbfakes.FakePipeline
+		publicPipeline                 *dbfakes.FakePipeline
+		anotherPublicPipeline          *dbfakes.FakePipeline
+		privatePipeline                *dbfakes.FakePipeline
+		privatePipelineFromAnotherTeam *dbfakes.FakePipeline
 	)
 	BeforeEach(func() {
 		dbPipeline = new(dbfakes.FakePipeline)
@@ -68,6 +69,13 @@ var _ = Describe("Pipelines API", func() {
 				Resources: []string{"resource1", "resource2"},
 			},
 		})
+
+		privatePipelineFromAnotherTeam = new(dbfakes.FakePipeline)
+		privatePipelineFromAnotherTeam.IDReturns(3)
+		privatePipelineFromAnotherTeam.PausedReturns(false)
+		privatePipelineFromAnotherTeam.PublicReturns(false)
+		privatePipelineFromAnotherTeam.TeamNameReturns("main")
+		privatePipelineFromAnotherTeam.NameReturns("private-pipeline")
 
 		fakeTeam.PipelinesReturns([]db.Pipeline{
 			privatePipeline,
@@ -200,6 +208,28 @@ var _ = Describe("Pipelines API", func() {
 					"public": true,
 					"team_name": "another"
 				}]`))
+			})
+
+			Context("user has the Admin privilege", func() {
+				BeforeEach(func() {
+					fakeaccess.IsAdminReturns(true)
+					dbPipelineFactory.AllPipelinesReturns(
+						[]db.Pipeline{publicPipeline, privatePipeline, anotherPublicPipeline, privatePipelineFromAnotherTeam},
+						nil)
+				})
+
+				It("user can see all private and public pipelines from all teams", func() {
+					Expect(dbPipelineFactory.AllPipelinesCallCount()).To(Equal(1),
+						"Expected AllPipelines() to be called once")
+
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					var pipelinesResponse []atc.Pipeline
+					err = json.Unmarshal(body, &pipelinesResponse)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(pipelinesResponse)).To(Equal(4))
+				})
 			})
 
 			Context("when the call to get active pipelines fails", func() {

--- a/atc/api/pipelineserver/list_all.go
+++ b/atc/api/pipelineserver/list_all.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/concourse/concourse/atc/api/accessor"
 	"github.com/concourse/concourse/atc/api/present"
+	"github.com/concourse/concourse/atc/db"
 )
 
 // show all public pipelines and team private pipelines if authorized
@@ -14,7 +15,15 @@ func (s *Server) ListAllPipelines(w http.ResponseWriter, r *http.Request) {
 
 	acc := accessor.GetAccessor(r)
 
-	pipelines, err := s.pipelineFactory.VisiblePipelines(acc.TeamNames())
+	var pipelines []db.Pipeline
+	var err error
+
+	if acc.IsAdmin() {
+		pipelines, err = s.pipelineFactory.AllPipelines()
+	} else {
+		pipelines, err = s.pipelineFactory.VisiblePipelines(acc.TeamNames())
+	}
+
 	if err != nil {
 		logger.Error("failed-to-get-all-visible-pipelines", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -164,6 +164,16 @@ var _ = Describe("Resources API", func() {
 					Expect(dbResourceFactory.VisibleResourcesCallCount()).To(Equal(1))
 					Expect(dbResourceFactory.VisibleResourcesArgsForCall(0)).To(ContainElement("some-team"))
 				})
+
+				Context("when user has admin privilege", func() {
+					BeforeEach(func() {
+						fakeaccess.IsAdminReturns(true)
+					})
+
+					It("returns all resources", func() {
+						Expect(dbResourceFactory.AllResourcesCallCount()).To(Equal(1))
+					})
+				})
 			})
 		})
 	})

--- a/atc/api/resourceserver/list_all.go
+++ b/atc/api/resourceserver/list_all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/accessor"
 	"github.com/concourse/concourse/atc/api/present"
+	"github.com/concourse/concourse/atc/db"
 )
 
 func (s *Server) ListAllResources(w http.ResponseWriter, r *http.Request) {
@@ -14,7 +15,15 @@ func (s *Server) ListAllResources(w http.ResponseWriter, r *http.Request) {
 
 	acc := accessor.GetAccessor(r)
 
-	dbResources, err := s.resourceFactory.VisibleResources(acc.TeamNames())
+	var (
+		dbResources []db.Resource
+		err         error
+	)
+	if acc.IsAdmin() {
+		dbResources, err = s.resourceFactory.AllResources()
+	} else {
+		dbResources, err = s.resourceFactory.VisibleResources(acc.TeamNames())
+	}
 	if err != nil {
 		logger.Error("failed-to-get-all-visible-resources", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/workerserver/list.go
+++ b/atc/api/workerserver/list.go
@@ -13,11 +13,19 @@ import (
 func (s *Server) ListWorkers(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.Session("list-workers")
 
-	var workers []db.Worker
+	var (
+		workers []db.Worker
+		err     error
+	)
 
 	acc := accessor.GetAccessor(r)
 
-	workers, err := s.dbWorkerFactory.VisibleWorkers(acc.TeamNames())
+	if acc.IsAdmin() {
+		workers, err = s.dbWorkerFactory.Workers()
+	} else {
+		workers, err = s.dbWorkerFactory.VisibleWorkers(acc.TeamNames())
+	}
+
 	if err != nil {
 		logger.Error("failed-to-get-workers", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -15,9 +15,7 @@ import (
 type BuildFactory interface {
 	Build(int) (Build, bool, error)
 	VisibleBuilds([]string, Page) ([]Build, Pagination, error)
-	VisibleBuildsWithTime([]string, Page) ([]Build, Pagination, error)
 	AllBuilds(Page) ([]Build, Pagination, error)
-	AllBuildsWithTime(Page) ([]Build, Pagination, error)
 	PublicBuilds(Page) ([]Build, Pagination, error)
 	GetAllStartedBuilds() ([]Build, error)
 	GetDrainableBuilds() ([]Build, error)
@@ -61,31 +59,26 @@ func (f *buildFactory) Build(buildID int) (Build, bool, error) {
 	return build, true, nil
 }
 
-func (f *buildFactory) VisibleBuildsWithTime(teamNames []string, page Page) ([]Build, Pagination, error) {
+func (f *buildFactory) VisibleBuilds(teamNames []string, page Page) ([]Build, Pagination, error) {
 	newBuildsQuery := buildsQuery.
 		Where(sq.Or{
 			sq.Eq{"p.public": true},
 			sq.Eq{"t.name": teamNames},
 		})
-	return getBuildsWithDates(newBuildsQuery, minMaxIdQuery, page, f.conn, f.lockFactory)
-}
 
-func (f *buildFactory) VisibleBuilds(teamNames []string, page Page) ([]Build, Pagination, error) {
-	newBuildsQuery := buildsQuery.
-		Where(sq.Or{
-			sq.Eq{"p.public": true},
-				sq.Eq{"t.name": teamNames},
-		})
-
-	return getBuildsWithPagination(newBuildsQuery, minMaxIdQuery,
-		page, f.conn, f.lockFactory)
-}
-
-func (f *buildFactory) AllBuildsWithTime(page Page) ([]Build, Pagination, error) {
-	return getBuildsWithDates(buildsQuery, minMaxIdQuery, page, f.conn, f.lockFactory)
+	if page.UseDate {
+		return getBuildsWithDates(newBuildsQuery, minMaxIdQuery, page, f.conn,
+			f.lockFactory)
+	}
+	return getBuildsWithPagination(newBuildsQuery, minMaxIdQuery, page, f.conn,
+		f.lockFactory)
 }
 
 func (f *buildFactory) AllBuilds(page Page) ([]Build, Pagination, error) {
+	if page.UseDate {
+		return getBuildsWithDates(buildsQuery, minMaxIdQuery, page, f.conn,
+			f.lockFactory)
+	}
 	return getBuildsWithPagination(buildsQuery, minMaxIdQuery,
 		page, f.conn, f.lockFactory)
 }

--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -16,6 +16,8 @@ type BuildFactory interface {
 	Build(int) (Build, bool, error)
 	VisibleBuilds([]string, Page) ([]Build, Pagination, error)
 	VisibleBuildsWithTime([]string, Page) ([]Build, Pagination, error)
+	AllBuilds(Page) ([]Build, Pagination, error)
+	AllBuildsWithTime(Page) ([]Build, Pagination, error)
 	PublicBuilds(Page) ([]Build, Pagination, error)
 	GetAllStartedBuilds() ([]Build, error)
 	GetDrainableBuilds() ([]Build, error)
@@ -72,10 +74,19 @@ func (f *buildFactory) VisibleBuilds(teamNames []string, page Page) ([]Build, Pa
 	newBuildsQuery := buildsQuery.
 		Where(sq.Or{
 			sq.Eq{"p.public": true},
-			sq.Eq{"t.name": teamNames},
+				sq.Eq{"t.name": teamNames},
 		})
 
 	return getBuildsWithPagination(newBuildsQuery, minMaxIdQuery,
+		page, f.conn, f.lockFactory)
+}
+
+func (f *buildFactory) AllBuildsWithTime(page Page) ([]Build, Pagination, error) {
+	return getBuildsWithDates(buildsQuery, minMaxIdQuery, page, f.conn, f.lockFactory)
+}
+
+func (f *buildFactory) AllBuilds(page Page) ([]Build, Pagination, error) {
+	return getBuildsWithPagination(buildsQuery, minMaxIdQuery,
 		page, f.conn, f.lockFactory)
 }
 

--- a/atc/db/build_factory_test.go
+++ b/atc/db/build_factory_test.go
@@ -260,6 +260,56 @@ var _ = Describe("BuildFactory", func() {
 		})
 	})
 
+	Describe("AllBuilds", func() {
+		var err error
+		var build1 db.Build
+		var build2 db.Build
+		var build3 db.Build
+		var build4 db.Build
+
+		BeforeEach(func() {
+			build1, err = team.CreateOneOffBuild()
+			Expect(err).NotTo(HaveOccurred())
+
+			config := atc.Config{Jobs: atc.JobConfigs{{Name: "some-job"}}}
+			privatePipeline, _, err := team.SavePipeline("private-pipeline", config, db.ConfigVersion(1), false)
+			Expect(err).NotTo(HaveOccurred())
+
+			privateJob, found, err := privatePipeline.Job("some-job")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			build2, err = privateJob.CreateBuild()
+			Expect(err).NotTo(HaveOccurred())
+
+			publicPipeline, _, err := team.SavePipeline("public-pipeline", config, db.ConfigVersion(1), false)
+			Expect(err).NotTo(HaveOccurred())
+			err = publicPipeline.Expose()
+			Expect(err).NotTo(HaveOccurred())
+
+			publicJob, found, err := publicPipeline.Job("some-job")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			build3, err = publicJob.CreateBuild()
+			Expect(err).NotTo(HaveOccurred())
+
+			otherTeam, err := teamFactory.CreateTeam(atc.Team{Name: "some-other-team"})
+			Expect(err).NotTo(HaveOccurred())
+
+			build4, err = otherTeam.CreateOneOffBuild()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns all builds from all teams private and public pipelines", func() {
+			builds, _, err := buildFactory.AllBuilds(db.Page{Limit: 10})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(builds).To(HaveLen(4))
+			Expect(builds).To(ConsistOf(build1, build2, build3, build4))
+		})
+	})
+
 	Describe("PublicBuilds", func() {
 		var publicBuild db.Build
 

--- a/atc/db/dbfakes/fake_build_factory.go
+++ b/atc/db/dbfakes/fake_build_factory.go
@@ -8,6 +8,36 @@ import (
 )
 
 type FakeBuildFactory struct {
+	AllBuildsStub        func(db.Page) ([]db.Build, db.Pagination, error)
+	allBuildsMutex       sync.RWMutex
+	allBuildsArgsForCall []struct {
+		arg1 db.Page
+	}
+	allBuildsReturns struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}
+	allBuildsReturnsOnCall map[int]struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}
+	AllBuildsWithTimeStub        func(db.Page) ([]db.Build, db.Pagination, error)
+	allBuildsWithTimeMutex       sync.RWMutex
+	allBuildsWithTimeArgsForCall []struct {
+		arg1 db.Page
+	}
+	allBuildsWithTimeReturns struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}
+	allBuildsWithTimeReturnsOnCall map[int]struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}
 	BuildStub        func(int) (db.Build, bool, error)
 	buildMutex       sync.RWMutex
 	buildArgsForCall []struct {
@@ -106,6 +136,138 @@ type FakeBuildFactory struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeBuildFactory) AllBuilds(arg1 db.Page) ([]db.Build, db.Pagination, error) {
+	fake.allBuildsMutex.Lock()
+	ret, specificReturn := fake.allBuildsReturnsOnCall[len(fake.allBuildsArgsForCall)]
+	fake.allBuildsArgsForCall = append(fake.allBuildsArgsForCall, struct {
+		arg1 db.Page
+	}{arg1})
+	fake.recordInvocation("AllBuilds", []interface{}{arg1})
+	fake.allBuildsMutex.Unlock()
+	if fake.AllBuildsStub != nil {
+		return fake.AllBuildsStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.allBuildsReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeBuildFactory) AllBuildsCallCount() int {
+	fake.allBuildsMutex.RLock()
+	defer fake.allBuildsMutex.RUnlock()
+	return len(fake.allBuildsArgsForCall)
+}
+
+func (fake *FakeBuildFactory) AllBuildsCalls(stub func(db.Page) ([]db.Build, db.Pagination, error)) {
+	fake.allBuildsMutex.Lock()
+	defer fake.allBuildsMutex.Unlock()
+	fake.AllBuildsStub = stub
+}
+
+func (fake *FakeBuildFactory) AllBuildsArgsForCall(i int) db.Page {
+	fake.allBuildsMutex.RLock()
+	defer fake.allBuildsMutex.RUnlock()
+	argsForCall := fake.allBuildsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeBuildFactory) AllBuildsReturns(result1 []db.Build, result2 db.Pagination, result3 error) {
+	fake.allBuildsMutex.Lock()
+	defer fake.allBuildsMutex.Unlock()
+	fake.AllBuildsStub = nil
+	fake.allBuildsReturns = struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeBuildFactory) AllBuildsReturnsOnCall(i int, result1 []db.Build, result2 db.Pagination, result3 error) {
+	fake.allBuildsMutex.Lock()
+	defer fake.allBuildsMutex.Unlock()
+	fake.AllBuildsStub = nil
+	if fake.allBuildsReturnsOnCall == nil {
+		fake.allBuildsReturnsOnCall = make(map[int]struct {
+			result1 []db.Build
+			result2 db.Pagination
+			result3 error
+		})
+	}
+	fake.allBuildsReturnsOnCall[i] = struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeBuildFactory) AllBuildsWithTime(arg1 db.Page) ([]db.Build, db.Pagination, error) {
+	fake.allBuildsWithTimeMutex.Lock()
+	ret, specificReturn := fake.allBuildsWithTimeReturnsOnCall[len(fake.allBuildsWithTimeArgsForCall)]
+	fake.allBuildsWithTimeArgsForCall = append(fake.allBuildsWithTimeArgsForCall, struct {
+		arg1 db.Page
+	}{arg1})
+	fake.recordInvocation("AllBuildsWithTime", []interface{}{arg1})
+	fake.allBuildsWithTimeMutex.Unlock()
+	if fake.AllBuildsWithTimeStub != nil {
+		return fake.AllBuildsWithTimeStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.allBuildsWithTimeReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeBuildFactory) AllBuildsWithTimeCallCount() int {
+	fake.allBuildsWithTimeMutex.RLock()
+	defer fake.allBuildsWithTimeMutex.RUnlock()
+	return len(fake.allBuildsWithTimeArgsForCall)
+}
+
+func (fake *FakeBuildFactory) AllBuildsWithTimeCalls(stub func(db.Page) ([]db.Build, db.Pagination, error)) {
+	fake.allBuildsWithTimeMutex.Lock()
+	defer fake.allBuildsWithTimeMutex.Unlock()
+	fake.AllBuildsWithTimeStub = stub
+}
+
+func (fake *FakeBuildFactory) AllBuildsWithTimeArgsForCall(i int) db.Page {
+	fake.allBuildsWithTimeMutex.RLock()
+	defer fake.allBuildsWithTimeMutex.RUnlock()
+	argsForCall := fake.allBuildsWithTimeArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeBuildFactory) AllBuildsWithTimeReturns(result1 []db.Build, result2 db.Pagination, result3 error) {
+	fake.allBuildsWithTimeMutex.Lock()
+	defer fake.allBuildsWithTimeMutex.Unlock()
+	fake.AllBuildsWithTimeStub = nil
+	fake.allBuildsWithTimeReturns = struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeBuildFactory) AllBuildsWithTimeReturnsOnCall(i int, result1 []db.Build, result2 db.Pagination, result3 error) {
+	fake.allBuildsWithTimeMutex.Lock()
+	defer fake.allBuildsWithTimeMutex.Unlock()
+	fake.AllBuildsWithTimeStub = nil
+	if fake.allBuildsWithTimeReturnsOnCall == nil {
+		fake.allBuildsWithTimeReturnsOnCall = make(map[int]struct {
+			result1 []db.Build
+			result2 db.Pagination
+			result3 error
+		})
+	}
+	fake.allBuildsWithTimeReturnsOnCall[i] = struct {
+		result1 []db.Build
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeBuildFactory) Build(arg1 int) (db.Build, bool, error) {
@@ -549,6 +711,10 @@ func (fake *FakeBuildFactory) VisibleBuildsWithTimeReturnsOnCall(i int, result1 
 func (fake *FakeBuildFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.allBuildsMutex.RLock()
+	defer fake.allBuildsMutex.RUnlock()
+	fake.allBuildsWithTimeMutex.RLock()
+	defer fake.allBuildsWithTimeMutex.RUnlock()
 	fake.buildMutex.RLock()
 	defer fake.buildMutex.RUnlock()
 	fake.getAllStartedBuildsMutex.RLock()

--- a/atc/db/dbfakes/fake_build_factory.go
+++ b/atc/db/dbfakes/fake_build_factory.go
@@ -23,21 +23,6 @@ type FakeBuildFactory struct {
 		result2 db.Pagination
 		result3 error
 	}
-	AllBuildsWithTimeStub        func(db.Page) ([]db.Build, db.Pagination, error)
-	allBuildsWithTimeMutex       sync.RWMutex
-	allBuildsWithTimeArgsForCall []struct {
-		arg1 db.Page
-	}
-	allBuildsWithTimeReturns struct {
-		result1 []db.Build
-		result2 db.Pagination
-		result3 error
-	}
-	allBuildsWithTimeReturnsOnCall map[int]struct {
-		result1 []db.Build
-		result2 db.Pagination
-		result3 error
-	}
 	BuildStub        func(int) (db.Build, bool, error)
 	buildMutex       sync.RWMutex
 	buildArgsForCall []struct {
@@ -118,22 +103,6 @@ type FakeBuildFactory struct {
 		result2 db.Pagination
 		result3 error
 	}
-	VisibleBuildsWithTimeStub        func([]string, db.Page) ([]db.Build, db.Pagination, error)
-	visibleBuildsWithTimeMutex       sync.RWMutex
-	visibleBuildsWithTimeArgsForCall []struct {
-		arg1 []string
-		arg2 db.Page
-	}
-	visibleBuildsWithTimeReturns struct {
-		result1 []db.Build
-		result2 db.Pagination
-		result3 error
-	}
-	visibleBuildsWithTimeReturnsOnCall map[int]struct {
-		result1 []db.Build
-		result2 db.Pagination
-		result3 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -198,72 +167,6 @@ func (fake *FakeBuildFactory) AllBuildsReturnsOnCall(i int, result1 []db.Build, 
 		})
 	}
 	fake.allBuildsReturnsOnCall[i] = struct {
-		result1 []db.Build
-		result2 db.Pagination
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakeBuildFactory) AllBuildsWithTime(arg1 db.Page) ([]db.Build, db.Pagination, error) {
-	fake.allBuildsWithTimeMutex.Lock()
-	ret, specificReturn := fake.allBuildsWithTimeReturnsOnCall[len(fake.allBuildsWithTimeArgsForCall)]
-	fake.allBuildsWithTimeArgsForCall = append(fake.allBuildsWithTimeArgsForCall, struct {
-		arg1 db.Page
-	}{arg1})
-	fake.recordInvocation("AllBuildsWithTime", []interface{}{arg1})
-	fake.allBuildsWithTimeMutex.Unlock()
-	if fake.AllBuildsWithTimeStub != nil {
-		return fake.AllBuildsWithTimeStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	fakeReturns := fake.allBuildsWithTimeReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakeBuildFactory) AllBuildsWithTimeCallCount() int {
-	fake.allBuildsWithTimeMutex.RLock()
-	defer fake.allBuildsWithTimeMutex.RUnlock()
-	return len(fake.allBuildsWithTimeArgsForCall)
-}
-
-func (fake *FakeBuildFactory) AllBuildsWithTimeCalls(stub func(db.Page) ([]db.Build, db.Pagination, error)) {
-	fake.allBuildsWithTimeMutex.Lock()
-	defer fake.allBuildsWithTimeMutex.Unlock()
-	fake.AllBuildsWithTimeStub = stub
-}
-
-func (fake *FakeBuildFactory) AllBuildsWithTimeArgsForCall(i int) db.Page {
-	fake.allBuildsWithTimeMutex.RLock()
-	defer fake.allBuildsWithTimeMutex.RUnlock()
-	argsForCall := fake.allBuildsWithTimeArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeBuildFactory) AllBuildsWithTimeReturns(result1 []db.Build, result2 db.Pagination, result3 error) {
-	fake.allBuildsWithTimeMutex.Lock()
-	defer fake.allBuildsWithTimeMutex.Unlock()
-	fake.AllBuildsWithTimeStub = nil
-	fake.allBuildsWithTimeReturns = struct {
-		result1 []db.Build
-		result2 db.Pagination
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakeBuildFactory) AllBuildsWithTimeReturnsOnCall(i int, result1 []db.Build, result2 db.Pagination, result3 error) {
-	fake.allBuildsWithTimeMutex.Lock()
-	defer fake.allBuildsWithTimeMutex.Unlock()
-	fake.AllBuildsWithTimeStub = nil
-	if fake.allBuildsWithTimeReturnsOnCall == nil {
-		fake.allBuildsWithTimeReturnsOnCall = make(map[int]struct {
-			result1 []db.Build
-			result2 db.Pagination
-			result3 error
-		})
-	}
-	fake.allBuildsWithTimeReturnsOnCall[i] = struct {
 		result1 []db.Build
 		result2 db.Pagination
 		result3 error
@@ -636,85 +539,11 @@ func (fake *FakeBuildFactory) VisibleBuildsReturnsOnCall(i int, result1 []db.Bui
 	}{result1, result2, result3}
 }
 
-func (fake *FakeBuildFactory) VisibleBuildsWithTime(arg1 []string, arg2 db.Page) ([]db.Build, db.Pagination, error) {
-	var arg1Copy []string
-	if arg1 != nil {
-		arg1Copy = make([]string, len(arg1))
-		copy(arg1Copy, arg1)
-	}
-	fake.visibleBuildsWithTimeMutex.Lock()
-	ret, specificReturn := fake.visibleBuildsWithTimeReturnsOnCall[len(fake.visibleBuildsWithTimeArgsForCall)]
-	fake.visibleBuildsWithTimeArgsForCall = append(fake.visibleBuildsWithTimeArgsForCall, struct {
-		arg1 []string
-		arg2 db.Page
-	}{arg1Copy, arg2})
-	fake.recordInvocation("VisibleBuildsWithTime", []interface{}{arg1Copy, arg2})
-	fake.visibleBuildsWithTimeMutex.Unlock()
-	if fake.VisibleBuildsWithTimeStub != nil {
-		return fake.VisibleBuildsWithTimeStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	fakeReturns := fake.visibleBuildsWithTimeReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakeBuildFactory) VisibleBuildsWithTimeCallCount() int {
-	fake.visibleBuildsWithTimeMutex.RLock()
-	defer fake.visibleBuildsWithTimeMutex.RUnlock()
-	return len(fake.visibleBuildsWithTimeArgsForCall)
-}
-
-func (fake *FakeBuildFactory) VisibleBuildsWithTimeCalls(stub func([]string, db.Page) ([]db.Build, db.Pagination, error)) {
-	fake.visibleBuildsWithTimeMutex.Lock()
-	defer fake.visibleBuildsWithTimeMutex.Unlock()
-	fake.VisibleBuildsWithTimeStub = stub
-}
-
-func (fake *FakeBuildFactory) VisibleBuildsWithTimeArgsForCall(i int) ([]string, db.Page) {
-	fake.visibleBuildsWithTimeMutex.RLock()
-	defer fake.visibleBuildsWithTimeMutex.RUnlock()
-	argsForCall := fake.visibleBuildsWithTimeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeBuildFactory) VisibleBuildsWithTimeReturns(result1 []db.Build, result2 db.Pagination, result3 error) {
-	fake.visibleBuildsWithTimeMutex.Lock()
-	defer fake.visibleBuildsWithTimeMutex.Unlock()
-	fake.VisibleBuildsWithTimeStub = nil
-	fake.visibleBuildsWithTimeReturns = struct {
-		result1 []db.Build
-		result2 db.Pagination
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakeBuildFactory) VisibleBuildsWithTimeReturnsOnCall(i int, result1 []db.Build, result2 db.Pagination, result3 error) {
-	fake.visibleBuildsWithTimeMutex.Lock()
-	defer fake.visibleBuildsWithTimeMutex.Unlock()
-	fake.VisibleBuildsWithTimeStub = nil
-	if fake.visibleBuildsWithTimeReturnsOnCall == nil {
-		fake.visibleBuildsWithTimeReturnsOnCall = make(map[int]struct {
-			result1 []db.Build
-			result2 db.Pagination
-			result3 error
-		})
-	}
-	fake.visibleBuildsWithTimeReturnsOnCall[i] = struct {
-		result1 []db.Build
-		result2 db.Pagination
-		result3 error
-	}{result1, result2, result3}
-}
-
 func (fake *FakeBuildFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.allBuildsMutex.RLock()
 	defer fake.allBuildsMutex.RUnlock()
-	fake.allBuildsWithTimeMutex.RLock()
-	defer fake.allBuildsWithTimeMutex.RUnlock()
 	fake.buildMutex.RLock()
 	defer fake.buildMutex.RUnlock()
 	fake.getAllStartedBuildsMutex.RLock()
@@ -727,8 +556,6 @@ func (fake *FakeBuildFactory) Invocations() map[string][][]interface{} {
 	defer fake.publicBuildsMutex.RUnlock()
 	fake.visibleBuildsMutex.RLock()
 	defer fake.visibleBuildsMutex.RUnlock()
-	fake.visibleBuildsWithTimeMutex.RLock()
-	defer fake.visibleBuildsWithTimeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/atc/db/dbfakes/fake_job_factory.go
+++ b/atc/db/dbfakes/fake_job_factory.go
@@ -8,6 +8,18 @@ import (
 )
 
 type FakeJobFactory struct {
+	AllActiveJobsStub        func() (db.Dashboard, error)
+	allActiveJobsMutex       sync.RWMutex
+	allActiveJobsArgsForCall []struct {
+	}
+	allActiveJobsReturns struct {
+		result1 db.Dashboard
+		result2 error
+	}
+	allActiveJobsReturnsOnCall map[int]struct {
+		result1 db.Dashboard
+		result2 error
+	}
 	VisibleJobsStub        func([]string) (db.Dashboard, error)
 	visibleJobsMutex       sync.RWMutex
 	visibleJobsArgsForCall []struct {
@@ -23,6 +35,61 @@ type FakeJobFactory struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeJobFactory) AllActiveJobs() (db.Dashboard, error) {
+	fake.allActiveJobsMutex.Lock()
+	ret, specificReturn := fake.allActiveJobsReturnsOnCall[len(fake.allActiveJobsArgsForCall)]
+	fake.allActiveJobsArgsForCall = append(fake.allActiveJobsArgsForCall, struct {
+	}{})
+	fake.recordInvocation("AllActiveJobs", []interface{}{})
+	fake.allActiveJobsMutex.Unlock()
+	if fake.AllActiveJobsStub != nil {
+		return fake.AllActiveJobsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.allActiveJobsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeJobFactory) AllActiveJobsCallCount() int {
+	fake.allActiveJobsMutex.RLock()
+	defer fake.allActiveJobsMutex.RUnlock()
+	return len(fake.allActiveJobsArgsForCall)
+}
+
+func (fake *FakeJobFactory) AllActiveJobsCalls(stub func() (db.Dashboard, error)) {
+	fake.allActiveJobsMutex.Lock()
+	defer fake.allActiveJobsMutex.Unlock()
+	fake.AllActiveJobsStub = stub
+}
+
+func (fake *FakeJobFactory) AllActiveJobsReturns(result1 db.Dashboard, result2 error) {
+	fake.allActiveJobsMutex.Lock()
+	defer fake.allActiveJobsMutex.Unlock()
+	fake.AllActiveJobsStub = nil
+	fake.allActiveJobsReturns = struct {
+		result1 db.Dashboard
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeJobFactory) AllActiveJobsReturnsOnCall(i int, result1 db.Dashboard, result2 error) {
+	fake.allActiveJobsMutex.Lock()
+	defer fake.allActiveJobsMutex.Unlock()
+	fake.AllActiveJobsStub = nil
+	if fake.allActiveJobsReturnsOnCall == nil {
+		fake.allActiveJobsReturnsOnCall = make(map[int]struct {
+			result1 db.Dashboard
+			result2 error
+		})
+	}
+	fake.allActiveJobsReturnsOnCall[i] = struct {
+		result1 db.Dashboard
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeJobFactory) VisibleJobs(arg1 []string) (db.Dashboard, error) {
@@ -96,6 +163,8 @@ func (fake *FakeJobFactory) VisibleJobsReturnsOnCall(i int, result1 db.Dashboard
 func (fake *FakeJobFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.allActiveJobsMutex.RLock()
+	defer fake.allActiveJobsMutex.RUnlock()
 	fake.visibleJobsMutex.RLock()
 	defer fake.visibleJobsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -2,11 +2,11 @@
 package dbfakes
 
 import (
-	sync "sync"
-	time "time"
+	"sync"
+	"time"
 
-	atc "github.com/concourse/concourse/atc"
-	db "github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
 )
 
 type FakeResource struct {

--- a/atc/db/dbfakes/fake_resource_factory.go
+++ b/atc/db/dbfakes/fake_resource_factory.go
@@ -8,6 +8,18 @@ import (
 )
 
 type FakeResourceFactory struct {
+	AllResourcesStub        func() ([]db.Resource, error)
+	allResourcesMutex       sync.RWMutex
+	allResourcesArgsForCall []struct {
+	}
+	allResourcesReturns struct {
+		result1 []db.Resource
+		result2 error
+	}
+	allResourcesReturnsOnCall map[int]struct {
+		result1 []db.Resource
+		result2 error
+	}
 	VisibleResourcesStub        func([]string) ([]db.Resource, error)
 	visibleResourcesMutex       sync.RWMutex
 	visibleResourcesArgsForCall []struct {
@@ -23,6 +35,61 @@ type FakeResourceFactory struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeResourceFactory) AllResources() ([]db.Resource, error) {
+	fake.allResourcesMutex.Lock()
+	ret, specificReturn := fake.allResourcesReturnsOnCall[len(fake.allResourcesArgsForCall)]
+	fake.allResourcesArgsForCall = append(fake.allResourcesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("AllResources", []interface{}{})
+	fake.allResourcesMutex.Unlock()
+	if fake.AllResourcesStub != nil {
+		return fake.AllResourcesStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.allResourcesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeResourceFactory) AllResourcesCallCount() int {
+	fake.allResourcesMutex.RLock()
+	defer fake.allResourcesMutex.RUnlock()
+	return len(fake.allResourcesArgsForCall)
+}
+
+func (fake *FakeResourceFactory) AllResourcesCalls(stub func() ([]db.Resource, error)) {
+	fake.allResourcesMutex.Lock()
+	defer fake.allResourcesMutex.Unlock()
+	fake.AllResourcesStub = stub
+}
+
+func (fake *FakeResourceFactory) AllResourcesReturns(result1 []db.Resource, result2 error) {
+	fake.allResourcesMutex.Lock()
+	defer fake.allResourcesMutex.Unlock()
+	fake.AllResourcesStub = nil
+	fake.allResourcesReturns = struct {
+		result1 []db.Resource
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeResourceFactory) AllResourcesReturnsOnCall(i int, result1 []db.Resource, result2 error) {
+	fake.allResourcesMutex.Lock()
+	defer fake.allResourcesMutex.Unlock()
+	fake.AllResourcesStub = nil
+	if fake.allResourcesReturnsOnCall == nil {
+		fake.allResourcesReturnsOnCall = make(map[int]struct {
+			result1 []db.Resource
+			result2 error
+		})
+	}
+	fake.allResourcesReturnsOnCall[i] = struct {
+		result1 []db.Resource
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeResourceFactory) VisibleResources(arg1 []string) ([]db.Resource, error) {
@@ -96,6 +163,8 @@ func (fake *FakeResourceFactory) VisibleResourcesReturnsOnCall(i int, result1 []
 func (fake *FakeResourceFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.allResourcesMutex.RLock()
+	defer fake.allResourcesMutex.RUnlock()
 	fake.visibleResourcesMutex.RLock()
 	defer fake.visibleResourcesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/db/pagination.go
+++ b/atc/db/pagination.go
@@ -7,7 +7,8 @@ type Page struct {
 	From int // inclusive
 	To   int // inclusive
 
-	Limit int
+	Limit   int
+	UseDate bool
 }
 
 type Pagination struct {

--- a/atc/db/resource_factory.go
+++ b/atc/db/resource_factory.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"database/sql"
-
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc/db/lock"
 )
@@ -43,7 +42,7 @@ func (r *resourceFactory) VisibleResources(teamNames []string) ([]Resource, erro
 		return nil, err
 	}
 
-	return r.parseResources(rows)
+	return scanResources(rows, r.conn, r.lockFactory)
 }
 
 func (r *resourceFactory) AllResources() ([]Resource, error) {
@@ -55,14 +54,14 @@ func (r *resourceFactory) AllResources() ([]Resource, error) {
 		return nil, err
 	}
 
-	return r.parseResources(rows)
+	return scanResources(rows, r.conn, r.lockFactory)
 }
 
-func (r *resourceFactory) parseResources(resourceRows *sql.Rows) ([]Resource, error) {
+func scanResources(resourceRows *sql.Rows, conn Conn, lockFactory lock.LockFactory) ([]Resource, error) {
 	var resources []Resource
 
 	for resourceRows.Next() {
-		resource := &resource{conn: r.conn, lockFactory: r.lockFactory}
+		resource := &resource{conn: conn, lockFactory: lockFactory}
 
 		err := scanResource(resource, resourceRows)
 		if err != nil {

--- a/atc/db/resource_factory.go
+++ b/atc/db/resource_factory.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"database/sql"
+
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc/db/lock"
 )
@@ -9,6 +11,7 @@ import (
 
 type ResourceFactory interface {
 	VisibleResources([]string) ([]Resource, error)
+	AllResources() ([]Resource, error)
 }
 
 type resourceFactory struct {
@@ -40,12 +43,28 @@ func (r *resourceFactory) VisibleResources(teamNames []string) ([]Resource, erro
 		return nil, err
 	}
 
+	return r.parseResources(rows)
+}
+
+func (r *resourceFactory) AllResources() ([]Resource, error) {
+	rows, err := resourcesQuery.
+		OrderBy("r.id ASC").
+		RunWith(r.conn).
+		Query()
+	if err != nil {
+		return nil, err
+	}
+
+	return r.parseResources(rows)
+}
+
+func (r *resourceFactory) parseResources(resourceRows *sql.Rows) ([]Resource, error) {
 	var resources []Resource
 
-	for rows.Next() {
+	for resourceRows.Next() {
 		resource := &resource{conn: r.conn, lockFactory: r.lockFactory}
 
-		err := scanResource(resource, rows)
+		err := scanResource(resource, resourceRows)
 		if err != nil {
 			return nil, err
 		}

--- a/atc/db/resource_factory_test.go
+++ b/atc/db/resource_factory_test.go
@@ -35,21 +35,44 @@ var _ = Describe("Resource Factory", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("returns resources in the provided teams and resources in public pipelines", func() {
-			visibleResources, err := resourceFactory.VisibleResources([]string{"default-team"})
-			Expect(err).ToNot(HaveOccurred())
+		Context("VisibleResources", func() {
+			It("returns resources in the provided teams and resources in public pipelines", func() {
+				visibleResources, err := resourceFactory.VisibleResources([]string{"default-team"})
+				Expect(err).ToNot(HaveOccurred())
 
-			Expect(len(visibleResources)).To(Equal(2))
-			Expect(visibleResources[0].Name()).To(Equal("some-resource"))
-			Expect(visibleResources[1].Name()).To(Equal("public-pipeline-resource"))
+				Expect(len(visibleResources)).To(Equal(2))
+				Expect(visibleResources[0].Name()).To(Equal("some-resource"))
+				Expect(visibleResources[1].Name()).To(Equal("public-pipeline-resource"))
+			})
+
+			It("returns team name and groups for each resource", func() {
+				visibleResources, err := resourceFactory.VisibleResources([]string{"default-team"})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(visibleResources[0].TeamName()).To(Equal("default-team"))
+				Expect(visibleResources[1].TeamName()).To(Equal("other-team"))
+			})
+
 		})
 
-		It("returns team name and groups for each resource", func() {
-			visibleResources, err := resourceFactory.VisibleResources([]string{"default-team"})
-			Expect(err).ToNot(HaveOccurred())
+		Context("AllResources", func() {
+			It("returns all private and public resources from all teams", func() {
+				visibleResources, err := resourceFactory.AllResources()
+				Expect(err).ToNot(HaveOccurred())
 
-			Expect(visibleResources[0].TeamName()).To(Equal("default-team"))
-			Expect(visibleResources[1].TeamName()).To(Equal("other-team"))
+				Expect(len(visibleResources)).To(Equal(3))
+				Expect(visibleResources[0].Name()).To(Equal("some-resource"))
+				Expect(visibleResources[1].Name()).To(Equal("public-pipeline-resource"))
+				Expect(visibleResources[2].Name()).To(Equal("private-pipeline-resource"))
+			})
+
+			It("returns team name and groups for each resource", func() {
+				visibleResources, err := resourceFactory.AllResources()
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(visibleResources[0].TeamName()).To(Equal("default-team"))
+				Expect(visibleResources[1].TeamName()).To(Equal("other-team"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
tl;dr: Modify endpoint behavior to return everything when the user is an `Admin` i.e. owner of the main team


- We modified the following methods to behave properly for an admin user:
  - ListAllPipelines
  - ListAllJobs
  - ListBuilds
  - ListAllResources
  - ListWorkers
- Added the appropriate tests.
- this is currently functional, that the admin user is able to see all the pipelines when logging in from the web ui.
- fly hits team endpoints, so still not working as per this PR, we will address that in #4195.
- Also, applying actions to pipelines in the web ui (unpause, expose, trigger job), this should be addressed in #4194. 

cc: @youssb 

fixes: #4193