### PR TITLE
fly pin resource version by version JSON string

### DIFF
--- a/atc/api/resourceserver/versionserver/pin_version.go
+++ b/atc/api/resourceserver/versionserver/pin_version.go
@@ -30,7 +30,11 @@ func (s *Server) PinResourceVersion(pipeline db.Pipeline) http.Handler {
 			return
 		}
 
-		err = resource.PinVersion(resourceConfigVersionID)
+		found, err = resource.PinVersion(resourceConfigVersionID)
+		if !found {
+			logger.Debug("resource-version-id-not-found", lager.Data{"resource_config_version_id": resourceConfigVersionID})
+			w.WriteHeader(http.StatusNotFound)
+		}
 		if err != nil {
 			logger.Error("failed-to-pin-resource-version", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -172,16 +172,18 @@ type FakeResource struct {
 	pinCommentReturnsOnCall map[int]struct {
 		result1 string
 	}
-	PinVersionStub        func(int) error
+	PinVersionStub        func(int) (bool, error)
 	pinVersionMutex       sync.RWMutex
 	pinVersionArgsForCall []struct {
 		arg1 int
 	}
 	pinVersionReturns struct {
-		result1 error
+		result1 bool
+		result2 error
 	}
 	pinVersionReturnsOnCall map[int]struct {
-		result1 error
+		result1 bool
+		result2 error
 	}
 	PipelineIDStub        func() int
 	pipelineIDMutex       sync.RWMutex
@@ -1266,7 +1268,7 @@ func (fake *FakeResource) PinCommentReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResource) PinVersion(arg1 int) error {
+func (fake *FakeResource) PinVersion(arg1 int) (bool, error) {
 	fake.pinVersionMutex.Lock()
 	ret, specificReturn := fake.pinVersionReturnsOnCall[len(fake.pinVersionArgsForCall)]
 	fake.pinVersionArgsForCall = append(fake.pinVersionArgsForCall, struct {
@@ -1278,10 +1280,10 @@ func (fake *FakeResource) PinVersion(arg1 int) error {
 		return fake.PinVersionStub(arg1)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
 	fakeReturns := fake.pinVersionReturns
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeResource) PinVersionCallCount() int {
@@ -1290,7 +1292,7 @@ func (fake *FakeResource) PinVersionCallCount() int {
 	return len(fake.pinVersionArgsForCall)
 }
 
-func (fake *FakeResource) PinVersionCalls(stub func(int) error) {
+func (fake *FakeResource) PinVersionCalls(stub func(int) (bool, error)) {
 	fake.pinVersionMutex.Lock()
 	defer fake.pinVersionMutex.Unlock()
 	fake.PinVersionStub = stub
@@ -1303,27 +1305,30 @@ func (fake *FakeResource) PinVersionArgsForCall(i int) int {
 	return argsForCall.arg1
 }
 
-func (fake *FakeResource) PinVersionReturns(result1 error) {
+func (fake *FakeResource) PinVersionReturns(result1 bool, result2 error) {
 	fake.pinVersionMutex.Lock()
 	defer fake.pinVersionMutex.Unlock()
 	fake.PinVersionStub = nil
 	fake.pinVersionReturns = struct {
-		result1 error
-	}{result1}
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeResource) PinVersionReturnsOnCall(i int, result1 error) {
+func (fake *FakeResource) PinVersionReturnsOnCall(i int, result1 bool, result2 error) {
 	fake.pinVersionMutex.Lock()
 	defer fake.pinVersionMutex.Unlock()
 	fake.PinVersionStub = nil
 	if fake.pinVersionReturnsOnCall == nil {
 		fake.pinVersionReturnsOnCall = make(map[int]struct {
-			result1 error
+			result1 bool
+			result2 error
 		})
 	}
 	fake.pinVersionReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeResource) PipelineID() int {

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -1266,12 +1266,44 @@ var _ = Describe("Resource", func() {
 			resID = resConf.ID()
 		})
 
-		Context("when we pin a resource to a version", func() {
+		Context("when we use an invalid version id (does not exist)", func() {
+			var (
+				pinnedVersion atc.Version
+			)
 			BeforeEach(func() {
-				err := resource.PinVersion(resID)
+				Expect(resource.CurrentPinnedVersion()).To(Equal(resource.APIPinnedVersion()))
+				pinnedVersion = resource.APIPinnedVersion()
+			})
+
+			It("returns not found and does not update anything", func() {
+				found, err := resource.PinVersion(-1)
+				Expect(found).To(BeFalse())
 				Expect(err).ToNot(HaveOccurred())
 
-				found, err := resource.Reload()
+				Expect(resource.APIPinnedVersion()).To(Equal(pinnedVersion))
+			})
+		})
+
+		Context("when we set the pin comment on a resource", func() {
+			BeforeEach(func() {
+				err := resource.SetPinComment("foo")
+				Expect(err).ToNot(HaveOccurred())
+				resource, _, err = pipeline.Resource("some-other-resource")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should set the pin comment", func() {
+				Expect(resource.PinComment()).To(Equal("foo"))
+			})
+		})
+
+		Context("when we pin a resource to a version", func() {
+			BeforeEach(func() {
+				found, err := resource.PinVersion(resID)
+				Expect(found).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+
+				found, err = resource.Reload()
 				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -1280,38 +1312,25 @@ var _ = Describe("Resource", func() {
 				Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 				Expect(resource.CurrentPinnedVersion()).To(Equal(resource.APIPinnedVersion()))
 			})
+		})
 
-			Context("when we set the pin comment on a resource", func() {
-				BeforeEach(func() {
-					err := resource.SetPinComment("foo")
-					Expect(err).ToNot(HaveOccurred())
-					resource, _, err = pipeline.Resource("some-other-resource")
-					Expect(err).ToNot(HaveOccurred())
-				})
+		Context("when we unpin a resource to a version", func() {
+			BeforeEach(func() {
+				err := resource.UnpinVersion()
+				Expect(err).ToNot(HaveOccurred())
 
-				It("should set the pin comment", func() {
-					Expect(resource.PinComment()).To(Equal("foo"))
-				})
+				found, err := resource.Reload()
+				Expect(found).To(BeTrue())
+				Expect(err).ToNot(HaveOccurred())
+			})
 
-				Context("when we unpin a resource to a version", func() {
-					BeforeEach(func() {
-						err := resource.UnpinVersion()
-						Expect(err).ToNot(HaveOccurred())
+			It("sets the api pinned version to nil", func() {
+				Expect(resource.APIPinnedVersion()).To(BeNil())
+				Expect(resource.CurrentPinnedVersion()).To(BeNil())
+			})
 
-						found, err := resource.Reload()
-						Expect(found).To(BeTrue())
-						Expect(err).ToNot(HaveOccurred())
-					})
-
-					It("sets the api pinned version to nil", func() {
-						Expect(resource.APIPinnedVersion()).To(BeNil())
-						Expect(resource.CurrentPinnedVersion()).To(BeNil())
-					})
-
-					It("unsets the pin comment", func() {
-						Expect(resource.PinComment()).To(BeEmpty())
-					})
-				})
+			It("unsets the pin comment", func() {
+				Expect(resource.PinComment()).To(BeEmpty())
 			})
 		})
 
@@ -1348,7 +1367,8 @@ var _ = Describe("Resource", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 
-				err = resource.PinVersion(resConf.ID())
+				found, err = resource.PinVersion(resConf.ID())
+				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 
 				found, err = resource.Reload()

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -1728,7 +1728,8 @@ var _ = Describe("Team", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			err = resource.PinVersion(rcv.ID())
+			found, err = resource.PinVersion(rcv.ID())
+			Expect(found).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 
 			reloaded, err := resource.Reload()
@@ -1782,7 +1783,8 @@ var _ = Describe("Team", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			err = resource.PinVersion(rcv.ID())
+			found, err = resource.PinVersion(rcv.ID())
+			Expect(found).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 
 			reloaded, err := resource.Reload()

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -55,9 +55,11 @@ type FlyCommand struct {
 	FormatPipeline   FormatPipelineCommand   `command:"format-pipeline"     alias:"fp"   description:"Format a pipeline config"`
 	OrderPipelines   OrderPipelinesCommand   `command:"order-pipelines"     alias:"op"   description:"Orders pipelines"`
 
-	Resources        ResourcesCommand        `command:"resources"           alias:"rs"   description:"List the resources in the pipeline"`
-	ResourceVersions ResourceVersionsCommand `command:"resource-versions"   alias:"rvs"  description:"List the versions of a resource"`
-	CheckResource    CheckResourceCommand    `command:"check-resource"      alias:"cr"   description:"Check a resource"`
+	Resources          ResourcesCommand          `command:"resources"               alias:"rs"   description:"List the resources in the pipeline"`
+	ResourceVersions   ResourceVersionsCommand   `command:"resource-versions"       alias:"rvs"  description:"List the versions of a resource"`
+	CheckResource      CheckResourceCommand      `command:"check-resource"          alias:"cr"   description:"Check a resource"`
+	PinResourceVersion PinResourceVersionCommand `command:"pin-resource-version"    alias:"prv"  description:"Pin a version to a resource"`
+	UnpinResource      UnpinResourceCommand      `command:"unpin-resource"          alias:"ur"  description:"Unpin a resource"`
 
 	CheckResourceType CheckResourceTypeCommand `command:"check-resource-type" alias:"crt"  description:"Check a resource-type"`
 

--- a/fly/commands/internal/flaghelpers/json_flag.go
+++ b/fly/commands/internal/flaghelpers/json_flag.go
@@ -1,0 +1,25 @@
+package flaghelpers
+
+import (
+	"encoding/json"
+
+	"github.com/concourse/concourse/atc"
+)
+
+type JsonFlag struct {
+	JsonString string
+	Version    atc.Version
+}
+
+func (v *JsonFlag) UnmarshalFlag(value string) error {
+	var version atc.Version
+	err := json.Unmarshal([]byte(value), &version)
+	if err != nil {
+		return err
+	}
+
+	v.Version = version
+	v.JsonString = value
+
+	return nil
+}

--- a/fly/commands/internal/flaghelpers/json_flag_test.go
+++ b/fly/commands/internal/flaghelpers/json_flag_test.go
@@ -1,0 +1,31 @@
+package flaghelpers_test
+
+import (
+	"github.com/concourse/concourse/atc"
+	. "github.com/concourse/concourse/fly/commands/internal/flaghelpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JsonFlag", func() {
+	Context("when JSON string is invalid", func() {
+		It("displays an error message", func() {
+			jsonFlag := &JsonFlag{}
+
+			err := jsonFlag.UnmarshalFlag("{some:value}")
+			Expect(err).To(MatchError("invalid character 's' looking for beginning of object key string"))
+		})
+	})
+
+	Context("when JSON string is valid", func() {
+		It("parse the JSON into version", func() {
+			jsonFlag := &JsonFlag{}
+
+			err := jsonFlag.UnmarshalFlag(`{"some":"value"}`)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(jsonFlag.Version).To(Equal(atc.Version{"some": "value"}))
+			Expect(jsonFlag.JsonString).To(Equal(`{"some":"value"}`))
+		})
+	})
+})

--- a/fly/commands/pin_resource_version.go
+++ b/fly/commands/pin_resource_version.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
+	"github.com/concourse/concourse/fly/rc"
+)
+
+type PinResourceVersionCommand struct {
+	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of the resource"`
+	ResourceVersionID int `short:"i" long:"version-id" required:"true" description:"ID of the version"`
+}
+
+
+func (command *PinResourceVersionCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	team := target.Team()
+
+	pinned, err := team.PinResourceVersion(command.Resource.PipelineName, command.Resource.ResourceName, command.ResourceVersionID)
+
+	if err != nil {
+		return err
+	}
+
+	if pinned {
+		fmt.Printf("pinned '%s/%s' at version id %d\n", command.Resource.PipelineName, command.Resource.ResourceName, command.ResourceVersionID)
+	} else {
+		displayhelpers.Failf("could not pin '%s/%s' at version %d, make sure the resource and version exists\n",
+			command.Resource.PipelineName, command.Resource.ResourceName, command.ResourceVersionID)
+	}
+
+	return nil
+}

--- a/fly/commands/pin_resource_version.go
+++ b/fly/commands/pin_resource_version.go
@@ -2,16 +2,17 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type PinResourceVersionCommand struct {
-	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of the resource"`
-	ResourceVersionID int `short:"i" long:"version-id" required:"true" description:"ID of the version"`
+	Resource        flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of the resource"`
+	ResourceVersion flaghelpers.JsonFlag     `short:"v" long:"version" required:"true" description:"JSON string of at least one field of the version. The given key value pair(s) has to be an exact match but not all fields need to be provided. In the case of multiple resource versions matched, it will pin the latest one."`
 }
-
 
 func (command *PinResourceVersionCommand) Execute([]string) error {
 	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
@@ -26,17 +27,27 @@ func (command *PinResourceVersionCommand) Execute([]string) error {
 
 	team := target.Team()
 
-	pinned, err := team.PinResourceVersion(command.Resource.PipelineName, command.Resource.ResourceName, command.ResourceVersionID)
+	versions, _, found, err := team.ResourceVersions(command.Resource.PipelineName, command.Resource.ResourceName, concourse.Page{}, command.ResourceVersion.Version)
+
+	if err != nil {
+		return err
+	}
+
+	if !found || len(versions) <= 0 {
+		displayhelpers.Failf("could not find version matching %s", command.ResourceVersion.JsonString)
+	}
+
+	latestResourceVer := versions[0]
+	pinned, err := team.PinResourceVersion(command.Resource.PipelineName, command.Resource.ResourceName, latestResourceVer.ID)
 
 	if err != nil {
 		return err
 	}
 
 	if pinned {
-		fmt.Printf("pinned '%s/%s' at version id %d\n", command.Resource.PipelineName, command.Resource.ResourceName, command.ResourceVersionID)
+		fmt.Printf("pinned '%s/%s' at version id %d with %+v\n", command.Resource.PipelineName, command.Resource.ResourceName, latestResourceVer.ID, latestResourceVer.Version)
 	} else {
-		displayhelpers.Failf("could not pin '%s/%s' at version %d, make sure the resource and version exists\n",
-			command.Resource.PipelineName, command.Resource.ResourceName, command.ResourceVersionID)
+		displayhelpers.Failf("could not pin '%s/%s', make sure the resource exists\n", command.Resource.PipelineName, command.Resource.ResourceName)
 	}
 
 	return nil

--- a/fly/commands/resource_versions.go
+++ b/fly/commands/resource_versions.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
@@ -15,7 +16,7 @@ import (
 )
 
 type ResourceVersionsCommand struct {
-	Count    int                      `short:"c" long:"count" default:"50" description:"Number of builds you want to limit the return to"`
+	Count    int                      `short:"c" long:"count" default:"50" description:"Number of versions you want to limit the return to"`
 	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to get versions for"`
 	Json     bool                     `long:"json" description:"Print command result as JSON"`
 }
@@ -35,7 +36,7 @@ func (command *ResourceVersionsCommand) Execute([]string) error {
 
 	team := target.Team()
 
-	versions, _, _, err := team.ResourceVersions(command.Resource.PipelineName, command.Resource.ResourceName, page)
+	versions, _, _, err := team.ResourceVersions(command.Resource.PipelineName, command.Resource.ResourceName, page, atc.Version{})
 	if err != nil {
 		return err
 	}

--- a/fly/commands/unpin_resource.go
+++ b/fly/commands/unpin_resource.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
+	"github.com/concourse/concourse/fly/rc"
+)
+
+type UnpinResourceCommand struct {
+	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of the resource"`
+}
+
+func (command *UnpinResourceCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	team := target.Team()
+
+	unpinned, err := team.UnpinResource(command.Resource.PipelineName, command.Resource.ResourceName)
+	if err != nil {
+		return err
+	}
+
+	if unpinned {
+		fmt.Printf("unpinned '%s/%s'\n", command.Resource.PipelineName, command.Resource.ResourceName)
+	} else {
+		displayhelpers.Failf("could not find resource '%s/%s'\n", command.Resource.PipelineName, command.Resource.ResourceName)
+	}
+
+	return nil
+}

--- a/fly/integration/pin_resource_version_test.go
+++ b/fly/integration/pin_resource_version_test.go
@@ -2,14 +2,15 @@ package integration_test
 
 import (
 	"fmt"
+	"net/http"
+	"os/exec"
+
 	"github.com/concourse/concourse/atc"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/ghttp"
 	"github.com/tedsuo/rata"
-	"net/http"
-	"os/exec"
 
 	"github.com/onsi/gomega/gexec"
 )
@@ -17,18 +18,32 @@ import (
 var _ = Describe("Fly CLI", func() {
 	Describe("pin-resource-version", func() {
 		var (
-			expectedStatus    int
-			path              string
-			err               error
-			teamName          = "main"
-			pipelineName      = "pipeline"
-			resourceName      = "resource"
-			resourceVersionID = "42"
-			pipelineResource  = fmt.Sprintf("%s/%s", pipelineName, resourceName)
+			expectedGetStatus         int
+			expectedPutStatus         int
+			pinPath                   string
+			getPath                   string
+			err                       error
+			teamName                  = "main"
+			pipelineName              = "pipeline"
+			resourceName              = "resource"
+			resourceVersionID         = "42"
+			resourceVersionJsonString = `{"some":"value"}`
+			pipelineResource          = fmt.Sprintf("%s/%s", pipelineName, resourceName)
+			expectedPinVersion        = atc.ResourceVersion{
+				ID:      42,
+				Version: atc.Version{"some": "value"},
+			}
 		)
 
 		BeforeEach(func() {
-			path, err = atc.Routes.CreatePathForRoute(atc.PinResourceVersion, rata.Params{
+			getPath, err = atc.Routes.CreatePathForRoute(atc.ListResourceVersions, rata.Params{
+				"pipeline_name": pipelineName,
+				"team_name":     teamName,
+				"resource_name": resourceName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pinPath, err = atc.Routes.CreatePathForRoute(atc.PinResourceVersion, rata.Params{
 				"pipeline_name":              pipelineName,
 				"team_name":                  teamName,
 				"resource_name":              resourceName,
@@ -40,8 +55,12 @@ var _ = Describe("Fly CLI", func() {
 		JustBeforeEach(func() {
 			atcServer.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("PUT", path),
-					ghttp.RespondWith(expectedStatus, nil),
+					ghttp.VerifyRequest("GET", getPath, "filter=some:value"),
+					ghttp.RespondWithJSONEncoded(expectedGetStatus, []atc.ResourceVersion{expectedPinVersion}),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", pinPath),
+					ghttp.RespondWith(expectedPutStatus, nil),
 				),
 			)
 		})
@@ -59,43 +78,43 @@ var _ = Describe("Fly CLI", func() {
 		})
 
 		Context("when the resource is specified", func() {
-			Context("when the resource version id is specified", func() {
-				Context("when the resource and version id exists", func() {
+			Context("when the resource version json string is specified", func() {
+				Context("when the resource and version exists", func() {
 					BeforeEach(func() {
-						expectedStatus = http.StatusOK
+						expectedGetStatus = http.StatusOK
+						expectedPutStatus = http.StatusOK
 					})
 
 					It("pins the resource version", func() {
 						Expect(func() {
-							flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version", "-r", pipelineResource, "-i", resourceVersionID)
+							flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version", "-r", pipelineResource, "-v", resourceVersionJsonString)
 
 							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 							Expect(err).NotTo(HaveOccurred())
 
-							Eventually(sess.Out).Should(gbytes.Say(fmt.Sprintf("pinned '%s' at version id %s\n", pipelineResource, resourceVersionID)))
+							Eventually(sess.Out.Contents).Should(ContainSubstring(fmt.Sprintf("pinned '%s' at version id %d with %+v\n", pipelineResource, expectedPinVersion.ID, expectedPinVersion.Version)))
 
 							<-sess.Exited
 							Expect(sess.ExitCode()).To(Equal(0))
 						}).To(Change(func() int {
 							return len(atcServer.ReceivedRequests())
-						}).By(2))
+						}).By(3))
 					})
 				})
 
-				Context("when the resource or version id does not exist", func() {
+				Context("when the versions does not exist", func() {
 					BeforeEach(func() {
-						expectedStatus = http.StatusNotFound
+						expectedGetStatus = http.StatusNotFound
 					})
 
-					It("fails to pin", func() {
+					It("errors", func() {
 						Expect(func() {
-							flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version", "-r", pipelineResource, "-i", resourceVersionID)
+							flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version", "-r", pipelineResource, "-v", resourceVersionJsonString)
 
 							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 							Expect(err).NotTo(HaveOccurred())
 
-							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not pin %s at version %s, make sure the resource and version exists",
-								pipelineResource, resourceVersionID)))
+							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not find version matching %s", resourceVersionJsonString)))
 
 							<-sess.Exited
 							Expect(sess.ExitCode()).To(Equal(1))
@@ -105,9 +124,31 @@ var _ = Describe("Fly CLI", func() {
 					})
 				})
 
+				Context("when the resource does not exist", func() {
+					BeforeEach(func() {
+						expectedPutStatus = http.StatusNotFound
+						expectedGetStatus = http.StatusOK
+					})
+
+					It("fails to pin", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version", "-r", pipelineResource, "-v", resourceVersionJsonString)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not pin '%s', make sure the resource exists", pipelineResource)))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(1))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(3))
+					})
+				})
 			})
 
-			Context("when the resource version id is not specified", func() {
+			Context("when the resource version is not specified", func() {
 				It("errors", func() {
 					Expect(func() {
 						flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version", "-r", pipelineResource)
@@ -115,7 +156,7 @@ var _ = Describe("Fly CLI", func() {
 						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 						Expect(err).NotTo(HaveOccurred())
 
-						Eventually(sess.Err).Should(gbytes.Say("error:.*-i, --version-id.*not specified"))
+						Eventually(sess.Err).Should(gbytes.Say("error:.*-v, --version.*not specified"))
 
 						<-sess.Exited
 						Expect(sess.ExitCode()).To(Equal(1))

--- a/fly/integration/pin_resource_version_test.go
+++ b/fly/integration/pin_resource_version_test.go
@@ -1,0 +1,147 @@
+package integration_test
+
+import (
+	"fmt"
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/tedsuo/rata"
+	"net/http"
+	"os/exec"
+
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Fly CLI", func() {
+	Describe("pin-resource-version", func() {
+		var (
+			expectedStatus    int
+			path              string
+			err               error
+			teamName          = "main"
+			pipelineName      = "pipeline"
+			resourceName      = "resource"
+			resourceVersionID = "42"
+			pipelineResource  = fmt.Sprintf("%s/%s", pipelineName, resourceName)
+		)
+
+		BeforeEach(func() {
+			path, err = atc.Routes.CreatePathForRoute(atc.PinResourceVersion, rata.Params{
+				"pipeline_name":              pipelineName,
+				"team_name":                  teamName,
+				"resource_name":              resourceName,
+				"resource_config_version_id": resourceVersionID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		JustBeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", path),
+					ghttp.RespondWith(expectedStatus, nil),
+				),
+			)
+		})
+
+		Context("make sure the command exists", func() {
+			It("calls the pin-resource-version command", func() {
+				flyCmd := exec.Command(flyPath, "pin-resource-version")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).ToNot(HaveOccurred())
+				Consistently(sess.Err).ShouldNot(gbytes.Say("error: Unknown command"))
+
+				<-sess.Exited
+			})
+		})
+
+		Context("when the resource is specified", func() {
+			Context("when the resource version id is specified", func() {
+				Context("when the resource and version id exists", func() {
+					BeforeEach(func() {
+						expectedStatus = http.StatusOK
+					})
+
+					It("pins the resource version", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version", "-r", pipelineResource, "-i", resourceVersionID)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Out).Should(gbytes.Say(fmt.Sprintf("pinned '%s' at version id %s\n", pipelineResource, resourceVersionID)))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(0))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(2))
+					})
+				})
+
+				Context("when the resource or version id does not exist", func() {
+					BeforeEach(func() {
+						expectedStatus = http.StatusNotFound
+					})
+
+					It("fails to pin", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version", "-r", pipelineResource, "-i", resourceVersionID)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not pin %s at version %s, make sure the resource and version exists",
+								pipelineResource, resourceVersionID)))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(1))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(2))
+					})
+				})
+
+			})
+
+			Context("when the resource version id is not specified", func() {
+				It("errors", func() {
+					Expect(func() {
+						flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version", "-r", pipelineResource)
+
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(sess.Err).Should(gbytes.Say("error:.*-i, --version-id.*not specified"))
+
+						<-sess.Exited
+						Expect(sess.ExitCode()).To(Equal(1))
+					}).To(Change(func() int {
+						return len(atcServer.ReceivedRequests())
+					}).By(0))
+				})
+			})
+		})
+
+		Context("when the resource is not specified", func() {
+			It("errors", func() {
+				Expect(func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource-version")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess.Err).Should(gbytes.Say("error:.*-r, --resource.*not specified"))
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(1))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(0))
+			})
+		})
+	})
+})

--- a/fly/integration/unpin_resource_test.go
+++ b/fly/integration/unpin_resource_test.go
@@ -1,0 +1,123 @@
+package integration_test
+
+import (
+	"fmt"
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/tedsuo/rata"
+	"net/http"
+	"os/exec"
+)
+
+var _ = Describe("Fly CLI", func() {
+	Describe("unpin-resource", func() {
+		var (
+			expectedStatus   int
+			path             string
+			err              error
+			teamName         = "main"
+			pipelineName     = "pipeline"
+			resourceName     = "resource"
+			pipelineResource = fmt.Sprintf("%s/%s", pipelineName, resourceName)
+		)
+
+		BeforeEach(func() {
+			path, err = atc.Routes.CreatePathForRoute(atc.UnpinResource, rata.Params{
+				"pipeline_name": pipelineName,
+				"team_name":     teamName,
+				"resource_name": resourceName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		JustBeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", path),
+					ghttp.RespondWith(expectedStatus, nil),
+				),
+			)
+		})
+
+		Context("make sure the command exists", func() {
+			It("calls the unpin-resource command", func() {
+				flyCmd := exec.Command(flyPath, "unpin-resource")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).ToNot(HaveOccurred())
+				Consistently(sess.Err).ShouldNot(gbytes.Say("error: Unknown command"))
+
+				<-sess.Exited
+			})
+		})
+
+		Context("when the resource is specified", func() {
+			Context("when the resource exists", func() {
+				BeforeEach(func() {
+					expectedStatus = http.StatusOK
+				})
+
+				It("pins the resource version", func() {
+					Expect(func() {
+						flyCmd := exec.Command(flyPath, "-t", targetName, "unpin-resource", "-r", pipelineResource)
+
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(sess.Out).Should(gbytes.Say(fmt.Sprintf("unpinned '%s'\n", pipelineResource)))
+
+						<-sess.Exited
+						Expect(sess.ExitCode()).To(Equal(0))
+					}).To(Change(func() int {
+						return len(atcServer.ReceivedRequests())
+					}).By(2))
+				})
+			})
+
+			Context("when the resource does not exist", func() {
+				BeforeEach(func() {
+					expectedStatus = http.StatusNotFound
+				})
+
+				It("fails to unpin", func() {
+					Expect(func() {
+						flyCmd := exec.Command(flyPath, "-t", targetName, "unpin-resource", "-r", pipelineResource)
+
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not find resource '%s'", pipelineResource)))
+
+						<-sess.Exited
+						Expect(sess.ExitCode()).To(Equal(1))
+					}).To(Change(func() int {
+						return len(atcServer.ReceivedRequests())
+					}).By(2))
+				})
+			})
+
+		})
+
+		Context("when the resource is not specified", func() {
+			It("errors", func() {
+				Expect(func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "unpin-resource")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess.Err).Should(gbytes.Say("error:.*-r, --resource.*not specified"))
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(1))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(0))
+			})
+		})
+	})
+})

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -486,6 +486,21 @@ type FakeTeam struct {
 		result1 bool
 		result2 error
 	}
+	PinResourceVersionStub        func(string, string, int) (bool, error)
+	pinResourceVersionMutex       sync.RWMutex
+	pinResourceVersionArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 int
+	}
+	pinResourceVersionReturns struct {
+		result1 bool
+		result2 error
+	}
+	pinResourceVersionReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	PipelineStub        func(string) (atc.Pipeline, bool, error)
 	pipelineMutex       sync.RWMutex
 	pipelineArgsForCall []struct {
@@ -580,12 +595,13 @@ type FakeTeam struct {
 		result2 bool
 		result3 error
 	}
-	ResourceVersionsStub        func(string, string, concourse.Page) ([]atc.ResourceVersion, concourse.Pagination, bool, error)
+	ResourceVersionsStub        func(string, string, concourse.Page, atc.Version) ([]atc.ResourceVersion, concourse.Pagination, bool, error)
 	resourceVersionsMutex       sync.RWMutex
 	resourceVersionsArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 concourse.Page
+		arg4 atc.Version
 	}
 	resourceVersionsReturns struct {
 		result1 []atc.ResourceVersion
@@ -638,6 +654,20 @@ type FakeTeam struct {
 		result2 error
 	}
 	unpausePipelineReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
+	UnpinResourceStub        func(string, string) (bool, error)
+	unpinResourceMutex       sync.RWMutex
+	unpinResourceArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	unpinResourceReturns struct {
+		result1 bool
+		result2 error
+	}
+	unpinResourceReturnsOnCall map[int]struct {
 		result1 bool
 		result2 error
 	}
@@ -2786,6 +2816,71 @@ func (fake *FakeTeam) PausePipelineReturnsOnCall(i int, result1 bool, result2 er
 	}{result1, result2}
 }
 
+func (fake *FakeTeam) PinResourceVersion(arg1 string, arg2 string, arg3 int) (bool, error) {
+	fake.pinResourceVersionMutex.Lock()
+	ret, specificReturn := fake.pinResourceVersionReturnsOnCall[len(fake.pinResourceVersionArgsForCall)]
+	fake.pinResourceVersionArgsForCall = append(fake.pinResourceVersionArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 int
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("PinResourceVersion", []interface{}{arg1, arg2, arg3})
+	fake.pinResourceVersionMutex.Unlock()
+	if fake.PinResourceVersionStub != nil {
+		return fake.PinResourceVersionStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.pinResourceVersionReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTeam) PinResourceVersionCallCount() int {
+	fake.pinResourceVersionMutex.RLock()
+	defer fake.pinResourceVersionMutex.RUnlock()
+	return len(fake.pinResourceVersionArgsForCall)
+}
+
+func (fake *FakeTeam) PinResourceVersionCalls(stub func(string, string, int) (bool, error)) {
+	fake.pinResourceVersionMutex.Lock()
+	defer fake.pinResourceVersionMutex.Unlock()
+	fake.PinResourceVersionStub = stub
+}
+
+func (fake *FakeTeam) PinResourceVersionArgsForCall(i int) (string, string, int) {
+	fake.pinResourceVersionMutex.RLock()
+	defer fake.pinResourceVersionMutex.RUnlock()
+	argsForCall := fake.pinResourceVersionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTeam) PinResourceVersionReturns(result1 bool, result2 error) {
+	fake.pinResourceVersionMutex.Lock()
+	defer fake.pinResourceVersionMutex.Unlock()
+	fake.PinResourceVersionStub = nil
+	fake.pinResourceVersionReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTeam) PinResourceVersionReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.pinResourceVersionMutex.Lock()
+	defer fake.pinResourceVersionMutex.Unlock()
+	fake.PinResourceVersionStub = nil
+	if fake.pinResourceVersionReturnsOnCall == nil {
+		fake.pinResourceVersionReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.pinResourceVersionReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTeam) Pipeline(arg1 string) (atc.Pipeline, bool, error) {
 	fake.pipelineMutex.Lock()
 	ret, specificReturn := fake.pipelineReturnsOnCall[len(fake.pipelineArgsForCall)]
@@ -3186,18 +3281,19 @@ func (fake *FakeTeam) ResourceReturnsOnCall(i int, result1 atc.Resource, result2
 	}{result1, result2, result3}
 }
 
-func (fake *FakeTeam) ResourceVersions(arg1 string, arg2 string, arg3 concourse.Page) ([]atc.ResourceVersion, concourse.Pagination, bool, error) {
+func (fake *FakeTeam) ResourceVersions(arg1 string, arg2 string, arg3 concourse.Page, arg4 atc.Version) ([]atc.ResourceVersion, concourse.Pagination, bool, error) {
 	fake.resourceVersionsMutex.Lock()
 	ret, specificReturn := fake.resourceVersionsReturnsOnCall[len(fake.resourceVersionsArgsForCall)]
 	fake.resourceVersionsArgsForCall = append(fake.resourceVersionsArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 concourse.Page
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("ResourceVersions", []interface{}{arg1, arg2, arg3})
+		arg4 atc.Version
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("ResourceVersions", []interface{}{arg1, arg2, arg3, arg4})
 	fake.resourceVersionsMutex.Unlock()
 	if fake.ResourceVersionsStub != nil {
-		return fake.ResourceVersionsStub(arg1, arg2, arg3)
+		return fake.ResourceVersionsStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
@@ -3212,17 +3308,17 @@ func (fake *FakeTeam) ResourceVersionsCallCount() int {
 	return len(fake.resourceVersionsArgsForCall)
 }
 
-func (fake *FakeTeam) ResourceVersionsCalls(stub func(string, string, concourse.Page) ([]atc.ResourceVersion, concourse.Pagination, bool, error)) {
+func (fake *FakeTeam) ResourceVersionsCalls(stub func(string, string, concourse.Page, atc.Version) ([]atc.ResourceVersion, concourse.Pagination, bool, error)) {
 	fake.resourceVersionsMutex.Lock()
 	defer fake.resourceVersionsMutex.Unlock()
 	fake.ResourceVersionsStub = stub
 }
 
-func (fake *FakeTeam) ResourceVersionsArgsForCall(i int) (string, string, concourse.Page) {
+func (fake *FakeTeam) ResourceVersionsArgsForCall(i int) (string, string, concourse.Page, atc.Version) {
 	fake.resourceVersionsMutex.RLock()
 	defer fake.resourceVersionsMutex.RUnlock()
 	argsForCall := fake.resourceVersionsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeTeam) ResourceVersionsReturns(result1 []atc.ResourceVersion, result2 concourse.Pagination, result3 bool, result4 error) {
@@ -3450,6 +3546,70 @@ func (fake *FakeTeam) UnpausePipelineReturnsOnCall(i int, result1 bool, result2 
 	}{result1, result2}
 }
 
+func (fake *FakeTeam) UnpinResource(arg1 string, arg2 string) (bool, error) {
+	fake.unpinResourceMutex.Lock()
+	ret, specificReturn := fake.unpinResourceReturnsOnCall[len(fake.unpinResourceArgsForCall)]
+	fake.unpinResourceArgsForCall = append(fake.unpinResourceArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("UnpinResource", []interface{}{arg1, arg2})
+	fake.unpinResourceMutex.Unlock()
+	if fake.UnpinResourceStub != nil {
+		return fake.UnpinResourceStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.unpinResourceReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTeam) UnpinResourceCallCount() int {
+	fake.unpinResourceMutex.RLock()
+	defer fake.unpinResourceMutex.RUnlock()
+	return len(fake.unpinResourceArgsForCall)
+}
+
+func (fake *FakeTeam) UnpinResourceCalls(stub func(string, string) (bool, error)) {
+	fake.unpinResourceMutex.Lock()
+	defer fake.unpinResourceMutex.Unlock()
+	fake.UnpinResourceStub = stub
+}
+
+func (fake *FakeTeam) UnpinResourceArgsForCall(i int) (string, string) {
+	fake.unpinResourceMutex.RLock()
+	defer fake.unpinResourceMutex.RUnlock()
+	argsForCall := fake.unpinResourceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeTeam) UnpinResourceReturns(result1 bool, result2 error) {
+	fake.unpinResourceMutex.Lock()
+	defer fake.unpinResourceMutex.Unlock()
+	fake.UnpinResourceStub = nil
+	fake.unpinResourceReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTeam) UnpinResourceReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.unpinResourceMutex.Lock()
+	defer fake.unpinResourceMutex.Unlock()
+	fake.UnpinResourceStub = nil
+	if fake.unpinResourceReturnsOnCall == nil {
+		fake.unpinResourceReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.unpinResourceReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTeam) VersionedResourceTypes(arg1 string) (atc.VersionedResourceTypes, bool, error) {
 	fake.versionedResourceTypesMutex.Lock()
 	ret, specificReturn := fake.versionedResourceTypesReturnsOnCall[len(fake.versionedResourceTypesArgsForCall)]
@@ -3585,6 +3745,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.pauseJobMutex.RUnlock()
 	fake.pausePipelineMutex.RLock()
 	defer fake.pausePipelineMutex.RUnlock()
+	fake.pinResourceVersionMutex.RLock()
+	defer fake.pinResourceVersionMutex.RUnlock()
 	fake.pipelineMutex.RLock()
 	defer fake.pipelineMutex.RUnlock()
 	fake.pipelineBuildsMutex.RLock()
@@ -3605,6 +3767,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.unpauseJobMutex.RUnlock()
 	fake.unpausePipelineMutex.RLock()
 	defer fake.unpausePipelineMutex.RUnlock()
+	fake.unpinResourceMutex.RLock()
+	defer fake.unpinResourceMutex.RUnlock()
 	fake.versionedResourceTypesMutex.RLock()
 	defer fake.versionedResourceTypesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/go-concourse/concourse/resourceversions.go
+++ b/go-concourse/concourse/resourceversions.go
@@ -50,6 +50,32 @@ func (team *team) EnableResourceVersion(pipelineName string, resourceName string
 	return team.sendResourceVersion(pipelineName, resourceName, resourceVersionID, atc.EnableResourceVersion)
 }
 
+func (team *team) PinResourceVersion(pipelineName string, resourceName string, resourceVersionID int) (bool, error) {
+	return team.sendResourceVersion(pipelineName, resourceName, resourceVersionID, atc.PinResourceVersion)
+}
+
+func (team *team) UnpinResource(pipelineName string, resourceName string) (bool, error) {
+	params := rata.Params{
+		"pipeline_name": pipelineName,
+		"resource_name": resourceName,
+		"team_name":     team.name,
+	}
+
+	err := team.connection.Send(internal.Request{
+		RequestName: atc.UnpinResource,
+		Params:      params,
+	}, nil)
+
+	switch err.(type) {
+	case nil:
+		return true, nil
+	case internal.ResourceNotFoundError:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
 func (team *team) sendResourceVersion(pipelineName string, resourceName string, resourceVersionID int, resourceVersionReq string) (bool, error) {
 	params := rata.Params{
 		"pipeline_name":              pipelineName,

--- a/go-concourse/concourse/resourceversions.go
+++ b/go-concourse/concourse/resourceversions.go
@@ -1,6 +1,7 @@
 package concourse
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/tedsuo/rata"
 )
 
-func (team *team) ResourceVersions(pipelineName string, resourceName string, page Page) ([]atc.ResourceVersion, Pagination, bool, error) {
+func (team *team) ResourceVersions(pipelineName string, resourceName string, page Page, filter atc.Version) ([]atc.ResourceVersion, Pagination, bool, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"resource_name": resourceName,
@@ -19,10 +20,15 @@ func (team *team) ResourceVersions(pipelineName string, resourceName string, pag
 	var resourceVersions []atc.ResourceVersion
 	headers := http.Header{}
 
+	queryParams := page.QueryParams()
+	for k, v := range filter {
+		queryParams.Add("filter", fmt.Sprintf("%s:%s", k, v))
+	}
+
 	err := team.connection.Send(internal.Request{
 		RequestName: atc.ListResourceVersions,
 		Params:      params,
-		Query:       page.QueryParams(),
+		Query:       queryParams,
 	}, &internal.Response{
 		Result:  &resourceVersions,
 		Headers: &headers,

--- a/go-concourse/concourse/resourceversions_test.go
+++ b/go-concourse/concourse/resourceversions_test.go
@@ -363,4 +363,138 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			})
 		})
 	})
+
+	Describe("PinResourceVersion", func() {
+		var (
+			expectedStatus    int
+			pipelineName      = "banana"
+			resourceName      = "myresource"
+			resourceVersionID = 42
+			expectedURL       = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/resources/%s/versions/%s/pin", pipelineName, resourceName, strconv.Itoa(resourceVersionID))
+		)
+
+		JustBeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", expectedURL),
+					ghttp.RespondWith(expectedStatus, nil),
+				),
+			)
+		})
+
+		Context("When the resource exists and there are no issues", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusOK
+			})
+
+			It("calls the pin resource and returns no error", func() {
+				Expect(func() {
+					pinned, err := team.PinResourceVersion(pipelineName, resourceName, resourceVersionID)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pinned).To(BeTrue())
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(1))
+			})
+		})
+
+		Context("when the resource does not exist", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusNotFound
+			})
+
+			It("calls the pin resource and returns an error", func() {
+				Expect(func() {
+					pinned, err := team.PinResourceVersion(pipelineName, resourceName, resourceVersionID)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pinned).To(BeFalse())
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(1))
+			})
+		})
+
+
+		Context("when the pin resource call fails", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusInternalServerError
+			})
+
+			It("calls the pin resource and returns an error", func() {
+				Expect(func() {
+					pinned, err := team.PinResourceVersion(pipelineName, resourceName, resourceVersionID)
+					Expect(err).To(HaveOccurred())
+					Expect(pinned).To(BeFalse())
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(1))
+			})
+		})
+	})
+
+	Describe("UnpinResource", func() {
+		var (
+			expectedStatus int
+			pipelineName   = "banana"
+			resourceName   = "myresource"
+			expectedURL    = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/resources/%s/unpin", pipelineName, resourceName)
+		)
+
+		JustBeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", expectedURL),
+					ghttp.RespondWith(expectedStatus, nil),
+				),
+			)
+		})
+
+		Context("When the resource exists and there are no issues", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusOK
+			})
+
+			It("calls the unpin resource and returns no error", func() {
+				Expect(func() {
+					pinned, err := team.UnpinResource(pipelineName, resourceName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pinned).To(BeTrue())
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(1))
+			})
+		})
+
+		Context("when the resource does not exist", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusNotFound
+			})
+
+			It("calls the unpin resource and returns an error", func() {
+				Expect(func() {
+					pinned, err := team.UnpinResource(pipelineName, resourceName)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pinned).To(BeFalse())
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(1))
+			})
+		})
+
+		Context("when the unpin resource call fails", func() {
+			BeforeEach(func() {
+				expectedStatus = http.StatusInternalServerError
+			})
+
+			It("calls the unpin resource and returns an error", func() {
+				Expect(func() {
+					pinned, err := team.UnpinResource(pipelineName, resourceName)
+					Expect(err).To(HaveOccurred())
+					Expect(pinned).To(BeFalse())
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(1))
+			})
+		})
+	})
 })

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -53,6 +53,9 @@ type Team interface {
 	DisableResourceVersion(pipelineName string, resourceName string, resourceVersionID int) (bool, error)
 	EnableResourceVersion(pipelineName string, resourceName string, resourceVersionID int) (bool, error)
 
+	PinResourceVersion(pipelineName string, resourceName string, resourceVersionID int) (bool, error)
+	UnpinResource(pipelineName string, resourceName string) (bool, error)
+
 	BuildsWithVersionAsInput(pipelineName string, resourceName string, resourceVersionID int) ([]atc.Build, bool, error)
 	BuildsWithVersionAsOutput(pipelineName string, resourceName string, resourceVersionID int) ([]atc.Build, bool, error)
 

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -47,7 +47,7 @@ type Team interface {
 	Resource(pipelineName string, resourceName string) (atc.Resource, bool, error)
 	ListResources(pipelineName string) ([]atc.Resource, error)
 	VersionedResourceTypes(pipelineName string) (atc.VersionedResourceTypes, bool, error)
-	ResourceVersions(pipelineName string, resourceName string, page Page) ([]atc.ResourceVersion, Pagination, bool, error)
+	ResourceVersions(pipelineName string, resourceName string, page Page, filter atc.Version) ([]atc.ResourceVersion, Pagination, bool, error)
 	CheckResource(pipelineName string, resourceName string, version atc.Version) (atc.Check, bool, error)
 	CheckResourceType(pipelineName string, resourceTypeName string, version atc.Version) (atc.Check, bool, error)
 	DisableResourceVersion(pipelineName string, resourceName string, resourceVersionID int) (bool, error)


### PR DESCRIPTION
implements #2702 

Example:
cmd
```
fly -t ci pin-resource-version -r pipeline/resource -v '{"tag":"1.1.3"}'
```
Available resource versions:
```
v1 {"tag":"1.1.3", "meta":"some-meta","commit":"12345"}
v2 {"tag":"1.1.3", "meta":"some-other-meta","commit":"23456"}
v3 {"tag":"1.2.0", "meta":"foo-meta","commit":"76543"}
```

will find resource versions v1 and v2 that have field ["tag":"1.1.3"] and pin the latest one v2