### PR TITLE
Add way to parse nested vault secret, in case if user request specific key from vault json data

### DIFF
--- a/atc/creds/vault/vault.go
+++ b/atc/creds/vault/vault.go
@@ -62,8 +62,6 @@ func (v Vault) Get(secretPath string) (interface{}, *time.Time, bool, error) {
 		secretVal, found := secret.Data[secretName]
 		if found {
 			return secretVal, expiration, true, nil
-		} else {
-			return nil, nil, false, nil
 		}
 	}
 

--- a/atc/creds/vault/vault.go
+++ b/atc/creds/vault/vault.go
@@ -63,6 +63,7 @@ func (v Vault) Get(secretPath string) (interface{}, *time.Time, bool, error) {
 		if found {
 			return secretVal, expiration, true, nil
 		}
+		return nil, nil, false, nil
 	}
 
 	val, found := secret.Data["value"]

--- a/atc/creds/vault/vault.go
+++ b/atc/creds/vault/vault.go
@@ -42,14 +42,14 @@ func (v Vault) NewSecretLookupPaths(teamName string, pipelineName string, allowR
 
 // Get retrieves the value and expiration of an individual secret
 func (v Vault) Get(secretPath string) (interface{}, *time.Time, bool, error) {
-	var secretName, secretRealPath string
+	var secretName string
+	secretRealPath := secretPath
 	if strings.Contains(secretPath, ".") {
 		parsed := strings.Split(secretPath, ".")
 		secretRealPath = parsed[0]
 		secretName = parsed[1]
-	} else {
-		secretRealPath = secretPath
 	}
+
 	secret, expiration, found, err := v.findSecret(secretRealPath)
 	if err != nil {
 		return nil, nil, false, err
@@ -58,7 +58,7 @@ func (v Vault) Get(secretPath string) (interface{}, *time.Time, bool, error) {
 		return nil, nil, false, nil
 	}
 
-	if len(secretName) != 0 {
+	if len(secretName) > 0 {
 		secretVal, found := secret.Data[secretName]
 		if found {
 			return secretVal, expiration, true, nil

--- a/atc/creds/vault/vault_test.go
+++ b/atc/creds/vault/vault_test.go
@@ -123,6 +123,27 @@ var _ = Describe("Vault", func() {
 			Expect(err).To(BeNil())
 		})
 
+		It("should get secret from shared if pipeline defaults not found", func() {
+			v.SecretReader = &MockSecretReader{&[]MockSecret{
+				{
+					path: "/concourse/shared/foo",
+					secret: &vaultapi.Secret{
+						Data: map[string]interface{}{"test": "value"},
+					},
+				},
+				{
+					path: "/concourse/team/foo",
+					secret: &vaultapi.Secret{
+						Data: map[string]interface{}{"value": "bar"},
+					},
+				}},
+			}
+			value, found, err := variables.Get(vars.VariableDefinition{Name: "foo.test"})
+			Expect(value).To(BeEquivalentTo("value"))
+			Expect(found).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
 		Context("without shared", func() {
 			BeforeEach(func() {
 				v = &vault.Vault{


### PR DESCRIPTION
Signed-off-by: kirillbilchenko <kirya7@gmail.com>

# Existing Issue

Fixes #5253 

# Why do we need this PR?
In case if you vault secret key is a json object which  contains nested secrets, it's failing to lookup target secret across all available path. As example `somesecret.key` with current implementation will fail because the secret itself was found but nested search inside the json struct is not happening so there is no fallback to shared path, team path, if you have this secret in you pipeline but secret missed for specific key.


# Changes proposed in this pull request

* if user specify with exactly secret he want to find in specific vault collection with dot separator, vault will try to find this secret in specified json  

# Contributor Checklist
- [x] Unit tests
- [x] Integration tests (if applicable)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
