### PR TITLE
[Web] add super admin web ui functionalities 

### DIFF
--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -799,6 +799,7 @@ type alias User =
     , userName : String
     , name : String
     , email : String
+    , isAdmin : Bool
     , teams : Dict String (List String)
     }
 
@@ -810,6 +811,7 @@ decodeUser =
         |> andMap (Json.Decode.field "user_name" Json.Decode.string)
         |> andMap (Json.Decode.field "name" Json.Decode.string)
         |> andMap (Json.Decode.field "email" Json.Decode.string)
+        |> andMap (Json.Decode.field "is_admin" Json.Decode.bool)
         |> andMap (Json.Decode.field "teams" (Json.Decode.dict (Json.Decode.list Json.Decode.string)))
 
 

--- a/web/elm/src/UserState.elm
+++ b/web/elm/src/UserState.elm
@@ -24,14 +24,15 @@ isMember : { a | teamName : String, userState : UserState } -> Bool
 isMember { teamName, userState } =
     case userState of
         UserStateLoggedIn user ->
-            case Dict.get teamName user.teams of
-                Just roles ->
-                    List.member "pipeline-operator" roles
-                        || List.member "member" roles
-                        || List.member "owner" roles
+            if user.isAdmin then True
+            else
+                case Dict.get teamName user.teams of
+                    Just roles ->
+                        List.member "pipeline-operator" roles
+                            || List.member "member" roles
+                            || List.member "owner" roles
 
-                Nothing ->
-                    False
-
+                    Nothing ->
+                        False
         _ ->
             False

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -3556,6 +3556,7 @@ userWithRoles roles =
     , userName = "test"
     , name = "test"
     , email = "test"
+    , isAdmin = False
     , teams =
         Dict.fromList roles
     }

--- a/web/elm/tests/PauseToggleTests.elm
+++ b/web/elm/tests/PauseToggleTests.elm
@@ -25,6 +25,7 @@ all =
                         , userName = "test"
                         , name = "test"
                         , email = "test"
+                        , isAdmin = False
                         , teams = Dict.fromList [ ( "team", [ "viewer" ] ) ]
                         }
             in

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -172,6 +172,7 @@ all =
                                     , userName = "test"
                                     , name = "test"
                                     , email = "test"
