### PR TITLE
web: fix highlighting logs on build page

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -70,3 +70,7 @@ errors from the library we used before.
 
 * @aledeganopix4d added a `last updated` column to the output of `fly pipelines` showing
 the last date where the pipeline was set or reset. #5113
+
+#### <sub><sup><a name="5275" href="#5275">:link:</a></sup></sub> fix
+
+* Ensure the build page doesn't get reloaded when you highlight a log line, and fix auto-scrolling to a highlighted log line. #5275

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -412,7 +412,11 @@ urlUpdate route model =
                 ( model.subModel, [] )
 
             else if routeMatchesModel route model then
-                SubPage.urlUpdate route ( model.subModel, [] )
+                SubPage.urlUpdate
+                    { from = model.route
+                    , to = route
+                    }
+                    ( model.subModel, [] )
 
             else
                 SubPage.init model.session route

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -72,6 +72,7 @@ bodyId =
 type alias Flags =
     { highlight : Routes.Highlight
     , pageType : BuildPageType
+    , fromBuildPage : Maybe Build.Header.Models.BuildPageType
     }
 
 

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -149,22 +149,30 @@ subscriptions model =
 
 
 changeToBuild : Flags -> ET Model
-changeToBuild { highlight, pageType } ( model, effects ) =
-    ( { model
-        | prep = Nothing
-        , output = Empty
-        , autoScroll = True
-        , page = pageType
-        , highlight = highlight
-      }
-    , case pageType of
-        OneOffBuildPage buildId ->
-            effects
-                ++ [ CloseBuildEventStream, FetchBuild 0 buildId ]
+changeToBuild { highlight, pageType, fromBuildPage } ( model, effects ) =
+    let
+        newModel =
+            { model | page = pageType }
+    in
+    (if fromBuildPage == Just pageType then
+        ( newModel, effects )
 
-        JobBuildPage jbi ->
-            effects
-                ++ [ CloseBuildEventStream, FetchJobBuild jbi ]
+     else
+        ( { newModel
+            | prep = Nothing
+            , output = Empty
+            , autoScroll = True
+            , highlight = highlight
+          }
+        , case pageType of
+            OneOffBuildPage buildId ->
+                effects
+                    ++ [ CloseBuildEventStream, FetchBuild 0 buildId ]
+
+            JobBuildPage jbi ->
+                effects
+                    ++ [ CloseBuildEventStream, FetchJobBuild jbi ]
+        )
     )
         |> Header.changeToBuild pageType
 

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -296,6 +296,9 @@ handleCallback action ( model, effects ) =
             -- https://github.com/concourse/concourse/issues/3201
             ( model, effects )
 
+        ScrollCompleted (ScrollDirection.ToId _) _ ->
+            ( { model | highlight = Routes.HighlightNothing }, effects )
+
         _ ->
             ( model, effects )
     )

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -46,8 +46,9 @@ import List.Extra
 import Login.Login as Login
 import Maybe.Extra
 import Message.Callback exposing (Callback(..), TooltipPolicy(..))
-import Message.Effects as Effects exposing (Effect(..), ScrollDirection(..))
+import Message.Effects as Effects exposing (Effect(..))
 import Message.Message exposing (DomID(..), Message(..))
+import Message.ScrollDirection as ScrollDirection
 import Message.Subscription as Subscription exposing (Delivery(..), Interval(..), Subscription(..))
 import Message.TopLevelMessage exposing (TopLevelMessage(..))
 import Routes
@@ -358,14 +359,14 @@ handleDelivery session delivery ( model, effects ) =
                             ScrollWindow ->
                                 effects
                                     ++ [ Effects.Scroll
-                                            Effects.ToBottom
+                                            ScrollDirection.ToBottom
                                             bodyId
                                        ]
 
                             ScrollToID id ->
                                 effects
                                     ++ [ Effects.Scroll
-                                            (Effects.ToId id)
+                                            (ScrollDirection.ToId id)
                                             bodyId
                                        ]
 

--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -22,8 +22,9 @@ import Html exposing (Html)
 import List.Extra
 import Maybe.Extra
 import Message.Callback exposing (Callback(..))
-import Message.Effects as Effects exposing (Effect(..), ScrollDirection(..))
+import Message.Effects as Effects exposing (Effect(..))
 import Message.Message exposing (DomID(..), Message(..))
+import Message.ScrollDirection exposing (ScrollDirection(..))
 import Message.Subscription
     exposing
         ( Delivery(..)

--- a/web/elm/src/Build/Shortcuts.elm
+++ b/web/elm/src/Build/Shortcuts.elm
@@ -8,8 +8,9 @@ import Html exposing (Html)
 import Html.Attributes exposing (class, classList)
 import Keyboard
 import Maybe.Extra
-import Message.Effects exposing (Effect(..), ScrollDirection(..))
+import Message.Effects exposing (Effect(..))
 import Message.Message exposing (DomID(..), Message(..))
+import Message.ScrollDirection exposing (ScrollDirection(..))
 import Message.Subscription exposing (Delivery(..))
 import Routes
 

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -15,6 +15,7 @@ import Message.Message
         , VersionToggleAction
         , VisibilityAction
         )
