### PR TITLE
Adding enable/disable resource version command to fly cli

### DIFF
--- a/fly/commands/disable_resource.go
+++ b/fly/commands/disable_resource.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
+	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/go-concourse/concourse"
+)
+
+type DisableResourceCommand struct {
+	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of the resource"`
+	Version  *atc.Version             `short:"v" long:"version" description:"Version of the resource to disable. The given key value pair(s) has to be an exact match but not all fields are needed. In the case of multiple resource versions matched, it will disable the latest one."`
+}
+
+func (command *DisableResourceCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	team := target.Team()
+
+	if command.Version != nil {
+		versions, _, found, err := team.ResourceVersions(command.Resource.PipelineName, command.Resource.ResourceName, concourse.Page{}, *command.Version)
+
+		if err != nil {
+			return err
+		}
+
+		if !found || len(versions) <= 0 {
+			enableVersionBytes, err := json.Marshal(command.Version)
+			if err != nil {
+				return err
+			}
+
+			displayhelpers.Failf("could not find version matching %s", string(enableVersionBytes))
+		}
+
+		latestResourceVer := versions[0]
+		disabled, err := team.DisableResourceVersion(command.Resource.PipelineName, command.Resource.ResourceName, latestResourceVer.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if disabled {
+			versionBytes, err := json.Marshal(latestResourceVer.Version)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("disabled '%s/%s' with version %s\n", command.Resource.PipelineName, command.Resource.ResourceName, string(versionBytes))
+		} else {
+			displayhelpers.Failf("could not disable '%s/%s', make sure the resource exists\n", command.Resource.PipelineName, command.Resource.ResourceName)
+		}
+	}
+
+	return nil
+}

--- a/fly/commands/enable_resource.go
+++ b/fly/commands/enable_resource.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
+	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/go-concourse/concourse"
+)
+
+type EnableResourceCommand struct {
+	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of the resource"`
+	Version  *atc.Version             `short:"v" long:"version" description:"Version of the resource to enable. The given key value pair(s) has to be an exact match but not all fields are needed. In the case of multiple resource versions matched, it will enable the latest one."`
+}
+
+func (command *EnableResourceCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	team := target.Team()
+
+	if command.Version != nil {
+		versions, _, found, err := team.ResourceVersions(command.Resource.PipelineName, command.Resource.ResourceName, concourse.Page{}, *command.Version)
+
+		if err != nil {
+			return err
+		}
+
+		if !found || len(versions) <= 0 {
+			enableVersionBytes, err := json.Marshal(command.Version)
+			if err != nil {
+				return err
+			}
+
+			displayhelpers.Failf("could not find version matching %s", string(enableVersionBytes))
+		}
+
+		latestResourceVer := versions[0]
+		enabled, err := team.EnableResourceVersion(command.Resource.PipelineName, command.Resource.ResourceName, latestResourceVer.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if enabled {
+			versionBytes, err := json.Marshal(latestResourceVer.Version)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("enabled '%s/%s' with version %s\n", command.Resource.PipelineName, command.Resource.ResourceName, string(versionBytes))
+		} else {
+			displayhelpers.Failf("could not enable '%s/%s', make sure the resource exists\n", command.Resource.PipelineName, command.Resource.ResourceName)
+		}
+	}
+
+	return nil
+}

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -58,8 +58,10 @@ type FlyCommand struct {
 	Resources        ResourcesCommand        `command:"resources"               alias:"rs"   description:"List the resources in the pipeline"`
 	ResourceVersions ResourceVersionsCommand `command:"resource-versions"       alias:"rvs"  description:"List the versions of a resource"`
 	CheckResource    CheckResourceCommand    `command:"check-resource"          alias:"cr"   description:"Check a resource"`
-	PinResource      PinResourceCommand      `command:"pin-resource"    alias:"pr"  description:"Pin a version to a resource"`
+	PinResource      PinResourceCommand      `command:"pin-resource"            alias:"pr"  description:"Pin a version to a resource"`
 	UnpinResource    UnpinResourceCommand    `command:"unpin-resource"          alias:"ur"  description:"Unpin a resource"`
+    EnableResource   EnableResourceCommand   `command:"enable-resource"            alias:"er"  description:"Enable a version of a resource"`
+    DisableResource  DisableResourceCommand  `command:"disable-resource"            alias:"dr"  description:"Disable a version of a resource"`
 
 	CheckResourceType CheckResourceTypeCommand `command:"check-resource-type" alias:"crt"  description:"Check a resource-type"`
 

--- a/fly/integration/disable_resource_test.go
+++ b/fly/integration/disable_resource_test.go
@@ -1,0 +1,152 @@
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/tedsuo/rata"
+
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Fly CLI", func() {
+	Describe("disable-resource", func() {
+		var (
+			expectedGetStatus             int
+			expectedPutStatus             int
+			disablePath, getPath           string
+			err                           error
+			teamName                      = "main"
+			pipelineName                  = "pipeline"
+			resourceName                  = "resource"
+			resourceVersionID             = "42"
+			disableVersion                    = "some:value"
+			pipelineResource              = fmt.Sprintf("%s/%s", pipelineName, resourceName)
+			expecteddisableVersion            = atc.ResourceVersion{
+				ID:      42,
+				Version: atc.Version{"some": "value"},
+			}
+		)
+
+		Context("make sure the command exists", func() {
+			It("calls the disable-resource command", func() {
+				flyCmd := exec.Command(flyPath, "disable-resource")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).ToNot(HaveOccurred())
+				Consistently(sess.Err).ShouldNot(gbytes.Say("error: Unknown command"))
+
+				<-sess.Exited
+			})
+		})
+
+		Context("when the resource is specified", func() {
+			Context("when the resource version json string is specified", func() {
+				BeforeEach(func() {
+					getPath, err = atc.Routes.CreatePathForRoute(atc.ListResourceVersions, rata.Params{
+						"pipeline_name": pipelineName,
+						"team_name":     teamName,
+						"resource_name": resourceName,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					disablePath, err = atc.Routes.CreatePathForRoute(atc.DisableResourceVersion, rata.Params{
+						"pipeline_name":              pipelineName,
+						"team_name":                  teamName,
+						"resource_name":              resourceName,
+						"resource_config_version_id": resourceVersionID,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+				})
+
+				JustBeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", getPath, "filter=some:value"),
+							ghttp.RespondWithJSONEncoded(expectedGetStatus, []atc.ResourceVersion{expecteddisableVersion}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("PUT", disablePath),
+							ghttp.RespondWith(expectedPutStatus, nil),
+						),
+					)
+				})
+				Context("when the resource and version exists", func() {
+					BeforeEach(func() {
+						expectedGetStatus = http.StatusOK
+						expectedPutStatus = http.StatusOK
+					})
+
+					It("disables the resource version", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "disable-resource", "-r", pipelineResource, "-v", disableVersion)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Out).Should(gbytes.Say(fmt.Sprintf("disabled '%s' with version {\"some\":\"value\"}\n", pipelineResource)))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(0))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(3))
+					})
+
+				})
+
+				Context("when the versions does not exist", func() {
+					BeforeEach(func() {
+						expectedGetStatus = http.StatusNotFound
+					})
+
+					It("errors", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "disable-resource", "-r", pipelineResource, "-v", disableVersion)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not find version matching {\"some\":\"value\"}\n")))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(1))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(2))
+					})
+				})
+
+				Context("when the resource does not exist", func() {
+					BeforeEach(func() {
+						expectedPutStatus = http.StatusNotFound
+						expectedGetStatus = http.StatusOK
+					})
+
+					It("fails to disable", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "disable-resource", "-r", pipelineResource, "-v", disableVersion)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not disable '%s', make sure the resource exists", pipelineResource)))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(1))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(3))
+					})
+				})
+			})
+		})
+	})
+})

