### PR TITLE
feat(atc): skip resource check for put-only resources.

### DIFF
--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -320,6 +320,7 @@ func (c *checkFactory) Resources() ([]Resource, error) {
 	var resources []Resource
 
 	rows, err := resourcesQuery.
+		Join("(select DISTINCT(resource_id) FROM job_inputs) ji ON ji.resource_id = r.id").
 		Where(sq.Eq{"p.paused": false}).
 		RunWith(c.conn).
 		Query()


### PR DESCRIPTION
# Existing Issue

Fixes #4940

# Why do we need this PR?

This change is based on @vito 's comment https://github.com/concourse/concourse/issues/4940#issuecomment-568079344 and @pivotal-jwinters 's comment https://github.com/concourse/concourse/issues/4940#issuecomment-568083030.

If a resource is put-only, then no need to run checks against it.

# Changes proposed in this pull request

In this commit, added a left join to `job_input` to `resourceQuery`, this way avoids to query `job_input` in the for loop of `resources` in lidar scanner. But side effect is the `ListResources` API will no longer return put-only resources. I feel that should be ok.

@vito please see if you are ok with this change.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [x] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
