### PR TITLE
Support `fly watch --url`

### DIFF
--- a/fly/commands/watch.go
+++ b/fly/commands/watch.go
@@ -26,7 +26,25 @@ func getBuildIDFromURL(target rc.Target, urlParam string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	urlMap := parseUrlPath(u.Path)
+
+	parsedTargetUrl := url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+	}
+
+	host := parsedTargetUrl.String()
+	if host != target.URL() {
+		err = fmt.Errorf("URL doesn't match target (%s, %s)", urlParam, target.URL())
+		return 0, err
+	}
+
+	team := urlMap["teams"]
+	if team != "" && team != target.Team().Name() {
+		err = fmt.Errorf("Team in URL doesn't match the current team of the target (%s, %s)", urlParam, team)
+		return 0, err
+	}
 
 	if urlMap["pipelines"] != "" && urlMap["jobs"] != "" {
 		build, err := GetBuild(client, target.Team(), urlMap["jobs"], urlMap["builds"], urlMap["pipelines"])

--- a/fly/integration/watch_test.go
+++ b/fly/integration/watch_test.go
@@ -121,6 +121,10 @@ var _ = Describe("Watching", func() {
 		It("Watches the given build id", func() {
 			watch("--build", "3")
 		})
+
+		It("Watches the given direct build URL", func() {
+			watch("--url", atcServer.URL()+"/builds/3")
+		})
 	})
 
 	Context("with a specific job and pipeline", func() {
@@ -176,6 +180,10 @@ var _ = Describe("Watching", func() {
 			It("watches the job's next build", func() {
 				watch("--job", "some-pipeline/some-job")
 			})
+
+			It("watches the job's next build URL", func() {
+				watch("--url", atcServer.URL()+"/teams/main/pipelines/some-pipeline/jobs/some-job")
+			})
 		})
 
 		Context("when the job only has a finished build", func() {
@@ -200,6 +208,10 @@ var _ = Describe("Watching", func() {
 			It("watches the job's finished build", func() {
 				watch("--job", "main/some-job")
 			})
+
+			It("watches the job's finished build URL", func() {
+				watch("--url", atcServer.URL()+"/teams/main/pipelines/main/jobs/some-job")
+			})
 		})
 
 		Context("with a specific build of the job", func() {
@@ -220,6 +232,10 @@ var _ = Describe("Watching", func() {
 
 			It("watches the given build", func() {
 				watch("--job", "main/some-job", "--build", "3")
+			})
+
+			It("watches the given build URL", func() {
+				watch("--url", atcServer.URL()+"/teams/main/pipelines/main/jobs/some-job/builds/3")
 			})
 		})
 	})


### PR DESCRIPTION
Sometimes you just want to fire whatever you're looking at into the
console, and for that, the quickest way is `fly watch --url <Paste>`

Should work with both regular team/pipeline/job URLs and raw /builds/
URLs.

Signed-off-by: hfinucane <h.finucane@gmail.com>