### PR TITLE
Update Quickstart Helm Chart Installation Link to New Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Consult their GitHub repos for more information:
 
 * [Docker image](https://github.com/concourse/concourse-docker)
 * [BOSH release](https://github.com/concourse/concourse-bosh-release)
-* [Kubernetes Helm chart](https://github.com/helm/charts/tree/master/stable/concourse)
+* [Kubernetes Helm chart](https://github.com/concourse/concourse-chart)
 
 
 ## Quick Start


### PR DESCRIPTION
# Existing Issue
N/A

# Why do we need this PR?
The helm chart installation link under Quick Start still points to the deprecated helm chart location.


# Changes proposed in this pull request
Update the link to https://github.com/concourse/concourse-chart


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
