### PR TITLE
GC unknown containers and volumes from workers

### DIFF
--- a/atc/api/containerserver/report.go
+++ b/atc/api/containerserver/report.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/metric"
 )
 
 func (s *Server) ReportWorkerContainers(w http.ResponseWriter, r *http.Request) {
@@ -52,6 +53,11 @@ func (s *Server) ReportWorkerContainers(w http.ResponseWriter, r *http.Request) 
 			"worker-name":   workerName,
 			"handles-count": numUnknownContainers,
 		})
+
+		metric.WorkerUnknownContainers{
+			WorkerName: workerName,
+			Containers: numUnknownContainers,
+		}.Emit(logger)
 	}
 
 	err = s.containerRepository.UpdateContainersMissingSince(workerName, handles)

--- a/atc/api/containerserver/report.go
+++ b/atc/api/containerserver/report.go
@@ -41,6 +41,13 @@ func (s *Server) ReportWorkerContainers(w http.ResponseWriter, r *http.Request) 
 		"num-handles": len(handles),
 	})
 
+	_, err = s.containerRepository.DestroyUnknownContainers(workerName, handles)
+	if err != nil {
+		logger.Error("failed-to-destroy-unknown-containers", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	err = s.containerRepository.UpdateContainersMissingSince(workerName, handles)
 	if err != nil {
 		logger.Error("failed-to-update-containers-missing-since", err)

--- a/atc/api/containerserver/report.go
+++ b/atc/api/containerserver/report.go
@@ -41,11 +41,17 @@ func (s *Server) ReportWorkerContainers(w http.ResponseWriter, r *http.Request) 
 		"num-handles": len(handles),
 	})
 
-	_, err = s.containerRepository.DestroyUnknownContainers(workerName, handles)
+	numUnknownContainers, err := s.containerRepository.DestroyUnknownContainers(workerName, handles)
 	if err != nil {
 		logger.Error("failed-to-destroy-unknown-containers", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
+	}
+	if numUnknownContainers > 0 {
+		logger.Info("unknown-container-handles", lager.Data{
+			"worker-name":   workerName,
+			"handles-count": numUnknownContainers,
+		})
 	}
 
 	err = s.containerRepository.UpdateContainersMissingSince(workerName, handles)

--- a/atc/api/containerserver/report.go
+++ b/atc/api/containerserver/report.go
@@ -5,8 +5,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/metric"
+
+	"code.cloudfoundry.org/lager"
 )
 
 func (s *Server) ReportWorkerContainers(w http.ResponseWriter, r *http.Request) {
@@ -53,12 +54,12 @@ func (s *Server) ReportWorkerContainers(w http.ResponseWriter, r *http.Request) 
 			"worker-name":   workerName,
 			"handles-count": numUnknownContainers,
 		})
-
-		metric.WorkerUnknownContainers{
-			WorkerName: workerName,
-			Containers: numUnknownContainers,
-		}.Emit(logger)
 	}
+
+	metric.WorkerUnknownContainers{
+		WorkerName: workerName,
+		Containers: numUnknownContainers,
+	}.Emit(logger)
 
 	err = s.containerRepository.UpdateContainersMissingSince(workerName, handles)
 	if err != nil {

--- a/atc/api/volumeserver/report.go
+++ b/atc/api/volumeserver/report.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/metric"
 )
 
 // ReportWorkerVolumes provides an API endpoint for workers to report their current volumes
@@ -53,6 +54,10 @@ func (s *Server) ReportWorkerVolumes(w http.ResponseWriter, r *http.Request) {
 			"worker-name":   workerName,
 			"handles-count": numUnknownVolumes,
 		})
+		metric.WorkerUnknownVolumes{
+			WorkerName: workerName,
+			Volumes:    numUnknownVolumes,
+		}.Emit(logger)
 	}
 
 	err = s.repository.UpdateVolumesMissingSince(workerName, handles)

--- a/atc/api/volumeserver/report.go
+++ b/atc/api/volumeserver/report.go
@@ -42,6 +42,13 @@ func (s *Server) ReportWorkerVolumes(w http.ResponseWriter, r *http.Request) {
 		"handles-count": len(handles),
 	})
 
