### PR TITLE
fix k8s topgun test charts path

### DIFF
--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -58,7 +57,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	}
 
 	if parsedEnv.ConcourseChartDir == "" {
-		parsedEnv.ConcourseChartDir = path.Join(parsedEnv.ChartsDir, "stable/concourse")
+		parsedEnv.ConcourseChartDir = parsedEnv.ChartsDir
 	}
 
 	By("Checking if kubectl has a context set")


### PR DESCRIPTION
since we are now using concourse/concourse-chart.

We would need to have this fix for all our release branches otherwise the job there won't work.