### PR TITLE
Use resourceType from plan when saving output

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -881,7 +881,7 @@ func (b *build) SaveOutput(
 		return err
 	}
 
-	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, b.conn, b.lockFactory, resourceConfig, resource, resourceTypes)
+	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, b.conn, b.lockFactory, resourceConfig, resource, resourceType, resourceTypes)
 	if err != nil {
 		return err
 	}

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -483,6 +483,62 @@ var _ = Describe("Build", func() {
 				Expect(newRCV.CheckOrder()).To(Equal(rcv.CheckOrder()))
 			})
 		})
+
+		Context("when global resources is enabled", func() {
+			BeforeEach(func() {
+				atc.EnableGlobalResources = true
+			})
+
+			Context("using a given resource type", func() {
+				var givenType string
+
+				BeforeEach(func() {
+					givenType = "given-type"
+				})
+
+				Context("the resource types contain the given type", func() {
+					var resourceTypes atc.VersionedResourceTypes
+
+					BeforeEach(func() {
+						resourceTypes = atc.VersionedResourceTypes{
+							{
+								ResourceType: atc.ResourceType{
+									Name:                 "given-type",
+									Source:               atc.Source{"some": "source"},
+									Type:                 "some-type",
+									UniqueVersionHistory: true,
+								},
+								Version: atc.Version{"some-resource-type": "version"},
+							},
+						}
+					})
+
+					Context("but the resource type is different in the db", func() {
+						var resourceName string
+
+						BeforeEach(func() {
+							resourceName = "some-explicit-resource" // type: "some-type"
+						})
+
+						It("saves the output", func() {
+							build, err := job.CreateBuild()
+							Expect(err).ToNot(HaveOccurred())
+
+							err = build.SaveOutput(
+								givenType,
+								atc.Source{"some": "explicit-source"},
+								resourceTypes,
+								atc.Version{"some": "new-version"},
+								[]db.ResourceConfigMetadataField{},
+								"output-name",
+								resourceName,
+							)
+							Expect(err).ToNot(HaveOccurred())
+						})
+					})
+				})
+			})
+		})
 	})
 
 	Describe("Resources", func() {

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -228,7 +228,7 @@ func (r *resource) SetResourceConfig(source atc.Source, resourceTypes atc.Versio
 		return nil, err
 	}
 
-	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, r.conn, r.lockFactory, resourceConfig, r, resourceTypes)
+	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, r.conn, r.lockFactory, resourceConfig, r, r.type_, resourceTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func (r *resource) SaveUncheckedVersion(version atc.Version, metadata ResourceCo
 
 	defer Rollback(tx)
 
-	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, r.conn, r.lockFactory, resourceConfig, r, resourceTypes)
+	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, r.conn, r.lockFactory, resourceConfig, r, r.type_, resourceTypes)
 	if err != nil {
 		return false, err
 	}

--- a/atc/db/resource_config.go
+++ b/atc/db/resource_config.go
@@ -281,19 +281,32 @@ func (r *ResourceConfigDescriptor) findWithParentID(tx Tx, parentColumnName stri
 	return id, true, nil
 }
 
-func findOrCreateResourceConfigScope(tx Tx, conn Conn, lockFactory lock.LockFactory, resourceConfig ResourceConfig, resource Resource, resourceTypes atc.VersionedResourceTypes) (ResourceConfigScope, error) {
+func findOrCreateResourceConfigScope(
+	tx Tx,
+	conn Conn,
+	lockFactory lock.LockFactory,
+	resourceConfig ResourceConfig,
+	resource Resource,
+	resourceType string,
+	resourceTypes atc.VersionedResourceTypes,
+) (ResourceConfigScope, error) {
+
 	var unique bool
 	var uniqueResource Resource
 	var resourceID *int
+
 	if resource != nil {
 		if !atc.EnableGlobalResources {
 			unique = true
 		} else {
-			customType, found := resourceTypes.Lookup(resource.Type())
+			customType, found := resourceTypes.Lookup(resourceType)
 			if found {
 				unique = customType.UniqueVersionHistory
 			} else {
-				unique = resourceConfig.CreatedByBaseResourceType().UniqueVersionHistory
+				baseType := resourceConfig.CreatedByBaseResourceType()
+				if baseType != nil {
+					unique = baseType.UniqueVersionHistory
+				}
 			}
 		}
 

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -240,7 +240,7 @@ func (t *resourceType) SetResourceConfig(source atc.Source, resourceTypes atc.Ve
 	}
 
 	// A nil value is passed into the Resource object parameter because we always want resource type versions to be shared
-	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, t.conn, t.lockFactory, resourceConfig, nil, resourceTypes)
+	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, t.conn, t.lockFactory, resourceConfig, nil, t.type_, resourceTypes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Existing Issue

Fixes #4546 

# Why do we need this PR?
- this fixes an issue where if you change the resource type while a
build is running it would cause a crash.

- this happens when the new type configured is not listed in the
resource_types that we encode into the build plan.

- so now we use the resource_type from the build plan, even if there's a
newer version in the database.

# Contributor Checklist

- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

