### PR TITLE
Task lock team platform

### DIFF
--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -49,8 +49,8 @@ func NewDatabaseMigrationLockID() LockID {
 	return LockID{LockTypeDatabaseMigration}
 }
 
-func NewActiveTasksLockID() LockID {
-	return LockID{LockTypeActiveTasks}
+func NewActiveTasksLockID(platform string, teamID int) LockID {
+	return LockID{LockTypeActiveTasks, lockIDFromString(platform + strconv.Itoa(teamID))}
 }
 
 //go:generate counterfeiter . LockFactory

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -477,6 +477,7 @@ var lockTypeNames = map[int]string{
 	lock.LockTypeVolumeCreating:         "VolumeCreating",
 	lock.LockTypeContainerCreating:      "ContainerCreating",
 	lock.LockTypeDatabaseMigration:      "DatabaseMigration",
+	lock.LockTypeActiveTasks:            "ActiveTasks",
 }
 
 type LockAcquired struct {

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -268,7 +268,7 @@ func (client *client) chooseTaskWorker(
 	for {
 		if strategy.ModifiesActiveTasks() {
 			var acquired bool
-			activeTasksLock, acquired, err = lockFactory.Acquire(logger, lock.NewActiveTasksLockID())
+			activeTasksLock, acquired, err = lockFactory.Acquire(logger, lock.NewActiveTasksLockID(workerSpec.Platform, workerSpec.TeamID))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The ActiveTask lock is acquired when a task wants to select a worker where to execute itself. The pools of workers where the task can run are separated by team and platform, thus having one lock for each
of these combination can improve the time it takes for unrelated, concurrent tasks to acquire a lock and
verify/reserve a worker where to be executed.

Also add `LockTypeActiveTasks` to the metrics as it was previously forgotten.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>