### PR TITLE
atc: rename auth_param config to auth_params

### DIFF
--- a/atc/creds/vault/manager.go
+++ b/atc/creds/vault/manager.go
@@ -78,8 +78,8 @@ func (manager *VaultManager) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&map[string]interface{}{
 		"url":                manager.URL,
 		"path_prefix":        manager.PathPrefix,
-		"shared_path":		  manager.SharedPath,
-		"namespace":		  manager.Namespace,
+		"shared_path":        manager.SharedPath,
+		"namespace":          manager.Namespace,
 		"ca_cert":            manager.TLS.CACert,
 		"server_name":        manager.TLS.ServerName,
 		"auth_backend":       manager.Auth.Backend,
@@ -129,10 +129,10 @@ func (manager *VaultManager) Config(config map[string]interface{}) {
 	manager.Auth.BackendMaxTTL = toDuration(config["auth_max_ttl"], 0)
 	manager.Auth.RetryMax = toDuration(config["auth_retry_max"], 5*time.Minute)
 	manager.Auth.RetryInitial = toDuration(config["auth_retry_initial"], 1*time.Second)
-	if config["auth_param"] == nil {
+	if config["auth_params"] == nil {
 		manager.Auth.Params = map[string]string{}
 	} else {
-		manager.Auth.Params = config["auth_param"].(map[string]string)
+		manager.Auth.Params = config["auth_params"].(map[string]string)
 	}
 }
 


### PR DESCRIPTION
# Why do we need this PR?

The value is a map, so it should be plural. the flag is singular because you pass it once per param.

This code hasn't shipped yet so this is 'no impact'. Just a quick fix. Noticed this while writing docs.

# Changes proposed in this pull request

* `auth_param` -> `auth_params`

# Contributor Checklist

- [ ] ~~Unit tests~~
- [ ] ~~Integration tests (if applicable)~~
- [x] Updated documentation (located at https://github.com/concourse/docs)
- [ ] ~~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~~

There is currently no test coverage for this stuff. Maybe we can tackle that once we add coverage for these in a testflight-style suite? :thinking: I've added a note here: https://project.concourse-ci.org/projects/MDc6UHJvamVjdDI5OTk2OTQ=

# Reviewer Checklist

- [x] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~ superceded by [this branch](https://github.com/concourse/docs/tree/var-sources)
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
