### PR TITLE
web: pin switching

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -19,9 +19,9 @@
 
 * All API payloads are now gzipped. This should help save bandwidth and make the web UI load faster. #4470
 
-#### <sub><sup><a name="4448" href="#4448">:link:</a></sup></sub> feature
+#### <sub><sup><a name="4448-4588" href="#4448-4588">:link:</a></sup></sub> feature
 
-* You can now use fly to pin a resource without unpinning it first. #4448
+* You can now pin a resource to different version without unpinning it first #4448, #4588.
 
 #### <sub><sup><a name="4507" href="#4507">:link:</a></sup></sub> fix
 

--- a/web/elm/src/Pinned.elm
+++ b/web/elm/src/Pinned.elm
@@ -23,6 +23,7 @@ type ResourcePinState version id comment
     | PinnedDynamicallyTo comment version
     | UnpinningFrom comment version
     | PinnedStaticallyTo version
+    | Switching comment version id
 
 
 type VersionPinState
@@ -39,7 +40,15 @@ startPinningTo :
     -> ResourcePinState version id CommentState
     -> ResourcePinState version id CommentState
 startPinningTo destination resourcePinState =
-    PinningTo destination
+    case resourcePinState of
+        NotPinned ->
+            PinningTo destination
+
+        PinnedDynamicallyTo comment version ->
+            Switching comment version destination
+
+        x ->
+            x
 
 
 finishPinning :
@@ -128,6 +137,13 @@ pinState version id resourcePinState =
 
         UnpinningFrom _ v ->
             if v == version then
+                InTransition
+
+            else
+                Disabled
+
+        Switching _ v destination ->
+            if destination == id || v == version then
                 InTransition
 
             else

--- a/web/elm/src/Pinned.elm
+++ b/web/elm/src/Pinned.elm
@@ -39,12 +39,7 @@ startPinningTo :
     -> ResourcePinState version id CommentState
     -> ResourcePinState version id CommentState
 startPinningTo destination resourcePinState =
-    case resourcePinState of
-        NotPinned ->
-            PinningTo destination
-
-        x ->
-            x
+    PinningTo destination
 
 
 finishPinning :

--- a/web/elm/src/Pinned.elm
+++ b/web/elm/src/Pinned.elm
@@ -28,6 +28,7 @@ type ResourcePinState version id comment
 type VersionPinState
     = Enabled
     | PinnedDynamically
+    | NotThePinnedVersion
     | PinnedStatically Bool
     | Disabled
     | InTransition
@@ -128,7 +129,7 @@ pinState version id resourcePinState =
                 PinnedDynamically
 
             else
-                Disabled
+                NotThePinnedVersion
 
         UnpinningFrom _ v ->
             if v == version then

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -175,7 +175,7 @@ updatePinnedVersion resource model =
                                 newVersion
                     }
 
-                Switching c v id ->
+                Switching _ v _ ->
                     if v == newVersion then
                         model
 
@@ -1383,7 +1383,7 @@ viewVersionedResource :
     , hovered : HoverState.HoverState
     }
     -> Html Message
