### PR TITLE
notes: add missing release notes for 5.7

### DIFF
--- a/release-notes/v5.7.0.md
+++ b/release-notes/v5.7.0.md
@@ -10,6 +10,10 @@ There is no configuration required to take advantage of these new improvements.
 
 * The CloudFoundry auth connector, when configured to authorize users based on CF space membership, will now authorize space auditors and space managers in addition to space developers. This is a breaking change as any teams with CF space-based configuration may grant access to users that they wouldn't have before. #4661
 
+#### <sub><sup><a name="4470" href="#4470">:link:</a></sup></sub> feature, breaking
+
+* All API payloads are now gzipped. This should help save bandwidth and make the web UI load faster. #4470
+
 #### <sub><sup><a name="4480" href="#4480">:link:</a></sup></sub> feature
 
 * @ProvoK added support for a `?title=` query parameter on the pipeline/job badge endpoints! Now you can make it say something other than "build". #4480
@@ -26,10 +30,6 @@ There is no configuration required to take advantage of these new improvements.
 #### <sub><sup><a name="4334" href="#4334">:link:</a></sup></sub> feature
 
 * @aledeganopix4d added a feature sort pipelines alphabetically #4334.
-
-#### <sub><sup><a name="4470" href="#4470">:link:</a></sup></sub> feature, breaking
-
-* All API payloads are now gzipped. This should help save bandwidth and make the web UI load faster. #4470
 
 #### <sub><sup><a name="4494" href="#4494">:link:</a></sup></sub> feature
 
@@ -79,15 +79,15 @@ There is no configuration required to take advantage of these new improvements.
 
 * @evanchaoli fixed a [bug](https://github.com/concourse/concourse/issues/4656) where secret redaction incorrectly "redacts" empty string resulting in mangled logs. #4668
 
-#### <sub><sup><a name="v561-4421" href="#v561-4421">:link:</a></sup></sub> feature
+#### <sub><sup><a name="v570-4421" href="#v570-4421">:link:</a></sup></sub> feature
 
 * We've restyled the resource metadata displayed in a get step on the build page. It should be easier to read and follow, let us know your critiques on the issue. #4421 #4476
 
-#### <sub><sup><a name="v510-note-git-resource-273" href="#v561-note-git-resource-273">:link:</a></sup></sub> fix
+#### <sub><sup><a name="v570-git-resource-273" href="#v570-git-resource-273">:link:</a></sup></sub> fix
 
 * @CliffHoogervorst fixed an [issue](https://github.com/concourse/git-resource/issues/275) in the [git resource](http://github.com/concourse/git-resource), where the version order was not correct when using [`paths`](https://github.com/concourse/git-resource#source-configuration) concourse/git-resource#273.
 
-#### <sub><sup><a name="v561-note-4548" href="#v561-note-4548">:link:</a></sup></sub> fix
+#### <sub><sup><a name="v570-4548" href="#v570-4548">:link:</a></sup></sub> fix
 
 * @evanchaoli fixed an [issue](https://github.com/concourse/concourse/issues/4545), where [`fly workers`](https://concourse-ci.org/administration.html#fly-workers) would show the wrong age for a worker if that worker was under an hour old #4548.
 
@@ -99,3 +99,29 @@ There is no configuration required to take advantage of these new improvements.
 
 * Made the [`registry-image` resource](https://github.com/concourse/registry-image-resource) more resilient - requests that get a 429 (Too Many Requests) from Docker Hub will be retried concourse/registry-image-resource#69.
 
+#### <sub><sup><a name="4425" href="4425">:link:</a></sup></sub> fix
+
+* @Provok fixed an [issue](https://github.com/concourse/concourse/issues/4425), that will help resource authors better understand the errors being returned by concourse.
+
+#### <sub><sup><a name="4599" href="4599">:link:</a></sup></sub> fix
+
+* We fixed an [issue](https://github.com/concourse/concourse/issues/4599), introduced in 5.6.0, where checking a resource would fail if the resource and resource type shared the same name.
+
+* This actually seemed to exacerbate [another issue](https://github.com/concourse/concourse/issues/4546), which we also took the time to fix in #4626.
+
+* You gotta spend money to make money.
+
+#### <sub><sup><a name="4026" href="4026">:link:</a></sup></sub> feature
+
+* @evanchaoli added `minimum_succeeded_builds` to the [build log rentention on the job config](https://concourse-ci.org/jobs.html#job-build-log-retention), that will ensure the build reaper keeps around logs for N successful builds, even if your builds are on a killer losing streak.
+
+#### <sub><sup><a name="4139" href="4139">:link:</a></sup></sub> fix
+
+* We [fixed](https://github.com/concourse/concourse/issues/4139) a migration from 5.4.0. It only affected a small number users that had old unused resources left over from the ancient times. This probably isn't you, so don't worry.
+
+* If you ran into this error `<3`s for being a long time concourse user.
+
+
+#### <sub><sup><a name="4471" href="4471">:link:</a></sup></sub> fix
+
+* @aledeganopix4d [added](https://github.com/concourse/concourse/pull/4471) some lock types that weren't getting emitted as part of our metrics, so that's neat. You might actually see your lock metrics shoot up because of this, don't panic, it's expected.


### PR DESCRIPTION
Release notes for 5.7

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Release notes reviewed

