### PR TITLE
add version_md5 to resouce_cache table

### DIFF
--- a/atc/db/migration/migrations/1575922657_version_md5_resource_cache.down.sql
+++ b/atc/db/migration/migrations/1575922657_version_md5_resource_cache.down.sql
@@ -1,4 +1,12 @@
 BEGIN;
+  ALTER TABLE resource_caches ADD COLUMN version text;
+
+  UPDATE resource_caches rc
+  SET version = rcv.version
+  LEFT JOIN resource_configs ON resource_configs.id = rc.resource_config_id
+  FROM resource_config_versions rcv
+  WHERE rcv.version_md5 = rc.version_md5;
+
   DROP INDEX resource_caches_resource_config_id_version_md5_params_hash_uniq
 
   ALTER TABLE resource_caches DROP COLUMN version_md5;

--- a/atc/db/migration/migrations/1575922657_version_md5_resource_cache.down.sql
+++ b/atc/db/migration/migrations/1575922657_version_md5_resource_cache.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+  DROP INDEX resource_caches_resource_config_id_version_md5_params_hash_uniq
+
+  ALTER TABLE resource_caches DROP COLUMN version_md5;
+
+  CREATE UNIQUE INDEX resource_caches_resource_config_id_version_params_hash_uniq
+  ON resource_caches (resource_config_id, md5(version::text), params_hash);
+COMMIT;

--- a/atc/db/migration/migrations/1575922657_version_md5_resource_cache.up.sql
+++ b/atc/db/migration/migrations/1575922657_version_md5_resource_cache.up.sql
@@ -5,6 +5,8 @@ BEGIN;
 
   DROP INDEX resource_caches_resource_config_id_version_params_hash_uniq;
 
+  ALTER TABLE resource_caches DROP COLUMN version;
+
   CREATE UNIQUE INDEX resource_caches_resource_config_id_version_md5_params_hash_uniq
   ON resource_caches (resource_config_id, version_md5, params_hash);
 COMMIT;

--- a/atc/db/migration/migrations/1575922657_version_md5_resource_cache.up.sql
+++ b/atc/db/migration/migrations/1575922657_version_md5_resource_cache.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+  ALTER TABLE resource_caches ADD COLUMN version_md5 text;
+
+  UPDATE resource_caches SET version_md5 = md5(version::text);
+
+  DROP INDEX resource_caches_resource_config_id_version_params_hash_uniq;
+
+  CREATE UNIQUE INDEX resource_caches_resource_config_id_version_md5_params_hash_uniq
+  ON resource_caches (resource_config_id, version_md5, params_hash);
+COMMIT;

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -996,25 +996,6 @@ func (p *pipeline) CreateStartedBuild(plan atc.Plan) (Build, error) {
 	return build, nil
 }
 
