### PR TITLE
atc/api: add 'archived' field to pipelines

### DIFF
--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -131,30 +131,12 @@ var _ = Describe("Pipelines API", func() {
 				body, err := ioutil.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(body).To(MatchJSON(`[
-				{
-					"id": 1,
-					"name": "public-pipeline",
-					"paused": true,
-					"public": true,
-					"team_name": "main",
-					"last_updated": 1,
-					"groups": [
-						{
-							"name": "group2",
-							"jobs": ["job3", "job4"],
-							"resources": ["resource3", "resource4"]
-						}
-					]
-				},
-				{
-					"id": 2,
-					"name": "another-pipeline",
-					"paused": true,
-					"public": true,
-					"team_name": "another",
-					"last_updated": 1
-				}]`))
+				var pipelines []map[string]interface{}
+				err = json.Unmarshal(body, &pipelines)
+				Expect(pipelines).To(ConsistOf(
+					HaveKeyWithValue("id", BeNumerically("==", publicPipeline.ID())),
+					HaveKeyWithValue("id", BeNumerically("==", anotherPublicPipeline.ID())),
+				))
 			})
 			It("populates pipeline factory with no team names", func() {
 				Expect(dbPipelineFactory.VisiblePipelinesCallCount()).To(Equal(1))
@@ -174,45 +156,13 @@ var _ = Describe("Pipelines API", func() {
 
 				Expect(dbPipelineFactory.VisiblePipelinesCallCount()).To(Equal(1))
 
-				Expect(body).To(MatchJSON(`[
-				{
-					"id": 3,
-					"name": "private-pipeline",
-					"paused": false,
-					"public": false,
-					"team_name": "main",
-					"last_updated": 1,
-					"groups": [
-						{
-							"name": "group1",
-							"jobs": ["job1", "job2"],
-							"resources": ["resource1", "resource2"]
-						}
-					]
-				},
-				{
-					"id": 1,
-					"name": "public-pipeline",
-					"paused": true,
-					"public": true,
-					"team_name": "main",
-					"last_updated": 1,
-					"groups": [
-						{
-							"name": "group2",
-							"jobs": ["job3", "job4"],
-							"resources": ["resource3", "resource4"]
-						}
-					]
-				},
-				{
-					"id": 2,
-					"name": "another-pipeline",
-					"paused": true,
-					"public": true,
-					"team_name": "another",
-					"last_updated": 1
-				}]`))
+				var pipelines []map[string]interface{}
+				err = json.Unmarshal(body, &pipelines)
+				Expect(pipelines).To(ConsistOf(
+					HaveKeyWithValue("id", BeNumerically("==", publicPipeline.ID())),
+					HaveKeyWithValue("id", BeNumerically("==", privatePipeline.ID())),
+					HaveKeyWithValue("id", BeNumerically("==", anotherPublicPipeline.ID())),
+				))
 			})
 
 			Context("user has the Admin privilege", func() {
@@ -284,38 +234,13 @@ var _ = Describe("Pipelines API", func() {
 			It("returns all team's pipelines", func() {
 				body, err := ioutil.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
+				var pipelines []map[string]interface{}
+				json.Unmarshal(body, &pipelines)
 
-				Expect(body).To(MatchJSON(`[
-					{
-						"id": 3,
-						"name": "private-pipeline",
-						"paused": false,
-						"public": false,
-						"team_name": "main",
-						"last_updated": 1,
-						"groups": [
-							{
-								"name": "group1",
-								"jobs": ["job1", "job2"],
-								"resources": ["resource1", "resource2"]
-							}
-						]
-					},
-					{
-						"id": 1,
-						"name": "public-pipeline",
-						"paused": true,
-						"public": true,
-						"team_name": "main",
-						"last_updated": 1,
-						"groups": [
-							{
-								"name": "group2",
-								"jobs": ["job3", "job4"],
-								"resources": ["resource3", "resource4"]
-							}
-						]
-					}]`))
+				Expect(pipelines).To(ConsistOf(
+					HaveKeyWithValue("id", BeNumerically("==", publicPipeline.ID())),
+					HaveKeyWithValue("id", BeNumerically("==", privatePipeline.ID())),
+				))
 			})
 
 			Context("when the call to get active pipelines fails", func() {
@@ -338,23 +263,12 @@ var _ = Describe("Pipelines API", func() {
 			It("returns only team's public pipelines", func() {
 				body, err := ioutil.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
+				var pipelines []map[string]interface{}
+				json.Unmarshal(body, &pipelines)
 
-				Expect(body).To(MatchJSON(`[
-					{
-						"id": 1,
-						"name": "public-pipeline",
-						"paused": true,
-						"public": true,
-						"team_name": "main",
-						"last_updated": 1,
-						"groups": [
-							{
-								"name": "group2",
-								"jobs": ["job3", "job4"],
-								"resources": ["resource3", "resource4"]
-							}
-						]
-					}]`))
+				Expect(pipelines).To(ConsistOf(
+					HaveKeyWithValue("id", BeNumerically("==", publicPipeline.ID())),
+				))
 			})
 		})
 
@@ -367,23 +281,12 @@ var _ = Describe("Pipelines API", func() {
 			It("returns only team's public pipelines", func() {
 				body, err := ioutil.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
+				var pipelines []map[string]interface{}
+				json.Unmarshal(body, &pipelines)
 
-				Expect(body).To(MatchJSON(`[
-					{
-						"id": 1,
-						"name": "public-pipeline",
-						"paused": true,
-						"public": true,
-						"team_name": "main",
-						"last_updated": 1,
-						"groups": [
-							{
-								"name": "group2",
-								"jobs": ["job3", "job4"],
-								"resources": ["resource3", "resource4"]
-							}
-						]
-					}]`))
+				Expect(pipelines).To(ConsistOf(
+					HaveKeyWithValue("id", BeNumerically("==", publicPipeline.ID())),
+				))
 			})
 		})
 	})

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -115,6 +115,38 @@ var _ = Describe("Pipelines API", func() {
 			Expect(response.Header.Get("Content-Type")).To(Equal("application/json"))
 		})
 
+		It("returns a JSON array of pipeline objects", func() {
+			body, err := ioutil.ReadAll(response.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(body).To(MatchJSON(`[
+				{
+					"id": 1,
+					"name": "public-pipeline",
+					"paused": true,
+					"public": true,
+					"archived": false,
+					"team_name": "main",
+					"last_updated": 1,
+					"groups": [
+						{
+							"name": "group2",
+							"jobs": ["job3", "job4"],
+							"resources": ["resource3", "resource4"]
+						}
+					]
+				},
+				{
+					"id": 2,
+					"name": "another-pipeline",
+					"paused": true,
+					"public": true,
+					"archived": false,
+					"team_name": "another",
+					"last_updated": 1
+				}
+			]`))
+		})
+
 		Context("when team is set in user context", func() {
 			BeforeEach(func() {
 				fakeaccess.TeamNamesReturns([]string{"some-team"})
@@ -138,6 +170,7 @@ var _ = Describe("Pipelines API", func() {
 					HaveKeyWithValue("id", BeNumerically("==", anotherPublicPipeline.ID())),
 				))
 			})
+
 			It("populates pipeline factory with no team names", func() {
 				Expect(dbPipelineFactory.VisiblePipelinesCallCount()).To(Equal(1))
 				Expect(dbPipelineFactory.VisiblePipelinesArgsForCall(0)).To(BeEmpty())
@@ -229,6 +262,45 @@ var _ = Describe("Pipelines API", func() {
 			It("constructs team with provided team name", func() {
 				Expect(dbTeamFactory.FindTeamCallCount()).To(Equal(1))
 				Expect(dbTeamFactory.FindTeamArgsForCall(0)).To(Equal("main"))
+			})
+
+			It("returns a JSON array of pipeline objects", func() {
+				body, err := ioutil.ReadAll(response.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(body).To(MatchJSON(`[
+					{
+						"id": 3,
+						"name": "private-pipeline",
+						"paused": false,
+						"public": false,
+						"archived": false,
+						"team_name": "main",
+						"last_updated": 1,
+						"groups": [
+							{
+								"name": "group1",
+								"jobs": ["job1", "job2"],
+								"resources": ["resource1", "resource2"]
+							}
+						]
+					},
+					{
+						"id": 1,
+						"name": "public-pipeline",
+						"paused": true,
+						"public": true,
+						"archived": false,
+						"team_name": "main",
+						"last_updated": 1,
+						"groups": [
+							{
+								"name": "group2",
+								"jobs": ["job3", "job4"],
+								"resources": ["resource3", "resource4"]
+							}
+						]
+					}
+				]`))
 			})
 
 			It("returns all team's pipelines", func() {
@@ -362,6 +434,7 @@ var _ = Describe("Pipelines API", func() {
 						"name": "some-specific-pipeline",
 						"paused": false,
 						"public": true,
+						"archived": false,
 						"team_name": "a-team",
 						"last_updated": 1,
 						"groups": [

--- a/atc/pipeline.go
+++ b/atc/pipeline.go
@@ -5,6 +5,7 @@ type Pipeline struct {
 	Name        string       `json:"name"`
 	Paused      bool         `json:"paused"`
 	Public      bool         `json:"public"`
+	Archived    bool         `json:"archived"`
 	Groups      GroupConfigs `json:"groups,omitempty"`
 	TeamName    string       `json:"team_name"`
 	LastUpdated int64        `json:"last_updated,omitempty"`

--- a/fly/integration/pipelines_test.go
+++ b/fly/integration/pipelines_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Fly CLI", func() {
                   "name": "pipeline-1-longer",
                   "paused": false,
                   "public": false,
+                  "archived": false,
                   "team_name": "",
                   "last_updated": 1
                 },
@@ -61,6 +62,7 @@ var _ = Describe("Fly CLI", func() {
                   "name": "pipeline-2",
                   "paused": true,
                   "public": false,
+                  "archived": false,
                   "team_name": "",
                   "last_updated": 1
                 },
@@ -69,6 +71,7 @@ var _ = Describe("Fly CLI", func() {
                   "name": "pipeline-3",
                   "paused": false,
                   "public": true,
+                  "archived": false,
                   "team_name": "",
                   "last_updated": 1
                 }
@@ -130,6 +133,7 @@ var _ = Describe("Fly CLI", func() {
                   "name": "pipeline-1-longer",
                   "paused": false,
                   "public": false,
+                  "archived": false,
                   "team_name": "main",
                   "last_updated": 1
                 },
@@ -138,6 +142,7 @@ var _ = Describe("Fly CLI", func() {
                   "name": "pipeline-2",
                   "paused": true,
                   "public": false,
+                  "archived": false,
                   "team_name": "main",
                   "last_updated": 1
                 },
@@ -146,6 +151,7 @@ var _ = Describe("Fly CLI", func() {
                   "name": "pipeline-3",
                   "paused": false,
                   "public": true,
+                  "archived": false,
                   "team_name": "main",
                   "last_updated": 1
                 },
@@ -154,6 +160,7 @@ var _ = Describe("Fly CLI", func() {
                   "name": "foreign-pipeline-1",
                   "paused": false,
                   "public": true,
+                  "archived": false,
                   "team_name": "other",
                   "last_updated": 1
                 },
@@ -162,6 +169,7 @@ var _ = Describe("Fly CLI", func() {
                   "name": "foreign-pipeline-2",
                   "paused": false,
                   "public": true,
+                  "archived": false,
                   "team_name": "other",
                   "last_updated": 1
                 }


### PR DESCRIPTION
# Existing Issue

Fixes #5314.

# Changes proposed in this pull request

* Add 'archived' field to the JSON obejcts in the resposes from the following endpoints:
    * `ListAllPipelines`
    * `ListPipelines`
    * `GetPipeline`
* The value is always `false` for now

# Contributor Checklist
- [ ] Unit tests
- [x] Integration tests (if applicable)
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~