+	_, err = s.repository.DestroyUnknownVolumes(workerName, handles)
+	if err != nil {
+		logger.Error("failed-to-destroy-unknown-volumes", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	err = s.repository.UpdateVolumesMissingSince(workerName, handles)
 	if err != nil {
 		logger.Error("failed-to-update-volumes-missing-since", err)

--- a/atc/api/volumeserver/report.go
+++ b/atc/api/volumeserver/report.go
@@ -42,11 +42,17 @@ func (s *Server) ReportWorkerVolumes(w http.ResponseWriter, r *http.Request) {
 		"handles-count": len(handles),
 	})
 
-	_, err = s.repository.DestroyUnknownVolumes(workerName, handles)
+	numUnknownVolumes, err := s.repository.DestroyUnknownVolumes(workerName, handles)
 	if err != nil {
 		logger.Error("failed-to-destroy-unknown-volumes", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
+	}
+	if numUnknownVolumes > 0 {
+		logger.Info("unknown-volume-handles", lager.Data{
+			"worker-name":   workerName,
+			"handles-count": numUnknownVolumes,
+		})
 	}
 
 	err = s.repository.UpdateVolumesMissingSince(workerName, handles)

--- a/atc/api/volumeserver/report.go
+++ b/atc/api/volumeserver/report.go
@@ -5,8 +5,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/metric"
+
+	"code.cloudfoundry.org/lager"
 )
 
 // ReportWorkerVolumes provides an API endpoint for workers to report their current volumes
@@ -54,11 +55,12 @@ func (s *Server) ReportWorkerVolumes(w http.ResponseWriter, r *http.Request) {
 			"worker-name":   workerName,
 			"handles-count": numUnknownVolumes,
 		})
-		metric.WorkerUnknownVolumes{
-			WorkerName: workerName,
-			Volumes:    numUnknownVolumes,
-		}.Emit(logger)
 	}
+
+	metric.WorkerUnknownVolumes{
+		WorkerName: workerName,
+		Volumes:    numUnknownVolumes,
+	}.Emit(logger)
 
 	err = s.repository.UpdateVolumesMissingSince(workerName, handles)
 	if err != nil {

--- a/atc/db/container_repository.go
+++ b/atc/db/container_repository.go
@@ -365,7 +365,6 @@ func (repository *containerRepository) DestroyFailedContainers() (int, error) {
 }
 
 func (repository *containerRepository) DestroyUnknownContainers(workerName string, reportedHandles []string) (int, error) {
-
 	dbHandles, err := repository.queryContainerHandles(sq.Eq{
 		"worker_name": workerName,
 	})

--- a/atc/db/container_repository.go
+++ b/atc/db/container_repository.go
@@ -374,6 +374,10 @@ func (repository *containerRepository) DestroyUnknownContainers(workerName strin
 
 	unknownHandles := diff(reportedHandles, dbHandles)
 
+	if len(unknownHandles) == 0 {
+		return 0, nil
+	}
+
 	tx, err := repository.conn.Begin()
 	if err != nil {
 		return 0, err

--- a/atc/db/container_repository_test.go
+++ b/atc/db/container_repository_test.go
@@ -1003,4 +1003,77 @@ var _ = Describe("ContainerRepository", func() {
 			})
 		})
 	})
+
+	Describe("DestroyUnknownContainers", func() {
+		var (
+			err                   error
+			workerReportedHandles []string
+			num                   int
+		)
+
+		BeforeEach(func() {
+			result, err := psql.Insert("containers").SetMap(map[string]interface{}{
+				"state":        atc.ContainerStateDestroying,
+				"handle":       "some-handle1",
+				"worker_name":  defaultWorker.Name(),
+				"hijacked":     false,
+				"discontinued": false,
+			}).RunWith(dbConn).Exec()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RowsAffected()).To(Equal(int64(1)))
+
+			result, err = psql.Insert("containers").SetMap(map[string]interface{}{
+				"state":        atc.ContainerStateCreated,
+				"handle":       "some-handle2",
+				"worker_name":  defaultWorker.Name(),
+				"hijacked":     false,
+				"discontinued": false,
+			}).RunWith(dbConn).Exec()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RowsAffected()).To(Equal(int64(1)))
+		})
+
+		JustBeforeEach(func() {
+			num, err = containerRepository.DestroyUnknownContainers(defaultWorker.Name(), workerReportedHandles)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Context("when there are containers on the worker that are not in the db", func() {
+			var destroyingContainerHandles []string
+			BeforeEach(func() {
+				workerReportedHandles = []string{"some-handle3", "some-handle4"}
+				destroyingContainerHandles = append(workerReportedHandles, "some-handle1")
+			})
+
+			It("adds new destroying containers to the database", func() {
+				result, err := psql.Select("handle").
+					From("containers").
+					Where(sq.Eq{"state": atc.ContainerStateDestroying}).
+					RunWith(dbConn).Query()
+
+				Expect(err).ToNot(HaveOccurred())
+
+				var handle string
+				for result.Next() {
+					err = result.Scan(&handle)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(handle).Should(BeElementOf(destroyingContainerHandles))
+				}
+				Expect(num).To(Equal(2))
+			})
+
+			It("does not affect containers in any other state", func() {
+				result, err := psql.Select("*").
+					From("containers").
+					Where(sq.Eq{"state": atc.ContainerStateCreated}).
+					RunWith(dbConn).Exec()
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.RowsAffected()).To(Equal(int64(1)))
+				Expect(num).To(Equal(2))
+			})
+		})
+	})
 })

