### PR TITLE
hack: add prometheus docker-compose override file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,27 @@ $ docker-compose \
 ```
 
 
+
+### Running Prometheus locally
+
+Just like for Jaeger, we have a docker-compose override file that enhances the
+base `docker-compose.yml` with the [Prometheus] service, bringing with it the
+necessary configuraton for collecting Concourse metrics.
+
+[Prometheus]: https://prometheus.io
+
+
+```sh
+$ docker-compose \
+  -f ./docker-compose.yml \
+  -f ./hack/overrides/prometheus.yml \
+  up -d
+```
+
+Now head to http://localhost:9090, and you'll be able to graph `concourse_`
+Prometheus metrics.
+
+
 ### Connecting to Postgres
 
 If you want to poke around the database, you can connect to the `db` node using

--- a/hack/overrides/prometheus.yml
+++ b/hack/overrides/prometheus.yml
@@ -1,0 +1,38 @@
+# prometheus.yml - a docker-compose override that adds 'prometheus' to the stack
+#
+# once running, head to `localhost:9090` to get access to the Prometheus console.
+#
+# ref: https://prometheus.io/
+# ref: https://docs.docker.com/compose/extends/
+#
+version: '3'
+
+services:
+  web:
+    environment:
+      CONCOURSE_PROMETHEUS_BIND_IP: "0.0.0.0"
+      CONCOURSE_PROMETHEUS_BIND_PORT: "9100"
+
+  prometheus:
+    image: prom/prometheus
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        echo "
+        global:
+          scrape_interval: '5s'
+          evaluation_interval: '5s'
+
+        scrape_configs:
+          - job_name: 'concourse'
+            static_configs:
+              - targets:
+                - 'web:9100'
+        " > config.yml
+
+          exec prometheus \
+            --config.file=config.yml \
+            --storage.tsdb.path=/prometheus
+    ports:
+      - '9090:9090'


### PR DESCRIPTION
### Why do we need this PR?

in the same way that we can have jaeger configured locally, we could do
the same for Prometheus.

here I introduce an override file that when tied together with the base
docker-compose file, brings Prometheus already pointing at
Concourse.


### Changes proposed in this pull request

add docker-compose override file that contains the config to target concourse.
