### PR TITLE
add release notes for registry-image invalid digest fix

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -23,3 +23,7 @@
 #### <sub><sup><a name="4804" href="#4804">:link:</a></sup></sub> fix
 
 * @vito bumped the `autocert` dependency so that Let's Encrypt will default to the ACME v2 API. #4804
+
+#### <sub><sup><a name="Registry Image Resource">:link:</a></sup></sub> fix
+
+* Drop hashicorp/go-retryablehttp in favor of an outer retryer to avoid mismatched digests during puts


### PR DESCRIPTION
https://github.com/concourse/registry-image-resource/pull/79

@vito pushed a fix to the retryer logic in registry-image. He found that a retryer via the transport messed up some invisible digest calculation.
