### PR TITLE
make the team names clickable to filter the dashboard view

### DIFF
--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -37,7 +37,7 @@ import Dashboard.Styles as Styles
 import HoverState
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, class, classList, draggable, id, style)
-import Html.Events exposing (on)
+import Html.Events exposing (on, onClick)
 import Json.Decode
 import List.Extra
 import Maybe.Extra
@@ -413,7 +413,14 @@ view { dragState, dropState, now, hovered, pipelineRunningKeyframes, userState }
             , class <| .sectionHeaderClass Effects.stickyHeaderConfig
             ]
             (Html.div
-                [ class "dashboard-team-name" ]
+                ([ class "dashboard-team-name" ]
+                ++ (if List.isEmpty g.pipelines then
+                        []
+                   else
+                        [ onClick (FilterMsg ("team:" ++ g.teamName))
+                        , style "cursor" "pointer" ]
+                   )
+                )
                 [ Html.text g.teamName ]
                 :: (Maybe.Extra.toList <|
                         Maybe.map (Tag.view False) g.tag

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -413,13 +413,12 @@ view { dragState, dropState, now, hovered, pipelineRunningKeyframes, userState }
             , class <| .sectionHeaderClass Effects.stickyHeaderConfig
             ]
             (Html.div
-                ([ class "dashboard-team-name" ]
-                ++ (if List.isEmpty g.pipelines then
-                        []
-                   else
-                        [ onClick (FilterMsg ("team:" ++ g.teamName))
-                        , style "cursor" "pointer" ]
-                   )
+                (if List.isEmpty g.pipelines then
+                    [ class "dashboard-team-name" ]
+                else
+                    [ class "dashboard-team-name"
+                    , onClick (FilterMsg ("team:" ++ g.teamName))
+                    , style "cursor" "pointer" ]
                 )
                 [ Html.text g.teamName ]
                 :: (Maybe.Extra.toList <|

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -415,10 +415,12 @@ view { dragState, dropState, now, hovered, pipelineRunningKeyframes, userState }
             (Html.div
                 (if List.isEmpty g.pipelines then
                     [ class "dashboard-team-name" ]
-                else
+
+                 else
                     [ class "dashboard-team-name"
                     , onClick (FilterMsg ("team:" ++ g.teamName))
-                    , style "cursor" "pointer" ]
+                    , style "cursor" "pointer"
+                    ]
                 )
                 [ Html.text g.teamName ]
                 :: (Maybe.Extra.toList <|

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -866,6 +866,39 @@ all =
                     |> Common.queryView
                     |> Query.find [ class "dashboard-team-name-wrapper" ]
                     |> Query.has [ style "letter-spacing" ".2em" ]
+        , describe "clicking on team name"
+            [ test
+                "filters by team when there are pipelines"
+              <|
+                \_ ->
+                    whenOnDashboard { highDensity = False }
+                        |> givenDataAndUser
+                            (oneTeamOnePipeline "teamA")
+                            (userWithRoles [ ( "team", [ "owner" ] ) ])
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find (teamHeaderSelector ++ [ containing [ text "teamA" ] ])
+                        |> Query.find [ class "dashboard-team-name"]
+                        |> Event.simulate Event.click
+                        |> Event.expect
+                            (ApplicationMsgs.Update <|
+                                Msgs.FilterMsg <|
+                                    "team:teamA"
+                            )
+            , test "does not filter by team when there are no pipelines" <|
+                \_ ->
+                    whenOnDashboard { highDensity = False }
+                        |> givenDataAndUser
+                            (apiData [ ( "teamA", [] ) ])
+                            (userWithRoles [ ( "team", [ "owner" ] ) ])
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find (teamHeaderSelector ++ [ containing [ text "teamA" ] ])
+                        |> Query.find [ class "dashboard-team-name"]
+                        |> Event.simulate Event.click
+                        |> Event.toResult
+                        |> Expect.err
+            ]
         , describe "team pills"
             [ test
                 ("shows team name with no pill when unauthenticated "

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -867,9 +867,7 @@ all =
                     |> Query.find [ class "dashboard-team-name-wrapper" ]
                     |> Query.has [ style "letter-spacing" ".2em" ]
         , describe "clicking on team name"
-            [ test
-                "filters by team when there are pipelines"
-              <|
+            [ test "filters by team when there are pipelines" <|
                 \_ ->
                     whenOnDashboard { highDensity = False }
                         |> givenDataAndUser
@@ -878,7 +876,7 @@ all =
                         |> Tuple.first
                         |> Common.queryView
                         |> Query.find (teamHeaderSelector ++ [ containing [ text "teamA" ] ])
-                        |> Query.find [ class "dashboard-team-name"]
+                        |> Query.find [ class "dashboard-team-name" ]
                         |> Event.simulate Event.click
                         |> Event.expect
                             (ApplicationMsgs.Update <|
@@ -894,7 +892,7 @@ all =
                         |> Tuple.first
                         |> Common.queryView
                         |> Query.find (teamHeaderSelector ++ [ containing [ text "teamA" ] ])
-                        |> Query.find [ class "dashboard-team-name"]
+                        |> Query.find [ class "dashboard-team-name" ]
                         |> Event.simulate Event.click
                         |> Event.toResult
                         |> Expect.err


### PR DESCRIPTION
# Why do we need this PR?
On the dashboard page I expect to be able to click on the team names to filter the view

# Changes proposed in this pull request
*  team name headings are now links that apply the filter `team:<team-name>`

# Contributor Checklist
- [x] Unit tests
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
