### PR TITLE
Add a dumb YAML credential provider

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -70,6 +70,7 @@ import (
 	_ "github.com/concourse/concourse/atc/creds/credhub"
 	_ "github.com/concourse/concourse/atc/creds/dummy"
 	_ "github.com/concourse/concourse/atc/creds/kubernetes"
+	_ "github.com/concourse/concourse/atc/creds/localfile"
 	_ "github.com/concourse/concourse/atc/creds/secretsmanager"
 	_ "github.com/concourse/concourse/atc/creds/ssm"
 	_ "github.com/concourse/concourse/atc/creds/vault"

--- a/atc/creds/localfile/manager.go
+++ b/atc/creds/localfile/manager.go
@@ -18,25 +18,6 @@ type Manager struct {
 
 func (manager *Manager) Init(logger lager.Logger) error {
 
-	// Just go through the motions to make sure everything can be parsed/read/etc.
-	yamlDoc, err := ioutil.ReadFile(manager.Path)
-	if err != nil {
-		return err
-	}
-
-	jsonDoc, err := yaml.YAMLToJSON(yamlDoc)
-	if err != nil {
-		fmt.Printf("Error converting YAML to JSON: %s\n", err.Error())
-		return err
-	}
-
-	var someStruct map[string]interface{}
-	err = json.Unmarshal(jsonDoc, &someStruct)
-	if err != nil {
-		fmt.Printf("Error unmarshaling JSON: %s\n", err.Error())
-		return err
-	}
-
 	manager.SecretsFactory = &SecretsFactory{
 		path:   manager.Path,
 		logger: logger,
@@ -61,8 +42,25 @@ func (manager Manager) IsConfigured() bool {
 func (manager Manager) Validate() error {
 	_, err := os.Stat(manager.Path)
 	if os.IsNotExist(err) {
+		fmt.Sprintf("Local credential file not found")
 		return fmt.Errorf("Local credential file not found")
 	}
+
+	// Just go through the motions to make sure everything can be parsed/read/etc.
+	yamlDoc, err := ioutil.ReadFile(manager.Path)
+	if err != nil {
+		// TODO: Proper error reporting
+		fmt.Sprintf("Error reading YAML file: %s\n", err.Error())
+		return fmt.Errorf("Error reading YAML file: %s\n", err.Error())
+	}
+
+	_, err = yaml.YAMLToJSON(yamlDoc)
+	if err != nil {
+		fmt.Sprintf("Error converting YAML to JSON: %s\n", err.Error())
+		return fmt.Errorf("Error converting YAML to JSON: %s\n", err.Error())
+	}
+
+	// TODO: Add gjson.validate() (or similar)
 
 	return nil
 }
@@ -74,9 +72,11 @@ func (manager Manager) Health() (*creds.HealthResponse, error) {
 }
 
 func (manager Manager) Close(logger lager.Logger) {
+	// Anything here?
 }
 
 func (manager Manager) NewSecretsFactory(logger lager.Logger) (creds.SecretsFactory, error) {
+	// TODO: Sanity check what/why this is happening here.
 	if manager.SecretsFactory == nil {
 		manager.SecretsFactory = &SecretsFactory{
 			path:   manager.Path,

--- a/atc/creds/localfile/manager.go
+++ b/atc/creds/localfile/manager.go
@@ -1,0 +1,88 @@
+package localfile
+
+import (
+	"code.cloudfoundry.org/lager"
+	"encoding/json"
+	"fmt"
+	"github.com/concourse/concourse/atc/creds"
+	"io/ioutil"
+	"os"
+	"sigs.k8s.io/yaml"
+)
+
+type Manager struct {
+	Path string `long:"path" description:"Path to YAML credentials file."`
+
+	SecretsFactory *SecretsFactory
+}
+
+func (manager *Manager) Init(logger lager.Logger) error {
+
+	// Just go through the motions to make sure everything can be parsed/read/etc.
+	yamlDoc, err := ioutil.ReadFile(manager.Path)
+	if err != nil {
+		return err
+	}
+
+	jsonDoc, err := yaml.YAMLToJSON(yamlDoc)
+	if err != nil {
+		fmt.Printf("Error converting YAML to JSON: %s\n", err.Error())
+		return err
+	}
+
+	var someStruct map[string]interface{}
+	err = json.Unmarshal(jsonDoc, &someStruct)
+	if err != nil {
+		fmt.Printf("Error unmarshaling JSON: %s\n", err.Error())
+		return err
+	}
+
+	manager.SecretsFactory = &SecretsFactory{
+		path:   manager.Path,
+		logger: logger,
+	}
+
+	return nil
+}
+
+func (manager *Manager) MarshalJSON() ([]byte, error) {
+	health, err := manager.Health()
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(&map[string]interface{}{"health": health})
+}
+
+func (manager Manager) IsConfigured() bool {
+	return len(manager.Path) > 0
+}
+
+func (manager Manager) Validate() error {
+	_, err := os.Stat(manager.Path)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("Local credential file not found")
+	}
+
+	return nil
+}
+
+func (manager Manager) Health() (*creds.HealthResponse, error) {
+	return &creds.HealthResponse{
+		Method: "noop",
+	}, nil
+}
+
+func (manager Manager) Close(logger lager.Logger) {
+}
+
+func (manager Manager) NewSecretsFactory(logger lager.Logger) (creds.SecretsFactory, error) {
+	if manager.SecretsFactory == nil {
+		manager.SecretsFactory = &SecretsFactory{
+			path:   manager.Path,
+			logger: logger,
+		}
+	}
+
+	return manager.SecretsFactory, nil
+}

--- a/atc/creds/localfile/manager_factory.go
+++ b/atc/creds/localfile/manager_factory.go
@@ -5,8 +5,7 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-type ManagerFactory struct {
-}
+type ManagerFactory struct{}
 
 func init() {
 	creds.Register("localfile", NewManagerFactory())

--- a/atc/creds/localfile/manager_factory.go
+++ b/atc/creds/localfile/manager_factory.go
@@ -1,0 +1,34 @@
+package localfile
+
+import (
+	"github.com/concourse/concourse/atc/creds"
+	"github.com/jessevdk/go-flags"
+)
+
+type ManagerFactory struct {
+}
+
+func init() {
+	creds.Register("localfile", NewManagerFactory())
+}
+
+func NewManagerFactory() creds.ManagerFactory {
+	return &ManagerFactory{}
+}
+
+func (factory *ManagerFactory) AddConfig(group *flags.Group) creds.Manager {
+	manager := &Manager{}
+
+	subGroup, err := group.AddGroup("Local File Credential Management", "", manager)
+	if err != nil {
+		panic(err)
+	}
+
+	subGroup.Namespace = "localfile"
+
+	return manager
+}
+
+func (factory *ManagerFactory) NewInstance(config interface{}) (creds.Manager, error) {
+	return &Manager{}, nil
+}

--- a/atc/creds/localfile/manager_test.go
+++ b/atc/creds/localfile/manager_test.go
@@ -1,0 +1,1 @@
+package localfile_test

--- a/atc/creds/localfile/secrets.go
+++ b/atc/creds/localfile/secrets.go
@@ -1,0 +1,92 @@
+package localfile
+
+import (
+	"code.cloudfoundry.org/lager"
+	"encoding/json"
+	"fmt"
+	"github.com/concourse/concourse/atc/creds"
+	"github.com/thedevsaddam/gojsonq"
+	yaml "sigs.k8s.io/yaml"
+	"time"
+)
+
+type Secrets struct {
+	path   string
+	logger lager.Logger
+}
+
+func (secrets *Secrets) NewSecretLookupPaths(teamName string, pipelineName string, allowRootPath bool) []creds.SecretLookupPath {
+	lookupPaths := []creds.SecretLookupPath{}
+
+	// Team + Pipeline Credentails
+	if len(pipelineName) > 0 {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix("teams."+teamName+"."+pipelineName+"."))
+	}
+
+	// Team credentails
+	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix("teams."+teamName+"."))
+
+	// Global Credentials
+	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix("shared."))
+
+	return lookupPaths
+}
+
+func (secrets *Secrets) Get(secretPath string) (interface{}, *time.Time, bool, error) {
+
+	secrets.logger.Info("secrets-get-path", lager.Data{
+		"path": secrets.path,
+	})
+
+	jq := gojsonq.New(gojsonq.SetDecoder(&yamlDecoder{})).File(secrets.path)
+
+	query := jq.Find("shared.some_key")
+
+	secrets.logger.Info("secrets-get", lager.Data{
+		"test-query": fmt.Sprintf("%v", query),
+	})
+
+	query2 := jq.Find("shared.some_key")
+
+	secrets.logger.Info(secretPath, lager.Data{
+		"test-query": fmt.Sprintf("%v", query2),
+	})
+
+	/*
+		result, err := jq.FindR(secretPath)
+
+		if err != nil {
+
+			secrets.logger.Info("secretes-get-error", lager.Data{
+				"error": fmt.Sprintf("%v", err),
+			})
+
+			// TODO: Figure out how to handle real errors and not just 404
+			return nil, nil, false, nil
+		}
+
+		secrets.logger.Info("secretes-get-error", lager.Data{
+			"error": "did not return",
+		})
+
+		value, _ := result.String()
+	*/
+
+	result := jq.Find(secretPath)
+
+	if result == nil {
+		return nil, nil, false, nil
+	}
+
+	return fmt.Sprintf("%v", result), nil, true, nil
+}
+
+type yamlDecoder struct{}
+
+func (i *yamlDecoder) Decode(data []byte, v interface{}) error {
+	bb, err := yaml.YAMLToJSON(data)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bb, &v)
+}

--- a/atc/creds/localfile/secrets_factory.go
+++ b/atc/creds/localfile/secrets_factory.go
@@ -1,0 +1,18 @@
+package localfile
+
+import (
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/creds"
+)
+
+type SecretsFactory struct {
+	path   string
+	logger lager.Logger
+}
+
+func (factory *SecretsFactory) NewSecrets() creds.Secrets {
+	return &Secrets{
+		path:   factory.path,
+		logger: factory.logger,
+	}
+}


### PR DESCRIPTION
### Why do we need this PR?

The goal of this change is to provide a relatively simple way to get started using credentials in pipelines.  It works by specifying the path to a YAML file on the web node(s) with top-level `shared` and `teams` keys, the rest is up to the user.

This PR is known incomplete, I am creating it now to gauge interest.

A sample `credentials.yml`

```
---

shared:
  some_key: "some key value from shared secrets"
  registry:
    username: localuser
    password: localpass

teams:
  main:
    hello-world:
      some_key: "some_key value from team/pipeline"
    some_key: "some_key value from main team"
```

Then just set `CONCOURSE_LOCALFILE_PATH=/src/credentials.yml` in docker-compose and fire it up.

Some technical things to sort out:

* When does it make sense to read the file?  Currently reading it with `Get()` so the file can be updated without restarting concourse. - This should be optimized for performance, IMO.  If credential cache busting is a thing then that would make sense for re-reading the file.
* Should this go so far as encrypting the yaml values? - No, IMO.
* Is it worth puling in a json query package for this? - No, IMO.  Only want a few levels of depth (at most `((name.subkey))`), can sort that out without pulling in another lib.

### Changes proposed in this pull request

* add `localfile` credential manager.

### Contributor Checklist
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


### Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
