### PR TITLE
Enable k8s-topgun to run inside k8s cluster

### DIFF
--- a/topgun/k8s/external_worker_test.go
+++ b/topgun/k8s/external_worker_test.go
@@ -3,8 +3,6 @@ package k8s_test
 import (
 	"time"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,8 +13,8 @@ var _ = Describe("external workers through separate deployments", func() {
 	const publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC496FSYFcBAKgDtMsBAJiF/6/NxlXKP5UZecyEsedYuTt1GOgJTwaA1qZ1LmHsbfLDE68oDdiM4uvxfI4wtLhz57w3u0jOUxZ2JeF7SVwEf1nVqLn4Gh/f8GUNQGSyIp1zUD5Bx9fq0PAyQ47mt7Ufi84rcf8LKl7nzAIHTcdg2BvTkQN9bUGPaq/Pb1W2bKPAQy4OzXTSIyrAJ89TH2jFeaZfyxQFGbD9jVHH/yl0oiMrDeaRYgccE5II+KY7WoLjsBry/9Qf2ERELKTK4UeIGIqWci9lab1ti+GxFPPiC3krNFjo4jShV4eUs4cNIrjwNrxVaKPXmU6o7Y3Hpayx Concourse"
 
 	var (
-		proxySession     *gexec.Session
-		atcEndpoint      string
+		atc Endpoint
+
 		workerKey        string
 		tsaPort          string
 		webDeployArgs    []string
@@ -30,7 +28,6 @@ var _ = Describe("external workers through separate deployments", func() {
 		tsaPort = "2222"
 		helmArgs := append(webDeployArgs,
 			"--set=worker.enabled=false",
-
 			"--set=web.tsa.bindPort="+tsaPort,
 		)
 		deployConcourseChart(releaseName+"-web", helmArgs...)
@@ -47,11 +44,13 @@ var _ = Describe("external workers through separate deployments", func() {
 		waitAllPodsInNamespaceToBeReady(namespace + "-worker")
 		waitAllPodsInNamespaceToBeReady(namespace + "-web")
 
-		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace+"-web", "service/"+releaseName+"-web-web", "8080")
+		atc = endpointFactory.NewServiceEndpoint(
+			namespace+"-web",
+			releaseName+"-web-web",
+			"8080",
+		)
 
-		By("Logging in")
-		fly.Login("test", "test", atcEndpoint)
+		fly.Login("test", "test", "http://"+atc.Address())
 
 	})
 
@@ -72,8 +71,9 @@ var _ = Describe("external workers through separate deployments", func() {
 	}
 
 	AfterEach(func() {
-		cleanup(releaseName+"-web", namespace+"-web", proxySession)
-		cleanup(releaseName+"-worker", namespace+"-worker", nil)
+		atc.Close()
+		cleanup(releaseName+"-web", namespace+"-web")
+		cleanup(releaseName+"-worker", namespace+"-worker")
 	})
 
 	Context("main team worker", func() {

--- a/topgun/k8s/https_web_tls_termination_test.go
+++ b/topgun/k8s/https_web_tls_termination_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 	"github.com/square/certstrap/pkix"
 
 	. "github.com/onsi/ginkgo"
@@ -15,6 +14,7 @@ import (
 )
 
 var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
+
 	var (
 		serverCertBytes []byte
 		serverKeyBytes  []byte
@@ -24,7 +24,9 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 	BeforeEach(func() {
 		var err error
 
-		CACert, serverKey, serverCert := generateKeyPairWithCA()
+		setReleaseNameAndNamespace("wtt")
+
+		CACert, serverKey, serverCert := generateKeyPairWithCA(namespace, releaseName+"-web")
 		CACertBytes, err := CACert.Export()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -43,31 +45,33 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 		os.Remove(caCertFile.Name())
 	})
 
-	Context("When configured correctly", func() {
+	Context("when configured correctly", func() {
+
 		var (
-			proxySession  *gexec.Session
-			atcEndpoint   string
-			chartConfig   []string
-			proxyPort     string
-			proxyProtocol string
+			atc Endpoint
+
+			chartConfig []string
+			proxyPort   string
 		)
 
 		JustBeforeEach(func() {
-			setReleaseNameAndNamespace("wtt")
-			deployConcourseChart(releaseName,
-				chartConfig...)
+			deployConcourseChart(releaseName, chartConfig...)
 
 			waitAllPodsInNamespaceToBeReady(namespace)
 
-			By("Creating the web proxy")
-			proxySession, atcEndpoint = startPortForwardingWithProtocol(namespace, "service/"+releaseName+"-web", proxyPort, proxyProtocol)
+			atc = endpointFactory.NewServiceEndpoint(
+				namespace,
+				releaseName+"-web",
+				proxyPort,
+			)
 		})
 
 		AfterEach(func() {
-			cleanup(releaseName, namespace, proxySession)
+			atc.Close()
+			cleanup(releaseName, namespace)
 		})
 
-		Context("configure helm chart for tls termination at web", func() {
+		Context("with tls termination at web", func() {
 
 			BeforeEach(func() {
 				chartConfig = generateChartConfig(
@@ -76,38 +80,29 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 					"--set=secrets.webTlsCert="+string(serverCertBytes),
 					"--set=secrets.webTlsKey="+string(serverKeyBytes),
 				)
+
 				proxyPort = "443"
-				proxyProtocol = "https"
 			})
 
 			It("fly login succeeds when using the correct CA and host", func() {
-				By("Logging in")
-				sess := fly.Start("login", "-u", "test", "-p", "test", "--ca-cert", caCertFile.Name(), "-c", atcEndpoint)
-				<-sess.Exited
-				Expect(sess.ExitCode()).To(Equal(0))
+				fly.Run("login", "-u", "test", "-p", "test",
+					"--ca-cert", caCertFile.Name(),
+					"-c", "https://"+atc.Address(),
+				)
 			})
 
 			It("fly login fails when NOT using the correct CA", func() {
-				By("Logging in")
-				sess := fly.Start("login", "-u", "test", "-p", "test", "--ca-cert", "k8s/certs/wrong-ca.crt", "-c", atcEndpoint)
+				sess := fly.Start("login", "-u", "test", "-p", "test",
+					"--ca-cert", "k8s/certs/wrong-ca.crt",
+					"-c", "https://"+atc.Address(),
+				)
 				<-sess.Exited
+
 				Expect(sess.ExitCode()).ToNot(Equal(0))
 				Expect(sess.Err).To(gbytes.Say(`x509: certificate signed by unknown authority`))
 			})
 		})
 
-		Context("DON'T configure tls termination at web in helm chart", func() {
-			BeforeEach(func() {
-				chartConfig = generateChartConfig("--set=concourse.web.externalUrl=http://test.com",
-					"--set=concourse.web.tls.enabled=false")
-				proxyPort = "8080"
-				proxyProtocol = "http"
-			})
-			It("fly login succeeds when connecting to web over http", func() {
-				By("Logging in")
-				fly.Login("test", "test", atcEndpoint)
-			})
-		})
 	})
 
 	Context("When NOT configured correctly", func() {
@@ -116,22 +111,26 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 			setReleaseNameAndNamespace("wtt")
 		})
 
-		It("helm deploy fails if tls is enabled but externalURL is NOT set", func() {
+		It("fails if tls is enabled but externalURL is NOT set", func() {
 			expectedErr := "Must specify HTTPS external URL when concourse.web.tls.enabled is true"
+
 			chartConfig := generateChartConfig(
 				"--set=concourse.web.tls.enabled=true",
 				"--set=secrets.webTlsCert="+string(serverCertBytes),
 				"--set=secrets.webTlsKey="+string(serverKeyBytes),
 			)
+
 			deployFailingConcourseChart(releaseName, expectedErr,
 				chartConfig...,
 			)
 		})
 
-		It("helm deploy fails when tls is enabled but ssl cert and ssl key are NOT set", func() {
+		It("fails when tls is enabled but ssl cert and ssl key are NOT set", func() {
 			expectedErr := "secrets.webTlsCert is required because secrets.create is true and concourse.web.tls.enabled is true"
+
 			chartConfig := generateChartConfig("--set=concourse.web.externalUrl=https://test.com",
 				"--set=concourse.web.tls.enabled=true")
+
 			deployFailingConcourseChart(releaseName, expectedErr,
 				chartConfig...,
 			)
@@ -142,12 +141,12 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 
 func generateChartConfig(args ...string) []string {
 	return append(args,
-		"--set=worker.replicas=1",
+		"--set=worker.enabled=false",
 		"--set=concourse.worker.baggageclaim.driver=detect",
 		"--set=concourse.web.tls.bindPort=443",
 	)
 }
-func generateKeyPairWithCA() (*pkix.Certificate, *pkix.Key, *pkix.Certificate) {
+func generateKeyPairWithCA(namespace, service string) (*pkix.Certificate, *pkix.Key, *pkix.Certificate) {
 	CAKey, err := pkix.CreateRSAKey(1024)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -157,11 +156,14 @@ func generateKeyPairWithCA() (*pkix.Certificate, *pkix.Key, *pkix.Certificate) {
 	serverKey, err := pkix.CreateRSAKey(1024)
 	Expect(err).NotTo(HaveOccurred())
 
-	certificateSigningRequest, err := pkix.CreateCertificateSigningRequest(serverKey, "", []net.IP{net.IPv4(127, 0, 0, 1)},
-		nil, "Pivotal", "", "", "", "127.0.0.1")
+	certificateSigningRequest, err := pkix.CreateCertificateSigningRequest(
+		serverKey, "", []net.IP{net.IPv4(127, 0, 0, 1)},
+		[]string{serviceAddress(namespace, service)},
+		"Pivotal", "", "", "", "127.0.0.1")
 	Expect(err).NotTo(HaveOccurred())
 
-	serverCert, err := pkix.CreateCertificateHost(CACert, CAKey, certificateSigningRequest, time.Now().Add(time.Hour))
+	serverCert, err := pkix.CreateCertificateHost(CACert, CAKey,
+		certificateSigningRequest, time.Now().Add(time.Hour))
 	Expect(err).NotTo(HaveOccurred())
 
 	return CACert, serverKey, serverCert

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -37,13 +37,14 @@ type environment struct {
 	ConcourseImageTag    string `env:"CONCOURSE_IMAGE_TAG"`
 	FlyPath              string `env:"FLY_PATH"`
 	K8sEngine            string `env:"K8S_ENGINE" envDefault:"GKE"`
+	InCluster            bool   `env:"IN_CLUSTER" envDefault:"false"`
 }
 
 var (
-	Environment environment
-	fly         FlyCli
-	namespace   string
-	releaseName string
+	Environment            environment
+	endpointFactory        EndpointFactory
+	fly                    FlyCli
+	releaseName, namespace string
 )
 
 var _ = SynchronizedBeforeSuite(func() []byte {
@@ -79,7 +80,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = BeforeEach(func() {
-	SetDefaultEventuallyTimeout(30 * time.Second)
+	SetDefaultEventuallyTimeout(90 * time.Second)
 	SetDefaultConsistentlyDuration(30 * time.Second)
 
 	tmp, err := ioutil.TempDir("", "topgun-tmp")
@@ -89,6 +90,11 @@ var _ = BeforeEach(func() {
 		Bin:    Environment.FlyPath,
 		Target: "concourse-topgun-k8s-" + strconv.Itoa(GinkgoParallelNode()),
 		Home:   filepath.Join(tmp, "fly-home-"+strconv.Itoa(GinkgoParallelNode())),
+	}
+
+	endpointFactory = PortForwardingEndpointFactory{}
+	if Environment.InCluster {
+		endpointFactory = AddressEndpointFactory{}
 	}
 
 	err = os.Mkdir(fly.Home, 0755)
@@ -101,23 +107,148 @@ func setReleaseNameAndNamespace(description string) {
 	namespace = releaseName
 }
 
+// pod corresponds to the Json object that represents a Kuberneted pod from the
+// apiserver perspective.
+//
 type pod struct {
 	Status struct {
+		Conditions []struct {
+			Type   string `json:"type"`
+			Status string `json:"status"`
+		} `json:"conditions"`
 		ContainerStatuses []struct {
 			Name  string `json:"name"`
 			Ready bool   `json:"ready"`
 		} `json:"containerStatuses"`
-		Phase  string `json:"phase"`
-		HostIp string `json:"hostIP"`
-		Ip     string `json:"podIP"`
+		Ip string `json:"podIP"`
 	} `json:"status"`
 	Metadata struct {
 		Name string `json:"name"`
 	} `json:"metadata"`
 }
 
-type podListResponse struct {
-	Items []pod `json:"items"`
+// Endpoint represents a service that can be reached from a given address.
+//
+type Endpoint interface {
+	Address() (addr string)
+	Close() (err error)
+}
+
+// EndpointFactory represents those entities able to generate Endpoints for
+// both services and pods.
+//
+type EndpointFactory interface {
+	NewServiceEndpoint(namespace, service, port string) (endpoint Endpoint)
+	NewPodEndpoint(namespace, pod, port string) (endpoint Endpoint)
+}
+
+// PortForwardingEndpoint is a service that can be reached through a local
+// address, having connections port forwarded to entities in a cluster.
+//
+type PortForwardingEndpoint struct {
+	session *gexec.Session
+	address string
+}
+
+func (p PortForwardingEndpoint) Address() string {
+	return p.address
+}
+
+func (p PortForwardingEndpoint) Close() error {
+	p.session.Interrupt()
+	return nil
+}
+
+// AddressEndpoint represents a direct address without any underlying session.
+//
+type AddressEndpoint struct {
+	address string
+}
+
+func (p AddressEndpoint) Address() string {
+	return p.address
+}
+
+func (p AddressEndpoint) Close() error {
+	return nil
+}
+
+// PortForwardingFactory deals with creating endpoints that reach the targets
+// through port-forwarding.
+//
+type PortForwardingEndpointFactory struct{}
+
+func (f PortForwardingEndpointFactory) NewServiceEndpoint(namespace, service, port string) Endpoint {
+	session, address := portForward(namespace, "service/"+service, port)
+
+	return PortForwardingEndpoint{
+		session: session,
+		address: address,
+	}
+}
+
+func (f PortForwardingEndpointFactory) NewPodEndpoint(namespace, pod, port string) Endpoint {
+	session, address := portForward(namespace, "pod/"+pod, port)
+
+	return PortForwardingEndpoint{
+		session: session,
+		address: address,
+	}
+}
+
+// AddressFactory deals with creating endpoints that reach the targets
+// through port-forwarding.
+//
+type AddressEndpointFactory struct{}
+
+func (f AddressEndpointFactory) NewServiceEndpoint(namespace, service, port string) Endpoint {
+	address := serviceAddress(namespace, service)
+
+	return AddressEndpoint{
+		address: address + ":" + port,
+	}
+}
+
+func (f AddressEndpointFactory) NewPodEndpoint(namespace, pod, port string) Endpoint {
+	address := podAddress(namespace, pod)
+
+	return AddressEndpoint{
+		address: address + ":" + port,
+	}
+}
+
+func podAddress(namespace, pod string) (address string) {
+	pods := getPods(namespace, "--field-selector=metadata.name="+pod)
+	Expect(pods).To(HaveLen(1))
+
+	return pods[0].Status.Ip
+}
+
+// serviceAddress retrieves the ClusterIP address of a service on a given
+// namespace.
+//
+func serviceAddress(namespace, serviceName string) (address string) {
+	return serviceName + "." + namespace
+}
+
+// portForward establishes a port-forwarding session against a given kubernetes
+// resource, for a particular port.
+//
+func portForward(namespace, resource, port string) (*gexec.Session, string) {
+	sess := Start(nil,
+		"kubectl", "port-forward",
+		"--namespace="+namespace,
+		resource,
+		":"+port,
+	)
+
+	Eventually(sess.Out).Should(gbytes.Say("Forwarding"))
+
+	address := regexp.MustCompile(`127\.0\.0\.1:[0-9]+`).
+		FindStringSubmatch(string(sess.Out.Contents()))
+	Expect(address).NotTo(BeEmpty())
+
+	return sess, address[0]
 }
 
 func helmDeploy(releaseName, namespace, chartDir string, args ...string) *gexec.Session {
@@ -125,7 +256,6 @@ func helmDeploy(releaseName, namespace, chartDir string, args ...string) *gexec.
 		"upgrade",
 		"--install",
 		"--force",
-		"--wait",
 		"--namespace", namespace,
 	}
 
@@ -139,12 +269,13 @@ func helmDeploy(releaseName, namespace, chartDir string, args ...string) *gexec.
 
 func helmInstallArgs(args ...string) []string {
 	helmArgs := []string{
-		"--set=web.livenessProbe.failureThreshold=3",
-		"--set=web.livenessProbe.initialDelaySeconds=3",
-		"--set=web.livenessProbe.periodSeconds=3",
-		"--set=web.livenessProbe.timeoutSeconds=3",
 		"--set=concourse.web.kubernetes.keepNamespaces=false",
+		"--set=concourse.worker.bindIp=0.0.0.0",
 		"--set=postgresql.persistence.enabled=false",
+		"--set=web.resources.requests.cpu=500m",
+		"--set=worker.readinessProbe.httpGet.path=/",
+		"--set=worker.readinessProbe.httpGet.port=worker-hc",
+		"--set=worker.resources.requests.cpu=500m",
 		"--set=image=" + Environment.ConcourseImageName}
 
 	if Environment.ConcourseImageTag != "" {
@@ -183,7 +314,10 @@ func helmDestroy(releaseName string) {
 
 func getPods(namespace string, flags ...string) []pod {
 	var (
-		pods podListResponse
+		pods struct {
+			Items []pod `json:"items"`
+		}
+
 		args = append([]string{"get", "pods",
 			"--namespace=" + namespace,
 			"--output=json",
@@ -200,16 +334,15 @@ func getPods(namespace string, flags ...string) []pod {
 }
 
 func isPodReady(p pod) bool {
-	total := len(p.Status.ContainerStatuses)
-	actual := 0
-
-	for _, containerStatus := range p.Status.ContainerStatuses {
-		if containerStatus.Ready {
-			actual++
+	for _, condition := range p.Status.Conditions {
+		if condition.Type != "ContainersReady" {
+			continue
 		}
+
+		return condition.Status == "True"
 	}
 
-	return total == actual
+	return false
 }
 
 func waitAllPodsInNamespaceToBeReady(namespace string) {
@@ -229,7 +362,7 @@ func waitAllPodsInNamespaceToBeReady(namespace string) {
 		}
 
 		return podsReady == len(expectedPods)
-	}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "expected all pods to be running")
+	}, 15*time.Minute, 10*time.Second).Should(BeTrue(), "expected all pods to be running")
 }
 
 func deletePods(namespace string, flags ...string) []string {
@@ -251,22 +384,6 @@ func deletePods(namespace string, flags ...string) []string {
 	return podNames
 }
 
-func startPortForwardingWithProtocol(namespace, resource, port, protocol string) (*gexec.Session, string) {
-	session := Start(nil, "kubectl", "port-forward", "--namespace="+namespace, resource, ":"+port)
-	Eventually(session.Out).Should(gbytes.Say("Forwarding"))
-
-	address := regexp.MustCompile(`127\.0\.0\.1:[0-9]+`).
-		FindStringSubmatch(string(session.Out.Contents()))
-
-	Expect(address).NotTo(BeEmpty())
-
-	return session, protocol + "://" + address[0]
-}
-
-func startPortForwarding(namespace, resource, port string) (*gexec.Session, string) {
-	return startPortForwardingWithProtocol(namespace, resource, port, "http")
-}
-
 func getRunningWorkers(workers []Worker) (running []Worker) {
 	for _, w := range workers {
 		if w.State == "running" {
@@ -276,13 +393,28 @@ func getRunningWorkers(workers []Worker) (running []Worker) {
 	return
 }
 
-func cleanup(releaseName, namespace string, proxySession *gexec.Session) {
+func waitAndLogin(namespace, service string) Endpoint {
+	waitAllPodsInNamespaceToBeReady(namespace)
+
+	atc := endpointFactory.NewServiceEndpoint(
+		namespace,
+		service,
+		"8080",
+	)
+
+	fly.Login("test", "test", "http://"+atc.Address())
+
+	Eventually(func() []Worker {
+		return getRunningWorkers(fly.GetWorkers())
+	}, 2*time.Minute, 10*time.Second).
+		ShouldNot(HaveLen(0))
+
+	return atc
+}
+
+func cleanup(releaseName, namespace string) {
 	helmDestroy(releaseName)
 	Run(nil, "kubectl", "delete", "namespace", namespace, "--wait=false")
-
-	if proxySession != nil {
-		Wait(proxySession.Interrupt())
-	}
 }
 
 func onPks(f func()) {

--- a/topgun/k8s/mainteam_role_test.go
+++ b/topgun/k8s/mainteam_role_test.go
@@ -1,8 +1,6 @@
 package k8s_test
 
 import (
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,11 +8,10 @@ import (
 
 var _ = Describe("Main team role config", func() {
 	var (
-		proxySession        *gexec.Session
-		atcEndpoint         string
+		atc Endpoint
+
 		helmDeployTestFlags []string
-		username            = "test-viewer"
-		password            = "test-viewer"
+		username, password  = "test-viewer", "test-viewer"
 	)
 
 	BeforeEach(func() {
@@ -27,25 +24,25 @@ var _ = Describe("Main team role config", func() {
 
 		waitAllPodsInNamespaceToBeReady(namespace)
 
-		pods := getPods(namespace, "--selector=app="+releaseName+"-worker")
-		Expect(pods).To(HaveLen(1))
+		atc = endpointFactory.NewServiceEndpoint(
+			namespace,
+			releaseName+"-web",
+			"8080",
+		)
 
-		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
-
-		By("Logging in")
-		fly.Login(username, password, atcEndpoint)
+		fly.Login(username, password, "http://"+atc.Address())
 
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		atc.Close()
+		cleanup(releaseName, namespace)
 	})
 
 	Context("Adding team role config yaml to web", func() {
 		BeforeEach(func() {
 			helmDeployTestFlags = []string{
-				`--set=worker.replicas=1`,
+				`--set=worker.enabled=false`,
 				`--set=web.additionalVolumes[0].name=team-role-config`,
 				`--set=web.additionalVolumes[0].configMap.name=team-role-config`,
 				`--set=web.additionalVolumeMounts[0].name=team-role-config`,

--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -6,11 +6,63 @@ import (
 	"path"
 	"time"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("Prometheus integration", func() {
+
+	var prometheusReleaseName string
+
+	BeforeEach(func() {
+		setReleaseNameAndNamespace("pi")
+		prometheusReleaseName = releaseName + "-prom"
+
+		deployConcourseChart(releaseName,
+			"--set=worker.replicas=1",
+			"--set=concourse.worker.ephemeral=true",
+			"--set=concourse.web.prometheus.enabled=true",
+			"--set=concourse.worker.baggageclaim.driver=detect")
+
+		helmDeploy(prometheusReleaseName,
+			namespace,
+			path.Join(Environment.ChartsDir, "stable/prometheus"),
+			"--set=nodeExporter.enabled=false",
+			"--set=kubeStateMetrics.enabled=false",
+			"--set=pushgateway.enabled=false",
+			"--set=alertmanager.enabled=false",
+			"--set=server.persistentVolume.enabled=false")
+
+		waitAllPodsInNamespaceToBeReady(namespace)
+	})
+
+	AfterEach(func() {
+		helmDestroy(prometheusReleaseName)
+		cleanup(releaseName, namespace)
+	})
+
+	It("Is able to retrieve concourse metrics", func() {
+		prometheus := endpointFactory.NewServiceEndpoint(
+			namespace,
+			prometheusReleaseName+"-prometheus-server",
+			"80",
+		)
+		defer prometheus.Close()
+
+		Eventually(func() bool {
+			metrics, err := getPrometheusMetrics("http://"+prometheus.Address(), releaseName)
+			if err != nil {
+				return false
+			}
+
+			if metrics.Status != "success" {
+				return false
+			}
+
+			return true
+		}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "be able to retrieve metrics")
+	})
+})
 
 type prometheusMetrics struct {
 	Status string `json:"status"`
@@ -43,56 +95,3 @@ func getPrometheusMetrics(endpoint, releaseName string) (*prometheusMetrics, err
 
 	return metrics, nil
 }
-
-var _ = Describe("Prometheus integration", func() {
-	var (
-		proxySession          *gexec.Session
-		prometheusReleaseName string
-		prometheusEndpoint    string
-	)
-
-	BeforeEach(func() {
-		setReleaseNameAndNamespace("pi")
-		prometheusReleaseName = releaseName + "-prom"
-
-		deployConcourseChart(releaseName,
-			"--set=worker.replicas=1",
-			"--set=concourse.worker.ephemeral=true",
-			"--set=concourse.web.prometheus.enabled=true",
-			"--set=concourse.worker.baggageclaim.driver=detect")
-
-		helmDeploy(prometheusReleaseName,
-			namespace,
-			path.Join(Environment.ChartsDir, "stable/prometheus"),
-			"--set=nodeExporter.enabled=false",
-			"--set=kubeStateMetrics.enabled=false",
-			"--set=pushgateway.enabled=false",
-			"--set=alertmanager.enabled=false",
-			"--set=server.persistentVolume.enabled=false")
-
-		waitAllPodsInNamespaceToBeReady(namespace)
-
-		By("Creating the prometheus proxy")
-		proxySession, prometheusEndpoint = startPortForwarding(namespace, "service/"+prometheusReleaseName+"-prometheus-server", "80")
-	})
-
-	AfterEach(func() {
-		helmDestroy(prometheusReleaseName)
-		cleanup(releaseName, namespace, proxySession)
-	})
-
-	It("Is able to retrieve concourse metrics", func() {
-		Eventually(func() bool {
-			metrics, err := getPrometheusMetrics(prometheusEndpoint, releaseName)
-			if err != nil {
-				return false
-			}
-
-			if metrics.Status != "success" {
-				return false
-			}
-
-			return true
-		}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "be able to retrieve metrics")
-	})
-})

--- a/topgun/k8s/tsa_node_port_test.go
+++ b/topgun/k8s/tsa_node_port_test.go
@@ -1,20 +1,10 @@
 package k8s_test
 
 import (
-	"time"
-
-	"github.com/onsi/gomega/gexec"
-
-	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("TSA Service Node Port", func() {
-
-	var (
-		proxySession *gexec.Session
-	)
 
 	JustBeforeEach(func() {
 		setReleaseNameAndNamespace("tnp")
@@ -25,19 +15,11 @@ var _ = Describe("TSA Service Node Port", func() {
 	})
 
 	It("deployment succeeds", func() {
-		var atcEndpoint string
-
-		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
-
-		fly.Login("test", "test", atcEndpoint)
-		Eventually(func() []Worker {
-			return getRunningWorkers(fly.GetWorkers())
-		}, 2*time.Minute, 10*time.Second).
-			ShouldNot(HaveLen(0))
+		waitAndLogin(namespace, releaseName+"-web").Close()
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace)
 	})
 
 })


### PR DESCRIPTION
# Existing Issue

fixes #4320
fixes https://github.com/concourse/ci/issues/182
closes #4581
closes #4613


# Why do we need this PR?

Running k8s-topgun outside of the k8s cluster has been flakey. These changes
allow us to run these tests inside or outside of the cluster with a new
environment variable `IN_CLUSTER`.


# Changes proposed in this pull request

We created an `Endpoint` interface and switch implementations based on the value
of `IN_CLUSTER`. The `Endpoint` implementation always returns an address, which
is either:

1. an address of a port-forwarding session (you're running the test suite
outside the cluster)

2. an internal (to the cluster network) address of either a k8s service/pod
(you're running the test suite inside the cluster)

We also:

- removed `--wait` from the helm installation command. We already have a way of
  waiting for all pods to come up. Having `--wait` was causing the baggageclaim
  tests to fail sometimes because helm would exit with 1 when all we really want
  it to do is run a failed deployment.

- added higher `resources.requests` to schedule less containers to the same
  kubernetes node (so that we let the cluster better auto scale when needed)

- added worker readinessProbe that relies on the Concourse worker healthchecking
  mechanism (so that we know when `gdn` and `baggageclaim` are ready)

- increased timeouts to account for autoscaling (takes ~5m in most cases)

Aside from that, We didn't change the behaviour of any tests. We did refactor
the structure of some things just as errors came up.


# Contributor Checklist

- ~Unit tests~
  - test updates only
- [x] Integration tests (if applicable) (:sweat_smile:)
- ~Updated documentation (located at https://github.com/concourse/docs)~
  - internal changes only
- ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~
  - internal changes only


# Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
