### PR TITLE
fix(db): fixed a bug where if query builds with a date that newer than all builds, it should return nothing but it actually returned all builds.

### DIFF
--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -178,7 +178,9 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 
 		defer sinceRow.Close()
 
+		found := false
 		for sinceRow.Next() {
+			found = true
 			build := &build{conn: conn, lockFactory: lockFactory}
 			err = scanBuild(build, sinceRow, conn.EncryptionStrategy())
 			if err != nil {
@@ -192,6 +194,9 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 			// Setting `Until` instead of `Since` to adapt to the point
 			// of view of pagination.
 			newPage.Until = build.ID() - 1
+		}
+		if !found {
+			return []Build{}, Pagination{}, nil
 		}
 	}
 
@@ -210,7 +215,10 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 		}
 
 		defer untilRow.Close()
+
+		found := false
 		for untilRow.Next() {
+			found = true
 			build := &build{conn: conn, lockFactory: lockFactory}
 			err = scanBuild(build, untilRow, conn.EncryptionStrategy())
 			if err != nil {
@@ -224,6 +232,9 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 			// Setting `Since` instead of `Until` to adapt to the point
 			// of view of pagination.
 			newPage.Since = build.ID() + 1
+		}
+		if !found {
+			return []Build{}, Pagination{}, nil
 		}
 	}
 


### PR DESCRIPTION
# Existing Issue

No

# Why do we need this PR?

As the subject, this bug causes `db.AllBuilds()` to return wrong builds, in turn causes the API `api/v1/teams/<team>/builds?timestamp=<unix time>` to return wrong builds if specified time is newer than all builds.

This bug also blocks my PR #4673.

# Changes proposed in this pull request

* The bug is in function `getBuildsWithDates()`. If query by time returns no date, then the fucntion should just return rather than going on to call `getBuildsWithPagination`.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

