### PR TITLE
web: improve dashboard performance at scale

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -24,6 +24,10 @@ other systems soon.
 `fly unpause-pipeline` commands. This allows users to pause or unpause every
 pipeline on a team at the same time. #4092
 
+#### <sub><sup><a name="5118" href="#5118">:link:</a></sup></sub> feature
+
+* Improved the performance of the dashboard by only rendering the pipeline cards that are visible. #5118
+
 [OpenTelemetry]: https://opentelemetry.io/
 [Jaeger]: https://www.jaegertracing.io/
 [Stackdriver]: https://cloud.google.com/trace/

--- a/web/assets/css/build.less
+++ b/web/assets/css/build.less
@@ -16,6 +16,7 @@
 
 .keyboard-help {
   position: fixed;
+  z-index: 2;
   width: 100%;
   bottom: 0;
   left: 0;

--- a/web/assets/css/dashboard.less
+++ b/web/assets/css/dashboard.less
@@ -9,24 +9,6 @@
     float: none;
     display: flex;
     padding: 40px*@scale 72px*@scale;
-    width: 400px * @scale;
-    height: 240px * @scale;
-  }
-
-  .pipeline-grid-tall {
-    height: 728px * @scale;
-  }
-
-  .pipeline-grid-wide {
-    width: 1004px * @scale;
-  }
-
-  .pipeline-grid-super-tall {
-    height: 1216px * @scale;
-  }
-
-  .pipeline-grid-super-wide {
-    width: 1608px * @scale;
   }
 
   .pipeline-grid > * {
@@ -74,7 +56,7 @@
     .drop-area {
       position: relative;
       left: (-125px * @scale);
-      margin-right: (-250px * @scale);
+      margin-right: (-200px * @scale);
       z-index: -1;
 
       &.active {

--- a/web/assets/css/dashboard.less
+++ b/web/assets/css/dashboard.less
@@ -51,17 +51,10 @@
     }
 
     .drop-area {
-      position: relative;
-      left: (-125px * @scale);
-      margin-right: (-200px * @scale);
       z-index: -1;
 
       &.active {
         z-index: 2;
-      }
-
-      &.animation {
-        transition: all 0.2s ease-in-out;
       }
     }
   }

--- a/web/assets/css/dashboard.less
+++ b/web/assets/css/dashboard.less
@@ -45,9 +45,6 @@
   }
 
   .dashboard-team-pipelines {
-    display: flex;
-    flex-wrap: wrap;
-    padding-left: (50px * @scale);
 
     .pipeline-wrapper {
       display: flex;

--- a/web/assets/css/dashboard.less
+++ b/web/assets/css/dashboard.less
@@ -45,7 +45,6 @@
   }
 
   .dashboard-team-pipelines {
-
     .pipeline-wrapper {
       display: flex;
     }

--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -88,7 +88,7 @@ main =
         Benchmark.describe "benchmark suite"
             [ Benchmark.compare "DashboardPreview.view"
                 "current"
-                (\_ -> DP.view HoverState.NoHover sampleJobs)
+                (\_ -> DP.view HoverState.NoHover (DP.groupByRank sampleJobs))
                 "old"
                 (\_ -> dashboardPreviewView sampleJobs)
             , Benchmark.compare "Build.view"

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -496,10 +496,13 @@ decodeBuildSetPipeline =
     Json.Decode.succeed BuildStepSetPipeline
         |> andMap (Json.Decode.field "name" Json.Decode.string)
 
+
 decodeBuildStepLoadVar : Json.Decode.Decoder BuildStep
 decodeBuildStepLoadVar =
     Json.Decode.succeed BuildStepLoadVar
         |> andMap (Json.Decode.field "name" Json.Decode.string)
+
+
 
 -- Info
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -325,7 +325,7 @@ handleCallback callback ( model, effects ) =
             , effects
             )
 
-        GotViewport _ (Ok viewport) ->
+        GotViewport Dashboard _ (Ok viewport) ->
             ( { model
                 | viewportWidth = viewport.viewport.width
                 , viewportHeight = viewport.viewport.height
@@ -372,6 +372,9 @@ handleDeliveryBody delivery ( model, effects ) =
             ( { model | now = Just time }, effects )
 
         WindowResized _ _ ->
+            ( model, effects ++ [ GetViewportOf Dashboard AlwaysShow ] )
+
+        SideBarStateReceived _ ->
             ( model, effects ++ [ GetViewportOf Dashboard AlwaysShow ] )
 
         _ ->
@@ -478,6 +481,9 @@ updateBody msg ( model, effects ) =
 
                 Nothing ->
                     ( model, effects )
+
+        Click HamburgerMenu ->
+            ( model, effects ++ [ GetViewportOf Dashboard AlwaysShow ] )
 
         Scrolled scrollState ->
             ( { model | scrollTop = scrollState.scrollTop }, effects )

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -786,6 +786,7 @@ pipelinesView session params =
                                             , totalOffset
                                                 + layout.height
                                                 + PipelineGridConstants.headerHeight
+                                                + PipelineGridConstants.padding
                                             )
                                        )
                             )

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -412,9 +412,10 @@ updateBody msg ( model, effects ) =
                                         dropIdx
 
                                     _ ->
-                                        dragIdx
+                                        dragIdx + 1
                                 )
                                 model.pipelines