--- a/atc/db/container_repository_test.go
+++ b/atc/db/container_repository_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ContainerRepository", func() {
+var _ = FDescribe("ContainerRepository", func() {
 	Describe("FindOrphanedContainers", func() {
 		Describe("check containers", func() {
 			var (
@@ -1006,9 +1006,9 @@ var _ = Describe("ContainerRepository", func() {
 
 	Describe("DestroyUnknownContainers", func() {
 		var (
-			err                   error
-			workerReportedHandles []string
-			num                   int
+			err                     error
+			workerReportedHandles   []string
+			numberUnknownContainers int
 		)
 
 		BeforeEach(func() {
@@ -1036,7 +1036,7 @@ var _ = Describe("ContainerRepository", func() {
 		})
 
 		JustBeforeEach(func() {
-			num, err = containerRepository.DestroyUnknownContainers(defaultWorker.Name(), workerReportedHandles)
+			numberUnknownContainers, err = containerRepository.DestroyUnknownContainers(defaultWorker.Name(), workerReportedHandles)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -1061,18 +1061,27 @@ var _ = Describe("ContainerRepository", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(handle).Should(BeElementOf(destroyingContainerHandles))
 				}
-				Expect(num).To(Equal(2))
+				Expect(numberUnknownContainers).To(Equal(2))
 			})
 
 			It("does not affect containers in any other state", func() {
-				result, err := psql.Select("*").
+				rows, err := psql.Select("handle").
 					From("containers").
 					Where(sq.Eq{"state": atc.ContainerStateCreated}).
-					RunWith(dbConn).Exec()
+					RunWith(dbConn).Query()
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result.RowsAffected()).To(Equal(int64(1)))
-				Expect(num).To(Equal(2))
+
+				var handle string
+				var rowsAffected int
+				for rows.Next() {
+					err = rows.Scan(&handle)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(handle).To(Equal("some-handle2"))
+					rowsAffected++
+				}
+
+				Expect(rowsAffected).To(Equal(1))
 			})
 		})
 
@@ -1082,14 +1091,25 @@ var _ = Describe("ContainerRepository", func() {
 			})
 
 			It("should not try to destroy anything", func() {
-				Expect(num).To(Equal(0))
-				result, err := psql.Select("handle, state").
+				Expect(numberUnknownContainers).To(Equal(0))
+
+				rows, err := psql.Select("handle").
 					From("containers").
 					Where(sq.Eq{"state": atc.ContainerStateDestroying}).
-					RunWith(dbConn).Exec()
+					RunWith(dbConn).Query()
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(result.RowsAffected()).To(Equal(int64(1)))
+
+				var handle string
+				var rowsAffected int
+				for rows.Next() {
+					err = rows.Scan(&handle)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(handle).To(Equal("some-handle1"))
+					rowsAffected++
+				}
+
+				Expect(rowsAffected).To(Equal(1))
 			})
 		})
 	})

--- a/atc/db/container_repository_test.go
+++ b/atc/db/container_repository_test.go
@@ -1075,5 +1075,22 @@ var _ = Describe("ContainerRepository", func() {
 				Expect(num).To(Equal(2))
 			})
 		})
+
+		Context("when there are no unknown containers on the worker", func() {
+			BeforeEach(func() {
+				workerReportedHandles = []string{"some-handle1", "some-handle2"}
+			})
+
+			It("should not try to destroy anything", func() {
+				Expect(num).To(Equal(0))
+				result, err := psql.Select("handle, state").
+					From("containers").
+					Where(sq.Eq{"state": atc.ContainerStateDestroying}).
+					RunWith(dbConn).Exec()
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.RowsAffected()).To(Equal(int64(1)))
+			})
+		})
 	})
 })

