### PR TITLE
Within one scanner tick, only create one check for a resource type

### DIFF
--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -246,5 +246,45 @@ var _ = Describe("Scanner", func() {
 				})
 			})
 		})
+
+		Context("when there are multiple resources that use the same resource type", func() {
+			var fakeResource1, fakeResource2 *dbfakes.FakeResource
+			var fakeResourceType *dbfakes.FakeResourceType
+
+			BeforeEach(func() {
+				fakeResource1 = new(dbfakes.FakeResource)
+				fakeResource1.NameReturns("some-name")
+				fakeResource1.SourceReturns(atc.Source{"some": "source"})
+				fakeResource1.TypeReturns("custom-type")
+				fakeResource1.PipelineIDReturns(1)
+				fakeResource1.LastCheckEndTimeReturns(time.Now())
+
+				fakeResource2 = new(dbfakes.FakeResource)
+				fakeResource2.NameReturns("some-name")
+				fakeResource2.SourceReturns(atc.Source{"some": "source"})
+				fakeResource2.TypeReturns("custom-type")
+				fakeResource2.PipelineIDReturns(1)
+				fakeResource2.LastCheckEndTimeReturns(time.Now())
+
+				fakeCheckFactory.ResourcesReturns([]db.Resource{fakeResource1, fakeResource2}, nil)
+
+				fakeResourceType = new(dbfakes.FakeResourceType)
+				fakeResourceType.NameReturns("custom-type")
+				fakeResourceType.PipelineIDReturns(1)
+				fakeResourceType.TypeReturns("some-base-type")
+				fakeResourceType.SourceReturns(atc.Source{"some": "type-source"})
+				fakeResourceType.LastCheckEndTimeReturns(time.Now().Add(-time.Hour))
+
+				fakeCheckFactory.ResourceTypesReturns([]db.ResourceType{fakeResourceType}, nil)
+			})
+
+			It("only tries to create a check for the resource type once", func() {
+				Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(1))
+
+				_, checkable, _, _, manuallyTriggered := fakeCheckFactory.TryCreateCheckArgsForCall(0)
+				Expect(checkable).To(Equal(fakeResourceType))
+				Expect(manuallyTriggered).To(BeFalse())
+			})
+		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Clara Fu <cfu@pivotal.io>

# Existing Issue

Fixes #5158

# Why do we need this PR?
If there are multiple resources that use the same resource type, lidar
will try to create the same resource type check for each resource that
uses it. This can potentially cause a lot of duplicate work with the
SetResourceConfig method for every check created.


# Changes proposed in this pull request
In order to avoid this duplication, there is now a sync map for resource
types so that if a check is already created for this resource type, we
won't try to create another check. This map is created every interval
tick and once we add a resource type into the map, it isn't removed
until the whole map is removed through the end of the scanner tick. This
is to ensure that once we have created a check for a resource type
within this interval tick, we will not try to create another check for
it within the same tick.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
