### PR TITLE
Add release notes for v5.8.0

### DIFF
--- a/release-notes/v5.8.0.md
+++ b/release-notes/v5.8.0.md
@@ -13,20 +13,32 @@
   * With [RFC #33: archiving pipelines](https://github.com/concourse/rfcs/pull/33), any pipelines set by a `set_pipeline` step will be subject to automatic archival once a new build of the same job completes that no longer sets the pipeline. This way pipelines that are removed from the build plan will automatically go away, while preserving their build history.
 
   * With [RFC #34: instanced pipelines](https://github.com/concourse/rfcs/pull/34), pipelines sharing a common template can be configured with a common name, using `((vars))` to identify the instance. For example, you could have many instances of a `branches` pipeline, with `((branch_name))` as the "instance" var. Building on the previous point, instances which are no longer set by the build will be automatically archived.
-  
+
   * With [RFC #29: spatial resources](https://github.com/concourse/rfcs/pull/29), the `set_pipeline` step can be automated to configure a pipeline instance corresponding to each "space" of a resource - i.e. all branches or pull requests in a repo. This RFC needs a bit of TLC (it hasn't been updated to be [prototype-based](https://blog.concourse-ci.org/reinventing-resource-types/)), but the basic idea is there.
-  
+
   With all three of these RFCs delivered, we will have complete automation of pipelines for branches and pull requests! For more detail on the whole approach, check out the original [v10 blog post](https://blog.concourse-ci.org/core-roadmap-towards-v10/).
-  
+
   Looking further ahead on the roadmap, [RFC #32: projects](https://github.com/concourse/rfcs/pull/32) proposes introduce a more explicit GitOps-style approach to configuration automation. In this context the `set_pipeline` step may feel a lot more natural. Until then, the `set_pipeline` step can be used as a simpler alternative to the [`concourse-pipeline` resource](https://github.com/concourse/concourse-pipeline-resource), with the key difference being that the `set_pipeline` step doesn't need any auth config.
+
+#### <sub><sup><a name="4657" href="#4657">:link:</a></sup></sub> feature
+
+* @evanchaoli added the ability to tune the [mapping between API actions and roles](https://concourse-ci.org/user-roles.html) via the `--config-rbac` flag. #4657
+
+#### <sub><sup><a name="4693" href="#4693">:link:</a></sup></sub> feature
+
+* @AndrewCopeland and @cyberark-bizdev added support for Conjur as a credential manager. #4693
+
+#### <sub><sup><a name="4684" href="4684">:link:</a></sup></sub> feature
+
+* @anianz added support for Microsoft login via [dex](https://github.com/dexidp/dex/blob/master/Documentation/connectors/microsoft.md). #4684
 
 #### <sub><sup><a name="4688" href="#4688">:link:</a></sup></sub> feature
 
-* The pin menu on the pipeline page now matches the sidebar, and the dropdown toggles on clicking the pin icon #4688.
+* The pin menu on the pipeline page now matches the sidebar, and the dropdown toggles on clicking the pin icon. #4688
 
 #### <sub><sup><a name="4556" href="#4556">:link:</a></sup></sub> feature
 
-* Prometheus and NewRelic can receive Lidar check-finished event now #4556.
+* Prometheus and NewRelic can receive Lidar check-finished event now. #4556
 
 #### <sub><sup><a name="4707" href="#4707">:link:</a></sup></sub> feature
 
@@ -34,11 +46,27 @@
 
 #### <sub><sup><a name="4698" href="#4698">:link:</a></sup></sub> feature
 
-* @pivotal-bin-ju @taylorsilva @xtreme-sameer-vohra added batching to the NewRelic emitter and logging info for non 2xx responses from NewRelic #4698.
+* @pivotal-bin-ju @taylorsilva @xtreme-sameer-vohra added batching to the NewRelic emitter and logging info for non 2xx responses from NewRelic. #4698
 
 #### <sub><sup><a name="4748" href="#4748">:link:</a></sup></sub> feature
 
 * @andhadley added support for Vault namespaces. #4748
+
+#### <sub><sup><a name="4323" href="#4323">:link:</a></sup></sub> feature
+
+* @hfinucane added a `--url` flag to `fly watch`, so now you can just copy the URL of a build from your browser and paste it in your terminal to keep watching the build. #4323
+
+#### <sub><sup><a name="4706" href="#4706">:link:</a></sup></sub> feature
+
+* Concourse team roles can now be assigned to different CF space roles independently. For example, you can now create role mappings like "auditors in my CF space should be viewers in my Concourse team", whereas before you could only assign Concourse roles to CF developers. #4712, #4729
+
+#### <sub><sup><a name="4692" href="#4692">:link:</a></sup></sub> feature
+
+* Concourse now emits some useful metrics when [lidar](https://github.com/concourse/concourse/releases#v560-note-4202) is enabled: the size of the check queue, the number of checks queued per atc each tick, number of checks GCed at a time, checks started and checks finished. #4692
+
+#### <sub><sup><a name="stub-containerd" href="#stub-containerd">:link:</a></sup></sub> feature, stub
+
+* The Concourse team is in the early stages of implementing a new backend for our container runtime based on [containerd](https://github.com/containerd/containerd), which is more featureful than the [guardian](https://github.com/cloudfoundry/guardian) we have relied on until now. We have not yet implemented all of the methods required by Garden, so the existing work (which can be enabled by passing the `--use-containerd` flag to `concourse worker`) is in a **non-functional state**. This work is tracked in [this project](https://github.com/concourse/concourse/projects/44). #4779, #4778, #4752, #4853, #4784
 
 #### <sub><sup><a name="4865" href="#4865">:link:</a></sup></sub> fix
 
@@ -46,7 +74,7 @@
 
 #### <sub><sup><a name="4749" href="#4749">:link:</a></sup></sub> fix
 
-* @evanchaoli fixed a weird behavior with secret redaction wherein a secret containing e.g. `{` on its own line (i.e. formatted JSON) would result in `{` being replaced with `((redacted))` in build logs. Single-character lines will instead be skipped.
+* @evanchaoli fixed a weird behavior with secret redaction wherein a secret containing e.g. `{` on its own line (i.e. formatted JSON) would result in `{` being replaced with `((redacted))` in build logs. Single-character lines will instead be skipped. #4749
 
   As an aside, anyone with a truly single-character credential *may* want to add another character or two.
 
@@ -68,11 +96,27 @@
 
 #### <sub><sup><a name="4746" href="#4746">:link:</a></sup></sub> fix
 
-* Fixed the problem of when fail_fast for in_parallel is true, a failing step causes the in_parallel to fall into on_error #4746
+* Fixed the problem of when fail_fast for in_parallel is true, a failing step causes the in_parallel to fall into on_error. #4746
 
 #### <sub><sup><a name="4816" href="#4816">:link:</a></sup></sub> fix
 
 * @witjem removed superfluous mentions of `register-worker` from TSA. #4816
+
+#### <sub><sup><a name="4858" href="#4858">:link:</a></sup></sub> fix
+
+* @evanchaoli changed the behaviour of `fly set-team` so that when a role has no groups or users configured, it no longer raises an error. #4858
+
+#### <sub><sup><a name="4758" href="#4758">:link:</a></sup></sub> fix
+
+* @witjem improved the error that fly reports when your `.flyrc` has invalid YAML. #4758
+
+#### <sub><sup><a name="4745" href="#4745">:link:</a></sup></sub> fix
+
+* @xtremerui changed the `concourse` CLI to output help text on `stdout` when the `-h` or `--help` flag is passed. This makes it easier to use other tools like `grep` to find relevant parts of the usage text. #4745
+
+#### <sub><sup><a name="4701" href="#4701">:link:</a></sup></sub> fix
+
+* Concourse used to check the existence of legacy migration table by accessing `information_schema` and parsed out the error message `does not exist` in English; @xtremerui changed it by using `to_regclass` in postgres 9.4+, which resolved the issue for users with non-English (i.e. German) system language setup failed to migrate database. #4701
 
 #### <sub><sup><a name="4869" href="#4869">:link:</a></sup></sub> fix
 
@@ -83,3 +127,7 @@
 #### <sub><sup><a name="4587" href="#4587">:link:</a></sup></sub> fix
 
 * @pivotal-bin-ju fixed x509 issue when the super admin login without CACert after the first sucessful login. #4587
+
+#### <sub><sup><a name="4895" href="#4895">:link:</a></sup></sub> fix
+
+* @kirillbilchenko fixed a [bug](https://github.com/concourse/concourse/issues/3856) where the `concourse_workers_registered` metric would never go below 1, even when workers were pruned. #4895


### PR DESCRIPTION
# Existing Issue

Part of #4859.

# Changes proposed in this pull request

* no code changes, just release notes

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).