### PR TITLE
fix(atc): change lidar checks to use resource_config_scope_id as lock id

### DIFF
--- a/atc/db/check.go
+++ b/atc/db/check.go
@@ -250,7 +250,7 @@ func (c *check) finish(status CheckStatus, checkError error) error {
 func (c *check) AcquireTrackingLock(logger lager.Logger) (lock.Lock, bool, error) {
 	return c.lockFactory.Acquire(
 		logger,
-		lock.NewResourceConfigCheckingLockID(c.ResourceConfigID()),
+		lock.NewResourceConfigCheckingLockID(c.ResourceConfigScopeID()),
 	)
 }
 


### PR DESCRIPTION
# Existing Issue

Fixes #4940 .

# Why do we need this PR?

@vito @pivotal-jwinters If you agree with https://github.com/concourse/concourse/issues/4940#issuecomment-568136099, then the code change is quite nit.

This is NOT a workaround, I believe it should be the expected behavior. The change fits both `global resources` and `non global resources` modes.


# Changes proposed in this pull request

Change to use `resource config scope id` as check lock id.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