-viewVersionedResource { version, pinnedVersion, hovered } =
+viewVersionedResource { version, hovered } =
     Html.li
         (case ( version.pinState, version.enabled ) of
             ( Disabled, _ ) ->

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -572,12 +572,23 @@ update msg ( model, effects ) =
                         |> List.Extra.find (\v -> v.id == versionID)
             in
             case model.pinnedVersion of
-                PinnedDynamicallyTo _ _ ->
+                PinnedDynamicallyTo _ v ->
                     ( { model
                         | pinnedVersion =
                             Pinned.startUnpinning model.pinnedVersion
                       }
-                    , effects ++ [ DoUnpinVersion model.resourceIdentifier ]
+                    , effects
+                        ++ (case version of
+                                Just vn ->
+                                    if vn.version == v then
+                                        [ DoUnpinVersion model.resourceIdentifier ]
+
+                                    else
+                                        [ DoPinVersion vn.id ]
+
+                                Nothing ->
+                                    []
+                           )
                     )
 
                 NotPinned ->
@@ -1309,6 +1320,9 @@ viewVersionedResource { version, pinnedVersion, hovered } =
             ( Disabled, _ ) ->
                 [ style "opacity" "0.5" ]
 
+            ( NotThePinnedVersion, _ ) ->
+                [ style "opacity" "0.5" ]
+
             ( _, Models.Disabled ) ->
                 [ style "opacity" "0.5" ]
 
@@ -1433,6 +1447,9 @@ viewPinButton { versionID, pinState, hovered } =
                     [ onClick <| Click <| PinButton versionID ]
 
                 PinnedDynamically ->
+                    [ onClick <| Click <| PinButton versionID ]
+
+                NotThePinnedVersion ->
                     [ onClick <| Click <| PinButton versionID ]
 
                 PinnedStatically _ ->

--- a/web/elm/src/Resource/Styles.elm
+++ b/web/elm/src/Resource/Styles.elm
@@ -148,6 +148,9 @@ pinButton pinState =
             Pinned.PinnedDynamically ->
                 "pointer"
 
+            Pinned.NotThePinnedVersion ->
+                "pointer"
+
             Pinned.PinnedStatically _ ->
                 "default"
 

--- a/web/elm/tests/Common.elm
+++ b/web/elm/tests/Common.elm
@@ -1,5 +1,6 @@
 module Common exposing
-    ( contains
+    ( and
+    , contains
     , defineHoverBehaviour
     , given
     , iOpenTheBuildPage
@@ -111,6 +112,10 @@ init path =
 
 
 given =
+    identity
+
+
+and =
     identity
 
 

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -1,6 +1,15 @@
-module Data exposing (check)
+module Data exposing
+    ( check
+    , pipelineName
+    , resource
+    , resourceName
+    , teamName
+    , version
+    , versionedResource
+    )
 
 import Concourse
+import Dict exposing (Dict)
 import Time
 
 
@@ -33,3 +42,45 @@ check status =
             , endTime = Just <| Time.millisToPosix 1000
             , checkError = Just "something broke"
             }
+
+
+resource : String -> Concourse.Resource
+resource pinnedVersion =
+    { teamName = teamName
+    , pipelineName = pipelineName
+    , name = resourceName
+    , failingToCheck = False
+    , checkError = ""
+    , checkSetupError = ""
+    , lastChecked = Nothing
+    , pinnedVersion = Just <| version pinnedVersion
+    , pinnedInConfig = False
+    , pinComment = Nothing
+    , icon = Nothing
+    }
+
+
+teamName =
+    "team"
+
+
+pipelineName =
+    "pipeline"
+
+
+resourceName =
+    "resource"
+
+
+versionedResource : String -> Int -> Concourse.VersionedResource
+versionedResource v id =
+    { id = id
+    , version = version v
+    , metadata = []
+    , enabled = True
+    }
+
+
+version : String -> Dict String String
+version v =
+    Dict.fromList [ ( "version", v ) ]

--- a/web/elm/tests/PinnedTests.elm
+++ b/web/elm/tests/PinnedTests.elm
@@ -31,5 +31,5 @@ all =
                     }
                     0
                     |> Pinned.startPinningTo 1
-                    |> Expect.equal (PinningTo 1)
+                    |> Expect.equal (Switching { comment = "", pristineComment = "" } 0 1)
         ]

--- a/web/elm/tests/PinnedTests.elm
+++ b/web/elm/tests/PinnedTests.elm
@@ -1,0 +1,24 @@
+module PinnedTests exposing (all)
+
+import Expect
+import Pinned exposing (ResourcePinState(..), VersionPinState(..))
+import Test exposing (Test, test)
+
+
+all : Test
+all =
+    test
+        ("when resource is dynamically pinned, other versions are "
+            ++ "NotThePinnedVersion"
+        )
+    <|
+        \_ ->
+            Pinned.pinState 1
+                0
+                (PinnedDynamicallyTo
+                    { comment = ""
+                    , pristineComment = ""
+                    }
+                    0
+                )
+                |> Expect.equal NotThePinnedVersion

--- a/web/elm/tests/PinnedTests.elm
+++ b/web/elm/tests/PinnedTests.elm
@@ -2,23 +2,34 @@ module PinnedTests exposing (all)
 
 import Expect
 import Pinned exposing (ResourcePinState(..), VersionPinState(..))
