### PR TITLE
add version column back to resource_caches

### DIFF
--- a/atc/db/migration/migrations/1575922657_version_md5_resource_cache.down.sql
+++ b/atc/db/migration/migrations/1575922657_version_md5_resource_cache.down.sql
@@ -1,15 +1,9 @@
 BEGIN;
-  ALTER TABLE resource_caches ADD COLUMN version text;
-
-  UPDATE resource_caches rc
-  SET version = rcv.version
-  LEFT JOIN resource_configs ON resource_configs.id = rc.resource_config_id
-  FROM resource_config_versions rcv
-  WHERE rcv.version_md5 = rc.version_md5;
-
   DROP INDEX resource_caches_resource_config_id_version_md5_params_hash_uniq
 
   ALTER TABLE resource_caches DROP COLUMN version_md5;
+
+  COMMENT ON COLUMN resource_caches.version IS NULL;
 
   CREATE UNIQUE INDEX resource_caches_resource_config_id_version_params_hash_uniq
   ON resource_caches (resource_config_id, md5(version::text), params_hash);

--- a/atc/db/migration/migrations/1575922657_version_md5_resource_cache.up.sql
+++ b/atc/db/migration/migrations/1575922657_version_md5_resource_cache.up.sql
@@ -3,9 +3,11 @@ BEGIN;
 
   UPDATE resource_caches SET version_md5 = md5(version::text);
 
+  ALTER TABLE resource_caches ALTER COLUMN version_md5 SET NOT NULL;
+
   DROP INDEX resource_caches_resource_config_id_version_params_hash_uniq;
 
-  ALTER TABLE resource_caches DROP COLUMN version;
+  COMMENT ON COLUMN resource_caches.version IS 'Deprecated only for backward compatibility';
 
   CREATE UNIQUE INDEX resource_caches_resource_config_id_version_md5_params_hash_uniq
   ON resource_caches (resource_config_id, version_md5, params_hash);

--- a/atc/db/resource_cache.go
+++ b/atc/db/resource_cache.go
@@ -60,17 +60,20 @@ func (cache *ResourceCacheDescriptor) findOrCreate(
 		err = psql.Insert("resource_caches").
 			Columns(
 				"resource_config_id",
+				"version",
 				"version_md5",
 				"params_hash",
 			).
 			Values(
 				resourceConfig.ID(),
+				cache.version(),
 				sq.Expr("md5(?)", cache.version()),
 				paramsHash(cache.Params),
 			).
 			Suffix(`
 				ON CONFLICT (resource_config_id, version_md5, params_hash) DO UPDATE SET
 				resource_config_id = EXCLUDED.resource_config_id,
+				version = EXCLUDED.version,
 				version_md5 = EXCLUDED.version_md5,
 				params_hash = EXCLUDED.params_hash
 				RETURNING id


### PR DESCRIPTION
to avoid trouble when running down migration if version can not be found for given version_md5

it will be used only when inserting.