### PR TITLE
atc: change how algorithm deals with version every

### DIFF
--- a/atc/db/migration/migrations/1579713181_add_to_build_id_index_to_build_pipes.down.sql
+++ b/atc/db/migration/migrations/1579713181_add_to_build_id_index_to_build_pipes.down.sql
@@ -1,5 +1,6 @@
 BEGIN;
   DROP INDEX build_pipes_to_build_id_idx;
 
-  DROP INDEX build_resource_config_version_inputs_version_md5_idx;
+  -- Removed due to the index no longer being used
+  -- DROP INDEX build_resource_config_version_inputs_version_md5_idx;
 COMMIT;

--- a/atc/db/migration/migrations/1579713181_add_to_build_id_index_to_build_pipes.up.sql
+++ b/atc/db/migration/migrations/1579713181_add_to_build_id_index_to_build_pipes.up.sql
@@ -1,5 +1,6 @@
 BEGIN;
   CREATE INDEX build_pipes_to_build_id_idx ON build_pipes (to_build_id);
 
-  CREATE INDEX build_resource_config_version_inputs_version_md5_idx ON build_resource_config_version_inputs (version_md5);
+  -- Removed due to the index no longer being used
+  -- CREATE INDEX build_resource_config_version_inputs_version_md5_idx ON build_resource_config_version_inputs (version_md5);
 COMMIT;

--- a/atc/db/migration/migrations/1581447344_drop_build_inputs_indexes_and_create_index_for_algorithm.down.sql
+++ b/atc/db/migration/migrations/1581447344_drop_build_inputs_indexes_and_create_index_for_algorithm.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+  CREATE INDEX build_resource_config_version_inputs_resource_id_idx ON build_resource_config_version_inputs (resource_id);
+  CREATE INDEX build_resource_config_version_inputs_build_id_idx ON build_resource_config_version_inputs (build_id);
+
+  DROP INDEX build_inputs_resource_versions_idx;
+COMMIT;

--- a/atc/db/migration/migrations/1581447344_drop_build_inputs_indexes_and_create_index_for_algorithm.up.sql
+++ b/atc/db/migration/migrations/1581447344_drop_build_inputs_indexes_and_create_index_for_algorithm.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+  DROP INDEX IF EXISTS build_resource_config_version_inputs_version_md5_idx;
+  DROP INDEX build_resource_config_version_inputs_resource_id_idx;
+  DROP INDEX build_resource_config_version_inputs_build_id_idx;
+
+  CREATE INDEX build_inputs_resource_versions_idx ON build_resource_config_version_inputs (resource_id, version_md5);
+COMMIT;

--- a/atc/scheduler/algorithm/group_resolver.go
+++ b/atc/scheduler/algorithm/group_resolver.go
@@ -342,7 +342,7 @@ func (r *groupResolver) paginatedBuilds(ctx context.Context, currentInputConfig 
 		if r.lastUsedPassedBuilds == nil {
 			lastUsedBuildIDs := map[int]db.BuildCursor{}
 
-			buildID, found, err := r.vdb.LatestBuildID(ctx, currentJobID)
+			buildID, found, err := r.vdb.LatestBuildUsingLatestVersion(ctx, currentJobID, currentInputConfig.ResourceID)
 			if err != nil {
 				return db.PaginatedBuilds{}, false, err
 			}


### PR DESCRIPTION
Signed-off-by: Clara Fu <cfu@pivotal.io>

# Existing Issue

Fixes #5125

# Why do we need this PR?
Before this change for a version every input, the algorithm would grab
the latest build of a job and try to use the next version after that
build in order to satisfy the version every constraint. This is great
until you have the situation where the latest build used an old pinned
version, and now the "next" version would be the version after that old
pinned version. This will cause the algorithm to produce builds for
versions it has possibly already ran before until it reaches the latest
version.

# Changes proposed in this pull request
In order to avoid the possibility of pinning versions to produce builds
using old versions it has already used before, we will now have the
algorithm grab the latest version (rather than build) that has passed
through this job. Then using that latest version that has been used by
the job, it will get the version right after that in order to satisfy
the version every constraint. This added a lot more complexity to the
query, but is the fastest known way to query for that version.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
