### PR TITLE
Add the token text to the fly_success page.

### DIFF
--- a/web/elm/src/FlySuccess/FlySuccess.elm
+++ b/web/elm/src/FlySuccess/FlySuccess.elm
@@ -14,7 +14,7 @@ import FlySuccess.Models as Models exposing (ButtonState(..), Model, hover)
 import FlySuccess.Styles as Styles
 import FlySuccess.Text as Text
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, href, id, style)
+import Html.Attributes exposing (attribute, class, href, id, style, value)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import Login.Login as Login
 import Message.Callback exposing (Callback(..))
@@ -184,13 +184,26 @@ body model =
             [ p1, p2 ]
 
         Models.NetworkTrouble ->
-            [ p1, copyTokenButton model, p2 ]
+            [ p1, tokenTextBox model.authToken, copyTokenButton model, p2 ]
 
         Models.BlockedByBrowser ->
-            [ p1, sendTokenButton model, p2, copyTokenButton model ]
+            [ p1, tokenTextBox model.authToken, sendTokenButton model, p2, copyTokenButton model ]
 
         Models.NoFlyPort ->
-            [ p1, copyTokenButton model, p2 ]
+            [ p1, tokenTextBox model.authToken, copyTokenButton model, p2 ]
+
+
+tokenTextBox : String -> Html Message
+tokenTextBox token =
+    Html.label []
+        [ Html.text Text.copyTokenInput
+        , Html.input
+            ([ value token
+             ]
+                ++ Styles.input
+            )
+            []
+        ]
 
 
 paragraph : { identifier : String, lines : Text.Paragraph } -> Html Message

--- a/web/elm/src/FlySuccess/FlySuccess.elm
+++ b/web/elm/src/FlySuccess/FlySuccess.elm
@@ -10,7 +10,7 @@ module FlySuccess.FlySuccess exposing
 
 import Assets
 import EffectTransformer exposing (ET)
-import FlySuccess.Models as Models exposing (ButtonState(..), Model, hover)
+import FlySuccess.Models as Models exposing (ButtonState(..), InputState(..), Model, hover)
 import FlySuccess.Styles as Styles
 import FlySuccess.Text as Text
 import Html exposing (Html)
@@ -44,6 +44,7 @@ init :
 init { authToken, flyPort, noop } =
     ( { copyTokenButtonState = Unhovered
       , sendTokenButtonState = Unhovered
+      , copyTokenInputState = InputUnhovered
       , authToken = authToken
       , tokenTransfer =
             case ( noop, flyPort ) of
@@ -100,10 +101,14 @@ update msg ( model, effects ) =
             , effects
             )
 
+        Hover (Just CopyTokenInput) ->
+            ( { model | copyTokenInputState = InputHovered }, effects )
+
         Hover Nothing ->
             ( { model
                 | copyTokenButtonState = hover False model.copyTokenButtonState
                 , sendTokenButtonState = hover False model.sendTokenButtonState
+                , copyTokenInputState = InputUnhovered
               }
             , effects
             )
@@ -184,21 +189,27 @@ body model =
             [ p1, p2 ]
 
         Models.NetworkTrouble ->
-            [ p1, tokenTextBox model.authToken, copyTokenButton model, p2 ]
+            [ p1, tokenTextBox model, copyTokenButton model, p2 ]
 
         Models.BlockedByBrowser ->
-            [ p1, tokenTextBox model.authToken, sendTokenButton model, p2, copyTokenButton model ]
+            [ p1, tokenTextBox model, sendTokenButton model, p2, copyTokenButton model ]
 
         Models.NoFlyPort ->
-            [ p1, tokenTextBox model.authToken, copyTokenButton model, p2 ]
+            [ p1, tokenTextBox model, copyTokenButton model, p2 ]
 
 
-tokenTextBox : String -> Html Message
-tokenTextBox token =
+tokenTextBox : Model -> Html Message
+tokenTextBox { copyTokenInputState, authToken } =
     Html.label []
         [ Html.text Text.copyTokenInput
         , Html.input
-            (value token :: Styles.input)
+            ([ id "manual-copy-token"
+             , value authToken
+             , onMouseEnter <| Hover <| Just CopyTokenInput
+             , onMouseLeave <| Hover Nothing
+             ]
+                ++ Styles.input copyTokenInputState
+            )
             []
         ]
 

--- a/web/elm/src/FlySuccess/FlySuccess.elm
+++ b/web/elm/src/FlySuccess/FlySuccess.elm
@@ -14,7 +14,7 @@ import FlySuccess.Models as Models exposing (ButtonState(..), Model, hover)
 import FlySuccess.Styles as Styles
 import FlySuccess.Text as Text
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, class, href, id, style, value)
+import Html.Attributes exposing (attribute, href, id, style, value)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import Login.Login as Login
 import Message.Callback exposing (Callback(..))