+                                    , isAdmin = False
                                     , teams =
                                         Dict.fromList
                                             [ ( teamName, [ "member" ] )
@@ -2321,6 +2322,7 @@ all =
                                         , userName = "some-user"
                                         , name = "some-user"
                                         , email = "some-user"
+                                        , isAdmin = False
                                         , teams =
                                             Dict.fromList
                                                 [ ( "some-team"
@@ -2652,6 +2654,7 @@ all =
                         , userName = "test"
                         , name = "test"
                         , email = "test"
+                        , isAdmin = False
                         , teams = Dict.fromList [ ( teamName, [ "member" ] ) ]
                         }
                 in
@@ -2966,6 +2969,7 @@ all =
                         , userName = "test"
                         , name = "test"
                         , email = "test"
+                        , isAdmin = False
                         , teams = Dict.fromList [ ( teamName, [ "viewer" ] ) ]
                         }
                 in
@@ -3169,6 +3173,7 @@ givenUserIsAuthorized =
                 , userName = "test"
                 , name = "test"
                 , email = "test"
+                , isAdmin = False
                 , teams =
                     Dict.fromList
                         [ ( teamName, [ "member" ] )

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -1335,6 +1335,7 @@ all =
                                 , userName = "test"
                                 , name = "test"
                                 , email = "test"
+                                , isAdmin = False
                                 , teams =
                                     Dict.fromList
                                         [ ( "t", [ "member" ] ) ]
@@ -1350,6 +1351,7 @@ all =
                                 , userName = "test"
                                 , name = "test"
                                 , email = "test"
+                                , isAdmin = False
                                 , teams =
                                     Dict.fromList
                                         [ ( "s", [ "member" ] ) ]
@@ -1607,7 +1609,7 @@ eachHasStyle property value =
 
 sampleUser : Concourse.User
 sampleUser =
-    { id = "1", userName = "test", name = "Bob", email = "bob@bob.com", teams = Dict.empty }
+    { id = "1", userName = "test", name = "Bob", isAdmin = False, email = "bob@bob.com", teams = Dict.empty }
 
 
 pipelineBreadcrumbSelector : List Selector.Selector

--- a/web/elm/tests/UserStateTests.elm
+++ b/web/elm/tests/UserStateTests.elm
@@ -1,0 +1,75 @@
+module UserStateTests exposing (all)
+
+import Dict exposing (Dict)
+import Expect
+import Test exposing (Test, describe, test)
+import UserState exposing (UserState(..), isAnonymous, isMember)
+
+-- This helper function takes input parameters:
+-- teamName rolesOnTeam isAdmin
+isMemberHelper : String -> Dict String (List String) -> Bool -> Bool
+isMemberHelper teamName roles isAdmin =
+    isMember
+        { teamName = teamName
+        , userState =
+            UserStateLoggedIn
+                { id = "test"
+                , userName = "user"
+                , name = "username"
+                , email = "test_email"
+                , isAdmin = isAdmin
+                , teams = roles
+                }
+        }
+
+
+all : Test
+all =
+    describe "user state"
+        [ describe "isAnonymous" <|
+            [ test "is true when the user is unknown" <|
+                \_ ->
+                    UserStateUnknown
+                        |> isAnonymous
+                        |> Expect.equal True
+            , test "is false when the user is logged in" <|
+                \_ ->
+                    UserStateLoggedIn
+                        { id = "test"
+                        , userName = "user"
+                        , name = "username"
+                        , email = "test_email"
+                        , isAdmin = True
+                        , teams = Dict.fromList [ ( "team1", [ "role" ] ) ]
+                        }
+                        |> isAnonymous
+                        |> Expect.false "logged-in user should not be anonymous"
+            , test "is true when the user is logged out" <|
+                \_ ->
+                    UserStateLoggedOut
+                        |> isAnonymous
+                        |> Expect.true "logged-out user should be anonymous"
+            ]
+        , describe "isMember"
+            [ test "is true when the super admin user is NOT the member on the given team" <|
+                \_ ->
+                    isMemberHelper "team1" (Dict.fromList [ ( "other-team", [ "owner" ] ) ]) True
+                        |> Expect.equal True
+            , test "is true when the member is the of role 'pipeline operator'" <|
+                \_ ->
+                    isMemberHelper "team1" (Dict.fromList [ ( "team1", [ "pipeline-operator" ] ) ]) False
+                        |> Expect.equal True
+            , test "is true when the member is the of role 'member'" <|
+                \_ ->
+                    isMemberHelper "team1" (Dict.fromList [ ( "team1", [ "member" ] ) ]) False
+                        |> Expect.equal True
+            , test "is true when the member is the of role 'owner'" <|
+                \_ ->
+                    isMemberHelper "team1" (Dict.fromList [ ( "team1", [ "owner" ] ) ]) False
+                        |> Expect.equal True
+            , test "is false when the member is NOT any of role 'owner' or 'member' or 'pipeline-operator' or admin" <|
+                \_ ->
+                    isMemberHelper "team1" (Dict.fromList [ ( "team1", [] ) ]) False
+                        |> Expect.equal False
+            ]
+        ]


### PR DESCRIPTION
fixes #4194 

There are a few areas in the web UI where the client tries to figure out if you're authorized to perform a certain action. These are:

- pause/unpause a pipeline
- force a check resource
- expose a pipeline

This commit changes this behaviour to allow a user to perform these functions from the web ui.

@pivotal-jamie-klassen is there anywhere that we could be adding tests? thx!

cc @taylorsilva 