### PR TITLE
atc: support org guid in cf auth connector

### DIFF
--- a/fly/integration/fixtures/team_config_with_cf_auth.yml
+++ b/fly/integration/fixtures/team_config_with_cf_auth.yml
@@ -2,16 +2,17 @@ roles:
   - name: member
     cf:
       users: ["some-member"]
-      spaces_with_developer_role: ["some-org:some-space"]
+      insecure_spaces_with_developer_role: ["some-org:some-space"]
   - name: owner
     cf:
       users: ["some-admin"]
-      orgs: ["some-org"]
-      spaceguids: ["some-guid"]
-      spaces_with_manager_role: ["some-org:some-space"]
+      spaceguids: ["some-space-guid"]
+      insecure_orgs: ["some-org"]
+      insecure_spaces_with_manager_role: ["some-org:some-space"]
   - name: viewer
     cf:
-      spaces: ["some-org:some-space"]
-      spaces_with_any_role: ["some-org:some-other-space"]
-      space_guids: ["some-guid"]
-      spaces_with_auditor_role: ["some-org:some-space"]
+      space_guids: ["some-space-guid"]
+      org_guids: ["some-org-guid"]
+      insecure_spaces: ["some-org:some-space"]
+      insecure_spaces_with_any_role: ["some-org:some-other-space"]
+      insecure_spaces_with_auditor_role: ["some-org:some-space"]

--- a/fly/integration/set_team_test.go
+++ b/fly/integration/set_team_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Fly CLI", func() {
 					Eventually(sess.Out).Should(gbytes.Say("groups:"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-org"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-org:some-space:manager"))
-					Eventually(sess.Out).Should(gbytes.Say("- cf:some-guid"))
+					Eventually(sess.Out).Should(gbytes.Say("- cf:some-space-guid"))
 
 					Eventually(sess.Out).Should(gbytes.Say("role viewer:"))
 					Eventually(sess.Out).Should(gbytes.Say("users:"))
@@ -164,7 +164,8 @@ var _ = Describe("Fly CLI", func() {
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-org:some-other-space"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-org:some-space:developer"))
 					Eventually(sess.Out).Should(gbytes.Say("- cf:some-org:some-space:auditor"))
-					Eventually(sess.Out).Should(gbytes.Say("- cf:some-guid"))
+					Eventually(sess.Out).Should(gbytes.Say("- cf:some-org-guid"))
+					Eventually(sess.Out).Should(gbytes.Say("- cf:some-space-guid"))
 
 					Eventually(sess).Should(gexec.Exit(1))
 				})
