### PR TITLE
redo vault var source config flow

### DIFF
--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Pipelines API", func() {
 					RetryInitial:  2,
 				}
 
-				tls := vault.TLS{
+				tls := vault.TLSConfig{
 					CACert:     "",
 					ServerName: "server-name",
 				}

--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -1,13 +1,17 @@
 package vault
 
 import (
+	"crypto/tls"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"path"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/hashicorp/go-rootcerts"
 	vaultapi "github.com/hashicorp/vault/api"
 )
 
@@ -18,7 +22,7 @@ type APIClient struct {
 
 	apiURL     string
 	namespace  string
-	tlsConfig  *vaultapi.TLSConfig
+	tlsConfig  TLSConfig
 	authConfig AuthConfig
 
 	clientValue *atomic.Value
@@ -27,7 +31,7 @@ type APIClient struct {
 }
 
 // NewAPIClient with the associated authorization config and underlying vault client.
-func NewAPIClient(logger lager.Logger, apiURL string, tlsConfig *vaultapi.TLSConfig, authConfig AuthConfig, namespace string) (*APIClient, error) {
+func NewAPIClient(logger lager.Logger, apiURL string, tlsConfig TLSConfig, authConfig AuthConfig, namespace string) (*APIClient, error) {
 	ac := &APIClient{
 		logger: logger,
 
@@ -174,7 +178,7 @@ func (ac *APIClient) setClient(client *vaultapi.Client) {
 func (ac *APIClient) baseClient() (*vaultapi.Client, error) {
 	config := vaultapi.DefaultConfig()
 
-	err := config.ConfigureTLS(ac.tlsConfig)
+	err := ac.configureTLS(config.HttpClient.Transport.(*http.Transport).TLSClientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -194,6 +198,73 @@ func (ac *APIClient) baseClient() (*vaultapi.Client, error) {
 	}
 
 	return client, nil
+}
+
+func (ac *APIClient) configureTLS(config *tls.Config) error {
+	if ac.tlsConfig.CACert != "" || ac.tlsConfig.CACertFile != "" || ac.tlsConfig.CAPath != "" {
+		rootConfig := &rootcerts.Config{
+			CAFile:        ac.tlsConfig.CACertFile,
+			CAPath:        ac.tlsConfig.CAPath,
+			CACertificate: []byte(ac.tlsConfig.CACert),
+		}
+
+		if err := rootcerts.ConfigureTLS(config, rootConfig); err != nil {
+			return err
+		}
+	}
+
+	if ac.tlsConfig.ClientCertFile != "" {
+		content, err := ioutil.ReadFile(ac.tlsConfig.ClientCertFile)
+		if err != nil {
+			return err
+		}
+
+		ac.tlsConfig.ClientCert = string(content)
+	}
+
+	if ac.tlsConfig.ClientKeyFile != "" {
+		content, err := ioutil.ReadFile(ac.tlsConfig.ClientKeyFile)
+		if err != nil {
+			return err
+		}
+
+		ac.tlsConfig.ClientKey = string(content)
+	}
+
+	if ac.tlsConfig.Insecure {
+		config.InsecureSkipVerify = true
+	}
+
+	var clientCert tls.Certificate
+	foundClientCert := false
+
+	switch {
+	case ac.tlsConfig.ClientCert != "" && ac.tlsConfig.ClientKey != "":
+		var err error
+		clientCert, err = tls.X509KeyPair([]byte(ac.tlsConfig.ClientCert), []byte(ac.tlsConfig.ClientKey))
+		if err != nil {
+			return err
+		}
+
+		foundClientCert = true
+	case ac.tlsConfig.ClientCert != "" || ac.tlsConfig.ClientKey != "":
+		return fmt.Errorf("both client cert and client key must be provided")
+	}
+
+	if foundClientCert {
+		// We use this function to ignore the server's preferential list of
+		// CAs, otherwise any CA used for the cert auth backend must be in the
+		// server's CA pool
+		config.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &clientCert, nil
+		}
+	}
+
+	if ac.tlsConfig.ServerName != "" {
+		config.ServerName = ac.tlsConfig.ServerName
+	}
+
+	return nil
 }
 
 func (ac *APIClient) clientWithToken(token string) (*vaultapi.Client, error) {

--- a/atc/creds/vault/manager_factory.go
+++ b/atc/creds/vault/manager_factory.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/jessevdk/go-flags"
 )
@@ -34,7 +35,12 @@ func (factory *vaultManagerFactory) NewInstance(config interface{}) (creds.Manag
 		return nil, fmt.Errorf("invalid vault config format")
 	} else {
 		manager := &VaultManager{}
-		manager.Config(c)
+
+		err := manager.Config(c)
+		if err != nil {
+			return nil, err
+		}
+
 		return manager, nil
 	}
 }

--- a/atc/creds/vault/manager_test.go
+++ b/atc/creds/vault/manager_test.go
@@ -1,8 +1,18 @@
 package vault_test
 
 import (
+	"crypto/tls"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/concourse/atc/creds/vault"
+	"github.com/hashicorp/vault/api"
 	"github.com/jessevdk/go-flags"
+	"github.com/square/certstrap/pkix"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -55,6 +65,159 @@ var _ = Describe("VaultManager", func() {
 		It("fails on missing vault auth credentials", func() {
 			manager.Auth = vault.AuthConfig{}
 			Expect(manager.Validate()).ToNot(BeNil())
+		})
+	})
+
+	Describe("Config", func() {
+		var config map[string]interface{}
+		var fakeVault *httptest.Server
+
+		var configErr error
+
+		BeforeEach(func() {
+			key, err := pkix.CreateRSAKey(1024)
+			Expect(err).ToNot(HaveOccurred())
+
+			ca, err := pkix.CreateCertificateAuthority(key, "", time.Now().Add(time.Hour), "", "", "", "", "vault-ca")
+			Expect(err).ToNot(HaveOccurred())
+
+			serverKey, err := pkix.CreateRSAKey(1024)
+			Expect(err).ToNot(HaveOccurred())
+
+			serverKeyBytes, err := serverKey.ExportPrivate()
+			Expect(err).ToNot(HaveOccurred())
+
+			serverName := "vault"
+
+			serverCSR, err := pkix.CreateCertificateSigningRequest(serverKey, "", []net.IP{net.ParseIP("127.0.0.1")}, []string{serverName}, "", "", "", "", "")
+			Expect(err).ToNot(HaveOccurred())
+
+			serverCert, err := pkix.CreateCertificateHost(ca, key, serverCSR, time.Now().Add(time.Hour))
+			Expect(err).ToNot(HaveOccurred())
+
+			clientKey, err := pkix.CreateRSAKey(1024)
+			Expect(err).ToNot(HaveOccurred())
+
+			clientKeyBytes, err := clientKey.ExportPrivate()
+			Expect(err).ToNot(HaveOccurred())
+
+			clientCSR, err := pkix.CreateCertificateSigningRequest(clientKey, "", nil, nil, "", "", "", "", "concourse")
+			Expect(err).ToNot(HaveOccurred())
+
+			clientCert, err := pkix.CreateCertificateHost(ca, key, clientCSR, time.Now().Add(time.Hour))
+			Expect(err).ToNot(HaveOccurred())
+
+			serverCertBytes, err := serverCert.Export()
+			Expect(err).ToNot(HaveOccurred())
+
+			clientCertBytes, err := clientCert.Export()
+			Expect(err).ToNot(HaveOccurred())
+
+			caBytes, err := ca.Export()
+			Expect(err).ToNot(HaveOccurred())
+
+			fakeVault = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				err := json.NewEncoder(w).Encode(api.Secret{
+					Data: map[string]interface{}{"value": "foo"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+			}))
+
+			tlsCert, err := tls.X509KeyPair(serverCertBytes, serverKeyBytes)
+			Expect(err).ToNot(HaveOccurred())
+
+			fakeVault.TLS = &tls.Config{
+				Certificates: []tls.Certificate{tlsCert},
+			}
+
+			fakeVault.StartTLS()
+
+			config = map[string]interface{}{
+				"url":                  fakeVault.URL,
+				"path_prefix":          "/path-prefix",
+				"shared_path":          "/shared-path",
+				"namespace":            "some-namespace",
+				"ca_cert":              string(caBytes),
+				"client_cert":          string(clientCertBytes),
+				"client_key":           string(clientKeyBytes),
+				"server_name":          serverName,
+				"insecure_skip_verify": true,
+				"client_token":         "some-client-token",
+				"auth_backend_max_ttl": "5m",
+				"auth_retry_max":       "15m",
+				"auth_retry_initial":   "10s",
+				"auth_backend":         "approle",
+				"auth_params": map[string]string{
+					"role_id":   "some-role-id",
+					"secret_id": "some-secret-id",
+				},
+			}
+
+			manager = vault.VaultManager{}
+		})
+
+		JustBeforeEach(func() {
+			configErr = manager.Config(config)
+		})
+
+		It("configures TLS appropriately", func() {
+			Expect(configErr).ToNot(HaveOccurred())
+
+			err := manager.Init(lagertest.NewTestLogger("test"))
+			Expect(err).ToNot(HaveOccurred())
+
+			secret, err := manager.Client.Read("some/path")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(secret).ToNot(BeNil())
+			Expect(secret.Data).To(Equal(map[string]interface{}{"value": "foo"}))
+		})
+
+		It("configures all attributes appropriately", func() {
+			Expect(configErr).ToNot(HaveOccurred())
+
+			Expect(manager.URL).To(Equal(fakeVault.URL))
+			Expect(manager.PathPrefix).To(Equal("/path-prefix"))
+			Expect(manager.SharedPath).To(Equal("/shared-path"))
+			Expect(manager.Namespace).To(Equal("some-namespace"))
+
+			Expect(manager.TLS.Insecure).To(BeTrue())
+
+			Expect(manager.Auth.ClientToken).To(Equal("some-client-token"))
+			Expect(manager.Auth.BackendMaxTTL).To(Equal(5 * time.Minute))
+			Expect(manager.Auth.RetryMax).To(Equal(15 * time.Minute))
+			Expect(manager.Auth.RetryInitial).To(Equal(10 * time.Second))
+			Expect(manager.Auth.Backend).To(Equal("approle"))
+			Expect(manager.Auth.Params).To(Equal(map[string]string{
+				"role_id":   "some-role-id",
+				"secret_id": "some-secret-id",
+			}))
+		})
+
+		Context("with optional configs omitted", func() {
+			BeforeEach(func() {
+				delete(config, "path_prefix")
+				delete(config, "auth_retry_max")
+				delete(config, "auth_retry_initial")
+			})
+
+			It("has sane defaults", func() {
+				Expect(configErr).ToNot(HaveOccurred())
+
+				Expect(manager.PathPrefix).To(Equal("/concourse"))
+				Expect(manager.Auth.RetryMax).To(Equal(5 * time.Minute))
+				Expect(manager.Auth.RetryInitial).To(Equal(time.Second))
+			})
+		})
+
+		Context("with extra keys in the config", func() {
+			BeforeEach(func() {
+				config["unknown_key"] = "whambam"
+			})
+
+			It("returns an error", func() {
+				Expect(configErr).To(HaveOccurred())
+				Expect(configErr.Error()).To(ContainSubstring("unknown_key"))
+			})
 		})
 	})
 })

--- a/atc/creds/vault/reauther_test.go
+++ b/atc/creds/vault/reauther_test.go
@@ -1,10 +1,11 @@
 package vault
 
 import (
-	"code.cloudfoundry.org/lager/lagertest"
 	"fmt"
 	"testing"
 	"time"
+
+	"code.cloudfoundry.org/lager/lagertest"
 
 	"github.com/cenkalti/backoff"
 )

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/gorilla/mux v1.6.2 // indirect
 	github.com/gorilla/websocket v1.4.0
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/vault/api v1.0.5-0.20191108163347-bdd38fca2cff
 	github.com/hashicorp/vault/sdk v0.1.14-0.20191112033314-390e96e22eb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/hashicorp/go-retryablehttp v0.6.2 h1:bHM2aVXwBtBJWxHtkSrWuI4umABCUczs
 github.com/hashicorp/go-retryablehttp v0.6.2/go.mod h1:gEx6HMUGxYYhJScX7W1Il64m6cc2C1mDaW3NQ9sY1FY=
 github.com/hashicorp/go-rootcerts v1.0.1 h1:DMo4fmknnz0E0evoNYnV48RjWndOsmd6OW+09R3cEP8=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
+github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
+github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=


### PR DESCRIPTION
# Existing Issue

Fixes #4934.

Fixes #4935.

# Changes proposed in this pull request

* leverage mapstructure for type validation and coercion
* take literal values for ca/client cert/key instead of file paths
* backfill unit tests

# Contributor Checklist
- [x] Unit tests
- [x] ~~Integration tests (if applicable)~~ Vault topgun already exists and should verify that the flag config forms haven't changed backwards-incompatibly.
- [x] Updated documentation (located at https://github.com/concourse/docs)
- [x] ~~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~~

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [x] ~Release notes reviewed~
- [x] PR acceptance performed - verified that #4934 and #4935 are fixed. however, I'd honestly be willing to consider not fixing #4935 if it saved enough maintenance burden.
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
