### PR TITLE
atc/db: behaviour: bump last update migration time

### DIFF
--- a/atc/db/migration/migrations/1583868323_add_pipelines_last_update.down.sql
+++ b/atc/db/migration/migrations/1583868323_add_pipelines_last_update.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+  ALTER TABLE pipelines
+    DROP COLUMN "last_updated";
+COMMIT;

--- a/atc/db/migration/migrations/1583868323_add_pipelines_last_update.up.sql
+++ b/atc/db/migration/migrations/1583868323_add_pipelines_last_update.up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+  ALTER TABLE pipelines
+    ADD COLUMN If NOT EXISTS "last_updated" timestamp with time zone NOT NULL DEFAULT '1970-01-01 00:00:00';
+COMMIT;


### PR DESCRIPTION
# Existing Issue

Related to concourse/concourse#5271. Merging this PR and waiting for it to pass CI is actually part of the acceptance criteria.

# Changes proposed in this pull request

* bump timestamp on the migration that went out of date in our smoke environments

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [ ] Code reviewed
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] ~PR acceptance performed~
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~