### PR TITLE
feat(fly): enable set-pipeline/validate-pipeline/execute's -c and -l options to take http/https URL.

### DIFF
--- a/atc/path_flag_test.go
+++ b/atc/path_flag_test.go
@@ -1,0 +1,182 @@
+package atc_test
+
+import (
+	"fmt"
+	"github.com/concourse/concourse/atc"
+	"github.com/jessevdk/go-flags"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+)
+
+const content = "__content__"
+
+var _ = Describe("PathFlag", func() {
+	Describe("IsURL", func() {
+		It("return true when path is a http url", func() {
+			path := atc.PathFlag(" http://a.com ")
+			Expect(path.IsURL()).To(BeTrue())
+		})
+
+		It("return true when path is a https url", func() {
+			path := atc.PathFlag(" https://a.com ")
+			Expect(path.IsURL()).To(BeTrue())
+		})
+
+		It("return false when path is a file path", func() {
+			path := atc.PathFlag("a/b.txt")
+			Expect(path.IsURL()).ToNot(BeTrue())
+		})
+	})
+
+	Describe("ReadContent", func() {
+		Context("local file", func() {
+			var (
+				tempFile *os.File
+				err      error
+			)
+			BeforeEach(func() {
+				tempFile, err = ioutil.TempFile("", "path-flag-test")
+				Expect(err).To(BeNil())
+				_, err = tempFile.Write([]byte(content))
+				Expect(err).ToNot(HaveOccurred())
+				tempFile.Close()
+			})
+			AfterEach(func() {
+				if tempFile != nil {
+					err = os.Remove(tempFile.Name())
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
+			It("should be read correctly", func() {
+				path := atc.PathFlag(tempFile.Name())
+				content, err := path.ReadContent()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(content).To(Equal([]byte(content)))
+			})
+		})
+
+		Context("http url", func() {
+			var tempServer *httptest.Server
+			BeforeEach(func() {
+				tempServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					res.Write([]byte(content))
+				}))
+			})
+			AfterEach(func() {
+				if tempServer != nil {
+					tempServer.Close()
+				}
+			})
+			It("should be read correctly", func() {
+				path := atc.PathFlag(tempServer.URL)
+				content, err := path.ReadContent()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(content).To(Equal([]byte(content)))
+			})
+			It("should fail upon invalid url", func() {
+				path := atc.PathFlag("http://fake.mycompany.com/aa.yml")
+				_, err := path.ReadContent()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("UnmarshalFlag", func() {
+		var (
+			path         atc.PathFlag
+			tempDir      string
+			err          error
+			file1, file2 string
+		)
+		BeforeEach(func() {
+			path = atc.PathFlag("")
+
+			tempDir, err = ioutil.TempDir("", "path_flag_test_unmarshalflag")
+			Expect(err).ToNot(HaveOccurred())
+
+			file1 = fmt.Sprintf("%s/aab", tempDir)
+			err = ioutil.WriteFile(file1, []byte("h"), os.ModePerm)
+			Expect(err).ToNot(HaveOccurred())
+
+			file2 = fmt.Sprintf("%s/aac", tempDir)
+			err = ioutil.WriteFile(file2, []byte("h"), os.ModePerm)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			err = os.RemoveAll(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should handle url", func() {
+			err = path.UnmarshalFlag("http://a.com")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(path)).To(Equal("http://a.com"))
+		})
+		It("should handle local file", func() {
+			err = path.UnmarshalFlag(file1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(path)).To(Equal(file1))
+		})
+		It("should fail if file not exist", func() {
+			err = path.UnmarshalFlag("dummy_file")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("path 'dummy_file' does not exist"))
+			Expect(string(path)).To(Equal(""))
+		})
+		It("should fail if filename is incomplete", func() {
+			f := fmt.Sprintf("%s/aa*", tempDir)
+			err = path.UnmarshalFlag(f)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("path '%s' resolves to multiple entries: %s, %s", f, file1, file2)))
+			Expect(string(path)).To(Equal(""))
+		})
+	})
+
+	Describe("Complete", func() {
+		var (
+			path         atc.PathFlag
+			tempDir      string
+			err          error
+			file1, file2 string
+		)
+		BeforeEach(func() {
+			path = atc.PathFlag("")
+
+			tempDir, err = ioutil.TempDir("", "path_flag_test_complete")
+			Expect(err).ToNot(HaveOccurred())
+
+			file1 = fmt.Sprintf("%s/aab", tempDir)
+			err = ioutil.WriteFile(file1, []byte("h"), os.ModePerm)
+			Expect(err).ToNot(HaveOccurred())
+
+			file2 = fmt.Sprintf("%s/aac", tempDir)
+			err = ioutil.WriteFile(file2, []byte("h"), os.ModePerm)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			err = os.RemoveAll(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should handle url", func() {
+			c := path.Complete("http://a.com")
+			Expect(c).To(Equal([]flags.Completion{}))
+		})
+		It("should handle local file", func() {
+			c := path.Complete(file1)
+			Expect(c).To(Equal([]flags.Completion{
+				flags.Completion{Item: file1},
+			}))
+		})
+		It("should handle multi-matches", func() {
+			f := fmt.Sprintf("%s/aa", tempDir)
+			c := path.Complete(f)
+			Expect(c).To(Equal([]flags.Completion{
+				flags.Completion{Item: file1},
+				flags.Completion{Item: file2},
+			}))
+		})
+	})
+})

--- a/fly/commands/internal/templatehelpers/yaml_template.go
+++ b/fly/commands/internal/templatehelpers/yaml_template.go
@@ -2,7 +2,6 @@ package templatehelpers
 
 import (
 	"fmt"
-	"io/ioutil"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
@@ -30,11 +29,10 @@ func (yamlTemplate YamlTemplateWithParams) Evaluate(
 	allowEmpty bool,
 	strict bool,
 ) ([]byte, error) {
-	config, err := ioutil.ReadFile(string(yamlTemplate.filePath))
+	config, err := yamlTemplate.filePath.ReadContent()
 	if err != nil {
-		return nil, fmt.Errorf("could not read file: %s", err.Error())
+		return nil, fmt.Errorf("could not read pipeline file (%s): %s", string(yamlTemplate.filePath), err.Error())
 	}
-
 	if strict {
 		// We use a generic map here, since templates are not evaluated yet.
 		// (else a template string may cause an error when a struct is expected)
@@ -63,7 +61,7 @@ func (yamlTemplate YamlTemplateWithParams) Evaluate(
 	// same values in the files specified earlier on command line
 	for i := len(yamlTemplate.templateVariablesFiles) - 1; i >= 0; i-- {
 		path := yamlTemplate.templateVariablesFiles[i]
-		templateVars, err := ioutil.ReadFile(string(path))
+		templateVars, err := path.ReadContent()
 		if err != nil {
 			return nil, fmt.Errorf("could not read template variables file (%s): %s", string(path), err.Error())
 		}


### PR DESCRIPTION
# Why do we need this PR?

Current `fly set-pipeline/validate-pipeline/execute` can only be fed with a local files to `-c` and `-l` options. A user must have a local copy of YAML files in order to `set-pipeline`.

Consider the following use cases:

* I want to share a pipeline template YAML file to others. Otherwise have to copy the file to their local, which has to downsides: 1) not efficient, 2) I cannot ensure others not changing the file in their local.
* I want to `set-pipeline` from my other laptop, so I have to copy files to that laptop.

With this PR, `set-pipeline` may take a http/https URL as input files, so that:
* I can share a readonly URL to others
* Storing pipeline files to shared place, say git, then I can `set-pipeline` from any computer, only need to download a `fly` binary.

This PR is very important to my team. We are planning to build a set of pipeline templates, as a lot of CI templates are very similar, so that users may quickly setup their CI pipeline without understand details of Concourse and copy YAML files to their local.

# Changes proposed in this pull request

Make `-c` and `-l` options can take http/https URL as input.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [x] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

