### PR TITLE
remove *'s from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,16 @@
-.github/*          @vito
+.github/           @vito
 CODE_OF_CONDUCT.md @vito
 CONTRIBUTING.md    @concourse/pivotal
-web/*              @concourse/ux
+web/               @concourse/ux
 package.json       @concourse/ux
 yarn.lock          @concourse/ux
-fly/*              @concourse/core-api @concourse/ux
-go-concourse/*     @concourse/core-api
-atc/*              @concourse/core-api
-skymarshal/*       @concourse/core-api
-vars/*             @concourse/core-api
-atc/exec/*         @concourse/runtime @concourse/core-api
-atc/worker/*       @concourse/runtime
-atc/runtime/*      @concourse/runtime
-worker/*           @concourse/runtime
-tsa/*              @concourse/runtime
+fly/               @concourse/core-api @concourse/ux
+go-concourse/      @concourse/core-api
+atc/               @concourse/core-api
+skymarshal/        @concourse/core-api
+vars/              @concourse/core-api
+atc/exec/          @concourse/runtime @concourse/core-api
+atc/worker/        @concourse/runtime
+atc/runtime/       @concourse/runtime
+worker/            @concourse/runtime
+tsa/               @concourse/runtime


### PR DESCRIPTION
fixes #4260

Originally we added the CODEOWNERS file intending to have various teams own entire directory trees, not just their top levels.

From https://help.github.com/en/articles/about-code-owners:
>        # In this example, @doctocat owns any files in the build/logs
>        # directory at the root of the repository and any of its
>        # subdirectories.
>        /build/logs/ @doctocat
>
>        # The `docs/*` pattern will match files like
>        # `docs/getting-started.md` but not further nested files like
>        # `docs/build-app/troubleshooting.md`.
>        docs/*  docs@example.com