### PR TITLE
Add batching to new relic

### DIFF
--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -2,8 +2,11 @@ package emitter
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -20,22 +23,29 @@ type (
 	}
 
 	NewRelicEmitter struct {
-		client     *http.Client
-		url        string
-		apikey     string
-		prefix     string
-		containers *stats
-		volumes    *stats
+		Client              *http.Client
+		Url                 string
+		apikey              string
+		prefix              string
+		containers          *stats
+		volumes             *stats
+		BatchSize           int
+		BatchDuration       time.Duration
+		CompressionDisabled bool
+		LastEmitTime        time.Time
+		NewRelicBatch       []NewRelicEvent
 	}
 
 	NewRelicConfig struct {
-		AccountID     string `long:"newrelic-account-id" description:"New Relic Account ID"`
-		APIKey        string `long:"newrelic-api-key" description:"New Relic Insights API Key"`
-		ServicePrefix string `long:"newrelic-service-prefix" default:"" description:"An optional prefix for emitted New Relic events"`
+		AccountID           string        `long:"newrelic-account-id" description:"New Relic Account ID"`
+		APIKey              string        `long:"newrelic-api-key" description:"New Relic Insights API Key"`
+		ServicePrefix       string        `long:"newrelic-service-prefix" default:"" description:"An optional prefix for emitted New Relic events"`
+		BatchSize           uint64        `long:"newrelic-batch-size" default:"2000" description:"Number of events to batch together before emitting"`
+		BatchDuration       time.Duration `long:"newrelic-batch-duration" default:"60s" description:"Length of time to wait between emitting until all currently batched events are emitted"`
+		CompressionDisabled bool          `long:"newrelic-batch-compression-disabled" description:"Compress the batch before emitting"`
 	}
 
-	singlePayload map[string]interface{}
-	fullPayload   []singlePayload
+	NewRelicEvent map[string]interface{}
 )
 
 func init() {
@@ -54,64 +64,22 @@ func (config *NewRelicConfig) NewEmitter() (metric.Emitter, error) {
 	}
 
 	return &NewRelicEmitter{
-		client:     client,
-		url:        fmt.Sprintf("https://insights-collector.newrelic.com/v1/accounts/%s/events", config.AccountID),
-		apikey:     config.APIKey,
-		prefix:     config.ServicePrefix,
-		containers: new(stats),
-		volumes:    new(stats),
+		Client:              client,
+		Url:                 fmt.Sprintf("https://insights-collector.newrelic.com/v1/accounts/%s/events", config.AccountID),
+		apikey:              config.APIKey,
+		prefix:              config.ServicePrefix,
+		containers:          new(stats),
+		volumes:             new(stats),
+		BatchSize:           int(config.BatchSize),
+		BatchDuration:       config.BatchDuration,
+		CompressionDisabled: config.CompressionDisabled,
+		LastEmitTime:        time.Now(),
+		NewRelicBatch:       make([]NewRelicEvent, 0),
 	}, nil
 }
 
