### PR TITLE
atc: log pipeline-id when failing to create check

### DIFF
--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -105,7 +105,9 @@ func (s *scanner) check(checkable db.Checkable, resourceTypes db.ResourceTypes) 
 
 	_, created, err := s.checkFactory.TryCreateCheck(s.logger, checkable, resourceTypes, version, false)
 	if err != nil {
-		s.logger.Error("failed-to-create-check", err)
+		s.logger.Error("failed-to-create-check", err, lager.Data{
+			"pipeline-id": checkable.PipelineID(),
+		})
 		return err
 	}
 


### PR DESCRIPTION
### Why do we need this PR?

Currently, when checkFactory fails to create a check for a pipeline, we
can't tell which pipeline had the problem.

![Screen Shot 2020-01-28 at 10 00 21 AM](https://user-images.githubusercontent.com/3574444/73275389-04954980-41b5-11ea-9fce-1d39df63d1e3.png)

(^ can't tell who's causing that)


### Changes proposed in this pull request

Include `lager.Data` containing the `pipeline-id` of that pipeline,
one is able to at least tell which pipline is the offending one.

### Contributor Checklist

- ~[ ] Unit tests~
- ~[ ] Integration tests (if applicable)~
- ~[ ] Updated documentation (located at https://github.com/concourse/docs)~
- ~[ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


### Reviewer Checklist

- [ ] Code reviewed

--

cc @pivotal-jwinters 