### PR TITLE
Small style fixes and remove an unused constant

### DIFF
--- a/atc/config.go
+++ b/atc/config.go
@@ -12,7 +12,6 @@ import (
 )
 
 const ConfigVersionHeader = "X-Concourse-Config-Version"
-const DefaultPipelineName = "main"
 const DefaultTeamName = "main"
 
 // TIMEOUT CONSTANTS

--- a/atc/task.go
+++ b/atc/task.go
@@ -67,7 +67,7 @@ func NewTaskConfig(configBytes []byte) (TaskConfig, error) {
 }
 
 func (config TaskConfig) Validate() error {
-	messages := []string{}
+	var messages []string
 
 	if config.Platform == "" {
 		messages = append(messages, "  missing 'platform'")
@@ -88,7 +88,7 @@ func (config TaskConfig) Validate() error {
 }
 
 func (config TaskConfig) validateOutputContainsNames() []string {
-	messages := []string{}
+	var messages []string
 
 	for i, output := range config.Outputs {
 		if output.Name == "" {

--- a/atc/validate.go
+++ b/atc/validate.go
@@ -25,8 +25,8 @@ type ConfigWarning struct {
 }
 
 func (c Config) Validate() ([]ConfigWarning, []string) {
-	warnings := []ConfigWarning{}
-	errorMessages := []string{}
+	var warnings []ConfigWarning
+	var errorMessages []string
 
 	groupsErr := validateGroups(c)
 	if groupsErr != nil {
@@ -53,7 +53,7 @@ func (c Config) Validate() ([]ConfigWarning, []string) {
 }
 
 func validateGroups(c Config) error {
-	errorMessages := []string{}
+	var errorMessages []string
 
 	jobsGrouped := make(map[string]bool)
 	groupNames := make(map[string]int)
@@ -109,7 +109,7 @@ func validateGroups(c Config) error {
 }
 
 func validateResources(c Config) error {
-	errorMessages := []string{}
+	var errorMessages []string
 
 	names := map[string]int{}
 
@@ -145,7 +145,7 @@ func validateResources(c Config) error {
 }
 
 func validateResourceTypes(c Config) error {
-	errorMessages := []string{}
+	var errorMessages []string
 
 	names := map[string]int{}
 
@@ -208,8 +208,8 @@ func usedResources(c Config) map[string]bool {
 }
 
 func validateJobs(c Config) ([]ConfigWarning, error) {
-	errorMessages := []string{}
-	warnings := []ConfigWarning{}
+	var errorMessages []string
+	var warnings []ConfigWarning
 
 	names := map[string]int{}
 
@@ -395,8 +395,8 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]ConfigWarning
 		return []ConfigWarning{}, []string{message}
 	}
 
-	errorMessages := []string{}
-	warnings := []ConfigWarning{}
+	var errorMessages []string
+	var warnings []ConfigWarning
 
 	switch {
 	case plan.Do != nil:
@@ -626,8 +626,8 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]ConfigWarning
 }
 
 func validateInapplicableFields(inapplicableFields []string, plan PlanConfig, identifier string) []string {
-	errorMessages := []string{}
-	foundInapplicableFields := []string{}
+	var errorMessages []string
+	var foundInapplicableFields []string
 
 	for _, field := range inapplicableFields {
 		switch field {


### PR DESCRIPTION
This PR mostly changes a few locations where we have empty slices assigned, into variable declarations that implicitly achieve the same thing but in a more Go idiomatic way. Also get rid of a constant that we don't use anymore.

Signed-off-by: Denise Yu <dyu@pivotal.io>

- [x] Unit tests still passing

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

