### PR TITLE
Release/5.7.1 pr

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -129,6 +129,8 @@ type RunCommand struct {
 	MaxActiveTasksPerWorker           int           `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
 	BaggageclaimResponseHeaderTimeout time.Duration `long:"baggageclaim-response-header-timeout" default:"1m" description:"How long to wait for Baggageclaim to send the response header."`
 
+	GardenRequestTimeout time.Duration `long:"garden-request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
+
 	CLIArtifactsDir flag.Dir `long:"cli-artifacts-dir" description:"Directory containing downloadable CLI binaries."`
 
 	Developer struct {
@@ -593,6 +595,7 @@ func (cmd *RunCommand) constructAPIMembers(
 		dbWorkerFactory,
 		workerVersion,
 		cmd.BaggageclaimResponseHeaderTimeout,
+		cmd.GardenRequestTimeout,
 	)
 
 	pool := worker.NewPool(workerProvider)
@@ -760,6 +763,7 @@ func (cmd *RunCommand) constructBackendMembers(
 		dbWorkerFactory,
 		workerVersion,
 		cmd.BaggageclaimResponseHeaderTimeout,
+		cmd.GardenRequestTimeout,
 	)
 
 	pool := worker.NewPool(workerProvider)
@@ -979,6 +983,7 @@ func (cmd *RunCommand) constructGCMember(
 		dbWorkerFactory,
 		workerVersion,
 		cmd.BaggageclaimResponseHeaderTimeout,
+		cmd.GardenRequestTimeout,
 	)
 
 	jobRunner := gc.NewWorkerJobRunner(

--- a/atc/config.go
+++ b/atc/config.go
@@ -6,16 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 )
 
 const ConfigVersionHeader = "X-Concourse-Config-Version"
 const DefaultTeamName = "main"
-
-// TIMEOUT CONSTANTS
-const GARDEN_CLIENT_HTTP_TIMEOUT = 5 * time.Minute
 
 type Tags []string
 

--- a/atc/worker/db_worker_provider.go
+++ b/atc/worker/db_worker_provider.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/concourse/concourse/atc"
-
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/lager"
 	bclient "github.com/concourse/baggageclaim/client"
@@ -32,6 +30,7 @@ type dbWorkerProvider struct {
 	dbWorkerFactory                   db.WorkerFactory
 	workerVersion                     version.Version
 	baggageclaimResponseHeaderTimeout time.Duration
+	gardenRequestTimeout              time.Duration
 }
 
 func NewDBWorkerProvider(
@@ -47,7 +46,7 @@ func NewDBWorkerProvider(
 	dbTeamFactory db.TeamFactory,
 	workerFactory db.WorkerFactory,
 	workerVersion version.Version,
-	baggageclaimResponseHeaderTimeout time.Duration,
+	baggageclaimResponseHeaderTimeout, gardenRequestTimeout time.Duration,
 ) WorkerProvider {
 	return &dbWorkerProvider{
 		lockFactory:                       lockFactory,
@@ -63,6 +62,7 @@ func NewDBWorkerProvider(
 		dbWorkerFactory:                   workerFactory,
 		workerVersion:                     workerVersion,
 		baggageclaimResponseHeaderTimeout: baggageclaimResponseHeaderTimeout,
+		gardenRequestTimeout:              gardenRequestTimeout,
 	}
 }
 
@@ -179,7 +179,7 @@ func (provider *dbWorkerProvider) NewGardenWorker(logger lager.Logger, tikTok cl
 		savedWorker.Name(),
 		savedWorker.GardenAddr(),
 		provider.retryBackOffFactory,
-		atc.GARDEN_CLIENT_HTTP_TIMEOUT,
+		provider.gardenRequestTimeout,
 	)
 
 	gClient := gcf.NewClient()

--- a/atc/worker/db_worker_provider_test.go
+++ b/atc/worker/db_worker_provider_test.go
@@ -35,14 +35,13 @@ var _ = Describe("DBProvider", func() {
 
 		logger *lagertest.TestLogger
 
-		fakeGardenBackend                 *gfakes.FakeBackend
-		gardenAddr                        string
-		baggageclaimURL                   string
-		wantWorkerVersion                 version.Version
-		baggageclaimServer                *ghttp.Server
-		gardenServer                      *server.GardenServer
-		provider                          WorkerProvider
-		baggageclaimResponseHeaderTimeout time.Duration
+		fakeGardenBackend  *gfakes.FakeBackend
+		gardenAddr         string
+		baggageclaimURL    string
+		wantWorkerVersion  version.Version
+		baggageclaimServer *ghttp.Server
+		gardenServer       *server.GardenServer
+		provider           WorkerProvider
 
 		fakeImageFactory                    *workerfakes.FakeImageFactory
 		fakeImageFetchingDelegate           *workerfakes.FakeImageFetchingDelegate
@@ -64,6 +63,11 @@ var _ = Describe("DBProvider", func() {
 
 		fakeWorker1 *dbfakes.FakeWorker
 		fakeWorker2 *dbfakes.FakeWorker
+	)
+
+	const (
+		baggageclaimResponseHeaderTimeout = 10 * time.Minute
+		gardenRequestTimeout              = 5 * time.Minute
 	)
 
 	BeforeEach(func() {
@@ -92,7 +96,6 @@ var _ = Describe("DBProvider", func() {
 		fakeGardenBackend = new(gfakes.FakeBackend)
 		logger = lagertest.NewTestLogger("test")
 		gardenServer = server.New("tcp", gardenAddr, 0, fakeGardenBackend, logger)
-		baggageclaimResponseHeaderTimeout = 10 * time.Minute
 
 		go func() {
 			defer GinkgoRecover()
@@ -176,6 +179,7 @@ var _ = Describe("DBProvider", func() {
 			fakeDBWorkerFactory,
 			wantWorkerVersion,
 			baggageclaimResponseHeaderTimeout,
+			gardenRequestTimeout,
 		)
 		baggageclaimURL = baggageclaimServer.URL()
 	})

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -5,7 +5,3 @@
 #### <sub><sup><a name="4556" href="#4556">:link:</a></sup></sub> feature
 
 * Prometheus and NewRelic can receive Lidar check-finished event now #4556.
-
-#### <sub><sup><a name="4707" href="#4707">:link:</a></sup></sub> feature
-
-* Make Garden client HTTP timeout configurable. #4707

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,0 +1,11 @@
+#### <sub><sup><a name="4688" href="#4688">:link:</a></sup></sub> feature
+
+* The pin menu on the pipeline page now matches the sidebar, and the dropdown toggles on clicking the pin icon #4688.
+
+#### <sub><sup><a name="4556" href="#4556">:link:</a></sup></sub> feature
+
+* Prometheus and NewRelic can receive Lidar check-finished event now #4556.
+
+#### <sub><sup><a name="4707" href="#4707">:link:</a></sup></sub> feature
+
+* Make Garden client HTTP timeout configurable. #4707

--- a/release-notes/v5.7.1.md
+++ b/release-notes/v5.7.1.md
@@ -1,0 +1,4 @@
+#### <sub><sup><a name="4699" href="#4699">:link:</a></sup></sub> fix
+
+* v5.7.0 added a breaking change to the CloudFoundry auth connector, which is reverted in this release.
+  The original change is documented in [v5.7.0 release notes](https://github.com/concourse/concourse/blob/master/release-notes/v5.7.0.md#4535). #4699

--- a/release-notes/v5.7.1.md
+++ b/release-notes/v5.7.1.md
@@ -1,4 +1,5 @@
 #### <sub><sup><a name="4699" href="#4699">:link:</a></sup></sub> fix
 
-* v5.7.0 added a breaking change to the CloudFoundry auth connector, which is reverted in this release.
+* v5.7.0 changed how CloudFoundry roles mapped to Concourse RBAC when using the CF Auth connector. 
+  Instead of enforcing this change, we would rather support both configurations in a future release.
   The original change is documented in [v5.7.0 release notes](https://github.com/concourse/concourse/blob/master/release-notes/v5.7.0.md#4535). #4699

--- a/release-notes/v5.7.1.md
+++ b/release-notes/v5.7.1.md
@@ -1,5 +1,9 @@
 #### <sub><sup><a name="4699" href="#4699">:link:</a></sup></sub> fix
 
-* v5.7.0 changed how CloudFoundry roles mapped to Concourse RBAC when using the CF Auth connector. 
+* v5.7.0 changed how CloudFoundry roles mapped to Concourse RBAC when using the CF Auth connector.
   Instead of enforcing this change, we would rather support both configurations in a future release.
   The original change is documented in [v5.7.0 release notes](https://github.com/concourse/concourse/blob/master/release-notes/v5.7.0.md#4535). #4699
+
+#### <sub><sup><a name="4707" href="#4707">:link:</a></sup></sub> feature
+
+* Make Garden client HTTP timeout configurable. #4707

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/concourse/concourse/atc"
-
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/baggageclaim/baggageclaimcmd"
 	bclient "github.com/concourse/baggageclaim/client"
@@ -109,7 +107,7 @@ func (cmd *WorkerCommand) Runner(args []string) (ifrit.Runner, error) {
 
 	gardenClient := gclient.BasicGardenClientWithRequestTimeout(
 		logger.Session("garden-connection"),
-		atc.GARDEN_CLIENT_HTTP_TIMEOUT,
+		cmd.Garden.RequestTimeout,
 		cmd.gardenURL(),
 	)
 

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/localip"
@@ -33,6 +34,8 @@ type GardenBackend struct {
 	GardenConfig flag.File `long:"config"               description:"Path to a config file to use for Garden. You can also specify Garden flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
 
 	DNS DNSConfig `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
+
+	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
 }
 
 func (cmd WorkerCommand) LessenRequirements(prefix string, command *flags.Command) {

--- a/worker/workercmd/worker_nonlinux.go
+++ b/worker/workercmd/worker_nonlinux.go
@@ -4,6 +4,7 @@ package workercmd
 
 import (
 	"runtime"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
@@ -11,7 +12,9 @@ import (
 	"github.com/tedsuo/ifrit"
 )
 
-type GardenBackend struct{}
+type GardenBackend struct {
+	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
+}
 
 type Certs struct{}
 


### PR DESCRIPTION
# Why do we need this PR?

This contains two cherry-picked features from master, to go out as a v5.7.1 patch.

1. Revert the CF auth RBAC change
1. Add configurability for Garden client(s) HTTP timeout

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Release notes reviewed