### PR TITLE
Dashboard fetch pipelines once

### DIFF
--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -259,10 +259,10 @@ sideBarHandleCallback callback ( model, effects ) =
                                         )
                                 )
 
-                        SubPage.DashboardModel dashboardModel ->
+                        SubPage.DashboardModel _ ->
                             SideBar.handleCallback
                                 (case callback of
-                                    APIDataFetched (Ok ( now, apiData )) ->
+                                    APIDataFetched (Ok ( _, apiData )) ->
                                         PipelinesFetched (Ok apiData.pipelines)
 
                                     _ ->

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -259,6 +259,17 @@ sideBarHandleCallback callback ( model, effects ) =
                                         )
                                 )
 
+                        SubPage.DashboardModel dashboardModel ->
+                            SideBar.handleCallback
+                                (case callback of
+                                    APIDataFetched (Ok ( now, apiData )) ->
+                                        PipelinesFetched (Ok apiData.pipelines)
+
+                                    _ ->
+                                        callback
+                                )
+                                RemoteData.NotAsked
+
                         _ ->
                             SideBar.handleCallback callback <|
                                 RemoteData.NotAsked

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -105,7 +105,6 @@ init flags =
     , [ FetchData
       , PinTeamNames Message.Effects.stickyHeaderConfig
       , GetScreenSize
-      , FetchPipelines
       ]
     )
 
@@ -266,7 +265,7 @@ handleDeliveryBody delivery ( model, effects ) =
             )
 
         ClockTicked FiveSeconds _ ->
-            ( model, effects ++ [ FetchData, FetchPipelines, FetchAllResources ] )
+            ( model, effects ++ [ FetchData, FetchAllResources ] )
 
         _ ->
             ( model, effects )

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -1103,9 +1103,25 @@ fiveSecondsPass =
             )
 
 
-myBrowserFetchesPipelines =
-    Tuple.second
-        >> Common.contains Effects.FetchPipelines
+myBrowserFetchesPipelines ( a, effects ) =
+    let
+        pipelinesDirectly =
+            List.member Effects.FetchPipelines effects
+
+        pipelinesThroughData =
+            List.member Effects.FetchData effects
+    in
+    if pipelinesDirectly || pipelinesThroughData then
+        Expect.pass
+
+    else
+        Expect.fail <|
+            "Expected "
+                ++ Debug.toString effects
+                ++ " to contain "
+                ++ Debug.toString Effects.FetchPipelines
+                ++ " or "
+                ++ Debug.toString Effects.FetchData
 
 
 iHaveAnOpenSideBar =


### PR DESCRIPTION
# Existing Issue

Helps #4372, #4646, #4482 & #2776.

# Why do we need this PR?
This follows up on @pivotal-jamie-klassen and @zoetian work to reduce the number of API calls issued from the dashboard page. It remove the duplicated call to `/api/v1/pipelines` that take place every 5 seconds.

# Changes proposed in this pull request
* Replaces the duplicated call to `fetchPipelines` by forwarding the list of pipelines received from `fetchData` to the sidebar.
* Fix tests accordingly

Note: This is my first experience with elm, so don't be afraid to point out stupid issues with my changes.

# Contributor Checklist
- [x] Unit tests
- [x] Integration tests (if applicable)
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~ (we will give credit when we merge `issue/4372` to master)
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~

# Thanks

Thanks to @aledeganopix4d, @marco-m and @wagdav for the help!