### PR TITLE
web: behaviour: bound cached jobs to 1000

### DIFF
--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -211,6 +211,9 @@ handleCallback callback ( model, effects ) =
                         |> Dict.fromList
                         |> Fetched
 
+                maxJobsInCache =
+                    1000
+
                 mapToJobIds jobsResult =
                     jobsResult
                         |> FetchResult.map (Dict.toList >> List.map Tuple.first)
@@ -222,6 +225,7 @@ handleCallback callback ( model, effects ) =
                 ( newModel |> precomputeJobMetadata
                 , effects
                     ++ [ allJobsInEntireCluster
+                            |> List.take maxJobsInCache
                             |> List.map removeBuild
                             |> SaveCachedJobs
                        ]

--- a/web/elm/tests/DashboardCacheTests.elm
+++ b/web/elm/tests/DashboardCacheTests.elm
@@ -198,6 +198,20 @@ all =
                         )
                     |> Tuple.second
                     |> Common.notContains (SaveCachedJobs [ Data.job 0 ])
+        , test "bounds the number of cached jobs to 1000" <|
+            \_ ->
+                let
+                    firstNJobs n =
+                        List.range 0 (n - 1) |> List.map Data.job
+                in
+                Common.init "/"
+                    |> Application.handleCallback
+                        (AllJobsFetched <|
+                            Ok <|
+                                firstNJobs 2000
+                        )
+                    |> Tuple.second
+                    |> Common.contains (SaveCachedJobs <| firstNJobs 1000)
         , test "saves pipelines to cache when fetched" <|
             \_ ->
                 Common.init "/"

--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -115,7 +115,11 @@ app.ports.saveToLocalStorage.subscribe(function(params) {
     return;
   }
   const [key, value] = params;
-  localStorage.setItem(key, JSON.stringify(value));
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch(err) {
+    console.error(err);
+  }
 });
 
 app.ports.saveToSessionStorage.subscribe(function(params) {
@@ -123,7 +127,11 @@ app.ports.saveToSessionStorage.subscribe(function(params) {
     return;
   }
   const [key, value] = params;
-  sessionStorage.setItem(key, JSON.stringify(value));
+  try {
+    sessionStorage.setItem(key, JSON.stringify(value));
+  } catch(err) {
+    console.error(err);
+  }
 });
 
 app.ports.loadFromLocalStorage.subscribe(function(key) {


### PR DESCRIPTION
# Why do we need this PR?

#5262 introduced a bug if there were many thousands of jobs - the `localStorage` capacity could be exceeded, causing Javascript to error and the UI to break.

# Changes proposed in this pull request

* Bound the number of jobs cached to 1000. Based on some numbers I've seen (on Hush House), this equated to around 1MB (compared to the localStorage limit of 5-10MB, depending on the browser)
* Catch errors when writing to localStorage/sessionStorage, so even if that still manages to exceed the limit, we can handle that case gracefully

# Contributor Checklist
- [x] Unit tests


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] PR acceptance performed