### PR TITLE
remove reference to db.containerMetadat from resource package

### DIFF
--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -198,9 +198,7 @@ func (step *GetStep) Run(ctx context.Context, state RunState) error {
 	versionedSource, err := step.resourceFetcher.Fetch(
 		ctx,
 		logger,
-		resource.Session{
-			Metadata: step.containerMetadata,
-		},
+		step.containerMetadata,
 		chosenWorker,
 		containerSpec,
 		resourceTypes,

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -182,15 +182,14 @@ var _ = Describe("GetStep", func() {
 			Expect(stepErr).ToNot(HaveOccurred())
 
 			Expect(fakeResourceFetcher.FetchCallCount()).To(Equal(1))
-			fctx, _, sid, actualWorker, actualContainerSpec, actualResourceTypes, resourceInstance, delegate := fakeResourceFetcher.FetchArgsForCall(0)
+			fctx, _, actualContainerMetadata, actualWorker, actualContainerSpec, actualResourceTypes, resourceInstance, delegate := fakeResourceFetcher.FetchArgsForCall(0)
 			Expect(fctx).To(Equal(ctx))
-			Expect(sid).To(Equal(resource.Session{
-				Metadata: db.ContainerMetadata{
+			Expect(actualContainerMetadata).To(Equal(
+				db.ContainerMetadata{
 					PipelineID:       4567,
 					Type:             db.ContainerTypeGet,
 					StepName:         "some-step",
 					WorkingDirectory: "/tmp/build/get",
-				},
 			}))
 			Expect(actualWorker.Name()).To(Equal("some-worker"))
 			Expect(actualContainerSpec).To(Equal(worker.ContainerSpec{

--- a/atc/fetcher/fetcher.go
+++ b/atc/fetcher/fetcher.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/resource"
 	"github.com/concourse/concourse/atc/worker"
@@ -25,7 +26,7 @@ type Fetcher interface {
 	Fetch(
 		ctx context.Context,
 		logger lager.Logger,
-		session resource.Session,
+		containerMetadata db.ContainerMetadata,
 		gardenWorker worker.Worker,
 		containerSpec worker.ContainerSpec,
 		resourceTypes atc.VersionedResourceTypes,
@@ -55,7 +56,7 @@ type fetcher struct {
 func (f *fetcher) Fetch(
 	ctx context.Context,
 	logger lager.Logger,
-	session resource.Session,
+	containerMetadata db.ContainerMetadata,
 	gardenWorker worker.Worker,
 	containerSpec worker.ContainerSpec,
 	resourceTypes atc.VersionedResourceTypes,
@@ -66,7 +67,7 @@ func (f *fetcher) Fetch(
 		"resource": resource.ResourcesDir("get"),
 	}
 
-	source := f.fetchSourceFactory.NewFetchSource(logger, gardenWorker, resourceInstance, resourceTypes, containerSpec, session, imageFetchingDelegate)
+	source := f.fetchSourceFactory.NewFetchSource(logger, gardenWorker, resourceInstance, resourceTypes, containerSpec, containerMetadata, imageFetchingDelegate)
 
 	ticker := f.clock.NewTicker(GetResourceLockInterval)
 	defer ticker.Stop()

--- a/atc/fetcher/fetcher_test.go
+++ b/atc/fetcher/fetcher_test.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/db/lock/lockfakes"
 	"github.com/concourse/concourse/atc/fetcher/fetcherfakes"
@@ -64,7 +65,7 @@ var _ = Describe("Fetcher", func() {
 		versionedSource, fetchErr = fetcher.Fetch(
 			ctx,
 			lagertest.NewTestLogger("test"),
-			resource.Session{},
+			db.ContainerMetadata{},
 			fakeWorker,
 			worker.ContainerSpec{
 				TeamID: teamID,

--- a/atc/fetcher/fetcherfakes/fake_fetch_source_factory.go
+++ b/atc/fetcher/fetcherfakes/fake_fetch_source_factory.go
@@ -6,13 +6,14 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/fetcher"
 	"github.com/concourse/concourse/atc/resource"
 	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeFetchSourceFactory struct {
-	NewFetchSourceStub        func(lager.Logger, worker.Worker, resource.ResourceInstance, atc.VersionedResourceTypes, worker.ContainerSpec, resource.Session, worker.ImageFetchingDelegate) fetcher.FetchSource
+	NewFetchSourceStub        func(lager.Logger, worker.Worker, resource.ResourceInstance, atc.VersionedResourceTypes, worker.ContainerSpec, db.ContainerMetadata, worker.ImageFetchingDelegate) fetcher.FetchSource
 	newFetchSourceMutex       sync.RWMutex
 	newFetchSourceArgsForCall []struct {
 		arg1 lager.Logger
@@ -20,7 +21,7 @@ type FakeFetchSourceFactory struct {
 		arg3 resource.ResourceInstance
 		arg4 atc.VersionedResourceTypes
 		arg5 worker.ContainerSpec
-		arg6 resource.Session
+		arg6 db.ContainerMetadata
 		arg7 worker.ImageFetchingDelegate
 	}
 	newFetchSourceReturns struct {
@@ -33,7 +34,7 @@ type FakeFetchSourceFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeFetchSourceFactory) NewFetchSource(arg1 lager.Logger, arg2 worker.Worker, arg3 resource.ResourceInstance, arg4 atc.VersionedResourceTypes, arg5 worker.ContainerSpec, arg6 resource.Session, arg7 worker.ImageFetchingDelegate) fetcher.FetchSource {
+func (fake *FakeFetchSourceFactory) NewFetchSource(arg1 lager.Logger, arg2 worker.Worker, arg3 resource.ResourceInstance, arg4 atc.VersionedResourceTypes, arg5 worker.ContainerSpec, arg6 db.ContainerMetadata, arg7 worker.ImageFetchingDelegate) fetcher.FetchSource {
 	fake.newFetchSourceMutex.Lock()
 	ret, specificReturn := fake.newFetchSourceReturnsOnCall[len(fake.newFetchSourceArgsForCall)]
 	fake.newFetchSourceArgsForCall = append(fake.newFetchSourceArgsForCall, struct {
@@ -42,7 +43,7 @@ func (fake *FakeFetchSourceFactory) NewFetchSource(arg1 lager.Logger, arg2 worke
 		arg3 resource.ResourceInstance
 		arg4 atc.VersionedResourceTypes
 		arg5 worker.ContainerSpec
-		arg6 resource.Session
+		arg6 db.ContainerMetadata
 		arg7 worker.ImageFetchingDelegate
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	fake.recordInvocation("NewFetchSource", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
@@ -63,13 +64,13 @@ func (fake *FakeFetchSourceFactory) NewFetchSourceCallCount() int {
 	return len(fake.newFetchSourceArgsForCall)
 }
 
-func (fake *FakeFetchSourceFactory) NewFetchSourceCalls(stub func(lager.Logger, worker.Worker, resource.ResourceInstance, atc.VersionedResourceTypes, worker.ContainerSpec, resource.Session, worker.ImageFetchingDelegate) fetcher.FetchSource) {
+func (fake *FakeFetchSourceFactory) NewFetchSourceCalls(stub func(lager.Logger, worker.Worker, resource.ResourceInstance, atc.VersionedResourceTypes, worker.ContainerSpec, db.ContainerMetadata, worker.ImageFetchingDelegate) fetcher.FetchSource) {
 	fake.newFetchSourceMutex.Lock()
 	defer fake.newFetchSourceMutex.Unlock()
 	fake.NewFetchSourceStub = stub
 }
 
-func (fake *FakeFetchSourceFactory) NewFetchSourceArgsForCall(i int) (lager.Logger, worker.Worker, resource.ResourceInstance, atc.VersionedResourceTypes, worker.ContainerSpec, resource.Session, worker.ImageFetchingDelegate) {
+func (fake *FakeFetchSourceFactory) NewFetchSourceArgsForCall(i int) (lager.Logger, worker.Worker, resource.ResourceInstance, atc.VersionedResourceTypes, worker.ContainerSpec, db.ContainerMetadata, worker.ImageFetchingDelegate) {
 	fake.newFetchSourceMutex.RLock()
 	defer fake.newFetchSourceMutex.RUnlock()
 	argsForCall := fake.newFetchSourceArgsForCall[i]

--- a/atc/fetcher/fetcherfakes/fake_fetcher.go
+++ b/atc/fetcher/fetcherfakes/fake_fetcher.go
@@ -7,18 +7,19 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/fetcher"
 	"github.com/concourse/concourse/atc/resource"
 	"github.com/concourse/concourse/atc/worker"
 )
 
 type FakeFetcher struct {
-	FetchStub        func(context.Context, lager.Logger, resource.Session, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate) (resource.VersionedSource, error)
+	FetchStub        func(context.Context, lager.Logger, db.ContainerMetadata, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate) (resource.VersionedSource, error)
 	fetchMutex       sync.RWMutex
 	fetchArgsForCall []struct {
 		arg1 context.Context
 		arg2 lager.Logger
-		arg3 resource.Session
+		arg3 db.ContainerMetadata
 		arg4 worker.Worker
 		arg5 worker.ContainerSpec
 		arg6 atc.VersionedResourceTypes
@@ -37,13 +38,13 @@ type FakeFetcher struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeFetcher) Fetch(arg1 context.Context, arg2 lager.Logger, arg3 resource.Session, arg4 worker.Worker, arg5 worker.ContainerSpec, arg6 atc.VersionedResourceTypes, arg7 resource.ResourceInstance, arg8 worker.ImageFetchingDelegate) (resource.VersionedSource, error) {
+func (fake *FakeFetcher) Fetch(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerMetadata, arg4 worker.Worker, arg5 worker.ContainerSpec, arg6 atc.VersionedResourceTypes, arg7 resource.ResourceInstance, arg8 worker.ImageFetchingDelegate) (resource.VersionedSource, error) {
 	fake.fetchMutex.Lock()
 	ret, specificReturn := fake.fetchReturnsOnCall[len(fake.fetchArgsForCall)]
 	fake.fetchArgsForCall = append(fake.fetchArgsForCall, struct {
 		arg1 context.Context
 		arg2 lager.Logger
-		arg3 resource.Session
+		arg3 db.ContainerMetadata
 		arg4 worker.Worker
 		arg5 worker.ContainerSpec
 		arg6 atc.VersionedResourceTypes
@@ -68,13 +69,13 @@ func (fake *FakeFetcher) FetchCallCount() int {
 	return len(fake.fetchArgsForCall)
 }
 
-func (fake *FakeFetcher) FetchCalls(stub func(context.Context, lager.Logger, resource.Session, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate) (resource.VersionedSource, error)) {
+func (fake *FakeFetcher) FetchCalls(stub func(context.Context, lager.Logger, db.ContainerMetadata, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate) (resource.VersionedSource, error)) {
 	fake.fetchMutex.Lock()
 	defer fake.fetchMutex.Unlock()
 	fake.FetchStub = stub
 }
 
-func (fake *FakeFetcher) FetchArgsForCall(i int) (context.Context, lager.Logger, resource.Session, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate) {
+func (fake *FakeFetcher) FetchArgsForCall(i int) (context.Context, lager.Logger, db.ContainerMetadata, worker.Worker, worker.ContainerSpec, atc.VersionedResourceTypes, resource.ResourceInstance, worker.ImageFetchingDelegate) {
 	fake.fetchMutex.RLock()
 	defer fake.fetchMutex.RUnlock()
 	argsForCall := fake.fetchArgsForCall[i]

--- a/atc/fetcher/resource_instance_fetch_source.go
+++ b/atc/fetcher/resource_instance_fetch_source.go
@@ -27,7 +27,7 @@ type FetchSourceFactory interface {
 		resourceInstance resource.ResourceInstance,
 		resourceTypes atc.VersionedResourceTypes,
 		containerSpec worker.ContainerSpec,
-		session resource.Session,
+		containerMetadata db.ContainerMetadata,
 		imageFetchingDelegate worker.ImageFetchingDelegate,
 	) FetchSource
 }
@@ -53,7 +53,7 @@ func (r *fetchSourceFactory) NewFetchSource(
 	resourceInstance resource.ResourceInstance,
 	resourceTypes atc.VersionedResourceTypes,
 	containerSpec worker.ContainerSpec,
-	session resource.Session,
+	containerMetadata db.ContainerMetadata,
 	imageFetchingDelegate worker.ImageFetchingDelegate,
 ) FetchSource {
 	return &resourceInstanceFetchSource{
@@ -62,7 +62,7 @@ func (r *fetchSourceFactory) NewFetchSource(
 		resourceInstance:       resourceInstance,
 		resourceTypes:          resourceTypes,
 		containerSpec:          containerSpec,
-		session:                session,
+		containerMetadata:      containerMetadata,
 		imageFetchingDelegate:  imageFetchingDelegate,
 		dbResourceCacheFactory: r.resourceCacheFactory,
 		resourceFactory:        r.resourceFactory,
@@ -75,7 +75,7 @@ type resourceInstanceFetchSource struct {
 	resourceInstance       resource.ResourceInstance
 	resourceTypes          atc.VersionedResourceTypes
 	containerSpec          worker.ContainerSpec
-	session                resource.Session
+	containerMetadata      db.ContainerMetadata
 	imageFetchingDelegate  worker.ImageFetchingDelegate
 	dbResourceCacheFactory db.ResourceCacheFactory
 	resourceFactory        resource.ResourceFactory
@@ -136,7 +136,7 @@ func (s *resourceInstanceFetchSource) Create(ctx context.Context) (resource.Vers
 		s.logger,
 		s.imageFetchingDelegate,
 		s.resourceInstance.ContainerOwner(),
-		s.session.Metadata,
+		s.containerMetadata,
 		s.containerSpec,
 		s.resourceTypes,
 	)

--- a/atc/fetcher/resource_instance_fetch_source_test.go
+++ b/atc/fetcher/resource_instance_fetch_source_test.go
@@ -117,9 +117,7 @@ var _ = Describe("ResourceInstanceFetchSource", func() {
 					"resource": resource.ResourcesDir("get"),
 				},
 			},
-			resource.Session{
-				Metadata: metadata,
-			},
+			metadata,
 			fakeDelegate,
 		)
 	})

--- a/atc/resource/resource.go
+++ b/atc/resource/resource.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/worker"
 )
 
@@ -19,10 +18,6 @@ type Resource interface {
 }
 
 type ResourceType string
-
-type Session struct {
-	Metadata db.ContainerMetadata
-}
 
 type Metadata interface {
 	Env() []string

--- a/atc/worker/image/image_resource_fetcher.go
+++ b/atc/worker/image/image_resource_fetcher.go
@@ -157,10 +157,8 @@ func (i *imageResourceFetcher) Fetch(
 		return nil, nil, nil, err
 	}
 
-	getSess := resource.Session{
-		Metadata: db.ContainerMetadata{
-			Type: db.ContainerTypeGet,
-		},
+	containerMetadata := db.ContainerMetadata{
+		Type: db.ContainerTypeGet,
 	}
 
 	containerSpec := worker.ContainerSpec{
@@ -175,7 +173,7 @@ func (i *imageResourceFetcher) Fetch(
 	versionedSource, err := i.resourceFetcher.Fetch(
 		ctx,
 		logger.Session("init-image"),
-		getSess,
+		containerMetadata,
 		i.worker,
 		containerSpec,
 		i.customTypes,

--- a/atc/worker/image/image_resource_fetcher_test.go
+++ b/atc/worker/image/image_resource_fetcher_test.go
@@ -344,12 +344,12 @@ var _ = Describe("Image", func() {
 
 							It("fetches resource with correct session", func() {
 								Expect(fakeResourceFetcher.FetchCallCount()).To(Equal(1))
-								_, _, session, actualWorker, containerSpec, actualCustomTypes, resourceInstance, delegate := fakeResourceFetcher.FetchArgsForCall(0)
-								Expect(session).To(Equal(resource.Session{
-									Metadata: db.ContainerMetadata{
+								_, _, actualContainerMetadata, actualWorker, containerSpec, actualCustomTypes, resourceInstance, delegate := fakeResourceFetcher.FetchArgsForCall(0)
+								Expect(actualContainerMetadata).To(Equal(
+									db.ContainerMetadata{
 										Type: db.ContainerTypeGet,
 									},
-								}))
+								))
 								Expect(actualWorker.Name()).To(Equal("some-worker"))
 								Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 									ResourceType: "docker",
@@ -565,12 +565,12 @@ var _ = Describe("Image", func() {
 
 					It("fetches resource with correct session", func() {
 						Expect(fakeResourceFetcher.FetchCallCount()).To(Equal(1))
-						_, _, session, actualWorker, containerSpec, actualCustomTypes, resourceInstance, delegate := fakeResourceFetcher.FetchArgsForCall(0)
-						Expect(session).To(Equal(resource.Session{
-							Metadata: db.ContainerMetadata{
+						_, _, actualContainerMetadata, actualWorker, containerSpec, actualCustomTypes, resourceInstance, delegate := fakeResourceFetcher.FetchArgsForCall(0)
+						Expect(actualContainerMetadata).To(Equal(
+							db.ContainerMetadata{
 								Type: db.ContainerTypeGet,
 							},
-						}))
+						))
 						Expect(actualWorker.Name()).To(Equal("some-worker"))
 						Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 							ResourceType: "docker",


### PR DESCRIPTION
I really don't know why we had this resource.Session wrapper. It did nothing so I got rid of it. It removes references to `db.conatinerMetadata` from the resource package as a benefit as well.

Signed-off-by: Krishna Mannem <kmannem@pivotal.io>