### PR TITLE
[release/5.7.x] Allow topgun to run all tests suites

### DIFF
--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -179,7 +179,7 @@ func StartDeploy(manifest string, args ...string) *gexec.Session {
 		append([]string{
 			"deploy", manifest,
 			"--vars-store", filepath.Join(tmp, DeploymentName+"-vars.yml"),
-			"-v", "suite='" + suiteName + "'",
+			"-v", "suite='-" + suiteName + "'",
 			"-v", "deployment_name='" + DeploymentName + "'",
 			"-v", "concourse_release_version='" + concourseReleaseVersion + "'",
 			"-v", "bpm_release_version='" + bpmReleaseVersion + "'",

--- a/topgun/deployments/concourse.yml
+++ b/topgun/deployments/concourse.yml
@@ -2,7 +2,7 @@
 name: ((deployment_name))
 
 releases:
-- name: concourse-((suite))
+- name: concourse((suite))
   version: ((concourse_release_version))
 - name: bpm
   version: ((bpm_release_version))
@@ -20,7 +20,7 @@ instance_groups:
   - release: bpm
     name: bpm
 
-  - release: concourse-((suite))
+  - release: concourse((suite))
     name: web
     properties:
       add_local_users:
@@ -74,7 +74,7 @@ instance_groups:
   vm_type: test
   stemcell: xenial
   jobs:
-  - release: concourse-((suite))
+  - release: concourse((suite))
     name: worker
     properties:
       log_level: debug


### PR DESCRIPTION
Currently for our newer release pipelines that have the refactored
version of bosh topgun (5.7.x), when we want to run all test suites we
don't specify `SUITE` and run `ginkgo` with the recursive flag. This
allows us to run all topgun suites.

The problem, that this commit resolves, is that the release referened in
the deployment yaml gets the wrong name. By moving the `-` out of the
deployment yaml, the naming will now be correct.

From CI we currently get this error:

```
Task 26668 | 19:56:13 | Error: Release 'concourse-' doesn't exist
```

because `concourse-((suite))` resolves to `concourse-` because `SUITE`
is empty. Now this commit appends the dash as part of the `((suite))`
variable.


# Reviewer Checklist
- [x] ~Code reviewed~
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] ~PR acceptance performed~
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
