### PR TITLE
5.5.x - Add k8s IN_CLUSTER param

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -1,8 +1,6 @@
 package k8s_test
 
 import (
-	"time"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -11,7 +9,7 @@ import (
 var _ = Describe("baggageclaim drivers", func() {
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, nil)
+		cleanup(releaseName, namespace)
 	})
 
 	onPks(func() {
@@ -47,18 +45,9 @@ func baggageclaimWorks(driver string, selectorFlags ...string) {
 		It("works", func() {
 			setReleaseNameAndNamespace("bd-" + driver)
 			deployWithDriverAndSelectors(driver, selectorFlags...)
-			waitAllPodsInNamespaceToBeReady(namespace)
 
-			By("Creating the web proxy")
-			_, atcEndpoint := startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
-
-			By("Logging in")
-			fly.Login("test", "test", atcEndpoint)
-
-			Eventually(func() []Worker {
-				return getRunningWorkers(fly.GetWorkers())
-			}, 2*time.Minute, 10*time.Second).
-				ShouldNot(HaveLen(0))
+			atc := waitAndLogin(namespace, releaseName+"-web")
+			defer atc.Close()
 
 			By("Setting and triggering a dumb pipeline")
 			fly.Run("set-pipeline", "-n", "-c", "../pipelines/get-task.yml", "-p", "some-pipeline")
@@ -82,7 +71,6 @@ func baggageclaimFails(driver string, selectorFlags ...string) {
 				return workerLogsSession.Out.Contents()
 
 			}).Should(ContainSubstring("failed-to-set-up-driver"))
-
 		})
 	})
 }

--- a/topgun/k8s/container_limits_test.go
+++ b/topgun/k8s/container_limits_test.go
@@ -1,8 +1,6 @@
 package k8s_test
 
 import (
-	"time"
-
 	"github.com/onsi/gomega/gbytes"
 
 	. "github.com/concourse/concourse/topgun"
@@ -32,26 +30,10 @@ var _ = Describe("Container Limits", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, nil)
+		cleanup(releaseName, namespace)
 	})
 
 })
