### PR TITLE
Include cluster name in log line.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -148,7 +148,8 @@ type RunCommand struct {
 		ClusterName   string `long:"cluster-name" description:"A name for this Concourse cluster, to be displayed on the dashboard page."`
 	} `group:"Web Server"`
 
-	LogDBQueries bool `long:"log-db-queries" description:"Log database queries."`
+	LogDBQueries   bool `long:"log-db-queries" description:"Log database queries."`
+	LogClusterName bool `long:"log-cluster-name" description:"Log cluster name."`
 
 	GC struct {
 		Interval time.Duration `long:"interval" default:"30s" description:"Interval on which to perform garbage collection."`
@@ -367,6 +368,11 @@ func (cmd *RunCommand) Runner(positionalArguments []string) (ifrit.Runner, error
 	}
 
 	logger, reconfigurableSink := cmd.Logger.Logger("atc")
+	if cmd.LogClusterName {
+		logger = logger.WithData(lager.Data{
+			"cluster": cmd.Server.ClusterName,
+		})
+	}
 
 	commandSession := logger.Session("cmd")
 	startTime := time.Now()

--- a/cmd/concourse/web.go
+++ b/cmd/concourse/web.go
@@ -88,5 +88,8 @@ func (cmd *WebCommand) populateTSAFlagsFromATCFlags() error {
 		cmd.TSACommand.ATCURLs = []flag.URL{cmd.RunCommand.DefaultURL()}
 	}
 
+	cmd.TSACommand.ClusterName = cmd.RunCommand.Server.ClusterName
+	cmd.TSACommand.LogClusterName = cmd.RunCommand.LogClusterName
+
 	return nil
 }

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -38,6 +38,9 @@ type TSACommand struct {
 	SessionSigningKey *flag.PrivateKey `long:"session-signing-key" required:"true" description:"Path to private key to use when signing tokens in reqests to the ATC during registration."`
 
 	HeartbeatInterval time.Duration `long:"heartbeat-interval" default:"30s" description:"interval on which to heartbeat workers to the ATC"`
+
+	ClusterName    string `long:"cluster-name" description:"A name for this Concourse cluster, to be displayed on the dashboard page."`
+	LogClusterName bool   `long:"log-cluster-name" description:"Log cluster name."`
 }
 
 type TeamAuthKeys struct {
@@ -121,6 +124,11 @@ func (cmd *TSACommand) Runner(args []string) (ifrit.Runner, error) {
 
 func (cmd *TSACommand) constructLogger() (lager.Logger, *lager.ReconfigurableSink) {
 	logger, reconfigurableSink := cmd.Logger.Logger("tsa")
+	if cmd.LogClusterName {
+		logger = logger.WithData(lager.Data{
+			"cluster": cmd.ClusterName,
+		})
+	}
 
 	return logger, reconfigurableSink
 }


### PR DESCRIPTION
When multiple Concourse clusters send logs to a single log server, this will be super helpful to decide where a log line comes from.

Say cluster name is "dev", them sample log lines are as below: (notice "source" field in logs)

    web_1     | {"timestamp":"2019-09-09T08:38:20.133553327Z","level":"info","source":"dev.tsa","message":"dev.tsa.connection.channel.command.register.done","data":{"command":"forward-worker","remote":"172.19.0.4:32946","session":"1.4.1.2","worker-address":"127.0.0.1:44903","worker-platform":"linux","worker-tags":""}}
    web_1     | {"timestamp":"2019-09-09T08:38:21.008126381Z","level":"info","source":"dev.atc","message":"dev.atc.pipelines.radar.scan-resource-type.interval-runner.tick.running-worker.garden-connection.retryable-http-client.retrying","data":{"error":"dial tcp 127.0.0.1:37871: connect: connection refused","failed-attempts":3,"pipeline":"p","ran-for":"3.012469958s","resource-type":"rt-tiny","session":"16.1.1.1.1.4.1.1","team":"main"}}

Signed-off-by: Chao Li <chaol@vmware.com>