### PR TITLE
topgun: fix manifest path

### DIFF
--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -174,7 +174,7 @@ func StartDeploy(manifest string, args ...string) *gexec.Session {
 
 	return SpawnBosh(
 		append([]string{
-			"deploy", manifest,
+			"deploy", "../" + manifest,
 			"--vars-store", filepath.Join(tmp, deploymentName+"-vars.yml"),
 			"-v", "deployment_name='" + deploymentName + "'",
 			"-v", "concourse_release_version='" + concourseReleaseVersion + "'",


### PR DESCRIPTION
since each suite is in a subdirectory of `topgun/`. This should fix failures like https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/bosh-topgun-pcf/builds/19#L5d7beaf3:578.