### PR TITLE
Decouple container_sweeper_test assertion to be go version agnostic

### DIFF
--- a/worker/container_sweeper_test.go
+++ b/worker/container_sweeper_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Container Sweeper", func() {
 		})
 
 		It("request to garden times out eventually", func() {
-			Eventually(testLogger.Buffer()).Should(gbytes.Say("failed-to-destroy-container\".*net/http: request canceled \\(Client.Timeout exceeded while awaiting headers\\)"))
+			Eventually(testLogger.Buffer()).Should(gbytes.Say("failed-to-destroy-container\".*\\(Client.Timeout exceeded while awaiting headers\\)"))
 		})
 		It("sweeper continues ticking and GC'ing", func() {
 			// ensure all 4 DELETEs are issues over 2 successive ticks


### PR DESCRIPTION
- go 1.14 changes the error for a http.Client timeout
  the test was too coupled and hence refactored the test to be agnostic

  the format changed from
  `net/http: request canceled (Client.Timeout exceeded while awaiting headers)`
  to
  `context deadline exceeded (Client.Timeout exceeded while awaiting headers)`

Signed-off-by: Sameer Vohra <vohra.sam@gmail.com>

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests

