### PR TITLE
Remove unused index and add missing index for checks

### DIFF
--- a/atc/db/migration/migrations/1581350441_remove_unused_idx_and_add_checks_idx.down.sql
+++ b/atc/db/migration/migrations/1581350441_remove_unused_idx_and_add_checks_idx.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+  CREATE INDEX builds_job_id_succeeded_idx ON builds (job_id, id DESC) where status = 'succeeded';
+
+  DROP INDEX started_checks_idx;
+
+COMMIT;

--- a/atc/db/migration/migrations/1581350441_remove_unused_idx_and_add_checks_idx.up.sql
+++ b/atc/db/migration/migrations/1581350441_remove_unused_idx_and_add_checks_idx.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+  DROP INDEX builds_job_id_succeeded_idx;
+
+  CREATE INDEX started_checks_idx ON checks (id) WHERE status = 'started';
+
+COMMIT;


### PR DESCRIPTION
Remove the succeeded builds index because it is no longer being used
anymore. Also added an index to speed up a checks query.

Signed-off-by: Clara Fu <cfu@pivotal.io>

# Existing Issue
Clean up any unused indexes.

Fixes #5045 .

# Why do we need this PR?
After all these incremental changes to the algorithm, there might be some indexes that were forgotten about. After deploying the changes to a large scale environment, figure out which indexes are not used anymore by using pg_stats.


# Changes proposed in this pull request
Removed an unused index for succeeded builds and also found an index that would speed up the checks query from 400 ms to less than 1 ms.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
