### PR TITLE
Restrict names by [0-9a-z-] when saving pipeline config 

### DIFF
--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -84,15 +84,15 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	warnings, errorMessages := config.Validate()
+	pipelineName := rata.Param(r, "pipeline_name")
+	teamName := rata.Param(r, "team_name")
+
+	warnings, errorMessages := config.Validate(pipelineName)
 	if len(errorMessages) > 0 {
 		session.Info("ignoring-invalid-config")
 		s.handleBadRequest(w, errorMessages...)
 		return
 	}
-
-	pipelineName := rata.Param(r, "pipeline_name")
-	teamName := rata.Param(r, "team_name")
 
 	if checkCredentials {
 		variables := creds.NewVariables(s.secretManager, teamName, pipelineName)

--- a/atc/validate.go
+++ b/atc/validate.go
@@ -25,11 +25,13 @@ type ConfigWarning struct {
 	Message string `json:"message"`
 }
 
-func (c Config) Validate(pipelineName string) ([]ConfigWarning, []string) {
+func (c Config) Validate(pipelineName ...string) ([]ConfigWarning, []string) {
 	warnings := []ConfigWarning{}
 	errorMessages := []string{}
 
-	errorMessages = validateName(pipelineName, errorMessages, "pipeline "+pipelineName)
+	if len(pipelineName) != 0 {
+		errorMessages = validateName(pipelineName[0], errorMessages, "pipeline "+pipelineName[0])
+	}
 
 	groupsErr := validateGroups(c)
 	if groupsErr != nil {

--- a/web/wats/fixtures/hooks-pipeline.yml
+++ b/web/wats/fixtures/hooks-pipeline.yml
@@ -1,5 +1,5 @@
 jobs:
-- name: on_abort
+- name: on-abort
   on_abort:
     task: say-bye-from-job
     config:

--- a/web/wats/fixtures/states-pipeline.yml
+++ b/web/wats/fixtures/states-pipeline.yml
@@ -33,9 +33,9 @@ jobs:
           echo i failed
           exit 1
 
-- name: passing_or_failing
+- name: passing-or-failing
   plan:
-  - task: pass_or_fail
+  - task: pass-or-fail
     config:
       platform: linux
 

--- a/web/wats/test/build.js
+++ b/web/wats/test/build.js
@@ -22,9 +22,9 @@ test('shows abort hooks', async t => {
   await t.context.fly.run('set-pipeline -n -p some-pipeline -c fixtures/hooks-pipeline.yml');
   await t.context.fly.run('unpause-pipeline -p some-pipeline');
 
-  await t.context.fly.run('trigger-job -j some-pipeline/on_abort');
+  await t.context.fly.run('trigger-job -j some-pipeline/on-abort');
 
-  await t.context.web.page.goto(t.context.web.route(`/teams/${t.context.teamName}/pipelines/some-pipeline/jobs/on_abort/builds/1`));
+  await t.context.web.page.goto(t.context.web.route(`/teams/${t.context.teamName}/pipelines/some-pipeline/jobs/on-abort/builds/1`));
   await t.context.web.page.setViewport({width: 1200, height: 900});
 
   await t.context.web.waitForText("say-bye-from-step");


### PR DESCRIPTION
names of pipeline, group, resource, resource type, job, get plan, put plan
and task plan are restricted to lower case alphanumeric and '-'

implements https://github.com/concourse/concourse/issues/3985