### PR TITLE
topgun: tolerate multiple compile locks

### DIFF
--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -529,21 +529,30 @@ func VolumesByResourceType(name string) []string {
 }
 
 func WaitForDeploymentAndCompileLocks() {
+	cloudConfig := Start(nil, "bosh", "cloud-config")
+	<-cloudConfig.Exited
+	cc := struct {
+		Compilation struct {
+			Workers int
+		}
+	}{}
+	yaml.Unmarshal(cloudConfig.Out.Contents(), &cc)
+	numCompilationVms := cc.Compilation.Workers
 	for {
 		locks := Bosh("locks", "--column", "type", "--column", "resource", "--column", "task id")
-		shouldWait := false
+		isDeploymentLockClaimed := false
+		numCompileLocksClaimed := 0
 
 		for _, lock := range ParseTable(string(locks.Out.Contents())) {
 			if lock[0] == "deployment" && lock[1] == DeploymentName {
 				fmt.Fprintf(GinkgoWriter, "waiting for deployment lock (task id %s)...\n", lock[2])
-				shouldWait = true
+				isDeploymentLockClaimed = true
 			} else if lock[0] == "compile" {
-				fmt.Fprintf(GinkgoWriter, "waiting for compile lock (task id %s)...\n", lock[2])
-				shouldWait = true
+				numCompileLocksClaimed += 1
 			}
 		}
 
-		if shouldWait {
+		if isDeploymentLockClaimed || numCompileLocksClaimed >= numCompilationVms {
 			time.Sleep(5 * time.Second)
 		} else {
 			break

--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"sigs.k8s.io/yaml"
+
 	_ "github.com/lib/pq"
 
 	gclient "code.cloudfoundry.org/garden/client"


### PR DESCRIPTION
We have seen some topgun logs where a test process was waiting just because
2 out of 3 compile locks were claimed. This change should make greater use of
the available compilation VM pool, and so hopefully reduce the total running
time for topgun suites.