### PR TITLE
[release/5.7.x] Remove hyphens from ops-files for bosh topgun

### DIFF
--- a/topgun/operations/add-other-worker.yml
+++ b/topgun/operations/add-other-worker.yml
@@ -8,7 +8,7 @@
     vm_type: test
     stemcell: xenial
     jobs:
-    - release: concourse-((suite))
+    - release: concourse((suite))
       name: worker
       properties:
         log_level: debug

--- a/topgun/operations/bbr-concourse-link.yml
+++ b/topgun/operations/bbr-concourse-link.yml
@@ -44,5 +44,5 @@
 - type: replace
   path: /instance_groups/name=db/jobs/-
   value:
-    release: concourse-((suite))
+    release: concourse((suite))
     name: bbr-atcdb

--- a/topgun/operations/bbr-with-properties.yml
+++ b/topgun/operations/bbr-with-properties.yml
@@ -48,7 +48,7 @@
 - type: replace
   path: /instance_groups/name=db/jobs/-
   value:
-    release: concourse-((suite))
+    release: concourse((suite))
     name: bbr-atcdb
     properties:
       postgresql:


### PR DESCRIPTION
Some tests in bosh topgun are still failing because they use these
ops-files which still have the hyphen.

I should have looked at the commit where `SUITE` was introduced to
ensure I covered everything. This commit catches everything that was
missed and I checked the commit where `SUITE` was introduced to 
ensure nothing else will come up because of this change.