### PR TITLE
Only bump resource version check order if there are new versions

### DIFF
--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -440,7 +440,6 @@ func (j *job) ScheduleBuild(build Build) (bool, error) {
 		return false, err
 	}
 
-	// XXX Do we need this??
 	result, err := psql.Update("jobs").
 		Set("max_in_flight_reached", reached).
 		Where(sq.Eq{

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -119,6 +119,16 @@ var _ = Describe("Resource Config Scope", func() {
 					{"ref": "v1"},
 					{"ref": "v3"},
 				}
+
+				err := resourceScope.SaveVersions(originalVersionSlice)
+				Expect(err).ToNot(HaveOccurred())
+
+				latestVR, found, err := resourceScope.LatestVersion()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				Expect(latestVR.Version()).To(Equal(db.Version{"ref": "v3"}))
+				Expect(latestVR.CheckOrder()).To(Equal(2))
 			})
 
 			It("does not change the check order", func() {


### PR DESCRIPTION
Signed-off-by: Clara Fu <cfu@pivotal.io>

# Existing Issue

Fixes #5127.

# Why do we need this PR?
The check order of versions were being bumped everytime it is saved into the db, regardless if the version already existed. This caused a bug in the mock-resource, when a version is pinned it becomes the latest version because of it's check order being bumped. It also would be best if we didn't have to increment the check order everytime a check is run for it. The reason why this was probably implemented this way was that lidar no longer knew about what the "from" version was, so it was unable to determine when the check order should be bumped or not.

# Changes proposed in this pull request
I changed it so that the versions are only bumped if there is at least one new version within the list of versions returned by the check. This should reflect the behaviour we expect, where we only want to bump the check order of the list of versions returned if there is one or more versions that are newly saved.

Also the fixed the tests for checking the check order is not bumped with existing versions, where it was passing because of some missing setup. The tests should now properly test the case that the check order is not bumped if it is trying to save an existing version.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