--- a/atc/db/container_repository_test.go
+++ b/atc/db/container_repository_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = FDescribe("ContainerRepository", func() {
+var _ = Describe("ContainerRepository", func() {
 	Describe("FindOrphanedContainers", func() {
 		Describe("check containers", func() {
 			var (

--- a/atc/db/dbfakes/fake_container_repository.go
+++ b/atc/db/dbfakes/fake_container_repository.go
@@ -21,6 +21,20 @@ type FakeContainerRepository struct {
 		result1 int
 		result2 error
 	}
+	DestroyUnknownContainersStub        func(string, []string) (int, error)
+	destroyUnknownContainersMutex       sync.RWMutex
+	destroyUnknownContainersArgsForCall []struct {
+		arg1 string
+		arg2 []string
+	}
+	destroyUnknownContainersReturns struct {
+		result1 int
+		result2 error
+	}
+	destroyUnknownContainersReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	FindDestroyingContainersStub        func(string) ([]string, error)
 	findDestroyingContainersMutex       sync.RWMutex
 	findDestroyingContainersArgsForCall []struct {
@@ -143,6 +157,75 @@ func (fake *FakeContainerRepository) DestroyFailedContainersReturnsOnCall(i int,
 		})
 	}
 	fake.destroyFailedContainersReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeContainerRepository) DestroyUnknownContainers(arg1 string, arg2 []string) (int, error) {
+	var arg2Copy []string
+	if arg2 != nil {
+		arg2Copy = make([]string, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.destroyUnknownContainersMutex.Lock()
+	ret, specificReturn := fake.destroyUnknownContainersReturnsOnCall[len(fake.destroyUnknownContainersArgsForCall)]
+	fake.destroyUnknownContainersArgsForCall = append(fake.destroyUnknownContainersArgsForCall, struct {
+		arg1 string
+		arg2 []string
+	}{arg1, arg2Copy})
+	fake.recordInvocation("DestroyUnknownContainers", []interface{}{arg1, arg2Copy})
+	fake.destroyUnknownContainersMutex.Unlock()
+	if fake.DestroyUnknownContainersStub != nil {
+		return fake.DestroyUnknownContainersStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.destroyUnknownContainersReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeContainerRepository) DestroyUnknownContainersCallCount() int {
+	fake.destroyUnknownContainersMutex.RLock()
+	defer fake.destroyUnknownContainersMutex.RUnlock()
+	return len(fake.destroyUnknownContainersArgsForCall)
+}
+
+func (fake *FakeContainerRepository) DestroyUnknownContainersCalls(stub func(string, []string) (int, error)) {
+	fake.destroyUnknownContainersMutex.Lock()
+	defer fake.destroyUnknownContainersMutex.Unlock()
+	fake.DestroyUnknownContainersStub = stub
+}
+
+func (fake *FakeContainerRepository) DestroyUnknownContainersArgsForCall(i int) (string, []string) {
+	fake.destroyUnknownContainersMutex.RLock()
+	defer fake.destroyUnknownContainersMutex.RUnlock()
+	argsForCall := fake.destroyUnknownContainersArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeContainerRepository) DestroyUnknownContainersReturns(result1 int, result2 error) {
+	fake.destroyUnknownContainersMutex.Lock()
+	defer fake.destroyUnknownContainersMutex.Unlock()
+	fake.DestroyUnknownContainersStub = nil
+	fake.destroyUnknownContainersReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeContainerRepository) DestroyUnknownContainersReturnsOnCall(i int, result1 int, result2 error) {
+	fake.destroyUnknownContainersMutex.Lock()
+	defer fake.destroyUnknownContainersMutex.Unlock()
+	fake.DestroyUnknownContainersStub = nil
+	if fake.destroyUnknownContainersReturnsOnCall == nil {
+		fake.destroyUnknownContainersReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.destroyUnknownContainersReturnsOnCall[i] = struct {
 		result1 int
 		result2 error
 	}{result1, result2}
@@ -475,6 +558,8 @@ func (fake *FakeContainerRepository) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.destroyFailedContainersMutex.RLock()
 	defer fake.destroyFailedContainersMutex.RUnlock()
+	fake.destroyUnknownContainersMutex.RLock()
+	defer fake.destroyUnknownContainersMutex.RUnlock()
 	fake.findDestroyingContainersMutex.RLock()
 	defer fake.findDestroyingContainersMutex.RUnlock()
 	fake.findOrphanedContainersMutex.RLock()

--- a/atc/db/dbfakes/fake_volume_repository.go
+++ b/atc/db/dbfakes/fake_volume_repository.go
@@ -93,6 +93,20 @@ type FakeVolumeRepository struct {
 		result1 int
 		result2 error
 	}
+	DestroyUnknownVolumesStub        func(string, []string) (int, error)
+	destroyUnknownVolumesMutex       sync.RWMutex
+	destroyUnknownVolumesArgsForCall []struct {
+		arg1 string
+		arg2 []string
+	}
+	destroyUnknownVolumesReturns struct {
+		result1 int
+		result2 error
+	}
+	destroyUnknownVolumesReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	FindBaseResourceTypeVolumeStub        func(*db.UsedWorkerBaseResourceType) (db.CreatingVolume, db.CreatedVolume, error)
 	findBaseResourceTypeVolumeMutex       sync.RWMutex
 	findBaseResourceTypeVolumeArgsForCall []struct {
@@ -656,6 +670,75 @@ func (fake *FakeVolumeRepository) DestroyFailedVolumesReturnsOnCall(i int, resul
 		})
 	}
 	fake.destroyFailedVolumesReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVolumeRepository) DestroyUnknownVolumes(arg1 string, arg2 []string) (int, error) {
+	var arg2Copy []string
+	if arg2 != nil {
+		arg2Copy = make([]string, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.destroyUnknownVolumesMutex.Lock()
+	ret, specificReturn := fake.destroyUnknownVolumesReturnsOnCall[len(fake.destroyUnknownVolumesArgsForCall)]
+	fake.destroyUnknownVolumesArgsForCall = append(fake.destroyUnknownVolumesArgsForCall, struct {
+		arg1 string
+		arg2 []string
+	}{arg1, arg2Copy})
+	fake.recordInvocation("DestroyUnknownVolumes", []interface{}{arg1, arg2Copy})
+	fake.destroyUnknownVolumesMutex.Unlock()
+	if fake.DestroyUnknownVolumesStub != nil {
+		return fake.DestroyUnknownVolumesStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.destroyUnknownVolumesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeVolumeRepository) DestroyUnknownVolumesCallCount() int {
+	fake.destroyUnknownVolumesMutex.RLock()
+	defer fake.destroyUnknownVolumesMutex.RUnlock()
+	return len(fake.destroyUnknownVolumesArgsForCall)
+}
+
+func (fake *FakeVolumeRepository) DestroyUnknownVolumesCalls(stub func(string, []string) (int, error)) {
+	fake.destroyUnknownVolumesMutex.Lock()
+	defer fake.destroyUnknownVolumesMutex.Unlock()
+	fake.DestroyUnknownVolumesStub = stub
+}
+
+func (fake *FakeVolumeRepository) DestroyUnknownVolumesArgsForCall(i int) (string, []string) {
+	fake.destroyUnknownVolumesMutex.RLock()
+	defer fake.destroyUnknownVolumesMutex.RUnlock()
+	argsForCall := fake.destroyUnknownVolumesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeVolumeRepository) DestroyUnknownVolumesReturns(result1 int, result2 error) {
+	fake.destroyUnknownVolumesMutex.Lock()
+	defer fake.destroyUnknownVolumesMutex.Unlock()
+	fake.DestroyUnknownVolumesStub = nil
+	fake.destroyUnknownVolumesReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVolumeRepository) DestroyUnknownVolumesReturnsOnCall(i int, result1 int, result2 error) {
+	fake.destroyUnknownVolumesMutex.Lock()
+	defer fake.destroyUnknownVolumesMutex.Unlock()
+	fake.DestroyUnknownVolumesStub = nil
+	if fake.destroyUnknownVolumesReturnsOnCall == nil {
+		fake.destroyUnknownVolumesReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.destroyUnknownVolumesReturnsOnCall[i] = struct {
 		result1 int
 		result2 error
 	}{result1, result2}
@@ -1521,6 +1604,8 @@ func (fake *FakeVolumeRepository) Invocations() map[string][][]interface{} {
 	defer fake.createVolumeMutex.RUnlock()
 	fake.destroyFailedVolumesMutex.RLock()
 	defer fake.destroyFailedVolumesMutex.RUnlock()
+	fake.destroyUnknownVolumesMutex.RLock()
+	defer fake.destroyUnknownVolumesMutex.RUnlock()
 	fake.findBaseResourceTypeVolumeMutex.RLock()
 	defer fake.findBaseResourceTypeVolumeMutex.RUnlock()
 	fake.findContainerVolumeMutex.RLock()

--- a/atc/db/volume_repository.go
+++ b/atc/db/volume_repository.go
@@ -552,6 +552,10 @@ func (repository *volumeRepository) DestroyUnknownVolumes(workerName string, rep
 
 	unknownHandles := diff(reportedHandles, dbHandles)
 
+	if len(unknownHandles) == 0 {
+		return 0, nil
+	}
+
 	tx, err := repository.conn.Begin()
 	if err != nil {
 		return 0, err

--- a/atc/db/volume_repository_test.go
+++ b/atc/db/volume_repository_test.go
@@ -976,5 +976,22 @@ var _ = Describe("VolumeFactory", func() {
 				Expect(num).To(Equal(2))
 			})
 		})
+
+		Context("when there are no unknown volumes on the worker", func() {
+			BeforeEach(func() {
+				workerReportedHandles = []string{"some-handle1", "some-handle2"}
+			})
+
+			It("should not try to destroy anything", func() {
+				Expect(num).To(Equal(0))
+				result, err := psql.Select("handle, state").
+					From("volumes").
+					Where(sq.Eq{"state": db.VolumeStateDestroying}).
+					RunWith(dbConn).Exec()
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.RowsAffected()).To(Equal(int64(1)))
+			})
+		})
 	})
 })

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -17,7 +17,6 @@ type (
 	stats struct {
 		created interface{}
 		deleted interface{}
-		unknown interface{}
 	}
 
 	NewRelicEmitter struct {
@@ -102,7 +101,6 @@ func (emitter *NewRelicEmitter) emitPayload(logger lager.Logger, payload fullPay
 	req.Header.Add("X-Insert-Key", emitter.apikey)
 
 	resp, err := emitter.client.Do(req)
-
 	if err != nil {
 		logger.Error("failed-to-send-request",
 			errors.Wrap(metric.ErrFailedToEmit, err.Error()))
@@ -124,7 +122,9 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		"worker volumes",
 		"http response time",
 		"database queries",
-		"database connections":
+		"database connections",
+		"worker unknown containers",
+		"worker unknown volumes":
 		payload = append(payload, emitter.simplePayload(logger, event, ""))
 
 	// These are periodic metrics that are consolidated and only emitted once
@@ -156,10 +156,6 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		delete(newPayload, "value")
 		payload = append(payload, newPayload)
 
-	case "worker unknown containers":
-		emitter.containers.unknown = event.Value
-	case "worker unknown volumes":
-		emitter.volumes.unknown = event.Value
 
 	// And a couple that need a small rename (new relic doesn't like some chars)
 	case "scheduling: full duration (ms)":

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -136,8 +136,6 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		emitter.containers.deleted = event.Value
 	case "containers created":
 		emitter.containers.created = event.Value
-	case "unknown containers":
-		emitter.containers.unknown = event.Value
 	case "failed containers":
 		newPayload := emitter.simplePayload(logger, event, "containers")
 		newPayload["failed"] = newPayload["value"]
@@ -150,8 +148,6 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		emitter.volumes.deleted = event.Value
 	case "volumes created":
 		emitter.volumes.created = event.Value
-	case "unknown volumes":
-		emitter.volumes.unknown = event.Value
 	case "failed volumes":
 		newPayload := emitter.simplePayload(logger, event, "volumes")
 		newPayload["failed"] = newPayload["value"]
@@ -159,6 +155,11 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		newPayload["deleted"] = emitter.volumes.deleted
 		delete(newPayload, "value")
 		payload = append(payload, newPayload)
+
+	case "worker unknown containers":
+		emitter.containers.unknown = event.Value
+	case "worker unknown volumes":
+		emitter.volumes.unknown = event.Value
 
 	// And a couple that need a small rename (new relic doesn't like some chars)
 	case "scheduling: full duration (ms)":

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -17,6 +17,7 @@ type (
 	stats struct {
 		created interface{}
 		deleted interface{}
+		unknown interface{}
 	}
 
 	NewRelicEmitter struct {
@@ -135,6 +136,8 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		emitter.containers.deleted = event.Value
 	case "containers created":
 		emitter.containers.created = event.Value
+	case "unknown containers":
+		emitter.containers.unknown = event.Value
 	case "failed containers":
 		newPayload := emitter.simplePayload(logger, event, "containers")
 		newPayload["failed"] = newPayload["value"]
@@ -147,6 +150,8 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		emitter.volumes.deleted = event.Value
 	case "volumes created":
 		emitter.volumes.created = event.Value
+	case "unknown volumes":
+		emitter.volumes.unknown = event.Value
 	case "failed volumes":
 		newPayload := emitter.simplePayload(logger, event, "volumes")
 		newPayload["failed"] = newPayload["value"]

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -43,12 +43,12 @@ type PrometheusEmitter struct {
 	schedulingFullDuration    *prometheus.CounterVec
 	schedulingLoadingDuration *prometheus.CounterVec
 
-	workerContainers       *prometheus.GaugeVec
+	workerContainers        *prometheus.GaugeVec
 	workerUnknownContainers *prometheus.GaugeVec
-	workerVolumes          *prometheus.GaugeVec
-	workerUnknownVolumes   *prometheus.GaugeVec
-	workerTasks            *prometheus.GaugeVec
-	workersRegistered      *prometheus.GaugeVec
+	workerVolumes           *prometheus.GaugeVec
+	workerUnknownVolumes    *prometheus.GaugeVec
+	workerTasks             *prometheus.GaugeVec
+	workersRegistered       *prometheus.GaugeVec
 
 	workerContainersLabels map[string]map[string]prometheus.Labels
 	workerVolumesLabels    map[string]map[string]prometheus.Labels
@@ -220,7 +220,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 	)
 	prometheus.MustRegister(workerVolumes)
 
-	workerUnknownVolumes:= prometheus.NewGaugeVec(
+	workerUnknownVolumes := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "concourse",
 			Subsystem: "workers",
@@ -400,7 +400,7 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 		emitter.workerContainersMetric(logger, event)
 	case "worker volumes":
 		emitter.workerVolumesMetric(logger, event)
-	case "worker unknown containers": ////
+	case "worker unknown containers":
 		emitter.workerUnknownContainersMetric(logger, event)
 	case "worker unknown volumes":
 		emitter.workerUnknownVolumesMetric(logger, event)
@@ -571,7 +571,7 @@ func (emitter *PrometheusEmitter) workerUnknownContainersMetric(logger lager.Log
 	}
 
 	labels := prometheus.Labels{
-		"worker":   worker,
+		"worker": worker,
 	}
 
 	containers, ok := event.Value.(int)
@@ -634,7 +634,7 @@ func (emitter *PrometheusEmitter) workerUnknownVolumesMetric(logger lager.Logger
 	}
 
 	labels := prometheus.Labels{
-		"worker":   worker,
+		"worker": worker,
 	}
 
 	volumes, ok := event.Value.(int)

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -581,11 +581,11 @@ func (emitter *PrometheusEmitter) workerUnknownContainersMetric(logger lager.Log
 	}
 
 	key := serializeLabels(&labels)
-	if emitter.workerVolumesLabels[worker] == nil {
-		emitter.workerVolumesLabels[worker] = make(map[string]prometheus.Labels)
+	if emitter.workerContainersLabels[worker] == nil {
+		emitter.workerContainersLabels[worker] = make(map[string]prometheus.Labels)
 	}
-	emitter.workerVolumesLabels[worker][key] = labels
-	emitter.workerVolumes.With(emitter.workerVolumesLabels[worker][key]).Set(float64(containers))
+	emitter.workerContainersLabels[worker][key] = labels
+	emitter.workerContainers.With(emitter.workerContainersLabels[worker][key]).Set(float64(containers))
 }
 
 func (emitter *PrometheusEmitter) workerVolumesMetric(logger lager.Logger, event metric.Event) {

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -648,7 +648,7 @@ func (emitter *PrometheusEmitter) workerUnknownVolumesMetric(logger lager.Logger
 		emitter.workerVolumesLabels[worker] = make(map[string]prometheus.Labels)
 	}
 	emitter.workerVolumesLabels[worker][key] = labels
-	emitter.workerVolumes.With(emitter.workerVolumesLabels[worker][key]).Set(float64(volumes))
+	emitter.workerUnknownVolumes.With(emitter.workerVolumesLabels[worker][key]).Set(float64(volumes))
 }
 
 func (emitter *PrometheusEmitter) workerTasksMetric(logger lager.Logger, event metric.Event) {

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -585,7 +585,7 @@ func (emitter *PrometheusEmitter) workerUnknownContainersMetric(logger lager.Log
 		emitter.workerContainersLabels[worker] = make(map[string]prometheus.Labels)
 	}
 	emitter.workerContainersLabels[worker][key] = labels
-	emitter.workerContainers.With(emitter.workerContainersLabels[worker][key]).Set(float64(containers))
+	emitter.workerUnknownContainers.With(emitter.workerContainersLabels[worker][key]).Set(float64(containers))
 }
 
 func (emitter *PrometheusEmitter) workerVolumesMetric(logger lager.Logger, event metric.Event) {

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -137,6 +137,24 @@ func (event WorkerContainers) Emit(logger lager.Logger) {
 	)
 }
 
+type WorkerUnknownContainers struct {
+	WorkerName string
+	Containers int
+}
+
+func (event WorkerUnknownContainers) Emit(logger lager.Logger) {
+	emit(
+		logger.Session("worker-unknown-containers"),
+		Event{
+			Name:  "worker unknown containers",
+			Value: event.Containers,
+			State: EventStateOK,
+			Attributes: map[string]string{
+				"worker":    event.WorkerName,
+			},
+		},
+	)
+}
 type WorkerVolumes struct {
 	WorkerName string
 	Platform   string
@@ -157,6 +175,25 @@ func (event WorkerVolumes) Emit(logger lager.Logger) {
 				"platform":  event.Platform,
 				"team_name": event.TeamName,
 				"tags":      strings.Join(event.Tags[:], "/"),
+			},
+		},
+	)
+}
+
+type WorkerUnknownVolumes struct {
+	WorkerName string
+	Volumes    int
+}
+
+func (event WorkerUnknownVolumes) Emit(logger lager.Logger) {
+	emit(
+		logger.Session("worker-unknown-volumes"),
+		Event{
+			Name:  "worker unknown volumes",
+			Value: event.Volumes,
+			State: EventStateOK,
+			Attributes: map[string]string{
+				"worker":    event.WorkerName,
 			},
 		},
 	)

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -150,11 +150,12 @@ func (event WorkerUnknownContainers) Emit(logger lager.Logger) {
 			Value: event.Containers,
 			State: EventStateOK,
 			Attributes: map[string]string{
-				"worker":    event.WorkerName,
+				"worker": event.WorkerName,
 			},
 		},
 	)
 }
+
 type WorkerVolumes struct {
 	WorkerName string
 	Platform   string
@@ -193,7 +194,7 @@ func (event WorkerUnknownVolumes) Emit(logger lager.Logger) {
 			Value: event.Volumes,
 			State: EventStateOK,
 			Attributes: map[string]string{
-				"worker":    event.WorkerName,
+				"worker": event.WorkerName,
 			},
 		},
 	)

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -37,4 +37,4 @@
 
 #### <sub><sup><a name="3600" href="#3600">:link:</a></sup></sub> feature
 
-* Concourse now garbage-collects worker containers and volumes that are not tracked in the database. In some niche cases, it is possible for containers and/or volumes to be created on the worker, but the database assumes their creation had failed. If this occurs, these untracked containers can pile up on the worker and use resources. #3600 ensures that they get cleaned appropriately.
+* Concourse now garbage-collects worker containers and volumes that are not tracked in the database. In some niche cases, it is possible for containers and/or volumes to be created on the worker, but the database (via the web) assumes their creation had failed. If this occurs, these untracked containers can pile up on the worker and use resources. #3600 ensures that they get cleaned appropriately.

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -34,3 +34,7 @@
 #### <sub><sup><a name="4492" href="#4492">:link:</a></sup></sub> fix
 
 * The `fly format-pipeline` now always produces a formatted pipeline, instead of declining to do so when it was already in the expected format. #4492
+
+#### <sub><sup><a name="3600" href="#3600">:link:</a></sup></sub> feature
+
+* Concourse now garbage-collects worker containers and volumes that are not tracked in the database. In some niche cases, it is possible for containers and/or volumes to be created on the worker, but the database assumes their creation had failed. If this occurs, these untracked containers can pile up on the worker and use resources. #3600 ensures that they get cleaned appropriately.


### PR DESCRIPTION
# Existing Issue
Fixes #3600
Fixes #4571 

# Changes proposed in this pull request
*  when reporting containers from worker, create destroying containers in the db for any unknown containers
*  these new destroying containers will then get gc-ed on the next gc tick
* metrics to be added in #4571 

# Contributor Checklist
- [X] Unit tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [x] Release notes reviewed
- [ ] PR acceptance performed