+import Message.ScrollDirection exposing (ScrollDirection)
 import Time
 
 
@@ -63,6 +64,7 @@ type Callback
     | AllPipelinesFetched (Fetched (List Concourse.Pipeline))
     | GotViewport DomID TooltipPolicy (Result Browser.Dom.Error Browser.Dom.Viewport)
     | GotElement (Result Browser.Dom.Error Browser.Dom.Element)
+    | ScrollCompleted ScrollDirection String
 
 
 type TooltipPolicy

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -487,7 +487,7 @@ scroll direction id =
         ToId toId ->
             scrollCoords toId id (.viewport >> .x) (.viewport >> .y)
     )
-        |> Task.attempt (\_ -> EmptyCallback)
+        |> Task.attempt (\_ -> ScrollCompleted direction id)
 
 
 scrollCoords :

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -466,6 +466,11 @@ toHtmlID domId =
             ""
 
 
+scrollToIdPadding : Float
+scrollToIdPadding =
+    60
+
+
 scroll : ScrollDirection -> String -> Cmd Callback
 scroll direction id =
     (case direction of
@@ -479,13 +484,20 @@ scroll direction id =
             scrollCoords id id (always 0) (.srcElem >> .viewport >> .y >> (+) -60)
 
         ToBottom ->
-            scrollCoords id id (always 0) (.srcElem >> .scene >> .height)
+            scrollCoords id id (always 0) (.parentElem >> .scene >> .height)
 
         Sideways delta ->
             scrollCoords id id (.srcElem >> .viewport >> .x >> (+) -delta) (always 0)
 
         ToId toId ->
-            scrollCoords toId id (.srcElem >> .viewport >> .x) (.srcElem >> .viewport >> .y)
+            scrollCoords toId
+                id
+                (\{ srcElem, parentElem } ->
+                    parentElem.viewport.x + srcElem.element.x - parentElem.element.x - scrollToIdPadding
+                )
+                (\{ srcElem, parentElem } ->
+                    parentElem.viewport.y + srcElem.element.y - parentElem.element.y - scrollToIdPadding
+                )
     )
         |> Task.attempt (\_ -> ScrollCompleted direction id)
 

--- a/web/elm/src/Message/ScrollDirection.elm
+++ b/web/elm/src/Message/ScrollDirection.elm
@@ -1,0 +1,10 @@
+module Message.ScrollDirection exposing (ScrollDirection(..))
+
+
+type ScrollDirection
+    = ToTop
+    | Down
+    | Up
+    | ToBottom
+    | Sideways Float
+    | ToId String

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -3,6 +3,7 @@ module Routes exposing
     , Route(..)
     , SearchType(..)
     , StepID
+    , Transition
     , buildRoute
     , dashboardRoute
     , extractPid
@@ -61,6 +62,12 @@ type Highlight
 
 type alias StepID =
     String
+
+
+type alias Transition =
+    { from : Route
+    , to : Route
+    }
 
 
 

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -382,6 +382,62 @@ all =
                         )
                     |> Tuple.second
                     |> Common.notContains (Effects.Scroll (ScrollDirection.ToId "stepid:2") "build-body")
+        , test "does not re-scroll to an id multiple times" <|
+            \_ ->
+                Application.init
+                    flags
+                    { protocol = Url.Http
+                    , host = ""
+                    , port_ = Nothing
+                    , path = "/teams/t/pipelines/p/jobs/j/builds/1"
+                    , query = Nothing
+                    , fragment = Just "Lstepid:1"
+                    }
+                    |> Tuple.first
+                    |> fetchBuild BuildStatusStarted
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.PlanAndResourcesFetched 1 <|
+                            Ok <|
+                                ( { id = "stepid"
+                                  , step =
+                                        Concourse.BuildStepTask
+                                            "step"
+                                  }
+                                , { inputs = [], outputs = [] }
+                                )
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (EventsReceived <|
+                            Ok <|
+                                [ { url = eventsUrl
+                                  , data =
+                                        STModels.StartTask
+                                            { source = "stdout"
+                                            , id = "stepid"
+                                            }
+                                            (Time.millisToPosix 0)
+                                  }
+                                , { url = eventsUrl
+                                  , data =
+                                        STModels.Log
+                                            { source = "stdout"
+                                            , id = "stepid"
+                                            }
+                                            "log message"
+                                            Nothing
+                                  }
+                                ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.ScrollCompleted (ScrollDirection.ToId "stepid:1") "build-body")
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (EventsReceived <| Ok [])
+                    |> Tuple.second
+                    |> Common.notContains (Effects.Scroll (ScrollDirection.ToId "stepid:1") "build-body")
         , describe "page title"
             [ test "with a job build" <|
                 \_ ->

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -22,6 +22,7 @@ import Keyboard
 import Message.Callback as Callback
 import Message.Effects as Effects
 import Message.Message
+import Message.ScrollDirection as ScrollDirection
 import Message.Subscription as Subscription exposing (Delivery(..), Interval(..))
 import Message.TopLevelMessage as Msgs
 import Routes
@@ -269,7 +270,7 @@ all =
                                     ]
                         )
                     |> Tuple.second
