### PR TITLE
Use all plans (nested ones) instead of only top level plan

### DIFF
--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Config API", func() {
 					Name:   "some-job",
 					Public: true,
 					Serial: true,
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Get:      "some-input",
 							Resource: "some-resource",
@@ -525,7 +525,7 @@ jobs:
 									Jobs: atc.JobConfigs{
 										{
 											Name: "some-job",
-											Plan: atc.PlanSequence{
+											ParentPlan: atc.PlanSequence{
 												{
 													Get: "some-resource",
 												},
@@ -738,7 +738,7 @@ jobs:
 									Jobs: atc.JobConfigs{
 										{
 											Name: "some-job",
-											Plan: atc.PlanSequence{
+											ParentPlan: atc.PlanSequence{
 												{
 													Get: "some-resource",
 												},
@@ -945,9 +945,9 @@ jobs:
 						Expect(savedConfig).To(Equal(atc.Config{
 							Jobs: atc.JobConfigs{
 								{
-									Name:   "some-job",
-									Public: true,
-									Plan:   atc.PlanSequence{},
+									Name:       "some-job",
+									Public:     true,
+									ParentPlan: atc.PlanSequence{},
 								},
 							},
 						}))

--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -147,7 +147,7 @@ func validateCredParams(credMgrVars vars.Variables, config atc.Config, session l
 	}
 
 	for _, job := range config.Jobs {
-		for _, plan := range job.Plan {
+		for _, plan := range job.Plans() {
 			_, err := creds.NewParams(credMgrVars, plan.Params).Evaluate()
 			if err != nil {
 				errs = multierror.Append(errs, err)

--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -1758,7 +1758,7 @@ var _ = Describe("Jobs API", func() {
 								BeforeEach(func() {
 									fakeJob.ConfigReturns(atc.JobConfig{
 										Name: "some-job",
-										Plan: atc.PlanSequence{
+										ParentPlan: atc.PlanSequence{
 											{
 												Get:      "some-input",
 												Resource: "some-resource",

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -276,7 +276,7 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 			}
 		}
 
-		planWarnings, planErrMessages := validatePlan(c, identifier+".plan", PlanConfig{Do: &job.Plan})
+		planWarnings, planErrMessages := validatePlan(c, identifier+".plan", PlanConfig{Do: &job.ParentPlan})
 		warnings = append(warnings, planWarnings...)
 		errorMessages = append(errorMessages, planErrMessages...)
 

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -61,7 +61,7 @@ var _ = Describe("ValidateConfig", func() {
 					Name:   "some-job",
 					Public: true,
 					Serial: true,
-					Plan: PlanSequence{
+					ParentPlan: PlanSequence{
 						{
 							Get:      "some-input",
 							Resource: "some-resource",
@@ -447,7 +447,7 @@ var _ = Describe("ValidateConfig", func() {
 				Jobs: JobConfigs{
 					{
 						Name: "some-job",
-						Plan: PlanSequence{
+						ParentPlan: PlanSequence{
 							{
 								Get: "get",
 							},
@@ -535,7 +535,7 @@ var _ = Describe("ValidateConfig", func() {
 					},
 					{
 						Name: "another-job",
-						Plan: PlanSequence{
+						ParentPlan: PlanSequence{
 							{
 								Get: "another-job",
 							},
@@ -656,10 +656,10 @@ var _ = Describe("ValidateConfig", func() {
 
 		Context("when a job has duplicate inputs", func() {
 			BeforeEach(func() {
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					Get: "some-resource",
 				})
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					Get: "some-resource",
 				})
 
@@ -675,11 +675,11 @@ var _ = Describe("ValidateConfig", func() {
 
 		Context("when a job has duplicate inputs with different resources", func() {
 			BeforeEach(func() {
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					Get:      "some-resource",
 					Resource: "a",
 				})
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					Get:      "some-resource",
 					Resource: "b",
 				})
@@ -696,11 +696,11 @@ var _ = Describe("ValidateConfig", func() {
 
 		Context("when a job gets the same resource multiple times but with different names", func() {
 			BeforeEach(func() {
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					Get:      "a",
 					Resource: "some-resource",
 				})
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					Get:      "b",
 					Resource: "some-resource",
 				})
@@ -715,10 +715,10 @@ var _ = Describe("ValidateConfig", func() {
 
 		Context("when a job has duplicate inputs via aggregate", func() {
 			BeforeEach(func() {
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					Get: "some-resource",
 				})
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					Aggregate: &PlanSequence{
 						{
 							Get: "some-resource",
@@ -738,10 +738,10 @@ var _ = Describe("ValidateConfig", func() {
 
 		Context("when a job has duplicate inputs via parallel", func() {
 			BeforeEach(func() {
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					Get: "some-resource",
 				})
-				job.Plan = append(job.Plan, PlanConfig{
+				job.ParentPlan = append(job.ParentPlan, PlanConfig{
 					InParallel: &InParallelConfig{
 						Steps: PlanSequence{
 							{
@@ -767,7 +767,7 @@ var _ = Describe("ValidateConfig", func() {
 			Context("when multiple actions are specified in the same plan", func() {
 				Context("when it's not just Get and Put", func() {
 					BeforeEach(func() {
-						job.Plan = append(job.Plan, PlanConfig{
+						job.ParentPlan = append(job.ParentPlan, PlanConfig{
 							Get:        "some-resource",
 							Put:        "some-resource",
 							Task:       "some-resource",
@@ -788,7 +788,7 @@ var _ = Describe("ValidateConfig", func() {
 
 				Context("when it's just Get and Put (this was valid at one point)", func() {
 					BeforeEach(func() {
-						job.Plan = append(job.Plan, PlanConfig{
+						job.ParentPlan = append(job.ParentPlan, PlanConfig{
 							Get:        "some-resource",
 							Put:        "some-resource",
 							Task:       "",
@@ -810,7 +810,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when no actions are specified in the plan", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{})
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{})
 
 					config.Jobs = append(config.Jobs, job)
 				})
@@ -824,7 +824,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a get plan has task-only fields specified", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get:        "lol",
 						Privileged: true,
 						ConfigPath: "task.yml",
@@ -842,7 +842,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a task plan has invalid fields specified", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Task:     "lol",
 						Resource: "some-resource",
 						Passed:   []string{"hi"},
@@ -861,7 +861,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a task plan has neither a config or a path set", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Task:              "lol",
 						ImageArtifactName: "some-image",
 					})
@@ -878,7 +878,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a task plan has config path and config specified", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Task:       "lol",
 						ConfigPath: "task.yml",
 						TaskConfig: &TaskConfig{
@@ -900,7 +900,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a task plan is invalid", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Task: "some-resource",
 						TaskConfig: &TaskConfig{
 							Params: TaskEnv{
@@ -922,7 +922,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a put plan has invalid fields specified", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Put:        "lol",
 						Passed:     []string{"get", "only"},
 						Trigger:    true,
@@ -942,7 +942,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a put plan has refers to a resource that does exist", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Put: "some-resource",
 					})
 
@@ -956,7 +956,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a get plan has refers to a resource that does not exist", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get: "some-nonexistent-resource",
 					})
 
@@ -972,7 +972,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a put plan has refers to a resource that does not exist", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Put: "some-nonexistent-resource",
 					})
 
@@ -988,7 +988,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a get plan has a custom name but refers to a resource that does exist", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get:      "custom-name",
 						Resource: "some-resource",
 					})
@@ -1003,7 +1003,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a get plan has a custom name but refers to a resource that does not exist", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get:      "custom-name",
 						Resource: "some-missing-resource",
 					})
@@ -1020,7 +1020,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a put plan has a custom name but refers to a resource that does exist", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Put:      "custom-name",
 						Resource: "some-resource",
 					})
@@ -1076,7 +1076,7 @@ var _ = Describe("ValidateConfig", func() {
 						Name: "job-two",
 					}
 
-					job1.Plan = append(job1.Plan, PlanConfig{
+					job1.ParentPlan = append(job1.ParentPlan, PlanConfig{
 						Task: "job-one",
 						Success: &PlanConfig{
 							Put: "some-resource",
@@ -1084,7 +1084,7 @@ var _ = Describe("ValidateConfig", func() {
 						ConfigPath: "job-one-config-path",
 					})
 
-					job2.Plan = append(job2.Plan, PlanConfig{
+					job2.ParentPlan = append(job2.ParentPlan, PlanConfig{
 						Get:    "some-resource",
 						Passed: []string{"job-one"},
 					})
@@ -1109,7 +1109,7 @@ var _ = Describe("ValidateConfig", func() {
 						Name: "job-two",
 					}
 
-					job1.Plan = append(job1.Plan, PlanConfig{
+					job1.ParentPlan = append(job1.ParentPlan, PlanConfig{
 						Task: "job-one",
 						Success: &PlanConfig{
 							Get: "some-resource",
@@ -1117,7 +1117,7 @@ var _ = Describe("ValidateConfig", func() {
 						ConfigPath: "job-one-config-path",
 					})
 
-					job2.Plan = append(job2.Plan, PlanConfig{
+					job2.ParentPlan = append(job2.ParentPlan, PlanConfig{
 						Get:    "some-resource",
 						Passed: []string{"job-one"},
 					})
@@ -1142,14 +1142,14 @@ var _ = Describe("ValidateConfig", func() {
 						Name: "job-two",
 					}
 
-					job1.Plan = append(job1.Plan, PlanConfig{
+					job1.ParentPlan = append(job1.ParentPlan, PlanConfig{
 						Try: &PlanConfig{
 							Put: "some-resource",
 						},
 						ConfigPath: "job-one-config-path",
 					})
 
-					job2.Plan = append(job2.Plan, PlanConfig{
+					job2.ParentPlan = append(job2.ParentPlan, PlanConfig{
 						Get:    "some-resource",
 						Passed: []string{"job-one"},
 					})
@@ -1175,14 +1175,14 @@ var _ = Describe("ValidateConfig", func() {
 						Name: "job-two",
 					}
 
-					job1.Plan = append(job1.Plan, PlanConfig{
+					job1.ParentPlan = append(job1.ParentPlan, PlanConfig{
 						Try: &PlanConfig{
 							Get: "some-resource",
 						},
 						ConfigPath: "job-one-config-path",
 					})
 
-					job2.Plan = append(job2.Plan, PlanConfig{
+					job2.ParentPlan = append(job2.ParentPlan, PlanConfig{
 						Get:    "some-resource",
 						Passed: []string{"job-one"},
 					})
@@ -1197,7 +1197,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a plan has an invalid step within an abort", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get: "some-resource",
 						Abort: &PlanConfig{
 							Put:      "custom-name",
@@ -1216,7 +1216,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a plan has an invalid step within an error", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get: "some-resource",
 						Error: &PlanConfig{
 							Put:      "custom-name",
@@ -1235,7 +1235,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a plan has an invalid step within an ensure", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get: "some-resource",
 						Ensure: &PlanConfig{
 							Put:      "custom-name",
@@ -1254,7 +1254,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a plan has an invalid step within a success", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get: "some-resource",
 						Success: &PlanConfig{
 							Put:      "custom-name",
@@ -1273,7 +1273,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a plan has an invalid step within a failure", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get: "some-resource",
 						Failure: &PlanConfig{
 							Put:      "custom-name",
@@ -1292,7 +1292,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a plan has an invalid timeout in a step", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get:     "some-resource",
 						Timeout: "nope",
 					})
@@ -1308,7 +1308,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a plan has an invalid step within a try", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Try: &PlanConfig{
 							Put:      "custom-name",
 							Resource: "some-missing-resource",
@@ -1326,7 +1326,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a retry plan has a negative attempts number", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Put:      "some-resource",
 						Attempts: -1,
 					})
@@ -1342,7 +1342,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a put plan has a custom name but refers to a resource that does not exist", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Put:      "custom-name",
 						Resource: "some-missing-resource",
 					})
@@ -1358,7 +1358,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a set_pipeline step has no file configured", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						SetPipeline: "other-pipeline",
 					})
 
@@ -1373,7 +1373,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a job's input's passed constraints reference a bogus job", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get:    "lol",
 						Passed: []string{"bogus-job"},
 					})
@@ -1389,12 +1389,12 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a job's input's passed constraints references a valid job that has the resource as an output", func() {
 				BeforeEach(func() {
-					config.Jobs[0].Plan = append(config.Jobs[0].Plan, PlanConfig{
+					config.Jobs[0].ParentPlan = append(config.Jobs[0].ParentPlan, PlanConfig{
 						Put:      "custom-name",
 						Resource: "some-resource",
 					})
 
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get:    "some-resource",
 						Passed: []string{"some-job"},
 					})
@@ -1409,7 +1409,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a job's input's passed constraints references a valid job that has the resource as an input", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get:    "some-resource",
 						Passed: []string{"some-job"},
 					})
@@ -1424,7 +1424,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a job's input's passed constraints references a valid job that has the resource (with a custom name) as an input", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get:      "custom-name",
 						Resource: "some-resource",
 						Passed:   []string{"some-job"},
@@ -1440,7 +1440,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			Context("when a job's input's passed constraints references a valid job that does not have the resource as an input or output", func() {
 				BeforeEach(func() {
-					job.Plan = append(job.Plan, PlanConfig{
+					job.ParentPlan = append(job.ParentPlan, PlanConfig{
 						Get:    "some-resource",
 						Passed: []string{"some-empty-job"},
 					})

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Build", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "some-job",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get: "some-resource",
 							},
@@ -205,7 +205,7 @@ var _ = Describe("Build", func() {
 					},
 					{
 						Name: "downstream-job",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get:    "some-resource",
 								Passed: []string{"some-job"},
@@ -214,7 +214,7 @@ var _ = Describe("Build", func() {
 					},
 					{
 						Name: "no-request-job",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get:    "some-resource",
 								Passed: []string{"downstream-job"},
@@ -784,7 +784,7 @@ var _ = Describe("Build", func() {
 					Jobs: atc.JobConfigs{
 						{
 							Name: "some-job",
-							Plan: atc.PlanSequence{
+							ParentPlan: atc.PlanSequence{
 								{
 									Get: "some-explicit-resource",
 								},
@@ -884,7 +884,7 @@ var _ = Describe("Build", func() {
 					Jobs: atc.JobConfigs{
 						{
 							Name: "some-job",
-							Plan: atc.PlanSequence{
+							ParentPlan: atc.PlanSequence{
 								{
 									Get: "some-explicit-resource",
 								},
@@ -1357,7 +1357,7 @@ var _ = Describe("Build", func() {
 					Jobs: atc.JobConfigs{
 						{
 							Name: "some-job",
-							Plan: atc.PlanSequence{
+							ParentPlan: atc.PlanSequence{
 								{
 									Get:      "some-input",
 									Resource: "some-resource",
@@ -1553,7 +1553,7 @@ var _ = Describe("Build", func() {
 									{
 										Name:           "some-job",
 										RawMaxInFlight: 1,
-										Plan: atc.PlanSequence{
+										ParentPlan: atc.PlanSequence{
 											{
 												Get:      "some-input",
 												Resource: "some-resource",
@@ -1614,7 +1614,7 @@ var _ = Describe("Build", func() {
 									{
 										Name:           "some-job",
 										RawMaxInFlight: 1,
-										Plan: atc.PlanSequence{
+										ParentPlan: atc.PlanSequence{
 											{
 												Get:      "some-input",
 												Resource: "some-resource",
@@ -1709,7 +1709,7 @@ var _ = Describe("Build", func() {
 						Jobs: atc.JobConfigs{
 							{
 								Name: "some-job",
-								Plan: atc.PlanSequence{
+								ParentPlan: atc.PlanSequence{
 									{
 										Get:     "input1",
 										Version: &atc.VersionConfig{Pinned: atc.Version{"version": "v1"}},
@@ -1764,7 +1764,7 @@ var _ = Describe("Build", func() {
 						Jobs: atc.JobConfigs{
 							{
 								Name: "some-job",
-								Plan: atc.PlanSequence{
+								ParentPlan: atc.PlanSequence{
 									{Get: "input1"},
 									{Get: "input2"},
 								},

--- a/atc/db/job_factory_test.go
+++ b/atc/db/job_factory_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Job Factory", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "public-pipeline-job-1",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get: "some-resource",
 							},
@@ -36,7 +36,7 @@ var _ = Describe("Job Factory", func() {
 					},
 					{
 						Name: "public-pipeline-job-2",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get:    "some-resource",
 								Passed: []string{"public-pipeline-job-1"},
@@ -53,7 +53,7 @@ var _ = Describe("Job Factory", func() {
 					},
 					{
 						Name: "public-pipeline-job-3",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get:    "some-resource",
 								Passed: []string{"public-pipeline-job-1", "public-pipeline-job-2"},
@@ -79,7 +79,7 @@ var _ = Describe("Job Factory", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "private-pipeline-job",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get: "some-resource",
 							},

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Job", func() {
 
 					Public: true,
 
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Put: "some-resource",
 							Params: atc.Params{
@@ -655,7 +655,7 @@ var _ = Describe("Job", func() {
 
 							RawMaxInFlight: 2,
 
-							Plan: atc.PlanSequence{
+							ParentPlan: atc.PlanSequence{
 								{
 									Put: "some-resource",
 									Params: atc.Params{
@@ -732,7 +732,7 @@ var _ = Describe("Job", func() {
 
 							RawMaxInFlight: 2,
 
-							Plan: atc.PlanSequence{
+							ParentPlan: atc.PlanSequence{
 								{
 									Put: "some-resource",
 									Params: atc.Params{
@@ -1226,7 +1226,7 @@ var _ = Describe("Job", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "some-job",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get:      "some-input",
 								Resource: "some-resource",
@@ -1976,7 +1976,7 @@ var _ = Describe("Job", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "some-job",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Put: "some-resource",
 							},
@@ -2015,7 +2015,7 @@ var _ = Describe("Job", func() {
 					},
 					{
 						Name: "some-other-job",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get:      "other-job-resource",
 								Resource: "some-resource",
@@ -2087,7 +2087,7 @@ var _ = Describe("Job", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "some-job",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Put: "some-other-resource",
 							},
@@ -2114,7 +2114,7 @@ var _ = Describe("Job", func() {
 					},
 					{
 						Name: "some-other-job",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Put:      "other-job-resource",
 								Resource: "some-resource",

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Pipeline", func() {
 
 					SerialGroups: []string{"serial-group"},
 
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Put: "some-resource",
 							Params: atc.Params{
@@ -422,7 +422,7 @@ var _ = Describe("Pipeline", func() {
 
 						SerialGroups: []string{"serial-group"},
 
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Put: "some-resource",
 								Params: atc.Params{

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Resource Config Scope", func() {
 			Jobs: atc.JobConfigs{
 				{
 					Name: "some-job",
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Get: "some-resource",
 						},
@@ -48,7 +48,7 @@ var _ = Describe("Resource Config Scope", func() {
 				},
 				{
 					Name: "downstream-job",
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Get:    "some-resource",
 							Passed: []string{"some-job"},

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Resource", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "job-using-resource",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get: "some-other-resource",
 							},
@@ -372,7 +372,7 @@ var _ = Describe("Resource", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "job-using-resource",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get: "some-resource",
 							},

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -1572,7 +1572,7 @@ var _ = Describe("Team", func() {
 						Serial:       true,
 						SerialGroups: []string{"serial-group-1", "serial-group-2"},
 
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get:      "some-input",
 								Resource: "some-resource",
@@ -1863,7 +1863,7 @@ var _ = Describe("Team", func() {
 					Serial:       true,
 					SerialGroups: []string{"serial-group-1", "serial-group-2"},
 
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task:       "some-task",
 							Privileged: true,
@@ -1998,7 +1998,7 @@ var _ = Describe("Team", func() {
 					Serial:       true,
 					SerialGroups: []string{"serial-group-1", "serial-group-2"},
 
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Get:      "some-input",
 							Resource: "some-resource",
@@ -2127,7 +2127,7 @@ var _ = Describe("Team", func() {
 			config.Jobs = []atc.JobConfig{
 				{
 					Name: "some-job",
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task:       "some-other-task",
 							ConfigPath: "some/config/path.yml",
@@ -2176,7 +2176,7 @@ var _ = Describe("Team", func() {
 			config.Jobs = []atc.JobConfig{
 				{
 					Name: "some-job",
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task:       "some-other-task",
 							ConfigPath: "some/config/path.yml",
@@ -2312,7 +2312,7 @@ var _ = Describe("Team", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "job-1",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get: "some-resource",
 							},
@@ -2320,7 +2320,7 @@ var _ = Describe("Team", func() {
 					},
 					{
 						Name: "job-2",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get: "some-resource",
 							},
@@ -2334,7 +2334,7 @@ var _ = Describe("Team", func() {
 						Serial:       true,
 						SerialGroups: []string{"serial-group-1", "serial-group-2"},
 
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Do: &atc.PlanSequence{
 									{
@@ -2476,7 +2476,7 @@ var _ = Describe("Team", func() {
 				Jobs: atc.JobConfigs{
 					{
 						Name: "job-2",
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get: "some-resource",
 							},
@@ -2490,7 +2490,7 @@ var _ = Describe("Team", func() {
 						Serial:       true,
 						SerialGroups: []string{"serial-group-1", "serial-group-2"},
 
-						Plan: atc.PlanSequence{
+						ParentPlan: atc.PlanSequence{
 							{
 								Get:      "some-input",
 								Resource: "some-resource",
@@ -2717,7 +2717,7 @@ var _ = Describe("Team", func() {
 
 			updatedConfig.Jobs = append(config.Jobs, atc.JobConfig{
 				Name: "new-job",
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Get:      "new-input",
 						Resource: "new-resource",

--- a/atc/db/worker_task_cache.go
+++ b/atc/db/worker_task_cache.go
@@ -82,7 +82,7 @@ func (workerTaskCache WorkerTaskCache) find(runner sq.Runner) (*UsedWorkerTaskCa
 func removeUnusedWorkerTaskCaches(tx Tx, pipelineID int, jobConfigs []atc.JobConfig) error {
 	steps := make(map[string][]string)
 	for _, jobConfig := range jobConfigs {
-		for _, jobConfigPlan := range jobConfig.Plan {
+		for _, jobConfigPlan := range jobConfig.Plans() {
 			if jobConfigPlan.Task != "" {
 				steps[jobConfig.Name] = append(steps[jobConfig.Name], jobConfigPlan.Task)
 			}

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -49,7 +49,7 @@ jobs:
 		Jobs: atc.JobConfigs{
 			{
 				Name: "some-job",
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "some-task",
 						TaskConfig: &atc.TaskConfig{
@@ -259,7 +259,7 @@ jobs:
 
 				Context("when there are some diff", func() {
 					BeforeEach(func() {
-						pipelineObject.Jobs[0].Plan[0].TaskConfig.Run.Args = []string{"hello world"}
+						pipelineObject.Jobs[0].ParentPlan[0].TaskConfig.Run.Args = []string{"hello world"}
 						fakePipeline.ConfigReturns(pipelineObject, nil)
 					})
 

--- a/atc/job_config.go
+++ b/atc/job_config.go
@@ -20,7 +20,11 @@ type JobConfig struct {
 	Ensure  *PlanConfig `json:"ensure,omitempty"`
 	Success *PlanConfig `json:"on_success,omitempty"`
 
-	Plan PlanSequence `json:"plan"`
+	// The parent plan is only the TOP LEVEL plan in the job config. If there are
+	// any nested plans in the job config, the parent plan does not cover it!
+	//
+	// Use Plans() if you need all the plans within the job config.
+	ParentPlan PlanSequence `json:"plan"`
 }
 
 type BuildLogRetention struct {
@@ -53,7 +57,7 @@ func (config JobConfig) MaxInFlight() int {
 
 func (config JobConfig) Plans() []PlanConfig {
 	plan := collectPlans(PlanConfig{
-		Do:      &config.Plan,
+		Do:      &config.ParentPlan,
 		Abort:   config.Abort,
 		Error:   config.Error,
 		Ensure:  config.Ensure,

--- a/atc/job_config_test.go
+++ b/atc/job_config_test.go
@@ -80,7 +80,7 @@ var _ = Describe("JobConfig", func() {
 		Context("with a build plan", func() {
 			Context("with an empty plan", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{}
+					jobConfig.ParentPlan = atc.PlanSequence{}
 				})
 
 				It("returns an empty set of inputs", func() {
@@ -90,7 +90,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("with two serial gets", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get:     "some-get-plan",
 							Passed:  []string{"a", "b"},
@@ -126,7 +126,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has a version on a get", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 							Version: &atc.VersionConfig{
@@ -155,7 +155,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has an ensure hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 						},
@@ -186,7 +186,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has a success hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 						},
@@ -218,7 +218,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has a failure hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 						},
@@ -250,7 +250,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has an abort hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 						},
@@ -282,7 +282,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has an error hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 						},
@@ -314,7 +314,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has an ensure hook on a get", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 							Ensure: &atc.PlanConfig{
@@ -345,7 +345,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has a success hook on a get", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 							Success: &atc.PlanConfig{
@@ -376,7 +376,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has a failure hook on a get", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 							Failure: &atc.PlanConfig{
@@ -407,7 +407,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has an abort hook on a get", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 							Abort: &atc.PlanConfig{
@@ -438,7 +438,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has an error hook on a get", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "a",
 							Error: &atc.PlanConfig{
@@ -469,7 +469,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a resource is specified", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get:      "some-get-plan",
 							Resource: "some-get-resource",
@@ -493,7 +493,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a simple aggregate plan is the first step", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Aggregate: &atc.PlanSequence{
 								{Get: "a"},
@@ -536,7 +536,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when an overly complicated aggregate plan is the first step", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Aggregate: &atc.PlanSequence{
 								{
@@ -582,7 +582,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a simple parallel plan is the first step", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							InParallel: &atc.InParallelConfig{
 								Steps: atc.PlanSequence{
@@ -629,7 +629,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when an overly complicated parallel plan is the first step", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							InParallel: &atc.InParallelConfig{
 								Steps: atc.PlanSequence{
@@ -682,7 +682,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when there are not gets in the plan", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "some-put-plan",
 						},
@@ -714,7 +714,7 @@ var _ = Describe("JobConfig", func() {
 		Context("with a build plan", func() {
 			Context("with an empty plan", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{}
+					jobConfig.ParentPlan = atc.PlanSequence{}
 				})
 
 				It("returns an empty set of outputs", func() {
@@ -724,7 +724,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when an overly complicated plan is configured", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Aggregate: &atc.PlanSequence{
 								{
@@ -766,7 +766,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has an ensure hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 						},
@@ -793,7 +793,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has a success hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 						},
@@ -821,7 +821,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has a failure hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 						},
@@ -849,7 +849,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has an abort hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 						},
@@ -877,7 +877,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a job has an error hook", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 						},
@@ -905,7 +905,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has an ensure on a put", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 							Ensure: &atc.PlanConfig{
@@ -932,7 +932,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has a success hook on a put", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 							Success: &atc.PlanConfig{
@@ -959,7 +959,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has a failure hook on a put", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 							Failure: &atc.PlanConfig{
@@ -986,7 +986,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has an abort hook on a put", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 							Abort: &atc.PlanConfig{
@@ -1013,7 +1013,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when a plan has an error hook on a put", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Put: "a",
 							Error: &atc.PlanConfig{
@@ -1040,7 +1040,7 @@ var _ = Describe("JobConfig", func() {
 
 			Context("when the plan contains no puts steps", func() {
 				BeforeEach(func() {
-					jobConfig.Plan = atc.PlanSequence{
+					jobConfig.ParentPlan = atc.PlanSequence{
 						{
 							Get: "some-put-plan",
 						},

--- a/atc/scheduler/algorithm/firstoccurrence_test.go
+++ b/atc/scheduler/algorithm/firstoccurrence_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Resolve", func() {
 			Jobs: atc.JobConfigs{
 				{
 					Name: "j1",
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Get:      "some-input",
 							Resource: "r1",
@@ -220,7 +220,7 @@ var _ = Describe("Resolve", func() {
 			Jobs: atc.JobConfigs{
 				{
 					Name: "j1",
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Get:      "some-input",
 							Resource: "r1",

--- a/atc/scheduler/algorithm/table_helpers_test.go
+++ b/atc/scheduler/algorithm/table_helpers_test.go
@@ -450,8 +450,8 @@ func (example Example) Run() {
 	jobs := atc.JobConfigs{}
 	for jobName, _ := range setup.jobIDs {
 		jobs = append(jobs, atc.JobConfig{
-			Name: jobName,
-			Plan: inputs,
+			Name:       jobName,
+			ParentPlan: inputs,
 		})
 	}
 

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -75,7 +75,7 @@ var _ = Describe("BuildStarter", func() {
 				job.GetPendingBuildsReturns(pendingBuilds, nil)
 				job.NameReturns("some-job")
 				job.IDReturns(1)
-				job.ConfigReturns(atc.JobConfig{Plan: atc.PlanSequence{{Get: "input-1", Resource: "some-resource"}, {Get: "input-2", Resource: "some-resource"}}}, nil)
+				job.ConfigReturns(atc.JobConfig{ParentPlan: atc.PlanSequence{{Get: "input-1", Resource: "some-resource"}, {Get: "input-2", Resource: "some-resource"}}}, nil)
 
 				relatedJobs = algorithm.NameToIDMap{"some-job": 1}
 
@@ -254,7 +254,7 @@ var _ = Describe("BuildStarter", func() {
 
 							fakePipeline.ResourceTypesReturns(db.ResourceTypes{fakeDBResourceType}, nil)
 
-							job.ConfigReturns(atc.JobConfig{Plan: atc.PlanSequence{{Get: "input-1", Resource: "some-resource"}, {Get: "input-2", Resource: "other-resource"}}}, nil)
+							job.ConfigReturns(atc.JobConfig{ParentPlan: atc.PlanSequence{{Get: "input-1", Resource: "some-resource"}, {Get: "input-2", Resource: "other-resource"}}}, nil)
 
 							createdBuild.IsNewerThanLastCheckOfReturns(false)
 

--- a/atc/scheduler/factory/build_factory.go
+++ b/atc/scheduler/factory/build_factory.go
@@ -60,7 +60,7 @@ func (factory *buildFactory) constructPlanFromJob(
 	resourceTypes atc.VersionedResourceTypes,
 	inputs []db.BuildInput,
 ) (atc.Plan, error) {
-	planSequence := job.Plan
+	planSequence := job.ParentPlan
 
 	if len(planSequence) == 1 {
 		return factory.constructPlanFromConfig(

--- a/atc/scheduler/factory/factory_aggregate_test.go
+++ b/atc/scheduler/factory/factory_aggregate_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Factory Aggregate", func() {
 	Context("when I have one aggregate", func() {
 		It("returns the correct plan", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
 							{
@@ -78,7 +78,7 @@ var _ = Describe("Factory Aggregate", func() {
 	Context("when I have nested aggregates", func() {
 		It("returns the correct plan", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
 							{
@@ -123,7 +123,7 @@ var _ = Describe("Factory Aggregate", func() {
 	Context("when I have an aggregate with hooks", func() {
 		It("returns the correct plan", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
 							{
@@ -157,7 +157,7 @@ var _ = Describe("Factory Aggregate", func() {
 	Context("when I have a hook on an aggregate", func() {
 		It("returns the correct plan", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
 							{

--- a/atc/scheduler/factory/factory_do_test.go
+++ b/atc/scheduler/factory/factory_do_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Factory Do", func() {
 	Context("when I have a nested do ", func() {
 		It("returns the correct plan", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Do: &atc.PlanSequence{
 							{
@@ -93,7 +93,7 @@ var _ = Describe("Factory Do", func() {
 	Context("when I have an aggregate inside a do", func() {
 		It("returns the correct plan", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Do: &atc.PlanSequence{
 							{
@@ -138,7 +138,7 @@ var _ = Describe("Factory Do", func() {
 	Context("when i have a do inside an aggregate inside a hook", func() {
 		It("returns the correct plan", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "starting-task",
 						Success: &atc.PlanConfig{
@@ -186,7 +186,7 @@ var _ = Describe("Factory Do", func() {
 	Context("when I have a do inside an aggregate", func() {
 		It("returns the correct plan", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Aggregate: &atc.PlanSequence{
 							{

--- a/atc/scheduler/factory/factory_get_test.go
+++ b/atc/scheduler/factory/factory_get_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Factory Get", func() {
 	Context("with a get at the top-level", func() {
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Get:      "some-get",
 						Resource: "some-resource",
@@ -85,7 +85,7 @@ var _ = Describe("Factory Get", func() {
 	Context("with a get for a non-existent resource", func() {
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Get:      "some-get",
 						Resource: "not-a-resource",
@@ -103,7 +103,7 @@ var _ = Describe("Factory Get", func() {
 	Context("with a get for an input with a non-existant version", func() {
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Get:      "some-get",
 						Resource: "some-resource",

--- a/atc/scheduler/factory/factory_hooks_test.go
+++ b/atc/scheduler/factory/factory_hooks_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Failure: &atc.PlanConfig{
@@ -102,7 +102,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Do: &atc.PlanSequence{
 							{
@@ -157,7 +157,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Do: &atc.PlanSequence{
 							{
@@ -215,7 +215,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "some-task",
 						Success: &atc.PlanConfig{
@@ -269,7 +269,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "some-task",
 						Success: &atc.PlanConfig{
@@ -310,7 +310,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "some-task",
 						Success: &atc.PlanConfig{
@@ -380,7 +380,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "some-task",
 						Success: &atc.PlanConfig{
@@ -436,7 +436,7 @@ var _ = Describe("Factory Hooks", func() {
 		It("can build a job with one abort hook", func() {
 			var input atc.JobConfig
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Abort: &atc.PlanConfig{
@@ -463,7 +463,7 @@ var _ = Describe("Factory Hooks", func() {
 		It("can build a job with one error hook", func() {
 			var input atc.JobConfig
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Error: &atc.PlanConfig{
@@ -489,7 +489,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		It("can build a job with one error hook that has a timeout", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Error: &atc.PlanConfig{
@@ -526,7 +526,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		It("can build a job with multiple error hooks", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Error: &atc.PlanConfig{
@@ -568,7 +568,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		It("can build a job with one failure hook", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Failure: &atc.PlanConfig{
@@ -601,7 +601,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		It("can build a job with one failure hook that has a timeout", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Failure: &atc.PlanConfig{
@@ -638,7 +638,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		It("can build a job with multiple failure hooks", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Failure: &atc.PlanConfig{
@@ -680,7 +680,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		It("can build a job with multiple ensure and failure hooks", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Failure: &atc.PlanConfig{
@@ -722,7 +722,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		It("can build a job with failure, success and ensure hooks at the same level", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Failure: &atc.PlanConfig{
@@ -767,7 +767,7 @@ var _ = Describe("Factory Hooks", func() {
 
 		It("can build a job with multiple ensure, failure and success hooks", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task: "those who resist our will",
 						Failure: &atc.PlanConfig{
@@ -825,7 +825,7 @@ var _ = Describe("Factory Hooks", func() {
 		Context("and multiple steps in my plan", func() {
 			It("can build a job with a task with hooks then 2 more tasks", func() {
 				actual, err := buildFactory.Create(atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task: "those who resist our will",
 							Failure: &atc.PlanConfig{
@@ -876,7 +876,7 @@ var _ = Describe("Factory Hooks", func() {
 
 			It("can build a job with a task then a do", func() {
 				actual, err := buildFactory.Create(atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task: "those who start resisting our will",
 						},
@@ -933,7 +933,7 @@ var _ = Describe("Factory Hooks", func() {
 
 			It("can build a job with a do then a task", func() {
 				actual, err := buildFactory.Create(atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Do: &atc.PlanSequence{
 								{

--- a/atc/scheduler/factory/factory_parallel_test.go
+++ b/atc/scheduler/factory/factory_parallel_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Factory Parallel", func() {
 	Context("when I have a parallel step", func() {
 		It("returns the correct plan", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						InParallel: &atc.InParallelConfig{
 							Steps: atc.PlanSequence{

--- a/atc/scheduler/factory/factory_put_test.go
+++ b/atc/scheduler/factory/factory_put_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Factory Put", func() {
 		Context("with a put at the top-level", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "some-resource",
@@ -91,7 +91,7 @@ var _ = Describe("Factory Put", func() {
 		Context("with a put for a non-existent resource", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "what-resource",
@@ -146,7 +146,7 @@ var _ = Describe("Factory Put", func() {
 		Context("when I have a put at the top-level", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "some-resource",
@@ -188,7 +188,7 @@ var _ = Describe("Factory Put", func() {
 		Context("when I have a put in a hook", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task: "some-task",
 							Success: &atc.PlanConfig{
@@ -240,7 +240,7 @@ var _ = Describe("Factory Put", func() {
 		Context("when I have a put inside an aggregate", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Aggregate: &atc.PlanSequence{
 								{
@@ -295,7 +295,7 @@ var _ = Describe("Factory Put", func() {
 		Context("when I have a put inside a parallel", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							InParallel: &atc.InParallelConfig{
 								Steps: atc.PlanSequence{
@@ -358,7 +358,7 @@ var _ = Describe("Factory Put", func() {
 		Context("when a put plan follows a task plan", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task: "some-task",
 						},
@@ -411,7 +411,7 @@ var _ = Describe("Factory Put", func() {
 		Context("when a put plan is between two task plans", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task: "those who resist our will",
 						},
@@ -471,7 +471,7 @@ var _ = Describe("Factory Put", func() {
 		Context("when I have a put specifying inputs", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "some-resource",
@@ -515,7 +515,7 @@ var _ = Describe("Factory Put", func() {
 		Context("when I have a put specifying all inputs", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "some-resource",
@@ -559,7 +559,7 @@ var _ = Describe("Factory Put", func() {
 		Context("when I have a put specifying no inputs", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Put:      "some-put",
 							Resource: "some-resource",

--- a/atc/scheduler/factory/factory_retry_test.go
+++ b/atc/scheduler/factory/factory_retry_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Factory Retry Step", func() {
 	Context("when there is a task annotated with 'attempts'", func() {
 		It("builds correctly", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task:     "second task",
 						Attempts: 3,
@@ -69,7 +69,7 @@ var _ = Describe("Factory Retry Step", func() {
 	Context("when there is a task annotated with 'attempts' and 'on_success'", func() {
 		It("builds correctly", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task:     "second task",
 						Attempts: 3,

--- a/atc/scheduler/factory/factory_set_pipeline_test.go
+++ b/atc/scheduler/factory/factory_set_pipeline_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Factory SetPipeline Step", func() {
 	Context("when set other pipeline", func() {
 		BeforeEach(func() {
 			input = atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						SetPipeline: "some-pipeline",
 						ConfigPath:  "some-file",

--- a/atc/scheduler/factory/factory_task_test.go
+++ b/atc/scheduler/factory/factory_task_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Factory Task", func() {
 				}
 
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task:   "some-task",
 							Params: params,
@@ -79,7 +79,7 @@ var _ = Describe("Factory Task", func() {
 		Context("when input mapping is specified", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task: "some-task",
 							InputMapping: map[string]string{
@@ -132,7 +132,7 @@ var _ = Describe("Factory Task", func() {
 		Context("when output mapping is specified", func() {
 			BeforeEach(func() {
 				input = atc.JobConfig{
-					Plan: atc.PlanSequence{
+					ParentPlan: atc.PlanSequence{
 						{
 							Task: "some-task",
 							OutputMapping: map[string]string{

--- a/atc/scheduler/factory/factory_timeout_test.go
+++ b/atc/scheduler/factory/factory_timeout_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Factory Timeout Step", func() {
 	Context("When there is a task with a timeout", func() {
 		It("builds correctly", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Task:    "first task",
 						Timeout: "10s",

--- a/atc/scheduler/factory/factory_try_test.go
+++ b/atc/scheduler/factory/factory_try_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Factory Try Step", func() {
 	Context("when there is a task wrapped in a try", func() {
 		It("builds correctly", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Try: &atc.PlanConfig{
 							Task: "first task",
@@ -71,7 +71,7 @@ var _ = Describe("Factory Try Step", func() {
 	Context("when the try also has a hook", func() {
 		It("builds correctly", func() {
 			actual, err := buildFactory.Create(atc.JobConfig{
-				Plan: atc.PlanSequence{
+				ParentPlan: atc.PlanSequence{
 					{
 						Try: &atc.PlanConfig{
 							Task: "first task",


### PR DESCRIPTION
Anything that loops over `(atc.JobConfig).Plan` is *probably* subtly broken, as it'll only be looping at the top level values and not recursing into `in_parallel`, job-level hooks, etc.

Instead everything should use `.Plans()` which collects all the build plans recursively into a flat slice.

There were two places where we found this was broken:

1. In `removeUnusedWorkerTaskCaches `
1. In `validateCredParams`