### PR TITLE
nit: fix a typo.

### DIFF
--- a/atc/api/accessor/handler_test.go
+++ b/atc/api/accessor/handler_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Handler", func() {
 				fakeAccess = new(accessorfakes.FakeAccess)
 				accessorFactory.CreateReturns(fakeAccess)
 			})
-			It("calls the innder handler", func() {
+			It("calls the inner handler", func() {
 				Expect(innerHandlerCalled).To(BeTrue())
 				Expect(access).To(Equal(fakeAccess))
 			})


### PR DESCRIPTION
# Why do we need this PR?

This PR fixed a nit typo, making the code better.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [x] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
