### PR TITLE
hack: add `vim` to dlv image

### DIFF
--- a/hack/dlv/Dockerfile
+++ b/hack/dlv/Dockerfile
@@ -1,5 +1,8 @@
 FROM concourse/concourse:local
 
+ENV EDITOR=vim
+
+RUN apt install -y vim
 RUN go get -u -v github.com/go-delve/delve/cmd/dlv
 
 ENTRYPOINT [ "dlv" ]


### PR DESCRIPTION
# Why do we need this PR?

by setting the EDITOR environment variable, and having `vim` installed,
we're able to jump from the view of a frame to the source code "like
magic"


![demo](https://user-images.githubusercontent.com/3574444/68680014-e6fa0180-052e-11ea-8938-eaae3c20918a.gif)

# Changes proposed in this pull request

- add `vim` to the image
- have `EDITOR` set to `vim` so that `dlv $ edit` uses it.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.

-  ~Unit tests~
-  ~Integration tests (if applicable)~
-  ~Updated documentation (located at https://github.com/concourse/docs)~
-  ~Updated release notes (located at
  https://github.com/concourse/concourse/tree/master/release-notes)~



# Reviewer Checklist
- [x] Code reviewed
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
