### PR TITLE
atc: partial version matching for pinned version

### DIFF
--- a/atc/db/migration/migrations/1568056691_create_resource_config_versions_version_index.down.sql
+++ b/atc/db/migration/migrations/1568056691_create_resource_config_versions_version_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+   DROP INDEX resource_config_versions_version;
+
+COMMIT;

--- a/atc/db/migration/migrations/1568056691_create_resource_config_versions_version_index.up.sql
+++ b/atc/db/migration/migrations/1568056691_create_resource_config_versions_version_index.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+  CREATE INDEX resource_config_versions_version ON resource_config_versions USING gin(version jsonb_path_ops) WITH (FASTUPDATE = false);
+
+COMMIT;

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -346,13 +346,15 @@ func (r *resource) ResourceConfigVersionID(version atc.Version) (int, bool, erro
 	}
 
 	var id int
-	err = psql.Select("rcv.id").
-		From("resource_config_versions rcv").
-		Join("resources r ON rcv.resource_config_scope_id = r.resource_config_scope_id").
-		Where(sq.Eq{"r.id": r.ID(), "version": requestedVersion}).
-		Where(sq.NotEq{"rcv.check_order": 0}).
-		RunWith(r.conn).
-		QueryRow().
+
+	query := `
+		SELECT rcv.id
+		FROM resource_config_versions rcv
+		JOIN resources r ON rcv.resource_config_scope_id = r.resource_config_scope_id
+		WHERE r.id = $1 AND version @> $2 AND rcv.check_order <> 0
+		ORDER BY rcv.check_order DESC
+	`
+	err = r.conn.QueryRow(query, r.ID(), requestedVersion).
 		Scan(&id)
 	if err != nil {
 		if err == sql.ErrNoRows {


### PR DESCRIPTION
implements #3990 

one can pin a version in get step or resource config by only giving partially matched field(s). If there are multiple partially matched versions existing, it will pick one version that has highest check order (latest).