### PR TITLE
Revert "skymarshal: strictly parsing redirect URI"

### DIFF
--- a/skymarshal/skyserver/skyserver.go
+++ b/skymarshal/skyserver/skyserver.go
@@ -227,15 +227,9 @@ func (s *SkyServer) Callback(w http.ResponseWriter, r *http.Request) {
 func (s *SkyServer) Redirect(w http.ResponseWriter, r *http.Request, token *oauth2.Token, redirectURI string) {
 	logger := s.config.Logger.Session("redirect")
 
-	redirectURL, err := url.ParseRequestURI(redirectURI)
+	redirectURL, err := url.Parse(redirectURI)
 	if err != nil {
 		logger.Error("failed-to-parse-redirect-url", err)
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	if redirectURL.Host != "" {
-		logger.Error("invalid-redirect", fmt.Errorf("Unsupported redirect uri: %s", redirectURI))
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -254,10 +248,17 @@ func (s *SkyServer) Redirect(w http.ResponseWriter, r *http.Request, token *oaut
 		return
 	}
 
+	if redirectURL.Host != "" {
+		logger.Error("invalid-redirect", fmt.Errorf("Unsupported redirect uri: %s", redirectURI))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	params := redirectURL.Query()
 	params.Set("csrf_token", csrfToken)
+	redirectURL.RawQuery = params.Encode()
 
-	http.Redirect(w, r, redirectURL.Path+"?"+params.Encode(), http.StatusTemporaryRedirect)
+	http.Redirect(w, r, redirectURL.String(), http.StatusTemporaryRedirect)
 }
 
 func (s *SkyServer) Token(w http.ResponseWriter, r *http.Request) {

--- a/skymarshal/skyserver/skyserver_test.go
+++ b/skymarshal/skyserver/skyserver_test.go
@@ -362,54 +362,18 @@ var _ = Describe("Sky Server API", func() {
 
 						fakeTokenVerifier.VerifyReturns(fakeVerifiedClaims, nil)
 						fakeTokenIssuer.IssueReturns(fakeOAuthToken, nil)
+
+						state, _ := json.Marshal(map[string]string{
+							"redirect_uri": "http://example.com",
+						})
+
+						stateToken := base64.StdEncoding.EncodeToString(state)
+						stateCookie = &http.Cookie{Name: "skymarshal_state", Value: stateToken}
+						reqPath = "/sky/callback?code=some-code&state=" + stateToken
 					})
 
-					Context("when redirect URI is http://example.com", func() {
-						BeforeEach(func() {
-							state, _ := json.Marshal(map[string]string{
-								"redirect_uri": "http://example.com",
-							})
-
-							stateToken := base64.StdEncoding.EncodeToString(state)
-							stateCookie = &http.Cookie{Name: "skymarshal_state", Value: stateToken}
-							reqPath = "/sky/callback?code=some-code&state=" + stateToken
-						})
-
-						It("errors", func() {
-							Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-						})
-					})
-
-					Context("when redirect URI is https:example.com", func() {
-						BeforeEach(func() {
-							state, _ := json.Marshal(map[string]string{
-								"redirect_uri": "https:google.com",
-							})
-
-							stateToken := base64.StdEncoding.EncodeToString(state)
-							stateCookie = &http.Cookie{Name: "skymarshal_state", Value: stateToken}
-							reqPath = "/sky/callback?code=some-code&state=" + stateToken
-						})
-
-						It("doesn't error on Get https:google.com", func() {
-							Expect(response.StatusCode).To(Equal(http.StatusNotFound))
-						})
-					})
-
-					Context("when redirect URI is example.com", func() {
-						BeforeEach(func() {
-							state, _ := json.Marshal(map[string]string{
-								"redirect_uri": "example.com",
-							})
-
-							stateToken := base64.StdEncoding.EncodeToString(state)
-							stateCookie = &http.Cookie{Name: "skymarshal_state", Value: stateToken}
-							reqPath = "/sky/callback?code=some-code&state=" + stateToken
-						})
-
-						It("errors", func() {
-							Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-						})
+					It("errors", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
 					})
 				})
 


### PR DESCRIPTION
The next release should only contains https://github.com/concourse/concourse/pull/5336