### PR TITLE
Fix resource types tree lookup when resource type name and type are the same

### DIFF
--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -57,7 +57,7 @@ type ResourceTypes []ResourceType
 func (resourceTypes ResourceTypes) Parent(checkable Checkable) (ResourceType, bool) {
 	for _, t := range resourceTypes {
 		if t.PipelineID() == checkable.PipelineID() {
-			if t.Name() != checkable.Name() && t.Name() == checkable.Type() {
+			if t != checkable && t.Name() == checkable.Type() {
 				return t, true
 			}
 		}

--- a/atc/db/resource_type_test.go
+++ b/atc/db/resource_type_test.go
@@ -130,6 +130,52 @@ var _ = Describe("ResourceType", func() {
 			})
 		})
 
+		Context("when the resource types list has resource with same name", func() {
+			BeforeEach(func() {
+				var (
+					created bool
+					err     error
+				)
+
+				pipeline, created, err = defaultTeam.SavePipeline(
+					"pipeline-with-types",
+					atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-name",
+								Type:   "some-name",
+								Source: atc.Source{},
+							},
+						},
+						ResourceTypes: atc.ResourceTypes{
+							{
+								Name:       "some-name",
+								Type:       "some-custom-type",
+								Source:     atc.Source{"some": "repository"},
+								CheckEvery: "10ms",
+							},
+						},
+					},
+					pipeline.ConfigVersion(),
+					false,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(created).To(BeFalse())
+			})
+
+			It("returns the resource types tree given a resource", func() {
+				resource, found, err := pipeline.Resource("some-name")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				tree := resourceTypes.Filter(resource)
+				Expect(len(tree)).To(Equal(1))
+
+				Expect(tree[0].Name()).To(Equal("some-name"))
+				Expect(tree[0].Type()).To(Equal("some-custom-type"))
+			})
+		})
+
 		Context("when building the dependency tree from resource types list", func() {
 			BeforeEach(func() {
 				var (


### PR DESCRIPTION
fixes #4599 