### PR TITLE
Release notes 5.2.6

### DIFF
--- a/release-notes/v5.2.6.md
+++ b/release-notes/v5.2.6.md
@@ -1,0 +1,5 @@
+#### <sub><sup><a name="v526-note-1">:link:</a></sup></sub> security
+
+* Updates the git resource to [v1.6.3](https://github.com/concourse/git-resource/releases/tag/v1.6.3) to address a recently reported security vulnerability:
+    * [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604):
+        * Arbitrary command execution is possible in Git before 2.20.2, 2.21.x before 2.21.1, 2.22.x before 2.22.2, 2.23.x before 2.23.1, and 2.24.x before 2.24.1 because a "git submodule update" operation can run commands found in the .gitmodules file of a malicious repository.


### PR DESCRIPTION
# Why do we need this PR?
- Adds release notes for 5.2.6

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)