+                                |> List.indexedMap (\i p -> { p | ordering = i })
                     in
                     ( { model
                         | pipelines = pipelines
@@ -763,6 +764,7 @@ pipelinesView session params =
                                     , viewportWidth = params.viewportWidth
                                     , viewportHeight = params.viewportHeight
                                     , scrollTop = params.scrollTop - totalOffset
+                                    , query = params.query
                                     }
                                     g
                                     |> (\( html, curOffset ) -> ( html :: htmlList, totalOffset + curOffset ))

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -761,7 +761,7 @@ pipelinesView session params =
                                             , pipelineLayers = params.pipelineLayers
                                             , viewportWidth = params.viewportWidth
                                             , viewportHeight = params.viewportHeight
-                                            , scrollTop = params.scrollTop + totalOffset
+                                            , scrollTop = params.scrollTop - totalOffset
                                             }
                                             g
                                 in

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -240,10 +240,9 @@ handleCallback callback ( model, effects ) =
             ( { model
                 | pipelines =
                     allPipelinesInEntireCluster
-                        |> List.indexedMap
-                            (\idx p ->
+                        |> List.map
+                            (\p ->
                                 { id = p.id
-                                , ordering = idx
                                 , name = p.name
                                 , teamName = p.teamName
                                 , public = p.public
@@ -398,17 +397,27 @@ updateBody msg ( model, effects ) =
             case model.dragState of
                 Dragging teamName dragIdx ->
                     let
-                        pipelines =
-                            Drag.drag dragIdx
-                                (case model.dropState of
-                                    Dropping dropIdx ->
-                                        dropIdx
+                        teamStartIndex =
+                            model.pipelines
+                                |> List.Extra.findIndex (\p -> p.teamName == teamName)
 
-                                    _ ->
-                                        dragIdx + 1
-                                )
-                                model.pipelines
-                                |> List.indexedMap (\i p -> { p | ordering = i })
+                        pipelines =
+                            case teamStartIndex of
+                                Just teamStartIdx ->
+                                    model.pipelines
+                                        |> Drag.drag (teamStartIdx + dragIdx)
+                                            (teamStartIdx
+                                                + (case model.dropState of
+                                                    Dropping dropIdx ->
+                                                        dropIdx
+
+                                                    _ ->
+                                                        dragIdx + 1
+                                                  )
+                                            )
+
+                                _ ->
+                                    model.pipelines
                     in
                     ( { model
                         | pipelines = pipelines

--- a/web/elm/src/Dashboard/DashboardPreview.elm
+++ b/web/elm/src/Dashboard/DashboardPreview.elm
@@ -13,13 +13,9 @@ import Message.Message exposing (DomID(..), Message(..))
 import Routes
 
 
-view : HoverState.HoverState -> List Concourse.Job -> Html Message
-view hovered jobs =
+view : HoverState.HoverState -> List (List Concourse.Job) -> Html Message
+view hovered layers =
     let
-        layers : List (List Concourse.Job)
-        layers =
-            groupByRank jobs
-
         width : Int
         width =
             List.length layers
@@ -32,14 +28,7 @@ view hovered jobs =
                 |> Maybe.withDefault 0
     in
     Html.div
-        [ classList
-            [ ( "pipeline-grid", True )
-            , ( "pipeline-grid-wide", width > 12 )
-            , ( "pipeline-grid-tall", height > 12 )
-            , ( "pipeline-grid-super-wide", width > 24 )
-            , ( "pipeline-grid-super-tall", height > 24 )
-            ]
-        ]
+        (class "pipeline-grid" :: Styles.pipelinePreviewGrid)
         (List.map (viewJobLayer hovered) layers)
 
 

--- a/web/elm/src/Dashboard/DashboardPreview.elm
+++ b/web/elm/src/Dashboard/DashboardPreview.elm
@@ -6,7 +6,7 @@ import Dashboard.Styles as Styles
 import Dict exposing (Dict)
 import HoverState
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, class, classList, href)
+import Html.Attributes exposing (attribute, class, href)
 import Html.Events exposing (onMouseEnter, onMouseLeave)
 import List.Extra
 import Message.Message exposing (DomID(..), Message(..))
@@ -15,18 +15,6 @@ import Routes
 
 view : HoverState.HoverState -> List (List Concourse.Job) -> Html Message
 view hovered layers =
-    let
-        width : Int
-        width =
-            List.length layers
-
-        height : Int
-        height =
-            layers
-                |> List.map List.length
-                |> List.maximum
-                |> Maybe.withDefault 0
-    in
     Html.div
         (class "pipeline-grid" :: Styles.pipelinePreviewGrid)
         (List.map (viewJobLayer hovered) layers)

--- a/web/elm/src/Dashboard/Filter.elm
+++ b/web/elm/src/Dashboard/Filter.elm
@@ -10,7 +10,7 @@ import Concourse.PipelineStatus
         )
 import Dashboard.Group.Models exposing (Group, Pipeline)
 import Dashboard.Pipeline as Pipeline
-import Dict
+import Dict exposing (Dict)
 import Parser
     exposing
         ( (|.)
@@ -39,7 +39,7 @@ type alias Filter =
     }
 
 
-filterGroups : List Concourse.Job -> String -> List Concourse.Team -> List Pipeline -> List Group
+filterGroups : Dict ( String, String ) (List Concourse.Job) -> String -> List Concourse.Team -> List Pipeline -> List Group
 filterGroups existingJobs query teams pipelines =
     let
         groupsToFilter =
@@ -62,7 +62,7 @@ filterGroups existingJobs query teams pipelines =
     parseFilters query |> List.foldr (runFilter existingJobs) groupsToFilter
 
 
-runFilter : List Concourse.Job -> Filter -> List Group -> List Group
+runFilter : Dict ( String, String ) (List Concourse.Job) -> Filter -> List Group -> List Group
 runFilter existingJobs f =
     let
         negater =
@@ -88,16 +88,13 @@ runFilter existingJobs f =
                 >> List.filter (.pipelines >> List.isEmpty >> not)
 
 
-pipelineFilter : PipelineFilter -> List Concourse.Job -> Pipeline -> Bool
+pipelineFilter : PipelineFilter -> Dict ( String, String ) (List Concourse.Job) -> Pipeline -> Bool
 pipelineFilter pf existingJobs pipeline =
     let
         jobsForPipeline =
             existingJobs
-                |> List.filter
-                    (\j ->
-                        (j.teamName == pipeline.teamName)
-                            && (j.pipelineName == pipeline.name)
-                    )
+                |> Dict.get ( pipeline.teamName, pipeline.name )
+                |> Maybe.withDefault []
     in
     case pf of
         Status sf ->

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -68,6 +68,7 @@ view session { dragState, dropState, now, hovered, pipelineRunningKeyframes, pip
                                 [ pipelineDropAreaView dragState dropState g.teamName pipeline.ordering
                                 , Html.div
                                     ([ class "card"
+                                     , id <| Effects.toHtmlID <| PipelineCard pipeline.id
                                      , attribute "data-pipeline-name" pipeline.name
                                      , attribute
                                         "ondragstart"

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -8,18 +8,19 @@ module Dashboard.Group exposing
     )
 
 import Concourse
-import Dashboard.DashboardPreview as DashboardPreview
+import Dashboard.Drag exposing (drag)
 import Dashboard.Group.Models exposing (Group, Pipeline)
 import Dashboard.Group.Tag as Tag
 import Dashboard.Models exposing (DragState(..), DropState(..))
 import Dashboard.Pipeline as Pipeline
-import Dashboard.PipelineGridLayout as PipelineGridLayout
+import Dashboard.PipelineGridLayout as PipelineGridLayout exposing (cardHeight, cardWidth, padding)
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
 import HoverState
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, class, classList, draggable, id, style)
 import Html.Events exposing (on, preventDefaultOn, stopPropagationOn)
+import Html.Keyed
 import Json.Decode
 import Maybe.Extra
 import Message.Effects as Effects
@@ -40,6 +41,14 @@ type alias PipelineIndex =
     Int
 
 
+type alias Bounds =
+    { x : Float
+    , y : Float
+    , width : Float
+    , height : Float
+    }
+
+
 view :
     { a | userState : UserState }
     ->
@@ -54,25 +63,33 @@ view :
         , viewportWidth : Float
         , viewportHeight : Float
         , scrollTop : Float
+        , query : String
         }
     -> Group
     -> ( Html Message, Float )
 view session params g =
     let
-        pipelinesForGroup =
-            g.pipelines
+        ( dragTeam, fromIndex, toIndex ) =
+            case ( params.dragState, params.dropState ) of
+                ( Dragging team fromIdx, NotDropping ) ->
+                    ( team, fromIdx, fromIdx + 1 )
 
-        padding =
-            PipelineGridLayout.padding
+                ( Dragging team fromIdx, Dropping toIdx ) ->
+                    ( team, fromIdx, toIdx )
+
+                _ ->
+                    ( "", -1, -1 )
+
+        orderedPipelines =
+            if (g.teamName == dragTeam) && (fromIndex >= 0) then
+                drag fromIndex toIndex g.pipelines
+                    |> List.indexedMap (\i p -> { p | ordering = i })
+
+            else
+                g.pipelines
 
         headerHeight =
             60
-
-        cardWidth =
-            PipelineGridLayout.cardWidth
-
-        cardHeight =
-            PipelineGridLayout.cardHeight
 
         numColumns =
             max 1 (floor (params.viewportWidth / (cardWidth + padding)))
@@ -87,16 +104,13 @@ view session params g =
             (numRowsOffset < row + height)
                 && (row <= numRowsOffset + numRowsVisible)
 
-        layersList =
-            pipelinesForGroup
+        previewSizes =
+            orderedPipelines
                 |> List.map
                     (\pipeline ->
                         Dict.get ( pipeline.name, pipeline.teamName ) params.pipelineLayers
                             |> Maybe.withDefault []
                     )
-
-        previewSizes =
-            layersList
                 |> List.map
                     (\layers ->
                         ( List.length layers
@@ -124,113 +138,196 @@ view session params g =
                 + padding
                 * (numRows - 1)
 
+        cardLookup =
+            cards
+                |> List.map2 Tuple.pair orderedPipelines
+                |> List.map (\( pipeline, card ) -> ( pipeline.id, card ))
+                |> Dict.fromList
+
+        prevAndCurrentCards =
+            cards
+                |> List.map2 Tuple.pair (Nothing :: (cards |> List.map Just))
+
+        dropAreas =
+            (prevAndCurrentCards
+                |> List.indexedMap Tuple.pair
+                |> List.filter (\( _, ( _, card ) ) -> isVisible card)
+                |> List.map
+                    (\( i, ( prevCard, card ) ) ->
+                        let
+                            cardBounds =
+                                { x = (toFloat card.column - 1) * (cardWidth + padding)
+                                , y = (toFloat card.row - 1) * (cardHeight + padding)
+                                , width = cardWidth * toFloat card.width + padding * toFloat card.width
+                                , height = cardHeight * toFloat card.height + padding * (toFloat card.height - 1)
+                                }
+
+                            boundsToRightOf otherCard =
+                                { x = toFloat (otherCard.column - 1 + otherCard.width) * (cardWidth + padding)
+                                , y = (toFloat otherCard.row - 1) * (cardHeight + padding)
+                                , width = cardWidth + padding
+                                , height = cardHeight
+                                }
+
+                            bounds =
+                                case prevCard of
+                                    Just otherCard ->
+                                        if
+                                            (otherCard.row < card.row)
+                                                && (otherCard.column + otherCard.width <= numColumns)
+                                        then
+                                            boundsToRightOf otherCard
+
+                                        else
+                                            cardBounds
+
+                                    Nothing ->
+                                        cardBounds
+                        in
+                        pipelineDropAreaView params.dragState
+                            g.teamName
+                            bounds
+                            (i + 1)
+                    )
+            )
+                ++ (case List.head (List.reverse cards) of
+                        Just lastCard ->
+                            if not (isVisible lastCard) then
+                                []
+
+                            else
+                                [ pipelineDropAreaView params.dragState
+                                    g.teamName
+                                    { x = toFloat lastCard.column * (cardWidth + padding)
+                                    , y = (toFloat lastCard.row - 1) * (cardHeight + padding)
+                                    , width = cardWidth + padding
+                                    , height = cardHeight
+                                    }
+                                    (List.length cards + 1)
+                                ]
+
+                        Nothing ->
+                            []
+                   )
+
         pipelineCards =
-            if List.isEmpty pipelinesForGroup then
-                [ Pipeline.pipelineNotSetView ]
+            if List.isEmpty orderedPipelines then
+                [ ( "not-set", Pipeline.pipelineNotSetView ) ]
 
             else
-                List.append
-                    (pipelinesForGroup
-                        |> List.map3
-                            (\card layers pipeline ->
-                                ( card, layers, pipeline )
-                            )
-                            cards
-                            layersList
-                        |> List.filter (\( card, _, _ ) -> isVisible card)
-                        |> List.map
-                            (\( card, layers, pipeline ) ->
-                                Html.div
-                                    [ class "pipeline-wrapper"
-                                    , style "position" "absolute"
-                                    , style "transform"
-                                        ("translate("
-                                            ++ String.fromInt ((card.column - 1) * (cardWidth + padding) + padding)
-                                            ++ "px,"
-                                            ++ String.fromInt ((card.row - 1) * (cardHeight + padding))
-                                            ++ "px)"
-                                        )
-                                    , style
-                                        "width"
-                                        (String.fromInt
-                                            (cardWidth
-                                                * card.width
-                                                + padding
-                                                * (card.width - 1)
-                                            )
-                                            ++ "px"
-                                        )
-                                    , style "height"
-                                        (String.fromInt
-                                            (cardHeight
-                                                * card.height
-                                                + padding
-                                                * (card.height - 1)
-                                            )
-                                            ++ "px"
-                                        )
-                                    ]
-                                    [ pipelineDropAreaView params.dragState params.dropState g.teamName pipeline.ordering
-                                    , Html.div
-                                        ([ class "card"
-                                         , style "width" "100%"
-                                         , id <| Effects.toHtmlID <| PipelineCard pipeline.id
-                                         , attribute "data-pipeline-name" pipeline.name
-                                         , attribute
-                                            "ondragstart"
-                                            "event.dataTransfer.setData('text/plain', '');"
-                                         , draggable "true"
-                                         , on "dragstart"
-                                            (Json.Decode.succeed (DragStart pipeline.teamName pipeline.ordering))
-                                         , on "dragend" (Json.Decode.succeed DragEnd)
-                                         ]
-                                            ++ (if params.dragState == Dragging pipeline.teamName pipeline.ordering then
-                                                    [ style "width" "0"
-                                                    , style "margin" "0 12.5px"
-                                                    , style "overflow" "hidden"
-                                                    ]
-
-                                                else
-                                                    []
-                                               )
-                                            ++ (if params.dropState == DroppingWhileApiRequestInFlight g.teamName then
-                                                    [ style "opacity" "0.45", style "pointer-events" "none" ]
-
-                                                else
-                                                    [ style "opacity" "1" ]
-                                               )
-                                        )
-                                        [ Pipeline.pipelineView
-                                            { now = params.now
-                                            , pipeline = pipeline
-                                            , resourceError =
-                                                params.pipelinesWithResourceErrors
-                                                    |> Dict.get ( pipeline.teamName, pipeline.name )
-                                                    |> Maybe.withDefault False
-                                            , existingJobs =
-                                                params.existingJobs
-                                                    |> List.filter
-                                                        (\j ->
-                                                            j.teamName == pipeline.teamName && j.pipelineName == pipeline.name
-                                                        )
-                                            , layers = layers
-                                            , hovered = params.hovered
-                                            , pipelineRunningKeyframes = params.pipelineRunningKeyframes
-                                            , userState = session.userState
-                                            }
-                                        ]
-                                    ]
-                            )
-                    )
-                    [ pipelineDropAreaView params.dragState
-                        params.dropState
-                        g.teamName
-                        (pipelinesForGroup
-                            |> List.map (.ordering >> (+) 1)
-                            |> List.maximum
-                            |> Maybe.withDefault 0
+                g.pipelines
+                    |> List.map
+                        (\p ->
+                            cardLookup
+                                |> Dict.get p.id
+                                |> Maybe.withDefault { row = 0, column = 0, width = 0, height = 0 }
+                                |> Tuple.pair p
                         )
-                    ]
+                    |> List.filter (\( _, card ) -> isVisible card)
+                    |> List.map
+                        (\( pipeline, card ) ->
+                            params.pipelineLayers
+                                |> Dict.get ( pipeline.name, pipeline.teamName )
+                                |> Maybe.withDefault []
+                                |> (\layers -> ( pipeline, card, layers ))
+                        )
+                    |> List.map
+                        (\( pipeline, card, layers ) ->
+                            Html.div
+                                ([ class "pipeline-wrapper"
+                                 , style "position" "absolute"
+                                 , style "transform"
+                                    ("translate("
+                                        ++ String.fromInt ((card.column - 1) * (cardWidth + padding) + padding)
+                                        ++ "px,"
+                                        ++ String.fromInt ((card.row - 1) * (cardHeight + padding))
+                                        ++ "px)"
+                                    )
+                                 , style
+                                    "width"
+                                    (String.fromInt
+                                        (cardWidth
+                                            * card.width
+                                            + padding
+                                            * (card.width - 1)
+                                        )
+                                        ++ "px"
+                                    )
+                                 , style "height"
+                                    (String.fromInt
+                                        (cardHeight
+                                            * card.height
+                                            + padding
+                                            * (card.height - 1)
+                                        )
+                                        ++ "px"
+                                    )
+                                 ]
+                                    ++ (if dragTeam == g.teamName then
+                                            [ style "transition" "transform 0.2s ease-in-out" ]
+
+                                        else
+                                            []
+                                       )
+                                )
+                                [ Html.div
+                                    ([ class "card"
+                                     , style "width" "100%"
+                                     , id <| Effects.toHtmlID <| PipelineCard pipeline.id
+                                     , attribute "data-pipeline-name" pipeline.name
+                                     ]
+                                        ++ (if String.isEmpty params.query then
+                                                [ attribute
+                                                    "ondragstart"
+                                                    "event.dataTransfer.setData('text/plain', '');"
+                                                , draggable "true"
+                                                , on "dragstart"
+                                                    (Json.Decode.succeed (DragStart pipeline.teamName pipeline.ordering))
+                                                , on "dragend" (Json.Decode.succeed DragEnd)
+                                                ]
+
+                                            else
+                                                []
+                                           )
+                                        ++ (if params.dragState == Dragging pipeline.teamName pipeline.ordering then
+                                                [ style "width" "0"
+                                                , style "margin" "0 12.5px"
+                                                , style "overflow" "hidden"
+                                                ]
+
+                                            else
+                                                []
+                                           )
+                                        ++ (if params.dropState == DroppingWhileApiRequestInFlight g.teamName then
+                                                [ style "opacity" "0.45", style "pointer-events" "none" ]
+
+                                            else
+                                                [ style "opacity" "1" ]
+                                           )
+                                    )
+                                    [ Pipeline.pipelineView
+                                        { now = params.now
+                                        , pipeline = pipeline
+                                        , resourceError =
+                                            params.pipelinesWithResourceErrors
+                                                |> Dict.get ( pipeline.teamName, pipeline.name )
+                                                |> Maybe.withDefault False
+                                        , existingJobs =
+                                            params.existingJobs
+                                                |> List.filter
+                                                    (\j ->
+                                                        j.teamName == pipeline.teamName && j.pipelineName == pipeline.name
+                                                    )
+                                        , layers = layers
+                                        , hovered = params.hovered
+                                        , pipelineRunningKeyframes = params.pipelineRunningKeyframes
+                                        , userState = session.userState
+                                        , query = params.query
+                                        }
+                                    ]
+                                ]
+                                |> Tuple.pair (String.fromInt pipeline.id)
+                        )
     in
     Html.div
         [ id <| Effects.toHtmlID <| DashboardGroup g.teamName
@@ -255,12 +352,12 @@ view session params g =
                         []
                    )
             )
-        , Html.div
+        , Html.Keyed.node "div"
             [ class <| .sectionBodyClass Effects.stickyHeaderConfig
             , style "position" "relative"
             , style "height" <| String.fromInt totalCardsHeight ++ "px"
             ]
-            pipelineCards
+            (pipelineCards ++ [ ( "drop-areas", Html.div [ style "position" "absolute" ] dropAreas ) ])
         ]
         |> (\html ->
                 ( html
@@ -289,7 +386,7 @@ hdView :
     -> List (Html Message)
 hdView { pipelineRunningKeyframes, pipelinesWithResourceErrors, existingJobs } session g =
     let
-        pipelinesForGroup =
+        orderedPipelines =
             g.pipelines
 
         header =
@@ -299,11 +396,11 @@ hdView { pipelineRunningKeyframes, pipelinesWithResourceErrors, existingJobs } s
                 :: (Maybe.Extra.toList <| Maybe.map (Tag.view True) (tag session g))
 
         teamPipelines =
-            if List.isEmpty pipelinesForGroup then
+            if List.isEmpty orderedPipelines then
                 [ pipelineNotSetView ]
 
             else
-                pipelinesForGroup
+                orderedPipelines
                     |> List.map
                         (\p ->
                             Pipeline.hdPipelineView
@@ -343,39 +440,36 @@ pipelineNotSetView =
         ]
 
 
-pipelineDropAreaView : DragState -> DropState -> String -> Int -> Html Message
-pipelineDropAreaView dragState dropState name index =
+pipelineDropAreaView : DragState -> String -> Bounds -> Int -> Html Message
+pipelineDropAreaView dragState name { x, y, width, height } index =
     let
-        ( active, over ) =
-            case ( dragState, dropState ) of
-                ( Dragging team dragIdx, NotDropping ) ->
-                    ( team == name, index == dragIdx )
-
-                ( Dragging team _, Dropping dropIdx ) ->
-                    ( team == name, index == dropIdx )
+        active =
+            case dragState of
+                Dragging team _ ->
+                    team == name
 
                 _ ->
-                    ( False, False )
+                    False
     in
     Html.div
         [ classList
             [ ( "drop-area", True )
             , ( "active", active )
-            , ( "animation", dropState /= NotDropping )
             ]
+        , style "position" "absolute"
+        , style "transform" <|
+            "translate("
+                ++ String.fromFloat x
+                ++ "px,"
+                ++ String.fromFloat y
+                ++ "px)"
+        , style "width" <| String.fromFloat width ++ "px"
+        , style "height" <| String.fromFloat height ++ "px"
         , on "dragenter" (Json.Decode.succeed (DragOver name index))
 
         -- preventDefault is required so that the card will not appear to
         -- "float" or "snap" back to its original position when dropped.
         , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver name index, True ))
         , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
-        , style "padding" <|
-            "0 "
-                ++ (if active && over then
-                        "198.5px"
-
-                    else
-                        "50px"
-                   )
         ]
         []

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -66,10 +66,10 @@ view session params g =
             else
                 params.pipelineCards
                     |> List.map
-                        (\{ bounds, pipeline } ->
+                        (\{ bounds, pipeline, index } ->
                             pipelineCardView session
                                 params
-                                { bounds = bounds, pipeline = pipeline }
+                                { bounds = bounds, pipeline = pipeline, index = index }
                                 g.teamName
                                 |> (\html -> ( String.fromInt pipeline.id, html ))
                         )
@@ -202,17 +202,18 @@ pipelineCardView :
             , hovered : HoverState.HoverState
             , pipelineRunningKeyframes : String
             , pipelinesWithResourceErrors : Dict ( String, String ) Bool
-            , existingJobs : List Concourse.Job
             , pipelineLayers : Dict ( String, String ) (List (List Concourse.Job))
             , query : String
+            , pipelineJobs : Dict ( String, String ) (List Concourse.Job)
         }
     ->
         { bounds : PipelineGrid.Bounds
         , pipeline : Pipeline
+        , index : Int
         }
     -> String
     -> Html Message
-pipelineCardView session params { bounds, pipeline } teamName =
+pipelineCardView session params { bounds, pipeline, index } teamName =
     Html.div
         ([ class "pipeline-wrapper"
          , style "position" "absolute"
@@ -266,14 +267,14 @@ pipelineCardView session params { bounds, pipeline } teamName =
                             "event.dataTransfer.setData('text/plain', '');"
                         , draggable "true"
                         , on "dragstart"
-                            (Json.Decode.succeed (DragStart pipeline.teamName pipeline.ordering))
+                            (Json.Decode.succeed (DragStart pipeline.teamName index))
                         , on "dragend" (Json.Decode.succeed DragEnd)
                         ]
 
                     else
                         []
                    )
-                ++ (if params.dragState == Dragging pipeline.teamName pipeline.ordering then
+                ++ (if params.dragState == Dragging pipeline.teamName index then
                         [ style "width" "0"
                         , style "margin" "0 12.5px"
                         , style "overflow" "hidden"

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -2,26 +2,21 @@ module Dashboard.Group exposing
     ( PipelineIndex
     , hdView
     , ordering
-    , pipelineDropAreaView
     , pipelineNotSetView
     , view
     )
 
 import Concourse
-import Dashboard.Drag exposing (drag)
 import Dashboard.Group.Models exposing (Group, Pipeline)
 import Dashboard.Group.Tag as Tag
 import Dashboard.Models exposing (DragState(..), DropState(..))
 import Dashboard.Pipeline as Pipeline
-import Dashboard.PipelineGridLayout as PipelineGridLayout exposing (cardHeight, cardWidth, padding)
+import Dashboard.PipelineGrid as PipelineGrid
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
 import HoverState
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, class, classList, draggable, id, style)
-import Html.Events exposing (on, preventDefaultOn, stopPropagationOn)
-import Html.Keyed
-import Json.Decode
+import Html.Attributes exposing (attribute, class, id, style)
 import Maybe.Extra
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..))
@@ -39,14 +34,6 @@ ordering session =
 
 type alias PipelineIndex =
     Int
-
-
-type alias Bounds =
-    { x : Float
-    , y : Float
-    , width : Float
-    , height : Float
-    }
 
 
 view :
@@ -69,279 +56,11 @@ view :
     -> ( Html Message, Float )
 view session params g =
     let
-        ( dragTeam, fromIndex, toIndex ) =
-            case ( params.dragState, params.dropState ) of
-                ( Dragging team fromIdx, NotDropping ) ->
-                    ( team, fromIdx, fromIdx + 1 )
-
-                ( Dragging team fromIdx, Dropping toIdx ) ->
-                    ( team, fromIdx, toIdx )
-
-                _ ->
-                    ( "", -1, -1 )
-
-        orderedPipelines =
-            if (g.teamName == dragTeam) && (fromIndex >= 0) then
-                drag fromIndex toIndex g.pipelines
-                    |> List.indexedMap (\i p -> { p | ordering = i })
-
-            else
-                g.pipelines
+        ( grid, gridHeight ) =
+            PipelineGrid.view session params g
 
         headerHeight =
             60
-
-        numColumns =
-            max 1 (floor (params.viewportWidth / (cardWidth + padding)))
-
-        numRowsVisible =
-            ceiling (params.viewportHeight / (cardHeight + padding)) + 1
-
-        numRowsOffset =
-            floor (params.scrollTop / (cardHeight + padding))
-
-        isVisible { row, height } =
-            (numRowsOffset < row + height)
-                && (row <= numRowsOffset + numRowsVisible)
-
-        previewSizes =
-            orderedPipelines
-                |> List.map
-                    (\pipeline ->
-                        Dict.get ( pipeline.name, pipeline.teamName ) params.pipelineLayers
-                            |> Maybe.withDefault []
-                    )
-                |> List.map
-                    (\layers ->
-                        ( List.length layers
-                        , layers
-                            |> List.map List.length
-                            |> List.maximum
-                            |> Maybe.withDefault 0
-                        )
-                    )
-
-        cards =
-            previewSizes
-                |> List.map PipelineGridLayout.cardSize
-                |> PipelineGridLayout.layout numColumns
-
-        numRows =
-            cards
-                |> List.map (\c -> c.row + c.height - 1)
-                |> List.maximum
-                |> Maybe.withDefault 1
-
-        totalCardsHeight =
-            numRows
-                * cardHeight
-                + padding
-                * (numRows - 1)
-
-        cardLookup =
-            cards
-                |> List.map2 Tuple.pair orderedPipelines
-                |> List.map (\( pipeline, card ) -> ( pipeline.id, card ))
-                |> Dict.fromList
-
-        prevAndCurrentCards =
-            cards
-                |> List.map2 Tuple.pair (Nothing :: (cards |> List.map Just))
-
-        dropAreas =
-            (prevAndCurrentCards
-                |> List.indexedMap Tuple.pair
-                |> List.filter (\( _, ( _, card ) ) -> isVisible card)
-                |> List.map
-                    (\( i, ( prevCard, card ) ) ->
-                        let
-                            cardBounds =
-                                { x = (toFloat card.column - 1) * (cardWidth + padding)
-                                , y = (toFloat card.row - 1) * (cardHeight + padding)
-                                , width = cardWidth * toFloat card.width + padding * toFloat card.width
-                                , height = cardHeight * toFloat card.height + padding * (toFloat card.height - 1)
-                                }
-
-                            boundsToRightOf otherCard =
-                                { x = toFloat (otherCard.column - 1 + otherCard.width) * (cardWidth + padding)
-                                , y = (toFloat otherCard.row - 1) * (cardHeight + padding)
-                                , width = cardWidth + padding
-                                , height = cardHeight
-                                }
-
-                            bounds =
-                                case prevCard of
-                                    Just otherCard ->
-                                        if
-                                            (otherCard.row < card.row)
-                                                && (otherCard.column + otherCard.width <= numColumns)
-                                        then
-                                            boundsToRightOf otherCard
-
-                                        else
-                                            cardBounds
-
-                                    Nothing ->
-                                        cardBounds
-                        in
-                        pipelineDropAreaView params.dragState
-                            g.teamName
-                            bounds
-                            (i + 1)
-                    )
-            )
-                ++ (case List.head (List.reverse cards) of
-                        Just lastCard ->
-                            if not (isVisible lastCard) then
-                                []
-
-                            else
-                                [ pipelineDropAreaView params.dragState
-                                    g.teamName
-                                    { x = toFloat lastCard.column * (cardWidth + padding)
-                                    , y = (toFloat lastCard.row - 1) * (cardHeight + padding)
-                                    , width = cardWidth + padding
-                                    , height = cardHeight
-                                    }
-                                    (List.length cards + 1)
-                                ]
-
-                        Nothing ->
-                            []
-                   )
-
-        pipelineCards =
-            if List.isEmpty orderedPipelines then
-                [ ( "not-set", Pipeline.pipelineNotSetView ) ]
-
-            else
-                g.pipelines
-                    |> List.map
-                        (\p ->
-                            cardLookup
-                                |> Dict.get p.id
-                                |> Maybe.withDefault { row = 0, column = 0, width = 0, height = 0 }
-                                |> Tuple.pair p
-                        )
-                    |> List.filter (\( _, card ) -> isVisible card)
-                    |> List.map
-                        (\( pipeline, card ) ->
-                            params.pipelineLayers
-                                |> Dict.get ( pipeline.name, pipeline.teamName )
-                                |> Maybe.withDefault []
-                                |> (\layers -> ( pipeline, card, layers ))
-                        )
-                    |> List.map
-                        (\( pipeline, card, layers ) ->
-                            Html.div
-                                ([ class "pipeline-wrapper"
-                                 , style "position" "absolute"
-                                 , style "transform"
-                                    ("translate("
-                                        ++ String.fromInt ((card.column - 1) * (cardWidth + padding) + padding)
-                                        ++ "px,"
-                                        ++ String.fromInt ((card.row - 1) * (cardHeight + padding))
-                                        ++ "px)"
-                                    )
-                                 , style
-                                    "width"
-                                    (String.fromInt
-                                        (cardWidth
-                                            * card.width
-                                            + padding
-                                            * (card.width - 1)
-                                        )
-                                        ++ "px"
-                                    )
-                                 , style "height"
-                                    (String.fromInt
-                                        (cardHeight
-                                            * card.height
-                                            + padding
-                                            * (card.height - 1)
-                                        )
-                                        ++ "px"
-                                    )
-                                 ]
-                                    ++ (if dragTeam == g.teamName then
-                                            [ style "transition" "transform 0.2s ease-in-out" ]
-
-                                        else
-                                            []
-                                       )
-                                    ++ (case HoverState.hoveredElement params.hovered of
-                                            Just (JobPreview jobID) ->
-                                                if
-                                                    (jobID.teamName == pipeline.teamName)
-                                                        && (jobID.pipelineName == pipeline.name)
-                                                then
-                                                    [ style "z-index" "1" ]
-
-                                                else
-                                                    []
-
-                                            _ ->
-                                                []
-                                       )
-                                )
-                                [ Html.div
-                                    ([ class "card"
-                                     , style "width" "100%"
-                                     , id <| Effects.toHtmlID <| PipelineCard pipeline.id
-                                     , attribute "data-pipeline-name" pipeline.name
-                                     ]
-                                        ++ (if String.isEmpty params.query then
-                                                [ attribute
-                                                    "ondragstart"
-                                                    "event.dataTransfer.setData('text/plain', '');"
-                                                , draggable "true"
-                                                , on "dragstart"
-                                                    (Json.Decode.succeed (DragStart pipeline.teamName pipeline.ordering))
-                                                , on "dragend" (Json.Decode.succeed DragEnd)
-                                                ]
-
-                                            else
-                                                []
-                                           )
-                                        ++ (if params.dragState == Dragging pipeline.teamName pipeline.ordering then
-                                                [ style "width" "0"
-                                                , style "margin" "0 12.5px"
-                                                , style "overflow" "hidden"
-                                                ]
-
-                                            else
-                                                []
-                                           )
-                                        ++ (if params.dropState == DroppingWhileApiRequestInFlight g.teamName then
-                                                [ style "opacity" "0.45", style "pointer-events" "none" ]
-
-                                            else
-                                                [ style "opacity" "1" ]
-                                           )
-                                    )
-                                    [ Pipeline.pipelineView
-                                        { now = params.now
-                                        , pipeline = pipeline
-                                        , resourceError =
-                                            params.pipelinesWithResourceErrors
-                                                |> Dict.get ( pipeline.teamName, pipeline.name )
-                                                |> Maybe.withDefault False
-                                        , existingJobs =
-                                            params.existingJobs
-                                                |> List.filter
-                                                    (\j ->
-                                                        j.teamName == pipeline.teamName && j.pipelineName == pipeline.name
-                                                    )
-                                        , layers = layers
-                                        , hovered = params.hovered
-                                        , pipelineRunningKeyframes = params.pipelineRunningKeyframes
-                                        , userState = session.userState
-                                        , query = params.query
-                                        }
-                                    ]
-                                ]
-                                |> Tuple.pair (String.fromInt pipeline.id)
-                        )
     in
     Html.div
         [ id <| Effects.toHtmlID <| DashboardGroup g.teamName
@@ -366,16 +85,11 @@ view session params g =
                         []
                    )
             )
-        , Html.Keyed.node "div"
-            [ class <| .sectionBodyClass Effects.stickyHeaderConfig
-            , style "position" "relative"
-            , style "height" <| String.fromInt totalCardsHeight ++ "px"
-            ]
-            (pipelineCards ++ [ ( "drop-areas", Html.div [ style "position" "absolute" ] dropAreas ) ])
+        , grid
         ]
         |> (\html ->
                 ( html
-                , toFloat <| totalCardsHeight + headerHeight
+                , gridHeight + headerHeight
                 )
            )
 
@@ -452,38 +166,3 @@ pipelineNotSetView =
                 [ Html.text "no pipelines set" ]
             ]
         ]
-
-
-pipelineDropAreaView : DragState -> String -> Bounds -> Int -> Html Message
-pipelineDropAreaView dragState name { x, y, width, height } index =
-    let
-        active =
-            case dragState of
-                Dragging team _ ->
-                    team == name
-
-                _ ->
-                    False
-    in
-    Html.div
-        [ classList
-            [ ( "drop-area", True )
-            , ( "active", active )
-            ]
-        , style "position" "absolute"
-        , style "transform" <|
-            "translate("
-                ++ String.fromFloat x
-                ++ "px,"
-                ++ String.fromFloat y
-                ++ "px)"
-        , style "width" <| String.fromFloat width ++ "px"
-        , style "height" <| String.fromFloat height ++ "px"
-        , on "dragenter" (Json.Decode.succeed (DragOver name index))
-
-        -- preventDefault is required so that the card will not appear to
-        -- "float" or "snap" back to its original position when dropped.
-        , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver name index, True ))
-        , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
-        ]
-        []

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -12,6 +12,7 @@ import Dashboard.Group.Tag as Tag
 import Dashboard.Models exposing (DragState(..), DropState(..))
 import Dashboard.Pipeline as Pipeline
 import Dashboard.PipelineGrid as PipelineGrid
+import Dashboard.PipelineGrid.Constants as PipelineGridConstants
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
 import HoverState
@@ -89,6 +90,7 @@ view session params g =
         [ Html.div
             [ style "display" "flex"
             , style "align-items" "center"
+            , style "margin-bottom" (String.fromInt PipelineGridConstants.padding ++ "px")
             , class <| .sectionHeaderClass Effects.stickyHeaderConfig
             ]
             (Html.div

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -269,6 +269,20 @@ view session params g =
                                         else
                                             []
                                        )
+                                    ++ (case HoverState.hoveredElement params.hovered of
+                                            Just (JobPreview jobID) ->
+                                                if
+                                                    (jobID.teamName == pipeline.teamName)
+                                                        && (jobID.pipelineName == pipeline.name)
+                                                then
+                                                    [ style "z-index" "1" ]
+
+                                                else
+                                                    []
+
+                                            _ ->
+                                                []
+                                       )
                                 )
                                 [ Html.div
                                     ([ class "card"

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -8,10 +8,12 @@ module Dashboard.Group exposing
     )
 
 import Concourse
-import Dashboard.Group.Models exposing (Group)
+import Dashboard.DashboardPreview as DashboardPreview
+import Dashboard.Group.Models exposing (Group, Pipeline)
 import Dashboard.Group.Tag as Tag
 import Dashboard.Models exposing (DragState(..), DropState(..))
 import Dashboard.Pipeline as Pipeline
+import Dashboard.PipelineGridLayout as PipelineGridLayout
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
 import HoverState
@@ -48,86 +50,169 @@ view :
         , pipelineRunningKeyframes : String
         , pipelinesWithResourceErrors : Dict ( String, String ) Bool
         , existingJobs : List Concourse.Job
+        , pipelineLayers : Dict ( String, String ) (List (List Concourse.Job))
+        , viewportWidth : Float
+        , viewportHeight : Float
+        , scrollTop : Float
         }
     -> Group
-    -> Html Message
-view session { dragState, dropState, now, hovered, pipelineRunningKeyframes, pipelinesWithResourceErrors, existingJobs } g =
+    -> ( Html Message, Float )
+view session params g =
     let
         pipelinesForGroup =
             g.pipelines
+
+        padding =
+            25
+
+        headerHeight =
+            60
+
+        cardWidth =
+            272
+
+        cardHeight =
+            268
+
+        numColumns =
+            max 1 (floor (params.viewportWidth / (cardWidth + padding)))
+
+        numRowsVisible =
+            max 1 (ceiling ((params.viewportHeight - headerHeight) / (cardHeight + padding)))
+
+        numRowsOffset =
+            floor ((params.scrollTop + headerHeight) / (cardHeight + padding))
+
+        isVisible { row, height } =
+            (numRowsOffset < row + height)
+                && (row <= numRowsOffset + numRowsVisible)
+
+        paddingElem =
+            Html.div
+                [ style "grid-row"
+                    ("1 / span " ++ String.fromInt numRows)
+                , style "grid-column" "1 / span 1"
+                , style "width" "1px"
+                ]
+                []
+
+        layersList =
+            pipelinesForGroup
+                |> List.map
+                    (\pipeline ->
+                        Dict.get ( pipeline.name, pipeline.teamName ) params.pipelineLayers
+                            |> Maybe.withDefault []
+                    )
+
+        previewSizes =
+            layersList
+                |> List.map
+                    (\layers ->
+                        ( List.length layers
+                        , layers
+                            |> List.map List.length
+                            |> List.maximum
+                            |> Maybe.withDefault 0
+                        )
+                    )
+
+        cards =
+            previewSizes
+                |> List.map PipelineGridLayout.cardSize
+                |> PipelineGridLayout.layout numColumns
+
+        numRows =
+            cards
+                |> List.map (\c -> c.row + c.height - 1)
+                |> List.maximum
+                |> Maybe.withDefault 1
 
         pipelineCards =
             if List.isEmpty pipelinesForGroup then
                 [ Pipeline.pipelineNotSetView ]
 
             else
-                List.append
-                    (List.map
-                        (\pipeline ->
-                            Html.div [ class "pipeline-wrapper" ]
-                                [ pipelineDropAreaView dragState dropState g.teamName pipeline.ordering
-                                , Html.div
-                                    ([ class "card"
-                                     , id <| Effects.toHtmlID <| PipelineCard pipeline.id
-                                     , attribute "data-pipeline-name" pipeline.name
-                                     , attribute
-                                        "ondragstart"
-                                        "event.dataTransfer.setData('text/plain', '');"
-                                     , draggable "true"
-                                     , on "dragstart"
-                                        (Json.Decode.succeed (DragStart pipeline.teamName pipeline.ordering))
-                                     , on "dragend" (Json.Decode.succeed DragEnd)
-                                     ]
-                                        ++ (if dragState == Dragging pipeline.teamName pipeline.ordering then
-                                                [ style "width" "0"
-                                                , style "margin" "0 12.5px"
-                                                , style "overflow" "hidden"
-                                                ]
-
-                                            else
-                                                []
-                                           )
-                                        ++ (if dropState == DroppingWhileApiRequestInFlight g.teamName then
-                                                [ style "opacity" "0.45", style "pointer-events" "none" ]
-
-                                            else
-                                                [ style "opacity" "1" ]
-                                           )
-                                    )
-                                    [ Pipeline.pipelineView
-                                        { now = now
-                                        , pipeline = pipeline
-                                        , resourceError =
-                                            pipelinesWithResourceErrors
-                                                |> Dict.get ( pipeline.teamName, pipeline.name )
-                                                |> Maybe.withDefault False
-                                        , existingJobs =
-                                            existingJobs
-                                                |> List.filter
-                                                    (\j ->
-                                                        j.teamName == pipeline.teamName && j.pipelineName == pipeline.name
-                                                    )
-                                        , hovered = hovered
-                                        , pipelineRunningKeyframes = pipelineRunningKeyframes
-                                        , userState = session.userState
-                                        }
-                                    ]
-                                ]
-                        )
-                        pipelinesForGroup
-                    )
-                    [ pipelineDropAreaView dragState
-                        dropState
-                        g.teamName
+                paddingElem
+                    :: List.append
                         (pipelinesForGroup
-                            |> List.map (.ordering >> (+) 1)
-                            |> List.maximum
-                            |> Maybe.withDefault 0
+                            |> List.map3
+                                (\card layers pipeline ->
+                                    ( card, layers, pipeline )
+                                )
+                                cards
+                                layersList
+                            |> List.filter (\( card, _, _ ) -> isVisible card)
+                            |> List.map
+                                (\( card, layers, pipeline ) ->
+                                    Html.div
+                                        [ class "pipeline-wrapper"
+                                        , style "grid-column" (String.fromInt card.column ++ " / span " ++ String.fromInt card.width)
+                                        , style "grid-row" (String.fromInt card.row ++ " / span " ++ String.fromInt card.height)
+                                        ]
+                                        [ pipelineDropAreaView params.dragState params.dropState g.teamName pipeline.ordering
+                                        , Html.div
+                                            ([ class "card"
+                                             , style "width" "100%"
+                                             , id <| Effects.toHtmlID <| PipelineCard pipeline.id
+                                             , attribute "data-pipeline-name" pipeline.name
+                                             , attribute
+                                                "ondragstart"
+                                                "event.dataTransfer.setData('text/plain', '');"
+                                             , draggable "true"
+                                             , on "dragstart"
+                                                (Json.Decode.succeed (DragStart pipeline.teamName pipeline.ordering))
+                                             , on "dragend" (Json.Decode.succeed DragEnd)
+                                             ]
+                                                ++ (if params.dragState == Dragging pipeline.teamName pipeline.ordering then
+                                                        [ style "width" "0"
+                                                        , style "margin" "0 12.5px"
+                                                        , style "overflow" "hidden"
+                                                        ]
+
+                                                    else
+                                                        []
+                                                   )
+                                                ++ (if params.dropState == DroppingWhileApiRequestInFlight g.teamName then
+                                                        [ style "opacity" "0.45", style "pointer-events" "none" ]
+
+                                                    else
+                                                        [ style "opacity" "1" ]
+                                                   )
+                                            )
+                                            [ Pipeline.pipelineView
+                                                { now = params.now
+                                                , pipeline = pipeline
+                                                , resourceError =
+                                                    params.pipelinesWithResourceErrors
+                                                        |> Dict.get ( pipeline.teamName, pipeline.name )
+                                                        |> Maybe.withDefault False
+                                                , existingJobs =
+                                                    params.existingJobs
+                                                        |> List.filter
+                                                            (\j ->
+                                                                j.teamName == pipeline.teamName && j.pipelineName == pipeline.name
+                                                            )
+                                                , layers = layers
+                                                , hovered = params.hovered
+                                                , pipelineRunningKeyframes = params.pipelineRunningKeyframes
+                                                , userState = session.userState
+                                                }
+                                            ]
+                                        ]
+                                )
                         )
-                    ]
+                        [ pipelineDropAreaView params.dragState
+                            params.dropState
+                            g.teamName
+                            (pipelinesForGroup
+                                |> List.map (.ordering >> (+) 1)
+                                |> List.maximum
+                                |> Maybe.withDefault 0
+                            )
+                        ]
     in
     Html.div
-        [ id g.teamName
+        [ id <| Effects.toHtmlID <| DashboardGroup g.teamName
         , class "dashboard-team-group"
         , attribute "data-team-name" g.teamName
         ]
@@ -142,7 +227,7 @@ view session { dragState, dropState, now, hovered, pipelineRunningKeyframes, pip
                 :: (Maybe.Extra.toList <|
                         Maybe.map (Tag.view False) (tag session g)
                    )
-                ++ (if dropState == DroppingWhileApiRequestInFlight g.teamName then
+                ++ (if params.dropState == DroppingWhileApiRequestInFlight g.teamName then
                         [ Spinner.spinner { sizePx = 20, margin = "0 0 0 10px" } ]
 
                     else
@@ -150,9 +235,34 @@ view session { dragState, dropState, now, hovered, pipelineRunningKeyframes, pip
                    )
             )
         , Html.div
-            [ class <| .sectionBodyClass Effects.stickyHeaderConfig ]
+            [ class <| .sectionBodyClass Effects.stickyHeaderConfig
+            , style "display" "grid"
+            , style "grid-template-columns" <|
+                "repeat("
+                    ++ String.fromInt numColumns
+                    ++ ","
+                    ++ String.fromInt cardWidth
+                    ++ "px)"
+            , style "grid-template-rows" <|
+                "repeat("
+                    ++ String.fromInt numRows
+                    ++ ","
+                    ++ String.fromInt cardHeight
+                    ++ "px)"
+            , style "grid-gap" <| String.fromInt padding ++ "px"
+            ]
             pipelineCards
         ]
+        |> (\html ->
+                ( html
+                , toFloat <|
+                    numRows
+                        * cardHeight
+                        + padding
+                        * (numRows - 1)
+                        + headerHeight
+                )
+           )
 
 
 tag : { a | userState : UserState } -> Group -> Maybe Tag.Tag

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -260,7 +260,6 @@ pipelineCardView session params { bounds, pipeline, index } teamName =
         [ Html.div
             ([ class "card"
              , style "width" "100%"
-             , id <| Effects.toHtmlID <| PipelineCard pipeline.id
              , attribute "data-pipeline-name" pipeline.name
              ]
                 ++ (if String.isEmpty params.query then

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -95,10 +95,10 @@ view session params g =
             max 1 (floor (params.viewportWidth / (cardWidth + padding)))
 
         numRowsVisible =
-            max 1 (ceiling ((params.viewportHeight - headerHeight) / (cardHeight + padding)))
+            ceiling (params.viewportHeight / (cardHeight + padding)) + 1
 
         numRowsOffset =
-            floor ((params.scrollTop + headerHeight) / (cardHeight + padding))
+            floor (params.scrollTop / (cardHeight + padding))
 
         isVisible { row, height } =
             (numRowsOffset < row + height)

--- a/web/elm/src/Dashboard/Group/Models.elm
+++ b/web/elm/src/Dashboard/Group/Models.elm
@@ -9,7 +9,6 @@ type alias Group =
 
 type alias Pipeline =
     { id : Int
-    , ordering : Int
     , name : String
     , teamName : String
     , public : Bool

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -22,12 +22,16 @@ type alias Model =
             , query : String
             , pipelinesWithResourceErrors : Dict ( String, String ) Bool
             , existingJobs : List Concourse.Job
+            , pipelineLayers : Dict ( String, String ) (List (List Concourse.Job))
             , dragState : DragState
             , dropState : DropState
             , isJobsRequestFinished : Bool
             , isTeamsRequestFinished : Bool
             , isPipelinesRequestFinished : Bool
             , isResourcesRequestFinished : Bool
+            , viewportWidth : Float
+            , viewportHeight : Float
+            , scrollTop : Float
             }
         )
 

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -32,6 +32,7 @@ type alias Model =
             , viewportWidth : Float
             , viewportHeight : Float
             , scrollTop : Float
+            , pipelineJobs : Dict ( String, String ) (List Concourse.Job)
             }
         )
 

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -87,11 +87,19 @@ pipelineView :
     , resourceError : Bool
     , existingJobs : List Concourse.Job
     , layers : List (List Concourse.Job)
+    , query : String
     }
     -> Html Message
-pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, resourceError, existingJobs, layers } =
+pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, resourceError, existingJobs, layers, query } =
     Html.div
-        Styles.pipelineCard
+        (Styles.pipelineCard
+            ++ (if String.isEmpty query then
+                    [ style "cursor" "move" ]
+
+                else
+                    []
+               )
+        )
         [ Html.div
             (class "banner"
                 :: Styles.pipelineCardBanner

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -27,7 +27,7 @@ import Views.Styles
 
 pipelineNotSetView : Html Message
 pipelineNotSetView =
-    Html.div [ class "card" ]
+    Html.div (class "card" :: Styles.noPipelineCard)
         [ Html.div
             (class "card-header" :: Styles.noPipelineCardHeader)
             [ Html.text "no pipeline set"
@@ -86,9 +86,10 @@ pipelineView :
     , userState : UserState
     , resourceError : Bool
     , existingJobs : List Concourse.Job
+    , layers : List (List Concourse.Job)
     }
     -> Html Message
-pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, resourceError, existingJobs } =
+pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, resourceError, existingJobs, layers } =
     Html.div
         Styles.pipelineCard
         [ Html.div
@@ -100,7 +101,7 @@ pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, reso
             )
             []
         , headerView pipeline resourceError
-        , bodyView hovered existingJobs
+        , bodyView hovered layers
         , footerView userState pipeline now hovered existingJobs
         ]
 
@@ -223,11 +224,11 @@ headerView pipeline resourceError =
         ]
 
 
