### PR TITLE
api query transaction

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -983,6 +983,13 @@ func (b *build) Resources() ([]BuildInput, []BuildOutput, error) {
 			AND i.build_id < builds.id
 		)`
 
+	tx, err := b.conn.Begin()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	defer Rollback(tx)
+
 	rows, err := psql.Select("inputs.name", "resources.id", "versions.version", firstOccurrence).
 		From("resource_config_versions versions, build_resource_config_version_inputs inputs, builds, resources").
 		Where(sq.Eq{"builds.id": b.id}).
@@ -999,7 +1006,7 @@ func (b *build) Resources() ([]BuildInput, []BuildOutput, error) {
 			AND outputs.resource_id = resources.id
 			AND outputs.build_id = inputs.build_id
 		)`)).
-		RunWith(b.conn).
+		RunWith(tx).
 		Query()
 	if err != nil {
 		return nil, nil, err
@@ -1042,7 +1049,7 @@ func (b *build) Resources() ([]BuildInput, []BuildOutput, error) {
 		Where(sq.Expr("outputs.version_md5 = versions.version_md5")).
 		Where(sq.Expr("outputs.resource_id = resources.id")).
 		Where(sq.Expr("resources.resource_config_scope_id = versions.resource_config_scope_id")).
-		RunWith(b.conn).
+		RunWith(tx).
 		Query()
 
 	if err != nil {
@@ -1072,6 +1079,11 @@ func (b *build) Resources() ([]BuildInput, []BuildOutput, error) {
 			Name:    outputName,
 			Version: version,
 		})
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return inputs, outputs, nil

--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -152,12 +152,19 @@ func getBuilds(buildsQuery sq.SelectBuilder, conn Conn, lockFactory lock.LockFac
 func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, conn Conn, lockFactory lock.LockFactory) ([]Build, Pagination, error) {
 	var newPage = Page{Limit: page.Limit}
 
+	tx, err := conn.Begin()
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+
+	defer Rollback(tx)
+
 	if page.Since != 0 {
 		sinceRow, err := buildsQuery.
 			Where(sq.Expr("b.start_time >= to_timestamp(" + strconv.Itoa(page.Since) + ")")).
 			OrderBy("b.id ASC").
 			Limit(1).
-			RunWith(conn).
+			RunWith(tx).
 			Query()
 
 		if err != nil {
@@ -193,7 +200,7 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 			Where(sq.Expr("b.start_time <= to_timestamp(" + strconv.Itoa(page.Until) + ")")).
 			OrderBy("b.id DESC").
 			Limit(1).
-			RunWith(conn).
+			RunWith(tx).
 			Query()
 		if err != nil {
 			// The user has no builds since that given time
@@ -220,6 +227,11 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 		}
 	}
 
+	err = tx.Commit()
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+
 	return getBuildsWithPagination(buildsQuery, minMaxIdQuery, newPage, conn, lockFactory)
 }
 
@@ -229,6 +241,13 @@ func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page P
 		err     error
 		reverse bool
 	)
+
+	tx, err := conn.Begin()
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+
+	defer Rollback(tx)
 
 	buildsQuery = buildsQuery.Limit(uint64(page.Limit))
 
@@ -257,7 +276,7 @@ func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page P
 			OrderBy("b.id ASC")
 	}
 
-	rows, err = buildsQuery.RunWith(conn).Query()
+	rows, err = buildsQuery.RunWith(tx).Query()
 	if err != nil {
 		return nil, Pagination{}, err
 	}
@@ -287,9 +306,14 @@ func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page P
 
 	var minID, maxID int
 	err = minMaxIdQuery.
-		RunWith(conn).
+		RunWith(tx).
 		QueryRow().
 		Scan(&maxID, &minID)
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+
+	err = tx.Commit()
 	if err != nil {
 		return nil, Pagination{}, err
 	}

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -161,12 +161,19 @@ func (j *job) Unpause() error {
 }
 
 func (j *job) FinishedAndNextBuild() (Build, Build, error) {
-	next, err := j.nextBuild()
+	tx, err := j.conn.Begin()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	finished, err := j.finishedBuild()
+	defer Rollback(tx)
+
+	next, err := j.nextBuild(tx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	finished, err := j.finishedBuild(tx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -175,10 +182,15 @@ func (j *job) FinishedAndNextBuild() (Build, Build, error) {
 	if next != nil && finished != nil && next.ID() == finished.ID() {
 		next = nil
 
-		next, err = j.nextBuild()
+		next, err = j.nextBuild(tx)
 		if err != nil {
 			return nil, nil, err
 		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return finished, next, nil
@@ -783,13 +795,13 @@ func (j *job) saveJobInputMapping(table string, inputMapping algorithm.InputMapp
 	return tx.Commit()
 }
 
-func (j *job) nextBuild() (Build, error) {
+func (j *job) nextBuild(tx Tx) (Build, error) {
 	var next Build
 
 	row := buildsQuery.
 		Where(sq.Eq{"j.id": j.id}).
 		Where(sq.Expr("b.id = j.next_build_id")).
-		RunWith(j.conn).
+		RunWith(tx).
 		QueryRow()
 
 	nextBuild := &build{conn: j.conn, lockFactory: j.lockFactory}
@@ -803,13 +815,13 @@ func (j *job) nextBuild() (Build, error) {
 	return next, nil
 }
 
-func (j *job) finishedBuild() (Build, error) {
+func (j *job) finishedBuild(tx Tx) (Build, error) {
 	var finished Build
 
 	row := buildsQuery.
 		Where(sq.Eq{"j.id": j.id}).
 		Where(sq.Expr("b.id = j.latest_completed_build_id")).
-		RunWith(j.conn).
+		RunWith(tx).
 		QueryRow()
 
 	finishedBuild := &build{conn: j.conn, lockFactory: j.lockFactory}

--- a/atc/db/job_factory.go
+++ b/atc/db/job_factory.go
@@ -25,63 +25,23 @@ func NewJobFactory(conn Conn, lockFactory lock.LockFactory) JobFactory {
 }
 
 func (j *jobFactory) VisibleJobs(teamNames []string) (Dashboard, error) {
-	currentTeamJobs, err := j.teamJobs(teamNames)
+	tx, err := j.conn.Begin()
 	if err != nil {
 		return nil, err
 	}
 
-	otherTeamPublicJobs, err := j.otherTeamPublicJobs(teamNames)
-	if err != nil {
-		return nil, err
-	}
+	defer Rollback(tx)
 
-	jobs := append(currentTeamJobs, otherTeamPublicJobs...)
-
-	return j.buildDashboard(jobs)
-}
-
-func (j *jobFactory) teamJobs(teamNames []string) (Jobs, error) {
-	rows, err := jobsQuery.
-		Where(sq.Eq{
-			"t.name":   teamNames,
-			"j.active": true,
-		}).
-		OrderBy("j.id ASC").
-		RunWith(j.conn).
-		Query()
-	if err != nil {
-		return nil, err
-	}
-
-	return scanJobs(j.conn, j.lockFactory, rows)
-}
-
-func (j *jobFactory) otherTeamPublicJobs(teamNames []string) (Jobs, error) {
-	rows, err := jobsQuery.
-		Where(sq.NotEq{
-			"t.name": teamNames,
-		}).
-		Where(sq.Eq{
-			"p.public": true,
-			"j.active": true,
-		}).
-		OrderBy("j.id ASC").
-		RunWith(j.conn).
-		Query()
-	if err != nil {
-		return nil, err
-	}
-
-	return scanJobs(j.conn, j.lockFactory, rows)
-}
-
-func (j *jobFactory) AllActiveJobs() (Dashboard, error) {
 	rows, err := jobsQuery.
 		Where(sq.Eq{
 			"j.active": true,
 		}).
+		Where(sq.Or{
+			sq.Eq{"t.name": teamNames},
+			sq.Eq{"p.public": true},
+		}).
 		OrderBy("j.id ASC").
-		RunWith(j.conn).
+		RunWith(tx).
 		Query()
 	if err != nil {
 		return nil, err
@@ -92,26 +52,27 @@ func (j *jobFactory) AllActiveJobs() (Dashboard, error) {
 		return nil, err
 	}
 
-	return j.buildDashboard(jobs)
-}
-
-func (j *jobFactory) buildDashboard(jobs Jobs) (Dashboard, error) {
 	var jobIDs []int
 	for _, job := range jobs {
 		jobIDs = append(jobIDs, job.ID())
 	}
 
-	nextBuilds, err := j.getBuildsFrom("next_build_id", jobIDs)
+	nextBuilds, err := j.getBuildsFrom(tx, "next_build_id", jobIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	finishedBuilds, err := j.getBuildsFrom("latest_completed_build_id", jobIDs)
+	finishedBuilds, err := j.getBuildsFrom(tx, "latest_completed_build_id", jobIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	transitionBuilds, err := j.getBuildsFrom("transition_build_id", jobIDs)
+	transitionBuilds, err := j.getBuildsFrom(tx, "transition_build_id", jobIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tx.Commit()
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +99,82 @@ func (j *jobFactory) buildDashboard(jobs Jobs) (Dashboard, error) {
 	return dashboard, nil
 }
 
-func (j *jobFactory) getBuildsFrom(col string, jobIDs []int) (map[int]Build, error) {
+func (j *jobFactory) AllActiveJobs() (Dashboard, error) {
+	tx, err := j.conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	defer Rollback(tx)
+
+	rows, err := jobsQuery.
+		Where(sq.Eq{
+			"j.active": true,
+		}).
+		OrderBy("j.id ASC").
+		RunWith(tx).
+		Query()
+	if err != nil {
+		return nil, err
+	}
+
+	jobs, err := scanJobs(j.conn, j.lockFactory, rows)
+	if err != nil {
+		return nil, err
+	}
+
+	return j.buildDashboard(tx, jobs)
+}
+
+func (j *jobFactory) buildDashboard(tx Tx, jobs Jobs) (Dashboard, error) {
+	var jobIDs []int
+	for _, job := range jobs {
+		jobIDs = append(jobIDs, job.ID())
+	}
+
+	nextBuilds, err := j.getBuildsFrom(tx, "next_build_id", jobIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	finishedBuilds, err := j.getBuildsFrom(tx, "latest_completed_build_id", jobIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	transitionBuilds, err := j.getBuildsFrom(tx, "transition_build_id", jobIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	dashboard := Dashboard{}
+	for _, job := range jobs {
+		dashboardJob := DashboardJob{Job: job}
+
+		if nextBuild, found := nextBuilds[job.ID()]; found {
+			dashboardJob.NextBuild = nextBuild
+		}
+
+		if finishedBuild, found := finishedBuilds[job.ID()]; found {
+			dashboardJob.FinishedBuild = finishedBuild
+		}
+
+		if transitionBuild, found := transitionBuilds[job.ID()]; found {
+			dashboardJob.TransitionBuild = transitionBuild
+		}
+
+		dashboard = append(dashboard, dashboardJob)
+	}
+
+	return dashboard, nil
+}
+
+func (j *jobFactory) getBuildsFrom(tx Tx, col string, jobIDs []int) (map[int]Build, error) {
+
 	rows, err := buildsQuery.
 		Where(sq.Eq{"j.id": jobIDs}).
 		Where(sq.Expr("j." + col + " = b.id")).
-		RunWith(j.conn).Query()
+		RunWith(tx).Query()
 	if err != nil {
 		return nil, err
 	}

--- a/atc/db/pipeline_factory.go
+++ b/atc/db/pipeline_factory.go
@@ -26,35 +26,18 @@ func NewPipelineFactory(conn Conn, lockFactory lock.LockFactory) PipelineFactory
 
 func (f *pipelineFactory) VisiblePipelines(teamNames []string) ([]Pipeline, error) {
 	rows, err := pipelinesQuery.
-		Where(sq.Eq{"t.name": teamNames}).
-		OrderBy("team_id ASC", "ordering ASC").
+		Where(sq.Or{
+			sq.Eq{"t.name": teamNames},
+			sq.Eq{"public": true},
+		}).
+		OrderBy("public ASC", "team_id ASC", "ordering ASC").
 		RunWith(f.conn).
 		Query()
 	if err != nil {
 		return nil, err
 	}
 
-	currentTeamPipelines, err := scanPipelines(f.conn, f.lockFactory, rows)
-	if err != nil {
-		return nil, err
-	}
-
-	rows, err = pipelinesQuery.
-		Where(sq.NotEq{"t.name": teamNames}).
-		Where(sq.Eq{"public": true}).
-		OrderBy("team_id ASC", "ordering ASC").
-		RunWith(f.conn).
-		Query()
-	if err != nil {
-		return nil, err
-	}
-
-	otherTeamPublicPipelines, err := scanPipelines(f.conn, f.lockFactory, rows)
-	if err != nil {
-		return nil, err
-	}
-
-	return append(currentTeamPipelines, otherTeamPublicPipelines...), nil
+	return scanPipelines(f.conn, f.lockFactory, rows)
 }
 
 func (f *pipelineFactory) AllPipelines() ([]Pipeline, error) {

--- a/atc/db/pipeline_factory.go
+++ b/atc/db/pipeline_factory.go
@@ -25,19 +25,48 @@ func NewPipelineFactory(conn Conn, lockFactory lock.LockFactory) PipelineFactory
 }
 
 func (f *pipelineFactory) VisiblePipelines(teamNames []string) ([]Pipeline, error) {
+	tx, err := f.conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	defer Rollback(tx)
+
 	rows, err := pipelinesQuery.
-		Where(sq.Or{
-			sq.Eq{"t.name": teamNames},
-			sq.Eq{"public": true},
-		}).
-		OrderBy("public ASC", "team_id ASC", "ordering ASC").
-		RunWith(f.conn).
+		Where(sq.Eq{"t.name": teamNames}).
+		OrderBy("team_id ASC", "ordering ASC").
+		RunWith(tx).
 		Query()
 	if err != nil {
 		return nil, err
 	}
 
-	return scanPipelines(f.conn, f.lockFactory, rows)
+	currentTeamPipelines, err := scanPipelines(f.conn, f.lockFactory, rows)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err = pipelinesQuery.
+		Where(sq.NotEq{"t.name": teamNames}).
+		Where(sq.Eq{"public": true}).
+		OrderBy("team_id ASC", "ordering ASC").
+		RunWith(tx).
+		Query()
+	if err != nil {
+		return nil, err
+	}
+
+	otherTeamPublicPipelines, err := scanPipelines(f.conn, f.lockFactory, rows)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(currentTeamPipelines, otherTeamPublicPipelines...), nil
 }
 
 func (f *pipelineFactory) AllPipelines() ([]Pipeline, error) {

--- a/atc/db/team_factory.go
+++ b/atc/db/team_factory.go
@@ -62,8 +62,8 @@ func (factory *teamFactory) createTeam(t atc.Team, admin bool) (Team, error) {
 		conn:        factory.conn,
 		lockFactory: factory.lockFactory,
 	}
-	err = factory.scanTeam(team, row)
 
+	err = factory.scanTeam(team, row)
 	if err != nil {
 		return nil, err
 	}

--- a/atc/db/volume_repository_test.go
+++ b/atc/db/volume_repository_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("VolumeFactory", func() {
+var _ = Describe("VolumeRepository", func() {
 	var (
 		team2             db.Team
 		usedResourceCache db.UsedResourceCache
@@ -809,6 +809,7 @@ var _ = Describe("VolumeFactory", func() {
 
 		JustBeforeEach(func() {
 			err = volumeRepository.UpdateVolumesMissingSince(defaultWorker.Name(), handles)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("when the reported handles is a subset", func() {

--- a/go.sum
+++ b/go.sum
@@ -531,6 +531,7 @@ github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cobra v0.0.0-20160615143614-bc81c21bd0d8/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v0.0.0-20160610190902-367864438f1b/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -19,6 +19,10 @@
 
 * All API payloads are now gzipped. This should help save bandwidth and make the web UI load faster. #4470
 
+#### <sub><sup><a name="4494" href="#4494">:link:</a></sup></sub> feature
+
+* Optimize certain API requests to use single transaction of DB, instead of making DB connection for each sub-query. #4494
+
 #### <sub><sup><a name="4448-4588" href="#4448-4588">:link:</a></sup></sub> feature
 
 * You can now pin a resource to different version without unpinning it first #4448, #4588.

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -21,7 +21,7 @@
 
 #### <sub><sup><a name="4494" href="#4494">:link:</a></sup></sub> feature
 
-* Optimize certain API requests to use single transaction of DB, instead of making DB connection for each sub-query. #4494
+* API endpoints have been changed to use a single transaction per request, so that they become "all or nothing" instead of holding data in memory while waiting for another connection from the pool. This could lead to snowballing and increased memory usage as requests from the web UI (polling every 5 seconds) piled up. #4494
 
 #### <sub><sup><a name="4448-4588" href="#4448-4588">:link:</a></sup></sub> feature
 


### PR DESCRIPTION
Fixes #4373 

When multiple queries are made, changed the use of conn to use transactions instead.
Also cleaned up some queries that could be made in a single query instead.