### PR TITLE
Schedule rerun builds separately

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1228,6 +1228,9 @@ func (b *build) AdoptRerunInputsAndPipes() ([]BuildInput, bool, error) {
 			QueryRow().
 			Scan(&versionBlob)
 		if err != nil {
+			if err == sql.ErrNoRows {
+				return nil, false, nil
+			}
 			return nil, false, err
 		}
 

--- a/atc/scheduler/build.go
+++ b/atc/scheduler/build.go
@@ -104,11 +104,11 @@ func (r *rerunBuild) PrepareInputs(logger lager.Logger) bool {
 func (r *rerunBuild) BuildInputs(logger lager.Logger) ([]db.BuildInput, bool, error) {
 	buildInputs, inputsReady, err := r.AdoptRerunInputsAndPipes()
 	if err != nil {
-		return nil, false, fmt.Errorf("adopt inputs and pipes: %w", err)
+		return nil, false, fmt.Errorf("adopt rerun inputs and pipes: %w", err)
 	}
 
 	if !inputsReady {
-		return nil, false, fmt.Errorf("adopt inputs and pipes: %w", db.ErrAdoptRerunBuildHasNoInputs)
+		return nil, false, nil
 	}
 
 	return buildInputs, true, nil


### PR DESCRIPTION
Schedule rerun builds separate from regular scheduler builds (and
manually triggered) so that if a rerun build cannot find its inputs, it
will not result in blocking the scheduler for that job.

fixes #4960

