### PR TITLE
Configurable Runner Interval

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -128,7 +128,7 @@ type RunCommand struct {
 	LidarScannerInterval time.Duration `long:"lidar-scanner-interval" default:"1m" description:"Interval on which the resource scanner will run to see if new checks need to be scheduled"`
 	LidarCheckerInterval time.Duration `long:"lidar-checker-interval" default:"10s" description:"Interval on which the resource checker runs any scheduled checks"`
 
-	RunnerInterval time.Duration `long:"runner-interval" default:"10s" description:"Interval on which runners are kicked off for builds, locks, scans, and checks"`
+	ComponentRunnerInterval time.Duration `long:"runner-interval" default:"10s" description:"Interval on which runners are kicked off for builds, locks, scans, and checks"`
 
 	GlobalResourceCheckTimeout time.Duration `long:"global-resource-check-timeout" default:"1h" description:"Time limit on checking for new versions of resources."`
 	ResourceCheckingInterval   time.Duration `long:"resource-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources."`
@@ -869,7 +869,7 @@ func (cmd *RunCommand) constructBackendMembers(
 				dbCheckFactory,
 				engine,
 			),
-			cmd.RunnerInterval,
+			cmd.ComponentRunnerInterval,
 			bus,
 			lockFactory,
 			componentFactory,
@@ -892,7 +892,7 @@ func (cmd *RunCommand) constructBackendMembers(
 				},
 				cmd.JobSchedulingMaxInFlight,
 			),
-			cmd.RunnerInterval,
+			cmd.ComponentRunnerInterval,
 		)},
 		{Name: atc.ComponentBuildTracker, Runner: builds.NewRunner(
 			logger.Session("tracker-runner"),
@@ -902,7 +902,7 @@ func (cmd *RunCommand) constructBackendMembers(
 				dbBuildFactory,
 				engine,
 			),
-			cmd.RunnerInterval,
+			cmd.ComponentRunnerInterval,
 			bus,
 			lockFactory,
 			componentFactory,
@@ -925,7 +925,7 @@ func (cmd *RunCommand) constructBackendMembers(
 			lockFactory,
 			componentFactory,
 			clock.NewClock(),
-			cmd.RunnerInterval,
+			cmd.ComponentRunnerInterval,
 		)},
 	}
 
@@ -944,7 +944,7 @@ func (cmd *RunCommand) constructBackendMembers(
 				lockFactory,
 				componentFactory,
 				clock.NewClock(),
-				cmd.RunnerInterval,
+				cmd.ComponentRunnerInterval,
 			)},
 		)
 	}
@@ -1039,7 +1039,7 @@ func (cmd *RunCommand) constructGCMember(
 				lockFactory,
 				componentFactory,
 				clock.NewClock(),
-				cmd.RunnerInterval,
+				cmd.ComponentRunnerInterval,
 			)},
 		)
 	}
@@ -1407,7 +1407,7 @@ func (cmd *RunCommand) configureComponentIntervals(componentFactory db.Component
 				Interval: cmd.BuildTrackerInterval,
 			}, {
 				Name:     atc.ComponentScheduler,
-				Interval: cmd.RunnerInterval,
+				Interval: 10 * time.Second,
 			}, {
 				Name:     atc.ComponentLidarChecker,
 				Interval: cmd.LidarCheckerInterval,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-js": "webpack --mode production",
     "test": "cd web/elm && elm-test",
     "build-less": "lessc web/assets/css/main.less web/public/main.out.css && cleancss -o web/public/main.css web/public/main.out.css && rm web/public/main.out.css",
-    "build-elm": "cd web/elm && elm make --optimize --output ../public/elm.js src/Main.elm && uglifyjs ../public/elm.js --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe' | uglifyjs --mangle --output=../public/elm.min.js",
+    "build-elm": "cd web/elm && elm make --optimize --output ../public/elm.js src/Main.elm && uglifyjs ../public/elm.js --compress \"pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe\" | uglifyjs --mangle --output=../public/elm.min.js",
     "build-elm-debug": "cd web/elm && elm make --debug --output ../public/elm.js src/Main.elm && uglifyjs < ../public/elm.js > ../public/elm.min.js",
     "update-mdi-svg": "./hack/update-mdi-svg \"node_modules/@mdi/svg/svg\" | tr -d '\n' > web/public/mdi-svg.min.js",
     "benchmark": "cd web/elm && elm make --optimize --output /tmp/benchmark.html benchmarks/Benchmarks.elm && node benchmarks/benchmark.js /tmp/benchmark.html"


### PR DESCRIPTION
# Existing Issue

Fixes https://github.com/concourse/concourse/issues/5333.

# Changes proposed in this pull request
* Small change to package.json to allow for `yarn build` on window's powershell
* Added configurable RunnerInterval to get around hard-coded runner limits of 10s

# Contributor Checklist
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
