### PR TITLE
atc, fly, topgun: run goimports

### DIFF
--- a/atc/db/container_repository.go
+++ b/atc/db/container_repository.go
@@ -374,7 +374,7 @@ func scanContainer(row sq.RowScanner, conn Conn) (CreatingContainer, CreatedCont
 func (repository *containerRepository) DestroyFailedContainers() (int, error) {
 	result, err := psql.Update("containers").
 		Set("state", atc.ContainerStateDestroying).
-		Where( sq.Eq{"state": string(atc.ContainerStateFailed)}).
+		Where(sq.Eq{"state": string(atc.ContainerStateFailed)}).
 		RunWith(repository.conn).
 		Exec()
 

--- a/atc/db/migration/bindata.go
+++ b/atc/db/migration/bindata.go
@@ -1,7 +1,9 @@
 package migration
 
-import "errors"
-import "os"
+import (
+	"errors"
+	"os"
+)
 
 func Asset(string) ([]byte, error) {
 	return nil, errors.New("no assets")

--- a/atc/gc/gc_suite_test.go
+++ b/atc/gc/gc_suite_test.go
@@ -1,9 +1,9 @@
 package gc_test
 
 import (
+	"context"
 	"os"
 	"time"
-	"context"
 
 	"code.cloudfoundry.org/lager"
 

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -156,7 +156,6 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		delete(newPayload, "value")
 		payload = append(payload, newPayload)
 
-
 	// And a couple that need a small rename (new relic doesn't like some chars)
 	case "scheduling: full duration (ms)":
 		payload = append(payload, emitter.simplePayload(logger, event, "scheduling_full_duration_ms"))

--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -322,7 +322,7 @@ func listenForTokenCallback(tokenChannel chan string, errorChannel chan error, p
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Access-Control-Allow-Origin", targetUrl)
 			tokenChannel <- r.FormValue("token")
-			if (r.Header.Get("Upgrade-Insecure-Requests") != "") {
+			if r.Header.Get("Upgrade-Insecure-Requests") != "" {
 				http.Redirect(w, r, fmt.Sprintf("%s/fly_success?noop=true", targetUrl), http.StatusFound)
 			}
 		}),

--- a/fly/commands/unpin_resource.go
+++ b/fly/commands/unpin_resource.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"

--- a/fly/integration/workers_test.go
+++ b/fly/integration/workers_test.go
@@ -1,6 +1,9 @@
 package integration_test
 
 import (
+	"os/exec"
+	"time"
+
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/ui"
 	"github.com/fatih/color"
@@ -9,8 +12,6 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
-	"os/exec"
-	"time"
 )
 
 const second = 1

--- a/topgun/k8s/container_limits_test.go
+++ b/topgun/k8s/container_limits_test.go
@@ -1,11 +1,8 @@
 package k8s_test
 
 import (
-	"time"
-
 	"github.com/onsi/gomega/gbytes"
 
-	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/topgun/runtime/build_artifact_transfer_test.go
+++ b/topgun/runtime/build_artifact_transfer_test.go
@@ -1,11 +1,11 @@
 package topgun_test
 
 import (
+	. "github.com/concourse/concourse/topgun/common"
 	_ "github.com/lib/pq"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	. "github.com/concourse/concourse/topgun/common"
 )
 
 var _ = Describe("Passing artifacts between build steps", func() {


### PR DESCRIPTION
# Why do we need this PR?
[k8s topgun builds are failing](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-topgun/builds/2163#L5db181c1:3:5). While I was at it, I figured I might as well run `goimports` on everything.

# Changes proposed in this pull request
* pure refactor
* remove unused import in container limits k8s topgun test
* format imports in other go files

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] ~PR acceptance performed~