### PR TITLE
atc: add flag to disable `ListAllJobs`

### DIFF
--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -192,6 +192,7 @@ var _ = BeforeEach(func() {
 		fakeSecretManager,
 		credsManagers,
 		interceptTimeoutFactory,
+		false,
 	)
 
 	Expect(err).NotTo(HaveOccurred())

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -68,6 +68,7 @@ func NewHandler(
 	secretManager creds.Secrets,
 	credsManagers creds.Managers,
 	interceptTimeoutFactory containerserver.InterceptTimeoutFactory,
+	disableListAllJobs bool,
 ) (http.Handler, error) {
 
 	absCLIDownloadsDir, err := filepath.Abs(cliDownloadsDir)
@@ -80,7 +81,7 @@ func NewHandler(
 	teamHandlerFactory := NewTeamScopedHandlerFactory(logger, dbTeamFactory)
 
 	buildServer := buildserver.NewServer(logger, externalURL, dbTeamFactory, dbBuildFactory, eventHandlerFactory)
-	jobServer := jobserver.NewServer(logger, externalURL, secretManager, dbJobFactory)
+	jobServer := jobserver.NewServer(logger, externalURL, secretManager, dbJobFactory, disableListAllJobs)
 	resourceServer := resourceserver.NewServer(logger, scannerFactory, secretManager, dbResourceFactory, dbResourceConfigFactory)
 
 	versionServer := versionserver.NewServer(logger, externalURL)

--- a/atc/api/jobserver/list_all.go
+++ b/atc/api/jobserver/list_all.go
@@ -12,6 +12,17 @@ import (
 
 func (s *Server) ListAllJobs(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.Session("list-all-jobs")
+	if s.disableListAllJobs {
+		logger.Debug("endpoint-disabled")
+		err := json.NewEncoder(w).Encode([]atc.Job{})
+		if err != nil {
+			logger.Error("failed-to-encode-jobs", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 
 	acc := accessor.GetAccessor(r)
 

--- a/atc/api/jobserver/server.go
+++ b/atc/api/jobserver/server.go
@@ -10,10 +10,11 @@ import (
 type Server struct {
 	logger lager.Logger
 
-	externalURL   string
-	rejector      auth.Rejector
-	secretManager creds.Secrets
-	jobFactory    db.JobFactory
+	externalURL        string
+	rejector           auth.Rejector
+	secretManager      creds.Secrets
+	jobFactory         db.JobFactory
+	disableListAllJobs bool
 }
 
 func NewServer(
@@ -21,12 +22,14 @@ func NewServer(
 	externalURL string,
 	secretManager creds.Secrets,
 	jobFactory db.JobFactory,
+	disableListAllJobs bool,
 ) *Server {
 	return &Server{
-		logger:        logger,
-		externalURL:   externalURL,
-		rejector:      auth.UnauthorizedRejector{},
-		secretManager: secretManager,
-		jobFactory:    jobFactory,
+		logger:             logger,
+		externalURL:        externalURL,
+		rejector:           auth.UnauthorizedRejector{},
+		secretManager:      secretManager,
+		jobFactory:         jobFactory,
+		disableListAllJobs: disableListAllJobs,
 	}
 }

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -192,6 +192,8 @@ type RunCommand struct {
 		AuthFlags     skycmd.AuthFlags
 		MainTeamFlags skycmd.AuthTeamFlags `group:"Authentication (Main Team)" namespace:"main-team"`
 	} `group:"Authentication"`
+
+	DisableListAllJobs bool `long:"disable-list-all-jobs" description:"Disable /api/v1/jobs endpoint, which is known to have performance issues."`
 }
 
 var HelpError = errors.New("must specify one of `--current-db-version`, `--supported-db-version`, or `--migrate-db-to-version`")
@@ -1393,6 +1395,7 @@ func (cmd *RunCommand) constructAPIHandler(
 		secretManager,
 		credsManagers,
 		containerserver.NewInterceptTimeoutFactory(cmd.InterceptIdleTimeout),
+		cmd.DisableListAllJobs,
 	)
 }
 


### PR DESCRIPTION
This endpoint definitely has performance problems, and issues like concourse/concourse#4373 just scratch the surface. With this change, you can pass the `--disable-list-all-jobs` flag or set `CONCOURSE_DISABLE_LIST_ALL_JOBS="true"` and the `/api/v1/jobs` endpoint will always return an empty JSON array. The most significant end-user impact of this change should be that the dashboard will no longer display pipeline previews.