### PR TITLE
Use transaction instead of open connection for api queries

### DIFF
--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -148,12 +148,19 @@ func getBuilds(buildsQuery sq.SelectBuilder, conn Conn, lockFactory lock.LockFac
 func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, conn Conn, lockFactory lock.LockFactory) ([]Build, Pagination, error) {
 	var newPage = Page{Limit: page.Limit}
 
+	tx, err := conn.Begin()
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+
+	defer Rollback(tx)
+
 	if page.Since != 0 {
 		sinceRow, err := buildsQuery.
 			Where(sq.Expr("b.start_time >= to_timestamp(" + strconv.Itoa(page.Since) + ")")).
 			OrderBy("b.id ASC").
 			Limit(1).
-			RunWith(conn).
+			RunWith(tx).
 			Query()
 
 		if err != nil {
@@ -189,7 +196,7 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 			Where(sq.Expr("b.start_time <= to_timestamp(" + strconv.Itoa(page.Until) + ")")).
 			OrderBy("b.id DESC").
 			Limit(1).
-			RunWith(conn).
+			RunWith(tx).
 			Query()
 		if err != nil {
 			// The user has no builds since that given time
@@ -216,6 +223,11 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 		}
 	}
 
+	err = tx.Commit()
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+
 	return getBuildsWithPagination(buildsQuery, minMaxIdQuery, newPage, conn, lockFactory)
 }
 
@@ -225,6 +237,13 @@ func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page P
 		err     error
 		reverse bool
 	)
+
+	tx, err := conn.Begin()
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+
+	defer Rollback(tx)
 
 	buildsQuery = buildsQuery.Limit(uint64(page.Limit))
 
@@ -253,7 +272,7 @@ func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page P
 			OrderBy("b.id ASC")
 	}
 
-	rows, err = buildsQuery.RunWith(conn).Query()
+	rows, err = buildsQuery.RunWith(tx).Query()
 	if err != nil {
 		return nil, Pagination{}, err
 	}
@@ -283,9 +302,14 @@ func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page P
 
 	var minID, maxID int
 	err = minMaxIdQuery.
-		RunWith(conn).
+		RunWith(tx).
 		QueryRow().
 		Scan(&maxID, &minID)
