### PR TITLE
fly: show status of websocket dial when hijack err

### DIFF
--- a/fly/commands/internal/hijacker/hijacker.go
+++ b/fly/commands/internal/hijacker/hijacker.go
@@ -53,9 +53,9 @@ func (h *Hijacker) Hijack(teamName, handle string, spec atc.HijackProcessSpec, p
 		TLSClientConfig: h.tlsConfig,
 		Proxy:           http.ProxyFromEnvironment,
 	}
-	conn, _, err := dialer.Dial(url, header)
+	conn, response, err := dialer.Dial(url, header)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("%s %w", response.Status, err)
 	}
 
 	defer conn.Close()


### PR DESCRIPTION
# Existing Issue
Fixes #4849 

# Why do we need this PR?
Showing err when hijack fail is not enough for debugging

# Changes proposed in this pull request
Show response status as well. So if an viewer wants to hijack into a container the error would be `403 Forbidden websocket: bad hanshake`. It would be obvious that it is about authorization failure.


# Reviewer Checklist
- [ ] Code reviewed
- [ ] PR acceptance performed