### PR TITLE
Rerun build inputs and pipes should make inputs ready be true

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1246,6 +1246,17 @@ func (b *build) AdoptRerunInputsAndPipes() ([]BuildInput, bool, error) {
 		return nil, false, err
 	}
 
+	_, err = psql.Update("builds").
+		Set("inputs_ready", true).
+		Where(sq.Eq{
+			"id": b.id,
+		}).
+		RunWith(tx).
+		Exec()
+	if err != nil {
+		return nil, false, err
+	}
+
 	err = tx.Commit()
 	if err != nil {
 		return nil, false, err

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -1760,9 +1760,17 @@ var _ = Describe("Build", func() {
 					}}, true)
 				Expect(err).ToNot(HaveOccurred())
 
+				Expect(build.InputsReady()).To(BeFalse())
+
 				_, found, err = build.AdoptInputsAndPipes()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
+
+				reloaded, err := build.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(reloaded).To(BeTrue())
+
+				Expect(build.InputsReady()).To(BeTrue())
 
 				// Set up new next build inputs
 				inputVersions := db.InputMapping{
@@ -1983,9 +1991,16 @@ var _ = Describe("Build", func() {
 					}}, true)
 				Expect(err).ToNot(HaveOccurred())
 
+				Expect(retriggerBuild.InputsReady()).To(BeFalse())
+
 				_, found, err = retriggerBuild.AdoptInputsAndPipes()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
+
+				reloaded, err := retriggerBuild.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(reloaded).To(BeTrue())
+				Expect(retriggerBuild.InputsReady()).To(BeTrue())
 
 				// Set up new next build inputs
 				inputVersions := db.InputMapping{
@@ -2060,6 +2075,11 @@ var _ = Describe("Build", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildPipes).To(HaveLen(1))
 				Expect(buildPipes[otherJob.ID()]).To(Equal(otherBuild.ID()))
+
+				reloaded, err := retriggerBuild.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(reloaded).To(BeTrue())
+				Expect(retriggerBuild.InputsReady()).To(BeTrue())
 			})
 		})
 
@@ -2073,6 +2093,11 @@ var _ = Describe("Build", func() {
 				buildPipes, err := versionsDB.LatestBuildPipes(build.ID())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildPipes).To(HaveLen(0))
+
+				reloaded, err := retriggerBuild.Reload()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(reloaded).To(BeTrue())
+				Expect(retriggerBuild.InputsReady()).To(BeFalse())
 			})
 		})
 	})

--- a/atc/db/pipeline_factory_test.go
+++ b/atc/db/pipeline_factory_test.go
@@ -206,6 +206,8 @@ var _ = Describe("Pipeline Factory", func() {
 
 				var requestedTime time.Time
 				err = dbConn.QueryRow("SELECT schedule_requested FROM pipelines WHERE id = $1", pipeline1.ID()).Scan(&requestedTime)
+				Expect(err).ToNot(HaveOccurred())
+
 				err = pipeline1.UpdateLastScheduled(requestedTime)
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -1737,21 +1737,4 @@ var _ = Describe("Pipeline", func() {
 			})
 		})
 	})
-
-	Describe("UpdateLastScheduled", func() {
-		var requestedTime time.Time
-		BeforeEach(func() {
-			requestedTime = time.Now()
-
-			err := pipeline.UpdateLastScheduled(requestedTime)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("update last scheduled to be the given requested time", func() {
-			var lastScheduled time.Time
-			err := dbConn.QueryRow("SELECT last_scheduled FROM pipelines WHERE id = $1", pipeline.ID()).Scan(&lastScheduled)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(lastScheduled).Should(BeTemporally("==", requestedTime))
-		})
-	})
 })

--- a/atc/scheduler/runner.go
+++ b/atc/scheduler/runner.go
@@ -60,7 +60,7 @@ func (s *schedulerRunner) Run(ctx context.Context) error {
 		requestedTime := pipeline.RequestedTime()
 
 		go func(pipeline db.Pipeline, requestedTime time.Time) {
-			err = s.schedulePipeline(pipeline)
+			err := s.schedulePipeline(pipeline)
 			if err != nil {
 				s.logger.Error("failed-to-schedule-pipeline", err, lager.Data{"pipeline": pipeline.Name()})
 				return
@@ -110,7 +110,7 @@ func (s *schedulerRunner) schedulePipeline(pipeline db.Pipeline) error {
 
 		s.guardJobScheduling <- struct{}{}
 		go func(job db.Job) {
-			err = s.scheduleJob(logger, schedulingLock, pipeline, job, resources, jobsMap)
+			err := s.scheduleJob(logger, schedulingLock, pipeline, job, resources, jobsMap)
 			if err != nil {
 				err = pipeline.RequestSchedule()
 				if err != nil {

--- a/testflight/download_cli_test.go
+++ b/testflight/download_cli_test.go
@@ -1,12 +1,32 @@
 package testflight_test
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Download Fly Cli", func() {
+	var beforeFly string
+
+	BeforeEach(func() {
+		beforeFly = config.FlyBin
+
+		var err error
+		config.FlyBin, err = gexec.Build("github.com/concourse/concourse/fly")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := os.RemoveAll(config.FlyBin)
+		Expect(err).ToNot(HaveOccurred())
+
+		config.FlyBin = beforeFly
+	})
+
 	It("can download fly cli without issue", func() {
 		watch := fly("sync", "--force")
 		Expect(watch).ToNot(gbytes.Say("warning: failed to parse Content-Length"))


### PR DESCRIPTION
Adopting rerun build inputs and pipes should also flip inputs ready to
be true.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
