### PR TITLE
testflight: download fly instead of building

### DIFF
--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -146,7 +146,7 @@ func downloadFly(atcUrl string) (string, error) {
 		return "", err
 	}
 	outFile.Close()
-	err = os.Chmod(outFile.Name(), 755)
+	err = outFile.Chmod(0755)
 	if err != nil {
 		return "", err
 	}

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -141,11 +141,11 @@ func downloadFly(atcUrl string) (string, error) {
 		return "", err
 	}
 	outFile, err := ioutil.TempFile("", "fly")
+	defer outFile.Close()
 	_, err = io.Copy(outFile, readCloser)
 	if err != nil {
 		return "", err
 	}
-	outFile.Close()
 	err = outFile.Chmod(0755)
 	if err != nil {
 		return "", err

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -141,6 +141,9 @@ func downloadFly(atcUrl string) (string, error) {
 		return "", err
 	}
 	outFile, err := ioutil.TempFile("", "fly")
+	if err != nil {
+		return "", err
+	}
 	defer outFile.Close()
 	_, err = io.Copy(outFile, readCloser)
 	if err != nil {


### PR DESCRIPTION
# Existing Issue

Fixes concourse/ci#276.

# Changes proposed in this pull request

There was a time when it was typical for dev builds of concourse to fail
to serve the CLI download endpoint. Since we have been using
docker-compose consistently, we have also been packaging fly into the
dev image, so it is safe for testflight to assume the CLI download API
will be working correctly. Hopefully this improves the dev/CI parity and
helps to surface problems in our CI builds of fly more clearly.

# Contributor Checklist
- [x] ~Unit tests~
- [x] Integration tests (if applicable)
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [x] ~Code reviewed~
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~