-import Test exposing (Test, test)
+import Test exposing (Test, describe, test)
 
 
 all : Test
 all =
-    test
-        ("when resource is dynamically pinned, other versions are "
-            ++ "NotThePinnedVersion"
-        )
-    <|
-        \_ ->
-            Pinned.pinState 1
-                0
-                (PinnedDynamicallyTo
+    describe "Pinned"
+        [ test
+            ("when resource is dynamically pinned, other versions are "
+                ++ "NotThePinnedVersion"
+            )
+          <|
+            \_ ->
+                Pinned.pinState 1
+                    0
+                    (PinnedDynamicallyTo
+                        { comment = ""
+                        , pristineComment = ""
+                        }
+                        0
+                    )
+                    |> Expect.equal NotThePinnedVersion
+        , test "startPinningTo allows switching without unpinning" <|
+            \_ ->
+                PinnedDynamicallyTo
                     { comment = ""
                     , pristineComment = ""
                     }
                     0
-                )
-                |> Expect.equal NotThePinnedVersion
+                    |> Pinned.startPinningTo 1
+                    |> Expect.equal (PinningTo 1)
+        ]

--- a/web/elm/tests/ResourceFeature.elm
+++ b/web/elm/tests/ResourceFeature.elm
@@ -30,6 +30,11 @@ all =
                 >> and theResourceIsAlreadyPinned
                 >> when iClickTheVersionThatIsNotPinned
                 >> then_ myBrowserSendsAPinResourceRequest
+        , test "clicking pinned version sends UnpinResource request" <|
+            given iAmOnTheResourcePage
+                >> and theResourceIsAlreadyPinned
+                >> when iClickTheVersionThatIsPinned
+                >> then_ myBrowserSendsAnUnpinResourceRequest
         ]
 
 
@@ -93,15 +98,27 @@ iSeeItIsClickable =
     Expect.all
         [ Query.has [ style "cursor" "pointer" ]
         , Event.simulate Event.click
-            >> Event.expect (Update <| Message.Click <| PinButton versionID)
+            >> Event.expect (Update <| Message.Click <| PinButton unpinnedVersionID)
         ]
 
 
 iClickTheVersionThatIsNotPinned =
-    Application.update (Update <| (Message.Click <| PinButton versionID))
+    Application.update (Update <| (Message.Click <| PinButton unpinnedVersionID))
 
 
-versionID =
+iClickTheVersionThatIsPinned =
+    Application.update (Update <| (Message.Click <| PinButton pinnedVersionID))
+
+
+pinnedVersionID =
+    { teamName = Data.teamName
+    , pipelineName = Data.pipelineName
+    , resourceName = Data.resourceName
+    , versionID = 0
+    }
+
+
+unpinnedVersionID =
     { teamName = Data.teamName
     , pipelineName = Data.pipelineName
     , resourceName = Data.resourceName
@@ -109,5 +126,16 @@ versionID =
     }
 
 
+resourceID =
+    { teamName = Data.teamName
+    , pipelineName = Data.pipelineName
+    , resourceName = Data.resourceName
+    }
+
+
 myBrowserSendsAPinResourceRequest =
-    Tuple.second >> Common.contains (Effects.DoPinVersion versionID)
+    Tuple.second >> Common.contains (Effects.DoPinVersion unpinnedVersionID)
+
+
+myBrowserSendsAnUnpinResourceRequest =
+    Tuple.second >> Common.contains (Effects.DoUnpinVersion resourceID)

--- a/web/elm/tests/ResourceFeature.elm
+++ b/web/elm/tests/ResourceFeature.elm
@@ -1,0 +1,113 @@
+module ResourceFeature exposing (all)
+
+import Application.Application as Application
+import Common exposing (and, given, then_, when)
+import Data
+import Dict
+import Expect
+import Html.Attributes as Attr
+import Message.Callback as Callback
+import Message.Effects as Effects
+import Message.Message as Message exposing (DomID(..))
+import Message.TopLevelMessage exposing (TopLevelMessage(..))
+import Test exposing (Test, describe, test)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (attribute, containing, style, tag, text)
+
+
+all : Test
+all =
+    describe "Resource page"
+        [ test "unpinned versions are clickable" <|
+            given iAmOnTheResourcePage
+                >> and theResourceIsAlreadyPinned
+                >> and iAmLookingAtAVersionOtherThanThePinnedOne
+                >> when iAmLookingAtThePinButton
+                >> then_ iSeeItIsClickable
+        , test "clicking unpinned version sends PinResource request" <|
+            given iAmOnTheResourcePage
+                >> and theResourceIsAlreadyPinned
+                >> when iClickTheVersionThatIsNotPinned
+                >> then_ myBrowserSendsAPinResourceRequest
+        ]
+
+
+iAmOnTheResourcePage _ =
+    Common.init
+        ("/teams/"
+            ++ Data.teamName
+            ++ "/pipelines/"
+            ++ Data.pipelineName
+            ++ "/resources/"
+            ++ Data.resourceName
+        )
+
+
+theResourceIsAlreadyPinned =
+    Application.handleCallback
+        (Callback.ResourceFetched <| Ok <| Data.resource pinnedVersion)
+        >> Tuple.first
+        >> Application.handleCallback
+            (Callback.VersionedResourcesFetched <|
+                Ok
+                    ( Nothing
+                    , { content =
+                            [ Data.versionedResource pinnedVersion 0
+                            , Data.versionedResource notThePinnedVersion 1
+                            ]
+                      , pagination =
+                            { previousPage = Nothing
+                            , nextPage = Nothing
+                            }
+                      }
+                    )
+            )
+        >> Tuple.first
+
+
+pinnedVersion =
+    "pinned-version"
+
+
+notThePinnedVersion =
+    "not-the-pinned-version"
+
+
+iAmLookingAtAVersionOtherThanThePinnedOne =
+    Common.queryView
+        >> Query.find
+            [ tag "li"
+            , containing [ text notThePinnedVersion ]
+            ]
+
+
+iAmLookingAtThePinButton =
+    Query.find
+        [ attribute <|
+            Attr.attribute "aria-label" "Pin Resource Version"
+        ]
+
+
+iSeeItIsClickable =
+    Expect.all
+        [ Query.has [ style "cursor" "pointer" ]
+        , Event.simulate Event.click
+            >> Event.expect (Update <| Message.Click <| PinButton versionID)
+        ]
+
+
+iClickTheVersionThatIsNotPinned =
+    Application.update (Update <| (Message.Click <| PinButton versionID))
+
+
+versionID =
+    { teamName = Data.teamName
+    , pipelineName = Data.pipelineName
+    , resourceName = Data.resourceName
+    , versionID = 1
+    }
+
+
+myBrowserSendsAPinResourceRequest =
+    Tuple.second >> Common.contains (Effects.DoPinVersion versionID)

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -1,6 +1,7 @@
 module ResourceTests exposing (all)
 
 import Application.Application as Application
+import Application.Models exposing (Session)
 import Common exposing (defineHoverBehaviour, queryView)
 import Concourse
 import Concourse.Pagination exposing (Direction(..))
@@ -14,6 +15,7 @@ import DashboardTests
 import Data
 import Dict
 import Expect exposing (..)
+import HoverState
 import Html.Attributes as Attr
 import Http
 import Keyboard
@@ -26,8 +28,13 @@ import Message.Subscription as Subscription
         , Interval(..)
         )
 import Message.TopLevelMessage as Msgs
+import Pinned exposing (VersionPinState(..))
+import RemoteData
 import Resource.Models as Models
+import Resource.Resource as Resource
 import Routes
+import ScreenSize
+import Set
 import Test exposing (..)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
@@ -1095,166 +1102,289 @@ all =
                 ]
             ]
         , describe "given resource is pinned dynamically"
