### PR TITLE
Dashboard jobs endpoints returns job outputs

### DIFF
--- a/atc/api/present/dashboard.go
+++ b/atc/api/present/dashboard.go
@@ -47,7 +47,8 @@ func DashboardJob(
 		Paused:       job.Paused,
 		HasNewInputs: job.HasNewInputs,
 
-		Inputs: sanitizedInputs,
+		Inputs:  sanitizedInputs,
+		Outputs: job.Outputs,
 
 		Groups: job.Groups,
 

--- a/atc/dashboard_job.go
+++ b/atc/dashboard_job.go
@@ -16,7 +16,8 @@ type DashboardJob struct {
 	NextBuild       *DashboardBuild
 	TransitionBuild *DashboardBuild
 
-	Inputs []DashboardJobInput
+	Inputs  []DashboardJobInput
+	Outputs []JobOutput
 
 	Groups []string
 }

--- a/atc/db/job_factory_test.go
+++ b/atc/db/job_factory_test.go
@@ -32,6 +32,9 @@ var _ = Describe("Job Factory", func() {
 							{
 								Get: "some-other-resource",
 							},
+							{
+								Put: "some-resource",
+							},
 						},
 					},
 					{
@@ -48,6 +51,13 @@ var _ = Describe("Job Factory", func() {
 							{
 								Get:      "resource",
 								Resource: "some-resource",
+							},
+							{
+								Put:      "resource",
+								Resource: "some-resource",
+							},
+							{
+								Put: "some-resource",
 							},
 						},
 					},
@@ -82,6 +92,9 @@ var _ = Describe("Job Factory", func() {
 						Plan: atc.PlanSequence{
 							{
 								Get: "some-resource",
+							},
+							{
+								Put: "some-resource",
 							},
 						},
 					},
@@ -141,6 +154,25 @@ var _ = Describe("Job Factory", func() {
 						Passed:   []string{"public-pipeline-job-1", "public-pipeline-job-2"},
 					},
 				}))
+
+				Expect(visibleJobs[0].Outputs).To(BeNil())
+				Expect(visibleJobs[1].Outputs).To(Equal([]atc.JobOutput{
+					atc.JobOutput{
+						Name:     "some-resource",
+						Resource: "some-resource",
+					},
+				}))
+				Expect(visibleJobs[2].Outputs).To(Equal([]atc.JobOutput{
+					atc.JobOutput{
+						Name:     "resource",
+						Resource: "some-resource",
+					},
+					atc.JobOutput{
+						Name:     "some-resource",
+						Resource: "some-resource",
+					},
+				}))
+				Expect(visibleJobs[3].Outputs).To(BeNil())
 			})
 
 			It("returns next build, latest completed build, and transition build for each job", func() {
@@ -252,6 +284,31 @@ var _ = Describe("Job Factory", func() {
 				}))
 				Expect(allJobs[4].Inputs).To(Equal([]atc.DashboardJobInput{
 					atc.DashboardJobInput{
+						Name:     "some-resource",
+						Resource: "some-resource",
+					},
+				}))
+
+				Expect(allJobs[0].Outputs).To(BeNil())
+				Expect(allJobs[1].Outputs).To(Equal([]atc.JobOutput{
+					atc.JobOutput{
+						Name:     "some-resource",
+						Resource: "some-resource",
+					},
+				}))
+				Expect(allJobs[2].Outputs).To(Equal([]atc.JobOutput{
+					atc.JobOutput{
+						Name:     "resource",
+						Resource: "some-resource",
+					},
+					atc.JobOutput{
+						Name:     "some-resource",
+						Resource: "some-resource",
+					},
+				}))
+				Expect(allJobs[3].Outputs).To(BeNil())
+				Expect(allJobs[4].Outputs).To(Equal([]atc.JobOutput{
+					atc.JobOutput{
 						Name:     "some-resource",
 						Resource: "some-resource",
 					},

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -559,9 +559,11 @@ func (p *pipeline) Dashboard() (atc.Dashboard, error) {
 
 	defer Rollback(tx)
 
-	dashboard, err := buildDashboard(tx, sq.Eq{
+	dashboardFactory := newDashboardFactory(tx, sq.Eq{
 		"j.pipeline_id": p.id,
 	})
+
+	dashboard, err := dashboardFactory.buildDashboard()
 	if err != nil {
 		return nil, err
 	}

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -1247,6 +1247,18 @@ var _ = Describe("Pipeline", func() {
 			Expect(actualDashboard[0].Name).To(Equal(job.Name()))
 			Expect(actualDashboard[0].NextBuild).To(BeNil())
 			Expect(actualDashboard[0].FinishedBuild.ID).To(Equal(secondJobBuild.ID()))
+
+			By("returning the job inputs and outputs")
+			Expect(actualDashboard[0].Outputs).To(ConsistOf(atc.JobOutput{
+				Name:     "some-resource",
+				Resource: "some-resource",
+			}))
+			Expect(actualDashboard[0].Inputs).To(ConsistOf(atc.DashboardJobInput{
+				Name:     "some-input",
+				Resource: "some-resource",
+				Passed:   []string{"job-1", "job-2"},
+				Trigger:  true,
+			}))
 		})
 	})
 


### PR DESCRIPTION
Fixes #5129.

# Why do we need this PR?

The output resources no longer show up in the pipeline UI page. This was because the outputs were removed from the DashboardJobs response from the ListJobs and ListAllJobs endpoints.

# Changes proposed in this pull request

The ListJobs and ListAllJobs endpoints will now return the outputs associated to the jobs.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [x] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
