### PR TITLE
hack/jaeger: add elasticsearch backend w kibana

### DIFF
--- a/hack/overrides/jaeger.yml
+++ b/hack/overrides/jaeger.yml
@@ -7,6 +7,8 @@
 #
 version: '3'
 
+volumes:
+  elasticsearch-data:
 services:
   web:
     environment:
@@ -20,6 +22,9 @@ services:
       - --log-level=debug
     environment:
       COLLECTOR_ZIPKIN_HTTP_PORT: 9411
+      SPAN_STORAGE_TYPE: elasticsearch
+      ES_SERVER_URLS: http://elasticsearch:9200
+      ES_TAGS_AS_FIELDS_ALL: "true"
     ports:
       - '14268:14268'
       - '25000:16686'
@@ -28,3 +33,20 @@ services:
       - '6831:6831/udp'
       - '6832:6832/udp'
       - '9411:9411'
+
+  elasticsearch:
+    image: elasticsearch:7.6.1
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    ports:
+      - '9200:9200'
+      - '9300:9300'
+    environment:
+      discovery.type: single-node
+
+  kibana:
+    image: kibana:7.6.1
+    environment:
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    ports:
+      - '5601:5601'

--- a/hack/overrides/jaeger.yml
+++ b/hack/overrides/jaeger.yml
@@ -26,6 +26,7 @@ services:
       SPAN_STORAGE_TYPE: elasticsearch
       ES_SERVER_URLS: http://elasticsearch:9200
       ES_TAGS_AS_FIELDS_ALL: "true"
+      ES_NUM_REPLICAS: 0
     ports:
       - '14268:14268'
       - '25000:16686'

--- a/hack/overrides/jaeger.yml
+++ b/hack/overrides/jaeger.yml
@@ -20,6 +20,7 @@ services:
     command:
       - --sampling.strategies-file=/etc/jaeger/sampling_strategies.json
       - --log-level=debug
+    restart: on-failure
     environment:
       COLLECTOR_ZIPKIN_HTTP_PORT: 9411
       SPAN_STORAGE_TYPE: elasticsearch


### PR DESCRIPTION
# Existing Issue

Related to concourse/concourse#5382.

# Changes proposed in this pull request

* jaeger override now includes elasticsearch & kibana
* as tracing features get expanded, using this override means you can immediately create sophisticated queries/visualizations across the whole span database

# Contributor Checklist
- [x] ~Unit tests~
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~