### PR TITLE
Enforced all version fields to be strings

### DIFF
--- a/atc/config.go
+++ b/atc/config.go
@@ -128,7 +128,10 @@ func (c *VersionConfig) UnmarshalJSON(version []byte) error {
 		for k, v := range actual {
 			if s, ok := v.(string); ok {
 				version[k] = strings.TrimSpace(s)
+				continue
 			}
+
+			return fmt.Errorf("the value %v of %s is not a string", v, k)
 		}
 
 		c.Pinned = version

--- a/atc/config.go
+++ b/atc/config.go
@@ -127,7 +127,7 @@ func (c *VersionConfig) UnmarshalJSON(version []byte) error {
 
 		for k, v := range actual {
 			if s, ok := v.(string); ok {
-				version[k] = strings.TrimSpace(s)
+				version[k] = s
 				continue
 			}
 

--- a/atc/config_test.go
+++ b/atc/config_test.go
@@ -4,45 +4,39 @@ import (
 	"encoding/json"
 
 	. "github.com/concourse/concourse/atc"
-	"sigs.k8s.io/yaml"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Config", func() {
 	Describe("VersionConfig", func() {
-		Context("when unmarshaling a pinned version from YAML", func() {
-			It("produces the correct version config without error", func() {
-				var versionConfig VersionConfig
-				bs := []byte(`some: version`)
-				err := yaml.Unmarshal(bs, &versionConfig)
-				Expect(err).NotTo(HaveOccurred())
-
-				expected := VersionConfig{
-					Pinned: Version{
-						"some": "version",
-					},
-				}
-
-				Expect(versionConfig).To(Equal(expected))
-			})
-		})
-
 		Context("when unmarshaling a pinned version from JSON", func() {
-			It("produces the correct version config without error", func() {
-				var versionConfig VersionConfig
-				bs := []byte(`{ "some": "version" }`)
-				err := json.Unmarshal(bs, &versionConfig)
-				Expect(err).NotTo(HaveOccurred())
+			Context("when the version is all string", func() {
+				It("produces the correct version config without error", func() {
+					var versionConfig VersionConfig
+					bs := []byte(`{ "some": "  version  ", "other": "8" }`)
+					err := json.Unmarshal(bs, &versionConfig)
+					Expect(err).NotTo(HaveOccurred())
 
-				expected := VersionConfig{
-					Pinned: Version{
-						"some": "version",
-					},
-				}
+					expected := VersionConfig{
+						Pinned: Version{
+							"some":  "version",
+							"other": "8",
+						},
+					}
 
-				Expect(versionConfig).To(Equal(expected))
+					Expect(versionConfig).To(Equal(expected))
+				})
+			})
+
+			Context("when the version contains not all string", func() {
+				It("produces an error", func() {
+					var versionConfig VersionConfig
+					bs := []byte(`{ "some": 8 }`)
+					err := json.Unmarshal(bs, &versionConfig)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("the value 8 of some is not a string"))
+				})
 			})
 		})
 	})

--- a/atc/config_test.go
+++ b/atc/config_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Config", func() {
 			Context("when the version is all string", func() {
 				It("produces the correct version config without error", func() {
 					var versionConfig VersionConfig
-					bs := []byte(`{ "some": "  version  ", "other": "8" }`)
+					bs := []byte(`{ "some": "version", "other": "8" }`)
 					err := json.Unmarshal(bs, &versionConfig)
 					Expect(err).NotTo(HaveOccurred())
 

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -9,3 +9,7 @@
 #### <sub><sup><a name="note-cluster-log" href="#note-cluster-log">:link:</a></sup></sub> fix
 
 * The cluster name can now be added to each and every log line with the handy dandy `--log-cluster-name` flag, available on the `web` nodes. This can be used in a scenario where you have multiple Concourse clusters forwarding logs to a common sink and have no other way of categorizing the logs. Thanks again @evanchaoli! #4387
+
+#### <sub><sup><a name="note-version-string" href="#note-version-string">:link:</a></sup></sub> fix
+
+* To pin a version for a resource on `get` step, the `set-pipeline` command for fly will now take only string value in key-value pair of given version. #4371


### PR DESCRIPTION
This pr fixes the bug #4236. An error is now returned when there is a non-string value in the version config.