### PR TITLE
atc(feat): graceful process termination when interrupted

### DIFF
--- a/atc/config.go
+++ b/atc/config.go
@@ -470,6 +470,9 @@ type PlanConfig struct {
 	// used on any step to interrupt the step after a given duration
 	Timeout string `json:"timeout,omitempty"`
 
+	// used on any step to force graceful terminal when interrupted
+	Interrupt string `json:"interrupt_timeout,omitempty"`
+
 	// not present in yaml
 	DependentGet string `json:"-" json:"-"`
 

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -656,6 +656,14 @@ func validatePlan(c Config, identifier string, plan PlanConfig) ([]ConfigWarning
 		}
 	}
 
+	if plan.Interrupt != "" {
+		_, err := time.ParseDuration(plan.Interrupt)
+		if err != nil {
+			subIdentifier := fmt.Sprintf("%s.interrupt", identifier)
+			errorMessages = append(errorMessages, subIdentifier+fmt.Sprintf(" refers to a duration that could not be parsed ('%s')", plan.Interrupt))
+		}
+	}
+
 	if plan.Attempts < 0 {
 		subIdentifier := fmt.Sprintf("%s.attempts", identifier)
 		errorMessages = append(errorMessages, subIdentifier+fmt.Sprintf(" has an invalid number of attempts (%d)", plan.Attempts))

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -1,8 +1,9 @@
 package configvalidate_test
 
 import (
-	"github.com/concourse/concourse/atc/configvalidate"
 	"strings"
+
+	"github.com/concourse/concourse/atc/configvalidate"
 
 	. "github.com/concourse/concourse/atc"
 
@@ -1307,6 +1308,22 @@ var _ = Describe("ValidateConfig", func() {
 				It("throws a validation error", func() {
 					Expect(errorMessages).To(HaveLen(1))
 					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan[0].get.some-resource.timeout refers to a duration that could not be parsed ('nope')"))
+				})
+			})
+
+			Context("when a plan has an invalid interrupt timeout in a step", func() {
+				BeforeEach(func() {
+					job.Plan = append(job.Plan, PlanConfig{
+						Get:       "some-resource",
+						Interrupt: "nah",
+					})
+
+					config.Jobs = append(config.Jobs, job)
+				})
+
+				It("throws a validation error", func() {
+					Expect(errorMessages).To(HaveLen(1))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan[0].get.some-resource.interrupt refers to a duration that could not be parsed ('nah')"))
 				})
 			})
 

--- a/atc/exec/interrupt_step.go
+++ b/atc/exec/interrupt_step.go
@@ -1,0 +1,44 @@
+package exec
+
+import (
+	"context"
+	"time"
+
+	"github.com/concourse/concourse/atc/worker"
+)
+
+// InterruptStep applies a timeout for aborts/interrupts of a step's Run.
+type InterruptStep struct {
+	step     Step
+	duration string
+}
+
+// Interrupt constructs a InterruptStep factory.
+func Interrupt(step Step, duration string) *InterruptStep {
+	return &InterruptStep{
+		step:     step,
+		duration: duration,
+	}
+}
+
+// Run parses the interrupt timeout duration and invokes the nested step.
+//
+//
+// The result of the nested step's Run is returned.
+func (is *InterruptStep) Run(ctx context.Context, state RunState) error {
+	parsedDuration, err := time.ParseDuration(is.duration)
+	if err != nil {
+		return err
+	}
+
+	interruptCtx := worker.WithInterruptTimeout(ctx, parsedDuration)
+
+	err = is.step.Run(interruptCtx, state)
+
+	return err
+}
+
+// Succeeded is true if the nested step completed successfully.
+func (is *InterruptStep) Succeeded() bool {
+	return is.step.Succeeded()
+}

--- a/atc/exec/interrupt_step_test.go
+++ b/atc/exec/interrupt_step_test.go
@@ -1,0 +1,94 @@
+package exec_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/concourse/concourse/atc/exec"
+	"github.com/concourse/concourse/atc/exec/build"
+	"github.com/concourse/concourse/atc/exec/execfakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Interrupt Step", func() {
+	var (
+		ctx context.Context
+
+		fakeStep *execfakes.FakeStep
+
+		repo  *build.Repository
+		state *execfakes.FakeRunState
+
+		step Step
+
+		interruptDuration string
+
+		stepErr error
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		fakeStep = new(execfakes.FakeStep)
+
+		repo = build.NewRepository()
+		state = new(execfakes.FakeRunState)
+		state.ArtifactRepositoryReturns(repo)
+
+		interruptDuration = "1h"
+	})
+
+	JustBeforeEach(func() {
+		step = Interrupt(fakeStep, interruptDuration)
+		stepErr = step.Run(ctx, state)
+	})
+
+	Context("when the duration is valid", func() {
+		Context("when the step returns an error", func() {
+			var someError error
+
+			BeforeEach(func() {
+				someError = errors.New("some error")
+				fakeStep.SucceededReturns(false)
+				fakeStep.RunReturns(someError)
+			})
+
+			It("returns the error", func() {
+				Expect(stepErr).NotTo(BeNil())
+				Expect(stepErr).To(Equal(someError))
+			})
+		})
+
+		Context("when the step is successful", func() {
+			BeforeEach(func() {
+				fakeStep.SucceededReturns(true)
+			})
+
+			It("is successful", func() {
+				Expect(step.Succeeded()).To(BeTrue())
+			})
+		})
+
+		Context("when the step fails", func() {
+			BeforeEach(func() {
+				fakeStep.SucceededReturns(false)
+			})
+
+			It("is not successful", func() {
+				Expect(step.Succeeded()).To(BeFalse())
+			})
+		})
+	})
+
+	Context("when the duration is invalid", func() {
+		BeforeEach(func() {
+			interruptDuration = "nope"
+		})
+
+		It("errors immediately without running the step", func() {
+			Expect(stepErr).To(HaveOccurred())
+			Expect(fakeStep.RunCallCount()).To(BeZero())
+		})
+	})
+})

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -20,6 +20,7 @@ type Plan struct {
 	OnFailure   *OnFailurePlan   `json:"on_failure,omitempty"`
 	Try         *TryPlan         `json:"try,omitempty"`
 	Timeout     *TimeoutPlan     `json:"timeout,omitempty"`
+	Interrupt   *InterruptPlan   `json:"interrupt_timeout,omitempty"`
 	Retry       *RetryPlan       `json:"retry,omitempty"`
 
 	// used for 'fly execute'
@@ -67,6 +68,11 @@ type OnSuccessPlan struct {
 }
 
 type TimeoutPlan struct {
+	Step     Plan   `json:"step"`
+	Duration string `json:"duration"`
+}
+
+type InterruptPlan struct {
 	Step     Plan   `json:"step"`
 	Duration string `json:"duration"`
 }

--- a/atc/plan_factory.go
+++ b/atc/plan_factory.go
@@ -57,6 +57,8 @@ func (factory PlanFactory) NewPlan(step Step) Plan {
 		plan.Try = &t
 	case TimeoutPlan:
 		plan.Timeout = &t
+	case InterruptPlan:
+		plan.Interrupt = &t
 	case RetryPlan:
 		plan.Retry = &t
 	case ArtifactInputPlan:

--- a/atc/public_plan.go
+++ b/atc/public_plan.go
@@ -23,6 +23,7 @@ func (plan Plan) Public() *json.RawMessage {
 		Try            *json.RawMessage `json:"try,omitempty"`
 		DependentGet   *json.RawMessage `json:"dependent_get,omitempty"`
 		Timeout        *json.RawMessage `json:"timeout,omitempty"`
+		Interrupt      *json.RawMessage `json:"interrupt_timeout,omitempty"`
 		Retry          *json.RawMessage `json:"retry,omitempty"`
 		ArtifactInput  *json.RawMessage `json:"artifact_input,omitempty"`
 		ArtifactOutput *json.RawMessage `json:"artifact_output,omitempty"`
@@ -92,6 +93,10 @@ func (plan Plan) Public() *json.RawMessage {
 
 	if plan.Timeout != nil {
 		public.Timeout = plan.Timeout.Public()
+	}
+
+	if plan.Interrupt != nil {
+		public.Interrupt = plan.Interrupt.Public()
 	}
 
 	if plan.Retry != nil {
@@ -276,6 +281,16 @@ func (plan LoadVarPlan) Public() *json.RawMessage {
 }
 
 func (plan TimeoutPlan) Public() *json.RawMessage {
+	return enc(struct {
+		Step     *json.RawMessage `json:"step"`
+		Duration string           `json:"duration"`
+	}{
+		Step:     plan.Step.Public(),
+		Duration: plan.Duration,
+	})
+}
+
+func (plan InterruptPlan) Public() *json.RawMessage {
 	return enc(struct {
 		Step     *json.RawMessage `json:"step"`
 		Duration string           `json:"duration"`

--- a/atc/public_plan_test.go
+++ b/atc/public_plan_test.go
@@ -359,6 +359,28 @@ var _ = Describe("Plan", func() {
 							Vars:     map[string]interface{}{"k1": "v1"},
 						},
 					},
+					atc.Plan{
+						ID: "38",
+						Interrupt: &atc.InterruptPlan{
+							Step: atc.Plan{
+								ID: "39",
+								Timeout: &atc.TimeoutPlan{
+									Step: atc.Plan{
+										ID: "40",
+										Task: &atc.TaskPlan{
+											Name:       "name",
+											ConfigPath: "some/config/path.yml",
+											Config: &atc.TaskConfig{
+												Params: atc.TaskEnv{"some": "secret"},
+											},
+										},
+									},
+									Duration: "lol",
+								},
+							},
+							Duration: "sometime",
+						},
+					},
 				},
 			}
 
@@ -623,6 +645,25 @@ var _ = Describe("Plan", func() {
 	  "set_pipeline": {
 		"name": "some-pipeline"
 	  }
+	},
+	{
+		"id": "38",
+		"interrupt_timeout": {
+			"step": {
+				"id": "39",
+				"timeout": {
+					"step": {
+						"id": "40",
+						"task": {
+							"name": "name",
+							"privileged": false
+						}
+					},
+					"duration": "lol"
+				}
+			},
+			"duration": "sometime"
+		}
 	}
   ]
 }

--- a/atc/scheduler/factory/build_factory.go
+++ b/atc/scheduler/factory/build_factory.go
@@ -348,6 +348,13 @@ func (factory *buildFactory) constructUnhookedPlan(
 		})
 	}
 
+	if planConfig.Interrupt != "" {
+		plan = factory.planFactory.NewPlan(atc.InterruptPlan{
+			Duration: planConfig.Interrupt,
+			Step:     plan,
+		})
+	}
+
 	return plan, nil
 }
 

--- a/atc/scheduler/factory/factory_interrupt_test.go
+++ b/atc/scheduler/factory/factory_interrupt_test.go
@@ -1,0 +1,60 @@
+package factory_test
+
+import (
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/scheduler/factory"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Factory Interrupt Step", func() {
+	var (
+		resourceTypes atc.VersionedResourceTypes
+
+		buildFactory        factory.BuildFactory
+		actualPlanFactory   atc.PlanFactory
+		expectedPlanFactory atc.PlanFactory
+	)
+
+	BeforeEach(func() {
+		actualPlanFactory = atc.NewPlanFactory(321)
+		expectedPlanFactory = atc.NewPlanFactory(321)
+		buildFactory = factory.NewBuildFactory(actualPlanFactory)
+
+		resourceTypes = atc.VersionedResourceTypes{
+			{
+				ResourceType: atc.ResourceType{
+					Name:   "some-custom-resource",
+					Type:   "registry-image",
+					Source: atc.Source{"some": "custom-source"},
+				},
+				Version: atc.Version{"some": "version"},
+			},
+		}
+	})
+
+	Context("When there is a task with an interrupt", func() {
+		It("builds correctly", func() {
+			actual, err := buildFactory.Create(atc.JobConfig{
+				Plan: atc.PlanSequence{
+					{
+						Task:      "first task",
+						Interrupt: "5m",
+					},
+				},
+			}, nil, resourceTypes, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			expected := expectedPlanFactory.NewPlan(atc.InterruptPlan{
+				Duration: "5m",
+				Step: expectedPlanFactory.NewPlan(atc.TaskPlan{
+					Name:                   "first task",
+					VersionedResourceTypes: resourceTypes,
+				}),
+			})
+
+			Expect(actual).To(Equal(expected))
+		})
+	})
+})

--- a/atc/worker/interrupt.go
+++ b/atc/worker/interrupt.go
@@ -1,0 +1,23 @@
+package worker
+
+import (
+	"context"
+	"time"
+)
+
+type intContextKey int
+
+// interruptTimeoutKey is the key for time.Duration values in Contexts. It is
+// unexported. Clients should use WithInterruptTimeout & InterruptTimeoutFromContext
+var interruptTimeoutKey intContextKey = 0
+
+// WithInterruptTimeout returns a new Context that carries value t.
+func WithInterruptTimeout(ctx context.Context, t time.Duration) context.Context {
+	return context.WithValue(ctx, interruptTimeoutKey, t)
+}
+
+// InterruptTimeoutFromContext returns the time.Duration value stored in ctx, if any.
+func InterruptTimeoutFromContext(ctx context.Context) (time.Duration, bool) {
+	u, ok := ctx.Value(interruptTimeoutKey).(time.Duration)
+	return u, ok
+}

--- a/atc/worker/interrupt_test.go
+++ b/atc/worker/interrupt_test.go
@@ -1,0 +1,35 @@
+package worker_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/concourse/concourse/atc/worker"
+)
+
+var _ = Describe("Interrupt", func() {
+	Describe("storing an interrupt timeout", func() {
+		Context("with a nil context", func() {
+			It("should store the value", func() {
+				newCtx := WithInterruptTimeout(nil, 1*time.Minute)
+				Expect(newCtx).ToNot(BeNil())
+				val, ok := InterruptTimeoutFromContext(newCtx)
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal(1 * time.Minute))
+			})
+		})
+
+		Context("with any other context", func() {
+			It("should store the value", func() {
+				newCtx := WithInterruptTimeout(context.TODO(), 1*time.Minute)
+				Expect(newCtx).ToNot(BeNil())
+				val, ok := InterruptTimeoutFromContext(newCtx)
+				Expect(ok).To(BeTrue())
+				Expect(val).To(Equal(1 * time.Minute))
+			})
+		})
+	})
+})

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,4 +1,8 @@
-#### <sub><sup><a name="4938" href="#4938">:link:</a></sup></sub> feature
+#### <sub><sup><a name="5191" href="#5191">:link:</a></sup></sub> feature
+
+* Added support for `interrupt_timeout` step modifier. #5191
+
+#### <sub><sup><a name="4976" href="#4976">:link:</a></sup></sub> feature
 
 * Include job label in build duration metrics exported to Prometheus. #4976
 


### PR DESCRIPTION
Signed-off-by: James King <james.r.king4@gmail.com>

# Existing Issue

Fixes #3737  .

# Why do we need this PR?
Per #3737

When using the timeout step modifier and the time limit is reached, the task is interrupted/exited without any graceful termination option.

This is problematic when using an infrastructure provisioning tool like Terraform which does not write the state back unless it gracefully exits. Therefore, we cannot do an on_abort/on_error/on_failure task to cleanup the half created resources.


# Changes proposed in this pull request

* Enable an annotation of interrupt_timeout which when present will change the process termination behavior in containers from SIGTERM -> wait 10s -> SIGKILL to SIGTERM -> wait interrupt_timeout -> SIGKILL.
* When not provided, the default behavor (SIGTERM -> wait 10s -> SIGKILL) would remain.


# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [X] Unit tests
- [ ] Integration tests (if applicable)
- [x] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
