### PR TITLE
notes: add release note for vault shared path bug

### DIFF
--- a/release-notes/v5.7.0.md
+++ b/release-notes/v5.7.0.md
@@ -125,3 +125,7 @@ There is no configuration required to take advantage of these new improvements.
 #### <sub><sup><a name="4471" href="4471">:link:</a></sup></sub> fix
 
 * @aledeganopix4d [added](https://github.com/concourse/concourse/pull/4471) some lock types that weren't getting emitted as part of our metrics, so that's neat. You might actually see your lock metrics shoot up because of this, don't panic, it's expected.
+
+#### <sub><sup><a name="4655" href="4655">:link:</a></sup></sub> fix
+
+* @evanchaoli fixed a [bug](https://github.com/concourse/concourse/pull/4655) where vault users, that hadn't configured a shared path, would end up searching the top level `prefix` path for secrets.


### PR DESCRIPTION
Release note for vault shared path bug.

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Release notes reviewed

