### PR TITLE
remove containerd dependencies from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,25 +10,6 @@ COPY go.mod .
 COPY go.sum .
 RUN grep '^replace' go.mod || go mod download
 
-
-# containerd tooling
-ARG RUNC_VERSION=v1.0.0-rc9
-ARG CNI_VERSION=v0.8.3
-ARG CONTAINERD_VERSION=1.3.2
-
-# make `ctr` target the default concourse namespace
-ENV CONTAINERD_NAMESPACE=concourse
-
-RUN set -x && \
-	apt install -y curl iptables && \
-	curl -sSL https://github.com/containerd/containerd/releases/download/v$CONTAINERD_VERSION/containerd-$CONTAINERD_VERSION.linux-amd64.tar.gz \
-		| tar -zvxf - -C /usr/local/concourse/bin --strip-components=1 && \
-	curl -sSL https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64 \ 
-		-o /usr/local/concourse/bin/runc && chmod +x /usr/local/concourse/bin/runc && \
-	curl -sSL https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION/cni-plugins-linux-amd64-$CNI_VERSION.tgz \
-		| tar -zvxf - -C /usr/local/concourse/bin
-
-
 # build Concourse without using 'packr' and set up a volume so the web assets
 # live-update
 COPY . .


### PR DESCRIPTION
# Existing Issue
Fixes #5295 .

# Why do we need this PR?
To reduce redundancy and possibly conflicting packages for containerd related dependencies in the Docker image. 

The dependencies are now installed in the [concourse/dev image](https://github.com/concourse/ci/blob/master/dockerfiles/dev/Dockerfile) through the [dev-image job](https://github.com/concourse/ci/blob/1719a3d11bc6b70b44e97411849b27ab39410420/pipelines/concourse.yml#L260). That job ensures that the base image used for bringing up Concourse via docker-compose is built with the latest versions of the dependencies.

# Changes proposed in this pull request
* Removed installation of containerd, runc, iptables
* Remove assignment of CONTAINERD_NAMESPACE

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] PR acceptance performed