### PR TITLE
Remove wildcard in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-*                  @concourse/pivotal
 .github/*          @vito
 CODE_OF_CONDUCT.md @vito
 CONTRIBUTING.md    @concourse/pivotal


### PR DESCRIPTION
~This pings everyone on every PR~

Actually I think its because modifications to the `db` package aren't assigned to a team. We should probably just remove this anyway. Thoughts?