### PR TITLE
notes: wrong builds release notes for 5.7.0

### DIFF
--- a/release-notes/v5.7.0.md
+++ b/release-notes/v5.7.0.md
@@ -149,3 +149,7 @@ There is no configuration required to take advantage of these new improvements.
 #### <sub><sup><a name="4655" href="4655">:link:</a></sup></sub> fix
 
 * @evanchaoli fixed a [bug](https://github.com/concourse/concourse/pull/4655) where vault users, that hadn't configured a shared path, would end up searching the top level `prefix` path for secrets.
+
+#### <sub><sup><a name="4683" href="4683">:link:</a></sup></sub> fix
+
+* @evanchaoli fixed yet another [bug](https://github.com/concourse/concourse/pull/4683) where the builds api would return the wrong builds if you gave it a date newer than the most recent build.


### PR DESCRIPTION
adds a release note for fixing the builds api

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [ ] Release notes reviewed

