### PR TITLE
metrics: batch newrelic emitter

### DIFF
--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -1,9 +1,13 @@
 package emitter
 
 import (
+	"bufio"
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -13,6 +17,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	newrelicPayloadMaxSize = 1024 * 1024
+)
+
 type (
 	stats struct {
 		created interface{}
@@ -20,22 +28,43 @@ type (
 	}
 
 	NewRelicEmitter struct {
-		client     *http.Client
-		url        string
-		apikey     string
-		prefix     string
-		containers *stats
-		volumes    *stats
+		prefix       string
+		containers   *stats
+		volumes      *stats
+		batchEmitter *batchEmitter
 	}
 
 	NewRelicConfig struct {
-		AccountID     string `long:"newrelic-account-id" description:"New Relic Account ID"`
-		APIKey        string `long:"newrelic-api-key" description:"New Relic Insights API Key"`
-		ServicePrefix string `long:"newrelic-service-prefix" default:"" description:"An optional prefix for emitted New Relic events"`
+		AccountID          string        `long:"newrelic-account-id" description:"New Relic Account ID"`
+		APIKey             string        `long:"newrelic-api-key" description:"New Relic Insights API Key"`
+		ServicePrefix      string        `long:"newrelic-service-prefix" default:"" description:"An optional prefix for emitted New Relic events"`
+		CompressionEnabled bool          `long:"newrelic-metric-compression" description:"New Relic payload compression flag"`
+		FlushInterval      time.Duration `long:"newrelic-flush-interval" default:"60s" description:"Newrelic metric flush interval in seconds"`
 	}
 
 	singlePayload map[string]interface{}
-	fullPayload   []singlePayload
+
+	batchPayload []byte
+
+	BatchEmitter interface {
+		Emit(logger lager.Logger, payload singlePayload)
+		Flush(logger lager.Logger)
+	}
+
+	batchEmitter struct {
+		client        *http.Client
+		url           string
+		apikey        string
+		emitBuffer    []byte
+		lastEmitTime  time.Time
+		compression   bool
+		flushInterval time.Duration
+	}
+
+	loggableError struct {
+		Action string
+		Error  error
+	}
 )
 
 func init() {
@@ -54,12 +83,17 @@ func (config *NewRelicConfig) NewEmitter() (metric.Emitter, error) {
 	}
 
 	return &NewRelicEmitter{
-		client:     client,
-		url:        fmt.Sprintf("https://insights-collector.newrelic.com/v1/accounts/%s/events", config.AccountID),
-		apikey:     config.APIKey,
 		prefix:     config.ServicePrefix,
 		containers: new(stats),
 		volumes:    new(stats),
+		batchEmitter: &batchEmitter{
+			client:        client,
+			url:           fmt.Sprintf("https://insights-collector.newrelic.com/v1/accounts/%s/events", config.AccountID),
+			apikey:        config.APIKey,
+			compression:   config.CompressionEnabled,
+			flushInterval: config.FlushInterval,
+			lastEmitTime:  time.Now(),
+		},
 	}, nil
 }
 
@@ -85,20 +119,33 @@ func (emitter *NewRelicEmitter) simplePayload(logger lager.Logger, event metric.
 	return payload
 }
 
-func (emitter *NewRelicEmitter) emitPayload(logger lager.Logger, payload fullPayload) {
-	payloadJSON, err := json.Marshal(payload)
-	if err != nil {
-		logger.Error("failed-to-serialize-payload", err)
-		return
+func (emitter *batchEmitter) emitBatch(logger lager.Logger, payload batchPayload) {
+	var (
+		payloadReader io.Reader
+		err           error
+	)
+
+	if emitter.compression {
+		payloadReader, err = gZipBuffer(payload)
+		if err != nil {
+			logger.Error("failed-to-zip-payload", errors.Wrap(metric.ErrFailedToEmit, err.Error()))
+			return
+		}
+	} else {
+		payloadReader = bytes.NewBuffer(payload)
 	}
 
-	req, err := http.NewRequest("POST", emitter.url, bytes.NewBuffer(payloadJSON))
+	req, err := http.NewRequest("POST", emitter.url, payloadReader)
 	if err != nil {
 		logger.Error("failed-to-construct-request", err)
+		return
 	}
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Insert-Key", emitter.apikey)
+	if emitter.compression {
+		req.Header.Add("Content-Encoding", "gzip")
+	}
 
 	resp, err := emitter.client.Do(req)
 	if err != nil {
@@ -106,15 +153,11 @@ func (emitter *NewRelicEmitter) emitPayload(logger lager.Logger, payload fullPay
 			errors.Wrap(metric.ErrFailedToEmit, err.Error()))
 		return
 	}
-
 	resp.Body.Close()
 }
 
 func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
-	payload := make(fullPayload, 0)
-
 	switch event.Name {
-
 	// These are the simple ones that only need a small name transformation
 	case "build started",
 		"build finished",
@@ -125,7 +168,7 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		"database connections",
 		"worker unknown containers",
 		"worker unknown volumes":
-		payload = append(payload, emitter.simplePayload(logger, event, ""))
+		emitter.batchEmitter.Emit(logger, emitter.simplePayload(logger, event, ""))
 
 	// These are periodic metrics that are consolidated and only emitted once
 	// per cycle (the emit trigger is chosen because it's currently last in the
@@ -142,7 +185,7 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		newPayload["created"] = emitter.containers.created
 		newPayload["deleted"] = emitter.containers.deleted
 		delete(newPayload, "value")
-		payload = append(payload, newPayload)
+		emitter.batchEmitter.Emit(logger, newPayload)
 
 	case "volumes deleted":
 		emitter.volumes.deleted = event.Value
@@ -154,15 +197,16 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		newPayload["created"] = emitter.volumes.created
 		newPayload["deleted"] = emitter.volumes.deleted
 		delete(newPayload, "value")
-		payload = append(payload, newPayload)
+		emitter.batchEmitter.Emit(logger, newPayload)
 
 	// And a couple that need a small rename (new relic doesn't like some chars)
 	case "scheduling: full duration (ms)":
-		payload = append(payload, emitter.simplePayload(logger, event, "scheduling_full_duration_ms"))
+		emitter.batchEmitter.Emit(logger, emitter.simplePayload(logger, event, "scheduling_full_duration_ms"))
 	case "scheduling: loading versions duration (ms)":
-		payload = append(payload, emitter.simplePayload(logger, event, "scheduling_load_duration_ms"))
+		emitter.batchEmitter.Emit(logger, emitter.simplePayload(logger, event, "scheduling_load_duration_ms"))
 	case "scheduling: job duration (ms)":
-		payload = append(payload, emitter.simplePayload(logger, event, "scheduling_job_duration_ms"))
+		emitter.batchEmitter.Emit(logger, emitter.simplePayload(logger, event, "scheduling_job_duration_ms"))
+
 	default:
 		// Ignore the rest
 	}
@@ -177,10 +221,139 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		// didn't; therefore, be consistently inconsistent and use the
 		// concourse metric names, not our translation layer.
 		singlePayload["metric"] = event.Name
-		payload = append(payload, singlePayload)
+		emitter.batchEmitter.Emit(logger, singlePayload)
+
+	}
+}
+
+func (emitter *batchEmitter) Flush(logger lager.Logger) {
+	if emitter.flushThreshold() {
+		batchPayload := emitter.flush()
+		if batchPayload != nil && len(batchPayload) > 0 {
+			emitter.updateLastEmitTime()
+			go emitter.emitBatch(logger, batchPayload)
+		}
+	}
+}
+
+func (emitter *batchEmitter) Emit(logger lager.Logger, payload singlePayload) {
+	// enqueue the data
+	// check the time since last time we emitted the data, if it is great than the threshold, emit right now
+	payloadToSend, err := emitter.enqueue(payload)
+	if err != nil {
+		logger.Error(err.Action, err.Error)
+		return
+	}
+	if payloadToSend != nil {
+		emitter.updateLastEmitTime()
+		go emitter.emitBatch(logger, payloadToSend)
 	}
 
-	if len(payload) > 0 {
-		emitter.emitPayload(logger, payload)
+	emitter.Flush(logger)
+}
+
+// enqueue new payload
+// if enqueue the new payload would exceed the max limit (1Mb)
+// return everything that's enqueued and enqueue the new payload
+// lock and unlock should be applied.
+func (emitter *batchEmitter) enqueue(newPayload singlePayload) (batchPayload, *loggableError) {
+	var (
+		tempBuff []byte
+		buff     batchPayload
+	)
+	newPayloadData, err := json.Marshal(newPayload)
+	if err != nil {
+		return nil, newLoggableError("failed-to-serialize-new-payload", err)
 	}
+
+	if newPayloadData == nil || len(newPayloadData) == 0 {
+		return nil, newLoggableError("empty-new-payload", err)
+	}
+
+	if len(emitter.emitBuffer) != 0 {
+		tempBuff = append(emitter.emitBuffer, ',')
+	}
+	tempBuff = append(tempBuff, newPayloadData...)
+
+	payloadSize, sizeError := emitter.bufferSize(tempBuff)
+	if sizeError != nil {
+		return nil, sizeError
+	}
+
+	// when combined new payload exceeds 1MB
+	if payloadSize > newrelicPayloadMaxSize-2 { // reduce '[' and ']' for the json payload
+		buff = formatBatchEmitBuffer(emitter.emitBuffer)
+		emitter.emitBuffer = newPayloadData
+	} else {
+		emitter.emitBuffer = tempBuff
+	}
+	return buff, nil
+}
+
+func (emitter *batchEmitter) bufferSize(buff []byte) (int, *loggableError) {
+	payloadSize := len(buff)
+	// for better performance, we only check compressed data size when the data in the buffer is larger than 1MB
+	if emitter.compression && payloadSize >= newrelicPayloadMaxSize-2 { // reduce size for '[' and ']'
+		zippedBuffer, err := gZipBuffer(buff)
+		if err != nil {
+			return 0, newLoggableError("failed-to-gzip-payload", err)
+		}
+
+		zippedData, err := ioutil.ReadAll(zippedBuffer)
+		if err != nil {
+			return 0, newLoggableError("failed-to-use-gzip-buffer-payload", err)
+		}
+		payloadSize = len(zippedData)
+	}
+	return payloadSize, nil
+}
+
+func (emitter *batchEmitter) flush() batchPayload {
+	var buff batchPayload
+
+	if emitter.emitBuffer != nil {
+		buff = formatBatchEmitBuffer(emitter.emitBuffer)
+		emitter.emitBuffer = nil
+	}
+	return buff
+}
+
+func (emitter *batchEmitter) updateLastEmitTime() {
+	emitter.lastEmitTime = time.Now()
+}
+
+func (emitter *batchEmitter) flushThreshold() bool {
+	return time.Now().Sub(emitter.lastEmitTime) > emitter.flushInterval
+}
+
+func gZipBuffer(body []byte) (io.Reader, error) {
+	var err error
+
+	readBuffer := bufio.NewReader(bytes.NewReader(body))
+	buffer := bytes.NewBuffer([]byte{})
+	writer := gzip.NewWriter(buffer)
+
+	_, err = readBuffer.WriteTo(writer)
+	if err != nil {
+		return nil, err
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer, nil
+}
+
+func newLoggableError(action string, err error) *loggableError {
+	return &loggableError{Action: action, Error: err}
+}
+
+func formatBatchEmitBuffer(buffer []byte) batchPayload {
+	buffTemp := buffer
+	buffTemp = append(append([]byte{'['}, buffTemp...), ']')
+	returnBuff := make([]byte, len(buffTemp))
+	copy(returnBuff, buffTemp)
+	return returnBuff
 }

--- a/atc/metric/emitter/newrelic_test.go
+++ b/atc/metric/emitter/newrelic_test.go
@@ -1,0 +1,100 @@
+package emitter
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/metric"
+	"github.com/concourse/flag"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("newrelic metric", func() {
+	OKResponse := `{"success":true,"uuid":"12345678-1234-5678-9012-123456789012"}`
+	var (
+		newrelicServer     *ghttp.Server
+		newrelicConfig     *NewRelicConfig
+		emitter            metric.Emitter
+		logger             lager.Logger
+		compressionEnabled bool
+	)
+	emitSampleMetrics := func(times int, expectLenInBuffer int) {
+		for i := 0; i < times; i++ {
+			emitter.Emit(logger, metric.Event{
+				Name:  "build started",
+				Value: "",
+				State: metric.EventStateOK,
+				Host:  "test-client-1",
+				Time:  time.Now(),
+			})
+		}
+
+		if newrelicEmitter, OK := emitter.(*NewRelicEmitter); OK {
+			Expect(newrelicEmitter.batchEmitter.emitBuffer).To(HaveLen(expectLenInBuffer))
+		} else {
+			Fail("failed to convert the emitter to NewRelicEmitter")
+		}
+	}
+
+	JustBeforeEach(func() {
+		logger, _ = flag.Lager{LogLevel: "debug"}.Logger("newrelic-test")
+		newrelicServer = ghttp.NewServer()
+		newrelicServer.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("POST", "/EVENTS"),
+			ghttp.RespondWithJSONEncoded(200, OKResponse),
+		))
+		newrelicConfig = &NewRelicConfig{
+			AccountID:          "ACCOUNT-1",
+			APIKey:             "INSERT-API-KEY-1",
+			ServicePrefix:      "",
+			CompressionEnabled: compressionEnabled,
+			FlushInterval:      30 * time.Second,
+		}
+		var err error
+		emitter, err = newrelicConfig.NewEmitter()
+		if err != nil {
+			Fail("failed to create emitter from new relic configuration")
+		}
+
+		if newrelicEmitter, OK := emitter.(*NewRelicEmitter); OK {
+			newrelicEmitter.batchEmitter.url = newrelicServer.URL() + "/EVENTS"
+		} else {
+			Fail("failed to convert the emitter to NewRelicEmitter")
+		}
+
+	})
+
+	JustAfterEach(func() {
+		newrelicServer.Close()
+	})
+
+	Context("when compression is enabled", func() {
+		BeforeEach(func() {
+			compressionEnabled = true
+		})
+		AfterEach(func() {
+			compressionEnabled = false
+		})
+		It("does not send out compressed data out when the data length is less than 1MB", func() {
+			emitSampleMetrics(10486, 1048600-1)
+		})
+
+		It("does send out compressed data when the data over the limit", func() {
+			emitSampleMetrics(10490, 1049000-1)
+		})
+	})
+
+	Context("when batch buffer is less than 1MB", func() {
+		It("enqueue to the batch buffer", func() {
+			emitSampleMetrics(1, 99)
+		})
+	})
+
+	Context("when batch buffer is great than 1MB", func() {
+		It("emit the existed metrics, enqueue the current metric", func() {
+			emitSampleMetrics(10486, 99)
+		})
+	})
+})

--- a/release-notes/v5.5.5.md
+++ b/release-notes/v5.5.5.md
@@ -1,0 +1,3 @@
+#### <sub><sup><a name="4641" href="#4641">:link:</a></sup></sub> fix
+
+* @pivotal-bin-ju and @zoetian fixed [issue](https://github.com/concourse/concourse/issues/4540), which enabled concourse deployment to emit batched metrics to [newrelic](https://newrelic.com/).

--- a/release-notes/v5.7.0.md
+++ b/release-notes/v5.7.0.md
@@ -125,7 +125,6 @@ There is no configuration required to take advantage of these new improvements.
 
 * If you ran into this error `<3`s for being a long time concourse user.
 
-
 #### <sub><sup><a name="4471" href="4471">:link:</a></sup></sub> fix
 
 * @aledeganopix4d [added](https://github.com/concourse/concourse/pull/4471) some lock types that weren't getting emitted as part of our metrics, so that's neat. You might actually see your lock metrics shoot up because of this, don't panic, it's expected.
@@ -133,3 +132,7 @@ There is no configuration required to take advantage of these new improvements.
 #### <sub><sup><a name="4655" href="4655">:link:</a></sup></sub> fix
 
 * @evanchaoli fixed a [bug](https://github.com/concourse/concourse/pull/4655) where vault users, that hadn't configured a shared path, would end up searching the top level `prefix` path for secrets.
+
+#### <sub><sup><a name="4641" href="#4641">:link:</a></sup></sub> fix
+
+* @pivotal-bin-ju and @zoetian fixed [issue](https://github.com/concourse/concourse/issues/4540), which enabled concourse deployment to emit batched metrics to [newrelic](https://newrelic.com/).


### PR DESCRIPTION
# Existing Issue
Fixes #4540.

# Why do we need this PR?

When using the concourse with newrelic emitter, the metrics is losing most events. The metrics buffer is full since it's only emitting single metric to newrelic server in an inefficient way.


# Changes proposed in this pull request
* implemented our own `enqueue`, `flush`, `compress` and `emitBatch` functions to emit metrics data in batch
* added unit test for newrelic emitter

# Contributor Checklist
- [x] Unit tests
~~-[ ] Updated documentation (located at https://github.com/concourse/docs)~~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

