### PR TITLE
[WIP] fix pagination params when building url

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -26,3 +26,7 @@
 #### <sub><sup><a name="4507" href="#4507">:link:</a></sup></sub> fix
 
 * @iamjarvo fixed a [bug](444://github.com/concourse/concourse/issues/4472) where `fly builds` would show the wrong duration for cancelled builds #4507.
+
+#### <sub><sup><a name="4596" href="#4596">:link:</a></sup></sub> fix
+
+* Pagination on the resources page will now properly respect the `to`, `from`, and `until` URL parameters #4596.

--- a/web/elm/src/Network/Pagination.elm
+++ b/web/elm/src/Network/Pagination.elm
@@ -64,13 +64,13 @@ params p =
                     Url.Builder.int "since" since
 
                 Until until ->
-                    Url.Builder.int "limit" until
+                    Url.Builder.int "until" until
 
                 From from ->
-                    Url.Builder.int "limit" from
+                    Url.Builder.int "from" from
 
                 To to ->
-                    Url.Builder.int "limit" to
+                    Url.Builder.int "to" to
             ]
 
         Nothing ->


### PR DESCRIPTION
# Why do we need this PR?
Resource pagination doesn't exactly work as intended. The `to`, `from`, and `until` parameters were being overwritten with `limit`. That would lead to urls like `Request URL: https://ci.concourse-ci.org/api/v1/teams/main/pipelines/concourse/resources/concourse/versions?limit=79&limit=60846285`. Which just doesn't make sense!

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

