### PR TITLE
[#5053] Updated resource_put step to use ProcessSpec.Args instead of …

### DIFF
--- a/atc/resource/resource_put.go
+++ b/atc/resource/resource_put.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/concourse/concourse/atc/runtime"
 )
@@ -22,7 +23,7 @@ func (resource *resource) Put(
 	err = runnable.RunScript(
 		ctx,
 		spec.Path,
-		[]string{spec.Dir},
+		spec.Args,
 		input,
 		&vr,
 		spec.StderrWriter,
@@ -32,7 +33,7 @@ func (resource *resource) Put(
 		return runtime.VersionResult{}, err
 	}
 	if vr.Version == nil {
-		return runtime.VersionResult{}, fmt.Errorf("resource script (%s %s) output a null version", spec.Path, spec.Dir)
+		return runtime.VersionResult{}, fmt.Errorf("resource script (%s %s) output a null version", spec.Path, strings.Join(spec.Args, " "))
 	}
 
 	return vr, nil

--- a/atc/resource/resource_put_test.go
+++ b/atc/resource/resource_put_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"strings"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/resource"
@@ -41,7 +42,7 @@ var _ = Describe("Resource Put", func() {
 		params = atc.Params{"some": "params"}
 
 		someProcessSpec.Path = "some/fake/path"
-		someProcessSpec.Dir = "some/other-dir"
+		someProcessSpec.Args = []string{"some/foo-dir"}
 		someProcessSpec.StderrWriter = gbytes.NewBuffer()
 
 		resource = resourceFactory.NewResource(source, params, version)
@@ -74,7 +75,7 @@ var _ = Describe("Resource Put", func() {
 
 			Expect(actualCtx).To(Equal(ctx))
 			Expect(actualSpecPath).To(Equal(someProcessSpec.Path))
-			Expect(actualArgs).To(Equal([]string{someProcessSpec.Dir}))
+			Expect(actualArgs).To(Equal(someProcessSpec.Args))
 			Expect(actualInput).To(Equal(signature))
 			Expect(actualVersionResultRef).To(Equal(&putVersionResult))
 			Expect(actualSpecStdErrWriter).To(Equal(someProcessSpec.StderrWriter))
@@ -90,7 +91,7 @@ var _ = Describe("Resource Put", func() {
 			fakeRunnable.RunScriptReturns(nil)
 		})
 		It("returns a corresponding error", func() {
-			Expect(putErr).To(MatchError("resource script (" + someProcessSpec.Path + " " + someProcessSpec.Dir + ") output a null version"))
+			Expect(putErr).To(MatchError("resource script (" + someProcessSpec.Path + " " + strings.Join(someProcessSpec.Args, " ") + ") output a null version"))
 		})
 	})
 


### PR DESCRIPTION
# Existing Issue

Fixes #5053

We also submitted a [change](https://github.com/concourse/mock-resource/commit/c5550e6c3d8cb3764c4deac727e56de1acd765c9) to mock-resource so that if an empty argument is passed to the out script, it will raise an error.  

**Do not merge this PR before the mock-resource with our changes has been released. This will ensure that integration tests fail due to the bug**

# Contributor Checklist
- [x] Unit tests
- [x] Integration tests (if applicable)

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] Code reviewed
- [x] Tests reviewed
- ~[ ] Documentation reviewed~ nothing public
- ~[ ] Release notes reviewed~ bug not present in older versions
- [x] PR acceptance performed
- ~[ ] New config flags added?~ no