### PR TITLE
Add release notes for dex downgrade

### DIFF
--- a/release-notes/v5.7.1.md
+++ b/release-notes/v5.7.1.md
@@ -1,0 +1,4 @@
+#### <sub><sup><a name="4699" href="#4699">:link:</a></sup></sub> fix
+
+* v5.7.0 added a breaking change to the CloudFoundry auth connector, which is reverted in this release.
+  The original change is documented in [v5.7.0 release notes](https://github.com/concourse/concourse/blob/master/release-notes/v5.7.0.md#4535). #4699

--- a/release-notes/v5.7.1.md
+++ b/release-notes/v5.7.1.md
@@ -1,4 +1,5 @@
 #### <sub><sup><a name="4699" href="#4699">:link:</a></sup></sub> fix
 
-* v5.7.0 added a breaking change to the CloudFoundry auth connector, which is reverted in this release.
+* v5.7.0 changed how CloudFoundry roles mapped to Concourse RBAC when using the CF Auth connector. 
+  Instead of enforcing this change, we would rather support both configurations in a future release.
   The original change is documented in [v5.7.0 release notes](https://github.com/concourse/concourse/blob/master/release-notes/v5.7.0.md#4535). #4699


### PR DESCRIPTION
[#4699](https://github.com/concourse/concourse/pull/4699)

for v5.7.1 patch release

Signed-off-by: Denise Yu <dyu@pivotal.io>