### PR TITLE
Do not allow duplicate rerun builds

### DIFF
--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -684,6 +684,21 @@ func (j *job) CreateBuild() (Build, error) {
 }
 
 func (j *job) RerunBuild(buildToRerun Build) (Build, error) {
+	for {
+		rerunBuild, err := j.tryRerunBuild(buildToRerun)
+		if err != nil {
+			if pqErr, ok := err.(*pq.Error); ok && pqErr.Code.Name() == pqUniqueViolationErrCode {
+				continue
+			}
+
+			return nil, err
+		}
+
+		return rerunBuild, nil
+	}
+}
+
+func (j *job) tryRerunBuild(buildToRerun Build) (Build, error) {
 	tx, err := j.conn.Begin()
 	if err != nil {
 		return nil, err
@@ -691,7 +706,36 @@ func (j *job) RerunBuild(buildToRerun Build) (Build, error) {
 
 	defer Rollback(tx)
 
-	rerunBuild, err := j.rerunBuild(tx, buildToRerun)
+	buildToRerunID := buildToRerun.ID()
+	if buildToRerun.RerunOf() != 0 {
+		buildToRerunID = buildToRerun.RerunOf()
+	}
+
+	rerunBuildName, rerunNumber, err := j.getNewRerunBuildName(tx, buildToRerunID)
+	if err != nil {
+		return nil, err
+	}
+
+	rerunBuild := newEmptyBuild(j.conn, j.lockFactory)
+	err = createBuild(tx, rerunBuild, map[string]interface{}{
+		"name":         rerunBuildName,
+		"job_id":       j.id,
+		"pipeline_id":  j.pipelineID,
+		"team_id":      j.teamID,
+		"status":       BuildStatusPending,
+		"rerun_of":     buildToRerunID,
+		"rerun_number": rerunNumber,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = updateNextBuildForJob(tx, j.id)
+	if err != nil {
+		return nil, err
+	}
+
+	err = requestSchedule(tx, j.id)
 	if err != nil {
 		return nil, err
 	}
@@ -1149,52 +1193,6 @@ func (j *job) getNextBuildInputs(tx Tx) ([]BuildInput, error) {
 	}
 
 	return buildInputs, err
-}
-
-func (j *job) rerunBuild(tx Tx, buildToRerun Build) (*build, error) {
-	buildToRerunID := buildToRerun.ID()
-	if buildToRerun.RerunOf() != 0 {
-		buildToRerunID = buildToRerun.RerunOf()
-	}
-
-	rerunBuildName, rerunNumber, err := j.getNewRerunBuildName(tx, buildToRerunID)
-	if err != nil {
-		return nil, err
-	}
-
-	rerunBuild := newEmptyBuild(j.conn, j.lockFactory)
-	err = createBuild(tx, rerunBuild, map[string]interface{}{
-		"name":         rerunBuildName,
-		"job_id":       j.id,
-		"pipeline_id":  j.pipelineID,
-		"team_id":      j.teamID,
-		"status":       BuildStatusPending,
-		"rerun_of":     buildToRerunID,
-		"rerun_number": rerunNumber,
-	})
-	if err != nil {
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code.Name() == pqUniqueViolationErrCode {
-			retriedRerunBuild, err := j.rerunBuild(tx, buildToRerun)
-			if err != nil {
-				return nil, err
-			}
-
-			return retriedRerunBuild, nil
-		}
-		return nil, err
-	}
-
-	err = updateNextBuildForJob(tx, j.id)
-	if err != nil {
-		return nil, err
-	}
-
-	err = requestSchedule(tx, j.id)
-	if err != nil {
-		return nil, err
-	}
-
-	return rerunBuild, nil
 }
 
 func scanJob(j *job, row scannable) error {

--- a/atc/db/migration/migrations/1581621620_add_unique_index_on_build_names.down.sql
+++ b/atc/db/migration/migrations/1581621620_add_unique_index_on_build_names.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+  CREATE INDEX builds_name ON builds USING btree (name);
+  CREATE INDEX builds_job_id ON builds USING btree (job_id);
+
+  DROP INDEX build_names_uniq_idx;
+
+COMMIT;

--- a/atc/db/migration/migrations/1581621620_add_unique_index_on_build_names.up.sql
+++ b/atc/db/migration/migrations/1581621620_add_unique_index_on_build_names.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+  CREATE UNIQUE INDEX build_names_uniq_idx ON builds (job_id, name);
+
+  DROP INDEX builds_job_id;
+  DROP INDEX builds_name;
+
+COMMIT;

--- a/atc/scheduler/algorithm/table_helpers_test.go
+++ b/atc/scheduler/algorithm/table_helpers_test.go
@@ -371,7 +371,7 @@ func (example Example) importVersionsDB(ctx context.Context, setup setupDB, cach
 				continue
 			}
 
-			_, err := stmt.Exec(setup.teamID, row.BuildID, row.JobID, "some-name", "succeeded")
+			_, err := stmt.Exec(setup.teamID, row.BuildID, row.JobID, row.BuildID, "succeeded")
 			Expect(err).ToNot(HaveOccurred())
 
 			imported[row.BuildID] = true
@@ -384,7 +384,7 @@ func (example Example) importVersionsDB(ctx context.Context, setup setupDB, cach
 
 			// any builds not created at this point must have failed as they weren't
 			// present via outputs
-			_, err := stmt.Exec(setup.teamID, row.BuildID, row.JobID, "some-name", "failed")
+			_, err := stmt.Exec(setup.teamID, row.BuildID, row.JobID, row.BuildID, "failed")
 			Expect(err).ToNot(HaveOccurred())
 
 			imported[row.BuildID] = true
@@ -888,7 +888,7 @@ func (s setupDB) insertRowBuild(row DBRow, needsV6Migration bool) {
 	var existingJobID int
 	err := s.psql.Insert("builds").
 		Columns("team_id", "id", "job_id", "name", "status", "scheduled", "inputs_ready", "rerun_of", "needs_v6_migration").
-		Values(s.teamID, row.BuildID, jobID, "some-name", buildStatus, true, true, rerunOf, needsV6Migration).
+		Values(s.teamID, row.BuildID, jobID, row.BuildID, buildStatus, true, true, rerunOf, needsV6Migration).
 		Suffix("ON CONFLICT (id) DO UPDATE SET name = excluded.name").
 		Suffix("RETURNING job_id").
 		QueryRow().


### PR DESCRIPTION
Signed-off-by: Clara Fu <cfu@pivotal.io>

# Existing Issue

Fixes #5185

# Why do we need this PR?
Spamming rerun build requests should not result in two or more of the same build being created.

# Changes proposed in this pull request
If there are two requests trying to create the same rerun build, one of them will fail using the unique constraint and will retry again in order to make a separate rerun build.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests ( this requires a race condition to happen that might be flaky if put into a ginkgo test )
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
