### PR TITLE
atc: fail in non-specific error in db container creation

### DIFF
--- a/atc/worker/worker.go
+++ b/atc/worker/worker.go
@@ -201,7 +201,6 @@ func (worker *gardenWorker) FindOrCreateContainer(
 	} else if createdContainer != nil {
 		containerHandle = createdContainer.Handle()
 	} else {
-
 		logger.Debug("creating-container-in-db")
 		creatingContainer, err = worker.dbWorker.CreateContainer(
 			owner,
@@ -212,6 +211,8 @@ func (worker *gardenWorker) FindOrCreateContainer(
 			if _, ok := err.(db.ContainerOwnerDisappearedError); ok {
 				return nil, ResourceConfigCheckSessionExpiredError
 			}
+
+			return nil, err
 		}
 		logger.Debug("created-creating-container-in-db")
 		containerHandle = creatingContainer.Handle()

--- a/release-notes/v5.8.0.md
+++ b/release-notes/v5.8.0.md
@@ -131,3 +131,7 @@
 #### <sub><sup><a name="4895" href="#4895">:link:</a></sup></sub> fix
 
 * @kirillbilchenko fixed a [bug](https://github.com/concourse/concourse/issues/3856) where the `concourse_workers_registered` metric would never go below 1, even when workers were pruned. #4895
+
+#### <sub><sup><a name="4947" href="#4947">:link:</a></sup></sub> fix
+
+* @cirocosta fixed a [bug](https://github.com/concourse/concourse/issues/4932) where an error that's not specific could lead to null pointer exception during the container creation phase. #4932


### PR DESCRIPTION



### Existing Issue


fixes #4932



### Why do we need this PR?

In `atc/worker/worker.go`'s garden's FindOrCreateContainer
implementation, there's an early return for the case when the error
returned in that creation is of a specific kind, but not for other
possible errors that could happen.

That meant that any error other than that specific one would lead to a
NPE as further steps would rely on a non-nil return.

These changes fix that by actually returning the err, making further
assumptions on "not being nil" not problematic anymore.


### Changes proposed in this pull request

* add a `return` with the non-specific err

### Contributor Checklist


- [x] Unit tests
- ~Integration tests (if applicable)~
- ~Updated documentation (located at https://github.com/concourse/docs)~ not user-facing
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


### Reviewer Checklist


- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