-bodyView : HoverState.HoverState -> List Concourse.Job -> Html Message
-bodyView hovered existingJobs =
+bodyView : HoverState.HoverState -> List (List Concourse.Job) -> Html Message
+bodyView hovered layers =
     Html.div
         (class "card-body" :: Styles.pipelineCardBody)
-        [ DashboardPreview.view hovered existingJobs ]
+        [ DashboardPreview.view hovered layers ]
 
 
 footerView :

--- a/web/elm/src/Dashboard/PipelineGrid.elm
+++ b/web/elm/src/Dashboard/PipelineGrid.elm
@@ -1,0 +1,367 @@
+module Dashboard.PipelineGrid exposing (view)
+
+import Concourse
+import Dashboard.Drag exposing (drag)
+import Dashboard.Group.Models exposing (Group, Pipeline)
+import Dashboard.Models exposing (DragState(..), DropState(..))
+import Dashboard.Pipeline as Pipeline
+import Dashboard.PipelineGrid.Constants exposing (cardHeight, cardWidth, padding)
+import Dashboard.PipelineGrid.Layout as Layout
+import Dict exposing (Dict)
+import HoverState
+import Html exposing (Html)
+import Html.Attributes exposing (attribute, class, classList, draggable, id, style)
+import Html.Events exposing (on, preventDefaultOn, stopPropagationOn)
+import Html.Keyed
+import Json.Decode
+import Message.Effects as Effects
+import Message.Message exposing (DomID(..), Message(..))
+import Time
+import UserState exposing (UserState(..))
+
+
+type alias Bounds =
+    { x : Float
+    , y : Float
+    , width : Float
+    , height : Float
+    }
+
+
+view :
+    { a | userState : UserState }
+    ->
+        { dragState : DragState
+        , dropState : DropState
+        , now : Maybe Time.Posix
+        , hovered : HoverState.HoverState
+        , pipelineRunningKeyframes : String
+        , pipelinesWithResourceErrors : Dict ( String, String ) Bool
+        , existingJobs : List Concourse.Job
+        , pipelineLayers : Dict ( String, String ) (List (List Concourse.Job))
+        , viewportWidth : Float
+        , viewportHeight : Float
+        , scrollTop : Float
+        , query : String
+        }
+    -> Group
+    -> ( Html Message, Float )
+view session params g =
+    let
+        ( dragTeam, fromIndex, toIndex ) =
+            case ( params.dragState, params.dropState ) of
+                ( Dragging team fromIdx, NotDropping ) ->
+                    ( team, fromIdx, fromIdx + 1 )
+
+                ( Dragging team fromIdx, Dropping toIdx ) ->
+                    ( team, fromIdx, toIdx )
+
+                _ ->
+                    ( "", -1, -1 )
+
+        orderedPipelines =
+            if (g.teamName == dragTeam) && (fromIndex >= 0) then
+                drag fromIndex toIndex g.pipelines
+                    |> List.indexedMap (\i p -> { p | ordering = i })
+
+            else
+                g.pipelines
+
+        numColumns =
+            max 1 (floor (params.viewportWidth / (cardWidth + padding)))
+
+        numRowsVisible =
+            ceiling (params.viewportHeight / (cardHeight + padding)) + 1
+
+        numRowsOffset =
+            floor (params.scrollTop / (cardHeight + padding))
+
+        isVisible { row, height } =
+            (numRowsOffset < row + height)
+                && (row <= numRowsOffset + numRowsVisible)
+
+        previewSizes =
+            orderedPipelines
+                |> List.map
+                    (\pipeline ->
+                        Dict.get ( pipeline.name, pipeline.teamName ) params.pipelineLayers
+                            |> Maybe.withDefault []
+                    )
+                |> List.map
+                    (\layers ->
+                        ( List.length layers
+                        , layers
+                            |> List.map List.length
+                            |> List.maximum
+                            |> Maybe.withDefault 0
+                        )
+                    )
+
+        cards =
+            previewSizes
+                |> List.map Layout.cardSize
+                |> Layout.layout numColumns
+
+        numRows =
+            cards
+                |> List.map (\c -> c.row + c.height - 1)
+                |> List.maximum
+                |> Maybe.withDefault 1
+
+        totalCardsHeight =
+            numRows
+                * cardHeight
+                + padding
+                * (numRows - 1)
+
+        cardLookup =
+            cards
+                |> List.map2 Tuple.pair orderedPipelines
+                |> List.map (\( pipeline, card ) -> ( pipeline.id, card ))
+                |> Dict.fromList
+
+        prevAndCurrentCards =
+            cards
+                |> List.map2 Tuple.pair (Nothing :: (cards |> List.map Just))
+
+        dropAreas =
+            (prevAndCurrentCards
+                |> List.indexedMap Tuple.pair
+                |> List.filter (\( _, ( _, card ) ) -> isVisible card)
+                |> List.map
+                    (\( i, ( prevCard, card ) ) ->
+                        let
+                            cardBounds =
+                                { x = (toFloat card.column - 1) * (cardWidth + padding)
+                                , y = (toFloat card.row - 1) * (cardHeight + padding)
+                                , width = cardWidth * toFloat card.width + padding * toFloat card.width
+                                , height = cardHeight * toFloat card.height + padding * (toFloat card.height - 1)
+                                }
+
+                            boundsToRightOf otherCard =
+                                { x = toFloat (otherCard.column - 1 + otherCard.width) * (cardWidth + padding)
+                                , y = (toFloat otherCard.row - 1) * (cardHeight + padding)
+                                , width = cardWidth + padding
+                                , height = cardHeight
+                                }
+
+                            bounds =
+                                case prevCard of
+                                    Just otherCard ->
+                                        if
+                                            (otherCard.row < card.row)
+                                                && (otherCard.column + otherCard.width <= numColumns)
+                                        then
+                                            boundsToRightOf otherCard
+
+                                        else
+                                            cardBounds
+
+                                    Nothing ->
+                                        cardBounds
+                        in
+                        pipelineDropAreaView params.dragState
+                            g.teamName
+                            bounds
+                            (i + 1)
+                    )
+            )
+                ++ (case List.head (List.reverse cards) of
+                        Just lastCard ->
+                            if not (isVisible lastCard) then
+                                []
+
+                            else
+                                [ pipelineDropAreaView params.dragState
+                                    g.teamName
+                                    { x = toFloat lastCard.column * (cardWidth + padding)
+                                    , y = (toFloat lastCard.row - 1) * (cardHeight + padding)
+                                    , width = cardWidth + padding
+                                    , height = cardHeight
+                                    }
+                                    (List.length cards + 1)
+                                ]
+
+                        Nothing ->
+                            []
+                   )
+
+        pipelineCards =
+            if List.isEmpty orderedPipelines then
+                [ ( "not-set", Pipeline.pipelineNotSetView ) ]
+
+            else
+                g.pipelines
+                    |> List.map
+                        (\p ->
+                            cardLookup
+                                |> Dict.get p.id
+                                |> Maybe.withDefault { row = 0, column = 0, width = 0, height = 0 }
+                                |> Tuple.pair p
+                        )
+                    |> List.filter (\( _, card ) -> isVisible card)
+                    |> List.map
+                        (\( pipeline, card ) ->
+                            params.pipelineLayers
+                                |> Dict.get ( pipeline.name, pipeline.teamName )
+                                |> Maybe.withDefault []
+                                |> (\layers -> ( pipeline, card, layers ))
+                        )
+                    |> List.map
+                        (\( pipeline, card, layers ) ->
+                            Html.div
+                                ([ class "pipeline-wrapper"
+                                 , style "position" "absolute"
+                                 , style "transform"
+                                    ("translate("
+                                        ++ String.fromInt ((card.column - 1) * (cardWidth + padding) + padding)
+                                        ++ "px,"
+                                        ++ String.fromInt ((card.row - 1) * (cardHeight + padding))
+                                        ++ "px)"
+                                    )
+                                 , style
+                                    "width"
+                                    (String.fromInt
+                                        (cardWidth
+                                            * card.width
+                                            + padding
+                                            * (card.width - 1)
+                                        )
+                                        ++ "px"
+                                    )
+                                 , style "height"
+                                    (String.fromInt
+                                        (cardHeight
+                                            * card.height
+                                            + padding
+                                            * (card.height - 1)
+                                        )
+                                        ++ "px"
+                                    )
+                                 ]
+                                    ++ (if dragTeam == g.teamName then
+                                            [ style "transition" "transform 0.2s ease-in-out" ]
+
+                                        else
+                                            []
+                                       )
+                                    ++ (case HoverState.hoveredElement params.hovered of
+                                            Just (JobPreview jobID) ->
+                                                if
+                                                    (jobID.teamName == pipeline.teamName)
+                                                        && (jobID.pipelineName == pipeline.name)
+                                                then
+                                                    [ style "z-index" "1" ]
+
+                                                else
+                                                    []
+
+                                            _ ->
+                                                []
+                                       )
+                                )
+                                [ Html.div
+                                    ([ class "card"
+                                     , style "width" "100%"
+                                     , id <| Effects.toHtmlID <| PipelineCard pipeline.id
+                                     , attribute "data-pipeline-name" pipeline.name
+                                     ]
+                                        ++ (if String.isEmpty params.query then
+                                                [ attribute
+                                                    "ondragstart"
+                                                    "event.dataTransfer.setData('text/plain', '');"
+                                                , draggable "true"
+                                                , on "dragstart"
+                                                    (Json.Decode.succeed (DragStart pipeline.teamName pipeline.ordering))
+                                                , on "dragend" (Json.Decode.succeed DragEnd)
+                                                ]
+
+                                            else
+                                                []
+                                           )
+                                        ++ (if params.dragState == Dragging pipeline.teamName pipeline.ordering then
+                                                [ style "width" "0"
+                                                , style "margin" "0 12.5px"
+                                                , style "overflow" "hidden"
+                                                ]
+
+                                            else
+                                                []
+                                           )
+                                        ++ (if params.dropState == DroppingWhileApiRequestInFlight g.teamName then
+                                                [ style "opacity" "0.45", style "pointer-events" "none" ]
+
+                                            else
+                                                [ style "opacity" "1" ]
+                                           )
+                                    )
+                                    [ Pipeline.pipelineView
+                                        { now = params.now
+                                        , pipeline = pipeline
+                                        , resourceError =
+                                            params.pipelinesWithResourceErrors
+                                                |> Dict.get ( pipeline.teamName, pipeline.name )
+                                                |> Maybe.withDefault False
+                                        , existingJobs =
+                                            params.existingJobs
+                                                |> List.filter
+                                                    (\j ->
+                                                        j.teamName == pipeline.teamName && j.pipelineName == pipeline.name
+                                                    )
+                                        , layers = layers
+                                        , hovered = params.hovered
+                                        , pipelineRunningKeyframes = params.pipelineRunningKeyframes
+                                        , userState = session.userState
+                                        , query = params.query
+                                        }
+                                    ]
+                                ]
+                                |> Tuple.pair (String.fromInt pipeline.id)
+                        )
+    in
+    Html.Keyed.node "div"
+        [ class <| .sectionBodyClass Effects.stickyHeaderConfig
+        , style "position" "relative"
+        , style "height" <| String.fromInt totalCardsHeight ++ "px"
+        ]
+        (pipelineCards ++ [ ( "drop-areas", Html.div [ style "position" "absolute" ] dropAreas ) ])
+        |> (\html ->
+                ( html
+                , toFloat <| totalCardsHeight
+                )
+           )
+
+
+pipelineDropAreaView : DragState -> String -> Bounds -> Int -> Html Message
+pipelineDropAreaView dragState name { x, y, width, height } index =
+    let
+        active =
+            case dragState of
+                Dragging team _ ->
+                    team == name
+
+                _ ->
+                    False
+    in
+    Html.div
+        [ classList
+            [ ( "drop-area", True )
+            , ( "active", active )
+            ]
+        , style "position" "absolute"
+        , style "transform" <|
+            "translate("
+                ++ String.fromFloat x
+                ++ "px,"
+                ++ String.fromFloat y
+                ++ "px)"
+        , style "width" <| String.fromFloat width ++ "px"
+        , style "height" <| String.fromFloat height ++ "px"
+        , on "dragenter" (Json.Decode.succeed (DragOver name index))
+
+        -- preventDefault is required so that the card will not appear to
+        -- "float" or "snap" back to its original position when dropped.
+        , preventDefaultOn "dragover" (Json.Decode.succeed ( DragOver name index, True ))
+        , stopPropagationOn "drop" (Json.Decode.succeed ( DragEnd, True ))
+        ]
+        []