-                    |> Common.contains (Effects.Scroll (Effects.ToId "stepid:1") "build-body")
+                    |> Common.contains (Effects.Scroll (ScrollDirection.ToId "stepid:1") "build-body")
         , test "scrolls to top of highlighted range" <|
             \_ ->
                 Application.init
@@ -320,7 +321,7 @@ all =
                                     ]
                         )
                     |> Tuple.second
-                    |> Common.contains (Effects.Scroll (Effects.ToId "stepid:1") "build-body")
+                    |> Common.contains (Effects.Scroll (ScrollDirection.ToId "stepid:1") "build-body")
         , test "does not scroll to an invalid range" <|
             \_ ->
                 Application.init
@@ -380,7 +381,7 @@ all =
                                     ]
                         )
                     |> Tuple.second
-                    |> Common.notContains (Effects.Scroll (Effects.ToId "stepid:2") "build-body")
+                    |> Common.notContains (Effects.Scroll (ScrollDirection.ToId "stepid:2") "build-body")
         , describe "page title"
             [ test "with a job build" <|
                 \_ ->
@@ -847,7 +848,7 @@ all =
                         , data = STModels.StartTask { id = "stepid", source = "" } (Time.millisToPosix 0)
                         }
                     |> Tuple.second
-                    |> Common.contains (Effects.Scroll Effects.ToBottom "build-body")
+                    |> Common.contains (Effects.Scroll ScrollDirection.ToBottom "build-body")
         , test "when build is not running it does not scroll on build event" <|
             \_ ->
                 Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -938,7 +939,7 @@ all =
                         , data = STModels.StartTask { id = "stepid", source = "" } (Time.millisToPosix 0)
                         }
                     |> Tuple.second
-                    |> Expect.equal [ Effects.Scroll Effects.ToBottom "build-body" ]
+                    |> Expect.equal [ Effects.Scroll ScrollDirection.ToBottom "build-body" ]
         , test "pressing 'T' twice triggers two builds" <|
             \_ ->
                 Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -1112,7 +1113,7 @@ all =
                                 }
                         )
                     |> Tuple.second
-                    |> Expect.equal [ Effects.Scroll Effects.ToTop "build-body" ]
+                    |> Expect.equal [ Effects.Scroll ScrollDirection.ToTop "build-body" ]
         , test "pressing 'G' scrolls to the bottom" <|
             \_ ->
                 Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -1129,7 +1130,7 @@ all =
                                 }
                         )
                     |> Tuple.second
-                    |> Expect.equal [ Effects.Scroll Effects.ToBottom "build-body" ]
+                    |> Expect.equal [ Effects.Scroll ScrollDirection.ToBottom "build-body" ]
         , test "pressing 'g' once does nothing" <|
             \_ ->
                 Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -2031,7 +2032,7 @@ all =
                         >> Application.handleDelivery
                             (Subscription.ElementVisible ( "1", False ))
                         >> Tuple.second
-                        >> Expect.equal [ Effects.Scroll (Effects.ToId "1") "builds" ]
+                        >> Expect.equal [ Effects.Scroll (ScrollDirection.ToId "1") "builds" ]
                 , test "does not scroll to current build more than once" <|
                     givenBuildFetched
                         >> Tuple.first

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1196,6 +1196,36 @@ all =
                             , buildName = "1"
                             }
                         )
+        , test "does not reload build when highlight is modified" <|
+            \_ ->
+                let
+                    buildParams =
+                        { id =
+                            { teamName = "t"
+                            , pipelineName = "p"
+                            , jobName = "j"
+                            , buildName = "1"
+                            }
+                        , highlight = Routes.HighlightNothing
+                        }
+                in
+                Common.init "/"
+                    |> Application.handleDelivery
+                        (RouteChanged <|
+                            Routes.Build
+                                buildParams
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (RouteChanged <|
+                            Routes.Build
+                                { buildParams
+                                    | highlight = Routes.HighlightLine "step" 1
+                                }
+                        )
+                    |> Tuple.second
+                    |> Common.notContains
+                        (Effects.FetchJobBuild <| buildParams.id)
         , test "gets current timezone on page load" <|
             \_ ->
                 Application.init


### PR DESCRIPTION
Existing Issue

Fixes #3994  .

# Why do we need this PR?
In addition to #3994, there are several other issues with highlights on the build page:

* Highlighting a build log refreshes the page
* Loading a page with a highlight always jumps to the top, rather than jumping to the highlighted log message


# Changes proposed in this pull request

* Track route transitions to check if we "came from" the same build page (the only difference being the highlight changed) - if so, don't reload
* Capture a `ScrollCompleted` event to remove the highlight (but not from rendering) when we scroll to it. This fixes #3994
* Use `Browser.Dom.getElement` instead of `Browser.Dom.getViewportOf` to determine the position to scroll to. `Browser.Dom.getViewportOf` always gives coords (0, 0) for the build log since it doesn't have a scrollable viewport, so it's scrollTop/scrollLeft are always 0s.

# Contributor Checklist
- [X] Unit tests
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] Release notes reviewed
- [x] PR acceptance performed
