### PR TITLE
web: behaviour: fix dashboard preview on safari

### DIFF
--- a/release-notes/v6.0.1.md
+++ b/release-notes/v6.0.1.md
@@ -10,3 +10,6 @@
   fly curl <url_path?query_params> -- <curl_options>
   ```
 
+#### <sub><sup><a name="5375" href="#5375">:link:</a></sup></sub> fix
+
+* Fix rendering pipeline previews on the dashboard on Safari. #5375

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -200,6 +200,7 @@ pipelineCardBody =
     [ style "background-color" Colors.card
     , style "margin" "2px 0"
     , style "flex-grow" "1"
+    , style "display" "flex"
     ]
 
 
@@ -207,7 +208,6 @@ pipelinePreviewGrid : List (Html.Attribute msg)
 pipelinePreviewGrid =
     [ style "box-sizing" "border-box"
     , style "width" "100%"
-    , style "height" "100%"
     ]
 
 

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -1011,14 +1011,17 @@ all =
                 setup
                     >> findBody
                     >> Query.has [ style "flex-grow" "1" ]
-            , test "pipeline-grid fills available space" <|
+            , test "allows pipeline-grid to fill available height" <|
+                setup
+                    >> findBody
+                    >> Query.has [ style "display" "flex" ]
+            , test "pipeline-grid fills available width" <|
                 setup
                     >> findBody
                     >> Query.find [ class "pipeline-grid" ]
                     >> Query.has
                         [ style "box-sizing" "border-box"
                         , style "width" "100%"
-                        , style "height" "100%"
                         ]
             ]
         , describe "footer" <|


### PR DESCRIPTION
Existing Issue

Fixes #5374  .


# Changes proposed in this pull request

* Change `height: 100%` to `display: flex` on the parent: https://stackoverflow.com/questions/33636796/chrome-safari-not-filling-100-height-of-flex-parent

# Contributor Checklist
- [x] Unit tests
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed