### PR TITLE
worker: backfill tests for updated container destroy behaviour

### DIFF
--- a/worker/backend/backend.go
+++ b/worker/backend/backend.go
@@ -212,7 +212,6 @@ func (b *Backend) Destroy(handle string) error {
 		return nil
 	}
 
-	const ungraceful = false
 	err = b.killer.Kill(ctx, task, KillGracefully)
 	if err != nil {
 		return fmt.Errorf("gracefully killing task: %w", err)

--- a/worker/backend/backend_test.go
+++ b/worker/backend/backend_test.go
@@ -338,7 +338,7 @@ func (s *BackendSuite) TestDestroyDeleteTaskFails() {
 	s.client.GetContainerReturns(fakeContainer, nil)
 	fakeContainer.TaskReturns(fakeTask, nil)
 
-	expectedError := errors.New("delete-container-failed")
+	expectedError := errors.New("delete-task-failed")
 	fakeTask.DeleteReturns(nil, expectedError)
 
 	err := s.backend.Destroy("some handle")


### PR DESCRIPTION
# Existing Issue
Fixes #5184.

# Why do we need this PR?
In #5114 the way containers are destroyed in a worker was modified. This made the old tests for the destroy functionality irrelevant, and now new ones needed.

# Changes proposed in this pull request
* Add unit tests for all the failure cases and the success case for destroying a container

# Contributor Checklist
- [x] Unit tests

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
