### PR TITLE
#4566: removed register-worker command from tsa

### DIFF
--- a/tsa/README.md
+++ b/tsa/README.md
@@ -50,37 +50,6 @@ The variables here should be set to:
 | `$SIGNING_KEY`  | RSA key used to sign the tokens used when communicating to the ATC.                                                  |
 | `$ATC_URL`      | ATC URL reachable by the TSA (e.g. `https://ci.concourse-ci.org`).                                                   |
 
-### registering workers
-
-In order to have a worker on the local network register with `tsa` you can run the following command:
-
-```bash
-ssh -p 2222 $TSA_HOST \
-  -i worker_key \
-  -o UserKnownHostsFile=host_key.pub \
-  < worker.json
-```
-
-The `worker.json` file should contain the following:
-
-```json
-{
-    "platform": "linux",
-    "tags": [],
-    "addr": "$GARDEN_ADDR",
-    "baggageclaim_url": "$BAGGAGECLAIM_URL"
-}
-```
-
-The variables here should be set to:
-
-| Variable             | Description                                                             |
-|----------------------|-------------------------------------------------------------------------|
-| `$TSA_HOST`          | The hostname or IP where the TSA server can be reached.                 |
-| `$GARDEN_ADDR`       | The address (host and port) of the Garden to advertise.                 |
-| `$BAGGAGECLAIM_URL`  | The API URL (scheme, host,  and port) of the BaggageClaim to advertise. |
-
-
 ### forwarding workers
 
 In order to have a worker on a remote network register with `tsa` and have its traffic forwarded you can run the following command:

--- a/tsa/README.md
+++ b/tsa/README.md
@@ -97,7 +97,7 @@ ssh -p 2222 $TSA_HOST \
   < worker.json
 ```
 
-Note that in this case you should always have Garden and BaggageClaim listen on `127.0.0.1` so that they're not exposed to the outside world. For this reason there is no `$GARDEN_ADDR` or `$BAGGAGECLAIM_URL` as is the case with `register-worker`.
+Note that in this case you should always have Garden and BaggageClaim listen on `127.0.0.1` so that they're not exposed to the outside world. For this reason there is no `$GARDEN_ADDR` or `$BAGGAGECLAIM_URL`.
 
 The `worker.json` file should contain the following:
 

--- a/tsa/README.md
+++ b/tsa/README.md
@@ -58,7 +58,6 @@ In order to have a worker on the local network register with `tsa` you can run t
 ssh -p 2222 $TSA_HOST \
   -i worker_key \
   -o UserKnownHostsFile=host_key.pub \
-  register-worker \
   < worker.json
 ```
 

--- a/tsa/commands.go
+++ b/tsa/commands.go
@@ -1,8 +1,7 @@
 package tsa
 
 const (
-	ForwardWorker  = "forward-worker"
-	RegisterWorker = "register-worker"
+	ForwardWorker = "forward-worker"
 
 	LandWorker   = "land-worker"
 	RetireWorker = "retire-worker"

--- a/tsa/tsacmd/server.go
+++ b/tsa/tsacmd/server.go
@@ -490,10 +490,6 @@ func (server *server) parseRequest(cli string) (request, string, error) {
 
 	var req request
 	switch command {
-	case tsa.RegisterWorker:
-		req = registerWorkerRequest{
-			server: server,
-		}
 	case tsa.ForwardWorker:
 		var fs = flag.NewFlagSet(command, flag.ContinueOnError)
 


### PR DESCRIPTION
# tsa: remove 'register-worker' command
Fixes #4566.

# Reviewer Checklist
- [x] Code reviewed
- [ ] Tests reviewed
- [x] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
