### PR TITLE
fix(atc/auditor): reduce audit logs

### DIFF
--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -78,9 +78,14 @@ func (a *auditor) ValidateAction(action string) bool {
 }
 
 func (a *auditor) Audit(action string, userName string, r *http.Request) {
-	err := r.ParseForm()
-	if err == nil && a.ValidateAction(action) {
-		a.logger.Info("audit", lager.Data{"action": action, "user": userName, "parameters": r.Form})
+	switch userName {
+	case "", "system":
+		return
+	default:
+		err := r.ParseForm()
+		if err == nil && a.ValidateAction(action) {
+			a.logger.Info("audit", lager.Data{"action": action, "user": userName, "parameters": r.Form})
+		}
 	}
 }
 


### PR DESCRIPTION
# Why do we need this PR?

We have turned off all audit logs, but realized audit logs are very noisy. A lot of system invoked actions are logged, such as:

```
{"timestamp":"2019-11-27T06:57:58.324099900Z","level":"info","source":"atc","message":"atc.audit","data":{"action":"ListAllPipelines","parameters":{},"user":""}}
{"timestamp":"2019-11-27T06:58:04.259709800Z","level":"info","source":"atc","message":"atc.audit","data":{"action":"ListAllPipelines","parameters":{},"user":""}}

{"timestamp":"2019-11-27T06:59:10.475297499Z","level":"info","source":"atc","message":"atc.audit","data":{"action":"ReportWorkerContainers","parameters":{"worker_name":["7EoikMcK4"]},"user":"system"}}
```

The noise makes it difficult to find useful info.

# Changes proposed in this pull request

To not generate audit log if user is empty or "system".

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
