### PR TITLE
Improve containerd implementation of Garden backend interface methods

### DIFF
--- a/worker/backend/backend_test.go
+++ b/worker/backend/backend_test.go
@@ -279,6 +279,9 @@ func (s *BackendSuite) TestDestroyGetTaskError() {
 }
 
 func (s *BackendSuite) TestDestroyGetTaskErrorNotFound() {
+	// If a container is created without a task, it means that creation
+	// did not complete successfully. These containers should be
+	// deletable without error, for garbage collection.
 	fakeContainer := new(libcontainerdfakes.FakeContainer)
 	fakeContainer.TaskReturns(nil, errdefs.ErrNotFound)
 	s.client.GetContainerReturns(fakeContainer, nil)

--- a/worker/backend/integration/README.md
+++ b/worker/backend/integration/README.md
@@ -7,7 +7,7 @@ These integration tests require a real containerd daemon and runc binary to be p
 From the project root, build the Dockerfile:
 
 ```bash
-docker build -t concourse/containerd-test -f Dockerfile.containerd .
+docker build -t concourse/containerd-test .
 ```
 
 Run the container in privileged mode, with volume mounting for faster feedback loops:

--- a/worker/backend/libcontainerd/client.go
+++ b/worker/backend/libcontainerd/client.go
@@ -62,9 +62,9 @@ type Client interface {
 		container containerd.Container, err error,
 	)
 
-	// Destroy stops any running tasks on a container and remove the container.
+	// Destroy stops any running tasks on a container and removes the container.
 	// If a task cannot be stopped gracefully, it will be forcefully stopped after
-	// the grace period (default 10 seconds).
+	// a timeout period (default 10 seconds).
 	//
 	Destroy(ctx context.Context, handle string) error
 }


### PR DESCRIPTION
This PR incorporates code review feedback from #4784, refactors out error types, and adds additional edge case handling to the runtime backend. Some interface methods are not yet implemented (`BulkInfo`, `BulkMetrics`, `Lookup`, and `GraceTime`) because they either read properties of a concrete implementation of the Garden `Container` interface, or they need to return this concrete type. That work will be delivered after #4877.

Everything is behind a feature flag that isn't exposed yet in any packaging, so is safe to continuously merge into master.

# Existing Issue

Addresses #4783 .

# Changes proposed in this pull request

* Create backend error types that can wrap client-side errors 
* Use context with timeout for all function calls that cross the backend/client boundary
* Add more error checks for Destroy edge cases
* Add godocs for backend methods

# Contributor Checklist
- [x] Unit tests
- [x] Integration tests (if applicable)

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] PR acceptance performed