### PR TITLE
The running state of a build that is a second rerun should show in the pipeline UI

### DIFF
--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -457,6 +457,26 @@ var _ = Describe("Build", func() {
 					It("updates job latest finished build id", func() {
 						Expect(getJobBuildID(latestCompletedBuildCol, job.ID())).To(Equal(pdBuild.ID()))
 					})
+
+					Context("when rerunning the rerun build", func() {
+						var rrBuild2 db.Build
+
+						BeforeEach(func() {
+							err = rrBuild.Finish(db.BuildStatusSucceeded)
+							Expect(err).NotTo(HaveOccurred())
+
+							rrBuild2, err = job.RerunBuild(rrBuild)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						It("updates job next build id to the rerun build", func() {
+							Expect(getJobBuildID(nextBuildCol, job.ID())).To(Equal(rrBuild2.ID()))
+						})
+
+						It("updates job latest finished build id", func() {
+							Expect(getJobBuildID(latestCompletedBuildCol, job.ID())).To(Equal(rrBuild.ID()))
+						})
+					})
 				})
 
 				Context("when pending build finished and rerunning a non latest build and it finishes", func() {

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -665,7 +665,12 @@ func (j *job) CreateBuild() (Build, error) {
 		return nil, err
 	}
 
-	err = updateNextBuildForJob(tx, j.id)
+	latestNonRerunID, err := latestCompletedNonRerunBuild(tx, j.id)
+	if err != nil {
+		return nil, err
+	}
+
+	err = updateNextBuildForJob(tx, j.id, latestNonRerunID)
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +720,12 @@ func (j *job) RerunBuild(buildToRerun Build) (Build, error) {
 		return nil, err
 	}
 
-	err = updateNextBuildForJob(tx, j.id)
+	latestNonRerunID, err := latestCompletedNonRerunBuild(tx, j.id)
+	if err != nil {
+		return nil, err
+	}
+
+	err = updateNextBuildForJob(tx, j.id, latestNonRerunID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There was a bug where the next build id of a job was not updated to the
correct build if the build was a rerun of a rerun. This was fixed by
having the rerun_of be compared to a non rerun build rather than the
latest completed build.

I also removed updating the next build id column on the Start method
because it should not be needed, since builds are added to the list of
possible "next build ids" when they are either pending or started and
since builds always go from pending -> started, we only need to update
the next build id when we create a new pending build (and then also
update it when we finish builds).

Fixes #5236

Signed-off-by: Clara Fu <cfu@pivotal.io>