### PR TITLE
add release note for `var_sources`

### DIFF
--- a/release-notes/v5.8.0.md
+++ b/release-notes/v5.8.0.md
@@ -20,9 +20,13 @@
 
   Looking further ahead on the roadmap, [RFC #32: projects](https://github.com/concourse/rfcs/pull/32) proposes introduce a more explicit GitOps-style approach to configuration automation. In this context the `set_pipeline` step may feel a lot more natural. Until then, the `set_pipeline` step can be used as a simpler alternative to the [`concourse-pipeline` resource](https://github.com/concourse/concourse-pipeline-resource), with the key difference being that the `set_pipeline` step doesn't need any auth config.
 
+#### <sub><sup><a name="4600" href="#4600">:link:</a></sup></sub> feature
+
+* @evanchaoli added support for [`var_sources`](https://concourse-ci.org/runtime-vars.html#var-sources) in the pipeline config. With this feature, concourse can fetch secrets from multiple independent credential managers per pipeline. This enables workflows where teams sharing a Concouse instance can independently manage their own credential managers. #4600, #4777
+
 #### <sub><sup><a name="4657" href="#4657">:link:</a></sup></sub> feature
 
-* @evanchaoli added the ability to tune the [mapping between API actions and roles](https://concourse-ci.org/user-roles.html) via the `--config-rbac` flag. #4657
+* @evanchaoli added the ability to tune the [mapping between API actions and roles](https://concourse-ci.org/user-roles.html#configuring-rbac) via the `--config-rbac` flag. While you can't yet create your own roles, you can customize the built-in ones by promoting and demoting the roles to which certain API actions are assigned. #4657
 
 #### <sub><sup><a name="4693" href="#4693">:link:</a></sup></sub> feature
 


### PR DESCRIPTION
# Why do we need this PR?

Final checkbox in https://github.com/concourse/concourse/issues/4859#issue-534024173.

# Changes proposed in this pull request

* Added a release note with a link to the new docs (which will be deployed after v5.8.0 ships)
* A bit more detail in the `--config-rbac` release note too

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [x] ~PR acceptance performed~
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~