### PR TITLE
atc(feat): expose RESOURCE_NAME to steps get and put.

### DIFF
--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -137,12 +137,15 @@ func (step *GetStep) run(ctx context.Context, state RunState) error {
 		return err
 	}
 
+	env := step.metadata.Env()
+	env = append(env, fmt.Sprintf("RESOURCE_NAME=%s", step.plan.Name))
+
 	containerSpec := worker.ContainerSpec{
 		ImageSpec: worker.ImageSpec{
 			ResourceType: step.plan.Type,
 		},
 		TeamID: step.metadata.TeamID,
-		Env:    step.metadata.Env(),
+		Env:    env,
 	}
 
 	workerSpec := worker.WorkerSpec{

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -182,7 +182,7 @@ var _ = Describe("GetStep", func() {
 					ResourceType: "some-resource-type",
 				},
 				TeamID: stepMetadata.TeamID,
-				Env:    stepMetadata.Env(),
+				Env:    append(stepMetadata.Env(), "RESOURCE_NAME=some-name"),
 			},
 		))
 	})

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"code.cloudfoundry.org/lager"
@@ -141,17 +142,17 @@ func (step *PutStep) run(ctx context.Context, state RunState) error {
 		return err
 	}
 
+	env := step.metadata.Env()
+	env = append(env, fmt.Sprintf("RESOURCE_NAME=%s", step.plan.Name))
+
 	containerSpec := worker.ContainerSpec{
 		ImageSpec: worker.ImageSpec{
 			ResourceType: step.plan.Type,
 		},
-		Tags:   step.plan.Tags,
-		TeamID: step.metadata.TeamID,
-
-		Dir: step.containerMetadata.WorkingDirectory,
-
-		Env: step.metadata.Env(),
-
+		Tags:           step.plan.Tags,
+		TeamID:         step.metadata.TeamID,
+		Dir:            step.containerMetadata.WorkingDirectory,
+		Env:            env,
 		ArtifactByPath: containerInputs,
 	}
 

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -3,7 +3,6 @@ package exec_test
 import (
 	"context"
 	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -233,7 +232,7 @@ var _ = Describe("PutStep", func() {
 		}))
 		Expect(actualContainerSpec.Tags).To(Equal([]string{"some", "tags"}))
 		Expect(actualContainerSpec.TeamID).To(Equal(123))
-		Expect(actualContainerSpec.Env).To(Equal(stepMetadata.Env()))
+		Expect(actualContainerSpec.Env).To(Equal(append(stepMetadata.Env(),"RESOURCE_NAME=some-name")))
 		Expect(actualContainerSpec.Dir).To(Equal("/tmp/build/put"))
 
 		Expect(actualContainerSpec.ArtifactByPath).To(HaveLen(3))


### PR DESCRIPTION
Fixes #5089 .

# Changes proposed in this pull request

Just expose environment variable `RESOURCE_NAME` to `get` and `put` containers.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [x] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