--- a/web/elm/src/Dashboard/PipelineGrid.elm
+++ b/web/elm/src/Dashboard/PipelineGrid.elm
@@ -27,6 +27,7 @@ type alias Bounds =
 type alias PipelineCard =
     { bounds : Bounds
     , pipeline : Pipeline
+    , index : Int
     }
 
 
@@ -66,7 +67,6 @@ computeLayout params g =
         orderedPipelines =
             if (g.teamName == dragTeam) && (fromIndex >= 0) then
                 drag fromIndex toIndex g.pipelines
-                    |> List.indexedMap (\i p -> { p | ordering = i })
 
             else
                 g.pipelines
@@ -189,16 +189,16 @@ computeLayout params g =
 
         pipelineCards =
             g.pipelines
-                |> List.map
-                    (\pipeline ->
+                |> List.indexedMap
+                    (\i pipeline ->
                         cardLookup
                             |> Dict.get pipeline.id
                             |> Maybe.withDefault { row = 0, column = 0, width = 0, height = 0 }
-                            |> (\card -> ( pipeline, card ))
+                            |> (\card -> ( i, pipeline, card ))
                     )
-                |> List.filter (\( _, card ) -> isVisible card)
+                |> List.filter (\( _, _, card ) -> isVisible card)
                 |> List.map
-                    (\( pipeline, card ) ->
+                    (\( i, pipeline, card ) ->
                         { pipeline = pipeline
                         , bounds =
                             { x = (toFloat card.column - 1) * (cardWidth + padding) + padding
@@ -214,6 +214,7 @@ computeLayout params g =
                                     + padding
                                     * (toFloat card.height - 1)
                             }
+                        , index = i
                         }
                     )
     in

--- a/web/elm/src/Dashboard/PipelineGrid.elm
+++ b/web/elm/src/Dashboard/PipelineGrid.elm
@@ -116,7 +116,7 @@ computeLayout params g =
             toFloat numRows
                 * cardHeight
                 + padding
-                * (toFloat numRows - 1)
+                * toFloat numRows
 
         cardLookup =
             cards

--- a/web/elm/src/Dashboard/PipelineGrid/Constants.elm
+++ b/web/elm/src/Dashboard/PipelineGrid/Constants.elm
@@ -1,0 +1,16 @@
+module Dashboard.PipelineGrid.Constants exposing (cardHeight, cardWidth, padding)
+
+
+cardWidth : number
+cardWidth =
+    272
+
+
+cardHeight : number
+cardHeight =
+    268
+
+
+padding : number
+padding =
+    25

--- a/web/elm/src/Dashboard/PipelineGrid/Constants.elm
+++ b/web/elm/src/Dashboard/PipelineGrid/Constants.elm
@@ -1,4 +1,9 @@
-module Dashboard.PipelineGrid.Constants exposing (cardHeight, cardWidth, padding)
+module Dashboard.PipelineGrid.Constants exposing
+    ( cardHeight
+    , cardWidth
+    , headerHeight
+    , padding
+    )
 
 
 cardWidth : number
@@ -14,3 +19,8 @@ cardHeight =
 padding : number
 padding =
     25
+
+
+headerHeight : number
+headerHeight =
+    60

--- a/web/elm/src/Dashboard/PipelineGrid/Layout.elm
+++ b/web/elm/src/Dashboard/PipelineGrid/Layout.elm
@@ -1,25 +1,4 @@
-module Dashboard.PipelineGridLayout exposing
-    ( cardHeight
-    , cardSize
-    , cardWidth
-    , layout
-    , padding
-    )
-
-
-cardWidth : number
-cardWidth =
-    272
-
-
-cardHeight : number
-cardHeight =
-    268
-
-
-padding : number
-padding =
-    25
+module Dashboard.PipelineGrid.Layout exposing (cardSize, layout)
 
 
 type alias GridSpan =

--- a/web/elm/src/Dashboard/PipelineGridLayout.elm
+++ b/web/elm/src/Dashboard/PipelineGridLayout.elm
@@ -1,0 +1,74 @@
+module Dashboard.PipelineGridLayout exposing (cardSize, layout)
+
+
+type alias GridSpan =
+    Int
+
+
+type alias Card =
+    { width : GridSpan
+    , height : GridSpan
+    , column : Int
+    , row : Int
+    }
+
+
+countToSpan : Int -> GridSpan
+countToSpan count =
+    if count > 24 then
+        3
+
+    else if count > 12 then
+        2
+
+    else
+        1
+
+
+cardSize : ( Int, Int ) -> ( GridSpan, GridSpan )
+cardSize ( w, h ) =
+    ( countToSpan w
+    , countToSpan h
+    )
+
+
+layout : Int -> List ( GridSpan, GridSpan ) -> List Card
+layout numColumns cardSizes =
+    cardSizes
+        |> List.foldl
+            (\( w, h ) { cards, column, row, rowHeight } ->
+                let
+                    breaksRow =
+                        (column + w > numColumns + 1)
+                            && (column /= 1)
+
+                    newColumn =
+                        if breaksRow then
+                            1
+
+                        else
+                            column
+
+                    newRow =
+                        if breaksRow then
+                            row + rowHeight
+
+                        else
+                            row
+
+                    newRowHeight =
+                        if breaksRow then
+                            h
+
+                        else
+                            max rowHeight h
+                in
+                { cards = { width = w, height = h, column = newColumn, row = newRow } :: cards
+                , column = newColumn + w
+                , row = newRow
+                , rowHeight = newRowHeight
+                }
+            )
+            { cards = [], column = 1, row = 1, rowHeight = 1 }
+        |> .cards
+        |> List.reverse

--- a/web/elm/src/Dashboard/PipelineGridLayout.elm
+++ b/web/elm/src/Dashboard/PipelineGridLayout.elm
@@ -1,4 +1,25 @@
-module Dashboard.PipelineGridLayout exposing (cardSize, layout)
+module Dashboard.PipelineGridLayout exposing
+    ( cardHeight
+    , cardSize
+    , cardWidth
+    , layout
+    , padding
+    )
+
+
+cardWidth : number
+cardWidth =
+    272
+
+
+cardHeight : number
+cardHeight =
+    268
+
+
+padding : number
+padding =
+    25
 
 
 type alias GridSpan =

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -17,6 +17,7 @@ module Dashboard.Styles exposing
     , legend
     , legendItem
     , legendSeparator
+    , noPipelineCard
     , noPipelineCardHd
     , noPipelineCardHeader
     , noPipelineCardTextHd
@@ -31,6 +32,7 @@ module Dashboard.Styles exposing
     , pipelineCardHeader
     , pipelineCardTransitionAge
     , pipelineName
+    , pipelinePreviewGrid
     , previewPlaceholder
     , resourceErrorTriangle
     , searchButton
@@ -93,7 +95,9 @@ content highDensity =
 pipelineCard : List (Html.Attribute msg)
 pipelineCard =
     [ style "cursor" "move"
-    , style "margin" "25px"
+    , style "height" "100%"
+    , style "display" "flex"
+    , style "flex-direction" "column"
     ]
 
 
@@ -111,6 +115,13 @@ pipelineCardBanner { status, pipelineRunningKeyframes } =
             Concourse.PipelineStatus.isRunning status
     in
     style "height" "7px" :: texture pipelineRunningKeyframes isRunning color
+
+
+noPipelineCard : List (Html.Attribute msg)
+noPipelineCard =
+    [ style "display" "flex"
+    , style "flex-direction" "column"
+    ]
 
 
 noPipelineCardHd : List (Html.Attribute msg)
@@ -166,12 +177,11 @@ pipelineName =
 
 cardBody : List (Html.Attribute msg)
 cardBody =
-    [ style "width" "200px"
-    , style "height" "120px"
-    , style "padding" "20px 36px"
+    [ style "padding" "20px 36px"
     , style "background-color" Colors.card
     , style "margin" "2px 0"
     , style "display" "flex"
+    , style "flex-grow" "1"
     ]
 
 
@@ -179,6 +189,15 @@ pipelineCardBody : List (Html.Attribute msg)
 pipelineCardBody =
     [ style "background-color" Colors.card
     , style "margin" "2px 0"
+    , style "flex-grow" "1"
+    ]
+
+
+pipelinePreviewGrid : List (Html.Attribute msg)
+pipelinePreviewGrid =
+    [ style "box-sizing" "border-box"
+    , style "width" "100%"
+    , style "height" "100%"
     ]
 
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -123,6 +123,7 @@ noPipelineCard =
     , style "flex-direction" "column"
     , style "width" <| String.fromInt PipelineGridConstants.cardWidth ++ "px"
     , style "height" <| String.fromInt PipelineGridConstants.cardHeight ++ "px"
+    , style "margin-left" <| String.fromInt PipelineGridConstants.padding ++ "px"
     ]
 
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -95,8 +95,7 @@ content highDensity =
 
 pipelineCard : List (Html.Attribute msg)
 pipelineCard =
-    [ style "cursor" "move"
-    , style "height" "100%"
+    [ style "height" "100%"
     , style "display" "flex"
     , style "flex-direction" "column"
     ]

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -56,6 +56,7 @@ import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.Cli as Cli
 import Concourse.PipelineStatus exposing (PipelineStatus(..))
+import Dashboard.PipelineGridLayout as PipelineGridLayout
 import Html
 import Html.Attributes exposing (style)
 import ScreenSize exposing (ScreenSize(..))
@@ -121,6 +122,8 @@ noPipelineCard : List (Html.Attribute msg)
 noPipelineCard =
     [ style "display" "flex"
     , style "flex-direction" "column"
+    , style "width" <| String.fromInt PipelineGridLayout.cardWidth ++ "px"
+    , style "height" <| String.fromInt PipelineGridLayout.cardHeight ++ "px"
     ]
 
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -56,7 +56,7 @@ import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.Cli as Cli
 import Concourse.PipelineStatus exposing (PipelineStatus(..))
-import Dashboard.PipelineGridLayout as PipelineGridLayout
+import Dashboard.PipelineGrid.Constants as PipelineGridConstants
 import Html
 import Html.Attributes exposing (style)
 import ScreenSize exposing (ScreenSize(..))
@@ -121,8 +121,8 @@ noPipelineCard : List (Html.Attribute msg)
 noPipelineCard =
     [ style "display" "flex"
     , style "flex-direction" "column"
-    , style "width" <| String.fromInt PipelineGridLayout.cardWidth ++ "px"
-    , style "height" <| String.fromInt PipelineGridLayout.cardHeight ++ "px"
+    , style "width" <| String.fromInt PipelineGridConstants.cardWidth ++ "px"
+    , style "height" <| String.fromInt PipelineGridConstants.cardHeight ++ "px"
     ]
 
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -345,6 +345,7 @@ infoBar :
     -> List (Html.Attribute msg)
 infoBar { hideLegend, screenSize } =
     [ style "position" "fixed"
+    , style "z-index" "2"
     , style "bottom" "0"
     , style "line-height" "35px"
     , style "padding" "7.5px 30px"

--- a/web/elm/src/HoverState.elm
+++ b/web/elm/src/HoverState.elm
@@ -1,6 +1,7 @@
 module HoverState exposing
     ( HoverState(..)
     , TooltipPosition(..)
+    , hoveredElement
     , isHovered
     )
 
@@ -19,17 +20,27 @@ type HoverState
     | Tooltip DomID TooltipPosition
 
 
-isHovered : DomID -> HoverState -> Bool
-isHovered domID hoverState =
+hoveredElement : HoverState -> Maybe DomID
+hoveredElement hoverState =
     case hoverState of
         NoHover ->
-            False
+            Nothing
 
         Hovered d ->
-            d == domID
+            Just d
 
         TooltipPending d ->
-            d == domID
+            Just d
 
         Tooltip d _ ->
+            Just d
+
+
+isHovered : DomID -> HoverState -> Bool
+isHovered domID hoverState =
+    case hoveredElement hoverState of
+        Nothing ->
+            False
+
+        Just d ->
             d == domID

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -13,6 +13,7 @@ import Message.Message
         ( VersionId
         , VersionToggleAction
         , VisibilityAction
+        , DomID
         )
 import Time
 
@@ -60,7 +61,7 @@ type Callback
     | BuildAborted (Fetched ())
     | VisibilityChanged VisibilityAction Concourse.PipelineIdentifier (Fetched ())
     | AllPipelinesFetched (Fetched (List Concourse.Pipeline))
-    | GotViewport TooltipPolicy (Result Browser.Dom.Error Browser.Dom.Viewport)
+    | GotViewport DomID TooltipPolicy (Result Browser.Dom.Error Browser.Dom.Viewport)
     | GotElement (Result Browser.Dom.Error Browser.Dom.Element)
 
 

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -10,10 +10,10 @@ import Http
 import Json.Encode
 import Message.Message
     exposing
-        ( VersionId
+        ( DomID
+        , VersionId
         , VersionToggleAction
         , VisibilityAction
-        , DomID
         )
 import Time
 

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -480,6 +480,9 @@ toHtmlID domId =
         StepState stepID ->
             stepID ++ "_state"
 
+        PipelineCard databaseID ->
+            "pipeline-" ++ String.fromInt databaseID
+
         _ ->
             ""
 

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -458,7 +458,7 @@ runEffect effect key csrfToken =
 
         GetViewportOf domID tooltipPolicy ->
             Browser.Dom.getViewportOf (toHtmlID domID)
-                |> Task.attempt (GotViewport tooltipPolicy)
+                |> Task.attempt (GotViewport domID tooltipPolicy)
 
         GetElement domID ->
             Browser.Dom.getElement (toHtmlID domID)

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -483,6 +483,12 @@ toHtmlID domId =
         PipelineCard databaseID ->
             "pipeline-" ++ String.fromInt databaseID
 
+        Dashboard ->
+            "dashboard"
+
+        DashboardGroup teamName ->
+            teamName
+
         _ ->
             ""
 

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -480,9 +480,6 @@ toHtmlID domId =
         StepState stepID ->
             stepID ++ "_state"
 
-        PipelineCard databaseID ->
-            "pipeline-" ++ String.fromInt databaseID
-
         Dashboard ->
             "dashboard"
 

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -80,7 +80,6 @@ type DomID
     | HamburgerMenu
     | SideBarTeam String
     | SideBarPipeline Concourse.PipelineIdentifier
-    | PipelineCard Int
     | Dashboard
     | DashboardGroup String
 

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -80,6 +80,7 @@ type DomID
     | HamburgerMenu
     | SideBarTeam String
     | SideBarPipeline Concourse.PipelineIdentifier
+    | PipelineCard Int
 
 
 type VersionToggleAction

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -81,6 +81,8 @@ type DomID
     | SideBarTeam String
     | SideBarPipeline Concourse.PipelineIdentifier
     | PipelineCard Int
+    | Dashboard
+    | DashboardGroup String
 
 
 type VersionToggleAction

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -17,7 +17,7 @@ type alias Model m =
 handleCallback : Callback -> ET (Model m)
 handleCallback callback ( model, effects ) =
     case callback of
-        GotViewport policy (Ok { scene, viewport }) ->
+        GotViewport _ policy (Ok { scene, viewport }) ->
             case model.hovered of
                 HoverState.Hovered domID ->
                     if policy == OnlyShowWhenOverflowing && viewport.width >= scene.width then

--- a/web/elm/tests/BuildStepTests.elm
+++ b/web/elm/tests/BuildStepTests.elm
@@ -255,10 +255,12 @@ iVisitABuildWithASetPipelineStep =
         >> myBrowserFetchedTheBuild
         >> thePlanContainsASetPipelineStep
 
+
 iVisitABuildWithALoadVarStep =
     iOpenTheBuildPage
         >> myBrowserFetchedTheBuild
         >> thePlanContainsALoadVarStep
+
 
 theGetStepIsExpanded =
     Tuple.first
@@ -274,9 +276,11 @@ theSetPipelineStepIsExpanded =
     Tuple.first
         >> Application.update (Update <| Message.Click <| StepHeader setPipelineStepId)
 
+
 theLoadVarStepIsExpanded =
     Tuple.first
         >> Application.update (Update <| Message.Click <| StepHeader setLoadVarStepId)
+
 
 thePlanContainsARetryStep =
     Tuple.first
@@ -344,6 +348,7 @@ thePlanContainsASetPipelineStep =
 setPipelineStepId =
     "setPipelineStep"
 
+
 thePlanContainsALoadVarStep =
     Tuple.first
         >> Application.handleCallback
@@ -358,8 +363,10 @@ thePlanContainsALoadVarStep =
                     )
             )
 
+
 setLoadVarStepId =
     "loadVarStep"
+
 
 thePlanContainsAGetStep =
     Tuple.first
@@ -545,8 +552,10 @@ iSeeATimestamp =
 iSeeThePipelineName =
     Query.has [ text "pipeline-name" ]
 
+
 iSeeTheLoadVarName =
     Query.has [ text "var-name" ]
+
 
 iAmLookingAtTheSecondTab =
     iAmLookingAtTheTabList >> Query.children [] >> Query.index 1

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -2885,7 +2885,7 @@ all =
                             )
                         >> Tuple.first
                         >> Application.handleCallback
-                            (Callback.GotViewport Callback.AlwaysShow <|
+                            (Callback.GotViewport firstOccurrenceLabelID Callback.AlwaysShow <|
                                 Ok
                                     { scene =
                                         { width = 1
@@ -3118,7 +3118,9 @@ all =
                             )
                         >> Tuple.first
                         >> Application.handleCallback
-                            (Callback.GotViewport Callback.AlwaysShow <|
+                            (Callback.GotViewport (Message.Message.StepState "plan")
+                                Callback.AlwaysShow
+                             <|
                                 Ok
                                     { scene =
                                         { width = 1
@@ -3203,7 +3205,9 @@ all =
                             )
                         >> Tuple.first
                         >> Application.handleCallback
-                            (Callback.GotViewport Callback.AlwaysShow <|
+                            (Callback.GotViewport (Message.Message.StepState "plan")
+                                Callback.AlwaysShow
+                             <|
                                 Ok
                                     { scene =
                                         { width = 1

--- a/web/elm/tests/DashboardPreviewTests.elm
+++ b/web/elm/tests/DashboardPreviewTests.elm
@@ -179,7 +179,6 @@ dashboardWithJob j =
                 Ok
                     [ j
                     , { j | pipelineName = "other" }
-                    , { j | teamName = "banana" }
                     ]
             )
         |> Tuple.first
@@ -187,7 +186,6 @@ dashboardWithJob j =
             (Callback.AllTeamsFetched <|
                 Ok
                     [ { id = 0, name = "team" }
-                    , { id = 1, name = "banana" }
                     ]
             )
         |> Tuple.first
@@ -206,13 +204,6 @@ dashboardWithJob j =
                       , paused = False
                       , public = True
                       , teamName = "team"
-                      , groups = []
-                      }
-                    , { id = 2
-                      , name = "pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "banana"
                       , groups = []
                       }
                     ]

--- a/web/elm/tests/DashboardRenderingTests.elm
+++ b/web/elm/tests/DashboardRenderingTests.elm
@@ -8,7 +8,7 @@ import Json.Encode as Encode
 import Message.Callback as Callback
 import Message.Effects exposing (Effect(..))
 import Message.Message exposing (DomID(..), Message(..))
-import Message.Subscription as Subscription
+import Message.Subscription as Subscription exposing (Delivery(..))
 import Message.TopLevelMessage exposing (TopLevelMessage(..))
 import Test exposing (Test, describe, test)
 import Test.Html.Event as Event
@@ -96,11 +96,23 @@ all =
                     }
                     |> Tuple.second
                     |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
-        , test "requests the dashboard viewport when the window is resized" <|
+        , test "fetches the viewport of the scrollable area when the window is resized" <|
             \_ ->
                 Common.init "/"
                     |> Application.handleDelivery
                         (Subscription.WindowResized 800 600)
+                    |> Tuple.second
+                    |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
+        , test "fetches the viewport of the scrollable area when the sidebar is opened" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.update (Update <| Click HamburgerMenu)
+                    |> Tuple.second
+                    |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
+        , test "fetches the viewport of the scrollable area when the sidebar state is loaded" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleDelivery (SideBarStateReceived Nothing)
                     |> Tuple.second
                     |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
         , test "renders pipeline cards in a single column grid when the viewport is narrow" <|
@@ -112,7 +124,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
                                 viewportWithSize 300 600
                         )
@@ -142,9 +154,45 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
                                 viewportWithSize 650 200
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Expect.all
+                        [ hasPipelineCard "pipeline-0"
+                            { x = 25
+                            , y = 0
+                            , width = 272
+                            , height = 268
+                            }
+                        , hasPipelineCard "pipeline-1"
+                            { x = 25 * 2 + 272
+                            , y = 0
+                            , width = 272
+                            , height = 268
+                            }
+                        ]
+        , test "ignores viewport updates for DOM elements other than the dashboard" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 650 200
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport LoginButton Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 100 50
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -178,7 +226,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
                                 viewportWithSize 600 300
                         )
@@ -209,7 +257,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
                                 viewportWithSize 600 500
                         )
@@ -246,7 +294,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
                                 viewportWithSize 600 200
                         )
@@ -293,7 +341,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
                                 viewportWithSize 600 250
                         )
@@ -325,7 +373,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
                                 viewportWithSize 600 250
                         )
@@ -351,7 +399,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
                                 viewportWithSize 300 300
                         )

--- a/web/elm/tests/DashboardRenderingTests.elm
+++ b/web/elm/tests/DashboardRenderingTests.elm
@@ -2,6 +2,7 @@ module DashboardRenderingTests exposing (all)
 
 import Application.Application as Application
 import Common
+import Concourse
 import Data
 import Expect
 import Json.Encode as Encode
@@ -33,20 +34,22 @@ all =
                 }
             }
 
-        hasPipelineCard name { x, y, width, height } =
+        findPipelineCard name =
             Query.find [ class "pipeline-wrapper", containing [ text name ] ]
-                >> Query.has
-                    [ style "position" "absolute"
-                    , style "transform"
-                        ("translate("
-                            ++ String.fromInt x
-                            ++ "px,"
-                            ++ String.fromInt y
-                            ++ "px)"
-                        )
-                    , style "width" (String.fromInt width ++ "px")
-                    , style "height" (String.fromInt height ++ "px")
-                    ]
+
+        hasBounds { x, y, width, height } =
+            Query.has
+                [ style "position" "absolute"
+                , style "transform"
+                    ("translate("
+                        ++ String.fromInt x
+                        ++ "px,"
+                        ++ String.fromInt y
+                        ++ "px)"
+                    )
+                , style "width" (String.fromInt width ++ "px")
+                , style "height" (String.fromInt height ++ "px")
+                ]
 
         containerHasHeight height =
             Query.has
@@ -132,18 +135,20 @@ all =
                     |> Common.queryView
                     |> Query.find [ class "dashboard-team-pipelines" ]
                     |> Expect.all
-                        [ hasPipelineCard "pipeline-0"
-                            { x = 25
-                            , y = 0
-                            , width = 272
-                            , height = 268
-                            }
-                        , hasPipelineCard "pipeline-1"
-                            { x = 25
-                            , y = 268 + 25
-                            , width = 272
-                            , height = 268
-                            }
+                        [ findPipelineCard "pipeline-0"
+                            >> hasBounds
+                                { x = 25
+                                , y = 0
+                                , width = 272
+                                , height = 268
+                                }
+                        , findPipelineCard "pipeline-1"
+                            >> hasBounds
+                                { x = 25
+                                , y = 268 + 25
+                                , width = 272
+                                , height = 268
+                                }
                         ]
         , test "renders pipeline cards in a multi-column grid when the viewport is wide" <|
             \_ ->
@@ -162,18 +167,20 @@ all =
                     |> Common.queryView
                     |> Query.find [ class "dashboard-team-pipelines" ]
                     |> Expect.all
-                        [ hasPipelineCard "pipeline-0"
-                            { x = 25
-                            , y = 0
-                            , width = 272
-                            , height = 268
-                            }
-                        , hasPipelineCard "pipeline-1"
-                            { x = 25 * 2 + 272
-                            , y = 0
-                            , width = 272
-                            , height = 268
-                            }
+                        [ findPipelineCard "pipeline-0"
+                            >> hasBounds
+                                { x = 25
+                                , y = 0
+                                , width = 272
+                                , height = 268
+                                }
+                        , findPipelineCard "pipeline-1"
+                            >> hasBounds
+                                { x = 25 * 2 + 272
+                                , y = 0
+                                , width = 272
+                                , height = 268
+                                }
                         ]
         , test "ignores viewport updates for DOM elements other than the dashboard" <|
             \_ ->
@@ -198,18 +205,20 @@ all =
                     |> Common.queryView
                     |> Query.find [ class "dashboard-team-pipelines" ]
                     |> Expect.all
-                        [ hasPipelineCard "pipeline-0"
-                            { x = 25
-                            , y = 0
-                            , width = 272
-                            , height = 268
-                            }
-                        , hasPipelineCard "pipeline-1"
-                            { x = 25 * 2 + 272
-                            , y = 0
-                            , width = 272
-                            , height = 268
-                            }
+                        [ findPipelineCard "pipeline-0"
+                            >> hasBounds
+                                { x = 25
+                                , y = 0
+                                , width = 272
+                                , height = 268
+                                }
+                        , findPipelineCard "pipeline-1"
+                            >> hasBounds
+                                { x = 25 * 2 + 272
+                                , y = 0
+                                , width = 272
+                                , height = 268
+                                }
                         ]
         , test "pipelines with many jobs are rendered as cards spanning several rows" <|
             \_ ->
@@ -234,19 +243,59 @@ all =
                     |> Common.queryView
                     |> Query.find [ class "dashboard-team-pipelines" ]
                     |> Expect.all
-                        [ hasPipelineCard "pipeline-0"
-                            { x = 25
-                            , y = 0
-                            , width = 272
-                            , height = 268 * 2 + 25
-                            }
-                        , hasPipelineCard "pipeline-1"
-                            { x = 25 * 2 + 272
-                            , y = 0
-                            , width = 272
-                            , height = 268
-                            }
+                        [ findPipelineCard "pipeline-0"
+                            >> hasBounds
+                                { x = 25
+                                , y = 0
+                                , width = 272
+                                , height = 268 * 2 + 25
+                                }
+                        , findPipelineCard "pipeline-1"
+                            >> hasBounds
+                                { x = 25 * 2 + 272
+                                , y = 0
+                                , width = 272
+                                , height = 268
+                                }
                         , containerHasHeight <| 268 * 2 + 25
+                        ]
+        , test "pipelines with many dependant jobs are rendered as spanning multiple columns" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllJobsFetched <|
+                            Ok <|
+                                jobsWithDepth 0 15
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 950 300
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Expect.all
+                        [ findPipelineCard "pipeline-0"
+                            >> hasBounds
+                                { x = 25
+                                , y = 0
+                                , width = 272 * 2 + 25
+                                , height = 268
+                                }
+                        , findPipelineCard "pipeline-1"
+                            >> hasBounds
+                                { x = 25 + 2 * (272 + 25)
+                                , y = 0
+                                , width = 272
+                                , height = 268
+                                }
                         ]
         , test "wraps cards to the next row" <|
             \_ ->
@@ -265,24 +314,27 @@ all =
                     |> Common.queryView
                     |> Query.find [ class "dashboard-team-pipelines" ]
                     |> Expect.all
-                        [ hasPipelineCard "pipeline-0"
-                            { x = 25
-                            , y = 0
-                            , width = 272
-                            , height = 268
-                            }
-                        , hasPipelineCard "pipeline-1"
-                            { x = 25 * 2 + 272
-                            , y = 0
-                            , width = 272
-                            , height = 268
-                            }
-                        , hasPipelineCard "pipeline-2"
-                            { x = 25
-                            , y = 268 + 25
-                            , width = 272
-                            , height = 268
-                            }
+                        [ findPipelineCard "pipeline-0"
+                            >> hasBounds
+                                { x = 25
+                                , y = 0
+                                , width = 272
+                                , height = 268
+                                }
+                        , findPipelineCard "pipeline-1"
+                            >> hasBounds
+                                { x = 25 * 2 + 272
+                                , y = 0
+                                , width = 272
+                                , height = 268
+                                }
+                        , findPipelineCard "pipeline-2"
+                            >> hasBounds
+                                { x = 25
+                                , y = 268 + 25
+                                , width = 272
+                                , height = 268
+                                }
                         , containerHasHeight <| 268 * 2 + 25
                         ]
         , test "doesn't render rows below the viewport" <|
@@ -407,4 +459,139 @@ all =
                     |> Common.queryView
                     |> Query.find [ id "team-2" ]
                     |> Query.hasNot [ class "pipeline-wrapper" ]
+        , describe "drop areas" <|
+            [ test "renders a drop area over each pipeline card" <|
+                \_ ->
+                    Common.init "/"
+                        |> Application.handleCallback
+                            (Callback.AllPipelinesFetched <|
+                                Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1, Data.pipeline "team" 2 ]
+                            )
+                        |> Tuple.first
+                        |> Application.handleCallback
+                            (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                                Ok <|
+                                    viewportWithSize 600 500
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find [ class "dashboard-team-pipelines" ]
+                        |> Query.findAll [ class "drop-area" ]
+                        |> Expect.all
+                            [ Query.index 0
+                                >> hasBounds
+                                    { x = 0
+                                    , y = 0
+                                    , width = 272 + 25
+                                    , height = 268
+                                    }
+                            , Query.index 1
+                                >> hasBounds
+                                    { x = 272 + 25
+                                    , y = 0
+                                    , width = 272 + 25
+                                    , height = 268
+                                    }
+                            , Query.index 2
+                                >> hasBounds
+                                    { x = 0
+                                    , y = 268 + 25
+                                    , width = 272 + 25
+                                    , height = 268
+                                    }
+                            ]
+            , test "does not render drop areas for rows that are not visible" <|
+                \_ ->
+                    Common.init "/"
+                        |> Application.handleCallback
+                            (Callback.AllPipelinesFetched <|
+                                Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                            )
+                        |> Tuple.first
+                        |> Application.handleCallback
+                            (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                                Ok <|
+                                    viewportWithSize 300 200
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find [ class "dashboard-team-pipelines" ]
+                        |> Query.findAll [ class "drop-area" ]
+                        |> Query.count (Expect.equal 1)
+            , test "renders the drop area up one row when the card breaks the row, but there is space for a smaller card" <|
+                \_ ->
+                    Common.init "/"
+                        |> Application.handleCallback
+                            (Callback.AllPipelinesFetched <|
+                                Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                            )
+                        |> Tuple.first
+                        |> Application.handleCallback
+                            (Callback.AllJobsFetched <|
+                                Ok <|
+                                    jobsWithDepth 1 15
+                            )
+                        |> Tuple.first
+                        |> Application.handleCallback
+                            (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                                Ok <|
+                                    viewportWithSize 600 500
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find [ class "dashboard-team-pipelines" ]
+                        |> Query.findAll [ class "drop-area" ]
+                        |> Expect.all
+                            [ Query.index 0
+                                >> hasBounds
+                                    { x = 0
+                                    , y = 0
+                                    , width = 272 + 25
+                                    , height = 268
+                                    }
+                            , Query.index 1
+                                >> hasBounds
+                                    { x = 272 + 25
+                                    , y = 0
+                                    , width = 272 + 25
+                                    , height = 268
+                                    }
+                            ]
+            ]
         ]
+
+
+jobsWithDepth : Int -> Int -> List Concourse.Job
+jobsWithDepth pipelineID depth =
+    let
+        job =
+            Data.job pipelineID
+    in
+    if depth < 1 then
+        []
+
+    else if depth == 1 then
+        [ { job
+            | name = "1"
+            , inputs =
+                [ { name = ""
+                  , resource = ""
+                  , passed = []
+                  , trigger = False
+                  }
+                ]
+          }
+        ]
+
+    else
+        { job
+            | name = String.fromInt depth
+            , inputs =
+                [ { name = ""
+                  , resource = ""
+                  , passed = [ String.fromInt <| depth - 1 ]
+                  , trigger = False
+                  }
+                ]
+        }
+            :: (jobsWithDepth pipelineID <| depth - 1)

--- a/web/elm/tests/DashboardRenderingTests.elm
+++ b/web/elm/tests/DashboardRenderingTests.elm
@@ -1,0 +1,365 @@
+module DashboardRenderingTests exposing (all)
+
+import Application.Application as Application
+import Common
+import Data
+import Expect
+import Json.Encode as Encode
+import Message.Callback as Callback
+import Message.Effects exposing (Effect(..))
+import Message.Message exposing (DomID(..), Message(..))
+import Message.Subscription as Subscription
+import Message.TopLevelMessage exposing (TopLevelMessage(..))
+import Test exposing (Test, describe, test)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (class, containing, id, style, text)
+import Url
+
+
+all : Test
+all =
+    let
+        viewportWithSize width height =
+            { scene =
+                { width = width
+                , height = height
+                }
+            , viewport =
+                { width = width
+                , height = height
+                , x = 0
+                , y = 0
+                }
+            }
+    in
+    describe "dashboard rendering"
+        [ test "renders pipeline cards in a grid" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 300 600
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Query.has
+                        [ style "display" "grid"
+                        , style "grid-template-columns" "repeat(1,272px)"
+                        , style "grid-template-rows" "repeat(2,268px)"
+                        , style "grid-gap" "25px"
+                        ]
+        , test "number of grid columns respects viewport size" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 650 200
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Query.has
+                        [ style "display" "grid"
+                        , style "grid-template-columns" "repeat(2,272px)"
+                        , style "grid-template-rows" "repeat(1,268px)"
+                        , style "grid-gap" "25px"
+                        ]
+        , test "fetches the viewport of the scrollable area on load" <|
+            \_ ->
+                Application.init
+                    { turbulenceImgSrc = ""
+                    , notFoundImgSrc = "notfound.svg"
+                    , csrfToken = "csrf_token"
+                    , authToken = ""
+                    , pipelineRunningKeyframes = "pipeline-running"
+                    }
+                    { protocol = Url.Http
+                    , host = ""
+                    , port_ = Nothing
+                    , path = "/"
+                    , query = Nothing
+                    , fragment = Nothing
+                    }
+                    |> Tuple.second
+                    |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
+        , test "requests the dashboard viewport when the window is resized" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleDelivery
+                        (Subscription.WindowResized 800 600)
+                    |> Tuple.second
+                    |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
+        , test "positions cards filling available columns" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 600 300
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Expect.all
+                        [ Query.find
+                            [ class "pipeline-wrapper"
+                            , containing [ text "pipeline-0" ]
+                            ]
+                            >> Query.has
+                                [ style "grid-column" "1 / span 1"
+                                , style "grid-row" "1 / span 1"
+                                ]
+                        , Query.find
+                            [ class "pipeline-wrapper"
+                            , containing [ text "pipeline-1" ]
+                            ]
+                            >> Query.has
+                                [ style "grid-column" "2 / span 1"
+                                , style "grid-row" "1 / span 1"
+                                ]
+                        ]
+        , test "pipelines with many jobs are rendered as cards spanning several rows" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllJobsFetched <|
+                            Ok <|
+                                List.repeat 15 (Data.job 0)
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 600 300
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Expect.all
+                        [ Query.has
+                            [ style "grid-template-columns" "repeat(2,272px)"
+                            , style "grid-template-rows" "repeat(2,268px)"
+                            ]
+                        , Query.find
+                            [ class "pipeline-wrapper"
+                            , containing [ text "pipeline-0" ]
+                            ]
+                            >> Query.has
+                                [ style "grid-column" "1 / span 1"
+                                , style "grid-row" "1 / span 2"
+                                ]
+                        , Query.find
+                            [ class "pipeline-wrapper"
+                            , containing [ text "pipeline-1" ]
+                            ]
+                            >> Query.has
+                                [ style "grid-column" "2 / span 1"
+                                , style "grid-row" "1 / span 1"
+                                ]
+                        ]
+        , test "wraps cards to the next row" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1, Data.pipeline "team" 2 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 600 500
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Expect.all
+                        [ Query.find
+                            [ class "pipeline-wrapper"
+                            , containing [ text "pipeline-0" ]
+                            ]
+                            >> Query.has
+                                [ style "grid-column" "1 / span 1"
+                                , style "grid-row" "1 / span 1"
+                                ]
+                        , Query.find
+                            [ class "pipeline-wrapper"
+                            , containing [ text "pipeline-1" ]
+                            ]
+                            >> Query.has
+                                [ style "grid-column" "2 / span 1"
+                                , style "grid-row" "1 / span 1"
+                                ]
+                        , Query.find
+                            [ class "pipeline-wrapper"
+                            , containing [ text "pipeline-2" ]
+                            ]
+                            >> Query.has
+                                [ style "grid-column" "1 / span 1"
+                                , style "grid-row" "2 / span 1"
+                                ]
+                        ]
+        , test "doesn't render rows below the viewport" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1, Data.pipeline "team" 2 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 600 200
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Query.hasNot [ class "pipeline-wrapper", containing [ text "pipeline-2" ] ]
+        , test "body has a scroll handler" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1, Data.pipeline "team" 2 ]
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ id "dashboard" ]
+                    |> Event.simulate
+                        (Event.custom "scroll" <|
+                            Encode.object
+                                [ ( "target"
+                                  , Encode.object
+                                        [ ( "clientHeight", Encode.int 0 )
+                                        , ( "scrollTop", Encode.int 0 )
+                                        , ( "scrollHeight", Encode.int 0 )
+                                        ]
+                                  )
+                                ]
+                        )
+                    |> Event.expect
+                        (Update <|
+                            Scrolled
+                                { scrollHeight = 0
+                                , scrollTop = 0
+                                , clientHeight = 0
+                                }
+                        )
+        , test "rows are hidden as they are scrolled out of view" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1, Data.pipeline "team" 2 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 600 250
+                        )
+                    |> Tuple.first
+                    |> Application.update
+                        (Update <|
+                            Scrolled
+                                { scrollTop = 600
+                                , scrollHeight = 3240
+                                , clientHeight = 250
+                                }
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Query.hasNot [ class "pipeline-wrapper", containing [ text "pipeline-0" ] ]
+        , test "tall cards are not hidden when only its top row is scrolled out of view" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllJobsFetched <|
+                            Ok <|
+                                List.repeat 30 (Data.job 0)
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 600 250
+                        )
+                    |> Tuple.first
+                    |> Application.update
+                        (Update <|
+                            Scrolled
+                                { scrollTop = 600
+                                , scrollHeight = 3240
+                                , clientHeight = 250
+                                }
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Query.has [ class "pipeline-wrapper", containing [ text "pipeline-0" ] ]
+        , test "renders an element that spans all rows to prevent scrolling jank" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1, Data.pipeline "team" 2 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 300 300
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Query.has [ style "grid-row" "1 / span 3" ]
+        , test "considers a group's y-offset when determining visibility" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1, Data.pipeline "team-2" 2 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 300 300
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ id "team-2" ]
+                    |> Query.hasNot [ class "pipeline-wrapper" ]
+        ]

--- a/web/elm/tests/DashboardRenderingTests.elm
+++ b/web/elm/tests/DashboardRenderingTests.elm
@@ -459,6 +459,28 @@ all =
                     |> Common.queryView
                     |> Query.find [ id "team-2" ]
                     |> Query.hasNot [ class "pipeline-wrapper" ]
+        , test "pipeline wrapper has a z-index of 1 when hovering over it" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0 ]
+                        )
+                    |> Tuple.first
+                    |> Application.update
+                        (Update <|
+                            Hover <|
+                                Just <|
+                                    JobPreview
+                                        { teamName = "team"
+                                        , pipelineName = "pipeline-0"
+                                        , jobName = "job"
+                                        }
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Query.has [ class "pipeline-wrapper", style "z-index" "1" ]
         , describe "drop areas" <|
             [ test "renders a drop area over each pipeline card" <|
                 \_ ->

--- a/web/elm/tests/DashboardRenderingTests.elm
+++ b/web/elm/tests/DashboardRenderingTests.elm
@@ -348,7 +348,7 @@ all =
                     |> Application.handleCallback
                         (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
-                                viewportWithSize 600 200
+                                viewportWithSize 300 200
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -453,7 +453,7 @@ all =
                     |> Application.handleCallback
                         (Callback.GotViewport Dashboard Callback.AlwaysShow <|
                             Ok <|
-                                viewportWithSize 300 300
+                                viewportWithSize 300 200
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -505,7 +505,7 @@ all =
                     Common.init "/"
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
-                                Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                                Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1, Data.pipeline "team" 2 ]
                             )
                         |> Tuple.first
                         |> Application.handleCallback
@@ -517,7 +517,7 @@ all =
                         |> Common.queryView
                         |> Query.find [ class "dashboard-team-pipelines" ]
                         |> Query.findAll [ class "drop-area" ]
-                        |> Query.count (Expect.equal 1)
+                        |> Query.count (Expect.equal 2)
             , test "renders the drop area up one row when the card breaks the row, but there is space for a smaller card" <|
                 \_ ->
                     Common.init "/"

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -1115,6 +1115,28 @@ all =
                                 , style "align-items" "center"
                                 ]
                             )
+            , test "team headers have a bottom margin of 25px" <|
+                \_ ->
+                    whenOnDashboard { highDensity = False }
+                        |> givenDataUnauthenticated (apiData [ ( "team", [] ) ])
+                        |> Tuple.first
+                        |> Application.handleCallback
+                            (Callback.AllPipelinesFetched <|
+                                Ok
+                                    [ { id = 0
+                                      , name = "pipeline"
+                                      , paused = False
+                                      , public = True
+                                      , teamName = "team"
+                                      , groups = []
+                                      }
+                                    ]
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.findAll teamHeaderSelector
+                        |> Query.each
+                            (Query.has [ style "margin-bottom" "25px" ])
             , test "on HD view, there is space between the list of pipelines and the role pill" <|
                 \_ ->
                     whenOnDashboard { highDensity = True }

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -1262,6 +1262,27 @@ all =
                             [ style "display" "flex"
                             , style "justify-content" "space-between"
                             ]
+            , test "has a z-index of 2" <|
+                \_ ->
+                    whenOnDashboard { highDensity = False }
+                        |> givenDataUnauthenticated (apiData [ ( "team", [] ) ])
+                        |> Tuple.first
+                        |> Application.handleCallback
+                            (Callback.AllPipelinesFetched <|
+                                Ok
+                                    [ { id = 0
+                                      , name = "pipeline"
+                                      , paused = False
+                                      , public = True
+                                      , teamName = "team"
+                                      , groups = []
+                                      }
+                                    ]
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find [ id "dashboard-info" ]
+                        |> Query.has [ style "z-index" "2" ]
             , test "two children are legend and concourse-info" <|
                 \_ ->
                     whenOnDashboard { highDensity = False }

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -1,7 +1,10 @@
 module Data exposing
     ( check
+    , job
     , jobBuild
     , jobId
+    , jobName
+    , pipeline
     , pipelineName
     , resource
     , resourceName
@@ -61,6 +64,41 @@ resource pinnedVersion =
     , pinComment = Nothing
     , icon = Nothing
     }
+
+
+pipeline : String -> Int -> Concourse.Pipeline
+pipeline team id =
+    { id = id
+    , name = "pipeline-" ++ String.fromInt id
+    , paused = False
+    , public = True
+    , teamName = team
+    , groups = []
+    }
+
+
+job : Int -> Concourse.Job
+job pipelineID =
+    { pipeline =
+        { teamName = teamName
+        , pipelineName = "pipeline-" ++ String.fromInt pipelineID
+        }
+    , name = jobName
+    , pipelineName = "pipeline-" ++ String.fromInt pipelineID
+    , teamName = teamName
+    , nextBuild = Nothing
+    , finishedBuild = Nothing
+    , transitionBuild = Nothing
+    , paused = False
+    , disableManualTrigger = False
+    , inputs = []
+    , outputs = []
+    , groups = []
+    }
+
+
+jobName =
+    "job"
 
 
 teamName =

--- a/web/elm/tests/DragAndDropTests.elm
+++ b/web/elm/tests/DragAndDropTests.elm
@@ -33,12 +33,12 @@ all =
                 >> given iAmDraggingTheFirstPipelineCard
                 >> when iAmLookingAtTheFirstPipelineCard
                 >> then_ itIsInvisible
-        , test "initial drop area grows when dragging starts" <|
+        , test "pipeline cards wrappers transition their transform when dragging" <|
             given iVisitedTheDashboard
                 >> given myBrowserFetchedOnePipeline
                 >> given iAmDraggingTheFirstPipelineCard
-                >> when iAmLookingAtTheInitialDropArea
-                >> then_ itIsWide
+                >> when iAmLookingAtTheFirstPipelineCardWrapper
+                >> then_ itHasTransformTransition
         , test "final drop area has dragenter listener" <|
             given iVisitedTheDashboard
                 >> given myBrowserFetchedOnePipeline
@@ -49,26 +49,12 @@ all =
                 >> given myBrowserFetchedOnePipeline
                 >> when iAmLookingAtTheFinalDropArea
                 >> then_ itListensForDragOverPreventingDefault
-        , test "initial drop area shrinks when dragging over final drop area" <|
-            given iVisitedTheDashboard
-                >> given myBrowserFetchedOnePipeline
-                >> given iAmDraggingTheFirstPipelineCard
-                >> given iAmDraggingOverTheSecondDropArea
-                >> when iAmLookingAtTheInitialDropArea
-                >> then_ itIsNarrow
         , test "pipeline card has dragend listener" <|
             given iVisitedTheDashboard
                 >> given myBrowserFetchedOnePipeline
                 >> given iAmDraggingTheFirstPipelineCard
                 >> when iAmLookingAtTheFirstPipelineCard
                 >> then_ itListensForDragEnd
-        , test "initial drop area shrinks when pipeline card is dropped" <|
-            given iVisitedTheDashboard
-                >> given myBrowserFetchedOnePipeline
-                >> given iAmDraggingTheFirstPipelineCard
-                >> given iDropThePipelineCard
-                >> when iAmLookingAtTheInitialDropArea
-                >> then_ itIsNarrow
         , test "pipeline card becomes visible when it is dropped" <|
             given iVisitedTheDashboard
                 >> given myBrowserFetchedOnePipeline
@@ -268,6 +254,13 @@ iAmLookingAtTheFirstPipelineCard =
         >> Query.first
 
 
+iAmLookingAtTheFirstPipelineCardWrapper =
+    Tuple.first
+        >> Common.queryView
+        >> Query.findAll [ class "pipeline-wrapper" ]
+        >> Query.first
+
+
 iAmLookingAtTheInitialDropArea =
     Tuple.first
         >> Common.queryView
@@ -311,12 +304,8 @@ itIsVisible =
         ]
 
 
-itIsWide =
-    Query.has [ style "padding" "0 198.5px" ]
-
-
-itIsNarrow =
-    Query.has [ style "padding" "0 50px" ]
+itHasTransformTransition =
+    Query.has [ style "transition" "transform 0.2s ease-in-out" ]
 
 
 theyAreClickable =
@@ -337,7 +326,7 @@ iAmLookingAtTheFinalDropArea =
 itListensForDragEnter =
     Event.simulate (Event.custom "dragenter" (Encode.object []))
         >> Event.expect
-            (TopLevelMessage.Update <| Message.DragOver "team" 1)
+            (TopLevelMessage.Update <| Message.DragOver "team" 2)
 
 
 
@@ -351,19 +340,19 @@ itListensForDragEnter =
 itListensForDragOverPreventingDefault =
     Event.simulate (Event.custom "dragover" (Encode.object []))
         >> Event.expect
-            (TopLevelMessage.Update <| Message.DragOver "team" 1)
+            (TopLevelMessage.Update <| Message.DragOver "team" 2)
 
 
 iAmDraggingOverTheSecondDropArea =
     Tuple.first
         >> Application.update
-            (TopLevelMessage.Update <| Message.DragOver "team" 1)
+            (TopLevelMessage.Update <| Message.DragOver "team" 2)
 
 
 iAmDraggingOverTheThirdDropArea =
     Tuple.first
         >> Application.update
-            (TopLevelMessage.Update <| Message.DragOver "team" 2)
+            (TopLevelMessage.Update <| Message.DragOver "team" 3)
 
 
 iAmLookingAtTheTeamHeader =

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -16,7 +16,7 @@ import Message.TopLevelMessage as ApplicationMsgs
 import Test exposing (Test, describe, test)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (attribute, class, containing, id, style, tag, text)
+import Test.Html.Selector exposing (attribute, class, containing, style, tag, text)
 import Time
 
 
@@ -277,30 +277,6 @@ all =
                         , style "display" "flex"
                         , style "flex-direction" "column"
                         ]
-        , test "has an id of 'pipeline-<id>'" <|
-            \_ ->
-                whenOnDashboard { highDensity = False }
-                    |> givenDataUnauthenticated (apiData [ ( "team", [] ) ])
-                    |> Tuple.first
-                    |> Application.handleCallback
-                        (Callback.AllPipelinesFetched <|
-                            Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
-                        )
-                    |> Tuple.first
-                    |> Common.queryView
-                    |> Query.find
-                        [ class "card"
-                        , containing [ text "pipeline" ]
-                        ]
-                    |> Query.has [ id "pipeline-0" ]
         , describe "header" <|
             let
                 header : () -> Query.Single ApplicationMsgs.TopLevelMessage

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -120,6 +120,10 @@ all =
                             [ style "width" "272px"
                             , style "height" "268px"
                             ]
+                , test "card has a left margin of 25px" <|
+                    noPipelinesCard
+                        >> Query.has
+                            [ style "margin-left" "25px" ]
                 ]
             , describe "header" <|
                 let

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -193,7 +193,7 @@ all =
                         , style "height" "47px"
                         ]
             ]
-        , test "has 'move' cursor" <|
+        , test "has 'move' cursor when not searching" <|
             \_ ->
                 whenOnDashboard { highDensity = False }
                     |> givenDataUnauthenticated (apiData [ ( "team", [] ) ])
@@ -217,6 +217,33 @@ all =
                         , containing [ text "pipeline" ]
                         ]
                     |> Query.has [ style "cursor" "move" ]
+        , test "does not have 'move' cursor when searching" <|
+            \_ ->
+                whenOnDashboard { highDensity = False }
+                    |> givenDataUnauthenticated (apiData [ ( "team", [] ) ])
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok
+                                [ { id = 0
+                                  , name = "pipeline"
+                                  , paused = False
+                                  , public = True
+                                  , teamName = "team"
+                                  , groups = []
+                                  }
+                                ]
+                        )
+                    |> Tuple.first
+                    |> Application.update
+                        (ApplicationMsgs.Update <| Msgs.FilterMsg "pipeline")
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find
+                        [ class "card"
+                        , containing [ text "pipeline" ]
+                        ]
+                    |> Query.hasNot [ style "cursor" "move" ]
         , test "fills available space" <|
             \_ ->
                 whenOnDashboard { highDensity = False }

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -1046,6 +1046,35 @@ all =
                             False
                         |> card
                         |> Query.has [ style "background-color" amber ]
