### PR TITLE
rewind to v5.6.0

### DIFF
--- a/fly/commands/workers.go
+++ b/fly/commands/workers.go
@@ -212,7 +212,7 @@ func (w *worker) ageCell() ui.TableCell {
 		} else if age/hour > 0 {
 			column.Contents = fmt.Sprintf("%dh%dm", age/hour, (age%hour)/minute)
 		} else if age/minute > 0 {
-			column.Contents = fmt.Sprintf("%dm%ds", age/minute, age%minute)
+			column.Contents = fmt.Sprintf("%dh%dm", age/minute, age%minute)
 		} else {
 			column.Contents = fmt.Sprintf("%ds", age)
 		}

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -706,7 +706,7 @@ viewMetadata : List MetadataField -> Html Message
 viewMetadata =
     List.map
         (\{ name, value } ->
-            ( Html.text name
+            ( name
             , Html.pre []
                 [ case fromString value of
                     Just _ ->
@@ -722,14 +722,8 @@ viewMetadata =
                 ]
             )
         )
-        >> List.map
-            (\( key, value ) ->
-                Html.tr []
-                    [ Html.td (Styles.metadataCell Styles.Key) [ key ]
-                    , Html.td (Styles.metadataCell Styles.Value) [ value ]
-                    ]
-            )
-        >> Html.table Styles.metadataTable
+        >> Dict.fromList
+        >> DictView.view []
 
 
 viewStepState : StepState -> StepID -> List (Html Message) -> Html Message

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -1,6 +1,5 @@
 module Build.Styles exposing
-    ( MetadataCellType(..)
-    , abortButton
+    ( abortButton
     , body
     , durationTooltip
     , durationTooltipArrow
@@ -9,8 +8,6 @@ module Build.Styles exposing
     , firstOccurrenceTooltipArrow
     , header
     , historyItem
-    , metadataCell
-    , metadataTable
     , retryTab
     , retryTabList
     , stepHeader
@@ -306,35 +303,3 @@ retryTab { isHovered, isCurrent, isStarted } =
         else
             "0.5"
     ]
-
-
-type MetadataCellType
-    = Key
-    | Value
-
-
-metadataTable : List (Html.Attribute msg)
-metadataTable =
-    [ style "border-collapse" "collapse"
-    , style "margin-bottom" "5px"
-    ]
-
-
-metadataCell : MetadataCellType -> List (Html.Attribute msg)
-metadataCell cell =
-    case cell of
-        Key ->
-            [ style "text-align" "left"
-            , style "vertical-align" "top"
-            , style "background-color" "rgb(45,45,45)"
-            , style "border-bottom" "5px solid rgb(45,45,45)"
-            , style "padding" "5px"
-            ]
-
-        Value ->
-            [ style "text-align" "left"
-            , style "vertical-align" "top"
-            , style "background-color" "rgb(30,30,30)"
-            , style "border-bottom" "5px solid rgb(45,45,45)"
-            , style "padding" "5px"
-            ]

--- a/web/elm/tests/BuildStepTests.elm
+++ b/web/elm/tests/BuildStepTests.elm
@@ -14,7 +14,6 @@ import Common
         , when
         )
 import Concourse
-import Dict
 import Expect
 import Message.Callback as Callback
 import Message.Message as Message exposing (DomID(..))
@@ -29,180 +28,127 @@ import Time
 
 all : Test
 all =
-    describe "build steps"
-        [ describe "get step metadata"
-            [ test "has a table that left aligns text in cells" <|
-                given iVisitABuildWithAGetStep
-                    >> given theGetStepIsExpanded
-                    >> when iAmLookingAtTheGetStepInTheBuildOutput
-                    >> when iAmLookingAtTheMetadataTableCells
-                    >> then_ iSeeTheyLeftAlignText
-            , test "has a table that top aligns text in cells" <|
-                given iVisitABuildWithAGetStep
-                    >> given theGetStepIsExpanded
-                    >> when iAmLookingAtTheGetStepInTheBuildOutput
-                    >> when iAmLookingAtTheMetadataTableCells
-                    >> then_ iSeeTheyTopAlignText
-            , test "has a table that padds in cells" <|
-                given iVisitABuildWithAGetStep
-                    >> given theGetStepIsExpanded
-                    >> when iAmLookingAtTheGetStepInTheBuildOutput
-                    >> when iAmLookingAtTheMetadataTableCells
-                    >> then_ iSeeTheyHavePaddingAllAround
-            , test "has a table that has a bottom margin to let content (logs) underneath breathe" <|
-                given iVisitABuildWithAGetStep
-                    >> given theGetStepIsExpanded
-                    >> when iAmLookingAtTheGetStepInTheBuildOutput
-                    >> when iAmLookingAtTheMetadataTable
-                    >> then_ iSeeABottomMargin
-            , test "has a table that has cells with bottom borders" <|
-                given iVisitABuildWithAGetStep
-                    >> given theGetStepIsExpanded
-                    >> when iAmLookingAtTheGetStepInTheBuildOutput
-                    >> when iAmLookingAtTheMetadataTableCells
-                    >> then_ iSeeLightGrayBottomBorder
-            , test "has a table with cells that don't have a shared border" <|
-                given iVisitABuildWithAGetStep
-                    >> given theGetStepIsExpanded
-                    >> when iAmLookingAtTheGetStepInTheBuildOutput
-                    >> when iAmLookingAtTheMetadataTable
-                    >> then_ iSeeATableWithBorderCollapse
-            , test "has a table that colors key cells light gray" <|
-                given iVisitABuildWithAGetStep
-                    >> given theGetStepIsExpanded
-                    >> when iAmLookingAtTheGetStepInTheBuildOutput
-                    >> when iAmLookingAtTheMetadataTableKeyCell
-                    >> then_ iSeeLightGrayCellBackground
-            , test "has a table that colors value cells dark gray" <|
-                given iVisitABuildWithAGetStep
-                    >> given theGetStepIsExpanded
-                    >> when iAmLookingAtTheGetStepInTheBuildOutput
-                    >> when iAmLookingAtTheMetadataTableValueCell
-                    >> then_ iSeeDarkGrayCellBackground
-            ]
-        , describe
-            "retry step"
-            [ test "has tab list above" <|
+    describe "retry step"
+        [ test "has tab list above" <|
+            given iVisitABuildWithARetryStep
+                >> when iAmLookingAtTheRetryStepInTheBuildOutput
+                >> then_ iSeeTwoChildren
+        , describe "tab list"
+            [ test "is a list" <|
                 given iVisitABuildWithARetryStep
-                    >> when iAmLookingAtTheRetryStepInTheBuildOutput
+                    >> when iAmLookingAtTheTabList
+                    >> then_ iSeeItIsAList
+            , test "does not have the default vertical margins" <|
+                given iVisitABuildWithARetryStep
+                    >> when iAmLookingAtTheTabList
+                    >> then_ iSeeNoMargin
+            , test "has large font" <|
+                given iVisitABuildWithARetryStep
+                    >> when iAmLookingAtTheTabList
+                    >> then_ iSeeLargeFont
+            , test "has tall lines" <|
+                given iVisitABuildWithARetryStep
+                    >> when iAmLookingAtTheTabList
+                    >> then_ iSeeTallLines
+            , test "has grey background" <|
+                given iVisitABuildWithARetryStep
+                    >> when iAmLookingAtTheTabList
+                    >> then_ iSeeAGreyBackground
+            , test "has as many tabs as retries" <|
+                given iVisitABuildWithARetryStep
+                    >> when iAmLookingAtTheTabList
                     >> then_ iSeeTwoChildren
-            , describe "tab list"
-                [ test "is a list" <|
+            , describe "tabs"
+                [ test "lay out horizontally" <|
                     given iVisitABuildWithARetryStep
                         >> when iAmLookingAtTheTabList
-                        >> then_ iSeeItIsAList
-                , test "does not have the default vertical margins" <|
+                        >> then_ iSeeItLaysOutHorizontally
+                , test "have bold font" <|
                     given iVisitABuildWithARetryStep
-                        >> when iAmLookingAtTheTabList
-                        >> then_ iSeeNoMargin
-                , test "has large font" <|
+                        >> when iAmLookingAtTheFirstTab
+                        >> then_ iSeeBoldFont
+                , test "have pointer cursor" <|
                     given iVisitABuildWithARetryStep
-                        >> when iAmLookingAtTheTabList
-                        >> then_ iSeeLargeFont
-                , test "has tall lines" <|
+                        >> when iAmLookingAtTheFirstTab
+                        >> then_ iSeePointerCursor
+                , test "have light grey text" <|
                     given iVisitABuildWithARetryStep
-                        >> when iAmLookingAtTheTabList
-                        >> then_ iSeeTallLines
-                , test "has grey background" <|
-                    given iVisitABuildWithARetryStep
-                        >> when iAmLookingAtTheTabList
-                        >> then_ iSeeAGreyBackground
-                , test "has as many tabs as retries" <|
-                    given iVisitABuildWithARetryStep
-                        >> when iAmLookingAtTheTabList
-                        >> then_ iSeeTwoChildren
-                , describe "tabs"
-                    [ test "lay out horizontally" <|
-                        given iVisitABuildWithARetryStep
-                            >> when iAmLookingAtTheTabList
-                            >> then_ iSeeItLaysOutHorizontally
-                    , test "have bold font" <|
-                        given iVisitABuildWithARetryStep
-                            >> when iAmLookingAtTheFirstTab
-                            >> then_ iSeeBoldFont
-                    , test "have pointer cursor" <|
-                        given iVisitABuildWithARetryStep
-                            >> when iAmLookingAtTheFirstTab
-                            >> then_ iSeePointerCursor
-                    , test "have light grey text" <|
-                        given iVisitABuildWithARetryStep
-                            >> when iAmLookingAtTheFirstTab
-                            >> then_ iSeeLightGreyText
-                    , defineHoverBehaviour
-                        { name = "build tab"
-                        , setup = iVisitABuildWithARetryStep () |> Tuple.first
-                        , query = (\m -> ( m, [] )) >> iAmLookingAtTheSecondTab
-                        , unhoveredSelector =
-                            { description = "grey background"
-                            , selector =
-                                [ style "background-color" Colors.background ]
-                            }
-                        , hoverable = StepTab "retryStepId" 2
-                        , hoveredSelector =
-                            { description = "lighter grey background"
-                            , selector =
-                                [ style "background-color" Colors.paginationHover ]
-                            }
+                        >> when iAmLookingAtTheFirstTab
+                        >> then_ iSeeLightGreyText
+                , defineHoverBehaviour
+                    { name = "build tab"
+                    , setup = iVisitABuildWithARetryStep () |> Tuple.first
+                    , query = (\m -> ( m, [] )) >> iAmLookingAtTheSecondTab
+                    , unhoveredSelector =
+                        { description = "grey background"
+                        , selector =
+                            [ style "background-color" Colors.background ]
                         }
-                    , test "have click handlers" <|
+                    , hoverable = StepTab "retryStepId" 2
+                    , hoveredSelector =
+                        { description = "lighter grey background"
+                        , selector =
+                            [ style "background-color" Colors.paginationHover ]
+                        }
+                    }
+                , test "have click handlers" <|
+                    given iVisitABuildWithARetryStep
+                        >> when iAmLookingAtTheFirstTab
+                        >> then_ (itIsClickable <| StepTab "retryStepId" 1)
+                , test "have horizontal spacing" <|
+                    given iVisitABuildWithARetryStep
+                        >> when iAmLookingAtTheFirstTab
+                        >> then_ itHasHorizontalSpacing
+                , describe "pending selected attempt"
+                    [ test "has lighter grey background" <|
                         given iVisitABuildWithARetryStep
                             >> when iAmLookingAtTheFirstTab
-                            >> then_ (itIsClickable <| StepTab "retryStepId" 1)
-                    , test "have horizontal spacing" <|
+                            >> then_ iSeeALighterGreyBackground
+                    , test "is transparent" <|
                         given iVisitABuildWithARetryStep
                             >> when iAmLookingAtTheFirstTab
-                            >> then_ itHasHorizontalSpacing
-                    , describe "pending selected attempt"
-                        [ test "has lighter grey background" <|
-                            given iVisitABuildWithARetryStep
-                                >> when iAmLookingAtTheFirstTab
-                                >> then_ iSeeALighterGreyBackground
-                        , test "is transparent" <|
-                            given iVisitABuildWithARetryStep
-                                >> when iAmLookingAtTheFirstTab
-                                >> then_ iSeeItIsTransparent
-                        ]
-                    , describe "started selected attempt"
-                        [ test "has lighter grey background" <|
-                            given iVisitABuildWithARetryStep
-                                >> given theFirstAttemptInitialized
-                                >> when iAmLookingAtTheFirstTab
-                                >> then_ iSeeALighterGreyBackground
-                        , test "is opaque" <|
-                            given iVisitABuildWithARetryStep
-                                >> given theFirstAttemptInitialized
-                                >> when iAmLookingAtTheFirstTab
-                                >> then_ iSeeItIsOpaque
-                        ]
-                    , describe "pending unselected attempt"
-                        [ test "has grey background" <|
-                            given iVisitABuildWithARetryStep
-                                >> when iAmLookingAtTheSecondTab
-                                >> then_ iSeeAGreyBackground
-                        , test "is transparent" <|
-                            given iVisitABuildWithARetryStep
-                                >> when iAmLookingAtTheSecondTab
-                                >> then_ iSeeItIsTransparent
-                        ]
-                    , describe "started unselected attempt"
-                        [ test "has lighter grey background" <|
-                            given iVisitABuildWithARetryStep
-                                >> given theSecondAttemptInitialized
-                                >> when iAmLookingAtTheFirstTab
-                                >> then_ iSeeAGreyBackground
-                        , test "is opaque" <|
-                            given iVisitABuildWithARetryStep
-                                >> given theSecondAttemptInitialized
-                                >> when iAmLookingAtTheSecondTab
-                                >> then_ iSeeItIsOpaque
-                        ]
-                    , describe "cancelled unselected attempt" <|
-                        [ test "is transparent" <|
-                            given iVisitABuildWithARetryStep
-                                >> given theBuildFinished
-                                >> when iAmLookingAtTheSecondTab
-                                >> then_ iSeeItIsTransparent
-                        ]
+                            >> then_ iSeeItIsTransparent
+                    ]
+                , describe "started selected attempt"
+                    [ test "has lighter grey background" <|
+                        given iVisitABuildWithARetryStep
+                            >> given theFirstAttemptInitialized
+                            >> when iAmLookingAtTheFirstTab
+                            >> then_ iSeeALighterGreyBackground
+                    , test "is opaque" <|
+                        given iVisitABuildWithARetryStep
+                            >> given theFirstAttemptInitialized
+                            >> when iAmLookingAtTheFirstTab
+                            >> then_ iSeeItIsOpaque
+                    ]
+                , describe "pending unselected attempt"
+                    [ test "has grey background" <|
+                        given iVisitABuildWithARetryStep
+                            >> when iAmLookingAtTheSecondTab
+                            >> then_ iSeeAGreyBackground
+                    , test "is transparent" <|
+                        given iVisitABuildWithARetryStep
+                            >> when iAmLookingAtTheSecondTab
+                            >> then_ iSeeItIsTransparent
+                    ]
+                , describe "started unselected attempt"
+                    [ test "has lighter grey background" <|
+                        given iVisitABuildWithARetryStep
+                            >> given theSecondAttemptInitialized
+                            >> when iAmLookingAtTheFirstTab
+                            >> then_ iSeeAGreyBackground
+                    , test "is opaque" <|
+                        given iVisitABuildWithARetryStep
+                            >> given theSecondAttemptInitialized
+                            >> when iAmLookingAtTheSecondTab
+                            >> then_ iSeeItIsOpaque
+                    ]
+                , describe "cancelled unselected attempt" <|
+                    [ test "is transparent" <|
+                        given iVisitABuildWithARetryStep
+                            >> given theBuildFinished
+                            >> when iAmLookingAtTheSecondTab
+                            >> then_ iSeeItIsTransparent
                     ]
                 ]
             ]
@@ -213,18 +159,6 @@ iVisitABuildWithARetryStep =
     iOpenTheBuildPage
         >> myBrowserFetchedTheBuild
         >> thePlanContainsARetryStep
-
-
-iVisitABuildWithAGetStep =
-    iOpenTheBuildPage
-        >> myBrowserFetchedTheBuild
-        >> thePlanContainsAGetStep
-        >> theGetStepReturnsMetadata
-
-
-theGetStepIsExpanded =
-    Tuple.first
-        >> Application.update (Update <| Message.Click <| StepHeader "getStepId")
 
 
 thePlanContainsARetryStep =
@@ -256,119 +190,14 @@ thePlanContainsARetryStep =
             )
 
 
-thePlanContainsAGetStep =
-    Tuple.first
-        >> Application.handleCallback
-            (Callback.PlanAndResourcesFetched 1 <|
-                Ok
-                    ( { id = "getStepId"
-                      , step =
-                            Concourse.BuildStepGet
-                                "the-git-resource"
-                                (Just (Dict.fromList [ ( "ref", "abc123" ) ]))
-                      }
-                    , { inputs = []
-                      , outputs = []
-                      }
-                    )
-            )
-
-
-theGetStepReturnsMetadata =
-    Tuple.first
-        >> Application.update
-            (DeliveryReceived <|
-                EventsReceived <|
-                    Ok <|
-                        [ { url = "http://localhost:8080/api/v1/builds/1/events"
-                          , data =
-                                FinishGet
-                                    { source = "stdout"
-                                    , id = "getStepId"
-                                    }
-                                    1
-                                    (Dict.fromList [ ( "ref", "abc123" ) ])
-                                    [ { name = "metadata-field"
-                                      , value = "metadata-value"
-                                      }
-                                    ]
-                                    Nothing
-                          }
-                        ]
-            )
-
-
 iAmLookingAtTheRetryStepInTheBuildOutput =
     Tuple.first
         >> Common.queryView
         >> Query.find [ class "retry" ]
 
 
-iAmLookingAtTheGetStepInTheBuildOutput =
-    Tuple.first
-        >> Common.queryView
-        >> Query.find [ class "build-step" ]
-
-
 iSeeTwoChildren =
     Query.children [] >> Query.count (Expect.equal 2)
-
-
-iAmLookingAtTheMetadataTable =
-    Query.find [ class "step-body" ]
-        >> Query.find [ tag "table" ]
-
-
-iAmLookingAtTheMetadataTableCells =
-    Query.find [ class "step-body" ]
-        >> Query.find [ tag "table" ]
-        >> Query.findAll [ tag "td" ]
-
-
-iAmLookingAtTheMetadataTableKeyCell =
-    Query.find [ class "step-body" ]
-        >> Query.find [ tag "table" ]
-        >> Query.findAll [ tag "td" ]
-        >> Query.first
-
-
-iAmLookingAtTheMetadataTableValueCell =
-    Query.find [ class "step-body" ]
-        >> Query.find [ tag "table" ]
-        >> Query.findAll [ tag "td" ]
-        >> Query.index 1
-
-
-iSeeTheyLeftAlignText =
-    Query.each (Query.has [ style "text-align" "left" ])
-
-
-iSeeTheyTopAlignText =
-    Query.each (Query.has [ style "vertical-align" "top" ])
-
-
-iSeeLightGrayCellBackground =
-    Query.has [ style "background-color" "rgb(45,45,45)" ]
-
-
-iSeeDarkGrayCellBackground =
-    Query.has [ style "background-color" "rgb(30,30,30)" ]
-
-
-iSeeATableWithBorderCollapse =
-    Query.has [ style "border-collapse" "collapse" ]
-
-
-iSeeABottomMargin =
-    Query.has [ style "margin-bottom" "5px" ]
-
-
-iSeeLightGrayBottomBorder =
-    Query.each (Query.has [ style "border-bottom" "5px solid rgb(45,45,45)" ])
-
-
-iSeeTheyHavePaddingAllAround =
-    Query.each (Query.has [ style "padding" "5px" ])
 
 
 iAmLookingAtTheTabList =


### PR DESCRIPTION
# Why do we need this PR?

We no longer planning to ship a v5.6.1 - instead we will just ship the relevant fixes in v5.7.0 and encourage an upgrade.

# Changes proposed in this pull request

* reverting the last few commits on the branch
* just clean-up so that anybody referring back to this branch doesn't get confused

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed