### PR TITLE
Revert "feat(atc): make pipeline and job badge API routes public"

### DIFF
--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -549,11 +549,10 @@ var _ = Describe("Jobs API", func() {
 			Context("and the pipeline is private", func() {
 				BeforeEach(func() {
 					fakePipeline.PublicReturns(false)
-					fakePipeline.JobReturns(fakeJob, true, nil)
 				})
 
-				It("returns 200", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusOK))
+				It("returns 403", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
 				})
 			})
 

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -589,8 +589,8 @@ var _ = Describe("Pipelines API", func() {
 					BeforeEach(func() {
 						fakeaccess.IsAuthenticatedReturns(true)
 					})
-					It("returns 200", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+					It("returns 403", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusForbidden))
 					})
 				})
 
@@ -599,8 +599,8 @@ var _ = Describe("Pipelines API", func() {
 						fakeaccess.IsAuthenticatedReturns(false)
 					})
 
-					It("returns 200", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
+					It("returns 401", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
 					})
 				})
 			})

--- a/atc/wrappa/api_auth_wrappa.go
+++ b/atc/wrappa/api_auth_wrappa.go
@@ -65,6 +65,8 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 		// pipeline is public or authorized
 		case atc.GetPipeline,
 			atc.GetJobBuild,
+			atc.PipelineBadge,
+			atc.JobBadge,
 			atc.ListJobs,
 			atc.GetJob,
 			atc.ListJobBuilds,
@@ -107,8 +109,6 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.ListAllJobs,
 			atc.ListAllResources,
 			atc.ListBuilds,
-			atc.PipelineBadge,
-			atc.JobBadge,
 			atc.MainJobBadge,
 			atc.GetWall:
 			newHandler = auth.CheckAuthenticationIfProvidedHandler(handler, rejector)

--- a/atc/wrappa/api_auth_wrappa_test.go
+++ b/atc/wrappa/api_auth_wrappa_test.go
@@ -168,6 +168,8 @@ var _ = Describe("APIAuthWrappa", func() {
 				// belongs to public pipeline or authorized
 				atc.GetPipeline:                   openForPublicPipelineOrAuthorized(inputHandlers[atc.GetPipeline]),
 				atc.GetJobBuild:                   openForPublicPipelineOrAuthorized(inputHandlers[atc.GetJobBuild]),
+				atc.PipelineBadge:                 openForPublicPipelineOrAuthorized(inputHandlers[atc.PipelineBadge]),
+				atc.JobBadge:                      openForPublicPipelineOrAuthorized(inputHandlers[atc.JobBadge]),
 				atc.ListJobs:                      openForPublicPipelineOrAuthorized(inputHandlers[atc.ListJobs]),
 				atc.GetJob:                        openForPublicPipelineOrAuthorized(inputHandlers[atc.GetJob]),
 				atc.ListJobBuilds:                 openForPublicPipelineOrAuthorized(inputHandlers[atc.ListJobBuilds]),
@@ -208,8 +210,6 @@ var _ = Describe("APIAuthWrappa", func() {
 				atc.ListAllJobs:          authenticateIfTokenProvided(inputHandlers[atc.ListAllJobs]),
 				atc.ListAllResources:     authenticateIfTokenProvided(inputHandlers[atc.ListAllResources]),
 				atc.ListTeams:            authenticateIfTokenProvided(inputHandlers[atc.ListTeams]),
-				atc.PipelineBadge:        authenticateIfTokenProvided(inputHandlers[atc.PipelineBadge]),
-				atc.JobBadge:             authenticateIfTokenProvided(inputHandlers[atc.JobBadge]),
 				atc.MainJobBadge:         authenticateIfTokenProvided(inputHandlers[atc.MainJobBadge]),
 				atc.GetWall:              authenticateIfTokenProvided(inputHandlers[atc.GetWall]),
 


### PR DESCRIPTION
Reverts concourse/concourse#5252

We do want a change sort of like this but we'll need to talk about it a bit more. For now, just going to revert it as it's backwards-incompatible.

See https://github.com/concourse/concourse/pull/5308#issuecomment-600283564 for details.