### PR TITLE
fix up k8s-topgun instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -484,7 +484,9 @@ The tests require a few environment variables to be set:
 when deploying Concourse in the k8s cluster
 - `CONCOURSE_IMAGE_NAME`: the name of the image to use when deploying Concourse
 to the Kubernetes cluster
-- `CHARTS_DIR`: location in the filesystem where a copy of [`the Concourse Helm
+- `HELM_CHARTS_DIR`: path to a clone of the [`helm/charts`][helm-charts] repo. This is used
+to define the postgres chart that Concourse depends on.
+- `CONCOURSE_CHART_DIR`: location in the filesystem where a copy of [`the Concourse Helm
 chart`][concourse-helm-chart] exists.
 
 With those set, go to `topgun/k8s` and run Ginkgo:
@@ -578,4 +580,5 @@ pushed commits without the signature.
 [style-guide]: https://github.com/concourse/concourse/wiki/Concourse-Go-Style-Guide
 [how-to-fork]: https://help.github.com/articles/fork-a-repo/
 [how-to-pr]: https://help.github.com/articles/creating-a-pull-request-from-a-fork/
-[concourse-helm-chart]: https://github.com/helm/charts/blob/master/stable/concourse/README.md
+[concourse-helm-chart]: https://github.com/concourse/concourse-chart/blob/master/README.md
+[helm-charts]: https://github.com/helm/charts/blob/master/README.md


### PR DESCRIPTION
# Why do we need this PR?

While trying to accept concourse/concourse-chart#79, I saw the instruction to
run k8s-topgun and I struggled with the existing instructions - they're a bit
off.

# Changes proposed in this pull request

* Most importantly, fix the description of the required environment variables. With that done the instructions at least allow you to run the test suite.
* While doing so, I noticed that the link to the concourse chart was out of date, so I updated it.

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [ ] Documentation reviewed - just the CONTRIBUTING.md
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed - try following the instructions in their current form!
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~