+	if err != nil {
+		return nil, Pagination{}, err
+	}
+
+	err = tx.Commit()
 	if err != nil {
 		return nil, Pagination{}, err
 	}

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -161,12 +161,19 @@ func (j *job) Unpause() error {
 }
 
 func (j *job) FinishedAndNextBuild() (Build, Build, error) {
-	next, err := j.nextBuild()
+	tx, err := j.conn.Begin()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	finished, err := j.finishedBuild()
+	defer Rollback(tx)
+
+	next, err := j.nextBuild(tx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	finished, err := j.finishedBuild(tx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -175,10 +182,15 @@ func (j *job) FinishedAndNextBuild() (Build, Build, error) {
 	if next != nil && finished != nil && next.ID() == finished.ID() {
 		next = nil
 
-		next, err = j.nextBuild()
+		next, err = j.nextBuild(tx)
 		if err != nil {
 			return nil, nil, err
 		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return finished, next, nil
@@ -783,13 +795,13 @@ func (j *job) saveJobInputMapping(table string, inputMapping algorithm.InputMapp
 	return tx.Commit()
 }
 
-func (j *job) nextBuild() (Build, error) {
+func (j *job) nextBuild(tx Tx) (Build, error) {
 	var next Build
 
 	row := buildsQuery.
 		Where(sq.Eq{"j.id": j.id}).
 		Where(sq.Expr("b.id = j.next_build_id")).
-		RunWith(j.conn).
+		RunWith(tx).
 		QueryRow()
 
 	nextBuild := &build{conn: j.conn, lockFactory: j.lockFactory}
@@ -803,13 +815,13 @@ func (j *job) nextBuild() (Build, error) {
 	return next, nil
 }
 
-func (j *job) finishedBuild() (Build, error) {
+func (j *job) finishedBuild(tx Tx) (Build, error) {
 	var finished Build
 
 	row := buildsQuery.
 		Where(sq.Eq{"j.id": j.id}).
 		Where(sq.Expr("b.id = j.latest_completed_build_id")).
-		RunWith(j.conn).
+		RunWith(tx).
 		QueryRow()
 
 	finishedBuild := &build{conn: j.conn, lockFactory: j.lockFactory}

--- a/atc/db/job_factory.go
+++ b/atc/db/job_factory.go
@@ -24,61 +24,100 @@ func NewJobFactory(conn Conn, lockFactory lock.LockFactory) JobFactory {
 }
 
 func (j *jobFactory) VisibleJobs(teamNames []string) (Dashboard, error) {
+	tx, err := j.conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	defer Rollback(tx)
+
 	rows, err := jobsQuery.
 		Where(sq.Eq{
-			"t.name":   teamNames,
 			"j.active": true,
 		}).
+		Where(sq.Or{
+			sq.Eq{"t.name": teamNames},
+			sq.Eq{"p.public": true},
+		}).
 		OrderBy("j.id ASC").
-		RunWith(j.conn).
+		RunWith(tx).
 		Query()
 	if err != nil {
 		return nil, err
 	}
 
-	currentTeamJobs, err := scanJobs(j.conn, j.lockFactory, rows)
+	jobs, err := scanJobs(j.conn, j.lockFactory, rows)
 	if err != nil {
 		return nil, err
 	}
 
-	rows, err = jobsQuery.
-		Where(sq.NotEq{
-			"t.name": teamNames,
-		}).
+	dashboard, err := j.buildDashboard(tx, jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	return dashboard, nil
+}
+
+func (j *jobFactory) AllActiveJobs() (Dashboard, error) {
+	tx, err := j.conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	defer Rollback(tx)
+
+	rows, err := jobsQuery.
 		Where(sq.Eq{
-			"p.public": true,
 			"j.active": true,
 		}).
 		OrderBy("j.id ASC").
-		RunWith(j.conn).
+		RunWith(tx).
 		Query()
 	if err != nil {
 		return nil, err
 	}
 
-	otherTeamPublicJobs, err := scanJobs(j.conn, j.lockFactory, rows)
+	jobs, err := scanJobs(j.conn, j.lockFactory, rows)
 	if err != nil {
 		return nil, err
 	}
 
-	jobs := append(currentTeamJobs, otherTeamPublicJobs...)
+	dashboard, err := j.buildDashboard(tx, jobs)
+	if err != nil {
+		return nil, err
+	}
 
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	return dashboard, nil
+}
+
+func (j *jobFactory) buildDashboard(tx Tx, jobs Jobs) (Dashboard, error) {
 	var jobIDs []int
 	for _, job := range jobs {
 		jobIDs = append(jobIDs, job.ID())
 	}
 
-	nextBuilds, err := j.getBuildsFrom("next_build_id", jobIDs)
+	nextBuilds, err := j.getBuildsFrom(tx, "next_build_id", jobIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	finishedBuilds, err := j.getBuildsFrom("latest_completed_build_id", jobIDs)
+	finishedBuilds, err := j.getBuildsFrom(tx, "latest_completed_build_id", jobIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	transitionBuilds, err := j.getBuildsFrom("transition_build_id", jobIDs)
+	transitionBuilds, err := j.getBuildsFrom(tx, "transition_build_id", jobIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -105,11 +144,13 @@ func (j *jobFactory) VisibleJobs(teamNames []string) (Dashboard, error) {
 	return dashboard, nil
 }
 
-func (j *jobFactory) getBuildsFrom(col string, jobIDs []int) (map[int]Build, error) {
+func (j *jobFactory) getBuildsFrom(tx Tx, col string, jobIDs []int) (map[int]Build, error) {
+
 	rows, err := buildsQuery.
 		Where(sq.Eq{"j.id": jobIDs}).
 		Where(sq.Expr("j." + col + " = b.id")).
-		RunWith(j.conn).Query()
+		RunWith(tx).
+		Query()
 	if err != nil {
 		return nil, err
 	}

--- a/atc/db/team_factory.go
+++ b/atc/db/team_factory.go
@@ -61,8 +61,8 @@ func (factory *teamFactory) createTeam(t atc.Team, admin bool) (Team, error) {
 		conn:        factory.conn,
 		lockFactory: factory.lockFactory,
 	}
-	err = factory.scanTeam(team, row)
 
+	err = factory.scanTeam(team, row)
 	if err != nil {
 		return nil, err
 	}

--- a/atc/db/volume_repository.go
+++ b/atc/db/volume_repository.go
@@ -56,13 +56,13 @@ func NewVolumeRepository(conn Conn) VolumeRepository {
 	}
 }
 
-func (repository *volumeRepository) queryVolumeHandles(cond sq.Eq) ([]string, error) {
+func (repository *volumeRepository) queryVolumeHandles(tx Tx, cond sq.Eq) ([]string, error) {
 	query, args, err := psql.Select("handle").From("volumes").Where(cond).ToSql()
 	if err != nil {
 		return nil, err
 	}
 
-	rows, err := repository.conn.Query(query, args...)
+	rows, err := tx.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -89,31 +89,33 @@ func (repository *volumeRepository) UpdateVolumesMissingSince(workerName string,
 	// clear out missing_since for reported volumes
 	query, args, err := psql.Update("volumes").
 		Set("missing_since", nil).
-		Where(
-			sq.And{
-				sq.NotEq{
-					"missing_since": nil,
-				},
-				sq.Eq{
-					"handle": reportedHandles,
-				},
-			},
+		Where(sq.And{
+			sq.Eq{"handle": reportedHandles},
+			sq.NotEq{"missing_since": nil},
+		},
 		).ToSql()
 	if err != nil {
 		return err
 	}
 
-	rows, err := repository.conn.Query(query, args...)
+	tx, err := repository.conn.Begin()
 	if err != nil {
 		return err
 	}
 
-	Close(rows)
+	defer Rollback(tx)
 
-	dbHandles, err := repository.queryVolumeHandles(sq.Eq{
-		"worker_name":   workerName,
-		"missing_since": nil,
-	})
+	_, err = tx.Exec(query, args...)
+	if err != nil {
+		return err
+	}
+
+	dbHandles, err := repository.queryVolumeHandles(
+		tx,
+		sq.Eq{
+			"worker_name":   workerName,
+			"missing_since": nil,
+		})
 	if err != nil {
 		return err
 	}
@@ -130,14 +132,12 @@ func (repository *volumeRepository) UpdateVolumesMissingSince(workerName string,
 		return err
 	}
 
-	rows, err = repository.conn.Query(query, args...)
+	_, err = tx.Exec(query, args...)
 	if err != nil {
 		return err
 	}
 
-	defer Close(rows)
-
-	return nil
+	return tx.Commit()
 }
 
 func (repository *volumeRepository) RemoveMissingVolumes(gracePeriod time.Duration) (int, error) {
@@ -510,12 +510,30 @@ func (repository *volumeRepository) DestroyFailedVolumes() (int, error) {
 }
 
 func (repository *volumeRepository) GetDestroyingVolumes(workerName string) ([]string, error) {
-	return repository.queryVolumeHandles(
+	tx, err := repository.conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	defer Rollback(tx)
+
+	volumes, err := repository.queryVolumeHandles(
+		tx,
 		sq.Eq{
 			"state":       string(VolumeStateDestroying),
 			"worker_name": workerName,
 		},
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	return volumes, nil
 }
 
 // 1. open tx

--- a/atc/db/volume_repository_test.go
+++ b/atc/db/volume_repository_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("VolumeFactory", func() {
+var _ = Describe("VolumeRepository", func() {
 	var (
 		team2             db.Team
 		usedResourceCache db.UsedResourceCache
@@ -813,6 +813,7 @@ var _ = Describe("VolumeFactory", func() {
 
 		JustBeforeEach(func() {
 			err = volumeRepository.UpdateVolumesMissingSince(defaultWorker.Name(), handles)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("when the reported handles is a subset", func() {

--- a/atc/db/worker.go
+++ b/atc/db/worker.go
@@ -190,6 +190,13 @@ func (worker *worker) Retire() error {
 }
 
 func (worker *worker) Prune() error {
+	tx, err := worker.conn.Begin()
+	if err != nil {
+		return err
+	}
+
+	defer Rollback(tx)
+
 	rows, err := sq.Delete("workers").
 		Where(sq.Eq{
 			"name": worker.name,
@@ -198,7 +205,7 @@ func (worker *worker) Prune() error {
 			"state": string(WorkerStateRunning),
 		}).
 		PlaceholderFormat(sq.Dollar).
-		RunWith(worker.conn).
+		RunWith(tx).
 		Exec()
 
 	if err != nil {
@@ -214,7 +221,7 @@ func (worker *worker) Prune() error {
 		//check whether the worker exists in the database at all
 		var one int
 		err := psql.Select("1").From("workers").Where(sq.Eq{"name": worker.name}).
-			RunWith(worker.conn).
+			RunWith(tx).
 			QueryRow().
 			Scan(&one)
 		if err != nil {
@@ -227,7 +234,7 @@ func (worker *worker) Prune() error {
 		return ErrCannotPruneRunningWorker
 	}
 
-	return nil
+	return tx.Commit()
 }
 
 func (worker *worker) Delete() error {

--- a/go.sum
+++ b/go.sum
@@ -520,6 +520,7 @@ github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa h1:E+gaaifzi2xF65PbDmuKI3PhLWY6G5opMLniFq8vmXA=
 github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa/go.mod h1:2RVY1rIf+2J2o/IM9+vPq9RzmHDSseB7FoXiSNIUsoU=
 github.com/spf13/cobra v0.0.0-20160615143614-bc81c21bd0d8/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v0.0.0-20160610190902-367864438f1b/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/release-notes/v5.2.5.md
+++ b/release-notes/v5.2.5.md
@@ -1,0 +1,4 @@
+#### <sub><sup><a name="v525-note-1">:link:</a></sup></sub> feature
+
+* API endpoints have been changed to use a single transaction per request, so that they become "all or nothing" instead of holding data in memory while waiting for another connection from the pool. This could lead to snowballing and increased memory usage as requests from the web UI (polling every 5 seconds) piled up. #4494
+


### PR DESCRIPTION
cherry picking fix of #4373  from master to 5.2.x. Should solve customer problem that many dashboards opened that satuated the API connection pool to DB causes huge memory usage that will eventually fail the web node.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