@@ -198,10 +198,7 @@ tokenTextBox token =
     Html.label []
         [ Html.text Text.copyTokenInput
         , Html.input
-            ([ value token
-             ]
-                ++ Styles.input
-            )
+            (value token :: Styles.input)
             []
         ]
 

--- a/web/elm/src/FlySuccess/Models.elm
+++ b/web/elm/src/FlySuccess/Models.elm
@@ -1,5 +1,6 @@
 module FlySuccess.Models exposing
     ( ButtonState(..)
+    , InputState(..)
     , Model
     , TokenTransfer(..)
     , hover
@@ -13,6 +14,7 @@ type alias Model =
     Login.Model
         { copyTokenButtonState : ButtonState
         , sendTokenButtonState : ButtonState
+        , copyTokenInputState : InputState
         , authToken : String
         , tokenTransfer : TokenTransfer
         , flyPort : Maybe Int
@@ -23,6 +25,11 @@ type ButtonState
     = Unhovered
     | Hovered
     | Clicked
+
+
+type InputState
+    = InputUnhovered
+    | InputHovered
 
 
 type TokenTransfer

--- a/web/elm/src/FlySuccess/Styles.elm
+++ b/web/elm/src/FlySuccess/Styles.elm
@@ -8,7 +8,7 @@ module FlySuccess.Styles exposing
     )
 
 import Colors
-import FlySuccess.Models exposing (ButtonState(..), isClicked)
+import FlySuccess.Models exposing (ButtonState(..), InputState(..), isClicked)
 import Html
 import Html.Attributes exposing (style)
 import Views.Styles
@@ -52,8 +52,8 @@ paragraph =
     ]
 
 
