### PR TITLE
add release notes for registry-image fixes

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -70,3 +70,11 @@ There is no configuration required to take advantage of these new improvements.
 #### <sub><sup><a name="4637" href="#4637">:link:</a></sup></sub> fix
 
 * Fixed a [bug](https://github.com/concourse/concourse/issues/3942) where log lines on the build page would have all their timestamps off by one. #4637
+
+#### <sub><sup><a name="registry-image-67" href="#registry-image-67">:link:</a></sup></sub> fix
+
+* @hbd fixed a [bug](https://github.com/concourse/registry-image-resource/issues/56) in the [`registry-image` resource](https://github.com/concourse/registry-image-resource) where `get` steps would mysteriously give a 404 error concourse/registry-image-resource#67.
+
+#### <sub><sup><a name="registry-image-69" href="#registry-image-69">:link:</a></sup></sub> fix
+
+* Made the [`registry-image` resource](https://github.com/concourse/registry-image-resource) more resilient - requests that get a 429 (Too Many Requests) from Docker Hub will be retried concourse/registry-image-resource#69.


### PR DESCRIPTION
# Why do we need this PR?

Documents the newest registry-image fixes that will be in the version bundled with concourse in the next minor.

# Changes proposed in this pull request

* just release notes, no code changes.
* we're shipping a new version of the registry-image resource right now: https://ci.concourse-ci.org/teams/resources/pipelines/registry-image/jobs/publish-patch/builds/2

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [x] ~PR acceptance performed~