### PR TITLE
atc: fix ListAllPipelines ordering

### DIFF
--- a/atc/db/pipeline_factory.go
+++ b/atc/db/pipeline_factory.go
@@ -59,7 +59,7 @@ func (f *pipelineFactory) VisiblePipelines(teamNames []string) ([]Pipeline, erro
 
 func (f *pipelineFactory) AllPipelines() ([]Pipeline, error) {
 	rows, err := pipelinesQuery.
-		OrderBy("ordering").
+		OrderBy("team_id ASC", "ordering ASC").
 		RunWith(f.conn).
 		Query()
 	if err != nil {

--- a/atc/db/pipeline_factory_test.go
+++ b/atc/db/pipeline_factory_test.go
@@ -98,7 +98,24 @@ var _ = Describe("Pipeline Factory", func() {
 			team, err := teamFactory.CreateTeam(atc.Team{Name: "some-team"})
 			Expect(err).ToNot(HaveOccurred())
 
-			pipeline1, _, err = team.SavePipeline("fake-pipeline", atc.Config{
+			pipeline2, _, err = team.SavePipeline("fake-pipeline-two", atc.Config{
+				Jobs: atc.JobConfigs{
+					{Name: "job-fake"},
+				},
+			}, db.ConfigVersion(1), false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pipeline2.Reload()).To(BeTrue())
+
+			pipeline3, _, err = team.SavePipeline("fake-pipeline-three", atc.Config{
+				Jobs: atc.JobConfigs{
+					{Name: "job-fake-two"},
+				},
+			}, db.ConfigVersion(1), false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pipeline3.Expose()).To(Succeed())
+			Expect(pipeline3.Reload()).To(BeTrue())
+
+			pipeline1, _, err = defaultTeam.SavePipeline("fake-pipeline", atc.Config{
 				Jobs: atc.JobConfigs{
 					{Name: "job-name"},
 				},
@@ -107,25 +124,9 @@ var _ = Describe("Pipeline Factory", func() {
 			Expect(pipeline1.Expose()).To(Succeed())
 			Expect(pipeline1.Reload()).To(BeTrue())
 
-			pipeline2, _, err = defaultTeam.SavePipeline("fake-pipeline-two", atc.Config{
-				Jobs: atc.JobConfigs{
-					{Name: "job-fake"},
-				},
-			}, db.ConfigVersion(1), false)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pipeline2.Reload()).To(BeTrue())
-
-			pipeline3, _, err = defaultTeam.SavePipeline("fake-pipeline-three", atc.Config{
-				Jobs: atc.JobConfigs{
-					{Name: "job-fake-two"},
-				},
-			}, db.ConfigVersion(1), false)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(pipeline3.Expose()).To(Succeed())
-			Expect(pipeline3.Reload()).To(BeTrue())
 		})
 
-		It("returns all pipelines", func() {
+		It("returns all pipelines ordered by team id", func() {
 			pipelines, err := pipelineFactory.AllPipelines()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(pipelines)).To(Equal(3))

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -928,68 +928,6 @@ var _ = Describe("Team", func() {
 		})
 	})
 
-	Describe("VisiblePipelines", func() {
-		var (
-			pipelines []db.Pipeline
-			pipeline1 db.Pipeline
-			pipeline2 db.Pipeline
-		)
-
-		JustBeforeEach(func() {
-			var err error
-			pipelines, err = team.VisiblePipelines()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		Context("when the team has configured pipelines", func() {
-			BeforeEach(func() {
-				var err error
-				pipeline1, _, err = team.SavePipeline("fake-pipeline", atc.Config{
-					Jobs: atc.JobConfigs{
-						{Name: "job-name"},
-					},
-				}, db.ConfigVersion(1), false)
-				Expect(err).ToNot(HaveOccurred())
-
-				pipeline2, _, err = otherTeam.SavePipeline("fake-pipeline-two", atc.Config{
-					Jobs: atc.JobConfigs{
-						{Name: "job-fake"},
-					},
-				}, db.ConfigVersion(1), false)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(pipeline2.Expose()).To(Succeed())
-				Expect(pipeline2.Reload()).To(BeTrue())
-			})
-
-			It("returns the pipelines", func() {
-				Expect(pipelines).To(Equal([]db.Pipeline{pipeline1, pipeline2}))
-			})
-
-			Context("when the other team has a private pipeline", func() {
-				BeforeEach(func() {
-					var err error
-					_, _, err = otherTeam.SavePipeline("fake-pipeline-three", atc.Config{
-						Jobs: atc.JobConfigs{
-							{Name: "job-fake-again"},
-						},
-					}, db.ConfigVersion(1), false)
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				It("does not return the other team private pipeline", func() {
-					Expect(pipelines).To(Equal([]db.Pipeline{pipeline1, pipeline2}))
-				})
-			})
-		})
-
-		Context("when the team has no configured pipelines", func() {
-			It("returns no pipelines", func() {
-				Expect(pipelines).To(Equal([]db.Pipeline{}))
-			})
-		})
-	})
-
 	Describe("OrderPipelines", func() {
 		var pipeline1 db.Pipeline
 		var pipeline2 db.Pipeline

--- a/release-notes/v5.5.0.md
+++ b/release-notes/v5.5.0.md
@@ -119,3 +119,7 @@
 #### <sub><sup><a name="v550-note-29" href="#v550-note-29">:link:</a></sup></sub> fix
 
 * Scrollbars have been given a touch of the Concourse design language. It should no longer use browser defaults. #4355
+
+#### <sub><sup><a name="v550-note-4375" href="#v550-note-4375">:link:</a></sup></sub> fix
+
+* Fixed a (probably-long-standing) issue where the pipelines in the sidebar could [randomly rearrange](https://github.com/concourse/concourse/issues/4346) #4375.


### PR DESCRIPTION
Fixes #4346

My thinking is that for acceptance:
1. Be a super admin
1. `fly login -n main`
1. `fly set-pipeline -p pipeline`
1. `fly set-team -n team`
1. `fly login -n team`
1. `fly set-pipeline -p pipeline`
1. Look at the sidebar - take note of the team order (`main`, `team`).
1. (still logged in to `team`) `fly order-pipelines -p pipeline`
1. Look at the sidebar - the team order should be the same (if you did this test on master, they'd be reversed).