### PR TITLE
Revert "switch to pure go impl of zstd"

### DIFF
--- a/atc/worker/artifact_source.go
+++ b/atc/worker/artifact_source.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/klauspost/compress/zstd"
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc/runtime"
 	"github.com/hashicorp/go-multierror"
 )
@@ -78,10 +78,7 @@ func (source *artifactSource) StreamFile(
 		return nil, err
 	}
 
-	zstdReader, err := zstd.NewReader(out)
-	if err != nil {
-		return nil, err
-	}
+	zstdReader := zstd.NewReader(out)
 	tarReader := tar.NewReader(zstdReader)
 
 	_, err = tarReader.Next()
@@ -93,7 +90,7 @@ func (source *artifactSource) StreamFile(
 		reader: tarReader,
 		closers: []io.Closer{
 			out,
-			CloseWithError{zstdReader},
+			zstdReader,
 		},
 	}, nil
 }
@@ -112,18 +109,6 @@ func NewCacheArtifactSource(artifact runtime.CacheArtifact) ArtifactSource {
 
 func (source *cacheArtifactSource) ExistsOn(logger lager.Logger, worker Worker) (Volume, bool, error) {
 	return worker.FindVolumeForTaskCache(logger, source.TeamID, source.JobID, source.StepName, source.Path)
-}
-
-type CloseWithError struct {
-	NoErringCloser interface {
-		Close()
-	}
-}
-
-// I know this is bad
-func (cwe CloseWithError) Close() error {
-	cwe.NoErringCloser.Close()
-	return nil
 }
 
 type fileReadMultiCloser struct {

--- a/atc/worker/artifact_source_test.go
+++ b/atc/worker/artifact_source_test.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/klauspost/compress/zstd"
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc/runtime"
 	"github.com/concourse/concourse/atc/runtime/runtimefakes"
 	"github.com/concourse/concourse/atc/worker"
@@ -115,14 +115,13 @@ var _ = Describe("StreamableArtifactSource", func() {
 			BeforeEach(func() {
 				tgzBuffer = gbytes.NewBuffer()
 				fakeVolume.StreamOutReturns(tgzBuffer, nil)
-				zstdWriter, err := zstd.NewWriter(tgzBuffer)
-				Expect(err).ToNot(HaveOccurred())
+				zstdWriter := zstd.NewWriter(tgzBuffer)
 				defer zstdWriter.Close()
 
 				tarWriter := tar.NewWriter(zstdWriter)
 				defer tarWriter.Close()
 
-				err = tarWriter.WriteHeader(&tar.Header{
+				err := tarWriter.WriteHeader(&tar.Header{
 					Name: "some-file",
 					Mode: 0644,
 					Size: int64(len(fileContent)),

--- a/atc/worker/image/image_resource_fetcher.go
+++ b/atc/worker/image/image_resource_fetcher.go
@@ -9,7 +9,7 @@ import (
 	"io"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/klauspost/compress/zstd"
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/resource"
@@ -206,10 +206,7 @@ func (i *imageResourceFetcher) Fetch(
 		return nil, nil, nil, err
 	}
 
-	zstdReader, err := zstd.NewReader(reader)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	zstdReader := zstd.NewReader(reader)
 	tarReader := tar.NewReader(zstdReader)
 
 	_, err = tarReader.Next()
@@ -221,7 +218,7 @@ func (i *imageResourceFetcher) Fetch(
 		reader: tarReader,
 		closers: []io.Closer{
 			reader,
-			CloseWithError{zstdReader},
+			zstdReader,
 		},
 	}
 
@@ -336,18 +333,6 @@ func (i *imageResourceFetcher) getLatestVersion(
 	}
 
 	return versions[0], nil
-}
-
-type CloseWithError struct {
-	NoErringCloser interface {
-		Close()
-	}
-}
-
-// I know this is bad
-func (cwe CloseWithError) Close() error {
-	cwe.NoErringCloser.Close()
-	return nil
 }
 
 type fileReadMultiCloser struct {

--- a/atc/worker/image/image_resource_fetcher_test.go
+++ b/atc/worker/image/image_resource_fetcher_test.go
@@ -9,7 +9,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
-	"github.com/klauspost/compress/zstd"
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
@@ -629,12 +629,10 @@ var _ = Describe("Image", func() {
 func tgzStreamWith(metadata string) io.ReadCloser {
 	buffer := gbytes.NewBuffer()
 
-	zstdWriter, err := zstd.NewWriter(buffer)
-	Expect(err).NotTo(HaveOccurred())
-
+	zstdWriter := zstd.NewWriter(buffer)
 	tarWriter := tar.NewWriter(zstdWriter)
 
-	err = tarWriter.WriteHeader(&tar.Header{
+	err := tarWriter.WriteHeader(&tar.Header{
 		Name: "metadata.json",
 		Mode: 0600,
 		Size: int64(len(metadata)),

--- a/fly/commands/internal/executehelpers/downloads.go
+++ b/fly/commands/internal/executehelpers/downloads.go
@@ -1,7 +1,7 @@
 package executehelpers
 
 import (
-	"github.com/klauspost/compress/zstd"
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/concourse/go-archive/tarfs"
 	"github.com/vbauerster/mpb/v4"
@@ -15,10 +15,5 @@ func Download(bar *mpb.Bar, team concourse.Team, artifactID int, path string) er
 
 	defer out.Close()
 
-	zstdReader, err := zstd.NewReader(bar.ProxyReader(out))
-	if err != nil {
-		return err
-	}
-
-	return tarfs.Extract(zstdReader, path)
+	return tarfs.Extract(zstd.NewReader(bar.ProxyReader(out)), path)
 }

--- a/fly/commands/internal/executehelpers/uploads.go
+++ b/fly/commands/internal/executehelpers/uploads.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"os/exec"
 
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/concourse/go-archive/tarfs"
-	"github.com/klauspost/compress/zstd"
 	"github.com/vbauerster/mpb/v4"
 )
 
@@ -18,20 +18,8 @@ func Upload(bar *mpb.Bar, team concourse.Team, path string, includeIgnored bool,
 
 	archiveStream, archiveWriter := io.Pipe()
 
-	zstdWriter, err := zstd.NewWriter(archiveWriter)
-	if err != nil {
-		return atc.WorkerArtifact{}, err
-	}
-
 	go func() {
-		err = tarfs.Compress(zstdWriter, path, files...)
-		if err != nil {
-			_ = zstdWriter.Close()
-			archiveWriter.CloseWithError(err)
-			return
-		}
-
-		archiveWriter.CloseWithError(zstdWriter.Close())
+		archiveWriter.CloseWithError(tarfs.Compress(zstd.NewWriter(archiveWriter), path, files...))
 	}()
 
 	return team.CreateArtifact(bar.ProxyReader(archiveStream), platform)

--- a/fly/integration/execute_multiple_inputs_test.go
+++ b/fly/integration/execute_multiple_inputs_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/event"
 	. "github.com/onsi/ginkgo"
@@ -18,7 +19,6 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/klauspost/compress/zstd"
 	"github.com/vito/go-sse/sse"
 )
 
@@ -133,10 +133,7 @@ run:
 				func(w http.ResponseWriter, req *http.Request) {
 					Expect(req.FormValue("platform")).To(Equal("some-platform"))
 
-					zstdReader, err := zstd.NewReader(req.Body)
-					Expect(err).NotTo(HaveOccurred())
-
-					tr := tar.NewReader(zstdReader)
+					tr := tar.NewReader(zstd.NewReader(req.Body))
 
 					hdr, err := tr.Next()
 					Expect(err).NotTo(HaveOccurred())

--- a/fly/integration/execute_overriding_inputs_test.go
+++ b/fly/integration/execute_overriding_inputs_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/event"
 	. "github.com/onsi/ginkgo"
@@ -17,7 +18,6 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/klauspost/compress/zstd"
 	"github.com/vito/go-sse/sse"
 )
 
@@ -166,10 +166,7 @@ run:
 
 					Expect(req.FormValue("platform")).To(Equal("some-platform"))
 
-					zstdReader, err := zstd.NewReader(req.Body)
-					Expect(err).NotTo(HaveOccurred())
-
-					tr := tar.NewReader(zstdReader)
+					tr := tar.NewReader(zstd.NewReader(req.Body))
 
 					hdr, err := tr.Next()
 					Expect(err).NotTo(HaveOccurred())

--- a/fly/integration/execute_test.go
+++ b/fly/integration/execute_test.go
@@ -16,9 +16,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/event"
-	"github.com/klauspost/compress/zstd"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -134,10 +134,7 @@ run:
 				func(w http.ResponseWriter, req *http.Request) {
 					close(uploading)
 
-					zstdReader, err := zstd.NewReader(req.Body)
-					Expect(err).NotTo(HaveOccurred())
-
-					tr := tar.NewReader(zstdReader)
+					tr := tar.NewReader(zstd.NewReader(req.Body))
 
 					hdr, err := tr.Next()
 					Expect(err).NotTo(HaveOccurred())

--- a/fly/integration/execute_with_outputs_test.go
+++ b/fly/integration/execute_with_outputs_test.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/DataDog/zstd"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/event"
-	"github.com/klauspost/compress/zstd"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -147,10 +147,7 @@ run:
 				func(w http.ResponseWriter, req *http.Request) {
 					Expect(req.FormValue("platform")).To(Equal("some-platform"))
 
-					zstdReader, err := zstd.NewReader(req.Body)
-					Expect(err).NotTo(HaveOccurred())
-
-					tr := tar.NewReader(zstdReader)
+					tr := tar.NewReader(zstd.NewReader(req.Body))
 
 					hdr, err := tr.Next()
 					Expect(err).NotTo(HaveOccurred())
@@ -277,13 +274,12 @@ run:
 })
 
 func tarHandler(w http.ResponseWriter, req *http.Request) {
-	zw, err := zstd.NewWriter(w)
-	Expect(err).NotTo(HaveOccurred())
+	zw := zstd.NewWriter(w)
 	tw := tar.NewWriter(zw)
 
 	tarContents := []byte("tar-contents")
 
-	err = tw.WriteHeader(&tar.Header{
+	err := tw.WriteHeader(&tar.Header{
 		Name: "some-file",
 		Mode: 0644,
 		Size: int64(len(tarContents)),

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	code.cloudfoundry.org/localip v0.0.0-20170223024724-b88ad0dea95c
 	code.cloudfoundry.org/urljoiner v0.0.0-20170223060717-5cabba6c0a50
 	github.com/DataDog/datadog-go v3.2.0+incompatible
+	github.com/DataDog/zstd v1.4.0
 	github.com/Masterminds/squirrel v1.1.0
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
 	github.com/NYTimes/gziphandler v1.1.1
@@ -60,7 +61,6 @@ require (
 	github.com/influxdata/influxdb1-client v0.0.0-20190118215656-f8cdb5d5f175
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/json-iterator/go v1.1.7 // indirect
-	github.com/klauspost/compress v1.9.7
 	github.com/kr/pty v1.1.8
 	github.com/krishicks/yaml-patch v0.0.10
 	github.com/lib/pq v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,6 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.9.7 h1:hYW1gP94JUmAhBtJ+LNz5My+gBobDxPR1iVuKug26aA=
-github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=


### PR DESCRIPTION
Reverts concourse/concourse#5024

We're seeing failures in CI when streaming volumes in the [`dev-image` build][1].

Also seeing high memory usage on the `web` nodes. We should probably [set a memory limit][2] on decoding? (Not sure if we need to do anything about encoding.)

[1]: https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/dev-image/builds/150
[2]: https://pkg.go.dev/github.com/klauspost/compress@v1.10.0/zstd?tab=doc#WithDecoderMaxMemory