### PR TITLE
Turn on `GO111MOD`

### DIFF
--- a/worker/backend/integration/Dockerfile
+++ b/worker/backend/integration/Dockerfile
@@ -5,6 +5,7 @@ FROM concourse/golang-builder
 
 RUN mkdir -p /go/src/github.com/concourse/ /usr/local/concourse/bin/
 ENV PATH=/usr/local/concourse/bin:$PATH
+ENV GO111MODULE=on
 
 COPY start.sh /usr/local/concourse/bin/start.sh
 VOLUME /go/src/github.com/concourse/concourse


### PR DESCRIPTION
Turn on `GO111MOD`

# Existing Issue
could not run the integration test due to the `GO111MOD` is not turned on.

Fixes # .

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