--- a/fly/integration/enable_resource_test.go
+++ b/fly/integration/enable_resource_test.go
@@ -1,0 +1,152 @@
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/tedsuo/rata"
+
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Fly CLI", func() {
+	Describe("enable-resource", func() {
+		var (
+			expectedGetStatus             int
+			expectedPutStatus             int
+			enablePath, getPath           string
+			err                           error
+			teamName                      = "main"
+			pipelineName                  = "pipeline"
+			resourceName                  = "resource"
+			resourceVersionID             = "42"
+			enableVersion                    = "some:value"
+			pipelineResource              = fmt.Sprintf("%s/%s", pipelineName, resourceName)
+			expectedEnableVersion            = atc.ResourceVersion{
+				ID:      42,
+				Version: atc.Version{"some": "value"},
+			}
+		)
+
+		Context("make sure the command exists", func() {
+			It("calls the enable-resource command", func() {
+				flyCmd := exec.Command(flyPath, "enable-resource")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+
+				Expect(err).ToNot(HaveOccurred())
+				Consistently(sess.Err).ShouldNot(gbytes.Say("error: Unknown command"))
+
+				<-sess.Exited
+			})
+		})
+
+		Context("when the resource is specified", func() {
+			Context("when the resource version json string is specified", func() {
+				BeforeEach(func() {
+					getPath, err = atc.Routes.CreatePathForRoute(atc.ListResourceVersions, rata.Params{
+						"pipeline_name": pipelineName,
+						"team_name":     teamName,
+						"resource_name": resourceName,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					enablePath, err = atc.Routes.CreatePathForRoute(atc.EnableResourceVersion, rata.Params{
+						"pipeline_name":              pipelineName,
+						"team_name":                  teamName,
+						"resource_name":              resourceName,
+						"resource_config_version_id": resourceVersionID,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+				})
+
+				JustBeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", getPath, "filter=some:value"),
+							ghttp.RespondWithJSONEncoded(expectedGetStatus, []atc.ResourceVersion{expectedEnableVersion}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("PUT", enablePath),
+							ghttp.RespondWith(expectedPutStatus, nil),
+						),
+					)
+				})
+				Context("when the resource and version exists", func() {
+					BeforeEach(func() {
+						expectedGetStatus = http.StatusOK
+						expectedPutStatus = http.StatusOK
+					})
+
+					It("enables the resource version", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "enable-resource", "-r", pipelineResource, "-v", enableVersion)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Out).Should(gbytes.Say(fmt.Sprintf("enabled '%s' with version {\"some\":\"value\"}\n", pipelineResource)))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(0))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(3))
+					})
+
+				})
+
+				Context("when the versions does not exist", func() {
+					BeforeEach(func() {
+						expectedGetStatus = http.StatusNotFound
+					})
+
+					It("errors", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "enable-resource", "-r", pipelineResource, "-v", enableVersion)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not find version matching {\"some\":\"value\"}\n")))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(1))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(2))
+					})
+				})
+
+				Context("when the resource does not exist", func() {
+					BeforeEach(func() {
+						expectedPutStatus = http.StatusNotFound
+						expectedGetStatus = http.StatusOK
+					})
+
+					It("fails to enable", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "enable-resource", "-r", pipelineResource, "-v", enableVersion)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not enable '%s', make sure the resource exists", pipelineResource)))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(1))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(3))
+					})
+				})
+			})
+		})
+	})
+})

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,0 +1,4 @@
+#### <sub><sup><a name="4938" href="#4938">:link:</a></sup></sub> feature
+
+* @dhawalseth Adding enable/disable resource version command to fly cli.
+


### PR DESCRIPTION
Adding enable/disable resource version command to fly cli.

# Why do we need this PR?
Users should be able to enable or disable a resource version from the fly cli.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [X] Integration tests (if applicable)
- [X] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
