### PR TITLE
Adopt the new concourse helm chart repo.

### DIFF
--- a/topgun/k8s/external_postgres_test.go
+++ b/topgun/k8s/external_postgres_test.go
@@ -15,7 +15,7 @@ var _ = Describe("External PostgreSQL", func() {
 
 		helmDeploy(pgReleaseName,
 			namespace,
-			path.Join(Environment.ChartsDir, "stable/postgresql"),
+			path.Join(Environment.HelmChartsDir, "stable/postgresql"),
 			"--set=livenessProbe.initialDelaySeconds=3",
 			"--set=livenessProbe.periodSeconds=3",
 			"--set=persistence.enabled=false",

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -29,8 +29,8 @@ func TestK8s(t *testing.T) {
 }
 
 type environment struct {
-	ChartsDir            string `env:"CHARTS_DIR,required"`
-	ConcourseChartDir    string `env:"CONCOURSE_CHART_DIR"`
+	HelmChartsDir        string `env:"HELM_CHARTS_DIR,required"`
+	ConcourseChartDir    string `env:"CONCOURSE_CHART_DIR,required"`
 	ConcourseImageDigest string `env:"CONCOURSE_IMAGE_DIGEST"`
 	ConcourseImageName   string `env:"CONCOURSE_IMAGE_NAME,required"`
 	ConcourseImageTag    string `env:"CONCOURSE_IMAGE_TAG"`
@@ -54,10 +54,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	if parsedEnv.FlyPath == "" {
 		parsedEnv.FlyPath = BuildBinary()
-	}
-
-	if parsedEnv.ConcourseChartDir == "" {
-		parsedEnv.ConcourseChartDir = parsedEnv.ChartsDir
 	}
 
 	By("Checking if kubectl has a context set")

--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Prometheus integration", func() {
 
 		helmDeploy(prometheusReleaseName,
 			namespace,
-			path.Join(Environment.ChartsDir, "stable/prometheus"),
+			path.Join(Environment.HelmChartsDir, "stable/prometheus"),
 			"--set=nodeExporter.enabled=false",
 			"--set=kubeStateMetrics.enabled=false",
 			"--set=pushgateway.enabled=false",


### PR DESCRIPTION
the chart directory of the new chart (https://github.com/concourse/concourse-chart.git) starts from the root directory, so the hardcoded `stable/concourse` is not needed anymore.

We do still rely on some charts from the `helm/charts` repo, so the `CHARTS_DIR` was renamed to `HELM_CHARTS_DIR`.

Related to https://github.com/concourse/ci/pull/200

# Existing Issue
The `topgun` testsuite hardcoded the chart directory `stable/concourse`. the new chart directory starts from root of the repo https://github.com/concourse/concourse-chart.git

Fixes https://github.com/pivotal/concourse-ops/issues/117

# Why do we need this PR?
It is mandatory if we migrate concourse helm chart to the new repo.


# Changes proposed in this pull request
remove the hardcoded chart path `stable/concourse`, since the new chart is hosted at the root directory.

# Contributor Checklist
- [x] Test `topgun` manually.


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 

cc @taylorsilva 