### PR TITLE
Revert "tf: temporary pend failing testflight test"

### DIFF
--- a/testflight/volume_mounting_test.go
+++ b/testflight/volume_mounting_test.go
@@ -36,8 +36,7 @@ var _ = Describe("A job with nested volume mounts", func() {
 		Expect(sess).To(gbytes.Say("hello"))
 	})
 
-	// Pending this test for now, @cirocosta will be looking into it
-	XIt("procceds through the plan with input same as output mounts", func() {
+	It("procceds through the plan with input same as output mounts", func() {
 		sess := fly("trigger-job", "-j", inPipeline("input-same-output"), "-w")
 		Expect(sess).To(gexec.Exit(0))
 		Expect(sess).To(gbytes.Say("hello"))


### PR DESCRIPTION
### Why do we need this PR?

Previously, we had marked the test where we create a copy-on-write of a copy-on-write pending so that we could have our pipelines unblocked (see more here: https://github.com/concourse/concourse/issues/4964)

Now that we've got a fix (see https://github.com/concourse/baggageclaim/pull/35) , there's no
need to have this test skipped anymore.

ps.: I'm currently marking this as a draft because it's not complete - it must come with a commit that bumps the version of `baggageclaim` (as the PR didn't get in yet, we don't have a tag to reference in `go.mod`).

### Changes proposed in this pull request

Reverts the commit where we skipped a failing test.

--

depends on https://github.com/concourse/concourse/pull/5160