-            [ test "when mousing over pin bar, tooltip does not appear" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> queryView
-                        |> Query.find [ id "pin-bar" ]
-                        |> Event.simulate Event.mouseEnter
-                        |> Event.toResult
-                        |> Expect.err
-            , test "pin icon on pin bar has pointer cursor" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> queryView
-                        |> Query.find [ id "pin-icon" ]
-                        |> Query.has pointerCursor
-            , test "clicking pin icon on bar triggers UnpinVersion msg" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> queryView
-                        |> Query.find [ id "pin-icon" ]
-                        |> Event.simulate Event.click
-                        |> Event.expect
-                            (Msgs.Update <|
-                                Message.Message.Click Message.Message.PinIcon
-                            )
-            , test "mousing over pin icon triggers PinIconHover msg" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> queryView
-                        |> Query.find [ id "pin-icon" ]
-                        |> Event.simulate Event.mouseEnter
-                        |> Event.expect
-                            (Msgs.Update <|
-                                Message.Message.Hover <|
+            [ describe "pin bar"
+                [ test "when mousing over pin bar, tooltip does not appear" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> queryView
+                            |> Query.find [ id "pin-bar" ]
+                            |> Event.simulate Event.mouseEnter
+                            |> Event.toResult
+                            |> Expect.err
+                , test "pin icon on pin bar has pointer cursor" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> queryView
+                            |> Query.find [ id "pin-icon" ]
+                            |> Query.has pointerCursor
+                , test "clicking pin icon on bar triggers UnpinVersion msg" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> queryView
+                            |> Query.find [ id "pin-icon" ]
+                            |> Event.simulate Event.click
+                            |> Event.expect
+                                (Msgs.Update <|
+                                    Message.Message.Click Message.Message.PinIcon
+                                )
+                , test "mousing over pin icon triggers PinIconHover msg" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> queryView
+                            |> Query.find [ id "pin-icon" ]
+                            |> Event.simulate Event.mouseEnter
+                            |> Event.expect
+                                (Msgs.Update <|
+                                    Message.Message.Hover <|
+                                        Just Message.Message.PinIcon
+                                )
+                , test "TogglePinIconHover msg causes pin icon to have dark background" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> update
+                                (Message.Message.Hover <|
                                     Just Message.Message.PinIcon
-                            )
-            , test "TogglePinIconHover msg causes pin icon to have dark background" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> update
-                            (Message.Message.Hover <|
-                                Just Message.Message.PinIcon
-                            )
-                        |> Tuple.first
-                        |> queryView
-                        |> Query.find [ id "pin-icon" ]
-                        |> Query.has [ style "background-color" darkGreyHex ]
-            , test "mousing off pin icon triggers Hover Nothing msg" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> update
-                            (Message.Message.Hover <|
-                                Just Message.Message.PinIcon
-                            )
-                        |> Tuple.first
-                        |> queryView
-                        |> Query.find [ id "pin-icon" ]
-                        |> Event.simulate Event.mouseLeave
-                        |> Event.expect
-                            (Msgs.Update <| Message.Message.Hover <| Nothing)
-            , test "second TogglePinIconHover msg causes pin icon to have transparent background color" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> update
-                            (Message.Message.Hover <|
-                                Just Message.Message.PinIcon
-                            )
-                        |> Tuple.first
-                        |> update (Message.Message.Hover Nothing)
-                        |> Tuple.first
-                        |> queryView
-                        |> Query.find [ id "pin-icon" ]
-                        |> Query.has [ style "background-color" "transparent" ]
-            , test "pin button on pinned version has a purple outline" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> Query.find pinButtonSelector
-                        |> Query.has purpleOutlineSelector
-            , test "checkbox on pinned version has a purple outline" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> Query.find checkboxSelector
-                        |> Query.has purpleOutlineSelector
-            , test "pin button on pinned version has a pointer cursor" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> Query.find pinButtonSelector
-                        |> Query.has pointerCursor
-            , test "pin button on an unpinned version has a pointer cursor" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> queryView
-                        |> Query.find (versionSelector otherVersion)
-                        |> Query.find pinButtonSelector
-                        |> Query.has pointerCursor
-            , test "pin button on pinned version has click handler" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> Query.find pinButtonSelector
-                        |> Event.simulate Event.click
-                        |> Event.expect
-                            (Msgs.Update <|
-                                Message.Message.Click <|
-                                    Message.Message.PinButton versionID
-                            )
-            , test "pin button on pinned version shows transition state when (UnpinVersion) is received" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> clickToUnpin
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> Query.find pinButtonSelector
-                        |> pinButtonHasTransitionState
-            , test "pin button on 'v1' still shows transition state on autorefresh before VersionUnpinned is recieved" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> clickToUnpin
-                        |> givenResourcePinnedDynamically
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> Query.find pinButtonSelector
-                        |> pinButtonHasTransitionState
-            , test "pin bar shows unpinned state when upon successful VersionUnpinned msg" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> clickToUnpin
-                        |> Application.handleCallback (Callback.VersionUnpinned (Ok ()))
-                        |> Tuple.first
-                        |> queryView
-                        |> pinBarHasUnpinnedState
+                                )
+                            |> Tuple.first
+                            |> queryView
+                            |> Query.find [ id "pin-icon" ]
+                            |> Query.has [ style "background-color" darkGreyHex ]
+                , test "mousing off pin icon triggers Hover Nothing msg" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> update
+                                (Message.Message.Hover <|
+                                    Just Message.Message.PinIcon
+                                )
+                            |> Tuple.first
+                            |> queryView
+                            |> Query.find [ id "pin-icon" ]
+                            |> Event.simulate Event.mouseLeave
+                            |> Event.expect
+                                (Msgs.Update <| Message.Message.Hover <| Nothing)
+                , test "second TogglePinIconHover msg causes pin icon to have transparent background color" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> update
+                                (Message.Message.Hover <|
+                                    Just Message.Message.PinIcon
+                                )
+                            |> Tuple.first
+                            |> update (Message.Message.Hover Nothing)
+                            |> Tuple.first
+                            |> queryView
+                            |> Query.find [ id "pin-icon" ]
+                            |> Query.has [ style "background-color" "transparent" ]
+                , test "pin bar shows unpinned state when upon successful VersionUnpinned msg" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> clickToUnpin
+                            |> Application.handleCallback (Callback.VersionUnpinned (Ok ()))
+                            |> Tuple.first
+                            |> queryView
+                            |> pinBarHasUnpinnedState
+                , test "pin bar shows unpinned state upon receiving failing (VersionUnpinned) msg" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> clickToUnpin
+                            |> Application.handleCallback (Callback.VersionUnpinned badResponse)
+                            |> Tuple.first
+                            |> queryView
+                            |> pinBarHasPinnedState version
+                , test "pin icon on pin bar is white" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> queryView
+                            |> Query.find [ id "pin-icon" ]
+                            |> Query.has [ style "background-image" "url(/public/images/pin-ic-white.svg)" ]
+                ]
+            , describe "versions list"
+                [ test "pin button on pinned version has a purple outline" <|
+                    \_ ->
+                        Resource.init
+                            { resourceId =
+                                { teamName = teamName
+                                , pipelineName = pipelineName
+                                , resourceName = resourceName
+                                }
+                            , paging = Nothing
+                            }
+                            |> Resource.handleCallback
+                                (Callback.ResourceFetched <|
+                                    Ok
+                                        { teamName = teamName
+                                        , pipelineName = pipelineName
+                                        , name = resourceName
+                                        , failingToCheck = False
+                                        , checkError = ""
+                                        , checkSetupError = ""
+                                        , lastChecked = Nothing
+                                        , pinnedVersion = Just (Dict.fromList [ ( "version", version ) ])
+                                        , pinnedInConfig = False
+                                        , pinComment = Nothing
+                                        , icon = Nothing
+                                        }
+                                )
+                                session
+                            |> Resource.handleCallback
+                                (Callback.VersionedResourcesFetched <|
+                                    Ok
+                                        ( Nothing
+                                        , { content =
+                                                [ { id = versionID.versionID
+                                                  , version = Dict.fromList [ ( "version", version ) ]
+                                                  , metadata = []
+                                                  , enabled = True
+                                                  }
+                                                , { id = otherVersionID.versionID
+                                                  , version = Dict.fromList [ ( "version", otherVersion ) ]
+                                                  , metadata = []
+                                                  , enabled = True
+                                                  }
+                                                , { id = disabledVersionID.versionID
+                                                  , version = Dict.fromList [ ( "version", disabledVersion ) ]
+                                                  , metadata = []
+                                                  , enabled = False
+                                                  }
+                                                ]
+                                          , pagination =
+                                                { previousPage = Nothing
+                                                , nextPage = Nothing
+                                                }
+                                          }
+                                        )
+                                )
+                                session
+                            |> Tuple.first
+                            |> Resource.versions
+                            |> List.map .pinState
+                            |> Expect.equal
+                                [ PinnedDynamically
+                                , NotThePinnedVersion
+                                , NotThePinnedVersion
+                                ]
+                , test "checkbox on pinned version has a purple outline" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> queryView
+                            |> Query.find (versionSelector version)
+                            |> Query.find checkboxSelector
+                            |> Query.has purpleOutlineSelector
+                , test "pin button on pinned version has a pointer cursor" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> queryView
+                            |> Query.find (versionSelector version)
+                            |> Query.find pinButtonSelector
+                            |> Query.has pointerCursor
+                , test "pin button on an unpinned version has a pointer cursor" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> queryView
+                            |> Query.find (versionSelector otherVersion)
+                            |> Query.find pinButtonSelector
+                            |> Query.has pointerCursor
+                , test "pin button on pinned version has click handler" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> queryView
+                            |> Query.find (versionSelector version)
+                            |> Query.find pinButtonSelector
+                            |> Event.simulate Event.click
+                            |> Event.expect
+                                (Msgs.Update <|
+                                    Message.Message.Click <|
+                                        Message.Message.PinButton versionID
+                                )
+                , test "pin button on pinned version shows transition state when (UnpinVersion) is received" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> clickToUnpin
+                            |> queryView
+                            |> Query.find (versionSelector version)
+                            |> Query.find pinButtonSelector
+                            |> pinButtonHasTransitionState
+                , test "pin button on 'v1' still shows transition state on autorefresh before VersionUnpinned is recieved" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> clickToUnpin
+                            |> givenResourcePinnedDynamically
+                            |> queryView
+                            |> Query.find (versionSelector version)
+                            |> Query.find pinButtonSelector
+                            |> pinButtonHasTransitionState
+                , test "version header on pinned version has a purple outline" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> queryView
+                            |> Query.find (versionSelector version)
+                            |> findLast [ tag "div", containing [ text version ] ]
+                            |> Query.has purpleOutlineSelector
+                , test "pin button on pinned version has a white icon" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> queryView
+                            |> Query.find (versionSelector version)
+                            |> Query.find pinButtonSelector
+                            |> Query.has [ style "background-image" "url(/public/images/pin-ic-white.svg)" ]
+                , test "does not show tooltip on the pin button on ToggleVersionTooltip" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> hoverOverPinButton
+                            |> queryView
+                            |> Query.find (versionSelector version)
+                            |> Query.hasNot versionTooltipSelector
+                , test "unpinned versions are lower opacity" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedDynamically
+                            |> givenVersionsWithoutPagination
+                            |> queryView
+                            |> Query.find (versionSelector otherVersion)
+                            |> Query.has [ style "opacity" "0.5" ]
+                , test "all pin buttons have dark background" <|
+                    \_ ->
+                        init
+                            |> givenResourceIsNotPinned
+                            |> givenVersionsWithoutPagination
+                            |> queryView
+                            |> Query.find [ class "resource-versions" ]
+                            |> Query.findAll anyVersionSelector
+                            |> Query.each
+                                (Query.find pinButtonSelector
+                                    >> Query.has [ style "background-color" "#1e1d1d" ]
+                                )
+                ]
             , test "resource refreshes on successful VersionUnpinned msg" <|
                 \_ ->
                     init
@@ -1270,78 +1400,14 @@ all =
                                 , teamName = teamName
                                 }
                             ]
