### PR TITLE
Fix topgun by exposing more common variables

### DIFF
--- a/topgun/both/both_suite_test.go
+++ b/topgun/both/both_suite_test.go
@@ -51,6 +51,6 @@ var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 func TestTOPGUN(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "TOPGUN Suite")
+	RunSpecs(t, "Core and Runtime Suite")
 }
 

--- a/topgun/core/atc_login_session_test.go
+++ b/topgun/core/atc_login_session_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Multiple ATCs Login Session Test", func() {
 		Describe("using database storage for dex", func() {
 			It("uses the same client for multiple ATCs", func() {
 				var numClient int
-				err := psql.Select("COUNT(*)").From("client").RunWith(dbConn).QueryRow().Scan(&numClient)
+				err := Psql.Select("COUNT(*)").From("client").RunWith(DbConn).QueryRow().Scan(&numClient)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(numClient).To(Equal(1))
 			})
@@ -47,7 +47,7 @@ var _ = Describe("Multiple ATCs Login Session Test", func() {
 
 			BeforeEach(func() {
 				var err error
-				token, err = FetchToken(atc0URL, atcUsername, atcPassword)
+				token, err = FetchToken(atc0URL, AtcUsername, AtcPassword)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("stopping the first atc")
@@ -91,14 +91,14 @@ var _ = Describe("Multiple ATCs Login Session Test", func() {
 			BeforeEach(deploy)
 
 			It("should be able to login to both ATCs", func() {
-				fly.Login(atcUsername, atcPassword, atc1URL)
-				fly.Login(atcUsername, atcPassword, atc0URL)
+				Fly.Login(AtcUsername, AtcPassword, atc1URL)
+				Fly.Login(AtcUsername, AtcPassword, atc0URL)
 
 				By("deploying a second time (with a different token signing key)")
 				deploy()
 
-				fly.Login(atcUsername, atcPassword, atc0URL)
-				fly.Login(atcUsername, atcPassword, atc1URL)
+				Fly.Login(AtcUsername, AtcPassword, atc0URL)
+				Fly.Login(AtcUsername, AtcPassword, atc1URL)
 			})
 		})
 	})

--- a/topgun/core/aws_ssm_test.go
+++ b/topgun/core/aws_ssm_test.go
@@ -74,7 +74,7 @@ var _ = Describe("AWS SSM", func() {
 			})
 
 			JustBeforeEach(func() {
-				token, err := FetchToken(atcURL, atcUsername, atcPassword)
+				token, err := FetchToken(atcURL, AtcUsername, AtcPassword)
 				Expect(err).ToNot(HaveOccurred())
 
 				body, err := RequestCredsInfo(atcURL, token.AccessToken)

--- a/topgun/core/containers_scoped_to_team_test.go
+++ b/topgun/core/containers_scoped_to_team_test.go
@@ -18,17 +18,17 @@ var _ = Describe("Container scope", func() {
 
 		It("is only hijackable by someone in that team", func() {
 			By("setting a pipeline for team `main`")
-			fly.Run("set-pipeline", "-n", "-c", "pipelines/get-task-put-waiting.yml", "-p", "container-scope-test")
+			Fly.Run("set-pipeline", "-n", "-c", "../pipelines/get-task-put-waiting.yml", "-p", "container-scope-test")
 
 			By("triggering the build")
-			fly.Run("unpause-pipeline", "-p", "container-scope-test")
-			buildSession := fly.Start("trigger-job", "-w", "-j", "container-scope-test/simple-job")
+			Fly.Run("unpause-pipeline", "-p", "container-scope-test")
+			buildSession := Fly.Start("trigger-job", "-w", "-j", "container-scope-test/simple-job")
 			Eventually(buildSession).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
 
 			By("demonstrating we can hijack into all of the containers")
 			buildContainers := ContainersBy("build #", "1")
 			for i := 1; i <= len(buildContainers); i++ {
-				hijackSession := fly.SpawnInteractive(
+				hijackSession := Fly.SpawnInteractive(
 					bytes.NewBufferString(strconv.Itoa(i)+"\n"),
 					"hijack",
 					"-b", "1",
@@ -40,7 +40,7 @@ var _ = Describe("Container scope", func() {
 			}
 
 			By("creating a separate team")
-			setTeamSession := fly.SpawnInteractive(
+			setTeamSession := Fly.SpawnInteractive(
 				bytes.NewBufferString("y\n"),
 				"set-team",
 				"--team-name", "no-access",
@@ -51,19 +51,19 @@ var _ = Describe("Container scope", func() {
 			Expect(setTeamSession.ExitCode()).To(Equal(0))
 
 			By("logging into other team")
-			fly.Run("login", "-n", "no-access", "-u", "guest", "-p", "guest")
+			Fly.Run("login", "-n", "no-access", "-u", "guest", "-p", "guest")
 
 			By("not allowing hijacking into any containers")
-			failedFly := fly.Start("hijack", "-b", "1")
+			failedFly := Fly.Start("hijack", "-b", "1")
 			<-failedFly.Exited
 			Expect(failedFly.ExitCode()).NotTo(Equal(0))
 			Expect(failedFly.Err).To(gbytes.Say("no containers matched your search parameters!"))
 
 			By("logging back into the other team")
-			fly.Run("login", "-n", "main", "-u", atcUsername, "-p", atcPassword)
+			Fly.Run("login", "-n", "main", "-u", AtcUsername, "-p", AtcPassword)
 
 			By("stopping the build")
-			hijackSession := fly.Start(
+			hijackSession := Fly.Start(
 				"hijack",
 				"-b", "1",
 				"-s", "simple-task",

--- a/topgun/core/core_suite_test.go
+++ b/topgun/core/core_suite_test.go
@@ -1,52 +1,11 @@
 package topgun_test
 
 import (
-	"database/sql"
 	"testing"
 
-	gclient "code.cloudfoundry.org/garden/client"
-	"code.cloudfoundry.org/lager/lagertest"
-	sq "github.com/Masterminds/squirrel"
-	bclient "github.com/concourse/baggageclaim/client"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	. "github.com/concourse/concourse/topgun"
-	. "github.com/concourse/concourse/topgun/common"
 )
-
-var (
-	deploymentNamePrefix string
-
-	fly                       = Fly{}
-	deploymentName, flyTarget string
-	instances                 map[string][]BoshInstance
-	jobInstances              map[string][]BoshInstance
-
-	dbInstance *BoshInstance
-	dbConn     *sql.DB
-
-	webInstance    *BoshInstance
-	atcExternalURL string
-	atcUsername    string
-	atcPassword    string
-
-	workerGardenClient       gclient.Client
-	workerBaggageclaimClient bclient.Client
-
-	concourseReleaseVersion, bpmReleaseVersion, postgresReleaseVersion string
-	vaultReleaseVersion, credhubReleaseVersion                         string
-	stemcellVersion                                                    string
-	backupAndRestoreReleaseVersion                                     string
-
-	pipelineName string
-
-	logger *lagertest.TestLogger
-
-	tmp string
-)
-
-var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 func TestCore(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/topgun/core/credhub_test.go
+++ b/topgun/core/credhub_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Credhub", func() {
 			})
 
 			JustBeforeEach(func() {
-				token, err := FetchToken(atcURL, atcUsername, atcPassword)
+				token, err := FetchToken(atcURL, AtcUsername, AtcPassword)
 				Expect(err).ToNot(HaveOccurred())
 
 				body, err := RequestCredsInfo(atcURL, token.AccessToken)

--- a/topgun/core/creds_test.go
+++ b/topgun/core/creds_test.go
@@ -40,10 +40,10 @@ func testCredentialManagement(
 			pipelineSetup()
 
 			By("setting a pipeline that uses vars for secrets")
-			fly.Run("set-pipeline", "-n", "-c", "pipelines/credential-management.yml", "-p", "pipeline-creds-test")
+			Fly.Run("set-pipeline", "-n", "-c", "../pipelines/credential-management.yml", "-p", "pipeline-creds-test")
 
 			By("getting the pipeline config")
-			session := fly.Start("get-pipeline", "-p", "pipeline-creds-test")
+			session := Fly.Start("get-pipeline", "-p", "pipeline-creds-test")
 			<-session.Exited
 			Expect(session.ExitCode()).To(Equal(0))
 			Expect(string(session.Out.Contents())).ToNot(ContainSubstring("some_canary"))
@@ -55,12 +55,12 @@ func testCredentialManagement(
 			Expect(string(session.Out.Contents())).To(ContainSubstring("((team_secret))"))
 
 			By("unpausing the pipeline")
-			fly.Run("unpause-pipeline", "-p", "pipeline-creds-test")
+			Fly.Run("unpause-pipeline", "-p", "pipeline-creds-test")
 		})
 
 		It("parameterizes via Vault and leaves the pipeline uninterpolated", func() {
 			By("triggering job")
-			watch := fly.Start("trigger-job", "-w", "-j", "pipeline-creds-test/some-job")
+			watch := Fly.Start("trigger-job", "-w", "-j", "pipeline-creds-test/some-job")
 			Wait(watch)
 			Expect(watch).To(gbytes.Say("all credentials matched expected values"))
 
@@ -79,12 +79,12 @@ func testCredentialManagement(
 		Context("when the job's inputs are used for a one-off build", func() {
 			It("parameterizes the values using the job's pipeline scope", func() {
 				By("triggering job to populate its inputs")
-				watch := fly.Start("trigger-job", "-w", "-j", "pipeline-creds-test/some-job")
+				watch := Fly.Start("trigger-job", "-w", "-j", "pipeline-creds-test/some-job")
 				Wait(watch)
 				Expect(watch).To(gbytes.Say("all credentials matched expected values"))
 
 				By("executing a task that parameterizes image_resource and uses a pipeline resource with credentials")
-				watch = fly.StartWithEnv(
+				watch = Fly.StartWithEnv(
 					[]string{
 						"EXPECTED_RESOURCE_SECRET=some_resource_secret",
 						"EXPECTED_RESOURCE_VERSION_SECRET=some_exposed_version_secret",
@@ -110,7 +110,7 @@ func testCredentialManagement(
 		BeforeEach(oneOffSetup)
 
 		It("parameterizes image_resource and params in a task config", func() {
-			watch := fly.StartWithEnv(
+			watch := Fly.StartWithEnv(
 				[]string{
 					"EXPECTED_TEAM_SECRET=some_team_secret",
 					"EXPECTED_RESOURCE_VERSION_SECRET=some_exposed_version_secret",

--- a/topgun/core/database_encryption_test.go
+++ b/topgun/core/database_encryption_test.go
@@ -15,11 +15,11 @@ import (
 var _ = Describe("Database secrets encryption", func() {
 	configurePipelineAndTeamAndTriggerJob := func() {
 		By("setting a pipeline that contains secrets")
-		fly.Run("set-pipeline", "-n", "-c", "pipelines/secrets.yml", "-p", "pipeline-secrets-test")
-		fly.Run("unpause-pipeline", "-p", "pipeline-secrets-test")
+		Fly.Run("set-pipeline", "-n", "-c", "../pipelines/secrets.yml", "-p", "pipeline-secrets-test")
+		Fly.Run("unpause-pipeline", "-p", "pipeline-secrets-test")
 
 		By("creating a team with auth")
-		setTeamSession := fly.SpawnInteractive(
+		setTeamSession := Fly.SpawnInteractive(
 			bytes.NewBufferString("y\n"),
 			"set-team",
 			"--team-name", "victoria",
@@ -28,13 +28,13 @@ var _ = Describe("Database secrets encryption", func() {
 		)
 		<-setTeamSession.Exited
 
-		buildSession := fly.Start("trigger-job", "-w", "-j", "pipeline-secrets-test/simple-job")
+		buildSession := Fly.Start("trigger-job", "-w", "-j", "pipeline-secrets-test/simple-job")
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(0))
 	}
 
 	getPipeline := func() *gexec.Session {
-		session := fly.Start("get-pipeline", "-p", "pipeline-secrets-test")
+		session := Fly.Start("get-pipeline", "-p", "pipeline-secrets-test")
 		<-session.Exited
 		Expect(session.ExitCode()).To(Equal(0))
 		return session
@@ -112,7 +112,7 @@ var _ = Describe("Database secrets encryption", func() {
 						Expect(string(session.Out.Contents())).To(ContainSubstring("image_resource_secret"))
 
 						By("setting the pipeline again")
-						fly.Run("set-pipeline", "-n", "-c", "pipelines/secrets.yml", "-p", "pipeline-secrets-test")
+						Fly.Run("set-pipeline", "-n", "-c", "../pipelines/secrets.yml", "-p", "pipeline-secrets-test")
 
 						By("getting the pipeline config again")
 						session = getPipeline()
@@ -143,7 +143,7 @@ var _ = Describe("Database secrets encryption", func() {
 						Expect(string(session.Out.Contents())).To(ContainSubstring("image_resource_secret"))
 
 						By("setting the pipeline again")
-						fly.Run("set-pipeline", "-n", "-c", "pipelines/secrets.yml", "-p", "pipeline-secrets-test")
+						Fly.Run("set-pipeline", "-n", "-c", "../pipelines/secrets.yml", "-p", "pipeline-secrets-test")
 
 						By("getting the pipeline config again")
 						session = getPipeline()

--- a/topgun/core/syslog_test.go
+++ b/topgun/core/syslog_test.go
@@ -22,10 +22,10 @@ var _ = Describe("An ATC with syslog draining set", func() {
 	})
 
 	It("sends the build logs to the syslog server.", func() {
-		fly.Run("set-pipeline", "-n", "-c", "pipelines/secrets.yml", "-p", "syslog-pipeline")
+		Fly.Run("set-pipeline", "-n", "-c", "../pipelines/secrets.yml", "-p", "syslog-pipeline")
 
-		fly.Run("unpause-pipeline", "-p", "syslog-pipeline")
-		buildSession := fly.Start("trigger-job", "-w", "-j", "syslog-pipeline/simple-job")
+		Fly.Run("unpause-pipeline", "-p", "syslog-pipeline")
+		buildSession := Fly.Start("trigger-job", "-w", "-j", "syslog-pipeline/simple-job")
 
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(0))

--- a/topgun/core/unique_versions_test.go
+++ b/topgun/core/unique_versions_test.go
@@ -17,30 +17,30 @@ var _ = Describe("Unique Version History", func() {
 	Context("with a time resource", func() {
 		BeforeEach(func() {
 			By("setting a pipeline with a time resource")
-			fly.Run("set-pipeline", "-n", "-c", "pipelines/time-resource.yml", "-p", "time-resource-1")
+			Fly.Run("set-pipeline", "-n", "-c", "../pipelines/time-resource.yml", "-p", "time-resource-1")
 
 			By("unpausing the pipeline")
-			fly.Run("unpause-pipeline", "-p", "time-resource-1")
+			Fly.Run("unpause-pipeline", "-p", "time-resource-1")
 
 			By("setting another pipeline with a time resource")
-			fly.Run("set-pipeline", "-n", "-c", "pipelines/time-resource.yml", "-p", "time-resource-2")
+			Fly.Run("set-pipeline", "-n", "-c", "../pipelines/time-resource.yml", "-p", "time-resource-2")
 
 			By("unpausing the pipeline")
-			fly.Run("unpause-pipeline", "-p", "time-resource-2")
+			Fly.Run("unpause-pipeline", "-p", "time-resource-2")
 		})
 
 		It("creates unique version history for each time resource", func() {
 			By("running the check for the first pipeline")
-			fly.Run("check-resource", "-r", "time-resource-1/time-resource")
+			Fly.Run("check-resource", "-r", "time-resource-1/time-resource")
 
 			By("running the check for the second pipeline")
-			fly.Run("check-resource", "-r", "time-resource-2/time-resource")
+			Fly.Run("check-resource", "-r", "time-resource-2/time-resource")
 
 			By("getting the versions for the first time resource")
-			versions1 := fly.GetVersions("time-resource-1", "time-resource")
+			versions1 := Fly.GetVersions("time-resource-1", "time-resource")
 
 			By("getting the versions for the second time resource")
-			versions2 := fly.GetVersions("time-resource-2", "time-resource")
+			versions2 := Fly.GetVersions("time-resource-2", "time-resource")
 
 			Expect(versions1).ToNot(Equal(versions2))
 		})
@@ -49,31 +49,31 @@ var _ = Describe("Unique Version History", func() {
 	Context("when a resource is specified to have a unique version history from the pipeline", func() {
 		BeforeEach(func() {
 			By("setting a pipeline with a unique version history resource")
-			fly.Run("set-pipeline", "-n", "-c", "pipelines/custom-unique-type.yml", "-p", "unique-resource-1")
+			Fly.Run("set-pipeline", "-n", "-c", "../pipelines/custom-unique-type.yml", "-p", "unique-resource-1")
 
 			By("unpausing the pipeline")
-			fly.Run("unpause-pipeline", "-p", "unique-resource-1")
+			Fly.Run("unpause-pipeline", "-p", "unique-resource-1")
 
 			By("setting another pipeline with a unique version history resource")
-			fly.Run("set-pipeline", "-n", "-c", "pipelines/custom-unique-type.yml", "-p", "unique-resource-2")
+			Fly.Run("set-pipeline", "-n", "-c", "../pipelines/custom-unique-type.yml", "-p", "unique-resource-2")
 
 			By("unpausing the pipeline")
-			fly.Run("unpause-pipeline", "-p", "unique-resource-2")
+			Fly.Run("unpause-pipeline", "-p", "unique-resource-2")
 		})
 
 		It("creates unique version history for each unique resource", func() {
 			By("running the check for the first pipeline")
-			fly.Run("check-resource", "-r", "unique-resource-1/some-resource", "-f", "version:v1")
+			Fly.Run("check-resource", "-r", "unique-resource-1/some-resource", "-f", "version:v1")
 
 			By("running the check for the second pipeline")
-			fly.Run("check-resource", "-r", "unique-resource-2/some-resource", "-f", "version:v2")
+			Fly.Run("check-resource", "-r", "unique-resource-2/some-resource", "-f", "version:v2")
 
 			By("getting the versions for the first unique resource")
-			versions1 := fly.GetVersions("unique-resource-1", "some-resource")
+			versions1 := Fly.GetVersions("unique-resource-1", "some-resource")
 			Expect(versions1).To(HaveLen(1))
 
 			By("getting the versions for the second unique resource")
-			versions2 := fly.GetVersions("unique-resource-2", "some-resource")
+			versions2 := Fly.GetVersions("unique-resource-2", "some-resource")
 			Expect(versions2).To(HaveLen(1))
 
 			Expect(versions1[0].Version).ToNot(Equal(versions2[0].Version))

--- a/topgun/core/vault_test.go
+++ b/topgun/core/vault_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Vault", func() {
 				})
 
 				It("renews the token", func() {
-					watch := fly.StartWithEnv(
+					watch := Fly.StartWithEnv(
 						[]string{
 							"EXPECTED_TEAM_SECRET=some_team_secret",
 							"EXPECTED_RESOURCE_VERSION_SECRET=some_exposed_version_secret",

--- a/topgun/fly.go
+++ b/topgun/fly.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type Fly struct {
+type FlyCli struct {
 	Bin    string
 	Target string
 	Home   string
@@ -48,7 +48,7 @@ type Version struct {
 	Enabled bool              `json:"enabled"`
 }
 
-func (f *Fly) Login(user, password, endpoint string) {
+func (f *FlyCli) Login(user, password, endpoint string) {
 	Eventually(func() *gexec.Session {
 		sess := f.Start(
 			"login",
@@ -63,23 +63,23 @@ func (f *Fly) Login(user, password, endpoint string) {
 		Should(gexec.Exit(0), "Fly should have been able to log in")
 }
 
-func (f *Fly) Run(argv ...string) {
+func (f *FlyCli) Run(argv ...string) {
 	Wait(f.Start(argv...))
 }
 
-func (f *Fly) Start(argv ...string) *gexec.Session {
+func (f *FlyCli) Start(argv ...string) *gexec.Session {
 	return Start([]string{"HOME=" + f.Home}, f.Bin, append([]string{"-t", f.Target}, argv...)...)
 }
 
-func (f *Fly) StartWithEnv(env []string, argv ...string) *gexec.Session {
+func (f *FlyCli) StartWithEnv(env []string, argv ...string) *gexec.Session {
 	return Start(append([]string{"HOME=" + f.Home}, env...), f.Bin, append([]string{"-t", f.Target}, argv...)...)
 }
 
-func (f *Fly) SpawnInteractive(stdin io.Reader, argv ...string) *gexec.Session {
+func (f *FlyCli) SpawnInteractive(stdin io.Reader, argv ...string) *gexec.Session {
 	return SpawnInteractive(stdin, []string{"HOME=" + f.Home}, f.Bin, append([]string{"-t", f.Target}, argv...)...)
 }
 
-func (f *Fly) GetContainers() []Container {
+func (f *FlyCli) GetContainers() []Container {
 	var containers = []Container{}
 
 	sess := f.Start("containers", "--json")
@@ -92,7 +92,7 @@ func (f *Fly) GetContainers() []Container {
 	return containers
 }
 
-func (f *Fly) GetWorkers() []Worker {
+func (f *FlyCli) GetWorkers() []Worker {
 	var workers = []Worker{}
 
 	sess := f.Start("workers", "--json")
@@ -105,7 +105,7 @@ func (f *Fly) GetWorkers() []Worker {
 	return workers
 }
 
-func (f *Fly) GetPipelines() []Pipeline {
+func (f *FlyCli) GetPipelines() []Pipeline {
 	var pipelines = []Pipeline{}
 
 	sess := f.Start("pipelines", "--json")
@@ -118,7 +118,7 @@ func (f *Fly) GetPipelines() []Pipeline {
 	return pipelines
 }
 
-func (f *Fly) GetVersions(pipeline string, resource string) []Version {
+func (f *FlyCli) GetVersions(pipeline string, resource string) []Version {
 	var versions = []Version{}
 
 	sess := f.Start("resource-versions", "-r", pipeline+"/"+resource, "--json")
@@ -131,7 +131,7 @@ func (f *Fly) GetVersions(pipeline string, resource string) []Version {
 	return versions
 }
 
-func (f *Fly) GetUserRole(teamName string) []string {
+func (f *FlyCli) GetUserRole(teamName string) []string {
 
 	type RoleInfo struct {
 		Teams map[string][]string `json:"teams"`

--- a/topgun/pcf/bbr_test.go
+++ b/topgun/pcf/bbr_test.go
@@ -17,13 +17,14 @@ var _ = Describe("BBR", func() {
 	var (
 		atcs       []BoshInstance
 		atc0URL    string
-		deployArgs = []string{}
+		deployArgs []string
 	)
 
 	BeforeEach(func() {
 		if !strings.Contains(string(Bosh("releases").Out.Contents()), "backup-and-restore-sdk") {
 			Skip("backup-and-restore-sdk release not uploaded")
 		}
+		deployArgs = []string{}
 	})
 
 	JustBeforeEach(func() {
@@ -32,7 +33,7 @@ var _ = Describe("BBR", func() {
 		atcs = JobInstances("web")
 		atc0URL = "http://" + atcs[0].IP + ":8080"
 
-		fly.Login(atcUsername, atcPassword, atc0URL)
+		Fly.Login(AtcUsername, AtcPassword, atc0URL)
 	})
 
 	Context("using different property providers", func() {
@@ -43,7 +44,7 @@ var _ = Describe("BBR", func() {
 
 		var successfullyExecutesBackup = func() {
 			It("successfully executes backup", func() {
-				Run(nil, "bbr", "deployment", "-d", deploymentName, "backup")
+				Run(nil, "bbr", "deployment", "-d", DeploymentName, "backup")
 			})
 		}
 
@@ -90,21 +91,21 @@ var _ = Describe("BBR", func() {
 
 			It("backups and restores", func() {
 				By("creating a new pipeline")
-				fly.Run("set-pipeline", "-n", "-p", "pipeline", "-c", "./pipelines/get-task.yml")
-				pipelines := fly.GetPipelines()
+				Fly.Run("set-pipeline", "-n", "-p", "pipeline", "-c", "../pipelines/get-task.yml")
+				pipelines := Fly.GetPipelines()
 				Expect(pipelines).ToNot(BeEmpty())
 				Expect(pipelines[0].Name).To(Equal("pipeline"))
 
 				By("unpausing the pipeline")
-				fly.Run("unpause-pipeline", "-p", "pipeline")
+				Fly.Run("unpause-pipeline", "-p", "pipeline")
 
 				By("triggering a build")
-				fly.Run("trigger-job", "-w", "-j", "pipeline/simple-job")
+				Fly.Run("trigger-job", "-w", "-j", "pipeline/simple-job")
 
 				By("creating a database backup")
 				backupArgs := []string{
 					"deployment",
-					"-d", deploymentName,
+					"-d", DeploymentName,
 					"backup",
 					"--artifact-path", tmpDir,
 				}
@@ -127,17 +128,17 @@ var _ = Describe("BBR", func() {
 				atcs = JobInstances("web")
 				atc0URL = "http://" + atcs[0].IP + ":8080"
 
-				fly.Login(atcUsername, atcPassword, atc0URL)
+				Fly.Login(AtcUsername, AtcPassword, atc0URL)
 
 				By("restoring the backup")
 				restoreArgs := []string{
 					"deployment",
-					"-d", deploymentName,
+					"-d", DeploymentName,
 					"restore",
 					"--artifact-path", path.Join(tmpDir, entries[0].Name()),
 				}
 				Run(nil, "bbr", restoreArgs...)
-				pipelines = fly.GetPipelines()
+				pipelines = Fly.GetPipelines()
 				Expect(pipelines).ToNot(BeEmpty())
 				Expect(pipelines[0].Name).To(Equal("pipeline"))
 			})
@@ -158,21 +159,21 @@ var _ = Describe("BBR", func() {
 
 			It("rolls back the partial restore", func() {
 				By("creating new pipeline")
-				fly.Run("set-pipeline", "-n", "-p", "pipeline", "-c", "./pipelines/get-task.yml")
-				pipelines := fly.GetPipelines()
+				Fly.Run("set-pipeline", "-n", "-p", "pipeline", "-c", "../pipelines/get-task.yml")
+				pipelines := Fly.GetPipelines()
 				Expect(pipelines).ToNot(BeEmpty())
 				Expect(pipelines[0].Name).To(Equal("pipeline"))
 
 				By("unpausing the pipeline")
-				fly.Run("unpause-pipeline", "-p", "pipeline")
+				Fly.Run("unpause-pipeline", "-p", "pipeline")
 
 				By("triggering a build")
-				fly.Run("trigger-job", "-w", "-j", "pipeline/simple-job")
+				Fly.Run("trigger-job", "-w", "-j", "pipeline/simple-job")
 
 				By("creating a database backup")
 				backupArgs := []string{
 					"deployment",
-					"-d", deploymentName,
+					"-d", DeploymentName,
 					"backup",
 					"--artifact-path", tmpDir,
 				}
@@ -183,22 +184,22 @@ var _ = Describe("BBR", func() {
 
 				By("creating new pipeline and triggering the new pipeling (this will fail the restore)")
 
-				fly.Run("set-pipeline", "-n", "-p", "pipeline-2", "-c", "./pipelines/get-task.yml")
-				pipelines = fly.GetPipelines()
+				Fly.Run("set-pipeline", "-n", "-p", "pipeline-2", "-c", "../pipelines/get-task.yml")
+				pipelines = Fly.GetPipelines()
 				Expect(pipelines).ToNot(BeEmpty())
 				Expect(pipelines[1].Name).To(Equal("pipeline-2"))
 
 				By("unpausing the pipeline")
-				fly.Run("unpause-pipeline", "-p", "pipeline-2")
+				Fly.Run("unpause-pipeline", "-p", "pipeline-2")
 
 				By("triggering a build")
-				fly.Run("trigger-job", "-w", "-j", "pipeline-2/simple-job")
+				Fly.Run("trigger-job", "-w", "-j", "pipeline-2/simple-job")
 
 				By("restoring concourse")
 
 				restoreArgs := []string{
 					"deployment",
-					"-d", deploymentName,
+					"-d", DeploymentName,
 					"restore",
 					"--artifact-path", path.Join(tmpDir, entries[0].Name()),
 				}
@@ -207,7 +208,7 @@ var _ = Describe("BBR", func() {
 				Expect(session.ExitCode()).To(Equal(1))
 
 				By("checking pipeline")
-				pipelines = fly.GetPipelines()
+				pipelines = Fly.GetPipelines()
 				Expect(pipelines).ToNot(BeEmpty())
 				Expect(len(pipelines)).To(Equal(2))
 			})

--- a/topgun/pcf/pcf_suite_test.go
+++ b/topgun/pcf/pcf_suite_test.go
@@ -1,56 +1,13 @@
 package topgun_test
 
 import (
-	"database/sql"
 	"testing"
 
-	gclient "code.cloudfoundry.org/garden/client"
-	"code.cloudfoundry.org/lager/lagertest"
-	sq "github.com/Masterminds/squirrel"
-	bclient "github.com/concourse/baggageclaim/client"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	. "github.com/concourse/concourse/topgun"
-	. "github.com/concourse/concourse/topgun/common"
 )
-
-
-var (
-	deploymentNamePrefix string
-
-	fly                       = Fly{}
-	deploymentName, flyTarget string
-	instances                 map[string][]BoshInstance
-	jobInstances              map[string][]BoshInstance
-
-	dbInstance *BoshInstance
-	dbConn     *sql.DB
-
-	webInstance    *BoshInstance
-	atcExternalURL string
-	atcUsername    string
-	atcPassword    string
-
-	workerGardenClient       gclient.Client
-	workerBaggageclaimClient bclient.Client
-
-	concourseReleaseVersion, bpmReleaseVersion, postgresReleaseVersion string
-	vaultReleaseVersion, credhubReleaseVersion                         string
-	stemcellVersion                                                    string
-	backupAndRestoreReleaseVersion                                     string
-
-	pipelineName string
-
-	logger *lagertest.TestLogger
-
-	tmp string
-)
-
-var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 func TestTOPGUN(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "TOPGUN Suite")
+	RunSpecs(t, "PCF Suite")
 }
-

--- a/topgun/runtime/runtime_suite_test.go
+++ b/topgun/runtime/runtime_suite_test.go
@@ -50,7 +50,5 @@ var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 func TestTOPGUN(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "TOPGUN Suite")
+	RunSpecs(t, "Runtime Suite")
 }
-
-


### PR DESCRIPTION
When splitting up topgun tests into individual packages, there were some issues when trying to share certain functions and variables that would be used commonly by those newly created packages.

This exposes many more variables to be used by the suites.

We also had some issues where some deploy arguments were being appended to more times than we wanted.

This is hopefully the last part in our ongoing series of `fixing topgun`.