### PR TITLE
atc: eliminate unused `tagsMatch` method

### DIFF
--- a/atc/db/worker_factory.go
+++ b/atc/db/worker_factory.go
@@ -557,22 +557,3 @@ func saveWorker(tx Tx, atcWorker atc.Worker, teamID *int, ttl time.Duration, con
 
 	return savedWorker, nil
 }
-
-func tagsMatch(workerTags []string, tags []string) bool {
-	if len(workerTags) > 0 && len(tags) == 0 {
-		return false
-	}
-
-insert_coin:
-	for _, stag := range tags {
-		for _, wtag := range workerTags {
-			if stag == wtag {
-				continue insert_coin
-			}
-		}
-
-		return false
-	}
-
-	return true
-}


### PR DESCRIPTION
# Why do we need this PR?

There is no where in our code where `tagsMatch` from the `db` package is being used (not even tests), making this method essentially unnecessary.

# Changes proposed in this pull request

- remove `db/tagsMatch`

# Contributor Checklist

-  ~Unit tests~ 
    - no new functionality or code previously tested changed
- ~Integration tests (if applicable)~ 
    - (same as ^)
-  ~Updated documentation (located at https://github.com/concourse/docs)~ 
    - no changes in functionality or behavior
- ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~ 
   - just internal refactoring


# Reviewer Checklist
- [x] Code reviewed
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] ~PR acceptance performed~
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
