### PR TITLE
Fix bosh-topgun for concourse pipeline

### DIFF
--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -175,11 +175,16 @@ type BoshInstance struct {
 func StartDeploy(manifest string, args ...string) *gexec.Session {
 	WaitForDeploymentAndCompileLocks()
 
+	var modifiedSuiteName string
+	if suiteName != "" {
+		modifiedSuiteName = "-" + suiteName
+	}
+
 	return SpawnBosh(
 		append([]string{
 			"deploy", manifest,
 			"--vars-store", filepath.Join(tmp, DeploymentName+"-vars.yml"),
-			"-v", "suite='-" + suiteName + "'",
+			"-v", "suite='" + modifiedSuiteName + "'",
 			"-v", "deployment_name='" + DeploymentName + "'",
 			"-v", "concourse_release_version='" + concourseReleaseVersion + "'",
 			"-v", "bpm_release_version='" + bpmReleaseVersion + "'",


### PR DESCRIPTION
Same problem that #4764 tried to fix

I just moved where the issue occured in the last commit. Needed logic
around what `suite` should be equal to.

# Reviewer Checklist
- [x] ~Code reviewed~
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
