### PR TITLE
fly: when prompt a fly command to run, use full fly path the is invoked instead of just hardcode "fly".

### DIFF
--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -89,7 +89,7 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 }
 
 func (atcConfig ATCConfig) UnpausePipelineCommand() string {
-	return fmt.Sprintf("fly -t %s unpause-pipeline -p %s", atcConfig.TargetName, atcConfig.PipelineName)
+	return fmt.Sprintf("%s -t %s unpause-pipeline -p %s", os.Args[0], atcConfig.TargetName, atcConfig.PipelineName)
 }
 
 func (atcConfig ATCConfig) showPipelineUpdateResult(created bool, updated bool) {

--- a/fly/commands/internal/setpipelinehelpers/atc_config_test.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config_test.go
@@ -1,7 +1,9 @@
 package setpipelinehelpers_test
 
 import (
+	"fmt"
 	. "github.com/concourse/concourse/fly/commands/internal/setpipelinehelpers"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -31,6 +33,7 @@ var _ = Describe("UnpausePipelineCommand", func() {
 			TargetName:   "my-target",
 			PipelineName: "my-pipeline",
 		}
-		Expect(atcConfig.UnpausePipelineCommand()).To(Equal("fly -t my-target unpause-pipeline -p my-pipeline"))
+		expected := fmt.Sprintf("%s -t my-target unpause-pipeline -p my-pipeline", os.Args[0])
+		Expect(atcConfig.UnpausePipelineCommand()).To(Equal(expected))
 	})
 })

--- a/fly/integration/login_test.go
+++ b/fly/integration/login_test.go
@@ -585,8 +585,8 @@ var _ = Describe("login Command", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(sess).Should(gexec.Exit(0))
-				Expect(sess.Err).To(gbytes.Say(`fly version \(%s\) is out of sync with the target \(%s\). to sync up, run the following:`, flyVersion, atcVersion))
-				Expect(sess.Err).To(gbytes.Say(`    fly -t some-target sync\n`))
+				Expect(sess.Err).To(gbytes.Say(`fly version \(%s\) is out of sync with the target \(%s\). to sync up, run the following:\n\n    `, flyVersion, atcVersion))
+				Expect(sess.Err).To(gbytes.Say(`fly -t some-target sync\n`))
 			})
 		})
 	})

--- a/fly/integration/set_pipeline_test.go
+++ b/fly/integration/set_pipeline_test.go
@@ -1028,7 +1028,7 @@ this is super secure
 
 							Eventually(sess).Should(gbytes.Say("the pipeline is currently paused. to unpause, either:"))
 							Eventually(sess).Should(gbytes.Say("  - run the unpause-pipeline command:"))
-							Eventually(sess).Should(gbytes.Say("    fly -t " + targetName + " unpause-pipeline -p awesome-pipeline"))
+							Eventually(sess).Should(gbytes.Say("    %s -t %s unpause-pipeline -p awesome-pipeline", flyPath, targetName))
 							Eventually(sess).Should(gbytes.Say("  - click play next to the pipeline in the web ui"))
 
 							<-sess.Exited

--- a/fly/integration/version_test.go
+++ b/fly/integration/version_test.go
@@ -54,8 +54,8 @@ var _ = Describe("Version Checks", func() {
 
 		It("warns the user that there is a difference", func() {
 			Eventually(flySession).Should(gexec.Exit(0))
-			Expect(flySession.Err).To(gbytes.Say(`fly version \(%s\) is out of sync with the target \(%s\). to sync up, run the following:`, flyVersion, atcVersion))
-			Expect(flySession.Err).To(gbytes.Say(`    fly -t %s sync\n`, targetName))
+			Expect(flySession.Err).To(gbytes.Say(`fly version \(%s\) is out of sync with the target \(%s\). to sync up, run the following:\n\n    `, flyVersion, atcVersion))
+			Expect(flySession.Err).To(gbytes.Say(`fly -t %s sync\n`, targetName))
 		})
 	})
 
