### PR TITLE
Improve help text for `fly order-pipelines`

### DIFF
--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -14,7 +14,7 @@ var ErrMissingPipelineName = errors.New("Need to specify atleast one pipeline na
 
 type OrderPipelinesCommand struct {
 	Alphabetical bool                       `short:"a"  long:"alphabetical" description:"Order all pipelines alphabetically"`
-	Pipelines    []flaghelpers.PipelineFlag `short:"p" long:"pipeline" description:"Name of pipeline to order"`
+	Pipelines    []flaghelpers.PipelineFlag `short:"p" long:"pipeline" description:"List of pipelines to order. This flag can be specified 1 or multiple times. For example, --pipeline pipeline-1 --pipeline pipeline-2"`
 }
 
 func (command *OrderPipelinesCommand) Validate() ([]string, error) {


### PR DESCRIPTION
Fixes #4760

```
Usage:
  fly [OPTIONS] order-pipelines [order-pipelines-OPTIONS]

Application Options:
  -t, --target=              Concourse target name
  -v, --version              Print the version of Fly and exit
      --verbose              Print API requests and responses
      --print-table-headers  Print table headers even for redirected output

Help Options:
  -h, --help                 Show this help message

[order-pipelines command options]
      -a, --alphabetical     Order all pipelines alphabetically
      -p, --pipeline=        List of pipelines to order. This flag can be specified 1 or multiple times. For example, --pipeline pipeline-1 --pipeline pipeline-2
```