### PR TITLE
atc/resource/resource_put: prevent a nil VersionResult from crashing atc

### DIFF
--- a/atc/resource/resource_put.go
+++ b/atc/resource/resource_put.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/concourse/concourse/atc"
 )
@@ -21,9 +22,10 @@ func (resource *resource) Put(
 
 	vr := &VersionResult{}
 
+	path := "/opt/resource/out"
 	err := resource.runScript(
 		ctx,
-		"/opt/resource/out",
+		path,
 		[]string{resourceDir},
 		putRequest{
 			Params: params,
@@ -35,6 +37,9 @@ func (resource *resource) Put(
 	)
 	if err != nil {
 		return VersionResult{}, err
+	}
+	if vr == nil {
+		return VersionResult{}, fmt.Errorf("resource script (%s %s) output a null version", path, resourceDir)
 	}
 
 	return *vr, nil

--- a/atc/resource/resource_put_test.go
+++ b/atc/resource/resource_put_test.go
@@ -186,6 +186,17 @@ var _ = Describe("Resource Put", func() {
 				})
 			})
 
+			Context("when /out outputs null", func() {
+				BeforeEach(func() {
+					outScriptStdout = `null`
+				})
+
+				It("emits an error", func() {
+					Expect(putErr).To(HaveOccurred())
+					Expect(putErr).To(Equal(errors.New("resource script (/opt/resource/out /tmp/build/put) output a null version")))
+				})
+			})
+
 			Context("when /out outputs to stderr", func() {
 				BeforeEach(func() {
 					outScriptStderr = "some stderr data"


### PR DESCRIPTION
We ran in to a *fun* instance where incorrectly configured resources in users' pipelines were crashing the `atc`.  This covers that case and prevents it from happening.

I didn't _really_ know what to include as an error message, so I just jotted down something that loosely makes sense.  I'm kinda expecting to have to change it during review.