-input : List (Html.Attribute msg)
-input =
+input : InputState -> List (Html.Attribute msg)
+input inputState =
     [ style "border" <|
         "1px solid "
             ++ Colors.text
@@ -65,6 +65,13 @@ input =
     , style "width" "192px"
     , style "text-align" "center"
     , style "background-color" Colors.flySuccessCard
+    , style "background-color" <|
+        case inputState of
+            InputUnhovered ->
+                Colors.flySuccessCard
+
+            InputHovered ->
+                Colors.flySuccessButtonHover
     , style "color" Colors.text
     , style "white-space" "nowrap"
     , style "overflow" "hidden"

--- a/web/elm/src/FlySuccess/Styles.elm
+++ b/web/elm/src/FlySuccess/Styles.elm
@@ -2,6 +2,7 @@ module FlySuccess.Styles exposing
     ( body
     , button
     , card
+    , input
     , paragraph
     , title
     )
@@ -48,6 +49,26 @@ body =
 paragraph : List (Html.Attribute msg)
 paragraph =
     [ style "margin" "5px 0"
+    ]
+
+
+input : List (Html.Attribute msg)
+input =
+    [ style "border" <|
+        "1px solid "
+            ++ Colors.text
+    , style "display" "flex"
+    , style "justify-content" "center"
+    , style "align-items" "center"
+    , style "margin" "15px 0"
+    , style "padding" "10px 10px"
+    , style "width" "192px"
+    , style "text-align" "center"
+    , style "background-color" Colors.flySuccessCard
+    , style "color" Colors.text
+    , style "white-space" "nowrap"
+    , style "overflow" "hidden"
+    , style "text-overflow" "ellipsis"
     ]
 
 

--- a/web/elm/src/FlySuccess/Text.elm
+++ b/web/elm/src/FlySuccess/Text.elm
@@ -1,6 +1,7 @@
 module FlySuccess.Text exposing
     ( Paragraph
     , copyTokenButton
+    , copyTokenInput
     , firstParagraph
     , flyLoginLinkDescription
     , flyLoginLinkText
@@ -91,6 +92,11 @@ copyTokenButton buttonState =
 
     else
         "copy token to clipboard"
+
+
+copyTokenInput : String
+copyTokenInput =
+    "copy token here"
 
 
 sendTokenButton : String

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -68,6 +68,7 @@ type DomID
     | WelcomeCardCliIcon Cli.Cli
     | CopyTokenButton
     | SendTokenButton
+    | CopyTokenInput
     | JobGroup Int
     | StepTab String Int
     | StepHeader String

--- a/web/elm/tests/FlySuccessFeature.elm
+++ b/web/elm/tests/FlySuccessFeature.elm
@@ -431,6 +431,30 @@ bodyParagraphPositions =
 
 
 
+-- body on any type of failure
+
+
+copyLinkInput : Property
+copyLinkInput =
+    property body "label gives instructions for manual copying" <|
+        Query.children []
+            >> Expect.all
+                [ Query.index 1
+                    >> Query.has
+                        [ text "copy token here" ]
+                , Query.index 1
+                    >> Query.children [ tag "input" ]
+                    >> Query.first
+                    >> Query.has
+                        [ attribute <| Attr.value authToken
+                        , style "white-space" "nowrap"
+                        , style "overflow" "hidden"
+                        , style "text-overflow" "ellipsis"
+                        ]
+                ]
+
+
+
 -- body on invalid fly port
 
 
@@ -744,10 +768,13 @@ all =
                     ]
             , invalidFlyPort |> firstParagraphFailureText
             , invalidFlyPort |> secondParagraphErrorText
+            , invalidFlyPort |> copyLinkInput
             , tokenSendBlocked |> firstParagraphBlockedText
             , tokenSendBlocked |> secondParagraphBlockedText
+            , tokenSendBlocked |> copyLinkInput
             , tokenSendFailed |> firstParagraphFailureText
             , tokenSendFailed |> secondParagraphFailureText
+            , tokenSendFailed |> copyLinkInput
             , tokenCopied |> firstParagraphFailureText
             , tokenCopied |> secondParagraphFailureText
             , whenOnFlySuccessPage |> bodyPendingText

--- a/web/elm/tests/FlySuccessFeature.elm
+++ b/web/elm/tests/FlySuccessFeature.elm
@@ -246,6 +246,11 @@ copyTokenButton =
     body >> Query.find [ id "copy-token" ]
 
 
+copyTokenInput : Query
+copyTokenInput =
+    body >> Query.find [ id "manual-copy-token" ]
+
+
 sendTokenButton : Query
 sendTokenButton =
     body >> Query.find [ id "send-token" ]
@@ -781,6 +786,25 @@ all =
             , whenOnFlySuccessPage |> bodyNoButton
             , tokenSendSuccess |> firstParagraphSuccessText
             , tokenSendSuccess |> secondParagraphSuccessText
+            ]
+        , describe "copy token input"
+            [ defineHoverBehaviour
+                { name = "copy token input"
+                , setup = steps tokenSendFailed () |> Tuple.first
+                , query = copyTokenInput
+                , unhoveredSelector =
+                    { description =
+                        "same background as card"
+                    , selector = [ style "background-color" darkGrey ]
+                    }
+                , hoverable =
+                    Message.Message.CopyTokenInput
+                , hoveredSelector =
+                    { description = "darker background"
+                    , selector =
+                        [ style "background-color" darkerGrey ]
+                    }
+                }
             ]
         , describe "copy token button"
             [ describe "always" <|


### PR DESCRIPTION
Some customers have security policies to disable automated copy/paste in the browser.  Copying using the 'manual' (ctrl+c / right-click + copy) methods still work as expected.  This change allows the user to manually copy the token.

# Existing Issue

Fixes #4914.

# Changes proposed in this pull request

* This change allows the user to manually copy the token, by adding the token text to the `fly_success` page

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
