### PR TITLE
container: add worker name to logger data

### DIFF
--- a/atc/worker/container.go
+++ b/atc/worker/container.go
@@ -48,7 +48,12 @@ func newGardenWorkerContainer(
 	volumeClient VolumeClient,
 	workerName string,
 ) (Container, error) {
-	logger = logger.WithData(lager.Data{"container": container.Handle()})
+	logger = logger.WithData(
+		lager.Data{
+			"container": container.Handle(),
+			"worker":    workerName,
+		},
+	)
 
 	workerContainer := &gardenWorkerContainer{
 		Container:   container,


### PR DESCRIPTION
This meta data will greatly improve our ability to identify the origin of container / volume errors.