### PR TITLE
web: show most-privileged role on team pills

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -24,6 +24,10 @@ other systems soon.
 `fly unpause-pipeline` commands. This allows users to pause or unpause every
 pipeline on a team at the same time. #4092
 
+#### <sub><sup><a name="5133" href="#5133">:link:</a></sup></sub> fix
+
+* In the case that a user has multiple roles on a team, the pills on the team headers on the dashboard now accurately reflect the logged-in user's most-privileged role on each team. #5133
+
 [OpenTelemetry]: https://opentelemetry.io/
 [Jaeger]: https://www.jaegertracing.io/
 [Stackdriver]: https://cloud.google.com/trace/

--- a/web/elm/src/Dashboard/Group/Tag.elm
+++ b/web/elm/src/Dashboard/Group/Tag.elm
@@ -73,12 +73,12 @@ splitFirst delim =
 
 tag : Concourse.User -> String -> Maybe Tag
 tag user teamName =
-    Dict.get teamName user.teams |> Maybe.andThen firstRole
-
-
-firstRole : List String -> Maybe Tag
-firstRole roles =
-    List.head roles |> Maybe.andThen parseRole
+    Dict.get teamName user.teams
+        |> Maybe.withDefault []
+        |> List.map parseRole
+        |> List.sortWith ordering
+        |> List.head
+        |> Maybe.withDefault Nothing
 
 
 parseRole : String -> Maybe Tag

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -1027,7 +1027,7 @@ all =
                         |> Common.queryView
                         |> teamHeaderHasNoPill "team"
             , test
-                ("shows pill for most-privileged role on team header for team"
+                ("shows pill for most-privileged role on team header for team "
                     ++ "on which user has multiple roles"
                 )
               <|

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -1026,12 +1026,16 @@ all =
                         |> Tuple.first
                         |> Common.queryView
                         |> teamHeaderHasNoPill "team"
-            , test "shows pill for first role on team header for team on which user has multiple roles" <|
+            , test
+                ("shows pill for most-privileged role on team header for team"
+                    ++ "on which user has multiple roles"
+                )
+              <|
                 \_ ->
                     whenOnDashboard { highDensity = False }
                         |> givenDataAndUser
                             (apiData [ ( "team", [] ) ])
-                            (userWithRoles [ ( "team", [ "member", "viewer" ] ) ])
+                            (userWithRoles [ ( "team", [ "viewer", "member" ] ) ])
                         |> Tuple.first
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|


### PR DESCRIPTION
# Existing Issue

Fixes #4399.

# Changes proposed in this pull request

It's possible to configure a team's auth such that a single user might have multiple roles - for example, if you grant "viewer" status to all members of a GitHub org, but "member" status to members of a specific GitHub team within that org. The UI only shows a single role in the pills on the team headers on the dashboard. The choice of which role to show was, until now, determined by whatever the API put first in the list of roles returned by the userinfo endpoint.

Users have justifiably found this confusing or misleading, and it generally seems sensible to show the most-privileged role a user has on any given team, since roles are in a strict hierarchy and the most-privileged role will be the one that determines the actions a user is authorized to take. 

With this change, the UI will make sure it displays the most-privileged role in the pills.

# Contributor Checklist
- [x] Unit tests
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [x] Release notes reviewed
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~