### PR TITLE
fix(atc): when secret redaction is not enabled, should not buffer build log lines

### DIFF
--- a/vars/vars_tracker.go
+++ b/vars/vars_tracker.go
@@ -16,6 +16,7 @@ type CredVarsTrackerIterator interface {
 type CredVarsTracker interface {
 	Variables
 	IterateInterpolatedCreds(iter CredVarsTrackerIterator)
+	Enabled() bool
 }
 
 func NewCredVarsTracker(credVars Variables, on bool) CredVarsTracker {
@@ -80,6 +81,10 @@ func (t credVarsTracker) IterateInterpolatedCreds(iter CredVarsTrackerIterator) 
 	t.lock.RUnlock()
 }
 
+func (t credVarsTracker) Enabled() bool {
+	return true
+}
+
 // DummyCredVarsTracker do nothing,
 
 type dummyCredVarsTracker struct {
@@ -96,6 +101,10 @@ func (t dummyCredVarsTracker) List() ([]VariableDefinition, error) {
 
 func (t dummyCredVarsTracker) IterateInterpolatedCreds(iter CredVarsTrackerIterator) {
 	// do nothing
+}
+
+func (t dummyCredVarsTracker) Enabled() bool {
+	return false
 }
 
 // MapCredVarsTrackerIterator implements a simple CredVarsTrackerIterator which just


### PR DESCRIPTION
# Existing Issue

Fixes #4799 .

# Changes proposed in this pull request

When secret redaction is not enabled, use `newDBEventWriter` to create stdout and stderr.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
