### PR TITLE
notes: carry over notes from 5.5.4 release

### DIFF
--- a/release-notes/v5.7.0.md
+++ b/release-notes/v5.7.0.md
@@ -55,9 +55,21 @@ There is no configuration required to take advantage of these new improvements.
 
 * Fixed a regression when running `fly sync` it shows warning of parsing Content-Length and progress bar not showing downloading progress. #4666
 
-#### <sub><sup><a name="3600" href="#3600">:link:</a></sup></sub> feature
-
+#### <sub><sup><a name="v570-3600" href="#v570-3600">:link:</a></sup></sub> feature
+  
 * Concourse now garbage-collects worker containers and volumes that are not tracked in the database. In some niche cases, it is possible for containers and/or volumes to be created on the worker, but the database (via the web) assumes their creation had failed. If this occurs, these untracked containers can pile up on the worker and use resources. #3600 ensures that they get cleaned appropriately.
+ 
+#### <sub><sup><a name="v570-4516" href="#v570-4516">:link:</a></sup></sub> feature
+  
+* Add 5 minute timeout for baggageclaim destroy calls. #4516
+ 
+#### <sub><sup><a name="v570-4467" href="#v570-4467">:link:</a></sup></sub> feature
+  
+* Add 5 minute timeout for worker's garden client http calls. This is primarily to address cases such as destroy which may hang indefinitely causing GC to stop occurring. #4467
+ 
+#### <sub><sup><a name="v570-4562" href="#v570-4562">:link:</a></sup></sub> fix
+  
+* Transition `failed` state containers to `destroying` resulting in them being GC'ed. This ensures that if web's call to garden to create a container times out, the container is subsequently deleted from garden prior to being deleted from the db. This keeps the web's and worker's state consistent. #4562
 
 #### <sub><sup><a name="4606" href="#4606">:link:</a></sup></sub> feature
 


### PR DESCRIPTION
more 5.7.0 release notes

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [ ] Release notes reviewed

