### PR TITLE
use ImportStrategy when step output is cow volume

### DIFF
--- a/atc/worker/image/image.go
+++ b/atc/worker/image/image.go
@@ -30,7 +30,7 @@ func (i *imageProvidedByPreviousStepOnSameWorker) FetchForContainer(
 	imageVolume, err := i.volumeClient.FindOrCreateCOWVolumeForContainer(
 		logger,
 		worker.VolumeSpec{
-			Strategy:   i.artifactVolume.COWStrategy(),
+			Strategy:   i.artifactVolume.CopyStrategy(),
 			Privileged: i.imageSpec.Privileged,
 		},
 		container,
@@ -213,7 +213,7 @@ func (i *imageFromBaseResourceType) FetchForContainer(
 			cowVolume, err := i.volumeClient.FindOrCreateCOWVolumeForContainer(
 				logger,
 				worker.VolumeSpec{
-					Strategy:   importVolume.COWStrategy(),
+					Strategy:   importVolume.CopyStrategy(),
 					Privileged: t.Privileged,
 				},
 				container,

--- a/atc/worker/image/image_test.go
+++ b/atc/worker/image/image_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Image", func() {
 			cowStrategy = baggageclaim.COWStrategy{
 				Parent: new(baggageclaimfakes.FakeVolume),
 			}
-			fakeArtifactVolume.COWStrategyReturns(cowStrategy)
+			fakeArtifactVolume.CopyStrategyReturns(cowStrategy)
 
 			fakeImageArtifactSource := new(workerfakes.FakeStreamableArtifactSource)
 			fakeImageArtifactSource.ExistsOnReturns(fakeArtifactVolume, true, nil)
@@ -231,7 +231,7 @@ var _ = Describe("Image", func() {
 			cowStrategy = baggageclaim.COWStrategy{
 				Parent: new(baggageclaimfakes.FakeVolume),
 			}
-			fakeResourceImageVolume.COWStrategyReturns(cowStrategy)
+			fakeResourceImageVolume.CopyStrategyReturns(cowStrategy)
 
 			fakeContainerRootfsVolume = new(workerfakes.FakeVolume)
 			fakeContainerRootfsVolume.PathReturns("some-path")
@@ -513,7 +513,7 @@ var _ = Describe("Image", func() {
 			cowStrategy = baggageclaim.COWStrategy{
 				Parent: new(baggageclaimfakes.FakeVolume),
 			}
-			fakeImportVolume.COWStrategyReturns(cowStrategy)
+			fakeImportVolume.CopyStrategyReturns(cowStrategy)
 			fakeVolumeClient.FindOrCreateVolumeForBaseResourceTypeReturns(fakeImportVolume, nil)
 
 			workerResourceType = atc.WorkerResourceType{

--- a/atc/worker/volume.go
+++ b/atc/worker/volume.go
@@ -14,6 +14,7 @@ import (
 type Volume interface {
 	Handle() string
 	Path() string
+	ParentHandle() string
 
 	SetProperty(key string, value string) error
 	Properties() (baggageclaim.VolumeProperties, error)
@@ -24,6 +25,7 @@ type Volume interface {
 	StreamOut(ctx context.Context, path string) (io.ReadCloser, error)
 
 	COWStrategy() baggageclaim.COWStrategy
+	ImportStrategy() baggageclaim.ImportStrategy
 
 	InitializeResourceCache(db.UsedResourceCache) error
 	InitializeTaskCache(logger lager.Logger, jobID int, stepName string, path string, privileged bool) error
@@ -76,6 +78,10 @@ func (v *volume) Handle() string { return v.bcVolume.Handle() }
 
 func (v *volume) Path() string { return v.bcVolume.Path() }
 
+func (v *volume) ParentHandle() string {
+	return v.dbVolume.ParentHandle()
+}
+
 func (v *volume) SetProperty(key string, value string) error {
 	return v.bcVolume.SetProperty(key, value)
 }
@@ -107,6 +113,13 @@ func (v *volume) Destroy() error {
 func (v *volume) COWStrategy() baggageclaim.COWStrategy {
 	return baggageclaim.COWStrategy{
 		Parent: v.bcVolume,
+	}
+}
+
+func (v *volume) ImportStrategy() baggageclaim.ImportStrategy {
+	return baggageclaim.ImportStrategy{
+		Path: v.bcVolume.Path(),
+		FollowSymlinks: true,
 	}
 }
 

--- a/atc/worker/worker.go
+++ b/atc/worker/worker.go
@@ -379,7 +379,7 @@ func (worker *gardenWorker) fetchImageForContainer(
 }
 
 type mountableLocalInput struct {
-	desiredCOWParent Volume
+	desiredParent    Volume
 	desiredMountPath string
 }
 
@@ -463,7 +463,7 @@ func (worker *gardenWorker) createVolumes(
 
 		if found {
 			localInputs = append(localInputs, mountableLocalInput{
-				desiredCOWParent: inputSourceVolume,
+				desiredParent:    inputSourceVolume,
 				desiredMountPath: cleanedInputPath,
 			})
 		} else {
@@ -546,14 +546,21 @@ func (worker *gardenWorker) cloneLocalVolumes(
 	mounts := make([]VolumeMount, len(locals))
 
 	for i, localInput := range locals {
+
+		// NOTE (runtime/#4964): in Linux kernel 5.x and greater,
+		// We lose the ability the make a COW of a COW. Overlay will return an error.
+		// The only time we do this is when the output of a prev step a COW and the
+		// input we clone here tries to become a COW of it.
+		duplicateStrategy := avoidCOWCOWVolume(localInput)
+
 		inputVolume, err := worker.volumeClient.FindOrCreateCOWVolumeForContainer(
 			logger,
 			VolumeSpec{
-				Strategy:   localInput.desiredCOWParent.COWStrategy(),
+				Strategy:   duplicateStrategy,
 				Privileged: privileged,
 			},
 			container,
-			localInput.desiredCOWParent,
+			localInput.desiredParent,
 			teamID,
 			localInput.desiredMountPath,
 		)
@@ -568,6 +575,15 @@ func (worker *gardenWorker) cloneLocalVolumes(
 	}
 
 	return mounts, nil
+}
+
+func avoidCOWCOWVolume(input mountableLocalInput) baggageclaim.Strategy {
+	// desired parent volume is a COW
+	if input.desiredParent.ParentHandle() != "" {
+		return input.desiredParent.ImportStrategy()
+	}
+
+	return input.desiredParent.COWStrategy()
 }
 
 func (worker *gardenWorker) cloneRemoteVolumes(

--- a/atc/worker/worker_test.go
+++ b/atc/worker/worker_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Worker", func() {
 		fakeLocalInputAS := new(workerfakes.FakeArtifactSource)
 		fakeLocalVolume = new(workerfakes.FakeVolume)
 		fakeLocalVolume.PathReturns("/fake/local/volume")
-		fakeLocalVolume.COWStrategyReturns(baggageclaim.COWStrategy{
+		fakeLocalVolume.CopyStrategyReturns(baggageclaim.COWStrategy{
 			Parent: new(baggageclaimfakes.FakeVolume),
 		})
 		fakeLocalInputAS.ExistsOnReturns(fakeLocalVolume, true, nil)
@@ -1358,7 +1358,7 @@ var _ = Describe("Worker", func() {
 						"/scratch":                    {Strategy: baggageclaim.EmptyStrategy{}},
 						"/some/work-dir":              {Strategy: baggageclaim.EmptyStrategy{}},
 						"/some/work-dir/output":       {Strategy: baggageclaim.EmptyStrategy{}},
-						"/some/work-dir/local-input":  {Strategy: fakeLocalVolume.COWStrategy()},
+						"/some/work-dir/local-input":  {Strategy: fakeLocalVolume.CopyStrategy()},
 						"/some/work-dir/remote-input": {Strategy: baggageclaim.EmptyStrategy{}},
 					}))
 				})
@@ -1404,7 +1404,7 @@ var _ = Describe("Worker", func() {
 							"/scratch":                    {Privileged: true, Strategy: baggageclaim.EmptyStrategy{}},
 							"/some/work-dir":              {Privileged: true, Strategy: baggageclaim.EmptyStrategy{}},
 							"/some/work-dir/output":       {Privileged: true, Strategy: baggageclaim.EmptyStrategy{}},
-							"/some/work-dir/local-input":  {Privileged: true, Strategy: fakeLocalVolume.COWStrategy()},
+							"/some/work-dir/local-input":  {Privileged: true, Strategy: fakeLocalVolume.CopyStrategy()},
 							"/some/work-dir/remote-input": {Privileged: true, Strategy: baggageclaim.EmptyStrategy{}},
 						}))
 					})

--- a/atc/worker/workerfakes/fake_volume.go
+++ b/atc/worker/workerfakes/fake_volume.go
@@ -13,15 +13,15 @@ import (
 )
 
 type FakeVolume struct {
-	COWStrategyStub        func() baggageclaim.COWStrategy
-	cOWStrategyMutex       sync.RWMutex
-	cOWStrategyArgsForCall []struct {
+	CopyStrategyStub        func() baggageclaim.Strategy
+	copyStrategyMutex       sync.RWMutex
+	copyStrategyArgsForCall []struct {
 	}
-	cOWStrategyReturns struct {
-		result1 baggageclaim.COWStrategy
+	copyStrategyReturns struct {
+		result1 baggageclaim.Strategy
 	}
-	cOWStrategyReturnsOnCall map[int]struct {
-		result1 baggageclaim.COWStrategy
+	copyStrategyReturnsOnCall map[int]struct {
+		result1 baggageclaim.Strategy
 	}
 	CreateChildForContainerStub        func(db.CreatingContainer, string) (db.CreatingVolume, error)
 	createChildForContainerMutex       sync.RWMutex
@@ -56,16 +56,6 @@ type FakeVolume struct {
 	}
 	handleReturnsOnCall map[int]struct {
 		result1 string
-	}
-	ImportStrategyStub        func() baggageclaim.ImportStrategy
-	importStrategyMutex       sync.RWMutex
-	importStrategyArgsForCall []struct {
-	}
-	importStrategyReturns struct {
-		result1 baggageclaim.ImportStrategy
-	}
-	importStrategyReturnsOnCall map[int]struct {
-		result1 baggageclaim.ImportStrategy
 	}
 	InitializeArtifactStub        func(string, int) (db.WorkerArtifact, error)
 	initializeArtifactMutex       sync.RWMutex
@@ -106,16 +96,6 @@ type FakeVolume struct {
 	}
 	initializeTaskCacheReturnsOnCall map[int]struct {
 		result1 error
-	}
-	ParentHandleStub        func() string
-	parentHandleMutex       sync.RWMutex
-	parentHandleArgsForCall []struct {
-	}
-	parentHandleReturns struct {
-		result1 string
-	}
-	parentHandleReturnsOnCall map[int]struct {
-		result1 string
 	}
 	PathStub        func() string
 	pathMutex       sync.RWMutex
@@ -203,55 +183,55 @@ type FakeVolume struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeVolume) COWStrategy() baggageclaim.COWStrategy {
-	fake.cOWStrategyMutex.Lock()
-	ret, specificReturn := fake.cOWStrategyReturnsOnCall[len(fake.cOWStrategyArgsForCall)]
-	fake.cOWStrategyArgsForCall = append(fake.cOWStrategyArgsForCall, struct {
+func (fake *FakeVolume) CopyStrategy() baggageclaim.Strategy {
+	fake.copyStrategyMutex.Lock()
+	ret, specificReturn := fake.copyStrategyReturnsOnCall[len(fake.copyStrategyArgsForCall)]
+	fake.copyStrategyArgsForCall = append(fake.copyStrategyArgsForCall, struct {
 	}{})
-	fake.recordInvocation("COWStrategy", []interface{}{})
-	fake.cOWStrategyMutex.Unlock()
-	if fake.COWStrategyStub != nil {
-		return fake.COWStrategyStub()
+	fake.recordInvocation("CopyStrategy", []interface{}{})
+	fake.copyStrategyMutex.Unlock()
+	if fake.CopyStrategyStub != nil {
+		return fake.CopyStrategyStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cOWStrategyReturns
+	fakeReturns := fake.copyStrategyReturns
 	return fakeReturns.result1
 }
 
-func (fake *FakeVolume) COWStrategyCallCount() int {
-	fake.cOWStrategyMutex.RLock()
-	defer fake.cOWStrategyMutex.RUnlock()
-	return len(fake.cOWStrategyArgsForCall)
+func (fake *FakeVolume) CopyStrategyCallCount() int {
+	fake.copyStrategyMutex.RLock()
+	defer fake.copyStrategyMutex.RUnlock()
+	return len(fake.copyStrategyArgsForCall)
 }
 
-func (fake *FakeVolume) COWStrategyCalls(stub func() baggageclaim.COWStrategy) {
-	fake.cOWStrategyMutex.Lock()
-	defer fake.cOWStrategyMutex.Unlock()
-	fake.COWStrategyStub = stub
+func (fake *FakeVolume) CopyStrategyCalls(stub func() baggageclaim.Strategy) {
+	fake.copyStrategyMutex.Lock()
+	defer fake.copyStrategyMutex.Unlock()
+	fake.CopyStrategyStub = stub
 }
 
-func (fake *FakeVolume) COWStrategyReturns(result1 baggageclaim.COWStrategy) {
-	fake.cOWStrategyMutex.Lock()
-	defer fake.cOWStrategyMutex.Unlock()
-	fake.COWStrategyStub = nil
-	fake.cOWStrategyReturns = struct {
-		result1 baggageclaim.COWStrategy
+func (fake *FakeVolume) CopyStrategyReturns(result1 baggageclaim.Strategy) {
+	fake.copyStrategyMutex.Lock()
+	defer fake.copyStrategyMutex.Unlock()
+	fake.CopyStrategyStub = nil
+	fake.copyStrategyReturns = struct {
+		result1 baggageclaim.Strategy
 	}{result1}
 }
 
-func (fake *FakeVolume) COWStrategyReturnsOnCall(i int, result1 baggageclaim.COWStrategy) {
-	fake.cOWStrategyMutex.Lock()
-	defer fake.cOWStrategyMutex.Unlock()
-	fake.COWStrategyStub = nil
-	if fake.cOWStrategyReturnsOnCall == nil {
-		fake.cOWStrategyReturnsOnCall = make(map[int]struct {
-			result1 baggageclaim.COWStrategy
+func (fake *FakeVolume) CopyStrategyReturnsOnCall(i int, result1 baggageclaim.Strategy) {
+	fake.copyStrategyMutex.Lock()
+	defer fake.copyStrategyMutex.Unlock()
+	fake.CopyStrategyStub = nil
+	if fake.copyStrategyReturnsOnCall == nil {
+		fake.copyStrategyReturnsOnCall = make(map[int]struct {
+			result1 baggageclaim.Strategy
 		})
 	}
-	fake.cOWStrategyReturnsOnCall[i] = struct {
-		result1 baggageclaim.COWStrategy
+	fake.copyStrategyReturnsOnCall[i] = struct {
+		result1 baggageclaim.Strategy
 	}{result1}
 }
 
@@ -420,58 +400,6 @@ func (fake *FakeVolume) HandleReturnsOnCall(i int, result1 string) {
 	}
 	fake.handleReturnsOnCall[i] = struct {
 		result1 string
-	}{result1}
-}
-
-func (fake *FakeVolume) ImportStrategy() baggageclaim.ImportStrategy {
-	fake.importStrategyMutex.Lock()
-	ret, specificReturn := fake.importStrategyReturnsOnCall[len(fake.importStrategyArgsForCall)]
-	fake.importStrategyArgsForCall = append(fake.importStrategyArgsForCall, struct {
-	}{})
-	fake.recordInvocation("ImportStrategy", []interface{}{})
-	fake.importStrategyMutex.Unlock()
-	if fake.ImportStrategyStub != nil {
-		return fake.ImportStrategyStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.importStrategyReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeVolume) ImportStrategyCallCount() int {
-	fake.importStrategyMutex.RLock()
-	defer fake.importStrategyMutex.RUnlock()
-	return len(fake.importStrategyArgsForCall)
-}
-
-func (fake *FakeVolume) ImportStrategyCalls(stub func() baggageclaim.ImportStrategy) {
-	fake.importStrategyMutex.Lock()
-	defer fake.importStrategyMutex.Unlock()
-	fake.ImportStrategyStub = stub
-}
-
-func (fake *FakeVolume) ImportStrategyReturns(result1 baggageclaim.ImportStrategy) {
-	fake.importStrategyMutex.Lock()
-	defer fake.importStrategyMutex.Unlock()
-	fake.ImportStrategyStub = nil
-	fake.importStrategyReturns = struct {
-		result1 baggageclaim.ImportStrategy
-	}{result1}
-}
-
-func (fake *FakeVolume) ImportStrategyReturnsOnCall(i int, result1 baggageclaim.ImportStrategy) {
-	fake.importStrategyMutex.Lock()
-	defer fake.importStrategyMutex.Unlock()
-	fake.ImportStrategyStub = nil
-	if fake.importStrategyReturnsOnCall == nil {
-		fake.importStrategyReturnsOnCall = make(map[int]struct {
-			result1 baggageclaim.ImportStrategy
-		})
-	}
-	fake.importStrategyReturnsOnCall[i] = struct {
-		result1 baggageclaim.ImportStrategy
 	}{result1}
 }
 
@@ -660,58 +588,6 @@ func (fake *FakeVolume) InitializeTaskCacheReturnsOnCall(i int, result1 error) {
 	}
 	fake.initializeTaskCacheReturnsOnCall[i] = struct {
 		result1 error
-	}{result1}
-}
-
-func (fake *FakeVolume) ParentHandle() string {
-	fake.parentHandleMutex.Lock()
-	ret, specificReturn := fake.parentHandleReturnsOnCall[len(fake.parentHandleArgsForCall)]
-	fake.parentHandleArgsForCall = append(fake.parentHandleArgsForCall, struct {
-	}{})
-	fake.recordInvocation("ParentHandle", []interface{}{})
-	fake.parentHandleMutex.Unlock()
-	if fake.ParentHandleStub != nil {
-		return fake.ParentHandleStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.parentHandleReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeVolume) ParentHandleCallCount() int {
-	fake.parentHandleMutex.RLock()
-	defer fake.parentHandleMutex.RUnlock()
-	return len(fake.parentHandleArgsForCall)
-}
-
-func (fake *FakeVolume) ParentHandleCalls(stub func() string) {
-	fake.parentHandleMutex.Lock()
-	defer fake.parentHandleMutex.Unlock()
-	fake.ParentHandleStub = stub
-}
-
-func (fake *FakeVolume) ParentHandleReturns(result1 string) {
-	fake.parentHandleMutex.Lock()
-	defer fake.parentHandleMutex.Unlock()
-	fake.ParentHandleStub = nil
-	fake.parentHandleReturns = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeVolume) ParentHandleReturnsOnCall(i int, result1 string) {
-	fake.parentHandleMutex.Lock()
-	defer fake.parentHandleMutex.Unlock()
-	fake.ParentHandleStub = nil
-	if fake.parentHandleReturnsOnCall == nil {
-		fake.parentHandleReturnsOnCall = make(map[int]struct {
-			result1 string
-		})
-	}
-	fake.parentHandleReturnsOnCall[i] = struct {
-		result1 string
 	}{result1}
 }
 
@@ -1124,24 +1000,20 @@ func (fake *FakeVolume) WorkerNameReturnsOnCall(i int, result1 string) {
 func (fake *FakeVolume) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.cOWStrategyMutex.RLock()
-	defer fake.cOWStrategyMutex.RUnlock()
+	fake.copyStrategyMutex.RLock()
+	defer fake.copyStrategyMutex.RUnlock()
 	fake.createChildForContainerMutex.RLock()
 	defer fake.createChildForContainerMutex.RUnlock()
 	fake.destroyMutex.RLock()
 	defer fake.destroyMutex.RUnlock()
 	fake.handleMutex.RLock()
 	defer fake.handleMutex.RUnlock()
-	fake.importStrategyMutex.RLock()
-	defer fake.importStrategyMutex.RUnlock()
 	fake.initializeArtifactMutex.RLock()
 	defer fake.initializeArtifactMutex.RUnlock()
 	fake.initializeResourceCacheMutex.RLock()
 	defer fake.initializeResourceCacheMutex.RUnlock()
 	fake.initializeTaskCacheMutex.RLock()
 	defer fake.initializeTaskCacheMutex.RUnlock()
-	fake.parentHandleMutex.RLock()
-	defer fake.parentHandleMutex.RUnlock()
 	fake.pathMutex.RLock()
 	defer fake.pathMutex.RUnlock()
 	fake.propertiesMutex.RLock()

--- a/atc/worker/workerfakes/fake_volume.go
+++ b/atc/worker/workerfakes/fake_volume.go
@@ -57,6 +57,16 @@ type FakeVolume struct {
 	handleReturnsOnCall map[int]struct {
 		result1 string
 	}
+	ImportStrategyStub        func() baggageclaim.ImportStrategy
+	importStrategyMutex       sync.RWMutex
+	importStrategyArgsForCall []struct {
+	}
+	importStrategyReturns struct {
+		result1 baggageclaim.ImportStrategy
+	}
+	importStrategyReturnsOnCall map[int]struct {
+		result1 baggageclaim.ImportStrategy
+	}
 	InitializeArtifactStub        func(string, int) (db.WorkerArtifact, error)
 	initializeArtifactMutex       sync.RWMutex
 	initializeArtifactArgsForCall []struct {
@@ -96,6 +106,16 @@ type FakeVolume struct {
 	}
 	initializeTaskCacheReturnsOnCall map[int]struct {
 		result1 error
+	}
+	ParentHandleStub        func() string
+	parentHandleMutex       sync.RWMutex
+	parentHandleArgsForCall []struct {
+	}
+	parentHandleReturns struct {
+		result1 string
+	}
+	parentHandleReturnsOnCall map[int]struct {
+		result1 string
 	}
 	PathStub        func() string
 	pathMutex       sync.RWMutex
@@ -403,6 +423,58 @@ func (fake *FakeVolume) HandleReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakeVolume) ImportStrategy() baggageclaim.ImportStrategy {
+	fake.importStrategyMutex.Lock()
+	ret, specificReturn := fake.importStrategyReturnsOnCall[len(fake.importStrategyArgsForCall)]
+	fake.importStrategyArgsForCall = append(fake.importStrategyArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ImportStrategy", []interface{}{})
+	fake.importStrategyMutex.Unlock()
+	if fake.ImportStrategyStub != nil {
+		return fake.ImportStrategyStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.importStrategyReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeVolume) ImportStrategyCallCount() int {
+	fake.importStrategyMutex.RLock()
+	defer fake.importStrategyMutex.RUnlock()
+	return len(fake.importStrategyArgsForCall)
+}
+
+func (fake *FakeVolume) ImportStrategyCalls(stub func() baggageclaim.ImportStrategy) {
+	fake.importStrategyMutex.Lock()
+	defer fake.importStrategyMutex.Unlock()
+	fake.ImportStrategyStub = stub
+}
+
+func (fake *FakeVolume) ImportStrategyReturns(result1 baggageclaim.ImportStrategy) {
+	fake.importStrategyMutex.Lock()
+	defer fake.importStrategyMutex.Unlock()
+	fake.ImportStrategyStub = nil
+	fake.importStrategyReturns = struct {
+		result1 baggageclaim.ImportStrategy
+	}{result1}
+}
+
+func (fake *FakeVolume) ImportStrategyReturnsOnCall(i int, result1 baggageclaim.ImportStrategy) {
+	fake.importStrategyMutex.Lock()
+	defer fake.importStrategyMutex.Unlock()
+	fake.ImportStrategyStub = nil
+	if fake.importStrategyReturnsOnCall == nil {
+		fake.importStrategyReturnsOnCall = make(map[int]struct {
+			result1 baggageclaim.ImportStrategy
+		})
+	}
+	fake.importStrategyReturnsOnCall[i] = struct {
+		result1 baggageclaim.ImportStrategy
+	}{result1}
+}
+
 func (fake *FakeVolume) InitializeArtifact(arg1 string, arg2 int) (db.WorkerArtifact, error) {
 	fake.initializeArtifactMutex.Lock()
 	ret, specificReturn := fake.initializeArtifactReturnsOnCall[len(fake.initializeArtifactArgsForCall)]
@@ -588,6 +660,58 @@ func (fake *FakeVolume) InitializeTaskCacheReturnsOnCall(i int, result1 error) {
 	}
 	fake.initializeTaskCacheReturnsOnCall[i] = struct {
 		result1 error
+	}{result1}
+}
+
+func (fake *FakeVolume) ParentHandle() string {
+	fake.parentHandleMutex.Lock()
+	ret, specificReturn := fake.parentHandleReturnsOnCall[len(fake.parentHandleArgsForCall)]
+	fake.parentHandleArgsForCall = append(fake.parentHandleArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ParentHandle", []interface{}{})
+	fake.parentHandleMutex.Unlock()
+	if fake.ParentHandleStub != nil {
+		return fake.ParentHandleStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.parentHandleReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeVolume) ParentHandleCallCount() int {
+	fake.parentHandleMutex.RLock()
+	defer fake.parentHandleMutex.RUnlock()
+	return len(fake.parentHandleArgsForCall)
+}
+
+func (fake *FakeVolume) ParentHandleCalls(stub func() string) {
+	fake.parentHandleMutex.Lock()
+	defer fake.parentHandleMutex.Unlock()
+	fake.ParentHandleStub = stub
+}
+
+func (fake *FakeVolume) ParentHandleReturns(result1 string) {
+	fake.parentHandleMutex.Lock()
+	defer fake.parentHandleMutex.Unlock()
+	fake.ParentHandleStub = nil
+	fake.parentHandleReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeVolume) ParentHandleReturnsOnCall(i int, result1 string) {
+	fake.parentHandleMutex.Lock()
+	defer fake.parentHandleMutex.Unlock()
+	fake.ParentHandleStub = nil
+	if fake.parentHandleReturnsOnCall == nil {
+		fake.parentHandleReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.parentHandleReturnsOnCall[i] = struct {
+		result1 string
 	}{result1}
 }
 
@@ -1008,12 +1132,16 @@ func (fake *FakeVolume) Invocations() map[string][][]interface{} {
 	defer fake.destroyMutex.RUnlock()
 	fake.handleMutex.RLock()
 	defer fake.handleMutex.RUnlock()
+	fake.importStrategyMutex.RLock()
+	defer fake.importStrategyMutex.RUnlock()
 	fake.initializeArtifactMutex.RLock()
 	defer fake.initializeArtifactMutex.RUnlock()
 	fake.initializeResourceCacheMutex.RLock()
 	defer fake.initializeResourceCacheMutex.RUnlock()
 	fake.initializeTaskCacheMutex.RLock()
 	defer fake.initializeTaskCacheMutex.RUnlock()
+	fake.parentHandleMutex.RLock()
+	defer fake.parentHandleMutex.RUnlock()
 	fake.pathMutex.RLock()
 	defer fake.pathMutex.RUnlock()
 	fake.propertiesMutex.RLock()

--- a/testflight/volume_mounting_test.go
+++ b/testflight/volume_mounting_test.go
@@ -36,8 +36,7 @@ var _ = Describe("A job with nested volume mounts", func() {
 		Expect(sess).To(gbytes.Say("hello"))
 	})
 
-	// Pending this test for now, @cirocosta will be looking into it
-	XIt("procceds through the plan with input same as output mounts", func() {
+	It("procceds through the plan with input same as output mounts", func() {
 		sess := fly("trigger-job", "-j", inPipeline("input-same-output"), "-w")
 		Expect(sess).To(gexec.Exit(0))
 		Expect(sess).To(gbytes.Say("hello"))


### PR DESCRIPTION
Signed-off-by: Krishna Mannem <kmannem@pivotal.io>

Fixes #4964  .

If you have a step that uses an output and input at the same mount path. The output will end up being a COW of the resource_cache volume. When this output is then used as an input to the next step in the plan, we try to create a COW of a COW(output volume of prev step). In newer versions of the kernel, this isn't something that is supported. With this change we can now achieve the same behavior by making a baggageclaim request using the ImportStrategy. Which will create a copy of the output volume by executing a `cp` command.
https://github.com/concourse/baggageclaim/blob/dc362b1f055e4836dc2afb16639383c61cee637a/volume/import_strategy.go#L29

We have a testflight test which catches this user behavior:
```
- step1:
    - input: some-resource
    - output: some-resource
- step2:
    - input: some-resource
```
https://github.com/concourse/concourse/blob/master/testflight/fixtures/volume-mounting.yml#L164

# Contributor Checklist
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
