### PR TITLE
Added release note for fly workers age fix

### DIFF
--- a/release-notes/v5.6.1.md
+++ b/release-notes/v5.6.1.md
@@ -1,3 +1,7 @@
 #### <sub><sup><a name="v510-note-git-resource-273" href="#v561-note-git-resource-273">:link:</a></sup></sub> fix
 
 * @CliffHoogervorst fixed an [issue](https://github.com/concourse/git-resource/issues/275) in the [git resource](http://github.com/concourse/git-resource), where the version order was not correct when using [`paths`](https://github.com/concourse/git-resource#source-configuration) concourse/git-resource#273.
+
+#### <sub><sup><a name="v510-note-4548" href="#v561-note-4548">:link:</a></sup></sub> fix
+
+* @evanchaoli fixed an [issue](https://github.com/concourse/concourse/issues/4545), where [`fly workers`](https://concourse-ci.org/administration.html#fly-workers) would show the wrong age for a worker if that worker was under an hour old #4548.


### PR DESCRIPTION
# Why do we need this PR?
Release note for #4548.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

