### PR TITLE
Fix flakey topgun tests

### DIFF
--- a/topgun/both/atc_shutdown_test.go
+++ b/topgun/both/atc_shutdown_test.go
@@ -103,7 +103,7 @@ var _ = Describe("ATC Shutting down", func() {
 					time.Sleep(10 * time.Second)
 
 					By("hijacking the build to tell it to finish")
-					Eventually(func()int {
+					Eventually(func() int {
 						hijackSession := Fly.Start(
 							"hijack",
 							"-b", buildID,

--- a/topgun/both/hijack_container_gc_test.go
+++ b/topgun/both/hijack_container_gc_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Hijacked containers", func() {
 		)
 
 		By("finishing the build")
-		Eventually(func()int {
+		Eventually(func() int {
 			hS := Fly.Start(
 				"hijack",
 				"-j", "hijacked-containers-test/simple-job",
@@ -80,7 +80,7 @@ var _ = Describe("Hijacked containers", func() {
 		//For the output from the running step
 		Eventually(buildSession).Should(gbytes.Say("waiting for /tmp/stop-waiting to exist"))
 
-		Eventually(func()int {
+		Eventually(func() int {
 			hS := Fly.Start(
 				"hijack",
 				"-j", "hijacked-containers-test/simple-job",
@@ -120,7 +120,7 @@ var _ = Describe("Hijacked containers", func() {
 		)
 
 		By("waiting for build to finish")
-		Eventually(func()int {
+		Eventually(func() int {
 			hS := Fly.Start(
 				"hijack",
 				"-b", "1",

--- a/topgun/both/image_resource_gc_test.go
+++ b/topgun/both/image_resource_gc_test.go
@@ -46,7 +46,10 @@ var _ = Describe("A build using an image_resource", func() {
 
 			By("triggering a build that waits")
 			watchSession := Fly.Start("trigger-job", "-w", "-j", "test/some-job")
-			Eventually(watchSession).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
+			//For the initializing block
+			Eventually(watchSession).Should(gbytes.Say("echo 'waiting for /tmp/stop-waiting to exist'"))
+			//For the output from the running step
+			Eventually(watchSession).Should(gbytes.Say("waiting for /tmp/stop-waiting to exist"))
 
 			By("getting the resource cache volumes")
 			volumes := FlyTable("volumes")

--- a/topgun/both/worker_landing_test.go
+++ b/topgun/both/worker_landing_test.go
@@ -194,7 +194,16 @@ var _ = Describe("Worker landing", func() {
 
 				It("finishes landing once the build is done", func() {
 					By("hijacking the build to tell it to finish")
-					Fly.Run("hijack", "-b", buildID, "-s", "one-off", "--", "touch", "/tmp/stop-waiting")
+					Eventually(func()int {
+						hijackSession := Fly.Start(
+							"hijack",
+							"-b", buildID,
+							"-s", "one-off", "--",
+							"touch", "/tmp/stop-waiting",
+						)
+						<-hijackSession.Exited
+						return hijackSession.ExitCode()
+					}).Should(Equal(0))
 
 					By("waiting for the build to exit")
 					Eventually(buildSession).Should(gbytes.Say("done"))

--- a/topgun/both/worker_landing_test.go
+++ b/topgun/both/worker_landing_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Worker landing", func() {
 
 				It("finishes landing once the build is done", func() {
 					By("hijacking the build to tell it to finish")
-					Eventually(func()int {
+					Eventually(func() int {
 						hijackSession := Fly.Start(
 							"hijack",
 							"-b", buildID,

--- a/topgun/both/worker_stalling_test.go
+++ b/topgun/both/worker_stalling_test.go
@@ -82,7 +82,10 @@ var _ = Describe("Worker stalling", func() {
 				matches := buildRegex.FindSubmatch(buildSession.Out.Contents())
 				buildID = string(matches[1])
 
-				Eventually(buildSession).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
+				//For the initializing block
+				Eventually(buildSession).Should(gbytes.Say("echo 'waiting for /tmp/stop-waiting to exist'"))
+				//For the output from the running step
+				Eventually(buildSession).Should(gbytes.Say("waiting for /tmp/stop-waiting to exist"))
 
 				By("stopping the worker without draining")
 				Bosh("ssh", "worker/0", "-c", "sudo /var/vcap/bosh/bin/monit stop worker")
@@ -118,7 +121,7 @@ var _ = Describe("Worker stalling", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					// wait for new output
-					Eventually(buildSession).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
+					Eventually(buildSession).Should(gbytes.Say("waiting for /tmp/stop-waiting to exist"))
 
 					By("hijacking the build to tell it to finish")
 					Eventually(func() int {

--- a/topgun/core/containers_scoped_to_team_test.go
+++ b/topgun/core/containers_scoped_to_team_test.go
@@ -63,15 +63,18 @@ var _ = Describe("Container scope", func() {
 			Fly.Run("login", "-n", "main", "-u", AtcUsername, "-p", AtcPassword)
 
 			By("stopping the build")
-			hijackSession := Fly.Start(
-				"hijack",
-				"-b", "1",
-				"-s", "simple-task",
-				"touch", "/tmp/stop-waiting",
-			)
+			Eventually(func()int {
+				hijackSession := Fly.Start(
+					"hijack",
+					"-b", "1",
+					"-s", "simple-task",
+					"touch", "/tmp/stop-waiting",
+				)
 
-			<-hijackSession.Exited
-			Expect(hijackSession.ExitCode()).To(Equal(0))
+				<-hijackSession.Exited
+				return hijackSession.ExitCode()
+
+			}).Should(Equal(0))
 
 			Eventually(buildSession).Should(gbytes.Say("done"))
 			<-buildSession.Exited

--- a/topgun/core/containers_scoped_to_team_test.go
+++ b/topgun/core/containers_scoped_to_team_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Container scope", func() {
 			Fly.Run("login", "-n", "main", "-u", AtcUsername, "-p", AtcPassword)
 
 			By("stopping the build")
-			Eventually(func()int {
+			Eventually(func() int {
 				hijackSession := Fly.Start(
 					"hijack",
 					"-b", "1",

--- a/topgun/core/syslog_test.go
+++ b/topgun/core/syslog_test.go
@@ -30,11 +30,10 @@ var _ = Describe("An ATC with syslog draining set", func() {
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(0))
 
-		Bosh("scp", "web/0:/var/vcap/store/syslog_storer/syslog.log", "/tmp/syslog.log")
-		found, err := checkContent("/tmp/syslog.log", "shhhh")
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(found).To(BeTrue())
+		Eventually(func()(bool, error){
+			Bosh("scp", "web/0:/var/vcap/store/syslog_storer/syslog.log", "/tmp/syslog.log")
+			return checkContent("/tmp/syslog.log", "shhhh")
+		}).Should(BeTrue())
 	})
 })
 

--- a/topgun/core/syslog_test.go
+++ b/topgun/core/syslog_test.go
@@ -30,7 +30,7 @@ var _ = Describe("An ATC with syslog draining set", func() {
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(0))
 
-		Eventually(func()(bool, error){
+		Eventually(func() (bool, error) {
 			Bosh("scp", "web/0:/var/vcap/store/syslog_storer/syslog.log", "/tmp/syslog.log")
 			return checkContent("/tmp/syslog.log", "shhhh")
 		}).Should(BeTrue())


### PR DESCRIPTION
- topgun/core team test
- topgun/both worker land test
- topgun/both image resource gc test
- topgun/both worker stalling test
- topgun/both atc shutdown test
- topgun/both hijack container gc test

# Why do we need this PR?
We encountered a bunch of race conditions when working on the [runtime refactor](https://nci.concourse-ci.org/teams/main/pipelines/runtime-refactor/jobs/bosh-topgun), where tests were blocked indefinitely till the 24h global timeout. 
This PR addresses the common patterns we observed when the tests got into a deadlock
- wrapping attempts to hijack with an Eventually
- adding an additional assertion when waiting for a script to start executing to ensure it had indeed started rather than just being in initializing state

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Integration tests (if applicable)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
