### PR TITLE
atc: add a dummy credential manager

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -67,6 +67,7 @@ import (
 
 	// dynamically registered credential managers
 	_ "github.com/concourse/concourse/atc/creds/credhub"
+	_ "github.com/concourse/concourse/atc/creds/dummy"
 	_ "github.com/concourse/concourse/atc/creds/kubernetes"
 	_ "github.com/concourse/concourse/atc/creds/secretsmanager"
 	_ "github.com/concourse/concourse/atc/creds/ssm"

--- a/atc/creds/dummy/flags.go
+++ b/atc/creds/dummy/flags.go
@@ -1,0 +1,29 @@
+package dummy
+
+import (
+	"fmt"
+	"strings"
+
+	yaml "sigs.k8s.io/yaml"
+)
+
+type VarFlag struct {
+	Name  string
+	Value interface{}
+}
+
+func (pair *VarFlag) UnmarshalFlag(value string) error {
+	vs := strings.SplitN(value, "=", 2)
+	if len(vs) != 2 {
+		return fmt.Errorf("invalid input pair '%s' (must be name=value)", value)
+	}
+
+	pair.Name = vs[0]
+
+	err := yaml.Unmarshal([]byte(vs[1]), &pair.Value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/atc/creds/dummy/manager.go
+++ b/atc/creds/dummy/manager.go
@@ -1,0 +1,46 @@
+package dummy
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/lager"
+
+	"github.com/concourse/concourse/atc/creds"
+)
+
+type Manager struct {
+	Vars []VarFlag `long:"var" description:"A YAML value to expose via credential management. Can be prefixed with a team and/or pipeline to limit scope." value-name:"[TEAM/[PIPELINE/]]VAR=VALUE"`
+}
+
+func (manager *Manager) Init(log lager.Logger) error {
+	return nil
+}
+
+func (manager *Manager) MarshalJSON() ([]byte, error) {
+	health, err := manager.Health()
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(&map[string]interface{}{
+		"health": health,
+	})
+}
+
+func (manager Manager) IsConfigured() bool {
+	return len(manager.Vars) > 0
+}
+
+func (manager Manager) Validate() error {
+	return nil
+}
+
+func (manager Manager) Health() (*creds.HealthResponse, error) {
+	return &creds.HealthResponse{
+		Method: "noop",
+	}, nil
+}
+
+func (manager Manager) NewSecretsFactory(logger lager.Logger) (creds.SecretsFactory, error) {
+	return NewSecretsFactory(manager.Vars), nil
+}

--- a/atc/creds/dummy/manager_factory.go
+++ b/atc/creds/dummy/manager_factory.go
@@ -1,0 +1,29 @@
+package dummy
+
+import (
+	"github.com/concourse/concourse/atc/creds"
+	flags "github.com/jessevdk/go-flags"
+)
+
+type managerFactory struct{}
+
+func init() {
+	creds.Register("dummy", NewManagerFactory())
+}
+
+func NewManagerFactory() creds.ManagerFactory {
+	return &managerFactory{}
+}
+
+func (factory *managerFactory) AddConfig(group *flags.Group) creds.Manager {
+	manager := &Manager{}
+
+	subGroup, err := group.AddGroup("Dummy Credential Management", "", manager)
+	if err != nil {
+		panic(err)
+	}
+
+	subGroup.Namespace = "dummy-creds"
+
+	return manager
+}

--- a/atc/creds/dummy/secrets.go
+++ b/atc/creds/dummy/secrets.go
@@ -1,0 +1,44 @@
+package dummy
+
+import (
+	"path"
+	"time"
+
+	"github.com/concourse/concourse/atc/creds"
+	"github.com/concourse/concourse/vars"
+)
+
+type Secrets struct {
+	vars.StaticVariables
+
+	TeamName     string
+	PipelineName string
+}
+
+func (secrets *Secrets) NewSecretLookupPaths(teamName string, pipelineName string) []creds.SecretLookupPath {
+	lookupPaths := []creds.SecretLookupPath{}
+
+	if len(pipelineName) > 0 {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(teamName, pipelineName)+"/"))
+	}
+
+	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(teamName+"/"))
+	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(""))
+
+	return lookupPaths
+}
+
+func (secrets *Secrets) Get(secretPath string) (interface{}, *time.Time, bool, error) {
+	v, found, err := secrets.StaticVariables.Get(vars.VariableDefinition{
+		Name: secretPath,
+	})
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	if found {
+		return v, nil, true, nil
+	}
+
+	return nil, nil, false, nil
+}

--- a/atc/creds/dummy/secrets_factory.go
+++ b/atc/creds/dummy/secrets_factory.go
@@ -1,0 +1,27 @@
+package dummy
+
+import (
+	"github.com/concourse/concourse/atc/creds"
+	"github.com/concourse/concourse/vars"
+)
+
+type SecretsFactory struct {
+	vars vars.StaticVariables
+}
+
+func NewSecretsFactory(flags []VarFlag) *SecretsFactory {
+	vars := vars.StaticVariables{}
+	for _, flag := range flags {
+		vars[flag.Name] = flag.Value
+	}
+
+	return &SecretsFactory{
+		vars: vars,
+	}
+}
+
+func (factory *SecretsFactory) NewSecrets() creds.Secrets {
+	return &Secrets{
+		StaticVariables: factory.vars,
+	}
+}


### PR DESCRIPTION
this is primarily to make testing credential management functionality a
bit easier

Signed-off-by: Alex Suraci <suraci.alex@gmail.com>