### PR TITLE
fix(atc): consider empty tag "" as null tag.

### DIFF
--- a/atc/worker/worker.go
+++ b/atc/worker/worker.go
@@ -752,6 +752,15 @@ func (worker *gardenWorker) Uptime() time.Duration {
 }
 
 func (worker *gardenWorker) tagsMatch(tags []string) bool {
+	// Ignore empty tag, so that [""] equals to [].
+	t := []string{}
+	for _, stag := range tags {
+		if len(strings.TrimSpace(stag)) > 0 {
+			t = append(t, stag)
+		}
+	}
+	tags = t
+
 	workerTags := worker.dbWorker.Tags()
 	if len(workerTags) > 0 && len(tags) == 0 {
 		return false

--- a/atc/worker/worker_test.go
+++ b/atc/worker/worker_test.go
@@ -696,6 +696,28 @@ var _ = Describe("Worker", func() {
 					Expect(satisfies).To(BeFalse())
 				})
 			})
+
+			Context("when empty tag is specified", func() {
+				BeforeEach(func() {
+					spec.Tags = []string{""}
+				})
+
+				Context("and the worker has no tag", func() {
+					BeforeEach(func(){
+						tags = []string{}
+					})
+
+					It("returns true", func() {
+						Expect(satisfies).To(BeTrue())
+					})
+				})
+
+				Context("and the worker has tags", func() {
+					It("returns false", func() {
+						Expect(satisfies).To(BeFalse())
+					})
+				})
+			})
 		})
 
 		Context("when the platform is incompatible", func() {


### PR DESCRIPTION
# Existing Issue

Fixes #5354 .


# Changes proposed in this pull request

Ignore empty tags before tag matching.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
