### PR TITLE
Add a new config "skip_team_path" to Vault. With turning on that, sec…

### DIFF
--- a/atc/creds/vault/manager.go
+++ b/atc/creds/vault/manager.go
@@ -19,6 +19,7 @@ type VaultManager struct {
 	PathPrefix string `long:"path-prefix" default:"/concourse" description:"Path under which to namespace credential lookup."`
 	SharedPath string `long:"shared-path" description:"Path under which to lookup shared credentials."`
 	Namespace  string `long:"namespace"   description:"Vault namespace to use for authentication and secret lookup."`
+	SkipTeamPath bool `long:"skip-team-path" description:"Skip team/ and team/pipeline/ from lookup path"`
 
 	TLS  TLS
 	Auth AuthConfig
@@ -116,6 +117,7 @@ func (manager *VaultManager) Config(config map[string]interface{}) {
 	manager.PathPrefix = toString(config["path_prefix"])
 	manager.SharedPath = toString(config["shared_path"])
 	manager.Namespace = toString(config["namespace"])
+	manager.SkipTeamPath = toBool(config["skip_team_path"])
 
 	manager.TLS.CACert = toString(config["ca_cert"])
 	manager.TLS.CAPath = toString(config["ca_path"])
@@ -179,7 +181,7 @@ func (manager VaultManager) Health() (*creds.HealthResponse, error) {
 func (manager *VaultManager) NewSecretsFactory(logger lager.Logger) (creds.SecretsFactory, error) {
 	if manager.SecretFactory == nil {
 		manager.ReAuther = NewReAuther(logger, manager.Client, manager.Auth.BackendMaxTTL, manager.Auth.RetryInitial, manager.Auth.RetryMax)
-		manager.SecretFactory = NewVaultFactory(manager.Client, manager.ReAuther.LoggedIn(), manager.PathPrefix, manager.SharedPath)
+		manager.SecretFactory = NewVaultFactory(manager.Client, manager.ReAuther.LoggedIn(), manager.PathPrefix, manager.SharedPath, manager.SkipTeamPath)
 	}
 	return manager.SecretFactory, nil
 }

--- a/atc/creds/vault/vault.go
+++ b/atc/creds/vault/vault.go
@@ -21,15 +21,18 @@ type Vault struct {
 	SecretReader SecretReader
 	Prefix       string
 	SharedPath   string
+	SkipTeamPath bool
 }
 
 // NewSecretLookupPaths defines how variables will be searched in the underlying secret manager
 func (v Vault) NewSecretLookupPaths(teamName string, pipelineName string, allowRootPath bool) []creds.SecretLookupPath {
 	lookupPaths := []creds.SecretLookupPath{}
-	if len(pipelineName) > 0 {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, teamName, pipelineName)+"/"))
+	if !v.SkipTeamPath {
+		if len(pipelineName) > 0 {
+			lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, teamName, pipelineName)+"/"))
+		}
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, teamName)+"/"))
 	}
-	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, teamName)+"/"))
 	if v.SharedPath != "" {
 		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, v.SharedPath)+"/"))
 	}

--- a/atc/creds/vault/vault_factory.go
+++ b/atc/creds/vault/vault_factory.go
@@ -8,18 +8,20 @@ import (
 
 // The vaultFactory will return a vault implementation of vars.Variables.
 type vaultFactory struct {
-	sr         SecretReader
-	prefix     string
-	sharedPath string
-	loggedIn   <-chan struct{}
+	sr           SecretReader
+	prefix       string
+	sharedPath   string
+	skipTeamPath bool
+	loggedIn     <-chan struct{}
 }
 
-func NewVaultFactory(sr SecretReader, loggedIn <-chan struct{}, prefix string, sharedPath string) *vaultFactory {
+func NewVaultFactory(sr SecretReader, loggedIn <-chan struct{}, prefix string, sharedPath string, skipTeamPath bool) *vaultFactory {
 	factory := &vaultFactory{
-		sr:         sr,
-		prefix:     prefix,
-		sharedPath: sharedPath,
-		loggedIn:   loggedIn,
+		sr:           sr,
+		prefix:       prefix,
+		sharedPath:   sharedPath,
+		skipTeamPath: skipTeamPath,
+		loggedIn:     loggedIn,
 	}
 
 	return factory
@@ -36,5 +38,6 @@ func (factory *vaultFactory) NewSecrets() creds.Secrets {
 		SecretReader: factory.sr,
 		Prefix:       factory.prefix,
 		SharedPath:   factory.sharedPath,
+		SkipTeamPath: factory.skipTeamPath,
 	}
 }

--- a/atc/creds/vault/vault_test.go
+++ b/atc/creds/vault/vault_test.go
@@ -184,5 +184,47 @@ var _ = Describe("Vault", func() {
 				})
 			})
 		})
+
+		Context("skipTeamPath", func() {
+			BeforeEach(func() {
+
+				msr = &MockSecretReader{&[]MockSecret{
+					{
+						path: "/concourse/team/foo",
+						secret: &vaultapi.Secret{
+							Data: map[string]interface{}{"value": "team-bar"},
+						},
+					},
+					{
+						path: "/concourse/team/pipeline/foo",
+						secret: &vaultapi.Secret{
+							Data: map[string]interface{}{"value": "pipeline-bar"},
+						},
+					},
+					{
+						path: "/concourse/shared/foo",
+						secret: &vaultapi.Secret{
+							Data: map[string]interface{}{"value": "shared-bar"},
+						},
+					},
+				}}
+
+				v = &vault.Vault{
+					SecretReader: msr,
+					Prefix:       "/concourse",
+					SharedPath:   "shared",
+					SkipTeamPath: true,
+				}
+
+				variables = creds.NewVariables(v, "team", "pipeline", false)
+			})
+
+			It("should get secret from shared", func() {
+				value, found, err := variables.Get(vars.VariableDefinition{Name: "foo"})
+				Expect(value).To(BeEquivalentTo("shared-bar"))
+				Expect(found).To(BeTrue())
+				Expect(err).To(BeNil())
+			})
+		})
 	})
 })


### PR DESCRIPTION
…ret lookup will skip paths of team/ and team/pipeline/.

This reverts commit ae303d098a13509aafb44fd657c8afeca6a597a6.

This is split out from #4777 per @vito 's request. 

@vito I know you must have some concern/comment on this, so I just create this PR and we can discuss. 

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
