### PR TITLE
fly: Better error messages for --team

### DIFF
--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -280,8 +280,8 @@ var _ = Describe("Teams API", func() {
 				fakeaccess.IsAuthenticatedReturns(true)
 			})
 
-			It("return 401", func() {
-				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			It("return 403", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusForbidden))
 			})
 		})
 	})

--- a/atc/api/teamserver/get.go
+++ b/atc/api/teamserver/get.go
@@ -35,7 +35,7 @@ func (s *Server) GetTeam(w http.ResponseWriter, r *http.Request) {
 		presentedTeam = present.Team(team)
 	} else {
 		hLog.Error("unauthorized", errors.New("not authorized to "+team.Name()))
-		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusForbidden)
 		return
 	}
 

--- a/fly/commands/get_team.go
+++ b/fly/commands/get_team.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -30,13 +29,9 @@ func (command *GetTeamCommand) Execute(args []string) error {
 	}
 
 	teamName := command.Team.Name()
-	team, found, err := target.Team().Team(teamName)
+	team, err := target.FindTeam(teamName)
 	if err != nil {
 		return err
-	}
-
-	if !found {
-		return errors.New("team not found")
 	}
 
 	if command.JSON {
@@ -52,9 +47,9 @@ func (command *GetTeamCommand) Execute(args []string) error {
 		{Contents: "groups", Color: color.New(color.Bold)},
 	}
 	table := ui.Table{Headers: headers}
-	for role, auth := range team.Auth {
+	for role, auth := range team.Auth() {
 		row := ui.TableRow{
-			{Contents: fmt.Sprintf("%s/%s", team.Name, role)},
+			{Contents: fmt.Sprintf("%s/%s", team.Name(), role)},
 		}
 		var usersCell, groupsCell ui.TableCell
 		hasUsers := len(auth["users"]) != 0

--- a/fly/commands/jobs.go
+++ b/fly/commands/jobs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
+	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/fatih/color"
 )
 
@@ -17,6 +18,10 @@ type JobsCommand struct {
 }
 
 func (command *JobsCommand) Execute([]string) error {
+	var (
+		headers []string
+		team    concourse.Team
+	)
 	pipelineName := command.Pipeline
 
 	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
@@ -29,8 +34,14 @@ func (command *JobsCommand) Execute([]string) error {
 		return err
 	}
 
-	var headers []string
-	team := GetTeam(target, command.Team)
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team)
+		if err != nil {
+			return err
+		}
+	} else {
+		team = target.Team()
+	}
 
 	var jobs []atc.Job
 	jobs, err = team.ListJobs(pipelineName)

--- a/fly/commands/pause_job.go
+++ b/fly/commands/pause_job.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type PauseJobCommand struct {
@@ -24,7 +25,16 @@ func (command *PauseJobCommand) Execute(args []string) error {
 		return err
 	}
 
-	team := GetTeam(target, command.Team)
+	var team concourse.Team
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team)
+		if err != nil {
+			return err
+		}
+	} else {
+		team = target.Team()
+	}
+
 	found, err := team.PauseJob(pipelineName, jobName)
 	if err != nil {
 		return err

--- a/fly/commands/trigger_job.go
+++ b/fly/commands/trigger_job.go
@@ -11,6 +11,7 @@ import (
 	"github.com/concourse/concourse/fly/eventstream"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
+	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type TriggerJobCommand struct {
@@ -32,8 +33,19 @@ func (command *TriggerJobCommand) Execute(args []string) error {
 		return err
 	}
 
-	var build atc.Build
-	team := GetTeam(target, command.Team)
+	var (
+		build atc.Build
+		team  concourse.Team
+	)
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team)
+		if err != nil {
+			return err
+		}
+	} else {
+		team = target.Team()
+	}
+
 	build, err = team.CreateJobBuild(pipelineName, jobName)
 	if err != nil {
 		return err

--- a/fly/commands/unpause_job.go
+++ b/fly/commands/unpause_job.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type UnpauseJobCommand struct {
@@ -24,7 +25,16 @@ func (command *UnpauseJobCommand) Execute(args []string) error {
 		return err
 	}
 
-	team := GetTeam(target, command.Team)
+	var team concourse.Team
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team)
+		if err != nil {
+			return err
+		}
+	} else {
+		team = target.Team()
+	}
+
 	found, err := team.UnpauseJob(pipelineName, jobName)
 	if err != nil {
 		return err

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -1,9 +1,11 @@
 package integration_test
 
 import (
+	"net/http"
 	"os/exec"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
@@ -86,4 +88,56 @@ var _ = Describe("Fly CLI", func() {
 			Expect(sess.Err).To(gbytes.Say("lol"))
 		})
 	})
+
+	DescribeTable("when the team does not exist",
+		func(flyCmd *exec.Cmd) {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/teams/doesnotexist"),
+					ghttp.RespondWith(http.StatusNotFound, nil),
+				),
+			)
+			flyCmd.Path = flyPath // idk why but the .Path is not getting set when we run exec.Command even though flyPath is available...
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess.Err.Contents).Should(ContainSubstring(`error: team 'doesnotexist' does not exist`))
+		},
+		Entry("trigger-job command returns an error",
+			exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+		Entry("hijack command returns an error",
+			exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", "doesnotexist")),
+		Entry("jobs command returns an error",
+			exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", "doesnotexist")),
+		Entry("pause-job command returns an error",
+			exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+		Entry("unpause-job command returns an error",
+			exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+	)
+
+	DescribeTable("when you are NOT authorized to view the team",
+		func(flyCmd *exec.Cmd) {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
+					ghttp.RespondWith(http.StatusForbidden, nil),
+				),
+			)
+			flyCmd.Path = flyPath // idk why but the .Path is not getting set when we run exec.Command even though flyPath is available...
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess.Err.Contents).Should(ContainSubstring(`error: you do not have a role on team 'other-team'`))
+		},
+		Entry("trigger-job command returns an error",
+			exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", "other-team")),
+		Entry("hijack command returns an error",
+			exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", "other-team")),
+		Entry("jobs command returns an error",
+			exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", "other-team")),
+		Entry("pause-job command returns an error",
+			exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "other-team")),
+		Entry("unpause-job command returns an error",
+			exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "other-team")),
+	)
 })

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -89,55 +89,57 @@ var _ = Describe("Fly CLI", func() {
 		})
 	})
 
-	DescribeTable("when the team does not exist",
-		func(flyCmd *exec.Cmd) {
-			atcServer.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/api/v1/teams/doesnotexist"),
-					ghttp.RespondWith(http.StatusNotFound, nil),
-				),
-			)
-			flyCmd.Path = flyPath // idk why but the .Path is not getting set when we run exec.Command even though flyPath is available...
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
+	Context("when --team is set", func() {
+		DescribeTable("and the team does not exist",
+			func(flyCmd *exec.Cmd) {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/doesnotexist"),
+						ghttp.RespondWith(http.StatusNotFound, nil),
+					),
+				)
+				flyCmd.Path = flyPath // idk why but the .Path is not getting set when we run exec.Command even though flyPath is available...
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
 
-			Eventually(sess.Err.Contents).Should(ContainSubstring(`error: team 'doesnotexist' does not exist`))
-		},
-		Entry("trigger-job command returns an error",
-			exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", "doesnotexist")),
-		Entry("hijack command returns an error",
-			exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", "doesnotexist")),
-		Entry("jobs command returns an error",
-			exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", "doesnotexist")),
-		Entry("pause-job command returns an error",
-			exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
-		Entry("unpause-job command returns an error",
-			exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
-	)
+				Eventually(sess.Err.Contents).Should(ContainSubstring(`error: team 'doesnotexist' does not exist`))
+			},
+			Entry("trigger-job command returns an error",
+				exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+			Entry("hijack command returns an error",
+				exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", "doesnotexist")),
+			Entry("jobs command returns an error",
+				exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", "doesnotexist")),
+			Entry("pause-job command returns an error",
+				exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+			Entry("unpause-job command returns an error",
+				exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+		)
 
-	DescribeTable("when you are NOT authorized to view the team",
-		func(flyCmd *exec.Cmd) {
-			atcServer.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
-					ghttp.RespondWith(http.StatusForbidden, nil),
-				),
-			)
-			flyCmd.Path = flyPath // idk why but the .Path is not getting set when we run exec.Command even though flyPath is available...
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
+		DescribeTable("and you are NOT authorized to view the team",
+			func(flyCmd *exec.Cmd) {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
+						ghttp.RespondWith(http.StatusForbidden, nil),
+					),
+				)
+				flyCmd.Path = flyPath // idk why but the .Path is not getting set when we run exec.Command even though flyPath is available...
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
 
-			Eventually(sess.Err.Contents).Should(ContainSubstring(`error: you do not have a role on team 'other-team'`))
-		},
-		Entry("trigger-job command returns an error",
-			exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", "other-team")),
-		Entry("hijack command returns an error",
-			exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", "other-team")),
-		Entry("jobs command returns an error",
-			exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", "other-team")),
-		Entry("pause-job command returns an error",
-			exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "other-team")),
-		Entry("unpause-job command returns an error",
-			exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "other-team")),
-	)
+				Eventually(sess.Err.Contents).Should(ContainSubstring(`error: you do not have a role on team 'other-team'`))
+			},
+			Entry("trigger-job command returns an error",
+				exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", "other-team")),
+			Entry("hijack command returns an error",
+				exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", "other-team")),
+			Entry("jobs command returns an error",
+				exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", "other-team")),
+			Entry("pause-job command returns an error",
+				exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "other-team")),
+			Entry("unpause-job command returns an error",
+				exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "other-team")),
+		)
+	})
 })

--- a/fly/integration/get_team_test.go
+++ b/fly/integration/get_team_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ = Describe("Fly CLI", func() {
-	FDescribe("get-team", func() {
+	Describe("get-team", func() {
 		var team atc.Team
 
 		BeforeEach(func() {
@@ -40,8 +40,7 @@ var _ = Describe("Fly CLI", func() {
 
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
-				Fail("TODO: weird backtick and single quote found together. See if this test actually runs")
-				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("n", "team-name") + "` was not specified"))
+				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("n", "team-name") + "' was not specified"))
 			})
 		})
 

--- a/fly/integration/get_team_test.go
+++ b/fly/integration/get_team_test.go
@@ -5,30 +5,31 @@ import (
 	"os/exec"
 
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/ui"
+	"github.com/fatih/color"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
 	"github.com/tedsuo/rata"
-	"sigs.k8s.io/yaml"
 )
 
-var _ = Describe("GetPipeline", func() {
-	var (
-		team atc.Team
-	)
+var _ = Describe("Fly CLI", func() {
+	FDescribe("get-team", func() {
+		var team atc.Team
 
-	BeforeEach(func() {
-		team = atc.Team{
-			ID:   1,
-			Name: "myTeam",
-			Auth: atc.TeamAuth{
-				"owner": map[string][]string{
-					"groups": {}, "users": {"local:username"},
+		BeforeEach(func() {
+			team = atc.Team{
+				ID:   1,
+				Name: "myTeam",
+				Auth: atc.TeamAuth{
+					"owner": map[string][]string{
+						"groups": {}, "users": {"local:username"},
+					},
 				},
-			},
-		}
+			}
+		})
 
 		Context("when not specifying a team name", func() {
 			It("fails and says you should give a team name", func() {
@@ -39,8 +40,8 @@ var _ = Describe("GetPipeline", func() {
 
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
-
-				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("n", "team") + "' was not specified"))
+				Fail("TODO: weird backtick and single quote found together. See if this test actually runs")
+				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("n", "team-name") + "` was not specified"))
 			})
 		})
 
@@ -83,20 +84,23 @@ var _ = Describe("GetPipeline", func() {
 					)
 				})
 
-				It("prints the config as yaml to stdout", func() {
-					flyCmd := exec.Command(flyPath, "-t", targetName, "get-team", "myTeam")
+				It("prints the team config to stdout", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "get-team", "-n", "myTeam")
 
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(gexec.Exit(0))
 
-					<-sess.Exited
-					Expect(sess.ExitCode()).To(Equal(0))
-
-					var printedConfig atc.Team
-					err = yaml.Unmarshal(sess.Out.Contents(), &printedConfig)
-					Expect(err).NotTo(HaveOccurred())
-
-					Expect(printedConfig).To(Equal(team))
+					Expect(sess.Out).To(PrintTable(ui.Table{
+						Headers: ui.TableRow{
+							{Contents: "name/role", Color: color.New(color.Bold)},
+							{Contents: "users", Color: color.New(color.Bold)},
+							{Contents: "groups", Color: color.New(color.Bold)},
+						},
+						Data: []ui.TableRow{
+							{{Contents: "myTeam/owner"}, {Contents: "local:username"}, {Contents: "none"}},
+						},
+					}))
 				})
 			})
 		})

--- a/fly/integration/hijack_test.go
+++ b/fly/integration/hijack_test.go
@@ -1045,46 +1045,4 @@ var _ = Describe("Hijacking", func() {
 			Expect(sess.ExitCode()).ToNot(Equal(0))
 		})
 	})
-
-	Context("when you are authenticated but the team does not exist", func() {
-		It("returns an error", func() {
-			loginATCServer.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/api/v1/teams/doesnotexist"),
-					ghttp.RespondWith(http.StatusNotFound, nil),
-				),
-			)
-
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "hijack", "--handle", "container-id", "--team", "doesnotexist")
-
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(sess.Err.Contents).Should(ContainSubstring(`error: team 'doesnotexist' does not exist`))
-
-			<-sess.Exited
-			Expect(sess.ExitCode()).To(Equal(1))
-		})
-	})
-
-	Context("when you are NOT authorized to view the team", func() {
-		It("returns an error", func() {
-			loginATCServer.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/api/v1/teams/main"),
-					ghttp.RespondWith(http.StatusForbidden, nil),
-				),
-			)
-
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "hijack", "--handle", "container-id", "--team", "main")
-
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(sess.Err.Contents).Should(ContainSubstring(`error: you do not have a role on team 'main'`))
-
-			<-sess.Exited
-			Expect(sess.ExitCode()).To(Equal(1))
-		})
-	})
 })

