### PR TITLE
adding styling to scrollbars

### DIFF
--- a/release-notes/v5.5.0.md
+++ b/release-notes/v5.5.0.md
@@ -111,3 +111,7 @@
 #### <sub><sup><a name="v550-note-28" href="#v550-note-28">:link:</a></sup></sub> fix
 
 * @xavierzwirtz also fixed `hg.pull` by passing the `sourceUri` in the Mercurial resource. This could fix some issues where Mercurial wasn't saving the full uri in the `hgrc` file concourse/hg-resource#13.
+
+#### <sub><sup><a name="v550-note-29" href="#v550-note-29">:link:</a></sup></sub> fix
+
+* Scrollbars have been given a touch of the Concourse design language. It should no longer use browser defaults. #4355

--- a/web/assets/css/globals.less
+++ b/web/assets/css/globals.less
@@ -9,6 +9,7 @@ body {
   margin: 0;
   background: @base02;
   color: @base05;
+  scrollbar-color: #555 rgba(0,0,0,0);
 }
 
 pre {
@@ -28,3 +29,18 @@ h3 {
   font-size: 14px;
 }
 
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0);
+}
+
+::-webkit-scrollbar-thumb {
+  background: #555;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #707070;
+}


### PR DESCRIPTION
The default scrollbar was hurting my eyes. So I tried applying the concourse styling to it. I used colors from the sidebar item active/inactive states.

![Screen Shot 2019-09-03 at 4 15 00 PM](https://user-images.githubusercontent.com/9054726/64205633-7667a200-ce66-11e9-8e9a-f463d3b2ae81.png)


Signed-off-by: Krishna Mannem <kmannem@pivotal.io>