### PR TITLE
bug: fixed a lidar bug that caused ATC crash.

### DIFF
--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -60,7 +60,7 @@ func (s *scanner) Run(ctx context.Context) error {
 		go func(resource db.Resource, resourceTypes db.ResourceTypes) {
 			defer waitGroup.Done()
 
-			err = s.check(resource, resourceTypes)
+			err := s.check(resource, resourceTypes)
 			s.setCheckError(s.logger, resource, err)
 
 		}(resource, resourceTypes)


### PR DESCRIPTION
# Existing Issue

Fixes #4807

# Why do we need this PR?

The bug causes ATC to intermittently crash.

# Changes proposed in this pull request

Problem code is:

```go
	for _, resource := range resources {
		waitGroup.Add(1)

		go func(resource db.Resource, resourceTypes db.ResourceTypes) {
			defer waitGroup.Done()

			err = s.check(resource, resourceTypes) // The bug is here!!!
			s.setCheckError(s.logger, resource, err)

		}(resource, resourceTypes)
	}
```

All go routines share the caller function's variable `err`, so that there is a race condition against `err` over all go routines. The fix is simple, just change the go routine to use a local `err`, which will avoid race condition.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
