### PR TITLE
Fix repository_test.go

### DIFF
--- a/atc/exec/build/repository_test.go
+++ b/atc/exec/build/repository_test.go
@@ -28,6 +28,7 @@ var _ = Describe("ArtifactRepository", func() {
 
 		BeforeEach(func() {
 			firstArtifact = new(runtimefakes.FakeArtifact)
+			firstArtifact.IDReturns("some-first")
 			repo.RegisterArtifact("first-artifact", firstArtifact)
 		})
 
@@ -46,29 +47,31 @@ var _ = Describe("ArtifactRepository", func() {
 		})
 
 		Context("when a second artifact is registered", func() {
-			var artifact *runtimefakes.FakeArtifact
+			var secondArtifact *runtimefakes.FakeArtifact
 
 			BeforeEach(func() {
-				artifact = new(runtimefakes.FakeArtifact)
-				repo.RegisterArtifact("second-artifact", artifact)
+				secondArtifact = new(runtimefakes.FakeArtifact)
+				secondArtifact.IDReturns("some-second")
+
+				repo.RegisterArtifact("second-artifact", secondArtifact)
 			})
 
 			Describe("ArtifactFor", func() {
 				It("yields the first artifact by the given name", func() {
-					artifact, found := repo.ArtifactFor("first-artifact")
-					Expect(artifact).To(Equal(firstArtifact))
+					actualArtifact, found := repo.ArtifactFor("first-artifact")
+					Expect(actualArtifact).To(Equal(firstArtifact))
 					Expect(found).To(BeTrue())
 				})
 
 				It("yields the second artifact by the given name", func() {
-					artifact, found := repo.ArtifactFor("second-artifact")
-					Expect(artifact).To(Equal(firstArtifact))
+					actualArtifact, found := repo.ArtifactFor("second-artifact")
+					Expect(actualArtifact).To(Equal(secondArtifact))
 					Expect(found).To(BeTrue())
 				})
 
 				It("yields nothing for unregistered names", func() {
-					artifact, found := repo.ArtifactFor("bogus-artifact")
-					Expect(artifact).To(BeNil())
+					actualArtifact, found := repo.ArtifactFor("bogus-artifact")
+					Expect(actualArtifact).To(BeNil())
 					Expect(found).To(BeFalse())
 				})
 			})


### PR DESCRIPTION
# Why do we need this PR?
Addresses @deniseyu's  comment in https://github.com/concourse/concourse/pull/4825
- unit test had a false positive with first_artifact == second_artifact
  due to the way fakes were compared
- refactored variable names to be clearer

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x ] Unit tests

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
