### PR TITLE
docker-compose: bump db's shm_size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   db:
     image: postgres
+    shm_size: 1gb
     ports:
     - 6543:5432
     environment:


### PR DESCRIPTION
### Why do we need this PR?

it seems like Postgres by default might need to resize the amount of
shared memory that it uses for performing parallel work.

I've hit this when making 100's of concurrent requests to certain api
endpoints:

	 could not resize shared memory segment "/PostgreSQL.<..>"
	 to $N bytes: No space left on device

after applying the change (which makes docker go from 64MB to 1GB), , I
can then execute those requests w/ no problems.

### Changes proposed in this pull request

bump the default shared memory device size from 64MB to 1GB
