### PR TITLE
Update main team config test

### DIFF
--- a/topgun/k8s/mainteam_role_test.go
+++ b/topgun/k8s/mainteam_role_test.go
@@ -43,29 +43,14 @@ var _ = Describe("Main team role config", func() {
 		BeforeEach(func() {
 			helmDeployTestFlags = []string{
 				`--set=worker.enabled=false`,
-				`--set=web.additionalVolumes[0].name=team-role-config`,
-				`--set=web.additionalVolumes[0].configMap.name=team-role-config`,
-				`--set=web.additionalVolumeMounts[0].name=team-role-config`,
-				`--set=web.additionalVolumeMounts[0].mountPath=/foo`,
-				`--set=concourse.web.auth.mainTeam.config=/foo/team-role-config.yml`,
-				`--set=secrets.localUsers=test-viewer:test-viewer`,
-			}
-
-			configMapCreationArgs := []string{
-				"create",
-				"configmap",
-				"team-role-config",
-				"--namespace=" + namespace,
-				`--from-literal=team-role-config.yml=
+				`--set=concourse.web.auth.mainTeam.config=
 roles:
  - name: viewer
    local:
      users: [ "test-viewer" ]
- `,
+`,
+				`--set=secrets.localUsers=test-viewer:test-viewer`,
 			}
-
-			Run(nil, "kubectl", configMapCreationArgs...)
-
 		})
 
 		It("returns the correct user role", func() {


### PR DESCRIPTION
The next version of the chart makes the ConfigMap for you. The test can
now pass in the YAML for the main team instead of manually making the
ConfigMap first.

# Why do we need this PR?
k8s-topgun will break when the next major version of the chart is released because the expected value of `mainTeam.config` has changed: https://github.com/concourse/concourse-chart/pull/33#pullrequestreview-332844796

I locally ran this test on the `topgun` GKE cluster and it passed.
