### PR TITLE
Do not acquire lock when decreasing task count.

### DIFF
--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -143,7 +143,7 @@ func (client *client) RunTaskStep(
 	}
 
 	if strategy.ModifiesActiveTasks() {
-		defer decreaseActiveTasks(logger.Session("decrease-active-tasks"), lockFactory, chosenWorker)
+		defer decreaseActiveTasks(logger.Session("decrease-active-tasks"), chosenWorker)
 	}
 
 	container, err := chosenWorker.FindOrCreateContainer(
@@ -341,40 +341,12 @@ func (client *client) chooseTaskWorker(
 	return chosenWorker, nil
 }
 
-func decreaseActiveTasks(logger lager.Logger, lockFactory lock.LockFactory, w Worker) {
-	var (
-		activeTasksLock lock.Lock
-		err             error
-		acquired        bool
-	)
-	for {
-		activeTasksLock, acquired, err = lockFactory.Acquire(logger, lock.NewActiveTasksLockID())
-		if err != nil {
-			logger.Error("failed-to-acquire-active-tasks-lock", err)
-			return
-		}
-
-		if !acquired {
-			time.Sleep(time.Second)
-			continue
-		} else {
-			break
-		}
-	}
-
-	err = w.DecreaseActiveTasks()
+func decreaseActiveTasks(logger lager.Logger, w Worker) {
+	err := w.DecreaseActiveTasks()
 	if err != nil {
 		logger.Error("failed-to-decrease-active-tasks", err)
 		return
 	}
-
-	err = activeTasksLock.Release()
-	if err != nil {
-		logger.Error("failed-to-release-active-tasks-lock", err)
-		return
-	}
-
-	return
 }
 
 type processStatus struct {


### PR DESCRIPTION
The tasks count decreasing (used in the limit-active-tasks strategy) can be
executed concourrently as the DB transaction will make sure that the end
value is consistent.

Trying to acquire a lock when decreasing the tasks count in a system with
several flying task can easily result in a race to acquire lock and eventually
even a "de facto" dead lock.

We observed this issue on our Production CI where it eventually all just hanged, what happens is the following:

- New tasks acquire the lock to check if a worker is free and all are busy
- Completed tasks try to acquire a lock to decrease the task and free the worker
- More tasks enter the queue and try to acquire a lock
- The decrease-active-tasks is can perform its operation once in a blue moon making the situation worse and worse

@deniseyu 
@ddadlani 