### PR TITLE
feat(atc): make pipeline and job badge API routes public

### DIFF
--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -549,10 +549,11 @@ var _ = Describe("Jobs API", func() {
 			Context("and the pipeline is private", func() {
 				BeforeEach(func() {
 					fakePipeline.PublicReturns(false)
+					fakePipeline.JobReturns(fakeJob, true, nil)
 				})
 
-				It("returns 403", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+				It("returns 200", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
 				})
 			})
 

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -574,8 +574,8 @@ var _ = Describe("Pipelines API", func() {
 					BeforeEach(func() {
 						fakeaccess.IsAuthenticatedReturns(true)
 					})
-					It("returns 403", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+					It("returns 200", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusOK))
 					})
 				})
 
@@ -584,8 +584,8 @@ var _ = Describe("Pipelines API", func() {
 						fakeaccess.IsAuthenticatedReturns(false)
 					})
 
-					It("returns 401", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+					It("returns 200", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusOK))
 					})
 				})
 			})

--- a/atc/wrappa/api_auth_wrappa.go
+++ b/atc/wrappa/api_auth_wrappa.go
@@ -65,8 +65,6 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 		// pipeline is public or authorized
 		case atc.GetPipeline,
 			atc.GetJobBuild,
-			atc.PipelineBadge,
-			atc.JobBadge,
 			atc.ListJobs,
 			atc.GetJob,
 			atc.ListJobBuilds,
@@ -109,6 +107,8 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.ListAllJobs,
 			atc.ListAllResources,
 			atc.ListBuilds,
+			atc.PipelineBadge,
+			atc.JobBadge,
 			atc.MainJobBadge,
 			atc.GetWall:
 			newHandler = auth.CheckAuthenticationIfProvidedHandler(handler, rejector)

--- a/atc/wrappa/api_auth_wrappa_test.go
+++ b/atc/wrappa/api_auth_wrappa_test.go
@@ -168,8 +168,6 @@ var _ = Describe("APIAuthWrappa", func() {
 				// belongs to public pipeline or authorized
 				atc.GetPipeline:                   openForPublicPipelineOrAuthorized(inputHandlers[atc.GetPipeline]),
 				atc.GetJobBuild:                   openForPublicPipelineOrAuthorized(inputHandlers[atc.GetJobBuild]),
-				atc.PipelineBadge:                 openForPublicPipelineOrAuthorized(inputHandlers[atc.PipelineBadge]),
-				atc.JobBadge:                      openForPublicPipelineOrAuthorized(inputHandlers[atc.JobBadge]),
 				atc.ListJobs:                      openForPublicPipelineOrAuthorized(inputHandlers[atc.ListJobs]),
 				atc.GetJob:                        openForPublicPipelineOrAuthorized(inputHandlers[atc.GetJob]),
 				atc.ListJobBuilds:                 openForPublicPipelineOrAuthorized(inputHandlers[atc.ListJobBuilds]),
@@ -210,6 +208,8 @@ var _ = Describe("APIAuthWrappa", func() {
 				atc.ListAllJobs:          authenticateIfTokenProvided(inputHandlers[atc.ListAllJobs]),
 				atc.ListAllResources:     authenticateIfTokenProvided(inputHandlers[atc.ListAllResources]),
 				atc.ListTeams:            authenticateIfTokenProvided(inputHandlers[atc.ListTeams]),
+				atc.PipelineBadge:        authenticateIfTokenProvided(inputHandlers[atc.PipelineBadge]),
+				atc.JobBadge:             authenticateIfTokenProvided(inputHandlers[atc.JobBadge]),
 				atc.MainJobBadge:         authenticateIfTokenProvided(inputHandlers[atc.MainJobBadge]),
 				atc.GetWall:              authenticateIfTokenProvided(inputHandlers[atc.GetWall]),
 


### PR DESCRIPTION
fixes #996

Signed-off-by: Joe Hosteny <jhosteny@carnegierobotics.com>

# Existing Issue

Fixes #996.

# Why do we need this PR?

Make the badge routes public, so that we can see the build status for private pipelines and jobs without authentication (e.g., in a github README).

# Changes proposed in this pull request

* Make PipelineBadge public 
* Make JobBadge public

# Contributor Checklist
- [x] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
