### PR TITLE
Adding lidar metrics

### DIFF
--- a/atc/db/check.go
+++ b/atc/db/check.go
@@ -145,13 +145,16 @@ func (c *check) Start() error {
 
 	defer Rollback(tx)
 
-	_, err = psql.Update("checks").
+	var startTime time.Time
+	err = psql.Update("checks").
 		Set("start_time", sq.Expr("now()")).
 		Where(sq.Eq{
 			"id": c.id,
 		}).
+		Suffix("RETURNING start_time").
 		RunWith(tx).
-		Exec()
+		QueryRow().
+		Scan(&startTime)
 	if err != nil {
 		return err
 	}
@@ -172,6 +175,8 @@ func (c *check) Start() error {
 		return err
 	}
 
+	c.startTime = startTime
+
 	return nil
 }
 
@@ -191,6 +196,7 @@ func (c *check) finish(status CheckStatus, checkError error) error {
 
 	defer Rollback(tx)
 
+	var endTime time.Time
 	builder := psql.Update("checks").
 		Set("status", status).
 		Set("end_time", sq.Expr("now()")).
@@ -202,9 +208,11 @@ func (c *check) finish(status CheckStatus, checkError error) error {
 		builder = builder.Set("check_error", checkError.Error())
 	}
 
-	_, err = builder.
+	err = builder.
+		Suffix("RETURNING end_time").
 		RunWith(tx).
-		Exec()
+		QueryRow().
+		Scan(&endTime)
 	if err != nil {
 		return err
 	}
@@ -232,6 +240,8 @@ func (c *check) finish(status CheckStatus, checkError error) error {
 	if err != nil {
 		return err
 	}
+
+	c.endTime = endTime
 
 	return nil
 }

--- a/atc/db/check.go
+++ b/atc/db/check.go
@@ -242,6 +242,7 @@ func (c *check) finish(status CheckStatus, checkError error) error {
 	}
 
 	c.endTime = endTime
+	c.status = status
 
 	return nil
 }

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -107,6 +107,7 @@ func (c *checkFactory) Check(id int) (Check, bool, error) {
 
 	return check, true, nil
 }
