### PR TITLE
WIP: feat: add pipeline collector

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1450,7 +1450,9 @@ func (cmd *RunCommand) configureComponentIntervals(componentFactory db.Component
 				Interval: 60 * time.Second,
 			}, {
 				Name:     atc.ComponentCollectorPipelines,
-				Interval: 5 * time.Minute,
+				// Pipeline collector is not a critical GC task, only run it
+				// every 10 GC cycles.
+				Interval: 10 * cmd.GC.Interval,
 			},
 		})
 }

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1010,7 +1010,7 @@ func (cmd *RunCommand) constructGCMember(
 		time.Minute,
 	)
 
-	collectors := map[string]lockrunner.Task{
+	collectors := map[string]lockrunner.Task {
 		atc.ComponentCollectorBuilds:            gc.NewBuildCollector(dbBuildFactory),
 		atc.ComponentCollectorWorkers:           gc.NewWorkerCollector(dbWorkerLifecycle),
 		atc.ComponentCollectorResourceConfigs:   gc.NewResourceConfigCollector(dbResourceConfigFactory),
@@ -1022,7 +1022,7 @@ func (cmd *RunCommand) constructGCMember(
 		atc.ComponentCollectorContainers:        gc.NewContainerCollector(dbContainerRepository, jobRunner, cmd.GC.MissingGracePeriod),
 		atc.ComponentCollectorCheckSessions:     gc.NewResourceConfigCheckSessionCollector(resourceConfigCheckSessionLifecycle),
 		atc.ComponentCollectorVarSources:        gc.NewCollectorTask(cmd.varSourcePool.(gc.Collector)),
-		atc.ComponentCollectorPipelines:         gc.NewPipelineCollector(dbPipelineFactory, cmd.PipelineTTL),
+		atc.ComponentCollectorPipelines:         gc.NewCollectorTask(gc.NewPipelineCollector(dbPipelineFactory, cmd.PipelineTTL)),
 	}
 
 	for collectorName, collector := range collectors {

--- a/atc/component.go
+++ b/atc/component.go
@@ -20,6 +20,7 @@ const (
 	ComponentCollectorVolumes           = "collector_volumes"
 	ComponentCollectorWorkers           = "collector_workers"
 	ComponentCollectorVarSources        = "collector_var_sources"
+	ComponentCollectorPipelines         = "collector_pipelines"
 )
 
 type Component struct {

--- a/atc/gc/pipeline_collector.go
+++ b/atc/gc/pipeline_collector.go
@@ -1,0 +1,88 @@
+package gc
+
+import (
+	"code.cloudfoundry.org/lager"
+	"context"
+	"time"
+
+	"code.cloudfoundry.org/lager/lagerctx"
+
+	"github.com/concourse/concourse/atc/db"
+)
+
+
+// pipelineCollector takes a parameter `ttl`, and checks all pipelines. If a
+// non-paused has no any build within `ttl`, then it will be paused; if a paused
+// pipeline has no any build within 2*`ttl`, then it will be destroyed. It `ttl`
+// is 0, then pipelineCollector will not touch any pipeline.
+type pipelineCollector struct {
+	pipelineFactory db.PipelineFactory
+	ttl             time.Duration
+}
+
+func NewPipelineCollector(pipelineFactory db.PipelineFactory, ttl time.Duration) *pipelineCollector {
+	return &pipelineCollector{
+		pipelineFactory: pipelineFactory,
+		ttl:             ttl,
+	}
+}
+
+func (p *pipelineCollector) Run(ctx context.Context) error {
+	logger := lagerctx.FromContext(ctx).Session("pipeline-collector")
+
+	logger.Debug("start")
+	defer logger.Debug("done")
+
+	if p.ttl == 0 {
+		logger.Debug("ttl-is-zero")
+		return nil
+	}
+
+	pipelines, err := p.pipelineFactory.AllPipelines()
+	if err != nil {
+		logger.Error("failed-to-get-pipelines", err)
+		return err
+	}
+	logger.Debug("after-get-all-pipelines", lager.Data{"total-pipeline-count": len(pipelines)})
+
+	for _, pipeline := range pipelines {
+		log := logger.Session("tick").WithData(lager.Data{"pipeline-id": pipeline.ID()})
+		if pipeline.Paused() {
+			page := db.Page{
+				Limit: 1,
+				Since: int(time.Now().Unix()-2*int64(p.ttl.Seconds())),
+			}
+			builds, _, err := pipeline.BuildsWithTime(page)
+			if err != nil {
+				logger.Error("failed-to-query-build-of-pipeline", err)
+			}
+			logger.Debug("paused-query-builds", lager.Data{"buillds": len(builds)})
+			if len(builds) == 0 {
+				log.Info("destroy-pipeline")
+				err := pipeline.Destroy()
+				if err != nil {
+					log.Error("failed-to-destroy-pipeline", err)
+				}
+			}
+		} else {
+			page := db.Page{
+				Limit: 1,
+				Since: int(time.Now().Unix()-int64(p.ttl.Seconds())),
+			}
+			builds, _, err := pipeline.BuildsWithTime(page)
+			if err != nil {
+				log.Error("failed-to-query-build-of-pipeline", err)
+			}
+			logger.Debug("running-query-builds", lager.Data{"buillds": len(builds)})
+			if len(builds) == 0 {
+				log.Info("pause-pipeline")
+				err := pipeline.Pause()
+				if err != nil {
+					log.Error("failed-to-pause-pipeline", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/atc/gc/pipeline_collector.go
+++ b/atc/gc/pipeline_collector.go
@@ -2,10 +2,7 @@ package gc
 
 import (
 	"code.cloudfoundry.org/lager"
-	"context"
 	"time"
-
-	"code.cloudfoundry.org/lager/lagerctx"
 
 	"github.com/concourse/concourse/atc/db"
 )
@@ -27,12 +24,7 @@ func NewPipelineCollector(pipelineFactory db.PipelineFactory, ttl time.Duration)
 	}
 }
 
-func (p *pipelineCollector) Run(ctx context.Context) error {
-	logger := lagerctx.FromContext(ctx).Session("pipeline-collector")
-
-	logger.Debug("start")
-	defer logger.Debug("done")
-
+func (p *pipelineCollector) Collect(logger lager.Logger) error {
 	if p.ttl == 0 {
 		logger.Debug("ttl-is-zero")
 		return nil

--- a/atc/gc/pipeline_collector_test.go
+++ b/atc/gc/pipeline_collector_test.go
@@ -1,0 +1,137 @@
+package gc_test
+
+import (
+	"context"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/gc"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PipelineCollector", func() {
+	var (
+		pipelineCollector   Collector
+		fakePipelineFactory *dbfakes.FakePipelineFactory
+	)
+
+	BeforeEach(func() {
+		fakePipelineFactory = new(dbfakes.FakePipelineFactory)
+	})
+
+	JustBeforeEach(func() {
+		pipelineCollector = NewPipelineCollector(
+			fakePipelineFactory,
+			5*time.Minute,
+		)
+	})
+
+	Context("when there is a paused pipelines with builds within ttl", func() {
+		var fakePipeline *dbfakes.FakePipeline
+
+		BeforeEach(func() {
+			fakePipeline = new(dbfakes.FakePipeline)
+			fakePipeline.IDReturns(42)
+			fakePipeline.BuildsWithTimeReturns([]db.Build{new(dbfakes.FakeBuild)}, db.Pagination{}, nil)
+			fakePipeline.PausedReturns(true)
+
+			fakePipelineFactory.AllPipelinesReturns([]db.Pipeline{fakePipeline}, nil)
+		})
+
+		It("should be destroyed", func() {
+			err := pipelineCollector.Run(context.TODO())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakePipeline.DestroyCallCount()).To(Equal(0))
+			Expect(fakePipeline.PauseCallCount()).To(Equal(0))
+		})
+	})
+
+	Context("when there is a paused pipelines without builds within ttl", func() {
+		var fakePipeline *dbfakes.FakePipeline
+
+		BeforeEach(func() {
+			fakePipeline = new(dbfakes.FakePipeline)
+			fakePipeline.IDReturns(42)
+			fakePipeline.BuildsWithTimeReturns([]db.Build{}, db.Pagination{}, nil)
+			fakePipeline.PausedReturns(true)
+
+			fakePipelineFactory.AllPipelinesReturns([]db.Pipeline{fakePipeline}, nil)
+		})
+
+		It("should be destroyed", func() {
+			err := pipelineCollector.Run(context.TODO())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakePipeline.DestroyCallCount()).To(Equal(1))
+			Expect(fakePipeline.PauseCallCount()).To(Equal(0))
+		})
+	})
+
+	Context("when there is a running pipelines with builds within ttl", func() {
+		var fakePipeline *dbfakes.FakePipeline
+
+		BeforeEach(func() {
+			fakePipeline = new(dbfakes.FakePipeline)
+			fakePipeline.IDReturns(42)
+			fakePipeline.BuildsWithTimeReturns([]db.Build{new(dbfakes.FakeBuild)}, db.Pagination{}, nil)
+			fakePipeline.PausedReturns(false)
+
+			fakePipelineFactory.AllPipelinesReturns([]db.Pipeline{fakePipeline}, nil)
+		})
+
+		It("should be destroyed", func() {
+			err := pipelineCollector.Run(context.TODO())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakePipeline.DestroyCallCount()).To(Equal(0))
+			Expect(fakePipeline.PauseCallCount()).To(Equal(0))
+		})
+	})
+
+	Context("when there is a running pipelines without builds within ttl", func() {
+		var fakePipeline *dbfakes.FakePipeline
+
+		BeforeEach(func() {
+			fakePipeline = new(dbfakes.FakePipeline)
+			fakePipeline.IDReturns(42)
+			fakePipeline.BuildsWithTimeReturns([]db.Build{}, db.Pagination{}, nil)
+			fakePipeline.PausedReturns(false)
+
+			fakePipelineFactory.AllPipelinesReturns([]db.Pipeline{fakePipeline}, nil)
+		})
+
+		It("should be destroyed", func() {
+			err := pipelineCollector.Run(context.TODO())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakePipeline.DestroyCallCount()).To(Equal(0))
+			Expect(fakePipeline.PauseCallCount()).To(Equal(1))
+		})
+	})
+
+	Context("ttl is 0", func() {
+		var fakePipeline *dbfakes.FakePipeline
+
+		BeforeEach(func() {
+			fakePipeline = new(dbfakes.FakePipeline)
+			fakePipeline.IDReturns(42)
+			fakePipeline.BuildsWithTimeReturns([]db.Build{}, db.Pagination{}, nil)
+			fakePipeline.PausedReturns(false)
+
+			fakePipelineFactory.AllPipelinesReturns([]db.Pipeline{fakePipeline}, nil)
+		})
+
+		JustBeforeEach(func() {
+			pipelineCollector = NewPipelineCollector(
+				fakePipelineFactory,
+				0,
+			)
+		})
+
+		It("should do nothing", func() {
+			err := pipelineCollector.Run(context.TODO())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakePipeline.DestroyCallCount()).To(Equal(0))
+			Expect(fakePipeline.PauseCallCount()).To(Equal(0))
+		})
+	})
+})

--- a/atc/gc/pipeline_collector_test.go
+++ b/atc/gc/pipeline_collector_test.go
@@ -1,7 +1,7 @@
 package gc_test
 
 import (
-	"context"
+	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
 	. "github.com/concourse/concourse/atc/gc"
@@ -15,10 +15,12 @@ var _ = Describe("PipelineCollector", func() {
 	var (
 		pipelineCollector   Collector
 		fakePipelineFactory *dbfakes.FakePipelineFactory
+		logger *lagertest.TestLogger
 	)
 
 	BeforeEach(func() {
 		fakePipelineFactory = new(dbfakes.FakePipelineFactory)
+		logger = lagertest.NewTestLogger("pipeline-collector-test")
 	})
 
 	JustBeforeEach(func() {
@@ -41,7 +43,7 @@ var _ = Describe("PipelineCollector", func() {
 		})
 
 		It("should be destroyed", func() {
-			err := pipelineCollector.Run(context.TODO())
+			err := pipelineCollector.Collect(logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakePipeline.DestroyCallCount()).To(Equal(0))
 			Expect(fakePipeline.PauseCallCount()).To(Equal(0))
@@ -61,7 +63,7 @@ var _ = Describe("PipelineCollector", func() {
 		})
 
 		It("should be destroyed", func() {
-			err := pipelineCollector.Run(context.TODO())
+			err := pipelineCollector.Collect(logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakePipeline.DestroyCallCount()).To(Equal(1))
 			Expect(fakePipeline.PauseCallCount()).To(Equal(0))
@@ -81,7 +83,7 @@ var _ = Describe("PipelineCollector", func() {
 		})
 
 		It("should be destroyed", func() {
-			err := pipelineCollector.Run(context.TODO())
+			err := pipelineCollector.Collect(logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakePipeline.DestroyCallCount()).To(Equal(0))
 			Expect(fakePipeline.PauseCallCount()).To(Equal(0))
@@ -101,7 +103,7 @@ var _ = Describe("PipelineCollector", func() {
 		})
 
 		It("should be destroyed", func() {
-			err := pipelineCollector.Run(context.TODO())
+			err := pipelineCollector.Collect(logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakePipeline.DestroyCallCount()).To(Equal(0))
 			Expect(fakePipeline.PauseCallCount()).To(Equal(1))
@@ -128,7 +130,7 @@ var _ = Describe("PipelineCollector", func() {
 		})
 
 		It("should do nothing", func() {
-			err := pipelineCollector.Run(context.TODO())
+			err := pipelineCollector.Collect(logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakePipeline.DestroyCallCount()).To(Equal(0))
 			Expect(fakePipeline.PauseCallCount()).To(Equal(0))


### PR DESCRIPTION
Added a CLI option `--pipeline-ttl` to concourse web. By default
this ttl is 0, meaning that pipeline collector won't work. When
ttl is set, if a non-paused has no any build within `ttl`, then
it will be paused; if a paused pipeline has no any build within
2*`ttl`, then it will be destroyed.

# Existing Issue
> Is there an existing issue related to this PR? Fill in the issue number as follows: Fixes #1234.

Fixes #4578 .

# Why do we need this PR?

It will help auto cleanup zombie pipelines, so that keep UI clean and save ATC resource.

# Changes proposed in this pull request

* Added a pipelineCollector
* Also fixed a bug of `func getBuildsWithDates()` in `atc/db/build_factory.go`. Where if query by time returns no data, then it should not go on to call `getBuildsWithPagination`.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

