### PR TITLE
worker: Add Dockerfile to run integration tests locally

### DIFF
--- a/worker/backend/integration/Dockerfile
+++ b/worker/backend/integration/Dockerfile
@@ -1,0 +1,29 @@
+# This Dockerfile is only for running integration tests that depend on a running containerd process
+# Not intended to be packaged or used for production
+
+FROM concourse/golang-builder
+
+RUN mkdir -p /go/src/github.com/concourse/ /usr/local/concourse/bin/
+ENV PATH=/usr/local/concourse/bin:$PATH
+
+COPY start.sh /usr/local/concourse/bin/start.sh
+VOLUME /go/src/github.com/concourse/concourse
+VOLUME /go
+
+ARG RUNC_VERSION=v1.0.0-rc8
+ARG CNI_VERSION=v0.8.2
+ARG CONTAINERD_VERSION=1.3.0
+
+RUN apt update && apt install -y curl vim
+
+RUN curl -sSL https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 -o /usr/local/concourse/bin/init && chmod +x /usr/local/concourse/bin/init
+RUN set -x && \
+	curl -sSL https://github.com/containerd/containerd/releases/download/v$CONTAINERD_VERSION/containerd-$CONTAINERD_VERSION.linux-amd64.tar.gz \
+		| tar -zvxf - -C /usr/local/concourse/bin --strip-components=1 && \
+	curl -sSL https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64 \
+		-o /usr/local/concourse/bin/runc && chmod +x /usr/local/concourse/bin/runc && \
+	curl -sSL https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION/cni-plugins-linux-amd64-$CNI_VERSION.tgz \
+		| tar -zvxf - -C /usr/local/concourse/bin
+
+ENTRYPOINT ["/usr/local/concourse/bin/init", "/usr/local/concourse/bin/start.sh"]
+

--- a/worker/backend/integration/README.md
+++ b/worker/backend/integration/README.md
@@ -1,0 +1,26 @@
+## Running integration tests
+
+These integration tests require a real containerd daemon and runc binary to be present on a host.
+
+#### In Docker
+
+From the project root, build the Dockerfile:
+
+```bash
+docker build -t concourse/containerd-test -f Dockerfile.containerd .
+```
+
+Run the container in privileged mode, with volume mounting for faster feedback loops:
+
+```bash
+docker run --privileged -v CONCOURSE_DIR:/go/src/github.com/concourse/concourse -it concourse/containerd-test /bin/bash
+```
+
+Optionally mount the entire $GOPATH to avoid re-pulling go modules:
+
+```bash
+docker run --privileged -v $PWD:/go/src/github.com/concourse/concourse -v $GOPATH:/go -it concourse/containerd-test /bin/bash
+```
+
+Hit 'enter' once when you're in the container to get back into the bash shell. Navigate to `/go/src/github.com/concourse/concourse`
+and run integration tests in this directory with `go test -v`.

--- a/worker/backend/integration/start.sh
+++ b/worker/backend/integration/start.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -m
+
+echo "starting runc"
+runc &
+
+echo "starting containerd"
+containerd &
+
+/bin/bash

--- a/worker/backend/spec/spec.go
+++ b/worker/backend/spec/spec.go
@@ -109,10 +109,10 @@ func OciSpecBindMounts(bindMounts []garden.BindMount) (mounts []specs.Mount, err
 	return
 }
 
-// defaultGardenOciSpec repreeseents a default set of properties necessary in
+// defaultGardenOciSpec represents a default set of properties necessary in
 // order to satisfy the garden interface.
 //
-// ps.: this spec is NOT complet - it must be merged with more properties to
+// ps.: this spec is NOT completed - it must be merged with more properties to
 // form a properly working container.
 //
 func defaultGardenOciSpec(privileged bool) *specs.Spec {


### PR DESCRIPTION
This commit adds a Dockerfile and readme to the integration test folder for the new containerd track of work, because running integration tests with a real containerd daemon is better to do in a sandboxed environment like Docker.

Note: The pipelines are not yet set up to run these tests, we should perform this integration when this track of work is further along.

Addresses #4850