### PR TITLE
fix worker state default metric value

### DIFF
--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -617,7 +617,7 @@ func (event WorkersState) Emit(logger lager.Logger) {
 	for _, workerState := range event.WorkerStateByName {
 		_, exists := perStateCounter[workerState]
 		if !exists {
-			perStateCounter[workerState] = 1
+			perStateCounter[workerState] = 0
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: kyrylo.bilchenko <kirya7@gmail.om>

# Existing Issue 
Fixes # .
Fixes #3856

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
