### PR TITLE
allow HTTPS *only* configuration in ATC

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -26,3 +26,6 @@
 #### <sub><sup><a name="4507" href="#4507">:link:</a></sup></sub> fix
 
 * @iamjarvo fixed a [bug](444://github.com/concourse/concourse/issues/4472) where `fly builds` would show the wrong duration for cancelled builds #4507.
+
+#### <sub><sup><a name="2958" href="#2958">:link:</a></sup></sub> feature
+* @ctorboh15 added support for a CONCOURSE_TLS_ONLY configuration that will disable the non-TLS API listener.


### PR DESCRIPTION
Fixes #2958

# Changes proposed in this pull request

added support for a CONCOURSE_TLS_ONLY configuration that will disable the non-TLS API listener.

** Note I had to reopen this as my other branch had a rogue unsigned commit that was getting out of hand **