-func (emitter *NewRelicEmitter) simplePayload(logger lager.Logger, event metric.Event, nameOverride string) singlePayload {
-	name := nameOverride
-	if name == "" {
-		name = strings.Replace(event.Name, " ", "_", -1)
-	}
-
-	eventType := fmt.Sprintf("%s%s", emitter.prefix, name)
-
-	payload := singlePayload{
-		"eventType": eventType,
-		"value":     event.Value,
-		"state":     string(event.State),
-		"host":      event.Host,
-		"timestamp": event.Time.Unix(),
-	}
-
-	for k, v := range event.Attributes {
-		payload[fmt.Sprintf("_%s", k)] = v
-	}
-	return payload
-}
-
-func (emitter *NewRelicEmitter) emitPayload(logger lager.Logger, payload fullPayload) {
-	payloadJSON, err := json.Marshal(payload)
-	if err != nil {
-		logger.Error("failed-to-serialize-payload", err)
-		return
-	}
-
-	req, err := http.NewRequest("POST", emitter.url, bytes.NewBuffer(payloadJSON))
-	if err != nil {
-		logger.Error("failed-to-construct-request", err)
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-Insert-Key", emitter.apikey)
-
-	resp, err := emitter.client.Do(req)
-	if err != nil {
-		logger.Error("failed-to-send-request",
-			errors.Wrap(metric.ErrFailedToEmit, err.Error()))
-		return
-	}
-
-	resp.Body.Close()
-}
-
 func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
-	payload := make(fullPayload, 0)
+	logger = logger.Session("new-relic")
 
 	switch event.Name {
 
@@ -127,7 +95,7 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		"database connections",
 		"worker unknown containers",
 		"worker unknown volumes":
-		payload = append(payload, emitter.simplePayload(logger, event, ""))
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(logger, event, ""))
 
 	// These are periodic metrics that are consolidated and only emitted once
 	// per cycle (the emit trigger is chosen because it's currently last in the
@@ -139,32 +107,35 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	case "containers created":
 		emitter.containers.created = event.Value
 	case "failed containers":
-		newPayload := emitter.simplePayload(logger, event, "containers")
-		newPayload["failed"] = newPayload["value"]
-		newPayload["created"] = emitter.containers.created
-		newPayload["deleted"] = emitter.containers.deleted
-		delete(newPayload, "value")
-		payload = append(payload, newPayload)
+		singleEvent := emitter.transformToNewRelicEvent(logger, event, "containers")
+		singleEvent["failed"] = singleEvent["value"]
+		singleEvent["created"] = emitter.containers.created
+		singleEvent["deleted"] = emitter.containers.deleted
+		delete(singleEvent, "value")
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, singleEvent)
 
 	case "volumes deleted":
 		emitter.volumes.deleted = event.Value
 	case "volumes created":
 		emitter.volumes.created = event.Value
 	case "failed volumes":
-		newPayload := emitter.simplePayload(logger, event, "volumes")
-		newPayload["failed"] = newPayload["value"]
-		newPayload["created"] = emitter.volumes.created
-		newPayload["deleted"] = emitter.volumes.deleted
-		delete(newPayload, "value")
-		payload = append(payload, newPayload)
+		singleEvent := emitter.transformToNewRelicEvent(logger, event, "volumes")
+		singleEvent["failed"] = singleEvent["value"]
+		singleEvent["created"] = emitter.volumes.created
+		singleEvent["deleted"] = emitter.volumes.deleted
+		delete(singleEvent, "value")
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, singleEvent)
 
 	// And a couple that need a small rename (new relic doesn't like some chars)
 	case "scheduling: full duration (ms)":
-		payload = append(payload, emitter.simplePayload(logger, event, "scheduling_full_duration_ms"))
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(logger, event,
+			"scheduling_full_duration_ms"))
 	case "scheduling: loading versions duration (ms)":
-		payload = append(payload, emitter.simplePayload(logger, event, "scheduling_load_duration_ms"))
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(logger, event,
+			"scheduling_load_duration_ms"))
 	case "scheduling: job duration (ms)":
-		payload = append(payload, emitter.simplePayload(logger, event, "scheduling_job_duration_ms"))
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(logger, event,
+			"scheduling_job_duration_ms"))
 	default:
 		// Ignore the rest
 	}
@@ -173,16 +144,117 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	// otherwise recording it. (This won't be easily graphable, that's okay,
 	// this is more for monitoring synthetics)
 	if event.State != metric.EventStateOK {
-		singlePayload := emitter.simplePayload(logger, event, "alert")
+		singlePayload := emitter.transformToNewRelicEvent(logger, event, "alert")
 		// We don't have friendly names for all the metrics, and part of the
 		// point of this alert is to catch events we should be logging but
 		// didn't; therefore, be consistently inconsistent and use the
 		// concourse metric names, not our translation layer.
 		singlePayload["metric"] = event.Name
-		payload = append(payload, singlePayload)
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, singlePayload)
 	}
 
