### PR TITLE
web: behaviour: fix scroll on build history list

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -15,6 +15,22 @@
 
   We are no longer relying on garden to clean up hijacked containers. Instead, we have implemented this functionality in concourse itself. This makes it much more portable to different container backends.
 
+#### <sub><sup><a name="5375" href="#5375">:link:</a></sup></sub> fix
+
+* Fix rendering pipeline previews on the dashboard on Safari. #5375
+
+#### <sub><sup><a name="5377" href="#5377">:link:</a></sup></sub> fix
+
+* Fix pipeline tooltips being hidden behind other cards. #5377
+
+#### <sub><sup><a name="5384" href="#5384">:link:</a></sup></sub> fix
+
+* Fix log highlighting on the one-off-build page. Previously, highlighting any log lines would cause the page to reload. #5384
+
+#### <sub><sup><a name="5392" href="#5392">:link:</a></sup></sub> fix
+
+* Fix regression which inhibited scrolling through the build history list. #5392
+
 #### <sub><sup><a name="5397" href="#5397">:link:</a></sup></sub> feature, breaking
 
 * @pnsantos updated the Material Design icon library version to `5.0.45`.

--- a/release-notes/v6.0.1.md
+++ b/release-notes/v6.0.1.md
@@ -22,3 +22,7 @@
 
 * Fix log highlighting on the one-off-build page. Previously, highlighting any log lines would cause the page to reload. #5384
 
+#### <sub><sup><a name="5392" href="#5392">:link:</a></sup></sub> fix
+
+* Fix regression which inhibited scrolling through the build history list. #5392
+

--- a/release-notes/v6.0.1.md
+++ b/release-notes/v6.0.1.md
@@ -9,20 +9,3 @@
   ```
   fly curl <url_path?query_params> -- <curl_options>
   ```
-
-#### <sub><sup><a name="5375" href="#5375">:link:</a></sup></sub> fix
-
-* Fix rendering pipeline previews on the dashboard on Safari. #5375
-
-#### <sub><sup><a name="5377" href="#5377">:link:</a></sup></sub> fix
-
-* Fix pipeline tooltips being hidden behind other cards. #5377
-
-#### <sub><sup><a name="5384" href="#5384">:link:</a></sup></sub> fix
-
-* Fix log highlighting on the one-off-build page. Previously, highlighting any log lines would cause the page to reload. #5384
-
-#### <sub><sup><a name="5392" href="#5392">:link:</a></sup></sub> fix
-
-* Fix regression which inhibited scrolling through the build history list. #5392
-

--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -43,7 +43,7 @@ import Routes exposing (Highlight)
 import ScreenSize
 import Set
 import SideBar.SideBar as SideBar
-import StrictEvents exposing (onLeftClick, onMouseWheel, onScroll)
+import StrictEvents exposing (onLeftClick, onScroll, onWheel)
 import Time
 import UserState
 import Views.BuildDuration as BuildDuration
@@ -364,7 +364,7 @@ viewBuildHeader session model build =
                 [ abortButton, triggerButton ]
             ]
         , Html.div
-            [ onMouseWheel ScrollBuilds ]
+            [ onWheel ScrollBuilds ]
             [ lazyViewHistory build model.history ]
         ]
 

--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -33,6 +33,7 @@ import Message.Subscription
         , Subscription(..)
         )
 import Routes
+import StrictEvents exposing (DeltaMode(..))
 import Time
 
 
@@ -394,12 +395,23 @@ update msg ( model, effects ) =
     case msg of
         ScrollBuilds event ->
             let
+                scrollFactor =
+                    case event.deltaMode of
+                        DeltaModePixel ->
+                            1
+
+                        DeltaModeLine ->
+                            20
+
+                        DeltaModePage ->
+                            800
+
                 scroll =
                     if event.deltaX == 0 then
-                        [ Scroll (Sideways event.deltaY) historyId ]
+                        [ Scroll (Sideways <| event.deltaY * scrollFactor) historyId ]
 
                     else
