### PR TITLE
Add wiki links to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+> Please remove all the lines starting with '>'
 > Hi there! Thanks for submitting a pull request to Concourse! 
 > If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md) and our [Contributing Guide](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md).
 > 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ Fixes # .
 
 # Why do we need this PR?
 > No issue number? Please give us a few lines of context describing the need for this PR.
+> Please review the [Anti-patterns page](https://github.com/concourse/concourse/wiki/Anti-Patterns) first.
 
 
 # Changes proposed in this pull request
@@ -22,7 +23,7 @@ Fixes # .
 *
 
 # Contributor Checklist
-> Are the following items included as part of this PR?
+> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
 - [ ] Unit tests
 - [ ] Integration tests (if applicable)
 - [ ] Updated documentation (located at https://github.com/concourse/docs)


### PR DESCRIPTION
Changes proposed in this pull request

* Add link to anti-patterns page to PR template

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] Code reviewed
- [x] Tests reviewed
- [x] Documentation reviewed
- [x] Release notes reviewed
- [x] PR acceptance performed

