### PR TITLE
Revert "Within one scanner tick, only create one check for a resource type"

### DIFF
--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -54,7 +54,6 @@ func (s *scanner) Run(ctx context.Context) error {
 	}
 
 	waitGroup := new(sync.WaitGroup)
-	resourceTypesChecked := &sync.Map{}
 
 	for _, resource := range resources {
 		waitGroup.Add(1)
@@ -62,7 +61,7 @@ func (s *scanner) Run(ctx context.Context) error {
 		go func(resource db.Resource, resourceTypes db.ResourceTypes) {
 			defer waitGroup.Done()
 
-			err := s.check(resource, resourceTypes, resourceTypesChecked)
+			err := s.check(resource, resourceTypes)
 			s.setCheckError(s.logger, resource, err)
 
 		}(resource, resourceTypes)
@@ -73,18 +72,13 @@ func (s *scanner) Run(ctx context.Context) error {
 	return s.checkFactory.NotifyChecker()
 }
 
-func (s *scanner) check(checkable db.Checkable, resourceTypes db.ResourceTypes, resourceTypesChecked *sync.Map) error {
+func (s *scanner) check(checkable db.Checkable, resourceTypes db.ResourceTypes) error {
 
 	var err error
 
 	parentType, found := resourceTypes.Parent(checkable)
 	if found {
-		if _, exists := resourceTypesChecked.LoadOrStore(parentType.ID(), true); exists {
-			// already trying to create check for resource type
-			return nil
-		}
-
-		err = s.check(parentType, resourceTypes, resourceTypesChecked)
+		err = s.check(parentType, resourceTypes)
 		s.setCheckError(s.logger, parentType, err)
 
 		if err != nil {

--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -246,45 +246,5 @@ var _ = Describe("Scanner", func() {
 				})
 			})
 		})
-
-		Context("when there are multiple resources that use the same resource type", func() {
-			var fakeResource1, fakeResource2 *dbfakes.FakeResource
-			var fakeResourceType *dbfakes.FakeResourceType
-
-			BeforeEach(func() {
-				fakeResource1 = new(dbfakes.FakeResource)
-				fakeResource1.NameReturns("some-name")
-				fakeResource1.SourceReturns(atc.Source{"some": "source"})
-				fakeResource1.TypeReturns("custom-type")
-				fakeResource1.PipelineIDReturns(1)
-				fakeResource1.LastCheckEndTimeReturns(time.Now())
-
-				fakeResource2 = new(dbfakes.FakeResource)
-				fakeResource2.NameReturns("some-name")
-				fakeResource2.SourceReturns(atc.Source{"some": "source"})
-				fakeResource2.TypeReturns("custom-type")
-				fakeResource2.PipelineIDReturns(1)
-				fakeResource2.LastCheckEndTimeReturns(time.Now())
-
-				fakeCheckFactory.ResourcesReturns([]db.Resource{fakeResource1, fakeResource2}, nil)
-
-				fakeResourceType = new(dbfakes.FakeResourceType)
-				fakeResourceType.NameReturns("custom-type")
-				fakeResourceType.PipelineIDReturns(1)
-				fakeResourceType.TypeReturns("some-base-type")
-				fakeResourceType.SourceReturns(atc.Source{"some": "type-source"})
-				fakeResourceType.LastCheckEndTimeReturns(time.Now().Add(-time.Hour))
-
-				fakeCheckFactory.ResourceTypesReturns([]db.ResourceType{fakeResourceType}, nil)
-			})
-
-			It("only tries to create a check for the resource type once", func() {
-				Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(1))
-
-				_, checkable, _, _, manuallyTriggered := fakeCheckFactory.TryCreateCheckArgsForCall(0)
-				Expect(checkable).To(Equal(fakeResourceType))
-				Expect(manuallyTriggered).To(BeFalse())
-			})
-		})
 	})
 })


### PR DESCRIPTION
Reverts concourse/concourse#5166

Just noticed the `if` conditional exits out of the whole thing. It probably shouldn't?