### PR TITLE
Add custom Gomega matcher for http response header

### DIFF
--- a/atc/api/artifacts_test.go
+++ b/atc/api/artifacts_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	"github.com/concourse/concourse/atc/worker"
 	"github.com/concourse/concourse/atc/worker/workerfakes"
 	. "github.com/onsi/ginkgo"
@@ -180,7 +181,10 @@ var _ = Describe("ArtifactRepository API", func() {
 							})
 
 							It("returns Content-Type 'application/json'", func() {
-								Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/json",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 							})
 
 							It("returns the artifact record", func() {
@@ -347,7 +351,10 @@ var _ = Describe("ArtifactRepository API", func() {
 						})
 
 						It("returns Content-Type 'application/octet-stream'", func() {
-							Expect(response.Header.Get("Content-Type")).To(Equal("application/octet-stream"))
+							expectedHeaderEntries := map[string]string{
+								"Content-Type": "application/octet-stream",
+							}
+							Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 						})
 
 						It("returns the contents of the volume", func() {

--- a/atc/api/builds_test.go
+++ b/atc/api/builds_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -112,7 +113,10 @@ var _ = Describe("Builds API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("creates a started build", func() {
@@ -242,7 +246,10 @@ var _ = Describe("Builds API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns all builds", func() {
@@ -366,7 +373,10 @@ var _ = Describe("Builds API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns all builds", func() {
@@ -561,7 +571,10 @@ var _ = Describe("Builds API", func() {
 						})
 
 						It("returns Content-Type 'application/json'", func() {
-							Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+							expectedHeaderEntries := map[string]string{
+								"Content-Type": "application/json",
+							}
+							Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 						})
 
 						It("returns the build with the given build_id", func() {
@@ -698,7 +711,10 @@ var _ = Describe("Builds API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns the build with it's input and output versioned resources", func() {
@@ -1196,7 +1212,10 @@ var _ = Describe("Builds API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns the build preparation", func() {
@@ -1410,7 +1429,10 @@ var _ = Describe("Builds API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns the plan", func() {
@@ -1430,7 +1452,10 @@ var _ = Describe("Builds API", func() {
 					})
 
 					It("returns no Content-Type header", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal(""))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "",
+						}
+						Expect(response).ShouldNot(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns not found", func() {

--- a/atc/api/buildserver/eventhandler_test.go
+++ b/atc/api/buildserver/eventhandler_test.go
@@ -3,6 +3,7 @@ package buildserver_test
 import (
 	"encoding/json"
 	"errors"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -114,15 +115,26 @@ var _ = Describe("Handler", func() {
 
 			It("returns Content-Type as text/event-stream", func() {
 				_ = response.Body.Close()
-				Expect(response.Header.Get("Content-Type")).To(Equal("text/event-stream; charset=utf-8"))
-				Expect(response.Header.Get("Cache-Control")).To(Equal("no-cache, no-store, must-revalidate"))
-				Expect(response.Header.Get("X-Accel-Buffering")).To(Equal("no"))
-				Expect(response.Header.Get("Connection")).NotTo(Equal("keep-alive"))
+				expectedHeaderEntries := map[string]string{
+					"Content-Type":      "text/event-stream; charset=utf-8",
+					"Cache-Control":     "no-cache, no-store, must-revalidate",
+					"X-Accel-Buffering": "no",
+				}
+				Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
+
+				expectedHeaderEntries = map[string]string{
+					"Connection":        "keep-alive",
+				}
+				Expect(response).ShouldNot(IncludeHeaderEntries(expectedHeaderEntries))
+
 			})
 
 			It("returns the protocol version as X-ATC-Stream-Version", func() {
 				_ = response.Body.Close()
-				Expect(response.Header.Get("X-ATC-Stream-Version")).To(Equal("2.0"))
+				expectedHeaderEntries := map[string]string{
+					"X-Atc-Stream-Version": "2.0",
+				}
+				Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 			})
 
 			It("emits them, followed by an end event", func() {

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	"github.com/tedsuo/rata"
 
 	. "github.com/onsi/ginkgo"
@@ -103,7 +104,10 @@ var _ = Describe("cc.xml", func() {
 							})
 
 							It("returns Content-Type 'application/xml'", func() {
-								Expect(response.Header.Get("Content-Type")).To(Equal("application/xml"))
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/xml",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 							})
 
 							It("returns the CC.xml", func() {

--- a/atc/api/checks_test.go
+++ b/atc/api/checks_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -144,7 +145,10 @@ var _ = Describe("Checks API", func() {
 							})
 
 							It("returns application/json", func() {
-								Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/json",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 							})
 
 							It("returns the check", func() {

--- a/atc/api/cli_test.go
+++ b/atc/api/cli_test.go
@@ -80,10 +80,17 @@ var _ = Describe("CLI Downloads API", func() {
 
 		It("returns 200", func() {
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
-			Expect(response.Header.Get("Content-Type")).To(Equal("application/octet-stream"))
-			Expect(response.Header.Get("Content-Length")).To(Equal("11"))
-			Expect(response.Header.Get("Content-Disposition")).To(Equal("attachment; filename=fly"))
-			Expect(response.Header.Get("Last-Modified")).To(Equal("Mon, 03 Jun 1991 05:30:45 GMT"))
+		})
+
+		It("returns the a response with expected headers", func() {
+			expectedHeaderEntries := map[string]string{
+				"Content-Type":        "application/octet-stream",
+				"Content-Length":      "11",
+				"Content-Disposition": "attachment; filename=fly",
+				"Last-Modified":       "Mon, 03 Jun 1991 05:30:45 GMT",
+			}
+
+			Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 		})
 
 		It("returns the file binary", func() {
@@ -102,10 +109,16 @@ var _ = Describe("CLI Downloads API", func() {
 
 		It("returns 200", func() {
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
-			Expect(response.Header.Get("Content-Type")).To(Equal("application/octet-stream"))
-			Expect(response.Header.Get("Content-Length")).To(Equal("25"))
-			Expect(response.Header.Get("Content-Disposition")).To(Equal("attachment; filename=fly.exe"))
-			Expect(response.Header.Get("Last-Modified")).To(Equal("Thu, 29 Jun 1989 05:30:44 GMT"))
+		})
+
+		It("returns the a response with expected headers", func() {
+			expectedHeaderEntries := map[string]string{
+				"Content-Type":        "application/octet-stream",
+				"Content-Length":      "25",
+				"Content-Disposition": "attachment; filename=fly.exe",
+				"Last-Modified":       "Thu, 29 Jun 1989 05:30:44 GMT",
+			}
+			Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 		})
 
 		It("returns the file binary", func() {

--- a/atc/api/cli_test.go
+++ b/atc/api/cli_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	. "github.com/concourse/concourse/atc/testhelpers"
 	"github.com/concourse/go-archive/archivetest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/concourse/concourse/atc/creds/noop"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/tedsuo/rata"
 	"sigs.k8s.io/yaml"
@@ -175,12 +176,12 @@ var _ = Describe("Config API", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusOK))
 						})
 
-						It("returns Content-Type 'application/json'", func() {
-							Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
-						})
-
-						It("returns the config version as X-Concourse-Config-Version", func() {
-							Expect(response.Header.Get(atc.ConfigVersionHeader)).To(Equal("1"))
+						It("returns Content-Type 'application/json' and config version as X-Concourse-Config-Version", func() {
+							expectedHeaderEntries := map[string]string{
+								"Content-Type":          "application/json",
+								atc.ConfigVersionHeader: "1",
+							}
+							Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 						})
 
 						It("returns the config", func() {
@@ -302,7 +303,10 @@ var _ = Describe("Config API", func() {
 						})
 
 						It("returns Content-Type 'application/json'", func() {
-							Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+							expectedHeaderEntries := map[string]string{
+								"Content-Type": "application/json",
+							}
+							Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 						})
 
 						It("returns error JSON", func() {
@@ -330,7 +334,10 @@ var _ = Describe("Config API", func() {
 						})
 
 						It("returns Content-Type 'application/json'", func() {
-							Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+							expectedHeaderEntries := map[string]string{
+								"Content-Type": "application/json",
+							}
+							Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 						})
 
 						It("returns error JSON", func() {
@@ -368,7 +375,10 @@ var _ = Describe("Config API", func() {
 						})
 
 						It("returns Content-Type 'application/json'", func() {
-							Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+							expectedHeaderEntries := map[string]string{
+								"Content-Type": "application/json",
+							}
+							Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 						})
 
 						It("saves it initially paused", func() {
@@ -423,7 +433,10 @@ var _ = Describe("Config API", func() {
 							})
 
 							It("returns Content-Type 'application/json'", func() {
-								Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/json",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 							})
 
 							It("returns error JSON", func() {
@@ -460,7 +473,10 @@ var _ = Describe("Config API", func() {
 						})
 
 						It("returns Content-Type 'application/json'", func() {
-							Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+							expectedHeaderEntries := map[string]string{
+								"Content-Type": "application/json",
+							}
+							Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 						})
 
 						It("saves it initially paused", func() {
@@ -504,7 +520,10 @@ jobs:
 							})
 
 							It("returns Content-Type 'application/json'", func() {
-								Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/json",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 							})
 
 							It("saves it", func() {
@@ -867,7 +886,10 @@ jobs:
 							})
 
 							It("returns Content-Type 'application/json'", func() {
-								Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/json",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 							})
 
 							It("returns error JSON", func() {
@@ -934,7 +956,10 @@ jobs:
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("saves it", func() {
@@ -981,7 +1006,10 @@ jobs:
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns an error in the response body", func() {
@@ -1004,7 +1032,10 @@ jobs:
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns an error in the response body", func() {

--- a/atc/api/containers_test.go
+++ b/atc/api/containers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	"github.com/concourse/concourse/atc/worker/workerfakes"
 	"github.com/gorilla/websocket"
 	. "github.com/onsi/ginkgo"
@@ -127,7 +128,10 @@ var _ = Describe("Containers API", func() {
 						response, err := client.Do(req)
 						Expect(err).NotTo(HaveOccurred())
 
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns all containers", func() {
@@ -438,7 +442,10 @@ var _ = Describe("Containers API", func() {
 						response, err := client.Do(req)
 						Expect(err).NotTo(HaveOccurred())
 
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("performs lookup by id", func() {
@@ -1148,7 +1155,10 @@ var _ = Describe("Containers API", func() {
 					response, err = client.Do(req)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 			})
 

--- a/atc/api/http_header_matcher_test.go
+++ b/atc/api/http_header_matcher_test.go
@@ -1,0 +1,52 @@
+package api_test
+
+import (
+	"fmt"
+	"github.com/onsi/gomega/types"
+	"net/http"
+)
+
+func IncludeHeaderEntries(expected map[string]string) types.GomegaMatcher {
+	return &includeHeaderEntries{
+		expected: expected,
+	}
+}
+
+type includeHeaderEntries struct {
+	expected map[string]string
+}
+
+func (h includeHeaderEntries) Match(actual interface{}) (bool, error) {
+	actualResponse, ok := actual.(*http.Response)
+	if !ok {
+		return false, fmt.Errorf("IncludeHeaderEntries matcher expects a *http.Response but got %T", actual)
+	}
+	return h.matchHeaderEntries(actualResponse.Header)
+}
+
+func (h includeHeaderEntries) matchHeaderEntries(header http.Header) (success bool, err error) {
+	for expectedKey, expectedVal := range h.expected {
+
+		_, keyFound := header[expectedKey]
+		if !keyFound {
+			err = fmt.Errorf("response does not contain header '%s'", expectedKey)
+			return false, err
+		}
+
+		actualVal := header.Get(expectedKey)
+		if expectedVal != actualVal {
+			err = fmt.Errorf("expected response header '%s' to have value '%s', but got '%s'", expectedKey, expectedVal, actualVal)
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (h includeHeaderEntries) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nto include headers\n\t%#v", actual, h.expected)
+}
+
+func (h includeHeaderEntries) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nto not include headers\n\t%#v", actual, h.expected)
+}

--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/concourse/concourse/atc/creds/secretsmanager"
 	"github.com/concourse/concourse/atc/creds/ssm"
 	"github.com/concourse/concourse/atc/creds/vault"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	vaultapi "github.com/hashicorp/vault/api"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -54,7 +55,10 @@ var _ = Describe("Pipelines API", func() {
 		})
 
 		It("returns Content-Type 'application/json'", func() {
-			Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+			expectedHeaderEntries := map[string]string{
+				"Content-Type": "application/json",
+			}
+			Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 		})
 
 		It("contains the version", func() {
@@ -86,7 +90,10 @@ var _ = Describe("Pipelines API", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
-			Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+			expectedHeaderEntries := map[string]string{
+				"Content-Type": "application/json",
+			}
+			Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 
 			body, err = ioutil.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())

--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -133,7 +134,10 @@ var _ = Describe("Jobs API", func() {
 		})
 
 		It("returns application/json", func() {
-			Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+			expectedHeaderEntries := map[string]string{
+				"Content-Type": "application/json",
+			}
+			Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 		})
 
 		It("returns all jobs from public pipelines and pipelines in authenticated teams", func() {
@@ -427,7 +431,10 @@ var _ = Describe("Jobs API", func() {
 							})
 
 							It("returns Content-Type 'application/json'", func() {
-								Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/json",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 							})
 
 							It("returns the job's name, if it's paused, and any running and finished builds", func() {
@@ -586,9 +593,12 @@ var _ = Describe("Jobs API", func() {
 			})
 
 			It("returns Content-Type as image/svg+xml and disables caching", func() {
-				Expect(response.Header.Get("Content-Type")).To(Equal("image/svg+xml"))
-				Expect(response.Header.Get("Cache-Control")).To(Equal("no-cache, no-store, must-revalidate"))
-				Expect(response.Header.Get("Expires")).To(Equal("0"))
+				expectedHeaderEntries := map[string]string{
+					"Content-Type":  "image/svg+xml",
+					"Cache-Control": "no-cache, no-store, must-revalidate",
+					"Expires":       "0",
+				}
+				Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 			})
 
 			Context("when generates bagde title", func() {
@@ -1060,7 +1070,10 @@ var _ = Describe("Jobs API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns each job's name and any running and finished builds", func() {
@@ -1303,7 +1316,10 @@ var _ = Describe("Jobs API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns the builds", func() {
@@ -1569,7 +1585,10 @@ var _ = Describe("Jobs API", func() {
 									})
 
 									It("returns Content-Type 'application/json'", func() {
-										Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+										expectedHeaderEntries := map[string]string{
+											"Content-Type": "application/json",
+										}
+										Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 									})
 
 									It("creates a check for the resource", func() {
@@ -1781,7 +1800,10 @@ var _ = Describe("Jobs API", func() {
 								})
 
 								It("returns Content-Type 'application/json'", func() {
-									Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+									expectedHeaderEntries := map[string]string{
+										"Content-Type": "application/json",
+									}
+									Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 								})
 
 								It("returns the inputs", func() {
@@ -1860,7 +1882,10 @@ var _ = Describe("Jobs API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("fetches by job and build name", func() {
@@ -2111,7 +2136,10 @@ var _ = Describe("Jobs API", func() {
 							})
 
 							It("returns Content-Type 'application/json'", func() {
-								Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/json",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 							})
 
 							It("returns the build", func() {
@@ -2343,7 +2371,10 @@ var _ = Describe("Jobs API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("it returns the number of rows deleted", func() {
@@ -2391,7 +2422,10 @@ var _ = Describe("Jobs API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("it returns the number of rows deleted", func() {

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -108,7 +109,10 @@ var _ = Describe("Pipelines API", func() {
 		})
 
 		It("returns application/json", func() {
-			Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+			expectedHeaderEntries := map[string]string{
+				"Content-Type": "application/json",
+			}
+			Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 		})
 
 		Context("when team is set in user context", func() {
@@ -264,7 +268,10 @@ var _ = Describe("Pipelines API", func() {
 			})
 
 			It("returns application/json", func() {
-				Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+				expectedHeaderEntries := map[string]string{
+					"Content-Type": "application/json",
+				}
+				Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 			})
 
 			It("constructs team with provided team name", func() {
@@ -432,7 +439,10 @@ var _ = Describe("Pipelines API", func() {
 			})
 
 			It("returns application/json", func() {
-				Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+				expectedHeaderEntries := map[string]string{
+					"Content-Type": "application/json",
+				}
+				Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 			})
 
 			It("returns a pipeline JSON", func() {
@@ -612,9 +622,12 @@ var _ = Describe("Pipelines API", func() {
 			})
 
 			It("returns Content-Type as image/svg+xml and disables caching", func() {
-				Expect(response.Header.Get("Content-Type")).To(Equal("image/svg+xml"))
-				Expect(response.Header.Get("Cache-Control")).To(Equal("no-cache, no-store, must-revalidate"))
-				Expect(response.Header.Get("Expires")).To(Equal("0"))
+				expectedHeaderEntries := map[string]string{
+					"Content-Type":  "image/svg+xml",
+					"Cache-Control": "no-cache, no-store, must-revalidate",
+					"Expires":       "0",
+				}
+				Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 			})
 
 			Context("when the pipeline has no finished builds", func() {
@@ -1397,7 +1410,10 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("returns application/json", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns a json representation of all the versions in the pipeline", func() {
@@ -1478,7 +1494,10 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("does not return application/json", func() {
-					Expect(response.Header.Get("Content-Type")).To(BeEmpty())
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "",
+					}
+					Expect(response).ShouldNot(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 			})
 		})
@@ -1681,7 +1700,10 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns the builds", func() {
@@ -1839,7 +1861,10 @@ var _ = Describe("Pipelines API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("creates a started build", func() {

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	"github.com/concourse/concourse/vars"
 )
 
@@ -88,7 +89,10 @@ var _ = Describe("Resources API", func() {
 			})
 
 			It("returns Content-Type 'application/json'", func() {
-				Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+				expectedHeaderEntries := map[string]string{
+					"Content-Type": "application/json",
+				}
+				Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 			})
 
 			It("returns each resource, including their check failure", func() {
@@ -243,7 +247,10 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns each resource, excluding their check failure", func() {
@@ -288,7 +295,10 @@ var _ = Describe("Resources API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns each resource, including their check failure", func() {
@@ -793,7 +803,10 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns application/json", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns each resource type, excluding the check errors", func() {
@@ -841,7 +854,10 @@ var _ = Describe("Resources API", func() {
 				})
 
 				It("returns application/json", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns each resource type", func() {
@@ -889,7 +905,10 @@ var _ = Describe("Resources API", func() {
 						})
 
 						It("returns application/json", func() {
-							Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+							expectedHeaderEntries := map[string]string{
+								"Content-Type": "application/json",
+							}
+							Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 						})
 					})
 
@@ -961,7 +980,10 @@ var _ = Describe("Resources API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns the resource json without the check error", func() {
@@ -1032,7 +1054,10 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns the resource json with the check error", func() {
@@ -1071,7 +1096,10 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns the resource json describing the pinned version", func() {
@@ -1157,7 +1185,10 @@ var _ = Describe("Resources API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns the resource json without the check error", func() {

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -215,7 +216,10 @@ var _ = Describe("Teams API", func() {
 			})
 
 			It("returns application/json", func() {
-				Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+				expectedHeaderEntries := map[string]string{
+					"Content-Type": "application/json",
+				}
+				Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 			})
 
 			It("returns a team JSON", func() {
@@ -251,7 +255,10 @@ var _ = Describe("Teams API", func() {
 			})
 
 			It("returns application/json", func() {
-				Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+				expectedHeaderEntries := map[string]string{
+					"Content-Type": "application/json",
+				}
+				Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 			})
 
 			It("returns a team JSON", func() {
@@ -717,7 +724,10 @@ var _ = Describe("Teams API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns the builds", func() {

--- a/atc/api/users_test.go
+++ b/atc/api/users_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -66,7 +67,10 @@ var _ = Describe("Users API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				Context("failing to retrieve users", func() {

--- a/atc/api/versions_test.go
+++ b/atc/api/versions_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -123,7 +124,10 @@ var _ = Describe("Versions API", func() {
 				})
 
 				It("returns content type application/json", func() {
-					Expect(response.Header.Get("Content-type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				Context("when resource is public", func() {
@@ -369,7 +373,10 @@ var _ = Describe("Versions API", func() {
 					})
 
 					It("returns content type application/json", func() {
-						Expect(response.Header.Get("Content-type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns the json", func() {
@@ -921,7 +928,10 @@ var _ = Describe("Versions API", func() {
 					})
 
 					It("returns content type application/json", func() {
-						Expect(response.Header.Get("Content-type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns the json", func() {
@@ -1118,7 +1128,10 @@ var _ = Describe("Versions API", func() {
 					})
 
 					It("returns content type application/json", func() {
-						Expect(response.Header.Get("Content-type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns the json", func() {

--- a/atc/api/volumes_test.go
+++ b/atc/api/volumes_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -133,7 +134,10 @@ var _ = Describe("Volumes API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 
 					It("returns all volumes", func() {
@@ -284,7 +288,10 @@ var _ = Describe("Volumes API", func() {
 					})
 
 					It("returns Content-Type 'application/json'", func() {
-						Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+						expectedHeaderEntries := map[string]string{
+							"Content-Type": "application/json",
+						}
+						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 					})
 				})
 			})
@@ -447,7 +454,10 @@ var _ = Describe("Volumes API", func() {
 					response, err = client.Do(req)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 			})
 

--- a/atc/api/wall_test.go
+++ b/atc/api/wall_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/concourse/concourse/atc"
+	. "github.com/concourse/concourse/atc/testhelpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,7 +34,10 @@ var _ = Describe("Wall API", func() {
 		})
 
 		It("returns Content-Type 'application/json'", func() {
-			Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+			expectedHeaderEntries := map[string]string{
+				"Content-Type": "application/json",
+			}
+			Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 		})
 
 		Context("the message does not expire", func() {

--- a/atc/api/workers_test.go
+++ b/atc/api/workers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/concourse/concourse/atc/api/accessor/accessorfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -81,7 +82,10 @@ var _ = Describe("Workers API", func() {
 
 				It("returns all the workers", func() {
 					Expect(response.StatusCode).To(Equal(http.StatusOK))
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 
 					Expect(dbWorkerFactory.WorkersCallCount()).To(Equal(1))
 
@@ -115,7 +119,10 @@ var _ = Describe("Workers API", func() {
 				})
 
 				It("returns Content-Type 'application/json'", func() {
-					Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
 				It("returns the workers", func() {
@@ -827,7 +834,10 @@ var _ = Describe("Workers API", func() {
 		})
 
 		It("returns Content-Type 'application/json'", func() {
-			Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
+			expectedHeaderEntries := map[string]string{
+				"Content-Type": "application/json",
+			}
+			Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 		})
 
 		It("returns saved worker", func() {

--- a/atc/testhelpers/http_header_matcher.go
+++ b/atc/testhelpers/http_header_matcher.go
@@ -1,6 +1,7 @@
-package api_test
+package testhelpers
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/onsi/gomega/types"
 	"net/http"
@@ -29,13 +30,11 @@ func (h includeHeaderEntries) matchHeaderEntries(header http.Header) (success bo
 
 		_, keyFound := header[expectedKey]
 		if !keyFound {
-			err = fmt.Errorf("response does not contain header '%s'", expectedKey)
 			return false, err
 		}
 
 		actualVal := header.Get(expectedKey)
 		if expectedVal != actualVal {
-			err = fmt.Errorf("expected response header '%s' to have value '%s', but got '%s'", expectedKey, expectedVal, actualVal)
 			return false, err
 		}
 	}
@@ -44,9 +43,23 @@ func (h includeHeaderEntries) matchHeaderEntries(header http.Header) (success bo
 }
 
 func (h includeHeaderEntries) FailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected\n\t%#v\nto include headers\n\t%#v", actual, h.expected)
+	actualResponse, _ := actual.(*http.Response)
+	bytes, _ := json.Marshal(actualResponse.Header)
+	actualHeaders := string(bytes)
+
+	bytes, _ = json.Marshal(h.expected)
+	expectedHeaders := string(bytes)
+
+	return fmt.Sprintf("Expected http response header\n\t%s\nto include headers\n\t%s", actualHeaders, expectedHeaders)
 }
 
 func (h includeHeaderEntries) NegatedFailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected\n\t%#v\nto not include headers\n\t%#v", actual, h.expected)
+	actualResponse, _ := actual.(*http.Response)
+	bytes, _ := json.Marshal(actualResponse.Header)
+	actualHeaders := string(bytes)
+
+	bytes, _ = json.Marshal(h.expected)
+	expectedHeaders := string(bytes)
+
+	return fmt.Sprintf("Expected http response header\n\t%s\nto not include headers\n\t%s", actualHeaders, expectedHeaders)
 }

--- a/atc/wrappa/versioned_handler_test.go
+++ b/atc/wrappa/versioned_handler_test.go
@@ -2,6 +2,7 @@ package wrappa_test
 
 import (
 	"fmt"
+	. "github.com/concourse/concourse/atc/testhelpers"
 	"net/http"
 	"net/http/httptest"
 
@@ -46,6 +47,9 @@ var _ = Describe("VersionedHandler", func() {
 	})
 
 	It("sets the X-Concourse-Version header", func() {
-		Expect(response.Header.Get("X-Concourse-Version")).To(Equal("1.2.3-test"))
+		expectedHeaderEntries := map[string]string{
+			"X-Concourse-Version": "1.2.3-test",
+		}
+		Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 	})
 })


### PR DESCRIPTION
Signed-off-by: Dimitry Besson <dbesson@pivotal.io>

# Existing Issue
No existing issue.

# Why do we need this PR?
Refactor for readability and more information on test assertion failure messages.


# Changes proposed in this pull request
* Introducing custom matcher for http response header. This helps reduce the number of `Expect` needed for testing http response headers.
* Simplify a couple of tests 

# Contributor Checklist
- [x] Unit tests

# Reviewer Checklist
- [x] ~Code reviewed~
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] ~PR acceptance performed~
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~