### PR TITLE
release notes for public badges

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -28,6 +28,10 @@ other systems soon.
 `fly unpause-pipeline` commands. This allows users to pause or unpause every
 pipeline on a team at the same time. #4092
 
+#### <sub><sup><a name="5252" href="#5252">:link:</a></sup></sub> feature
+
+* @jhosteny changed the [badge endpoints](https://concourse-ci.org/observation.html#badges) to always be accessible when unauthenticated - this means that it is now possible to show the status of a private pipeline or job in a README on a code-hosting site. #5252
+
 #### <sub><sup><a name="5133" href="#5133">:link:</a></sup></sub> fix
 
 * In the case that a user has multiple roles on a team, the pills on the team headers on the dashboard now accurately reflect the logged-in user's most-privileged role on each team. #5133


### PR DESCRIPTION
# Why do we need this PR?

concourse/concourse#5252 was contributed by community member @jhosteny, and I didn't want to block the PR on release notes.

# Changes proposed in this pull request

* No code changes, just release notes.

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [x] ~PR acceptance performed~
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~