### PR TITLE
atc: always emit a metric for each worker state

### DIFF
--- a/atc/db/worker.go
+++ b/atc/db/worker.go
@@ -36,6 +36,16 @@ const (
 	WorkerStateRetiring = WorkerState("retiring")
 )
 
+func AllWorkerStates() []WorkerState {
+	return []WorkerState{
+		WorkerStateRunning,
+		WorkerStateStalled,
+		WorkerStateLanding,
+		WorkerStateLanded,
+		WorkerStateRetiring,
+	}
+}
+
 //go:generate counterfeiter . Worker
 
 type Worker interface {

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -675,20 +675,20 @@ func (event WorkersState) Emit(logger lager.Logger) {
 	for _, workerState := range event.WorkerStateByName {
 		_, exists := perStateCounter[workerState]
 		if !exists {
-			perStateCounter[workerState] = 0
+			perStateCounter[workerState] = 1
 			continue
 		}
 
 		perStateCounter[workerState] += 1
 	}
 
-	for state, count := range perStateCounter {
+	for _, state := range db.AllWorkerStates() {
+		count := perStateCounter[state]
 		if state == db.WorkerStateStalled && count > 0 {
 			eventState = EventStateWarning
 		} else {
 			eventState = EventStateOK
 		}
-
 		emit(
 			logger.Session("worker-state"),
 			Event{

--- a/atc/metric/metrics_test.go
+++ b/atc/metric/metrics_test.go
@@ -1,0 +1,105 @@
+package metric_test
+
+import (
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/metric"
+	"github.com/concourse/concourse/atc/metric/metricfakes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Metrics", func() {
+	Describe("worker state metric", func() {
+		var emitter *smartFakeEmitter
+
+		BeforeEach(func() {
+			emitter = registerFakeEmitterInUnsafeGlobalMap()
+		})
+
+		AfterEach(func() {
+			metric.Deinitialize(testLogger)
+		})
+
+		It("emits a value for every state", func() {
+			givenNoWorkers().Emit(testLogger)
+
+			waitForEventsOnUnsafeGlobalChannel(emitter)
+
+			for _, state := range db.AllWorkerStates() {
+				event := emitter.eventWithState(state)
+				Expect(event.Value).To(Equal(0))
+			}
+		})
+
+		It("correctly emits the number of running workers", func() {
+			givenOneWorkerWithState(db.WorkerStateRunning).
+				Emit(testLogger)
+
+			waitForEventsOnUnsafeGlobalChannel(emitter)
+
+			event := emitter.eventWithState(db.WorkerStateRunning)
+			Expect(event.Value).To(Equal(1))
+		})
+
+		It("emits warning event for stalled workers", func() {
+			givenOneWorkerWithState(db.WorkerStateStalled).
+				Emit(testLogger)
+
+			waitForEventsOnUnsafeGlobalChannel(emitter)
+
+			event := emitter.eventWithState(db.WorkerStateStalled)
+			Expect(event.State).To(Equal(metric.EventStateWarning))
+		})
+
+		It("if no workers are stalled, emitted event has OK status", func() {
+			givenNoWorkers().Emit(testLogger)
+
+			waitForEventsOnUnsafeGlobalChannel(emitter)
+
+			event := emitter.eventWithState(db.WorkerStateStalled)
+			Expect(event.State).To(Equal(metric.EventStateOK))
+		})
+	})
+})
+
+type smartFakeEmitter struct {
+	metricfakes.FakeEmitter
+}
+
+func (fakeEmitter *smartFakeEmitter) eventWithState(state db.WorkerState) *metric.Event {
+	for i := 0; i < fakeEmitter.EmitCallCount(); i++ {
+		_, event := fakeEmitter.EmitArgsForCall(i)
+		if event.Attributes["state"] == string(state) {
+			return &event
+		}
+	}
+	return nil
+}
+
+func givenNoWorkers() metric.WorkersState {
+	return metric.WorkersState{
+		WorkerStateByName: make(map[string]db.WorkerState),
+	}
+}
+
+func givenOneWorkerWithState(state db.WorkerState) metric.WorkersState {
+	workersState := givenNoWorkers()
+	workersState.WorkerStateByName["my-worker"] = state
+	return workersState
+}
+
+func waitForEventsOnUnsafeGlobalChannel(fakeEmitter *smartFakeEmitter) {
+	numberOfWorkerStates := len(db.AllWorkerStates())
+	Eventually(fakeEmitter.EmitCallCount).Should(Equal(numberOfWorkerStates))
+}
+
+func registerFakeEmitterInUnsafeGlobalMap() *smartFakeEmitter {
+	fakeEmitter := new(smartFakeEmitter)
+	emitterFactory := new(metricfakes.FakeEmitterFactory)
+	emitterFactory.IsConfiguredReturns(true)
+	emitterFactory.NewEmitterReturns(fakeEmitter, nil)
+	metric.RegisterEmitter(emitterFactory)
+	metric.Initialize(testLogger, "test", map[string]string{}, 1000)
+	return fakeEmitter
+}


### PR DESCRIPTION
# Existing Issue

Fixes #4985.

# Changes proposed in this pull request

The key change is to ensure that 0 values for state counts are emitted. I have a bit of a concern around the scalability of this - before this change we only emitted metrics for states where the count of workers was greater than zero, but now we're guaranteed 5 worker state metric events every tick. I guess a typical healthy cluster probably tends to have all running workers most of the time, so this could effectively mean 5 times as many worker state metrics events.

I don't know what the typical "utilization rate" of the metrics queue is (like how many events tend to be queued up as a proportion of the max length and in particular the typical proportion of the queue's max length that are worker state metrics), but if a cluster has a tendency to get that "queue-full" error I could see this change exacerbating it.

Outside of the "queue utilization" problem is the question of how the various metrics emitters are implemented -- if the emitter makes a request to an external (potentially costly or rate-limited) system, then increasing the number of events in this fashion could also put pressure on those systems. Obviously Prometheus wouldn't suffer from this problem, and I tried to figure out how the Datadog client worked, but couldn't see a non-noop concrete implementation of the `Gauge` method. Admittedly I didn't look for that long.

# Contributor Checklist
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~