### PR TITLE
fix(atc): fixed a crash from credVarsTracker.

### DIFF
--- a/vars/vars_tracker.go
+++ b/vars/vars_tracker.go
@@ -21,7 +21,7 @@ type CredVarsTracker interface {
 
 func NewCredVarsTracker(credVars Variables, on bool) CredVarsTracker {
 	if on {
-		return credVarsTracker{
+		return &credVarsTracker{
 			credVars:          credVars,
 			interpolatedCreds: map[string]string{},
 			lock:              sync.RWMutex{},
@@ -39,7 +39,7 @@ type credVarsTracker struct {
 	lock sync.RWMutex
 }
 
-func (t credVarsTracker) Get(varDef VariableDefinition) (interface{}, bool, error) {
+func (t *credVarsTracker) Get(varDef VariableDefinition) (interface{}, bool, error) {
 	val, found, err := t.credVars.Get(varDef)
 	if found {
 		t.lock.Lock()
@@ -50,7 +50,7 @@ func (t credVarsTracker) Get(varDef VariableDefinition) (interface{}, bool, erro
 	return val, found, err
 }
 
-func (t credVarsTracker) track(name string, val interface{}) {
+func (t *credVarsTracker) track(name string, val interface{}) {
 	switch v := val.(type) {
 	case map[interface{}]interface{}:
 		for kk, vv := range v {
@@ -69,11 +69,11 @@ func (t credVarsTracker) track(name string, val interface{}) {
 	}
 }
 
-func (t credVarsTracker) List() ([]VariableDefinition, error) {
+func (t *credVarsTracker) List() ([]VariableDefinition, error) {
 	return t.credVars.List()
 }
 
-func (t credVarsTracker) IterateInterpolatedCreds(iter CredVarsTrackerIterator) {
+func (t *credVarsTracker) IterateInterpolatedCreds(iter CredVarsTrackerIterator) {
 	t.lock.RLock()
 	for k, v := range t.interpolatedCreds {
 		iter.YieldCred(k, v)
@@ -81,7 +81,7 @@ func (t credVarsTracker) IterateInterpolatedCreds(iter CredVarsTrackerIterator) 
 	t.lock.RUnlock()
 }
 
-func (t credVarsTracker) Enabled() bool {
+func (t *credVarsTracker) Enabled() bool {
 	return true
 }
 


### PR DESCRIPTION
# Existing Issue

Fixes #4845  .

# Why do we need this PR?

Without this fix, ATC with secret redaction may crash.

# Changes proposed in this pull request

This is a lock for read/write accessing the var tracker map, but unfortunately we copied the lock, which made the lock to not really work. The fix is just to change to use pointer.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [x] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
