### PR TITLE
containerd: implement getter/setter for grace time

### DIFF
--- a/worker/backend/backend.go
+++ b/worker/backend/backend.go
@@ -281,10 +281,20 @@ func (b *Backend) Lookup(handle string) (garden.Container, error) {
 	), nil
 }
 
-// GraceTime - Not Implemented
+// GraceTime returns the value of the "garden.grace-time" property
 //
 func (b *Backend) GraceTime(container garden.Container) (duration time.Duration) {
-	return
+	property, err := container.Property(GraceTimeKey)
+	if err != nil {
+		return 0
+	}
+
+	_, err = fmt.Sscanf(property, "%d", &duration)
+	if err != nil {
+		return 0
+	}
+
+	return duration
 }
 
 // Capacity - Not Implemented

--- a/worker/backend/container.go
+++ b/worker/backend/container.go
@@ -13,6 +13,8 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+const GraceTimeKey = "garden.grace-time"
+
 type Container struct {
 	container     containerd.Container
 	killer        Killer
@@ -230,10 +232,15 @@ func (c *Container) StreamOut(spec garden.StreamOutSpec) (readCloser io.ReadClos
 	return
 }
 
-// SetGraceTime - Not Implemented
-func (c *Container) SetGraceTime(graceTime time.Duration) (err error) {
-	err = ErrNotImplemented
-	return
+// SetGraceTime stores the grace time as a containerd label with key "garden.grace-time"
+//
+func (c *Container) SetGraceTime(graceTime time.Duration) error {
+	err := c.SetProperty(GraceTimeKey, fmt.Sprintf("%d", graceTime))
+	if err != nil {
+		return fmt.Errorf("set grace time: %w", err)
+	}
+
+	return nil
 }
 
 // CurrentBandwidthLimits - Not Implemented


### PR DESCRIPTION
# Existing Issue

Fixes #5134  .

# Changes proposed in this pull request

* Implement getter/setter for grace time

# Contributor Checklist
- [X] Unit tests

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