+            , test "card is not affected by jobs from other pipelines" <|
+                \_ ->
+                    whenOnDashboard { highDensity = True }
+                        |> Application.handleCallback
+                            (Callback.AllPipelinesFetched <|
+                                Ok
+                                    [ { id = 0
+                                      , name = "pipeline"
+                                      , paused = False
+                                      , public = True
+                                      , teamName = "team"
+                                      , groups = []
+                                      }
+                                    ]
+                            )
+                        |> Tuple.first
+                        |> Application.handleCallback
+                            (Callback.AllJobsFetched <|
+                                let
+                                    baseJob =
+                                        job BuildStatusErrored
+                                in
+                                Ok
+                                    [ { baseJob | pipelineName = "other-pipeline" } ]
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> card
+                        |> Query.hasNot [ style "background-color" amber ]
             ]
         , describe "body" <|
             let

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -16,7 +16,7 @@ import Message.TopLevelMessage as ApplicationMsgs
 import Test exposing (Test, describe, test)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (attribute, class, containing, style, tag, text)
+import Test.Html.Selector exposing (attribute, class, containing, id, style, tag, text)
 import Time
 
 
@@ -227,6 +227,30 @@ all =
                         , containing [ text "pipeline" ]
                         ]
                     |> Query.has [ style "margin" "25px" ]
+        , test "has an id of 'pipeline-<id>'" <|
+            \_ ->
+                whenOnDashboard { highDensity = False }
+                    |> givenDataUnauthenticated (apiData [ ( "team", [] ) ])
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok
+                                [ { id = 0
+                                  , name = "pipeline"
+                                  , paused = False
+                                  , public = True
+                                  , teamName = "team"
+                                  , groups = []
+                                  }
+                                ]
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find
+                        [ class "card"
+                        , containing [ text "pipeline" ]
+                        ]
+                    |> Query.has [ id "pipeline-0" ]
         , describe "header" <|
             let
                 header : () -> Query.Single ApplicationMsgs.TopLevelMessage

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -114,6 +114,12 @@ all =
                             [ style "display" "flex"
                             , style "flex-direction" "column"
                             ]
+                , test "card has width 272px and height 268px" <|
+                    noPipelinesCard
+                        >> Query.has
+                            [ style "width" "272px"
+                            , style "height" "268px"
+                            ]
                 ]
             , describe "header" <|
                 let

--- a/web/elm/tests/PipelineGridLayoutTests.elm
+++ b/web/elm/tests/PipelineGridLayoutTests.elm
@@ -1,6 +1,6 @@
 module PipelineGridLayoutTests exposing (all)
 
