### PR TITLE
web: fix build log timestamps

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -50,3 +50,8 @@
 #### <sub><sup><a name="4625" href="#4625">:link:</a></sup></sub> fix
 
 * Fixed a [bug](https://github.com/concourse/concourse/issues/4313) where your dashboard search string would end up with `+`s instead of spaces when logging in. #4265
+
+#### <sub><sup><a name="4637" href="#4637">:link:</a></sup></sub> fix
+
+* Fixed a [bug](https://github.com/concourse/concourse/issues/3942) where log lines on the build page would have all their timestamps off by one. #4637
+

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -232,19 +232,21 @@ appendStepLog output mtime tree =
         \step ->
             let
                 outputLineCount =
-                    Ansi.Log.update output (Ansi.Log.init Ansi.Log.Cooked) |> .lines |> Array.length
+                    Ansi.Log.update output (Ansi.Log.init Ansi.Log.Cooked)
+                        |> .lines
+                        |> Array.length
 
-                logLineCount =
-                    max (Array.length step.log.lines - 1) 0
+                lastLineNo =
+                    max (Array.length step.log.lines) 1
 
-                setLineTimestamp line timestamps =
-                    Dict.update line (always mtime) timestamps
+                setLineTimestamp lineNo timestamps =
+                    Dict.update lineNo (always mtime) timestamps
 
                 newTimestamps =
                     List.foldl
                         setLineTimestamp
                         step.timestamps
-                        (List.range logLineCount (logLineCount + outputLineCount - 1))
+                        (List.range lastLineNo (lastLineNo + outputLineCount - 1))
 
                 newLog =
                     Ansi.Log.update output step.log

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -645,7 +645,7 @@ viewTimestampedLine { timestamps, highlight, id, lineNo, line, timeZone } =
         ]
         [ viewTimestamp
             { id = id
-            , line = lineNo
+            , lineNo = lineNo
             , date = ts
             , timeZone = timeZone
             }
@@ -662,17 +662,17 @@ viewLine line =
 
 viewTimestamp :
     { id : String
-    , line : Int
+    , lineNo : Int
     , date : Maybe Time.Posix
     , timeZone : Time.Zone
     }
     -> Html Message
-viewTimestamp { id, line, date, timeZone } =
+viewTimestamp { id, lineNo, date, timeZone } =
     Html.a
-        [ href (showHighlight (HighlightLine id line))
+        [ href (showHighlight (HighlightLine id lineNo))
         , StrictEvents.onLeftClickOrShiftLeftClick
-            (SetHighlight id line)
-            (ExtendHighlight id line)
+            (SetHighlight id lineNo)
+            (ExtendHighlight id lineNo)
         ]
         [ case date of
             Just d ->


### PR DESCRIPTION
# Existing Issue

Fixes #3942.

# Changes proposed in this pull request

* in the `timestamps` Dict on a `Step`, the keys are now line _numbers_ rather than line _indices_

# Contributor Checklist
- [x] Unit tests
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed