### PR TITLE
feat(fly): add "age" column to "fly workers" command.

### DIFF
--- a/fly/integration/workers_test.go
+++ b/fly/integration/workers_test.go
@@ -1,8 +1,6 @@
 package integration_test
 
 import (
-	"os/exec"
-
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
@@ -11,12 +9,26 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
+	"os/exec"
+	"time"
 )
+
+const second = 1
+const minute = 60 * second
+const hour = minute * 60
+const day = hour * 24
 
 var _ = Describe("Fly CLI", func() {
 	Describe("workers", func() {
 		var (
-			flyCmd *exec.Cmd
+			flyCmd           *exec.Cmd
+			worker1StartTime int64
+			worker2StartTime int64
+			worker3StartTime int64
+			worker4StartTime int64
+			worker5StartTime int64
+			worker6StartTime int64
+			worker7StartTime int64
 		)
 
 		BeforeEach(func() {
@@ -24,7 +36,7 @@ var _ = Describe("Fly CLI", func() {
 		})
 
 		Context("when workers are returned from the API", func() {
-			BeforeEach(func() {
+			JustBeforeEach(func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/workers"),
@@ -39,9 +51,10 @@ var _ = Describe("Fly CLI", func() {
 								ResourceTypes: []atc.WorkerResourceType{
 									{Type: "resource-1", Image: "/images/resource-1"},
 								},
-								Team:    "team-1",
-								State:   "running",
-								Version: "4.5.6",
+								Team:      "team-1",
+								State:     "running",
+								Version:   "4.5.6",
+								StartTime: worker2StartTime,
 							},
 							{
 								Name:             "worker-6",
@@ -54,6 +67,7 @@ var _ = Describe("Fly CLI", func() {
 								State:            "running",
 								Version:          "1.2.3",
 								Ephemeral:        true,
+								StartTime:        worker6StartTime,
 							},
 							{
 								Name:             "worker-7",
@@ -65,6 +79,7 @@ var _ = Describe("Fly CLI", func() {
 								Team:             "team-1",
 								State:            "running",
 								Version:          "",
+								StartTime:        worker7StartTime,
 							},
 							{
 								Name:             "worker-1",
@@ -78,9 +93,10 @@ var _ = Describe("Fly CLI", func() {
 									{Type: "resource-1", Image: "/images/resource-1"},
 									{Type: "resource-2", Image: "/images/resource-2"},
 								},
-								Team:    "team-1",
-								State:   "landing",
-								Version: "4.5.6",
+								Team:      "team-1",
+								State:     "landing",
+								Version:   "4.5.6",
+								StartTime: worker1StartTime,
 							},
 							{
 								Name:             "worker-3",
@@ -91,6 +107,7 @@ var _ = Describe("Fly CLI", func() {
 								Tags:             []string{},
 								State:            "landed",
 								Version:          "4.5.6",
+								StartTime:        worker3StartTime,
 							},
 							{
 								Name:             "worker-4",
@@ -102,6 +119,7 @@ var _ = Describe("Fly CLI", func() {
 								Team:             "team-1",
 								State:            "stalled",
 								Version:          "4.5.6",
+								StartTime:        worker4StartTime,
 							},
 							{
 								Name:             "worker-5",
@@ -112,10 +130,21 @@ var _ = Describe("Fly CLI", func() {
 								Tags:             []string{},
 								State:            "retiring",
 								Version:          "4.5.6",
+								StartTime:        worker5StartTime,
 							},
 						}),
 					),
 				)
+			})
+
+			BeforeEach(func() {
+				worker1StartTime = time.Now().Unix() - 2*day - 90*second
+				worker2StartTime = time.Now().Unix() - 1*day - 90*second
+				worker3StartTime = time.Now().Unix() - 10*hour - 3*minute - 5*second
+				worker4StartTime = time.Now().Unix() - 8*hour - 30*minute - 5*second
+				worker5StartTime = time.Now().Unix() - 33*minute - 5*second
+				worker6StartTime = time.Now().Unix() - 17*second
+				worker7StartTime = time.Now().Unix() + 700*second
 			})
 
 			It("lists them to the user, ordered by name, with outdated and stalled workers grouped together", func() {
@@ -132,15 +161,16 @@ var _ = Describe("Fly CLI", func() {
 						{Contents: "team", Color: color.New(color.Bold)},
 						{Contents: "state", Color: color.New(color.Bold)},
 						{Contents: "version", Color: color.New(color.Bold)},
+						{Contents: "age", Color: color.New(color.Bold)},
 					},
 					Data: []ui.TableRow{
-						{{Contents: "worker-1"}, {Contents: "1"}, {Contents: "platform1"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "landing"}, {Contents: "4.5.6"}},
-						{{Contents: "worker-2"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag2, tag3"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "4.5.6"}},
-						{{Contents: "worker-3"}, {Contents: "10"}, {Contents: "platform3"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "landed"}, {Contents: "4.5.6"}},
-						{{Contents: "worker-5"}, {Contents: "5"}, {Contents: "platform5"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "retiring"}, {Contents: "4.5.6"}},
-						{{Contents: "worker-6"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "1.2.3", Color: color.New(color.FgRed)}},
-						{{Contents: "worker-7"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "none", Color: color.New(color.FgRed)}},
-						{{Contents: "worker-4"}, {Contents: "7"}, {Contents: "platform4"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "stalled"}, {Contents: "4.5.6"}},
+						{{Contents: "worker-1"}, {Contents: "1"}, {Contents: "platform1"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "landing"}, {Contents: "4.5.6"}, {Contents: "2d"}},
+						{{Contents: "worker-2"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag2, tag3"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "4.5.6"}, {Contents: "1d"}},
+						{{Contents: "worker-3"}, {Contents: "10"}, {Contents: "platform3"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "landed"}, {Contents: "4.5.6"}, {Contents: "10h3m"}},
+						{{Contents: "worker-5"}, {Contents: "5"}, {Contents: "platform5"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "retiring"}, {Contents: "4.5.6"}, {Contents: "33h5m"}},
+						{{Contents: "worker-6"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "1.2.3", Color: color.New(color.FgRed)}, {Contents: "17s"}},
+						{{Contents: "worker-7"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "none", Color: color.New(color.FgRed)}, {Contents: "n/a", Color: color.New(color.Faint)}},
+						{{Contents: "worker-4"}, {Contents: "7"}, {Contents: "platform4"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "stalled"}, {Contents: "4.5.6"}, {Contents: "8h30m"}},
 					},
 				}))
 			})
@@ -148,6 +178,13 @@ var _ = Describe("Fly CLI", func() {
 			Context("when --json is given", func() {
 				BeforeEach(func() {
 					flyCmd.Args = append(flyCmd.Args, "--json")
+					worker1StartTime = 0
+					worker2StartTime = 0
+					worker3StartTime = 0
+					worker4StartTime = 0
+					worker5StartTime = 0
+					worker6StartTime = 0
+					worker7StartTime = 0
 				})
 
 				It("prints response in json as stdout", func() {
@@ -181,7 +218,7 @@ var _ = Describe("Fly CLI", func() {
                 "version": "4.5.6",
                 "start_time": 0,
                 "state": "running",
-								"ephemeral": false
+                "ephemeral": false
               },
               {
                 "addr": "5.5.5.5:7777",
@@ -199,7 +236,7 @@ var _ = Describe("Fly CLI", func() {
                 "version": "1.2.3",
                 "start_time": 0,
                 "state": "running",
-								"ephemeral": true
+                "ephemeral": true
               },
               {
                 "addr": "7.7.7.7:7777",
@@ -217,7 +254,7 @@ var _ = Describe("Fly CLI", func() {
                 "version": "",
                 "start_time": 0,
                 "state": "running",
-								"ephemeral": false
+                "ephemeral": false
               },
               {
                 "addr": "2.2.3.4:7777",
@@ -250,7 +287,7 @@ var _ = Describe("Fly CLI", func() {
                 "version": "4.5.6",
                 "start_time": 0,
                 "state": "landing",
-								"ephemeral": false
+                "ephemeral": false
               },
               {
                 "addr": "3.2.3.4:7777",
@@ -266,7 +303,7 @@ var _ = Describe("Fly CLI", func() {
                 "version": "4.5.6",
                 "start_time": 0,
                 "state": "landed",
-								"ephemeral": false
+                "ephemeral": false
               },
               {
                 "addr": "",
@@ -284,7 +321,7 @@ var _ = Describe("Fly CLI", func() {
                 "version": "4.5.6",
                 "start_time": 0,
                 "state": "stalled",
-								"ephemeral": false
+                "ephemeral": false
               },
               {
                 "addr": "3.2.3.4:7777",
@@ -300,7 +337,7 @@ var _ = Describe("Fly CLI", func() {
                 "version": "4.5.6",
                 "start_time": 0,
                 "state": "retiring",
-								"ephemeral": false
+                "ephemeral": false
               }
             ]`))
 				})
@@ -309,6 +346,13 @@ var _ = Describe("Fly CLI", func() {
 			Context("when --details is given", func() {
 				BeforeEach(func() {
 					flyCmd.Args = append(flyCmd.Args, "--details")
+					worker1StartTime = 0
+					worker2StartTime = 0
+					worker3StartTime = 0
+					worker4StartTime = 0
+					worker5StartTime = 0
+					worker6StartTime = 0
+					worker7StartTime = 0
 				})
 
 				It("lists them to the user, ordered by name", func() {
@@ -324,19 +368,21 @@ var _ = Describe("Fly CLI", func() {
 							{Contents: "tags", Color: color.New(color.Bold)},
 							{Contents: "team", Color: color.New(color.Bold)},
 							{Contents: "state", Color: color.New(color.Bold)},
+							{Contents: "version", Color: color.New(color.Bold)},
+							{Contents: "age", Color: color.New(color.Bold)},
 							{Contents: "garden address", Color: color.New(color.Bold)},
 							{Contents: "baggageclaim url", Color: color.New(color.Bold)},
 							{Contents: "active tasks", Color: color.New(color.Bold)},
 							{Contents: "resource types", Color: color.New(color.Bold)},
 						},
 						Data: []ui.TableRow{
-							{{Contents: "worker-1"}, {Contents: "1"}, {Contents: "platform1"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "landing"}, {Contents: "4.5.6"}, {Contents: "2.2.3.4:7777"}, {Contents: "http://2.2.3.4:7788"}, {Contents: "1"}, {Contents: "resource-1, resource-2"}},
-							{{Contents: "worker-2"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag2, tag3"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "4.5.6"}, {Contents: "1.2.3.4:7777"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "resource-1"}},
-							{{Contents: "worker-3"}, {Contents: "10"}, {Contents: "platform3"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "landed"}, {Contents: "4.5.6"}, {Contents: "3.2.3.4:7777"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "none", Color: color.New(color.Faint)}},
-							{{Contents: "worker-5"}, {Contents: "5"}, {Contents: "platform5"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "retiring"}, {Contents: "4.5.6"}, {Contents: "3.2.3.4:7777"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "none", Color: color.New(color.Faint)}},
-							{{Contents: "worker-6"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "1.2.3", Color: color.New(color.FgRed)}, {Contents: "5.5.5.5:7777", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "none", Color: color.New(color.Faint)}},
-							{{Contents: "worker-7"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "none", Color: color.New(color.FgRed)}, {Contents: "7.7.7.7:7777", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "0"}, {Contents: "none", Color: color.New(color.Faint)}},
-							{{Contents: "worker-4"}, {Contents: "7"}, {Contents: "platform4"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "stalled"}, {Contents: "4.5.6"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "none", Color: color.New(color.Faint)}},
+							{{Contents: "worker-1"}, {Contents: "1"}, {Contents: "platform1"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "landing"}, {Contents: "4.5.6"}, {Contents: "n/a", Color: color.New(color.Faint)}, {Contents: "2.2.3.4:7777"}, {Contents: "http://2.2.3.4:7788"}, {Contents: "1"}, {Contents: "resource-1, resource-2"}},
+							{{Contents: "worker-2"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag2, tag3"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "4.5.6"}, {Contents: "n/a", Color: color.New(color.Faint)}, {Contents: "1.2.3.4:7777"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "resource-1"}},
+							{{Contents: "worker-3"}, {Contents: "10"}, {Contents: "platform3"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "landed"}, {Contents: "4.5.6"}, {Contents: "n/a", Color: color.New(color.Faint)}, {Contents: "3.2.3.4:7777"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "none", Color: color.New(color.Faint)}},
+							{{Contents: "worker-5"}, {Contents: "5"}, {Contents: "platform5"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "retiring"}, {Contents: "4.5.6"}, {Contents: "n/a", Color: color.New(color.Faint)}, {Contents: "3.2.3.4:7777"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "none", Color: color.New(color.Faint)}},
+							{{Contents: "worker-6"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "1.2.3", Color: color.New(color.FgRed)}, {Contents: "n/a", Color: color.New(color.Faint)}, {Contents: "5.5.5.5:7777", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "none", Color: color.New(color.Faint)}},
+							{{Contents: "worker-7"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "none", Color: color.New(color.FgRed)}, {Contents: "n/a", Color: color.New(color.Faint)}, {Contents: "7.7.7.7:7777", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "0"}, {Contents: "none", Color: color.New(color.Faint)}},
+							{{Contents: "worker-4"}, {Contents: "7"}, {Contents: "platform4"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "stalled"}, {Contents: "4.5.6"}, {Contents: "n/a", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "1"}, {Contents: "none", Color: color.New(color.Faint)}},
 						},
 					}))
 				})
@@ -358,6 +404,7 @@ var _ = Describe("Fly CLI", func() {
 								Team:             "team-1",
 								State:            "running",
 								Version:          "4.5.6",
+								StartTime:        0,
 							},
 							{
 								Name:             "worker-1",
@@ -368,6 +415,7 @@ var _ = Describe("Fly CLI", func() {
 								Team:             "team-1",
 								State:            "landing",
 								Version:          "4.5.6",
+								StartTime:        0,
 							},
 							{
 								Name:             "worker-3",
@@ -377,6 +425,7 @@ var _ = Describe("Fly CLI", func() {
 								Tags:             []string{},
 								State:            "retiring",
 								Version:          "4.5.6",
+								StartTime:        0,
 							},
 						}),
 					),
@@ -397,11 +446,12 @@ var _ = Describe("Fly CLI", func() {
 						{Contents: "team", Color: color.New(color.Bold)},
 						{Contents: "state", Color: color.New(color.Bold)},
 						{Contents: "version", Color: color.New(color.Bold)},
+						{Contents: "age", Color: color.New(color.Bold)},
 					},
 					Data: []ui.TableRow{
-						{{Contents: "worker-1"}, {Contents: "10"}, {Contents: "platform1"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "team-1"}, {Contents: "landing"}, {Contents: "4.5.6", Color: color.New(color.Faint)}},
-						{{Contents: "worker-2"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "4.5.6", Color: color.New(color.Faint)}},
-						{{Contents: "worker-3"}, {Contents: "5"}, {Contents: "platform3"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "retiring"}, {Contents: "4.5.6", Color: color.New(color.Faint)}},
+						{{Contents: "worker-1"}, {Contents: "10"}, {Contents: "platform1"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "team-1"}, {Contents: "landing"}, {Contents: "4.5.6", Color: color.New(color.Faint)}, {Contents: "n/a", Color: color.New(color.Faint)}},
+						{{Contents: "worker-2"}, {Contents: "0"}, {Contents: "platform2"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "running"}, {Contents: "4.5.6", Color: color.New(color.Faint)}, {Contents: "n/a", Color: color.New(color.Faint)}},
+						{{Contents: "worker-3"}, {Contents: "5"}, {Contents: "platform3"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "retiring"}, {Contents: "4.5.6", Color: color.New(color.Faint)}, {Contents: "n/a", Color: color.New(color.Faint)}},
 					},
 				}))
 				Expect(sess.Out).NotTo(PrintTable(ui.Table{
@@ -413,9 +463,10 @@ var _ = Describe("Fly CLI", func() {
 						{Contents: "team", Color: color.New(color.Bold)},
 						{Contents: "state", Color: color.New(color.Bold)},
 						{Contents: "version", Color: color.New(color.Bold)},
+						{Contents: "age", Color: color.New(color.Bold)},
 					},
 					Data: []ui.TableRow{
-						{{Contents: "worker-4"}, {Contents: "7"}, {Contents: "platform4"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "stalled"}, {Contents: "4.5.6"}},
+						{{Contents: "worker-4"}, {Contents: "7"}, {Contents: "platform4"}, {Contents: "tag1"}, {Contents: "team-1"}, {Contents: "stalled"}, {Contents: "4.5.6"}, {Contents: "n/a", Color: color.New(color.Faint)}},
 					},
 				}))
 			})

--- a/release-notes/v5.6.0.md
+++ b/release-notes/v5.6.0.md
@@ -17,6 +17,10 @@
 
 * Fly has a new sub-command `pin-resource`. It allows you to pin a resource given a partially matched version. It can also be used to set or update a pin comment. #2702 #4417.
 
+#### <sub><sup><a name="v560-note-4481" href="#v560-note-4481">:link:</a></sup></sub> feature
+
+* @evanchaoli added `age` colume to `fly workers`, #4481.
+
 #### <sub><sup><a name="v560-note-4314" href="#v560-note-4314">:link:</a></sup></sub> fix
 
 * @robwhitby fixed an issue with `fly login` where Safari would block your token from being transferred to fly #4314, #4423, #4439.


### PR DESCRIPTION
It should be very helpful to provide age info to Concourse cluster ops. Output looks like below:

    $ ./fly -t test workers
    name                                          containers  platform  tags  team  state    version  age
    worker-sc-prd-vc010-10.160.142.107-jMxSReSOV  54          linux     none  none  running  2.2      6h14m
    worker-sc-prd-vc066-10.161.108.40-ozpIkYSBE   81          linux     none  none  running  2.2      6h15m
    worker-sc-prd-vc075-10.193.7.99-QA8snquPr     63          linux     none  none  running  2.2      6h15m