### PR TITLE
[k8s-topgun] Retry every fly command until it works

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -61,9 +61,9 @@ func baggageclaimWorks(driver string, selectorFlags ...string) {
 				ShouldNot(HaveLen(0))
 
 			By("Setting and triggering a dumb pipeline")
-			fly.Run("set-pipeline", "-n", "-c", "pipelines/get-task.yml", "-p", "some-pipeline")
-			fly.Run("unpause-pipeline", "-p", "some-pipeline")
-			fly.Run("trigger-job", "-w", "-j", "some-pipeline/simple-job")
+			fly.RunWithRetry("set-pipeline", "-n", "-c", "pipelines/get-task.yml", "-p", "some-pipeline")
+			fly.RunWithRetry("unpause-pipeline", "-p", "some-pipeline")
+			fly.RunWithRetry("trigger-job", "-w", "-j", "some-pipeline/simple-job")
 		})
 	})
 }
@@ -81,7 +81,7 @@ func baggageclaimFails(driver string, selectorFlags ...string) {
 
 				return workerLogsSession.Out.Contents()
 
-			}).Should(ContainSubstring("failed-to-set-up-driver"))
+			}, 5*time.Minute, 60*time.Second).Should(ContainSubstring("failed-to-set-up-driver"))
 
 		})
 	})

--- a/topgun/k8s/ephemeral_worker_test.go
+++ b/topgun/k8s/ephemeral_worker_test.go
@@ -58,6 +58,6 @@ var _ = Describe("Ephemeral workers", func() {
 				}
 			}
 			return
-		}, 1*time.Minute, 1*time.Second).Should(HaveLen(0), "the running worker should go away")
+		}, 1*time.Minute).Should(HaveLen(0), "the running worker should go away")
 	})
 })

--- a/topgun/k8s/external_postgres_test.go
+++ b/topgun/k8s/external_postgres_test.go
@@ -59,7 +59,7 @@ var _ = Describe("External PostgreSQL", func() {
 		By("Logging in")
 		fly.Login("test", "test", atcEndpoint)
 
-		By("Setting and triggering a dumb pipeline")
-		fly.Run("set-pipeline", "-n", "-c", "pipelines/get-task.yml", "-p", "pipeline")
+		By("Setting a dumb pipeline")
+		fly.RunWithRetry("set-pipeline", "-n", "-c", "pipelines/get-task.yml", "-p", "pipeline")
 	})
 })

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -167,8 +167,10 @@ func deployFailingConcourseChart(releaseName string, expectedErr string, args ..
 
 func deployConcourseChart(releaseName string, args ...string) {
 	helmArgs := helmInstallArgs(args...)
-	sess := helmDeploy(releaseName, releaseName, Environment.ConcourseChartDir, helmArgs...)
-	Expect(sess.ExitCode()).To(Equal(0))
+	Eventually(func() int {
+		sess := helmDeploy(releaseName, releaseName, Environment.ConcourseChartDir, helmArgs...)
+		return sess.ExitCode()
+	}).Should(BeZero())
 }
 
 func helmDestroy(releaseName string) {


### PR DESCRIPTION
# Existing Issue

Fixes [#182](https://github.com/concourse/ci/issues/182)

# Why do we need this PR?
k8s-topgun hasn't been stable since September 25th. This PR makes it stable again by retrying **every fly command** until it works or hits the timeout. It's a heavy-handed solution that we didn't want to come to. We've come to this solution because we can't figure out why `kubectl port-forward` is _sometimes_ unstable on GKE clusters. See [#182](https://github.com/concourse/ci/issues/182) for full details on all the things we tried since September 26th.

# Contributor Checklist
- [x] Integration tests (if applicable)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

