### PR TITLE
release-notes: add v5.2.5

### DIFF
--- a/release-notes/v5.2.5.md
+++ b/release-notes/v5.2.5.md
@@ -1,0 +1,3 @@
+#### <sub><sup><a name="v525-note-1" href="#v525-note-1">:link:</a></sup></sub> Security
+
+* This is a security patch using GoLang v1.13.2 that addresses a recently reported issue with Go crypto/dsa (CVE-2019-17596). 


### PR DESCRIPTION

# Why do we need this PR?

Although we got 5.2.5 (that addresses CVE-2019-17596) all tested and ready to ship in the release-5.2.x pipeline, we didn't have a release note about it.

# Changes proposed in this pull request

* add a release note for 5.2.5


# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- ~Unit tests~
- ~Integration tests (if applicable)~
- ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] Release notes reviewed
- [x] ~PR acceptance performed~