### PR TITLE
atc: skip gzip on download cli endpoint

### DIFF
--- a/atc/wrappa/compression_wrappa.go
+++ b/atc/wrappa/compression_wrappa.go
@@ -21,19 +21,21 @@ func (wrappa CompressionWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 	wrapped := rata.Handlers{}
 
 	for name, handler := range handlers {
-
+		switch name {
 		// always gzip for events
-		if name == atc.BuildEvents {
+		case atc.BuildEvents:
 			gzipEnforcedHandler, err := gziphandler.GzipHandlerWithOpts(gziphandler.MinSize(0))
 			if err != nil {
 				wrappa.Logger.Error("failed-to-create-gzip-handler", err)
 			}
 
 			wrapped[name] = gzipEnforcedHandler(handler)
-			continue
+		// skip gzip as this endpoint does it already
+		case atc.DownloadCLI:
+			wrapped[name] = handler
+		default:
+			wrapped[name] = gziphandler.GzipHandler(handler)
 		}
-
-		wrapped[name] = gziphandler.GzipHandler(handler)
 	}
 
 	return wrapped

--- a/release-notes/v5.7.0.md
+++ b/release-notes/v5.7.0.md
@@ -51,6 +51,10 @@ There is no configuration required to take advantage of these new improvements.
 
 * The `fly format-pipeline` now always produces a formatted pipeline, instead of declining to do so when it was already in the expected format. #4492
 
+#### <sub><sup><a name="4666" href="#4666">:link:</a></sup></sub> fix
+
+* Fixed a regression when running `fly sync` it shows warning of parsing Content-Length and progress bar not showing downloading progress. #4666
+
 #### <sub><sup><a name="3600" href="#3600">:link:</a></sup></sub> feature
 
 * Concourse now garbage-collects worker containers and volumes that are not tracked in the database. In some niche cases, it is possible for containers and/or volumes to be created on the worker, but the database (via the web) assumes their creation had failed. If this occurs, these untracked containers can pile up on the worker and use resources. #3600 ensures that they get cleaned appropriately.

--- a/testflight/download_cli_test.go
+++ b/testflight/download_cli_test.go
@@ -1,0 +1,15 @@
+package testflight_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("Download Fly Cli", func() {
+	It("can download fly cli without issue", func() {
+		watch := fly("sync", "--force")
+		Expect(watch).ToNot(gbytes.Say("warning: failed to parse Content-Length"))
+		Expect(watch).To(gbytes.Say("done"))
+	})
+})


### PR DESCRIPTION
Fixes below error and progress bar displaying wrongly when running `fly sync`.
```
warning: failed to parse Content-Length: strconv.ParseInt: parsing "": invalid syntax
```

# Why do we need this PR?
By https://github.com/concourse/concourse/pull/4470, the gzip handler removes `Content-length` during its process caused the above error


# Changes proposed in this pull request
Skip gziphandler gzips `DownloadCLI` endpoint

# Contributor Checklist
- [x] ~Unit tests~
- [x] Integration tests (if applicable)
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [x] Release notes reviewed
- [x] PR acceptance performed