### PR TITLE
fix: fixed of bug of secret redaction. issue #4656

### DIFF
--- a/atc/engine/builder/delegate_factory.go
+++ b/atc/engine/builder/delegate_factory.go
@@ -360,7 +360,10 @@ type credVarsIterator struct {
 
 func (it *credVarsIterator) YieldCred(name, value string) {
 	for _, lineValue := range strings.Split(value, "\n") {
-		it.line = strings.Replace(it.line, lineValue, "((redacted))", -1)
+		lineValue = strings.TrimSpace(lineValue)
+		if lineValue != "" {
+			it.line = strings.Replace(it.line, lineValue, "((redacted))", -1)
+		}
 	}
 }
 

--- a/atc/engine/builder/delegate_factory_test.go
+++ b/atc/engine/builder/delegate_factory_test.go
@@ -39,7 +39,7 @@ var _ = Describe("DelegateFactory", func() {
 		fakeClock = fakeclock.NewFakeClock(time.Unix(123456789, 0))
 		credVars := vars.StaticVariables{
 			"source-param": "super-secret-source",
-			"git-key":      "123\n456\n789",
+			"git-key":      "123\n456\n789\n",
 		}
 		credVarsTracker = vars.NewCredVarsTracker(credVars, true)
 	})

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -70,3 +70,7 @@ There is no configuration required to take advantage of these new improvements.
 #### <sub><sup><a name="4637" href="#4637">:link:</a></sup></sub> fix
 
 * Fixed a [bug](https://github.com/concourse/concourse/issues/3942) where log lines on the build page would have all their timestamps off by one. #4637
+
+#### <sub><sup><a name="4668" href="#4668">:link:</a></sup></sub> fix
+
+* @evanchaoli fixed a [bug](https://github.com/concourse/concourse/issues/4656) where secret redaction incorrectly "redacts" empty string resulting in mangled logs. #4668


### PR DESCRIPTION
# Existing Issue

Fixes #4656 .

# Changes proposed in this pull request

When split a multi-line secrets by "\n", last element will be an empty string. We should not treat an empty string as a secret.

I can reproduce the bug in unit test, so I have updated the unit test as well.

# Contributor Checklist
- [x] Unit tests
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed