### PR TITLE
atc: create worker dir if not exist when using containerd

### DIFF
--- a/topgun/k8s/garden_config_test.go
+++ b/topgun/k8s/garden_config_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("Garden Config", func() {
@@ -101,29 +100,6 @@ var _ = Describe("Garden Config", func() {
 			<-buildSession.Exited
 
 			Expect(buildSession.ExitCode()).NotTo(Equal(0))
-		})
-	})
-
-	Context("passing the CONCOURSE_GARDEN_USE_CONTAINERD env var to the gdn server with non existing work dir", func() {
-		BeforeEach(func() {
-			helmDeployTestFlags = []string{
-				`--set=worker.replicas=1`,
-				`--set=concourse.worker.garden.useContainerd=true`,
-				`--set=concourse.worker.workDir=/dummy-worker-dir`,
-			}
-		})
-
-		It("creates the worker dir and starts running", func() {
-			pods := getPods(namespace, "--selector=app="+releaseName+"-worker")
-			Expect(pods).To(HaveLen(1))
-
-			args := []string{"exec", pods[0].Metadata.Name, "-n", releaseName, "ls", "--", "/"}
-
-			session := Start(nil, "kubectl", args...)
-			<-session.Exited
-
-			Expect(session.Out).To(gbytes.Say(`dummy-worker-dir`))
-			Expect(session.ExitCode()).To(Equal(0))
 		})
 	})
 })

--- a/worker/integration/README.md
+++ b/worker/integration/README.md
@@ -1,0 +1,22 @@
+## Running The `worker/integration` Test Suite
+
+This test suite only works on Linux. If you're on macOS or Windows you can use
+docker to run the Linux parts of the codebase. Use the following commands to
+run this test suite:
+
+```bash
+$ docker run -v ~/workspace/concourse:/src -it --entrypoint "/bin/bash" golang
+```
+
+The above command will put you in a terminal session inside a container with
+your local Concourse code mounted at `/src`.
+
+To run the tests:
+
+```bash
+$ cd /src/worker/integration
+$ go test
+```
+
+You can leave the container running while you modify your code. Return to the
+container whenever you want to run your tests to see if your changes work.

--- a/worker/integration/integration_test.go
+++ b/worker/integration/integration_test.go
@@ -1,0 +1,57 @@
+package integration_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"io/ioutil"
+	"os"
+
+	"github.com/concourse/concourse/worker/workercmd"
+	"github.com/concourse/flag"
+	"github.com/jessevdk/go-flags"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type WorkerRunnerSuite struct {
+	suite.Suite
+	*require.Assertions
+	wrkcmd workercmd.WorkerCommand
+}
+
+func (s *WorkerRunnerSuite) BeforeTest(suiteName, testName string) {
+	tmpdir, err := ioutil.TempDir("", suiteName+testName)
+	s.NoError(err)
+
+	err = os.Chdir(tmpdir)
+	s.NoError(err)
+
+	parser := flags.NewParser(&s.wrkcmd, flags.HelpFlag|flags.PassDoubleDash)
+	parser.NamespaceDelimiter = "-"
+
+	parser.FindOptionByLongName("baggageclaim-volumes").Required = false
+	parser.FindOptionByLongName("tsa-worker-private-key").Required = false
+	parser.FindOptionByLongName("work-dir").Required = false
+
+	_, err = parser.ParseArgs([]string{""})
+	s.NoError(err)
+
+	signingKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	s.NoError(err)
+
+	s.wrkcmd.TSA.WorkerPrivateKey = &flag.PrivateKey{PrivateKey: signingKey}
+}
+
+func (s *WorkerRunnerSuite) TestWorkDirIsCreated() {
+	s.wrkcmd.WorkDir = "somedir"
+	s.wrkcmd.Garden.UseContainerd = true
+
+	_, err := s.wrkcmd.Runner([]string{})
+	s.NoError(err)
+
+	fileInfo, err := os.Stat("somedir")
+	s.Equal(!os.IsNotExist(err), true)
+	s.Equal(fileInfo.IsDir(), true)
+	s.Equal(fileInfo.Mode().Perm(), os.FileMode(0755))
+	s.NoError(err)
+}

--- a/worker/integration/suite_test.go
+++ b/worker/integration/suite_test.go
@@ -1,0 +1,13 @@
+package integration_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, &WorkerRunnerSuite{
+		Assertions: require.New(t),
+	})
+}

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -88,6 +88,11 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 		bin    = "containerd"
 	)
 
+	err := os.MkdirAll(root, 0755)
+	if err != nil {
+		return nil, err
+	}
+
 	if cmd.Garden.Config.Path() != "" {
 		config = cmd.Garden.Config.Path()
 	} else {


### PR DESCRIPTION
# Existing Issue
Fixes #5294

# Changes proposed in this pull request
Create the worker dir if it does not exist, similar to what concoures does in https://github.com/concourse/concourse/blob/master/worker/workercmd/worker_linux.go#L108-L111

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