-func (p *pipeline) incrementCheckOrderWhenNewerVersion(tx Tx, resourceID int, resourceType string, version string) error {
-	_, err := tx.Exec(`
-		WITH max_checkorder AS (
-			SELECT max(check_order) co
-			FROM versioned_resources
-			WHERE resource_id = $1
-			AND type = $2
-		)
-
-		UPDATE versioned_resources
-		SET check_order = mc.co + 1
-		FROM max_checkorder mc
-		WHERE resource_id = $1
-		AND type = $2
-		AND version = $3
-		AND check_order <= mc.co;`, resourceID, resourceType, version)
-	return err
-}
-
 func (p *pipeline) getBuildsFrom(tx Tx, col string) (map[string]Build, error) {
 	rows, err := buildsQuery.
 		Where(sq.Eq{

--- a/atc/db/resource_cache.go
+++ b/atc/db/resource_cache.go
@@ -60,13 +60,11 @@ func (cache *ResourceCacheDescriptor) findOrCreate(
 		err = psql.Insert("resource_caches").
 			Columns(
 				"resource_config_id",
-				"version",
 				"version_md5",
 				"params_hash",
 			).
 			Values(
 				resourceConfig.ID(),
-				cache.version(),
 				sq.Expr("md5(?)", cache.version()),
 				paramsHash(cache.Params),
 			).
@@ -87,7 +85,6 @@ func (cache *ResourceCacheDescriptor) findOrCreate(
 		rc = &usedResourceCache{
 			id:             id,
 			resourceConfig: resourceConfig,
-			version:        cache.Version,
 			lockFactory:    lockFactory,
 			conn:           conn,
 		}
@@ -153,7 +150,6 @@ func (cache *ResourceCacheDescriptor) findWithResourceConfig(tx Tx, resourceConf
 	return &usedResourceCache{
 		id:             id,
 		resourceConfig: resourceConfig,
-		version:        cache.Version,
 		lockFactory:    lockFactory,
 		conn:           conn,
 	}, true, nil
@@ -190,7 +186,6 @@ type UsedResourceCache interface {
 	ID() int
 
 	ResourceConfig() ResourceConfig
-	Version() atc.Version
 
 	Destroy(Tx) (bool, error)
 	BaseResourceType() *UsedBaseResourceType
@@ -199,7 +194,6 @@ type UsedResourceCache interface {
 type usedResourceCache struct {
 	id             int
 	resourceConfig ResourceConfig
-	version        atc.Version
 
 	lockFactory lock.LockFactory
 	conn        Conn
@@ -207,7 +201,6 @@ type usedResourceCache struct {
 
 func (cache *usedResourceCache) ID() int                        { return cache.id }
 func (cache *usedResourceCache) ResourceConfig() ResourceConfig { return cache.resourceConfig }
-func (cache *usedResourceCache) Version() atc.Version           { return cache.version }
 
 func (cache *usedResourceCache) Destroy(tx Tx) (bool, error) {
 	rows, err := psql.Delete("resource_caches").

--- a/atc/db/resource_cache.go
+++ b/atc/db/resource_cache.go
@@ -135,9 +135,9 @@ func (cache *ResourceCacheDescriptor) findWithResourceConfig(tx Tx, resourceConf
 		From("resource_caches").
 		Where(sq.Eq{
 			"resource_config_id": resourceConfig.ID(),
-			"version":            cache.version(),
 			"params_hash":        paramsHash(cache.Params),
 		}).
+		Where(sq.Expr("version_md5 = md5(?)", cache.version())).
 		Suffix("FOR SHARE").
 		RunWith(tx).
 		QueryRow().

--- a/atc/db/resource_cache_factory.go
+++ b/atc/db/resource_cache_factory.go
@@ -123,25 +123,18 @@ func (f *resourceCacheFactory) ResourceCacheMetadata(resourceCache UsedResourceC
 
 func findResourceCacheByID(tx Tx, resourceCacheID int, lock lock.LockFactory, conn Conn) (UsedResourceCache, bool, error) {
 	var rcID int
-	var versionBytes string
 
-	err := psql.Select("resource_config_id", "version").
+	err := psql.Select("resource_config_id").
 		From("resource_caches").
 		Where(sq.Eq{"id": resourceCacheID}).
 		RunWith(tx).
 		QueryRow().
-		Scan(&rcID, &versionBytes)
+		Scan(&rcID)
 
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, false, nil
 		}
-		return nil, false, err
-	}
-
-	var version atc.Version
-	err = json.Unmarshal([]byte(versionBytes), &version)
-	if err != nil {
 		return nil, false, err
 	}
 
@@ -156,7 +149,6 @@ func findResourceCacheByID(tx Tx, resourceCacheID int, lock lock.LockFactory, co
 
 	usedResourceCache := &usedResourceCache{
 		id:             resourceCacheID,
-		version:        version,
 		resourceConfig: rc,
 		lockFactory:    lock,
 		conn:           conn,

--- a/atc/db/resource_cache_lifecycle.go
+++ b/atc/db/resource_cache_lifecycle.go
@@ -78,7 +78,7 @@ func (f *resourceCacheLifecycle) CleanUpInvalidCaches(logger lager.Logger) error
 		From("next_build_inputs nbi").
 		Join("resources r ON r.id = nbi.resource_id").
 		Join("resource_config_versions rcv ON rcv.version_md5 = nbi.version_md5 AND rcv.resource_config_scope_id = r.resource_config_scope_id").
-		Join("resource_caches r_cache ON r_cache.resource_config_id = r.resource_config_id AND r_cache.version = rcv.version").
+		Join("resource_caches r_cache ON r_cache.resource_config_id = r.resource_config_id AND r_cache.version_md5 = rcv.version_md5").
 		Join("jobs j ON nbi.job_id = j.id").
 		Join("pipelines p ON j.pipeline_id = p.id").
 		Where(sq.Expr("p.paused = false")).

--- a/atc/db/versions_db.go
+++ b/atc/db/versions_db.go
@@ -594,41 +594,6 @@ func (versions VersionsDB) latestVersionOfResource(tx Tx, resourceID int) (Resou
 	return version, true, nil
 }
 
-// Migrates all the builds created later than the build cursor for
-// the same job. It is used for the UnusedBuildsVersionConstrained methods to
-// migrate all the builds created after the cursor.
-func (versions VersionsDB) migrateUpper(jobID int, buildIDCursor int) (bool, error) {
-	buildsToMigrateQueryBuilder := psql.Select("id", "job_id", "rerun_of").
-		From("builds").
-		Where(sq.Eq{
-			"job_id":             jobID,
-			"needs_v6_migration": true,
-			"status":             "succeeded",
-		}).
-		Where(sq.Or{
-			sq.And{
-				sq.Gt{
-					"rerun_of": buildIDCursor,
-				},
-				sq.NotEq{
-					"rerun_of": nil,
-				},
-			},
-			sq.And{
-				sq.Gt{
-					"id": buildIDCursor,
-				},
-				sq.Eq{
-					"rerun_of": nil,
-				},
-			},
-		}).
-		OrderBy("COALESCE(rerun_of, id) DESC, id DESC").
-		Limit(uint64(versions.limitRows))
-
-	return migrate(versions.conn, buildsToMigrateQueryBuilder)
-}
-
 // Migrates a single build into the successful build outputs table.
 func (versions VersionsDB) migrateSingle(buildID int) (string, error) {
 	var outputs string

--- a/atc/db/volume.go
+++ b/atc/db/volume.go
@@ -242,9 +242,10 @@ func (volume *createdVolume) findVolumeResourceTypeByCacheID(resourceCacheID int
 	var sqBaseResourceTypeID sql.NullInt64
 	var sqResourceCacheID sql.NullInt64
 
-	err := psql.Select("rc.version, rcfg.base_resource_type_id, rcfg.resource_cache_id").
+	err := psql.Select("rcv.version, rcfg.base_resource_type_id, rcfg.resource_cache_id").
 		From("resource_caches rc").
 		LeftJoin("resource_configs rcfg ON rcfg.id = rc.resource_config_id").
+		LeftJoin("resource_config_versions rcv ON rcv.version_md5 = rc.version_md5").
 		Where(sq.Eq{
 			"rc.id": resourceCacheID,
 		}).

--- a/atc/db/volume_test.go
+++ b/atc/db/volume_test.go
@@ -434,6 +434,24 @@ var _ = Describe("Volume", func() {
 			)
 			Expect(err).ToNot(HaveOccurred())
 
+			resourceConfigScope, err := defaultResourceType.SetResourceConfig(
+				atc.Source{"some": "source"},
+				atc.VersionedResourceTypes{
+					{
+						ResourceType: atc.ResourceType{
+							Name:   "some-type",
+							Type:   "some-base-resource-type",
+							Source: atc.Source{"some-type": "((source-param))"},
+						},
+						Version: atc.Version{"some-custom-type": "version"},
+					},
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			resourceConfigScope.SaveVersions([]atc.Version{atc.Version{"some": "version"}})
+			resourceConfigScope.SaveVersions([]atc.Version{atc.Version{"some-custom-type": "version"}})
+
 			creatingContainer, err := defaultWorker.CreateContainer(db.NewBuildStepContainerOwner(build.ID(), "some-plan", defaultTeam.ID()), db.ContainerMetadata{
 				Type:     "get",
 				StepName: "some-resource",


### PR DESCRIPTION
# Why do we need this PR?
look up by version_md5 (text)  is faster than version (jsonb) 

# Changes proposed in this pull request
added `version_md5` column to `resource_caches` table. Use version_md5 when quering.

