### PR TITLE
web: fix build-history-tab-switching bug

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -750,18 +750,6 @@ sampleModel =
     , history = []
     , nextPage = Nothing
     , prep = Nothing
-    , build =
-        RemoteData.Success
-            { id = 0
-            , name = "0"
-            , job = Nothing
-            , status = Concourse.BuildStatus.BuildStatusStarted
-            , duration =
-                { startedAt = Nothing
-                , finishedAt = Nothing
-                }
-            , reapTime = Nothing
-            }
     , duration = { startedAt = Nothing, finishedAt = Nothing }
     , status = Concourse.BuildStatus.BuildStatusStarted
     , output =
@@ -782,6 +770,9 @@ sampleModel =
     , scrolledToCurrentBuild = False
     , shiftDown = False
     , isUserMenuExpanded = False
+    , hasLoadedYet = True
+    , notFound = False
+    , reapTime = Nothing
     }
 
 

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -261,16 +261,12 @@ sideBarHandleCallback callback ( model, effects ) =
 
                         SubPage.BuildModel buildModel ->
                             SideBar.handleCallback callback
-                                (buildModel.build
-                                    |> RemoteData.andThen
-                                        (\b ->
-                                            case b.job of
-                                                Just j ->
-                                                    RemoteData.Success j
+                                (case buildModel.job of
+                                    Just j ->
+                                        RemoteData.Success j
 
-                                                Nothing ->
-                                                    RemoteData.NotAsked
-                                        )
+                                    Nothing ->
+                                        RemoteData.NotAsked
                                 )
 
                         _ ->

--- a/web/elm/src/Build/Header/Models.elm
+++ b/web/elm/src/Build/Header/Models.elm
@@ -26,6 +26,7 @@ type alias Model r =
         , fetchingHistory : Bool
         , nextPage : Maybe Page
         , previousTriggerBuildByKey : Bool
+        , hasLoadedYet : Bool
     }
 
 
@@ -33,6 +34,7 @@ type alias HistoryItem =
     { id : Int
     , name : String
     , status : BuildStatus.BuildStatus
+    , duration : Concourse.BuildDuration
     }
 
 

--- a/web/elm/src/Build/Models.elm
+++ b/web/elm/src/Build/Models.elm
@@ -9,8 +9,8 @@ import Build.Output.Models exposing (OutputModel)
 import Concourse
 import Keyboard
 import Login.Login as Login
-import RemoteData
 import Routes exposing (Highlight)
+import Time
 
 
 
@@ -20,8 +20,7 @@ import Routes exposing (Highlight)
 type alias Model =
     Login.Model
         (Build.Header.Models.Model
-            { build : RemoteData.WebData Concourse.Build
-            , autoScroll : Bool
+            { autoScroll : Bool
             , previousKeyPress : Maybe Keyboard.KeyEvent
             , shiftDown : Bool
             , showHelp : Bool
@@ -30,6 +29,9 @@ type alias Model =
             , output : CurrentOutput
             , prep : Maybe Concourse.BuildPrep
             , page : BuildPageType
+            , hasLoadedYet : Bool
+            , notFound : Bool
+            , reapTime : Maybe Time.Posix
             }
         )
 

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -58,7 +58,6 @@ module Concourse exposing
     , decodeUser
     , decodeVersion
     , decodeVersionedResource
-    , receiveStatus
     , retrieveCSRFToken
     )
 
@@ -160,24 +159,6 @@ type alias Build =
     , status : BuildStatus
     , duration : BuildDuration
     , reapTime : Maybe Time.Posix
-    }
-
-
-receiveStatus : BuildStatus -> Time.Posix -> Build -> Build
-receiveStatus newStatus date ({ duration, status } as build) =
-    { build
-        | status =
-            if Concourse.BuildStatus.isRunning status then
-                newStatus
-
-            else
-                status
-        , duration =
-            if Concourse.BuildStatus.isRunning newStatus then
-                duration
-
-            else
-                { duration | finishedAt = Just date }
     }
 
 

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -50,7 +50,7 @@ type Callback
     | ScreenResized Browser.Dom.Viewport
     | BuildJobDetailsFetched (Fetched Concourse.Job)
     | BuildFetched (Fetched Concourse.Build)
