### PR TITLE
worker: add build constraints to `containerd.go`

### DIFF
--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package workercmd
 
 import (


### PR DESCRIPTION
### Why do we need this PR?

Without the constraint, `concourse` will simply not compile as such file
contains constructs only present in `linux`-based compilations.

Also, given that at the moment we're focusing solely on the linux
implementation, there's no need to bother about the other cases (darwin
& windows).

e.g., on Windows:

	unknown field 'Pdeathsig' in struct literal of type
	syscall.SysProcAttr Error: exit status 2

ref: https://golang.org/pkg/go/build/#hdr-Build_Constraints

### Changes proposed in this pull request

add `linux` build constraint on `containerd.go` under `workercmd` pkg.

### Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- ~Unit tests~
- ~Integration tests~
- ~Updated documentation (located at https://github.com/concourse/docs)~
- ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


### Reviewer Checklist


- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
