### PR TITLE
atc: fix metric test data race

### DIFF
--- a/atc/metric/error_sink_collector_test.go
+++ b/atc/metric/error_sink_collector_test.go
@@ -16,8 +16,6 @@ var _ = Describe("ErrorSinkCollector", func() {
 	)
 
 	BeforeEach(func() {
-		testLogger := lager.NewLogger("test")
-
 		errorSinkCollector = metric.NewErrorSinkCollector(testLogger)
 
 		emitterFactory := &metricfakes.FakeEmitterFactory{}

--- a/atc/metric/http_test.go
+++ b/atc/metric/http_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/metric"
 	"github.com/concourse/concourse/atc/metric/metricfakes"
 
@@ -26,8 +25,6 @@ func noopHandler(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-var dummyLogger = lager.NewLogger("dont care")
-
 var _ = Describe("MetricsHandler", func() {
 	var (
 		ts      *httptest.Server
@@ -42,15 +39,15 @@ var _ = Describe("MetricsHandler", func() {
 		emitterFactory.IsConfiguredReturns(true)
 		emitterFactory.NewEmitterReturns(emitter, nil)
 
-		metric.Initialize(dummyLogger, "test", map[string]string{}, 1000)
+		metric.Initialize(testLogger, "test", map[string]string{}, 1000)
 
 		ts = httptest.NewServer(
-			WrapHandler(dummyLogger, "ApiEndpoint", http.HandlerFunc(noopHandler)))
+			WrapHandler(testLogger, "ApiEndpoint", http.HandlerFunc(noopHandler)))
 	})
 
 	AfterEach(func() {
 		ts.Close()
-		metric.Deinitialize(dummyLogger)
+		metric.Deinitialize(testLogger)
 	})
 
 	Context("when serving requests", func() {

--- a/atc/metric/metric_suite_test.go
+++ b/atc/metric/metric_suite_test.go
@@ -1,6 +1,8 @@
 package metric_test
 
 import (
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/metric"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -11,3 +13,9 @@ func TestMetric(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Metric Suite")
 }
+
+var testLogger = lager.NewLogger("test")
+
+var _ = BeforeSuite(func() {
+	metric.Initialize(testLogger, "test", map[string]string{}, 1000)
+})

--- a/atc/metric/periodic_test.go
+++ b/atc/metric/periodic_test.go
@@ -24,8 +24,6 @@ var _ = Describe("Periodic emission of metrics", func() {
 	)
 
 	BeforeEach(func() {
-		testLogger := lager.NewLogger("test")
-
 		emitterFactory := &metricfakes.FakeEmitterFactory{}
 		emitter = &metricfakes.FakeEmitter{}
 


### PR DESCRIPTION
metric.Initialize was being called multiple times in parallel, causing a race
for the emitters global constant. Fixed by only calling metric.Initialize once
before the suite and passing around a shared logger.

sample failure:
https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/unit/builds/1098#L5d8a5acb:543:625