### PR TITLE
web: behaviour: fix tooltip for long pipeline names

### DIFF
--- a/release-notes/v6.0.1.md
+++ b/release-notes/v6.0.1.md
@@ -13,3 +13,8 @@
 #### <sub><sup><a name="5375" href="#5375">:link:</a></sup></sub> fix
 
 * Fix rendering pipeline previews on the dashboard on Safari. #5375
+
+#### <sub><sup><a name="5377" href="#5377">:link:</a></sup></sub> fix
+
+* Fix pipeline tooltips being hidden behind other cards. #5377
+

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -18,7 +18,7 @@ import Dict exposing (Dict)
 import HoverState
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, class, classList, draggable, id, style)
-import Html.Events exposing (on, preventDefaultOn, stopPropagationOn)
+import Html.Events exposing (on, onMouseOut, onMouseOver, preventDefaultOn, stopPropagationOn)
 import Html.Keyed
 import Json.Decode
 import Maybe.Extra
@@ -249,6 +249,14 @@ pipelineCardView session params { bounds, pipeline, index } teamName =
             (String.fromFloat bounds.height
                 ++ "px"
             )
+         , onMouseOver <|
+            Hover <|
+                Just <|
+                    PipelineWrapper
+                        { pipelineName = pipeline.name
+                        , teamName = pipeline.teamName
+                        }
+         , onMouseOut <| Hover Nothing
          ]
             ++ (if params.dragState /= NotDragging then
                     [ style "transition" "transform 0.2s ease-in-out" ]
@@ -256,16 +264,23 @@ pipelineCardView session params { bounds, pipeline, index } teamName =
                 else
                     []
                )
-            ++ (case HoverState.hoveredElement params.hovered of
-                    Just (JobPreview jobID) ->
+            ++ (let
+                    hoverStyle id =
                         if
-                            (jobID.teamName == pipeline.teamName)
-                                && (jobID.pipelineName == pipeline.name)
+                            (id.pipelineName == pipeline.name)
+                                && (id.teamName == pipeline.teamName)
                         then
                             [ style "z-index" "1" ]
 
                         else
                             []
+                in
+                case HoverState.hoveredElement params.hovered of
+                    Just (JobPreview jobID) ->
+                        hoverStyle jobID
+
+                    Just (PipelineWrapper pipelineID) ->
+                        hoverStyle pipelineID
 
                     _ ->
                         []

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -76,6 +76,7 @@ type DomID
     | VersionHeader VersionId
     | VersionToggle VersionId
     | BuildTab Int String
+    | PipelineWrapper Concourse.PipelineIdentifier
     | JobPreview Concourse.JobIdentifier
     | HamburgerMenu
     | SideBarTeam String

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -491,7 +491,7 @@ all =
                     |> Common.queryView
                     |> Query.find [ id "team-2" ]
                     |> Query.has [ class "pipeline-wrapper", containing [ text "pipeline-2" ] ]
-        , test "pipeline wrapper has a z-index of 1 when hovering over it" <|
+        , test "pipeline wrapper has a z-index of 1 when hovering over a job" <|
             \_ ->
                 Common.init "/"
                     |> Application.handleCallback
@@ -513,6 +513,57 @@ all =
                     |> Common.queryView
                     |> Query.find [ class "dashboard-team-pipelines" ]
                     |> Query.has [ class "pipeline-wrapper", style "z-index" "1" ]
+        , test "pipeline wrapper has a z-index of 1 when hovering over the wrapper" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0 ]
+                        )
+                    |> Tuple.first
+                    |> Application.update
+                        (Update <|
+                            Hover <|
+                                Just <|
+                                    PipelineWrapper
+                                        { teamName = "team"
+                                        , pipelineName = "pipeline-0"
+                                        }
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "dashboard-team-pipelines" ]
+                    |> Query.has [ class "pipeline-wrapper", style "z-index" "1" ]
+        , test "pipeline wrapper responds to mouse over" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0 ]
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "pipeline-wrapper" ]
+                    |> Event.simulate Event.mouseOver
+                    |> Event.expect
+                        (Update <|
+                            Hover <|
+                                Just <|
+                                    PipelineWrapper <|
+                                        { pipelineName = "pipeline-0", teamName = "team" }
+                        )
+        , test "pipeline wrapper responds to mouse out" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <|
+                            Ok [ Data.pipeline "team" 0 ]
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ class "pipeline-wrapper" ]
+                    |> Event.simulate Event.mouseOut
+                    |> Event.expect (Update <| Hover Nothing)
         , describe "drop areas" <|
             [ test "renders a drop area over each pipeline card" <|
                 \_ ->


### PR DESCRIPTION
# Existing Issue

Fixes #5376 .

# Changes proposed in this pull request

* Respond to `mouseOver` and `mouseOut` events on the `.pipeline-wrapper`, and increase the z-index in that case.

Similar to e664c21e1228b465921192221c45e844b2f3b356, but for the pipeline name tooltip instead of the job name tooltip.

Note: using `mouseOver` and `mouseOut` since I don't want `mouseLeave` events to trigger when hovering over child elements (e.g. the jobs).

# Contributor Checklist
- [x] Unit tests
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed