### PR TITLE
fix go.mod to properly comply to 1.13 strict rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -219,7 +219,9 @@ require (
 	gotest.tools v2.1.0+incompatible // indirect
 	k8s.io/api v0.0.0-20171027084545-218912509d74
 	k8s.io/apimachinery v0.0.0-20171027084411-18a564baac72
-	k8s.io/client-go v2.0.0-alpha.0.0.20171101191150-72e1c2a1ef30+incompatible
+	k8s.io/client-go v0.0.0-20171101191150-72e1c2a1ef30
 	k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c // indirect
 	layeh.com/radius v0.0.0-20190101232339-d3a4fc175dc9 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -727,6 +727,8 @@ k8s.io/api v0.0.0-20171027084545-218912509d74 h1:CYism0UbF96TF8s8sYrKagsJn3oqR45
 k8s.io/api v0.0.0-20171027084545-218912509d74/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20171027084411-18a564baac72 h1:pPbfmsjOvePqojmf5AhR0o7bxZTCxE0nkDakanV50CM=
 k8s.io/apimachinery v0.0.0-20171027084411-18a564baac72/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/client-go v0.0.0-20171101191150-72e1c2a1ef30 h1:7AKWxiRHfPOXJ/yFjUQ0/kuAdZr5ueEm4ePdxviSSWs=
+k8s.io/client-go v0.0.0-20171101191150-72e1c2a1ef30/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/client-go v2.0.0-alpha.0.0.20171101191150-72e1c2a1ef30+incompatible h1:mFaVD8Zk1a4jTvn0EYIk8ecGpmIZ1ymZ4WdL3vexMPU=
 k8s.io/client-go v2.0.0-alpha.0.0.20171101191150-72e1c2a1ef30+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c h1:3KSCztE7gPitlZmWbNwue/2U0YruD65DqX3INopDAQM=


### PR DESCRIPTION
With the bump to go 1.13, there's a more strict validation against
the tags used in the [pseudo versions], meaning that it ends up really
reaching out to the source provider to validate if the sha matches the
tag (which, in this case, doesn't):

	git show v2.0.0-alpha.1
	commit d81cb85237595f720d83eda492bae8f6162fc5c0 (tag: v2.0.0-alpha.1)

By removing the tag, we can then let go perform the validation against
just the SHA.

[pseudo versions]: https://golang.org/cmd/go/#hdr-Pseudo_versions

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>