-    | BuildPrepFetched (Fetched Concourse.BuildPrep)
+    | BuildPrepFetched Concourse.BuildId (Fetched Concourse.BuildPrep)
     | BuildHistoryFetched (Fetched (Paginated Concourse.Build))
     | PlanAndResourcesFetched Int (Fetched ( Concourse.BuildPlan, Concourse.BuildResources ))
     | BuildAborted (Fetched ())

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -355,7 +355,7 @@ runEffect effect key csrfToken =
         FetchBuildPrep delay buildId ->
             Process.sleep delay
                 |> Task.andThen (always <| Network.BuildPrep.fetch buildId)
-                |> Task.attempt BuildPrepFetched
+                |> Task.attempt (BuildPrepFetched buildId)
 
         FetchBuildPlanAndResources buildId ->
             Task.map2 (\a b -> ( a, b )) (Network.BuildPlan.fetch buildId) (Network.BuildResources.fetch buildId)

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -10,6 +10,8 @@ import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Expect
 import HoverState
+import Keyboard
+import List.Extra
 import Message.Callback as Callback
 import Message.Effects as Effects
 import Message.Subscription as Subscription
@@ -95,22 +97,6 @@ all =
                         )
         , test "stops fetching history once current build appears" <|
             \_ ->
-                let
-                    jobId =
-                        { teamName = "team"
-                        , pipelineName = "pipeline"
-                        , jobName = "job"
-                        }
-
-                    build =
-                        { id = 0
-                        , name = "4"
-                        , job = Just jobId
-                        , status = model.status
-                        , duration = model.duration
-                        , reapTime = Nothing
-                        }
-                in
                 ( model, [] )
                     |> Header.handleCallback
                         (Callback.BuildFetched <| Ok build)
@@ -126,24 +112,46 @@ all =
                         )
                     |> Tuple.second
                     |> Common.notContains (Effects.FetchBuildHistory jobId Nothing)
+        , test "updates duration on finishing status event" <|
+            \_ ->
+                ( model, [] )
+                    |> Header.handleCallback
+                        (Callback.BuildFetched <|
+                            Ok
+                                { build
+                                    | status = BuildStatusStarted
+                                    , duration =
+                                        { startedAt =
+                                            Just <| Time.millisToPosix 0
+                                        , finishedAt = Nothing
+                                        }
+                                }
+                        )
+                    |> Header.handleDelivery
+                        (Subscription.EventsReceived <|
+                            Ok
+                                [ { data =
+                                        STModels.BuildStatus BuildStatusSucceeded <|
+                                            Time.millisToPosix 1000
+                                  , url = "http://localhost:8080/api/v1/builds/0/events"
+                                  }
+                                ]
+                        )
+                    |> Tuple.first
+                    |> Header.header session
+                    |> .leftWidgets
+                    |> Common.contains
+                        (Views.Duration <|
+                            Views.Finished
+                                { started =
+                                    Views.Absolute "Jan 1 1970 12:00:00 AM" Nothing
+                                , finished =
+                                    Views.Absolute "Jan 1 1970 12:00:01 AM" Nothing
+                                , duration = Views.JustSeconds 1
+                                }
+                        )
         , test "status event from wrong build is discarded" <|
             \_ ->
-                let
-                    jobId =
-                        { teamName = "team"
-                        , pipelineName = "pipeline"
-                        , jobName = "job"
-                        }
-
-                    build =
-                        { id = 0
-                        , name = "4"
-                        , job = Just jobId
-                        , status = model.status
-                        , duration = model.duration
-                        , reapTime = Nothing
-                        }
-                in
                 ( model, [] )
                     |> Header.handleCallback
                         (Callback.BuildFetched <| Ok build)
@@ -159,6 +167,100 @@ all =
                     |> Header.header session
                     |> .backgroundColor
                     |> Expect.equal BuildStatusPending
