### PR TITLE
containerd: implement basic resource limits

### DIFF
--- a/worker/backend/container.go
+++ b/worker/backend/container.go
@@ -261,7 +261,7 @@ func (c *Container) getOCISpec() (*specs.Spec, error) {
 
 	v, err := typeurl.UnmarshalAny(info.Spec)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal any: %w", err)
 	}
 	spec, ok := v.(*specs.Spec)
 	if !ok {

--- a/worker/backend/spec/devices.go
+++ b/worker/backend/spec/devices.go
@@ -22,6 +22,10 @@ var (
 		// we allow this
 		{Access: "rwm", Type: "c", Major: intRef(10), Minor: intRef(229), Allow: true}, // /dev/fuse
 	}
+
+	PrivilegedOnlyDevices = []specs.LinuxDeviceCgroup{
+		{Allow: false, Access: "rwm"},
+	}
 )
 
 func intRef(i int64) *int64  { return &i }

--- a/worker/backend/spec/mounts.go
+++ b/worker/backend/spec/mounts.go
@@ -50,6 +50,12 @@ var (
 			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 		},
 		{
+			Destination: "/sys/fs/cgroup",
+			Type: "cgroup",
+			Source: "cgroup",
+			Options: []string{"ro", "nosuid", "noexec", "nodev"},
+		},
+		{
 			Destination: "/run",
 			Type:        "tmpfs",
 			Source:      "tmpfs",

--- a/worker/backend/spec/spec.go
+++ b/worker/backend/spec/spec.go
@@ -208,6 +208,11 @@ func defaultGardenOciSpec(privileged bool, maxUid, maxGid uint32) *specs.Spec {
 		capabilities = OciCapabilities(privileged)
 	)
 
+	devices := AnyContainerDevices
+	if privileged {
+		devices = append(PrivilegedOnlyDevices, devices...)
+	}
+
 	spec := &specs.Spec{
 		Process: &specs.Process{
 			Args:         []string{"/tmp/gdn-init"},
@@ -217,7 +222,7 @@ func defaultGardenOciSpec(privileged bool, maxUid, maxGid uint32) *specs.Spec {
 		Linux: &specs.Linux{
 			Namespaces: namespaces,
 			Resources: &specs.LinuxResources{
-				Devices: AnyContainerDevices,
+				Devices: devices,
 			},
 			UIDMappings: OciIDMappings(privileged, maxUid),
 			GIDMappings: OciIDMappings(privileged, maxGid),

--- a/worker/backend/spec/spec_test.go
+++ b/worker/backend/spec/spec_test.go
@@ -367,6 +367,16 @@ func (s *SpecSuite) TestContainerSpec() {
 			},
 		},
 		{
+			desc: "default devices privileged",
+			gdn:  garden.ContainerSpec{
+				Handle: "handle", RootFSPath: "raw:///rootfs",
+				Privileged: true,
+			},
+			check: func(oci *specs.Spec) {
+				s.Equal(append(spec.PrivilegedOnlyDevices, spec.AnyContainerDevices...), oci.Linux.Resources.Devices)
+			},
+		},
+		{
 			desc: "env + default path",
 			gdn: garden.ContainerSpec{
 				Handle: "handle", RootFSPath: "raw:///rootfs",


### PR DESCRIPTION
# Existing Issue

Fixes #5111 .

# Changes proposed in this pull request

* Convert garden spec for resource limits to OCI spec

**Note:** this change does not yet achieve full parity with `gdn`, as `gdn` can be configured through flags to go beyond the Garden spec for resource limits. See #5226

# Contributor Checklist
- [X] Unit tests
- [ ] ~Integration tests (if applicable)~ - no tests added, but existing tests (esp. related to setting CPU and memory limits) are passing


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
