### PR TITLE
Explicitly whitelist all traffic from concourse containers

### DIFF
--- a/atc/worker/worker_helper.go
+++ b/atc/worker/worker_helper.go
@@ -25,6 +25,8 @@ func (w workerHelper) createGardenContainer(
 	bindMounts []garden.BindMount,
 ) (gclient.Container, error) {
 
+	networkOutRules := []garden.NetOutRule{{Protocol: garden.ProtocolAll}}
+
 	gardenProperties := garden.Properties{}
 
 	if containerSpec.User != "" {
@@ -54,6 +56,7 @@ func (w workerHelper) createGardenContainer(
 			Privileged: fetchedImage.Privileged,
 			BindMounts: bindMounts,
 			Limits:     containerSpec.Limits.ToGardenLimits(),
+			NetOut:     networkOutRules,
 			Env:        env,
 			Properties: gardenProperties,
 		})

--- a/atc/worker/worker_test.go
+++ b/atc/worker/worker_test.go
@@ -951,6 +951,7 @@ var _ = Describe("Worker", func() {
 					Expect(actualSpec).To(Equal(garden.ContainerSpec{
 						Handle:     "some-handle",
 						RootFSPath: "some-image-url",
+						NetOut:     []garden.NetOutRule{{Protocol: garden.ProtocolAll}},
 						Properties: garden.Properties{"user": "some-user"},
 						BindMounts: []garden.BindMount{
 							{
@@ -1057,6 +1058,7 @@ var _ = Describe("Worker", func() {
 							Expect(actualSpec).To(Equal(garden.ContainerSpec{
 								Handle:     "some-handle",
 								RootFSPath: "some-image-url",
+								NetOut:     []garden.NetOutRule{{Protocol: garden.ProtocolAll}},
 								Properties: garden.Properties{"user": "some-user"},
 								BindMounts: []garden.BindMount{
 									{
@@ -1116,6 +1118,7 @@ var _ = Describe("Worker", func() {
 							Expect(actualSpec).To(Equal(garden.ContainerSpec{
 								Handle:     "some-handle",
 								RootFSPath: "some-image-url",
+								NetOut:     []garden.NetOutRule{{Protocol: garden.ProtocolAll}},
 								Properties: garden.Properties{"user": "some-user"},
 								BindMounts: []garden.BindMount{
 									{
@@ -1175,6 +1178,7 @@ var _ = Describe("Worker", func() {
 							Expect(actualSpec).To(Equal(garden.ContainerSpec{
 								Handle:     "some-handle",
 								RootFSPath: "some-image-url",
+								NetOut:     []garden.NetOutRule{{Protocol: garden.ProtocolAll}},
 								Properties: garden.Properties{"user": "some-user"},
 								BindMounts: []garden.BindMount{
 									{
@@ -1235,6 +1239,7 @@ var _ = Describe("Worker", func() {
 							Expect(actualSpec).To(Equal(garden.ContainerSpec{
 								Handle:     "some-handle",
 								RootFSPath: "some-image-url",
+								NetOut:     []garden.NetOutRule{{Protocol: garden.ProtocolAll}},
 								Properties: garden.Properties{"user": "some-user"},
 								BindMounts: []garden.BindMount{
 									{
@@ -1296,6 +1301,7 @@ var _ = Describe("Worker", func() {
 							Expect(actualSpec).To(Equal(garden.ContainerSpec{
 								Handle:     "some-handle",
 								RootFSPath: "some-image-url",
+								NetOut:     []garden.NetOutRule{{Protocol: garden.ProtocolAll}},
 								Properties: garden.Properties{"user": "some-user"},
 								BindMounts: []garden.BindMount{
 									{


### PR DESCRIPTION
* This declaration is necessary for platforms where this is not
  the standard networking behavior (like windows).

# Existing Issue

Fixes #5028 .

# Changes proposed in this pull request

* Explicitly whitelist all traffic from concourse containers. This is already done implicitly for the linux platform, but we need it to **explicit** for behavior parity with the windows platform.

# Contributor Checklist

- [x] Unit tests

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 

@jfeeny @genevieve
