### PR TITLE
Migrate all types of serial groups and error checks that fail to create check step

### DIFF
--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -807,7 +807,11 @@ func (j *job) isMaxInFlightReached(tx Tx, buildID int) (bool, error) {
 		return true, nil
 	}
 
-	return nextMostPendingBuild.ID() != buildID, nil
+	if nextMostPendingBuild.ID() != buildID {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (j *job) getSerialGroups(tx Tx) ([]string, error) {

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -366,6 +366,7 @@ func (c *engineCheck) Run(logger lager.Logger) {
 	step, err := c.builder.CheckStep(logger, c.check)
 	if err != nil {
 		logger.Error("failed-to-create-check-step", err)
+		c.check.FinishWithError(fmt.Errorf("create check step: %w", err))
 		return
 	}
 
@@ -387,7 +388,7 @@ func (c *engineCheck) Run(logger lager.Logger) {
 	case err = <-done:
 		if err != nil {
 			logger.Info("errored", lager.Data{"error": err.Error()})
-			c.check.FinishWithError(err)
+			c.check.FinishWithError(fmt.Errorf("run check step: %w", err))
 		} else {
 			logger.Info("succeeded")
 			if err = c.check.Finish(); err != nil {

--- a/atc/engine/engine_test.go
+++ b/atc/engine/engine_test.go
@@ -3,6 +3,7 @@ package engine_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -458,6 +459,7 @@ var _ = Describe("Engine", func() {
 							It("finishes the check", func() {
 								waitGroup.Wait()
 								Expect(fakeCheck.FinishWithErrorCallCount()).To(Equal(1))
+								Expect(fakeCheck.FinishWithErrorArgsForCall(0)).To(Equal(fmt.Errorf("run check step: %w", errors.New("nope"))))
 							})
 						})
 
@@ -480,6 +482,7 @@ var _ = Describe("Engine", func() {
 
 						It("releases the lock", func() {
 							Expect(fakeLock.ReleaseCallCount()).To(Equal(1))
+							Expect(fakeCheck.FinishWithErrorArgsForCall(0)).To(Equal(fmt.Errorf("create check step: %w", errors.New("nope"))))
 						})
 					})
 				})


### PR DESCRIPTION
This PR includes two bug fixes:
1. Concourse v6.0 expects all types of serial groups to be in the `jobs_serial_groups` table but prior to it, there was a bug where only one type of serial group was inserted into that table on set pipeline. This PR includes a migration that will move over all the serial groups into the table.
2. We will now error and finish a check step if it fails when it is being created in the engine. This was added in order to avoid cases where creating a check step will never succeed because it has outdated information in it's metadata.  