### PR TITLE
web: fix dashboard filtering

### DIFF
--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -532,24 +532,7 @@ dashboardView session model =
             (class (.pageBodyClass Message.Effects.stickyHeaderConfig)
                 :: Styles.content model.highDensity
             )
-        <|
-            welcomeCard session model
-                :: pipelinesView
-                    session
-                    { teams = model.teams
-                    , query = model.query
-                    , hovered = session.hovered
-                    , pipelineRunningKeyframes =
-                        session.pipelineRunningKeyframes
-                    , highDensity = model.highDensity
-                    , pipelinesWithResourceErrors =
-                        model.pipelinesWithResourceErrors
-                    , existingJobs = model.existingJobs
-                    , pipelines = model.pipelines
-                    , dragState = model.dragState
-                    , dropState = model.dropState
-                    , now = model.now
-                    }
+            (welcomeCard session model :: pipelinesView session model)
 
 
 welcomeCard :
@@ -659,19 +642,22 @@ turbulenceView path =
 
 
 pipelinesView :
-    { a | userState : UserState.UserState }
-    ->
-        { teams : List Concourse.Team
+    { a
+        | userState : UserState.UserState
         , hovered : HoverState.HoverState
         , pipelineRunningKeyframes : String
-        , query : String
-        , highDensity : Bool
-        , pipelinesWithResourceErrors : Dict ( String, String ) Bool
-        , existingJobs : List Concourse.Job
-        , pipelines : List Pipeline
-        , dragState : DragState
-        , dropState : DropState
-        , now : Maybe Time.Posix
+    }
+    ->
+        { b
+            | teams : List Concourse.Team
+            , query : String
+            , highDensity : Bool
+            , pipelinesWithResourceErrors : Dict ( String, String ) Bool
+            , existingJobs : List Concourse.Job
+            , pipelines : List Pipeline
+            , dragState : DragState
+            , dropState : DropState
+            , now : Maybe Time.Posix
         }
     -> List (Html Message)
 pipelinesView session params =
@@ -685,10 +671,9 @@ pipelinesView session params =
                 |> (if params.highDensity then
                         List.concatMap
                             (Group.hdView
-                                { pipelineRunningKeyframes = params.pipelineRunningKeyframes
+                                { pipelineRunningKeyframes = session.pipelineRunningKeyframes
                                 , pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
                                 , existingJobs = params.existingJobs
-                                , pipelines = params.pipelines
                                 }
                                 session
                             )
@@ -700,11 +685,10 @@ pipelinesView session params =
                                 { dragState = params.dragState
                                 , dropState = params.dropState
                                 , now = params.now
-                                , hovered = params.hovered
-                                , pipelineRunningKeyframes = params.pipelineRunningKeyframes
+                                , hovered = session.hovered
+                                , pipelineRunningKeyframes = session.pipelineRunningKeyframes
                                 , pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
                                 , existingJobs = params.existingJobs
-                                , pipelines = params.pipelines
                                 }
                             )
                    )

--- a/web/elm/src/Dashboard/Filter.elm
+++ b/web/elm/src/Dashboard/Filter.elm
@@ -89,18 +89,27 @@ runFilter existingJobs f =
 
 
 pipelineFilter : PipelineFilter -> List Concourse.Job -> Pipeline -> Bool
-pipelineFilter pf existingJobs =
+pipelineFilter pf existingJobs pipeline =
+    let
+        jobsForPipeline =
+            existingJobs
+                |> List.filter
+                    (\j ->
+                        (j.teamName == pipeline.teamName)
+                            && (j.pipelineName == pipeline.name)
+                    )
+    in
     case pf of
         Status sf ->
             case sf of
                 PipelineStatus ps ->
-                    Pipeline.pipelineStatus existingJobs >> equal ps
+                    pipeline |> Pipeline.pipelineStatus jobsForPipeline |> equal ps
 
                 PipelineRunning ->
-                    Pipeline.pipelineStatus existingJobs >> isRunning
+                    pipeline |> Pipeline.pipelineStatus jobsForPipeline |> isRunning
 
         FuzzyName term ->
-            .name >> Simple.Fuzzy.match term
+            pipeline.name |> Simple.Fuzzy.match term
 
 
 parseFilters : String -> List Filter

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -55,7 +55,7 @@ view :
 view session { dragState, dropState, now, hovered, pipelineRunningKeyframes, pipelinesWithResourceErrors, existingJobs, pipelines } g =
     let
         pipelinesForGroup =
-            pipelines |> List.filter (.teamName >> (==) g.teamName)
+            g.pipelines
 
         pipelineCards =
             if List.isEmpty pipelinesForGroup then
@@ -177,7 +177,7 @@ hdView :
 hdView { pipelineRunningKeyframes, pipelinesWithResourceErrors, existingJobs, pipelines } session g =
     let
         pipelinesForGroup =
-            pipelines |> List.filter (.teamName >> (==) g.teamName)
+            g.pipelines
 
         header =
             Html.div

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -48,11 +48,10 @@ view :
         , pipelineRunningKeyframes : String
         , pipelinesWithResourceErrors : Dict ( String, String ) Bool
         , existingJobs : List Concourse.Job
-        , pipelines : List Pipeline
         }
     -> Group
     -> Html Message
-view session { dragState, dropState, now, hovered, pipelineRunningKeyframes, pipelinesWithResourceErrors, existingJobs, pipelines } g =
+view session { dragState, dropState, now, hovered, pipelineRunningKeyframes, pipelinesWithResourceErrors, existingJobs } g =
     let
         pipelinesForGroup =
             g.pipelines
@@ -169,12 +168,11 @@ hdView :
     { pipelineRunningKeyframes : String
     , pipelinesWithResourceErrors : Dict ( String, String ) Bool
     , existingJobs : List Concourse.Job
-    , pipelines : List Pipeline
     }
     -> { a | userState : UserState }
     -> Group
     -> List (Html Message)
-hdView { pipelineRunningKeyframes, pipelinesWithResourceErrors, existingJobs, pipelines } session g =
+hdView { pipelineRunningKeyframes, pipelinesWithResourceErrors, existingJobs } session g =
     let
         pipelinesForGroup =
             g.pipelines

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -8,7 +8,7 @@ module Dashboard.Group exposing
     )
 
 import Concourse
-import Dashboard.Group.Models exposing (Group, Pipeline)
+import Dashboard.Group.Models exposing (Group)
 import Dashboard.Group.Tag as Tag
 import Dashboard.Models exposing (DragState(..), DropState(..))
 import Dashboard.Pipeline as Pipeline

--- a/web/elm/tests/DashboardSearchTests.elm
+++ b/web/elm/tests/DashboardSearchTests.elm
@@ -93,6 +93,13 @@ all =
                           , teamName = "team1"
                           , groups = []
                           }
+                        , { id = 1
+                          , name = "other-pipeline"
+                          , paused = False
+                          , public = True
+                          , teamName = "team1"
+                          , groups = []
+                          }
                         ]
                 )
             |> Tuple.first


### PR DESCRIPTION
# Existing Issue

Fixes #5107.

# Changes proposed in this pull request

* Makes sure that pipelines actually get filtered based on the user's input, and makes sure that the filtering algorithm uses the correct jobs.

# Contributor Checklist
- [x] Unit tests - we noticed a lack of coverage in DashboardSearchTests, which probably explains the presence of the bug
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~