### PR TITLE
fix topgun test affected by splitting the main topgun tests

### DIFF
--- a/topgun/k8s/container_limits_test.go
+++ b/topgun/k8s/container_limits_test.go
@@ -67,7 +67,7 @@ func containerLimitsWork(selectorFlags ...string) {
 		It("returns the configure default container limit", func() {
 			deployWithSelectors(selectorFlags...)
 			waitAndLogin()
-			buildSession := fly.Start("execute", "-c", "../tasks/tiny.yml")
+			buildSession := fly.Start("execute", "-c", "tasks/tiny.yml")
 			<-buildSession.Exited
 			Expect(buildSession.ExitCode()).To(Equal(0))
 
@@ -90,7 +90,7 @@ func containerLimitsFail(selectorFlags ...string) {
 		It("fails to set the memory limit", func() {
 			deployWithSelectors(selectorFlags...)
 			waitAndLogin()
-			buildSession := fly.Start("execute", "-c", "../tasks/tiny.yml")
+			buildSession := fly.Start("execute", "-c", "tasks/tiny.yml")
 			<-buildSession.Exited
 			Expect(buildSession.ExitCode()).To(Equal(2))
 

--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -74,7 +74,7 @@ var _ = Describe("DNS Resolution", func() {
 		func(c Case) {
 			setupDeployment(c.enableDnsProxy, c.dnsServer)
 
-			sess := fly.Start("execute", "-c", "../tasks/dns-proxy-task.yml", "-v", "url="+c.addressFunction())
+			sess := fly.Start("execute", "-c", "tasks/dns-proxy-task.yml", "-v", "url="+c.addressFunction())
 			<-sess.Exited
 
 			if !c.shouldWork {

--- a/topgun/k8s/https_web_tls_termination_test.go
+++ b/topgun/k8s/https_web_tls_termination_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 
 			It("fly login fails when NOT using the correct CA", func() {
 				By("Logging in")
-				sess := fly.Start("login", "-u", "test", "-p", "test", "--ca-cert", "certs/wrong-ca.crt", "-c", atcEndpoint)
+				sess := fly.Start("login", "-u", "test", "-p", "test", "--ca-cert", "k8s/certs/wrong-ca.crt", "-c", atcEndpoint)
 				<-sess.Exited
 				Expect(sess.ExitCode()).ToNot(Equal(0))
 				Expect(sess.Err).To(gbytes.Say(`x509: certificate signed by unknown authority`))

--- a/topgun/k8s/kubernetes_creds_mgmt_test.go
+++ b/topgun/k8s/kubernetes_creds_mgmt_test.go
@@ -170,13 +170,13 @@ var _ = Describe("Kubernetes credential management", func() {
 
 			By("successfully running the one-off build")
 			fly.Run("execute",
-				"-c", "../tasks/simple-secret.yml")
+				"-c", "tasks/simple-secret.yml")
 		})
 
 		It("one-off build fails", func() {
 			By("not creating the secret")
 			sess := fly.Start("execute",
-				"-c", "../tasks/simple-secret.yml")
+				"-c", "tasks/simple-secret.yml")
 			<-sess.Exited
 			Expect(sess.ExitCode()).NotTo(Equal(0))
 		})


### PR DESCRIPTION
the tests failing here: https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-topgun/builds/1955 were a result of changing the command directory in the `FlyCli` `Start` function that is inherited from the main topgun tests.