### PR TITLE
Garbage collect missing parent volumes along with it's child volumes

### DIFF
--- a/atc/db/migration/migrations/1579207767_alter_parent_id_constraint_on_volumes.down.sql
+++ b/atc/db/migration/migrations/1579207767_alter_parent_id_constraint_on_volumes.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+  ALTER TABLE volumes DROP CONSTRAINT volumes_parent_id_fkey;
+
+  ALTER TABLE ONLY volumes
+      ADD CONSTRAINT volumes_parent_id_fkey FOREIGN KEY (parent_id, parent_state) REFERENCES volumes(id, state) ON DELETE RESTRICT;
+
+  DROP INDEX missing_volumes_idx;
+COMMIT;

--- a/atc/db/migration/migrations/1579207767_alter_parent_id_constraint_on_volumes.up.sql
+++ b/atc/db/migration/migrations/1579207767_alter_parent_id_constraint_on_volumes.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+  ALTER TABLE volumes DROP CONSTRAINT volumes_parent_id_fkey;
+
+  ALTER TABLE volumes ADD CONSTRAINT volumes_parent_id_fkey
+    FOREIGN KEY (parent_id, parent_state)
+    REFERENCES volumes (id, state) ON DELETE NO ACTION DEFERRABLE;
+
+  CREATE INDEX missing_volumes_idx ON volumes (state) WHERE missing_since IS NOT NULL;
+COMMIT;


### PR DESCRIPTION
Fixed the RemoveMissingVolumes GC query to be able to garbage collect missing volumes that are referenced by other volumes. 