### PR TITLE
fly: fix curl command when passing options

### DIFF
--- a/fly/commands/curl.go
+++ b/fly/commands/curl.go
@@ -12,9 +12,8 @@ import (
 
 type CurlCommand struct {
 	Args struct {
-		Path  string   `positional-arg-name:"PATH" required:"true"`
-		Query string   `positional-arg-name:"QUERY"`
-		Rest  []string `positional-arg-name:"curl flags" description:"To pass flags to curl, pass a -- argument, so that fly can distinguish them from its own flags"`
+		Path string   `positional-arg-name:"PATH" required:"true"`
+		Rest []string `positional-arg-name:"curl flags" description:"To pass flags to curl, pass a -- argument, so that fly can distinguish them from its own flags"`
 	} `positional-args:"yes"`
 	PrintAndExit bool `long:"print-and-exit" description:"Print curl command and exit"`
 }
@@ -30,7 +29,7 @@ func (command *CurlCommand) Execute([]string) error {
 		return err
 	}
 
-	fullUrl, err := command.makeFullUrl(target.URL(), command.Args.Path, command.Args.Query)
+	fullUrl, err := command.makeFullUrl(target.URL(), command.Args.Path)
 	if err != nil {
 		return err
 	}
@@ -54,13 +53,17 @@ func (command *CurlCommand) Execute([]string) error {
 	return nil
 }
 
-func (command *CurlCommand) makeFullUrl(host, path string, query string) (string, error) {
+func (command *CurlCommand) makeFullUrl(host, path string) (string, error) {
 	u, err := url.Parse(host)
 	if err != nil {
 		return "", err
 	}
-	u.Path = path
-	u.RawQuery = query
+	p, err := url.Parse(path)
+	if err != nil {
+		return "", err
+	}
+	u.Path = p.Path
+	u.RawQuery = p.RawQuery
 	return u.String(), nil
 }
 

--- a/fly/commands/curl.go
+++ b/fly/commands/curl.go
@@ -12,7 +12,7 @@ import (
 
 type CurlCommand struct {
 	Args struct {
-		Path string   `positional-arg-name:"PATH" required:"true"`
+		Path string   `positional-arg-name:"PATH" required:"true" description:"Pass query params as normal curl path like path?key=value"`
 		Rest []string `positional-arg-name:"curl flags" description:"To pass flags to curl, pass a -- argument, so that fly can distinguish them from its own flags"`
 	} `positional-args:"yes"`
 	PrintAndExit bool `long:"print-and-exit" description:"Print curl command and exit"`

--- a/fly/integration/curl_test.go
+++ b/fly/integration/curl_test.go
@@ -14,9 +14,9 @@ var _ = Describe("Fly CLI", func() {
 			flyCmd *exec.Cmd
 		)
 
-		Context("when providing a query args", func() {
+		Context("when providing a query args and curl command flags", func() {
 			It("parse the query params correctly", func() {
-				flyCmd = exec.Command(flyPath, "-t", targetName, "curl", "--print-and-exit", "some-path", "some-query-param=value")
+				flyCmd = exec.Command(flyPath, "-t", targetName, "curl", "--print-and-exit", "some-path?some-query-param=value", "--", "-X", "PUT")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -24,6 +24,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(0))
 
+				Expect(string(sess.Out.Contents())).To(ContainSubstring("-X PUT"))
 				Expect(string(sess.Out.Contents())).To(ContainSubstring("some-path?some-query-param=value"))
 			})
 		})

--- a/fly/integration/curl_test.go
+++ b/fly/integration/curl_test.go
@@ -14,9 +14,23 @@ var _ = Describe("Fly CLI", func() {
 			flyCmd *exec.Cmd
 		)
 
-		Context("when providing a query args and curl command flags", func() {
+		Context("when providing query params with path", func() {
 			It("parse the query params correctly", func() {
-				flyCmd = exec.Command(flyPath, "-t", targetName, "curl", "--print-and-exit", "some-path?some-query-param=value", "--", "-X", "PUT")
+				flyCmd = exec.Command(flyPath, "-t", targetName, "curl", "--print-and-exit", "some-path?some-query-param=value")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+
+				Expect(string(sess.Out.Contents())).To(ContainSubstring("some-path?some-query-param=value"))
+			})
+		})
+
+		Context("when providing curl command flags", func() {
+			It("append flags to curl command correctly", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "curl", "--print-and-exit", "some-path", "--", "-X", "PUT")
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -25,7 +39,6 @@ var _ = Describe("Fly CLI", func() {
 				Expect(sess.ExitCode()).To(Equal(0))
 
 				Expect(string(sess.Out.Contents())).To(ContainSubstring("-X PUT"))
-				Expect(string(sess.Out.Contents())).To(ContainSubstring("some-path?some-query-param=value"))
 			})
 		})
 	})

--- a/release-notes/v6.0.1.md
+++ b/release-notes/v6.0.1.md
@@ -1,0 +1,12 @@
+#### <sub><sup><a name="5371" href="#5371">:link:</a></sup></sub> fix, breaking
+
+* Remove `Query` argument from `fly curl` command. 
+
+  When passing curl options as `fly curl <url_path> -- <curl_options>`, the first curl option is parsed as query argument incorrectly, which then causes unexpected curl behaviour. #5366
+
+  With fix in #5371, `<curl_options>` functions as documented and the way to add query params to `fly curl` is more intuitive as following:
+
+  ```
+  fly curl <url_path?query_params> -- <curl_options>
+  ```
+


### PR DESCRIPTION
# Existing Issue
Fixes #5366 

# Why do we need this PR?
#4048 introduced a `Query` arg that break passing extra curl options when doing `fly curl -- -some-option`

# Changes proposed in this pull request
Parse the `Path` argument so it won't encode `?` to produce a wrong URL as mention in #4048 and thus allowing passing extra curl options back to normal 

# Contributor Checklist
- [ ] Integration tests (if applicable)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Release notes reviewed
- [x] PR acceptance performed