### PR TITLE
atc: check step refactor (move from `exec` to `worker`)

### DIFF
--- a/atc/engine/builder/step_factory.go
+++ b/atc/engine/builder/step_factory.go
@@ -112,6 +112,7 @@ func (factory *stepFactory) CheckStep(
 		worker.NewRandomPlacementStrategy(),
 		factory.pool,
 		delegate,
+		factory.client,
 	)
 
 	return checkStep

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -136,7 +136,7 @@ func (step *CheckStep) Run(ctx context.Context, state RunState) error {
 		return fmt.Errorf("run check step: %w", err)
 	}
 
-	err = step.delegate.SaveVersions(result)
+	err = step.delegate.SaveVersions(result.Versions)
 	if err != nil {
 		return fmt.Errorf("save versions: %w", err)
 	}

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -11,7 +11,6 @@ import (
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/resource"
-	"github.com/concourse/concourse/atc/runtime"
 	"github.com/concourse/concourse/atc/worker"
 )
 
@@ -25,6 +24,7 @@ type CheckStep struct {
 	pool              worker.Pool
 	delegate          CheckDelegate
 	succeeded         bool
+	workerClient      worker.Client
 }
 
 //go:generate counterfeiter . CheckDelegate
@@ -44,6 +44,7 @@ func NewCheckStep(
 	strategy worker.ContainerPlacementStrategy,
 	pool worker.Pool,
 	delegate CheckDelegate,
+	client worker.Client,
 ) *CheckStep {
 	return &CheckStep{
 		planID:            planID,
@@ -54,6 +55,7 @@ func NewCheckStep(
 		pool:              pool,
 		strategy:          strategy,
 		delegate:          delegate,
+		workerClient:      client,
 	}
 }
 
@@ -72,6 +74,12 @@ func (step *CheckStep) Run(ctx context.Context, state RunState) error {
 
 	resourceTypes, err := creds.NewVersionedResourceTypes(variables, step.plan.VersionedResourceTypes).Evaluate()
 	if err != nil {
+		return err
+	}
+
+	timeout, err := time.ParseDuration(step.plan.Timeout)
+	if err != nil {
+		logger.Error("failed-to-parse-timeout", err)
 		return err
 	}
 
@@ -105,56 +113,31 @@ func (step *CheckStep) Run(ctx context.Context, state RunState) error {
 		expires,
 	)
 
-	chosenWorker, err := step.pool.FindOrChooseWorkerForContainer(
+	checkable := step.resourceFactory.NewResource(
+		source,
+		nil,
+		step.plan.FromVersion,
+	)
+
+	result, err := step.workerClient.RunCheckStep(
 		ctx,
 		logger,
 		owner,
 		containerSpec,
 		workerSpec,
 		step.strategy,
-	)
-	if err != nil {
-		logger.Error("failed-to-find-or-choose-worker", err)
-		return err
-	}
 
-	container, err := chosenWorker.FindOrCreateContainer(
-		ctx,
-		logger,
-		step.delegate,
-		owner,
 		step.containerMetadata,
-		containerSpec,
 		resourceTypes,
+
+		timeout,
+		checkable,
 	)
 	if err != nil {
-		logger.Error("failed-to-find-or-create-container", err)
-		return err
+		return fmt.Errorf("run check step: %w", err)
 	}
 
-	timeout, err := time.ParseDuration(step.plan.Timeout)
-	if err != nil {
-		logger.Error("failed-to-parse-timeout", err)
-		return err
-	}
-
-	deadline, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	processSpec := runtime.ProcessSpec{
-		Path: "/opt/resource/check",
-	}
-
-	checkable := step.resourceFactory.NewResource(source, nil, step.plan.FromVersion)
-	versions, err := checkable.Check(deadline, processSpec, container)
-	if err != nil {
-		if err == context.DeadlineExceeded {
-			return fmt.Errorf("Timed out after %v while checking for new versions", timeout)
-		}
-		return err
-	}
-
-	err = step.delegate.SaveVersions(versions)
+	err = step.delegate.SaveVersions(result)
 	if err != nil {
 		logger.Error("failed-to-save-versions", err)
 		return err

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -69,18 +69,17 @@ func (step *CheckStep) Run(ctx context.Context, state RunState) error {
 
 	source, err := creds.NewSource(variables, step.plan.Source).Evaluate()
 	if err != nil {
-		return err
+		return fmt.Errorf("resource config creds evaluation: %w", err)
 	}
 
 	resourceTypes, err := creds.NewVersionedResourceTypes(variables, step.plan.VersionedResourceTypes).Evaluate()
 	if err != nil {
-		return err
+		return fmt.Errorf("resource types creds evaluation: %w", err)
 	}
 
 	timeout, err := time.ParseDuration(step.plan.Timeout)
 	if err != nil {
-		logger.Error("failed-to-parse-timeout", err)
-		return err
+		return fmt.Errorf("timeout parse: %w", err)
 	}
 
 	containerSpec := worker.ContainerSpec{
@@ -139,8 +138,7 @@ func (step *CheckStep) Run(ctx context.Context, state RunState) error {
 
 	err = step.delegate.SaveVersions(result)
 	if err != nil {
-		logger.Error("failed-to-save-versions", err)
-		return err
+		return fmt.Errorf("save versions: %w", err)
 	}
 
 	step.succeeded = true

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -3,12 +3,14 @@ package exec_test
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/exec"
 	"github.com/concourse/concourse/atc/exec/execfakes"
 	"github.com/concourse/concourse/atc/resource/resourcefakes"
+	"github.com/concourse/concourse/atc/worker"
 	"github.com/concourse/concourse/atc/worker/workerfakes"
 	"github.com/concourse/concourse/vars/varsfakes"
 
@@ -21,13 +23,16 @@ var _ = Describe("CheckStep", func() {
 	var (
 		fakeRunState        *execfakes.FakeRunState
 		fakeResourceFactory *resourcefakes.FakeResourceFactory
+		fakeResource        *resourcefakes.FakeResource
 		fakePool            *workerfakes.FakePool
 		fakeStrategy        *workerfakes.FakeContainerPlacementStrategy
 		fakeDelegate        *execfakes.FakeCheckDelegate
 		fakeClient          *workerfakes.FakeClient
 
-		checkStep *exec.CheckStep
-		checkPlan atc.CheckPlan
+		stepMetadata      exec.StepMetadata
+		checkStep         *exec.CheckStep
+		checkPlan         atc.CheckPlan
+		containerMetadata db.ContainerMetadata
 
 		err error
 	)
@@ -35,15 +40,19 @@ var _ = Describe("CheckStep", func() {
 	BeforeEach(func() {
 		fakeRunState = new(execfakes.FakeRunState)
 		fakeResourceFactory = new(resourcefakes.FakeResourceFactory)
+		fakeResource = new(resourcefakes.FakeResource)
 		fakePool = new(workerfakes.FakePool)
 		fakeStrategy = new(workerfakes.FakeContainerPlacementStrategy)
 		fakeDelegate = new(execfakes.FakeCheckDelegate)
 		fakeClient = new(workerfakes.FakeClient)
+
+		stepMetadata = exec.StepMetadata{}
+		containerMetadata = db.ContainerMetadata{}
+
+		fakeResourceFactory.NewResourceReturns(fakeResource)
 	})
 
 	JustBeforeEach(func() {
-		containerMetadata := db.ContainerMetadata{}
-		stepMetadata := exec.StepMetadata{}
 		planID := atc.PlanID("some-plan-id")
 
 		checkStep = exec.NewCheckStep(
@@ -139,9 +148,137 @@ var _ = Describe("CheckStep", func() {
 
 	Context("with a resonable configuration", func() {
 		BeforeEach(func() {
-			checkPlan = atc.CheckPlan{
-				Timeout: "10s",
+			resTypes := atc.VersionedResourceTypes{
+				{
+					ResourceType: atc.ResourceType{
+						Source: atc.Source{
+							"foo": "((bar))",
+						},
+					},
+				},
 			}
+
+			checkPlan = atc.CheckPlan{
+				Timeout:                "10s",
+				Type:                   "resource-type",
+				Tags:                   []string{"tag"},
+				VersionedResourceTypes: resTypes,
+			}
+
+			containerMetadata = db.ContainerMetadata{
+				User: "test-user",
+			}
+
+			stepMetadata = exec.StepMetadata{
+				TeamID:             345,
+				ResourceConfigID:   501,
+				BaseResourceTypeID: 502,
+			}
+
+			fakeCredVarsTracker := new(varsfakes.FakeCredVarsTracker)
+			fakeCredVarsTracker.GetReturns("caz", true, nil)
+			fakeDelegate.VariablesReturns(fakeCredVarsTracker)
+		})
+
+		It("uses ResourceConfigCheckSessionOwner", func() {
+			_, _, owner, _, _, _, _, _, _, _ := fakeClient.RunCheckStepArgsForCall(0)
+			expected := db.NewResourceConfigCheckSessionContainerOwner(
+				501,
+				502,
+				db.ContainerOwnerExpiries{Min: 5 * time.Minute, Max: 1 * time.Hour},
+			)
+
+			Expect(owner).To(Equal(expected))
+		})
+
+		Context("uses containerspec", func() {
+			var containerSpec worker.ContainerSpec
+
+			JustBeforeEach(func() {
+				_, _, _, containerSpec, _, _, _, _, _, _ = fakeClient.RunCheckStepArgsForCall(0)
+			})
+
+			It("with certs volume mount", func() {
+				Expect(containerSpec.BindMounts).To(HaveLen(1))
+				mount := containerSpec.BindMounts[0]
+
+				_, ok := mount.(*worker.CertsVolumeMount)
+				Expect(ok).To(BeTrue())
+			})
+
+			It("with imagespec w/ resource type", func() {
+				Expect(containerSpec.ImageSpec).To(Equal(worker.ImageSpec{
+					ResourceType: "resource-type",
+				}))
+			})
+
+			It("with tags set", func() {
+				Expect(containerSpec.Tags).To(ConsistOf("tag"))
+			})
+
+			It("with teamid set", func() {
+				Expect(containerSpec.TeamID).To(Equal(345))
+			})
+
+			It("with env vars", func() {
+				Expect(containerSpec.Env).To(ContainElement("BUILD_TEAM_ID=345"))
+			})
+		})
+
+		Context("uses workerspec", func() {
+			var workerSpec worker.WorkerSpec
+
+			JustBeforeEach(func() {
+				_, _, _, _, workerSpec, _, _, _, _, _ = fakeClient.RunCheckStepArgsForCall(0)
+			})
+
+			It("with resource type", func() {
+				Expect(workerSpec.ResourceType).To(Equal("resource-type"))
+			})
+
+			It("with tags", func() {
+				Expect(workerSpec.Tags).To(ConsistOf("tag"))
+			})
+
+			It("with resource types", func() {
+				Expect(workerSpec.ResourceTypes).To(HaveLen(1))
+				interpolatedResourceType := workerSpec.ResourceTypes[0]
+
+				Expect(interpolatedResourceType.Source).To(Equal(atc.Source{"foo": "caz"}))
+			})
+
+			It("with teamid", func() {
+				Expect(workerSpec.TeamID).To(Equal(345))
+			})
+		})
+
+		It("uses container placement strategy", func() {
+			_, _, _, _, _, strategy, _, _, _, _ := fakeClient.RunCheckStepArgsForCall(0)
+			Expect(strategy).To(Equal(fakeStrategy))
+		})
+
+		It("uses container metadata", func() {
+			_, _, _, _, _, _, metadata, _, _, _ := fakeClient.RunCheckStepArgsForCall(0)
+			Expect(metadata).To(Equal(containerMetadata))
+		})
+
+		It("uses interpolated resource types", func() {
+			_, _, _, _, _, _, _, resourceTypes, _, _ := fakeClient.RunCheckStepArgsForCall(0)
+
+			Expect(resourceTypes).To(HaveLen(1))
+			interpolatedResourceType := resourceTypes[0]
+
+			Expect(interpolatedResourceType.Source).To(Equal(atc.Source{"foo": "caz"}))
+		})
+
+		It("uses the timeout parsed", func() {
+			_, _, _, _, _, _, _, _, timeout, _ := fakeClient.RunCheckStepArgsForCall(0)
+			Expect(timeout).To(Equal(10 * time.Second))
+		})
+
+		It("uses the resource created", func() {
+			_, _, _, _, _, _, _, _, _, resource := fakeClient.RunCheckStepArgsForCall(0)
+			Expect(resource).To(Equal(fakeResource))
 		})
 
 		Context("having RunCheckStep erroring", func() {
@@ -149,8 +286,7 @@ var _ = Describe("CheckStep", func() {
 
 			BeforeEach(func() {
 				expectedErr = errors.New("run-check-step-err")
-
-				fakeClient.RunCheckStepReturns(nil, expectedErr)
+				fakeClient.RunCheckStepReturns(worker.CheckResult{}, expectedErr)
 			})
 
 			It("errors", func() {

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -220,7 +220,7 @@ var _ = Describe("Client", func() {
 	Describe("RunCheckStep", func() {
 
 		var (
-			result           []atc.Version
+			result           worker.CheckResult
 			err, expectedErr error
 			fakeResource     *resourcefakes.FakeResource
 		)
@@ -330,8 +330,8 @@ var _ = Describe("Client", func() {
 					})
 
 					It("returns the versions", func() {
-						Expect(result).To(HaveLen(1))
-						Expect(result[0]).To(Equal(atc.Version{"version": "1"}))
+						Expect(result.Versions).To(HaveLen(1))
+						Expect(result.Versions[0]).To(Equal(atc.Version{"version": "1"}))
 					})
 				})
 			})

--- a/atc/worker/workerfakes/fake_client.go
+++ b/atc/worker/workerfakes/fake_client.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"io"
 	"sync"
+	"time"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/resource"
@@ -64,6 +66,28 @@ type FakeClient struct {
 		result1 worker.Volume
 		result2 bool
 		result3 error
+	}
+	RunCheckStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, atc.VersionedResourceTypes, time.Duration, resource.Resource) ([]atc.Version, error)
+	runCheckStepMutex       sync.RWMutex
+	runCheckStepArgsForCall []struct {
+		arg1  context.Context
+		arg2  lager.Logger
+		arg3  db.ContainerOwner
+		arg4  worker.ContainerSpec
+		arg5  worker.WorkerSpec
+		arg6  worker.ContainerPlacementStrategy
+		arg7  db.ContainerMetadata
+		arg8  atc.VersionedResourceTypes
+		arg9  time.Duration
+		arg10 resource.Resource
+	}
+	runCheckStepReturns struct {
+		result1 []atc.Version
+		result2 error
+	}
+	runCheckStepReturnsOnCall map[int]struct {
+		result1 []atc.Version
+		result2 error
 	}
 	RunGetStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, db.UsedResourceCache, resource.Resource) (worker.GetResult, error)
 	runGetStepMutex       sync.RWMutex
@@ -355,6 +379,78 @@ func (fake *FakeClient) FindVolumeReturnsOnCall(i int, result1 worker.Volume, re
 		result2 bool
 		result3 error
 	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) RunCheckStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 atc.VersionedResourceTypes, arg9 time.Duration, arg10 resource.Resource) ([]atc.Version, error) {
+	fake.runCheckStepMutex.Lock()
+	ret, specificReturn := fake.runCheckStepReturnsOnCall[len(fake.runCheckStepArgsForCall)]
+	fake.runCheckStepArgsForCall = append(fake.runCheckStepArgsForCall, struct {
+		arg1  context.Context
+		arg2  lager.Logger
+		arg3  db.ContainerOwner
+		arg4  worker.ContainerSpec
+		arg5  worker.WorkerSpec
+		arg6  worker.ContainerPlacementStrategy
+		arg7  db.ContainerMetadata
+		arg8  atc.VersionedResourceTypes
+		arg9  time.Duration
+		arg10 resource.Resource
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10})
+	fake.recordInvocation("RunCheckStep", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10})
+	fake.runCheckStepMutex.Unlock()
+	if fake.RunCheckStepStub != nil {
+		return fake.RunCheckStepStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.runCheckStepReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) RunCheckStepCallCount() int {
+	fake.runCheckStepMutex.RLock()
+	defer fake.runCheckStepMutex.RUnlock()
+	return len(fake.runCheckStepArgsForCall)
+}
+
+func (fake *FakeClient) RunCheckStepCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, atc.VersionedResourceTypes, time.Duration, resource.Resource) ([]atc.Version, error)) {
+	fake.runCheckStepMutex.Lock()
+	defer fake.runCheckStepMutex.Unlock()
+	fake.RunCheckStepStub = stub
+}
+
+func (fake *FakeClient) RunCheckStepArgsForCall(i int) (context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, atc.VersionedResourceTypes, time.Duration, resource.Resource) {
+	fake.runCheckStepMutex.RLock()
+	defer fake.runCheckStepMutex.RUnlock()
+	argsForCall := fake.runCheckStepArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8, argsForCall.arg9, argsForCall.arg10
+}
+
+func (fake *FakeClient) RunCheckStepReturns(result1 []atc.Version, result2 error) {
+	fake.runCheckStepMutex.Lock()
+	defer fake.runCheckStepMutex.Unlock()
+	fake.RunCheckStepStub = nil
+	fake.runCheckStepReturns = struct {
+		result1 []atc.Version
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) RunCheckStepReturnsOnCall(i int, result1 []atc.Version, result2 error) {
+	fake.runCheckStepMutex.Lock()
+	defer fake.runCheckStepMutex.Unlock()
+	fake.RunCheckStepStub = nil
+	if fake.runCheckStepReturnsOnCall == nil {
+		fake.runCheckStepReturnsOnCall = make(map[int]struct {
+			result1 []atc.Version
+			result2 error
+		})
+	}
+	fake.runCheckStepReturnsOnCall[i] = struct {
+		result1 []atc.Version
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeClient) RunGetStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 worker.ImageFetcherSpec, arg9 runtime.ProcessSpec, arg10 runtime.StartingEventDelegate, arg11 db.UsedResourceCache, arg12 resource.Resource) (worker.GetResult, error) {
@@ -652,6 +748,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.findContainerMutex.RUnlock()
 	fake.findVolumeMutex.RLock()
 	defer fake.findVolumeMutex.RUnlock()
+	fake.runCheckStepMutex.RLock()
+	defer fake.runCheckStepMutex.RUnlock()
 	fake.runGetStepMutex.RLock()
 	defer fake.runGetStepMutex.RUnlock()
 	fake.runPutStepMutex.RLock()

--- a/atc/worker/workerfakes/fake_client.go
+++ b/atc/worker/workerfakes/fake_client.go
@@ -67,7 +67,7 @@ type FakeClient struct {
 		result2 bool
 		result3 error
 	}
-	RunCheckStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, atc.VersionedResourceTypes, time.Duration, resource.Resource) ([]atc.Version, error)
+	RunCheckStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, atc.VersionedResourceTypes, time.Duration, resource.Resource) (worker.CheckResult, error)
 	runCheckStepMutex       sync.RWMutex
 	runCheckStepArgsForCall []struct {
 		arg1  context.Context
@@ -82,11 +82,11 @@ type FakeClient struct {
 		arg10 resource.Resource
 	}
 	runCheckStepReturns struct {
-		result1 []atc.Version
+		result1 worker.CheckResult
 		result2 error
 	}
 	runCheckStepReturnsOnCall map[int]struct {
-		result1 []atc.Version
+		result1 worker.CheckResult
 		result2 error
 	}
 	RunGetStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, worker.ImageFetcherSpec, runtime.ProcessSpec, runtime.StartingEventDelegate, db.UsedResourceCache, resource.Resource) (worker.GetResult, error)
@@ -381,7 +381,7 @@ func (fake *FakeClient) FindVolumeReturnsOnCall(i int, result1 worker.Volume, re
 	}{result1, result2, result3}
 }
 
-func (fake *FakeClient) RunCheckStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 atc.VersionedResourceTypes, arg9 time.Duration, arg10 resource.Resource) ([]atc.Version, error) {
+func (fake *FakeClient) RunCheckStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 atc.VersionedResourceTypes, arg9 time.Duration, arg10 resource.Resource) (worker.CheckResult, error) {
 	fake.runCheckStepMutex.Lock()
 	ret, specificReturn := fake.runCheckStepReturnsOnCall[len(fake.runCheckStepArgsForCall)]
 	fake.runCheckStepArgsForCall = append(fake.runCheckStepArgsForCall, struct {
@@ -414,7 +414,7 @@ func (fake *FakeClient) RunCheckStepCallCount() int {
 	return len(fake.runCheckStepArgsForCall)
 }
 
-func (fake *FakeClient) RunCheckStepCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, atc.VersionedResourceTypes, time.Duration, resource.Resource) ([]atc.Version, error)) {
+func (fake *FakeClient) RunCheckStepCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, atc.VersionedResourceTypes, time.Duration, resource.Resource) (worker.CheckResult, error)) {
 	fake.runCheckStepMutex.Lock()
 	defer fake.runCheckStepMutex.Unlock()
 	fake.RunCheckStepStub = stub
@@ -427,28 +427,28 @@ func (fake *FakeClient) RunCheckStepArgsForCall(i int) (context.Context, lager.L
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8, argsForCall.arg9, argsForCall.arg10
 }
 
-func (fake *FakeClient) RunCheckStepReturns(result1 []atc.Version, result2 error) {
+func (fake *FakeClient) RunCheckStepReturns(result1 worker.CheckResult, result2 error) {
 	fake.runCheckStepMutex.Lock()
 	defer fake.runCheckStepMutex.Unlock()
 	fake.RunCheckStepStub = nil
 	fake.runCheckStepReturns = struct {
-		result1 []atc.Version
+		result1 worker.CheckResult
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeClient) RunCheckStepReturnsOnCall(i int, result1 []atc.Version, result2 error) {
+func (fake *FakeClient) RunCheckStepReturnsOnCall(i int, result1 worker.CheckResult, result2 error) {
 	fake.runCheckStepMutex.Lock()
 	defer fake.runCheckStepMutex.Unlock()
 	fake.RunCheckStepStub = nil
 	if fake.runCheckStepReturnsOnCall == nil {
 		fake.runCheckStepReturnsOnCall = make(map[int]struct {
-			result1 []atc.Version
+			result1 worker.CheckResult
 			result2 error
 		})
 	}
 	fake.runCheckStepReturnsOnCall[i] = struct {
-		result1 []atc.Version
+		result1 worker.CheckResult
 		result2 error
 	}{result1, result2}
 }

--- a/testflight/resource_check_timeout_test.go
+++ b/testflight/resource_check_timeout_test.go
@@ -33,7 +33,7 @@ var _ = Describe("A resource check which times out", func() {
 			<-check.Exited
 			Expect(check).To(gexec.Exit(1))
 			Expect(check.Out).To(gbytes.Say("errored"))
-			Expect(check.Out).To(gbytes.Say("Timed out"))
+			Expect(check.Out).To(gbytes.Say("timed out"))
 		})
 	})
 

--- a/vars/template.go
+++ b/vars/template.go
@@ -1,13 +1,13 @@
 package vars
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -97,7 +97,7 @@ func (i interpolator) Interpolate(node interface{}, varsLookup varsLookup) (inte
 		for _, name := range i.extractVarNames(typedNode) {
 			foundVal, found, err := varsLookup.Get(name)
 			if err != nil {
-				return nil, errors.WithMessagef(err, "Finding variable '%s'", name)
+				return nil, fmt.Errorf("var lookup '%s': %w", name, err)
 			}
 
 			if found {


### PR DESCRIPTION
### existing issue

fixes #4957 

### changes proposed in this pull request

- move the garden logic from the `exec` package to `worker`

ps.: this is strictly a refactor (no changes in behavior) 


### Contributor Checklist

- [x] Unit tests
- ~[ ] Integration tests (if applicable)~
- ~[ ] Updated documentation (located at https://github.com/concourse/docs)~
- ~[ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


### Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
