### PR TITLE
Issue # 2958

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -690,13 +690,7 @@ func (cmd *RunCommand) constructAPIMembers(
 		)})
 
 		if cmd.TLSOnly {
-			tmp := members[:0]
-			for _, apiMember := range members {
-				if apiMember.Name != "web" {
-					tmp = append(tmp, apiMember)
-				}
-			}
-			members = tmp
+			members = cmd.filterMembersForTLSOnly(members, "web")
 		}
 	}
 
@@ -1551,4 +1545,14 @@ func (cmd *RunCommand) appendStaticWorker(
 
 func (cmd *RunCommand) isTLSEnabled() bool {
 	return cmd.TLSBindPort != 0
+}
+
+func (cmd *RunCommand) filterMembersForTLSOnly(apiMembersArray []grouper.Member, memberNameToFilter string) []grouper.Member {
+	tmp := apiMembersArray[:0]
+	for _, apiMember := range apiMembersArray {
+		if apiMember.Name != memberNameToFilter {
+			tmp = append(tmp, apiMember)
+		}
+	}
+	return tmp
 }

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -87,6 +87,7 @@ type RunCommand struct {
 	BindIP   flag.IP `long:"bind-ip"   default:"0.0.0.0" description:"IP address on which to listen for web traffic."`
 	BindPort uint16  `long:"bind-port" default:"8080"    description:"Port on which to listen for HTTP traffic."`
 
+	TLSOnly     bool      `long:"tls-only" description:"Configure concourse to only accept HTTPS requests"`
 	TLSBindPort uint16    `long:"tls-bind-port" description:"Port on which to listen for HTTPS traffic."`
 	TLSCert     flag.File `long:"tls-cert"      description:"File containing an SSL certificate."`
 	TLSKey      flag.File `long:"tls-key"       description:"File containing an RSA private key, used to encrypt HTTPS traffic."`
@@ -687,6 +688,16 @@ func (cmd *RunCommand) constructAPIMembers(
 			httpsHandler,
 			tlsConfig,
 		)})
+
+		if cmd.TLSOnly {
+			tmp := members[:0]
+			for _, apiMember := range members {
+				if apiMember.Name != "web" {
+					tmp = append(tmp, apiMember)
+				}
+			}
+			members = tmp
+		}
 	}
 
 	return members, nil

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -4,3 +4,6 @@
   badge endpoints! Now you can make it say something other than "build". #4480
 
   ![badge](https://ci.concourse-ci.org/api/v1/teams/main/pipelines/concourse/badge?title=check%20it%20out)
+
+
+* @ctorboh15 added support for a CONCOURSE_TLS_ONLY configuration that will remove all non TLS api members at startup


### PR DESCRIPTION
Fixes # 2958

# Changes proposed in this pull request
We now remove any api members that are not TLS specific in the even that we set the CONCOURSE_TLS_ONLY env variable
