### PR TITLE
atc algorithm: fix non-deterministic version order

### DIFF
--- a/atc/scheduler/algorithm/algorithm_test.go
+++ b/atc/scheduler/algorithm/algorithm_test.go
@@ -2426,39 +2426,129 @@ var _ = DescribeTable("Input resolving",
 	Entry("only uses the first build output/input to set a version candidate and disregards the other (it should use the output version first)", Example{
 		DB: DB{
 			BuildInputs: []DBRow{
-				{Job: "simple-a", BuildID: 1, Resource: "resource-x", Version: "rxv1", CheckOrder: 1},
-				{Job: "simple-a", BuildID: 2, Resource: "resource-x", Version: "rxv2", CheckOrder: 2},
+				{Job: "simple-a", BuildID: 1, Resource: "version", Version: "5.5.6-rc.23", CheckOrder: 1},
+				{Job: "simple-a", BuildID: 1, Resource: "resource-1", Version: "r1v1", CheckOrder: 1},
+				{Job: "simple-a", BuildID: 1, Resource: "resource-2", Version: "r2v1", CheckOrder: 1},
+				{Job: "simple-a", BuildID: 1, Resource: "resource-3", Version: "r3v1", CheckOrder: 1},
+				{Job: "simple-a", BuildID: 1, Resource: "resource-4", Version: "r4v1", CheckOrder: 1},
+				{Job: "simple-a", BuildID: 1, Resource: "resource-5", Version: "r5v1", CheckOrder: 1},
+				{Job: "simple-a", BuildID: 1, Resource: "resource-6", Version: "r6v1", CheckOrder: 1},
+				{Job: "simple-a", BuildID: 1, Resource: "resource-7", Version: "r7v1", CheckOrder: 1},
+				{Job: "simple-a", BuildID: 1, Resource: "resource-8", Version: "r8v1", CheckOrder: 1},
+
+				{Job: "simple-a", BuildID: 2, Resource: "version", Version: "5.5.7-rc.23", CheckOrder: 3},
+				{Job: "simple-a", BuildID: 2, Resource: "resource-1", Version: "r1v2", CheckOrder: 2},
+				{Job: "simple-a", BuildID: 2, Resource: "resource-2", Version: "r2v2", CheckOrder: 2},
+				{Job: "simple-a", BuildID: 2, Resource: "resource-3", Version: "r3v2", CheckOrder: 2},
+				{Job: "simple-a", BuildID: 2, Resource: "resource-4", Version: "r4v2", CheckOrder: 2},
+				{Job: "simple-a", BuildID: 2, Resource: "resource-5", Version: "r5v2", CheckOrder: 2},
+				{Job: "simple-a", BuildID: 2, Resource: "resource-6", Version: "r6v2", CheckOrder: 2},
+				{Job: "simple-a", BuildID: 2, Resource: "resource-7", Version: "r7v2", CheckOrder: 2},
+				{Job: "simple-a", BuildID: 2, Resource: "resource-8", Version: "r8v2", CheckOrder: 2},
 			},
 
 			BuildOutputs: []DBRow{
-				{Job: "simple-a", BuildID: 1, Resource: "resource-x", Version: "rxv3", CheckOrder: 3},
-				{Job: "simple-a", BuildID: 2, Resource: "resource-x", Version: "rxv4", CheckOrder: 4},
-
-				{Job: "simple-b", BuildID: 5, Resource: "resource-x", Version: "rxv3", CheckOrder: 4},
+				{Job: "simple-a", BuildID: 1, Resource: "version", Version: "5.5.6", CheckOrder: 2},
+				{Job: "simple-a", BuildID: 2, Resource: "version", Version: "5.5.7", CheckOrder: 4},
 			},
 
 			Resources: []DBRow{
-				{Resource: "resource-x", Version: "rxv1", CheckOrder: 1},
-				{Resource: "resource-x", Version: "rxv2", CheckOrder: 2},
-				{Resource: "resource-x", Version: "rxv3", CheckOrder: 3},
-				{Resource: "resource-x", Version: "rxv4", CheckOrder: 4},
+				{Resource: "resource-1", Version: "r1v1", CheckOrder: 1},
+				{Resource: "resource-1", Version: "r1v2", CheckOrder: 2},
+
+				{Resource: "resource-2", Version: "r2v1", CheckOrder: 1},
+				{Resource: "resource-2", Version: "r2v2", CheckOrder: 2},
+
+				{Resource: "resource-3", Version: "r3v1", CheckOrder: 1},
+				{Resource: "resource-3", Version: "r3v2", CheckOrder: 2},
+
+				{Resource: "resource-4", Version: "r4v1", CheckOrder: 1},
+				{Resource: "resource-4", Version: "r4v2", CheckOrder: 2},
+
+				{Resource: "resource-5", Version: "r5v1", CheckOrder: 1},
+				{Resource: "resource-5", Version: "r5v2", CheckOrder: 2},
+
+				{Resource: "resource-6", Version: "r6v1", CheckOrder: 1},
+				{Resource: "resource-6", Version: "r6v2", CheckOrder: 2},
+
+				{Resource: "resource-7", Version: "r7v1", CheckOrder: 1},
+				{Resource: "resource-7", Version: "r7v2", CheckOrder: 2},
+
+				{Resource: "resource-8", Version: "r7v1", CheckOrder: 1},
+				{Resource: "resource-8", Version: "r7v2", CheckOrder: 2},
+
+				{Resource: "version", Version: "5.5.6-rc.22", CheckOrder: 1},
+				{Resource: "version", Version: "5.5.6", CheckOrder: 2},
+				{Resource: "version", Version: "5.5.7-rc.23", CheckOrder: 3},
+				{Resource: "version", Version: "5.5.7", CheckOrder: 4},
 			},
 		},
 
 		Inputs: Inputs{
 			{
-				Name:     "resource-x",
-				Resource: "resource-x",
-				Passed:   []string{"simple-a", "simple-b"},
+				Name:     "version",
+				Resource: "version",
+				Passed:   []string{"simple-a"},
+			},
+			{
+				Name:     "resource-1",
+				Resource: "resource-1",
+				Passed:   []string{"simple-a"},
+			},
+			{
+				Name:     "resource-2",
+				Resource: "resource-2",
+				Passed:   []string{"simple-a"},
+			},
+			{
+				Name:     "resource-3",
+				Resource: "resource-3",
+				Passed:   []string{"simple-a"},
+			},
+			{
+				Name:     "resource-4",
+				Resource: "resource-4",
+				Passed:   []string{"simple-a"},
+			},
+			{
+				Name:     "resource-5",
+				Resource: "resource-5",
+				Passed:   []string{"simple-a"},
+			},
+			{
+				Name:     "resource-6",
+				Resource: "resource-6",
+				Passed:   []string{"simple-a"},
+			},
+			{
+				Name:     "resource-7",
+				Resource: "resource-7",
+				Passed:   []string{"simple-a"},
+			},
+			{
+				Name:     "resource-8",
+				Resource: "resource-8",
+				Passed:   []string{"simple-a"},
 			},
 		},
 
 		Result: Result{
 			OK: true,
 			Values: map[string]string{
-				"resource-x": "rxv3",
+				"version":    "5.5.7",
+				"resource-1": "r1v2",
+				"resource-2": "r2v2",
+				"resource-3": "r3v2",
+				"resource-4": "r4v2",
+				"resource-5": "r5v2",
+				"resource-6": "r6v2",
+				"resource-7": "r7v2",
+				"resource-8": "r8v2",
 			},
 		},
+
+		// run this test enough times to shake out any non-deterministic ordering issues
+		Iterations: 100,
 	}),
 
 	Entry("with very every and passed, it does not use retrigger builds as latest build", Example{

--- a/atc/scheduler/algorithm/compute.go
+++ b/atc/scheduler/algorithm/compute.go
@@ -12,17 +12,17 @@ type Resolver interface {
 	InputConfigs() InputConfigs
 }
 
-func New(versionsDB db.VersionsDB) *algorithm {
-	return &algorithm{
+func New(versionsDB db.VersionsDB) *Algorithm {
+	return &Algorithm{
 		versionsDB: versionsDB,
 	}
 }
 
-type algorithm struct {
+type Algorithm struct {
 	versionsDB db.VersionsDB
 }
 
-func (a *algorithm) Compute(
+func (a *Algorithm) Compute(
 	job db.Job,
 	inputs []atc.JobInput,
 	resources db.Resources,
@@ -41,7 +41,7 @@ func (a *algorithm) Compute(
 	return a.computeResolvers(resolvers, inputMapper)
 }
 
-func (a *algorithm) computeResolvers(resolvers []Resolver, inputMapper inputMapper) (db.InputMapping, bool, bool, error) {
+func (a *Algorithm) computeResolvers(resolvers []Resolver, inputMapper inputMapper) (db.InputMapping, bool, bool, error) {
 	finalHasNext := false
 	finalResolved := true
 	finalMapping := db.InputMapping{}
@@ -70,7 +70,7 @@ func (a *algorithm) computeResolvers(resolvers []Resolver, inputMapper inputMapp
 	return finalMapping, finalResolved, finalHasNext, nil
 }
 
-func (a *algorithm) finalizeHasNext(versionCandidates map[string]*versionCandidate) bool {
+func (a *Algorithm) finalizeHasNext(versionCandidates map[string]*versionCandidate) bool {
 	hasNextCombined := false
 	for _, candidate := range versionCandidates {
 		hasNextCombined = hasNextCombined || candidate.HasNextEveryVersion


### PR DESCRIPTION
# Existing Issue

Context is in https://github.com/concourse/concourse/issues/5063#issuecomment-579337229

# Why do we need this PR?

> previously, there was a good chance that the 'outputs over inputs'
> behavior of the algorithm would be lost due to a sort.Slice call which
> was not exhaustive and could therefore result in the order shifting for
> versions belonging to the same resource

# Changes proposed in this pull request

* order only by resource ID, preserving order of the resource's versions present in the db
* expand test to make use of more inputs so that it has a higher chance of demonstrating the issue
* run test for 100 iterations

# Contributor Checklist

- [x] Unit tests
- [ ] ~~Integration tests (if applicable)~~
- [ ] ~~Updated documentation (located at https://github.com/concourse/docs)~~
- [ ] ~~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~~


# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
