### PR TITLE
Allow task abortion waiting for worker in limit-active-tasks.

### DIFF
--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -302,6 +302,17 @@ func (client *client) chooseTaskWorker(
 		if strategy.ModifiesActiveTasks() {
 			waitWorker := time.Duration(5 * time.Second) // Workers polling frequency
 
+			select {
+			case <-ctx.Done():
+				logger.Info("aborted-waiting-worker")
+				err = activeTasksLock.Release()
+				if err != nil {
+					return nil, err
+				}
+				return nil, ctx.Err()
+			default:
+			}
+
 			if chosenWorker == nil {
 				err = activeTasksLock.Release()
 				if err != nil {

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -368,6 +368,17 @@ var _ = Describe("Client", func() {
 					})
 				})
 
+				Context("when the task is aborted waiting for an available worker", func() {
+					BeforeEach(func() {
+						cancel()
+					})
+					It("exits releasing the lock", func() {
+						Expect(err).To(Equal(context.Canceled))
+						Expect(status).To(Equal(-1))
+						Expect(fakeLock.ReleaseCallCount()).To(Equal(fakeLockFactory.AcquireCallCount()))
+					})
+				})
+
 				Context("when a container in worker returns an error", func() {
 					BeforeEach(func() {
 						fakePool.ContainerInWorkerReturns(false, errors.New("nope"))


### PR DESCRIPTION
If the user aborts the job while the task is waiting for a worker the task will immediately exit and return the correct error to allow the UI to display the job as "aborted".

Unit test is added to ensure that the correct values are returned and the locks released.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>