### PR TITLE
atc/db: behaviour: last_update down is idempotent

### DIFF
--- a/atc/db/migration/migrations/1580135204_add_pipelines_last_update.down.sql
+++ b/atc/db/migration/migrations/1580135204_add_pipelines_last_update.down.sql
@@ -1,4 +1,4 @@
 BEGIN;
   ALTER TABLE pipelines
-    DROP COLUMN "last_updated";
+    DROP COLUMN IF EXISTS "last_updated";
 COMMIT;


### PR DESCRIPTION
# Existing Issue

Related to #5271. Let's not close the issue until the bin-smoke and bosh-smoke jobs are green.

# Changes proposed in this pull request

* We considered the case where the "same" migration would be running twice during an upgrade, but forgot the downgrade case. Here's hoping this covers it!

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [ ] Code reviewed
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] ~PR acceptance performed~
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~