### PR TITLE
web - add yellow border to running steps

### DIFF
--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -159,7 +159,7 @@ stepHeader state =
                         Colors.frame
 
                     StepStateRunning ->
-                        Colors.frame
+                        Colors.started
 
                     StepStateInterrupted ->
                         Colors.frame

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -3264,6 +3264,26 @@ all =
                         >> Query.find [ class "header" ]
                         >> Query.has
                             [ style "border" <| "1px solid " ++ Colors.failure ]
+                , test "started step has a yellow border" <|
+                    fetchPlanWithTaskStep
+                        >> Application.handleDelivery
+                            (EventsReceived <|
+                                Ok <|
+                                    [ { url = eventsUrl
+                                      , data =
+                                            STModels.StartTask
+                                                { source = "stdout"
+                                                , id = "plan"
+                                                }
+                                                (Time.millisToPosix 0)
+                                      }
+                                    ]
+                            )
+                        >> Tuple.first
+                        >> Common.queryView
+                        >> Query.find [ class "header" ]
+                        >> Query.has
+                            [ style "border" <| "1px solid " ++ Colors.started ]
                 , test "network error on first event shows passport officer" <|
                     let
                         imgUrl =


### PR DESCRIPTION
fixes #4248

# Release Note
```tex
\note{feature}{
  Having red and orange borders for failing and erroring steps were such a \link{big hit}{https://github.com/concourse/concourse/pull/4164}, we decided to add another!

  Now running steps have a nice yellow border, making it easy to see what is currently running. \link{#4250}{https://github.com/concourse/concourse/pull/4250} 
}
```