### PR TITLE
improve k8s-topgun resilience

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -50,7 +50,7 @@ func baggageclaimWorks(driver string, selectorFlags ...string) {
 			waitAllPodsInNamespaceToBeReady(namespace)
 
 			By("Creating the web proxy")
-			_, atcEndpoint := startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+			atcEndpoint := getExternalUrl(namespace, releaseName+"-web")
 
 			By("Logging in")
 			fly.Login("test", "test", atcEndpoint)

--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -72,7 +72,13 @@ func baggageclaimFails(driver string, selectorFlags ...string) {
 	Context(driver, func() {
 		It("fails", func() {
 			setReleaseNameAndNamespace("bd-" + driver)
-			deployWithDriverAndSelectors(driver, selectorFlags...)
+			helmDeployTestFlags := []string{
+				"--set=concourse.web.kubernetes.enabled=false",
+				"--set=concourse.worker.baggageclaim.driver=" + driver,
+				"--set=worker.replicas=1",
+			}
+
+			deployFailingConcourseChart(releaseName, "", append(helmDeployTestFlags, selectorFlags...)...)
 
 			Eventually(func() []byte {
 				workerLogsSession := Start(nil, "kubectl", "logs",

--- a/topgun/k8s/container_limits_test.go
+++ b/topgun/k8s/container_limits_test.go
@@ -41,7 +41,7 @@ func waitAndLogin() {
 	waitAllPodsInNamespaceToBeReady(namespace)
 
 	By("Creating the web proxy")
-	_, atcEndpoint := startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+	atcEndpoint := getExternalUrl(namespace, releaseName+"-web")
 
 	By("Logging in")
 	fly.Login("test", "test", atcEndpoint)

--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -3,8 +3,6 @@ package k8s_test
 import (
 	"time"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -14,8 +12,7 @@ import (
 var _ = Describe("DNS Resolution", func() {
 
 	var (
-		atcEndpoint  string
-		proxySession *gexec.Session
+		atcEndpoint string
 	)
 
 	BeforeEach(func() {
@@ -36,7 +33,7 @@ var _ = Describe("DNS Resolution", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+		atcEndpoint = getExternalUrl(namespace, releaseName+"-web")
 
 		By("Logging in")
 		fly.Login("test", "test", atcEndpoint)
@@ -57,7 +54,7 @@ var _ = Describe("DNS Resolution", func() {
 	}
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace, nil)
 	})
 
 	type Case struct {

--- a/topgun/k8s/ephemeral_worker_test.go
+++ b/topgun/k8s/ephemeral_worker_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,8 +11,7 @@ import (
 
 var _ = Describe("Ephemeral workers", func() {
 	var (
-		proxySession *gexec.Session
-		atcEndpoint  string
+		atcEndpoint string
 	)
 
 	BeforeEach(func() {
@@ -30,7 +27,7 @@ var _ = Describe("Ephemeral workers", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+		atcEndpoint = getExternalUrl(namespace, releaseName+"-web")
 
 		By("Logging in")
 		fly.Login("test", "test", atcEndpoint)
@@ -43,7 +40,7 @@ var _ = Describe("Ephemeral workers", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace, nil)
 	})
 
 	It("Gets properly cleaned when getting removed and then put back on", func() {

--- a/topgun/k8s/external_postgres_test.go
+++ b/topgun/k8s/external_postgres_test.go
@@ -3,15 +3,12 @@ package k8s_test
 import (
 	"path"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/onsi/ginkgo"
 )
 
 var _ = Describe("External PostgreSQL", func() {
 	var (
 		pgReleaseName string
-		proxySession  *gexec.Session
 		atcEndpoint   string
 	)
 
@@ -44,18 +41,15 @@ var _ = Describe("External PostgreSQL", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(
-			namespace, "service/"+releaseName+"-web", "8080")
+		atcEndpoint = getExternalUrl(namespace, releaseName+"-web")
 	})
 
 	AfterEach(func() {
 		helmDestroy(pgReleaseName)
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace, nil)
 	})
 
 	It("can have pipelines set", func() {
-		defer proxySession.Interrupt()
-
 		By("Logging in")
 		fly.Login("test", "test", atcEndpoint)
 

--- a/topgun/k8s/external_worker_test.go
+++ b/topgun/k8s/external_worker_test.go
@@ -3,8 +3,6 @@ package k8s_test
 import (
 	"time"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,7 +13,6 @@ var _ = Describe("external workers through separate deployments", func() {
 	const publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC496FSYFcBAKgDtMsBAJiF/6/NxlXKP5UZecyEsedYuTt1GOgJTwaA1qZ1LmHsbfLDE68oDdiM4uvxfI4wtLhz57w3u0jOUxZ2JeF7SVwEf1nVqLn4Gh/f8GUNQGSyIp1zUD5Bx9fq0PAyQ47mt7Ufi84rcf8LKl7nzAIHTcdg2BvTkQN9bUGPaq/Pb1W2bKPAQy4OzXTSIyrAJ89TH2jFeaZfyxQFGbD9jVHH/yl0oiMrDeaRYgccE5II+KY7WoLjsBry/9Qf2ERELKTK4UeIGIqWci9lab1ti+GxFPPiC3krNFjo4jShV4eUs4cNIrjwNrxVaKPXmU6o7Y3Hpayx Concourse"
 
 	var (
-		proxySession     *gexec.Session
 		atcEndpoint      string
 		workerKey        string
 		tsaPort          string
@@ -48,7 +45,7 @@ var _ = Describe("external workers through separate deployments", func() {
 		waitAllPodsInNamespaceToBeReady(namespace + "-web")
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace+"-web", "service/"+releaseName+"-web-web", "8080")
+		atcEndpoint = getExternalUrl(namespace+"-web", releaseName+"-web-web")
 
 		By("Logging in")
 		fly.Login("test", "test", atcEndpoint)
@@ -72,7 +69,7 @@ var _ = Describe("external workers through separate deployments", func() {
 	}
 
 	AfterEach(func() {
-		cleanup(releaseName+"-web", namespace+"-web", proxySession)
+		cleanup(releaseName+"-web", namespace+"-web", nil)
 		cleanup(releaseName+"-worker", namespace+"-worker", nil)
 	})
 

--- a/topgun/k8s/kubernetes_creds_mgmt_test.go
+++ b/topgun/k8s/kubernetes_creds_mgmt_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,10 +11,9 @@ import (
 
 var _ = Describe("Kubernetes credential management", func() {
 	var (
-		proxySession *gexec.Session
-		atcEndpoint  string
-		username     = "test"
-		password     = "test"
+		atcEndpoint string
+		username    = "test"
+		password    = "test"
 	)
 
 	BeforeEach(func() {
@@ -27,7 +24,7 @@ var _ = Describe("Kubernetes credential management", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+		atcEndpoint = getExternalUrl(namespace, releaseName+"-web")
 
 		By("Logging in")
 		fly.Login(username, password, atcEndpoint)
@@ -183,7 +180,7 @@ var _ = Describe("Kubernetes credential management", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace, nil)
 	})
 
 })

--- a/topgun/k8s/mainteam_role_test.go
+++ b/topgun/k8s/mainteam_role_test.go
@@ -1,8 +1,6 @@
 package k8s_test
 
 import (
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,7 +8,6 @@ import (
 
 var _ = Describe("Main team role config", func() {
 	var (
-		proxySession        *gexec.Session
 		atcEndpoint         string
 		helmDeployTestFlags []string
 		username            = "test-viewer"
@@ -31,7 +28,7 @@ var _ = Describe("Main team role config", func() {
 		Expect(pods).To(HaveLen(1))
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+		atcEndpoint = getExternalUrl(namespace, releaseName+"-web")
 
 		By("Logging in")
 		fly.Login(username, password, atcEndpoint)
@@ -39,7 +36,7 @@ var _ = Describe("Main team role config", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace, nil)
 	})
 
 	Context("Adding team role config yaml to web", func() {

--- a/topgun/k8s/rebalance_test.go
+++ b/topgun/k8s/rebalance_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,8 +11,7 @@ import (
 
 var _ = Describe("Worker Rebalancing", func() {
 	var (
-		proxySession *gexec.Session
-		atcEndpoint  string
+		atcEndpoint string
 	)
 
 	BeforeEach(func() {
@@ -30,7 +27,7 @@ var _ = Describe("Worker Rebalancing", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
+		atcEndpoint = getExternalUrl(namespace, releaseName+"-web")
 
 		By("Logging in")
 		fly.Login("test", "test", atcEndpoint)
@@ -43,7 +40,7 @@ var _ = Describe("Worker Rebalancing", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace, nil)
 	})
 
 	It("eventually has worker connecting to each web nodes over a period of time", func() {

--- a/topgun/k8s/web_scaling_test.go
+++ b/topgun/k8s/web_scaling_test.go
@@ -35,8 +35,7 @@ func successfullyDeploysConcourse(webReplicas, workerReplicas int) {
 	waitAllPodsInNamespaceToBeReady(namespace)
 
 	By("Creating the web proxy")
-	proxySession, atcEndpoint := startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
-	defer proxySession.Interrupt()
+	atcEndpoint := getExternalUrl(namespace, releaseName+"-web")
 
 	By("Logging in")
 	fly.Login("test", "test", atcEndpoint)

--- a/topgun/k8s/worker_lifecycle_test.go
+++ b/topgun/k8s/worker_lifecycle_test.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
@@ -14,9 +13,8 @@ import (
 var _ = Describe("Worker lifecycle", func() {
 
 	var (
-		proxySession *gexec.Session
-		atcEndpoint  string
-		gracePeriod  string
+		atcEndpoint string
+		gracePeriod string
 	)
 
 	JustBeforeEach(func() {
@@ -31,9 +29,7 @@ var _ = Describe("Worker lifecycle", func() {
 		waitAllPodsInNamespaceToBeReady(namespace)
 
 		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(
-			namespace, "service/"+releaseName+"-web", "8080",
-		)
+		atcEndpoint = getExternalUrl(namespace, releaseName+"-web")
 
 		By("Logging in")
 		fly.Login("test", "test", atcEndpoint)
@@ -72,7 +68,7 @@ var _ = Describe("Worker lifecycle", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace, nil)
 	})
 
 	Context("terminating the worker", func() {


### PR DESCRIPTION
# Existing Issue

Some improvements towards concourse/ci#182. I wouldn't say it completely fixes the issue at this point.

# Changes proposed in this pull request
There are two improvements in this PR:

1. we have found that `kubectl port-forward` seems to intermittently fail, and it has gotten worse lately. Accordingly we will not rely on it to broker our connections to the web nodes during topgun test cases; instead we actually have GKE deploy a load balancer to handle that traffic.
1. the BTRFS cases where failure was expected were making use of the wrong helper function, which meant that they could only pass in certain flaky circumstances.

# Contributor Checklist
- [X] ~Unit tests~
- [X] Integration tests (if applicable)
- [X] ~Updated documentation (located at https://github.com/concourse/docs)~
- [X] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [X] ~Code reviewed~
- [ ] Tests reviewed
- [X] ~Documentation reviewed~
- [X] ~Release notes reviewed~
- [X] ~PR acceptance performed~