@@ -82,8 +82,8 @@ var _ = Describe("Version Checks", func() {
 
 		It("error and tell the user to upgrade", func() {
 			Eventually(flySession).Should(gexec.Exit(1))
-			Expect(flySession.Err).To(gbytes.Say(`fly version \(%s\) is out of sync with the target \(%s\). to sync up, run the following:`, flyVersion, atcVersion))
-			Expect(flySession.Err).To(gbytes.Say(`    fly -t %s sync\n`, targetName))
+			Expect(flySession.Err).To(gbytes.Say(`fly version \(%s\) is out of sync with the target \(%s\). to sync up, run the following:\n\n    `, flyVersion, atcVersion))
+			Expect(flySession.Err).To(gbytes.Say(`fly -t %s sync\n`, targetName))
 			Expect(flySession.Err).To(gbytes.Say("cowardly refusing to run due to significant version discrepancy"))
 		})
 	})
@@ -99,8 +99,8 @@ var _ = Describe("Version Checks", func() {
 
 		It("error and tell the user to upgrade", func() {
 			Eventually(flySession).Should(gexec.Exit(1))
-			Expect(flySession.Err).To(gbytes.Say(`fly version \(%s\) is out of sync with the target \(%s\). to sync up, run the following:`, flyVersion, atcVersion))
-			Expect(flySession.Err).To(gbytes.Say(`    fly -t %s sync\n`, targetName))
+			Expect(flySession.Err).To(gbytes.Say(`fly version \(%s\) is out of sync with the target \(%s\). to sync up, run the following:\n\n    `, flyVersion, atcVersion))
+			Expect(flySession.Err).To(gbytes.Say(`fly -t %s sync\n`, targetName))
 			Expect(flySession.Err).To(gbytes.Say("cowardly refusing to run due to significant version discrepancy"))
 		})
 	})

--- a/fly/main.go
+++ b/fly/main.go
@@ -47,12 +47,12 @@ func handleError(helpParser *flags.Parser, err error) {
 		if err == concourse.ErrUnauthorized {
 			fmt.Fprintln(ui.Stderr, "not authorized. run the following to log in:")
 			fmt.Fprintln(ui.Stderr, "")
-			fmt.Fprintln(ui.Stderr, "    "+ui.Embolden("fly -t %s login", commands.Fly.Target))
+			fmt.Fprintln(ui.Stderr, "    "+ui.Embolden("%s -t %s login", os.Args[0], commands.Fly.Target))
 			fmt.Fprintln(ui.Stderr, "")
 		} else if err == rc.ErrNoTargetSpecified {
 			fmt.Fprintln(ui.Stderr, "no target specified. specify the target with "+ui.Embolden("-t")+" or log in like so:")
 			fmt.Fprintln(ui.Stderr, "")
-			fmt.Fprintln(ui.Stderr, "    "+ui.Embolden("fly -t (alias) login -c (concourse url)"))
+			fmt.Fprintln(ui.Stderr, "    "+ui.Embolden("%s -t (alias) login -c (concourse url)", os.Args[0]))
 			fmt.Fprintln(ui.Stderr, "")
 		} else if versionErr, ok := err.(rc.ErrVersionMismatch); ok {
 			fmt.Fprintln(ui.Stderr, versionErr.Error())

--- a/fly/rc/target.go
+++ b/fly/rc/target.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"runtime"
 	"time"
 
@@ -34,7 +35,9 @@ func NewErrVersionMismatch(flyVersion string, atcVersion string, targetName Targ
 }
 
 func (e ErrVersionMismatch) Error() string {
-	return fmt.Sprintf("fly version (%s) is out of sync with the target (%s). to sync up, run the following:\n\n    fly -t %s sync\n", ui.Embolden(e.flyVersion), ui.Embolden(e.atcVersion), e.targetName)
+	return fmt.Sprintf(
+		"fly version (%s) is out of sync with the target (%s). to sync up, run the following:\n\n    %s -t %s sync\n",
+		ui.Embolden(e.flyVersion), ui.Embolden(e.atcVersion), os.Args[0], e.targetName)
 }
 
 type Target interface {


### PR DESCRIPTION
Test:

    $ fly/fly -t tt sp -c pipeline.yml -p pp
    ...
    the pipeline is currently paused. to unpause, either:
      - run the unpause-pipeline command:
        fly/fly -t tt unpause-pipeline -p pp
     - click play next to the pipeline in the web ui

Fixes: #4283 