### PR TITLE
feat(atc): support "set-pipeline: self".

### DIFF
--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -16,7 +16,8 @@ import (
 	"github.com/concourse/concourse/vars"
 )
 
-// SetPipelineStep sets a pipeline to current team. This step takes pipeline
+// SetPipelineStep sets a pipeline to current team. If pipeline_name specified
+// is "self", then it will self set the current pipeline. This step takes pipeline
 // configure file and var files from some resource in the pipeline, like git.
 type SetPipelineStep struct {
 	planID      atc.PlanID

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -23,7 +23,7 @@ type BuildStarter interface {
 //go:generate counterfeiter . BuildFactory
 
 type BuildFactory interface {
-	Create(atc.JobConfig, atc.ResourceConfigs, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)
+	Create(db.Job, atc.ResourceConfigs, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)
 }
 
 func NewBuildStarter(
@@ -182,7 +182,7 @@ func (s *buildStarter) tryStartNextPendingBuild(
 		})
 	}
 
-	plan, err := s.factory.Create(job.Config(), resourceConfigs, resourceTypes, buildInputs)
+	plan, err := s.factory.Create(job, resourceConfigs, resourceTypes, buildInputs)
 	if err != nil {
 		// Don't use ErrorBuild because it logs a build event, and this build hasn't started
 		if err = nextPendingBuild.Finish(db.BuildStatusErrored); err != nil {

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -290,7 +290,7 @@ var _ = Describe("BuildStarter", func() {
 								Expect(tryStartErr).NotTo(HaveOccurred())
 							})
 
-							Context("when creaing a build plan", func() {
+							Context("when creating a build plan", func() {
 								BeforeEach(func() {
 									job.GetNextBuildInputsReturns([]db.BuildInput{}, true, nil)
 									fakePipeline.CheckPausedReturns(false, nil)
@@ -471,8 +471,8 @@ var _ = Describe("BuildStarter", func() {
 
 								It("stops creating builds for job", func() {
 									Expect(fakeFactory.CreateCallCount()).To(Equal(1))
-									actualJobConfig, actualResourceConfigs, actualResourceTypes, actualBuildInputs := fakeFactory.CreateArgsForCall(0)
-									Expect(actualJobConfig).To(Equal(atc.JobConfig{Name: "some-job"}))
+									actualJob, actualResourceConfigs, actualResourceTypes, actualBuildInputs := fakeFactory.CreateArgsForCall(0)
+									Expect(actualJob).To(Equal(job))
 									Expect(actualResourceConfigs).To(Equal(atc.ResourceConfigs{{Name: "some-resource"}}))
 									Expect(actualResourceTypes).To(Equal(versionedResourceTypes))
 									Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
@@ -515,20 +515,20 @@ var _ = Describe("BuildStarter", func() {
 
 								It("creates build plans for all builds", func() {
 									Expect(fakeFactory.CreateCallCount()).To(Equal(3))
-									actualJobConfig, actualResourceConfigs, actualResourceTypes, actualBuildInputs := fakeFactory.CreateArgsForCall(0)
-									Expect(actualJobConfig).To(Equal(atc.JobConfig{Name: "some-job"}))
+									actualJob, actualResourceConfigs, actualResourceTypes, actualBuildInputs := fakeFactory.CreateArgsForCall(0)
+									Expect(actualJob).To(Equal(job))
 									Expect(actualResourceConfigs).To(Equal(atc.ResourceConfigs{{Name: "some-resource"}}))
 									Expect(actualResourceTypes).To(Equal(versionedResourceTypes))
 									Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
 
-									actualJobConfig, actualResourceConfigs, actualResourceTypes, actualBuildInputs = fakeFactory.CreateArgsForCall(1)
-									Expect(actualJobConfig).To(Equal(atc.JobConfig{Name: "some-job"}))
+									actualJob, actualResourceConfigs, actualResourceTypes, actualBuildInputs = fakeFactory.CreateArgsForCall(1)
+									Expect(actualJob).To(Equal(job))
 									Expect(actualResourceConfigs).To(Equal(atc.ResourceConfigs{{Name: "some-resource"}}))
 									Expect(actualResourceTypes).To(Equal(versionedResourceTypes))
 									Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
 
-									actualJobConfig, actualResourceConfigs, actualResourceTypes, actualBuildInputs = fakeFactory.CreateArgsForCall(2)
-									Expect(actualJobConfig).To(Equal(atc.JobConfig{Name: "some-job"}))
+									actualJob, actualResourceConfigs, actualResourceTypes, actualBuildInputs = fakeFactory.CreateArgsForCall(2)
+									Expect(actualJob).To(Equal(job))
 									Expect(actualResourceConfigs).To(Equal(atc.ResourceConfigs{{Name: "some-resource"}}))
 									Expect(actualResourceTypes).To(Equal(versionedResourceTypes))
 									Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))

--- a/atc/scheduler/factory/factory_aggregate_test.go
+++ b/atc/scheduler/factory/factory_aggregate_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/scheduler/factory"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,6 +16,8 @@ var _ = Describe("Factory Aggregate", func() {
 		resourceTypes       atc.VersionedResourceTypes
 		actualPlanFactory   atc.PlanFactory
 		expectedPlanFactory atc.PlanFactory
+
+		fakeJob *dbfakes.FakeJob
 	)
 
 	BeforeEach(func() {
@@ -41,11 +44,13 @@ var _ = Describe("Factory Aggregate", func() {
 				Version: atc.Version{"some": "version"},
 			},
 		}
+
+		fakeJob = new(dbfakes.FakeJob)
 	})
 
 	Context("when I have one aggregate", func() {
-		It("returns the correct plan", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
@@ -58,7 +63,10 @@ var _ = Describe("Factory Aggregate", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+		})
+		It("returns the correct plan", func() {
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.AggregatePlan{
@@ -76,8 +84,8 @@ var _ = Describe("Factory Aggregate", func() {
 	})
 
 	Context("when I have nested aggregates", func() {
-		It("returns the correct plan", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
@@ -97,7 +105,10 @@ var _ = Describe("Factory Aggregate", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+		})
+		It("returns the correct plan", func() {
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.AggregatePlan{
@@ -121,8 +132,8 @@ var _ = Describe("Factory Aggregate", func() {
 	})
 
 	Context("when I have an aggregate with hooks", func() {
-		It("returns the correct plan", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
@@ -135,7 +146,10 @@ var _ = Describe("Factory Aggregate", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+		})
+		It("returns the correct plan", func() {
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.AggregatePlan{
@@ -155,8 +169,8 @@ var _ = Describe("Factory Aggregate", func() {
 	})
 
 	Context("when I have a hook on an aggregate", func() {
-		It("returns the correct plan", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
@@ -169,7 +183,10 @@ var _ = Describe("Factory Aggregate", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+		})
+		It("returns the correct plan", func() {
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnSuccessPlan{

--- a/atc/scheduler/factory/factory_do_test.go
+++ b/atc/scheduler/factory/factory_do_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/scheduler/factory"
 	"github.com/concourse/concourse/atc/testhelpers"
 
@@ -17,6 +18,8 @@ var _ = Describe("Factory Do", func() {
 		resourceTypes       atc.VersionedResourceTypes
 		actualPlanFactory   atc.PlanFactory
 		expectedPlanFactory atc.PlanFactory
+
+		fakeJob *dbfakes.FakeJob
 	)
 
 	BeforeEach(func() {
@@ -43,11 +46,13 @@ var _ = Describe("Factory Do", func() {
 				Version: atc.Version{"some": "version"},
 			},
 		}
+
+		fakeJob = new(dbfakes.FakeJob)
 	})
 
 	Context("when I have a nested do ", func() {
-		It("returns the correct plan", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Do: &atc.PlanSequence{
@@ -67,7 +72,10 @@ var _ = Describe("Factory Do", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+		})
+		It("returns the correct plan", func() {
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.DoPlan{
@@ -91,8 +99,8 @@ var _ = Describe("Factory Do", func() {
 	})
 
 	Context("when I have an aggregate inside a do", func() {
-		It("returns the correct plan", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Do: &atc.PlanSequence{
@@ -112,7 +120,10 @@ var _ = Describe("Factory Do", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+		})
+		It("returns the correct plan", func() {
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.DoPlan{
@@ -136,8 +147,8 @@ var _ = Describe("Factory Do", func() {
 	})
 
 	Context("when i have a do inside an aggregate inside a hook", func() {
-		It("returns the correct plan", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "starting-task",
@@ -157,7 +168,10 @@ var _ = Describe("Factory Do", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+		})
+		It("returns the correct plan", func() {
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnSuccessPlan{
@@ -184,8 +198,8 @@ var _ = Describe("Factory Do", func() {
 	})
 
 	Context("when I have a do inside an aggregate", func() {
-		It("returns the correct plan", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
@@ -208,7 +222,10 @@ var _ = Describe("Factory Do", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+		})
+		It("returns the correct plan", func() {
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.AggregatePlan{

--- a/atc/scheduler/factory/factory_get_test.go
+++ b/atc/scheduler/factory/factory_get_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/scheduler/factory"
 	"github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
@@ -14,7 +15,7 @@ var _ = Describe("Factory Get", func() {
 
 		resources           atc.ResourceConfigs
 		resourceTypes       atc.VersionedResourceTypes
-		input               atc.JobConfig
+		fakeJob             *dbfakes.FakeJob
 		actualPlanFactory   atc.PlanFactory
 		expectedPlanFactory atc.PlanFactory
 		version             atc.Version
@@ -43,22 +44,24 @@ var _ = Describe("Factory Get", func() {
 				Version: atc.Version{"some": "version"},
 			},
 		}
+
+		fakeJob = new(dbfakes.FakeJob)
 	})
 
 	Context("with a get at the top-level", func() {
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Get:      "some-get",
 						Resource: "some-resource",
 					},
 				},
-			}
+			})
 		})
 
 		It("returns the correct plan", func() {
-			actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.GetPlan{
@@ -77,18 +80,18 @@ var _ = Describe("Factory Get", func() {
 
 	Context("with a get for a non-existent resource", func() {
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Get:      "some-get",
 						Resource: "not-a-resource",
 					},
 				},
-			}
+			})
 		})
 
 		It("returns the correct error", func() {
-			_, err := buildFactory.Create(input, resources, resourceTypes, nil)
+			_, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).To(Equal(factory.ErrResourceNotFound))
 		})
 	})

--- a/atc/scheduler/factory/factory_hooks_test.go
+++ b/atc/scheduler/factory/factory_hooks_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/scheduler/factory"
 	"github.com/concourse/concourse/atc/testhelpers"
 
@@ -18,6 +19,7 @@ var _ = Describe("Factory Hooks", func() {
 		actualPlanFactory   atc.PlanFactory
 		expectedPlanFactory atc.PlanFactory
 		version             atc.Version
+		fakeJob             *dbfakes.FakeJob
 	)
 
 	BeforeEach(func() {
@@ -43,13 +45,13 @@ var _ = Describe("Factory Hooks", func() {
 				Version: atc.Version{"some": "version"},
 			},
 		}
+
+		fakeJob = new(dbfakes.FakeJob)
 	})
 
 	Context("when there are step- and job-level hooks", func() {
-		var input atc.JobConfig
-
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -61,11 +63,11 @@ var _ = Describe("Factory Hooks", func() {
 				Failure: &atc.PlanConfig{
 					Task: "job failure",
 				},
-			}
+			})
 		})
 
 		It("builds the plan correctly", func() {
-			actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnFailurePlan{
@@ -90,10 +92,8 @@ var _ = Describe("Factory Hooks", func() {
 	})
 
 	Context("when there is a do with three steps with a hook", func() {
-		var input atc.JobConfig
-
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Do: &atc.PlanSequence{
@@ -112,11 +112,11 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}
+			})
 		})
 
 		It("builds the plan correctly", func() {
-			actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnFailurePlan{
@@ -145,10 +145,8 @@ var _ = Describe("Factory Hooks", func() {
 	})
 
 	Context("when there is a do with a hook", func() {
-		var input atc.JobConfig
-
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Do: &atc.PlanSequence{
@@ -164,11 +162,11 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}
+			})
 		})
 
 		It("builds the plan correctly", func() {
-			actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnFailurePlan{
@@ -193,8 +191,11 @@ var _ = Describe("Factory Hooks", func() {
 	})
 
 	Context("when I have an empty plan", func() {
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{})
+		})
 		It("returns an empty 'do' plan", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{}, resources, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := atc.Plan{Do: &atc.DoPlan{}}
@@ -203,10 +204,8 @@ var _ = Describe("Factory Hooks", func() {
 	})
 
 	Context("when I have aggregate in an aggregate in a hook", func() {
-		var input atc.JobConfig
-
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "some-task",
@@ -226,11 +225,11 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}
+			})
 		})
 
 		It("builds correctly", func() {
-			actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnSuccessPlan{
@@ -257,10 +256,8 @@ var _ = Describe("Factory Hooks", func() {
 	})
 
 	Context("when I have nested do in a hook", func() {
-		var input atc.JobConfig
-
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "some-task",
@@ -273,11 +270,11 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}
+			})
 		})
 
 		It("builds correctly", func() {
-			actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnSuccessPlan{
@@ -298,10 +295,8 @@ var _ = Describe("Factory Hooks", func() {
 	})
 
 	Context("when I have multiple nested do steps in hooks", func() {
-		var input atc.JobConfig
-
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "some-task",
@@ -327,11 +322,11 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}
+			})
 		})
 
 		It("builds correctly", func() {
-			actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnSuccessPlan{
@@ -368,10 +363,8 @@ var _ = Describe("Factory Hooks", func() {
 	})
 
 	Context("when I have nested aggregates in a hook", func() {
-		var input atc.JobConfig
-
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "some-task",
@@ -390,11 +383,11 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}
+			})
 		})
 
 		It("builds correctly", func() {
-			actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnSuccessPlan{
@@ -426,8 +419,7 @@ var _ = Describe("Factory Hooks", func() {
 
 	Context("when I have hooks in my plan", func() {
 		It("can build a job with one abort hook", func() {
-			var input atc.JobConfig
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -436,8 +428,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}
-			actual, err := buildFactory.Create(input, nil, nil, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnAbortPlan{
@@ -453,8 +445,7 @@ var _ = Describe("Factory Hooks", func() {
 		})
 
 		It("can build a job with one error hook", func() {
-			var input atc.JobConfig
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -463,8 +454,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}
-			actual, err := buildFactory.Create(input, nil, nil, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnErrorPlan{
@@ -480,7 +471,7 @@ var _ = Describe("Factory Hooks", func() {
 		})
 
 		It("can build a job with one error hook that has a timeout", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -490,7 +481,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnErrorPlan{
@@ -517,7 +509,7 @@ var _ = Describe("Factory Hooks", func() {
 		})
 
 		It("can build a job with multiple error hooks", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -529,7 +521,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnErrorPlan{
@@ -559,7 +552,7 @@ var _ = Describe("Factory Hooks", func() {
 		})
 
 		It("can build a job with one failure hook", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -568,7 +561,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnFailurePlan{
@@ -592,7 +586,7 @@ var _ = Describe("Factory Hooks", func() {
 		})
 
 		It("can build a job with one failure hook that has a timeout", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -602,7 +596,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnFailurePlan{
@@ -629,7 +624,7 @@ var _ = Describe("Factory Hooks", func() {
 		})
 
 		It("can build a job with multiple failure hooks", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -641,7 +636,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnFailurePlan{
@@ -671,7 +667,7 @@ var _ = Describe("Factory Hooks", func() {
 		})
 
 		It("can build a job with multiple ensure and failure hooks", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -683,7 +679,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnFailurePlan{
@@ -713,7 +710,7 @@ var _ = Describe("Factory Hooks", func() {
 		})
 
 		It("can build a job with failure, success and ensure hooks at the same level", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -728,7 +725,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.EnsurePlan{
@@ -758,7 +756,7 @@ var _ = Describe("Factory Hooks", func() {
 		})
 
 		It("can build a job with multiple ensure, failure and success hooks", func() {
-			actual, err := buildFactory.Create(atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
@@ -773,7 +771,8 @@ var _ = Describe("Factory Hooks", func() {
 						},
 					},
 				},
-			}, resources, resourceTypes, nil)
+			})
+			actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.OnSuccessPlan{
@@ -816,7 +815,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		Context("and multiple steps in my plan", func() {
 			It("can build a job with a task with hooks then 2 more tasks", func() {
-				actual, err := buildFactory.Create(atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Task: "those who resist our will",
@@ -834,7 +833,8 @@ var _ = Describe("Factory Hooks", func() {
 							Task: "shall be defeated",
 						},
 					},
-				}, resources, resourceTypes, nil)
+				})
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expected := expectedPlanFactory.NewPlan(atc.DoPlan{
@@ -867,7 +867,7 @@ var _ = Describe("Factory Hooks", func() {
 			})
 
 			It("can build a job with a task then a do", func() {
-				actual, err := buildFactory.Create(atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Task: "those who start resisting our will",
@@ -889,7 +889,8 @@ var _ = Describe("Factory Hooks", func() {
 							},
 						},
 					},
-				}, resources, resourceTypes, nil)
+				})
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expected := expectedPlanFactory.NewPlan(atc.DoPlan{
@@ -924,7 +925,7 @@ var _ = Describe("Factory Hooks", func() {
 			})
 
 			It("can build a job with a do then a task", func() {
-				actual, err := buildFactory.Create(atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Do: &atc.PlanSequence{
@@ -940,7 +941,8 @@ var _ = Describe("Factory Hooks", func() {
 							Task: "those who start resisting our will",
 						},
 					},
-				}, resources, resourceTypes, nil)
+				})
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expected := expectedPlanFactory.NewPlan(atc.DoPlan{

--- a/atc/scheduler/factory/factory_put_test.go
+++ b/atc/scheduler/factory/factory_put_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/scheduler/factory"
 	"github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
@@ -9,13 +10,18 @@ import (
 )
 
 var _ = Describe("Factory Put", func() {
+	var fakeJob *dbfakes.FakeJob
+
+	BeforeEach(func() {
+		fakeJob = new(dbfakes.FakeJob)
+	})
+
 	Describe("Put/Get locations", func() {
 		var (
 			buildFactory factory.BuildFactory
 
 			resources           atc.ResourceConfigs
 			resourceTypes       atc.VersionedResourceTypes
-			input               atc.JobConfig
 			actualPlanFactory   atc.PlanFactory
 			expectedPlanFactory atc.PlanFactory
 		)
@@ -47,18 +53,18 @@ var _ = Describe("Factory Put", func() {
 
 		Context("with a put at the top-level", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "some-resource",
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				putPlan := expectedPlanFactory.NewPlan(atc.PutPlan{
@@ -90,18 +96,18 @@ var _ = Describe("Factory Put", func() {
 
 		Context("with a put for a non-existent resource", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "what-resource",
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct error", func() {
-				_, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				_, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).To(Equal(factory.ErrResourceNotFound))
 			})
 		})
@@ -113,7 +119,6 @@ var _ = Describe("Factory Put", func() {
 
 			resources           atc.ResourceConfigs
 			resourceTypes       atc.VersionedResourceTypes
-			input               atc.JobConfig
 			actualPlanFactory   atc.PlanFactory
 			expectedPlanFactory atc.PlanFactory
 		)
@@ -145,18 +150,18 @@ var _ = Describe("Factory Put", func() {
 
 		Context("when I have a put at the top-level", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "some-resource",
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				putPlan := expectedPlanFactory.NewPlan(atc.PutPlan{
@@ -187,7 +192,7 @@ var _ = Describe("Factory Put", func() {
 
 		Context("when I have a put in a hook", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Task: "some-task",
@@ -196,11 +201,11 @@ var _ = Describe("Factory Put", func() {
 							},
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				putPlan := expectedPlanFactory.NewPlan(atc.PutPlan{
@@ -239,7 +244,7 @@ var _ = Describe("Factory Put", func() {
 
 		Context("when I have a put inside an aggregate", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Aggregate: &atc.PlanSequence{
@@ -252,11 +257,11 @@ var _ = Describe("Factory Put", func() {
 							},
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				putPlan := expectedPlanFactory.NewPlan(atc.PutPlan{
@@ -294,7 +299,7 @@ var _ = Describe("Factory Put", func() {
 
 		Context("when I have a put inside a parallel", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							InParallel: &atc.InParallelConfig{
@@ -311,11 +316,11 @@ var _ = Describe("Factory Put", func() {
 							},
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				putPlan := expectedPlanFactory.NewPlan(atc.PutPlan{
@@ -357,7 +362,7 @@ var _ = Describe("Factory Put", func() {
 
 		Context("when a put plan follows a task plan", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Task: "some-task",
@@ -367,11 +372,11 @@ var _ = Describe("Factory Put", func() {
 							Resource: "some-resource",
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				putPlan := expectedPlanFactory.NewPlan(atc.PutPlan{
@@ -410,7 +415,7 @@ var _ = Describe("Factory Put", func() {
 
 		Context("when a put plan is between two task plans", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Task: "those who resist our will",
@@ -422,7 +427,7 @@ var _ = Describe("Factory Put", func() {
 							Task: "some-other-task",
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan", func() {
@@ -461,7 +466,7 @@ var _ = Describe("Factory Put", func() {
 					}),
 				})
 
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(actual).To(testhelpers.MatchPlan(expectedPlan))
@@ -470,7 +475,7 @@ var _ = Describe("Factory Put", func() {
 
 		Context("when I have a put specifying inputs", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Put:      "some-put",
@@ -478,11 +483,11 @@ var _ = Describe("Factory Put", func() {
 							Inputs:   &atc.InputsConfig{Specified: []string{"input-1", "input-2"}},
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan with inputs specified", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				putPlan := expectedPlanFactory.NewPlan(atc.PutPlan{
@@ -514,7 +519,7 @@ var _ = Describe("Factory Put", func() {
 
 		Context("when I have a put specifying all inputs", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Put:      "some-put",
@@ -522,11 +527,11 @@ var _ = Describe("Factory Put", func() {
 							Inputs:   &atc.InputsConfig{All: true},
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan with all inputs", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				putPlan := expectedPlanFactory.NewPlan(atc.PutPlan{
@@ -558,18 +563,18 @@ var _ = Describe("Factory Put", func() {
 
 		Context("when I have a put specifying no inputs", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "some-resource",
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan without inputs specified", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				putPlan := expectedPlanFactory.NewPlan(atc.PutPlan{

--- a/atc/scheduler/factory/factory_set_pipeline_test.go
+++ b/atc/scheduler/factory/factory_set_pipeline_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/scheduler/factory"
 	"github.com/concourse/concourse/atc/testhelpers"
 
@@ -16,13 +17,14 @@ var _ = Describe("Factory SetPipeline Step", func() {
 		buildFactory        factory.BuildFactory
 		actualPlanFactory   atc.PlanFactory
 		expectedPlanFactory atc.PlanFactory
-		input               atc.JobConfig
+		fakeJob             *dbfakes.FakeJob
 	)
 
 	BeforeEach(func() {
 		actualPlanFactory = atc.NewPlanFactory(123)
 		expectedPlanFactory = atc.NewPlanFactory(123)
 		buildFactory = factory.NewBuildFactory(actualPlanFactory)
+		fakeJob = new(dbfakes.FakeJob)
 
 		resourceTypes = atc.VersionedResourceTypes{
 			{
@@ -38,7 +40,7 @@ var _ = Describe("Factory SetPipeline Step", func() {
 
 	Context("when set other pipeline", func() {
 		BeforeEach(func() {
-			input = atc.JobConfig{
+			fakeJob.ConfigReturns(atc.JobConfig{
 				Plan: atc.PlanSequence{
 					{
 						SetPipeline: "some-pipeline",
@@ -47,14 +49,44 @@ var _ = Describe("Factory SetPipeline Step", func() {
 						Vars:        map[string]interface{}{"k1": "v1"},
 					},
 				},
-			}
+			})
 		})
 		It("builds correctly", func() {
-			actual, err := buildFactory.Create(input, nil, resourceTypes, nil)
+			actual, err := buildFactory.Create(fakeJob, nil, resourceTypes, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			expected := expectedPlanFactory.NewPlan(atc.SetPipelinePlan{
 				Name:     "some-pipeline",
+				File:     "some-file",
+				VarFiles: []string{"vf1", "vf2"},
+				Vars:     map[string]interface{}{"k1": "v1"},
+			})
+
+			Expect(actual).To(testhelpers.MatchPlan(expected))
+		})
+	})
+
+	Context("when set self", func() {
+		BeforeEach(func() {
+			fakeJob.ConfigReturns(atc.JobConfig{
+				Plan: atc.PlanSequence{
+					{
+						SetPipeline: "self",
+						ConfigPath:  "some-file",
+						VarFiles:    []string{"vf1", "vf2"},
+						Vars:        map[string]interface{}{"k1": "v1"},
+					},
+				},
+			})
+
+			fakeJob.PipelineNameReturns("self-pipeline")
+		})
+		It("builds correctly", func() {
+			actual, err := buildFactory.Create(fakeJob, nil, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			expected := expectedPlanFactory.NewPlan(atc.SetPipelinePlan{
+				Name:     "self-pipeline",
 				File:     "some-file",
 				VarFiles: []string{"vf1", "vf2"},
 				Vars:     map[string]interface{}{"k1": "v1"},

--- a/atc/scheduler/factory/factory_task_test.go
+++ b/atc/scheduler/factory/factory_task_test.go
@@ -2,6 +2,7 @@ package factory_test
 
 import (
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/scheduler/factory"
 	"github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
@@ -15,7 +16,7 @@ var _ = Describe("Factory Task", func() {
 
 			resources           atc.ResourceConfigs
 			resourceTypes       atc.VersionedResourceTypes
-			input               atc.JobConfig
+			fakeJob             *dbfakes.FakeJob
 			actualPlanFactory   atc.PlanFactory
 			expectedPlanFactory atc.PlanFactory
 			params              atc.Params
@@ -25,6 +26,7 @@ var _ = Describe("Factory Task", func() {
 			actualPlanFactory = atc.NewPlanFactory(123)
 			expectedPlanFactory = atc.NewPlanFactory(123)
 			buildFactory = factory.NewBuildFactory(actualPlanFactory)
+			fakeJob = new(dbfakes.FakeJob)
 
 			resources = atc.ResourceConfigs{
 				{
@@ -53,18 +55,18 @@ var _ = Describe("Factory Task", func() {
 					"baz": "qux",
 				}
 
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Task:   "some-task",
 							Params: params,
 						},
 					},
-				}
+				})
 			})
 
 			It("returns the correct plan", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expected := expectedPlanFactory.NewPlan(atc.TaskPlan{
@@ -78,7 +80,7 @@ var _ = Describe("Factory Task", func() {
 
 		Context("when input mapping is specified", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Task: "some-task",
@@ -99,11 +101,11 @@ var _ = Describe("Factory Task", func() {
 							},
 						},
 					},
-				}
+				})
 			})
 
 			It("creates build plan with aliased inputs", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expected := expectedPlanFactory.NewPlan(atc.TaskPlan{
@@ -131,7 +133,7 @@ var _ = Describe("Factory Task", func() {
 
 		Context("when output mapping is specified", func() {
 			BeforeEach(func() {
-				input = atc.JobConfig{
+				fakeJob.ConfigReturns(atc.JobConfig{
 					Plan: atc.PlanSequence{
 						{
 							Task: "some-task",
@@ -152,11 +154,11 @@ var _ = Describe("Factory Task", func() {
 							},
 						},
 					},
-				}
+				})
 			})
 
 			It("creates build plan with aliased output", func() {
-				actual, err := buildFactory.Create(input, resources, resourceTypes, nil)
+				actual, err := buildFactory.Create(fakeJob, resources, resourceTypes, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				expected := expectedPlanFactory.NewPlan(atc.TaskPlan{

--- a/atc/scheduler/schedulerfakes/fake_build_factory.go
+++ b/atc/scheduler/schedulerfakes/fake_build_factory.go
@@ -10,10 +10,10 @@ import (
 )
 
 type FakeBuildFactory struct {
-	CreateStub        func(atc.JobConfig, atc.ResourceConfigs, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)
+	CreateStub        func(db.Job, atc.ResourceConfigs, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
-		arg1 atc.JobConfig
+		arg1 db.Job
 		arg2 atc.ResourceConfigs
 		arg3 atc.VersionedResourceTypes
 		arg4 []db.BuildInput
@@ -30,7 +30,7 @@ type FakeBuildFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeBuildFactory) Create(arg1 atc.JobConfig, arg2 atc.ResourceConfigs, arg3 atc.VersionedResourceTypes, arg4 []db.BuildInput) (atc.Plan, error) {
+func (fake *FakeBuildFactory) Create(arg1 db.Job, arg2 atc.ResourceConfigs, arg3 atc.VersionedResourceTypes, arg4 []db.BuildInput) (atc.Plan, error) {
 	var arg4Copy []db.BuildInput
 	if arg4 != nil {
 		arg4Copy = make([]db.BuildInput, len(arg4))
@@ -39,7 +39,7 @@ func (fake *FakeBuildFactory) Create(arg1 atc.JobConfig, arg2 atc.ResourceConfig
 	fake.createMutex.Lock()
 	ret, specificReturn := fake.createReturnsOnCall[len(fake.createArgsForCall)]
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
-		arg1 atc.JobConfig
+		arg1 db.Job
 		arg2 atc.ResourceConfigs
 		arg3 atc.VersionedResourceTypes
 		arg4 []db.BuildInput
@@ -62,13 +62,13 @@ func (fake *FakeBuildFactory) CreateCallCount() int {
 	return len(fake.createArgsForCall)
 }
 
-func (fake *FakeBuildFactory) CreateCalls(stub func(atc.JobConfig, atc.ResourceConfigs, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)) {
+func (fake *FakeBuildFactory) CreateCalls(stub func(db.Job, atc.ResourceConfigs, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)) {
 	fake.createMutex.Lock()
 	defer fake.createMutex.Unlock()
 	fake.CreateStub = stub
 }
 
-func (fake *FakeBuildFactory) CreateArgsForCall(i int) (atc.JobConfig, atc.ResourceConfigs, atc.VersionedResourceTypes, []db.BuildInput) {
+func (fake *FakeBuildFactory) CreateArgsForCall(i int) (db.Job, atc.ResourceConfigs, atc.VersionedResourceTypes, []db.BuildInput) {
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
 	argsForCall := fake.createArgsForCall[i]

--- a/testflight/set-pipeline-step_test.go
+++ b/testflight/set-pipeline-step_test.go
@@ -100,4 +100,31 @@ jobs:
 			Expect(execS.Out).To(gbytes.Say("hello world"))
 		})
 	})
+
+	Context("set self", func() {
+		BeforeEach(func() {
+			pipelineName = "self-reset"
+
+			err := ioutil.WriteFile(
+				filepath.Join(fixture, pipelineName+".yml"),
+				[]byte(fmt.Sprintf(pipeline_content, "self")),
+				0755,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			fly("set-pipeline", "-n", "-p", pipelineName, "-c", fixture+"/"+pipelineName+".yml")
+			fly("unpause-pipeline", "-p", pipelineName)
+		})
+
+		It("set the other pipeline", func() {
+			By("set-pipeline step should succeed")
+			execS := fly("trigger-job", "-w", "-j", pipelineName+"/sp")
+			Expect(execS.Out).To(gbytes.Say("setting pipeline: self-reset"))
+			Expect(execS.Out).To(gbytes.Say("done"))
+
+			By("should trigger the pipeline job successfully")
+			execS = fly("trigger-job", "-w", "-j", pipelineName+"/normal-job")
+			Expect(execS.Out).To(gbytes.Say("hello world"))
+		})
+	})
 })


### PR DESCRIPTION
This is a follow-up change of PR#4708 to add "set-pipeline: self".
The RFC is https://github.com/concourse/rfcs/pull/31.

This commit is just a revert of:
> 4b00001  Remove "set-pipeline: self". Will use a separate PR to add "self" back.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
