### PR TITLE
Use version column in resource caches

### DIFF
--- a/atc/db/migration/migrations/1575922657_version_md5_resource_cache.down.sql
+++ b/atc/db/migration/migrations/1575922657_version_md5_resource_cache.down.sql
@@ -3,8 +3,6 @@ BEGIN;
 
   ALTER TABLE resource_caches DROP COLUMN version_md5;
 
-  COMMENT ON COLUMN resource_caches.version IS NULL;
-
   CREATE UNIQUE INDEX resource_caches_resource_config_id_version_params_hash_uniq
   ON resource_caches (resource_config_id, md5(version::text), params_hash);
 COMMIT;

--- a/atc/db/migration/migrations/1575922657_version_md5_resource_cache.up.sql
+++ b/atc/db/migration/migrations/1575922657_version_md5_resource_cache.up.sql
@@ -7,8 +7,6 @@ BEGIN;
 
   DROP INDEX resource_caches_resource_config_id_version_params_hash_uniq;
 
-  COMMENT ON COLUMN resource_caches.version IS 'Deprecated only for backward compatibility';
-
   CREATE UNIQUE INDEX resource_caches_resource_config_id_version_md5_params_hash_uniq
   ON resource_caches (resource_config_id, version_md5, params_hash);
 COMMIT;

--- a/atc/db/volume.go
+++ b/atc/db/volume.go
@@ -242,10 +242,9 @@ func (volume *createdVolume) findVolumeResourceTypeByCacheID(resourceCacheID int
 	var sqBaseResourceTypeID sql.NullInt64
 	var sqResourceCacheID sql.NullInt64
 
-	err := psql.Select("rcv.version, rcfg.base_resource_type_id, rcfg.resource_cache_id").
+	err := psql.Select("rc.version, rcfg.base_resource_type_id, rcfg.resource_cache_id").
 		From("resource_caches rc").
 		LeftJoin("resource_configs rcfg ON rcfg.id = rc.resource_config_id").
-		LeftJoin("resource_config_versions rcv ON rcv.version_md5 = rc.version_md5").
 		Where(sq.Eq{
 			"rc.id": resourceCacheID,
 		}).


### PR DESCRIPTION
Switch to using the version column in resource caches within the code because there can be cases where the resource config version does not exist for a resource cache (for example, with image resources we never save its versions into the database as a resource config version)