### PR TITLE
Update next build for job for scheduler builds

### DIFF
--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -1876,15 +1876,6 @@ var _ = Describe("Job", func() {
 
 	Describe("EnsurePendingBuildExists", func() {
 		Context("when only a started build exists", func() {
-			BeforeEach(func() {
-				build1, err := job.CreateBuild()
-				Expect(err).NotTo(HaveOccurred())
-
-				started, err := build1.Start(atc.Plan{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(started).To(BeTrue())
-			})
-
 			It("creates a build and updates the next build for the job", func() {
 				err := job.EnsurePendingBuildExists()
 				Expect(err).NotTo(HaveOccurred())

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -1885,13 +1885,17 @@ var _ = Describe("Job", func() {
 				Expect(started).To(BeTrue())
 			})
 
-			It("creates a build", func() {
+			It("creates a build and updates the next build for the job", func() {
 				err := job.EnsurePendingBuildExists()
 				Expect(err).NotTo(HaveOccurred())
 
 				pendingBuilds, err := job.GetPendingBuilds()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pendingBuilds).To(HaveLen(1))
+
+				_, nextBuild, err := job.FinishedAndNextBuild()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pendingBuilds[0].ID()).To(Equal(nextBuild.ID()))
 			})
 
 			It("doesn't create another build the second time it's called", func() {


### PR DESCRIPTION
# Why do we need this PR?
With the changes from #5270, we no longer update the next build ID for a job when a build is started because we rely on the creation of the pending build to update the next build ID. Whenever the scheduler creates a new build, it will call EnsurePendingBuildExists which originally did not update the next build ID. This caused a bug where any builds created by the scheduler will not show up in the next build ID column or be returned back by any api endpoints.

Also the EnsurePendingBuildExists method does not call the `createBuild` method, so it will need to also add the `needs_v6_migration = false` to the query for creating the pending build.

# Changes proposed in this pull request
Update the next build id for a job when a new build is created by the scheduler through EnsurePendingBuildExists. Have any builds created through that method also mark it as does not need v6 migration.


# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