+
 func (c *checkFactory) StartedChecks() ([]Check, error) {
 	rows, err := checksQuery.
 		Where(sq.Eq{"status": CheckStatusStarted}).

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -21,6 +21,7 @@ type Checkable interface {
 
 	Name() string
 	TeamID() int
+	ResourceConfigScopeID() int
 	TeamName() string
 	Type() string
 	Source() atc.Source

--- a/atc/db/check_lifecycle_test.go
+++ b/atc/db/check_lifecycle_test.go
@@ -9,7 +9,11 @@ import (
 )
 
 var _ = Describe("CheckLifecycle", func() {
-	var checkLifecycle db.CheckLifecycle
+	var (
+		checkLifecycle db.CheckLifecycle
+		removedChecks  int
+		err            error
+	)
 
 	BeforeEach(func() {
 		checkLifecycle = db.NewCheckLifecycle(dbConn)
@@ -17,7 +21,7 @@ var _ = Describe("CheckLifecycle", func() {
 
 	Describe("RemoveExpiredChecks", func() {
 		JustBeforeEach(func() {
-			err := checkLifecycle.RemoveExpiredChecks(time.Hour * 24)
+			removedChecks, err = checkLifecycle.RemoveExpiredChecks(time.Hour * 24)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -33,6 +37,7 @@ var _ = Describe("CheckLifecycle", func() {
 				err := dbConn.QueryRow("SELECT count(*) from checks").Scan(&count)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(count).To(Equal(0))
+				Expect(removedChecks).To(Equal(1))
 			})
 		})
 
@@ -48,6 +53,7 @@ var _ = Describe("CheckLifecycle", func() {
 				err := dbConn.QueryRow("SELECT count(*) from checks").Scan(&count)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(count).To(Equal(1))
+				Expect(removedChecks).To(Equal(0))
 			})
 		})
 
@@ -66,6 +72,7 @@ var _ = Describe("CheckLifecycle", func() {
 				err := dbConn.QueryRow("SELECT count(*) from checks").Scan(&count)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(count).To(Equal(1))
+				Expect(removedChecks).To(Equal(1))
 			})
 		})
 	})

--- a/atc/db/check_test.go
+++ b/atc/db/check_test.go
@@ -89,10 +89,13 @@ var _ = Describe("Check", func() {
 			Expect(check.EndTime()).To(BeTemporally("~", time.Now(), time.Second))
 		})
 
+		It("sets the status of check", func() {
+			Expect(check.Status()).To(Equal(db.CheckStatusSucceeded))
+		})
+
 		It("finishes the check", func() {
 			check.Reload()
 
-			Expect(check.Status()).To(Equal(db.CheckStatusSucceeded))
 			Expect(check.CheckError()).To(BeNil())
 		})
 
@@ -118,11 +121,17 @@ var _ = Describe("Check", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("sets the endTime of check", func() {
+			Expect(check.EndTime()).To(BeTemporally("~", time.Now(), time.Second))
+		})
+
+		It("sets the status of check", func() {
+			Expect(check.Status()).To(Equal(db.CheckStatusErrored))
+		})
+
 		It("finishes the check", func() {
 			check.Reload()
 
-			Expect(check.Status()).To(Equal(db.CheckStatusErrored))
-			Expect(check.EndTime()).To(BeTemporally("~", time.Now(), time.Second))
 			Expect(check.CheckError()).To(Equal(errors.New("nope")))
 		})
 

--- a/atc/db/check_test.go
+++ b/atc/db/check_test.go
@@ -65,9 +65,7 @@ var _ = Describe("Check", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("starts the check", func() {
-			check.Reload()
-
+		It("sets the startTime of check", func() {
 			Expect(check.StartTime()).To(BeTemporally("~", time.Now(), time.Second))
 		})
 
@@ -87,11 +85,14 @@ var _ = Describe("Check", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("sets the endTime of check", func() {
+			Expect(check.EndTime()).To(BeTemporally("~", time.Now(), time.Second))
+		})
+
 		It("finishes the check", func() {
 			check.Reload()
 
 			Expect(check.Status()).To(Equal(db.CheckStatusSucceeded))
-			Expect(check.EndTime()).To(BeTemporally("~", time.Now(), time.Second))
 			Expect(check.CheckError()).To(BeNil())
 		})
 

--- a/atc/db/db_suite_test.go
+++ b/atc/db/db_suite_test.go
@@ -180,8 +180,8 @@ var _ = BeforeEach(func() {
 
 	var found bool
 	defaultResourceType, found, err = defaultPipeline.ResourceType("some-type")
-	Expect(found).To(BeTrue())
 	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
 
 	defaultResource, found, err = defaultPipeline.Resource("some-resource")
 	Expect(err).NotTo(HaveOccurred())

--- a/atc/db/dbfakes/fake_check_lifecycle.go
+++ b/atc/db/dbfakes/fake_check_lifecycle.go
@@ -2,29 +2,31 @@
 package dbfakes
 
 import (
-	"sync"
-	"time"
+	sync "sync"
+	time "time"
 
-	"github.com/concourse/concourse/atc/db"
+	db "github.com/concourse/concourse/atc/db"
 )
 
 type FakeCheckLifecycle struct {
-	RemoveExpiredChecksStub        func(time.Duration) error
+	RemoveExpiredChecksStub        func(time.Duration) (int, error)
 	removeExpiredChecksMutex       sync.RWMutex
 	removeExpiredChecksArgsForCall []struct {
 		arg1 time.Duration
 	}
 	removeExpiredChecksReturns struct {
-		result1 error
+		result1 int
+		result2 error
 	}
 	removeExpiredChecksReturnsOnCall map[int]struct {
-		result1 error
+		result1 int
+		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCheckLifecycle) RemoveExpiredChecks(arg1 time.Duration) error {
+func (fake *FakeCheckLifecycle) RemoveExpiredChecks(arg1 time.Duration) (int, error) {
 	fake.removeExpiredChecksMutex.Lock()
 	ret, specificReturn := fake.removeExpiredChecksReturnsOnCall[len(fake.removeExpiredChecksArgsForCall)]
 	fake.removeExpiredChecksArgsForCall = append(fake.removeExpiredChecksArgsForCall, struct {
@@ -36,10 +38,10 @@ func (fake *FakeCheckLifecycle) RemoveExpiredChecks(arg1 time.Duration) error {
 		return fake.RemoveExpiredChecksStub(arg1)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
 	fakeReturns := fake.removeExpiredChecksReturns
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCheckLifecycle) RemoveExpiredChecksCallCount() int {
@@ -48,7 +50,7 @@ func (fake *FakeCheckLifecycle) RemoveExpiredChecksCallCount() int {
 	return len(fake.removeExpiredChecksArgsForCall)
 }
 
-func (fake *FakeCheckLifecycle) RemoveExpiredChecksCalls(stub func(time.Duration) error) {
+func (fake *FakeCheckLifecycle) RemoveExpiredChecksCalls(stub func(time.Duration) (int, error)) {
 	fake.removeExpiredChecksMutex.Lock()
 	defer fake.removeExpiredChecksMutex.Unlock()
 	fake.RemoveExpiredChecksStub = stub
@@ -61,27 +63,30 @@ func (fake *FakeCheckLifecycle) RemoveExpiredChecksArgsForCall(i int) time.Durat
 	return argsForCall.arg1
 }
 
-func (fake *FakeCheckLifecycle) RemoveExpiredChecksReturns(result1 error) {
+func (fake *FakeCheckLifecycle) RemoveExpiredChecksReturns(result1 int, result2 error) {
 	fake.removeExpiredChecksMutex.Lock()
 	defer fake.removeExpiredChecksMutex.Unlock()
 	fake.RemoveExpiredChecksStub = nil
 	fake.removeExpiredChecksReturns = struct {
-		result1 error
-	}{result1}
+		result1 int
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeCheckLifecycle) RemoveExpiredChecksReturnsOnCall(i int, result1 error) {
+func (fake *FakeCheckLifecycle) RemoveExpiredChecksReturnsOnCall(i int, result1 int, result2 error) {
 	fake.removeExpiredChecksMutex.Lock()
 	defer fake.removeExpiredChecksMutex.Unlock()
 	fake.RemoveExpiredChecksStub = nil
 	if fake.removeExpiredChecksReturnsOnCall == nil {
 		fake.removeExpiredChecksReturnsOnCall = make(map[int]struct {
-			result1 error
+			result1 int
+			result2 error
 		})
 	}
 	fake.removeExpiredChecksReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+		result1 int
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeCheckLifecycle) Invocations() map[string][][]interface{} {

--- a/atc/db/dbfakes/fake_checkable.go
+++ b/atc/db/dbfakes/fake_checkable.go
@@ -94,6 +94,16 @@ type FakeCheckable struct {
 	pipelineNameReturnsOnCall map[int]struct {
 		result1 string
 	}
+	ResourceConfigScopeIDStub        func() int
+	resourceConfigScopeIDMutex       sync.RWMutex
+	resourceConfigScopeIDArgsForCall []struct {
+	}
+	resourceConfigScopeIDReturns struct {
+		result1 int
+	}
+	resourceConfigScopeIDReturnsOnCall map[int]struct {
+		result1 int
+	}
 	SetCheckSetupErrorStub        func(error) error
 	setCheckSetupErrorMutex       sync.RWMutex
 	setCheckSetupErrorArgsForCall []struct {
@@ -595,6 +605,58 @@ func (fake *FakeCheckable) PipelineNameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakeCheckable) ResourceConfigScopeID() int {
+	fake.resourceConfigScopeIDMutex.Lock()
+	ret, specificReturn := fake.resourceConfigScopeIDReturnsOnCall[len(fake.resourceConfigScopeIDArgsForCall)]
+	fake.resourceConfigScopeIDArgsForCall = append(fake.resourceConfigScopeIDArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ResourceConfigScopeID", []interface{}{})
+	fake.resourceConfigScopeIDMutex.Unlock()
+	if fake.ResourceConfigScopeIDStub != nil {
+		return fake.ResourceConfigScopeIDStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.resourceConfigScopeIDReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeCheckable) ResourceConfigScopeIDCallCount() int {
+	fake.resourceConfigScopeIDMutex.RLock()
+	defer fake.resourceConfigScopeIDMutex.RUnlock()
+	return len(fake.resourceConfigScopeIDArgsForCall)
+}
+
+func (fake *FakeCheckable) ResourceConfigScopeIDCalls(stub func() int) {
+	fake.resourceConfigScopeIDMutex.Lock()
+	defer fake.resourceConfigScopeIDMutex.Unlock()
+	fake.ResourceConfigScopeIDStub = stub
+}
+
+func (fake *FakeCheckable) ResourceConfigScopeIDReturns(result1 int) {
+	fake.resourceConfigScopeIDMutex.Lock()
+	defer fake.resourceConfigScopeIDMutex.Unlock()
+	fake.ResourceConfigScopeIDStub = nil
+	fake.resourceConfigScopeIDReturns = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeCheckable) ResourceConfigScopeIDReturnsOnCall(i int, result1 int) {
+	fake.resourceConfigScopeIDMutex.Lock()
+	defer fake.resourceConfigScopeIDMutex.Unlock()
+	fake.ResourceConfigScopeIDStub = nil
+	if fake.resourceConfigScopeIDReturnsOnCall == nil {
+		fake.resourceConfigScopeIDReturnsOnCall = make(map[int]struct {
+			result1 int
+		})
+	}
+	fake.resourceConfigScopeIDReturnsOnCall[i] = struct {
+		result1 int
+	}{result1}
+}
+
 func (fake *FakeCheckable) SetCheckSetupError(arg1 error) error {
 	fake.setCheckSetupErrorMutex.Lock()
 	ret, specificReturn := fake.setCheckSetupErrorReturnsOnCall[len(fake.setCheckSetupErrorArgsForCall)]
@@ -998,6 +1060,8 @@ func (fake *FakeCheckable) Invocations() map[string][][]interface{} {
 	defer fake.pipelineIDMutex.RUnlock()
 	fake.pipelineNameMutex.RLock()
 	defer fake.pipelineNameMutex.RUnlock()
+	fake.resourceConfigScopeIDMutex.RLock()
+	defer fake.resourceConfigScopeIDMutex.RUnlock()
 	fake.setCheckSetupErrorMutex.RLock()
 	defer fake.setCheckSetupErrorMutex.RUnlock()
 	fake.setResourceConfigMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_type.go
+++ b/atc/db/dbfakes/fake_resource_type.go
@@ -166,6 +166,16 @@ type FakeResourceType struct {
 		result1 bool
 		result2 error
 	}
+	ResourceConfigScopeIDStub        func() int
+	resourceConfigScopeIDMutex       sync.RWMutex
+	resourceConfigScopeIDArgsForCall []struct {
+	}
+	resourceConfigScopeIDReturns struct {
+		result1 int
+	}
+	resourceConfigScopeIDReturnsOnCall map[int]struct {
+		result1 int
+	}
 	SetCheckSetupErrorStub        func(error) error
 	setCheckSetupErrorMutex       sync.RWMutex
 	setCheckSetupErrorArgsForCall []struct {
@@ -1054,6 +1064,58 @@ func (fake *FakeResourceType) ReloadReturnsOnCall(i int, result1 bool, result2 e
 	}{result1, result2}
 }
 
+func (fake *FakeResourceType) ResourceConfigScopeID() int {
+	fake.resourceConfigScopeIDMutex.Lock()
+	ret, specificReturn := fake.resourceConfigScopeIDReturnsOnCall[len(fake.resourceConfigScopeIDArgsForCall)]
+	fake.resourceConfigScopeIDArgsForCall = append(fake.resourceConfigScopeIDArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ResourceConfigScopeID", []interface{}{})
+	fake.resourceConfigScopeIDMutex.Unlock()
+	if fake.ResourceConfigScopeIDStub != nil {
+		return fake.ResourceConfigScopeIDStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.resourceConfigScopeIDReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeResourceType) ResourceConfigScopeIDCallCount() int {
+	fake.resourceConfigScopeIDMutex.RLock()
+	defer fake.resourceConfigScopeIDMutex.RUnlock()
+	return len(fake.resourceConfigScopeIDArgsForCall)
+}
+
+func (fake *FakeResourceType) ResourceConfigScopeIDCalls(stub func() int) {
+	fake.resourceConfigScopeIDMutex.Lock()
+	defer fake.resourceConfigScopeIDMutex.Unlock()
+	fake.ResourceConfigScopeIDStub = stub
+}
+
+func (fake *FakeResourceType) ResourceConfigScopeIDReturns(result1 int) {
+	fake.resourceConfigScopeIDMutex.Lock()
+	defer fake.resourceConfigScopeIDMutex.Unlock()
+	fake.ResourceConfigScopeIDStub = nil
+	fake.resourceConfigScopeIDReturns = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeResourceType) ResourceConfigScopeIDReturnsOnCall(i int, result1 int) {
+	fake.resourceConfigScopeIDMutex.Lock()
+	defer fake.resourceConfigScopeIDMutex.Unlock()
+	fake.ResourceConfigScopeIDStub = nil
+	if fake.resourceConfigScopeIDReturnsOnCall == nil {
+		fake.resourceConfigScopeIDReturnsOnCall = make(map[int]struct {
+			result1 int
+		})
+	}
+	fake.resourceConfigScopeIDReturnsOnCall[i] = struct {
+		result1 int
+	}{result1}
+}
+
 func (fake *FakeResourceType) SetCheckSetupError(arg1 error) error {
 	fake.setCheckSetupErrorMutex.Lock()
 	ret, specificReturn := fake.setCheckSetupErrorReturnsOnCall[len(fake.setCheckSetupErrorArgsForCall)]
@@ -1575,6 +1637,8 @@ func (fake *FakeResourceType) Invocations() map[string][][]interface{} {
 	defer fake.privilegedMutex.RUnlock()
 	fake.reloadMutex.RLock()
 	defer fake.reloadMutex.RUnlock()
+	fake.resourceConfigScopeIDMutex.RLock()
+	defer fake.resourceConfigScopeIDMutex.RUnlock()
 	fake.setCheckSetupErrorMutex.RLock()
 	defer fake.setCheckSetupErrorMutex.RUnlock()
 	fake.setResourceConfigMutex.RLock()

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -43,6 +44,7 @@ type ResourceType interface {
 	CheckError() error
 	UniqueVersionHistory() bool
 	CurrentPinnedVersion() atc.Version
+	ResourceConfigScopeID() int
 
 	SetResourceConfig(atc.Source, atc.VersionedResourceTypes) (ResourceConfigScope, error)
 	SetCheckSetupError(error) error
@@ -132,6 +134,7 @@ var resourceTypesQuery = psql.Select(
 	"p.name",
 	"t.id",
 	"t.name",
+	"ro.id",
 	"ro.check_error",
 	"ro.last_check_start_time",
 	"ro.last_check_end_time",
@@ -153,22 +156,23 @@ var resourceTypesQuery = psql.Select(
 type resourceType struct {
 	pipelineRef
 
-	id                   int
-	teamID               int
-	teamName             string
-	name                 string
-	type_                string
-	privileged           bool
-	source               atc.Source
-	params               atc.Params
-	tags                 atc.Tags
-	version              atc.Version
-	checkEvery           string
-	lastCheckStartTime   time.Time
-	lastCheckEndTime     time.Time
-	checkSetupError      error
-	checkError           error
-	uniqueVersionHistory bool
+	id                    int
+	teamID                int
+	resourceConfigScopeID int
+	teamName              string
+	name                  string
+	type_                 string
+	privileged            bool
+	source                atc.Source
+	params                atc.Params
+	tags                  atc.Tags
+	version               atc.Version
+	checkEvery            string
+	lastCheckStartTime    time.Time
+	lastCheckEndTime      time.Time
+	checkSetupError       error
+	checkError            error
+	uniqueVersionHistory  bool
 }
 
 func (t *resourceType) ID() int                       { return t.id }
@@ -187,6 +191,7 @@ func (t *resourceType) Tags() atc.Tags                { return t.tags }
 func (t *resourceType) CheckSetupError() error        { return t.checkSetupError }
 func (t *resourceType) CheckError() error             { return t.checkError }
 func (t *resourceType) UniqueVersionHistory() bool    { return t.uniqueVersionHistory }
+func (t *resourceType) ResourceConfigScopeID() int    { return t.resourceConfigScopeID }
 
 func (t *resourceType) Version() atc.Version              { return t.version }
 func (t *resourceType) CurrentPinnedVersion() atc.Version { return nil }
@@ -274,12 +279,12 @@ func (t *resourceType) SetCheckSetupError(cause error) error {
 
 func scanResourceType(t *resourceType, row scannable) error {
 	var (
-		configJSON                            []byte
-		checkErr, rcsCheckErr, version, nonce sql.NullString
-		lastCheckStartTime, lastCheckEndTime  pq.NullTime
+		configJSON                                   []byte
+		checkErr, rcsCheckErr, rcsID, version, nonce sql.NullString
+		lastCheckStartTime, lastCheckEndTime         pq.NullTime
 	)
 
-	err := row.Scan(&t.id, &t.pipelineID, &t.name, &t.type_, &configJSON, &version, &nonce, &checkErr, &t.pipelineName, &t.teamID, &t.teamName, &rcsCheckErr, &lastCheckStartTime, &lastCheckEndTime)
+	err := row.Scan(&t.id, &t.pipelineID, &t.name, &t.type_, &configJSON, &version, &nonce, &checkErr, &t.pipelineName, &t.teamID, &t.teamName, &rcsID, &rcsCheckErr, &lastCheckStartTime, &lastCheckEndTime)
 	if err != nil {
 		return err
 	}
@@ -321,6 +326,13 @@ func scanResourceType(t *resourceType, row scannable) error {
 
 	if checkErr.Valid {
 		t.checkSetupError = errors.New(checkErr.String)
+	}
+
+	if rcsID.Valid {
+		t.resourceConfigScopeID, err = strconv.Atoi(rcsID.String)
+		if err != nil {
+			return err
+		}
 	}
 
 	if rcsCheckErr.Valid {

--- a/atc/db/resource_type_test.go
+++ b/atc/db/resource_type_test.go
@@ -365,6 +365,10 @@ var _ = Describe("ResourceType", func() {
 			Expect(resourceTypeScope.ResourceConfig()).ToNot(BeNil())
 		})
 
+		It("returns the resource config scope id", func() {
+			Expect(resourceType.ResourceConfigScopeID()).To(Equal(resourceTypeScope.ID()))
+		})
+
 		Context("when the resource type has proper versions", func() {
 			BeforeEach(func() {
 				err := resourceTypeScope.SaveVersions([]atc.Version{

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -412,6 +412,7 @@ func (c *engineCheck) trackStarted(logger lager.Logger) {
 	metric.CheckStarted{
 		CheckName:             c.check.Plan().Check.Name,
 		ResourceConfigScopeID: c.check.ResourceConfigScopeID(),
+		CheckStatus:           c.check.Status(),
 		CheckPendingDuration:  c.check.StartTime().Sub(c.check.CreateTime()),
 	}.Emit(logger)
 }

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -359,15 +359,15 @@ func (c *engineCheck) Run(logger lager.Logger) {
 		logger.Error("failed-to-start-check", err)
 		return
 	}
+
 	c.trackStarted(logger)
+	defer c.trackFinished(logger)
 
 	step, err := c.builder.CheckStep(logger, c.check)
 	if err != nil {
 		logger.Error("failed-to-create-check-step", err)
 		return
 	}
-
-	defer c.trackFinished(logger)
 
 	logger.Info("running")
 
@@ -409,17 +409,6 @@ func (c *engineCheck) clearRunState() {
 }
 
 func (c *engineCheck) trackStarted(logger lager.Logger) {
-	found, err := c.check.Reload()
-	if err != nil {
-		logger.Error("failed-to-load-check-from-db", err)
-		return
-	}
-
-	if !found {
-		logger.Info("check-removed")
-		return
-	}
-
 	metric.CheckStarted{
 		CheckName:             c.check.Plan().Check.Name,
 		ResourceConfigScopeID: c.check.ResourceConfigScopeID(),
@@ -428,17 +417,6 @@ func (c *engineCheck) trackStarted(logger lager.Logger) {
 }
 
 func (c *engineCheck) trackFinished(logger lager.Logger) {
-	found, err := c.check.Reload()
-	if err != nil {
-		logger.Error("failed-to-load-check-from-db", err)
-		return
-	}
-
-	if !found {
-		logger.Info("check-removed")
-		return
-	}
-
 	metric.CheckFinished{
 		CheckName:             c.check.Plan().Check.Name,
 		ResourceConfigScopeID: c.check.ResourceConfigScopeID(),

--- a/atc/engine/engine_test.go
+++ b/atc/engine/engine_test.go
@@ -8,6 +8,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/db/lock/lockfakes"
@@ -377,6 +378,11 @@ var _ = Describe("Engine", func() {
 
 			BeforeEach(func() {
 				logger = lagertest.NewTestLogger("test")
+				fakeCheck.PlanReturns(atc.Plan{
+					Check: &atc.CheckPlan{
+						Name: "some-name",
+					},
+				})
 			})
 
 			JustBeforeEach(func() {

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"code.cloudfoundry.org/lager"
@@ -11,7 +10,6 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/metric"
 	"github.com/concourse/concourse/atc/resource"
 	"github.com/concourse/concourse/atc/worker"
 )
@@ -151,12 +149,6 @@ func (step *CheckStep) Run(ctx context.Context, state RunState) error {
 		}
 		return err
 	}
-
-	metric.CheckFinished{
-		CheckName:             step.plan.Name,
-		ResourceConfigScopeID: strconv.Itoa(step.metadata.ResourceConfigScopeID),
-		Success:               err == nil,
-	}.Emit(logger)
 
 	err = step.delegate.SaveVersions(versions)
 	if err != nil {

--- a/atc/gc/checks_collector.go
+++ b/atc/gc/checks_collector.go
@@ -6,6 +6,7 @@ import (
 
 	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/metric"
 )
 
 type checkCollector struct {
@@ -26,5 +27,13 @@ func (c *checkCollector) Run(ctx context.Context) error {
 	logger.Debug("start")
 	defer logger.Debug("done")
 
-	return c.checkLifecycle.RemoveExpiredChecks(c.recyclePeriod)
+	deleted, err := c.checkLifecycle.RemoveExpiredChecks(c.recyclePeriod)
+	if err != nil {
+		logger.Error("failed-to-remove-expired-checks", err)
+		return err
+	}
+
+	metric.ChecksDeleted.IncDelta(deleted)
+
+	return nil
 }

--- a/atc/lidar/checker.go
+++ b/atc/lidar/checker.go
@@ -7,6 +7,7 @@ import (
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/engine"
+	"github.com/concourse/concourse/atc/metric"
 )
 
 func NewChecker(
@@ -40,6 +41,10 @@ func (c *checker) Run(ctx context.Context) error {
 		c.logger.Error("failed-to-fetch-resource-checks", err)
 		return err
 	}
+
+	metric.CheckQueueSize{
+		Checks: len(checks),
+	}.Emit(c.logger)
 
 	for _, ck := range checks {
 		if _, exists := c.running.LoadOrStore(ck.ID(), true); !exists {

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -114,7 +114,8 @@ func (s *scanner) check(checkable db.Checkable, resourceTypes db.ResourceTypes) 
 	}
 
 	metric.CheckEnqueue{
-		CheckName: checkable.Name(),
+		CheckName:             checkable.Name(),
+		ResourceConfigScopeID: checkable.ResourceConfigScopeID(),
 	}.Emit(s.logger)
 
 	return nil

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/metric"
 	"github.com/pkg/errors"
 )
 
@@ -111,6 +112,10 @@ func (s *scanner) check(checkable db.Checkable, resourceTypes db.ResourceTypes) 
 	if !created {
 		s.logger.Debug("check-already-exists")
 	}
+
+	metric.CheckEnqueue{
+		CheckName: checkable.Name(),
+	}.Emit(s.logger)
 
 	return nil
 }

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -26,6 +26,7 @@ type (
 		Url                string
 		apikey             string
 		prefix             string
+		checks             *stats
 		containers         *stats
 		volumes            *stats
 		BatchSize          int
@@ -86,6 +87,9 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	case "build started",
 		"build finished",
 		"resource checked",
+		"check enqueue",
+		"check queue size",
+		"check started",
 		"check finished",
 		"worker containers",
 		"worker volumes",
@@ -101,6 +105,8 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	// periodic list, so we should have a coherent view). We do this because
 	// new relic has a hard limit on the total number of metrics in a 24h
 	// period, so batching similar data where possible makes sense.
+	case "checks deleted":
+		emitter.checks.deleted = event.Value
 	case "containers deleted":
 		emitter.containers.deleted = event.Value
 	case "containers created":

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -39,7 +39,10 @@ type PrometheusEmitter struct {
 	pipelineScheduled *prometheus.CounterVec
 
 	resourceChecksVec *prometheus.CounterVec
-	checksVec         *prometheus.CounterVec
+
+	checksVec       *prometheus.HistogramVec
+	checkEnqueueVec *prometheus.CounterVec
+	checkQueueSize  prometheus.Gauge
 
 	schedulingFullDuration    *prometheus.CounterVec
 	schedulingLoadingDuration *prometheus.CounterVec
@@ -330,16 +333,38 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 	)
 	prometheus.MustRegister(resourceChecksVec)
 
-	checksVec := prometheus.NewCounterVec(
+	checksVec := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "concourse",
+			Subsystem: "lidar",
+			Name:      "duration_seconds",
+			Help:      "Check time in seconds",
+			Buckets:   []float64{0.001, 0.05, 0.1, 0.5, 1, 60, 180, 360, 720, 1440, 2880},
+		},
+		[]string{"scope_id", "status"},
+	)
+	prometheus.MustRegister(checksVec)
+
+	checkEnqueueVec := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "concourse",
 			Subsystem: "lidar",
-			Name:      "checks_total",
-			Help:      "Counts the number of checks finished",
+			Name:      "check_enqueue",
+			Help:      "Counts the number of checks enqueued",
 		},
-		[]string{"scopeID", "checkName"},
+		[]string{"name"},
 	)
-	prometheus.MustRegister(checksVec)
+	prometheus.MustRegister(checkEnqueueVec)
+
+	checkQueueSize := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "concourse",
+			Subsystem: "lidar",
+			Name:      "check_queue_size",
+			Help:      "Records the size of check queue",
+		},
+	)
+	prometheus.MustRegister(checkQueueSize)
 
 	listener, err := net.Listen("tcp", config.bind())
 	if err != nil {
@@ -370,7 +395,10 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 		pipelineScheduled: pipelineScheduled,
 
 		resourceChecksVec: resourceChecksVec,
-		checksVec:         checksVec,
+
+		checksVec:       checksVec,
+		checkEnqueueVec: checkEnqueueVec,
+		checkQueueSize:  checkQueueSize,
 
 		schedulingFullDuration:    schedulingFullDuration,
 		schedulingLoadingDuration: schedulingLoadingDuration,
@@ -435,6 +463,12 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 		emitter.databaseMetrics(logger, event)
 	case "resource checked":
 		emitter.resourceMetric(logger, event)
+	case "check enqueued":
+		emitter.checkEnqueueMetric(logger, event)
+	case "check queue size":
+		emitter.checkQueueSizeMetric(logger, event)
+	case "check started":
+		emitter.checkMetric(logger, event)
 	case "check finished":
 		emitter.checkMetric(logger, event)
 	default:
@@ -786,19 +820,47 @@ func (emitter *PrometheusEmitter) resourceMetric(logger lager.Logger, event metr
 	emitter.resourceChecksVec.WithLabelValues(team, pipeline).Inc()
 }
 
-func (emitter *PrometheusEmitter) checkMetric(logger lager.Logger, event metric.Event) {
-	scopeID, exists := event.Attributes["scope_id"]
-	if !exists {
-		logger.Error("failed-to-find-resource-config-scope-id-in-event", fmt.Errorf("expected scope_id to exist in event.Attributes"))
+func (emitter *PrometheusEmitter) checkQueueSizeMetric(logger lager.Logger, event metric.Event) {
+	value, ok := event.Value.(int)
+	if !ok {
+		logger.Error("check-queue-size-type-mismatch", fmt.Errorf("expected event.Value to be a int"))
 		return
 	}
+
+	emitter.checkQueueSize.Set(float64(value))
+}
+
+func (emitter *PrometheusEmitter) checkEnqueueMetric(logger lager.Logger, event metric.Event) {
 	checkName, exists := event.Attributes["check_name"]
 	if !exists {
 		logger.Error("failed-to-find-check-name-in-event", fmt.Errorf("expected check_name to exist in event.Attributes"))
 		return
 	}
 
-	emitter.checksVec.WithLabelValues(scopeID, checkName).Inc()
+	emitter.checkEnqueueVec.WithLabelValues(checkName).Inc()
+}
+
+func (emitter *PrometheusEmitter) checkMetric(logger lager.Logger, event metric.Event) {
+	scopeID, exists := event.Attributes["scope_id"]
+	if !exists {
+		logger.Error("failed-to-find-resource-config-scope-id-in-event", fmt.Errorf("expected scope_id to exist in event.Attributes"))
+		return
+	}
+	checkStatus, exists := event.Attributes["check_status"]
+	if !exists {
+		logger.Error("failed-to-find-check-status-in-event", fmt.Errorf("expected check_status to exist in event.Attributes"))
+		return
+	}
+
+	duration, ok := event.Value.(float64)
+	if !ok {
+		logger.Error("check-event-value-type-mismatch", fmt.Errorf("expected event.Value to be a float64"))
+		return
+	}
+	// seconds are the standard prometheus base unit for time
+	duration = duration / 1000
+
+	emitter.checksVec.WithLabelValues(scopeID, checkStatus).Observe(duration)
 }
 
 // updateLastSeen tracks for each worker when it last received a metric event.

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -555,17 +555,19 @@ func (event CheckFinished) Emit(logger lager.Logger) {
 }
 
 type CheckEnqueue struct {
-	CheckName string
+	CheckName             string
+	ResourceConfigScopeID int
 }
 
 func (event CheckEnqueue) Emit(logger lager.Logger) {
 	emit(
 		logger.Session("check-enqueued"),
 		Event{
-			Name:  "check enqueue",
+			Name:  "check enqueued",
 			Value: 1,
 			State: EventStateOK,
 			Attributes: map[string]string{
+				"scope_id":   strconv.Itoa(event.ResourceConfigScopeID),
 				"check_name": event.CheckName,
 			},
 		},

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -511,6 +511,7 @@ func (event ResourceCheck) Emit(logger lager.Logger) {
 type CheckStarted struct {
 	ResourceConfigScopeID int
 	CheckName             string
+	CheckStatus           db.CheckStatus
 	CheckPendingDuration  time.Duration
 }
 
@@ -522,8 +523,9 @@ func (event CheckStarted) Emit(logger lager.Logger) {
 			Value: ms(event.CheckPendingDuration),
 			State: EventStateOK,
 			Attributes: map[string]string{
-				"scope_id":   strconv.Itoa(event.ResourceConfigScopeID),
-				"check_name": event.CheckName,
+				"scope_id":     strconv.Itoa(event.ResourceConfigScopeID),
+				"check_name":   event.CheckName,
+				"check_status": string(event.CheckStatus),
 			},
 		},
 	)

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -22,6 +22,7 @@ var FailedVolumes = Meter(0)
 
 var ContainersDeleted = Meter(0)
 var VolumesDeleted = Meter(0)
+var ChecksDeleted = Meter(0)
 
 type SchedulingFullDuration struct {
 	PipelineName string
@@ -507,27 +508,80 @@ func (event ResourceCheck) Emit(logger lager.Logger) {
 	)
 }
 
-type CheckFinished struct {
-	ResourceConfigScopeID string
+type CheckStarted struct {
+	ResourceConfigScopeID int
 	CheckName             string
-	Success               bool
+	CheckPendingDuration  time.Duration
+}
+
+func (event CheckStarted) Emit(logger lager.Logger) {
+	emit(
+		logger.Session("check-started"),
+		Event{
+			Name:  "check started",
+			Value: ms(event.CheckPendingDuration),
+			State: EventStateOK,
+			Attributes: map[string]string{
+				"scope_id":   strconv.Itoa(event.ResourceConfigScopeID),
+				"check_name": event.CheckName,
+			},
+		},
+	)
+}
+
+type CheckFinished struct {
+	ResourceConfigScopeID int
+	CheckName             string
+	CheckStatus           db.CheckStatus
+	CheckDuration         time.Duration
 }
 
 func (event CheckFinished) Emit(logger lager.Logger) {
-	state := EventStateOK
-	if !event.Success {
-		state = EventStateWarning
-	}
 	emit(
 		logger.Session("check-finished"),
 		Event{
 			Name:  "check finished",
-			Value: 1,
-			State: state,
+			Value: ms(event.CheckDuration),
+			State: EventStateOK,
 			Attributes: map[string]string{
-				"scope_id":   event.ResourceConfigScopeID,
+				"scope_id":     strconv.Itoa(event.ResourceConfigScopeID),
+				"check_name":   event.CheckName,
+				"check_status": string(event.CheckStatus),
+			},
+		},
+	)
+}
+
+type CheckEnqueue struct {
+	CheckName string
+}
+
+func (event CheckEnqueue) Emit(logger lager.Logger) {
+	emit(
+		logger.Session("check-enqueued"),
+		Event{
+			Name:  "check enqueue",
+			Value: 1,
+			State: EventStateOK,
+			Attributes: map[string]string{
 				"check_name": event.CheckName,
 			},
+		},
+	)
+}
+
+type CheckQueueSize struct {
+	Checks int
+}
+
+func (event CheckQueueSize) Emit(logger lager.Logger) {
+	emit(
+		logger.Session("check-queue-size"),
+		Event{
+			Name:       "check queue size",
+			Value:      event.Checks,
+			State:      EventStateOK,
+			Attributes: map[string]string{},
 		},
 	)
 }

--- a/atc/metric/periodic.go
+++ b/atc/metric/periodic.go
@@ -72,6 +72,15 @@ func tick(logger lager.Logger) {
 	)
 
 	emit(
+		logger.Session("checks-deleted"),
+		Event{
+			Name:  "Checks deleted",
+			Value: ChecksDeleted.Delta(),
+			State: EventStateOK,
+		},
+	)
+
+	emit(
 		logger.Session("containers-created"),
 		Event{
 			Name:  "containers created",

--- a/atc/metric/periodic.go
+++ b/atc/metric/periodic.go
@@ -74,7 +74,7 @@ func tick(logger lager.Logger) {
 	emit(
 		logger.Session("checks-deleted"),
 		Event{
-			Name:  "Checks deleted",
+			Name:  "checks deleted",
 			Value: ChecksDeleted.Delta(),
 			State: EventStateOK,
 		},


### PR DESCRIPTION
# Existing Issue

Fixes #4554

# Why do we need this PR?
So we could have metrics available when Lidar is enabled.

# Changes proposed in this pull request
Added below metrics for Lidar
 - `check_started`
 - `check_finished`
 - `check_enqueue`
 - `check_queue_size`
 - `checks_deleted`

# Contributor Checklist
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