-                        [ Scroll (Sideways -event.deltaX) historyId ]
+                        [ Scroll (Sideways <| -event.deltaX * scrollFactor) historyId ]
 
                 checkVisibility =
                     case model.history |> List.Extra.last of

--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -29,7 +29,7 @@ import Html.Events exposing (onBlur, onFocus, onMouseEnter, onMouseLeave)
 import Html.Lazy
 import Message.Message as Message exposing (Message(..))
 import Routes
-import StrictEvents exposing (onLeftClick, onMouseWheel)
+import StrictEvents exposing (onLeftClick, onWheel)
 import Views.Icon as Icon
 
 
@@ -376,4 +376,4 @@ viewHistory : BuildStatus -> List BuildTab -> Html Message
 viewHistory backgroundColor =
     lazyViewHistory backgroundColor
         >> List.singleton
-        >> Html.div [ onMouseWheel ScrollBuilds ]
+        >> Html.div [ onWheel ScrollBuilds ]

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -11,7 +11,7 @@ import Api
 import Api.Endpoints as Endpoints
 import Assets
 import Base64
-import Browser.Dom exposing (Element, getElement, getViewport, getViewportOf, setViewportOf)
+import Browser.Dom exposing (Element, Viewport, getElement, getViewport, getViewportOf, setViewportOf)
 import Browser.Navigation as Navigation
 import Concourse exposing (encodeJob, encodePipeline, encodeTeam)
 import Concourse.BuildStatus exposing (BuildStatus)
@@ -657,19 +657,19 @@ scroll : ScrollDirection -> String -> Cmd Callback
 scroll direction id =
     (case direction of
         ToTop ->
-            scrollCoords id id (always 0) (always 0)
+            scrollCoordsSimple id (always 0) (always 0)
 
         Down ->
-            scrollCoords id id (always 0) (.srcElem >> .viewport >> .y >> (+) 60)
+            scrollCoordsSimple id (always 0) (.viewport >> .y >> (+) 60)
 
         Up ->
-            scrollCoords id id (always 0) (.srcElem >> .viewport >> .y >> (+) -60)
+            scrollCoordsSimple id (always 0) (.viewport >> .y >> (+) -60)
 
         ToBottom ->
-            scrollCoords id id (always 0) (.parentElem >> .scene >> .height)
+            scrollCoordsSimple id (always 0) (.scene >> .height)
 
         Sideways delta ->
-            scrollCoords id id (.srcElem >> .viewport >> .x >> (+) -delta) (always 0)
+            scrollCoordsSimple id (.viewport >> .x >> (+) -delta) (always 0)
 
         ToId toId ->
             scrollCoords toId
@@ -682,6 +682,22 @@ scroll direction id =
                 )
     )
         |> Task.attempt (\_ -> ScrollCompleted direction id)
+
+
+scrollCoordsSimple :
+    String
+    -> (Viewport -> Float)
+    -> (Viewport -> Float)
+    -> Task.Task Browser.Dom.Error ()
+scrollCoordsSimple id getX getY =
+    getViewportOf id
+        |> Task.andThen
+            (\viewport ->
+                setViewportOf
+                    id
+                    (getX viewport)
+                    (getY viewport)
+            )
 
 
 scrollCoords :

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -32,7 +32,7 @@ type Message
     | FocusTextArea
     | BlurTextArea
       -- Build
-    | ScrollBuilds StrictEvents.MouseWheelEvent
+    | ScrollBuilds StrictEvents.WheelEvent
     | RevealCurrentBuildInHistory
     | SetHighlight String Int
     | ExtendHighlight String Int

--- a/web/elm/src/StrictEvents.elm
+++ b/web/elm/src/StrictEvents.elm
@@ -1,5 +1,6 @@
 module StrictEvents exposing