+        , test "can use keyboard to switch builds after status change event" <|
+            \_ ->
+                ( model, [] )
+                    |> Header.handleCallback
+                        (Callback.BuildFetched <| Ok build)
+                    |> Header.handleCallback
+                        (Callback.BuildHistoryFetched <|
+                            Ok
+                                { content =
+                                    [ build
+                                    , { build | id = 1, name = "1" }
+                                    ]
+                                , pagination =
+                                    { previousPage = Nothing
+                                    , nextPage = Nothing
+                                    }
+                                }
+                        )
+                    |> Header.handleDelivery
+                        (Subscription.EventsReceived <|
+                            Ok
+                                [ { data =
+                                        STModels.BuildStatus BuildStatusSucceeded <|
+                                            Time.millisToPosix 0
+                                  , url = "http://localhost:8080/api/v1/builds/0/events"
+                                  }
+                                ]
+                        )
+                    |> Header.handleDelivery
+                        (Subscription.KeyDown
+                            { ctrlKey = False
+                            , shiftKey = False
+                            , metaKey = False
+                            , code = Keyboard.L
+                            }
+                        )
+                    |> Tuple.second
+                    |> Common.contains
+                        (Effects.NavigateTo "/teams/team/pipelines/pipeline/jobs/job/builds/1")
+        , test "updates when route changes" <|
+            \_ ->
+                ( model, [] )
+                    |> Header.handleCallback
+                        (Callback.BuildFetched <| Ok build)
+                    |> Header.handleCallback
+                        (Callback.BuildHistoryFetched <|
+                            Ok
+                                { content =
+                                    [ build
+                                    , { build
+                                        | id = 1
+                                        , name = "1"
+                                        , status = BuildStatusStarted
+                                        , duration =
+                                            { startedAt =
+                                                Just <|
+                                                    Time.millisToPosix 0
+                                            , finishedAt = Nothing
+                                            }
+                                      }
+                                    ]
+                                , pagination =
+                                    { previousPage = Nothing
+                                    , nextPage = Nothing
+                                    }
+                                }
+                        )
+                    |> Header.changeToBuild
+                        (Models.JobBuildPage
+                            { teamName = "team"
+                            , pipelineName = "pipeline"
+                            , jobName = "job"
+                            , buildName = "1"
+                            }
+                        )
+                    |> Tuple.first
+                    |> Header.header session
+                    |> Expect.all
+                        [ .backgroundColor
+                            >> Expect.equal BuildStatusStarted
+                        , .leftWidgets
+                            >> Expect.equal
+                                [ Views.Title "1" (Just jobId)
+                                , Views.Duration <|
+                                    Views.Running <|
+                                        Views.Absolute
+                                            "Jan 1 1970 12:00:00 AM"
+                                            Nothing
+                                ]
+                        , .tabs
+                            >> List.Extra.last
+                            >> Maybe.map .isCurrent
+                            >> Expect.equal (Just True)
+                        ]
         ]
 
 
@@ -194,4 +296,22 @@ model =
     , fetchingHistory = False
     , nextPage = Nothing
     , previousTriggerBuildByKey = False -- TODO WTF variable name
+    , hasLoadedYet = False
+    }
+
+
+jobId =
+    { teamName = "team"
+    , pipelineName = "pipeline"
+    , jobName = "job"
+    }
+
+
+build =
+    { id = 0
+    , name = "0"
+    , job = Just jobId
+    , status = model.status
+    , duration = model.duration
+    , reapTime = Nothing
     }


### PR DESCRIPTION
# Existing Issue

Fixes #4962.

# Changes proposed in this pull request

The bug was observed in cases where you triggered a new build -- it turns out the important part of this flow was simply viewing a pending build. In such cases, the UI polls the GetBuild and GetBuildPrep endpoints with a 1-second delay. It is quite possible that, during this delay, the user will switch tabs and view a different build. Then, after the delay, the app will receive callbacks containing the build/prep for the pending build that was originally viewed. It is necessary to gracefully handle this data without displaying invalid or irrelevant data.

The fix ended up being to carefully ignore messages containing data from irrelevant builds - including build events being received and build/prep being fetched. This replaces the old `browsingIndex` method and has better (but not perfect) test coverage.

# Contributor Checklist
- [x] Unit tests
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~