### PR TITLE
fly: default to intercepting with sh instead of bash

### DIFF
--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -31,7 +31,7 @@ type HijackCommand struct {
 	StepType       string                   `          long:"step-type"                         description:"Type of step to hijack (e.g. get, put, task)"`
 	Attempt        string                   `short:"a" long:"attempt" value-name:"N[,N,...]"    description:"Attempt number of step to hijack."`
 	PositionalArgs struct {
-		Command []string `positional-arg-name:"command" description:"The command to run in the container (default: bash)"`
+		Command []string `positional-arg-name:"command" description:"The command to run in the container (default: sh)"`
 	} `positional-args:"yes"`
 }
 
@@ -314,7 +314,7 @@ func remoteCommand(argv []string) (string, []string) {
 
 	switch len(argv) {
 	case 0:
-		path = "bash"
+		path = "sh"
 	case 1:
 		path = argv[0]
 	default:

--- a/fly/integration/hijack_test.go
+++ b/fly/integration/hijack_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Hijacking", func() {
 		hijacked = nil
 		workingDirectory = ""
 		user = "root"
-		path = "bash"
+		path = "sh"
 		args = nil
 	})
 
@@ -738,7 +738,7 @@ var _ = Describe("Hijacking", func() {
 
 		Context("when called with a specific path and args", func() {
 			BeforeEach(func() {
-				path = "sh"
+				path = "bash"
 				args = []string{"echo hello"}
 
 				containerArguments = "build_id=2&step_name=some-step"
@@ -748,7 +748,7 @@ var _ = Describe("Hijacking", func() {
 			})
 
 			It("hijacks and runs the provided path with args", func() {
-				hijack("-b", "2", "-s", "some-step", "sh", "echo hello")
+				hijack("-b", "2", "-s", "some-step", "bash", "echo hello")
 			})
 		})
 

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -14,7 +14,7 @@
 
 * @pivotal-bin-ju @taylorsilva @xtreme-sameer-vohra added batching to the NewRelic emitter and logging info for non 2xx responses from NewRelic #4698.
 
-#### <sub><sup><a name="4753" href="#4753">:link:</a></sup></sub> feature
+#### <sub><sup><a name="4755" href="#4755">:link:</a></sup></sub> feature
 
-* When using `fly intercept` to get a shell inside a target container, we default to the more ubiquitous `sh` over `bash` #4753.
+* When using `fly intercept` to get a shell inside a target container, we default to the more ubiquitous `sh` over `bash` #4755.
 

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -13,3 +13,8 @@
 #### <sub><sup><a name="4698" href="#4698">:link:</a></sup></sub> feature
 
 * @pivotal-bin-ju @taylorsilva @xtreme-sameer-vohra added batching to the NewRelic emitter and logging info for non 2xx responses from NewRelic #4698.
+
+#### <sub><sup><a name="4753" href="#4753">:link:</a></sup></sub> feature
+
+* When using `fly intercept` to get a shell inside a target container, we default to the more ubiquitous `sh` over `bash` #4753.
+


### PR DESCRIPTION
# Existing Issue

Related to #1073, but this PR does something different from what that issue suggests.

#2802 is an example in the wild of someone running into problems with a target that doesn't have bash.

#833 covers how the existing error message was made to be visible (vs. hidden in ATC logs)

# Why do we need this PR?

The `fly hijack` / `fly intercept` command will try to invoke bash unless told otherwise. Not all containers have bash - in particular, alpine-based ones are quite common, and typically don't. The fly error message we get in this case is not very friendly:
```
Backend error: Exit status: 500, message: {"Type":"ExecutableNotFoundError","Message":"exec failed: container_linux.go:345: starting container process caused \"exec: \\\"bash\\\": executable file not found in $PATH\"\n","Handle":"","ProcessID":"","Binary":""}
```

While it does identify the problem, in practice many users are quite thrown on seeing it. It comes across as "something mysterious is deeply broken with the platform".

# Changes proposed in this PR

Defaulting to `sh` instead of `bash` should be more portable in the first instance, while not presenting many difficulties for people doing the interception. If I'm just `cd`ing and `ls`ing around, it works in the same way. If I test-invoke a bash script, its shebang line should be enough to get it started.

Issue #1073 suggests a probing process for finding different shells on the target. This could be a bit gnarly, if we have to create a succession of different process specs and try them in turn. A hacky workaround might be to default to something like
```
sh -c 'which -s bash && bash || sh'
```
which seems like it might also be confusing when it breaks, for not much advantage.

# Contributor Checklist
- [ ] Unit tests
- [X] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [X] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

doc note: some examples in https://github.com/concourse/docs/blob/master/lit/docs/install/worker.lit demonstrate a bash shell, but the intercept default-shell behavior isn't otherwise mentioned

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 


Signed-off-by: Alexander Gurney <alexander_gurney@cable.comcast.com>