--- a/fly/integration/jobs_test.go
+++ b/fly/integration/jobs_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Fly CLI", func() {
 		Context("jobs for 'other-team'", func() {
 			Context("using --team parameter", func() {
 				BeforeEach(func() {
-					loginATCServer.AppendHandlers(
+					adminAtcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{Name: "other-team"}),

--- a/fly/integration/jobs_test.go
+++ b/fly/integration/jobs_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"fmt"
+	"net/http"
 	"os/exec"
 
 	"github.com/concourse/concourse/atc"
@@ -175,6 +176,10 @@ var _ = Describe("Fly CLI", func() {
 			Context("using --team parameter", func() {
 				BeforeEach(func() {
 					loginATCServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{Name: "other-team"}),
+						),
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/other-team/pipelines/pipeline/jobs"),
 							ghttp.RespondWithJSONEncoded(200, sampleJobs),

--- a/fly/integration/jobs_test.go
+++ b/fly/integration/jobs_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Fly CLI", func() {
 		Context("jobs for 'other-team'", func() {
 			Context("using --team parameter", func() {
 				BeforeEach(func() {
-					adminAtcServer.AppendHandlers(
+					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{Name: "other-team"}),
@@ -187,7 +187,7 @@ var _ = Describe("Fly CLI", func() {
 					)
 				})
 				It("can list jobs in 'other-team'", func() {
-					flyJobCmd := exec.Command(flyPath, "-t", "some-target", "jobs", "-p", pipelineName, "--team", "other-team", "--json")
+					flyJobCmd := exec.Command(flyPath, "-t", targetName, "jobs", "-p", pipelineName, "--team", "other-team", "--json")
 					sess, err := gexec.Start(flyJobCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
 

--- a/fly/integration/login_insecure_test.go
+++ b/fly/integration/login_insecure_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = Describe("login -k Command", func() {
-	var loginATCServer *ghttp.Server
+	var adminAtcServer *ghttp.Server
 
 	Describe("login", func() {
 		var (
@@ -27,23 +27,23 @@ var _ = Describe("login -k Command", func() {
 		)
 		BeforeEach(func() {
 			l := log.New(GinkgoWriter, "TLSServer", 0)
-			loginATCServer = ghttp.NewUnstartedServer()
-			loginATCServer.HTTPTestServer.Config.ErrorLog = l
-			loginATCServer.HTTPTestServer.StartTLS()
+			adminAtcServer = ghttp.NewUnstartedServer()
+			adminAtcServer.HTTPTestServer.Config.ErrorLog = l
+			adminAtcServer.HTTPTestServer.StartTLS()
 		})
 
 		AfterEach(func() {
-			loginATCServer.Close()
+			adminAtcServer.Close()
 		})
 
 		Context("to new target with invalid SSL with -k", func() {
 			BeforeEach(func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-k", "-u", "some_user", "-p", "some_pass")
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-k", "-u", "some_user", "-p", "some_pass")
 
 				var err error
 				stdin, err = flyCmd.StdinPipe()
@@ -68,7 +68,7 @@ var _ = Describe("login -k Command", func() {
 			Context("login to existing target", func() {
 				var otherCmd *exec.Cmd
 				BeforeEach(func() {
-					loginATCServer.AppendHandlers(
+					adminAtcServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
 					)
@@ -118,7 +118,7 @@ var _ = Describe("login -k Command", func() {
 		Context("to new target with invalid SSL without -k", func() {
 			Context("without --ca-cert", func() {
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "some_user", "-p", "some_pass")
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "some_user", "-p", "some_pass")
 
 					var err error
 					stdin, err = flyCmd.StdinPipe()
@@ -147,7 +147,7 @@ var _ = Describe("login -k Command", func() {
 				BeforeEach(func() {
 					sslCert = string(pem.EncodeToMemory(&pem.Block{
 						Type:  "CERTIFICATE",
-						Bytes: loginATCServer.HTTPTestServer.TLS.Certificates[0].Certificate[0],
+						Bytes: adminAtcServer.HTTPTestServer.TLS.Certificates[0].Certificate[0],
 					}))
 
 					caCertFile, err := ioutil.TempFile("", "ca_cert.pem")
@@ -156,9 +156,9 @@ var _ = Describe("login -k Command", func() {
 					_, err = caCertFile.WriteString(sslCert)
 					Expect(err).NotTo(HaveOccurred())
 
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "--ca-cert", caCertFile.Name(), "-u", "some_user", "-p", "some_pass")
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "--ca-cert", caCertFile.Name(), "-u", "some_user", "-p", "some_pass")
 
-					loginATCServer.AppendHandlers(
+					adminAtcServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
 					)
@@ -194,7 +194,7 @@ var _ = Describe("login -k Command", func() {
 				BeforeEach(func() {
 					flyrcContents := `targets:
   some-target:
-    api: ` + loginATCServer.URL() + `
+    api: ` + adminAtcServer.URL() + `
     team: main
     ca_cert: some-ca-cert
     token:
@@ -205,7 +205,7 @@ var _ = Describe("login -k Command", func() {
 
 				Context("with -k", func() {
 					BeforeEach(func() {
-						loginATCServer.AppendHandlers(
+						adminAtcServer.AppendHandlers(
 							infoHandler(),
 							tokenHandler(),
 						)

--- a/fly/integration/login_insecure_test.go
+++ b/fly/integration/login_insecure_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = Describe("login -k Command", func() {
-	var adminAtcServer *ghttp.Server
+	var loginAtcServer *ghttp.Server
 
 	Describe("login", func() {
 		var (
@@ -27,23 +27,23 @@ var _ = Describe("login -k Command", func() {
 		)
 		BeforeEach(func() {
 			l := log.New(GinkgoWriter, "TLSServer", 0)
-			adminAtcServer = ghttp.NewUnstartedServer()
-			adminAtcServer.HTTPTestServer.Config.ErrorLog = l
-			adminAtcServer.HTTPTestServer.StartTLS()
+			loginAtcServer = ghttp.NewUnstartedServer()
+			loginAtcServer.HTTPTestServer.Config.ErrorLog = l
+			loginAtcServer.HTTPTestServer.StartTLS()
 		})
 
 		AfterEach(func() {
-			adminAtcServer.Close()
+			loginAtcServer.Close()
 		})
 
 		Context("to new target with invalid SSL with -k", func() {
 			BeforeEach(func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-k", "-u", "some_user", "-p", "some_pass")
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-k", "-u", "some_user", "-p", "some_pass")
 
 				var err error
 				stdin, err = flyCmd.StdinPipe()
@@ -68,7 +68,7 @@ var _ = Describe("login -k Command", func() {
 			Context("login to existing target", func() {
 				var otherCmd *exec.Cmd
 				BeforeEach(func() {
-					adminAtcServer.AppendHandlers(
+					loginAtcServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
 					)
@@ -118,7 +118,7 @@ var _ = Describe("login -k Command", func() {
 		Context("to new target with invalid SSL without -k", func() {
 			Context("without --ca-cert", func() {
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "some_user", "-p", "some_pass")
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "some_user", "-p", "some_pass")
 
 					var err error
 					stdin, err = flyCmd.StdinPipe()
@@ -147,7 +147,7 @@ var _ = Describe("login -k Command", func() {
 				BeforeEach(func() {
 					sslCert = string(pem.EncodeToMemory(&pem.Block{
 						Type:  "CERTIFICATE",
-						Bytes: adminAtcServer.HTTPTestServer.TLS.Certificates[0].Certificate[0],
+						Bytes: loginAtcServer.HTTPTestServer.TLS.Certificates[0].Certificate[0],
 					}))
 
 					caCertFile, err := ioutil.TempFile("", "ca_cert.pem")
@@ -156,9 +156,9 @@ var _ = Describe("login -k Command", func() {
 					_, err = caCertFile.WriteString(sslCert)
 					Expect(err).NotTo(HaveOccurred())
 
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "--ca-cert", caCertFile.Name(), "-u", "some_user", "-p", "some_pass")
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "--ca-cert", caCertFile.Name(), "-u", "some_user", "-p", "some_pass")
 
-					adminAtcServer.AppendHandlers(
+					loginAtcServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
 					)
@@ -194,7 +194,7 @@ var _ = Describe("login -k Command", func() {
 				BeforeEach(func() {
 					flyrcContents := `targets:
   some-target:
-    api: ` + adminAtcServer.URL() + `
+    api: ` + loginAtcServer.URL() + `
     team: main
     ca_cert: some-ca-cert
     token:
@@ -205,7 +205,7 @@ var _ = Describe("login -k Command", func() {
 
 				Context("with -k", func() {
 					BeforeEach(func() {
-						adminAtcServer.AppendHandlers(
+						loginAtcServer.AppendHandlers(
 							infoHandler(),
 							tokenHandler(),
 						)

--- a/fly/integration/login_insecure_test.go
+++ b/fly/integration/login_insecure_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = Describe("login -k Command", func() {
-	var loginAtcServer *ghttp.Server
+	var loginATCServer *ghttp.Server
 
 	Describe("login", func() {
 		var (
@@ -27,23 +27,23 @@ var _ = Describe("login -k Command", func() {
 		)
 		BeforeEach(func() {
 			l := log.New(GinkgoWriter, "TLSServer", 0)
-			loginAtcServer = ghttp.NewUnstartedServer()
-			loginAtcServer.HTTPTestServer.Config.ErrorLog = l
-			loginAtcServer.HTTPTestServer.StartTLS()
+			loginATCServer = ghttp.NewUnstartedServer()
+			loginATCServer.HTTPTestServer.Config.ErrorLog = l
+			loginATCServer.HTTPTestServer.StartTLS()
 		})
 
 		AfterEach(func() {
-			loginAtcServer.Close()
+			loginATCServer.Close()
 		})
 
 		Context("to new target with invalid SSL with -k", func() {
 			BeforeEach(func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-k", "-u", "some_user", "-p", "some_pass")
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-k", "-u", "some_user", "-p", "some_pass")
 
 				var err error
 				stdin, err = flyCmd.StdinPipe()
@@ -68,7 +68,7 @@ var _ = Describe("login -k Command", func() {
 			Context("login to existing target", func() {
 				var otherCmd *exec.Cmd
 				BeforeEach(func() {
-					loginAtcServer.AppendHandlers(
+					loginATCServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
 					)
@@ -118,7 +118,7 @@ var _ = Describe("login -k Command", func() {
 		Context("to new target with invalid SSL without -k", func() {
 			Context("without --ca-cert", func() {
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "some_user", "-p", "some_pass")
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "some_user", "-p", "some_pass")
 
 					var err error
 					stdin, err = flyCmd.StdinPipe()
@@ -147,7 +147,7 @@ var _ = Describe("login -k Command", func() {
 				BeforeEach(func() {
 					sslCert = string(pem.EncodeToMemory(&pem.Block{
 						Type:  "CERTIFICATE",
-						Bytes: loginAtcServer.HTTPTestServer.TLS.Certificates[0].Certificate[0],
+						Bytes: loginATCServer.HTTPTestServer.TLS.Certificates[0].Certificate[0],
 					}))
 
 					caCertFile, err := ioutil.TempFile("", "ca_cert.pem")
@@ -156,9 +156,9 @@ var _ = Describe("login -k Command", func() {
 					_, err = caCertFile.WriteString(sslCert)
 					Expect(err).NotTo(HaveOccurred())
 
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "--ca-cert", caCertFile.Name(), "-u", "some_user", "-p", "some_pass")
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "--ca-cert", caCertFile.Name(), "-u", "some_user", "-p", "some_pass")
 
-					loginAtcServer.AppendHandlers(
+					loginATCServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
 					)
@@ -194,7 +194,7 @@ var _ = Describe("login -k Command", func() {
 				BeforeEach(func() {
 					flyrcContents := `targets:
   some-target:
-    api: ` + loginAtcServer.URL() + `
+    api: ` + loginATCServer.URL() + `
     team: main
     ca_cert: some-ca-cert
     token:
@@ -205,7 +205,7 @@ var _ = Describe("login -k Command", func() {
 
 				Context("with -k", func() {
 					BeforeEach(func() {
-						loginAtcServer.AppendHandlers(
+						loginATCServer.AppendHandlers(
 							infoHandler(),
 							tokenHandler(),
 						)

--- a/fly/integration/login_test.go
+++ b/fly/integration/login_test.go
@@ -24,7 +24,7 @@ import (
 
 var _ = Describe("login Command", func() {
 	var (
-		loginATCServer *ghttp.Server
+		adminAtcServer *ghttp.Server
 		tmpDir         string
 	)
 
@@ -46,15 +46,15 @@ var _ = Describe("login Command", func() {
 		)
 
 		BeforeEach(func() {
-			loginATCServer = ghttp.NewServer()
-			loginATCServer.AppendHandlers(
+			adminAtcServer = ghttp.NewServer()
+			adminAtcServer.AppendHandlers(
 				infoHandler(),
 			)
-			flyCmd = exec.Command(flyPath, "login", "-c", loginATCServer.URL())
+			flyCmd = exec.Command(flyPath, "login", "-c", adminAtcServer.URL())
 		})
 
 		AfterEach(func() {
-			loginATCServer.Close()
+			adminAtcServer.Close()
 		})
 
 		It("instructs the user to specify --target", func() {
@@ -70,20 +70,20 @@ var _ = Describe("login Command", func() {
 
 	Context("with no team name", func() {
 		BeforeEach(func() {
-			loginATCServer = ghttp.NewServer()
+			adminAtcServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			loginATCServer.Close()
+			adminAtcServer.Close()
 		})
 
 		It("falls back to atc.DefaultTeamName team", func() {
-			loginATCServer.AppendHandlers(
+			adminAtcServer.AppendHandlers(
 				infoHandler(),
 				tokenHandler(),
 			)
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "user", "-p", "pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "user", "-p", "pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -96,18 +96,18 @@ var _ = Describe("login Command", func() {
 
 		Context("when already logged in as different team", func() {
 			BeforeEach(func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 				err := setupFlyCmd.Run()
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("uses the saved team name", func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -126,16 +126,16 @@ var _ = Describe("login Command", func() {
 	Context("with no specified flag but extra arguments ", func() {
 
 		BeforeEach(func() {
-			loginATCServer = ghttp.NewServer()
+			adminAtcServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			loginATCServer.Close()
+			adminAtcServer.Close()
 		})
 
 		It("return error indicating login failed with unknown arguments", func() {
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "unknown-argument", "blah")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "unknown-argument", "blah")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -148,7 +148,7 @@ var _ = Describe("login Command", func() {
 
 	Context("with a team name", func() {
 		flyLogin := func() *gexec.Session {
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -159,20 +159,20 @@ var _ = Describe("login Command", func() {
 		}
 
 		BeforeEach(func() {
-			loginATCServer = ghttp.NewServer()
+			adminAtcServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			loginATCServer.Close()
+			adminAtcServer.Close()
 		})
 
 		It("uses specified team", func() {
-			loginATCServer.AppendHandlers(
+			adminAtcServer.AppendHandlers(
 				infoHandler(),
 				tokenHandler(),
 			)
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -189,7 +189,7 @@ var _ = Describe("login Command", func() {
 			JustBeforeEach(func() {
 				Expect(encodedString).NotTo(Equal(""))
 				encodedToken := base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(encodedString))
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("POST", "/sky/token"),
@@ -280,7 +280,7 @@ var _ = Describe("login Command", func() {
 				})
 
 				It("fails", func() {
-					flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
+					flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
 
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
@@ -297,12 +297,12 @@ var _ = Describe("login Command", func() {
 
 		Context("when tracing is not enabled", func() {
 			It("does not print out API calls", func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -317,12 +317,12 @@ var _ = Describe("login Command", func() {
 
 		Context("when tracing is enabled", func() {
 			It("prints out API calls", func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				flyCmd := exec.Command(flyPath, "--verbose", "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				flyCmd := exec.Command(flyPath, "--verbose", "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -336,18 +336,18 @@ var _ = Describe("login Command", func() {
 
 		Context("when already logged in as different team", func() {
 			BeforeEach(func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 				err := setupFlyCmd.Run()
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("passes provided team name", func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -365,25 +365,25 @@ var _ = Describe("login Command", func() {
 
 	Describe("with ca cert", func() {
 		BeforeEach(func() {
-			loginATCServer = ghttp.NewUnstartedServer()
+			adminAtcServer = ghttp.NewUnstartedServer()
 			cert, err := tls.X509KeyPair([]byte(serverCert), []byte(serverKey))
 			Expect(err).NotTo(HaveOccurred())
 
-			loginATCServer.HTTPTestServer.TLS = &tls.Config{
+			adminAtcServer.HTTPTestServer.TLS = &tls.Config{
 				Certificates: []tls.Certificate{cert},
 			}
-			loginATCServer.HTTPTestServer.StartTLS()
+			adminAtcServer.HTTPTestServer.StartTLS()
 		})
 
 		AfterEach(func() {
-			loginATCServer.Close()
+			adminAtcServer.Close()
 		})
 
 		Context("when already logged in with ca cert", func() {
 			var caCertFilePath string
 
 			BeforeEach(func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -395,7 +395,7 @@ var _ = Describe("login Command", func() {
 				err = ioutil.WriteFile(caCertFilePath, []byte(serverCert), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(setupFlyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -409,7 +409,7 @@ var _ = Describe("login Command", func() {
 
 			Context("when ca cert is not provided", func() {
 				It("is using saved ca cert", func() {
-					loginATCServer.AppendHandlers(
+					adminAtcServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
 					)
@@ -432,22 +432,22 @@ var _ = Describe("login Command", func() {
 		)
 
 		BeforeEach(func() {
-			loginATCServer = ghttp.NewServer()
+			adminAtcServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			loginATCServer.Close()
+			adminAtcServer.Close()
 		})
 
 		Context("with authorization_code grant", func() {
 			BeforeEach(func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 				)
 			})
 
 			It("instructs the user to visit the top-level login endpoint with fly port", func() {
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL())
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL())
 
 				stdin, err := flyCmd.StdinPipe()
 				Expect(err).NotTo(HaveOccurred())
@@ -475,7 +475,7 @@ var _ = Describe("login Command", func() {
 				var sess *gexec.Session
 
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL())
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL())
 					_, err := flyCmd.StdinPipe()
 					Expect(err).NotTo(HaveOccurred())
 					sess, err = gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
@@ -497,7 +497,7 @@ var _ = Describe("login Command", func() {
 				})
 
 				JustBeforeEach(func() {
-					loginATCServer.AppendHandlers(ghttp.CombineHandlers(
+					adminAtcServer.AppendHandlers(ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/fly_success"),
 						ghttp.RespondWith(200, ""),
 					))
@@ -515,7 +515,7 @@ var _ = Describe("login Command", func() {
 
 				It("sets a CORS header for the ATC being logged in to", func() {
 					corsHeader := resp.Header.Get("Access-Control-Allow-Origin")
-					Expect(corsHeader).To(Equal(loginATCServer.URL()))
+					Expect(corsHeader).To(Equal(adminAtcServer.URL()))
 				})
 
 				It("responds successfully", func() {
@@ -530,7 +530,7 @@ var _ = Describe("login Command", func() {
 					It("redirects back to noop fly success page", func() {
 						Expect(resp.StatusCode).To(Equal(http.StatusFound))
 						locationHeader := resp.Header.Get("Location")
-						Expect(locationHeader).To(Equal(fmt.Sprintf("%s/fly_success?noop=true", loginATCServer.URL())))
+						Expect(locationHeader).To(Equal(fmt.Sprintf("%s/fly_success?noop=true", adminAtcServer.URL())))
 					})
 				})
 			})
@@ -539,7 +539,7 @@ var _ = Describe("login Command", func() {
 		Context("with password grant", func() {
 			BeforeEach(func() {
 				credentials := base64.StdEncoding.EncodeToString([]byte("fly:Zmx5"))
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("POST", "/sky/token"),
@@ -558,7 +558,7 @@ var _ = Describe("login Command", func() {
 			})
 
 			It("takes username and password as cli arguments", func() {
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "some_username", "-p", "some_password")
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "some_username", "-p", "some_password")
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -572,7 +572,7 @@ var _ = Describe("login Command", func() {
 
 			Context("after logging in succeeds", func() {
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "some_username", "-p", "some_password")
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "some_username", "-p", "some_password")
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -592,7 +592,7 @@ var _ = Describe("login Command", func() {
 
 				Describe("running other commands", func() {
 					BeforeEach(func() {
-						loginATCServer.AppendHandlers(
+						adminAtcServer.AppendHandlers(
 							infoHandler(),
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
@@ -622,7 +622,7 @@ var _ = Describe("login Command", func() {
 					BeforeEach(func() {
 						credentials := base64.StdEncoding.EncodeToString([]byte("fly:Zmx5"))
 
-						loginATCServer.AppendHandlers(
+						adminAtcServer.AppendHandlers(
 							infoHandler(),
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("POST", "/sky/token"),
@@ -689,9 +689,9 @@ var _ = Describe("login Command", func() {
 					"-ldflags", fmt.Sprintf("-X github.com/concourse/concourse.Version=%s", flyVersion),
 				)
 				Expect(err).NotTo(HaveOccurred())
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "user", "-p", "pass")
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "user", "-p", "pass")
 
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -756,14 +756,14 @@ var _ = Describe("login Command", func() {
 				},
 			}
 
-			loginATCServer = ghttp.NewServer()
-			loginATCServer.AppendHandlers(
+			adminAtcServer = ghttp.NewServer()
+			adminAtcServer.AppendHandlers(
 				infoHandler(),
 				adminTokenHandler(),
 				teamHandler(teams),
 			)
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "main", "-u", "user", "-p", "pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "main", "-u", "user", "-p", "pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -776,12 +776,12 @@ var _ = Describe("login Command", func() {
 		})
 
 		AfterEach(func() {
-			loginATCServer.Close()
+			adminAtcServer.Close()
 		})
 
 		Context("with the ATC Url unspecified", func() {
 			It("User logs in to any team", func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					adminTokenHandler(),
 					teamHandler(teams),
@@ -802,18 +802,18 @@ var _ = Describe("login Command", func() {
 
 		Context("when the CACert is provided", func() {
 			var caCertFilePath string
-			var loginSecuredATCServer *ghttp.Server
+			var adminAtcServer *ghttp.Server
 			BeforeEach(func(){
-				loginSecuredATCServer = ghttp.NewUnstartedServer()
+				adminAtcServer = ghttp.NewUnstartedServer()
 				cert, err := tls.X509KeyPair([]byte(serverCert), []byte(serverKey))
 				Expect(err).NotTo(HaveOccurred())
 
-				loginSecuredATCServer.HTTPTestServer.TLS = &tls.Config{
+				adminAtcServer.HTTPTestServer.TLS = &tls.Config{
 					Certificates: []tls.Certificate{cert},
 				}
-				loginSecuredATCServer.HTTPTestServer.StartTLS()
+				adminAtcServer.HTTPTestServer.StartTLS()
 
-				loginSecuredATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					infoHandler(),
 					adminTokenHandler(),
 					teamHandler(teams),
@@ -825,7 +825,7 @@ var _ = Describe("login Command", func() {
 
 				err = ioutil.WriteFile(caCertFilePath, []byte(serverCert), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginSecuredATCServer.URL(), "-n", "main", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "main", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(setupFlyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -835,12 +835,12 @@ var _ = Describe("login Command", func() {
 
 			AfterEach(func() {
 				os.RemoveAll(caCertFilePath)
-				loginSecuredATCServer.Close()
+				adminAtcServer.Close()
 			})
 
 			Context("when ca cert is not provided this time", func() {
 				It("is using saved ca cert", func() {
-					loginSecuredATCServer.AppendHandlers(
+					adminAtcServer.AppendHandlers(
 						infoHandler(),
 						adminTokenHandler(),
 						teamHandler(teams),

--- a/fly/integration/login_test.go
+++ b/fly/integration/login_test.go
@@ -24,7 +24,7 @@ import (
 
 var _ = Describe("login Command", func() {
 	var (
-		adminAtcServer *ghttp.Server
+		loginAtcServer *ghttp.Server
 		tmpDir         string
 	)
 
@@ -46,15 +46,15 @@ var _ = Describe("login Command", func() {
 		)
 
 		BeforeEach(func() {
-			adminAtcServer = ghttp.NewServer()
-			adminAtcServer.AppendHandlers(
+			loginAtcServer = ghttp.NewServer()
+			loginAtcServer.AppendHandlers(
 				infoHandler(),
 			)
-			flyCmd = exec.Command(flyPath, "login", "-c", adminAtcServer.URL())
+			flyCmd = exec.Command(flyPath, "login", "-c", loginAtcServer.URL())
 		})
 
 		AfterEach(func() {
-			adminAtcServer.Close()
+			loginAtcServer.Close()
 		})
 
 		It("instructs the user to specify --target", func() {
@@ -70,20 +70,20 @@ var _ = Describe("login Command", func() {
 
 	Context("with no team name", func() {
 		BeforeEach(func() {
-			adminAtcServer = ghttp.NewServer()
+			loginAtcServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			adminAtcServer.Close()
+			loginAtcServer.Close()
 		})
 
 		It("falls back to atc.DefaultTeamName team", func() {
-			adminAtcServer.AppendHandlers(
+			loginAtcServer.AppendHandlers(
 				infoHandler(),
 				tokenHandler(),
 			)
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "user", "-p", "pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "user", "-p", "pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -96,18 +96,18 @@ var _ = Describe("login Command", func() {
 
 		Context("when already logged in as different team", func() {
 			BeforeEach(func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 				err := setupFlyCmd.Run()
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("uses the saved team name", func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -126,16 +126,16 @@ var _ = Describe("login Command", func() {
 	Context("with no specified flag but extra arguments ", func() {
 
 		BeforeEach(func() {
-			adminAtcServer = ghttp.NewServer()
+			loginAtcServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			adminAtcServer.Close()
+			loginAtcServer.Close()
 		})
 
 		It("return error indicating login failed with unknown arguments", func() {
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "unknown-argument", "blah")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "unknown-argument", "blah")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -148,7 +148,7 @@ var _ = Describe("login Command", func() {
 
 	Context("with a team name", func() {
 		flyLogin := func() *gexec.Session {
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -159,20 +159,20 @@ var _ = Describe("login Command", func() {
 		}
 
 		BeforeEach(func() {
-			adminAtcServer = ghttp.NewServer()
+			loginAtcServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			adminAtcServer.Close()
+			loginAtcServer.Close()
 		})
 
 		It("uses specified team", func() {
-			adminAtcServer.AppendHandlers(
+			loginAtcServer.AppendHandlers(
 				infoHandler(),
 				tokenHandler(),
 			)
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -189,7 +189,7 @@ var _ = Describe("login Command", func() {
 			JustBeforeEach(func() {
 				Expect(encodedString).NotTo(Equal(""))
 				encodedToken := base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(encodedString))
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("POST", "/sky/token"),
@@ -280,7 +280,7 @@ var _ = Describe("login Command", func() {
 				})
 
 				It("fails", func() {
-					flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
+					flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
 
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
@@ -297,12 +297,12 @@ var _ = Describe("login Command", func() {
 
 		Context("when tracing is not enabled", func() {
 			It("does not print out API calls", func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -317,12 +317,12 @@ var _ = Describe("login Command", func() {
 
 		Context("when tracing is enabled", func() {
 			It("prints out API calls", func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				flyCmd := exec.Command(flyPath, "--verbose", "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				flyCmd := exec.Command(flyPath, "--verbose", "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -336,18 +336,18 @@ var _ = Describe("login Command", func() {
 
 		Context("when already logged in as different team", func() {
 			BeforeEach(func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 				err := setupFlyCmd.Run()
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("passes provided team name", func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -365,25 +365,25 @@ var _ = Describe("login Command", func() {
 
 	Describe("with ca cert", func() {
 		BeforeEach(func() {
-			adminAtcServer = ghttp.NewUnstartedServer()
+			loginAtcServer = ghttp.NewUnstartedServer()
 			cert, err := tls.X509KeyPair([]byte(serverCert), []byte(serverKey))
 			Expect(err).NotTo(HaveOccurred())
 
-			adminAtcServer.HTTPTestServer.TLS = &tls.Config{
+			loginAtcServer.HTTPTestServer.TLS = &tls.Config{
 				Certificates: []tls.Certificate{cert},
 			}
-			adminAtcServer.HTTPTestServer.StartTLS()
+			loginAtcServer.HTTPTestServer.StartTLS()
 		})
 
 		AfterEach(func() {
-			adminAtcServer.Close()
+			loginAtcServer.Close()
 		})
 
 		Context("when already logged in with ca cert", func() {
 			var caCertFilePath string
 
 			BeforeEach(func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -395,7 +395,7 @@ var _ = Describe("login Command", func() {
 				err = ioutil.WriteFile(caCertFilePath, []byte(serverCert), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "some-team", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(setupFlyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -409,7 +409,7 @@ var _ = Describe("login Command", func() {
 
 			Context("when ca cert is not provided", func() {
 				It("is using saved ca cert", func() {
-					adminAtcServer.AppendHandlers(
+					loginAtcServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
 					)
@@ -432,22 +432,22 @@ var _ = Describe("login Command", func() {
 		)
 
 		BeforeEach(func() {
-			adminAtcServer = ghttp.NewServer()
+			loginAtcServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			adminAtcServer.Close()
+			loginAtcServer.Close()
 		})
 
 		Context("with authorization_code grant", func() {
 			BeforeEach(func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 				)
 			})
 
 			It("instructs the user to visit the top-level login endpoint with fly port", func() {
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL())
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL())
 
 				stdin, err := flyCmd.StdinPipe()
 				Expect(err).NotTo(HaveOccurred())
@@ -475,7 +475,7 @@ var _ = Describe("login Command", func() {
 				var sess *gexec.Session
 
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL())
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL())
 					_, err := flyCmd.StdinPipe()
 					Expect(err).NotTo(HaveOccurred())
 					sess, err = gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
@@ -497,7 +497,7 @@ var _ = Describe("login Command", func() {
 				})
 
 				JustBeforeEach(func() {
-					adminAtcServer.AppendHandlers(ghttp.CombineHandlers(
+					loginAtcServer.AppendHandlers(ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/fly_success"),
 						ghttp.RespondWith(200, ""),
 					))
@@ -515,7 +515,7 @@ var _ = Describe("login Command", func() {
 
 				It("sets a CORS header for the ATC being logged in to", func() {
 					corsHeader := resp.Header.Get("Access-Control-Allow-Origin")
-					Expect(corsHeader).To(Equal(adminAtcServer.URL()))
+					Expect(corsHeader).To(Equal(loginAtcServer.URL()))
 				})
 
 				It("responds successfully", func() {
@@ -530,7 +530,7 @@ var _ = Describe("login Command", func() {
 					It("redirects back to noop fly success page", func() {
 						Expect(resp.StatusCode).To(Equal(http.StatusFound))
 						locationHeader := resp.Header.Get("Location")
-						Expect(locationHeader).To(Equal(fmt.Sprintf("%s/fly_success?noop=true", adminAtcServer.URL())))
+						Expect(locationHeader).To(Equal(fmt.Sprintf("%s/fly_success?noop=true", loginAtcServer.URL())))
 					})
 				})
 			})
@@ -539,7 +539,7 @@ var _ = Describe("login Command", func() {
 		Context("with password grant", func() {
 			BeforeEach(func() {
 				credentials := base64.StdEncoding.EncodeToString([]byte("fly:Zmx5"))
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("POST", "/sky/token"),
@@ -558,7 +558,7 @@ var _ = Describe("login Command", func() {
 			})
 
 			It("takes username and password as cli arguments", func() {
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "some_username", "-p", "some_password")
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "some_username", "-p", "some_password")
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -572,7 +572,7 @@ var _ = Describe("login Command", func() {
 
 			Context("after logging in succeeds", func() {
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "some_username", "-p", "some_password")
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "some_username", "-p", "some_password")
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -592,7 +592,7 @@ var _ = Describe("login Command", func() {
 
 				Describe("running other commands", func() {
 					BeforeEach(func() {
-						adminAtcServer.AppendHandlers(
+						loginAtcServer.AppendHandlers(
 							infoHandler(),
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
@@ -622,7 +622,7 @@ var _ = Describe("login Command", func() {
 					BeforeEach(func() {
 						credentials := base64.StdEncoding.EncodeToString([]byte("fly:Zmx5"))
 
-						adminAtcServer.AppendHandlers(
+						loginAtcServer.AppendHandlers(
 							infoHandler(),
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("POST", "/sky/token"),
@@ -689,9 +689,9 @@ var _ = Describe("login Command", func() {
 					"-ldflags", fmt.Sprintf("-X github.com/concourse/concourse.Version=%s", flyVersion),
 				)
 				Expect(err).NotTo(HaveOccurred())
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-u", "user", "-p", "pass")
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "user", "-p", "pass")
 
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -756,14 +756,14 @@ var _ = Describe("login Command", func() {
 				},
 			}
 
-			adminAtcServer = ghttp.NewServer()
-			adminAtcServer.AppendHandlers(
+			loginAtcServer = ghttp.NewServer()
+			loginAtcServer.AppendHandlers(
 				infoHandler(),
 				adminTokenHandler(),
 				teamHandler(teams),
 			)
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "main", "-u", "user", "-p", "pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "main", "-u", "user", "-p", "pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -776,12 +776,12 @@ var _ = Describe("login Command", func() {
 		})
 
 		AfterEach(func() {
-			adminAtcServer.Close()
+			loginAtcServer.Close()
 		})
 
 		Context("with the ATC Url unspecified", func() {
 			It("User logs in to any team", func() {
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					adminTokenHandler(),
 					teamHandler(teams),
@@ -802,18 +802,18 @@ var _ = Describe("login Command", func() {
 
 		Context("when the CACert is provided", func() {
 			var caCertFilePath string
-			var adminAtcServer *ghttp.Server
-			BeforeEach(func(){
-				adminAtcServer = ghttp.NewUnstartedServer()
+			var loginAtcServer *ghttp.Server
+			BeforeEach(func() {
+				loginAtcServer = ghttp.NewUnstartedServer()
 				cert, err := tls.X509KeyPair([]byte(serverCert), []byte(serverKey))
 				Expect(err).NotTo(HaveOccurred())
 
-				adminAtcServer.HTTPTestServer.TLS = &tls.Config{
+				loginAtcServer.HTTPTestServer.TLS = &tls.Config{
 					Certificates: []tls.Certificate{cert},
 				}
-				adminAtcServer.HTTPTestServer.StartTLS()
+				loginAtcServer.HTTPTestServer.StartTLS()
 
-				adminAtcServer.AppendHandlers(
+				loginAtcServer.AppendHandlers(
 					infoHandler(),
 					adminTokenHandler(),
 					teamHandler(teams),
@@ -825,7 +825,7 @@ var _ = Describe("login Command", func() {
 
 				err = ioutil.WriteFile(caCertFilePath, []byte(serverCert), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "main", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "main", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(setupFlyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -835,12 +835,12 @@ var _ = Describe("login Command", func() {
 
 			AfterEach(func() {
 				os.RemoveAll(caCertFilePath)
-				adminAtcServer.Close()
+				loginAtcServer.Close()
 			})
 
 			Context("when ca cert is not provided this time", func() {
 				It("is using saved ca cert", func() {
-					adminAtcServer.AppendHandlers(
+					loginAtcServer.AppendHandlers(
 						infoHandler(),
 						adminTokenHandler(),
 						teamHandler(teams),

--- a/fly/integration/login_test.go
+++ b/fly/integration/login_test.go
@@ -24,7 +24,7 @@ import (
 
 var _ = Describe("login Command", func() {
 	var (
-		loginAtcServer *ghttp.Server
+		loginATCServer *ghttp.Server
 		tmpDir         string
 	)
 
@@ -46,15 +46,15 @@ var _ = Describe("login Command", func() {
 		)
 
 		BeforeEach(func() {
-			loginAtcServer = ghttp.NewServer()
-			loginAtcServer.AppendHandlers(
+			loginATCServer = ghttp.NewServer()
+			loginATCServer.AppendHandlers(
 				infoHandler(),
 			)
-			flyCmd = exec.Command(flyPath, "login", "-c", loginAtcServer.URL())
+			flyCmd = exec.Command(flyPath, "login", "-c", loginATCServer.URL())
 		})
 
 		AfterEach(func() {
-			loginAtcServer.Close()
+			loginATCServer.Close()
 		})
 
 		It("instructs the user to specify --target", func() {
@@ -70,20 +70,20 @@ var _ = Describe("login Command", func() {
 
 	Context("with no team name", func() {
 		BeforeEach(func() {
-			loginAtcServer = ghttp.NewServer()
+			loginATCServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			loginAtcServer.Close()
+			loginATCServer.Close()
 		})
 
 		It("falls back to atc.DefaultTeamName team", func() {
-			loginAtcServer.AppendHandlers(
+			loginATCServer.AppendHandlers(
 				infoHandler(),
 				tokenHandler(),
 			)
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "user", "-p", "pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "user", "-p", "pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -96,18 +96,18 @@ var _ = Describe("login Command", func() {
 
 		Context("when already logged in as different team", func() {
 			BeforeEach(func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 				err := setupFlyCmd.Run()
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("uses the saved team name", func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -126,16 +126,16 @@ var _ = Describe("login Command", func() {
 	Context("with no specified flag but extra arguments ", func() {
 
 		BeforeEach(func() {
-			loginAtcServer = ghttp.NewServer()
+			loginATCServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			loginAtcServer.Close()
+			loginATCServer.Close()
 		})
 
 		It("return error indicating login failed with unknown arguments", func() {
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "unknown-argument", "blah")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "unknown-argument", "blah")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -148,7 +148,7 @@ var _ = Describe("login Command", func() {
 
 	Context("with a team name", func() {
 		flyLogin := func() *gexec.Session {
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -159,20 +159,20 @@ var _ = Describe("login Command", func() {
 		}
 
 		BeforeEach(func() {
-			loginAtcServer = ghttp.NewServer()
+			loginATCServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			loginAtcServer.Close()
+			loginATCServer.Close()
 		})
 
 		It("uses specified team", func() {
-			loginAtcServer.AppendHandlers(
+			loginATCServer.AppendHandlers(
 				infoHandler(),
 				tokenHandler(),
 			)
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -189,7 +189,7 @@ var _ = Describe("login Command", func() {
 			JustBeforeEach(func() {
 				Expect(encodedString).NotTo(Equal(""))
 				encodedToken := base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(encodedString))
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("POST", "/sky/token"),
@@ -280,7 +280,7 @@ var _ = Describe("login Command", func() {
 				})
 
 				It("fails", func() {
-					flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
+					flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "dummy-user", "-p", "dummy-pass")
 
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
@@ -297,12 +297,12 @@ var _ = Describe("login Command", func() {
 
 		Context("when tracing is not enabled", func() {
 			It("does not print out API calls", func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -317,12 +317,12 @@ var _ = Describe("login Command", func() {
 
 		Context("when tracing is enabled", func() {
 			It("prints out API calls", func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				flyCmd := exec.Command(flyPath, "--verbose", "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				flyCmd := exec.Command(flyPath, "--verbose", "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -336,18 +336,18 @@ var _ = Describe("login Command", func() {
 
 		Context("when already logged in as different team", func() {
 			BeforeEach(func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
 
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "-u", "user", "-p", "pass")
 				err := setupFlyCmd.Run()
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("passes provided team name", func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -365,25 +365,25 @@ var _ = Describe("login Command", func() {
 
 	Describe("with ca cert", func() {
 		BeforeEach(func() {
-			loginAtcServer = ghttp.NewUnstartedServer()
+			loginATCServer = ghttp.NewUnstartedServer()
 			cert, err := tls.X509KeyPair([]byte(serverCert), []byte(serverKey))
 			Expect(err).NotTo(HaveOccurred())
 
-			loginAtcServer.HTTPTestServer.TLS = &tls.Config{
+			loginATCServer.HTTPTestServer.TLS = &tls.Config{
 				Certificates: []tls.Certificate{cert},
 			}
-			loginAtcServer.HTTPTestServer.StartTLS()
+			loginATCServer.HTTPTestServer.StartTLS()
 		})
 
 		AfterEach(func() {
-			loginAtcServer.Close()
+			loginATCServer.Close()
 		})
 
 		Context("when already logged in with ca cert", func() {
 			var caCertFilePath string
 
 			BeforeEach(func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -395,7 +395,7 @@ var _ = Describe("login Command", func() {
 				err = ioutil.WriteFile(caCertFilePath, []byte(serverCert), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "some-team", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(setupFlyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -409,7 +409,7 @@ var _ = Describe("login Command", func() {
 
 			Context("when ca cert is not provided", func() {
 				It("is using saved ca cert", func() {
-					loginAtcServer.AppendHandlers(
+					loginATCServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
 					)
@@ -432,22 +432,22 @@ var _ = Describe("login Command", func() {
 		)
 
 		BeforeEach(func() {
-			loginAtcServer = ghttp.NewServer()
+			loginATCServer = ghttp.NewServer()
 		})
 
 		AfterEach(func() {
-			loginAtcServer.Close()
+			loginATCServer.Close()
 		})
 
 		Context("with authorization_code grant", func() {
 			BeforeEach(func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 				)
 			})
 
 			It("instructs the user to visit the top-level login endpoint with fly port", func() {
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL())
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL())
 
 				stdin, err := flyCmd.StdinPipe()
 				Expect(err).NotTo(HaveOccurred())
@@ -475,7 +475,7 @@ var _ = Describe("login Command", func() {
 				var sess *gexec.Session
 
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL())
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL())
 					_, err := flyCmd.StdinPipe()
 					Expect(err).NotTo(HaveOccurred())
 					sess, err = gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
@@ -497,7 +497,7 @@ var _ = Describe("login Command", func() {
 				})
 
 				JustBeforeEach(func() {
-					loginAtcServer.AppendHandlers(ghttp.CombineHandlers(
+					loginATCServer.AppendHandlers(ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/fly_success"),
 						ghttp.RespondWith(200, ""),
 					))
@@ -515,7 +515,7 @@ var _ = Describe("login Command", func() {
 
 				It("sets a CORS header for the ATC being logged in to", func() {
 					corsHeader := resp.Header.Get("Access-Control-Allow-Origin")
-					Expect(corsHeader).To(Equal(loginAtcServer.URL()))
+					Expect(corsHeader).To(Equal(loginATCServer.URL()))
 				})
 
 				It("responds successfully", func() {
@@ -530,7 +530,7 @@ var _ = Describe("login Command", func() {
 					It("redirects back to noop fly success page", func() {
 						Expect(resp.StatusCode).To(Equal(http.StatusFound))
 						locationHeader := resp.Header.Get("Location")
-						Expect(locationHeader).To(Equal(fmt.Sprintf("%s/fly_success?noop=true", loginAtcServer.URL())))
+						Expect(locationHeader).To(Equal(fmt.Sprintf("%s/fly_success?noop=true", loginATCServer.URL())))
 					})
 				})
 			})
@@ -539,7 +539,7 @@ var _ = Describe("login Command", func() {
 		Context("with password grant", func() {
 			BeforeEach(func() {
 				credentials := base64.StdEncoding.EncodeToString([]byte("fly:Zmx5"))
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("POST", "/sky/token"),
@@ -558,7 +558,7 @@ var _ = Describe("login Command", func() {
 			})
 
 			It("takes username and password as cli arguments", func() {
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "some_username", "-p", "some_password")
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "some_username", "-p", "some_password")
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -572,7 +572,7 @@ var _ = Describe("login Command", func() {
 
 			Context("after logging in succeeds", func() {
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "some_username", "-p", "some_password")
+					flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "some_username", "-p", "some_password")
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -592,7 +592,7 @@ var _ = Describe("login Command", func() {
 
 				Describe("running other commands", func() {
 					BeforeEach(func() {
-						loginAtcServer.AppendHandlers(
+						loginATCServer.AppendHandlers(
 							infoHandler(),
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
@@ -622,7 +622,7 @@ var _ = Describe("login Command", func() {
 					BeforeEach(func() {
 						credentials := base64.StdEncoding.EncodeToString([]byte("fly:Zmx5"))
 
-						loginAtcServer.AppendHandlers(
+						loginATCServer.AppendHandlers(
 							infoHandler(),
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("POST", "/sky/token"),
@@ -689,9 +689,9 @@ var _ = Describe("login Command", func() {
 					"-ldflags", fmt.Sprintf("-X github.com/concourse/concourse.Version=%s", flyVersion),
 				)
 				Expect(err).NotTo(HaveOccurred())
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-u", "user", "-p", "pass")
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "user", "-p", "pass")
 
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
 				)
@@ -756,14 +756,14 @@ var _ = Describe("login Command", func() {
 				},
 			}
 
-			loginAtcServer = ghttp.NewServer()
-			loginAtcServer.AppendHandlers(
+			loginATCServer = ghttp.NewServer()
+			loginATCServer.AppendHandlers(
 				infoHandler(),
 				adminTokenHandler(),
 				teamHandler(teams),
 			)
 
-			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "main", "-u", "user", "-p", "pass")
+			flyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "main", "-u", "user", "-p", "pass")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -776,12 +776,12 @@ var _ = Describe("login Command", func() {
 		})
 
 		AfterEach(func() {
-			loginAtcServer.Close()
+			loginATCServer.Close()
 		})
 
 		Context("with the ATC Url unspecified", func() {
 			It("User logs in to any team", func() {
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					adminTokenHandler(),
 					teamHandler(teams),
@@ -802,18 +802,18 @@ var _ = Describe("login Command", func() {
 
 		Context("when the CACert is provided", func() {
 			var caCertFilePath string
-			var loginAtcServer *ghttp.Server
+			var loginATCServer *ghttp.Server
 			BeforeEach(func() {
-				loginAtcServer = ghttp.NewUnstartedServer()
+				loginATCServer = ghttp.NewUnstartedServer()
 				cert, err := tls.X509KeyPair([]byte(serverCert), []byte(serverKey))
 				Expect(err).NotTo(HaveOccurred())
 
-				loginAtcServer.HTTPTestServer.TLS = &tls.Config{
+				loginATCServer.HTTPTestServer.TLS = &tls.Config{
 					Certificates: []tls.Certificate{cert},
 				}
-				loginAtcServer.HTTPTestServer.StartTLS()
+				loginATCServer.HTTPTestServer.StartTLS()
 
-				loginAtcServer.AppendHandlers(
+				loginATCServer.AppendHandlers(
 					infoHandler(),
 					adminTokenHandler(),
 					teamHandler(teams),
@@ -825,7 +825,7 @@ var _ = Describe("login Command", func() {
 
 				err = ioutil.WriteFile(caCertFilePath, []byte(serverCert), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
-				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginAtcServer.URL(), "-n", "main", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
+				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "main", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
 
 				sess, err := gexec.Start(setupFlyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -835,12 +835,12 @@ var _ = Describe("login Command", func() {
 
 			AfterEach(func() {
 				os.RemoveAll(caCertFilePath)
-				loginAtcServer.Close()
+				loginATCServer.Close()
 			})
 
 			Context("when ca cert is not provided this time", func() {
 				It("is using saved ca cert", func() {
-					loginAtcServer.AppendHandlers(
+					oginATCServer.AppendHandlers(
 						infoHandler(),
 						adminTokenHandler(),
 						teamHandler(teams),

--- a/fly/integration/pause_job_test.go
+++ b/fly/integration/pause_job_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os/exec"
 
+	"github.com/concourse/concourse/atc"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -27,141 +28,107 @@ var _ = Describe("Fly CLI", func() {
 			jobName = "job-name-potato"
 			fullJobName = fmt.Sprintf("%s/%s", pipelineName, jobName)
 			apiPath = fmt.Sprintf("/api/v1/teams/main/pipelines/%s/jobs/%s/pause", pipelineName, jobName)
-
-			flyCmd = exec.Command(flyPath, "-t", "some-target", "pause-job", "-j", fullJobName)
 		})
 
-		Context("when the job flag is provided", func() {
-			Context("when user is on the same team as the given pipeline/job's team", func() {
-					BeforeEach(func() {
-						adminAtcServer.AppendHandlers(
-							ghttp.CombineHandlers(
-								ghttp.VerifyRequest("PUT", apiPath),
-								ghttp.RespondWith(http.StatusOK, nil),
-							),
-						)
-					})
-
-					It("successfully pauses the job", func() {
-						Expect(func() {
-							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-							Expect(err).NotTo(HaveOccurred())
-							<-sess.Exited
-							Expect(sess.ExitCode()).To(Equal(0))
-							Eventually(sess).Should(gbytes.Say(fmt.Sprintf("paused '%s'\n", jobName)))
-						}).To(Change(func() int {
-							return len(adminAtcServer.ReceivedRequests())
-						}).By(2))
-					})
-			})
-
-			Context("user is admin and NOT currently on the same team as the given pipeline/job", func() {
-				BeforeEach(func() {
-					apiPath = fmt.Sprintf("/api/v1/teams/other-team/pipelines/%s/jobs/%s/pause", pipelineName, jobName)
-
-					adminAtcServer.AppendHandlers(
-						ghttp.CombineHandlers(
-							ghttp.VerifyRequest("PUT", apiPath),
-							ghttp.RespondWith(http.StatusOK, nil),
-						),
-					)
-				})
-
-				It("successfully pauses the job", func() {
-					Expect(func() {
-						flyCmd = exec.Command(flyPath, "-t", "some-target", "pause-job", "-j", fullJobName, "--team", "other-team")
-						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-						Expect(err).NotTo(HaveOccurred())
-						<-sess.Exited
-						Expect(sess.ExitCode()).To(Equal(0))
-						Eventually(sess).Should(gbytes.Say(fmt.Sprintf("paused '%s'\n", jobName)))
-					}).To(Change(func() int {
-						return len(adminAtcServer.ReceivedRequests())
-					}).By(2))
-				})
-			})
-
-			Context("when user does NOT own the pipeline's team or pipeline/job doesn't exist", func() {
-				Context("when user does NOT on the pipeline's team", func() {
-					BeforeEach(func() {
-						randomApiPath := fmt.Sprintf("/api/v1/teams/random-team/pipelines/random-pipeline/jobs/random-job/pause")
-						adminAtcServer.AppendHandlers(
-							ghttp.CombineHandlers(
-								ghttp.VerifyRequest("PUT", randomApiPath),
-								ghttp.RespondWith(http.StatusNotFound, nil),
-							),
-						)
-					})
-					It("exits 1 and outputs the corresponding error", func() {
-						Expect(func() {
-
-							flyCmd = exec.Command(flyPath, "-t", "some-target", "pause-job", "-j", "random-pipeline/random-job", "--team", "random-team")
-
-							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-							Expect(err).NotTo(HaveOccurred())
-							Eventually(sess.Err).Should(gbytes.Say(`random-pipeline/random-job not found on team random-team`))
-							<-sess.Exited
-							Expect(sess.ExitCode()).To(Equal(1))
-						}).To(Change(func() int {
-							return len(adminAtcServer.ReceivedRequests())
-						}).By(2))
-					})
-				})
-
-				Context("when user owns the pipeline's team, but either the pipeline or job does NOT exist", func() {
-					BeforeEach(func() {
-						adminAtcServer.AppendHandlers(
-							ghttp.CombineHandlers(
-								ghttp.VerifyRequest("PUT", apiPath),
-								ghttp.RespondWith(http.StatusNotFound, nil),
-							),
-						)
-					})
-					It("exits 1 and outputs the corresponding error", func() {
-						Expect(func() {
-							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-							Expect(err).NotTo(HaveOccurred())
-							Eventually(sess.Err).Should(gbytes.Say(`pipeline/job-name-potato not found on team main`))
-							<-sess.Exited
-							Expect(sess.ExitCode()).To(Equal(1))
-						}).To(Change(func() int {
-							return len(adminAtcServer.ReceivedRequests())
-						}).By(2))
-					})
-				})
-
-			})
-
-			Context("when a job fails to be paused using the API", func() {
-				BeforeEach(func() {
-					adminAtcServer.AppendHandlers(
-						ghttp.CombineHandlers(
-							ghttp.VerifyRequest("PUT", apiPath),
-							ghttp.RespondWith(http.StatusInternalServerError, nil),
-						),
-					)
-				})
-
-				It("exits 1 and outputs an error", func() {
-					Expect(func() {
-						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-						Expect(err).NotTo(HaveOccurred())
-						Eventually(sess.Err).Should(gbytes.Say(`error`))
-						<-sess.Exited
-						Expect(sess.ExitCode()).To(Equal(1))
-					}).To(Change(func() int {
-						return len(adminAtcServer.ReceivedRequests())
-					}).By(2))
-				})
-			})
-		})
-
-		Context("when the job flag is not provided", func() {
+		Context("when user is on the same team as the given pipeline/job's team", func() {
 			BeforeEach(func() {
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "pause-job")
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", apiPath),
+						ghttp.RespondWith(http.StatusOK, nil),
+					),
+				)
+			})
+
+			It("successfully pauses the job", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "pause-job", "-j", fullJobName)
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+				Eventually(sess.Out.Contents).Should(ContainSubstring(fmt.Sprintf("paused '%s'\n", jobName)))
+			})
+		})
+
+		Context("user is NOT on the same team as the given pipeline/job's team", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", apiPath),
+						ghttp.RespondWith(http.StatusForbidden, nil),
+					),
+				)
+			})
+
+			It("fails to pause the job", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "pause-job", "-j", fullJobName)
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
+				Eventually(sess.Err.Contents).Should(ContainSubstring("error"))
+			})
+		})
+
+		Context("user is NOT currently targeted to the team the given pipeline/job belongs to", func() {
+			BeforeEach(func() {
+				apiPath = fmt.Sprintf("/api/v1/teams/other-team/pipelines/%s/jobs/%s/pause", pipelineName, jobName)
+
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{Name: "other-team"}),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", apiPath),
+						ghttp.RespondWith(http.StatusOK, nil),
+					),
+				)
+			})
+
+			It("successfully pauses the job", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "pause-job", "-j", fullJobName, "--team", "other-team")
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+				Eventually(sess).Should(gbytes.Say(fmt.Sprintf("paused '%s'\n", jobName)))
+			})
+		})
+
+		Context("the pipeline/job does not exist", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", "/api/v1/teams/main/pipelines/doesnotexist-pipeline/jobs/doesnotexist-job/pause"),
+						ghttp.RespondWith(http.StatusNotFound, nil),
+					),
+				)
+			})
+
+			It("returns an error", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "doesnotexist-pipeline/doesnotexist-job")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
+				Eventually(sess.Err.Contents).Should(ContainSubstring("doesnotexist-pipeline/doesnotexist-job not found on team main"))
+			})
+		})
+
+		Context("when a job fails to be paused using the API", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("PUT", apiPath),
+						ghttp.RespondWith(http.StatusInternalServerError, nil),
+					),
+				)
 			})
 
 			It("exits 1 and outputs an error", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "pause-job", "-j", fullJobName)
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess.Err).Should(gbytes.Say(`error`))

--- a/fly/integration/pause_job_test.go
+++ b/fly/integration/pause_job_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Fly CLI", func() {
 			})
 		})
 
-		Context("when a job fails to be paused using the API", func() {
+		Context("when pause-job fails", func() {
 			BeforeEach(func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(

--- a/fly/integration/suite_test.go
+++ b/fly/integration/suite_test.go
@@ -27,6 +27,7 @@ var atcServer *ghttp.Server
 var adminAtcServer *ghttp.Server
 
 const targetName = "testserver"
+const adminTarget = "admin-target"
 const teamName = "main"
 const atcVersion = "4.0.0"
 const workerVersion = "4.5.6"
@@ -143,7 +144,7 @@ var _ = BeforeEach(func() {
 
 	Expect(session.ExitCode()).To(Equal(0))
 
-	// super admin login server
+	// Login as a super admin
 	adminAtcServer = ghttp.NewServer()
 	adminAtcServer.AppendHandlers(
 		infoHandler(),
@@ -152,7 +153,7 @@ var _ = BeforeEach(func() {
 		infoHandler(),
 	)
 
-	flyLoginCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "main", "-u", "test", "-p", "test")
+	flyLoginCmd := exec.Command(flyPath, "-t", adminTarget, "login", "-c", adminAtcServer.URL(), "-n", "main", "-u", "test", "-p", "test")
 	sess, err := gexec.Start(flyLoginCmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/fly/integration/suite_test.go
+++ b/fly/integration/suite_test.go
@@ -24,7 +24,7 @@ var flyPath string
 var homeDir string
 
 var atcServer *ghttp.Server
-var loginATCServer *ghttp.Server
+var adminAtcServer *ghttp.Server
 
 const targetName = "testserver"
 const teamName = "main"
@@ -144,15 +144,15 @@ var _ = BeforeEach(func() {
 	Expect(session.ExitCode()).To(Equal(0))
 
 	// super admin login server
-	loginATCServer = ghttp.NewServer()
-	loginATCServer.AppendHandlers(
+	adminAtcServer = ghttp.NewServer()
+	adminAtcServer.AppendHandlers(
 		infoHandler(),
 		adminTokenHandler(encodedTokenString(true)),
 		teamHandler(teams, encodedTokenString(true)),
 		infoHandler(),
 	)
 
-	flyLoginCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "main", "-u", "test", "-p", "test")
+	flyLoginCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", adminAtcServer.URL(), "-n", "main", "-u", "test", "-p", "test")
 	sess, err := gexec.Start(flyLoginCmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -167,7 +167,7 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() {
 	atcServer.Close()
 	os.RemoveAll(homeDir)
-	loginATCServer.Close()
+	adminAtcServer.Close()
 
 })
 

--- a/fly/integration/trigger_job_test.go
+++ b/fly/integration/trigger_job_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/tedsuo/rata"
 )
 
-var _ = FDescribe("Fly CLI", func() {
+var _ = Describe("Fly CLI", func() {
 	Describe("trigger-job", func() {
 		var (
 			mainPath        string
@@ -240,7 +240,7 @@ var _ = FDescribe("Fly CLI", func() {
 			})
 		})
 
-		Context("when you are authorized to view the team but the team does not exist", func() {
+		Context("when you are authenticated but the team does not exist", func() {
 			It("returns an error", func() {
 				loginATCServer.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -261,7 +261,7 @@ var _ = FDescribe("Fly CLI", func() {
 			})
 		})
 		Context("when you are NOT authorized to view the team", func() {
-			FIt("returns an error", func() {
+			It("returns an error", func() {
 				loginATCServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/teams/banana"),
@@ -274,7 +274,7 @@ var _ = FDescribe("Fly CLI", func() {
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(sess.Err).Should(gbytes.Say(`error: you are not part of team 'banana'`))
+				Eventually(sess.Err).Should(gbytes.Say(`error: you do not have a role on team 'banana'`))
 
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))

--- a/fly/integration/trigger_job_test.go
+++ b/fly/integration/trigger_job_test.go
@@ -261,11 +261,11 @@ var _ = FDescribe("Fly CLI", func() {
 			})
 		})
 		Context("when you are NOT authorized to view the team", func() {
-			It("returns an error", func() {
+			FIt("returns an error", func() {
 				loginATCServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/teams/banana"),
-						ghttp.RespondWith(http.StatusUnauthorized, nil),
+						ghttp.RespondWith(http.StatusForbidden, nil),
 					),
 				)
 

--- a/fly/integration/trigger_job_test.go
+++ b/fly/integration/trigger_job_test.go
@@ -240,47 +240,6 @@ var _ = Describe("Fly CLI", func() {
 			})
 		})
 
-		Context("when you are authenticated but the team does not exist", func() {
-			It("returns an error", func() {
-				loginATCServer.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/teams/banana"),
-						ghttp.RespondWith(http.StatusNotFound, nil),
-					),
-				)
-
-				flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job", "-j", "awesome-pipeline/awesome-job", "--team", "banana")
-
-				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(sess.Err).Should(gbytes.Say(`error: team 'banana' does not exist`))
-
-				<-sess.Exited
-				Expect(sess.ExitCode()).To(Equal(1))
-			})
-		})
-		Context("when you are NOT authorized to view the team", func() {
-			It("returns an error", func() {
-				loginATCServer.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/teams/banana"),
-						ghttp.RespondWith(http.StatusForbidden, nil),
-					),
-				)
-
-				flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job", "-j", "awesome-pipeline/awesome-job", "--team", "banana")
-
-				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(sess.Err).Should(gbytes.Say(`error: you do not have a role on team 'banana'`))
-
-				<-sess.Exited
-				Expect(sess.ExitCode()).To(Equal(1))
-			})
-		})
-
 		Context("when the pipeline/job name is not specified", func() {
 			It("errors", func() {
 				reqsBefore := len(loginATCServer.ReceivedRequests())

--- a/fly/integration/trigger_job_test.go
+++ b/fly/integration/trigger_job_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Fly CLI", func() {
 					Context("user is currently on pipeline's team", func() {
 
 						BeforeEach(func() {
-							loginATCServer.AppendHandlers(
+							adminAtcServer.AppendHandlers(
 								ghttp.CombineHandlers(
 									ghttp.VerifyRequest("POST", mainPath),
 									ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Build{ID: 57, Name: "42"}),
@@ -69,7 +69,7 @@ var _ = Describe("Fly CLI", func() {
 					Context("user is NOT currently targeted to the pipeline's team", func() {
 
 						BeforeEach(func() {
-							loginATCServer.AppendHandlers(
+							adminAtcServer.AppendHandlers(
 								ghttp.CombineHandlers(
 									ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
 									ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
@@ -102,7 +102,7 @@ var _ = Describe("Fly CLI", func() {
 
 				Context("when user does NOT own the same team as the given pipeline", func() {
 					BeforeEach(func() {
-						loginATCServer.AppendHandlers(
+						adminAtcServer.AppendHandlers(
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("GET", "/api/v1/teams/random-team"),
 								ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
@@ -138,7 +138,7 @@ var _ = Describe("Fly CLI", func() {
 					BeforeEach(func() {
 						streaming = make(chan struct{})
 						events = make(chan atc.Event)
-						loginATCServer.AppendHandlers(
+						adminAtcServer.AppendHandlers(
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("POST", mainPath),
 								ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Build{ID: 57, Name: "42"}),
@@ -210,7 +210,7 @@ var _ = Describe("Fly CLI", func() {
 
 			Context("when the pipeline/job doesn't exist", func() {
 				BeforeEach(func() {
-					loginATCServer.AppendHandlers(
+					adminAtcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/random-team"),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
@@ -242,7 +242,7 @@ var _ = Describe("Fly CLI", func() {
 
 		Context("when the pipeline/job name is not specified", func() {
 			It("errors", func() {
-				reqsBefore := len(loginATCServer.ReceivedRequests())
+				reqsBefore := len(adminAtcServer.ReceivedRequests())
 				flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
@@ -250,7 +250,7 @@ var _ = Describe("Fly CLI", func() {
 
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
-				Expect(loginATCServer.ReceivedRequests()).To(HaveLen(reqsBefore))
+				Expect(adminAtcServer.ReceivedRequests()).To(HaveLen(reqsBefore))
 			})
 		})
 
@@ -264,7 +264,7 @@ var _ = Describe("Fly CLI", func() {
 			})
 
 			It("returns all matching pipelines", func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
 						ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
@@ -285,7 +285,7 @@ var _ = Describe("Fly CLI", func() {
 			})
 
 			It("returns all matching jobs", func() {
-				loginATCServer.AppendHandlers(
+				adminAtcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines/some-pipeline/jobs"),
 						ghttp.RespondWithJSONEncoded(200, []atc.Job{

--- a/fly/integration/trigger_job_test.go
+++ b/fly/integration/trigger_job_test.go
@@ -41,11 +41,11 @@ var _ = Describe("Fly CLI", func() {
 
 		Context("when the pipeline and job name are specified", func() {
 			Context("when the pipeline and job exists", func() {
-				Context("when user owns the same team as the given pipeline", func() {
-					Context("user is currently on pipeline's team", func() {
+				Context("user and pipeline are part of the main team", func() {
+					Context("user is targeting the same team that the pipeline belongs to", func() {
 
 						BeforeEach(func() {
-							adminAtcServer.AppendHandlers(
+							atcServer.AppendHandlers(
 								ghttp.CombineHandlers(
 									ghttp.VerifyRequest("POST", mainPath),
 									ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Build{ID: 57, Name: "42"}),
@@ -54,7 +54,7 @@ var _ = Describe("Fly CLI", func() {
 						})
 
 						It("starts the build", func() {
-							flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job", "-j", "awesome-pipeline/awesome-job")
+							flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "awesome-pipeline/awesome-job")
 
 							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 							Expect(err).NotTo(HaveOccurred())
@@ -66,16 +66,14 @@ var _ = Describe("Fly CLI", func() {
 						})
 					})
 
-					Context("user is NOT currently targeted to the pipeline's team", func() {
+					Context("user is NOT targeting the same team that the pipeline belongs to", func() {
 
 						BeforeEach(func() {
-							adminAtcServer.AppendHandlers(
+							atcServer.AppendHandlers(
 								ghttp.CombineHandlers(
 									ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
 									ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
 										Name: "other-team",
-										ID:   0,
-										Auth: atc.TeamAuth{},
 									}),
 								),
 								ghttp.CombineHandlers(
@@ -86,7 +84,7 @@ var _ = Describe("Fly CLI", func() {
 						})
 
 						It("starts the build", func() {
-							flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job", "-j", "awesome-pipeline/awesome-job", "--team", "other-team")
+							flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "awesome-pipeline/awesome-job", "--team", "other-team")
 
 							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 							Expect(err).NotTo(HaveOccurred())
@@ -100,37 +98,6 @@ var _ = Describe("Fly CLI", func() {
 					})
 				})
 
-				Context("when user does NOT own the same team as the given pipeline", func() {
-					BeforeEach(func() {
-						adminAtcServer.AppendHandlers(
-							ghttp.CombineHandlers(
-								ghttp.VerifyRequest("GET", "/api/v1/teams/random-team"),
-								ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
-									Name: "random-team",
-									ID:   0,
-									Auth: atc.TeamAuth{},
-								}),
-							),
-							ghttp.CombineHandlers(
-								ghttp.VerifyRequest("POST", otherRandomPath),
-								ghttp.RespondWith(http.StatusNotFound, nil),
-							),
-						)
-					})
-
-					It("prints an error message", func() {
-						flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job", "-j", "awesome-pipeline/awesome-job", "--team", "random-team")
-
-						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-						Expect(err).NotTo(HaveOccurred())
-
-						Eventually(sess.Err).Should(gbytes.Say(`error: resource not found`))
-
-						<-sess.Exited
-						Expect(sess.ExitCode()).To(Equal(1))
-					})
-				})
-
 				Context("when -w option is provided", func() {
 					var streaming chan struct{}
 					var events chan atc.Event
@@ -138,7 +105,7 @@ var _ = Describe("Fly CLI", func() {
 					BeforeEach(func() {
 						streaming = make(chan struct{})
 						events = make(chan atc.Event)
-						adminAtcServer.AppendHandlers(
+						atcServer.AppendHandlers(
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("POST", mainPath),
 								ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Build{ID: 57, Name: "42"}),
@@ -188,7 +155,7 @@ var _ = Describe("Fly CLI", func() {
 					})
 
 					It("watches the build", func() {
-						flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job", "-j", "awesome-pipeline/awesome-job", "-w")
+						flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "awesome-pipeline/awesome-job", "-w")
 
 						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 						Expect(err).NotTo(HaveOccurred())
@@ -210,7 +177,7 @@ var _ = Describe("Fly CLI", func() {
 
 			Context("when the pipeline/job doesn't exist", func() {
 				BeforeEach(func() {
-					adminAtcServer.AppendHandlers(
+					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/random-team"),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
@@ -227,7 +194,7 @@ var _ = Describe("Fly CLI", func() {
 				})
 
 				It("prints an error message", func() {
-					flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job", "-j", "awesome-pipeline/awesome-job", "--team", "random-team")
+					flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "awesome-pipeline/awesome-job", "--team", "random-team")
 
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
@@ -242,15 +209,13 @@ var _ = Describe("Fly CLI", func() {
 
 		Context("when the pipeline/job name is not specified", func() {
 			It("errors", func() {
-				reqsBefore := len(adminAtcServer.ReceivedRequests())
-				flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job")
+				flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
-				Expect(adminAtcServer.ReceivedRequests()).To(HaveLen(reqsBefore))
 			})
 		})
 
@@ -264,7 +229,7 @@ var _ = Describe("Fly CLI", func() {
 			})
 
 			It("returns all matching pipelines", func() {
-				adminAtcServer.AppendHandlers(
+				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
 						ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
@@ -275,7 +240,7 @@ var _ = Describe("Fly CLI", func() {
 					),
 				)
 
-				flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job", "-j", "some-")
+				flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "some-")
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(gexec.Exit(0))
@@ -285,7 +250,7 @@ var _ = Describe("Fly CLI", func() {
 			})
 
 			It("returns all matching jobs", func() {
-				adminAtcServer.AppendHandlers(
+				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines/some-pipeline/jobs"),
 						ghttp.RespondWithJSONEncoded(200, []atc.Job{
@@ -296,7 +261,7 @@ var _ = Describe("Fly CLI", func() {
 					),
 				)
 
-				flyCmd := exec.Command(flyPath, "-t", "some-target", "trigger-job", "-j", "some-pipeline/some-")
+				flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "some-pipeline/some-")
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				Eventually(sess).Should(gexec.Exit(0))

--- a/fly/integration/unpause_job_test.go
+++ b/fly/integration/unpause_job_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Fly CLI", func() {
 			Context("when user owns the same team as the given pipeline", func() {
 				Context("user is currently on the same team as the given job", func() {
 					BeforeEach(func() {
-						loginATCServer.AppendHandlers(
+						adminAtcServer.AppendHandlers(
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("PUT", apiPath),
 								ghttp.RespondWith(http.StatusOK, nil),
@@ -52,7 +52,7 @@ var _ = Describe("Fly CLI", func() {
 							Expect(sess.ExitCode()).To(Equal(0))
 							Eventually(sess).Should(gbytes.Say(fmt.Sprintf("unpaused '%s'\n", jobName)))
 						}).To(Change(func() int {
-							return len(loginATCServer.ReceivedRequests())
+							return len(adminAtcServer.ReceivedRequests())
 						}).By(2))
 					})
 				})
@@ -61,7 +61,7 @@ var _ = Describe("Fly CLI", func() {
 					BeforeEach(func() {
 						apiPath = fmt.Sprintf("/api/v1/teams/other-team/pipelines/%s/jobs/%s/unpause", pipelineName, jobName)
 
-						loginATCServer.AppendHandlers(
+						adminAtcServer.AppendHandlers(
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("PUT", apiPath),
 								ghttp.RespondWith(http.StatusOK, nil),
@@ -78,7 +78,7 @@ var _ = Describe("Fly CLI", func() {
 							Expect(sess.ExitCode()).To(Equal(0))
 							Eventually(sess).Should(gbytes.Say(fmt.Sprintf("unpaused '%s'\n", jobName)))
 						}).To(Change(func() int {
-							return len(loginATCServer.ReceivedRequests())
+							return len(adminAtcServer.ReceivedRequests())
 						}).By(2))
 					})
 				})
@@ -87,7 +87,7 @@ var _ = Describe("Fly CLI", func() {
 			Context("when user does NOT own the pipeline's team or pipeline/job doesn't exist", func() {
 				BeforeEach(func() {
 					randomApiPath := fmt.Sprintf("/api/v1/teams/random-team/pipelines/random-pipeline/jobs/random-job/unpause")
-					loginATCServer.AppendHandlers(
+					adminAtcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("PUT", randomApiPath),
 							ghttp.RespondWith(http.StatusNotFound, nil),
@@ -103,7 +103,7 @@ var _ = Describe("Fly CLI", func() {
 						<-sess.Exited
 						Expect(sess.ExitCode()).To(Equal(1))
 					}).To(Change(func() int {
-						return len(loginATCServer.ReceivedRequests())
+						return len(adminAtcServer.ReceivedRequests())
 					}).By(2))
 				})
 			})
@@ -111,7 +111,7 @@ var _ = Describe("Fly CLI", func() {
 			Context("when a job is failed to be unpaused using the API", func() {
 				BeforeEach(func() {
 					apiPath := fmt.Sprintf("/api/v1/teams/main/pipelines/%s/jobs/%s/unpause", pipelineName, jobName)
-					loginATCServer.AppendHandlers(
+					adminAtcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("PUT", apiPath),
 							ghttp.RespondWith(http.StatusInternalServerError, nil),
@@ -129,7 +129,7 @@ var _ = Describe("Fly CLI", func() {
 						<-sess.Exited
 						Expect(sess.ExitCode()).To(Equal(1))
 					}).To(Change(func() int {
-						return len(loginATCServer.ReceivedRequests())
+						return len(adminAtcServer.ReceivedRequests())
 					}).By(2))
 				})
 			})

--- a/fly/integration/unpause_job_test.go
+++ b/fly/integration/unpause_job_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os/exec"
 
+	"github.com/concourse/concourse/atc"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -28,14 +29,14 @@ var _ = Describe("Fly CLI", func() {
 			fullJobName = fmt.Sprintf("%s/%s", pipelineName, jobName)
 			apiPath = fmt.Sprintf("/api/v1/teams/main/pipelines/%s/jobs/%s/unpause", pipelineName, jobName)
 
-			flyCmd = exec.Command(flyPath, "-t", "some-target", "unpause-job", "-j", fullJobName)
+			flyCmd = exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", fullJobName)
 		})
 
 		Context("when the job flag is provided", func() {
-			Context("when user owns the same team as the given pipeline", func() {
-				Context("user is currently on the same team as the given job", func() {
+			Context("when user and pipeline belong to the same team", func() {
+				Context("user is targeting the same team that the pipeline belongs to", func() {
 					BeforeEach(func() {
-						adminAtcServer.AppendHandlers(
+						atcServer.AppendHandlers(
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("PUT", apiPath),
 								ghttp.RespondWith(http.StatusOK, nil),
@@ -44,24 +45,26 @@ var _ = Describe("Fly CLI", func() {
 					})
 
 					It("successfully unpauses the job", func() {
-						Expect(func() {
-							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-							Expect(err).NotTo(HaveOccurred())
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
 
-							<-sess.Exited
-							Expect(sess.ExitCode()).To(Equal(0))
-							Eventually(sess).Should(gbytes.Say(fmt.Sprintf("unpaused '%s'\n", jobName)))
-						}).To(Change(func() int {
-							return len(adminAtcServer.ReceivedRequests())
-						}).By(2))
+						<-sess.Exited
+						Expect(sess.ExitCode()).To(Equal(0))
+						Eventually(sess).Should(gbytes.Say(fmt.Sprintf("unpaused '%s'\n", jobName)))
 					})
 				})
 
-				Context("user is NOT currently on the same team as the given job", func() {
+				Context("user is NOT targeting the same team that the pipeline belongs to", func() {
 					BeforeEach(func() {
 						apiPath = fmt.Sprintf("/api/v1/teams/other-team/pipelines/%s/jobs/%s/unpause", pipelineName, jobName)
 
-						adminAtcServer.AppendHandlers(
+						atcServer.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
+								ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+									Name: "other-team",
+								}),
+							),
 							ghttp.CombineHandlers(
 								ghttp.VerifyRequest("PUT", apiPath),
 								ghttp.RespondWith(http.StatusOK, nil),
@@ -70,48 +73,20 @@ var _ = Describe("Fly CLI", func() {
 					})
 
 					It("successfully unpauses the job", func() {
-						Expect(func() {
-							flyCmd = exec.Command(flyPath, "-t", "some-target", "unpause-job", "-j", fullJobName, "--team", "other-team")
-							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-							Expect(err).NotTo(HaveOccurred())
-							<-sess.Exited
-							Expect(sess.ExitCode()).To(Equal(0))
-							Eventually(sess).Should(gbytes.Say(fmt.Sprintf("unpaused '%s'\n", jobName)))
-						}).To(Change(func() int {
-							return len(adminAtcServer.ReceivedRequests())
-						}).By(2))
+						flyCmd = exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", fullJobName, "--team", "other-team")
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+						<-sess.Exited
+						Expect(sess.ExitCode()).To(Equal(0))
+						Eventually(sess).Should(gbytes.Say(fmt.Sprintf("unpaused '%s'\n", jobName)))
 					})
 				})
 			})
 
-			Context("when user does NOT own the pipeline's team or pipeline/job doesn't exist", func() {
-				BeforeEach(func() {
-					randomApiPath := fmt.Sprintf("/api/v1/teams/random-team/pipelines/random-pipeline/jobs/random-job/unpause")
-					adminAtcServer.AppendHandlers(
-						ghttp.CombineHandlers(
-							ghttp.VerifyRequest("PUT", randomApiPath),
-							ghttp.RespondWith(http.StatusNotFound, nil),
-						),
-					)
-				})
-				It("exits 1 and outputs the corresponding error", func() {
-					Expect(func() {
-						flyCmd = exec.Command(flyPath, "-t", "some-target", "unpause-job", "-j", "random-pipeline/random-job", "--team", "random-team")
-						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-						Expect(err).NotTo(HaveOccurred())
-						Eventually(sess.Err).Should(gbytes.Say(`random-pipeline/random-job not found on team random-team`))
-						<-sess.Exited
-						Expect(sess.ExitCode()).To(Equal(1))
-					}).To(Change(func() int {
-						return len(adminAtcServer.ReceivedRequests())
-					}).By(2))
-				})
-			})
-
-			Context("when a job is failed to be unpaused using the API", func() {
+			Context("when unpause-job fails", func() {
 				BeforeEach(func() {
 					apiPath := fmt.Sprintf("/api/v1/teams/main/pipelines/%s/jobs/%s/unpause", pipelineName, jobName)
-					adminAtcServer.AppendHandlers(
+					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("PUT", apiPath),
 							ghttp.RespondWith(http.StatusInternalServerError, nil),
@@ -120,24 +95,20 @@ var _ = Describe("Fly CLI", func() {
 				})
 
 				It("exits 1 and outputs an error", func() {
-					Expect(func() {
-						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-						Expect(err).NotTo(HaveOccurred())
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
 
-						Eventually(sess.Err).Should(gbytes.Say(`error`))
+					Eventually(sess.Err).Should(gbytes.Say(`error`))
 
-						<-sess.Exited
-						Expect(sess.ExitCode()).To(Equal(1))
-					}).To(Change(func() int {
-						return len(adminAtcServer.ReceivedRequests())
-					}).By(2))
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(1))
 				})
 			})
 		})
 
 		Context("when the job flag is not provided", func() {
 			BeforeEach(func() {
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "unpause-job")
+				flyCmd = exec.Command(flyPath, "-t", targetName, "unpause-job")
 			})
 
 			It("exits 1 and outputs an error", func() {

--- a/fly/rc/rcfakes/fake_target.go
+++ b/fly/rc/rcfakes/fake_target.go
@@ -30,6 +30,19 @@ type FakeTarget struct {
 	clientReturnsOnCall map[int]struct {
 		result1 concourse.Client
 	}
+	FindTeamStub        func(string) (concourse.Team, error)
+	findTeamMutex       sync.RWMutex
+	findTeamArgsForCall []struct {
+		arg1 string
+	}
+	findTeamReturns struct {
+		result1 concourse.Team
+		result2 error
+	}
+	findTeamReturnsOnCall map[int]struct {
+		result1 concourse.Team
+		result2 error
+	}
 	IsWorkerVersionCompatibleStub        func(string) (bool, error)
 	isWorkerVersionCompatibleMutex       sync.RWMutex
 	isWorkerVersionCompatibleArgsForCall []struct {
@@ -245,6 +258,69 @@ func (fake *FakeTarget) ClientReturnsOnCall(i int, result1 concourse.Client) {
 	fake.clientReturnsOnCall[i] = struct {
 		result1 concourse.Client
 	}{result1}
+}
+
+func (fake *FakeTarget) FindTeam(arg1 string) (concourse.Team, error) {
+	fake.findTeamMutex.Lock()
+	ret, specificReturn := fake.findTeamReturnsOnCall[len(fake.findTeamArgsForCall)]
+	fake.findTeamArgsForCall = append(fake.findTeamArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("FindTeam", []interface{}{arg1})
+	fake.findTeamMutex.Unlock()
+	if fake.FindTeamStub != nil {
+		return fake.FindTeamStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.findTeamReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTarget) FindTeamCallCount() int {
+	fake.findTeamMutex.RLock()
+	defer fake.findTeamMutex.RUnlock()
+	return len(fake.findTeamArgsForCall)
+}
+
+func (fake *FakeTarget) FindTeamCalls(stub func(string) (concourse.Team, error)) {
+	fake.findTeamMutex.Lock()
+	defer fake.findTeamMutex.Unlock()
+	fake.FindTeamStub = stub
+}
+
+func (fake *FakeTarget) FindTeamArgsForCall(i int) string {
+	fake.findTeamMutex.RLock()
+	defer fake.findTeamMutex.RUnlock()
+	argsForCall := fake.findTeamArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTarget) FindTeamReturns(result1 concourse.Team, result2 error) {
+	fake.findTeamMutex.Lock()
+	defer fake.findTeamMutex.Unlock()
+	fake.FindTeamStub = nil
+	fake.findTeamReturns = struct {
+		result1 concourse.Team
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTarget) FindTeamReturnsOnCall(i int, result1 concourse.Team, result2 error) {
+	fake.findTeamMutex.Lock()
+	defer fake.findTeamMutex.Unlock()
+	fake.FindTeamStub = nil
+	if fake.findTeamReturnsOnCall == nil {
+		fake.findTeamReturnsOnCall = make(map[int]struct {
+			result1 concourse.Team
+			result2 error
+		})
+	}
+	fake.findTeamReturnsOnCall[i] = struct {
+		result1 concourse.Team
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeTarget) IsWorkerVersionCompatible(arg1 string) (bool, error) {
@@ -794,6 +870,8 @@ func (fake *FakeTarget) Invocations() map[string][][]interface{} {
 	defer fake.cACertMutex.RUnlock()
 	fake.clientMutex.RLock()
 	defer fake.clientMutex.RUnlock()
+	fake.findTeamMutex.RLock()
+	defer fake.findTeamMutex.RUnlock()
 	fake.isWorkerVersionCompatibleMutex.RLock()
 	defer fake.isWorkerVersionCompatibleMutex.RUnlock()
 	fake.tLSConfigMutex.RLock()

--- a/fly/rc/target.go
+++ b/fly/rc/target.go
@@ -45,6 +45,7 @@ func (e ErrVersionMismatch) Error() string {
 type Target interface {
 	Client() concourse.Client
 	Team() concourse.Team
+	FindTeam(string) (concourse.Team, error)
 	CACert() string
 	Validate() error
 	ValidateWithWarningOnly() error
@@ -68,7 +69,7 @@ type target struct {
 	info      atc.Info
 }
 
-func newTarget(
+func NewTarget(
 	name TargetName,
 	teamName string,
 	url string,
@@ -124,7 +125,7 @@ func LoadTarget(selectedTarget TargetName, tracing bool) (Target, error) {
 	httpClient := defaultHttpClient(targetProps.Token, targetProps.Insecure, caCertPool)
 	client := concourse.NewClient(targetProps.API, httpClient, tracing)
 
-	return newTarget(
+	return NewTarget(
 		selectedTarget,
 		targetProps.TeamName,
 		targetProps.API,
@@ -167,7 +168,7 @@ func LoadUnauthenticatedTarget(
 
 	httpClient := &http.Client{Transport: transport(insecure, caCertPool)}
 
-	return newTarget(
+	return NewTarget(
 		selectedTarget,
 		teamName,
 		targetProps.API,
@@ -194,7 +195,7 @@ func NewUnauthenticatedTarget(
 
 	httpClient := &http.Client{Transport: transport(insecure, caCertPool)}
 	client := concourse.NewClient(url, httpClient, tracing)
-	return newTarget(
+	return NewTarget(
 		name,
 		teamName,
 		url,
@@ -222,7 +223,7 @@ func NewAuthenticatedTarget(
 	httpClient := defaultHttpClient(token, insecure, caCertPool)
 	client := concourse.NewClient(url, httpClient, tracing)
 
-	return newTarget(
+	return NewTarget(
 		name,
 		teamName,
 		url,
@@ -251,7 +252,7 @@ func NewBasicAuthTarget(
 	httpClient := basicAuthHttpClient(username, password, insecure, caCertPool)
 	client := concourse.NewClient(url, httpClient, tracing)
 
-	return newTarget(
+	return NewTarget(
 		name,
 		teamName,
 		url,
@@ -269,6 +270,10 @@ func (t *target) Client() concourse.Client {
 
 func (t *target) Team() concourse.Team {
 	return t.client.Team(t.teamName)
+}
+
+func (t *target) FindTeam(teamName string) (concourse.Team, error) {
+	return t.client.FindTeam(teamName)
 }
 
 func (t *target) CACert() string {

--- a/fly/rc/target_test.go
+++ b/fly/rc/target_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"github.com/concourse/concourse/fly/rc"
+	fakes "github.com/concourse/concourse/go-concourse/concourse/concoursefakes"
 	"golang.org/x/oauth2"
 	"sigs.k8s.io/yaml"
 
@@ -155,6 +156,26 @@ AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 					RootCAs:            expectedCaCertPool,
 				}))
 			})
+		})
+	})
+
+	Describe("FindTeam", func() {
+		It("finds the team", func() {
+			fakeClient := new(fakes.FakeClient)
+
+			rc.NewTarget(
+				"test-target",
+				"default-team",
+				"http://example.com",
+				nil,
+				"ca-cert",
+				nil,
+				true,
+				fakeClient,
+			).FindTeam("the-team")
+
+			Expect(fakeClient.FindTeamCallCount()).To(Equal(1), "client.FindTeam should be used")
+			Expect(fakeClient.FindTeamArgsForCall(0)).To(Equal("the-team"), "FindTeam should pass through team name")
 		})
 	})
 })

--- a/go-concourse/concourse/concoursefakes/fake_client.go
+++ b/go-concourse/concourse/concoursefakes/fake_client.go
@@ -111,6 +111,21 @@ type FakeClient struct {
 		result2 bool
 		result3 error
 	}
+	FindTeamStub        func(string) (concourse.Team, bool, error)
+	findTeamMutex       sync.RWMutex
+	findTeamArgsForCall []struct {
+		arg1 string
+	}
+	findTeamReturns struct {
+		result1 concourse.Team
+		result2 bool
+		result3 error
+	}
+	findTeamReturnsOnCall map[int]struct {
+		result1 concourse.Team
+		result2 bool
+		result3 error
+	}
 	GetCLIReaderStub        func(string, string) (io.ReadCloser, http.Header, error)
 	getCLIReaderMutex       sync.RWMutex
 	getCLIReaderArgsForCall []struct {
@@ -732,6 +747,72 @@ func (fake *FakeClient) CheckReturnsOnCall(i int, result1 atc.Check, result2 boo
 	}
 	fake.checkReturnsOnCall[i] = struct {
 		result1 atc.Check
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) FindTeam(arg1 string) (concourse.Team, bool, error) {
+	fake.findTeamMutex.Lock()
+	ret, specificReturn := fake.findTeamReturnsOnCall[len(fake.findTeamArgsForCall)]
+	fake.findTeamArgsForCall = append(fake.findTeamArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("FindTeam", []interface{}{arg1})
+	fake.findTeamMutex.Unlock()
+	if fake.FindTeamStub != nil {
+		return fake.FindTeamStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.findTeamReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) FindTeamCallCount() int {
+	fake.findTeamMutex.RLock()
+	defer fake.findTeamMutex.RUnlock()
+	return len(fake.findTeamArgsForCall)
+}
+
+func (fake *FakeClient) FindTeamCalls(stub func(string) (concourse.Team, bool, error)) {
+	fake.findTeamMutex.Lock()
+	defer fake.findTeamMutex.Unlock()
+	fake.FindTeamStub = stub
+}
+
+func (fake *FakeClient) FindTeamArgsForCall(i int) string {
+	fake.findTeamMutex.RLock()
+	defer fake.findTeamMutex.RUnlock()
+	argsForCall := fake.findTeamArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) FindTeamReturns(result1 concourse.Team, result2 bool, result3 error) {
+	fake.findTeamMutex.Lock()
+	defer fake.findTeamMutex.Unlock()
+	fake.FindTeamStub = nil
+	fake.findTeamReturns = struct {
+		result1 concourse.Team
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) FindTeamReturnsOnCall(i int, result1 concourse.Team, result2 bool, result3 error) {
+	fake.findTeamMutex.Lock()
+	defer fake.findTeamMutex.Unlock()
+	fake.FindTeamStub = nil
+	if fake.findTeamReturnsOnCall == nil {
+		fake.findTeamReturnsOnCall = make(map[int]struct {
+			result1 concourse.Team
+			result2 bool
+			result3 error
+		})
+	}
+	fake.findTeamReturnsOnCall[i] = struct {
+		result1 concourse.Team
 		result2 bool
 		result3 error
 	}{result1, result2, result3}
@@ -1570,6 +1651,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.buildsMutex.RUnlock()
 	fake.checkMutex.RLock()
 	defer fake.checkMutex.RUnlock()
+	fake.findTeamMutex.RLock()
+	defer fake.findTeamMutex.RUnlock()
 	fake.getCLIReaderMutex.RLock()
 	defer fake.getCLIReaderMutex.RUnlock()
 	fake.getInfoMutex.RLock()

--- a/go-concourse/concourse/concoursefakes/fake_client.go
+++ b/go-concourse/concourse/concoursefakes/fake_client.go
@@ -111,20 +111,18 @@ type FakeClient struct {
 		result2 bool
 		result3 error
 	}
-	FindTeamStub        func(string) (concourse.Team, bool, error)
+	FindTeamStub        func(string) (concourse.Team, error)
 	findTeamMutex       sync.RWMutex
 	findTeamArgsForCall []struct {
 		arg1 string
 	}
 	findTeamReturns struct {
 		result1 concourse.Team
-		result2 bool
-		result3 error
+		result2 error
 	}
 	findTeamReturnsOnCall map[int]struct {
 		result1 concourse.Team
-		result2 bool
-		result3 error
+		result2 error
 	}
 	GetCLIReaderStub        func(string, string) (io.ReadCloser, http.Header, error)
 	getCLIReaderMutex       sync.RWMutex
@@ -752,7 +750,7 @@ func (fake *FakeClient) CheckReturnsOnCall(i int, result1 atc.Check, result2 boo
 	}{result1, result2, result3}
 }
 
-func (fake *FakeClient) FindTeam(arg1 string) (concourse.Team, bool, error) {
+func (fake *FakeClient) FindTeam(arg1 string) (concourse.Team, error) {
 	fake.findTeamMutex.Lock()
 	ret, specificReturn := fake.findTeamReturnsOnCall[len(fake.findTeamArgsForCall)]
 	fake.findTeamArgsForCall = append(fake.findTeamArgsForCall, struct {
@@ -764,10 +762,10 @@ func (fake *FakeClient) FindTeam(arg1 string) (concourse.Team, bool, error) {
 		return fake.FindTeamStub(arg1)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
 	fakeReturns := fake.findTeamReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) FindTeamCallCount() int {
@@ -776,7 +774,7 @@ func (fake *FakeClient) FindTeamCallCount() int {
 	return len(fake.findTeamArgsForCall)
 }
 
-func (fake *FakeClient) FindTeamCalls(stub func(string) (concourse.Team, bool, error)) {
+func (fake *FakeClient) FindTeamCalls(stub func(string) (concourse.Team, error)) {
 	fake.findTeamMutex.Lock()
 	defer fake.findTeamMutex.Unlock()
 	fake.FindTeamStub = stub
@@ -789,33 +787,30 @@ func (fake *FakeClient) FindTeamArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
-func (fake *FakeClient) FindTeamReturns(result1 concourse.Team, result2 bool, result3 error) {
+func (fake *FakeClient) FindTeamReturns(result1 concourse.Team, result2 error) {
 	fake.findTeamMutex.Lock()
 	defer fake.findTeamMutex.Unlock()
 	fake.FindTeamStub = nil
 	fake.findTeamReturns = struct {
 		result1 concourse.Team
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeClient) FindTeamReturnsOnCall(i int, result1 concourse.Team, result2 bool, result3 error) {
+func (fake *FakeClient) FindTeamReturnsOnCall(i int, result1 concourse.Team, result2 error) {
 	fake.findTeamMutex.Lock()
 	defer fake.findTeamMutex.Unlock()
 	fake.FindTeamStub = nil
 	if fake.findTeamReturnsOnCall == nil {
 		fake.findTeamReturnsOnCall = make(map[int]struct {
 			result1 concourse.Team
-			result2 bool
-			result3 error
+			result2 error
 		})
 	}
 	fake.findTeamReturnsOnCall[i] = struct {
 		result1 concourse.Team
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeClient) GetCLIReader(arg1 string, arg2 string) (io.ReadCloser, http.Header, error) {

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -10,6 +10,16 @@ import (
 )
 
 type FakeTeam struct {
+	AuthStub        func() atc.TeamAuth
+	authMutex       sync.RWMutex
+	authArgsForCall []struct {
+	}
+	authReturns struct {
+		result1 atc.TeamAuth
+	}
+	authReturnsOnCall map[int]struct {
+		result1 atc.TeamAuth
+	}
 	BuildInputsForJobStub        func(string, string) ([]atc.BuildInput, bool, error)
 	buildInputsForJobMutex       sync.RWMutex
 	buildInputsForJobArgsForCall []struct {
@@ -732,6 +742,58 @@ type FakeTeam struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeTeam) Auth() atc.TeamAuth {
+	fake.authMutex.Lock()
+	ret, specificReturn := fake.authReturnsOnCall[len(fake.authArgsForCall)]
+	fake.authArgsForCall = append(fake.authArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Auth", []interface{}{})
+	fake.authMutex.Unlock()
+	if fake.AuthStub != nil {
+		return fake.AuthStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.authReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeTeam) AuthCallCount() int {
+	fake.authMutex.RLock()
+	defer fake.authMutex.RUnlock()
+	return len(fake.authArgsForCall)
+}
+
+func (fake *FakeTeam) AuthCalls(stub func() atc.TeamAuth) {
+	fake.authMutex.Lock()
+	defer fake.authMutex.Unlock()
+	fake.AuthStub = stub
+}
+
+func (fake *FakeTeam) AuthReturns(result1 atc.TeamAuth) {
+	fake.authMutex.Lock()
+	defer fake.authMutex.Unlock()
+	fake.AuthStub = nil
+	fake.authReturns = struct {
+		result1 atc.TeamAuth
+	}{result1}
+}
+
+func (fake *FakeTeam) AuthReturnsOnCall(i int, result1 atc.TeamAuth) {
+	fake.authMutex.Lock()
+	defer fake.authMutex.Unlock()
+	fake.AuthStub = nil
+	if fake.authReturnsOnCall == nil {
+		fake.authReturnsOnCall = make(map[int]struct {
+			result1 atc.TeamAuth
+		})
+	}
+	fake.authReturnsOnCall[i] = struct {
+		result1 atc.TeamAuth
+	}{result1}
 }
 
 func (fake *FakeTeam) BuildInputsForJob(arg1 string, arg2 string) ([]atc.BuildInput, bool, error) {
@@ -3917,6 +3979,8 @@ func (fake *FakeTeam) VersionedResourceTypesReturnsOnCall(i int, result1 atc.Ver
 func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.authMutex.RLock()
+	defer fake.authMutex.RUnlock()
 	fake.buildInputsForJobMutex.RLock()
 	defer fake.buildInputsForJobMutex.RUnlock()
 	fake.buildsMutex.RLock()

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -669,21 +669,6 @@ type FakeTeam struct {
 		result1 bool
 		result2 error
 	}
-	TeamStub        func(string) (atc.Team, bool, error)
-	teamMutex       sync.RWMutex
-	teamArgsForCall []struct {
-		arg1 string
-	}
-	teamReturns struct {
-		result1 atc.Team
-		result2 bool
-		result3 error
-	}
-	teamReturnsOnCall map[int]struct {
-		result1 atc.Team
-		result2 bool
-		result3 error
-	}
 	UnpauseJobStub        func(string, string) (bool, error)
 	unpauseJobMutex       sync.RWMutex
 	unpauseJobArgsForCall []struct {
@@ -3653,72 +3638,6 @@ func (fake *FakeTeam) SetPinCommentReturnsOnCall(i int, result1 bool, result2 er
 	}{result1, result2}
 }
 
-func (fake *FakeTeam) Team(arg1 string) (atc.Team, bool, error) {
-	fake.teamMutex.Lock()
-	ret, specificReturn := fake.teamReturnsOnCall[len(fake.teamArgsForCall)]
-	fake.teamArgsForCall = append(fake.teamArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("Team", []interface{}{arg1})
-	fake.teamMutex.Unlock()
-	if fake.TeamStub != nil {
-		return fake.TeamStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	fakeReturns := fake.teamReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakeTeam) TeamCallCount() int {
-	fake.teamMutex.RLock()
-	defer fake.teamMutex.RUnlock()
-	return len(fake.teamArgsForCall)
-}
-
-func (fake *FakeTeam) TeamCalls(stub func(string) (atc.Team, bool, error)) {
-	fake.teamMutex.Lock()
-	defer fake.teamMutex.Unlock()
-	fake.TeamStub = stub
-}
-
-func (fake *FakeTeam) TeamArgsForCall(i int) string {
-	fake.teamMutex.RLock()
-	defer fake.teamMutex.RUnlock()
-	argsForCall := fake.teamArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeTeam) TeamReturns(result1 atc.Team, result2 bool, result3 error) {
-	fake.teamMutex.Lock()
-	defer fake.teamMutex.Unlock()
-	fake.TeamStub = nil
-	fake.teamReturns = struct {
-		result1 atc.Team
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakeTeam) TeamReturnsOnCall(i int, result1 atc.Team, result2 bool, result3 error) {
-	fake.teamMutex.Lock()
-	defer fake.teamMutex.Unlock()
-	fake.TeamStub = nil
-	if fake.teamReturnsOnCall == nil {
-		fake.teamReturnsOnCall = make(map[int]struct {
-			result1 atc.Team
-			result2 bool
-			result3 error
-		})
-	}
-	fake.teamReturnsOnCall[i] = struct {
-		result1 atc.Team
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
 func (fake *FakeTeam) UnpauseJob(arg1 string, arg2 string) (bool, error) {
 	fake.unpauseJobMutex.Lock()
 	ret, specificReturn := fake.unpauseJobReturnsOnCall[len(fake.unpauseJobArgsForCall)]
@@ -4069,8 +3988,6 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.scheduleJobMutex.RUnlock()
 	fake.setPinCommentMutex.RLock()
 	defer fake.setPinCommentMutex.RUnlock()
-	fake.teamMutex.RLock()
-	defer fake.teamMutex.RUnlock()
 	fake.unpauseJobMutex.RLock()
 	defer fake.unpauseJobMutex.RUnlock()
 	fake.unpausePipelineMutex.RLock()

--- a/go-concourse/concourse/internal/connection.go
+++ b/go-concourse/concourse/internal/connection.go
@@ -19,6 +19,7 @@ import (
 
 //go:generate counterfeiter . Connection
 
+// Deprecated. Use HTTPAgent instead
 type Connection interface {
 	URL() string
 	HTTPClient() *http.Client
@@ -43,6 +44,7 @@ type Response struct {
 	Created bool
 }
 
+// Deprecated
 type connection struct {
 	url        string
 	httpClient *http.Client
@@ -51,6 +53,7 @@ type connection struct {
 	requestGenerator *rata.RequestGenerator
 }
 
+// Deprecated
 func NewConnection(apiURL string, httpClient *http.Client, tracing bool) Connection {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
@@ -67,14 +70,17 @@ func NewConnection(apiURL string, httpClient *http.Client, tracing bool) Connect
 	}
 }
 
+// Deprecated
 func (connection *connection) URL() string {
 	return connection.url
 }
 
+// Deprecated
 func (connection *connection) HTTPClient() *http.Client {
 	return connection.httpClient
 }
 
+// Deprecated
 func (connection *connection) Send(passedRequest Request, passedResponse *Response) error {
 	req, err := connection.createHTTPRequest(passedRequest)
 	if err != nil {
@@ -84,10 +90,12 @@ func (connection *connection) Send(passedRequest Request, passedResponse *Respon
 	return connection.send(req, passedRequest.ReturnResponseBody, passedResponse)
 }
 
+// Deprecated
 func (connection *connection) SendHTTPRequest(request *http.Request, returnResponseBody bool, passedResponse *Response) error {
 	return connection.send(request, returnResponseBody, passedResponse)
 }
 
+// Deprecated
 func (connection *connection) send(req *http.Request, returnResponseBody bool, passedResponse *Response) error {
 	if connection.tracing {
 		b, err := httputil.DumpRequestOut(req, true)
@@ -119,6 +127,7 @@ func (connection *connection) send(req *http.Request, returnResponseBody bool, p
 	return connection.populateResponse(response, returnResponseBody, passedResponse)
 }
 
+// Deprecated
 func (connection *connection) ConnectToEventStream(passedRequest Request) (*sse.EventSource, error) {
 	source, err := sse.Connect(connection.httpClient, time.Second, func() *http.Request {
 		request, reqErr := connection.createHTTPRequest(passedRequest)
@@ -144,6 +153,7 @@ func (connection *connection) ConnectToEventStream(passedRequest Request) (*sse.
 	return source, nil
 }
 
+// Deprecated
 func (connection *connection) createHTTPRequest(passedRequest Request) (*http.Request, error) {
 	body := connection.getBody(passedRequest)
 
@@ -167,6 +177,7 @@ func (connection *connection) createHTTPRequest(passedRequest Request) (*http.Re
 	return req, nil
 }
 
+// Deprecated
 func (connection *connection) getBody(passedRequest Request) io.Reader {
 	if passedRequest.Header != nil && passedRequest.Body != nil {
 		if _, ok := passedRequest.Header["Content-Type"]; !ok {
@@ -178,6 +189,7 @@ func (connection *connection) getBody(passedRequest Request) io.Reader {
 	return nil
 }
 
+// Deprecated
 func (connection *connection) populateResponse(response *http.Response, returnResponseBody bool, passedResponse *Response) error {
 	if response.StatusCode == http.StatusNotFound {
 		var errors ResourceNotFoundError
@@ -221,7 +233,7 @@ func (connection *connection) populateResponse(response *http.Response, returnRe
 		}
 	}
 
-	if returnResponseBody {
+	if returnResponseBody { // THIS IS SO CONFUSING
 		passedResponse.Result = response.Body
 		return nil
 	}

--- a/go-concourse/concourse/internal/connection.go
+++ b/go-concourse/concourse/internal/connection.go
@@ -233,7 +233,7 @@ func (connection *connection) populateResponse(response *http.Response, returnRe
 		}
 	}
 
-	if returnResponseBody { // THIS IS SO CONFUSING
+	if returnResponseBody {
 		passedResponse.Result = response.Body
 		return nil
 	}

--- a/go-concourse/concourse/internal/connection_test.go
+++ b/go-concourse/concourse/internal/connection_test.go
@@ -25,6 +25,7 @@ var _ = Describe("ATC Connection", func() {
 		atcServer *ghttp.Server
 
 		connection Connection
+		agent      HTTPAgent
 
 		tracing bool
 	)
@@ -33,6 +34,7 @@ var _ = Describe("ATC Connection", func() {
 		atcServer = ghttp.NewServer()
 
 		connection = NewConnection(atcServer.URL(), nil, tracing)
+		agent = NewHTTPAgent(atcServer.URL(), nil, tracing)
 	})
 
 	Describe("#Send", func() {
@@ -355,7 +357,7 @@ var _ = Describe("ATC Connection", func() {
 				BeforeEach(func() {
 					atcServer = ghttp.NewServer()
 
-					connection = NewConnection(atcServer.URL(), nil, tracing)
+					agent = NewHTTPAgent(atcServer.URL(), nil, tracing)
 
 					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
@@ -365,16 +367,17 @@ var _ = Describe("ATC Connection", func() {
 					)
 				})
 
-				It("returns back ErrForbidden", func() {
-					err := connection.Send(Request{
+				It("returns back 403", func() {
+					resp, err := agent.Send(Request{
 						RequestName: atc.DeletePipeline,
 						Params: rata.Params{
 							"pipeline_name": "foo",
 							"team_name":     atc.DefaultTeamName,
 						},
-					}, nil)
+					})
 
-					Expect(err).To(Equal(ErrForbidden))
+					Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 

--- a/go-concourse/concourse/internal/http_agent.go
+++ b/go-concourse/concourse/internal/http_agent.go
@@ -1,0 +1,114 @@
+package internal
+
+import (
+	"github.com/concourse/concourse/atc"
+	"github.com/tedsuo/rata"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+)
+
+type HTTPAgent interface {
+	Send(request Request) (http.Response, error)
+}
+
+type httpAgent struct { // Make http requests and return the response to me
+	url        string
+	httpClient *http.Client
+	tracing    bool
+
+	requestGenerator *rata.RequestGenerator
+}
+
+func NewHTTPAgent(apiURL string, httpClient *http.Client, tracing bool) HTTPAgent {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	apiURL = strings.TrimRight(apiURL, "/")
+
+	return &httpAgent{
+		url:        apiURL,
+		httpClient: httpClient,
+		tracing:    tracing,
+
+		requestGenerator: rata.NewRequestGenerator(apiURL, atc.Routes),
+	}
+}
+
+func (a *httpAgent) Send(request Request) (http.Response, error) {
+
+	req, err := a.createHTTPRequest(request)
+	if err != nil {
+		return http.Response{}, err
+	}
+
+	return a.send(req)
+}
+
+func (a *httpAgent) send(req *http.Request) (http.Response, error) {
+	if a.tracing {
+		b, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return http.Response{}, err
+		}
+
+		log.Println(string(b))
+	}
+
+	response, err := a.httpClient.Do(req)
+	if err != nil {
+		return http.Response{}, err
+	}
+
+	if a.tracing {
+		b, err := httputil.DumpResponse(response, true)
+		if err != nil {
+			return http.Response{}, err
+		}
+
+		log.Println(string(b))
+	}
+
+	//if !returnResponseBody {
+	//	defer response.Body.Close()
+	//}
+
+	return *response, nil
+}
+
+func (a *httpAgent) createHTTPRequest(request Request) (*http.Request, error) {
+	body := a.getBody(request)
+
+	req, err := a.requestGenerator.CreateRequest(
+		request.RequestName,
+		request.Params,
+		body,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	req.URL.RawQuery = request.Query.Encode()
+
+	for h, vs := range request.Header {
+		for _, v := range vs {
+			req.Header.Add(h, v)
+		}
+	}
+
+	return req, nil
+}
+
+func (a *httpAgent) getBody(request Request) io.Reader {
+	if request.Header != nil && request.Body != nil {
+		if _, ok := request.Header["Content-Type"]; !ok {
+			panic("You must pass a 'Content-Type' Header with a body")
+		}
+		return request.Body
+	}
+
+	return nil
+}

--- a/go-concourse/concourse/internal/http_agent.go
+++ b/go-concourse/concourse/internal/http_agent.go
@@ -1,20 +1,21 @@
 package internal
 
 import (
-	"github.com/concourse/concourse/atc"
-	"github.com/tedsuo/rata"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
 	"strings"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/tedsuo/rata"
 )
 
 type HTTPAgent interface {
 	Send(request Request) (http.Response, error)
 }
 
-type httpAgent struct { // Make http requests and return the response to me
+type httpAgent struct {
 	url        string
 	httpClient *http.Client
 	tracing    bool
@@ -71,10 +72,6 @@ func (a *httpAgent) send(req *http.Request) (http.Response, error) {
 
 		log.Println(string(b))
 	}
-
-	//if !returnResponseBody {
-	//	defer response.Body.Close()
-	//}
 
 	return *response, nil
 }

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -12,7 +12,8 @@ import (
 type Team interface {
 	Name() string
 
-	Team(teamName string) (atc.Team, bool, error)
+	Auth() atc.TeamAuth
+
 	CreateOrUpdate(team atc.Team) (atc.Team, bool, bool, error)
 	RenameTeam(teamName, name string) (bool, error)
 	DestroyTeam(teamName string) error
@@ -76,6 +77,7 @@ type Team interface {
 type team struct {
 	name       string
 	connection internal.Connection
+	auth       atc.TeamAuth
 }
 
 func (team *team) Name() string {
@@ -87,4 +89,8 @@ func (client *client) Team(name string) Team {
 		name:       name,
 		connection: client.connection,
 	}
+}
+
+func (team *team) Auth() atc.TeamAuth {
+	return team.auth
 }

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -76,7 +76,8 @@ type Team interface {
 
 type team struct {
 	name       string
-	connection internal.Connection
+	connection internal.Connection //Deprecated
+	httpAgent  internal.HTTPAgent
 	auth       atc.TeamAuth
 }
 

--- a/go-concourse/concourse/teams.go
+++ b/go-concourse/concourse/teams.go
@@ -14,27 +14,6 @@ import (
 
 var ErrDestroyRefused = errors.New("not-permitted-to-destroy-as-requested")
 
-// Team get team with the name given as argument.
-func (team *team) Team(teamName string) (atc.Team, bool, error) {
-	var t atc.Team
-	params := rata.Params{"team_name": teamName}
-	err := team.connection.Send(internal.Request{
-		RequestName: atc.GetTeam,
-		Params:      params,
-	}, &internal.Response{
-		Result: &t,
-	})
-
-	switch err.(type) {
-	case nil:
-		return t, true, nil
-	case internal.ResourceNotFoundError:
-		return atc.Team{}, false, nil
-	default:
-		return atc.Team{}, false, err
-	}
-}
-
 // CreateOrUpdate creates or updates team teamName with the settings provided in passedTeam.
 // passedTeam should reflect the desired state of team's configuration.
 func (team *team) CreateOrUpdate(passedTeam atc.Team) (atc.Team, bool, bool, error) {

--- a/go-concourse/concourse/teams_test.go
+++ b/go-concourse/concourse/teams_test.go
@@ -74,7 +74,7 @@ var _ = Describe("ATC Handler Teams", func() {
 
 			It("returns false and error", func() {
 				_, err := client.FindTeam(teamName)
-				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(errors.New("team 'myTeam' does not exist")))
 			})
 		})
 

--- a/go-concourse/concourse/teams_test.go
+++ b/go-concourse/concourse/teams_test.go
@@ -67,7 +67,7 @@ var _ = Describe("ATC Handler Teams", func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", expectedURL),
-						ghttp.RespondWith(http.StatusUnauthorized, ""),
+						ghttp.RespondWith(http.StatusNotFound, ""),
 					),
 				)
 			})


### PR DESCRIPTION
# Existing Issue

Fixes #5126 

# Why do we need this PR?
`--team` does not return any helpful error messages for when:

- User does not belong to a team
- The team does not exist

This PR adds error messages for both of those cases.

# Changes proposed in this pull request

* Added an `httpAgent` which will replace `connection` in the `go-concourse` client library. Expanding `connection` was painful because it does too many things (send HTTP requests AND parse the response). `httpAgent` does one thing: send HTTP requests.
* Removed the mock HTTP server `adminATCServer`. It was not needed and was added in the context of Super Admin stories done in September.
* Refactored the existing `--team` tests so they make sense.
* With all the above refactoring we were able to add better error messages for when `--team` fails.
  * User is not on a team user gets `you do not have a role on team 'team-name'`
  * Team does not exist user gets `team 'team-name' does not exist`

# Contributor Checklist

- [x] Unit tests
- [x] Integration tests (if applicable)
- [ ] ~Updated documentation (located at https://github.com/concourse/docs)~
- [ ] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 

cc @muntac @pivotal-izabela-gomes 