### PR TITLE
Add a timeout when acquiring mutex lock

### DIFF
--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 )
@@ -65,9 +66,9 @@ type LockFactory interface {
 }
 
 type lockFactory struct {
-	db           LockDB
-	locks        lockRepo
-	acquireMutex *sync.Mutex
+	db    LockDB
+	locks lockRepo
+	mutex *mutex
 
 	acquireFunc LogFunc
 	releaseFunc LogFunc
@@ -91,7 +92,7 @@ func NewLockFactory(
 			locks: map[string]bool{},
 			mutex: &sync.Mutex{},
 		},
-		acquireMutex: &sync.Mutex{},
+		mutex: &mutex{make(chan struct{}, 1)},
 	}
 }
 
@@ -102,21 +103,21 @@ func NewTestLockFactory(db LockDB) LockFactory {
 			locks: map[string]bool{},
 			mutex: &sync.Mutex{},
 		},
-		acquireMutex: &sync.Mutex{},
-		acquireFunc:  func(logger lager.Logger, id LockID) {},
-		releaseFunc:  func(logger lager.Logger, id LockID) {},
+		mutex:       &mutex{make(chan struct{}, 1)},
+		acquireFunc: func(logger lager.Logger, id LockID) {},
+		releaseFunc: func(logger lager.Logger, id LockID) {},
 	}
 }
 
 func (f *lockFactory) Acquire(logger lager.Logger, id LockID) (Lock, bool, error) {
 	l := &lock{
-		logger:       logger,
-		db:           f.db,
-		id:           id,
-		locks:        f.locks,
-		acquireMutex: f.acquireMutex,
-		acquired:     f.acquireFunc,
-		released:     f.releaseFunc,
+		logger:   logger,
+		db:       f.db,
+		id:       id,
+		locks:    f.locks,
+		mutex:    f.mutex,
+		acquired: f.acquireFunc,
+		released: f.releaseFunc,
 	}
 
 	acquired, err := l.Acquire()
@@ -147,42 +148,44 @@ type LockDB interface {
 type lock struct {
 	id LockID
 
-	logger       lager.Logger
-	db           LockDB
-	locks        lockRepo
-	acquireMutex *sync.Mutex
+	logger lager.Logger
+	db     LockDB
+	locks  lockRepo
+	mutex  *mutex
 
 	acquired LogFunc
 	released LogFunc
 }
 
 func (l *lock) Acquire() (bool, error) {
-	l.acquireMutex.Lock()
-	defer l.acquireMutex.Unlock()
+	if l.mutex.Lock(time.Second) {
+		defer l.mutex.Unlock()
 
-	logger := l.logger.Session("acquire", lager.Data{"id": l.id})
+		logger := l.logger.Session("acquire", lager.Data{"id": l.id})
 
-	if l.locks.IsRegistered(l.id) {
-		logger.Debug("not-acquired-already-held-locally")
-		return false, nil
+		if l.locks.IsRegistered(l.id) {
+			logger.Debug("not-acquired-already-held-locally")
+			return false, nil
+		}
+
+		acquired, err := l.db.Acquire(l.id)
+		if err != nil {
+			logger.Error("failed-to-register-in-db", err)
+			return false, err
+		}
+
+		if !acquired {
+			logger.Debug("not-acquired-already-held-in-db")
+			return false, nil
+		}
+
+		l.locks.Register(l.id)
+
+		l.acquired(logger, l.id)
+
+		return true, nil
 	}
-
-	acquired, err := l.db.Acquire(l.id)
-	if err != nil {
-		logger.Error("failed-to-register-in-db", err)
-		return false, err
-	}
-
-	if !acquired {
-		logger.Debug("not-acquired-already-held-in-db")
-		return false, nil
-	}
-
-	l.locks.Register(l.id)
-
-	l.acquired(logger, l.id)
-
-	return true, nil
+	return false, nil
 }
 
 func (l *lock) Release() error {
@@ -203,6 +206,23 @@ func (l *lock) Release() error {
 	l.released(logger, l.id)
 
 	return nil
+}
+
+type mutex struct {
+	c chan struct{}
+}
+
+func (m *mutex) Lock(timeout time.Duration) bool {
+	select {
+	case m.c <- struct{}{}:
+		return true
+	case <-time.After(timeout):
+	}
+	return false
+}
+
+func (m *mutex) Unlock() {
+	<-m.c
 }
 
 type lockDB struct {

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -27,6 +27,8 @@ const (
 
 var ErrLostLock = errors.New("lock was lost while held, possibly due to connection breakage")
 
+const lockTimeout = time.Second
+
 func NewBuildTrackingLockID(buildID int) LockID {
 	return LockID{LockTypeBuildTracking, buildID}
 }
@@ -158,7 +160,7 @@ type lock struct {
 }
 
 func (l *lock) Acquire() (bool, error) {
-	if l.mutex.Lock(time.Second) {
+	if l.mutex.Lock(lockTimeout) {
 		defer l.mutex.Unlock()
 
 		logger := l.logger.Session("acquire", lager.Data{"id": l.id})

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -27,7 +27,7 @@ const (
 
 var ErrLostLock = errors.New("lock was lost while held, possibly due to connection breakage")
 
-const lockTimeout = time.Second
+const lockTimeout = 10 * time.Second
 
 func NewBuildTrackingLockID(buildID int) LockID {
 	return LockID{LockTypeBuildTracking, buildID}
@@ -187,6 +187,8 @@ func (l *lock) Acquire() (bool, error) {
 
 		return true, nil
 	}
+
+	l.logger.Debug("timed-out-acquiring-lock")
 	return false, nil
 }
 

--- a/atc/db/lock/lock_test.go
+++ b/atc/db/lock/lock_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Locks", func() {
 
 			fakeLockDB.AcquireStub = func(id lock.LockID) (bool, error) {
 				select {
-				case <-time.After(time.Minute):
+				case <-time.After(2 * time.Second):
 				case <-done:
 				}
 				return true, nil

--- a/atc/db/lock/lock_test.go
+++ b/atc/db/lock/lock_test.go
@@ -104,6 +104,36 @@ var _ = Describe("Locks", func() {
 			Expect(acquired).To(BeFalse())
 		})
 
+		It("Acquire times out acquiring the mutex lock", func() {
+
+			done := make(chan struct{})
+			readyToAcquire := make(chan struct{})
+
+			fakeLockDB := new(lockfakes.FakeLockDB)
+			factory := lock.NewTestLockFactory(fakeLockDB)
+
+			fakeLockDB.AcquireStub = func(id lock.LockID) (bool, error) {
+				select {
+				case <-time.After(time.Minute):
+				case <-done:
+				}
+				return true, nil
+			}
+
+			go func() {
+				close(readyToAcquire)
+				_, acquired, err := factory.Acquire(logger, lock.LockID{42})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(acquired).To(BeTrue())
+			}()
+
+			<-readyToAcquire
+			_, acquired, err := factory.Acquire(logger, lock.LockID{420000})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(acquired).To(BeFalse())
+			close(done)
+		})
+
 		It("Acquire accepts list of ids", func() {
 			var acquired bool
 			var err error

--- a/atc/db/lock/lock_test.go
+++ b/atc/db/lock/lock_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Locks", func() {
 
 			fakeLockDB.AcquireStub = func(id lock.LockID) (bool, error) {
 				select {
-				case <-time.After(2 * time.Second):
+				case <-time.After(11 * time.Second):
 				case <-done:
 				}
 				return true, nil


### PR DESCRIPTION
fixes #4393 

In the lockFactory, when acquiring a lock, it can get stuck talking to the database. Future calls will block on the mutex.Lock. This can lead to an avalanche of goroutines from the buildtracker, scheduler, and lidar as each tick piles on more work.

We want to add a timeout to the mutex.Lock so that new goroutines will die quicker when they can't fetch the lock.
