### PR TITLE
Newputget error cleanup

### DIFF
--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -218,7 +218,7 @@ func (step *GetStep) run(ctx context.Context, state RunState) error {
 
 	step.delegate.Finished(
 		logger,
-		ExitStatus(getResult.Status),
+		ExitStatus(getResult.ExitStatus),
 		getResult.VersionResult,
 	)
 

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -203,7 +203,7 @@ func (step *GetStep) run(ctx context.Context, state RunState) error {
 		return err
 	}
 
-	if getResult.ExitSuccessful() {
+	if getResult.ExitStatus == 0 {
 		state.ArtifactRepository().RegisterArtifact(
 			build.ArtifactName(step.plan.Name),
 			getResult.GetArtifact,

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -270,7 +270,7 @@ var _ = Describe("GetStep", func() {
 		BeforeEach(func() {
 			fakeClient.RunGetStepReturns(
 				worker.GetResult{
-					Status: 0,
+					ExitStatus: 0,
 					VersionResult: runtime.VersionResult{
 						Version:  atc.Version{"some": "version"},
 						Metadata: []atc.MetadataField{{Name: "some", Value: "metadata"}},
@@ -330,7 +330,7 @@ var _ = Describe("GetStep", func() {
 		BeforeEach(func() {
 			fakeClient.RunGetStepReturns(
 				worker.GetResult{
-					Status:        1,
+					ExitStatus:    1,
 					VersionResult: runtime.VersionResult{},
 				}, nil)
 		})

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -182,7 +182,7 @@ func (step *PutStep) run(ctx context.Context, state RunState) error {
 
 	resourceToPut := step.resourceFactory.NewResource(source, params, nil)
 
-	result := step.workerClient.RunPutStep(
+	result, err := step.workerClient.RunPutStep(
 		ctx,
 		logger,
 		owner,
@@ -195,21 +195,17 @@ func (step *PutStep) run(ctx context.Context, state RunState) error {
 		step.delegate,
 		resourceToPut,
 	)
-
-	versionResult := result.VersionResult
-	err = result.Err
-
 	if err != nil {
 		logger.Error("failed-to-put-resource", err)
-
-		if err, ok := err.(runtime.ErrResourceScriptFailed); ok {
-			step.delegate.Finished(logger, ExitStatus(err.ExitStatus), runtime.VersionResult{})
-			return nil
-		}
-
 		return err
 	}
 
+	if failure, ok := result.Failure.(runtime.ErrResourceScriptFailed); ok {
+		step.delegate.Finished(logger, ExitStatus(failure.ExitStatus), runtime.VersionResult{})
+		return nil
+	}
+
+	versionResult := result.VersionResult
 	// step.plan.Resource maps to an actual resource that may have been used outside of a pipeline context.
 	// Hence, if it was used outside the pipeline context, we don't want to save the output.
 	if step.plan.Resource != "" {

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -200,8 +200,8 @@ func (step *PutStep) run(ctx context.Context, state RunState) error {
 		return err
 	}
 
-	if failure, ok := result.Failure.(runtime.ErrResourceScriptFailed); ok {
-		step.delegate.Finished(logger, ExitStatus(failure.ExitStatus), runtime.VersionResult{})
+	if result.Status != 0 {
+		step.delegate.Finished(logger, ExitStatus(result.Status), runtime.VersionResult{})
 		return nil
 	}
 

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -200,8 +200,8 @@ func (step *PutStep) run(ctx context.Context, state RunState) error {
 		return err
 	}
 
-	if result.Status != 0 {
-		step.delegate.Finished(logger, ExitStatus(result.Status), runtime.VersionResult{})
+	if result.ExitStatus != 0 {
+		step.delegate.Finished(logger, ExitStatus(result.ExitStatus), runtime.VersionResult{})
 		return nil
 	}
 

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -166,7 +166,7 @@ var _ = Describe("PutStep", func() {
 		}
 
 		fakeClient.RunPutStepReturns(
-			worker.PutResult{Status: someExitStatus, VersionResult: versionResult},
+			worker.PutResult{ExitStatus: someExitStatus, VersionResult: versionResult},
 		clientErr,
 			)
 

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -71,8 +71,8 @@ var _ = Describe("PutStep", func() {
 
 		planID atc.PlanID
 
-		versionResult runtime.VersionResult
-		clientErr     error
+		versionResult  runtime.VersionResult
+		clientErr      error
 		someExitStatus int
 	)
 
@@ -167,8 +167,8 @@ var _ = Describe("PutStep", func() {
 
 		fakeClient.RunPutStepReturns(
 			worker.PutResult{ExitStatus: someExitStatus, VersionResult: versionResult},
-		clientErr,
-			)
+			clientErr,
+		)
 
 		putStep = exec.NewPutStep(
 			plan.ID,

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -73,6 +73,7 @@ var _ = Describe("PutStep", func() {
 
 		versionResult runtime.VersionResult
 		clientErr     error
+		failErr		  error
 	)
 
 	BeforeEach(func() {
@@ -162,7 +163,10 @@ var _ = Describe("PutStep", func() {
 			Put: putPlan,
 		}
 
-		fakeClient.RunPutStepReturns(worker.PutResult{Status: 0, VersionResult: versionResult, Err: clientErr})
+		fakeClient.RunPutStepReturns(
+			worker.PutResult{Status: 0, VersionResult: versionResult, Failure: failErr},
+		clientErr,
+			)
 
 		putStep = exec.NewPutStep(
 			plan.ID,
@@ -347,7 +351,7 @@ var _ = Describe("PutStep", func() {
 	Context("when RunPutStep exits unsuccessfully", func() {
 		BeforeEach(func() {
 			versionResult = runtime.VersionResult{}
-			clientErr = runtime.ErrResourceScriptFailed{
+			failErr = runtime.ErrResourceScriptFailed{
 				ExitStatus: 42,
 			}
 		})

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -73,7 +73,7 @@ var _ = Describe("PutStep", func() {
 
 		versionResult runtime.VersionResult
 		clientErr     error
-		failErr		  error
+		someExitStatus int
 	)
 
 	BeforeEach(func() {
@@ -151,6 +151,8 @@ var _ = Describe("PutStep", func() {
 
 		fakeResourceFactory.NewResourceReturns(fakeResource)
 
+		someExitStatus = 0
+
 	})
 
 	AfterEach(func() {
@@ -164,7 +166,7 @@ var _ = Describe("PutStep", func() {
 		}
 
 		fakeClient.RunPutStepReturns(
-			worker.PutResult{Status: 0, VersionResult: versionResult, Failure: failErr},
+			worker.PutResult{Status: someExitStatus, VersionResult: versionResult},
 		clientErr,
 			)
 
@@ -351,9 +353,7 @@ var _ = Describe("PutStep", func() {
 	Context("when RunPutStep exits unsuccessfully", func() {
 		BeforeEach(func() {
 			versionResult = runtime.VersionResult{}
-			failErr = runtime.ErrResourceScriptFailed{
-				ExitStatus: 42,
-			}
+			someExitStatus = 42
 		})
 
 		It("finishes the step via the delegate", func() {

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -224,7 +224,7 @@ func (step *TaskStep) run(ctx context.Context, state RunState) error {
 
 	owner := db.NewBuildStepContainerOwner(step.metadata.BuildID, step.planID, step.metadata.TeamID)
 
-	result := step.workerClient.RunTaskStep(
+	result, err := step.workerClient.RunTaskStep(
 		ctx,
 		logger,
 		owner,
@@ -238,7 +238,6 @@ func (step *TaskStep) run(ctx context.Context, state RunState) error {
 		step.lockFactory,
 	)
 
-	err = result.Err
 	if err != nil {
 		if err == context.Canceled || err == context.DeadlineExceeded {
 			step.registerOutputs(logger, repository, config, result.VolumeMounts, step.containerMetadata)

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -239,13 +239,16 @@ func (step *TaskStep) run(ctx context.Context, state RunState) error {
 	)
 
 	if err != nil {
-		if err == context.Canceled || err == context.DeadlineExceeded {
+		switch err {
+		case context.Canceled:
+		case context.DeadlineExceeded:
 			step.registerOutputs(logger, repository, config, result.VolumeMounts, step.containerMetadata)
 		}
+
 		return err
 	}
 
-	step.succeeded = (result.ExitStatus == 0)
+	step.succeeded = result.ExitStatus == 0
 	step.delegate.Finished(logger, ExitStatus(result.ExitStatus))
 
 	step.registerOutputs(logger, repository, config, result.VolumeMounts, step.containerMetadata)
@@ -259,7 +262,6 @@ func (step *TaskStep) run(ctx context.Context, state RunState) error {
 	}
 
 	return nil
-
 }
 
 func (step *TaskStep) Succeeded() bool {

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -239,12 +239,9 @@ func (step *TaskStep) run(ctx context.Context, state RunState) error {
 	)
 
 	if err != nil {
-		switch err {
-		case context.Canceled:
-		case context.DeadlineExceeded:
+		if err == context.Canceled || err == context.DeadlineExceeded {
 			step.registerOutputs(logger, repository, config, result.VolumeMounts, step.containerMetadata)
 		}
-
 		return err
 	}
 

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -245,8 +245,8 @@ func (step *TaskStep) run(ctx context.Context, state RunState) error {
 		return err
 	}
 
-	step.succeeded = (result.Status == 0)
-	step.delegate.Finished(logger, ExitStatus(result.Status))
+	step.succeeded = (result.ExitStatus == 0)
+	step.delegate.Finished(logger, ExitStatus(result.ExitStatus))
 
 	step.registerOutputs(logger, repository, config, result.VolumeMounts, step.containerMetadata)
 

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -424,7 +424,7 @@ var _ = Describe("TaskStep", func() {
 				fakeVolume1 = new(workerfakes.FakeVolume)
 				fakeVolume2 = new(workerfakes.FakeVolume)
 				taskResult := worker.TaskResult{
-					Status: 0,
+					ExitStatus: 0,
 					VolumeMounts: []worker.VolumeMount{
 						{
 							Volume:    fakeVolume1,
@@ -783,7 +783,7 @@ var _ = Describe("TaskStep", func() {
 				BeforeEach(func() {
 					taskStepStatus = 0
 					taskResult := worker.TaskResult{
-						Status:       taskStepStatus,
+						ExitStatus:       taskStepStatus,
 						VolumeMounts: []worker.VolumeMount{},
 					}
 					fakeClient.RunTaskStepReturns(taskResult, nil)
@@ -823,7 +823,7 @@ var _ = Describe("TaskStep", func() {
 						fakeVolume3.HandleReturns("some-handle-3")
 
 						fakeTaskResult := worker.TaskResult{
-							Status: 0,
+							ExitStatus: 0,
 							VolumeMounts: []worker.VolumeMount{
 								{
 									Volume:    fakeVolume1,
@@ -875,7 +875,7 @@ var _ = Describe("TaskStep", func() {
 			Context("when the task exits with nonzero status", func() {
 				BeforeEach(func() {
 					taskStepStatus = 5
-					taskResult := worker.TaskResult{Status: taskStepStatus, VolumeMounts: []worker.VolumeMount{}}
+					taskResult := worker.TaskResult{ExitStatus: taskStepStatus, VolumeMounts: []worker.VolumeMount{}}
 					fakeClient.RunTaskStepReturns(taskResult, nil)
 				})
 				It("finishes the task via the delegate", func() {
@@ -894,7 +894,7 @@ var _ = Describe("TaskStep", func() {
 			disaster := errors.New("task run failed")
 
 			BeforeEach(func() {
-				taskResult := worker.TaskResult{Status: -1, VolumeMounts: []worker.VolumeMount{}}
+				taskResult := worker.TaskResult{ExitStatus: -1, VolumeMounts: []worker.VolumeMount{}}
 				fakeClient.RunTaskStepReturns(taskResult, disaster)
 			})
 
@@ -911,7 +911,7 @@ var _ = Describe("TaskStep", func() {
 			BeforeEach(func() {
 				fakeClient.RunTaskStepReturns(
 					worker.TaskResult{
-						Status:       -1,
+						ExitStatus:       -1,
 						VolumeMounts: []worker.VolumeMount{},
 					}, context.Canceled)
 				cancel()
@@ -970,7 +970,7 @@ var _ = Describe("TaskStep", func() {
 				fakeVolume3.HandleReturns("some-handle-3")
 
 				taskResult := worker.TaskResult{
-					Status: 0,
+					ExitStatus: 0,
 					VolumeMounts: []worker.VolumeMount{
 						{
 							Volume:    fakeVolume1,
@@ -1025,7 +1025,7 @@ var _ = Describe("TaskStep", func() {
 				fakeVolume.HandleReturns("some-handle")
 
 				taskResult := worker.TaskResult{
-					Status: 0,
+					ExitStatus: 0,
 					VolumeMounts: []worker.VolumeMount{
 						{
 							Volume:    fakeVolume,

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -435,9 +435,8 @@ var _ = Describe("TaskStep", func() {
 							MountPath: "some-artifact-root/some-path-2",
 						},
 					},
-					Err: nil,
 				}
-				fakeClient.RunTaskStepReturns(taskResult)
+				fakeClient.RunTaskStepReturns(taskResult, nil)
 			})
 
 			It("creates the containerSpec with the caches in the inputs", func() {
@@ -786,9 +785,8 @@ var _ = Describe("TaskStep", func() {
 					taskResult := worker.TaskResult{
 						Status:       taskStepStatus,
 						VolumeMounts: []worker.VolumeMount{},
-						Err:          nil,
 					}
-					fakeClient.RunTaskStepReturns(taskResult)
+					fakeClient.RunTaskStepReturns(taskResult, nil)
 				})
 				It("finishes the task via the delegate", func() {
 					Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
@@ -840,9 +838,8 @@ var _ = Describe("TaskStep", func() {
 									MountPath: fakeMountPath3,
 								},
 							},
-							Err: nil,
 						}
-						fakeClient.RunTaskStepReturns(fakeTaskResult)
+						fakeClient.RunTaskStepReturns(fakeTaskResult, nil)
 					})
 
 					JustBeforeEach(func() {
@@ -878,8 +875,8 @@ var _ = Describe("TaskStep", func() {
 			Context("when the task exits with nonzero status", func() {
 				BeforeEach(func() {
 					taskStepStatus = 5
-					taskResult := worker.TaskResult{Status: taskStepStatus, VolumeMounts: []worker.VolumeMount{}, Err: nil}
-					fakeClient.RunTaskStepReturns(taskResult)
+					taskResult := worker.TaskResult{Status: taskStepStatus, VolumeMounts: []worker.VolumeMount{}}
+					fakeClient.RunTaskStepReturns(taskResult, nil)
 				})
 				It("finishes the task via the delegate", func() {
 					Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
@@ -897,8 +894,8 @@ var _ = Describe("TaskStep", func() {
 			disaster := errors.New("task run failed")
 
 			BeforeEach(func() {
-				taskResult := worker.TaskResult{Status: -1, VolumeMounts: []worker.VolumeMount{}, Err: disaster}
-				fakeClient.RunTaskStepReturns(taskResult)
+				taskResult := worker.TaskResult{Status: -1, VolumeMounts: []worker.VolumeMount{}}
+				fakeClient.RunTaskStepReturns(taskResult, disaster)
 			})
 
 			It("returns the error", func() {
@@ -916,9 +913,7 @@ var _ = Describe("TaskStep", func() {
 					worker.TaskResult{
 						Status:       -1,
 						VolumeMounts: []worker.VolumeMount{},
-						Err:          context.Canceled,
-					},
-				)
+					}, context.Canceled)
 				cancel()
 			})
 
@@ -990,9 +985,8 @@ var _ = Describe("TaskStep", func() {
 							MountPath: fakeMountPath3,
 						},
 					},
-					Err: nil,
 				}
-				fakeClient.RunTaskStepReturns(taskResult)
+				fakeClient.RunTaskStepReturns(taskResult, nil)
 			})
 
 			It("re-registers the outputs as artifacts", func() {
@@ -1038,9 +1032,8 @@ var _ = Describe("TaskStep", func() {
 							MountPath: fakeMountPath,
 						},
 					},
-					Err: nil,
 				}
-				fakeClient.RunTaskStepReturns(taskResult)
+				fakeClient.RunTaskStepReturns(taskResult, nil)
 			})
 
 			JustBeforeEach(func() {

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -49,7 +49,7 @@ type CacheArtifact struct {
 func (art CacheArtifact) ID() string {
 	return fmt.Sprintf("%d, %d, %s, %s", art.TeamID, art.JobID, art.StepName, art.Path)
 }
-
+// TODO (Krishna/Sameer): get rid of these - can GetArtifact and TaskArtifact be merged ?
 type GetArtifact struct {
 	VolumeHandle string
 }

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -49,6 +49,7 @@ type CacheArtifact struct {
 func (art CacheArtifact) ID() string {
 	return fmt.Sprintf("%d, %d, %s, %s", art.TeamID, art.JobID, art.StepName, art.Path)
 }
+
 // TODO (Krishna/Sameer): get rid of these - can GetArtifact and TaskArtifact be merged ?
 type GetArtifact struct {
 	VolumeHandle string

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -107,6 +107,7 @@ type GetResult struct {
 	Status        int
 	VersionResult runtime.VersionResult
 	GetArtifact   runtime.GetArtifact
+	Failure error
 }
 
 func (result GetResult) ExitSuccessful() bool {

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -93,12 +93,12 @@ type client struct {
 }
 
 type TaskResult struct {
-	Status       int
+	ExitStatus       int
 	VolumeMounts []VolumeMount
 }
 
 type PutResult struct {
-	Status        int
+	ExitStatus        int
 	VersionResult runtime.VersionResult
 }
 
@@ -106,10 +106,6 @@ type GetResult struct {
 	ExitStatus    int
 	VersionResult runtime.VersionResult
 	GetArtifact   runtime.GetArtifact
-}
-
-func (result GetResult) ExitSuccessful() bool {
-	return result.ExitStatus == 0
 }
 
 type ImageFetcherSpec struct {
@@ -229,7 +225,7 @@ func (client *client) RunTaskStep(
 		}
 
 		return TaskResult{
-			Status:       status,
+			ExitStatus:       status,
 			VolumeMounts: container.VolumeMounts(),
 		}, err
 	}
@@ -289,25 +285,25 @@ func (client *client) RunTaskStep(
 
 		status := <-exitStatusChan
 		return TaskResult{
-			Status:       status.processStatus,
+			ExitStatus:       status.processStatus,
 			VolumeMounts: container.VolumeMounts(),
 		}, ctx.Err()
 
 	case status := <-exitStatusChan:
 		if status.processErr != nil {
 			return TaskResult{
-				Status:       status.processStatus,
+				ExitStatus:       status.processStatus,
 			}, status.processErr
 		}
 
 		err = container.SetProperty(taskExitStatusPropertyName, fmt.Sprintf("%d", status.processStatus))
 		if err != nil {
 			return TaskResult{
-				Status: status.processStatus,
+				ExitStatus: status.processStatus,
 			}, err
 		}
 		return TaskResult{
-			Status: status.processStatus,
+			ExitStatus: status.processStatus,
 			VolumeMounts: container.VolumeMounts(),
 		}, err
 	}
@@ -545,7 +541,7 @@ func (client *client) RunPutStep(
 		}
 
 		return PutResult{
-			Status: status,
+			ExitStatus: status,
 			VersionResult: runtime.VersionResult{},
 		}, nil
 	}
@@ -556,7 +552,7 @@ func (client *client) RunPutStep(
 	if err != nil {
 		if failErr, ok := err.(runtime.ErrResourceScriptFailed); ok {
 			return PutResult{
-				Status:        failErr.ExitStatus,
+				ExitStatus:        failErr.ExitStatus,
 				VersionResult: runtime.VersionResult{},
 			}, nil
 		} else {
@@ -564,7 +560,7 @@ func (client *client) RunPutStep(
 		}
 	}
 	return PutResult{
-		Status: 0,
+		ExitStatus: 0,
 		VersionResult: vr,
 	}, nil
 }

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -100,18 +100,16 @@ type TaskResult struct {
 type PutResult struct {
 	Status        int
 	VersionResult runtime.VersionResult
-	Failure       error
 }
 
 type GetResult struct {
-	Status        int
+	ExitStatus    int
 	VersionResult runtime.VersionResult
 	GetArtifact   runtime.GetArtifact
-	Failure error
 }
 
 func (result GetResult) ExitSuccessful() bool {
-	return result.Status == 0
+	return result.ExitStatus == 0
 }
 
 type ImageFetcherSpec struct {
@@ -560,7 +558,6 @@ func (client *client) RunPutStep(
 			return PutResult{
 				Status:        failErr.ExitStatus,
 				VersionResult: runtime.VersionResult{},
-				Failure:       failErr,
 			}, nil
 		} else {
 			return PutResult{}, err

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -93,12 +93,12 @@ type client struct {
 }
 
 type TaskResult struct {
-	ExitStatus       int
+	ExitStatus   int
 	VolumeMounts []VolumeMount
 }
 
 type PutResult struct {
-	ExitStatus        int
+	ExitStatus    int
 	VersionResult runtime.VersionResult
 }
 
@@ -225,7 +225,7 @@ func (client *client) RunTaskStep(
 		}
 
 		return TaskResult{
-			ExitStatus:       status,
+			ExitStatus:   status,
 			VolumeMounts: container.VolumeMounts(),
 		}, err
 	}
@@ -285,14 +285,14 @@ func (client *client) RunTaskStep(
 
 		status := <-exitStatusChan
 		return TaskResult{
-			ExitStatus:       status.processStatus,
+			ExitStatus:   status.processStatus,
 			VolumeMounts: container.VolumeMounts(),
 		}, ctx.Err()
 
 	case status := <-exitStatusChan:
 		if status.processErr != nil {
 			return TaskResult{
-				ExitStatus:       status.processStatus,
+				ExitStatus: status.processStatus,
 			}, status.processErr
 		}
 
@@ -303,7 +303,7 @@ func (client *client) RunTaskStep(
 			}, err
 		}
 		return TaskResult{
-			ExitStatus: status.processStatus,
+			ExitStatus:   status.processStatus,
 			VolumeMounts: container.VolumeMounts(),
 		}, err
 	}
@@ -541,7 +541,7 @@ func (client *client) RunPutStep(
 		}
 
 		return PutResult{
-			ExitStatus: status,
+			ExitStatus:    status,
 			VersionResult: runtime.VersionResult{},
 		}, nil
 	}
@@ -552,7 +552,7 @@ func (client *client) RunPutStep(
 	if err != nil {
 		if failErr, ok := err.(runtime.ErrResourceScriptFailed); ok {
 			return PutResult{
-				ExitStatus:        failErr.ExitStatus,
+				ExitStatus:    failErr.ExitStatus,
 				VersionResult: runtime.VersionResult{},
 			}, nil
 		} else {
@@ -560,7 +560,7 @@ func (client *client) RunPutStep(
 		}
 	}
 	return PutResult{
-		ExitStatus: 0,
+		ExitStatus:    0,
 		VersionResult: vr,
 	}, nil
 }

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -488,7 +488,7 @@ var _ = Describe("Client", func() {
 				fakeEventDelegate,
 				fakeLockFactory,
 			)
-			status = taskResult.Status
+			status = taskResult.ExitStatus
 			volumeMounts = taskResult.VolumeMounts
 		})
 
@@ -1206,7 +1206,7 @@ var _ = Describe("Client", func() {
 				fakeResource,
 			)
 			versionResult = result.VersionResult
-			status = result.Status
+			status = result.ExitStatus
 		})
 
 		It("finds/chooses a worker", func() {

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -389,6 +389,7 @@ var _ = Describe("Client", func() {
 			status       int
 			volumeMounts []worker.VolumeMount
 			inputSources []worker.InputSource
+			taskResult worker.TaskResult
 			err          error
 
 			fakeWorker           *workerfakes.FakeWorker
@@ -488,7 +489,7 @@ var _ = Describe("Client", func() {
 		})
 
 		JustBeforeEach(func() {
-			taskResult := client.RunTaskStep(
+			taskResult, err = client.RunTaskStep(
 				ctx,
 				logger,
 				fakeContainerOwner,
@@ -503,7 +504,6 @@ var _ = Describe("Client", func() {
 			)
 			status = taskResult.Status
 			volumeMounts = taskResult.VolumeMounts
-			err = taskResult.Err
 		})
 
 		Context("choosing a worker", func() {
@@ -550,7 +550,6 @@ var _ = Describe("Client", func() {
 					})
 					It("exits releasing the lock", func() {
 						Expect(err).To(Equal(context.Canceled))
-						Expect(status).To(Equal(-1))
 						Expect(fakeLock.ReleaseCallCount()).To(Equal(fakeLockFactory.AcquireCallCount()))
 					})
 				})
@@ -565,8 +564,8 @@ var _ = Describe("Client", func() {
 				})
 			})
 
-			Context("when finding or choosing the worker fails", func() {
-				workerDisaster := errors.New("worker selection failed")
+			Context("when finding or choosing the worker errors", func() {
+				workerDisaster := errors.New("worker selection errored")
 
 				BeforeEach(func() {
 					fakePool.FindOrChooseWorkerForContainerReturns(nil, workerDisaster)
@@ -592,7 +591,6 @@ var _ = Describe("Client", func() {
 				Type:             db.ContainerTypeTask,
 				StepName:         "some-step",
 			}))
-
 		})
 
 		Context("found a container that has already exited", func() {
@@ -1168,6 +1166,8 @@ var _ = Describe("Client", func() {
 			versionResult runtime.VersionResult
 			status        int
 			err           error
+			failure error
+			result worker.PutResult
 
 			disasterErr error
 		)
@@ -1207,7 +1207,7 @@ var _ = Describe("Client", func() {
 		})
 
 		JustBeforeEach(func() {
-			result := client.RunPutStep(
+			result, err = client.RunPutStep(
 				ctx,
 				logger,
 				owner,
@@ -1221,8 +1221,8 @@ var _ = Describe("Client", func() {
 				fakeResource,
 			)
 			versionResult = result.VersionResult
-			err = result.Err
 			status = result.Status
+			failure = result.Failure
 		})
 
 		It("finds/chooses a worker", func() {
@@ -1320,7 +1320,8 @@ var _ = Describe("Client", func() {
 
 					It("returns a PutResult with the exit status from ErrResourceScriptFailed", func() {
 						Expect(status).To(Equal(10))
-						Expect(err).To(Equal(scriptFailErr))
+						Expect(failure).To(Equal(scriptFailErr))
+						Expect(err).To(BeNil())
 					})
 				})
 
@@ -1332,8 +1333,8 @@ var _ = Describe("Client", func() {
 						)
 					})
 
-					It("returns a PutResult with status -1 and the error", func() {
-						Expect(status).To(Equal(-1))
+					It("returns an error", func() {
+						Expect(failure).To(BeNil())
 						Expect(err).To(Equal(disasterErr))
 					})
 

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -358,6 +358,20 @@ var _ = Describe("Client", func() {
 				Expect(result).To(Equal(worker.GetResult{}))
 			})
 		})
+		Context("Worker.Fetch returns an Script Error", func() {
+			var someScriptError error
+			BeforeEach(func() {
+				someScriptError = runtime.ErrResourceScriptFailed{Path:"some-path"}
+				fakePool.FindOrChooseWorkerReturns(fakeChosenWorker, nil)
+				fakeChosenWorker.FetchReturns(worker.GetResult{Status: 17, Failure: someScriptError}, nil, nil)
+			})
+
+			It("Returns the failure", func() {
+				Expect(err).To(BeNil())
+				Expect(result.Failure).To(Equal(someScriptError))
+				Expect(result.Status).To(Equal(17))
+			})
+		})
 
 		Context("worker.Fetch is successful", func() {
 			var (

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -345,13 +345,13 @@ var _ = Describe("Client", func() {
 			})
 		})
 
-		Context("Calling chosenWorker.Fetch", func(){
+		Context("Calling chosenWorker.Fetch", func() {
 			var (
-				someError error
+				someError     error
 				someGetResult worker.GetResult
-				fakeVolume *workerfakes.FakeVolume
+				fakeVolume    *workerfakes.FakeVolume
 			)
-			BeforeEach(func(){
+			BeforeEach(func() {
 				someGetResult = worker.GetResult{
 					ExitStatus: 0,
 					VersionResult: runtime.VersionResult{
@@ -375,7 +375,7 @@ var _ = Describe("Client", func() {
 			status       int
 			volumeMounts []worker.VolumeMount
 			inputSources []worker.InputSource
-			taskResult worker.TaskResult
+			taskResult   worker.TaskResult
 			err          error
 
 			fakeWorker           *workerfakes.FakeWorker
@@ -1152,7 +1152,7 @@ var _ = Describe("Client", func() {
 			versionResult runtime.VersionResult
 			status        int
 			err           error
-			result worker.PutResult
+			result        worker.PutResult
 
 			disasterErr error
 		)

--- a/atc/worker/container.go
+++ b/atc/worker/container.go
@@ -248,7 +248,7 @@ func (container *gardenWorkerContainer) RunScript(
 		return err
 
 	case <-ctx.Done():
-		container.Stop(false)
+		_ = container.Stop(false)
 		<-processExited
 		return ctx.Err()
 	}

--- a/atc/worker/fetch_source.go
+++ b/atc/worker/fetch_source.go
@@ -124,12 +124,12 @@ func (s *fetchSource) Find() (GetResult, Volume, bool, error) {
 	}
 
 	return GetResult{
-			0,
-			runtime.VersionResult{
+			Status: 0,
+			VersionResult: runtime.VersionResult{
 				Version:  s.cache.Version(),
 				Metadata: atcMetaData,
 			},
-			runtime.GetArtifact{VolumeHandle: volume.Handle()},
+			GetArtifact: runtime.GetArtifact{VolumeHandle: volume.Handle()},
 		},
 		volume, true, nil
 }
@@ -173,10 +173,9 @@ func (s *fetchSource) Create(ctx context.Context) (GetResult, Volume, error) {
 		// TODO: Is this compatible with previous behaviour of returning a nil when error type is NOT ErrResourceScriptFailed
 
 		if failErr, ok := err.(runtime.ErrResourceScriptFailed); ok {
-			// TODO: we need to pass along the script error message
-			//		 contained in failErr.Stderr
 			return GetResult{
 				Status: failErr.ExitStatus,
+				Failure: failErr,
 			}, nil, nil
 		}
 		return GetResult{}, nil, err

--- a/atc/worker/fetch_source.go
+++ b/atc/worker/fetch_source.go
@@ -124,7 +124,7 @@ func (s *fetchSource) Find() (GetResult, Volume, bool, error) {
 	}
 
 	return GetResult{
-			Status: 0,
+			ExitStatus: 0,
 			VersionResult: runtime.VersionResult{
 				Version:  s.cache.Version(),
 				Metadata: atcMetaData,
@@ -174,8 +174,7 @@ func (s *fetchSource) Create(ctx context.Context) (GetResult, Volume, error) {
 
 		if failErr, ok := err.(runtime.ErrResourceScriptFailed); ok {
 			return GetResult{
-				Status: failErr.ExitStatus,
-				Failure: failErr,
+				ExitStatus: failErr.ExitStatus,
 			}, nil, nil
 		}
 		return GetResult{}, nil, err
@@ -202,7 +201,7 @@ func (s *fetchSource) Create(ctx context.Context) (GetResult, Volume, error) {
 	}
 
 	return GetResult{
-		Status:        0,
+		ExitStatus:    0,
 		VersionResult: vr,
 		GetArtifact: runtime.GetArtifact{
 			VolumeHandle: volume.Handle(),

--- a/atc/worker/fetch_source_test.go
+++ b/atc/worker/fetch_source_test.go
@@ -146,7 +146,7 @@ var _ = Describe("FetchSource", func() {
 					{Name: "some", Value: "metadata"},
 				}
 				expectedGetResult = worker.GetResult{
-					Status:        0,
+					ExitStatus:    0,
 					VersionResult: runtime.VersionResult{Metadata: expectedMetadata},
 					GetArtifact:   runtime.GetArtifact{fakeVolume.Handle()},
 				}
@@ -197,7 +197,7 @@ var _ = Describe("FetchSource", func() {
 					{Name: "some", Value: "metadata"},
 				}
 				expectedGetResult = worker.GetResult{
-					Status:        0,
+					ExitStatus:    0,
 					VersionResult: runtime.VersionResult{Metadata: expectedMetadata},
 					GetArtifact:   runtime.GetArtifact{fakeVolume.Handle()},
 				}
@@ -281,7 +281,7 @@ var _ = Describe("FetchSource", func() {
 			})
 
 			It("returns a successful GetResult and volume with fetched bits", func() {
-				Expect(getResult.Status).To(BeZero())
+				Expect(getResult.ExitStatus).To(BeZero())
 				Expect(getResult.GetArtifact.VolumeHandle).To(Equal(fakeVolume.Handle()))
 				Expect(volume).ToNot(BeNil())
 			})

--- a/atc/worker/gclient/connection/connection.go
+++ b/atc/worker/gclient/connection/connection.go
@@ -274,7 +274,7 @@ func (c *connection) streamProcess(ctx context.Context, handle string, processIO
 
 		select {
 		case <-ctx.Done():
-			process.exited(-1, errors.New("stdin/stdout/stderr streams were canceled by context.Done"))
+			process.exited(-1, fmt.Errorf("stdin/stdout/stderr streams were canceled by: %w", ctx.Err()))
 		case waitedFor := <-streamHandler.wait(decoder):
 			process.exited(waitedFor.exitCode, waitedFor.err)
 		}

--- a/atc/worker/workerfakes/fake_client.go
+++ b/atc/worker/workerfakes/fake_client.go
@@ -89,7 +89,7 @@ type FakeClient struct {
 		result1 worker.GetResult
 		result2 error
 	}
-	RunPutStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource) worker.PutResult
+	RunPutStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource) (worker.PutResult, error)
 	runPutStepMutex       sync.RWMutex
 	runPutStepArgsForCall []struct {
 		arg1  context.Context
@@ -106,11 +106,13 @@ type FakeClient struct {
 	}
 	runPutStepReturns struct {
 		result1 worker.PutResult
+		result2 error
 	}
 	runPutStepReturnsOnCall map[int]struct {
 		result1 worker.PutResult
+		result2 error
 	}
-	RunTaskStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, lock.LockFactory) worker.TaskResult
+	RunTaskStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, lock.LockFactory) (worker.TaskResult, error)
 	runTaskStepMutex       sync.RWMutex
 	runTaskStepArgsForCall []struct {
 		arg1  context.Context
@@ -127,9 +129,11 @@ type FakeClient struct {
 	}
 	runTaskStepReturns struct {
 		result1 worker.TaskResult
+		result2 error
 	}
 	runTaskStepReturnsOnCall map[int]struct {
 		result1 worker.TaskResult
+		result2 error
 	}
 	StreamFileFromArtifactStub        func(context.Context, lager.Logger, runtime.Artifact, string) (io.ReadCloser, error)
 	streamFileFromArtifactMutex       sync.RWMutex
@@ -427,7 +431,7 @@ func (fake *FakeClient) RunGetStepReturnsOnCall(i int, result1 worker.GetResult,
 	}{result1, result2}
 }
 
-func (fake *FakeClient) RunPutStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 worker.ImageFetcherSpec, arg9 runtime.ProcessSpec, arg10 runtime.StartingEventDelegate, arg11 resource.Resource) worker.PutResult {
+func (fake *FakeClient) RunPutStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 worker.ImageFetcherSpec, arg9 runtime.ProcessSpec, arg10 runtime.StartingEventDelegate, arg11 resource.Resource) (worker.PutResult, error) {
 	fake.runPutStepMutex.Lock()
 	ret, specificReturn := fake.runPutStepReturnsOnCall[len(fake.runPutStepArgsForCall)]
 	fake.runPutStepArgsForCall = append(fake.runPutStepArgsForCall, struct {
@@ -449,10 +453,10 @@ func (fake *FakeClient) RunPutStep(arg1 context.Context, arg2 lager.Logger, arg3
 		return fake.RunPutStepStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
 	fakeReturns := fake.runPutStepReturns
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) RunPutStepCallCount() int {
@@ -461,7 +465,7 @@ func (fake *FakeClient) RunPutStepCallCount() int {
 	return len(fake.runPutStepArgsForCall)
 }
 
-func (fake *FakeClient) RunPutStepCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource) worker.PutResult) {
+func (fake *FakeClient) RunPutStepCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource) (worker.PutResult, error)) {
 	fake.runPutStepMutex.Lock()
 	defer fake.runPutStepMutex.Unlock()
 	fake.RunPutStepStub = stub
@@ -474,30 +478,33 @@ func (fake *FakeClient) RunPutStepArgsForCall(i int) (context.Context, lager.Log
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8, argsForCall.arg9, argsForCall.arg10, argsForCall.arg11
 }
 
-func (fake *FakeClient) RunPutStepReturns(result1 worker.PutResult) {
+func (fake *FakeClient) RunPutStepReturns(result1 worker.PutResult, result2 error) {
 	fake.runPutStepMutex.Lock()
 	defer fake.runPutStepMutex.Unlock()
 	fake.RunPutStepStub = nil
 	fake.runPutStepReturns = struct {
 		result1 worker.PutResult
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeClient) RunPutStepReturnsOnCall(i int, result1 worker.PutResult) {
+func (fake *FakeClient) RunPutStepReturnsOnCall(i int, result1 worker.PutResult, result2 error) {
 	fake.runPutStepMutex.Lock()
 	defer fake.runPutStepMutex.Unlock()
 	fake.RunPutStepStub = nil
 	if fake.runPutStepReturnsOnCall == nil {
 		fake.runPutStepReturnsOnCall = make(map[int]struct {
 			result1 worker.PutResult
+			result2 error
 		})
 	}
 	fake.runPutStepReturnsOnCall[i] = struct {
 		result1 worker.PutResult
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeClient) RunTaskStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 worker.ImageFetcherSpec, arg9 runtime.ProcessSpec, arg10 runtime.StartingEventDelegate, arg11 lock.LockFactory) worker.TaskResult {
+func (fake *FakeClient) RunTaskStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 worker.ImageFetcherSpec, arg9 runtime.ProcessSpec, arg10 runtime.StartingEventDelegate, arg11 lock.LockFactory) (worker.TaskResult, error) {
 	fake.runTaskStepMutex.Lock()
 	ret, specificReturn := fake.runTaskStepReturnsOnCall[len(fake.runTaskStepArgsForCall)]
 	fake.runTaskStepArgsForCall = append(fake.runTaskStepArgsForCall, struct {
@@ -519,10 +526,10 @@ func (fake *FakeClient) RunTaskStep(arg1 context.Context, arg2 lager.Logger, arg
 		return fake.RunTaskStepStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
 	fakeReturns := fake.runTaskStepReturns
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) RunTaskStepCallCount() int {
@@ -531,7 +538,7 @@ func (fake *FakeClient) RunTaskStepCallCount() int {
 	return len(fake.runTaskStepArgsForCall)
 }
 
-func (fake *FakeClient) RunTaskStepCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, lock.LockFactory) worker.TaskResult) {
+func (fake *FakeClient) RunTaskStepCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, lock.LockFactory) (worker.TaskResult, error)) {
 	fake.runTaskStepMutex.Lock()
 	defer fake.runTaskStepMutex.Unlock()
 	fake.RunTaskStepStub = stub
@@ -544,27 +551,30 @@ func (fake *FakeClient) RunTaskStepArgsForCall(i int) (context.Context, lager.Lo
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8, argsForCall.arg9, argsForCall.arg10, argsForCall.arg11
 }
 
-func (fake *FakeClient) RunTaskStepReturns(result1 worker.TaskResult) {
+func (fake *FakeClient) RunTaskStepReturns(result1 worker.TaskResult, result2 error) {
 	fake.runTaskStepMutex.Lock()
 	defer fake.runTaskStepMutex.Unlock()
 	fake.RunTaskStepStub = nil
 	fake.runTaskStepReturns = struct {
 		result1 worker.TaskResult
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeClient) RunTaskStepReturnsOnCall(i int, result1 worker.TaskResult) {
+func (fake *FakeClient) RunTaskStepReturnsOnCall(i int, result1 worker.TaskResult, result2 error) {
 	fake.runTaskStepMutex.Lock()
 	defer fake.runTaskStepMutex.Unlock()
 	fake.RunTaskStepStub = nil
 	if fake.runTaskStepReturnsOnCall == nil {
 		fake.runTaskStepReturnsOnCall = make(map[int]struct {
 			result1 worker.TaskResult
+			result2 error
 		})
 	}
 	fake.runTaskStepReturnsOnCall[i] = struct {
 		result1 worker.TaskResult
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeClient) StreamFileFromArtifact(arg1 context.Context, arg2 lager.Logger, arg3 runtime.Artifact, arg4 string) (io.ReadCloser, error) {


### PR DESCRIPTION
# Existing Issue

Fixes #4969  .

# Why do we need this PR?
This cleans up the return results form client.RunXStep funcs. Previously they used values such as -1 exit code to indicate concourse errors which didn't fit go paradigms and just were'n't that transparent.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [x] Integration tests (if applicable)
- [x] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
