### PR TITLE
Assign pipeline operator role to RerunJobBuild route

### DIFF
--- a/atc/api/accessor/accessor_test.go
+++ b/atc/api/accessor/accessor_test.go
@@ -1,15 +1,16 @@
 package accessor_test
 
 import (
-	"code.cloudfoundry.org/lager"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
+	"net/http"
+
+	"code.cloudfoundry.org/lager"
 	"github.com/dgrijalva/jwt-go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"net/http"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/accessor"
@@ -517,6 +518,11 @@ var _ = Describe("Accessor", func() {
 		Entry("member :: "+atc.CreateJobBuild, atc.CreateJobBuild, "member", true),
 		Entry("pipeline-operator :: "+atc.CreateJobBuild, atc.CreateJobBuild, "pipeline-operator", true),
 		Entry("viewer :: "+atc.CreateJobBuild, atc.CreateJobBuild, "viewer", false),
+
+		Entry("owner :: "+atc.RerunJobBuild, atc.RerunJobBuild, "owner", true),
+		Entry("member :: "+atc.RerunJobBuild, atc.RerunJobBuild, "member", true),
+		Entry("pipeline-operator :: "+atc.RerunJobBuild, atc.RerunJobBuild, "pipeline-operator", true),
+		Entry("viewer :: "+atc.RerunJobBuild, atc.RerunJobBuild, "viewer", false),
 
 		Entry("owner :: "+atc.ListAllJobs, atc.ListAllJobs, "owner", true),
 		Entry("member :: "+atc.ListAllJobs, atc.ListAllJobs, "member", true),

--- a/atc/api/accessor/role_action_map.go
+++ b/atc/api/accessor/role_action_map.go
@@ -1,9 +1,10 @@
 package accessor
 
 import (
+	"io/ioutil"
+
 	"code.cloudfoundry.org/lager"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 
 	"github.com/concourse/concourse/atc"
 )
@@ -24,6 +25,7 @@ var requiredRoles = map[string]string{
 	atc.GetBuildPreparation:           "viewer",
 	atc.GetJob:                        "viewer",
 	atc.CreateJobBuild:                "pipeline-operator",
+	atc.RerunJobBuild:                 "pipeline-operator",
 	atc.ListAllJobs:                   "viewer",
 	atc.ListJobs:                      "viewer",
 	atc.ListJobBuilds:                 "viewer",


### PR DESCRIPTION
Signed-off-by: Clara Fu <cfu@pivotal.io>

# Existing Issue
The rerun build endpoint was not added to the action role map so only admin users were allowed to rerun builds.

Fixes #5115.

# Why do we need this PR?
The correct permissions for rerunning builds should be the same creating builds, which is a pipeline-operator role action so rerunning builds was added to the role action map for a pipeline-operator role.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
