### PR TITLE
web: remove browsingIndex from Build page

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -62,7 +62,6 @@ type alias Model =
         , history : List Concourse.Build
         , nextPage : Maybe Page
         , currentBuild : WebData CurrentBuild
-        , browsingIndex : Int
         , autoScroll : Bool
         , previousKeyPress : Maybe Keyboard.KeyEvent
         , shiftDown : Bool
@@ -726,7 +725,6 @@ sampleOldModel =
                     , highlight = Routes.HighlightNothing
                     }
             }
-    , browsingIndex = 0
     , autoScroll = True
     , previousKeyPress = Nothing
     , shiftDown = False
@@ -774,7 +772,6 @@ sampleModel =
             , eventStreamUrlPath = Nothing
             , highlight = Routes.HighlightNothing
             }
-    , browsingIndex = 0
     , autoScroll = True
     , previousKeyPress = Nothing
     , previousTriggerBuildByKey = False

--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -466,8 +466,8 @@ update msg ( model, effects ) =
 handleCallback : Callback -> ET (Model r)
 handleCallback callback ( model, effects ) =
     case callback of
-        BuildFetched (Ok ( browsingIndex, b )) ->
-            handleBuildFetched browsingIndex b ( model, effects )
+        BuildFetched (Ok b) ->
+            handleBuildFetched b ( model, effects )
 
         BuildTriggered (Ok b) ->
             ( { model
@@ -493,27 +493,23 @@ handleCallback callback ( model, effects ) =
             ( model, effects )
 
 
-handleBuildFetched : Int -> Concourse.Build -> ET (Model r)
-handleBuildFetched browsingIndex b ( model, effects ) =
-    if browsingIndex == model.browsingIndex then
-        ( { model
-            | history =
-                List.Extra.setIf (.id >> (==) b.id)
-                    { id = b.id
-                    , name = b.name
-                    , status = b.status
-                    }
-                    model.history
-            , fetchingHistory = True
-            , job = b.job
-            , id = b.id
-            , name = b.name
-          }
-        , effects
-        )
-
-    else
-        ( model, effects )
+handleBuildFetched : Concourse.Build -> ET (Model r)
+handleBuildFetched b ( model, effects ) =
+    ( { model
+        | history =
+            List.Extra.setIf (.id >> (==) b.id)
+                { id = b.id
+                , name = b.name
+                , status = b.status
+                }
+                model.history
+        , fetchingHistory = True
+        , job = b.job
+        , id = b.id
+        , name = b.name
+      }
+    , effects
+    )
 
 
 handleHistoryFetched : Paginated Concourse.Build -> ET (Model r)

--- a/web/elm/src/Build/Header/Models.elm
+++ b/web/elm/src/Build/Header/Models.elm
@@ -26,7 +26,6 @@ type alias Model r =
         , fetchingHistory : Bool
         , nextPage : Maybe Page
         , previousTriggerBuildByKey : Bool
-        , browsingIndex : Int
     }
 
 

--- a/web/elm/src/Build/Models.elm
+++ b/web/elm/src/Build/Models.elm
@@ -21,7 +21,6 @@ type alias Model =
     Login.Model
         (Build.Header.Models.Model
             { build : RemoteData.WebData Concourse.Build
-            , browsingIndex : Int
             , autoScroll : Bool
             , previousKeyPress : Maybe Keyboard.KeyEvent
             , shiftDown : Bool

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -49,8 +49,8 @@ type Callback
     | LoggedOut (Fetched ())
     | ScreenResized Browser.Dom.Viewport
     | BuildJobDetailsFetched (Fetched Concourse.Job)
-    | BuildFetched (Fetched ( Int, Concourse.Build ))
-    | BuildPrepFetched (Fetched ( Int, Concourse.BuildPrep ))
+    | BuildFetched (Fetched Concourse.Build)
+    | BuildPrepFetched (Fetched Concourse.BuildPrep)
     | BuildHistoryFetched (Fetched (Paginated Concourse.Build))
     | PlanAndResourcesFetched Int (Fetched ( Concourse.BuildPlan, Concourse.BuildResources ))
     | BuildAborted (Fetched ())

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -122,11 +122,11 @@ type Effect
     | FetchOutputOf Concourse.VersionedResourceIdentifier
     | FetchData
     | FetchUser
-    | FetchBuild Float Int Int
-    | FetchJobBuild Int Concourse.JobBuildIdentifier
+    | FetchBuild Float Int
+    | FetchJobBuild Concourse.JobBuildIdentifier
     | FetchBuildJobDetails Concourse.JobIdentifier
     | FetchBuildHistory Concourse.JobIdentifier (Maybe Page)
-    | FetchBuildPrep Float Int Int
+    | FetchBuildPrep Float Int
     | FetchBuildPlan Concourse.BuildId
     | FetchBuildPlanAndResources Concourse.BuildId
     | FetchPipelines
@@ -335,15 +335,13 @@ runEffect effect key csrfToken =
         PinTeamNames shc ->
             pinTeamNames shc
 
-        FetchBuild delay browsingIndex buildId ->
+        FetchBuild delay buildId ->
             Process.sleep delay
                 |> Task.andThen (always <| Network.Build.fetch buildId)
-                |> Task.map (\b -> ( browsingIndex, b ))
                 |> Task.attempt BuildFetched
 
-        FetchJobBuild browsingIndex jbi ->
+        FetchJobBuild jbi ->
             Network.Build.fetchJobBuild jbi
-                |> Task.map (\b -> ( browsingIndex, b ))
                 |> Task.attempt BuildFetched
 
         FetchBuildJobDetails buildJob ->
@@ -354,10 +352,9 @@ runEffect effect key csrfToken =
             Network.Build.fetchJobBuilds job page
                 |> Task.attempt BuildHistoryFetched
 
-        FetchBuildPrep delay browsingIndex buildId ->
+        FetchBuildPrep delay buildId ->
             Process.sleep delay
                 |> Task.andThen (always <| Network.BuildPrep.fetch buildId)
-                |> Task.map (\b -> ( browsingIndex, b ))
                 |> Task.attempt BuildPrepFetched
 
         FetchBuildPlanAndResources buildId ->

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -102,7 +102,7 @@ handleCallback callback currentPipeline ( model, effects ) =
             , effects
             )
 
-        BuildFetched (Ok ( _, build )) ->
+        BuildFetched (Ok build) ->
             ( { model
                 | expandedTeams =
                     case ( currentPipeline, build.job ) of

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -113,7 +113,7 @@ all =
                 in
                 ( model, [] )
                     |> Header.handleCallback
-                        (Callback.BuildFetched <| Ok ( 0, build ))
+                        (Callback.BuildFetched <| Ok build)
                     |> Header.handleCallback
                         (Callback.BuildHistoryFetched <|
                             Ok
@@ -146,7 +146,7 @@ all =
                 in
                 ( model, [] )
                     |> Header.handleCallback
-                        (Callback.BuildFetched <| Ok ( 0, build ))
+                        (Callback.BuildFetched <| Ok build)
                     |> Header.handleDelivery
                         (Subscription.EventsReceived <|
                             Ok
@@ -194,5 +194,4 @@ model =
     , fetchingHistory = False
     , nextPage = Nothing
     , previousTriggerBuildByKey = False -- TODO WTF variable name
-    , browsingIndex = 0
     }

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -108,7 +108,7 @@ all =
             fetchBuild =
                 Application.handleCallback <|
                     Callback.BuildFetched <|
-                        Ok ( 1, theBuild )
+                        Ok theBuild
 
             fetchBuildWithStatus :
                 BuildStatus
@@ -118,18 +118,16 @@ all =
                 Application.handleCallback
                     (Callback.BuildFetched
                         (Ok
-                            ( 1
-                            , { id = 1
-                              , name = "1"
-                              , job = Nothing
-                              , status = status
-                              , duration =
-                                    { startedAt = Nothing
-                                    , finishedAt = Nothing
-                                    }
-                              , reapTime = Nothing
-                              }
-                            )
+                            { id = 1
+                            , name = "1"
+                            , job = Nothing
+                            , status = status
+                            , duration =
+                                { startedAt = Nothing
+                                , finishedAt = Nothing
+                                }
+                            , reapTime = Nothing
+                            }
                         )
                     )
                     >> Tuple.first
@@ -163,7 +161,7 @@ all =
             fetchStartedBuild =
                 Application.handleCallback <|
                     Callback.BuildFetched <|
-                        Ok ( 1, startedBuild )
+                        Ok startedBuild
 
             fetchJobDetails :
                 Application.Model
@@ -256,23 +254,21 @@ all =
                     |> Application.handleCallback
                         (Callback.BuildFetched <|
                             Ok
-                                ( 1
-                                , { id = 307
-                                  , name = "307"
-                                  , job =
-                                        Just
-                                            { teamName = "t"
-                                            , pipelineName = "p"
-                                            , jobName = "j"
-                                            }
-                                  , status = BuildStatusStarted
-                                  , duration =
-                                        { startedAt = Nothing
-                                        , finishedAt = Nothing
+                                { id = 307
+                                , name = "307"
+                                , job =
+                                    Just
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , jobName = "j"
                                         }
-                                  , reapTime = Nothing
-                                  }
-                                )
+                                , status = BuildStatusStarted
+                                , duration =
+                                    { startedAt = Nothing
+                                    , finishedAt = Nothing
+                                    }
+                                , reapTime = Nothing
+                                }
                         )
                     |> Tuple.first
                     |> Application.handleCallback
@@ -332,23 +328,21 @@ all =
                     |> Application.handleCallback
                         (Callback.BuildFetched <|
                             Ok
-                                ( 1
-                                , { id = 307
-                                  , name = "307"
-                                  , job =
-                                        Just
-                                            { teamName = "t"
-                                            , pipelineName = "p"
-                                            , jobName = "j"
-                                            }
-                                  , status = BuildStatusStarted
-                                  , duration =
-                                        { startedAt = Nothing
-                                        , finishedAt = Nothing
+                                { id = 307
+                                , name = "307"
+                                , job =
+                                    Just
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , jobName = "j"
                                         }
-                                  , reapTime = Nothing
-                                  }
-                                )
+                                , status = BuildStatusStarted
+                                , duration =
+                                    { startedAt = Nothing
+                                    , finishedAt = Nothing
+                                    }
+                                , reapTime = Nothing
+                                }
                         )
                     |> Tuple.first
                     |> Application.handleCallback
@@ -403,23 +397,21 @@ all =
                     |> Application.handleCallback
                         (Callback.BuildFetched <|
                             Ok
-                                ( 1
-                                , { id = 307
-                                  , name = "307"
-                                  , job =
-                                        Just
-                                            { teamName = "t"
-                                            , pipelineName = "p"
-                                            , jobName = "j"
-                                            }
-                                  , status = BuildStatusStarted
-                                  , duration =
-                                        { startedAt = Nothing
-                                        , finishedAt = Nothing
+                                { id = 307
+                                , name = "307"
+                                , job =
+                                    Just
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , jobName = "j"
                                         }
-                                  , reapTime = Nothing
-                                  }
-                                )
+                                , status = BuildStatusStarted
+                                , duration =
+                                    { startedAt = Nothing
+                                    , finishedAt = Nothing
+                                    }
+                                , reapTime = Nothing
+                                }
                         )
                     |> Tuple.first
                     |> Application.handleCallback
@@ -474,23 +466,21 @@ all =
                     |> Application.handleCallback
                         (Callback.BuildFetched <|
                             Ok
-                                ( 1
-                                , { id = 307
-                                  , name = "307"
-                                  , job =
-                                        Just
-                                            { teamName = "t"
-                                            , pipelineName = "p"
-                                            , jobName = "j"
-                                            }
-                                  , status = BuildStatusStarted
-                                  , duration =
-                                        { startedAt = Nothing
-                                        , finishedAt = Nothing
+                                { id = 307
+                                , name = "307"
+                                , job =
+                                    Just
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , jobName = "j"
                                         }
-                                  , reapTime = Nothing
-                                  }
-                                )
+                                , status = BuildStatusStarted
+                                , duration =
+                                    { startedAt = Nothing
+                                    , finishedAt = Nothing
+                                    }
+                                , reapTime = Nothing
+                                }
                         )
                     |> Tuple.first
                     |> Application.handleCallback
@@ -601,23 +591,21 @@ all =
                     |> Application.handleCallback
                         (Callback.BuildFetched <|
                             Ok
-                                ( 1
-                                , { id = 1
-                                  , name = "1"
-                                  , job =
-                                        Just
-                                            { teamName = "team"
-                                            , pipelineName = "pipeline"
-                                            , jobName = "job"
-                                            }
-                                  , status = BuildStatusSucceeded
-                                  , duration =
-                                        { startedAt = buildTime
-                                        , finishedAt = buildTime
+                                { id = 1
+                                , name = "1"
+                                , job =
+                                    Just
+                                        { teamName = "team"
+                                        , pipelineName = "pipeline"
+                                        , jobName = "job"
                                         }
-                                  , reapTime = buildTime
-                                  }
-                                )
+                                , status = BuildStatusSucceeded
+                                , duration =
+                                    { startedAt = buildTime
+                                    , finishedAt = buildTime
+                                    }
+                                , reapTime = buildTime
+                                }
                         )
                     |> Tuple.first
                     |> Application.handleCallback
@@ -632,7 +620,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, theBuild ))
+                        (Callback.BuildFetched <| Ok theBuild)
                     |> Tuple.first
                     |> Application.handleCallback
                         (Callback.PlanAndResourcesFetched 1 <|
@@ -656,23 +644,21 @@ all =
                     |> Application.handleCallback
                         (Callback.BuildFetched <|
                             Ok
-                                ( 1
-                                , { id = 1
-                                  , name = "1"
-                                  , job =
-                                        Just
-                                            { teamName = "team"
-                                            , pipelineName = "pipeline"
-                                            , jobName = "job"
-                                            }
-                                  , status = BuildStatusAborted
-                                  , duration =
-                                        { startedAt = Nothing
-                                        , finishedAt = Just <| Time.millisToPosix 0
+                                { id = 1
+                                , name = "1"
+                                , job =
+                                    Just
+                                        { teamName = "team"
+                                        , pipelineName = "pipeline"
+                                        , jobName = "job"
                                         }
-                                  , reapTime = Nothing
-                                  }
-                                )
+                                , status = BuildStatusAborted
+                                , duration =
+                                    { startedAt = Nothing
+                                    , finishedAt = Just <| Time.millisToPosix 0
+                                    }
+                                , reapTime = Nothing
+                                }
                         )
                     |> Tuple.first
                     |> Application.handleCallback
@@ -702,23 +688,21 @@ all =
                     |> Application.handleCallback
                         (Callback.BuildFetched <|
                             Ok
-                                ( 1
-                                , { id = 1
-                                  , name = "1"
-                                  , job =
-                                        Just
-                                            { teamName = "team"
-                                            , pipelineName = "pipeline"
-                                            , jobName = "job"
-                                            }
-                                  , status = BuildStatusPending
-                                  , duration =
-                                        { startedAt = Nothing
-                                        , finishedAt = Nothing
+                                { id = 1
+                                , name = "1"
+                                , job =
+                                    Just
+                                        { teamName = "team"
+                                        , pipelineName = "pipeline"
+                                        , jobName = "job"
                                         }
-                                  , reapTime = Nothing
-                                  }
-                                )
+                                , status = BuildStatusPending
+                                , duration =
+                                    { startedAt = Nothing
+                                    , finishedAt = Nothing
+                                    }
+                                , reapTime = Nothing
+                                }
                         )
                     |> Tuple.first
                     |> Application.handleCallback
@@ -742,7 +726,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, theBuild ))
+                        (Callback.BuildFetched <| Ok theBuild)
                     |> Tuple.second
                     |> Common.contains (Effects.Focus Build.bodyId)
         , test "events from a different build are discarded" <|
@@ -760,18 +744,16 @@ all =
                     |> Application.handleCallback
                         (Callback.BuildFetched <|
                             Ok
-                                ( 1
-                                , { id = 1
-                                  , name = "1"
-                                  , job = Nothing
-                                  , status = BuildStatusStarted
-                                  , duration =
-                                        { startedAt = Nothing
-                                        , finishedAt = Nothing
-                                        }
-                                  , reapTime = Nothing
-                                  }
-                                )
+                                { id = 1
+                                , name = "1"
+                                , job = Nothing
+                                , status = BuildStatusStarted
+                                , duration =
+                                    { startedAt = Nothing
+                                    , finishedAt = Nothing
+                                    }
+                                , reapTime = Nothing
+                                }
                         )
                     |> Tuple.first
                     |> Application.handleCallback
@@ -821,19 +803,17 @@ all =
                     |> Application.handleCallback
                         (Callback.BuildFetched <|
                             Ok
-                                ( 1
-                                , { id = 1
-                                  , name = "1"
-                                  , job = Nothing
-                                  , status = BuildStatusStarted
-                                  , duration =
-                                        { startedAt =
-                                            Just <| Time.millisToPosix 0
-                                        , finishedAt = Nothing
-                                        }
-                                  , reapTime = Nothing
-                                  }
-                                )
+                                { id = 1
+                                , name = "1"
+                                , job = Nothing
+                                , status = BuildStatusStarted
+                                , duration =
+                                    { startedAt =
+                                        Just <| Time.millisToPosix 0
+                                    , finishedAt = Nothing
+                                    }
+                                , reapTime = Nothing
+                                }
                         )
                     |> Tuple.first
                     |> Application.handleCallback
@@ -888,7 +868,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        (Callback.BuildFetched <| Ok startedBuild)
                     |> Tuple.first
                     |> receiveEvent
                         { url = "http://localhost:8080/api/v1/builds/1/events"
@@ -900,7 +880,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, theBuild ))
+                        (Callback.BuildFetched <| Ok theBuild)
                     |> Tuple.first
                     |> receiveEvent
                         { url = "http://localhost:8080/api/v1/builds/1/events"
@@ -912,7 +892,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, theBuild ))
+                        (Callback.BuildFetched <| Ok theBuild)
                     |> Tuple.first
                     |> Common.queryView
                     |> Query.find [ id "build-body" ]
@@ -940,7 +920,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        (Callback.BuildFetched <| Ok startedBuild)
                     |> Tuple.first
                     |> Application.update
                         (Msgs.Update <|
@@ -961,7 +941,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        (Callback.BuildFetched <| Ok startedBuild)
                     |> Tuple.first
                     |> Application.update
                         (Msgs.Update <|
@@ -991,7 +971,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        (Callback.BuildFetched <| Ok startedBuild)
                     |> Tuple.first
                     |> Application.handleCallback
                         (Callback.BuildJobDetailsFetched <|
@@ -1055,7 +1035,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        (Callback.BuildFetched <| Ok startedBuild)
                     |> Tuple.first
                     |> Application.update
                         (Msgs.DeliveryReceived <|
@@ -1082,7 +1062,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        (Callback.BuildFetched <| Ok startedBuild)
                     |> Tuple.first
                     |> Application.update
                         (Msgs.DeliveryReceived <|
@@ -1099,7 +1079,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        (Callback.BuildFetched <| Ok startedBuild)
                     |> Tuple.first
                     |> Application.update
                         (Msgs.DeliveryReceived <|
@@ -1116,7 +1096,7 @@ all =
             \_ ->
                 initFromApplication
                     |> Application.handleCallback
-                        (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        (Callback.BuildFetched <| Ok startedBuild)
                     |> Tuple.first
                     |> Application.update
                         (Msgs.DeliveryReceived <|
@@ -1154,7 +1134,7 @@ all =
                     }
                     |> Tuple.second
                     |> Common.contains
-                        (Effects.FetchJobBuild 1
+                        (Effects.FetchJobBuild
                             { teamName = "team"
                             , pipelineName = "pipeline"
                             , jobName = "job"
@@ -1297,7 +1277,7 @@ all =
             , test "when build finishes, shows finished timestamp" <|
                 \_ ->
                     initFromApplication
-                        |> Application.handleCallback (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        |> Application.handleCallback (Callback.BuildFetched <| Ok startedBuild)
                         |> Tuple.first
                         |> receiveEvent
                             { url = "http://localhost:8080/api/v1/builds/1/events"
@@ -1318,7 +1298,7 @@ all =
             , test "when build finishes succesfully, header background is green" <|
                 \_ ->
                     initFromApplication
-                        |> Application.handleCallback (Callback.BuildFetched <| Ok ( 1, startedBuild ))
+                        |> Application.handleCallback (Callback.BuildFetched <| Ok startedBuild)
                         |> Tuple.first
                         |> receiveEvent
                             { url = "http://localhost:8080/api/v1/builds/1/events"
@@ -1338,7 +1318,7 @@ all =
             , test "when less than 24h old, shows relative time since build" <|
                 \_ ->
                     initFromApplication
-                        |> Application.handleCallback (Callback.BuildFetched <| Ok ( 1, theBuild ))
+                        |> Application.handleCallback (Callback.BuildFetched <| Ok theBuild)
                         |> Tuple.first
                         |> Application.update
                             (Msgs.DeliveryReceived <|
@@ -1354,9 +1334,7 @@ all =
                 \_ ->
                     initFromApplication
                         |> Application.handleCallback
-                            (Callback.BuildFetched <|
-                                Ok ( 1, theBuild )
-                            )
+                            (Callback.BuildFetched <| Ok theBuild)
                         |> Tuple.first
                         |> Application.update
                             (Msgs.DeliveryReceived <|
@@ -1377,9 +1355,7 @@ all =
                             )
                         |> Tuple.first
                         |> Application.handleCallback
-                            (Callback.BuildFetched <|
-                                Ok ( 1, theBuild )
-                            )
+                            (Callback.BuildFetched <| Ok theBuild)
                         |> Tuple.first
                         |> Application.update
                             (Msgs.DeliveryReceived <|
@@ -2174,7 +2150,7 @@ all =
                     givenBuildStarted
                         >> Tuple.first
                         >> Application.handleCallback
-                            (Callback.BuildPrepFetched <| Ok ( 1, prep ))
+                            (Callback.BuildPrepFetched <| Ok prep)
                         >> Tuple.first
                         >> Common.queryView
                         >> Query.find [ class "prep-status-list" ]
@@ -2213,7 +2189,7 @@ all =
                     givenBuildStarted
                         >> Tuple.first
                         >> Application.handleCallback
-                            (Callback.BuildPrepFetched <| Ok ( 1, prep ))
+                            (Callback.BuildPrepFetched <| Ok prep)
                         >> Tuple.first
                         >> Common.queryView
                         >> Query.find [ class "prep-status-list" ]
@@ -2250,7 +2226,7 @@ all =
                     givenBuildStarted
                         >> Tuple.first
                         >> Application.handleCallback
-                            (Callback.BuildPrepFetched <| Ok ( 1, prep ))
+                            (Callback.BuildPrepFetched <| Ok prep)
                         >> Tuple.first
                         >> Common.queryView
                         >> Query.find [ class "prep-status-list" ]
@@ -3469,23 +3445,21 @@ all =
                             |> Application.handleCallback
                                 (Callback.BuildFetched <|
                                     Ok
-                                        ( 1
-                                        , { id = 307
-                                          , name = "307"
-                                          , job =
-                                                Just
-                                                    { teamName = "t"
-                                                    , pipelineName = "p"
-                                                    , jobName = "j"
-                                                    }
-                                          , status = BuildStatusStarted
-                                          , duration =
-                                                { startedAt = Nothing
-                                                , finishedAt = Nothing
+                                        { id = 307
+                                        , name = "307"
+                                        , job =
+                                            Just
+                                                { teamName = "t"
+                                                , pipelineName = "p"
+                                                , jobName = "j"
                                                 }
-                                          , reapTime = Nothing
-                                          }
-                                        )
+                                        , status = BuildStatusStarted
+                                        , duration =
+                                            { startedAt = Nothing
+                                            , finishedAt = Nothing
+                                            }
+                                        , reapTime = Nothing
+                                        }
                                 )
                             |> Tuple.first
                             |> Application.handleCallback

--- a/web/elm/tests/Common.elm
+++ b/web/elm/tests/Common.elm
@@ -150,23 +150,21 @@ myBrowserFetchedTheBuild =
         >> Application.handleCallback
             (Callback.BuildFetched <|
                 Ok
-                    ( 1
-                    , { id = 1
-                      , name = "1"
-                      , job =
-                            Just
-                                { teamName = "other-team"
-                                , pipelineName = "yet-another-pipeline"
-                                , jobName = "job"
-                                }
-                      , status = BuildStatusStarted
-                      , duration =
-                            { startedAt = Nothing
-                            , finishedAt = Nothing
+                    { id = 1
+                    , name = "1"
+                    , job =
+                        Just
+                            { teamName = "other-team"
+                            , pipelineName = "yet-another-pipeline"
+                            , jobName = "job"
                             }
-                      , reapTime = Nothing
-                      }
-                    )
+                    , status = BuildStatusStarted
+                    , duration =
+                        { startedAt = Nothing
+                        , finishedAt = Nothing
+                        }
+                    , reapTime = Nothing
+                    }
             )
 
 

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -1634,15 +1634,13 @@ iAmLookingAtAOneOffBuildPageOnANonPhoneScreen =
         >> Application.handleCallback
             (Callback.BuildFetched
                 (Ok
-                    ( 1
-                    , { id = 1
-                      , name = "1"
-                      , job = Nothing
-                      , status = BuildStatusStarted
-                      , duration = { startedAt = Nothing, finishedAt = Nothing }
-                      , reapTime = Nothing
-                      }
-                    )
+                    { id = 1
+                    , name = "1"
+                    , job = Nothing
+                    , status = BuildStatusStarted
+                    , duration = { startedAt = Nothing, finishedAt = Nothing }
+                    , reapTime = Nothing
+                    }
                 )
             )
         >> Tuple.first


### PR DESCRIPTION
# Why do we need this PR?

I'm pretty sure this field was added as a correlation ID for parallel in-flight requests to fetch builds or plans. From my manual testing I've validated that it seems no longer to be possible to have multiple in-flight requests to those endpoints - pressing 'H' and 'L' doesn't do anything until the page has loaded.

# Changes proposed in this pull request

* remove browsingIndex from Build Model
* remove browsingIndex from build/plan fetching effects/callbacks
* just a refactor, but might be worth some cursory checks for regressions

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).