-	if len(payload) > 0 {
-		emitter.emitPayload(logger, payload)
+	duration := time.Since(emitter.LastEmitTime)
+	if len(emitter.NewRelicBatch) >= emitter.BatchSize || duration >= emitter.BatchDuration {
+		logger.Debug("pre-emit-batch", lager.Data{
+			"batch-size":         emitter.BatchSize,
+			"current-batch-size": len(emitter.NewRelicBatch),
+			"batch-duration":     emitter.BatchDuration,
+			"current-duration":   duration,
+		})
+		emitter.submitBatch(logger)
 	}
+}
+
+// NewRelic has strict requirements around the structure of the events
+// Keys must be alphanumeric and can contain hyphens or underscores
+// Values must be sting, int, or unix timestamps. No maps/arrays.
+func (emitter *NewRelicEmitter) transformToNewRelicEvent(logger lager.Logger, event metric.Event, nameOverride string) NewRelicEvent {
+	name := nameOverride
+	if name == "" {
+		name = strings.Replace(event.Name, " ", "_", -1)
+	}
+
+	eventType := fmt.Sprintf("%s%s", emitter.prefix, name)
+
+	payload := NewRelicEvent{
+		"eventType": eventType,
+		"value":     event.Value,
+		"state":     string(event.State),
+		"host":      event.Host,
+		"timestamp": event.Time.Unix(),
+	}
+
+	for k, v := range event.Attributes {
+		payload[fmt.Sprintf("_%s", k)] = v
+	}
+	return payload
+}
+
+func (emitter *NewRelicEmitter) submitBatch(logger lager.Logger) {
+	batchToSubmit := make([]NewRelicEvent, len(emitter.NewRelicBatch))
+	copy(batchToSubmit, emitter.NewRelicBatch)
+	emitter.NewRelicBatch = make([]NewRelicEvent, 0)
+	emitter.LastEmitTime = time.Now()
+	go emitter.emitBatch(logger, batchToSubmit)
+}
+
+func (emitter *NewRelicEmitter) emitBatch(logger lager.Logger, payload []NewRelicEvent) {
+	batch, err := emitter.marshalJSON(logger, payload)
+	if err != nil {
+		logger.Error("failed-to-marshal-batch", err)
+		return
+	}
+
+	req, err := http.NewRequest("POST", emitter.Url, batch)
+	if err != nil {
+		logger.Error("failed-to-construct-request", err)
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-Insert-Key", emitter.apikey)
+	if !emitter.CompressionDisabled {
+		req.Header.Add("Content-Encoding", "gzip")
+	}
+
+	resp, err := emitter.Client.Do(req)
+	defer resp.Body.Close()
+	if err != nil {
+		logger.Error("failed-to-send-request",
+			errors.Wrap(metric.ErrFailedToEmit, err.Error()))
+		return
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			logger.Info("failed-to-read-response-body",
+				lager.Data{"error": err.Error(), "status-code": resp.StatusCode})
+			return
+		}
+		logger.Info("received-non-2xx-response-status-code",
+			lager.Data{"response-body": string(bodyBytes), "status-code": resp.StatusCode})
+		return
+	}
+}
+
+func (emitter *NewRelicEmitter) marshalJSON(logger lager.Logger, batch []NewRelicEvent) (io.Reader, error) {
+	var batchJson *bytes.Buffer
+	if emitter.CompressionDisabled {
+		marshaled, err := json.Marshal(batch)
+		if err != nil {
+			logger.Error("failed-to-serialize-payload", err)
+			return nil, err
+		}
+		batchJson = bytes.NewBuffer(marshaled)
+	} else {
+		batchJson = bytes.NewBuffer([]byte{})
+		encoder := gzip.NewWriter(batchJson)
+		defer encoder.Close()
+		err := json.NewEncoder(encoder).Encode(batch)
+		if err != nil {
+			logger.Error("failed-to-compress-and-serialize-payload", err)
+			return nil, err
+		}
+	}
+	return batchJson, nil
 }

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -23,26 +22,26 @@ type (
 	}
 
 	NewRelicEmitter struct {
-		Client              *http.Client
-		Url                 string
-		apikey              string
-		prefix              string
-		containers          *stats
-		volumes             *stats
-		BatchSize           int
-		BatchDuration       time.Duration
-		CompressionDisabled bool
-		LastEmitTime        time.Time
-		NewRelicBatch       []NewRelicEvent
+		Client             *http.Client
+		Url                string
+		apikey             string
+		prefix             string
+		containers         *stats
+		volumes            *stats
+		BatchSize          int
+		BatchDuration      time.Duration
+		DisableCompression bool
+		LastEmitTime       time.Time
+		NewRelicBatch      []NewRelicEvent
 	}
 
 	NewRelicConfig struct {
-		AccountID           string        `long:"newrelic-account-id" description:"New Relic Account ID"`
-		APIKey              string        `long:"newrelic-api-key" description:"New Relic Insights API Key"`
-		ServicePrefix       string        `long:"newrelic-service-prefix" default:"" description:"An optional prefix for emitted New Relic events"`
-		BatchSize           uint64        `long:"newrelic-batch-size" default:"2000" description:"Number of events to batch together before emitting"`
-		BatchDuration       time.Duration `long:"newrelic-batch-duration" default:"60s" description:"Length of time to wait between emitting until all currently batched events are emitted"`
-		CompressionDisabled bool          `long:"newrelic-batch-compression-disabled" description:"Compress the batch before emitting"`
+		AccountID          string        `long:"newrelic-account-id" description:"New Relic Account ID"`
+		APIKey             string        `long:"newrelic-api-key" description:"New Relic Insights API Key"`
+		ServicePrefix      string        `long:"newrelic-service-prefix" default:"" description:"An optional prefix for emitted New Relic events"`
+		BatchSize          uint64        `long:"newrelic-batch-size" default:"2000" description:"Number of events to batch together before emitting"`
+		BatchDuration      time.Duration `long:"newrelic-batch-duration" default:"60s" description:"Length of time to wait between emitting until all currently batched events are emitted"`
+		DisableCompression bool          `long:"newrelic-batch-disable-compression" description:"Disables compression of the batch before sending it"`
 	}
 
 	NewRelicEvent map[string]interface{}
