### PR TITLE
revert #4661

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
 	github.com/concourse/baggageclaim v1.6.5
-	github.com/concourse/dex v0.0.0-20191028164029-00bcc75bd8b9
+	github.com/concourse/dex v0.0.0-20190417202333-2202f4ef4172
 	github.com/concourse/flag v1.0.0
 	github.com/concourse/go-archive v1.0.1
 	github.com/concourse/retryhttp v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,6 @@ github.com/concourse/baggageclaim v1.6.5 h1:nqUNImvNPagFWLpjmYM3K/iUtXcgjWCXGUVE
 github.com/concourse/baggageclaim v1.6.5/go.mod h1:XEX/nfW5iJQwJVLUh1AxyqtFRLeyM+iZLeKMUEloiKc=
 github.com/concourse/dex v0.0.0-20190417202333-2202f4ef4172 h1:lYBXqY+XJmyMD3uthg734qIxdHU+lAF8mnVk72gdFCA=
 github.com/concourse/dex v0.0.0-20190417202333-2202f4ef4172/go.mod h1:jq+kdbXyj+bEdch50oYfPCNK4ZCRKAd/R0wlZuAG+Gc=
-github.com/concourse/dex v0.0.0-20191028164029-00bcc75bd8b9 h1:S+UP8yiQgYSZksNEbAYwftvabbyJmHvu6xs07XiA8cw=
-github.com/concourse/dex v0.0.0-20191028164029-00bcc75bd8b9/go.mod h1:jq+kdbXyj+bEdch50oYfPCNK4ZCRKAd/R0wlZuAG+Gc=
 github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/flag v1.0.0 h1:XG+A/Y+8kNdNDUC9T+SQ55dZ1+xYQN6LNVBg3cGJ080=
 github.com/concourse/flag v1.0.0/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=


### PR DESCRIPTION
# Why do we need this PR?
v5.7.0 was released with a breaking change and no way to opt out. We can afford to more carefully consider how to extend the CF auth connector without excluding certain use cases.

# Changes proposed in this pull request

* downgrade dex

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [ ] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


# Reviewer Checklist
- [ ] Code reviewed
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [ ] PR acceptance performed