### PR TITLE
topgun/k8s: test GARDEN_DENY_NETWORK

### DIFF
--- a/topgun/tasks/garden-deny-network.yml
+++ b/topgun/tasks/garden-deny-network.yml
@@ -1,0 +1,11 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: alpine
+
+run:
+  path: nc
+  args: ["-w", "3", "8.8.8.8", "53"]


### PR DESCRIPTION
# Why do we need this PR?

Even though #5198 is resolved in #5199, there are still no tests for this behaviour. This PR addresses that need. This PR will not pass CI until #5199 is merged.

# Changes proposed in this pull request

* New k8s-topgun test asserting that GARDEN_DENY_NETWORK actually denies the network
* We could have gone with bosh-topgun but wanted the quicker feedback for a property that is probably a bit of an edge case.

# Contributor Checklist
- [x] ~Unit tests~
- [x] Integration tests (if applicable)
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [x] ~Code reviewed~
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
