### PR TITLE
fly: always emit output in format-pipeline

### DIFF
--- a/fly/commands/format_pipeline.go
+++ b/fly/commands/format_pipeline.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -39,24 +38,22 @@ func (command *FormatPipelineCommand) Execute(args []string) error {
 		displayhelpers.FailWithErrorf("could not marshal config", err)
 	}
 
-	if !bytes.Equal(configBytes, formattedBytes) {
-		unwrappedConfigBytes := placeholderWrapper.Unwrap(formattedBytes)
+	unwrappedConfigBytes := placeholderWrapper.Unwrap(formattedBytes)
 
-		if command.Write {
-			fi, err := os.Stat(configPath)
-			if err != nil {
-				displayhelpers.FailWithErrorf("could not stat config file", err)
-			}
+	if command.Write {
+		fi, err := os.Stat(configPath)
+		if err != nil {
+			displayhelpers.FailWithErrorf("could not stat config file", err)
+		}
 
-			err = ioutil.WriteFile(configPath, unwrappedConfigBytes, fi.Mode())
-			if err != nil {
-				displayhelpers.FailWithErrorf("could not write formatted config to %s", err, command.Config)
-			}
-		} else {
-			_, err = fmt.Fprint(os.Stdout, string(unwrappedConfigBytes))
-			if err != nil {
-				displayhelpers.FailWithErrorf("could not write formatted config to stdout", err)
-			}
+		err = ioutil.WriteFile(configPath, unwrappedConfigBytes, fi.Mode())
+		if err != nil {
+			displayhelpers.FailWithErrorf("could not write formatted config to %s", err, command.Config)
+		}
+	} else {
+		_, err = fmt.Fprint(os.Stdout, string(unwrappedConfigBytes))
+		if err != nil {
+			displayhelpers.FailWithErrorf("could not write formatted config to stdout", err)
 		}
 	}
 

--- a/fly/integration/fixtures/format-expected.yml
+++ b/fly/integration/fixtures/format-expected.yml
@@ -1,0 +1,52 @@
+groups:
+  - jobs:
+    - job-1
+    - job-2
+    name: some-group
+    resources:
+    - resource-1
+    - resource-2
+  - jobs:
+    - job-3
+    - job-4
+    name: some-other-group
+    resources:
+    - resource-6
+    - resource-4
+jobs:
+  - name: some-job
+    plan: null
+    public: true
+    serial: true
+  - name: some-unchanged-job
+    plan: null
+  - name: some-other-job
+    plan: null
+  - name: pinned-resource-job
+    plan:
+    - get: some-resource
+      version:
+        ref: some-ref
+resource_types:
+  - name: some-resource-type
+    source:
+      source-config: some-value
+    type: some-type
+  - name: some-other-resource-type
+    source:
+      source-config: some-value
+    type: some-other-type
+resources:
+  - name: some-resource
+    source:
+      source-config: some-value
+      parameterized: ((fill-me-in))
+    type: some-type
+  - name: some-other-resource
+    source:
+      source-config: some-value
+    type: some-other-type
+  - name: some-resource-with-int-field
+    source:
+      source-config: 5
+    type: some-type

--- a/fly/integration/fixtures/format-input.yml
+++ b/fly/integration/fixtures/format-input.yml
@@ -1,0 +1,52 @@
+groups:
+  - jobs:
+    - job-1
+    - job-2
+    name: some-group
+    resources:
+    - resource-1
+    - resource-2
+  - jobs: [job-3, job-4]
+    name: some-other-group
+    resources:
+    - resource-6
+    - resource-4
+
+jobs:
+  - name: some-job
+    public: yes
+    serial:       true
+
+  - name: some-unchanged-job
+  - name: some-other-job
+    plan: null
+  - name: pinned-resource-job
+    plan:
+    - get: some-resource
+      version:
+        ref: some-ref
+
+resource_types:
+        - {"name": "some-resource-type",
+           "source": {"source-config": "some-value"},
+           "type": "some-type"}
+        - name: some-other-resource-type
+          source: {source-config: some-value}
+          type: some-other-type
+
+# comment on its own line
+
+resources:
+  - name: some-resource
+    source:
+      source-config: some-value
+      parameterized: ((fill-me-in))
+    type: some-type # comment at the end of a line
+  - name: some-other-resource
+    type: some-other-type
+    source:
+      source-config: some-value
+  - name: some-resource-with-int-field
+    source:
+      source-config: 5
+    type: some-type

--- a/fly/integration/format_pipeline_test.go
+++ b/fly/integration/format_pipeline_test.go
@@ -1,0 +1,143 @@
+package integration_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Fly CLI", func() {
+	Describe("format-pipeline", func() {
+		var (
+			configFile   *os.File
+			inputYaml    []byte
+			expectedYaml []byte
+		)
+
+		BeforeEach(func() {
+			var err error
+			configFile, err = ioutil.TempFile("", "format-pipeline-test-*.yml")
+			Expect(err).NotTo(HaveOccurred())
+
+			inputYaml, err = ioutil.ReadFile("fixtures/format-input.yml")
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedYaml, err = ioutil.ReadFile("fixtures/format-expected.yml")
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = configFile.Write(inputYaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = configFile.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := os.RemoveAll(configFile.Name())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("prints the formatted pipeline YAML to stdout", func() {
+			flyCmd := exec.Command(
+				flyPath,
+				"format-pipeline",
+				"-c", configFile.Name(),
+			)
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			<-sess.Exited
+			Expect(sess.ExitCode()).To(Equal(0))
+
+			Expect(sess.Out.Contents()).To(MatchYAML(expectedYaml))
+		})
+
+		It("preserves the original pipeline file", func() {
+			oldFileInfo, err := os.Stat(configFile.Name())
+			Expect(err).NotTo(HaveOccurred())
+
+			flyCmd := exec.Command(
+				flyPath,
+				"format-pipeline",
+				"-c", configFile.Name(),
+			)
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			<-sess.Exited
+			Expect(sess.ExitCode()).To(Equal(0))
+
+			newFileInfo, err := os.Stat(configFile.Name())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newFileInfo.ModTime()).To(Equal(oldFileInfo.ModTime()))
+
+			newYaml, err := ioutil.ReadFile(configFile.Name())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newYaml).To(Equal(inputYaml))
+		})
+
+		Context("when given the -w option", func() {
+			It("overwrites the file in-place", func() {
+				flyCmd := exec.Command(
+					flyPath,
+					"format-pipeline",
+					"-c", configFile.Name(),
+					"-w",
+				)
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+
+				newYaml, err := ioutil.ReadFile(configFile.Name())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(newYaml).To(MatchYAML(expectedYaml))
+			})
+
+			It("is idempotent", func() {
+				flyCmd := exec.Command(
+					flyPath,
+					"format-pipeline",
+					"-c", configFile.Name(),
+					"-w",
+				)
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+
+				firstPassYaml, err := ioutil.ReadFile(configFile.Name())
+				Expect(err).NotTo(HaveOccurred())
+
+				flyCmd2 := exec.Command(
+					flyPath,
+					"format-pipeline",
+					"-c", configFile.Name(),
+					"-w",
+				)
+
+				sess2, err := gexec.Start(flyCmd2, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess2.Exited
+				Expect(sess2.ExitCode()).To(Equal(0))
+
+				secondPassYaml, err := ioutil.ReadFile(configFile.Name())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(firstPassYaml).To(MatchYAML(secondPassYaml))
+			})
+		})
+	})
+})

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -26,3 +26,8 @@
 #### <sub><sup><a name="4507" href="#4507">:link:</a></sup></sub> fix
 
 * @iamjarvo fixed a [bug](444://github.com/concourse/concourse/issues/4472) where `fly builds` would show the wrong duration for cancelled builds #4507.
+
+#### <sub><sup><a name="4492" href="#4492">:link:</a></sup></sub> fix
+
+* The `fly format-pipeline` now always produces a formatted pipeline, instead of declining to do so when it was already in the expected format. #4492
+  


### PR DESCRIPTION
The `format-pipeline` command had logic to suppress output in the case where the formatted pipeline was unchanged from the input. This complicates use of the command in automated workflows, where we'd like to use `format-pipeline` as a canonicalization step. The new behavior lets the output be consumed unconditionally. For example, one can find out whether two pipelines - say, one stored in git and one retrieved from `fly get-pipeline` - are the same after `format-pipeline` has been applied to both.

Also add tests for the command, to demonstrate how a given input pipeline with various formatting oddities will be converted into a standard form, and that reformatting will preserve that form.
