### PR TITLE
[BUGFIX] Release lock if pool.ContainerInWorker errors.

### DIFF
--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/runtime"
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 const taskProcessID = "task"
@@ -278,6 +279,10 @@ func (client *client) chooseTaskWorker(
 			}
 			existingContainer, err = client.pool.ContainerInWorker(logger, owner, containerSpec, workerSpec)
 			if err != nil {
+				release_err := activeTasksLock.Release()
+				if release_err != nil {
+					err = multierror.Append(err, release_err)
+				}
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Whenever ContainerInWorker returned an error the Active Tasks Lock
would never be released, blocking any task to check for available
workers and thus to start.

Here the bug is fixed, by releasing the lock if the ContainerInWorker
returns an error.

Additionally the unit tests are expanded to verify that for every
lock acquisition a lock release is also called.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>