### PR TITLE
web: behaviour: fix log highlighting on OneOffBuild page

### DIFF
--- a/release-notes/v6.0.1.md
+++ b/release-notes/v6.0.1.md
@@ -18,3 +18,7 @@
 
 * Fix pipeline tooltips being hidden behind other cards. #5377
 
+#### <sub><sup><a name="5384" href="#5384">:link:</a></sup></sub> fix
+
+* Fix log highlighting on the one-off-build page. Previously, highlighting any log lines would cause the page to reload. #5384
+

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -462,6 +462,9 @@ routeMatchesModel route model =
         ( Routes.Build _, SubPage.BuildModel _ ) ->
             True
 
+        ( Routes.OneOffBuild _, SubPage.BuildModel _ ) ->
+            True
+
         ( Routes.Job _, SubPage.JobModel _ ) ->
             True
 

--- a/web/elm/src/SubPage/SubPage.elm
+++ b/web/elm/src/SubPage/SubPage.elm
@@ -260,6 +260,19 @@ urlUpdate routes =
                                 Nothing
                     }
 
+            Routes.OneOffBuild { id, highlight } ->
+                Build.changeToBuild
+                    { pageType = Build.Header.Models.OneOffBuildPage id
+                    , highlight = highlight
+                    , fromBuildPage =
+                        case routes.from of
+                            Routes.OneOffBuild params ->
+                                Just <| Build.Header.Models.OneOffBuildPage params.id
+
+                            _ ->
+                                Nothing
+                    }
+
             _ ->
                 identity
         )

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1264,6 +1264,31 @@ all =
                     |> Tuple.second
                     |> Common.notContains
                         (Effects.FetchJobBuild <| buildParams.id)
+        , test "does not reload one off build page when highlight is modified" <|
+            \_ ->
+                let
+                    buildParams =
+                        { id = 1
+                        , highlight = Routes.HighlightNothing
+                        }
+                in
+                Common.init "/"
+                    |> Application.handleDelivery
+                        (RouteChanged <|
+                            Routes.OneOffBuild
+                                buildParams
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (RouteChanged <|
+                            Routes.OneOffBuild
+                                { buildParams
+                                    | highlight = Routes.HighlightLine "step" 1
+                                }
+                        )
+                    |> Tuple.second
+                    |> Common.notContains
+                        (Effects.FetchBuild 0 buildParams.id)
         , test "gets current timezone on page load" <|
             \_ ->
                 Application.init


### PR DESCRIPTION
# Existing Issue

Fixes #5384 .

# Changes proposed in this pull request

* Keep track of the route we came from for OneOffBuilds (the same approach as for JobBuilds)

**note:** this was fixed for the JobBuild page in #5275

# Contributor Checklist
- [x] Unit tests
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] Release notes reviewed
- [x] PR acceptance performed