### PR TITLE
fix: (creds/vault) fixed a bug when "vault-shared" is not configured, secrets under prefix can be fetched.

### DIFF
--- a/atc/creds/vault/vault.go
+++ b/atc/creds/vault/vault.go
@@ -30,7 +30,9 @@ func (v Vault) NewSecretLookupPaths(teamName string, pipelineName string) []cred
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, teamName, pipelineName)+"/"))
 	}
 	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, teamName)+"/"))
-	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, v.SharedPath)+"/"))
+	if v.SharedPath != "" {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, v.SharedPath)+"/"))
+	}
 	return lookupPaths
 }
 

--- a/atc/creds/vault/vault_test.go
+++ b/atc/creds/vault/vault_test.go
@@ -122,5 +122,30 @@ var _ = Describe("Vault", func() {
 			Expect(found).To(BeTrue())
 			Expect(err).To(BeNil())
 		})
+
+		Context("without shared", func() {
+			JustBeforeEach(func() {
+				v = &vault.Vault{
+					SecretReader: msr,
+					Prefix:       "/concourse",
+				}
+
+				variables = creds.NewVariables(v, "team", "pipeline")
+			})
+
+			It("should not get secret from root", func() {
+				v.SecretReader = &MockSecretReader{&[]MockSecret{
+					{
+						path: "/concourse/foo",
+						secret: &vaultapi.Secret{
+							Data: map[string]interface{}{"value": "foo"},
+						},
+					}},
+				}
+				_, found, err := variables.Get(vars.VariableDefinition{Name: "foo"})
+				Expect(found).To(BeFalse())
+				Expect(err).To(BeNil())
+			})
+		})
 	})
 })


### PR DESCRIPTION
# Existing Issue

No

# Why do we need this PR?

For credential manager Vault, secrets should be fetched from only "prefix/team/pipeline", "prefix/team", or "prefix/shared". It should never fetch secrets directly from "prefix/". But there is a bug, when `vault-shared` is not configured, it will fetch secrets directly from "prefix/".

# Changes proposed in this pull request

Change is simple. When shared path is not configured, it should not be appended to search path.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