-            , test "pin bar shows unpinned state upon receiving failing (VersionUnpinned) msg" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> clickToUnpin
-                        |> Application.handleCallback (Callback.VersionUnpinned badResponse)
-                        |> Tuple.first
-                        |> queryView
-                        |> pinBarHasPinnedState version
-            , test "version header on pinned version has a purple outline" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> findLast [ tag "div", containing [ text version ] ]
-                        |> Query.has purpleOutlineSelector
-            , test "pin button on pinned version has a white icon" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> Query.find pinButtonSelector
-                        |> Query.has [ style "background-image" "url(/public/images/pin-ic-white.svg)" ]
-            , test "does not show tooltip on the pin button on ToggleVersionTooltip" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> hoverOverPinButton
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> Query.hasNot versionTooltipSelector
-            , test "unpinned versions are lower opacity" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> givenVersionsWithoutPagination
-                        |> queryView
-                        |> Query.find (versionSelector otherVersion)
-                        |> Query.has [ style "opacity" "0.5" ]
-            , test "pin icon on pin bar is white" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedDynamically
-                        |> queryView
-                        |> Query.find [ id "pin-icon" ]
-                        |> Query.has [ style "background-image" "url(/public/images/pin-ic-white.svg)" ]
-            , test "all pin buttons have dark background" <|
-                \_ ->
-                    init
-                        |> givenResourceIsNotPinned
-                        |> givenVersionsWithoutPagination
-                        |> queryView
-                        |> Query.find [ class "resource-versions" ]
-                        |> Query.findAll anyVersionSelector
-                        |> Query.each
-                            (Query.find pinButtonSelector
-                                >> Query.has [ style "background-color" "#1e1d1d" ]
-                            )
-            , test "pin comment bar is visible" <|
-                \_ ->
-                    init
-                        |> givenResourcePinnedWithComment
-                        |> queryView
-                        |> Query.has [ id "comment-bar" ]
             , describe "pin comment bar" <|
