### PR TITLE
Clean up v5.6.1 release notes

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,18 +1,28 @@
-#### <sub><sup><a name="v560-note-4480" href="#v560-note-4480">:link:</a></sup></sub> feature
+#### <sub><sup><a name="4480" href="#4480">:link:</a></sup></sub> feature
 
-* @ProvoK added support for a `?title=` query parameter on the pipeline/job
-  badge endpoints! Now you can make it say something other than "build". #4480
-
+* @ProvoK added support for a `?title=` query parameter on the pipeline/job badge endpoints! Now you can make it say something other than "build". #4480
   ![badge](https://ci.concourse-ci.org/api/v1/teams/main/pipelines/concourse/badge?title=check%20it%20out)
 
-#### <sub><sup><a name="v561-note-4518" href="#v561-note-4518">:link:</a></sup></sub> feature
+#### <sub><sup><a name="4518" href="#4518">:link:</a></sup></sub> feature
 
 * @evanchaoli added a feature to stop ATC from attempting to renew Vault leases that are not renewable #4518.
 
-#### <sub><sup><a name="v561-note-4516" href="#v561-note-4516">:link:</a></sup></sub> feature
+#### <sub><sup><a name="4516" href="#4516">:link:</a></sup></sub> feature
 
 * Add 5 minute timeout for baggageclaim destroy calls #4516.
 
-#### <sub><sup><a name="v561-note-4334" href="#v561-note-4334">:link:</a></sup></sub> feature
+#### <sub><sup><a name="4334" href="#4334">:link:</a></sup></sub> feature
 
 * @aledeganopix4d added a feature sort pipelines alphabetically #4334.
+
+#### <sub><sup><a name="4470" href="#4470">:link:</a></sup></sub> feature, breaking
+
+* All API payloads are now gzipped. This should help save bandwidth and make the web UI load faster. #4470
+
+#### <sub><sup><a name="4448" href="#4448">:link:</a></sup></sub> feature
+
+* You can now use fly to pin a resource without unpinning it first. #4448
+
+#### <sub><sup><a name="4507" href="#4507">:link:</a></sup></sub> fix
+
+* @iamjarvo fixed a [bug](444://github.com/concourse/concourse/issues/4472) where `fly builds` would show the wrong duration for cancelled builds #4507.

--- a/release-notes/v5.6.1.md
+++ b/release-notes/v5.6.1.md
@@ -2,14 +2,6 @@
 
 * We've restyled the resource metadata displayed in a get step on the build page. It should be easier to read and follow, let us know your critiques on the issue. #4421 #4476
 
-#### <sub><sup><a name="v561-4470" href="#v561-4470">:link:</a></sup></sub> feature
-
-* GZIP compression is applied to response of all API endpoints. It should help saving bandwidth and making web UI loads faster. #4470
-
-#### <sub><sup><a name="v561-4448" href="#v561-4448">:link:</a></sup></sub> feature
-
-* Fly can now pin a resource without unpin it first. #4448
-
 #### <sub><sup><a name="v510-note-git-resource-273" href="#v561-note-git-resource-273">:link:</a></sup></sub> fix
 
 * @CliffHoogervorst fixed an [issue](https://github.com/concourse/git-resource/issues/275) in the [git resource](http://github.com/concourse/git-resource), where the version order was not correct when using [`paths`](https://github.com/concourse/git-resource#source-configuration) concourse/git-resource#273.


### PR DESCRIPTION
# Why do we need this PR?

Cleans up release notes for v5.6.1, and adds a note for #4507.

# Changes proposed in this pull request

No code changes.

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [x] ~PR acceptance performed~