### PR TITLE
notes: warn that var_sources is experimental

### DIFF
--- a/release-notes/v5.8.0.md
+++ b/release-notes/v5.8.0.md
@@ -22,7 +22,7 @@
 
 #### <sub><sup><a name="4600" href="#4600">:link:</a></sup></sub> feature
 
-* @evanchaoli added support for [`var_sources`](https://concourse-ci.org/runtime-vars.html#var-sources) in the pipeline config. With this feature, concourse can fetch secrets from multiple independent credential managers per pipeline. This enables workflows where teams sharing a Concouse instance can independently manage their own credential managers. #4600, #4777
+* @evanchaoli added support for [`var_sources`](https://concourse-ci.org/runtime-vars.html#var-sources) in the pipeline config. With this feature, concourse can fetch secrets from multiple independent credential managers per pipeline. While this feature is currently in an **experimental** state and not yet tested in production, it is the first step to enabling workflows where teams sharing a Concourse instance can independently manage their own credential managers. For the moment, only vault or the dummy credential manager can be used to back a `var_source` (the other credential manager types do not work). #4600, #4777
 
 #### <sub><sup><a name="4657" href="#4657">:link:</a></sup></sub> feature
 


### PR DESCRIPTION
# Why do we need this PR?

`var_sources` is early in its development, and we should not give Concourse users the impression that it is operationally stable or that we will guarantee backwards compatibility in its future configurations.

# Changes proposed in this pull request

* Just a release note change

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [x] ~PR acceptance performed~
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~