### PR TITLE
notes: add 5.7.0 note about stalled worker gc

### DIFF
--- a/release-notes/v5.7.0.md
+++ b/release-notes/v5.7.0.md
@@ -71,6 +71,10 @@ There is no configuration required to take advantage of these new improvements.
   
 * Transition `failed` state containers to `destroying` resulting in them being GC'ed. This ensures that if web's call to garden to create a container times out, the container is subsequently deleted from garden prior to being deleted from the db. This keeps the web's and worker's state consistent. #4562
 
+#### <sub><sup><a name="4536" href="4536">:link:</a></sup></sub> fix
+
+* Previously, if a worker stalled, the atc would still countdown and remove any 'missing' containers. If the worker ever came back it would still have these containers, but we would not longer be tracking them in the database. Even though we're now garbage collecting these unknown containers, we'd rather that be a last resort. So we [fixed it](https://github.com/concourse/concourse/pull/4536).
+
 #### <sub><sup><a name="4606" href="#4606">:link:</a></sup></sub> feature
 
 * @wagdav updated worker heartbeat log level from `debug` to `info` to reduce extraneous log output for operators #4606


### PR DESCRIPTION
more notes for 5.7.0

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [ ] Release notes reviewed