### PR TITLE
worker/backend: source formatting

### DIFF
--- a/worker/backend/backend.go
+++ b/worker/backend/backend.go
@@ -19,18 +19,19 @@ import (
 var _ garden.Backend = (*Backend)(nil)
 
 type Backend struct {
-	client    libcontainerd.Client
-	namespace string
+	client        libcontainerd.Client
+	namespace     string
 	clientTimeout time.Duration
 }
 
-type InputValidationError struct{
+type InputValidationError struct {
 	Message string
 }
 
 func (e InputValidationError) Error() string {
 	return "input validation error: " + e.Message
 }
+
 type ClientError struct {
 	InnerError error
 }
@@ -41,16 +42,16 @@ func (e ClientError) Error() string {
 
 func New(client libcontainerd.Client, namespace string) Backend {
 	return Backend{
-		namespace: namespace,
-		client:    client,
+		namespace:     namespace,
+		client:        client,
 		clientTimeout: 10 * time.Second,
 	}
 }
 
 func NewWithTimeout(client libcontainerd.Client, namespace string, clientTimeout time.Duration) Backend {
 	return Backend{
-		namespace: namespace,
-		client:    client,
+		namespace:     namespace,
+		client:        client,
 		clientTimeout: clientTimeout,
 	}
 }
@@ -60,7 +61,7 @@ func NewWithTimeout(client libcontainerd.Client, namespace string, clientTimeout
 func (b *Backend) Start() (err error) {
 	err = b.client.Init()
 	if err != nil {
-		return ClientError{ InnerError: fmt.Errorf("failed to initialize containerd client: %w", err) }
+		return ClientError{InnerError: fmt.Errorf("failed to initialize containerd client: %w", err)}
 	}
 
 	return
@@ -86,7 +87,7 @@ func (b *Backend) GraceTime(container garden.Container) (duration time.Duration)
 func (b *Backend) Ping() (err error) {
 	err = b.client.Version(context.Background())
 	if err != nil {
-		return ClientError{ InnerError: err }
+		return ClientError{InnerError: err}
 	}
 	return
 }
@@ -106,7 +107,7 @@ func (b *Backend) Create(gdnSpec garden.ContainerSpec) (container garden.Contain
 
 	oci, err = bespec.OciSpec(gdnSpec)
 	if err != nil {
-		err = ClientError{ InnerError: fmt.Errorf("failed to convert garden spec to oci spec: %w", err) }
+		err = ClientError{InnerError: fmt.Errorf("failed to convert garden spec to oci spec: %w", err)}
 		return
 	}
 
@@ -115,13 +116,13 @@ func (b *Backend) Create(gdnSpec garden.ContainerSpec) (container garden.Contain
 	)
 
 	if err != nil {
-		err = ClientError{ InnerError: fmt.Errorf("failed to create a container in containerd: %w", err) }
+		err = ClientError{InnerError: fmt.Errorf("failed to create a container in containerd: %w", err)}
 		return
 	}
 
 	_, err = cont.NewTask(ctxWithTimeout, cio.NullIO)
 	if err != nil {
-		err = ClientError{ InnerError: fmt.Errorf("failed to create a task in container: %w", err) }
+		err = ClientError{InnerError: fmt.Errorf("failed to create a task in container: %w", err)}
 		return
 	}
 
@@ -157,24 +158,24 @@ func (b *Backend) Destroy(handle string) error {
 
 	container, err := b.client.GetContainer(ctxWithTimeout, handle)
 	if err != nil {
-		return ClientError{ InnerError: err }
+		return ClientError{InnerError: err}
 	}
 
 	task, err := container.Task(ctxWithTimeout, nil)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
-			return ClientError { InnerError: err }
+			return ClientError{InnerError: err}
 		}
 	} else {
 		err = killTasks(ctxWithTimeout, task)
 		if err != nil {
-			return ClientError{ InnerError: err }
+			return ClientError{InnerError: err}
 		}
 	}
 
 	err = b.client.Destroy(ctxWithTimeout, handle)
 	if err != nil {
-		return ClientError{ InnerError: err }
+		return ClientError{InnerError: err}
 	}
 	return nil
 }
@@ -225,13 +226,13 @@ func (b *Backend) Containers(properties garden.Properties) (containers []garden.
 
 	filters, err := propertiesToFilterList(properties)
 	if err != nil {
-		err = ClientError{ InnerError: err }
+		err = ClientError{InnerError: err}
 		return
 	}
 
 	res, err := b.client.Containers(ctxWithTimeout, filters...)
 	if err != nil {
-		err = ClientError{ InnerError: err }
+		err = ClientError{InnerError: err}
 		return
 	}
 
@@ -270,7 +271,7 @@ func (b *Backend) Lookup(handle string) (garden.Container, error) {
 
 	containerdContainer, err := b.client.GetContainer(ctxWithTimeout, handle)
 	if err != nil {
-		return nil, ClientError{ InnerError: err }
+		return nil, ClientError{InnerError: err}
 	}
 
 	return &Container{handle: containerdContainer.ID()}, nil

--- a/worker/backend/backend_test.go
+++ b/worker/backend/backend_test.go
@@ -369,7 +369,7 @@ func (s *BackendSuite) TestDestroyKillTaskSIGTERMFailedError() {
 	fakeContainer := new(libcontainerdfakes.FakeContainer)
 	fakeTask := new(libcontainerdfakes.FakeTask)
 
-	fakeTask.WaitStub = func(ctx context.Context) (<- chan containerd.ExitStatus, error) {
+	fakeTask.WaitStub = func(ctx context.Context) (<-chan containerd.ExitStatus, error) {
 		c := make(chan containerd.ExitStatus, 1)
 		go func() {
 			es := containerd.NewExitStatus(0, time.Now(), errors.New("sigterm error"))
@@ -392,7 +392,7 @@ func (s *BackendSuite) TestDestroyKillTaskSIGTERMFailedError() {
 
 func (s *BackendSuite) TestDestroyKillTaskTimeoutError() {
 	// so we don't have to wait 10 seconds for the default timeout
-	s.backend = backend.NewWithTimeout(s.client, testNamespace, 10 * time.Millisecond)
+	s.backend = backend.NewWithTimeout(s.client, testNamespace, 10*time.Millisecond)
 	fakeContainer := new(libcontainerdfakes.FakeContainer)
 	fakeTask := new(libcontainerdfakes.FakeTask)
 
@@ -517,7 +517,7 @@ func TestSuite(t *testing.T) {
 	})
 }
 
-func exitBeforeTimeout(ctx context.Context) (<- chan containerd.ExitStatus, error) {
+func exitBeforeTimeout(ctx context.Context) (<-chan containerd.ExitStatus, error) {
 	c := make(chan containerd.ExitStatus, 1)
 	go func() {
 		es := containerd.NewExitStatus(0, time.Now(), nil)

--- a/worker/backend/backend_test.go
+++ b/worker/backend/backend_test.go
@@ -1,9 +1,13 @@
 package backend_test
 
 import (
-	"code.cloudfoundry.org/garden"
 	"context"
 	"errors"
+	"syscall"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/garden"
 	"github.com/concourse/concourse/worker/backend"
 	"github.com/concourse/concourse/worker/backend/libcontainerd/libcontainerdfakes"
 	"github.com/containerd/containerd"
@@ -11,9 +15,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"syscall"
-	"testing"
-	"time"
 )
 
 type BackendSuite struct {

--- a/worker/backend/container.go
+++ b/worker/backend/container.go
@@ -7,7 +7,7 @@ import (
 	"code.cloudfoundry.org/garden"
 )
 
-type Container struct{
+type Container struct {
 	handle string
 }
 


### PR DESCRIPTION
### Why do we need this PR?

The source needed to be formatted.

Giving the source formatting its own PR will make further PRs easier to at a glance figure out the really valuable changes.

**there are no behavior our actual significant source changes in this PR**

### Changes proposed in this pull request

- format all `worker/backend` files (`containerd`-related source code)
- update import order

### Contributor Checklist


- ~[ ] Unit tests~
- ~[ ] Integration tests (if applicable)~
- ~[ ] Updated documentation (located at https://github.com/concourse/docs)~
- ~[ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
