### PR TITLE
update relase-notes for 5.7.3

### DIFF
--- a/release-notes/v5.7.3.md
+++ b/release-notes/v5.7.3.md
@@ -1,3 +1,10 @@
+#### <sub><sup><a name="cve" href="#cve">:link:</a></sup></sub> security
+
+* Updates the git resource to [v1.6.3](https://github.com/concourse/git-resource/releases/tag/v1.6.3) to address a recently reported security vulnerability:
+    * [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604):
+        * Arbitrary command execution is possible in Git before 2.20.2, 2.21.x before 2.21.1, 2.22.x before 2.22.2, 2.23.x before 2.23.1, and 2.24.x before 2.24.1 because a "git submodule update" operation can run commands found in the .gitmodules file of a malicious repository.
+
+
 #### <sub><sup><a name="4869" href="#4869">:link:</a></sup></sub> fix
 
 * @vito bumped the default value for the Let's Encrypt ACME URL to point to their v2 API instead of v1. This should have been in v5.7.2, but we had no automated testing for Let's Encrypt integration so there wasn't really a mental cue to check for this sort of thing.


### PR DESCRIPTION
# Why do we need this PR?
- Adds release notes for 5.7.3

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)