-    ( ScrollState
+    ( DeltaMode(..)
+    , ScrollState
     , WheelEvent
     , onLeftClick
     , onLeftClickNoPreventDefault
@@ -18,6 +19,7 @@ import Json.Decode
 type alias WheelEvent =
     { deltaX : Float
     , deltaY : Float
+    , deltaMode : DeltaMode
     }
 
 
@@ -26,6 +28,12 @@ type alias ScrollState =
     , scrollTop : Float
     , clientHeight : Float
     }
+
+
+type DeltaMode
+    = DeltaModePixel
+    | DeltaModeLine
+    | DeltaModePage
 
 
 onLeftClick : msg -> Html.Attribute msg
@@ -192,9 +200,30 @@ assertLeftButton =
 
 decodeWheelEvent : Json.Decode.Decoder WheelEvent
 decodeWheelEvent =
-    Json.Decode.map2 WheelEvent
+    Json.Decode.map3 WheelEvent
         (Json.Decode.field "deltaX" Json.Decode.float)
         (Json.Decode.field "deltaY" Json.Decode.float)
+        (Json.Decode.field "deltaMode" decodeDeltaMode)
+
+
+decodeDeltaMode : Json.Decode.Decoder DeltaMode
+decodeDeltaMode =
+    Json.Decode.int
+        |> Json.Decode.andThen
+            (\mode ->
+                case mode of
+                    0 ->
+                        Json.Decode.succeed DeltaModePixel
+
+                    1 ->
+                        Json.Decode.succeed DeltaModeLine
+
+                    2 ->
+                        Json.Decode.succeed DeltaModePage
+
+                    _ ->
+                        Json.Decode.fail <| "invalid deltaMode " ++ String.fromInt mode
+            )
 
 
 decodeScrollEvent : Json.Decode.Decoder ScrollState

--- a/web/elm/src/StrictEvents.elm
+++ b/web/elm/src/StrictEvents.elm
@@ -1,13 +1,13 @@
 module StrictEvents exposing
-    ( MouseWheelEvent
-    , ScrollState
+    ( ScrollState
+    , WheelEvent
     , onLeftClick
     , onLeftClickNoPreventDefault
     , onLeftClickOrShiftLeftClick
     , onLeftMouseDown
     , onLeftMouseDownCapturing
-    , onMouseWheel
     , onScroll
+    , onWheel
     )
 
 import Html
@@ -15,7 +15,7 @@ import Html.Events
 import Json.Decode
 
 
-type alias MouseWheelEvent =
+type alias WheelEvent =
     { deltaX : Float
     , deltaY : Float
     }
@@ -120,9 +120,9 @@ onLeftMouseDownCapturing captured msg =
         )
 
 
-onMouseWheel : (MouseWheelEvent -> msg) -> Html.Attribute msg
-onMouseWheel cons =
-    Html.Events.custom "mousewheel"
+onWheel : (WheelEvent -> msg) -> Html.Attribute msg
+onWheel cons =
+    Html.Events.custom "wheel"
         (Json.Decode.map
             (\x ->
                 { message = cons x
@@ -130,7 +130,7 @@ onMouseWheel cons =
                 , preventDefault = True
                 }
             )
-            decodeMouseWheelEvent
+            decodeWheelEvent
         )
 
 
@@ -190,9 +190,9 @@ assertLeftButton =
                 Err "not left button"
 
 
-decodeMouseWheelEvent : Json.Decode.Decoder MouseWheelEvent
-decodeMouseWheelEvent =
-    Json.Decode.map2 MouseWheelEvent
+decodeWheelEvent : Json.Decode.Decoder WheelEvent
+decodeWheelEvent =
+    Json.Decode.map2 WheelEvent
         (Json.Decode.field "deltaX" Json.Decode.float)
         (Json.Decode.field "deltaY" Json.Decode.float)
 


### PR DESCRIPTION
# Existing Issue

Fixes #5383 .

# Changes proposed in this pull request

* Introduce `scrollCoordsSimple` function for dealing with simple cases of computing scroll position (that don't require knowing the coordinates of the source and parent elements)
* Replace the deprecated DOM event `mousewheel` with `wheel`, which fixes scrolling on Firefox (which seems to have been broken for a while)

Note that this behaviour could be shoehorned in to the more complicated `scrollCoords` function, but there is a noticeable performance hit in scrolling due to the increased number of calls out to `Elm.Browser`.

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed