### PR TITLE
Remove update last scheduled test

### DIFF
--- a/atc/db/pipeline_factory_test.go
+++ b/atc/db/pipeline_factory_test.go
@@ -206,6 +206,8 @@ var _ = Describe("Pipeline Factory", func() {
 
 				var requestedTime time.Time
 				err = dbConn.QueryRow("SELECT schedule_requested FROM pipelines WHERE id = $1", pipeline1.ID()).Scan(&requestedTime)
+				Expect(err).ToNot(HaveOccurred())
+
 				err = pipeline1.UpdateLastScheduled(requestedTime)
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -1737,21 +1737,4 @@ var _ = Describe("Pipeline", func() {
 			})
 		})
 	})
-
-	Describe("UpdateLastScheduled", func() {
-		var requestedTime time.Time
-		BeforeEach(func() {
-			requestedTime = time.Now()
-
-			err := pipeline.UpdateLastScheduled(requestedTime)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("update last scheduled to be the given requested time", func() {
-			var lastScheduled time.Time
-			err := dbConn.QueryRow("SELECT last_scheduled FROM pipelines WHERE id = $1", pipeline.ID()).Scan(&lastScheduled)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(lastScheduled).Should(BeTemporally("==", requestedTime))
-		})
-	})
 })

--- a/atc/scheduler/runner.go
+++ b/atc/scheduler/runner.go
@@ -60,7 +60,7 @@ func (s *schedulerRunner) Run(ctx context.Context) error {
 		requestedTime := pipeline.RequestedTime()
 
 		go func(pipeline db.Pipeline, requestedTime time.Time) {
-			err = s.schedulePipeline(pipeline)
+			err := s.schedulePipeline(pipeline)
 			if err != nil {
 				s.logger.Error("failed-to-schedule-pipeline", err, lager.Data{"pipeline": pipeline.Name()})
 				return
@@ -110,7 +110,7 @@ func (s *schedulerRunner) schedulePipeline(pipeline db.Pipeline) error {
 
 		s.guardJobScheduling <- struct{}{}
 		go func(job db.Job) {
-			err = s.scheduleJob(logger, schedulingLock, pipeline, job, resources, jobsMap)
+			err := s.scheduleJob(logger, schedulingLock, pipeline, job, resources, jobsMap)
 			if err != nil {
 				err = pipeline.RequestSchedule()
 				if err != nil {


### PR DESCRIPTION
Update last scheduled is already tested behaviourally within the pipeline factory test for PipelinesToSchedule. https://github.com/concourse/concourse/blob/release/6.0.x/atc/db/pipeline_factory_test.go#L141