### PR TITLE
Documentation: https://github.com/concourse/concourse/issues/4348

### DIFF
--- a/fly/commands/set_team.go
+++ b/fly/commands/set_team.go
@@ -117,7 +117,7 @@ func (command *SetTeamCommand) ErrorAuthNotConfigured(err error) {
 		fmt.Fprintln(ui.Stderr, "You have not provided a list of users and groups for one of the roles in your config yaml.")
 
 	case skycmd.ErrAuthNotConfiguredFromFlags:
-		fmt.Fprintln(ui.Stderr, "You have not provided a list of users and groups for the specified team.")
+		fmt.Fprintln(ui.Stderr, "You have not provided users and groups for the specified team.")
 
 	default:
 		fmt.Fprintln(ui.Stderr, "error:", err)

--- a/fly/integration/set_team_test.go
+++ b/fly/integration/set_team_test.go
@@ -444,7 +444,7 @@ var _ = Describe("Fly CLI", func() {
 					It("returns an error", func() {
 						sess, err := gexec.Start(flyCmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 						Expect(err).ToNot(HaveOccurred())
-						Eventually(sess.Err).Should(gbytes.Say("You have not provided a list of users and groups for the specified team."))
+						Eventually(sess.Err).Should(gbytes.Say("You have not provided users and groups for the specified team."))
 						Eventually(sess).Should(gexec.Exit(1))
 					})
 				})
@@ -457,7 +457,7 @@ var _ = Describe("Fly CLI", func() {
 					It("returns an error", func() {
 						sess, err := gexec.Start(flyCmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 						Expect(err).ToNot(HaveOccurred())
-						Eventually(sess.Err).Should(gbytes.Say("You have not provided a list of users and groups for the specified team."))
+						Eventually(sess.Err).Should(gbytes.Say("You have not provided users and groups for the specified team."))
 						Eventually(sess).Should(gexec.Exit(1))
 					})
 				})

--- a/skymarshal/skycmd/bitbucketcloud_flags.go
+++ b/skymarshal/skycmd/bitbucketcloud_flags.go
@@ -52,8 +52,8 @@ func (flag *BitbucketCloudFlags) Serialize(redirectURI string) ([]byte, error) {
 }
 
 type BitbucketCloudTeamFlags struct {
-	Users []string `long:"user" description:"List of whitelisted Bitbucket Cloud users" value-name:"USERNAME"`
-	Teams []string `long:"team" description:"List of whitelisted Bitbucket Cloud teams" value-name:"TEAM_NAME"`
+	Users []string `long:"user" description:"A whitelisted Bitbucket Cloud user" value-name:"USERNAME"`
+	Teams []string `long:"team" description:"A whitelisted Bitbucket Cloud team" value-name:"TEAM_NAME"`
 }
 
 func (flag *BitbucketCloudTeamFlags) GetUsers() []string {

--- a/skymarshal/skycmd/cf_flags.go
+++ b/skymarshal/skycmd/cf_flags.go
@@ -68,10 +68,10 @@ func (flag *CFFlags) Serialize(redirectURI string) ([]byte, error) {
 }
 
 type CFTeamFlags struct {
-	Users      []string `long:"user" description:"List of whitelisted CloudFoundry users." value-name:"USERNAME"`
-	Orgs       []string `long:"org" description:"List of whitelisted CloudFoundry orgs" value-name:"ORG_NAME"`
-	Spaces     []string `long:"space" description:"List of whitelisted CloudFoundry spaces" value-name:"ORG_NAME:SPACE_NAME"`
-	SpaceGuids []string `long:"space-guid" description:"(Deprecated) List of whitelisted CloudFoundry space guids" value-name:"SPACE_GUID"`
+	Users      []string `long:"user" description:"A whitelisted CloudFoundry user" value-name:"USERNAME"`
+	Orgs       []string `long:"org" description:"A whitelisted CloudFoundry org" value-name:"ORG_NAME"`
+	Spaces     []string `long:"space" description:"A whitelisted CloudFoundry space" value-name:"ORG_NAME:SPACE_NAME"`
+	SpaceGuids []string `long:"space-guid" description:"(Deprecated) A whitelisted CloudFoundry space guid" value-name:"SPACE_GUID"`
 }
 
 func (flag *CFTeamFlags) GetUsers() []string {

--- a/skymarshal/skycmd/flags.go
+++ b/skymarshal/skycmd/flags.go
@@ -51,7 +51,7 @@ type AuthFlags struct {
 }
 
 type AuthTeamFlags struct {
-	LocalUsers []string  `long:"local-user" description:"List of whitelisted local concourse users. These are the users you've added at web startup with the --add-local-user flag." value-name:"USERNAME"`
+	LocalUsers []string  `long:"local-user" description:"A whitelisted local concourse user. These are the users you've added at web startup with the --add-local-user flag." value-name:"USERNAME"`
 	Config     flag.File `short:"c" long:"config" description:"Configuration file for specifying team params"`
 }
 

--- a/skymarshal/skycmd/github_flags.go
+++ b/skymarshal/skycmd/github_flags.go
@@ -59,9 +59,9 @@ func (flag *GithubFlags) Serialize(redirectURI string) ([]byte, error) {
 }
 
 type GithubTeamFlags struct {
-	Users []string `long:"user" description:"List of whitelisted GitHub users" value-name:"USERNAME"`
-	Orgs  []string `long:"org" description:"List of whitelisted GitHub orgs" value-name:"ORG_NAME"`
-	Teams []string `long:"team" description:"List of whitelisted GitHub teams" value-name:"ORG_NAME:TEAM_NAME"`
+	Users []string `long:"user" description:"A whitelisted GitHub user" value-name:"USERNAME"`
+	Orgs  []string `long:"org" description:"A whitelisted GitHub org" value-name:"ORG_NAME"`
+	Teams []string `long:"team" description:"A whitelisted GitHub team" value-name:"ORG_NAME:TEAM_NAME"`
 }
 
 func (flag *GithubTeamFlags) GetUsers() []string {

--- a/skymarshal/skycmd/gitlab_flags.go
+++ b/skymarshal/skycmd/gitlab_flags.go
@@ -54,8 +54,8 @@ func (flag *GitlabFlags) Serialize(redirectURI string) ([]byte, error) {
 }
 
 type GitlabTeamFlags struct {
-	Users  []string `long:"user" description:"List of whitelisted GitLab users" value-name:"USERNAME"`
-	Groups []string `long:"group" description:"List of whitelisted GitLab groups" value-name:"GROUP_NAME"`
+	Users  []string `long:"user" description:"A whitelisted GitLab user" value-name:"USERNAME"`
+	Groups []string `long:"group" description:"A whitelisted GitLab group" value-name:"GROUP_NAME"`
 }
 
 func (flag *GitlabTeamFlags) GetUsers() []string {

--- a/skymarshal/skycmd/ldap_flags.go
+++ b/skymarshal/skycmd/ldap_flags.go
@@ -106,8 +106,8 @@ func (flag *LDAPFlags) Serialize(redirectURI string) ([]byte, error) {
 }
 
 type LDAPTeamFlags struct {
-	Users  []string `json:"users" long:"user" description:"List of whitelisted LDAP users" value-name:"USERNAME"`
-	Groups []string `json:"groups" long:"group" description:"List of whitelisted LDAP groups" value-name:"GROUP_NAME"`
+	Users  []string `json:"users" long:"user" description:"A whitelisted LDAP user" value-name:"USERNAME"`
+	Groups []string `json:"groups" long:"group" description:"A whitelisted LDAP group" value-name:"GROUP_NAME"`
 }
 
 func (flag *LDAPTeamFlags) GetUsers() []string {

--- a/skymarshal/skycmd/oauth_flags.go
+++ b/skymarshal/skycmd/oauth_flags.go
@@ -92,8 +92,8 @@ func (flag *OAuthFlags) Serialize(redirectURI string) ([]byte, error) {
 }
 
 type OAuthTeamFlags struct {
-	Users  []string `json:"users" long:"user" description:"List of whitelisted OAuth2 users" value-name:"USERNAME"`
-	Groups []string `json:"groups" long:"group" description:"List of whitelisted OAuth2 groups" value-name:"GROUP_NAME"`
+	Users  []string `json:"users" long:"user" description:"A whitelisted OAuth2 user" value-name:"USERNAME"`
+	Groups []string `json:"groups" long:"group" description:"A whitelisted OAuth2 group" value-name:"GROUP_NAME"`
 }
 
 func (flag *OAuthTeamFlags) GetUsers() []string {

--- a/skymarshal/skycmd/oidc_flags.go
+++ b/skymarshal/skycmd/oidc_flags.go
@@ -80,8 +80,8 @@ func (flag *OIDCFlags) Serialize(redirectURI string) ([]byte, error) {
 }
 
 type OIDCTeamFlags struct {
-	Users  []string `json:"users" long:"user" description:"List of whitelisted OIDC users" value-name:"USERNAME"`
-	Groups []string `json:"groups" long:"group" description:"List of whitelisted OIDC groups" value-name:"GROUP_NAME"`
+	Users  []string `json:"users" long:"user" description:"A whitelisted OIDC user" value-name:"USERNAME"`
+	Groups []string `json:"groups" long:"group" description:"A whitelisted OIDC group" value-name:"GROUP_NAME"`
 }
 
 func (flag *OIDCTeamFlags) GetUsers() []string {


### PR DESCRIPTION
In response to: https://github.com/concourse/concourse/issues/4348

The current wording seems to suggest a list is a valid input to any of these flags, where a single value is instead what is required.

I believe this brings the fly documentation more in line with: https://concourse-ci.org/github-auth.html