### PR TITLE
Don't store secrets in the check plan

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -113,8 +113,10 @@ type RunCommand struct {
 
 	InterceptIdleTimeout time.Duration `long:"intercept-idle-timeout" default:"0m" description:"Length of time for a intercepted session to be idle before terminating."`
 
-	EnableGlobalResources bool `long:"enable-global-resources" description:"Enable equivalent resources across pipelines and teams to share a single version history."`
-	EnableLidar           bool `long:"enable-lidar" description:"The Future™ of resource checking."`
+	EnableGlobalResources bool          `long:"enable-global-resources" description:"Enable equivalent resources across pipelines and teams to share a single version history."`
+	EnableLidar           bool          `long:"enable-lidar" description:"The Future™ of resource checking."`
+	LidarScannerInterval  time.Duration `long:"lidar-scanner-interval" default:"1m" description:"Interval on which the resource scanner will run to see if new checks need to be scheduled"`
+	LidarCheckerInterval  time.Duration `long:"lidar-checker-interval" default:"10s" description:"Interval on which the resource checker runs any scheduled checks"`
 
 	GlobalResourceCheckTimeout   time.Duration `long:"global-resource-check-timeout" default:"1h" description:"Time limit on checking for new versions of resources."`
 	ResourceCheckingInterval     time.Duration `long:"resource-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources."`
@@ -880,13 +882,13 @@ func (cmd *RunCommand) constructBackendMembers(
 				cmd.GlobalResourceCheckTimeout,
 				cmd.ResourceCheckingInterval,
 			),
-			time.Minute,
+			cmd.LidarScannerInterval,
 			lidar.NewChecker(
 				logger.Session("lidar-checker"),
 				dbCheckFactory,
 				engine,
 			),
-			10*time.Second,
+			cmd.LidarCheckerInterval,
 			bus,
 		)
 	} else {
@@ -898,7 +900,7 @@ func (cmd *RunCommand) constructBackendMembers(
 				dbCheckFactory,
 				engine,
 			),
-			10*time.Second,
+			cmd.LidarCheckerInterval,
 			bus,
 		)
 	}

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -16,6 +16,7 @@ var _ = Describe("CheckFactory", func() {
 	var (
 		err                 error
 		resourceConfigScope db.ResourceConfigScope
+		metadata            db.CheckMetadata
 	)
 
 	BeforeEach(func() {
@@ -32,6 +33,14 @@ var _ = Describe("CheckFactory", func() {
 
 		resourceConfigScope, err = defaultResource.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
 		Expect(err).NotTo(HaveOccurred())
+
+		metadata = db.CheckMetadata{
+			TeamID:             defaultTeam.ID(),
+			TeamName:           defaultTeam.Name(),
+			PipelineName:       defaultPipeline.Name(),
+			ResourceConfigID:   resourceConfigScope.ResourceConfig().ID(),
+			BaseResourceTypeID: resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
+		}
 	})
 
 	Describe("Check", func() {
@@ -41,11 +50,9 @@ var _ = Describe("CheckFactory", func() {
 		BeforeEach(func() {
 			check, created, err = checkFactory.CreateCheck(
 				resourceConfigScope.ID(),
-				resourceConfigScope.ResourceConfig().ID(),
-				resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
-				defaultTeam.ID(),
 				false,
 				atc.Plan{Check: &atc.CheckPlan{Name: "some-name", Type: "some-type"}},
+				metadata,
 			)
 			Expect(created).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
@@ -184,7 +191,7 @@ var _ = Describe("CheckFactory", func() {
 									Expect(check.Plan().Check.FromVersion).To(Equal(atc.Version{"version": "a"}))
 									Expect(check.Plan().Check.Name).To(Equal("some-name"))
 									Expect(check.Plan().Check.Type).To(Equal("base-type"))
-									Expect(check.Plan().Check.Source).To(Equal(atc.Source{"some": "source"}))
+									Expect(check.Plan().Check.Source).To(Equal(atc.Source{"some": "((secret))"}))
 									Expect(check.Plan().Check.Tags).To(ConsistOf("tag-a", "tag-b"))
 									Expect(check.Plan().Check.Timeout).To(Equal("10s"))
 								})
@@ -211,7 +218,7 @@ var _ = Describe("CheckFactory", func() {
 										Expect(check.Plan().Check.FromVersion).To(BeNil())
 										Expect(check.Plan().Check.Name).To(Equal("some-name"))
 										Expect(check.Plan().Check.Type).To(Equal("base-type"))
-										Expect(check.Plan().Check.Source).To(Equal(atc.Source{"some": "source"}))
+										Expect(check.Plan().Check.Source).To(Equal(atc.Source{"some": "((secret))"}))
 										Expect(check.Plan().Check.Tags).To(ConsistOf("tag-a", "tag-b"))
 										Expect(check.Plan().Check.Timeout).To(Equal("10s"))
 									})
@@ -234,7 +241,7 @@ var _ = Describe("CheckFactory", func() {
 										Expect(check.Plan().Check.FromVersion).To(Equal(atc.Version{"some": "version"}))
 										Expect(check.Plan().Check.Name).To(Equal("some-name"))
 										Expect(check.Plan().Check.Type).To(Equal("base-type"))
-										Expect(check.Plan().Check.Source).To(Equal(atc.Source{"some": "source"}))
+										Expect(check.Plan().Check.Source).To(Equal(atc.Source{"some": "((secret))"}))
 										Expect(check.Plan().Check.Tags).To(ConsistOf("tag-a", "tag-b"))
 										Expect(check.Plan().Check.Timeout).To(Equal("10s"))
 									})
@@ -304,11 +311,9 @@ var _ = Describe("CheckFactory", func() {
 		JustBeforeEach(func() {
 			check, created, err = checkFactory.CreateCheck(
 				resourceConfigScope.ID(),
-				resourceConfigScope.ResourceConfig().ID(),
-				resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
-				defaultTeam.ID(),
 				false,
 				atc.Plan{Check: &atc.CheckPlan{Name: "some-name", Type: "some-type"}},
+				metadata,
 			)
 		})
 
@@ -334,11 +339,9 @@ var _ = Describe("CheckFactory", func() {
 			BeforeEach(func() {
 				_, created, err := checkFactory.CreateCheck(
 					resourceConfigScope.ID(),
-					resourceConfigScope.ResourceConfig().ID(),
-					resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
-					defaultTeam.ID(),
 					false,
 					atc.Plan{},
+					metadata,
 				)
 				Expect(created).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
@@ -397,11 +400,9 @@ var _ = Describe("CheckFactory", func() {
 				var created bool
 				check, created, err = checkFactory.CreateCheck(
 					resourceConfigScope.ID(),
-					resourceConfigScope.ResourceConfig().ID(),
-					resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
-					defaultTeam.ID(),
 					false,
 					atc.Plan{},
+					metadata,
 				)
 				Expect(created).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())

--- a/atc/db/check_test.go
+++ b/atc/db/check_test.go
@@ -38,13 +38,19 @@ var _ = Describe("Check", func() {
 		resourceTypeConfigScope, err = defaultResourceType.SetResourceConfig(atc.Source{"some": "type-repository"}, atc.VersionedResourceTypes{})
 		Expect(err).NotTo(HaveOccurred())
 
+		metadata := db.CheckMetadata{
+			TeamID:             defaultTeam.ID(),
+			TeamName:           defaultTeam.Name(),
+			PipelineName:       defaultPipeline.Name(),
+			ResourceConfigID:   resourceConfigScope.ResourceConfig().ID(),
+			BaseResourceTypeID: resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
+		}
+
 		check, created, err = checkFactory.CreateCheck(
 			resourceConfigScope.ID(),
-			resourceConfigScope.ResourceConfig().ID(),
-			resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
-			defaultTeam.ID(),
 			false,
 			atc.Plan{},
+			metadata,
 		)
 		Expect(created).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
@@ -149,13 +155,20 @@ var _ = Describe("Check", func() {
 
 		Context("with resource types", func() {
 			BeforeEach(func() {
+
+				metadata := db.CheckMetadata{
+					TeamID:             defaultTeam.ID(),
+					TeamName:           defaultTeam.Name(),
+					PipelineName:       defaultPipeline.Name(),
+					ResourceConfigID:   resourceConfigScope.ResourceConfig().ID(),
+					BaseResourceTypeID: resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
+				}
+
 				check, created, err = checkFactory.CreateCheck(
 					resourceTypeConfigScope.ID(),
-					resourceTypeConfigScope.ResourceConfig().ID(),
-					resourceTypeConfigScope.ResourceConfig().OriginBaseResourceType().ID,
-					defaultTeam.ID(),
 					false,
 					atc.Plan{},
+					metadata,
 				)
 				Expect(created).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())

--- a/atc/db/dbfakes/fake_check.go
+++ b/atc/db/dbfakes/fake_check.go
@@ -110,6 +110,16 @@ type FakeCheck struct {
 	iDReturnsOnCall map[int]struct {
 		result1 int
 	}
+	PipelineNameStub        func() string
+	pipelineNameMutex       sync.RWMutex
+	pipelineNameArgsForCall []struct {
+	}
+	pipelineNameReturns struct {
+		result1 string
+	}
+	pipelineNameReturnsOnCall map[int]struct {
+		result1 string
+	}
 	PlanStub        func() atc.Plan
 	planMutex       sync.RWMutex
 	planArgsForCall []struct {
@@ -212,6 +222,16 @@ type FakeCheck struct {
 	}
 	teamIDReturnsOnCall map[int]struct {
 		result1 int
+	}
+	TeamNameStub        func() string
+	teamNameMutex       sync.RWMutex
+	teamNameArgsForCall []struct {
+	}
+	teamNameReturns struct {
+		result1 string
+	}
+	teamNameReturnsOnCall map[int]struct {
+		result1 string
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -707,6 +727,58 @@ func (fake *FakeCheck) IDReturnsOnCall(i int, result1 int) {
 	}
 	fake.iDReturnsOnCall[i] = struct {
 		result1 int
+	}{result1}
+}
+
+func (fake *FakeCheck) PipelineName() string {
+	fake.pipelineNameMutex.Lock()
+	ret, specificReturn := fake.pipelineNameReturnsOnCall[len(fake.pipelineNameArgsForCall)]
+	fake.pipelineNameArgsForCall = append(fake.pipelineNameArgsForCall, struct {
+	}{})
+	fake.recordInvocation("PipelineName", []interface{}{})
+	fake.pipelineNameMutex.Unlock()
+	if fake.PipelineNameStub != nil {
+		return fake.PipelineNameStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.pipelineNameReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeCheck) PipelineNameCallCount() int {
+	fake.pipelineNameMutex.RLock()
+	defer fake.pipelineNameMutex.RUnlock()
+	return len(fake.pipelineNameArgsForCall)
+}
+
+func (fake *FakeCheck) PipelineNameCalls(stub func() string) {
+	fake.pipelineNameMutex.Lock()
+	defer fake.pipelineNameMutex.Unlock()
+	fake.PipelineNameStub = stub
+}
+
+func (fake *FakeCheck) PipelineNameReturns(result1 string) {
+	fake.pipelineNameMutex.Lock()
+	defer fake.pipelineNameMutex.Unlock()
+	fake.PipelineNameStub = nil
+	fake.pipelineNameReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeCheck) PipelineNameReturnsOnCall(i int, result1 string) {
+	fake.pipelineNameMutex.Lock()
+	defer fake.pipelineNameMutex.Unlock()
+	fake.PipelineNameStub = nil
+	if fake.pipelineNameReturnsOnCall == nil {
+		fake.pipelineNameReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.pipelineNameReturnsOnCall[i] = struct {
+		result1 string
 	}{result1}
 }
 
@@ -1246,6 +1318,58 @@ func (fake *FakeCheck) TeamIDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
+func (fake *FakeCheck) TeamName() string {
+	fake.teamNameMutex.Lock()
+	ret, specificReturn := fake.teamNameReturnsOnCall[len(fake.teamNameArgsForCall)]
+	fake.teamNameArgsForCall = append(fake.teamNameArgsForCall, struct {
+	}{})
+	fake.recordInvocation("TeamName", []interface{}{})
+	fake.teamNameMutex.Unlock()
+	if fake.TeamNameStub != nil {
+		return fake.TeamNameStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.teamNameReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeCheck) TeamNameCallCount() int {
+	fake.teamNameMutex.RLock()
+	defer fake.teamNameMutex.RUnlock()
+	return len(fake.teamNameArgsForCall)
+}
+
+func (fake *FakeCheck) TeamNameCalls(stub func() string) {
+	fake.teamNameMutex.Lock()
+	defer fake.teamNameMutex.Unlock()
+	fake.TeamNameStub = stub
+}
+
+func (fake *FakeCheck) TeamNameReturns(result1 string) {
+	fake.teamNameMutex.Lock()
+	defer fake.teamNameMutex.Unlock()
+	fake.TeamNameStub = nil
+	fake.teamNameReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeCheck) TeamNameReturnsOnCall(i int, result1 string) {
+	fake.teamNameMutex.Lock()
+	defer fake.teamNameMutex.Unlock()
+	fake.TeamNameStub = nil
+	if fake.teamNameReturnsOnCall == nil {
+		fake.teamNameReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.teamNameReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakeCheck) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1267,6 +1391,8 @@ func (fake *FakeCheck) Invocations() map[string][][]interface{} {
 	defer fake.finishWithErrorMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
+	fake.pipelineNameMutex.RLock()
+	defer fake.pipelineNameMutex.RUnlock()
 	fake.planMutex.RLock()
 	defer fake.planMutex.RUnlock()
 	fake.reloadMutex.RLock()
@@ -1287,6 +1413,8 @@ func (fake *FakeCheck) Invocations() map[string][][]interface{} {
 	defer fake.statusMutex.RUnlock()
 	fake.teamIDMutex.RLock()
 	defer fake.teamIDMutex.RUnlock()
+	fake.teamNameMutex.RLock()
+	defer fake.teamNameMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/atc/db/dbfakes/fake_check_factory.go
+++ b/atc/db/dbfakes/fake_check_factory.go
@@ -41,15 +41,13 @@ type FakeCheckFactory struct {
 		result2 bool
 		result3 error
 	}
-	CreateCheckStub        func(int, int, int, int, bool, atc.Plan) (db.Check, bool, error)
+	CreateCheckStub        func(int, bool, atc.Plan, db.CheckMetadata) (db.Check, bool, error)
 	createCheckMutex       sync.RWMutex
 	createCheckArgsForCall []struct {
 		arg1 int
-		arg2 int
-		arg3 int
-		arg4 int
-		arg5 bool
-		arg6 atc.Plan
+		arg2 bool
+		arg3 atc.Plan
+		arg4 db.CheckMetadata
 	}
 	createCheckReturns struct {
 		result1 db.Check
@@ -261,21 +259,19 @@ func (fake *FakeCheckFactory) CheckReturnsOnCall(i int, result1 db.Check, result
 	}{result1, result2, result3}
 }
 
-func (fake *FakeCheckFactory) CreateCheck(arg1 int, arg2 int, arg3 int, arg4 int, arg5 bool, arg6 atc.Plan) (db.Check, bool, error) {
+func (fake *FakeCheckFactory) CreateCheck(arg1 int, arg2 bool, arg3 atc.Plan, arg4 db.CheckMetadata) (db.Check, bool, error) {
 	fake.createCheckMutex.Lock()
 	ret, specificReturn := fake.createCheckReturnsOnCall[len(fake.createCheckArgsForCall)]
 	fake.createCheckArgsForCall = append(fake.createCheckArgsForCall, struct {
 		arg1 int
-		arg2 int
-		arg3 int
-		arg4 int
-		arg5 bool
-		arg6 atc.Plan
-	}{arg1, arg2, arg3, arg4, arg5, arg6})
-	fake.recordInvocation("CreateCheck", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
+		arg2 bool
+		arg3 atc.Plan
+		arg4 db.CheckMetadata
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("CreateCheck", []interface{}{arg1, arg2, arg3, arg4})
 	fake.createCheckMutex.Unlock()
 	if fake.CreateCheckStub != nil {
-		return fake.CreateCheckStub(arg1, arg2, arg3, arg4, arg5, arg6)
+		return fake.CreateCheckStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -290,17 +286,17 @@ func (fake *FakeCheckFactory) CreateCheckCallCount() int {
 	return len(fake.createCheckArgsForCall)
 }
 
-func (fake *FakeCheckFactory) CreateCheckCalls(stub func(int, int, int, int, bool, atc.Plan) (db.Check, bool, error)) {
+func (fake *FakeCheckFactory) CreateCheckCalls(stub func(int, bool, atc.Plan, db.CheckMetadata) (db.Check, bool, error)) {
 	fake.createCheckMutex.Lock()
 	defer fake.createCheckMutex.Unlock()
 	fake.CreateCheckStub = stub
 }
 
-func (fake *FakeCheckFactory) CreateCheckArgsForCall(i int) (int, int, int, int, bool, atc.Plan) {
+func (fake *FakeCheckFactory) CreateCheckArgsForCall(i int) (int, bool, atc.Plan, db.CheckMetadata) {
 	fake.createCheckMutex.RLock()
 	defer fake.createCheckMutex.RUnlock()
 	argsForCall := fake.createCheckArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeCheckFactory) CreateCheckReturns(result1 db.Check, result2 bool, result3 error) {

--- a/atc/engine/builder/builderfakes/fake_delegate_factory.go
+++ b/atc/engine/builder/builderfakes/fake_delegate_factory.go
@@ -25,11 +25,12 @@ type FakeDelegateFactory struct {
 	buildStepDelegateReturnsOnCall map[int]struct {
 		result1 exec.BuildStepDelegate
 	}
-	CheckDelegateStub        func(db.Check, atc.PlanID) exec.CheckDelegate
+	CheckDelegateStub        func(db.Check, atc.PlanID, vars.CredVarsTracker) exec.CheckDelegate
 	checkDelegateMutex       sync.RWMutex
 	checkDelegateArgsForCall []struct {
 		arg1 db.Check
 		arg2 atc.PlanID
+		arg3 vars.CredVarsTracker
 	}
 	checkDelegateReturns struct {
 		result1 exec.CheckDelegate
@@ -142,17 +143,18 @@ func (fake *FakeDelegateFactory) BuildStepDelegateReturnsOnCall(i int, result1 e
 	}{result1}
 }
 
-func (fake *FakeDelegateFactory) CheckDelegate(arg1 db.Check, arg2 atc.PlanID) exec.CheckDelegate {
+func (fake *FakeDelegateFactory) CheckDelegate(arg1 db.Check, arg2 atc.PlanID, arg3 vars.CredVarsTracker) exec.CheckDelegate {
 	fake.checkDelegateMutex.Lock()
 	ret, specificReturn := fake.checkDelegateReturnsOnCall[len(fake.checkDelegateArgsForCall)]
 	fake.checkDelegateArgsForCall = append(fake.checkDelegateArgsForCall, struct {
 		arg1 db.Check
 		arg2 atc.PlanID
-	}{arg1, arg2})
-	fake.recordInvocation("CheckDelegate", []interface{}{arg1, arg2})
+		arg3 vars.CredVarsTracker
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("CheckDelegate", []interface{}{arg1, arg2, arg3})
 	fake.checkDelegateMutex.Unlock()
 	if fake.CheckDelegateStub != nil {
-		return fake.CheckDelegateStub(arg1, arg2)
+		return fake.CheckDelegateStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -167,17 +169,17 @@ func (fake *FakeDelegateFactory) CheckDelegateCallCount() int {
 	return len(fake.checkDelegateArgsForCall)
 }
 
-func (fake *FakeDelegateFactory) CheckDelegateCalls(stub func(db.Check, atc.PlanID) exec.CheckDelegate) {
+func (fake *FakeDelegateFactory) CheckDelegateCalls(stub func(db.Check, atc.PlanID, vars.CredVarsTracker) exec.CheckDelegate) {
 	fake.checkDelegateMutex.Lock()
 	defer fake.checkDelegateMutex.Unlock()
 	fake.CheckDelegateStub = stub
 }
 
-func (fake *FakeDelegateFactory) CheckDelegateArgsForCall(i int) (db.Check, atc.PlanID) {
+func (fake *FakeDelegateFactory) CheckDelegateArgsForCall(i int) (db.Check, atc.PlanID, vars.CredVarsTracker) {
 	fake.checkDelegateMutex.RLock()
 	defer fake.checkDelegateMutex.RUnlock()
 	argsForCall := fake.checkDelegateArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeDelegateFactory) CheckDelegateReturns(result1 exec.CheckDelegate) {

--- a/atc/engine/builder/delegate_factory.go
+++ b/atc/engine/builder/delegate_factory.go
@@ -35,8 +35,8 @@ func (delegate *delegateFactory) TaskDelegate(build db.Build, planID atc.PlanID,
 	return NewTaskDelegate(build, planID, credVarsTracker, clock.NewClock())
 }
 
-func (delegate *delegateFactory) CheckDelegate(check db.Check, planID atc.PlanID) exec.CheckDelegate {
-	return NewCheckDelegate(check, planID, clock.NewClock())
+func (delegate *delegateFactory) CheckDelegate(check db.Check, planID atc.PlanID, credVarsTracker vars.CredVarsTracker) exec.CheckDelegate {
+	return NewCheckDelegate(check, planID, credVarsTracker, clock.NewClock())
 }
 
 func (delegate *delegateFactory) BuildStepDelegate(build db.Build, planID atc.PlanID, credVarsTracker vars.CredVarsTracker) exec.BuildStepDelegate {
@@ -282,8 +282,10 @@ func (d *taskDelegate) Finished(logger lager.Logger, exitStatus exec.ExitStatus)
 	logger.Info("finished", lager.Data{"exit-status": exitStatus})
 }
 
-func NewCheckDelegate(check db.Check, planID atc.PlanID, clock clock.Clock) exec.CheckDelegate {
+func NewCheckDelegate(check db.Check, planID atc.PlanID, credVarsTracker vars.CredVarsTracker, clock clock.Clock) exec.CheckDelegate {
 	return &checkDelegate{
+		BuildStepDelegate: NewBuildStepDelegate(nil, planID, credVarsTracker, clock),
+
 		eventOrigin: event.Origin{ID: event.OriginID(planID)},
 		check:       check,
 		clock:       clock,

--- a/atc/engine/builder/delegate_factory_test.go
+++ b/atc/engine/builder/delegate_factory_test.go
@@ -273,7 +273,7 @@ var _ = Describe("DelegateFactory", func() {
 		BeforeEach(func() {
 			fakeCheck = new(dbfakes.FakeCheck)
 
-			delegate = builder.NewCheckDelegate(fakeCheck, "some-plan-id", fakeClock)
+			delegate = builder.NewCheckDelegate(fakeCheck, "some-plan-id", credVarsTracker, fakeClock)
 			versions = []atc.Version{{"some": "version"}}
 		})
 


### PR DESCRIPTION
A topgun test was failing for lidar changes because we saved the check plan into the DB with variables interpolated and the topgun test checks to make sure there are no secrets stored in the DB. We changed it so that we will interpolate the vars in the check step instead.