### PR TITLE
algorithm: fix pagination of rerun builds, add tracing

### DIFF
--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
@@ -19,9 +20,13 @@ var _ = Describe("Build", func() {
 	var (
 		team       db.Team
 		versionsDB db.VersionsDB
+
+		ctx context.Context
 	)
 
 	BeforeEach(func() {
+		ctx = context.Background()
+
 		var err error
 		team, err = teamFactory.CreateTeam(atc.Team{Name: "some-team"})
 		Expect(err).ToNot(HaveOccurred())
@@ -502,7 +507,7 @@ var _ = Describe("Build", func() {
 		})
 
 		It("inserts inputs and outputs into successful build versions", func() {
-			outputs, err := versionsDB.SuccessfulBuildOutputs(build.ID())
+			outputs, err := versionsDB.SuccessfulBuildOutputs(ctx, build.ID())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(outputs).To(ConsistOf(expectedOutputs))
 		})
@@ -2052,7 +2057,7 @@ var _ = Describe("Build", func() {
 
 				Expect(buildInputs).To(ConsistOf(expectedBuildInputs))
 
-				buildPipes, err := versionsDB.LatestBuildPipes(build.ID())
+				buildPipes, err := versionsDB.LatestBuildPipes(ctx, build.ID())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildPipes[otherJob.ID()]).To(Equal(otherBuild.ID()))
 
@@ -2075,7 +2080,7 @@ var _ = Describe("Build", func() {
 
 				Expect(buildInputs).To(BeNil())
 
-				buildPipes, err := versionsDB.LatestBuildPipes(build.ID())
+				buildPipes, err := versionsDB.LatestBuildPipes(ctx, build.ID())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildPipes).To(HaveLen(0))
 
@@ -2286,7 +2291,7 @@ var _ = Describe("Build", func() {
 
 				Expect(buildInputs).To(ConsistOf(expectedBuildInputs))
 
-				buildPipes, err := versionsDB.LatestBuildPipes(retriggerBuild.ID())
+				buildPipes, err := versionsDB.LatestBuildPipes(ctx, retriggerBuild.ID())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildPipes).To(HaveLen(1))
 				Expect(buildPipes[otherJob.ID()]).To(Equal(otherBuild.ID()))
@@ -2305,7 +2310,7 @@ var _ = Describe("Build", func() {
 
 				Expect(buildInputs).To(BeNil())
 
-				buildPipes, err := versionsDB.LatestBuildPipes(build.ID())
+				buildPipes, err := versionsDB.LatestBuildPipes(ctx, build.ID())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildPipes).To(HaveLen(0))
 

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -2059,7 +2059,9 @@ var _ = Describe("Build", func() {
 
 				buildPipes, err := versionsDB.LatestBuildPipes(ctx, build.ID())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(buildPipes[otherJob.ID()]).To(Equal(otherBuild.ID()))
+				Expect(buildPipes[otherJob.ID()]).To(Equal(db.BuildCursor{
+					ID: otherBuild.ID(),
+				}))
 
 				Expect(build.InputsReady()).To(BeTrue())
 			})
@@ -2294,7 +2296,9 @@ var _ = Describe("Build", func() {
 				buildPipes, err := versionsDB.LatestBuildPipes(ctx, retriggerBuild.ID())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildPipes).To(HaveLen(1))
-				Expect(buildPipes[otherJob.ID()]).To(Equal(otherBuild.ID()))
+				Expect(buildPipes[otherJob.ID()]).To(Equal(db.BuildCursor{
+					ID: otherBuild.ID(),
+				}))
 
 				reloaded, err := retriggerBuild.Reload()
 				Expect(err).ToNot(HaveOccurred())

--- a/atc/db/dbfakes/fake_check_lifecycle.go
+++ b/atc/db/dbfakes/fake_check_lifecycle.go
@@ -2,10 +2,10 @@
 package dbfakes
 
 import (
-	sync "sync"
-	time "time"
+	"sync"
+	"time"
 
-	db "github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db"
 )
 
 type FakeCheckLifecycle struct {

--- a/atc/db/dbfakes/fake_conn.go
+++ b/atc/db/dbfakes/fake_conn.go
@@ -2,6 +2,7 @@
 package dbfakes
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"sync"
@@ -21,6 +22,20 @@ type FakeConn struct {
 		result2 error
 	}
 	beginReturnsOnCall map[int]struct {
+		result1 db.Tx
+		result2 error
+	}
+	BeginTxStub        func(context.Context, *sql.TxOptions) (db.Tx, error)
+	beginTxMutex       sync.RWMutex
+	beginTxArgsForCall []struct {
+		arg1 context.Context
+		arg2 *sql.TxOptions
+	}
+	beginTxReturns struct {
+		result1 db.Tx
+		result2 error
+	}
+	beginTxReturnsOnCall map[int]struct {
 		result1 db.Tx
 		result2 error
 	}
@@ -78,6 +93,21 @@ type FakeConn struct {
 		result1 sql.Result
 		result2 error
 	}
+	ExecContextStub        func(context.Context, string, ...interface{}) (sql.Result, error)
+	execContextMutex       sync.RWMutex
+	execContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}
+	execContextReturns struct {
+		result1 sql.Result
+		result2 error
+	}
+	execContextReturnsOnCall map[int]struct {
+		result1 sql.Result
+		result2 error
+	}
 	NameStub        func() string
 	nameMutex       sync.RWMutex
 	nameArgsForCall []struct {
@@ -111,6 +141,20 @@ type FakeConn struct {
 		result1 *sql.Stmt
 		result2 error
 	}
+	PrepareContextStub        func(context.Context, string) (*sql.Stmt, error)
+	prepareContextMutex       sync.RWMutex
+	prepareContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	prepareContextReturns struct {
+		result1 *sql.Stmt
+		result2 error
+	}
+	prepareContextReturnsOnCall map[int]struct {
+		result1 *sql.Stmt
+		result2 error
+	}
 	QueryStub        func(string, ...interface{}) (*sql.Rows, error)
 	queryMutex       sync.RWMutex
 	queryArgsForCall []struct {
@@ -125,6 +169,21 @@ type FakeConn struct {
 		result1 *sql.Rows
 		result2 error
 	}
+	QueryContextStub        func(context.Context, string, ...interface{}) (*sql.Rows, error)
+	queryContextMutex       sync.RWMutex
+	queryContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}
+	queryContextReturns struct {
+		result1 *sql.Rows
+		result2 error
+	}
+	queryContextReturnsOnCall map[int]struct {
+		result1 *sql.Rows
+		result2 error
+	}
 	QueryRowStub        func(string, ...interface{}) squirrel.RowScanner
 	queryRowMutex       sync.RWMutex
 	queryRowArgsForCall []struct {
@@ -135,6 +194,19 @@ type FakeConn struct {
 		result1 squirrel.RowScanner
 	}
 	queryRowReturnsOnCall map[int]struct {
+		result1 squirrel.RowScanner
+	}
+	QueryRowContextStub        func(context.Context, string, ...interface{}) squirrel.RowScanner
+	queryRowContextMutex       sync.RWMutex
+	queryRowContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}
+	queryRowContextReturns struct {
+		result1 squirrel.RowScanner
+	}
+	queryRowContextReturnsOnCall map[int]struct {
 		result1 squirrel.RowScanner
 	}
 	SetMaxIdleConnsStub        func(int)
@@ -211,6 +283,70 @@ func (fake *FakeConn) BeginReturnsOnCall(i int, result1 db.Tx, result2 error) {
 		})
 	}
 	fake.beginReturnsOnCall[i] = struct {
+		result1 db.Tx
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeConn) BeginTx(arg1 context.Context, arg2 *sql.TxOptions) (db.Tx, error) {
+	fake.beginTxMutex.Lock()
+	ret, specificReturn := fake.beginTxReturnsOnCall[len(fake.beginTxArgsForCall)]
+	fake.beginTxArgsForCall = append(fake.beginTxArgsForCall, struct {
+		arg1 context.Context
+		arg2 *sql.TxOptions
+	}{arg1, arg2})
+	fake.recordInvocation("BeginTx", []interface{}{arg1, arg2})
+	fake.beginTxMutex.Unlock()
+	if fake.BeginTxStub != nil {
+		return fake.BeginTxStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.beginTxReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeConn) BeginTxCallCount() int {
+	fake.beginTxMutex.RLock()
+	defer fake.beginTxMutex.RUnlock()
+	return len(fake.beginTxArgsForCall)
+}
+
+func (fake *FakeConn) BeginTxCalls(stub func(context.Context, *sql.TxOptions) (db.Tx, error)) {
+	fake.beginTxMutex.Lock()
+	defer fake.beginTxMutex.Unlock()
+	fake.BeginTxStub = stub
+}
+
+func (fake *FakeConn) BeginTxArgsForCall(i int) (context.Context, *sql.TxOptions) {
+	fake.beginTxMutex.RLock()
+	defer fake.beginTxMutex.RUnlock()
+	argsForCall := fake.beginTxArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeConn) BeginTxReturns(result1 db.Tx, result2 error) {
+	fake.beginTxMutex.Lock()
+	defer fake.beginTxMutex.Unlock()
+	fake.BeginTxStub = nil
+	fake.beginTxReturns = struct {
+		result1 db.Tx
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeConn) BeginTxReturnsOnCall(i int, result1 db.Tx, result2 error) {
+	fake.beginTxMutex.Lock()
+	defer fake.beginTxMutex.Unlock()
+	fake.BeginTxStub = nil
+	if fake.beginTxReturnsOnCall == nil {
+		fake.beginTxReturnsOnCall = make(map[int]struct {
+			result1 db.Tx
+			result2 error
+		})
+	}
+	fake.beginTxReturnsOnCall[i] = struct {
 		result1 db.Tx
 		result2 error
 	}{result1, result2}
@@ -488,6 +624,71 @@ func (fake *FakeConn) ExecReturnsOnCall(i int, result1 sql.Result, result2 error
 	}{result1, result2}
 }
 
+func (fake *FakeConn) ExecContext(arg1 context.Context, arg2 string, arg3 ...interface{}) (sql.Result, error) {
+	fake.execContextMutex.Lock()
+	ret, specificReturn := fake.execContextReturnsOnCall[len(fake.execContextArgsForCall)]
+	fake.execContextArgsForCall = append(fake.execContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("ExecContext", []interface{}{arg1, arg2, arg3})
+	fake.execContextMutex.Unlock()
+	if fake.ExecContextStub != nil {
+		return fake.ExecContextStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.execContextReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeConn) ExecContextCallCount() int {
+	fake.execContextMutex.RLock()
+	defer fake.execContextMutex.RUnlock()
+	return len(fake.execContextArgsForCall)
+}
+
+func (fake *FakeConn) ExecContextCalls(stub func(context.Context, string, ...interface{}) (sql.Result, error)) {
+	fake.execContextMutex.Lock()
+	defer fake.execContextMutex.Unlock()
+	fake.ExecContextStub = stub
+}
+
+func (fake *FakeConn) ExecContextArgsForCall(i int) (context.Context, string, []interface{}) {
+	fake.execContextMutex.RLock()
+	defer fake.execContextMutex.RUnlock()
+	argsForCall := fake.execContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeConn) ExecContextReturns(result1 sql.Result, result2 error) {
+	fake.execContextMutex.Lock()
+	defer fake.execContextMutex.Unlock()
+	fake.ExecContextStub = nil
+	fake.execContextReturns = struct {
+		result1 sql.Result
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeConn) ExecContextReturnsOnCall(i int, result1 sql.Result, result2 error) {
+	fake.execContextMutex.Lock()
+	defer fake.execContextMutex.Unlock()
+	fake.ExecContextStub = nil
+	if fake.execContextReturnsOnCall == nil {
+		fake.execContextReturnsOnCall = make(map[int]struct {
+			result1 sql.Result
+			result2 error
+		})
+	}
+	fake.execContextReturnsOnCall[i] = struct {
+		result1 sql.Result
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeConn) Name() string {
 	fake.nameMutex.Lock()
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
@@ -655,6 +856,70 @@ func (fake *FakeConn) PrepareReturnsOnCall(i int, result1 *sql.Stmt, result2 err
 	}{result1, result2}
 }
 
+func (fake *FakeConn) PrepareContext(arg1 context.Context, arg2 string) (*sql.Stmt, error) {
+	fake.prepareContextMutex.Lock()
+	ret, specificReturn := fake.prepareContextReturnsOnCall[len(fake.prepareContextArgsForCall)]
+	fake.prepareContextArgsForCall = append(fake.prepareContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("PrepareContext", []interface{}{arg1, arg2})
+	fake.prepareContextMutex.Unlock()
+	if fake.PrepareContextStub != nil {
+		return fake.PrepareContextStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.prepareContextReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeConn) PrepareContextCallCount() int {
+	fake.prepareContextMutex.RLock()
+	defer fake.prepareContextMutex.RUnlock()
+	return len(fake.prepareContextArgsForCall)
+}
+
+func (fake *FakeConn) PrepareContextCalls(stub func(context.Context, string) (*sql.Stmt, error)) {
+	fake.prepareContextMutex.Lock()
+	defer fake.prepareContextMutex.Unlock()
+	fake.PrepareContextStub = stub
+}
+
+func (fake *FakeConn) PrepareContextArgsForCall(i int) (context.Context, string) {
+	fake.prepareContextMutex.RLock()
+	defer fake.prepareContextMutex.RUnlock()
+	argsForCall := fake.prepareContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeConn) PrepareContextReturns(result1 *sql.Stmt, result2 error) {
+	fake.prepareContextMutex.Lock()
+	defer fake.prepareContextMutex.Unlock()
+	fake.PrepareContextStub = nil
+	fake.prepareContextReturns = struct {
+		result1 *sql.Stmt
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeConn) PrepareContextReturnsOnCall(i int, result1 *sql.Stmt, result2 error) {
+	fake.prepareContextMutex.Lock()
+	defer fake.prepareContextMutex.Unlock()
+	fake.PrepareContextStub = nil
+	if fake.prepareContextReturnsOnCall == nil {
+		fake.prepareContextReturnsOnCall = make(map[int]struct {
+			result1 *sql.Stmt
+			result2 error
+		})
+	}
+	fake.prepareContextReturnsOnCall[i] = struct {
+		result1 *sql.Stmt
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeConn) Query(arg1 string, arg2 ...interface{}) (*sql.Rows, error) {
 	fake.queryMutex.Lock()
 	ret, specificReturn := fake.queryReturnsOnCall[len(fake.queryArgsForCall)]
@@ -719,6 +984,71 @@ func (fake *FakeConn) QueryReturnsOnCall(i int, result1 *sql.Rows, result2 error
 	}{result1, result2}
 }
 
+func (fake *FakeConn) QueryContext(arg1 context.Context, arg2 string, arg3 ...interface{}) (*sql.Rows, error) {
+	fake.queryContextMutex.Lock()
+	ret, specificReturn := fake.queryContextReturnsOnCall[len(fake.queryContextArgsForCall)]
+	fake.queryContextArgsForCall = append(fake.queryContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("QueryContext", []interface{}{arg1, arg2, arg3})
+	fake.queryContextMutex.Unlock()
+	if fake.QueryContextStub != nil {
+		return fake.QueryContextStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.queryContextReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeConn) QueryContextCallCount() int {
+	fake.queryContextMutex.RLock()
+	defer fake.queryContextMutex.RUnlock()
+	return len(fake.queryContextArgsForCall)
+}
+
+func (fake *FakeConn) QueryContextCalls(stub func(context.Context, string, ...interface{}) (*sql.Rows, error)) {
+	fake.queryContextMutex.Lock()
+	defer fake.queryContextMutex.Unlock()
+	fake.QueryContextStub = stub
+}
+
+func (fake *FakeConn) QueryContextArgsForCall(i int) (context.Context, string, []interface{}) {
+	fake.queryContextMutex.RLock()
+	defer fake.queryContextMutex.RUnlock()
+	argsForCall := fake.queryContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeConn) QueryContextReturns(result1 *sql.Rows, result2 error) {
+	fake.queryContextMutex.Lock()
+	defer fake.queryContextMutex.Unlock()
+	fake.QueryContextStub = nil
+	fake.queryContextReturns = struct {
+		result1 *sql.Rows
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeConn) QueryContextReturnsOnCall(i int, result1 *sql.Rows, result2 error) {
+	fake.queryContextMutex.Lock()
+	defer fake.queryContextMutex.Unlock()
+	fake.QueryContextStub = nil
+	if fake.queryContextReturnsOnCall == nil {
+		fake.queryContextReturnsOnCall = make(map[int]struct {
+			result1 *sql.Rows
+			result2 error
+		})
+	}
+	fake.queryContextReturnsOnCall[i] = struct {
+		result1 *sql.Rows
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeConn) QueryRow(arg1 string, arg2 ...interface{}) squirrel.RowScanner {
 	fake.queryRowMutex.Lock()
 	ret, specificReturn := fake.queryRowReturnsOnCall[len(fake.queryRowArgsForCall)]
@@ -776,6 +1106,68 @@ func (fake *FakeConn) QueryRowReturnsOnCall(i int, result1 squirrel.RowScanner) 
 		})
 	}
 	fake.queryRowReturnsOnCall[i] = struct {
+		result1 squirrel.RowScanner
+	}{result1}
+}
+
+func (fake *FakeConn) QueryRowContext(arg1 context.Context, arg2 string, arg3 ...interface{}) squirrel.RowScanner {
+	fake.queryRowContextMutex.Lock()
+	ret, specificReturn := fake.queryRowContextReturnsOnCall[len(fake.queryRowContextArgsForCall)]
+	fake.queryRowContextArgsForCall = append(fake.queryRowContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("QueryRowContext", []interface{}{arg1, arg2, arg3})
+	fake.queryRowContextMutex.Unlock()
+	if fake.QueryRowContextStub != nil {
+		return fake.QueryRowContextStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.queryRowContextReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeConn) QueryRowContextCallCount() int {
+	fake.queryRowContextMutex.RLock()
+	defer fake.queryRowContextMutex.RUnlock()
+	return len(fake.queryRowContextArgsForCall)
+}
+
+func (fake *FakeConn) QueryRowContextCalls(stub func(context.Context, string, ...interface{}) squirrel.RowScanner) {
+	fake.queryRowContextMutex.Lock()
+	defer fake.queryRowContextMutex.Unlock()
+	fake.QueryRowContextStub = stub
+}
+
+func (fake *FakeConn) QueryRowContextArgsForCall(i int) (context.Context, string, []interface{}) {
+	fake.queryRowContextMutex.RLock()
+	defer fake.queryRowContextMutex.RUnlock()
+	argsForCall := fake.queryRowContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeConn) QueryRowContextReturns(result1 squirrel.RowScanner) {
+	fake.queryRowContextMutex.Lock()
+	defer fake.queryRowContextMutex.Unlock()
+	fake.QueryRowContextStub = nil
+	fake.queryRowContextReturns = struct {
+		result1 squirrel.RowScanner
+	}{result1}
+}
+
+func (fake *FakeConn) QueryRowContextReturnsOnCall(i int, result1 squirrel.RowScanner) {
+	fake.queryRowContextMutex.Lock()
+	defer fake.queryRowContextMutex.Unlock()
+	fake.QueryRowContextStub = nil
+	if fake.queryRowContextReturnsOnCall == nil {
+		fake.queryRowContextReturnsOnCall = make(map[int]struct {
+			result1 squirrel.RowScanner
+		})
+	}
+	fake.queryRowContextReturnsOnCall[i] = struct {
 		result1 squirrel.RowScanner
 	}{result1}
 }
@@ -899,6 +1291,8 @@ func (fake *FakeConn) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.beginMutex.RLock()
 	defer fake.beginMutex.RUnlock()
+	fake.beginTxMutex.RLock()
+	defer fake.beginTxMutex.RUnlock()
 	fake.busMutex.RLock()
 	defer fake.busMutex.RUnlock()
 	fake.closeMutex.RLock()
@@ -909,16 +1303,24 @@ func (fake *FakeConn) Invocations() map[string][][]interface{} {
 	defer fake.encryptionStrategyMutex.RUnlock()
 	fake.execMutex.RLock()
 	defer fake.execMutex.RUnlock()
+	fake.execContextMutex.RLock()
+	defer fake.execContextMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
 	fake.pingMutex.RLock()
 	defer fake.pingMutex.RUnlock()
 	fake.prepareMutex.RLock()
 	defer fake.prepareMutex.RUnlock()
+	fake.prepareContextMutex.RLock()
+	defer fake.prepareContextMutex.RUnlock()
 	fake.queryMutex.RLock()
 	defer fake.queryMutex.RUnlock()
+	fake.queryContextMutex.RLock()
+	defer fake.queryContextMutex.RUnlock()
 	fake.queryRowMutex.RLock()
 	defer fake.queryRowMutex.RUnlock()
+	fake.queryRowContextMutex.RLock()
+	defer fake.queryRowContextMutex.RUnlock()
 	fake.setMaxIdleConnsMutex.RLock()
 	defer fake.setMaxIdleConnsMutex.RUnlock()
 	fake.setMaxOpenConnsMutex.RLock()

--- a/atc/db/dbfakes/fake_tx.go
+++ b/atc/db/dbfakes/fake_tx.go
@@ -2,6 +2,7 @@
 package dbfakes
 
 import (
+	"context"
 	"database/sql"
 	"sync"
 
@@ -34,6 +35,21 @@ type FakeTx struct {
 		result1 sql.Result
 		result2 error
 	}
+	ExecContextStub        func(context.Context, string, ...interface{}) (sql.Result, error)
+	execContextMutex       sync.RWMutex
+	execContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}
+	execContextReturns struct {
+		result1 sql.Result
+		result2 error
+	}
+	execContextReturnsOnCall map[int]struct {
+		result1 sql.Result
+		result2 error
+	}
 	PrepareStub        func(string) (*sql.Stmt, error)
 	prepareMutex       sync.RWMutex
 	prepareArgsForCall []struct {
@@ -44,6 +60,20 @@ type FakeTx struct {
 		result2 error
 	}
 	prepareReturnsOnCall map[int]struct {
+		result1 *sql.Stmt
+		result2 error
+	}
+	PrepareContextStub        func(context.Context, string) (*sql.Stmt, error)
+	prepareContextMutex       sync.RWMutex
+	prepareContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	prepareContextReturns struct {
+		result1 *sql.Stmt
+		result2 error
+	}
+	prepareContextReturnsOnCall map[int]struct {
 		result1 *sql.Stmt
 		result2 error
 	}
@@ -61,6 +91,21 @@ type FakeTx struct {
 		result1 *sql.Rows
 		result2 error
 	}
+	QueryContextStub        func(context.Context, string, ...interface{}) (*sql.Rows, error)
+	queryContextMutex       sync.RWMutex
+	queryContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}
+	queryContextReturns struct {
+		result1 *sql.Rows
+		result2 error
+	}
+	queryContextReturnsOnCall map[int]struct {
+		result1 *sql.Rows
+		result2 error
+	}
 	QueryRowStub        func(string, ...interface{}) squirrel.RowScanner
 	queryRowMutex       sync.RWMutex
 	queryRowArgsForCall []struct {
@@ -71,6 +116,19 @@ type FakeTx struct {
 		result1 squirrel.RowScanner
 	}
 	queryRowReturnsOnCall map[int]struct {
+		result1 squirrel.RowScanner
+	}
+	QueryRowContextStub        func(context.Context, string, ...interface{}) squirrel.RowScanner
+	queryRowContextMutex       sync.RWMutex
+	queryRowContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}
+	queryRowContextReturns struct {
+		result1 squirrel.RowScanner
+	}
+	queryRowContextReturnsOnCall map[int]struct {
 		result1 squirrel.RowScanner
 	}
 	RollbackStub        func() error
@@ -214,6 +272,71 @@ func (fake *FakeTx) ExecReturnsOnCall(i int, result1 sql.Result, result2 error) 
 	}{result1, result2}
 }
 
+func (fake *FakeTx) ExecContext(arg1 context.Context, arg2 string, arg3 ...interface{}) (sql.Result, error) {
+	fake.execContextMutex.Lock()
+	ret, specificReturn := fake.execContextReturnsOnCall[len(fake.execContextArgsForCall)]
+	fake.execContextArgsForCall = append(fake.execContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("ExecContext", []interface{}{arg1, arg2, arg3})
+	fake.execContextMutex.Unlock()
+	if fake.ExecContextStub != nil {
+		return fake.ExecContextStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.execContextReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTx) ExecContextCallCount() int {
+	fake.execContextMutex.RLock()
+	defer fake.execContextMutex.RUnlock()
+	return len(fake.execContextArgsForCall)
+}
+
+func (fake *FakeTx) ExecContextCalls(stub func(context.Context, string, ...interface{}) (sql.Result, error)) {
+	fake.execContextMutex.Lock()
+	defer fake.execContextMutex.Unlock()
+	fake.ExecContextStub = stub
+}
+
+func (fake *FakeTx) ExecContextArgsForCall(i int) (context.Context, string, []interface{}) {
+	fake.execContextMutex.RLock()
+	defer fake.execContextMutex.RUnlock()
+	argsForCall := fake.execContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTx) ExecContextReturns(result1 sql.Result, result2 error) {
+	fake.execContextMutex.Lock()
+	defer fake.execContextMutex.Unlock()
+	fake.ExecContextStub = nil
+	fake.execContextReturns = struct {
+		result1 sql.Result
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTx) ExecContextReturnsOnCall(i int, result1 sql.Result, result2 error) {
+	fake.execContextMutex.Lock()
+	defer fake.execContextMutex.Unlock()
+	fake.ExecContextStub = nil
+	if fake.execContextReturnsOnCall == nil {
+		fake.execContextReturnsOnCall = make(map[int]struct {
+			result1 sql.Result
+			result2 error
+		})
+	}
+	fake.execContextReturnsOnCall[i] = struct {
+		result1 sql.Result
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTx) Prepare(arg1 string) (*sql.Stmt, error) {
 	fake.prepareMutex.Lock()
 	ret, specificReturn := fake.prepareReturnsOnCall[len(fake.prepareArgsForCall)]
@@ -272,6 +395,70 @@ func (fake *FakeTx) PrepareReturnsOnCall(i int, result1 *sql.Stmt, result2 error
 		})
 	}
 	fake.prepareReturnsOnCall[i] = struct {
+		result1 *sql.Stmt
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTx) PrepareContext(arg1 context.Context, arg2 string) (*sql.Stmt, error) {
+	fake.prepareContextMutex.Lock()
+	ret, specificReturn := fake.prepareContextReturnsOnCall[len(fake.prepareContextArgsForCall)]
+	fake.prepareContextArgsForCall = append(fake.prepareContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("PrepareContext", []interface{}{arg1, arg2})
+	fake.prepareContextMutex.Unlock()
+	if fake.PrepareContextStub != nil {
+		return fake.PrepareContextStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.prepareContextReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTx) PrepareContextCallCount() int {
+	fake.prepareContextMutex.RLock()
+	defer fake.prepareContextMutex.RUnlock()
+	return len(fake.prepareContextArgsForCall)
+}
+
+func (fake *FakeTx) PrepareContextCalls(stub func(context.Context, string) (*sql.Stmt, error)) {
+	fake.prepareContextMutex.Lock()
+	defer fake.prepareContextMutex.Unlock()
+	fake.PrepareContextStub = stub
+}
+
+func (fake *FakeTx) PrepareContextArgsForCall(i int) (context.Context, string) {
+	fake.prepareContextMutex.RLock()
+	defer fake.prepareContextMutex.RUnlock()
+	argsForCall := fake.prepareContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeTx) PrepareContextReturns(result1 *sql.Stmt, result2 error) {
+	fake.prepareContextMutex.Lock()
+	defer fake.prepareContextMutex.Unlock()
+	fake.PrepareContextStub = nil
+	fake.prepareContextReturns = struct {
+		result1 *sql.Stmt
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTx) PrepareContextReturnsOnCall(i int, result1 *sql.Stmt, result2 error) {
+	fake.prepareContextMutex.Lock()
+	defer fake.prepareContextMutex.Unlock()
+	fake.PrepareContextStub = nil
+	if fake.prepareContextReturnsOnCall == nil {
+		fake.prepareContextReturnsOnCall = make(map[int]struct {
+			result1 *sql.Stmt
+			result2 error
+		})
+	}
+	fake.prepareContextReturnsOnCall[i] = struct {
 		result1 *sql.Stmt
 		result2 error
 	}{result1, result2}
@@ -341,6 +528,71 @@ func (fake *FakeTx) QueryReturnsOnCall(i int, result1 *sql.Rows, result2 error) 
 	}{result1, result2}
 }
 
+func (fake *FakeTx) QueryContext(arg1 context.Context, arg2 string, arg3 ...interface{}) (*sql.Rows, error) {
+	fake.queryContextMutex.Lock()
+	ret, specificReturn := fake.queryContextReturnsOnCall[len(fake.queryContextArgsForCall)]
+	fake.queryContextArgsForCall = append(fake.queryContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("QueryContext", []interface{}{arg1, arg2, arg3})
+	fake.queryContextMutex.Unlock()
+	if fake.QueryContextStub != nil {
+		return fake.QueryContextStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.queryContextReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTx) QueryContextCallCount() int {
+	fake.queryContextMutex.RLock()
+	defer fake.queryContextMutex.RUnlock()
+	return len(fake.queryContextArgsForCall)
+}
+
+func (fake *FakeTx) QueryContextCalls(stub func(context.Context, string, ...interface{}) (*sql.Rows, error)) {
+	fake.queryContextMutex.Lock()
+	defer fake.queryContextMutex.Unlock()
+	fake.QueryContextStub = stub
+}
+
+func (fake *FakeTx) QueryContextArgsForCall(i int) (context.Context, string, []interface{}) {
+	fake.queryContextMutex.RLock()
+	defer fake.queryContextMutex.RUnlock()
+	argsForCall := fake.queryContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTx) QueryContextReturns(result1 *sql.Rows, result2 error) {
+	fake.queryContextMutex.Lock()
+	defer fake.queryContextMutex.Unlock()
+	fake.QueryContextStub = nil
+	fake.queryContextReturns = struct {
+		result1 *sql.Rows
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTx) QueryContextReturnsOnCall(i int, result1 *sql.Rows, result2 error) {
+	fake.queryContextMutex.Lock()
+	defer fake.queryContextMutex.Unlock()
+	fake.QueryContextStub = nil
+	if fake.queryContextReturnsOnCall == nil {
+		fake.queryContextReturnsOnCall = make(map[int]struct {
+			result1 *sql.Rows
+			result2 error
+		})
+	}
+	fake.queryContextReturnsOnCall[i] = struct {
+		result1 *sql.Rows
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeTx) QueryRow(arg1 string, arg2 ...interface{}) squirrel.RowScanner {
 	fake.queryRowMutex.Lock()
 	ret, specificReturn := fake.queryRowReturnsOnCall[len(fake.queryRowArgsForCall)]
@@ -398,6 +650,68 @@ func (fake *FakeTx) QueryRowReturnsOnCall(i int, result1 squirrel.RowScanner) {
 		})
 	}
 	fake.queryRowReturnsOnCall[i] = struct {
+		result1 squirrel.RowScanner
+	}{result1}
+}
+
+func (fake *FakeTx) QueryRowContext(arg1 context.Context, arg2 string, arg3 ...interface{}) squirrel.RowScanner {
+	fake.queryRowContextMutex.Lock()
+	ret, specificReturn := fake.queryRowContextReturnsOnCall[len(fake.queryRowContextArgsForCall)]
+	fake.queryRowContextArgsForCall = append(fake.queryRowContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 []interface{}
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("QueryRowContext", []interface{}{arg1, arg2, arg3})
+	fake.queryRowContextMutex.Unlock()
+	if fake.QueryRowContextStub != nil {
+		return fake.QueryRowContextStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.queryRowContextReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeTx) QueryRowContextCallCount() int {
+	fake.queryRowContextMutex.RLock()
+	defer fake.queryRowContextMutex.RUnlock()
+	return len(fake.queryRowContextArgsForCall)
+}
+
+func (fake *FakeTx) QueryRowContextCalls(stub func(context.Context, string, ...interface{}) squirrel.RowScanner) {
+	fake.queryRowContextMutex.Lock()
+	defer fake.queryRowContextMutex.Unlock()
+	fake.QueryRowContextStub = stub
+}
+
+func (fake *FakeTx) QueryRowContextArgsForCall(i int) (context.Context, string, []interface{}) {
+	fake.queryRowContextMutex.RLock()
+	defer fake.queryRowContextMutex.RUnlock()
+	argsForCall := fake.queryRowContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTx) QueryRowContextReturns(result1 squirrel.RowScanner) {
+	fake.queryRowContextMutex.Lock()
+	defer fake.queryRowContextMutex.Unlock()
+	fake.QueryRowContextStub = nil
+	fake.queryRowContextReturns = struct {
+		result1 squirrel.RowScanner
+	}{result1}
+}
+
+func (fake *FakeTx) QueryRowContextReturnsOnCall(i int, result1 squirrel.RowScanner) {
+	fake.queryRowContextMutex.Lock()
+	defer fake.queryRowContextMutex.Unlock()
+	fake.QueryRowContextStub = nil
+	if fake.queryRowContextReturnsOnCall == nil {
+		fake.queryRowContextReturnsOnCall = make(map[int]struct {
+			result1 squirrel.RowScanner
+		})
+	}
+	fake.queryRowContextReturnsOnCall[i] = struct {
 		result1 squirrel.RowScanner
 	}{result1}
 }
@@ -521,12 +835,20 @@ func (fake *FakeTx) Invocations() map[string][][]interface{} {
 	defer fake.commitMutex.RUnlock()
 	fake.execMutex.RLock()
 	defer fake.execMutex.RUnlock()
+	fake.execContextMutex.RLock()
+	defer fake.execContextMutex.RUnlock()
 	fake.prepareMutex.RLock()
 	defer fake.prepareMutex.RUnlock()
+	fake.prepareContextMutex.RLock()
+	defer fake.prepareContextMutex.RUnlock()
 	fake.queryMutex.RLock()
 	defer fake.queryMutex.RUnlock()
+	fake.queryContextMutex.RLock()
+	defer fake.queryContextMutex.RUnlock()
 	fake.queryRowMutex.RLock()
 	defer fake.queryRowMutex.RUnlock()
+	fake.queryRowContextMutex.RLock()
+	defer fake.queryRowContextMutex.RUnlock()
 	fake.rollbackMutex.RLock()
 	defer fake.rollbackMutex.RUnlock()
 	fake.stmtMutex.RLock()

--- a/atc/db/open.go
+++ b/atc/db/open.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -28,13 +29,19 @@ type Conn interface {
 	Driver() driver.Driver
 
 	Begin() (Tx, error)
-	Exec(query string, args ...interface{}) (sql.Result, error)
-	Prepare(query string) (*sql.Stmt, error)
-	Query(query string, args ...interface{}) (*sql.Rows, error)
-	QueryRow(query string, args ...interface{}) squirrel.RowScanner
+	Exec(string, ...interface{}) (sql.Result, error)
+	Prepare(string) (*sql.Stmt, error)
+	Query(string, ...interface{}) (*sql.Rows, error)
+	QueryRow(string, ...interface{}) squirrel.RowScanner
 
-	SetMaxIdleConns(n int)
-	SetMaxOpenConns(n int)
+	BeginTx(context.Context, *sql.TxOptions) (Tx, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	PrepareContext(context.Context, string) (*sql.Stmt, error)
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...interface{}) squirrel.RowScanner
+
+	SetMaxIdleConns(int)
+	SetMaxOpenConns(int)
 	Stats() sql.DBStats
 
 	Close() error
@@ -45,12 +52,16 @@ type Conn interface {
 
 type Tx interface {
 	Commit() error
-	Exec(query string, args ...interface{}) (sql.Result, error)
-	Prepare(query string) (*sql.Stmt, error)
-	Query(query string, args ...interface{}) (*sql.Rows, error)
-	QueryRow(query string, args ...interface{}) squirrel.RowScanner
+	Exec(string, ...interface{}) (sql.Result, error)
+	Prepare(string) (*sql.Stmt, error)
+	Query(string, ...interface{}) (*sql.Rows, error)
+	QueryRow(string, ...interface{}) squirrel.RowScanner
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	PrepareContext(context.Context, string) (*sql.Stmt, error)
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...interface{}) squirrel.RowScanner
 	Rollback() error
-	Stmt(stmt *sql.Stmt) *sql.Stmt
+	Stmt(*sql.Stmt) *sql.Stmt
 }
 
 func Open(logger lager.Logger, sqlDriver string, sqlDataSource string, newKey *encryption.Key, oldKey *encryption.Key, connectionName string, lockFactory lock.LockFactory) (Conn, error) {
@@ -407,6 +418,36 @@ func (db *db) QueryRow(query string, args ...interface{}) squirrel.RowScanner {
 	return db.DB.QueryRow(query, args...)
 }
 
+func (db *db) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error) {
+	tx, err := db.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dbTx{tx, GlobalConnectionTracker.Track()}, nil
+}
+
+func (db *db) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	defer GlobalConnectionTracker.Track().Release()
+	return db.DB.ExecContext(ctx, query, args...)
+}
+
+func (db *db) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	defer GlobalConnectionTracker.Track().Release()
+	return db.DB.PrepareContext(ctx, query)
+}
+
+func (db *db) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	defer GlobalConnectionTracker.Track().Release()
+	return db.DB.QueryContext(ctx, query, args...)
+}
+
+// to conform to squirrel.Runner interface
+func (db *db) QueryRowContext(ctx context.Context, query string, args ...interface{}) squirrel.RowScanner {
+	defer GlobalConnectionTracker.Track().Release()
+	return db.DB.QueryRowContext(ctx, query, args...)
+}
+
 type dbTx struct {
 	*sql.Tx
 
@@ -416,6 +457,10 @@ type dbTx struct {
 // to conform to squirrel.Runner interface
 func (tx *dbTx) QueryRow(query string, args ...interface{}) squirrel.RowScanner {
 	return tx.Tx.QueryRow(query, args...)
+}
+
+func (tx *dbTx) QueryRowContext(ctx context.Context, query string, args ...interface{}) squirrel.RowScanner {
+	return tx.Tx.QueryRowContext(ctx, query, args...)
 }
 
 func (tx *dbTx) Commit() error {

--- a/atc/db/versions_db.go
+++ b/atc/db/versions_db.go
@@ -627,6 +627,11 @@ func (cursor BuildCursor) OlderBuilds(idCol string) sq.Sqlizer {
 	if cursor.RerunOf.Valid {
 		return sq.Or{
 			sq.Expr("COALESCE(rerun_of, "+idCol+") < ?", cursor.RerunOf.Int64),
+
+			// include original build of the rerun
+			sq.Eq{idCol: cursor.RerunOf.Int64},
+
+			// include earlier reruns of the same build
 			sq.And{
 				sq.Eq{"rerun_of": cursor.RerunOf.Int64},
 				sq.Lt{idCol: cursor.ID},
@@ -647,7 +652,12 @@ func (cursor BuildCursor) NewerBuilds(idCol string) sq.Sqlizer {
 			},
 		}
 	} else {
-		return sq.Expr("COALESCE(rerun_of, "+idCol+") > ?", cursor.ID)
+		return sq.Or{
+			sq.Expr("COALESCE(rerun_of, "+idCol+") > ?", cursor.ID),
+
+			// include reruns of the build
+			sq.Eq{"rerun_of": cursor.ID},
+		}
 	}
 }
 

--- a/atc/db/versions_db_test.go
+++ b/atc/db/versions_db_test.go
@@ -1,0 +1,384 @@
+package db_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/concourse/concourse/atc/db"
+	gocache "github.com/patrickmn/go-cache"
+)
+
+var _ = Describe("VersionsDB", func() {
+	var vdb db.VersionsDB
+	var pageLimit int
+	var cache *gocache.Cache
+
+	var ctx context.Context
+
+	BeforeEach(func() {
+		pageLimit = 5
+		cache = gocache.New(-1, -1)
+		vdb = db.NewVersionsDB(dbConn, pageLimit, cache)
+
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		cache.Flush()
+	})
+
+	Describe("SuccessfulBuilds", func() {
+		var paginatedBuilds db.PaginatedBuilds
+
+		JustBeforeEach(func() {
+			paginatedBuilds = vdb.SuccessfulBuilds(ctx, defaultJob.ID())
+		})
+
+		Context("with one build", func() {
+			var build db.Build
+
+			BeforeEach(func() {
+				var err error
+				build, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = build.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns the build and finishes", func() {
+				buildID, ok, err := paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+				Expect(buildID).To(BeZero())
+			})
+		})
+
+		Context("with the same number of builds as the page limit", func() {
+			var builds []db.Build
+
+			BeforeEach(func() {
+				builds = []db.Build{}
+
+				for i := 0; i < pageLimit; i++ {
+					build, err := defaultJob.CreateBuild()
+					Expect(err).ToNot(HaveOccurred())
+
+					err = build.Finish(db.BuildStatusSucceeded)
+					Expect(err).ToNot(HaveOccurred())
+
+					builds = append(builds, build)
+				}
+			})
+
+			It("returns all of the builds, newest first, and then finishes", func() {
+				for i := pageLimit - 1; i >= 0; i-- {
+					buildID, ok, err := paginatedBuilds.Next(ctx)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ok).To(BeTrue())
+					Expect(buildID).To(Equal(builds[i].ID()))
+				}
+
+				buildID, ok, err := paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+				Expect(buildID).To(BeZero())
+			})
+		})
+
+		Context("with a page of filler and then rerun builds created after their original builds", func() {
+			var build1Succeeded db.Build
+			var build2Failed db.Build
+			var build3Succeeded db.Build
+			var build4Rerun2Succeeded db.Build
+			var build5Rerun2Succeeded db.Build
+			var build6Succeeded db.Build
+			var fillerBuilds []db.Build
+
+			BeforeEach(func() {
+				var err error
+				build1Succeeded, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build1Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build2Failed, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build2Failed.Finish(db.BuildStatusFailed)
+				Expect(err).ToNot(HaveOccurred())
+
+				build3Succeeded, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build3Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build4Rerun2Succeeded, err = defaultJob.RerunBuild(build2Failed)
+				Expect(err).ToNot(HaveOccurred())
+				err = build4Rerun2Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build5Rerun2Succeeded, err = defaultJob.RerunBuild(build2Failed)
+				Expect(err).ToNot(HaveOccurred())
+				err = build5Rerun2Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build6Succeeded, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build6Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				for i := 0; i < pageLimit; i++ {
+					build, err := defaultJob.CreateBuild()
+					Expect(err).ToNot(HaveOccurred())
+
+					err = build.Finish(db.BuildStatusSucceeded)
+					Expect(err).ToNot(HaveOccurred())
+
+					fillerBuilds = append(fillerBuilds, build)
+				}
+			})
+
+			It("returns all of the builds, newest first, with reruns relative to original build's order, and then finishes", func() {
+				for i := len(fillerBuilds) - 1; i >= 0; i-- {
+					buildID, ok, err := paginatedBuilds.Next(ctx)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ok).To(BeTrue())
+					Expect(buildID).To(Equal(fillerBuilds[i].ID()))
+				}
+
+				buildID, ok, err := paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build6Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build3Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build5Rerun2Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build4Rerun2Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build1Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+				Expect(buildID).To(BeZero())
+			})
+		})
+
+		Context("with rerun builds created after their original builds", func() {
+			var build1Succeeded db.Build
+			var build2Failed db.Build
+			var build3Succeeded db.Build
+			var build4Rerun2Succeeded db.Build
+			var build5Rerun2Succeeded db.Build
+			var build6Succeeded db.Build
+
+			BeforeEach(func() {
+				var err error
+				build1Succeeded, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build1Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build2Failed, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build2Failed.Finish(db.BuildStatusFailed)
+				Expect(err).ToNot(HaveOccurred())
+
+				build3Succeeded, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build3Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build4Rerun2Succeeded, err = defaultJob.RerunBuild(build2Failed)
+				Expect(err).ToNot(HaveOccurred())
+				err = build4Rerun2Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build5Rerun2Succeeded, err = defaultJob.RerunBuild(build2Failed)
+				Expect(err).ToNot(HaveOccurred())
+				err = build5Rerun2Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build6Succeeded, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build6Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns all of the builds, newest first, with reruns relative to original build's order, and then finishes", func() {
+				buildID, ok, err := paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build6Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build3Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build5Rerun2Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build4Rerun2Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build1Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+				Expect(buildID).To(BeZero())
+			})
+		})
+
+		Context("with a rerun build on the page limit boundary", func() {
+			var build1Failed db.Build
+			var fillerBuilds []db.Build
+			var build6Rerun1Succeeded db.Build
+
+			BeforeEach(func() {
+				var err error
+				build1Failed, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build1Failed.Finish(db.BuildStatusFailed)
+				Expect(err).ToNot(HaveOccurred())
+
+				fillerBuilds = []db.Build{}
+
+				for i := 0; i < pageLimit-1; i++ {
+					build, err := defaultJob.CreateBuild()
+					Expect(err).ToNot(HaveOccurred())
+
+					err = build.Finish(db.BuildStatusSucceeded)
+					Expect(err).ToNot(HaveOccurred())
+
+					fillerBuilds = append(fillerBuilds, build)
+				}
+
+				build6Rerun1Succeeded, err = defaultJob.RerunBuild(build1Failed)
+				Expect(err).ToNot(HaveOccurred())
+				err = build6Rerun1Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("finishes after the rerun", func() {
+				for i := len(fillerBuilds) - 1; i >= 0; i-- {
+					buildID, ok, err := paginatedBuilds.Next(ctx)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ok).To(BeTrue())
+					Expect(buildID).To(Equal(fillerBuilds[i].ID()))
+				}
+
+				buildID, ok, err := paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build6Rerun1Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+				Expect(buildID).To(BeZero())
+			})
+		})
+
+		Context("with multiple reruns of the same build crossing the page limit boundary", func() {
+			var build1Failed db.Build
+			var fillerBuilds []db.Build
+			var build6Rerun1Succeeded db.Build
+			var build7Rerun1Succeeded db.Build
+			var build8Rerun1Succeeded db.Build
+
+			BeforeEach(func() {
+				var err error
+				build1Failed, err = defaultJob.CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
+				err = build1Failed.Finish(db.BuildStatusFailed)
+				Expect(err).ToNot(HaveOccurred())
+
+				fillerBuilds = []db.Build{}
+
+				for i := 0; i < pageLimit-1; i++ {
+					build, err := defaultJob.CreateBuild()
+					Expect(err).ToNot(HaveOccurred())
+
+					err = build.Finish(db.BuildStatusSucceeded)
+					Expect(err).ToNot(HaveOccurred())
+
+					fillerBuilds = append(fillerBuilds, build)
+				}
+
+				build6Rerun1Succeeded, err = defaultJob.RerunBuild(build1Failed)
+				Expect(err).ToNot(HaveOccurred())
+				err = build6Rerun1Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build7Rerun1Succeeded, err = defaultJob.RerunBuild(build1Failed)
+				Expect(err).ToNot(HaveOccurred())
+				err = build7Rerun1Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				build8Rerun1Succeeded, err = defaultJob.RerunBuild(build1Failed)
+				Expect(err).ToNot(HaveOccurred())
+				err = build8Rerun1Succeeded.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns all builds, and then all three reruns, and finishes", func() {
+				for i := len(fillerBuilds) - 1; i >= 0; i-- {
+					buildID, ok, err := paginatedBuilds.Next(ctx)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ok).To(BeTrue())
+					Expect(buildID).To(Equal(fillerBuilds[i].ID()))
+				}
+
+				buildID, ok, err := paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build8Rerun1Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build7Rerun1Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(buildID).To(Equal(build6Rerun1Succeeded.ID()))
+
+				buildID, ok, err = paginatedBuilds.Next(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+				Expect(buildID).To(BeZero())
+			})
+		})
+	})
+})

--- a/atc/scheduler/algorithm/firstoccurrence_test.go
+++ b/atc/scheduler/algorithm/firstoccurrence_test.go
@@ -1,6 +1,7 @@
 package algorithm_test
 
 import (
+	"context"
 	"crypto/md5"
 	"database/sql"
 	"encoding/hex"
@@ -255,7 +256,7 @@ var _ = Describe("Resolve", func() {
 		algorithm := algorithm.New(versionsDB)
 
 		var ok bool
-		inputMapping, ok, _, err = algorithm.Compute(job, jobInputs, dbResources, map[string]int{"j1": 1})
+		inputMapping, ok, _, err = algorithm.Compute(context.Background(), job, jobInputs, dbResources, map[string]int{"j1": 1})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ok).To(BeTrue())
 	})

--- a/atc/scheduler/algorithm/input_mapper.go
+++ b/atc/scheduler/algorithm/input_mapper.go
@@ -1,6 +1,8 @@
 package algorithm
 
 import (
+	"context"
+
 	"github.com/concourse/concourse/atc/db"
 )
 
@@ -10,13 +12,13 @@ type inputMapper struct {
 	hasLatestBuild bool
 }
 
-func newInputMapper(vdb db.VersionsDB, currentJobID int) (inputMapper, error) {
-	latestBuildID, found, err := vdb.LatestBuildID(currentJobID)
+func newInputMapper(ctx context.Context, vdb db.VersionsDB, currentJobID int) (inputMapper, error) {
+	latestBuildID, found, err := vdb.LatestBuildID(ctx, currentJobID)
 	if err != nil {
 		return inputMapper{}, err
 	}
 
-	outputs, err := vdb.BuildOutputs(latestBuildID)
+	outputs, err := vdb.BuildOutputs(ctx, latestBuildID)
 	if err != nil {
 		return inputMapper{}, err
 	}

--- a/atc/scheduler/algorithm/pinned_resolver.go
+++ b/atc/scheduler/algorithm/pinned_resolver.go
@@ -1,19 +1,23 @@
 package algorithm
 
-import "github.com/concourse/concourse/atc/db"
+import (
+	"context"
+
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/tracing"
+	"go.opentelemetry.io/otel/api/key"
+	"google.golang.org/grpc/codes"
+)
 
 type pinnedResolver struct {
 	vdb         db.VersionsDB
 	inputConfig InputConfig
-
-	debug debugger
 }
 
 func NewPinnedResolver(vdb db.VersionsDB, inputConfig InputConfig) Resolver {
 	return &pinnedResolver{
 		vdb:         vdb,
 		inputConfig: inputConfig,
-		debug:       debugger{},
 	}
 }
 
@@ -21,19 +25,30 @@ func (r *pinnedResolver) InputConfigs() InputConfigs {
 	return InputConfigs{r.inputConfig}
 }
 
-func (r *pinnedResolver) Resolve(depth int) (map[string]*versionCandidate, db.ResolutionFailure, error) {
-	version, found, err := r.vdb.FindVersionOfResource(r.inputConfig.ResourceID, r.inputConfig.PinnedVersion)
+func (r *pinnedResolver) Resolve(ctx context.Context) (map[string]*versionCandidate, db.ResolutionFailure, error) {
+	ctx, span := tracing.StartSpan(ctx, "pinnedResolver.Resolve", tracing.Attrs{
+		"input": r.inputConfig.Name,
+	})
+	defer span.End()
+
+	version, found, err := r.vdb.FindVersionOfResource(ctx, r.inputConfig.ResourceID, r.inputConfig.PinnedVersion)
 	if err != nil {
+		tracing.End(span, err)
 		return nil, "", err
 	}
 
 	if !found {
+		span.AddEvent(ctx, "pinned version not found")
+		span.SetStatus(codes.NotFound)
 		return nil, db.PinnedVersionNotFound{PinnedVersion: r.inputConfig.PinnedVersion}.String(), nil
 	}
+
+	span.AddEvent(ctx, "found via pin", key.New("version").String(string(version)))
 
 	versionCandidate := map[string]*versionCandidate{
 		r.inputConfig.Name: newCandidateVersion(version),
 	}
 
+	span.SetStatus(codes.OK)
 	return versionCandidate, "", nil
 }

--- a/atc/scheduler/algorithm/regression_test.go
+++ b/atc/scheduler/algorithm/regression_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 )
 
-var _ = DescribeTable("Input resolving",
+var _ = DescribeTable("Regression tests",
 	(Example).Run,
 
 	Entry("bosh memory leak regression test", Example{

--- a/atc/scheduler/algorithm/resolver.go
+++ b/atc/scheduler/algorithm/resolver.go
@@ -2,14 +2,29 @@ package algorithm
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/tracing"
 )
 
 type NameToIDMap map[string]int
 
 type InputConfigs []InputConfig
+
+func (cfgs InputConfigs) String() string {
+	if !tracing.Configured {
+		return ""
+	}
+
+	names := make([]string, len(cfgs))
+	for i, cfg := range cfgs {
+		names[i] = cfg.Name
+	}
+
+	return strings.Join(names, ",")
+}
 
 type InputConfig struct {
 	Name            string

--- a/atc/scheduler/build.go
+++ b/atc/scheduler/build.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 
 	"code.cloudfoundry.org/lager"
@@ -42,8 +43,8 @@ func (m *manualTriggerBuild) PrepareInputs(logger lager.Logger) bool {
 	return true
 }
 
-func (m *manualTriggerBuild) BuildInputs(logger lager.Logger) ([]db.BuildInput, bool, error) {
-	inputMapping, resolved, hasNextInputs, err := m.algorithm.Compute(m.job, m.jobInputs, m.resources, m.relatedJobIDs)
+func (m *manualTriggerBuild) BuildInputs(ctx context.Context) ([]db.BuildInput, bool, error) {
+	inputMapping, resolved, hasNextInputs, err := m.algorithm.Compute(ctx, m.job, m.jobInputs, m.resources, m.relatedJobIDs)
 	if err != nil {
 		return nil, false, fmt.Errorf("compute inputs: %w", err)
 	}
@@ -80,7 +81,7 @@ func (s *schedulerBuild) PrepareInputs(logger lager.Logger) bool {
 	return true
 }
 
-func (s *schedulerBuild) BuildInputs(logger lager.Logger) ([]db.BuildInput, bool, error) {
+func (s *schedulerBuild) BuildInputs(ctx context.Context) ([]db.BuildInput, bool, error) {
 	buildInputs, satisfableInputs, err := s.AdoptInputsAndPipes()
 	if err != nil {
 		return nil, false, fmt.Errorf("adopt inputs and pipes: %w", err)
@@ -101,7 +102,7 @@ func (r *rerunBuild) PrepareInputs(logger lager.Logger) bool {
 	return true
 }
 
-func (r *rerunBuild) BuildInputs(logger lager.Logger) ([]db.BuildInput, bool, error) {
+func (r *rerunBuild) BuildInputs(ctx context.Context) ([]db.BuildInput, bool, error) {
 	buildInputs, inputsReady, err := r.AdoptRerunInputsAndPipes()
 	if err != nil {
 		return nil, false, fmt.Errorf("adopt rerun inputs and pipes: %w", err)

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 
 	"code.cloudfoundry.org/lager"
@@ -32,7 +33,7 @@ type Build interface {
 	db.Build
 
 	PrepareInputs(lager.Logger) bool
-	BuildInputs(lager.Logger) ([]db.BuildInput, bool, error)
+	BuildInputs(context.Context) ([]db.BuildInput, bool, error)
 }
 
 func NewBuildStarter(
@@ -201,7 +202,7 @@ func (s *buildStarter) tryStartNextPendingBuild(
 		}, nil
 	}
 
-	buildInputs, found, err := nextPendingBuild.BuildInputs(logger)
+	buildInputs, found, err := nextPendingBuild.BuildInputs(context.TODO())
 	if err != nil {
 		return startResults{}, fmt.Errorf("get build inputs: %w", err)
 	}

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -278,7 +278,7 @@ var _ = Describe("BuildStarter", func() {
 
 							It("computes the next inputs for the right job and versions", func() {
 								Expect(fakeAlgorithm.ComputeCallCount()).To(Equal(1))
-								actualJob, actualInputs, _, actualRelatedJobs := fakeAlgorithm.ComputeArgsForCall(0)
+								_, actualJob, actualInputs, _, actualRelatedJobs := fakeAlgorithm.ComputeArgsForCall(0)
 								Expect(actualJob.Name()).To(Equal(job.Name()))
 								Expect(actualRelatedJobs).To(Equal(relatedJobs))
 								Expect(actualInputs).To(Equal(jobInputs))

--- a/atc/scheduler/runner.go
+++ b/atc/scheduler/runner.go
@@ -17,6 +17,7 @@ import (
 
 type BuildScheduler interface {
 	Schedule(
+		ctx context.Context,
 		logger lager.Logger,
 		pipeline db.Pipeline,
 		job db.Job,
@@ -60,7 +61,7 @@ func (s *schedulerRunner) Run(ctx context.Context) error {
 	for pipelineID, jobsToSchedule := range pipelineIDToJobs {
 		pipeline := pipelineIDToPipeline[pipelineID]
 
-		err := s.schedulePipeline(errGroup, pipeline, jobsToSchedule)
+		err := s.schedulePipeline(ctx, errGroup, pipeline, jobsToSchedule)
 		if err != nil {
 			s.logger.Error("failed-to-schedule-pipeline", err, lager.Data{"pipeline": pipeline.Name()})
 		}
@@ -69,7 +70,7 @@ func (s *schedulerRunner) Run(ctx context.Context) error {
 	return errGroup.Wait().ErrorOrNil()
 }
 
-func (s *schedulerRunner) schedulePipeline(errGroup *multierror.Group, pipeline db.Pipeline, jobsToSchedule db.Jobs) error {
+func (s *schedulerRunner) schedulePipeline(ctx context.Context, errGroup *multierror.Group, pipeline db.Pipeline, jobsToSchedule db.Jobs) error {
 	logger := s.logger.Session("pipeline", lager.Data{"pipeline": pipeline.Name()})
 
 	resources, err := pipeline.Resources()
@@ -106,14 +107,14 @@ func (s *schedulerRunner) schedulePipeline(errGroup *multierror.Group, pipeline 
 				<-s.guardJobScheduling
 			}()
 
-			return s.scheduleJob(logger, schedulingLock, pipeline, job, resources, jobsMap)
+			return s.scheduleJob(ctx, logger, schedulingLock, pipeline, job, resources, jobsMap)
 		})
 	}
 
 	return nil
 }
 
-func (s *schedulerRunner) scheduleJob(logger lager.Logger, schedulingLock lock.Lock, pipeline db.Pipeline, job db.Job, resources db.Resources, jobs algorithm.NameToIDMap) error {
+func (s *schedulerRunner) scheduleJob(ctx context.Context, logger lager.Logger, schedulingLock lock.Lock, pipeline db.Pipeline, job db.Job, resources db.Resources, jobs algorithm.NameToIDMap) error {
 	logger = logger.Session("schedule-job", lager.Data{"job": job.Name()})
 
 	logger.Debug("schedule")
@@ -138,6 +139,7 @@ func (s *schedulerRunner) scheduleJob(logger lager.Logger, schedulingLock lock.L
 	jStart := time.Now()
 
 	needsRetry, err := s.scheduler.Schedule(
+		ctx,
 		logger,
 		pipeline,
 		job,

--- a/atc/scheduler/runner_test.go
+++ b/atc/scheduler/runner_test.go
@@ -192,13 +192,13 @@ var _ = Describe("Runner", func() {
 									Eventually(fakeScheduler.ScheduleCallCount).Should(Equal(2))
 
 									jobs := []string{}
-									_, pipeline, job, resources, jobsMap := fakeScheduler.ScheduleArgsForCall(0)
+									_, _, pipeline, job, resources, jobsMap := fakeScheduler.ScheduleArgsForCall(0)
 									Expect(pipeline.Name()).To(Equal("fake-pipeline"))
 									Expect(resources).To(Equal(db.Resources{fakeResource1, fakeResource2}))
 									Expect(jobsMap).To(Equal(expectedJobsMap))
 									jobs = append(jobs, job.Name())
 
-									_, pipeline, job, resources, jobsMap = fakeScheduler.ScheduleArgsForCall(1)
+									_, _, pipeline, job, resources, jobsMap = fakeScheduler.ScheduleArgsForCall(1)
 									Expect(pipeline.Name()).To(Equal("fake-pipeline"))
 									Expect(resources).To(Equal(db.Resources{fakeResource1, fakeResource2}))
 									Expect(jobsMap).To(Equal(expectedJobsMap))
@@ -276,7 +276,7 @@ var _ = Describe("Runner", func() {
 									fakeJob1.ReloadReturns(false, nil)
 								})
 
-								It("updates last schedule", func() {
+								It("does not update last schedule", func() {
 									Expect(schedulerErr).ToNot(HaveOccurred())
 									Eventually(fakeJob1.UpdateLastScheduledCallCount).Should(Equal(0))
 									Eventually(fakeJob2.UpdateLastScheduledCallCount).Should(Equal(1))
@@ -294,7 +294,7 @@ var _ = Describe("Runner", func() {
 								Expect(schedulerErr).ToNot(HaveOccurred())
 								Eventually(fakeScheduler.ScheduleCallCount).Should(Equal(1))
 
-								_, pipeline, job, resources, jobIDs := fakeScheduler.ScheduleArgsForCall(0)
+								_, _, pipeline, job, resources, jobIDs := fakeScheduler.ScheduleArgsForCall(0)
 								Expect(job).To(Equal(fakeJob2))
 								Expect(resources).To(Equal(db.Resources{fakeResource1, fakeResource2}))
 								Expect(pipeline).To(Equal(fakePipeline))

--- a/atc/scheduler/scheduler.go
+++ b/atc/scheduler/scheduler.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 
 	"code.cloudfoundry.org/lager"
@@ -12,7 +13,13 @@ import (
 //go:generate counterfeiter . Algorithm
 
 type Algorithm interface {
-	Compute(db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) (db.InputMapping, bool, bool, error)
+	Compute(
+		context.Context,
+		db.Job,
+		[]atc.JobInput,
+		db.Resources,
+		algorithm.NameToIDMap,
+	) (db.InputMapping, bool, bool, error)
 }
 
 type Scheduler struct {
@@ -21,6 +28,7 @@ type Scheduler struct {
 }
 
 func (s *Scheduler) Schedule(
+	ctx context.Context,
 	logger lager.Logger,
 	pipeline db.Pipeline,
 	job db.Job,
@@ -32,7 +40,7 @@ func (s *Scheduler) Schedule(
 		return false, fmt.Errorf("inputs: %w", err)
 	}
 
-	inputMapping, resolved, runAgain, err := s.Algorithm.Compute(job, jobInputs, resources, relatedJobs)
+	inputMapping, resolved, runAgain, err := s.Algorithm.Compute(ctx, job, jobInputs, resources, relatedJobs)
 	if err != nil {
 		return false, fmt.Errorf("compute inputs: %w", err)
 	}

--- a/atc/scheduler/scheduler_test.go
+++ b/atc/scheduler/scheduler_test.go
@@ -1,6 +1,7 @@
 package scheduler_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -64,6 +65,7 @@ var _ = Describe("Scheduler", func() {
 			var waiter interface{ Wait() }
 
 			_, scheduleErr = scheduler.Schedule(
+				context.TODO(),
 				lagertest.NewTestLogger("test"),
 				fakePipeline,
 				fakeJob,
@@ -113,7 +115,7 @@ var _ = Describe("Scheduler", func() {
 
 				It("computed the inputs", func() {
 					Expect(fakeAlgorithm.ComputeCallCount()).To(Equal(1))
-					actualJob, actualInputs, resources, relatedJobs := fakeAlgorithm.ComputeArgsForCall(0)
+					_, actualJob, actualInputs, resources, relatedJobs := fakeAlgorithm.ComputeArgsForCall(0)
 					Expect(actualJob.Name()).To(Equal(fakeJob.Name()))
 					Expect(resources).To(Equal(expectedResources))
 					Expect(relatedJobs).To(Equal(expectedJobIDs))

--- a/atc/scheduler/schedulerfakes/fake_algorithm.go
+++ b/atc/scheduler/schedulerfakes/fake_algorithm.go
@@ -2,6 +2,7 @@
 package schedulerfakes
 
 import (
+	"context"
 	"sync"
 
 	"github.com/concourse/concourse/atc"
@@ -11,13 +12,14 @@ import (
 )
 
 type FakeAlgorithm struct {
-	ComputeStub        func(db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) (db.InputMapping, bool, bool, error)
+	ComputeStub        func(context.Context, db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) (db.InputMapping, bool, bool, error)
 	computeMutex       sync.RWMutex
 	computeArgsForCall []struct {
-		arg1 db.Job
-		arg2 []atc.JobInput
-		arg3 db.Resources
-		arg4 algorithm.NameToIDMap
+		arg1 context.Context
+		arg2 db.Job
+		arg3 []atc.JobInput
+		arg4 db.Resources
+		arg5 algorithm.NameToIDMap
 	}
 	computeReturns struct {
 		result1 db.InputMapping
@@ -35,24 +37,25 @@ type FakeAlgorithm struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAlgorithm) Compute(arg1 db.Job, arg2 []atc.JobInput, arg3 db.Resources, arg4 algorithm.NameToIDMap) (db.InputMapping, bool, bool, error) {
-	var arg2Copy []atc.JobInput
-	if arg2 != nil {
-		arg2Copy = make([]atc.JobInput, len(arg2))
-		copy(arg2Copy, arg2)
+func (fake *FakeAlgorithm) Compute(arg1 context.Context, arg2 db.Job, arg3 []atc.JobInput, arg4 db.Resources, arg5 algorithm.NameToIDMap) (db.InputMapping, bool, bool, error) {
+	var arg3Copy []atc.JobInput
+	if arg3 != nil {
+		arg3Copy = make([]atc.JobInput, len(arg3))
+		copy(arg3Copy, arg3)
 	}
 	fake.computeMutex.Lock()
 	ret, specificReturn := fake.computeReturnsOnCall[len(fake.computeArgsForCall)]
 	fake.computeArgsForCall = append(fake.computeArgsForCall, struct {
-		arg1 db.Job
-		arg2 []atc.JobInput
-		arg3 db.Resources
-		arg4 algorithm.NameToIDMap
-	}{arg1, arg2Copy, arg3, arg4})
-	fake.recordInvocation("Compute", []interface{}{arg1, arg2Copy, arg3, arg4})
+		arg1 context.Context
+		arg2 db.Job
+		arg3 []atc.JobInput
+		arg4 db.Resources
+		arg5 algorithm.NameToIDMap
+	}{arg1, arg2, arg3Copy, arg4, arg5})
+	fake.recordInvocation("Compute", []interface{}{arg1, arg2, arg3Copy, arg4, arg5})
 	fake.computeMutex.Unlock()
 	if fake.ComputeStub != nil {
-		return fake.ComputeStub(arg1, arg2, arg3, arg4)
+		return fake.ComputeStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
@@ -67,17 +70,17 @@ func (fake *FakeAlgorithm) ComputeCallCount() int {
 	return len(fake.computeArgsForCall)
 }
 
-func (fake *FakeAlgorithm) ComputeCalls(stub func(db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) (db.InputMapping, bool, bool, error)) {
+func (fake *FakeAlgorithm) ComputeCalls(stub func(context.Context, db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) (db.InputMapping, bool, bool, error)) {
 	fake.computeMutex.Lock()
 	defer fake.computeMutex.Unlock()
 	fake.ComputeStub = stub
 }
 
-func (fake *FakeAlgorithm) ComputeArgsForCall(i int) (db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) {
+func (fake *FakeAlgorithm) ComputeArgsForCall(i int) (context.Context, db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) {
 	fake.computeMutex.RLock()
 	defer fake.computeMutex.RUnlock()
 	argsForCall := fake.computeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeAlgorithm) ComputeReturns(result1 db.InputMapping, result2 bool, result3 bool, result4 error) {

--- a/atc/scheduler/schedulerfakes/fake_build_scheduler.go
+++ b/atc/scheduler/schedulerfakes/fake_build_scheduler.go
@@ -2,6 +2,7 @@
 package schedulerfakes
 
 import (
+	"context"
 	"sync"
 
 	"code.cloudfoundry.org/lager"
@@ -11,14 +12,15 @@ import (
 )
 
 type FakeBuildScheduler struct {
-	ScheduleStub        func(lager.Logger, db.Pipeline, db.Job, db.Resources, algorithm.NameToIDMap) (bool, error)
+	ScheduleStub        func(context.Context, lager.Logger, db.Pipeline, db.Job, db.Resources, algorithm.NameToIDMap) (bool, error)
 	scheduleMutex       sync.RWMutex
 	scheduleArgsForCall []struct {
-		arg1 lager.Logger
-		arg2 db.Pipeline
-		arg3 db.Job
-		arg4 db.Resources
-		arg5 algorithm.NameToIDMap
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 db.Pipeline
+		arg4 db.Job
+		arg5 db.Resources
+		arg6 algorithm.NameToIDMap
 	}
 	scheduleReturns struct {
 		result1 bool
@@ -32,20 +34,21 @@ type FakeBuildScheduler struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeBuildScheduler) Schedule(arg1 lager.Logger, arg2 db.Pipeline, arg3 db.Job, arg4 db.Resources, arg5 algorithm.NameToIDMap) (bool, error) {
+func (fake *FakeBuildScheduler) Schedule(arg1 context.Context, arg2 lager.Logger, arg3 db.Pipeline, arg4 db.Job, arg5 db.Resources, arg6 algorithm.NameToIDMap) (bool, error) {
 	fake.scheduleMutex.Lock()
 	ret, specificReturn := fake.scheduleReturnsOnCall[len(fake.scheduleArgsForCall)]
 	fake.scheduleArgsForCall = append(fake.scheduleArgsForCall, struct {
-		arg1 lager.Logger
-		arg2 db.Pipeline
-		arg3 db.Job
-		arg4 db.Resources
-		arg5 algorithm.NameToIDMap
-	}{arg1, arg2, arg3, arg4, arg5})
-	fake.recordInvocation("Schedule", []interface{}{arg1, arg2, arg3, arg4, arg5})
+		arg1 context.Context
+		arg2 lager.Logger
+		arg3 db.Pipeline
+		arg4 db.Job
+		arg5 db.Resources
+		arg6 algorithm.NameToIDMap
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.recordInvocation("Schedule", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.scheduleMutex.Unlock()
 	if fake.ScheduleStub != nil {
-		return fake.ScheduleStub(arg1, arg2, arg3, arg4, arg5)
+		return fake.ScheduleStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -60,17 +63,17 @@ func (fake *FakeBuildScheduler) ScheduleCallCount() int {
 	return len(fake.scheduleArgsForCall)
 }
 
-func (fake *FakeBuildScheduler) ScheduleCalls(stub func(lager.Logger, db.Pipeline, db.Job, db.Resources, algorithm.NameToIDMap) (bool, error)) {
+func (fake *FakeBuildScheduler) ScheduleCalls(stub func(context.Context, lager.Logger, db.Pipeline, db.Job, db.Resources, algorithm.NameToIDMap) (bool, error)) {
 	fake.scheduleMutex.Lock()
 	defer fake.scheduleMutex.Unlock()
 	fake.ScheduleStub = stub
 }
 
-func (fake *FakeBuildScheduler) ScheduleArgsForCall(i int) (lager.Logger, db.Pipeline, db.Job, db.Resources, algorithm.NameToIDMap) {
+func (fake *FakeBuildScheduler) ScheduleArgsForCall(i int) (context.Context, lager.Logger, db.Pipeline, db.Job, db.Resources, algorithm.NameToIDMap) {
 	fake.scheduleMutex.RLock()
 	defer fake.scheduleMutex.RUnlock()
 	argsForCall := fake.scheduleArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeBuildScheduler) ScheduleReturns(result1 bool, result2 error) {

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/vito/houdini v1.1.1
 	github.com/vito/twentythousandtonnesofcrudeoil v0.0.0-20180305154709-3b21ad808fcb
 	go.etcd.io/bbolt v1.3.3 // indirect
-	go.opencensus.io v0.22.2 // indirect
+	go.opencensus.io v0.22.2
 	go.opentelemetry.io/otel v0.2.1
 	go.opentelemetry.io/otel/exporter/trace/jaeger v0.2.1
 	go.opentelemetry.io/otel/exporter/trace/stackdriver v0.2.1


### PR DESCRIPTION
# Existing Issue

Fixes #5094.

The actual bugfix here isn't captured in a separate issue, but there is (some) context in https://github.com/concourse/concourse/issues/5063#issuecomment-580271863.

# Why do we need this PR?

A bug with the algorithm's pagination logic (used for walking over chunks of 100 builds at a time) caused it to get stuck in a loop when looking for builds prior to a rerun.

This PR slings a bunch of code around in service of introducing tracing, which allowed this issue to be discovered and diagnosed pretty easily!

# Changes proposed in this pull request

* fix pagination bug
* backfill unit tests for `VersionsDB` covering this scenario and a few others
* introduce tracing, and the ability to use tracing for algorithm tests
* threads `ctx` through `VersionsDB` and uses it to trace the incremental migrations
* adds support for `context.Context` in our `db.Conn` interface, though we don't actually make use of it yet (for e.g. canceling in flight queries). just figured I'd add this along the way.

# Contributor Checklist

- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
