### PR TITLE
atc: fix piling on build tracking

### DIFF
--- a/atc/builds/tracker.go
+++ b/atc/builds/tracker.go
@@ -1,6 +1,8 @@
 package builds
 
 import (
+	"sync"
+
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/engine"
@@ -16,6 +18,7 @@ func NewTracker(
 		logger:       logger,
 		buildFactory: buildFactory,
 		engine:       engine,
+		running:      &sync.Map{},
 	}
 }
 
@@ -24,6 +27,8 @@ type Tracker struct {
 
 	buildFactory db.BuildFactory
 	engine       engine.Engine
+
+	running *sync.Map
 }
 
 func (bt *Tracker) Track() error {
@@ -38,15 +43,19 @@ func (bt *Tracker) Track() error {
 		return err
 	}
 
-	for _, build := range builds {
-		btLog := tLog.WithData(lager.Data{
-			"build":    build.ID(),
-			"pipeline": build.PipelineName(),
-			"job":      build.JobName(),
-		})
+	for _, b := range builds {
+		if _, exists := bt.running.LoadOrStore(b.ID(), true); !exists {
+			go func(build db.Build) {
+				defer bt.running.Delete(build.ID())
 
-		engineBuild := bt.engine.NewBuild(build)
-		go engineBuild.Run(btLog)
+				engineBuild := bt.engine.NewBuild(build)
+				engineBuild.Run(tLog.WithData(lager.Data{
+					"build":    build.ID(),
+					"pipeline": build.PipelineName(),
+					"job":      build.JobName(),
+				}))
+			}(b)
+		}
 	}
 
 	return nil

--- a/atc/builds/tracker_test.go
+++ b/atc/builds/tracker_test.go
@@ -64,10 +64,11 @@ var _ = Describe("Tracker", func() {
 
 			fakeBuildFactory.GetAllStartedBuildsReturns(returnedBuilds, nil)
 
-			engineBuilds = make(chan *enginefakes.FakeRunnable, 3)
+			builds := make(chan *enginefakes.FakeRunnable, 3)
+			engineBuilds = builds
 			fakeEngine.NewBuildStub = func(build db.Build) engine.Runnable {
 				engineBuild := new(enginefakes.FakeRunnable)
-				engineBuilds <- engineBuild
+				builds <- engineBuild
 				return engineBuild
 			}
 		})

--- a/go.sum
+++ b/go.sum
@@ -602,6 +602,7 @@ github.com/spf13/cobra v0.0.0-20160615143614-bc81c21bd0d8/go.mod h1:1l0Ry5zgKvJa
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=


### PR DESCRIPTION
rather than unconditionally firing off a goroutine for each in-flight
build (which then locks and short-circuits if the build is already
tracked), only do so if we don't have a goroutine for it already.

Signed-off-by: Alex Suraci <suraci.alex@gmail.com>

# Existing Issue

n/a

# Why do we need this PR?

This PR attempts to address a gradual increase in memory utilization observed in the `algorithm` environment, which is current creating ~25k builds per hour and can have ~1,000 builds running at a time.

Heap dumps don't seem to account for the used memory reported by the OS, so the working theory is that it's being used on the stack, probably through goroutines that are leaking or "piling on" through periodic things like the build tracker and job scheduler. The scheduling pile-on situation was addressed in #5025.

# Changes proposed in this pull request

* Keep track of builds which are being 'tracked' by the current ATC and do a no-op instead of spawning a goroutine. This is almost the exact same approach as implemented in https://github.com/concourse/concourse/commit/451ce407a7e1898f1e724c0a1e8d660014676954.

# Contributor Checklist

- [x] Unit tests
- [ ] ~~Integration tests (if applicable)~~
- [ ] ~~Updated documentation (located at https://github.com/concourse/docs)~~
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

Not sure if this really warrants a release note as this issue was never reported by a user and only really came about in our stress testing. I can add one if there's interest!

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
