### PR TITLE
fix(fly): set-team discards roles with no user and group from team config file.

### DIFF
--- a/fly/integration/fixtures/team_config_empty_users.yml
+++ b/fly/integration/fixtures/team_config_empty_users.yml
@@ -1,5 +1,7 @@
 roles:
   - name: owner
     local:
-      users: [""]
-
+      users: [some-admin]
+  - name: viewer
+    local:
+      users: []

--- a/fly/integration/set_team_test.go
+++ b/fly/integration/set_team_test.go
@@ -42,10 +42,25 @@ var _ = Describe("Fly CLI", func() {
 						cmdParams = []string{"-c", "fixtures/team_config_no_auth_for_role.yml"}
 					})
 
-					It("returns an error", func() {
+					It("discard role with missing auth", func() {
 						sess, err := gexec.Start(flyCmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 						Expect(err).ToNot(HaveOccurred())
-						Eventually(sess.Err).Should(gbytes.Say("You have not provided a list of users and groups for one of the roles in your config yaml."))
+
+						Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
+
+						Eventually(sess.Out).Should(gbytes.Say("role member:"))
+						Eventually(sess.Out).Should(gbytes.Say("users:"))
+						Eventually(sess.Out).Should(gbytes.Say("- local:some-user"))
+						Eventually(sess.Out).Should(gbytes.Say("groups:"))
+						Eventually(sess.Out).Should(gbytes.Say("none"))
+						Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+						Eventually(sess.Out).Should(gbytes.Say("users:"))
+						Eventually(sess.Out).Should(gbytes.Say("- local:some-admin"))
+						Eventually(sess.Out).Should(gbytes.Say("groups:"))
+						Eventually(sess.Out).Should(gbytes.Say("none"))
+
+						Eventually(sess.Out).ShouldNot(gbytes.Say("role viewer:"))
+
 						Eventually(sess).Should(gexec.Exit(1))
 					})
 				})
@@ -55,10 +70,19 @@ var _ = Describe("Fly CLI", func() {
 						cmdParams = []string{"-c", "fixtures/team_config_empty_users.yml"}
 					})
 
-					It("returns an error", func() {
+					It("discard role with no user and group", func() {
 						sess, err := gexec.Start(flyCmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
 						Expect(err).ToNot(HaveOccurred())
-						Eventually(sess.Err).Should(gbytes.Say("You have not provided a list of users and groups for one of the roles in your config yaml."))
+						Eventually(sess.Out).Should(gbytes.Say("setting team: venture"))
+
+						Eventually(sess.Out).Should(gbytes.Say("role owner:"))
+						Eventually(sess.Out).Should(gbytes.Say("users:"))
+						Eventually(sess.Out).Should(gbytes.Say("- local:some-admin"))
+						Eventually(sess.Out).Should(gbytes.Say("groups:"))
+						Eventually(sess.Out).Should(gbytes.Say("none"))
+
+						Eventually(sess.Out).ShouldNot(gbytes.Say("role viewer:"))
+
 						Eventually(sess).Should(gexec.Exit(1))
 					})
 				})

--- a/skymarshal/skycmd/flags.go
+++ b/skymarshal/skycmd/flags.go
@@ -134,7 +134,7 @@ func (flag *AuthTeamFlags) formatFromFile() (AuthConfig, error) {
 		}
 
 		if len(users) == 0 && len(groups) == 0 {
-			return nil, ErrAuthNotConfiguredFromFile
+			continue
 		}
 
 		auth[roleName] = map[string][]string{


### PR DESCRIPTION
# Existing Issue

Fixes #4852 .

# Changes proposed in this pull request

Just silently discard roles that have no user and group.

This is a pure `fly` side change, data sent to the server side is not changed at all.

# Contributor Checklist
- [x] Unit tests
- [x] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
