### PR TITLE
fly: fix use of zstd reader in tests

### DIFF
--- a/fly/integration/execute_test.go
+++ b/fly/integration/execute_test.go
@@ -377,7 +377,10 @@ run: {}
 							func(w http.ResponseWriter, req *http.Request) {
 								close(uploading)
 
-								tr := tar.NewReader(zstd.NewReader(req.Body))
+								zstdReader, err := zstd.NewReader(req.Body)
+								Expect(err).ToNot(HaveOccurred())
+
+								tr := tar.NewReader(zstdReader)
 
 								var matchFound = false
 								for {
@@ -426,7 +429,10 @@ run: {}
 
 								Expect(req.FormValue("platform")).To(Equal("some-platform"))
 
-								tr := tar.NewReader(zstd.NewReader(req.Body))
+								zstdReader, err := zstd.NewReader(req.Body)
+								Expect(err).ToNot(HaveOccurred())
+
+								tr := tar.NewReader(zstdReader)
 
 								var matchFound = false
 								for {


### PR DESCRIPTION
### Why do we need this PR?

Some fly integration tests were not update when we switched from the
cgo-based zstd library to the new go-based one in #5024.

This made `fly`'s integration tests not compile (thus, not run lol)

### Changes proposed in this pull request

Update the tests to properly leverage `zstd.NewReader`.

