### PR TITLE
remove EnsureDBContainerExists

### DIFF
--- a/atc/worker/db_worker_provider_test.go
+++ b/atc/worker/db_worker_provider_test.go
@@ -490,14 +490,6 @@ var _ = Describe("DBProvider", func() {
 					fakeGardenBackend.CreateReturns(fakeContainer, nil)
 					fakeGardenBackend.LookupReturns(fakeContainer, nil)
 
-					err := workers[0].EnsureDBContainerExists(
-						context.TODO(),
-						logger,
-						db.NewBuildStepContainerOwner(42, atc.PlanID("some-plan-id"), 1),
-						db.ContainerMetadata{},
-					)
-					Expect(err).NotTo(HaveOccurred())
-
 					container, err := workers[0].FindOrCreateContainer(
 						context.TODO(),
 						logger,


### PR DESCRIPTION
Fixes #4244.

Signed-off-by: Divya Dadlani <ddadlani@pivotal.io>
Co-authored-by: Nader Ziada <nziada@pivotal.io>

We also need to find a solution to delete the existing orphaned creating containers from users' databases. A migration, perhaps?