### PR TITLE
Order passed jobs for dashboard job inputs

### DIFF
--- a/atc/db/job_factory.go
+++ b/atc/db/job_factory.go
@@ -175,7 +175,7 @@ func buildDashboard(tx Tx, pred interface{}) (atc.Dashboard, error) {
 		dashboard = append(dashboard, j)
 	}
 
-	rows, err = psql.Select("j.id", "i.name", "r.name", "array_agg(jp.name)", "i.trigger").
+	rows, err = psql.Select("j.id", "i.name", "r.name", "array_agg(jp.name ORDER BY jp.id)", "i.trigger").
 		From("job_inputs i").
 		Join("jobs j ON j.id = i.job_id").
 		Join("pipelines p ON p.id = j.pipeline_id").

--- a/atc/db/resource_cache.go
+++ b/atc/db/resource_cache.go
@@ -87,6 +87,7 @@ func (cache *ResourceCacheDescriptor) findOrCreate(
 
 		rc = &usedResourceCache{
 			id:             id,
+			version:        cache.Version,
 			resourceConfig: resourceConfig,
 			lockFactory:    lockFactory,
 			conn:           conn,
@@ -152,6 +153,7 @@ func (cache *ResourceCacheDescriptor) findWithResourceConfig(tx Tx, resourceConf
 
 	return &usedResourceCache{
 		id:             id,
+		version:        cache.Version,
 		resourceConfig: resourceConfig,
 		lockFactory:    lockFactory,
 		conn:           conn,
@@ -187,6 +189,7 @@ func paramsHash(p atc.Params) string {
 
 type UsedResourceCache interface {
 	ID() int
+	Version() atc.Version
 
 	ResourceConfig() ResourceConfig
 
@@ -197,6 +200,7 @@ type UsedResourceCache interface {
 type usedResourceCache struct {
 	id             int
 	resourceConfig ResourceConfig
+	version        atc.Version
 
 	lockFactory lock.LockFactory
 	conn        Conn
@@ -204,6 +208,7 @@ type usedResourceCache struct {
 
 func (cache *usedResourceCache) ID() int                        { return cache.id }
 func (cache *usedResourceCache) ResourceConfig() ResourceConfig { return cache.resourceConfig }
+func (cache *usedResourceCache) Version() atc.Version           { return cache.version }
 
 func (cache *usedResourceCache) Destroy(tx Tx) (bool, error) {
 	rows, err := psql.Delete("resource_caches").

--- a/atc/db/resource_cache_factory.go
+++ b/atc/db/resource_cache_factory.go
@@ -123,18 +123,25 @@ func (f *resourceCacheFactory) ResourceCacheMetadata(resourceCache UsedResourceC
 
 func findResourceCacheByID(tx Tx, resourceCacheID int, lock lock.LockFactory, conn Conn) (UsedResourceCache, bool, error) {
 	var rcID int
+	var versionBytes string
 
-	err := psql.Select("resource_config_id").
+	err := psql.Select("resource_config_id", "version").
 		From("resource_caches").
 		Where(sq.Eq{"id": resourceCacheID}).
 		RunWith(tx).
 		QueryRow().
-		Scan(&rcID)
+		Scan(&rcID, &versionBytes)
 
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, false, nil
 		}
+		return nil, false, err
+	}
+
+	var version atc.Version
+	err = json.Unmarshal([]byte(versionBytes), &version)
+	if err != nil {
 		return nil, false, err
 	}
 
@@ -149,6 +156,7 @@ func findResourceCacheByID(tx Tx, resourceCacheID int, lock lock.LockFactory, co
 
 	usedResourceCache := &usedResourceCache{
 		id:             resourceCacheID,
+		version:        version,
 		resourceConfig: rc,
 		lockFactory:    lock,
 		conn:           conn,


### PR DESCRIPTION
Order the passed jobs before aggregating them. Fixes a flaky test (https://ci.concourse-ci.org/teams/main/pipelines/release-6.0.x/jobs/unit/builds/26) that expects them to be ordered a certain way every time.

Also added back version to resource cache object in order to get the code to compile. It seems to have broke with the removing of resource cache version commit (https://github.com/concourse/concourse/commit/fc805aa8a76a354b465a028c9a3e5352734df235#diff-aec4784b5c20d59cb9d946e4a4752ca1) 
