### PR TITLE
fixes #4587 when cert is not given, super admin loads the cert from `.flyrc`.

### DIFF
--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -137,7 +137,7 @@ func (command *LoginCommand) Execute(args []string) error {
 
 	if payload != nil {
 		if isAdmin(payload) {
-			err = command.adminCheckTeamExists(target.URL(), tokenType, tokenValue, caCert)
+			err = command.adminCheckTeamExists(target.URL(), tokenType, tokenValue, target.CACert())
 		} else {
 			err = checkTokenTeams(payload, command.TeamName)
 		}

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -51,3 +51,7 @@
 #### <sub><sup><a name="4816" href="#4816">:link:</a></sup></sub> fix
 
 * @witjem removed superfluous mentions of `register-worker` from TSA. #4816
+
+#### <sub><sup><a name="4587" href="#4587">:link:</a></sup></sub> fix
+
+* @pivotal-bin-ju fixed x509 issue when the super admin login without CACert after the first sucessful login. #4587


### PR DESCRIPTION
# Existing Issue
 Fixes #4587 .

# Why do we need this PR?
This PR solve the issue #4587.  When the the super admin login without providing the CACert after the first successful login, the CACert will be loaded from `.flyrc`.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
