### PR TITLE
Don't redact single-char secret. mitigate #4749.

### DIFF
--- a/atc/engine/builder/delegate_factory.go
+++ b/atc/engine/builder/delegate_factory.go
@@ -361,7 +361,8 @@ type credVarsIterator struct {
 func (it *credVarsIterator) YieldCred(name, value string) {
 	for _, lineValue := range strings.Split(value, "\n") {
 		lineValue = strings.TrimSpace(lineValue)
-		if lineValue != "" {
+		// Don't consider a single char as a secret.
+		if len(lineValue) > 1 {
 			it.line = strings.Replace(it.line, lineValue, "((redacted))", -1)
 		}
 	}

--- a/atc/engine/builder/delegate_factory_test.go
+++ b/atc/engine/builder/delegate_factory_test.go
@@ -39,7 +39,7 @@ var _ = Describe("DelegateFactory", func() {
 		fakeClock = fakeclock.NewFakeClock(time.Unix(123456789, 0))
 		credVars := vars.StaticVariables{
 			"source-param": "super-secret-source",
-			"git-key":      "123\n456\n789\n",
+			"git-key":      "{\n123\n456\n789\n}\n",
 		}
 		credVarsTracker = vars.NewCredVarsTracker(credVars, true)
 	})
@@ -591,7 +591,7 @@ var _ = Describe("DelegateFactory", func() {
 					var logLines string
 
 					JustBeforeEach(func() {
-						logLines = "ok123ok\nok456ok\nok789ok\n"
+						logLines = "{\nok123ok\nok456ok\nok789ok\n}\n"
 						writer = delegate.Stderr()
 						writtenBytes, writeErr = writer.Write([]byte(logLines))
 						writer.(io.Closer).Close()
@@ -603,7 +603,7 @@ var _ = Describe("DelegateFactory", func() {
 						Expect(fakeBuild.SaveEventCallCount()).To(Equal(1))
 						Expect(fakeBuild.SaveEventArgsForCall(0)).To(Equal(event.Log{
 							Time:    123456789,
-							Payload: "ok((redacted))ok\nok((redacted))ok\nok((redacted))ok\n",
+							Payload: "{\nok((redacted))ok\nok((redacted))ok\nok((redacted))ok\n}\n",
 							Origin: event.Origin{
 								Source: event.OriginSourceStderr,
 								ID:     "some-plan-id",


### PR DESCRIPTION

# Existing Issue

Fixes #4749.

# Changes proposed in this pull request

This is a quick change to only redact secrets whose lengths are longer than 1.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
