### PR TITLE
switch to pure go impl of zstd

### DIFF
--- a/atc/worker/artifact_source_test.go
+++ b/atc/worker/artifact_source_test.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/DataDog/zstd"
+	"github.com/klauspost/compress/zstd"
 	"github.com/concourse/concourse/atc/runtime"
 	"github.com/concourse/concourse/atc/runtime/runtimefakes"
 	"github.com/concourse/concourse/atc/worker"
@@ -115,13 +115,14 @@ var _ = Describe("StreamableArtifactSource", func() {
 			BeforeEach(func() {
 				tgzBuffer = gbytes.NewBuffer()
 				fakeVolume.StreamOutReturns(tgzBuffer, nil)
-				zstdWriter := zstd.NewWriter(tgzBuffer)
+				zstdWriter, err := zstd.NewWriter(tgzBuffer)
+				Expect(err).ToNot(HaveOccurred())
 				defer zstdWriter.Close()
 
 				tarWriter := tar.NewWriter(zstdWriter)
 				defer tarWriter.Close()
 
-				err := tarWriter.WriteHeader(&tar.Header{
+				err = tarWriter.WriteHeader(&tar.Header{
 					Name: "some-file",
 					Mode: 0644,
 					Size: int64(len(fileContent)),

--- a/atc/worker/image/image_resource_fetcher_test.go
+++ b/atc/worker/image/image_resource_fetcher_test.go
@@ -9,7 +9,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
-	"github.com/DataDog/zstd"
+	"github.com/klauspost/compress/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
@@ -629,10 +629,12 @@ var _ = Describe("Image", func() {
 func tgzStreamWith(metadata string) io.ReadCloser {
 	buffer := gbytes.NewBuffer()
 
-	zstdWriter := zstd.NewWriter(buffer)
+	zstdWriter, err := zstd.NewWriter(buffer)
+	Expect(err).NotTo(HaveOccurred())
+
 	tarWriter := tar.NewWriter(zstdWriter)
 
-	err := tarWriter.WriteHeader(&tar.Header{
+	err = tarWriter.WriteHeader(&tar.Header{
 		Name: "metadata.json",
 		Mode: 0600,
 		Size: int64(len(metadata)),

--- a/fly/commands/internal/executehelpers/downloads.go
+++ b/fly/commands/internal/executehelpers/downloads.go
@@ -1,7 +1,7 @@
 package executehelpers
 
 import (
-	"github.com/DataDog/zstd"
+	"github.com/klauspost/compress/zstd"
 	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/concourse/go-archive/tarfs"
 	"github.com/vbauerster/mpb/v4"
@@ -15,5 +15,10 @@ func Download(bar *mpb.Bar, team concourse.Team, artifactID int, path string) er
 
 	defer out.Close()
 
-	return tarfs.Extract(zstd.NewReader(bar.ProxyReader(out)), path)
+	zstdReader, err := zstd.NewReader(bar.ProxyReader(out))
+	if err != nil {
+		return err
+	}
+
+	return tarfs.Extract(zstdReader, path)
 }

--- a/fly/integration/execute_multiple_inputs_test.go
+++ b/fly/integration/execute_multiple_inputs_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/event"
 	. "github.com/onsi/ginkgo"
@@ -19,6 +18,7 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/klauspost/compress/zstd"
 	"github.com/vito/go-sse/sse"
 )
 
@@ -133,7 +133,10 @@ run:
 				func(w http.ResponseWriter, req *http.Request) {
 					Expect(req.FormValue("platform")).To(Equal("some-platform"))
 
-					tr := tar.NewReader(zstd.NewReader(req.Body))
+					zstdReader, err := zstd.NewReader(req.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					tr := tar.NewReader(zstdReader)
 
 					hdr, err := tr.Next()
 					Expect(err).NotTo(HaveOccurred())

--- a/fly/integration/execute_overriding_inputs_test.go
+++ b/fly/integration/execute_overriding_inputs_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/event"
 	. "github.com/onsi/ginkgo"
@@ -18,6 +17,7 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/klauspost/compress/zstd"
 	"github.com/vito/go-sse/sse"
 )
 
@@ -166,7 +166,10 @@ run:
 
 					Expect(req.FormValue("platform")).To(Equal("some-platform"))
 
-					tr := tar.NewReader(zstd.NewReader(req.Body))
+					zstdReader, err := zstd.NewReader(req.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					tr := tar.NewReader(zstdReader)
 
 					hdr, err := tr.Next()
 					Expect(err).NotTo(HaveOccurred())

--- a/fly/integration/execute_test.go
+++ b/fly/integration/execute_test.go
@@ -16,9 +16,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/event"
+	"github.com/klauspost/compress/zstd"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -134,7 +134,10 @@ run:
 				func(w http.ResponseWriter, req *http.Request) {
 					close(uploading)
 
-					tr := tar.NewReader(zstd.NewReader(req.Body))
+					zstdReader, err := zstd.NewReader(req.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					tr := tar.NewReader(zstdReader)
 
 					hdr, err := tr.Next()
 					Expect(err).NotTo(HaveOccurred())

--- a/fly/integration/execute_with_outputs_test.go
+++ b/fly/integration/execute_with_outputs_test.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/event"
+	"github.com/klauspost/compress/zstd"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -147,7 +147,10 @@ run:
 				func(w http.ResponseWriter, req *http.Request) {
 					Expect(req.FormValue("platform")).To(Equal("some-platform"))
 
-					tr := tar.NewReader(zstd.NewReader(req.Body))
+					zstdReader, err := zstd.NewReader(req.Body)
+					Expect(err).NotTo(HaveOccurred())
+
+					tr := tar.NewReader(zstdReader)
 
 					hdr, err := tr.Next()
 					Expect(err).NotTo(HaveOccurred())
@@ -274,12 +277,13 @@ run:
 })
 
 func tarHandler(w http.ResponseWriter, req *http.Request) {
-	zw := zstd.NewWriter(w)
+	zw, err := zstd.NewWriter(w)
+	Expect(err).NotTo(HaveOccurred())
 	tw := tar.NewWriter(zw)
 
 	tarContents := []byte("tar-contents")
 
-	err := tw.WriteHeader(&tar.Header{
+	err = tw.WriteHeader(&tar.Header{
 		Name: "some-file",
 		Mode: 0644,
 		Size: int64(len(tarContents)),

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/influxdata/influxdb1-client v0.0.0-20190118215656-f8cdb5d5f175
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/json-iterator/go v1.1.7 // indirect
+	github.com/klauspost/compress v1.9.7
 	github.com/kr/pty v1.1.8
 	github.com/krishicks/yaml-patch v0.0.10
 	github.com/lib/pq v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	code.cloudfoundry.org/localip v0.0.0-20170223024724-b88ad0dea95c
 	code.cloudfoundry.org/urljoiner v0.0.0-20170223060717-5cabba6c0a50
 	github.com/DataDog/datadog-go v3.2.0+incompatible
-	github.com/DataDog/zstd v1.4.0
 	github.com/Masterminds/squirrel v1.1.0
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
 	github.com/NYTimes/gziphandler v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.9.7 h1:hYW1gP94JUmAhBtJ+LNz5My+gBobDxPR1iVuKug26aA=
+github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=


### PR DESCRIPTION
Signed-off-by: Alex Suraci <asuraci@pivotal.io>
Co-authored-by: Krishna Mannem <kmannem@pivotal.io>

Fixes #4621

# Changes proposed in this pull request

* converts datadog/zstd dependency to klauspost/compress/zstd


# Contributor Checklist
- [x] Unit tests
- [x] Integration tests (if applicable)
- [x] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
