### PR TITLE
github: update PR template to focus on "why"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,38 +1,58 @@
-> Please remove all the lines starting with '>'
-> Hi there! Thanks for submitting a pull request to Concourse! 
-> If you haven't already, please take a look at our [Code of Conduct](https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md) and our [Contributing Guide](https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md).
-> 
+> Hi there! Thanks for submitting a pull request to Concourse!
+
+> If you haven't already, please take a look at our [Code of Conduct] and our
+> [Contributing Guide]. There are certain anti-patterns that we try to avoid -
+> check the [Anti-patterns page] to now more.
+
 > To help us review your PR, please fill in the following information.
-> Feel free to delete any sections not applicable to your pull request.
 
-# Existing Issue
-> Is there an existing issue related to this PR? Fill in the issue number as follows: Fixes #1234.
-
-Fixes # .
-
-# Why do we need this PR?
-> No issue number? Please give us a few lines of context describing the need for this PR.
-> Please review the [Anti-patterns page](https://github.com/concourse/concourse/wiki/Anti-Patterns) first.
+> Also, before submitting, please remove all the lines starting with '>'.
 
 
-# Changes proposed in this pull request
-> What are the changes included in this PR? Feel free to add as many lines as needed below.
+[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
+[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
+[Anti-patterns page]: https://github.com/concourse/concourse/wiki/Anti-Patterns
 
-* 
-* 
-*
+
+# Why is this PR needed?
+
+> There must be a reason why the change being submitted is necessary.
+> Why is Concourse worse off without it?
+
+
+
+# What is this PR trying to accomplish?
+
+> What is the end goal of this PR?
+> What is it trying to solve / improve / add?
+> Is there an existing issue related to this PR? Fill in the issue number as follows: closes #1234.
+
+closes # .
+
+
+# How does it accomplish that?
+
+> What is the approach that you took to get to the end goal of this PR?
+> Succintly, what are the changes included in this PR?
+
+
 
 # Contributor Checklist
-> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
+
+> Are the following items included as part of this PR? If no, please say why not.
+
 - [ ] Unit tests
-- [ ] Integration tests (if applicable)
+- [ ] Integration tests
 - [ ] Updated documentation (located at https://github.com/concourse/docs)
 - [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)
 
 
 # Reviewer Checklist
-> This section is intended for the core maintainers only, to track review progress. Please do not
-> fill out this section.
+
+> This section is intended for the core maintainers only, to track review progress.
+
+> Please do not fill out this section.
+
 - [ ] Code reviewed
 - [ ] Tests reviewed
 - [ ] Documentation reviewed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 > If you haven't already, please take a look at our [Code of Conduct] and our
 > [Contributing Guide]. There are certain anti-patterns that we try to avoid -
-> check the [Anti-patterns page] to now more.
+> check the [Anti-patterns page] to know more.
 
 > To help us review your PR, please fill in the following information.
 
@@ -33,7 +33,7 @@ closes # .
 # How does it accomplish that?
 
 > What is the approach that you took to get to the end goal of this PR?
-> Succintly, what are the changes included in this PR?
+> Succinctly, what are the changes included in this PR?
 
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,7 @@ closes # .
 # How does it accomplish that?
 
 > What is the approach that you took to get to the end goal of this PR?
-> Succinctly, what are the changes included in this PR?
+> Briefly, what are the changes included in this PR?
 
 
 


### PR DESCRIPTION
### Why do we need this PR?

Previously, the PR template was very focused on describing the changes
that were made, leaving less space for a presentation of why the given
change is even needed in the first place.

Although it did incentivize the user to provide an issue (where previous
discussion would've been held), it's not always the case that a given PR
is a 1:1 with the issue that it references.

By forcing ourselves to reiterate why we're submitting the PR, it might
prompt us to better think about whether we're solving the problem in the
right way.

### Changes proposed in this pull request

- have a section specifically focused on reiterating why a given PR is needed

This is supposed to lead us to rethinking not only whether PR is important or
not, but also communicate the impact of it.

- have another section focused only on what the PR is fixing.

With a section like this, we can better understand whether the PR that we're
claiming to be important something tangible that is necessary given the "why"
the PR is needed in the first place.

Naturally, huge PRs would make this section very big and complicated, bringing a
smell that the PR would be pretty scary to review, hard to understand and thus,
very likely to need to be broken into smaller pieces.


### Contributor Checklist


N/A


### Reviewer Checklist


- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

