### PR TITLE
hack/trace: ensure dlv server port is forwarded

### DIFF
--- a/hack/trace
+++ b/hack/trace
@@ -5,7 +5,13 @@ set -e -u
 cd $(dirname $0)/..
 
 container_name=""
-listen_cmd=""
+dlv_flags=""
+docker_flags="--interactive --privileged --rm --tty"
+
+usage() {
+    echo "Usage: trace (web|worker) [--listen port]"
+    exit 1
+}
 
 while test $# -gt 0; do
    case "$1" in
@@ -19,27 +25,24 @@ while test $# -gt 0; do
             ;;
         --listen)
             shift
-            listen_cmd=" --headless=true --listen=:$1"
+            dlv_flags=" --headless=true --listen=:$1"
+            docker_flags+=" -p $1:$1"
             shift
             ;;
         *)
-          echo "Usage: trace (web|worker) [--listen port]"
-          exit 1
-          ;;
+            usage
+            ;;
   esac
 done
 
-
+if [ -z "$container_name" ]; then
+  usage
+fi
 
 trace_pid=$(docker exec $container_name pidof concourse)
 
 docker build --tag dlv ./hack/dlv
 
-docker run \
-  --interactive \
+docker run $docker_flags \
   --pid=container:$container_name \
-  --privileged \
-  --rm \
-  --tty \
-  dlv \
-  attach $trace_pid $listen_cmd
+  dlv attach $trace_pid $dlv_flags


### PR DESCRIPTION
# Why do we need this PR?
@huguesalary rightly observed that the script in this configuration is kinda unusable :grimacing::
https://github.com/concourse/concourse/pull/4593#issuecomment-547104894

# Changes proposed in this pull request

* just a dev script, no code changes!
* adds the correct `-p` flag to docker
* bails with usage text if no service name is provided
* refactored a bit to ease my own mental model

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


# Reviewer Checklist
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed: I tried running `hack/trace web --listen 1234` and I saw port 1234 being forwarded in the output from `docker ps`.