### PR TITLE
Update steps for creating a migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,7 +256,8 @@ To generate a migration:
 1. Build the CLI:
 
 ```sh
-$ go build atc/db/migration/cli -o mig
+$ cd atc/db/migration
+$ go build -o mig ./cli
 ```
 2. Run the `generate` command. It takes the migration name, file type (SQL or Go)
 and optionally, the directory in which to put the migration files (by default,


### PR DESCRIPTION
When using the original command in `CONTRIBUTING.md` on macOS and a Linux container
I was getting a few errors:

```
$ go build atc/db/migration/cli -o mig
can't load package: package atc/db/migration/cli: malformed module path "atc/db/migration/cli": missing dot in first path element
can't load package: package -o: malformed module path "-o": leading dash
can't load package: package mig: malformed module path "mig": missing dot in first path element
```

The updated command successfully compiles the cli app on macOS and Linux.

Trying to remove any developer friction.