### PR TITLE
Revert "Update main team config test"

### DIFF
--- a/topgun/k8s/mainteam_role_test.go
+++ b/topgun/k8s/mainteam_role_test.go
@@ -43,14 +43,29 @@ var _ = Describe("Main team role config", func() {
 		BeforeEach(func() {
 			helmDeployTestFlags = []string{
 				`--set=worker.enabled=false`,
-				`--set=concourse.web.auth.mainTeam.config=
+				`--set=web.additionalVolumes[0].name=team-role-config`,
+				`--set=web.additionalVolumes[0].configMap.name=team-role-config`,
+				`--set=web.additionalVolumeMounts[0].name=team-role-config`,
+				`--set=web.additionalVolumeMounts[0].mountPath=/foo`,
+				`--set=concourse.web.auth.mainTeam.config=/foo/team-role-config.yml`,
+				`--set=secrets.localUsers=test-viewer:test-viewer`,
+			}
+
+			configMapCreationArgs := []string{
+				"create",
+				"configmap",
+				"team-role-config",
+				"--namespace=" + namespace,
+				`--from-literal=team-role-config.yml=
 roles:
  - name: viewer
    local:
      users: [ "test-viewer" ]
-`,
-				`--set=secrets.localUsers=test-viewer:test-viewer`,
+ `,
 			}
+
+			Run(nil, "kubectl", configMapCreationArgs...)
+
 		})
 
 		It("returns the correct user role", func() {


### PR DESCRIPTION
Reverts #4915

I'll change how helm-prs work to this:

- `helm-prs` will use `master` of concourse/concourse
- `helm-prs-5.7.x` will use `release/5.7.x` of concourse/concourse
and so on...