### PR TITLE
Rename job max in flight flag

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -181,7 +181,7 @@ type RunCommand struct {
 	DefaultDaysToRetainBuildLogs uint64 `long:"default-days-to-retain-build-logs" description:"Default days to retain build logs. 0 means unlimited"`
 	MaxDaysToRetainBuildLogs     uint64 `long:"max-days-to-retain-build-logs" description:"Maximum days to retain build logs, 0 means not specified. Will override values configured in jobs"`
 
-	MaxJobsInFlight uint64 `long:"max-jobs-in-flight" default:"32" description:"Maximum number of jobs to be scheduling at the same time"`
+	JobSchedulingMaxInFlight uint64 `long:"job-scheduling-max-in-flight" default:"32" description:"Maximum number of jobs to be scheduling at the same time"`
 
 	DefaultCpuLimit    *int    `long:"default-task-cpu-limit" description:"Default max number of cpu shares per task, 0 means unlimited"`
 	DefaultMemoryLimit *string `long:"default-task-memory-limit" description:"Default maximum memory per task, 0 means unlimited"`
@@ -864,7 +864,7 @@ func (cmd *RunCommand) constructBackendMembers(
 						),
 						alg),
 				},
-				cmd.MaxJobsInFlight,
+				cmd.JobSchedulingMaxInFlight,
 			),
 			10*time.Second,
 		)},


### PR DESCRIPTION
Renaming the max jobs in flight ATC flag to job scheduling max in flight in order to be more explicit with the purpose of the flag. This was raised because of this comment https://github.com/concourse/concourse/issues/4351#issuecomment-556037324.