### PR TITLE
Fix the backport of IN_CLUSTER param for k8s-topgun

### DIFF
--- a/topgun/k8s/container_limits_test.go
+++ b/topgun/k8s/container_limits_test.go
@@ -3,7 +3,6 @@ package k8s_test
 import (
 	"github.com/onsi/gomega/gbytes"
 
-	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -52,7 +51,7 @@ func containerLimitsWork(selectorFlags ...string) {
 			atc := waitAndLogin(namespace, releaseName+"-web")
 			defer atc.Close()
 
-			buildSession := fly.Start("execute", "-c", "tasks/tiny.yml")
+			buildSession := fly.Start("execute", "-c", "../tasks/tiny.yml")
 			<-buildSession.Exited
 
 			Expect(buildSession.ExitCode()).To(Equal(0))
@@ -79,7 +78,7 @@ func containerLimitsFail(selectorFlags ...string) {
 			atc := waitAndLogin(namespace, releaseName+"-web")
 			defer atc.Close()
 
-			buildSession := fly.Start("execute", "-c", "tasks/tiny.yml")
+			buildSession := fly.Start("execute", "-c", "../tasks/tiny.yml")
 			<-buildSession.Exited
 			Expect(buildSession.ExitCode()).To(Equal(2))
 			Expect(buildSession).To(gbytes.Say(

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -42,7 +42,7 @@ type environment struct {
 var (
 	Environment            environment
 	endpointFactory        EndpointFactory
-	fly                    FlyCli
+	fly                    Fly
 	releaseName, namespace string
 )
 


### PR DESCRIPTION
5.5.x is the older version of k8s-topgun where all of topgun hasn't been
broken into smaller packages. Therefore there were some incompatibilities
when backporting the IN_CLUSTER param

Tested that it works by running `ginkgo -dryRun ./topgun/k8s/`