### PR TITLE
Change checks gc default to 1m

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -172,7 +172,7 @@ type RunCommand struct {
 
 		OneOffBuildGracePeriod time.Duration `long:"one-off-grace-period" default:"5m" description:"Period after which one-off build containers will be garbage-collected."`
 		MissingGracePeriod     time.Duration `long:"missing-grace-period" default:"5m" description:"Period after which to reap containers and volumes that were created but went missing from the worker."`
-		CheckRecyclePeriod     time.Duration `long:"check-recycle-period" default:"6h" description:"Period after which to reap checks that are completed."`
+		CheckRecyclePeriod     time.Duration `long:"check-recycle-period" default:"1m" description:"Period after which to reap checks that are completed."`
 	} `group:"Garbage Collection" namespace:"gc"`
 
 	BuildTrackerInterval time.Duration `long:"build-tracker-interval" default:"10s" description:"Interval on which to run build tracking."`


### PR DESCRIPTION
Signed-off-by: Clara Fu <cfu@pivotal.io>

# Existing Issue

Fixes #5157

# Why do we need this PR?
With the previous default being 6 hours, this caused a lot of build up
of checks within large scale deployments and results in slowness to
the gc query. It was only decided to be a long time period for the
default to allow for operators to find information on the checks that
had previously happened.


# Changes proposed in this pull request
We decided to optimize for a faster checks GC rather than more
checks history by default, and if the user deems it necessary to keep
around the history for longer they can configure the GC interval to be
longer.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
