### PR TITLE
Record and expose pipelines last update date.

### DIFF
--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Pipelines API", func() {
 				Resources: []string{"resource3", "resource4"},
 			},
 		})
+		publicPipeline.LastUpdatedReturns(time.Unix(1, 0))
 
 		anotherPublicPipeline = new(dbfakes.FakePipeline)
 		anotherPublicPipeline.IDReturns(2)
@@ -54,6 +55,7 @@ var _ = Describe("Pipelines API", func() {
 		anotherPublicPipeline.PublicReturns(true)
 		anotherPublicPipeline.TeamNameReturns("another")
 		anotherPublicPipeline.NameReturns("another-pipeline")
+		anotherPublicPipeline.LastUpdatedReturns(time.Unix(1, 0))
 
 		privatePipeline = new(dbfakes.FakePipeline)
 		privatePipeline.IDReturns(3)
@@ -68,6 +70,7 @@ var _ = Describe("Pipelines API", func() {
 				Resources: []string{"resource1", "resource2"},
 			},
 		})
+		privatePipeline.LastUpdatedReturns(time.Unix(1, 0))
 
 		privatePipelineFromAnotherTeam = new(dbfakes.FakePipeline)
 		privatePipelineFromAnotherTeam.IDReturns(3)
@@ -75,6 +78,7 @@ var _ = Describe("Pipelines API", func() {
 		privatePipelineFromAnotherTeam.PublicReturns(false)
 		privatePipelineFromAnotherTeam.TeamNameReturns("main")
 		privatePipelineFromAnotherTeam.NameReturns("private-pipeline")
+		privatePipelineFromAnotherTeam.LastUpdatedReturns(time.Unix(1, 0))
 
 		fakeTeam.PipelinesReturns([]db.Pipeline{
 			privatePipeline,
@@ -134,6 +138,7 @@ var _ = Describe("Pipelines API", func() {
 					"paused": true,
 					"public": true,
 					"team_name": "main",
+					"last_updated": 1,
 					"groups": [
 						{
 							"name": "group2",
@@ -147,7 +152,8 @@ var _ = Describe("Pipelines API", func() {
 					"name": "another-pipeline",
 					"paused": true,
 					"public": true,
-					"team_name": "another"
+					"team_name": "another",
+					"last_updated": 1
 				}]`))
 			})
 			It("populates pipeline factory with no team names", func() {
@@ -175,6 +181,7 @@ var _ = Describe("Pipelines API", func() {
 					"paused": false,
 					"public": false,
 					"team_name": "main",
+					"last_updated": 1,
 					"groups": [
 						{
 							"name": "group1",
@@ -189,6 +196,7 @@ var _ = Describe("Pipelines API", func() {
 					"paused": true,
 					"public": true,
 					"team_name": "main",
+					"last_updated": 1,
 					"groups": [
 						{
 							"name": "group2",
@@ -202,7 +210,8 @@ var _ = Describe("Pipelines API", func() {
 					"name": "another-pipeline",
 					"paused": true,
 					"public": true,
-					"team_name": "another"
+					"team_name": "another",
+					"last_updated": 1
 				}]`))
 			})
 
@@ -283,6 +292,7 @@ var _ = Describe("Pipelines API", func() {
 						"paused": false,
 						"public": false,
 						"team_name": "main",
+						"last_updated": 1,
 						"groups": [
 							{
 								"name": "group1",
@@ -297,6 +307,7 @@ var _ = Describe("Pipelines API", func() {
 						"paused": true,
 						"public": true,
 						"team_name": "main",
+						"last_updated": 1,
 						"groups": [
 							{
 								"name": "group2",
@@ -335,6 +346,7 @@ var _ = Describe("Pipelines API", func() {
 						"paused": true,
 						"public": true,
 						"team_name": "main",
+						"last_updated": 1,
 						"groups": [
 							{
 								"name": "group2",
@@ -363,6 +375,7 @@ var _ = Describe("Pipelines API", func() {
 						"paused": true,
 						"public": true,
 						"team_name": "main",
+						"last_updated": 1,
 						"groups": [
 							{
 								"name": "group2",
@@ -398,6 +411,7 @@ var _ = Describe("Pipelines API", func() {
 					Resources: []string{"resource3", "resource4"},
 				},
 			})
+			fakePipeline.LastUpdatedReturns(time.Unix(1, 0))
 		})
 
 		JustBeforeEach(func() {
@@ -446,6 +460,7 @@ var _ = Describe("Pipelines API", func() {
 						"paused": false,
 						"public": true,
 						"team_name": "a-team",
+						"last_updated": 1,
 						"groups": [
 							{
 								"name": "group1",

--- a/atc/api/present/pipeline.go
+++ b/atc/api/present/pipeline.go
@@ -7,11 +7,12 @@ import (
 
 func Pipeline(savedPipeline db.Pipeline) atc.Pipeline {
 	return atc.Pipeline{
-		ID:       savedPipeline.ID(),
-		Name:     savedPipeline.Name(),
-		TeamName: savedPipeline.TeamName(),
-		Paused:   savedPipeline.Paused(),
-		Public:   savedPipeline.Public(),
-		Groups:   savedPipeline.Groups(),
+		ID:          savedPipeline.ID(),
+		Name:        savedPipeline.Name(),
+		TeamName:    savedPipeline.TeamName(),
+		Paused:      savedPipeline.Paused(),
+		Public:      savedPipeline.Public(),
+		Groups:      savedPipeline.Groups(),
+		LastUpdated: savedPipeline.LastUpdated().Unix(),
 	}
 }

--- a/atc/db/dbfakes/fake_pipeline.go
+++ b/atc/db/dbfakes/fake_pipeline.go
@@ -3,6 +3,7 @@ package dbfakes
 
 import (
 	"sync"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
@@ -241,6 +242,16 @@ type FakePipeline struct {
 	jobsReturnsOnCall map[int]struct {
 		result1 db.Jobs
 		result2 error
+	}
+	LastUpdatedStub        func() time.Time
+	lastUpdatedMutex       sync.RWMutex
+	lastUpdatedArgsForCall []struct {
+	}
+	lastUpdatedReturns struct {
+		result1 time.Time
+	}
+	lastUpdatedReturnsOnCall map[int]struct {
+		result1 time.Time
 	}
 	LoadDebugVersionsDBStub        func() (*atc.DebugVersionsDB, error)
 	loadDebugVersionsDBMutex       sync.RWMutex
@@ -1579,6 +1590,58 @@ func (fake *FakePipeline) JobsReturnsOnCall(i int, result1 db.Jobs, result2 erro
 	}{result1, result2}
 }
 
+func (fake *FakePipeline) LastUpdated() time.Time {
+	fake.lastUpdatedMutex.Lock()
+	ret, specificReturn := fake.lastUpdatedReturnsOnCall[len(fake.lastUpdatedArgsForCall)]
+	fake.lastUpdatedArgsForCall = append(fake.lastUpdatedArgsForCall, struct {
+	}{})
+	fake.recordInvocation("LastUpdated", []interface{}{})
+	fake.lastUpdatedMutex.Unlock()
+	if fake.LastUpdatedStub != nil {
+		return fake.LastUpdatedStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.lastUpdatedReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakePipeline) LastUpdatedCallCount() int {
+	fake.lastUpdatedMutex.RLock()
+	defer fake.lastUpdatedMutex.RUnlock()
+	return len(fake.lastUpdatedArgsForCall)
+}
+
+func (fake *FakePipeline) LastUpdatedCalls(stub func() time.Time) {
+	fake.lastUpdatedMutex.Lock()
+	defer fake.lastUpdatedMutex.Unlock()
+	fake.LastUpdatedStub = stub
+}
+
+func (fake *FakePipeline) LastUpdatedReturns(result1 time.Time) {
+	fake.lastUpdatedMutex.Lock()
+	defer fake.lastUpdatedMutex.Unlock()
+	fake.LastUpdatedStub = nil
+	fake.lastUpdatedReturns = struct {
+		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakePipeline) LastUpdatedReturnsOnCall(i int, result1 time.Time) {
+	fake.lastUpdatedMutex.Lock()
+	defer fake.lastUpdatedMutex.Unlock()
+	fake.LastUpdatedStub = nil
+	if fake.lastUpdatedReturnsOnCall == nil {
+		fake.lastUpdatedReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+		})
+	}
+	fake.lastUpdatedReturnsOnCall[i] = struct {
+		result1 time.Time
+	}{result1}
+}
+
 func (fake *FakePipeline) LoadDebugVersionsDB() (*atc.DebugVersionsDB, error) {
 	fake.loadDebugVersionsDBMutex.Lock()
 	ret, specificReturn := fake.loadDebugVersionsDBReturnsOnCall[len(fake.loadDebugVersionsDBArgsForCall)]
@@ -2711,6 +2774,8 @@ func (fake *FakePipeline) Invocations() map[string][][]interface{} {
 	defer fake.jobMutex.RUnlock()
 	fake.jobsMutex.RLock()
 	defer fake.jobsMutex.RUnlock()
+	fake.lastUpdatedMutex.RLock()
+	defer fake.lastUpdatedMutex.RUnlock()
 	fake.loadDebugVersionsDBMutex.RLock()
 	defer fake.loadDebugVersionsDBMutex.RUnlock()
 	fake.nameMutex.RLock()

--- a/atc/db/migration/migrations/1580135204_add_pipelines_last_update.down.sql
+++ b/atc/db/migration/migrations/1580135204_add_pipelines_last_update.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+  ALTER TABLE pipelines
+    DROP COLUMN "last_updated";
+COMMIT;

--- a/atc/db/migration/migrations/1580135204_add_pipelines_last_update.up.sql
+++ b/atc/db/migration/migrations/1580135204_add_pipelines_last_update.up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+  ALTER TABLE pipelines
+    ADD COLUMN "last_updated" timestamp with time zone NOT NULL DEFAULT '1970-01-01 00:00:00';
+COMMIT;

--- a/atc/pipeline.go
+++ b/atc/pipeline.go
@@ -1,12 +1,13 @@
 package atc
 
 type Pipeline struct {
-	ID       int          `json:"id"`
-	Name     string       `json:"name"`
-	Paused   bool         `json:"paused"`
-	Public   bool         `json:"public"`
-	Groups   GroupConfigs `json:"groups,omitempty"`
-	TeamName string       `json:"team_name"`
+	ID          int          `json:"id"`
+	Name        string       `json:"name"`
+	Paused      bool         `json:"paused"`
+	Public      bool         `json:"public"`
+	Groups      GroupConfigs `json:"groups,omitempty"`
+	TeamName    string       `json:"team_name"`
+	LastUpdated int64        `json:"last_updated,omitempty"`
 }
 
 type RenameRequest struct {

--- a/fly/commands/pipelines.go
+++ b/fly/commands/pipelines.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
@@ -31,10 +32,10 @@ func (command *PipelinesCommand) Execute([]string) error {
 
 	if command.All {
 		pipelines, err = target.Client().ListPipelines()
-		headers = []string{"name", "team", "paused", "public"}
+		headers = []string{"name", "team", "paused", "public", "last updated"}
 	} else {
 		pipelines, err = target.Team().ListPipelines()
-		headers = []string{"name", "paused", "public"}
+		headers = []string{"name", "paused", "public", "last updated"}
 	}
 	if err != nil {
 		return err
@@ -77,6 +78,7 @@ func (command *PipelinesCommand) Execute([]string) error {
 		}
 		row = append(row, pausedColumn)
 		row = append(row, publicColumn)
+		row = append(row, ui.TableCell{Contents: time.Unix(p.LastUpdated, 0).String()})
 
 		table.Data = append(table.Data, row)
 	}

--- a/fly/integration/pipelines_test.go
+++ b/fly/integration/pipelines_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/ui"
@@ -28,9 +29,9 @@ var _ = Describe("Fly CLI", func() {
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
 							ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
-								{Name: "pipeline-1-longer", Paused: false, Public: false},
-								{Name: "pipeline-2", Paused: true, Public: false},
-								{Name: "pipeline-3", Paused: false, Public: true},
+								{Name: "pipeline-1-longer", Paused: false, Public: false, LastUpdated: 1},
+								{Name: "pipeline-2", Paused: true, Public: false, LastUpdated: 1},
+								{Name: "pipeline-3", Paused: false, Public: true, LastUpdated: 1},
 							}),
 						),
 					)
@@ -52,21 +53,24 @@ var _ = Describe("Fly CLI", func() {
                   "name": "pipeline-1-longer",
                   "paused": false,
                   "public": false,
-                  "team_name": ""
+                  "team_name": "",
+                  "last_updated": 1
                 },
                 {
                   "id": 0,
                   "name": "pipeline-2",
                   "paused": true,
                   "public": false,
-                  "team_name": ""
+                  "team_name": "",
+                  "last_updated": 1
                 },
                 {
                   "id": 0,
                   "name": "pipeline-3",
                   "paused": false,
                   "public": true,
-                  "team_name": ""
+                  "team_name": "",
+                  "last_updated": 1
                 }
               ]`))
 					})
@@ -82,11 +86,12 @@ var _ = Describe("Fly CLI", func() {
 							{Contents: "name", Color: color.New(color.Bold)},
 							{Contents: "paused", Color: color.New(color.Bold)},
 							{Contents: "public", Color: color.New(color.Bold)},
+							{Contents: "last updated", Color: color.New(color.Bold)},
 						},
 						Data: []ui.TableRow{
-							{{Contents: "pipeline-1-longer"}, {Contents: "no"}, {Contents: "no"}},
-							{{Contents: "pipeline-2"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "no"}},
-							{{Contents: "pipeline-3"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}},
+							{{Contents: "pipeline-1-longer"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "pipeline-2"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "pipeline-3"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
 						},
 					}))
 				})
@@ -99,11 +104,11 @@ var _ = Describe("Fly CLI", func() {
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/pipelines"),
 							ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
-								{Name: "pipeline-1-longer", Paused: false, Public: false, TeamName: "main"},
-								{Name: "pipeline-2", Paused: true, Public: false, TeamName: "main"},
-								{Name: "pipeline-3", Paused: false, Public: true, TeamName: "main"},
-								{Name: "foreign-pipeline-1", Paused: false, Public: true, TeamName: "other"},
-								{Name: "foreign-pipeline-2", Paused: false, Public: true, TeamName: "other"},
+								{Name: "pipeline-1-longer", Paused: false, Public: false, TeamName: "main", LastUpdated: 1},
+								{Name: "pipeline-2", Paused: true, Public: false, TeamName: "main", LastUpdated: 1},
+								{Name: "pipeline-3", Paused: false, Public: true, TeamName: "main", LastUpdated: 1},
+								{Name: "foreign-pipeline-1", Paused: false, Public: true, TeamName: "other", LastUpdated: 1},
+								{Name: "foreign-pipeline-2", Paused: false, Public: true, TeamName: "other", LastUpdated: 1},
 							}),
 						),
 					)
@@ -125,35 +130,40 @@ var _ = Describe("Fly CLI", func() {
                   "name": "pipeline-1-longer",
                   "paused": false,
                   "public": false,
-                  "team_name": "main"
+                  "team_name": "main",
+                  "last_updated": 1
                 },
                 {
                   "id": 0,
                   "name": "pipeline-2",
                   "paused": true,
                   "public": false,
-                  "team_name": "main"
+                  "team_name": "main",
+                  "last_updated": 1
                 },
                 {
                   "id": 0,
                   "name": "pipeline-3",
                   "paused": false,
                   "public": true,
-                  "team_name": "main"
+                  "team_name": "main",
+                  "last_updated": 1
                 },
                 {
                   "id": 0,
                   "name": "foreign-pipeline-1",
                   "paused": false,
                   "public": true,
-                  "team_name": "other"
+                  "team_name": "other",
+                  "last_updated": 1
                 },
                 {
                   "id": 0,
                   "name": "foreign-pipeline-2",
                   "paused": false,
                   "public": true,
-                  "team_name": "other"
+                  "team_name": "other",
+                  "last_updated": 1
                 }
               ]`))
 					})
@@ -170,13 +180,14 @@ var _ = Describe("Fly CLI", func() {
 							{Contents: "team", Color: color.New(color.Bold)},
 							{Contents: "paused", Color: color.New(color.Bold)},
 							{Contents: "public", Color: color.New(color.Bold)},
+							{Contents: "last updated", Color: color.New(color.Bold)},
 						},
 						Data: []ui.TableRow{
-							{{Contents: "pipeline-1-longer"}, {Contents: "main"}, {Contents: "no"}, {Contents: "no"}},
-							{{Contents: "pipeline-2"}, {Contents: "main"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "no"}},
-							{{Contents: "pipeline-3"}, {Contents: "main"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}},
-							{{Contents: "foreign-pipeline-1"}, {Contents: "other"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}},
-							{{Contents: "foreign-pipeline-2"}, {Contents: "other"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}},
+							{{Contents: "pipeline-1-longer"}, {Contents: "main"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "pipeline-2"}, {Contents: "main"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "pipeline-3"}, {Contents: "main"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "foreign-pipeline-1"}, {Contents: "other"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "foreign-pipeline-2"}, {Contents: "other"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
 						},
 					}))
 				})
@@ -190,9 +201,9 @@ var _ = Describe("Fly CLI", func() {
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
 							ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
-								{Name: "some-pipeline-1", Paused: false, Public: false},
-								{Name: "some-pipeline-2", Paused: false, Public: false},
-								{Name: "another-pipeline", Paused: false, Public: false},
+								{Name: "some-pipeline-1", Paused: false, Public: false, LastUpdated: 1},
+								{Name: "some-pipeline-2", Paused: false, Public: false, LastUpdated: 1},
+								{Name: "another-pipeline", Paused: false, Public: false, LastUpdated: 1},
 							}),
 						),
 					)

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -27,3 +27,9 @@ pipeline on a team at the same time. #4092
 [OpenTelemetry]: https://opentelemetry.io/
 [Jaeger]: https://www.jaegertracing.io/
 [Stackdriver]: https://cloud.google.com/trace/
+
+
+#### <sub><sup><a name="5113" href="#5113">:link:</a></sup></sub> feature
+
+* @aledeganopix4d added a `last updated` column to the output of `fly pipelines` showing
+the last date where the pipeline was set or reset. #5113


### PR DESCRIPTION
# Existing Issue
Record pipelines creation/update time #4809

Fixes #4809.

# Changes proposed in this pull request

* Add a new column into the `pipelines` table called `last_updated`
  * When the pipeline is (re-)set the `last_updated` column is set to the current time
* Add a column in the output of `fly pipelines` to display the last updated date of the pipelines being displayed

# Contributor Checklist
- [X] Unit tests
- [X] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [X] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [x] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
