### PR TITLE
web: structure: use Data.pipeline in tests

### DIFF
--- a/web/elm/tests/DashboardPreviewTests.elm
+++ b/web/elm/tests/DashboardPreviewTests.elm
@@ -6,6 +6,7 @@ import Common exposing (defineHoverBehaviour, isColorWithStripes, queryView)
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Dashboard.DashboardPreview as DP
+import Data
 import Expect
 import Message.Callback as Callback
 import Message.Message exposing (DomID(..))
@@ -192,20 +193,8 @@ dashboardWithJob j =
         |> Application.handleCallback
             (Callback.AllPipelinesFetched <|
                 Ok
-                    [ { id = 0
-                      , name = "pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
-                    , { id = 1
-                      , name = "other"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
+                    [ Data.pipeline "team" 0 |> Data.withName "pipeline"
+                    , Data.pipeline "team" 1 |> Data.withName "other"
                     ]
             )
         |> Tuple.first

--- a/web/elm/tests/DashboardSearchTests.elm
+++ b/web/elm/tests/DashboardSearchTests.elm
@@ -4,6 +4,7 @@ import Application.Application as Application
 import Common exposing (queryView)
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
+import Data
 import Expect exposing (Expectation)
 import Message.Callback as Callback
 import Message.Message
@@ -80,20 +81,8 @@ hasData =
             |> Application.handleCallback
                 (Callback.AllPipelinesFetched <|
                     Ok
-                        [ { id = 0
-                          , name = "pipeline"
-                          , paused = False
-                          , public = True
-                          , teamName = "team1"
-                          , groups = []
-                          }
-                        , { id = 1
-                          , name = "other-pipeline"
-                          , paused = False
-                          , public = True
-                          , teamName = "team1"
-                          , groups = []
-                          }
+                        [ Data.pipeline "team1" 0 |> Data.withName "pipeline"
+                        , Data.pipeline "team1" 1 |> Data.withName "other-pipeline"
                         ]
                 )
             |> Tuple.first
@@ -184,14 +173,7 @@ hasData =
                 >> Application.handleCallback
                     (Callback.AllPipelinesFetched <|
                         Ok
-                            [ { id = 0
-                              , name = "pipeline"
-                              , paused = False
-                              , public = True
-                              , teamName = "team"
-                              , groups = []
-                              }
-                            ]
+                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                     )
                 >> Tuple.first
                 >> Application.update

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -38,6 +38,7 @@ import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.Cli as Cli
 import Concourse.PipelineStatus exposing (PipelineStatus(..))
+import Data
 import Dict
 import Expect exposing (Expectation)
 import Html.Attributes as Attr
@@ -356,14 +357,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -382,14 +376,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -408,14 +395,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -432,14 +412,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -456,14 +429,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -483,14 +449,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -510,14 +469,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -540,14 +492,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -563,14 +508,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> afterSeconds 6
@@ -600,14 +538,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Application.update
@@ -622,14 +553,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> givenDataUnauthenticated []
@@ -642,14 +566,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "a-pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "a-pipeline" ]
                         )
                     |> Tuple.first
                     |> givenDataUnauthenticated []
@@ -695,14 +612,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -750,14 +660,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Expect.all
                         [ Tuple.second
@@ -789,14 +692,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Application.update (ApplicationMsgs.Update Msgs.FocusMsg)
@@ -876,14 +772,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -902,14 +791,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -924,14 +806,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -946,14 +821,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -968,14 +836,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -990,14 +851,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1012,14 +866,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1038,14 +885,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1072,14 +912,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "owner-team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "owner-team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1099,14 +932,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1125,14 +951,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1149,14 +968,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1173,14 +985,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1197,14 +1002,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1221,14 +1019,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1241,14 +1032,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1270,14 +1054,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1294,14 +1071,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1315,14 +1085,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1342,14 +1105,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Application.update
@@ -1369,14 +1125,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1390,14 +1139,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1444,14 +1186,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1468,14 +1203,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1492,14 +1220,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Application.update
@@ -1522,14 +1243,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Application.update
@@ -1548,14 +1262,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1577,14 +1284,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1601,14 +1301,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1652,14 +1345,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1724,14 +1410,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -1755,14 +1434,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -1777,14 +1449,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -1804,14 +1469,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1910,14 +1568,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                         , query = Common.queryView >> Query.find [ id "cli-osx" ]
@@ -1956,14 +1607,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                         , query =
@@ -2006,14 +1650,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                         , query =
@@ -2062,14 +1699,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> afterSeconds 6
@@ -2083,14 +1713,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> afterSeconds 6
@@ -2108,14 +1731,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Application.update
@@ -2342,28 +1958,6 @@ givenClusterInfo version clusterName =
         (Callback.ClusterInfoFetched <|
             Ok { version = version, clusterName = clusterName }
         )
-
-
-onePipeline : String -> Concourse.Pipeline
-onePipeline teamName =
-    { id = 0
-    , name = "pipeline"
-    , paused = False
-    , public = True
-    , teamName = teamName
-    , groups = []
-    }
-
-
-onePipelinePaused : String -> Concourse.Pipeline
-onePipelinePaused teamName =
-    { id = 0
-    , name = "pipeline"
-    , paused = True
-    , public = True
-    , teamName = teamName
-    , groups = []
-    }
 
 
 apiData : List ( String, List String ) -> List Concourse.Team

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -11,10 +11,10 @@ module Data exposing
     , teamName
     , version
     , versionedResource
+    , withGroups
     , withName
     , withPaused
     , withPublic
-    , withGroups
     )
 
 import Concourse
@@ -94,6 +94,7 @@ withPublic public p =
 withName : String -> { r | name : String } -> { r | name : String }
 withName name p =
     { p | name = name }
+
 
 withGroups : List Concourse.PipelineGroup -> { r | groups : List Concourse.PipelineGroup } -> { r | groups : List Concourse.PipelineGroup }
 withGroups groups p =

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -11,6 +11,10 @@ module Data exposing
     , teamName
     , version
     , versionedResource
+    , withName
+    , withPaused
+    , withPublic
+    , withGroups
     )
 
 import Concourse
@@ -75,6 +79,25 @@ pipeline team id =
     , teamName = team
     , groups = []
     }
+
+
+withPaused : Bool -> { r | paused : Bool } -> { r | paused : Bool }
+withPaused paused p =
+    { p | paused = paused }
+
+
+withPublic : Bool -> { r | public : Bool } -> { r | public : Bool }
+withPublic public p =
+    { p | public = public }
+
+
+withName : String -> { r | name : String } -> { r | name : String }
+withName name p =
+    { p | name = name }
+
+withGroups : List Concourse.PipelineGroup -> { r | groups : List Concourse.PipelineGroup } -> { r | groups : List Concourse.PipelineGroup }
+withGroups groups p =
+    { p | groups = groups }
 
 
 job : Int -> Concourse.Job

--- a/web/elm/tests/DragAndDropTests.elm
+++ b/web/elm/tests/DragAndDropTests.elm
@@ -2,6 +2,7 @@ module DragAndDropTests exposing (all)
 
 import Application.Application as Application
 import Common exposing (given, then_, when)
+import Data
 import Dict exposing (Dict)
 import Expect exposing (Expectation)
 import Http
@@ -185,14 +186,7 @@ myBrowserFetchedOnePipeline =
     Application.handleCallback
         (Callback.AllPipelinesFetched <|
             Ok
-                [ { id = 0
-                  , name = "pipeline"
-                  , paused = False
-                  , public = True
-                  , teamName = "team"
-                  , groups = []
-                  }
-                ]
+                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
         )
 
 
@@ -200,20 +194,8 @@ myBrowserFetchedTwoPipelines =
     Application.handleCallback
         (Callback.AllPipelinesFetched <|
             Ok
-                [ { id = 0
-                  , name = "pipeline"
-                  , paused = False
-                  , public = True
-                  , teamName = "team"
-                  , groups = []
-                  }
-                , { id = 1
-                  , name = "other-pipeline"
-                  , paused = False
-                  , public = True
-                  , teamName = "team"
-                  , groups = []
-                  }
+                [ Data.pipeline "team" 0 |> Data.withName "pipeline"
+                , Data.pipeline "team" 1 |> Data.withName "other-pipeline"
                 ]
         )
 
@@ -222,27 +204,9 @@ myBrowserFetchedPipelinesFromMultipleTeams =
     Application.handleCallback
         (Callback.AllPipelinesFetched <|
             Ok
-                [ { id = 0
-                  , name = "pipeline"
-                  , paused = False
-                  , public = True
-                  , teamName = "team"
-                  , groups = []
-                  }
-                , { id = 1
-                  , name = "other-pipeline"
-                  , paused = False
-                  , public = True
-                  , teamName = "team"
-                  , groups = []
-                  }
-                , { id = 2
-                  , name = "third-pipeline"
-                  , paused = False
-                  , public = True
-                  , teamName = "other-team"
-                  , groups = []
-                  }
+                [ Data.pipeline "team" 0 |> Data.withName "pipeline"
+                , Data.pipeline "team" 1 |> Data.withName "other-pipeline"
+                , Data.pipeline "other-team" 2 |> Data.withName "third-pipeline"
                 ]
         )
 
@@ -452,20 +416,8 @@ dashboardRefreshPipelines =
         >> Application.handleCallback
             (Callback.PipelinesFetched <|
                 Ok
-                    [ { id = 0
-                      , name = "pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
-                    , { id = 1
-                      , name = "other-pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
+                    [ Data.pipeline "team" 0 |> Data.withName "pipeline"
+                    , Data.pipeline "team" 1 |> Data.withName "other-pipeline"
                     ]
             )
 

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -61,14 +61,7 @@ all =
                     >> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     >> Tuple.first
                     >> Application.handleDelivery
@@ -91,14 +84,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "other-team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "other-team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -208,14 +194,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -232,14 +211,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Application.update
@@ -259,14 +231,7 @@ all =
                     |> Application.handleDelivery
                         (CachedPipelinesReceived <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -283,14 +248,7 @@ all =
                     |> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -315,14 +273,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -381,14 +332,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -402,13 +346,9 @@ all =
                             |> Application.handleDelivery
                                 (CachedPipelinesReceived <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = True
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
+                                        [ Data.pipeline "team" 0
+                                            |> Data.withName "pipeline"
+                                            |> Data.withPaused True
                                         ]
                                 )
                             |> Tuple.first
@@ -423,13 +363,9 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = True
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
+                                        [ Data.pipeline "team" 0
+                                            |> Data.withName "pipeline"
+                                            |> Data.withPaused True
                                         ]
                                 )
                             |> Tuple.first
@@ -461,14 +397,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -551,14 +480,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -602,14 +524,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -625,14 +540,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -646,13 +554,9 @@ all =
                                 |> Application.handleDelivery
                                     (CachedPipelinesReceived <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = True
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
+                                            [ Data.pipeline "team" 0
+                                                |> Data.withName "pipeline"
+                                                |> Data.withPaused True
                                             ]
                                     )
                                 |> Tuple.first
@@ -667,13 +571,9 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = True
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
+                                            [ Data.pipeline "team" 0
+                                                |> Data.withName "pipeline"
+                                                |> Data.withPaused True
                                             ]
                                     )
                                 |> Tuple.first
@@ -705,14 +605,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -795,14 +688,7 @@ all =
                                     |> Application.handleCallback
                                         (Callback.AllPipelinesFetched <|
                                             Ok
-                                                [ { id = 0
-                                                  , name = "pipeline"
-                                                  , paused = False
-                                                  , public = True
-                                                  , teamName = "team"
-                                                  , groups = []
-                                                  }
-                                                ]
+                                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                         )
                                     |> Tuple.first
                                     |> Common.queryView
@@ -850,14 +736,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -875,14 +754,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "other-team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "other-team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1014,14 +886,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -1097,14 +962,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Application.handleCallback
@@ -1132,14 +990,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1182,14 +1033,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1215,14 +1059,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1243,14 +1080,7 @@ all =
                         |> Application.handleCallback
                             (Callback.AllPipelinesFetched <|
                                 Ok
-                                    [ { id = 0
-                                      , name = "pipeline"
-                                      , paused = False
-                                      , public = True
-                                      , teamName = "team"
-                                      , groups = []
-                                      }
-                                    ]
+                                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
                         |> Common.queryView
@@ -1283,13 +1113,9 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = True
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
+                                            [ Data.pipeline "team" 0
+                                                |> Data.withName "pipeline"
+                                                |> Data.withPaused True
                                             ]
                                     )
                                 |> Tuple.first
@@ -1341,13 +1167,9 @@ all =
                                 |> Application.handleDelivery
                                     (CachedPipelinesReceived <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = True
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
+                                            [ Data.pipeline "team" 0
+                                                |> Data.withName "pipeline"
+                                                |> Data.withPaused True
                                             ]
                                     )
                                 |> Tuple.first
@@ -1473,14 +1295,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> afterSeconds 1
@@ -2000,14 +1815,7 @@ all =
                                     >> Application.handleCallback
                                         (Callback.AllPipelinesFetched <|
                                             Ok
-                                                [ { id = 0
-                                                  , name = "pipeline"
-                                                  , paused = False
-                                                  , public = True
-                                                  , teamName = "team"
-                                                  , groups = []
-                                                  }
-                                                ]
+                                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                         )
 
                             whenAuthorizedNonPublic =
@@ -2020,13 +1828,9 @@ all =
                                     >> Application.handleCallback
                                         (Callback.AllPipelinesFetched <|
                                             Ok
-                                                [ { id = 0
-                                                  , name = "pipeline"
-                                                  , paused = False
-                                                  , public = False
-                                                  , teamName = "team"
-                                                  , groups = []
-                                                  }
+                                                [ Data.pipeline "team" 0
+                                                    |> Data.withName "pipeline"
+                                                    |> Data.withPublic False
                                                 ]
                                         )
                         in
@@ -2047,14 +1851,7 @@ all =
                                     >> Application.handleCallback
                                         (Callback.AllPipelinesFetched <|
                                             Ok
-                                                [ { id = 0
-                                                  , name = "pipeline"
-                                                  , paused = False
-                                                  , public = True
-                                                  , teamName = "team"
-                                                  , groups = []
-                                                  }
-                                                ]
+                                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                         )
 
                             whenUnauthorizedNonPublic =
@@ -2067,13 +1864,9 @@ all =
                                     >> Application.handleCallback
                                         (Callback.AllPipelinesFetched <|
                                             Ok
-                                                [ { id = 0
-                                                  , name = "pipeline"
-                                                  , paused = False
-                                                  , public = False
-                                                  , teamName = "team"
-                                                  , groups = []
-                                                  }
+                                                [ Data.pipeline "team" 0
+                                                    |> Data.withName "pipeline"
+                                                    |> Data.withPublic False
                                                 ]
                                         )
                         in
@@ -2092,14 +1885,7 @@ all =
                                     >> Application.handleCallback
                                         (Callback.AllPipelinesFetched <|
                                             Ok
-                                                [ { id = 0
-                                                  , name = "pipeline"
-                                                  , paused = False
-                                                  , public = True
-                                                  , teamName = "team"
-                                                  , groups = []
-                                                  }
-                                                ]
+                                                [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                         )
                         in
                         [ describe "on public pipeline" <|
@@ -2116,14 +1902,7 @@ all =
                             |> Application.handleCallback
                                 (Callback.AllPipelinesFetched <|
                                     Ok
-                                        [ { id = 0
-                                          , name = "pipeline"
-                                          , paused = False
-                                          , public = True
-                                          , teamName = "team"
-                                          , groups = []
-                                          }
-                                        ]
+                                        [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                 )
                             |> Tuple.first
                             |> Common.queryView
@@ -2146,14 +1925,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -2178,14 +1950,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -2207,14 +1972,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -2237,14 +1995,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                         , query =
@@ -2293,13 +2044,9 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = True
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
+                                            [ Data.pipeline "team" 0
+                                                |> Data.withName "pipeline"
+                                                |> Data.withPaused True
                                             ]
                                     )
                                 |> Tuple.first
@@ -2348,14 +2095,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -2384,14 +2124,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Application.update
@@ -2416,14 +2149,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Application.update
@@ -2452,14 +2178,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Application.update
@@ -2489,14 +2208,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ { id = 0
-                                              , name = "pipeline"
-                                              , paused = False
-                                              , public = True
-                                              , teamName = "team"
-                                              , groups = []
-                                              }
-                                            ]
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Application.update

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -5,6 +5,7 @@ import Assets
 import Char
 import Common exposing (defineHoverBehaviour)
 import Concourse.Cli exposing (Cli(..))
+import Data
 import Expect exposing (..)
 import Html.Attributes as Attr
 import Json.Encode
@@ -88,14 +89,11 @@ all =
                         |> Tuple.first
                         |> Application.handleCallback
                             (Callback.PipelineFetched
-                                (Ok
-                                    { id = 0
-                                    , name = "pipeline"
-                                    , paused = False
-                                    , public = True
-                                    , teamName = "team"
-                                    , groups = groups
-                                    }
+                                (Ok <|
+                                    (Data.pipeline "team" 0
+                                        |> Data.withName "pipeline"
+                                        |> Data.withGroups groups
+                                    )
                                 )
                             )
                         |> Tuple.first
@@ -548,14 +546,11 @@ all =
                     Common.init "/teams/team/pipelines/pipeline"
                         |> Application.handleCallback
                             (Callback.PipelineFetched
-                                (Ok
-                                    { id = 0
-                                    , name = "pipeline"
-                                    , paused = True
-                                    , public = True
-                                    , teamName = "team"
-                                    , groups = []
-                                    }
+                                (Ok <|
+                                    (Data.pipeline "team" 0
+                                        |> Data.withName "pipeline"
+                                        |> Data.withPaused True
+                                    )
                                 )
                             )
                         |> Tuple.first

--- a/web/elm/tests/SideBar/PipelineTests.elm
+++ b/web/elm/tests/SideBar/PipelineTests.elm
@@ -2,6 +2,7 @@ module SideBar.PipelineTests exposing (all)
 
 import Colors
 import Common
+import Data
 import Expect
 import HoverState exposing (TooltipPosition(..))
 import Html exposing (Html)
@@ -112,13 +113,7 @@ pipeline { active, hovered } =
 
 
 singlePipeline =
-    { id = 1
-    , name = "pipeline"
-    , paused = False
-    , public = True
-    , teamName = "team"
-    , groups = []
-    }
+    Data.pipeline "team" 0 |> Data.withName "pipeline"
 
 
 pipelineIcon : Html Message -> Query.Single Message

--- a/web/elm/tests/SideBar/TeamTests.elm
+++ b/web/elm/tests/SideBar/TeamTests.elm
@@ -1,6 +1,7 @@
 module SideBar.TeamTests exposing (all)
 
 import Common
+import Data
 import Expect
 import HoverState exposing (TooltipPosition(..))
 import Html exposing (Html)
@@ -300,14 +301,7 @@ team { active, expanded, hovered } =
                 HoverState.NoHover
 
         pipelines =
-            [ { id = 1
-              , name = "pipeline"
-              , paused = False
-              , public = True
-              , teamName = "team"
-              , groups = []
-              }
-            ]
+            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
 
         activePipeline =
             if active then

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -16,6 +16,7 @@ import Common
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import DashboardTests
+import Data
 import Dict
 import Expect
 import Html.Attributes as Attr
@@ -756,20 +757,8 @@ apiDataLoads =
         >> Application.handleCallback
             (Callback.AllPipelinesFetched <|
                 Ok
-                    [ { id = 0
-                      , name = "pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
-                    , { id = 1
-                      , name = "other-pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
+                    [ Data.pipeline "team" 0 |> Data.withName "pipeline"
+                    , Data.pipeline "team" 1 |> Data.withName "other-pipeline"
                     ]
             )
 
@@ -780,20 +769,8 @@ dataRefreshes =
         >> Application.handleCallback
             (Callback.AllPipelinesFetched <|
                 Ok
-                    [ { id = 0
-                      , name = "pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
-                    , { id = 1
-                      , name = "other-pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
+                    [ Data.pipeline "team" 0 |> Data.withName "pipeline"
+                    , Data.pipeline "team" 1 |> Data.withName "other-pipeline"
                     ]
             )
 
@@ -1216,22 +1193,6 @@ iShrankTheViewport =
     Tuple.first >> Application.handleDelivery (Subscription.WindowResized 300 300)
 
 
-thePipelineIsPaused =
-    Tuple.first
-        >> Application.handleCallback
-            (Callback.PipelineFetched
-                (Ok
-                    { id = 1
-                    , name = "pipeline"
-                    , paused = True
-                    , public = True
-                    , teamName = "team"
-                    , groups = []
-                    }
-                )
-            )
-
-
 iAmLookingAtTheHamburgerIcon =
     iAmLookingAtTheHamburgerMenu
         >> Query.children []
@@ -1284,34 +1245,10 @@ myBrowserFetchedPipelinesFromMultipleTeams =
         >> Application.handleCallback
             (Callback.AllPipelinesFetched <|
                 Ok
-                    [ { id = 0
-                      , name = "pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
-                    , { id = 1
-                      , name = "other-pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
-                    , { id = 2
-                      , name = "yet-another-pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
-                    , { id = 3
-                      , name = "yet-another-pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "other-team"
-                      , groups = []
-                      }
+                    [ Data.pipeline "team" 0 |> Data.withName "pipeline"
+                    , Data.pipeline "team" 1 |> Data.withName "other-pipeline"
+                    , Data.pipeline "team" 2 |> Data.withName "yet-another-pipeline"
+                    , Data.pipeline "other-team" 3 |> Data.withName "yet-another-pipeline"
                     ]
             )
 
@@ -1321,20 +1258,8 @@ myBrowserFetchedPipelines =
         >> Application.handleCallback
             (Callback.AllPipelinesFetched <|
                 Ok
-                    [ { id = 0
-                      , name = "pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
-                    , { id = 1
-                      , name = "other-pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
+                    [ Data.pipeline "team" 0 |> Data.withName "pipeline"
+                    , Data.pipeline "team" 1 |> Data.withName "other-pipeline"
                     ]
             )
 
@@ -1628,14 +1553,7 @@ iAmLookingAtAOneOffBuildPageOnANonPhoneScreen =
         >> Application.handleCallback
             (Callback.AllPipelinesFetched
                 (Ok
-                    [ { id = 0
-                      , name = "pipeline"
-                      , paused = False
-                      , public = True
-                      , teamName = "team"
-                      , groups = []
-                      }
-                    ]
+                    [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                 )
             )
         >> Tuple.first

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -2,6 +2,7 @@ module SideBarTests exposing (all)
 
 import Browser.Dom
 import Common
+import Data
 import Expect
 import HoverState
 import Message.Callback as Callback exposing (TooltipPolicy(..))
@@ -40,14 +41,7 @@ model =
     { expandedTeams = Set.fromList [ "team" ]
     , pipelines =
         RemoteData.Success
-            [ { id = 0
-              , name = "pipeline"
-              , paused = False
-              , public = True
-              , teamName = "team"
-              , groups = []
-              }
-            ]
+            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
     , hovered = HoverState.NoHover
     , isSideBarOpen = True
     , screenSize = ScreenSize.Desktop

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -7,6 +7,7 @@ import Common exposing (defineHoverBehaviour, queryView)
 import Concourse
 import Dashboard.SearchBar as SearchBar
 import DashboardTests exposing (iconSelector)
+import Data
 import Dict
 import Expect exposing (..)
 import Html.Attributes as Attr
@@ -326,14 +327,11 @@ all =
             , context "when pipeline is paused"
                 (Application.handleCallback
                     (Callback.PipelineFetched <|
-                        Ok
-                            { id = 0
-                            , name = "p"
-                            , paused = True
-                            , public = True
-                            , teamName = "t"
-                            , groups = []
-                            }
+                        Ok <|
+                            (Data.pipeline "t" 0
+                                |> Data.withName "p"
+                                |> Data.withPaused True
+                            )
                     )
                     >> Tuple.first
                     >> Application.handleCallback
@@ -579,14 +577,7 @@ all =
                 |> Application.handleCallback
                     (Callback.AllPipelinesFetched <|
                         Ok
-                            [ { id = 0
-                              , name = "pipeline"
-                              , paused = False
-                              , public = True
-                              , teamName = "team1"
-                              , groups = []
-                              }
-                            ]
+                            [ Data.pipeline "team1" 0 |> Data.withName "pipeline" ]
                     )
                 |> Tuple.first
             )
@@ -630,14 +621,7 @@ all =
                 |> Application.handleCallback
                     (Callback.AllPipelinesFetched <|
                         Ok
-                            [ { id = 0
-                              , name = "pipeline"
-                              , paused = False
-                              , public = True
-                              , teamName = "team1"
-                              , groups = []
-                              }
-                            ]
+                            [ Data.pipeline "team1" 0 |> Data.withName "pipeline" ]
                     )
                 |> Tuple.first
             )
@@ -911,14 +895,7 @@ all =
                 |> Application.handleCallback
                     (Callback.AllPipelinesFetched <|
                         Ok
-                            [ { id = 0
-                              , name = "pipeline"
-                              , paused = False
-                              , public = True
-                              , teamName = "team1"
-                              , groups = []
-                              }
-                            ]
+                            [ Data.pipeline "team1" 0 |> Data.withName "pipeline" ]
                     )
                 |> Tuple.first
             )
@@ -988,14 +965,7 @@ all =
                 |> Application.handleCallback
                     (Callback.AllPipelinesFetched <|
                         Ok
-                            [ { id = 0
-                              , name = "pipeline"
-                              , paused = False
-                              , public = True
-                              , teamName = "team1"
-                              , groups = []
-                              }
-                            ]
+                            [ Data.pipeline "team1" 0 |> Data.withName "pipeline" ]
                     )
                 |> Tuple.first
             )
@@ -1039,14 +1009,7 @@ all =
                     >> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team1"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team1" 0 |> Data.withName "pipeline" ]
                         )
                     >> Tuple.first
                     >> Application.update
@@ -1081,14 +1044,7 @@ all =
                     >> Application.handleCallback
                         (Callback.AllPipelinesFetched <|
                             Ok
-                                [ { id = 0
-                                  , name = "pipeline"
-                                  , paused = False
-                                  , public = True
-                                  , teamName = "team1"
-                                  , groups = []
-                                  }
-                                ]
+                                [ Data.pipeline "team1" 0 |> Data.withName "pipeline" ]
                         )
                     >> Tuple.first
                     >> Application.update
@@ -1110,14 +1066,7 @@ all =
                 |> Application.handleCallback
                     (Callback.AllPipelinesFetched <|
                         Ok
-                            [ { id = 0
-                              , name = "pipeline"
-                              , paused = False
-                              , public = True
-                              , teamName = "team"
-                              , groups = []
-                              }
-                            ]
+                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                     )
                 |> Tuple.first
             )
@@ -1341,13 +1290,10 @@ all =
                         |> Application.handleCallback
                             (Callback.PipelineFetched <|
                                 Ok
-                                    { id = 0
-                                    , name = "p"
-                                    , paused = True
-                                    , public = True
-                                    , teamName = "t"
-                                    , groups = []
-                                    }
+                                    (Data.pipeline "t" 0
+                                        |> Data.withName "p"
+                                        |> Data.withPaused True
+                                    )
                             )
                         |> Tuple.first
 
@@ -1661,17 +1607,6 @@ resourceBreadcrumbSelector =
             Just (Assets.BreadcrumbIcon Assets.ResourceComponent)
     , style "background-repeat" "no-repeat"
     ]
-
-
-onePipeline : String -> Concourse.Pipeline
-onePipeline teamName =
-    { id = 0
-    , name = "pipeline"
-    , paused = False
-    , public = True
-    , teamName = teamName
-    , groups = []
-    }
 
 
 viewNormally :

--- a/web/elm/tests/WelcomeCardTests.elm
+++ b/web/elm/tests/WelcomeCardTests.elm
@@ -6,6 +6,7 @@ import Common exposing (defineHoverBehaviour)
 import Concourse
 import Concourse.Cli as Cli
 import DashboardTests exposing (apiData, darkGrey, givenDataAndUser, givenDataUnauthenticated, iconSelector, userWithRoles, whenOnDashboard)
+import Data
 import Expect
 import Html.Attributes as Attr
 import Message.Callback as Callback
@@ -100,14 +101,7 @@ all =
             \_ ->
                 whenOnDashboard { highDensity = False }
                     |> givenPipelines
-                        [ { id = 0
-                          , name = ""
-                          , paused = False
-                          , public = True
-                          , teamName = ""
-                          , groups = []
-                          }
-                        ]
+                        [ Data.pipeline "team" 0 ]
                     |> Tuple.first
                     |> givenDataUnauthenticated (apiData [ ( "team", [] ) ])
                     |> Tuple.first


### PR DESCRIPTION
# Why do we need this PR?

Useful for: #5321 

Currently, pipelines are being defined as record literals in many places throughout the tests. This makes it difficult to, say, add a new field to the Pipelines type alias (e.g. `archived`)

This commit does not change the tests in any meaningful way (if it does, I made a mistake!), nor does it change any behaviour.

# Changes proposed in this pull request

* Change every Pipeline record definition to use the `Data.pipeline` function.
* Add some `Data` helpers (e.g. `Data.withName`, `Data.withPaused`, etc.) to modify those pipelines

# Contributor Checklist
- [x] Unit tests

# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [ ] PR acceptance performed