@@ -64,17 +63,17 @@ func (config *NewRelicConfig) NewEmitter() (metric.Emitter, error) {
 	}
 
 	return &NewRelicEmitter{
-		Client:              client,
-		Url:                 fmt.Sprintf("https://insights-collector.newrelic.com/v1/accounts/%s/events", config.AccountID),
-		apikey:              config.APIKey,
-		prefix:              config.ServicePrefix,
-		containers:          new(stats),
-		volumes:             new(stats),
-		BatchSize:           int(config.BatchSize),
-		BatchDuration:       config.BatchDuration,
-		CompressionDisabled: config.CompressionDisabled,
-		LastEmitTime:        time.Now(),
-		NewRelicBatch:       make([]NewRelicEvent, 0),
+		Client:             client,
+		Url:                "https://insights-collector.newrelic.com/v1/accounts/" + config.AccountID + "/events",
+		apikey:             config.APIKey,
+		prefix:             config.ServicePrefix,
+		containers:         new(stats),
+		volumes:            new(stats),
+		BatchSize:          int(config.BatchSize),
+		BatchDuration:      config.BatchDuration,
+		DisableCompression: config.DisableCompression,
+		LastEmitTime:       time.Now(),
+		NewRelicBatch:      make([]NewRelicEvent, 0),
 	}, nil
 }
 
@@ -95,7 +94,7 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		"database connections",
 		"worker unknown containers",
 		"worker unknown volumes":
