### PR TITLE
Adding release notes for v5.6.1

### DIFF
--- a/release-notes/v5.6.1.md
+++ b/release-notes/v5.6.1.md
@@ -1,0 +1,3 @@
+#### <sub><sup><a name="v510-note-git-resource-273" href="#v561-note-git-resource-273">:link:</a></sup></sub> fix
+
+* @CliffHoogervorst fixed an [issue](https://github.com/concourse/git-resource/issues/275) in the [git resource](http://github.com/concourse/git-resource), where the version order was not correct when using [`paths`](https://github.com/concourse/git-resource#source-configuration) concourse/git-resource#273.


### PR DESCRIPTION
# Why do we need this PR?
Release notes for a patch version release which will contain a fix for the git-resource. concourse/git-resource#273

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] Documentation reviewed
- [x] Release notes reviewed
- [x] ~PR acceptance performed~

