### PR TITLE
atc: remove error from TaskStep.registerOutputs

### DIFF
--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -234,10 +234,7 @@ func (step *TaskStep) Run(ctx context.Context, state RunState) error {
 	err = result.Err
 	if err != nil {
 		if err == context.Canceled || err == context.DeadlineExceeded {
-			registerErr := step.registerOutputs(logger, repository, config, result.VolumeMounts, step.containerMetadata)
-			if registerErr != nil {
-				return registerErr
-			}
+			step.registerOutputs(logger, repository, config, result.VolumeMounts, step.containerMetadata)
 		}
 		return err
 	}
@@ -245,10 +242,7 @@ func (step *TaskStep) Run(ctx context.Context, state RunState) error {
 	step.succeeded = (result.Status == 0)
 	step.delegate.Finished(logger, ExitStatus(result.Status))
 
-	err = step.registerOutputs(logger, repository, config, result.VolumeMounts, step.containerMetadata)
-	if err != nil {
-		return err
-	}
+	step.registerOutputs(logger, repository, config, result.VolumeMounts, step.containerMetadata)
 
 	// Do not initialize caches for one-off builds
 	if step.metadata.JobID != 0 {
@@ -392,7 +386,7 @@ func (step *TaskStep) workerSpec(logger lager.Logger, resourceTypes atc.Versione
 	return workerSpec, nil
 }
 
-func (step *TaskStep) registerOutputs(logger lager.Logger, repository *artifact.Repository, config atc.TaskConfig, volumeMounts []worker.VolumeMount, metadata db.ContainerMetadata) error {
+func (step *TaskStep) registerOutputs(logger lager.Logger, repository *artifact.Repository, config atc.TaskConfig, volumeMounts []worker.VolumeMount, metadata db.ContainerMetadata) {
 	logger.Debug("registering-outputs", lager.Data{"outputs": config.Outputs})
 
 	for _, output := range config.Outputs {
@@ -410,8 +404,6 @@ func (step *TaskStep) registerOutputs(logger lager.Logger, repository *artifact.
 			}
 		}
 	}
-
-	return nil
 }
 
 func (step *TaskStep) registerCaches(logger lager.Logger, repository *artifact.Repository, config atc.TaskConfig, volumeMounts []worker.VolumeMount, metadata db.ContainerMetadata) error {


### PR DESCRIPTION
# Why do we need this PR?
I was trying to enumerate the various scenarios that might cause an `on_error` hook to evaluate [here](https://github.com/concourse/docs/issues/267#issuecomment-546555199), and when trying to describe this case I realized there never actually was an error thrown.

# Changes proposed in this pull request

* pure refactor, just changing a function signature

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [ ] Code reviewed
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] ~PR acceptance performed~