### PR TITLE
skymarshal: use escaped path for redirect URI

### DIFF
--- a/skymarshal/skyserver/skyserver.go
+++ b/skymarshal/skyserver/skyserver.go
@@ -266,7 +266,7 @@ func (s *SkyServer) Redirect(w http.ResponseWriter, r *http.Request, token *oaut
 	params := redirectURL.Query()
 	params.Set("csrf_token", csrfToken)
 
-	http.Redirect(w, r, redirectURL.Path+"?"+params.Encode(), http.StatusTemporaryRedirect)
+	http.Redirect(w, r, redirectURL.EscapedPath()+"?"+params.Encode(), http.StatusTemporaryRedirect)
 }
 
 func (s *SkyServer) Token(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
# Why do we need this PR?
Previously concours use `url.String()` for redirect URL, whose path is actually escaped. With the recent fix https://github.com/concourse/concourse/commit/d19f4a560c416e49e086f538759f4aef7eb647b9 changed that. 


# Changes proposed in this pull request
Use the same way to construct redirect URL by escaped path

