### PR TITLE
Add role for GetWall

### DIFF
--- a/atc/api/accessor/accessor_test.go
+++ b/atc/api/accessor/accessor_test.go
@@ -1,15 +1,16 @@
 package accessor_test
 
 import (
-	"code.cloudfoundry.org/lager"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
+	"net/http"
+
+	"code.cloudfoundry.org/lager"
 	"github.com/dgrijalva/jwt-go"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"net/http"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/accessor"
@@ -856,6 +857,11 @@ var _ = Describe("Accessor", func() {
 		Entry("member :: "+atc.ListBuildArtifacts, atc.ListBuildArtifacts, "member", true),
 		Entry("pipeline-operator :: "+atc.ListBuildArtifacts, atc.ListBuildArtifacts, "pipeline-operator", true),
 		Entry("viewer :: "+atc.ListBuildArtifacts, atc.ListBuildArtifacts, "viewer", true),
+
+		Entry("owner :: "+atc.GetWall, atc.GetWall, "owner", true),
+		Entry("member :: "+atc.GetWall, atc.GetWall, "member", true),
+		Entry("pipeline-operator :: "+atc.GetWall, atc.GetWall, "pipeline-operator", true),
+		Entry("viewer :: "+atc.GetWall, atc.GetWall, "viewer", true),
 	)
 
 	Describe("Customize RBAC", func() {

--- a/atc/api/accessor/role_action_map.go
+++ b/atc/api/accessor/role_action_map.go
@@ -1,9 +1,10 @@
 package accessor
 
 import (
+	"io/ioutil"
+
 	"code.cloudfoundry.org/lager"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 
 	"github.com/concourse/concourse/atc"
 )
@@ -95,6 +96,7 @@ var requiredRoles = map[string]string{
 	atc.CreateArtifact:                "member",
 	atc.GetArtifact:                   "member",
 	atc.ListBuildArtifacts:            "viewer",
+	atc.GetWall:                       "viewer",
 }
 
 type CustomActionRoleMap map[string][]string


### PR DESCRIPTION
Signed-off-by: Clara Fu <cfu@pivotal.io>

# Existing Issue

Fixes #5176

# Why do we need this PR?
I noticed after adding the tests #5175 for making sure all routes are assigned to either a role or is admin only that GetWall is missing an assigned role. I added a role for GetWall in the PR for adding the test but it is built ontop of the use-dex-token branch which will not be merged until after the 6.0.0 beta release.

# Changes proposed in this pull request
In order to give GetWall a role for the beta 6.0 release, we should probably assign it a role onto master for now. I assigned it to viewer role because anyone should be able to see the wall, but I might be wrong?

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
