### PR TITLE
web: behaviour: don't render archived pipelines

### DIFF
--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -689,6 +689,7 @@ type alias Pipeline =
     { id : Int
     , name : PipelineName
     , paused : Bool
+    , archived : Bool
     , public : Bool
     , teamName : TeamName
     , groups : List PipelineGroup
@@ -708,6 +709,7 @@ encodePipeline pipeline =
         [ ( "id", pipeline.id |> Json.Encode.int )
         , ( "name", pipeline.name |> Json.Encode.string )
         , ( "paused", pipeline.paused |> Json.Encode.bool )
+        , ( "archived", pipeline.archived |> Json.Encode.bool )
         , ( "public", pipeline.public |> Json.Encode.bool )
         , ( "team_name", pipeline.teamName |> Json.Encode.string )
         , ( "groups", pipeline.groups |> Json.Encode.list encodePipelineGroup )
@@ -720,6 +722,7 @@ decodePipeline =
         |> andMap (Json.Decode.field "id" Json.Decode.int)
         |> andMap (Json.Decode.field "name" Json.Decode.string)
         |> andMap (Json.Decode.field "paused" Json.Decode.bool)
+        |> andMap (Json.Decode.field "archived" Json.Decode.bool)
         |> andMap (Json.Decode.field "public" Json.Decode.bool)
         |> andMap (Json.Decode.field "team_name" Json.Decode.string)
         |> andMap (defaultTo [] <| Json.Decode.field "groups" (Json.Decode.list decodePipelineGroup))

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -463,6 +463,7 @@ toDashboardPipeline p =
     , isToggleLoading = False
     , isVisibilityLoading = False
     , paused = p.paused
+    , archived = p.archived
     }
 
 
@@ -473,6 +474,7 @@ toConcoursePipeline p =
     , teamName = p.teamName
     , public = p.public
     , paused = p.paused
+    , archived = p.archived
     , groups = []
     }
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -915,6 +915,7 @@ pipelinesView session params =
         pipelines =
             params.pipelines
                 |> FetchResult.withDefault []
+                |> List.filter (not << .archived)
 
         jobs =
             params.jobs

--- a/web/elm/src/Dashboard/Group/Models.elm
+++ b/web/elm/src/Dashboard/Group/Models.elm
@@ -15,4 +15,5 @@ type alias Pipeline =
     , isToggleLoading : Bool
     , isVisibilityLoading : Bool
     , paused : Bool
+    , archived : Bool
     }

--- a/web/elm/tests/DashboardArchiveTests.elm
+++ b/web/elm/tests/DashboardArchiveTests.elm
@@ -1,0 +1,29 @@
+module DashboardArchiveTests exposing (all)
+
+import Application.Application as Application
+import Common
+import Data
+import Message.Callback as Callback
+import Test exposing (Test, describe, test)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (class, containing, text)
+
+
+all : Test
+all =
+    describe "DashboardArchive"
+        [ test "archived pipelines are not rendered" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok
+                                [ Data.pipeline "team" 1
+                                    |> Data.withName "archived-pipeline"
+                                    |> Data.withArchived True
+                                ]
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.hasNot [ class "pipeline-wrapper", containing [ text "archived-pipeline" ] ]
+        ]

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -11,6 +11,7 @@ module Data exposing
     , teamName
     , version
     , versionedResource
+    , withArchived
     , withGroups
     , withName
     , withPaused
@@ -85,6 +86,11 @@ pipeline team id =
 withPaused : Bool -> { r | paused : Bool } -> { r | paused : Bool }
 withPaused paused p =
     { p | paused = paused }
+
+
+withArchived : Bool -> { r | archived : Bool } -> { r | archived : Bool }
+withArchived archived p =
+    { p | archived = archived }
 
 
 withPublic : Bool -> { r | public : Bool } -> { r | public : Bool }

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -75,6 +75,7 @@ pipeline team id =
     { id = id
     , name = "pipeline-" ++ String.fromInt id
     , paused = False
+    , archived = False
     , public = True
     , teamName = team
     , groups = []


### PR DESCRIPTION
# Existing Issue

~Branched off of: #5369 - merge this first~  MERGED
Fixes #5321  .

# Changes proposed in this pull request

* Add archived field to Pipeline model
* Filter out archived pipelines for rendering

# Contributor Checklist
- [x] Unit tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed