### PR TITLE
dockerfile: mount go build cache when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,53 @@
+# syntax = docker/dockerfile:experimental
+
 # NOTE: this Dockerfile is purely for local development! it is *not* used for
 # the official 'concourse/concourse' image.
+#
+# Usage:
+#
+#  1. enable `buildkit` in dockerd (`/etc/docker/daemon.json` in linux or daemon
+#  preferences in macOS):
+#
+#	{"experimental": true, "features": {"buildkit": true}}
+#
+#
+#  2. build the image
+#
+#	with docker:
+#	
+#		docker build -t concourse/concourse:local .
+#
+#	with docker-compose
+#
+#		COMPOSE_DOCKER_CLI_BUILD=true docker-compose build
+#
 
 FROM concourse/dev
 
-
-# download go modules separately so this doesn't re-run on every change
 WORKDIR /src
-COPY go.mod .
-COPY go.sum .
-RUN grep '^replace' go.mod || go mod download
-
-# build Concourse without using 'packr' and set up a volume so the web assets
-# live-update
 COPY . .
-RUN go build -gcflags=all="-N -l" -o /usr/local/concourse/bin/concourse \
-      ./cmd/concourse
+
+# build concourse and containerd's init
+RUN \
+	--mount=type=cache,target=/root/.cache/go-build \
+	--mount=type=cache,target=/go/pkg/mod \
+	set -ex && \
+		go build -gcflags=all="-N -l" \
+			-o /usr/local/concourse/bin/concourse \
+			./cmd/concourse && \
+		gcc -O2 -static \
+			-o /usr/local/concourse/bin/init \
+			./cmd/init/init.c
+
+
+# have a volume at runtime so that assets live-update
 VOLUME /src
 
 
-# build the init executable for containerd
-RUN  set -x && \
-	gcc -O2 -static -o /usr/local/concourse/bin/init ./cmd/init/init.c
-
-
 # generate keys (with 1024 bits just so they generate faster)
-RUN mkdir -p /concourse-keys
-RUN concourse generate-key -t rsa -b 1024 -f /concourse-keys/session_signing_key
-RUN concourse generate-key -t ssh -b 1024 -f /concourse-keys/tsa_host_key
-RUN concourse generate-key -t ssh -b 1024 -f /concourse-keys/worker_key
-RUN cp /concourse-keys/worker_key.pub /concourse-keys/authorized_worker_keys
+RUN set -ex && \
+	mkdir -p /concourse-keys && \
+	concourse generate-key -t rsa -b 1024 -f /concourse-keys/session_signing_key && \
+	concourse generate-key -t ssh -b 1024 -f /concourse-keys/tsa_host_key && \
+	concourse generate-key -t ssh -b 1024 -f /concourse-keys/worker_key && \
+	cp /concourse-keys/worker_key.pub /concourse-keys/authorized_worker_keys


### PR DESCRIPTION



### Why do we need this PR?

even though `concourse/dev` warms both module and build caches, when
developing, these quickly get invalidated and never refreshed during
subsequent runs.

this means that iterating with `docker-compose` locally can be quite
time-consuming.


### Changes proposed in this pull request

by leveraging local mounts that the experimental dockerfile buildkit
frontend brings (see [1]), we can have a volume mount that keeps both
the build and module caches around.

unfortunately, such feature is not enabled by default - a little bit of
setup is necessary.

```
Usage:

 1. enable `buildkit` in dockerd (`/etc/docker/daemon.json` in linux or daemon
 preferences in macOS):

      {"experimental": true, "features": {"buildkit": true}}


 2. build the image

      with docker:

        docker build -t concourse/concourse:local .

      with docker-compose

        COMPOSE_DOCKER_CLI_BUILD=true docker-compose build
```

[1] - https://docs.docker.com/develop/develop-images/build_enhancements/
