### PR TITLE
backport let's encrypt bump + default fix to 5.5.x

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -92,7 +92,7 @@ type RunCommand struct {
 
 	LetsEncrypt struct {
 		Enable  bool     `long:"enable-lets-encrypt"   description:"Automatically configure TLS certificates via Let's Encrypt/ACME."`
-		ACMEURL flag.URL `long:"lets-encrypt-acme-url" description:"URL of the ACME CA directory endpoint." default:"https://acme-v01.api.letsencrypt.org/directory"`
+		ACMEURL flag.URL `long:"lets-encrypt-acme-url" description:"URL of the ACME CA directory endpoint." default:"https://acme-v02.api.letsencrypt.org/directory"`
 	} `group:"Let's Encrypt Configuration"`
 
 	ExternalURL flag.URL `long:"external-url" description:"URL used to reach any ATC from the outside world."`

--- a/atc/atccmd/command_test.go
+++ b/atc/atccmd/command_test.go
@@ -1,0 +1,34 @@
+package atccmd_test
+
+import (
+	"testing"
+
+	"github.com/concourse/concourse/atc/atccmd"
+	"github.com/jessevdk/go-flags"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+type CommandSuite struct {
+	suite.Suite
+	*require.Assertions
+}
+
+func (s *CommandSuite) TestLetsEncryptDefaultIsUpToDate() {
+	cmd := &atccmd.ATCCommand{}
+
+	parser := flags.NewParser(cmd, flags.Default)
+	parser.NamespaceDelimiter = "-"
+
+	opt := parser.Find("run").FindOptionByLongName("lets-encrypt-acme-url")
+	s.NotNil(opt)
+
+	s.Equal(opt.Default, []string{autocert.DefaultACMEDirectory})
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, &CommandSuite{
+		Assertions: require.New(t),
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ require (
 	github.com/square/certstrap v1.1.1
 	github.com/streadway/amqp v0.0.0-20190225234609-30f8ed68076e // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc
 	github.com/tedsuo/rata v1.0.1-0.20170830210128-07d200713958
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,7 @@ require (
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect
-	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
+	golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58

--- a/go.sum
+++ b/go.sum
@@ -596,6 +596,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 h1:Gv7RPwsi3eZ2Fgewe3CBsuOebPwO27PoXzRpJPsvSSM=
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba h1:9bFeDpN3gTqNanMVqNcoR/pJQuP5uroC3t1D7eXozTE=
+golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/release-notes/v5.5.7.md
+++ b/release-notes/v5.5.7.md
@@ -1,0 +1,6 @@
+#### <sub><sup><a name="4912" href="#4912">:link:</a></sup></sub> fix
+
+* @vito bumped the `autocert` dependency so that Let's Encrypt will default to the ACME v2 API. #4912
+
+  > Note: This backported fix includes the bump to the default value, which was
+  > originally a follow-up patch in v5.7.3.


### PR DESCRIPTION
original PRs: https://github.com/concourse/concourse/pull/4804, https://github.com/concourse/concourse/pull/4869