### PR TITLE
job label for prometheus build_duration metrics

### DIFF
--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -186,7 +186,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Help:      "Build time in seconds",
 			Buckets:   []float64{1, 60, 180, 300, 600, 900, 1200, 1800, 2700, 3600, 7200, 18000, 36000},
 		},
-		[]string{"team", "pipeline"},
+		[]string{"team", "pipeline", "job"},
 	)
 	prometheus.MustRegister(buildDurationsVec)
 
@@ -555,7 +555,7 @@ func (emitter *PrometheusEmitter) buildFinishedMetrics(logger lager.Logger, even
 	}
 	// seconds are the standard prometheus base unit for time
 	duration = duration / 1000
-	emitter.buildDurationsVec.WithLabelValues(team, pipeline).Observe(duration)
+	emitter.buildDurationsVec.WithLabelValues(team, pipeline, job).Observe(duration)
 }
 
 func (emitter *PrometheusEmitter) workerContainersMetric(logger lager.Logger, event metric.Event) {

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,0 +1,3 @@
+#### <sub><sup><a name="4938" href="#4938">:link:</a></sup></sub> feature
+
+* Include job label in build duration metrics exported to Prometheus. #4976


### PR DESCRIPTION
# Why do we need this PR?

before this change the build_duration metrics exposed to prometheus are not very useful to us, as it bundles
together all builds across an entire pipeline. Since a build duration from one
job is usually very distinct from a build of another job, bundling them
together makes it hard to extract useful information such as:

* Which job(s) in the pipeline are performing badly?
* Under what conditions cause job A to perform badly?

Or create alerts/indicators based on the metric such as:

* Job X should always run within Y minutes

By allowing the build_durations metric to contain the job label, these
things become possible.

# Changes proposed in this pull request

* includes the job name as a label in build_duration metrics exposed to
prometheus so that it is possible to gain insights into where time is
being spent in a complex pipeline, observe trends and create alerts at
job level.

# Contributor Checklist

- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist

- [x] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [x] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