-		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(logger, event, ""))
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(event, ""))
 
 	// These are periodic metrics that are consolidated and only emitted once
 	// per cycle (the emit trigger is chosen because it's currently last in the
@@ -107,7 +106,7 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	case "containers created":
 		emitter.containers.created = event.Value
 	case "failed containers":
-		singleEvent := emitter.transformToNewRelicEvent(logger, event, "containers")
+		singleEvent := emitter.transformToNewRelicEvent(event, "containers")
 		singleEvent["failed"] = singleEvent["value"]
 		singleEvent["created"] = emitter.containers.created
 		singleEvent["deleted"] = emitter.containers.deleted
@@ -119,7 +118,7 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	case "volumes created":
 		emitter.volumes.created = event.Value
 	case "failed volumes":
-		singleEvent := emitter.transformToNewRelicEvent(logger, event, "volumes")
+		singleEvent := emitter.transformToNewRelicEvent(event, "volumes")
 		singleEvent["failed"] = singleEvent["value"]
 		singleEvent["created"] = emitter.volumes.created
 		singleEvent["deleted"] = emitter.volumes.deleted
@@ -128,13 +127,13 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 
 	// And a couple that need a small rename (new relic doesn't like some chars)
 	case "scheduling: full duration (ms)":
-		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(logger, event,
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(event,
 			"scheduling_full_duration_ms"))
 	case "scheduling: loading versions duration (ms)":
-		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(logger, event,
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(event,
 			"scheduling_load_duration_ms"))
 	case "scheduling: job duration (ms)":
-		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(logger, event,
+		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(event,
 			"scheduling_job_duration_ms"))
 	default:
 		// Ignore the rest
@@ -144,7 +143,7 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	// otherwise recording it. (This won't be easily graphable, that's okay,
 	// this is more for monitoring synthetics)
 	if event.State != metric.EventStateOK {
-		singlePayload := emitter.transformToNewRelicEvent(logger, event, "alert")
+		singlePayload := emitter.transformToNewRelicEvent(event, "alert")
 		// We don't have friendly names for all the metrics, and part of the
 		// point of this alert is to catch events we should be logging but
 		// didn't; therefore, be consistently inconsistent and use the
@@ -168,13 +167,13 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 // NewRelic has strict requirements around the structure of the events
 // Keys must be alphanumeric and can contain hyphens or underscores
 // Values must be sting, int, or unix timestamps. No maps/arrays.
-func (emitter *NewRelicEmitter) transformToNewRelicEvent(logger lager.Logger, event metric.Event, nameOverride string) NewRelicEvent {
+func (emitter *NewRelicEmitter) transformToNewRelicEvent(event metric.Event, nameOverride string) NewRelicEvent {
 	name := nameOverride
 	if name == "" {
 		name = strings.Replace(event.Name, " ", "_", -1)
 	}
 
-	eventType := fmt.Sprintf("%s%s", emitter.prefix, name)
+	eventType := emitter.prefix + name
 
 	payload := NewRelicEvent{
 		"eventType": eventType,
@@ -185,7 +184,7 @@ func (emitter *NewRelicEmitter) transformToNewRelicEvent(logger lager.Logger, ev
 	}
 
 	for k, v := range event.Attributes {
-		payload[fmt.Sprintf("_%s", k)] = v
+		payload["_"+k] = v
 	}
 	return payload
 }
@@ -208,11 +207,12 @@ func (emitter *NewRelicEmitter) emitBatch(logger lager.Logger, payload []NewReli
 	req, err := http.NewRequest("POST", emitter.Url, batch)
 	if err != nil {
 		logger.Error("failed-to-construct-request", err)
+		return
 	}
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Insert-Key", emitter.apikey)
-	if !emitter.CompressionDisabled {
+	if !emitter.DisableCompression {
 		req.Header.Add("Content-Encoding", "gzip")
 	}
 
@@ -239,7 +239,7 @@ func (emitter *NewRelicEmitter) emitBatch(logger lager.Logger, payload []NewReli
 
 func (emitter *NewRelicEmitter) marshalJSON(logger lager.Logger, batch []NewRelicEvent) (io.Reader, error) {
 	var batchJson *bytes.Buffer
-	if emitter.CompressionDisabled {
+	if emitter.DisableCompression {
 		marshaled, err := json.Marshal(batch)
 		if err != nil {
 			logger.Error("failed-to-serialize-payload", err)

--- a/atc/metric/emitter/newrelic_test.go
+++ b/atc/metric/emitter/newrelic_test.go
@@ -1,0 +1,171 @@
+package emitter_test
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/metric"
+	"github.com/concourse/concourse/atc/metric/emitter"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("NewRelicEmitter", func() {
+
+	var (
+		testEmitter emitter.NewRelicEmitter
+		server      *Server
+		client      *http.Client
+		testEvent   metric.Event
+		testLogger  lager.Logger
+	)
+
+	BeforeEach(func() {
+		testEvent = metric.Event{
+			Name:  "build started",
+			Value: 1,
+			State: metric.EventStateOK,
+		}
+
+		testLogger = lager.NewLogger("newrelic")
+
+		server = NewServer()
+
+		client = &http.Client{
+			Transport: &http.Transport{},
+			Timeout:   time.Minute,
+		}
+
+		server.RouteToHandler(http.MethodPost, "/", verifyFakeEvent)
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	Context("Emits metrics", func() {
+		Context("when batch size is 2", func() {
+			BeforeEach(func() {
+				testEmitter = emitter.NewRelicEmitter{
+					NewRelicBatch: make([]emitter.NewRelicEvent, 0),
+					BatchDuration: 100 * time.Second,
+					BatchSize:     2,
+					LastEmitTime:  time.Now(),
+					Url:           server.URL(),
+					Client:        client,
+				}
+			})
+			It("should write one batch to NewRelic", func() {
+				for i := 0; i < 3; i++ {
+					testEmitter.Emit(testLogger, testEvent)
+				}
+				Eventually(server.ReceivedRequests).Should(HaveLen(1))
+				Expect(testEmitter.NewRelicBatch).To(HaveLen(1))
+			})
+			It("should write two batches to NewRelic", func() {
+				for i := 0; i < 4; i++ {
+					testEmitter.Emit(testLogger, testEvent)
+				}
+				Eventually(server.ReceivedRequests).Should(HaveLen(2))
+				Expect(testEmitter.NewRelicBatch).To(HaveLen(0))
+			})
+			It("should write no batches to NewRelic", func() {
+				testEmitter.Emit(testLogger, testEvent)
+
+				time.Sleep(500 * time.Millisecond)
+				Eventually(server.ReceivedRequests).Should(HaveLen(0))
+				Expect(testEmitter.NewRelicBatch).To(HaveLen(1))
+			})
+		})
+		Context("when batch duration is 1 millisecond", func() {
+			BeforeEach(func() {
+				testEmitter = emitter.NewRelicEmitter{
+					NewRelicBatch: make([]emitter.NewRelicEvent, 0),
+					BatchDuration: 1 * time.Millisecond,
+					BatchSize:     100,
+					LastEmitTime:  time.Now(),
+					Url:           server.URL(),
+					Client:        client,
+				}
+			})
+			It("should write one batch to NewRelic", func() {
+				time.Sleep(1 * time.Millisecond)
+				testEmitter.Emit(testLogger, testEvent)
+				Eventually(server.ReceivedRequests).Should(HaveLen(1))
+				Expect(testEmitter.NewRelicBatch).To(HaveLen(0))
+			})
+			It("should write two batches to NewRelic", func() {
+				for i := 0; i < 2; i++ {
+					time.Sleep(1 * time.Millisecond)
+					testEmitter.Emit(testLogger, testEvent)
+				}
+				Eventually(server.ReceivedRequests).Should(HaveLen(2))
+				Expect(testEmitter.NewRelicBatch).To(HaveLen(0))
+			})
+			It("should write no batches to NewRelic", func() {
+				testEmitter.Emit(testLogger, testEvent)
+				Eventually(server.ReceivedRequests).Should(HaveLen(0))
+				Expect(testEmitter.NewRelicBatch).To(HaveLen(1))
+
+			})
+		})
+
+		DescribeTable("Compression", func(compressionState bool, expectedEncoding string) {
+			testEmitter = emitter.NewRelicEmitter{
+				NewRelicBatch:       make([]emitter.NewRelicEvent, 0),
+				BatchDuration:       100 * time.Second,
+				BatchSize:           1,
+				LastEmitTime:        time.Now(),
+				Url:                 server.URL(),
+				Client:              client,
+				CompressionDisabled: compressionState,
+			}
+
+			testEmitter.Emit(testLogger, testEvent)
+			Eventually(server.ReceivedRequests).Should(HaveLen(1))
+			request := (server.ReceivedRequests())[0]
+			Expect(request.Header.Get("Content-Encoding")).To(Equal(expectedEncoding))
+		},
+			Entry("is enabled", false, "gzip"),
+			Entry("is disabled", true, ""),
+		)
+	})
+})
+
+func verifyFakeEvent(writer http.ResponseWriter, request *http.Request) {
+	var (
+		givenBody []byte
+		err       error
+	)
+
+	if request.Header.Get("Content-Encoding") == "gzip" {
+		reader, err := gzip.NewReader(request.Body)
+		Expect(err).To(Not(HaveOccurred()))
+		givenBody, err = ioutil.ReadAll(reader)
+		Expect(err).To(Not(HaveOccurred()))
+	} else {
+		givenBody, err = ioutil.ReadAll(request.Body)
+		Expect(err).To(Not(HaveOccurred()))
+	}
+
+	var events []emitter.NewRelicEvent
+	err = json.Unmarshal(givenBody, &events)
+	Expect(err).To(Not(HaveOccurred()))
+
+	Expect(len(events)).To(BeNumerically(">=", 1))
+
+	for _, event := range events {
+		Expect(event["eventType"]).To(Equal("build_started"))
+		Expect(event["value"]).To(Equal(float64(1)))
+		Expect(event["state"]).To(Equal("ok"))
+	}
+
+	writer.WriteHeader(http.StatusOK)
+}

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -9,3 +9,7 @@
 #### <sub><sup><a name="4707" href="#4707">:link:</a></sup></sub> feature
 
 * Make Garden client HTTP timeout configurable. #4707
+
+#### <sub><sup><a name="4698" href="#4698">:link:</a></sup></sub> feature
+
+* @pivotal-bin-ju @taylorsilva @xtreme-sameer-vohra added batching to the NewRelic emitter and logging info for non 2xx responses from NewRelic #4698.


### PR DESCRIPTION
# Existing Issue

Fixes #4540

# Changes proposed in this pull request
This PR adds three flags to the NewRelic emitter:
- `CONCOURSE_NEWRELIC_BATCH_DURATION`
- `CONCOURSE_NEWRELIC_BATCH_SIZE`
- `CONCOURSE_NEWRELIC_COMPRESSION_DISABLED`

This change will allow users to adjust the batch size that the
NewRelic emitter uses with the `CONCOURSE_NEWRELIC_BATCH_SIZE` flag.

They can also adjust the frequency that data is emitted by
changing `CONCOURSE_NEWRELIC_BATCH_DURATION`.

We now compress the batch by default. Users can turn this off
by using the `CONCOURSE_NEWRELIC_COMPRESSION_DISABLED` flag.

This also includes the changes made by @xtreme-sameer-vohra in #4617 

CC: @pivotal-bin-ju @xtreme-sameer-vohra 

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
