### PR TITLE
use basic garden client with timeout in container sweeper

### DIFF
--- a/atc/config.go
+++ b/atc/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -13,6 +14,9 @@ import (
 const ConfigVersionHeader = "X-Concourse-Config-Version"
 const DefaultPipelineName = "main"
 const DefaultTeamName = "main"
+
+// TIMEOUT CONSTANTS
+const GARDEN_CLIENT_HTTP_TIMEOUT = 5 * time.Minute
 
 type Tags []string
 

--- a/atc/worker/db_worker_provider.go
+++ b/atc/worker/db_worker_provider.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/concourse/concourse/atc"
+
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/lager"
 	bclient "github.com/concourse/baggageclaim/client"
@@ -177,7 +179,7 @@ func (provider *dbWorkerProvider) NewGardenWorker(logger lager.Logger, tikTok cl
 		savedWorker.Name(),
 		savedWorker.GardenAddr(),
 		provider.retryBackOffFactory,
-		5*time.Minute,
+		atc.GARDEN_CLIENT_HTTP_TIMEOUT,
 	)
 
 	gClient := gcf.NewClient()

--- a/atc/worker/gclient/factory.go
+++ b/atc/worker/gclient/factory.go
@@ -70,3 +70,18 @@ func (gcf *gardenClientFactory) NewClient() Client {
 
 	return NewClient(NewRetryableConnection(connection.NewWithHijacker(hijackStreamer, gcf.logger)))
 }
+
+// Do not try any client method that requires hijack functionality (streaming logs)!
+func BasicGardenClientWithRequestTimeout(logger lager.Logger, requestTimeout time.Duration, address string) Client {
+	streamClient := &http.Client{
+		Timeout: requestTimeout,
+	}
+
+	streamer := &transport.WorkerHijackStreamer{
+		HttpClient:       streamClient,
+		HijackableClient: nil,
+		Req:              rata.NewRequestGenerator(address, routes.Routes),
+	}
+
+	return NewClient(connection.NewWithHijacker(streamer, logger))
+}

--- a/worker/container_sweeper.go
+++ b/worker/container_sweeper.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
+	"github.com/concourse/concourse/atc/worker/gclient"
 )
 
 // containerSweeper is an ifrit.Runner that periodically reports and
@@ -17,7 +18,7 @@ type containerSweeper struct {
 	logger       lager.Logger
 	interval     time.Duration
 	tsaClient    TSAClient
-	gardenClient garden.Client
+	gardenClient gclient.Client
 	maxInFlight  uint16
 }
 
@@ -25,7 +26,7 @@ func NewContainerSweeper(
 	logger lager.Logger,
 	sweepInterval time.Duration,
 	tsaClient TSAClient,
-	gardenClient garden.Client,
+	gardenClient gclient.Client,
 	maxInFlight uint16,
 ) *containerSweeper {
 	return &containerSweeper{

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/concourse/concourse/atc"
+
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/baggageclaim/baggageclaimcmd"
 	bclient "github.com/concourse/baggageclaim/client"
@@ -107,7 +109,7 @@ func (cmd *WorkerCommand) Runner(args []string) (ifrit.Runner, error) {
 
 	gardenClient := gclient.BasicGardenClientWithRequestTimeout(
 		logger.Session("garden-connection"),
-		5*time.Minute,
+		atc.GARDEN_CLIENT_HTTP_TIMEOUT,
 		cmd.gardenURL(),
 	)
 

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -108,7 +108,7 @@ func (cmd *WorkerCommand) Runner(args []string) (ifrit.Runner, error) {
 	gardenClient := gclient.BasicGardenClientWithRequestTimeout(
 		logger.Session("garden-connection"),
 		5*time.Minute,
-		cmd.gardenAddr(),
+		cmd.gardenURL(),
 	)
 
 	baggageclaimClient := bclient.NewWithHTTPClient(

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -7,12 +7,11 @@ import (
 	"path/filepath"
 	"time"
 
-	gclient "code.cloudfoundry.org/garden/client"
-	gconn "code.cloudfoundry.org/garden/client/connection"
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/baggageclaim/baggageclaimcmd"
 	bclient "github.com/concourse/baggageclaim/client"
 	"github.com/concourse/concourse"
+	"github.com/concourse/concourse/atc/worker/gclient"
 	concourseCmd "github.com/concourse/concourse/cmd"
 	"github.com/concourse/concourse/worker"
 	"github.com/concourse/flag"
@@ -106,12 +105,10 @@ func (cmd *WorkerCommand) Runner(args []string) (ifrit.Runner, error) {
 		cmd.baggageclaimAddr(),
 	)
 
-	gardenClient := gclient.New(
-		gconn.NewWithLogger(
-			"tcp",
-			cmd.gardenAddr(),
-			logger.Session("garden-connection"),
-		),
+	gardenClient := gclient.BasicGardenClientWithRequestTimeout(
+		logger.Session("garden-connection"),
+		5*time.Minute,
+		cmd.gardenAddr(),
 	)
 
 	baggageclaimClient := bclient.NewWithHTTPClient(
@@ -130,7 +127,7 @@ func (cmd *WorkerCommand) Runner(args []string) (ifrit.Runner, error) {
 			// we've seen destroy calls to baggageclaim hang and lock gc
 			// gc is periodic so we don't need to retry here, we can rely
 			// on the next sweeper tick.
-			Timeout: 5*time.Minute,
+			Timeout: 5 * time.Minute,
 		},
 	)
 


### PR DESCRIPTION
Signed-off-by: Krishna Mannem <kmannem@pivotal.io>
Co-authored-by: Divya Dadlani <ddadlani@pivotal.io>

# Existing Issue
Fixes #4467.

# Changes proposed in this pull request
> What are the changes included in this PR? Feel free to add as many lines as needed below.

* add a DefaultGardenClientWithTimeout in `gclient`
* use the new garden client in the `worker` for the `container_sweeper`
* the baggageclaim client already has a timeout set

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

