### PR TITLE
Test for container sweeper ctx timeout

### DIFF
--- a/worker/container_sweeper.go
+++ b/worker/container_sweeper.go
@@ -12,9 +12,9 @@ import (
 	"github.com/concourse/concourse/atc/worker/gclient"
 )
 
-// containerSweeper is an ifrit.Runner that periodically reports and
+// ContainerSweeper is an ifrit.Runner that periodically reports and
 // garbage-collects a worker's containers
-type containerSweeper struct {
+type ContainerSweeper struct {
 	logger       lager.Logger
 	interval     time.Duration
 	tsaClient    TSAClient
@@ -28,8 +28,8 @@ func NewContainerSweeper(
 	tsaClient TSAClient,
 	gardenClient gclient.Client,
 	maxInFlight uint16,
-) *containerSweeper {
-	return &containerSweeper{
+) *ContainerSweeper {
+	return &ContainerSweeper{
 		logger:       logger,
 		interval:     sweepInterval,
 		tsaClient:    tsaClient,
@@ -38,7 +38,7 @@ func NewContainerSweeper(
 	}
 }
 
-func (sweeper *containerSweeper) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
+func (sweeper *ContainerSweeper) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 	timer := time.NewTicker(sweeper.interval)
 
 	close(ready)
@@ -55,7 +55,7 @@ func (sweeper *containerSweeper) Run(signals <-chan os.Signal, ready chan<- stru
 	}
 }
 
-func (sweeper *containerSweeper) sweep(logger lager.Logger) {
+func (sweeper *ContainerSweeper) sweep(logger lager.Logger) {
 	ctx := lagerctx.NewContext(context.Background(), logger)
 
 	containers, err := sweeper.gardenClient.Containers(garden.Properties{})

--- a/worker/container_sweeper_test.go
+++ b/worker/container_sweeper_test.go
@@ -1,0 +1,158 @@
+package worker_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/onsi/gomega/gbytes"
+
+	"github.com/concourse/concourse/worker/workerfakes"
+
+	"code.cloudfoundry.org/lager/lagertest"
+	"github.com/concourse/concourse/atc/worker/gclient"
+	"github.com/concourse/concourse/worker"
+	"github.com/onsi/gomega/ghttp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Container Sweeper", func() {
+	var (
+		garden *ghttp.Server
+
+		testLogger = lagertest.NewTestLogger("container-sweeper")
+
+		sweepInterval time.Duration
+		maxInFlight   uint16
+
+		fakeTSAClient workerfakes.FakeTSAClient
+		gardenClient  gclient.Client
+
+		sweeper *worker.ContainerSweeper
+
+		gardenClientRequestTimeout time.Duration
+
+		osSignal  chan os.Signal
+		readyChan chan struct{}
+		exited    chan struct{}
+
+		//err error
+	)
+
+	BeforeEach(func() {
+		sweepInterval = 50 * time.Millisecond
+		maxInFlight = 1
+
+		gardenClientRequestTimeout = 5 * time.Millisecond
+
+		garden = ghttp.NewServer()
+
+		osSignal = make(chan os.Signal)
+		readyChan = make(chan struct{})
+		exited = make(chan struct{})
+
+		gardenAddr := fmt.Sprintf("http://%s", garden.Addr())
+		gardenClient = gclient.BasicGardenClientWithRequestTimeout(testLogger, gardenClientRequestTimeout, gardenAddr)
+
+		fakeTSAClient.ReportContainersReturns(nil)
+
+		sweeper = worker.NewContainerSweeper(testLogger, sweepInterval, &fakeTSAClient, gardenClient, maxInFlight)
+
+	})
+
+	AfterEach(func() {
+		garden.Close()
+	})
+
+	Context("when garden doesn't respond on DELETE", func() {
+		var (
+			gardenContext context.Context
+			gardenCancel  context.CancelFunc
+		)
+		JustBeforeEach(func() {
+			go func() {
+				_ = sweeper.Run(osSignal, readyChan)
+				close(exited)
+			}()
+		})
+
+		BeforeEach(func() {
+			gardenContext, gardenCancel = context.WithCancel(context.Background())
+			garden.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/containers"),
+					ghttp.RespondWithJSONEncoded(200, []map[string]string{}),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("DELETE", "/containers/some-handle-1"),
+					func(w http.ResponseWriter, r *http.Request) {
+						<-gardenContext.Done()
+					},
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("DELETE", "/containers/some-handle-2"),
+					func(w http.ResponseWriter, r *http.Request) {
+						<-gardenContext.Done()
+					},
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/containers"),
+					ghttp.RespondWithJSONEncoded(200, []map[string]string{}),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("DELETE", "/containers/some-handle-3"),
+					func(w http.ResponseWriter, r *http.Request) {
+						<-gardenContext.Done()
+					},
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("DELETE", "/containers/some-handle-4"),
+					func(w http.ResponseWriter, r *http.Request) {
+						<-gardenContext.Done()
+					},
+				),
+			)
+			// First GC Tick
+			fakeTSAClient.ContainersToDestroyReturnsOnCall(0, []string{"some-handle-1", "some-handle-2"}, nil)
+			// Second GC Tick
+			fakeTSAClient.ContainersToDestroyReturnsOnCall(1, []string{"some-handle-3", "some-handle-4"}, nil)
+
+			garden.AllowUnhandledRequests = true
+
+		})
+		AfterEach(func() {
+			close(osSignal)
+			<-exited
+			gardenCancel()
+		})
+
+		It("request to garden times out eventually", func() {
+			Eventually(testLogger.Buffer()).Should(gbytes.Say("failed-to-destroy-container\".*net/http: request canceled \\(Client.Timeout exceeded while awaiting headers\\)"))
+		})
+		It("sweeper continues ticking and GC'ing", func() {
+			// ensure all 4 DELETEs are issues over 2 successive ticks
+			Eventually(func() []string {
+				// Gather all containers deleted
+				var deleteRequestPaths []string
+				for _, req := range garden.ReceivedRequests() {
+					if req.Method == http.MethodDelete {
+						deleteRequestPaths = append(deleteRequestPaths, req.RequestURI)
+					}
+				}
+				return deleteRequestPaths
+			}).Should(ConsistOf(
+				"/containers/some-handle-1",
+				"/containers/some-handle-2",
+				"/containers/some-handle-3",
+				"/containers/some-handle-4"))
+
+			// Check calls to TSA for containers to destroy > 1
+			Expect(fakeTSAClient.ContainersToDestroyCallCount()).To(BeNumerically(">=", 2))
+		})
+	})
+
+})

--- a/worker/container_sweeper_test.go
+++ b/worker/container_sweeper_test.go
@@ -123,7 +123,6 @@ var _ = Describe("Container Sweeper", func() {
 		})
 		AfterEach(func() {
 			gardenCancel()
-
 		})
 
 		It("request to garden times out eventually", func() {

--- a/worker/container_sweeper_test.go
+++ b/worker/container_sweeper_test.go
@@ -65,7 +65,16 @@ var _ = Describe("Container Sweeper", func() {
 
 	})
 
+	JustBeforeEach(func() {
+		go func() {
+			_ = sweeper.Run(osSignal, readyChan)
+			close(exited)
+		}()
+	})
+
 	AfterEach(func() {
+		close(osSignal)
+		<-exited
 		garden.Close()
 	})
 
@@ -74,12 +83,6 @@ var _ = Describe("Container Sweeper", func() {
 			gardenContext context.Context
 			gardenCancel  context.CancelFunc
 		)
-		JustBeforeEach(func() {
-			go func() {
-				_ = sweeper.Run(osSignal, readyChan)
-				close(exited)
-			}()
-		})
 
 		BeforeEach(func() {
 			gardenContext, gardenCancel = context.WithCancel(context.Background())
@@ -126,9 +129,8 @@ var _ = Describe("Container Sweeper", func() {
 
 		})
 		AfterEach(func() {
-			close(osSignal)
-			<-exited
 			gardenCancel()
+
 		})
 
 		It("request to garden times out eventually", func() {

--- a/worker/container_sweeper_test.go
+++ b/worker/container_sweeper_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-
 	"github.com/concourse/concourse/worker/workerfakes"
 
 	"code.cloudfoundry.org/lager/lagertest"
@@ -15,16 +14,16 @@ import (
 	"github.com/concourse/concourse/worker"
 	"github.com/onsi/gomega/ghttp"
 
-	"github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("Container Sweeper", func() {
 	const (
-	 sweepInterval              = 50 * time.Millisecond
-	 maxInFlight                =  uint16(1)
-	 gardenClientTimeoutRequest = 5 * time.Millisecond
+		sweepInterval              = 50 * time.Millisecond
+		maxInFlight                = uint16(1)
+		gardenClientTimeoutRequest = 5 * time.Millisecond
 	)
 
 	var (
@@ -37,9 +36,8 @@ var _ = Describe("Container Sweeper", func() {
 
 		sweeper *worker.ContainerSweeper
 
-		osSignal  chan os.Signal
-		exited    chan struct{}
-
+		osSignal chan os.Signal
+		exited   chan struct{}
 	)
 
 	BeforeEach(func() {

--- a/worker/container_sweeper_test.go
+++ b/worker/container_sweeper_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Container Sweeper", func() {
 		gardenAddr := fmt.Sprintf("http://%s", garden.Addr())
 		gardenClient = gclient.BasicGardenClientWithRequestTimeout(testLogger, gardenClientRequestTimeout, gardenAddr)
 
+		fakeTSAClient = workerfakes.FakeTSAClient{}
 		fakeTSAClient.ReportContainersReturns(nil)
 
 		sweeper = worker.NewContainerSweeper(testLogger, sweepInterval, &fakeTSAClient, gardenClient, maxInFlight)

--- a/worker/container_sweeper_test.go
+++ b/worker/container_sweeper_test.go
@@ -7,16 +7,15 @@ import (
 	"os"
 	"time"
 
-	"github.com/concourse/concourse/worker/workerfakes"
-
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/concourse/atc/worker/gclient"
 	"github.com/concourse/concourse/worker"
-	"github.com/onsi/gomega/ghttp"
+	"github.com/concourse/concourse/worker/workerfakes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/ghttp"
 )
 
 var _ = Describe("Container Sweeper", func() {


### PR DESCRIPTION
This adds a regression test to validate that container sweeper doesn't block when the garden client is configured with a timeout.

Note: This test just validates the non-blocking functionality if the timeout is configured. It doesn't validate that the configuration utilized by the worker includes a timeout.


# Existing Issue
Enhances #4582

# Why do we need this PR?
Demonstrate that container sweeper is non-blocking when gardenClient calls hang and GC doesn't stop occurring in this event

# Changes proposed in this pull request
Adds container_sweeper test

# Contributor Checklist
- [x] Integration tests (if applicable)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Tests reviewed
- [ ] PR acceptance performed