-                [ test "pin comment bar has dark background" <|
+                [ test "pin comment bar is visible" <|
+                    \_ ->
+                        init
+                            |> givenResourcePinnedWithComment
+                            |> queryView
+                            |> Query.has [ id "comment-bar" ]
+                , test "pin comment bar has dark background" <|
                     \_ ->
                         init
                             |> givenResourcePinnedWithComment
@@ -3609,3 +3675,21 @@ versionHasDisabledState =
         , Query.find checkboxSelector
             >> checkboxHasDisabledState
         ]
+
+
+session : Session
+session =
+    { userState = UserStateUnknown
+    , hovered = HoverState.NoHover
+    , clusterName = ""
+    , turbulenceImgSrc = flags.turbulenceImgSrc
+    , notFoundImgSrc = flags.notFoundImgSrc
+    , csrfToken = flags.csrfToken
+    , authToken = flags.authToken
+    , pipelineRunningKeyframes = flags.pipelineRunningKeyframes
+    , expandedTeams = Set.empty
+    , pipelines = RemoteData.NotAsked
+    , isSideBarOpen = False
+    , screenSize = ScreenSize.Desktop
+    , timeZone = Time.utc
+    }

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -202,7 +202,7 @@ all =
                                     Routes.Normal Nothing
                         ]
             ]
-        , test "has title with resouce name" <|
+        , test "has title with resource name" <|
             \_ ->
                 init
                     |> Application.view

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -1201,7 +1201,7 @@ all =
                         |> Query.find (versionSelector version)
                         |> Query.find pinButtonSelector
                         |> Query.has pointerCursor
-            , test "pin button on an unpinned version has a default cursor" <|
+            , test "pin button on an unpinned version has a pointer cursor" <|
                 \_ ->
                     init
                         |> givenResourcePinnedDynamically
@@ -1209,7 +1209,7 @@ all =
                         |> queryView
                         |> Query.find (versionSelector otherVersion)
                         |> Query.find pinButtonSelector
-                        |> Query.has defaultCursor
+                        |> Query.has pointerCursor
             , test "pin button on pinned version has click handler" <|
                 \_ ->
                     init


### PR DESCRIPTION
# Existing Issue

Fixes #4561.

# Changes proposed in this pull request

* pin buttons on versions other than the pinned one are now clickable.
* clicking them will hit the PinVersion API appropriately
* there are reasonably-graceful visual transition states (spinners on both versions being switched between).

# Contributor Checklist
- [X] Unit tests
- [X] ~Integration tests (if applicable)~
- [X] ~Updated documentation (located at https://github.com/concourse/docs)~
- [X] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] Documentation reviewed
- [x] Release notes reviewed
- [x] PR acceptance performed