-
-func waitAndLogin() {
-	waitAllPodsInNamespaceToBeReady(namespace)
-
-	By("Creating the web proxy")
-	_, atcEndpoint := startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
-
-	By("Logging in")
-	fly.Login("test", "test", atcEndpoint)
-
-	Eventually(func() []Worker {
-		return getRunningWorkers(fly.GetWorkers())
-	}, 2*time.Minute, 10*time.Second).
-		ShouldNot(HaveLen(0))
-
-}
 
 func deployWithSelectors(selectorFlags ...string) {
 	helmDeployTestFlags := []string{
@@ -66,9 +48,13 @@ func containerLimitsWork(selectorFlags ...string) {
 	Context("container limits work", func() {
 		It("returns the configure default container limit", func() {
 			deployWithSelectors(selectorFlags...)
-			waitAndLogin()
-			buildSession := fly.Start("execute", "-c", "../tasks/tiny.yml")
+
+			atc := waitAndLogin(namespace, releaseName+"-web")
+			defer atc.Close()
+
+			buildSession := fly.Start("execute", "-c", "tasks/tiny.yml")
 			<-buildSession.Exited
+
 			Expect(buildSession.ExitCode()).To(Equal(0))
 
 			hijackSession := fly.Start(
@@ -89,12 +75,16 @@ func containerLimitsFail(selectorFlags ...string) {
 	Context("container limits fail", func() {
 		It("fails to set the memory limit", func() {
 			deployWithSelectors(selectorFlags...)
-			waitAndLogin()
-			buildSession := fly.Start("execute", "-c", "../tasks/tiny.yml")
+
+			atc := waitAndLogin(namespace, releaseName+"-web")
+			defer atc.Close()
+
+			buildSession := fly.Start("execute", "-c", "tasks/tiny.yml")
 			<-buildSession.Exited
 			Expect(buildSession.ExitCode()).To(Equal(2))
-
-			Expect(buildSession).To(gbytes.Say("failed to write 1073741824 to memory.memsw.limit_in_bytes"))
+			Expect(buildSession).To(gbytes.Say(
+				"failed to write 1073741824 to memory.memsw.limit_in_bytes",
+			))
 			Expect(buildSession).To(gbytes.Say("permission denied"))
 		})
 	})

--- a/topgun/k8s/external_postgres_test.go
+++ b/topgun/k8s/external_postgres_test.go
@@ -3,17 +3,11 @@ package k8s_test
 import (
 	"path"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/onsi/ginkgo"
 )
 
 var _ = Describe("External PostgreSQL", func() {
-	var (
-		pgReleaseName string
-		proxySession  *gexec.Session
-		atcEndpoint   string
-	)
+	var pgReleaseName string
 
 	BeforeEach(func() {
 		setReleaseNameAndNamespace("ep")
@@ -41,23 +35,25 @@ var _ = Describe("External PostgreSQL", func() {
 			"--set=secrets.postgresUser=pg-user",
 			"--set=worker.replicas=0",
 		)
-		waitAllPodsInNamespaceToBeReady(namespace)
 
-		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(
-			namespace, "service/"+releaseName+"-web", "8080")
+		waitAllPodsInNamespaceToBeReady(namespace)
 	})
 
 	AfterEach(func() {
 		helmDestroy(pgReleaseName)
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace)
 	})
 
 	It("can have pipelines set", func() {
-		defer proxySession.Interrupt()
+		atc := endpointFactory.NewServiceEndpoint(
+			namespace,
+			releaseName+"-web",
+			"8080",
+		)
+		defer atc.Close()
 
 		By("Logging in")
-		fly.Login("test", "test", atcEndpoint)
+		fly.Login("test", "test", "http://"+atc.Address())
 
 		By("Setting and triggering a dumb pipeline")
 		fly.Run("set-pipeline", "-n", "-c", "../pipelines/get-task.yml", "-p", "pipeline")

--- a/topgun/k8s/external_worker_test.go
+++ b/topgun/k8s/external_worker_test.go
@@ -3,8 +3,6 @@ package k8s_test
 import (
 	"time"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,8 +13,8 @@ var _ = Describe("external workers through separate deployments", func() {
 	const publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC496FSYFcBAKgDtMsBAJiF/6/NxlXKP5UZecyEsedYuTt1GOgJTwaA1qZ1LmHsbfLDE68oDdiM4uvxfI4wtLhz57w3u0jOUxZ2JeF7SVwEf1nVqLn4Gh/f8GUNQGSyIp1zUD5Bx9fq0PAyQ47mt7Ufi84rcf8LKl7nzAIHTcdg2BvTkQN9bUGPaq/Pb1W2bKPAQy4OzXTSIyrAJ89TH2jFeaZfyxQFGbD9jVHH/yl0oiMrDeaRYgccE5II+KY7WoLjsBry/9Qf2ERELKTK4UeIGIqWci9lab1ti+GxFPPiC3krNFjo4jShV4eUs4cNIrjwNrxVaKPXmU6o7Y3Hpayx Concourse"
 
 	var (
-		proxySession     *gexec.Session
-		atcEndpoint      string
+		atc Endpoint
+
 		workerKey        string
 		tsaPort          string
 		webDeployArgs    []string
@@ -30,7 +28,6 @@ var _ = Describe("external workers through separate deployments", func() {
 		tsaPort = "2222"
 		helmArgs := append(webDeployArgs,
 			"--set=worker.enabled=false",
-
 			"--set=web.tsa.bindPort="+tsaPort,
 		)
 		deployConcourseChart(releaseName+"-web", helmArgs...)
@@ -47,11 +44,13 @@ var _ = Describe("external workers through separate deployments", func() {
 		waitAllPodsInNamespaceToBeReady(namespace + "-worker")
 		waitAllPodsInNamespaceToBeReady(namespace + "-web")
 
-		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace+"-web", "service/"+releaseName+"-web-web", "8080")
+		atc = endpointFactory.NewServiceEndpoint(
+			namespace+"-web",
+			releaseName+"-web-web",
+			"8080",
+		)
 
-		By("Logging in")
-		fly.Login("test", "test", atcEndpoint)
+		fly.Login("test", "test", "http://"+atc.Address())
 
 	})
 
@@ -72,8 +71,9 @@ var _ = Describe("external workers through separate deployments", func() {
 	}
 
 	AfterEach(func() {
-		cleanup(releaseName+"-web", namespace+"-web", proxySession)
-		cleanup(releaseName+"-worker", namespace+"-worker", nil)
+		atc.Close()
+		cleanup(releaseName+"-web", namespace+"-web")
+		cleanup(releaseName+"-worker", namespace+"-worker")
 	})
 
 	Context("main team worker", func() {

--- a/topgun/k8s/https_web_tls_termination_test.go
+++ b/topgun/k8s/https_web_tls_termination_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 	"github.com/square/certstrap/pkix"
 
 	. "github.com/onsi/ginkgo"
@@ -15,6 +14,7 @@ import (
 )
 
 var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
+
 	var (
 		serverCertBytes []byte
 		serverKeyBytes  []byte
@@ -24,7 +24,9 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 	BeforeEach(func() {
 		var err error
 
-		CACert, serverKey, serverCert := generateKeyPairWithCA()
+		setReleaseNameAndNamespace("wtt")
+
+		CACert, serverKey, serverCert := generateKeyPairWithCA(namespace, releaseName+"-web")
 		CACertBytes, err := CACert.Export()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -43,31 +45,33 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 		os.Remove(caCertFile.Name())
 	})
 
-	Context("When configured correctly", func() {
+	Context("when configured correctly", func() {
+
 		var (
-			proxySession  *gexec.Session
-			atcEndpoint   string
-			chartConfig   []string
-			proxyPort     string
-			proxyProtocol string
+			atc Endpoint
+
+			chartConfig []string
+			proxyPort   string
 		)
 
 		JustBeforeEach(func() {
-			setReleaseNameAndNamespace("wtt")
-			deployConcourseChart(releaseName,
-				chartConfig...)
+			deployConcourseChart(releaseName, chartConfig...)
 
 			waitAllPodsInNamespaceToBeReady(namespace)
 
-			By("Creating the web proxy")
-			proxySession, atcEndpoint = startPortForwardingWithProtocol(namespace, "service/"+releaseName+"-web", proxyPort, proxyProtocol)
+			atc = endpointFactory.NewServiceEndpoint(
+				namespace,
+				releaseName+"-web",
+				proxyPort,
+			)
 		})
 
 		AfterEach(func() {
-			cleanup(releaseName, namespace, proxySession)
+			atc.Close()
+			cleanup(releaseName, namespace)
 		})
 
-		Context("configure helm chart for tls termination at web", func() {
+		Context("with tls termination at web", func() {
 
 			BeforeEach(func() {
 				chartConfig = generateChartConfig(
@@ -76,38 +80,29 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 					"--set=secrets.webTlsCert="+string(serverCertBytes),
 					"--set=secrets.webTlsKey="+string(serverKeyBytes),
 				)
+
 				proxyPort = "443"
-				proxyProtocol = "https"
 			})
 
 			It("fly login succeeds when using the correct CA and host", func() {
-				By("Logging in")
-				sess := fly.Start("login", "-u", "test", "-p", "test", "--ca-cert", caCertFile.Name(), "-c", atcEndpoint)
-				<-sess.Exited
-				Expect(sess.ExitCode()).To(Equal(0))
+				fly.Run("login", "-u", "test", "-p", "test",
+					"--ca-cert", caCertFile.Name(),
+					"-c", "https://"+atc.Address(),
+				)
 			})
 
 			It("fly login fails when NOT using the correct CA", func() {
-				By("Logging in")
-				sess := fly.Start("login", "-u", "test", "-p", "test", "--ca-cert", "certs/wrong-ca.crt", "-c", atcEndpoint)
+				sess := fly.Start("login", "-u", "test", "-p", "test",
+					"--ca-cert", "k8s/certs/wrong-ca.crt",
+					"-c", "https://"+atc.Address(),
+				)
 				<-sess.Exited
+
 				Expect(sess.ExitCode()).ToNot(Equal(0))
 				Expect(sess.Err).To(gbytes.Say(`x509: certificate signed by unknown authority`))
 			})
 		})
 
-		Context("DON'T configure tls termination at web in helm chart", func() {
-			BeforeEach(func() {
-				chartConfig = generateChartConfig("--set=concourse.web.externalUrl=http://test.com",
-					"--set=concourse.web.tls.enabled=false")
-				proxyPort = "8080"
-				proxyProtocol = "http"
-			})
-			It("fly login succeeds when connecting to web over http", func() {
-				By("Logging in")
-				fly.Login("test", "test", atcEndpoint)
-			})
-		})
 	})
 
 	Context("When NOT configured correctly", func() {
@@ -116,22 +111,26 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 			setReleaseNameAndNamespace("wtt")
 		})
 
-		It("helm deploy fails if tls is enabled but externalURL is NOT set", func() {
+		It("fails if tls is enabled but externalURL is NOT set", func() {
 			expectedErr := "Must specify HTTPS external URL when concourse.web.tls.enabled is true"
+
 			chartConfig := generateChartConfig(
 				"--set=concourse.web.tls.enabled=true",
 				"--set=secrets.webTlsCert="+string(serverCertBytes),
 				"--set=secrets.webTlsKey="+string(serverKeyBytes),
 			)
+
 			deployFailingConcourseChart(releaseName, expectedErr,
 				chartConfig...,
 			)
 		})
 
-		It("helm deploy fails when tls is enabled but ssl cert and ssl key are NOT set", func() {
+		It("fails when tls is enabled but ssl cert and ssl key are NOT set", func() {
 			expectedErr := "secrets.webTlsCert is required because secrets.create is true and concourse.web.tls.enabled is true"
+
 			chartConfig := generateChartConfig("--set=concourse.web.externalUrl=https://test.com",
 				"--set=concourse.web.tls.enabled=true")
+
 			deployFailingConcourseChart(releaseName, expectedErr,
 				chartConfig...,
 			)
@@ -142,12 +141,12 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 
 func generateChartConfig(args ...string) []string {
 	return append(args,
-		"--set=worker.replicas=1",
+		"--set=worker.enabled=false",
 		"--set=concourse.worker.baggageclaim.driver=detect",
 		"--set=concourse.web.tls.bindPort=443",
 	)
 }
-func generateKeyPairWithCA() (*pkix.Certificate, *pkix.Key, *pkix.Certificate) {
+func generateKeyPairWithCA(namespace, service string) (*pkix.Certificate, *pkix.Key, *pkix.Certificate) {
 	CAKey, err := pkix.CreateRSAKey(1024)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -157,11 +156,14 @@ func generateKeyPairWithCA() (*pkix.Certificate, *pkix.Key, *pkix.Certificate) {
 	serverKey, err := pkix.CreateRSAKey(1024)
 	Expect(err).NotTo(HaveOccurred())
 
-	certificateSigningRequest, err := pkix.CreateCertificateSigningRequest(serverKey, "", []net.IP{net.IPv4(127, 0, 0, 1)},
-		nil, "Pivotal", "", "", "", "127.0.0.1")
+	certificateSigningRequest, err := pkix.CreateCertificateSigningRequest(
+		serverKey, "", []net.IP{net.IPv4(127, 0, 0, 1)},
+		[]string{serviceAddress(namespace, service)},
+		"Pivotal", "", "", "", "127.0.0.1")
 	Expect(err).NotTo(HaveOccurred())
 
-	serverCert, err := pkix.CreateCertificateHost(CACert, CAKey, certificateSigningRequest, time.Now().Add(time.Hour))
+	serverCert, err := pkix.CreateCertificateHost(CACert, CAKey,
+		certificateSigningRequest, time.Now().Add(time.Hour))
 	Expect(err).NotTo(HaveOccurred())
 
 	return CACert, serverKey, serverCert

--- a/topgun/k8s/mainteam_role_test.go
+++ b/topgun/k8s/mainteam_role_test.go
@@ -1,8 +1,6 @@
 package k8s_test
 
 import (
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,11 +8,10 @@ import (
 
 var _ = Describe("Main team role config", func() {
 	var (
-		proxySession        *gexec.Session
-		atcEndpoint         string
+		atc Endpoint
+
 		helmDeployTestFlags []string
-		username            = "test-viewer"
-		password            = "test-viewer"
+		username, password  = "test-viewer", "test-viewer"
 	)
 
 	BeforeEach(func() {
@@ -27,25 +24,25 @@ var _ = Describe("Main team role config", func() {
 
 		waitAllPodsInNamespaceToBeReady(namespace)
 
-		pods := getPods(namespace, "--selector=app="+releaseName+"-worker")
-		Expect(pods).To(HaveLen(1))
+		atc = endpointFactory.NewServiceEndpoint(
+			namespace,
+			releaseName+"-web",
+			"8080",
+		)
 
-		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
-
-		By("Logging in")
-		fly.Login(username, password, atcEndpoint)
+		fly.Login(username, password, "http://"+atc.Address())
 
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		atc.Close()
+		cleanup(releaseName, namespace)
 	})
 
 	Context("Adding team role config yaml to web", func() {
 		BeforeEach(func() {
 			helmDeployTestFlags = []string{
-				`--set=worker.replicas=1`,
+				`--set=worker.enabled=false`,
 				`--set=web.additionalVolumes[0].name=team-role-config`,
 				`--set=web.additionalVolumes[0].configMap.name=team-role-config`,
 				`--set=web.additionalVolumeMounts[0].name=team-role-config`,

--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -6,11 +6,63 @@ import (
 	"path"
 	"time"
 
-	"github.com/onsi/gomega/gexec"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("Prometheus integration", func() {
+
+	var prometheusReleaseName string
+
+	BeforeEach(func() {
+		setReleaseNameAndNamespace("pi")
+		prometheusReleaseName = releaseName + "-prom"
+
+		deployConcourseChart(releaseName,
+			"--set=worker.replicas=1",
+			"--set=concourse.worker.ephemeral=true",
+			"--set=concourse.web.prometheus.enabled=true",
+			"--set=concourse.worker.baggageclaim.driver=detect")
+
+		helmDeploy(prometheusReleaseName,
+			namespace,
+			path.Join(Environment.HelmChartsDir, "stable/prometheus"),
+			"--set=nodeExporter.enabled=false",
+			"--set=kubeStateMetrics.enabled=false",
+			"--set=pushgateway.enabled=false",
+			"--set=alertmanager.enabled=false",
+			"--set=server.persistentVolume.enabled=false")
+
+		waitAllPodsInNamespaceToBeReady(namespace)
+	})
+
+	AfterEach(func() {
+		helmDestroy(prometheusReleaseName)
+		cleanup(releaseName, namespace)
+	})
+
+	It("Is able to retrieve concourse metrics", func() {
+		prometheus := endpointFactory.NewServiceEndpoint(
+			namespace,
+			prometheusReleaseName+"-prometheus-server",
+			"80",
+		)
+		defer prometheus.Close()
+
+		Eventually(func() bool {
+			metrics, err := getPrometheusMetrics("http://"+prometheus.Address(), releaseName)
+			if err != nil {
+				return false
+			}
+
+			if metrics.Status != "success" {
+				return false
+			}
+
+			return true
+		}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "be able to retrieve metrics")
+	})
+})
 
 type prometheusMetrics struct {
 	Status string `json:"status"`
@@ -43,56 +95,3 @@ func getPrometheusMetrics(endpoint, releaseName string) (*prometheusMetrics, err
 
 	return metrics, nil
 }
-
-var _ = Describe("Prometheus integration", func() {
-	var (
-		proxySession          *gexec.Session
-		prometheusReleaseName string
-		prometheusEndpoint    string
-	)
-
-	BeforeEach(func() {
-		setReleaseNameAndNamespace("pi")
-		prometheusReleaseName = releaseName + "-prom"
-
-		deployConcourseChart(releaseName,
-			"--set=worker.replicas=1",
-			"--set=concourse.worker.ephemeral=true",
-			"--set=concourse.web.prometheus.enabled=true",
-			"--set=concourse.worker.baggageclaim.driver=detect")
-
-		helmDeploy(prometheusReleaseName,
-			namespace,
-			path.Join(Environment.HelmChartsDir, "stable/prometheus"),
-			"--set=nodeExporter.enabled=false",
-			"--set=kubeStateMetrics.enabled=false",
-			"--set=pushgateway.enabled=false",
-			"--set=alertmanager.enabled=false",
-			"--set=server.persistentVolume.enabled=false")
-
-		waitAllPodsInNamespaceToBeReady(namespace)
-
-		By("Creating the prometheus proxy")
-		proxySession, prometheusEndpoint = startPortForwarding(namespace, "service/"+prometheusReleaseName+"-prometheus-server", "80")
-	})
-
-	AfterEach(func() {
-		helmDestroy(prometheusReleaseName)
-		cleanup(releaseName, namespace, proxySession)
-	})
-
-	It("Is able to retrieve concourse metrics", func() {
-		Eventually(func() bool {
-			metrics, err := getPrometheusMetrics(prometheusEndpoint, releaseName)
-			if err != nil {
-				return false
-			}
-
-			if metrics.Status != "success" {
-				return false
-			}
-
-			return true
-		}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "be able to retrieve metrics")
-	})
-})

--- a/topgun/k8s/tsa_node_port_test.go
+++ b/topgun/k8s/tsa_node_port_test.go
@@ -1,20 +1,10 @@
 package k8s_test
 
 import (
-	"time"
-
-	"github.com/onsi/gomega/gexec"
-
-	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("TSA Service Node Port", func() {
-
-	var (
-		proxySession *gexec.Session
-	)
 
 	JustBeforeEach(func() {
 		setReleaseNameAndNamespace("tnp")
@@ -25,19 +15,11 @@ var _ = Describe("TSA Service Node Port", func() {
 	})
 
 	It("deployment succeeds", func() {
-		var atcEndpoint string
-
-		proxySession, atcEndpoint = startPortForwarding(namespace, "service/"+releaseName+"-web", "8080")
-
-		fly.Login("test", "test", atcEndpoint)
-		Eventually(func() []Worker {
-			return getRunningWorkers(fly.GetWorkers())
-		}, 2*time.Minute, 10*time.Second).
-			ShouldNot(HaveLen(0))
+		waitAndLogin(namespace, releaseName+"-web").Close()
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		cleanup(releaseName, namespace)
 	})
 
 })

--- a/topgun/k8s/worker_lifecycle_test.go
+++ b/topgun/k8s/worker_lifecycle_test.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
@@ -14,9 +13,8 @@ import (
 var _ = Describe("Worker lifecycle", func() {
 
 	var (
-		proxySession *gexec.Session
-		atcEndpoint  string
-		gracePeriod  string
+		atc         Endpoint
+		gracePeriod string
 	)
 
 	JustBeforeEach(func() {
@@ -28,21 +26,7 @@ var _ = Describe("Worker lifecycle", func() {
 			`--set=worker.terminationGracePeriodSeconds=`+gracePeriod,
 		)
 
-		waitAllPodsInNamespaceToBeReady(namespace)
-
-		By("Creating the web proxy")
-		proxySession, atcEndpoint = startPortForwarding(
-			namespace, "service/"+releaseName+"-web", "8080",
-		)
-
-		By("Logging in")
-		fly.Login("test", "test", atcEndpoint)
-
-		By("waiting for a running worker")
-		Eventually(func() []Worker {
-			return getRunningWorkers(fly.GetWorkers())
-		}, 2*time.Minute, 10*time.Second).
-			ShouldNot(HaveLen(0))
+		atc = waitAndLogin(namespace, releaseName+"-web")
 
 		fly.Run("set-pipeline", "-n",
 			"-c", "../pipelines/task-waiting.yml",
@@ -72,7 +56,8 @@ var _ = Describe("Worker lifecycle", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace, proxySession)
+		atc.Close()
+		cleanup(releaseName, namespace)
 	})
 
 	Context("terminating the worker", func() {


### PR DESCRIPTION
Back-porting #4643, which adds the `IN_CLUSTER` parameter. Currently k8s-topgun in the 5.5.x release pipeline has test failures related to [port-forwarding breaking](https://nci.concourse-ci.org/teams/main/pipelines/release-5.5.x/jobs/k8s-topgun/builds/10#L5de9362c:21684). The entire test suite does pass because now we use ginkgo's [`--flakeAttempts` flag](https://github.com/concourse/ci/blob/43d09072d69eeecafd547596a0e608bc9941e184/tasks/scripts/k8s-topgun#L28). 