### PR TITLE
Builds can get stuck in pending state with a mixture of rerun and non rerun builds

### DIFF
--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -617,7 +617,7 @@ func (j *job) GetPendingBuilds() ([]Build, error) {
 			"b.job_id": j.id,
 			"b.status": BuildStatusPending,
 		}).
-		OrderBy("b.id ASC").
+		OrderBy("COALESCE(b.rerun_of, b.id) ASC, b.id ASC").
 		RunWith(j.conn).
 		Query()
 	if err != nil {

--- a/atc/scheduler/algorithm/table_helpers_test.go
+++ b/atc/scheduler/algorithm/table_helpers_test.go
@@ -751,22 +751,6 @@ type setupDB struct {
 	psql sq.StatementBuilderType
 }
 
-func (s setupDB) insertTeamsPipelines() {
-	_, err := s.psql.Insert("teams").
-		Columns("id", "name").
-		Values(s.teamID, "algorithm").
-		Suffix("ON CONFLICT DO NOTHING").
-		Exec()
-	Expect(err).ToNot(HaveOccurred())
-
-	_, err = s.psql.Insert("pipelines").
-		Columns("id", "team_id", "name").
-		Values(s.pipelineID, s.teamID, "algorithm").
-		Suffix("ON CONFLICT DO NOTHING").
-		Exec()
-	Expect(err).ToNot(HaveOccurred())
-}
-
 func (s setupDB) insertJob(jobName string) int {
 	id := s.jobIDs.ID(jobName)
 	_, err := s.psql.Insert("jobs").

--- a/atc/scheduler/build.go
+++ b/atc/scheduler/build.go
@@ -21,7 +21,7 @@ type manualTriggerBuild struct {
 	algorithm Algorithm
 }
 
-func (m *manualTriggerBuild) PrepareInputs(logger lager.Logger) bool {
+func (m *manualTriggerBuild) IsReadyToDetermineInputs(logger lager.Logger) bool {
 	for _, input := range m.jobInputs {
 		resource, found := m.resources.Lookup(input.Resource)
 
@@ -77,7 +77,7 @@ type schedulerBuild struct {
 	db.Build
 }
 
-func (s *schedulerBuild) PrepareInputs(logger lager.Logger) bool {
+func (s *schedulerBuild) IsReadyToDetermineInputs(logger lager.Logger) bool {
 	return true
 }
 
@@ -98,7 +98,7 @@ type rerunBuild struct {
 	db.Build
 }
 
-func (r *rerunBuild) PrepareInputs(logger lager.Logger) bool {
+func (r *rerunBuild) IsReadyToDetermineInputs(logger lager.Logger) bool {
 	return true
 }
 

--- a/atc/scheduler/job_scheduling_test.go
+++ b/atc/scheduler/job_scheduling_test.go
@@ -1,0 +1,396 @@
+package scheduler_test
+
+import (
+	"errors"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbfakes"
+	"github.com/concourse/concourse/atc/scheduler"
+	"github.com/concourse/concourse/atc/scheduler/algorithm"
+	"github.com/concourse/concourse/atc/scheduler/schedulerfakes"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeTable("Job Scheduling",
+	(Example).Run,
+
+	Entry("one pending build that can be successfully started", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{1},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("one pending build that is aborted", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, Aborted: true},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("one pending build that is owned by a paused pipeline", Example{
+		Job: DBJob{
+			PipelinePaused: true,
+
+			Builds: []DBBuild{
+				{ID: 1},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    true,
+		},
+	}),
+
+	Entry("one pending build that is owned by a paused job", Example{
+		Job: DBJob{
+			Paused: true,
+
+			Builds: []DBBuild{
+				{ID: 1},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    true,
+		},
+	}),
+
+	Entry("one pending build that has reached max in flight", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, MaxInFlightReached: true},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    true,
+		},
+	}),
+
+	Entry("one manually triggered pending build that does not have resources checked", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, ManuallyTriggered: true, ResourcesNotChecked: true},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    true,
+		},
+	}),
+
+	Entry("one pending build that does not have inputs determined", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, InputsNotDetermined: true},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("one pending build that cannot create build plan", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, CreatingBuildPlanFails: true},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("one pending build that is unable to start", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, UnableToStart: true},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("one scheduler build, one manually triggered build and one rerun build", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 4, RerunOfBuildID: 1},
+				{ID: 2},
+				{ID: 3, ManuallyTriggered: true},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{4, 2, 3},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("if pending builds is aborted, next build will continue to schedule", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, Aborted: true},
+				{ID: 2},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{2},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("if max in flight is reached, next builds will not schedule", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, MaxInFlightReached: true},
+				{ID: 2},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    true,
+		},
+	}),
+
+	Entry("if resources have not checked for a manually triggered build, next builds will not schedule", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, ManuallyTriggered: true, ResourcesNotChecked: true},
+				{ID: 2},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    true,
+		},
+	}),
+
+	Entry("if the rerun build has no inputs determined, the normal build will continue to get scheduled", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 3, RerunOfBuildID: 1, InputsNotDetermined: true},
+				{ID: 2},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{2},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("if inputs are not determined on a regular build, next builds will not schedule", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 1, InputsNotDetermined: true},
+				{ID: 2},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("if both rerun builds cannot determine inputs, next build will continue to schedule", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 4, RerunOfBuildID: 1, InputsNotDetermined: true},
+				{ID: 3, RerunOfBuildID: 1, InputsNotDetermined: true},
+				{ID: 2},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{2},
+			NeedsRetry:    false,
+		},
+	}),
+
+	Entry("if regular build fails to schedule, next rerun build will not schedule", Example{
+		Job: DBJob{
+			Builds: []DBBuild{
+				{ID: 2, InputsNotDetermined: true},
+				{ID: 4, RerunOfBuildID: 3},
+			},
+		},
+
+		Result: Result{
+			StartedBuilds: []int{},
+			NeedsRetry:    false,
+		},
+	}),
+)
+
+type Example struct {
+	Job    DBJob
+	Result Result
+}
+
+type DBJob struct {
+	Paused         bool
+	PipelinePaused bool
+
+	Builds []DBBuild
+}
+
+type DBBuild struct {
+	ID                int
+	RerunOfBuildID    int
+	ManuallyTriggered bool
+
+	Aborted bool
+
+	InputsNotDetermined bool
+	ResourcesNotChecked bool
+	MaxInFlightReached  bool
+
+	CreatingBuildPlanFails bool
+	UnableToStart          bool
+}
+
+type Result struct {
+	StartedBuilds []int
+	NeedsRetry    bool
+	Errored       bool
+}
+
+func (example Example) Run() {
+	fakeFactory := new(schedulerfakes.FakeBuildFactory)
+	fakeAlgorithm := new(schedulerfakes.FakeAlgorithm)
+	fakeAlgorithm.ComputeReturns(nil, true, false, nil)
+
+	buildStarter := scheduler.NewBuildStarter(fakeFactory, fakeAlgorithm)
+
+	fakeDBResourceType := new(dbfakes.FakeResourceType)
+	fakeDBResourceType.NameReturns("fake-resource-type")
+	fakeDBResourceType.TypeReturns("fake")
+	fakeDBResourceType.SourceReturns(atc.Source{"im": "fake"})
+	fakeDBResourceType.PrivilegedReturns(true)
+	fakeDBResourceType.VersionReturns(atc.Version{"version": "1.2.3"})
+
+	fakeResource := new(dbfakes.FakeResource)
+	fakeResource.NameReturns("fake-resource")
+	fakeResource.TypeReturns("fake-resource-type")
+	fakeResource.SourceReturns(atc.Source{"some": "source"})
+
+	fakePipeline := new(dbfakes.FakePipeline)
+	fakePipeline.NameReturns("some-pipeline")
+	fakePipeline.ResourceTypesReturns(db.ResourceTypes{fakeDBResourceType}, nil)
+
+	if example.Job.PipelinePaused {
+		fakePipeline.CheckPausedReturns(true, nil)
+	} else {
+		fakePipeline.CheckPausedReturns(false, nil)
+	}
+
+	fakeJob := new(dbfakes.FakeJob)
+	fakeJob.ConfigReturns(atc.JobConfig{}, nil)
+	fakeJob.SaveNextInputMappingReturns(nil)
+
+	if example.Job.Paused {
+		fakeJob.PausedReturns(true)
+	} else {
+		fakeJob.PausedReturns(false)
+	}
+
+	var expectedScheduledBuilds []*dbfakes.FakeBuild
+	var pendingBuilds []db.Build
+	for i, build := range example.Job.Builds {
+		fakeBuild := new(dbfakes.FakeBuild)
+		fakeBuild.IDReturns(build.ID)
+		fakeBuild.NameReturns(string(build.ID))
+		fakeBuild.IsAbortedReturns(build.Aborted)
+		fakeBuild.RerunOfReturns(build.RerunOfBuildID)
+		fakeBuild.IsManuallyTriggeredReturns(build.ManuallyTriggered)
+		fakeBuild.FinishReturns(nil)
+
+		if build.MaxInFlightReached {
+			fakeJob.ScheduleBuildReturnsOnCall(i, false, nil)
+		} else {
+			fakeJob.ScheduleBuildReturnsOnCall(i, true, nil)
+		}
+
+		if build.ResourcesNotChecked {
+			fakeBuild.IsNewerThanLastCheckOfReturns(true)
+		} else {
+			fakeBuild.IsNewerThanLastCheckOfReturns(false)
+		}
+
+		if build.InputsNotDetermined {
+			fakeBuild.AdoptInputsAndPipesReturns(nil, false, nil)
+			fakeBuild.AdoptRerunInputsAndPipesReturns(nil, false, nil)
+		} else {
+			fakeBuild.AdoptInputsAndPipesReturns(nil, true, nil)
+			fakeBuild.AdoptRerunInputsAndPipesReturns(nil, true, nil)
+		}
+
+		if build.CreatingBuildPlanFails {
+			fakeFactory.CreateReturns(atc.Plan{}, errors.New("disaster"))
+		} else {
+			fakeFactory.CreateReturns(atc.Plan{}, nil)
+		}
+
+		if build.UnableToStart {
+			fakeBuild.StartReturns(false, nil)
+		} else {
+			fakeBuild.StartReturns(true, nil)
+		}
+
+		expectedScheduledBuilds = append(expectedScheduledBuilds, fakeBuild)
+		pendingBuilds = append(pendingBuilds, fakeBuild)
+	}
+
+	fakeJob.GetPendingBuildsReturns(pendingBuilds, nil)
+
+	jobInputs := []atc.JobInput{
+		{
+			Resource: "fake-resource",
+		},
+	}
+
+	needsRetry, err := buildStarter.TryStartPendingBuildsForJob(lager.NewLogger("job-scheduling-tests"), fakePipeline, fakeJob, jobInputs, db.Resources{fakeResource}, algorithm.NameToIDMap{})
+	if err != nil {
+		Expect(example.Result.Errored).To(BeTrue())
+	} else {
+		Expect(example.Result.Errored).To(BeFalse())
+		Expect(needsRetry).To(Equal(example.Result.NeedsRetry))
+		for i, buildID := range example.Result.StartedBuilds {
+			if expectedScheduledBuilds[i].StartCallCount() > 0 {
+				Expect(expectedScheduledBuilds[i].ID()).To(Equal(buildID))
+				Expect(expectedScheduledBuilds[i].StartCallCount()).To(Equal(1))
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Existing Issue

Fixes #5312 

# Why do we need this PR?
A job configured with serial: true will currently end up with builds stuck in a pending state if a re-run is triggered and then a non-rerun is triggered before the re-run is scheduled.


# Changes proposed in this pull request
This PR will change the way the pending builds are ordered to schedule in order to ensure that the the bug can never happen. It will order the pending builds according to the same ordering as the algorithm, but in ascending order. For example, the pending builds will be ordered 1, 1.1, 1.2, 2 rather than before this change it would've order the rerun builds first in 1.1, 1.2, 1, 2. 

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
