### PR TITLE
web: add no builds message on job page

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -50,3 +50,7 @@
 #### <sub><sup><a name="4625" href="#4625">:link:</a></sup></sub> fix
 
 * Fixed a [bug](https://github.com/concourse/concourse/issues/4313) where your dashboard search string would end up with `+`s instead of spaces when logging in. #4265
+
+#### <sub><sup><a name="4636" href="#4636">:link:</a></sup></sub> fix
+
+* Fixed a [bug](https://github.com/concourse/concourse/issues/4493) where the job page would show a loading spinner forever when there were no builds (like before the job had ever been run) #4636.

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -539,11 +539,19 @@ viewMainJobsSection session model =
                         , viewPaginationBar session model
                         ]
                     ]
-        , case model.buildsWithResources.content of
-            [] ->
+        , case ( model.buildsWithResources.content, model.currentPage ) of
+            ( _, Nothing ) ->
                 LoadingIndicator.view
 
-            anyList ->
+            ( [], Just _ ) ->
+                Html.div Styles.noBuildsMessage
+                    [ Html.text <|
+                        "no builds for job “"
+                            ++ model.jobIdentifier.jobName
+                            ++ "”"
+                    ]
+
+            ( anyList, Just _ ) ->
                 Html.div
                     [ class "scrollable-body job-body"
                     , style "overflow-y" "auto"

--- a/web/elm/src/Job/Styles.elm
+++ b/web/elm/src/Job/Styles.elm
@@ -2,6 +2,7 @@ module Job.Styles exposing
     ( buildResourceHeader
     , buildResourceIcon
     , icon
+    , noBuildsMessage
     , triggerButton
     , triggerTooltip
     )
@@ -74,4 +75,11 @@ buildResourceIcon : List (Html.Attribute msg)
 buildResourceIcon =
     [ style "background-size" "contain"
     , style "margin-right" "5px"
+    ]
+
+
+noBuildsMessage : List (Html.Attribute msg)
+noBuildsMessage =
+    [ style "font-size" "16px"
+    , style "padding" "10px 0 0 30px"
     ]

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -835,6 +835,24 @@ all =
                     }
                 , hoverable = Message.Message.PreviousPageButton
                 }
+            , describe "When fetching builds"
+                [ test "says no builds" <|
+                    \_ ->
+                        init { disabled = False, paused = False } ()
+                            |> Application.handleCallback
+                                (JobBuildsFetched <|
+                                    Ok
+                                        { pagination =
+                                            { previousPage = Nothing
+                                            , nextPage = Nothing
+                                            }
+                                        , content = []
+                                        }
+                                )
+                            |> Tuple.first
+                            |> queryView
+                            |> Query.has [ text "no builds for job “job”" ]
+                ]
             , test "JobBuildsFetched" <|
                 \_ ->
                     let


### PR DESCRIPTION
# Existing Issue

Fixes #4493.

# Changes proposed in this pull request

* say 'no builds for job JOBNAME' instead of loading forever
* styles involve some magic numbers, but we don't expect this page to live much longer with https://github.com/concourse/concourse/projects/12 on the horizon.
* overflow behaviour (horizontal scrollbar, not the end of the world):
![Screen Shot 2019-10-23 at 11 55 58 AM](https://user-images.githubusercontent.com/22056320/67411784-28306e80-f58c-11e9-84b6-10051286e27d.png)


# Contributor Checklist
- [x] Unit tests
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [x] Release notes reviewed
- [ ] PR acceptance performed