@@ -492,7 +493,7 @@ var _ = Describe("Fly CLI", func() {
 
 			Context("Setting cf auth", func() {
 				BeforeEach(func() {
-					cmdParams = []string{"--cf-org", "myorg-1", "--cf-space", "myorg-2:myspace", "--cf-user", "my-username", "--cf-space-guid", "myspace-guid"}
+					cmdParams = []string{"--cf-insecure-org", "myorg-1", "--cf-insecure-space", "myorg-2:myspace", "--cf-user", "my-username", "--cf-space-guid", "myspace-guid"}
 				})
 
 				It("shows the users and groups configured for cf auth", func() {

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
 	github.com/concourse/baggageclaim v1.6.5
-	github.com/concourse/dex v0.0.0-20191119220255-bcdd275f4da6
+	github.com/concourse/dex v0.0.0-20191125175843-b6ce2a14fdd7
 	github.com/concourse/flag v1.0.0
 	github.com/concourse/go-archive v1.0.1
 	github.com/concourse/retryhttp v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
 	github.com/concourse/baggageclaim v1.6.5
-	github.com/concourse/dex v0.0.0-20191105150807-8bbc2a6df1ea
+	github.com/concourse/dex v0.0.0-20191119220255-bcdd275f4da6
 	github.com/concourse/flag v1.0.0
 	github.com/concourse/go-archive v1.0.1
 	github.com/concourse/retryhttp v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/concourse/dex v0.0.0-20191105150807-8bbc2a6df1ea h1:xJzMZ1Bgd37JiTdD0
 github.com/concourse/dex v0.0.0-20191105150807-8bbc2a6df1ea/go.mod h1:jq+kdbXyj+bEdch50oYfPCNK4ZCRKAd/R0wlZuAG+Gc=
 github.com/concourse/dex v0.0.0-20191119220255-bcdd275f4da6 h1:19EYY7x5+pJWiio03BP+02VgG7Ht7rEIznN2HkLuNZ0=
 github.com/concourse/dex v0.0.0-20191119220255-bcdd275f4da6/go.mod h1:jq+kdbXyj+bEdch50oYfPCNK4ZCRKAd/R0wlZuAG+Gc=
+github.com/concourse/dex v0.0.0-20191125175843-b6ce2a14fdd7 h1:Aody1iZ+d3+GdEWOWWvm8n61WhzeaoKRb3BTnCw9URw=
+github.com/concourse/dex v0.0.0-20191125175843-b6ce2a14fdd7/go.mod h1:jq+kdbXyj+bEdch50oYfPCNK4ZCRKAd/R0wlZuAG+Gc=
 github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/flag v1.0.0 h1:XG+A/Y+8kNdNDUC9T+SQ55dZ1+xYQN6LNVBg3cGJ080=
 github.com/concourse/flag v1.0.0/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/concourse/dex v0.0.0-20191028164029-00bcc75bd8b9 h1:S+UP8yiQgYSZksNEb
 github.com/concourse/dex v0.0.0-20191028164029-00bcc75bd8b9/go.mod h1:jq+kdbXyj+bEdch50oYfPCNK4ZCRKAd/R0wlZuAG+Gc=
 github.com/concourse/dex v0.0.0-20191105150807-8bbc2a6df1ea h1:xJzMZ1Bgd37JiTdD0BX1gGBNjPoIo9ddbPayZHRTq7I=
 github.com/concourse/dex v0.0.0-20191105150807-8bbc2a6df1ea/go.mod h1:jq+kdbXyj+bEdch50oYfPCNK4ZCRKAd/R0wlZuAG+Gc=
+github.com/concourse/dex v0.0.0-20191119220255-bcdd275f4da6 h1:19EYY7x5+pJWiio03BP+02VgG7Ht7rEIznN2HkLuNZ0=
+github.com/concourse/dex v0.0.0-20191119220255-bcdd275f4da6/go.mod h1:jq+kdbXyj+bEdch50oYfPCNK4ZCRKAd/R0wlZuAG+Gc=
 github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/flag v1.0.0 h1:XG+A/Y+8kNdNDUC9T+SQ55dZ1+xYQN6LNVBg3cGJ080=
 github.com/concourse/flag v1.0.0/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,6 +1,45 @@
+#### <sub><sup><a name="4797" href="#4797">:link:</a></sup></sub> fix, security
+
+* *Attention CF auth users*
+
+  We recently discovered that cloud foundry org (and space) names can contain
+  all sorts of special characters. This is a problem because the cf auth
+  connector uses a `:` as a delimiter. When a user logs in using the cf auth
+  connector we get back a token with a `groups` claim, where groups are of the
+  form `CONNECTOR:ORG` and `CONNECTOR:ORG:SPACE`. This means that an org
+  `myorg` with space `myspace` would be returned as `cf:myorg:myspace` which is
+  equivalent to an org named `myorg:myspace`.
+
+  *If a malicious user has the ability to create orgs or spaces within their
+  cloud foundry deployment, they would be able to use this fact to gain access
+  to unauthorized teams in concourse.*
+  
+  As a result, we have introduced a way to map org and space `guids` to teams
+  in concourse, and now discourage the use of referencing orgs and spaces by
+  `name`. In order to emphasize this behaviour we have made a breaking change
+  to the cf auth team flags, used during `fly set-team` or as `env` variables
+  when configuring the main team at startup.  These affected flags are now
+  prefixed with an `insecure` label.
+
+  If you configure the `main` team with cf auth during startup, your concourse
+  may fail to start after migrating to this version. You will need to either
+  use these new `insecure` flags, or use org and space guids.
+
+  Any teams using cf auth that have been configure with `fly set-team` will
+  continue to work as before however the next time you update your team config,
+  you will need to use the new flags.
+
+#### <sub><sup><a name="4712" href="#4712">:link:</a></sup></sub> feature
+
+* In addition to fixing the above issue, CF auth users also now have the
+  ability to grant team access based on specific user roles in CloudFoundry.
+
+  Previously, you could only grant access to users having the 'developer' role.
+
 #### <sub><sup><a name="4688" href="#4688">:link:</a></sup></sub> feature
 
-* The pin menu on the pipeline page now matches the sidebar, and the dropdown toggles on clicking the pin icon #4688.
+* The pin menu on the pipeline page now matches the sidebar, and the dropdown
+  toggles on clicking the pin icon #4688.
 
 #### <sub><sup><a name="4556" href="#4556">:link:</a></sup></sub> feature
 
@@ -12,4 +51,5 @@
 
 #### <sub><sup><a name="4698" href="#4698">:link:</a></sup></sub> feature
 
-* @pivotal-bin-ju @taylorsilva @xtreme-sameer-vohra added batching to the NewRelic emitter and logging info for non 2xx responses from NewRelic #4698.
+* @pivotal-bin-ju @taylorsilva @xtreme-sameer-vohra added batching to the
+  NewRelic emitter and logging info for non 2xx responses from NewRelic #4698.

--- a/skymarshal/skycmd/cf_flags.go
+++ b/skymarshal/skycmd/cf_flags.go
@@ -70,14 +70,17 @@ func (flag *CFFlags) Serialize(redirectURI string) ([]byte, error) {
 
 type CFTeamFlags struct {
 	Users            []string `long:"user" description:"A whitelisted CloudFoundry user" value-name:"USERNAME"`
-	Orgs             []string `long:"org" description:"A whitelisted CloudFoundry org" value-name:"ORG_NAME"`
-	Spaces           []string `long:"space" description:"(Deprecated) A whitelisted CloudFoundry space for users with the 'developer' role" value-name:"ORG_NAME:SPACE_NAME"`
-	SpacesAll        []string `long:"space-with-any-role" description:"A whitelisted CloudFoundry space for users with any role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"spaces_with_any_role"`
-	SpacesDeveloper  []string `long:"space-with-developer-role" description:"A whitelisted CloudFoundry space for users with the 'developer' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"spaces_with_developer_role"`
-	SpacesAuditor    []string `long:"space-with-auditor-role" description:"A whitelisted CloudFoundry space for users with the 'auditor' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"spaces_with_auditor_role"`
-	SpacesManager    []string `long:"space-with-manager-role" description:"A whitelisted CloudFoundry space for users with the 'manager' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"spaces_with_manager_role"`
-	SpaceGuids       []string `long:"space-guid" description:"(Deprecated) A whitelisted CloudFoundry space guid" value-name:"SPACE_GUID" mapstructure:"space_guids"`
+	OrgGuids         []string `long:"org-guid" description:"A whitelisted CloudFoundry org guid" value-name:"ORG_GUID" mapstructure:"org_guids"`
+	SpaceGuids       []string `long:"space-guid" description:"A whitelisted CloudFoundry space guid" value-name:"SPACE_GUID" mapstructure:"space_guids"`
+	OrgGuidsLegacy   []string `mapstructure:"orgguids"`
 	SpaceGuidsLegacy []string `mapstructure:"spaceguids"`
+
+	Orgs            []string `long:"insecure-org" description:"A whitelisted CloudFoundry org" value-name:"ORG_NAME" mapstructure:"insecure_orgs"`
+	Spaces          []string `long:"insecure-space" description:"(Deprecated) A whitelisted CloudFoundry space for users with the 'developer' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces"`
+	SpacesAll       []string `long:"insecure-space-with-any-role" description:"A whitelisted CloudFoundry space for users with any role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces_with_any_role"`
+	SpacesDeveloper []string `long:"insecure-space-with-developer-role" description:"A whitelisted CloudFoundry space for users with the 'developer' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces_with_developer_role"`
+	SpacesAuditor   []string `long:"insecure-space-with-auditor-role" description:"A whitelisted CloudFoundry space for users with the 'auditor' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces_with_auditor_role"`
+	SpacesManager   []string `long:"insecure-space-with-manager-role" description:"A whitelisted CloudFoundry space for users with the 'manager' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces_with_manager_role"`
 }
 
 func (flag *CFTeamFlags) GetUsers() []string {
@@ -100,7 +103,9 @@ func (flag *CFTeamFlags) GetGroups() []string {
 	for _, space := range flag.SpacesManager {
 		groups = append(groups, fmt.Sprintf("%s:manager", space))
 	}
+	groups = append(groups, flag.OrgGuids...)
 	groups = append(groups, flag.SpaceGuids...)
+	groups = append(groups, flag.OrgGuidsLegacy...)
 	groups = append(groups, flag.SpaceGuidsLegacy...)
 	return groups
 }

--- a/skymarshal/skycmd/cf_flags.go
+++ b/skymarshal/skycmd/cf_flags.go
@@ -75,12 +75,13 @@ type CFTeamFlags struct {
 	OrgGuidsLegacy   []string `mapstructure:"orgguids"`
 	SpaceGuidsLegacy []string `mapstructure:"spaceguids"`
 
-	Orgs            []string `long:"insecure-org" description:"A whitelisted CloudFoundry org" value-name:"ORG_NAME" mapstructure:"insecure_orgs"`
-	Spaces          []string `long:"insecure-space" description:"(Deprecated) A whitelisted CloudFoundry space for users with the 'developer' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces"`
-	SpacesAll       []string `long:"insecure-space-with-any-role" description:"A whitelisted CloudFoundry space for users with any role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces_with_any_role"`
-	SpacesDeveloper []string `long:"insecure-space-with-developer-role" description:"A whitelisted CloudFoundry space for users with the 'developer' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces_with_developer_role"`
-	SpacesAuditor   []string `long:"insecure-space-with-auditor-role" description:"A whitelisted CloudFoundry space for users with the 'auditor' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces_with_auditor_role"`
-	SpacesManager   []string `long:"insecure-space-with-manager-role" description:"A whitelisted CloudFoundry space for users with the 'manager' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces_with_manager_role"`
+	Orgs   []string `long:"insecure-org" description:"A whitelisted CloudFoundry org" value-name:"ORG_NAME" mapstructure:"insecure_orgs"`
+	Spaces []string `long:"insecure-space" description:"(Deprecated) A whitelisted CloudFoundry space for users with the 'developer' role" value-name:"ORG_NAME:SPACE_NAME" mapstructure:"insecure_spaces"`
+
+	SpacesAll       []string `long:"space-with-any-role" description:"A whitelisted CloudFoundry space for users with any role" value-name:"SPACE_GUID" mapstructure:"spaces_with_any_role"`
+	SpacesDeveloper []string `long:"space-with-developer-role" description:"A whitelisted CloudFoundry space for users with the 'developer' role" value-name:"SPACE_GUID" mapstructure:"spaces_with_developer_role"`
+	SpacesAuditor   []string `long:"space-with-auditor-role" description:"A whitelisted CloudFoundry space for users with the 'auditor' role" value-name:"SPACE_GUID" mapstructure:"spaces_with_auditor_role"`
+	SpacesManager   []string `long:"space-with-manager-role" description:"A whitelisted CloudFoundry space for users with the 'manager' role" value-name:"SPACE_GUID" mapstructure:"spaces_with_manager_role"`
 }
 
 func (flag *CFTeamFlags) GetUsers() []string {


### PR DESCRIPTION
# Why do we need this PR?
Support org guid in auth connector

# Changes proposed in this pull request
 - add support of config team auth using org guid. 

# Contributor Checklist
- [x] Unit tests
- [x] Integration tests (if applicable)
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] ~PR acceptance performed~ it's a pretty big hassle to find a CF to test this with
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~ ignoring for now
