### PR TITLE
Handle help error in concourse cmd properly

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -209,8 +209,6 @@ type RunCommand struct {
 	ConfigRBAC string `long:"config-rbac" description:"Customize RBAC role-action mapping."`
 }
 
-var HelpError = errors.New("must specify one of `--current-db-version`, `--supported-db-version`, or `--migrate-db-to-version`")
-
 type Migration struct {
 	Postgres           flag.PostgresConfig `group:"PostgreSQL Configuration" namespace:"postgres"`
 	EncryptionKey      flag.Cipher         `long:"encryption-key"     description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
@@ -229,7 +227,8 @@ func (m *Migration) Execute(args []string) error {
 	if m.MigrateDBToVersion > 0 {
 		return m.migrateDBToVersion()
 	}
-	return HelpError
+	return errors.New("must specify one of `--current-db-version`, `--supported-db-version`, or `--migrate-db-to-version`")
+
 }
 
 func (cmd *Migration) currentDBVersion() error {

--- a/cmd/concourse/main.go
+++ b/cmd/concourse/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/concourse/concourse"
-	"github.com/concourse/concourse/atc/atccmd"
 	flags "github.com/jessevdk/go-flags"
 	"github.com/vito/twentythousandtonnesofcrudeoil"
 )
@@ -29,13 +28,18 @@ func main() {
 	twentythousandtonnesofcrudeoil.TheEnvironmentIsPerfectlySafe(parser, "CONCOURSE_")
 
 	_, err := parser.Parse()
+	handleError(parser, err)
+}
+
+func handleError(helpParser *flags.Parser, err error) {
 	if err != nil {
-		if err == atccmd.HelpError {
-			parser.WriteHelp(os.Stdout)
-			os.Exit(1)
+		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+			fmt.Println(err)
+			os.Exit(0)
 		} else {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		}
+
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
# Existing Issue
Fixes #4731 .

# Why do we need this PR?
concourse cmd with `--help` exit with status code 1


# Changes proposed in this pull request
Follow what fly cli is doing, handle error and exits with 0 if it is a help error

# Contributor Checklist
- [ ] Integration tests (if applicable)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