-import Dashboard.PipelineGridLayout exposing (cardSize, layout)
+import Dashboard.PipelineGrid.Layout exposing (cardSize, layout)
 import Expect
 import Test exposing (Test, describe, test, todo)
 

--- a/web/elm/tests/PipelineGridLayoutTests.elm
+++ b/web/elm/tests/PipelineGridLayoutTests.elm
@@ -1,0 +1,145 @@
+module PipelineGridLayoutTests exposing (all)
+
+import Dashboard.PipelineGridLayout exposing (cardSize, layout)
+import Expect
+import Test exposing (Test, describe, test, todo)
+
+
+all : Test
+all =
+    describe "pipeline grid layout"
+        [ describe "card size"
+            [ test "is wide when pipeline has more than 12 layers of jobs" <|
+                \_ ->
+                    cardSize ( 13, 1 )
+                        |> Tuple.first
+                        |> Expect.equal 2
+            , test "is super wide when pipeline has more than 24 layers of jobs" <|
+                \_ ->
+                    cardSize ( 25, 1 )
+                        |> Tuple.first
+                        |> Expect.equal 3
+            , test "is narrow when pipeline has no more than 12 layers of jobs" <|
+                \_ ->
+                    cardSize ( 12, 1 )
+                        |> Tuple.first
+                        |> Expect.equal 1
+            , test "is tall when pipeline is more than 12 jobs tall" <|
+                \_ ->
+                    cardSize ( 1, 13 )
+                        |> Tuple.second
+                        |> Expect.equal 2
+            , test "is short when pipeline is very few jobs tall" <|
+                \_ ->
+                    cardSize ( 1, 3 )
+                        |> Tuple.second
+                        |> Expect.equal 1
+            ]
+        , describe "layout"
+            [ test "unit cards fill available columns" <|
+                \_ ->
+                    layout 2 [ ( 1, 1 ), ( 1, 1 ) ]
+                        |> Expect.equal
+                            [ { width = 1
+                              , height = 1
+                              , column = 1
+                              , row = 1
+                              }
+                            , { width = 1
+                              , height = 1
+                              , column = 2
+                              , row = 1
+                              }
+                            ]
+            , test "unit cards wrap rows" <|
+                \_ ->
+                    layout 1 [ ( 1, 1 ), ( 1, 1 ) ]
+                        |> Expect.equal
+                            [ { width = 1
+                              , height = 1
+                              , column = 1
+                              , row = 1
+                              }
+                            , { width = 1
+                              , height = 1
+                              , column = 1
+                              , row = 2
+                              }
+                            ]
+            , test "wide cards take up two columns" <|
+                \_ ->
+                    layout 2 [ ( 2, 1 ), ( 1, 1 ) ]
+                        |> Expect.equal
+                            [ { width = 2
+                              , height = 1
+                              , column = 1
+                              , row = 1
+                              }
+                            , { width = 1
+                              , height = 1
+                              , column = 1
+                              , row = 2
+                              }
+                            ]
+            , test "wide cards break rows" <|
+                \_ ->
+                    layout 2 [ ( 1, 1 ), ( 2, 1 ) ]
+                        |> Expect.equal
+                            [ { width = 1
+                              , height = 1
+                              , column = 1
+                              , row = 1
+                              }
+                            , { width = 2
+                              , height = 1
+                              , column = 1
+                              , row = 2
+                              }
+                            ]
+            , test "overflowing cards don't break rows" <|
+                \_ ->
+                    layout 1 [ ( 2, 1 ) ]
+                        |> Expect.equal
+                            [ { width = 2
+                              , height = 1
+                              , column = 1
+                              , row = 1
+                              }
+                            ]
+            , test "tall cards take up multiple rows" <|
+                \_ ->
+                    layout 1 [ ( 1, 2 ), ( 1, 1 ) ]
+                        |> Expect.equal
+                            [ { width = 1
+                              , height = 2
+                              , column = 1
+                              , row = 1
+                              }
+                            , { width = 1
+                              , height = 1
+                              , column = 1
+                              , row = 3
+                              }
+                            ]
+            , test "the height of a row is the height of the tallest card in the row" <|
+                \_ ->
+                    layout 2 [ ( 1, 2 ), ( 1, 1 ), ( 1, 1 ) ]
+                        |> Expect.equal
+                            [ { width = 1
+                              , height = 2
+                              , column = 1
+                              , row = 1
+                              }
+                            , { width = 1
+                              , height = 1
+                              , column = 2
+                              , row = 1
+                              }
+                            , { width = 1
+                              , height = 1
+                              , column = 1
+                              , row = 3
+                              }
+                            ]
+            ]
+        ]

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -448,7 +448,7 @@ all =
                     |> Common.queryView
                     |> Query.find [ class "dashboard-team-pipelines" ]
                     |> Query.has [ class "pipeline-wrapper", containing [ text "pipeline-0" ] ]
-        , test "considers a group's y-offset when determining visibility" <|
+        , test "groups that are outside the viewport have no visible pipelines" <|
             \_ ->
                 Common.init "/"
                     |> Application.handleCallback
@@ -465,6 +465,32 @@ all =
                     |> Common.queryView
                     |> Query.find [ id "team-2" ]
                     |> Query.hasNot [ class "pipeline-wrapper" ]
+        , test "groups that are scrolled into view have visible pipelines" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1, Data.pipeline "team-2" 2 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 300 200
+                        )
+                    |> Tuple.first
+                    |> Application.update
+                        (Update <|
+                            Scrolled
+                                { scrollTop = 600
+                                , scrollHeight = 3240
+                                , clientHeight = 200
+                                }
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ id "team-2" ]
+                    |> Query.has [ class "pipeline-wrapper", containing [ text "pipeline-2" ] ]
         , test "pipeline wrapper has a z-index of 1 when hovering over it" <|
             \_ ->
                 Common.init "/"

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -1,4 +1,4 @@
-module DashboardRenderingTests exposing (all)
+module PipelineGridTests exposing (all)
 
 import Application.Application as Application
 import Common

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -71,16 +71,6 @@ all =
                         [ class "dashboard-team-pipelines"
                         , style "position" "relative"
                         ]
-        , test "sets the container height to the height of the cards" <|
-            \_ ->
-                Common.init "/"
-                    |> Application.handleCallback
-                        (Callback.AllPipelinesFetched <|
-                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
-                        )
-                    |> Tuple.first
-                    |> Common.queryView
-                    |> containerHasHeight 268
         , test "fetches the viewport of the scrollable area on load" <|
             \_ ->
                 Application.init
@@ -257,7 +247,7 @@ all =
                                 , width = 272
                                 , height = 268
                                 }
-                        , containerHasHeight <| 268 * 2 + 25
+                        , containerHasHeight <| (268 + 25) * 2
                         ]
         , test "pipelines with many dependant jobs are rendered as spanning multiple columns" <|
             \_ ->
@@ -335,8 +325,24 @@ all =
                                 , width = 272
                                 , height = 268
                                 }
-                        , containerHasHeight <| 268 * 2 + 25
+                        , containerHasHeight <| (268 + 25) * 2
                         ]
+        , test "sets the container height to the height of the cards" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0, Data.pipeline "team" 1 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                            Ok <|
+                                viewportWithSize 300 600
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> containerHasHeight ((268 + 25) * 2)
         , test "doesn't render rows below the viewport" <|
             \_ ->
                 Common.init "/"

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -1037,19 +1037,6 @@ iHoveredTheFirstPipelineLink =
             )
 
 
-theFirstPipelineLinkWasOverflowing =
-    Tuple.first
-        >> Application.handleCallback
-            (Callback.GotViewport Callback.OnlyShowWhenOverflowing <|
-                Ok
-                    { scene = { width = 1, height = 0 }
-                    , viewport = { width = 0, height = 0, x = 0, y = 0 }
-
-                    -- , element = { width = 0, height = 0, x = 0, y = 0 }
-                    }
-            )
-
-
 iSeeItContainsThePipelineName =
     Query.has [ text "pipeline" ]
 

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -150,6 +150,7 @@ initLoadVar =
                     (Models.LoadVar (someStep "some-id" "some-name" Models.StepStateSucceeded))
         ]
 
+
 initGet : Test
 initGet =
     let

--- a/web/elm/tests/TooltipTests.elm
+++ b/web/elm/tests/TooltipTests.elm
@@ -13,117 +13,55 @@ import Tooltip
 
 all : Test
 all =
-    describe ".handleCallback"
+    describe ".handleCallback" <|
         [ describe "OnlyShowWhenOverflowing policy"
             [ test "callback with overflowing viewport turns hover -> pending" <|
                 \_ ->
-                    ( { hovered =
-                            HoverState.Hovered <|
-                                SideBarPipeline
-                                    { teamName = "team"
-                                    , pipelineName = "pipeline"
-                                    }
-                      }
-                    , []
-                    )
+                    ( { hovered = HoverState.Hovered domID }, [] )
                         |> Tooltip.handleCallback
-                            (Callback.GotViewport Callback.OnlyShowWhenOverflowing <|
+                            (Callback.GotViewport domID Callback.OnlyShowWhenOverflowing <|
                                 Ok overflowingViewport
                             )
                         |> Tuple.first
                         |> .hovered
-                        |> Expect.equal
-                            (HoverState.TooltipPending
-                                (SideBarPipeline
-                                    { teamName = "team"
-                                    , pipelineName = "pipeline"
-                                    }
-                                )
-                            )
+                        |> Expect.equal (HoverState.TooltipPending domID)
             , test "callback with overflowing viewport gets element position" <|
                 \_ ->
-                    ( { hovered =
-                            HoverState.Hovered <|
-                                SideBarPipeline
-                                    { teamName = "team"
-                                    , pipelineName = "pipeline"
-                                    }
-                      }
-                    , []
-                    )
+                    ( { hovered = HoverState.Hovered domID }, [] )
                         |> Tooltip.handleCallback
-                            (Callback.GotViewport Callback.OnlyShowWhenOverflowing <|
+                            (Callback.GotViewport domID Callback.OnlyShowWhenOverflowing <|
                                 Ok overflowingViewport
                             )
                         |> Tuple.second
                         |> Common.contains (Effects.GetElement domID)
             , test "callback with non-overflowing does nothing" <|
                 \_ ->
-                    ( { hovered =
-                            HoverState.Hovered <|
-                                SideBarPipeline
-                                    { teamName = "team"
-                                    , pipelineName = "pipeline"
-                                    }
-                      }
-                    , []
-                    )
+                    ( { hovered = HoverState.Hovered domID }, [] )
                         |> Tooltip.handleCallback
-                            (Callback.GotViewport Callback.OnlyShowWhenOverflowing <|
+                            (Callback.GotViewport domID Callback.OnlyShowWhenOverflowing <|
                                 Ok nonOverflowingViewport
                             )
                         |> Tuple.first
                         |> .hovered
-                        |> Expect.equal
-                            (HoverState.Hovered <|
-                                SideBarPipeline
-                                    { teamName = "team"
-                                    , pipelineName = "pipeline"
-                                    }
-                            )
+                        |> Expect.equal (HoverState.Hovered domID)
             ]
         , test "AlwaysShow callback with non-overflowing viewport gets element" <|
             \_ ->
-                ( { hovered =
-                        HoverState.Hovered <|
-                            SideBarPipeline
-                                { teamName = "team"
-                                , pipelineName = "pipeline"
-                                }
-                  }
-                , []
-                )
+                ( { hovered = HoverState.Hovered domID }, [] )
                     |> Tooltip.handleCallback
-                        (Callback.GotViewport Callback.AlwaysShow <|
+                        (Callback.GotViewport domID Callback.AlwaysShow <|
                             Ok nonOverflowingViewport
                         )
                     |> Tuple.second
                     |> Common.contains (Effects.GetElement domID)
         , test "callback with tooltip position turns pending -> tooltip" <|
             \_ ->
-                ( { hovered =
-                        HoverState.TooltipPending
-                            (SideBarPipeline
-                                { teamName = "team"
-                                , pipelineName = "pipeline"
-                                }
-                            )
-                  }
-                , []
-                )
+                ( { hovered = HoverState.TooltipPending domID }, [] )
                     |> Tooltip.handleCallback
                         (Callback.GotElement <| Ok elementPosition)
                     |> Tuple.first
                     |> .hovered
-                    |> Expect.equal
-                        (HoverState.Tooltip
-                            (SideBarPipeline
-                                { teamName = "team"
-                                , pipelineName = "pipeline"
-                                }
-                            )
-                            (Top 0.5 1)
-                        )
+                    |> Expect.equal (HoverState.Tooltip domID (Top 0.5 1))
         ]
 
 

--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -69,9 +69,9 @@ app.ports.tooltip.subscribe(function (pipelineInfo) {
   var pipelineTeamName = pipelineInfo[1];
 
   var team = $('div[id="' + pipelineTeamName + '"]');
-  var title = team.find('.card[data-pipeline-name="' + pipelineName + '"]').find('.dashboard-pipeline-name');
+  var title = team.find('.card[data-pipeline-name="' + pipelineName + '"]').find('.dashboard-pipeline-name').get(0);
 
-  if(title.get(0).offsetWidth < title.get(0).scrollWidth){
+  if(title && title.offsetWidth < title.scrollWidth){
       title.parent().attr('data-tooltip', pipelineName);
   }
 });

--- a/web/wats/helpers/web.js
+++ b/web/wats/helpers/web.js
@@ -48,6 +48,14 @@ class Web {
     }, text)
   }
 
+  async scrollIntoView(selector) {
+    await this.page.waitFor(selector);
+    await this.page.evaluate(selector => {
+      const elem = document.querySelector(selector);
+      elem.scrollIntoView(true);
+    }, selector);
+  }
+
   async login(t) {
     await this.visitLoginPage();
     await this.performLogin();

--- a/web/wats/test/dashboard.js
+++ b/web/wats/test/dashboard.js
@@ -30,6 +30,7 @@ async function showsPipelineState(t, setup, assertions) {
   await t.context.web.page.goto(t.context.web.route('/'));
 
   const group = `.dashboard-team-group[data-team-name="${t.context.teamName}"]`;
+  await t.context.web.scrollIntoView(group);
   await t.context.web.page.waitFor(`${group} .card`);
   const pipeline = await t.context.web.page.$(`${group} .card`);
   const text = await t.context.web.text(pipeline);
@@ -76,6 +77,7 @@ test('shows pipelines in their correct order', async t => {
   await t.context.web.page.goto(t.context.web.route('/'));
 
   const group = `.dashboard-team-group[data-team-name="${t.context.teamName}"]`;
+  await t.context.web.scrollIntoView(group);
   await t.context.web.page.waitFor(`${group} .pipeline-wrapper:nth-child(${pipelineOrder.length}) .card`);
 
   const names = await t.context.web.page.$$eval(`${group} .dashboard-pipeline-name`, nameElements => {

--- a/web/wats/test/login.js
+++ b/web/wats/test/login.js
@@ -55,6 +55,8 @@ test('can fly login with browser and reuse same browser without CSRF issues', as
   let pipelineSelector = '.card[data-pipeline-name=some-pipeline]';
   let playButton = `${pipelineSelector} [style*="ic-play"]`;
   let pauseButton = `${pipelineSelector} [style*="ic-pause"]`;
+  const group = `.dashboard-team-group[data-team-name="main"]`;
+  await t.context.web.scrollIntoView(group);
   await t.context.web.page.waitFor(playButton);
   await t.context.web.page.click(playButton);
   await t.context.web.page.waitForSelector(pauseButton, {timeout: 90000});

--- a/web/wats/test/smoke.js
+++ b/web/wats/test/smoke.js
@@ -24,6 +24,8 @@ test('running pipelines', async t => {
   t.regex(result.stdout, /pushing version: put-version/);
 
   await t.context.web.page.goto(t.context.web.route(`/`));
+  const group = `.dashboard-team-group[data-team-name="${t.context.teamName}"]`;
+  await t.context.web.scrollIntoView(group);
   await t.context.web.waitForText('some-pipeline');
 
   await t.context.web.page.goto(t.context.web.route(`/teams/${t.context.teamName}/pipelines/some-pipeline`));


### PR DESCRIPTION
# Existing Issues

* Fixes #5031
* Fixes #5029 
* Fixes a bug on the HD view introduced here: https://github.com/concourse/concourse/pull/5023/files#diff-d13b96daebf3506023c6ed386f13d3eeR203 - **all** jobs in the cluster are considered for determining the status of a pipeline, not just the jobs for the pipeline (similar to #5107)

# Why do we need this PR?
When there are many pipelines visible on the dashboard (100s-1000s), re-renders are very slow. This is a side effect of a few things, but notably:

* The DOM tree is just too large - rendering all pipelines on the page can result in tens of thousands of DOM nodes. According to https://developers.google.com/web/tools/lighthouse/audits/dom-size, the recommended upper limit for DOM size is 1,500, which we greatly exceed even for a modest number of pipelines. Not only do the browsers struggle with rendering this large a DOM tree, but it also puts strain on Elm's virtual DOM.
* We perform lots of computation for each re-render - every time we re-render the dashboard, for every pipeline, we filter the full list of jobs to find the jobs for that pipeline, and then group the jobs by rank for displaying the pipeline preview. When there are thousands of jobs spread across thousands of pipelines, this can be very slow.


# Changes proposed in this pull request

* Lazily render pipeline cards so that only cards that are visible on screen are rendered (see #5031). This requires managing the layout of cards in elm, rather than relying on the browser to position the cards.
* Precompute the list of jobs and the grouping by rank for each pipeline (see #5029)
* Make drag and drop feel more "natural" - users can now drag a pipeline to the end of the row, rather than having to drag it to the start of the next row (without any visual indication that it will place it above)

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [x] Integration tests (if applicable)
- [ ] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
