### PR TITLE
atc: handle wrapped context canceled error

### DIFF
--- a/atc/exec/in_parallel.go
+++ b/atc/exec/in_parallel.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -69,7 +70,7 @@ func (step InParallelStep) Run(ctx context.Context, state RunState) error {
 	var errorMessages []string
 	for i := 0; i < executedSteps; i++ {
 		err := <-errs
-		if err != nil && err != context.Canceled {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			// The Run context being cancelled only means that one or more steps failed, not
 			// in_parallel itself. If we return context.Canceled error messages the step will
 			// be marked as errored instead of failed, and therefore they should be ignored.

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -35,3 +35,7 @@
 #### <sub><sup><a name="4817" href="#4817">:link:</a></sup></sub> fix
 
 * @evanchaoli fixed a regression introduced with the secret redaction work which resulted in build logs being buffered. #4817
+
+#### <sub><sup><a name="4746" href="#4746">:link:</a></sup></sub> fix
+
+* Fixed the problem of when fail_fast for in_parallel is true, a failing step causes the in_parallel to fall into on_error #4746


### PR DESCRIPTION
# Existing Issue
Fixes #4746 

# Why do we need this PR?
The way concourse handles errors from in parallel steps does not capture wrapped context.Canceled

# Changes proposed in this pull request
Based on https://github.com/golang/go/blob/master/src/net/url/url.go#L22-L28 and https://github.com/golang/go/blob/master/src/net/http/client.go#L702
use `errors.Is` for error comparison

# Contributor Checklist
- [x] Unit tests
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Release notes reviewed
