### PR TITLE
Add release notes for v5.6.0

### DIFF
--- a/release-notes/v5.6.0.md
+++ b/release-notes/v5.6.0.md
@@ -1,0 +1,10 @@
+#### <sub><sup><a name="v560-note-3895" href="#v560-note-3895">:link:</a></sup></sub> feature
+
+* @ralekseenkov added a web runtime flag `CONCOURSE_SECRET_CACHE_DURATION_NOTFOUND` to set a
+  separate caching interval when a secret is not successfully found in the config store.
+  Defaults to 10s. Addresses [#3895](https://github.com/concourse/concourse/issues/3895) #4009.
+
+#### <sub><sup><a name="v560-note-4153" href="#v560-note-4153">:link:</a></sup></sub> feature
+
+* @thoHeinze added `CONCOURSE_GARDEN_NETWORK_POOL` as configurable flag in BOSH release.
+  Defaults to Garden's range of 10.254.0.0/22. Addresses [#4153](https://github.com/concourse/concourse/issues/4153).


### PR DESCRIPTION
* Addition of secrets duration flag
* Expose GARDEN_NETWORK_POOL in BOSH release

Signed-off-by: Denise Yu <dyu@pivotal.io>