### PR TITLE
Do not schedule any jobs that are paused, inactive or in a paused pipeline

### DIFF
--- a/atc/db/job_factory.go
+++ b/atc/db/job_factory.go
@@ -77,7 +77,12 @@ func (j *jobFactory) AllActiveJobs() (atc.Dashboard, error) {
 
 func (j *jobFactory) JobsToSchedule() (Jobs, error) {
 	rows, err := jobsQuery.
-		Where(sq.Expr("schedule_requested > last_scheduled")).
+		Where(sq.Expr("j.schedule_requested > j.last_scheduled")).
+		Where(sq.Eq{
+			"j.active": true,
+			"j.paused": false,
+			"p.paused": false,
+		}).
 		RunWith(j.conn).
 		Query()
 	if err != nil {

--- a/atc/db/job_factory_test.go
+++ b/atc/db/job_factory_test.go
@@ -290,7 +290,7 @@ var _ = Describe("Job Factory", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("fetches that pipeline", func() {
+			It("fetches that job", func() {
 				jobs, err := jobFactory.JobsToSchedule()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(jobs)).To(Equal(1))
@@ -316,7 +316,7 @@ var _ = Describe("Job Factory", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("does not fetch that pipeline", func() {
+			It("does not fetch that job", func() {
 				jobs, err := jobFactory.JobsToSchedule()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(jobs)).To(Equal(0))
@@ -348,14 +348,14 @@ var _ = Describe("Job Factory", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("does not fetch that pipeline", func() {
+			It("does not fetch that job", func() {
 				jobs, err := jobFactory.JobsToSchedule()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(jobs)).To(Equal(0))
 			})
 		})
 
-		Context("when there are multiple pipelines with different times", func() {
+		Context("when there are multiple jobs with different times", func() {
 			BeforeEach(func() {
 				pipeline1, _, err := defaultTeam.SavePipeline("fake-pipeline", atc.Config{
 					Jobs: atc.JobConfigs{
@@ -404,12 +404,96 @@ var _ = Describe("Job Factory", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("fetches the pipelines that have a requested schedule time later than it's last scheduled", func() {
+			It("fetches the jobs that have a requested schedule time later than it's last scheduled", func() {
 				jobs, err := jobFactory.JobsToSchedule()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(jobs)).To(Equal(2))
 				jobNames := []string{jobs[0].Name(), jobs[1].Name()}
 				Expect(jobNames).To(ConsistOf(job1.Name(), job3.Name()))
+			})
+		})
+
+		Context("when the job is paused but has a later schedule requested time", func() {
+			BeforeEach(func() {
+				pipeline1, _, err := defaultTeam.SavePipeline("fake-pipeline", atc.Config{
+					Jobs: atc.JobConfigs{
+						{Name: "job-name"},
+					},
+				}, db.ConfigVersion(1), false)
+				Expect(err).ToNot(HaveOccurred())
+
+				var found bool
+				job1, found, err = pipeline1.Job("job-name")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				err = job1.RequestSchedule()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = job1.Pause()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("does not fetch that job", func() {
+				jobs, err := jobFactory.JobsToSchedule()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(jobs)).To(Equal(0))
+			})
+		})
+
+		Context("when the job is inactive but has a later schedule requested time", func() {
+			BeforeEach(func() {
+				pipeline1, _, err := defaultTeam.SavePipeline("fake-pipeline", atc.Config{
+					Jobs: atc.JobConfigs{
+						{Name: "job-name"},
+					},
+				}, db.ConfigVersion(1), false)
+				Expect(err).ToNot(HaveOccurred())
+
+				var found bool
+				job1, found, err = pipeline1.Job("job-name")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				err = job1.RequestSchedule()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, _, err = defaultTeam.SavePipeline("fake-pipeline", atc.Config{}, pipeline1.ConfigVersion(), false)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("does not fetch that job", func() {
+				jobs, err := jobFactory.JobsToSchedule()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(jobs)).To(Equal(0))
+			})
+		})
+
+		Context("when the pipeline is paused but it's job has a later schedule requested time", func() {
+			BeforeEach(func() {
+				pipeline1, _, err := defaultTeam.SavePipeline("fake-pipeline", atc.Config{
+					Jobs: atc.JobConfigs{
+						{Name: "job-name"},
+					},
+				}, db.ConfigVersion(1), false)
+				Expect(err).ToNot(HaveOccurred())
+
+				var found bool
+				job1, found, err = pipeline1.Job("job-name")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				err = job1.RequestSchedule()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = pipeline1.Pause()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("does not fetch that job", func() {
+				jobs, err := jobFactory.JobsToSchedule()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(jobs)).To(Equal(0))
 			})
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Clara Fu <cfu@pivotal.io>

# Existing Issue

Fixes #5142

# Why do we need this PR?
If we try to schedule any jobs that are under these conditions, the algorithm will not be able to find any candidates because of the state of the job. So let's just not bother trying to schedule them and only schedule the jobs after they have been unpaused or brought back to active. (We request schedule for any of those triggers)


# Changes proposed in this pull request
JobsToSchedule will no longer grab jobs that are either inactive, paused or in a paused pipeline.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
