### PR TITLE
Keep release notes synced for 5.7.1

### DIFF
--- a/release-notes/v5.7.1.md
+++ b/release-notes/v5.7.1.md
@@ -1,5 +1,13 @@
 #### <sub><sup><a name="4699" href="#4699">:link:</a></sup></sub> fix
 
-* v5.7.0 changed how CloudFoundry roles mapped to Concourse RBAC when using the CF Auth connector. 
+* v5.7.0 changed how CloudFoundry roles mapped to Concourse RBAC when using the CF Auth connector.
   Instead of enforcing this change, we would rather support both configurations in a future release.
   The original change is documented in [v5.7.0 release notes](https://github.com/concourse/concourse/blob/master/release-notes/v5.7.0.md#4535). #4699
+
+#### <sub><sup><a name="4707" href="#4707">:link:</a></sup></sub> feature
+
+* Make Garden client HTTP timeout configurable. #4707
+
+#### <sub><sup><a name="4698" href="#4698">:link:</a></sup></sub> feature
+
+* Batch emissions and logging info for non-2xx responses from NewRelic, for NewRelic emitter #4698.


### PR DESCRIPTION
Release notes got out of sync between master and the 5.7.1 branch because of some merge conflicts and back-and-forth. This PR pulls the latest correct version of the v5.7.1 release notes into master.