### PR TITLE
web: behaviour: add loading view to dashboard

### DIFF
--- a/release-notes/v5.5.11.md
+++ b/release-notes/v5.5.11.md
@@ -1,0 +1,4 @@
+#### <sub><sup><a name="v5511-note-1" href="#5511-note-1">:link:</a></sup></sub> feature
+
+* Add loading indicator on dashboard while awaiting API responses. #5427
+

--- a/release-notes/v5.5.11.md
+++ b/release-notes/v5.5.11.md
@@ -1,4 +1,4 @@
 #### <sub><sup><a name="v5511-note-1" href="#5511-note-1">:link:</a></sup></sub> feature
 
-* Add loading indicator on dashboard while awaiting API responses. #5427
+* Add loading indicator on dashboard while awaiting initial API response. #5427
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -562,7 +562,7 @@ dashboardView session model =
 loadingView : Html Message
 loadingView =
     Html.div
-        ([ class "loading" ] ++ Styles.loadingView)
+        (class "loading" :: Styles.loadingView)
         [ Spinner.spinner { sizePx = 24, margin = "0" }
         , Html.span Styles.loadingText [ Html.text "loading, please wait..." ]
         ]

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -71,6 +71,7 @@ import Routes
 import ScreenSize exposing (ScreenSize(..))
 import SideBar.SideBar as SideBar
 import UserState
+import Views.Spinner as Spinner
 import Views.Styles
 
 
@@ -531,10 +532,10 @@ dashboardView :
 dashboardView session model =
     case model.state of
         RemoteData.NotAsked ->
-            Html.text ""
+            loadingView
 
         RemoteData.Loading ->
-            Html.text ""
+            loadingView
 
         RemoteData.Failure (Turbulence path) ->
             turbulenceView path
@@ -556,6 +557,15 @@ dashboardView session model =
                         , userState = model.userState
                         , highDensity = model.highDensity
                         }
+
+
+loadingView : Html Message
+loadingView =
+    Html.div
+        ([ class "loading" ] ++ Styles.loadingView)
+        [ Spinner.spinner { sizePx = 24, margin = "0" }
+        , Html.span Styles.loadingText [ Html.text "loading, please wait..." ]
+        ]
 
 
 welcomeCard :

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -17,6 +17,8 @@ module Dashboard.Styles exposing
     , legend
     , legendItem
     , legendSeparator
+    , loadingText
+    , loadingView
     , noPipelineCardHd
     , noPipelineCardHeader
     , noPipelineCardTextHd
@@ -762,3 +764,18 @@ clusterName =
     , style "letter-spacing" "0.1em"
     , style "margin-left" "10px"
     ]
+
+
+loadingView : List (Html.Attribute msg)
+loadingView =
+    [ style "padding-top" "50px"
+    , style "display" "flex"
+    , style "justify-content" "center"
+    , style "width" "100%"
+    , style "font-size" "20px"
+    ]
+
+
+loadingText : List (Html.Attribute msg)
+loadingText =
+    [ style "margin-left" "10px" ]

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -222,6 +222,52 @@ all =
                     |> Common.queryView
                     |> Query.find [ id "top-bar-app" ]
                     |> Query.has [ style "height" "54px" ]
+        , describe "loading section" <|
+            [ test "has a loading section when awaiting API data" <|
+                \_ ->
+                    Common.init "/"
+                        |> Common.queryView
+                        |> Query.has [ class "loading" ]
+            , test "has top padding" <|
+                \_ ->
+                    Common.init "/"
+                        |> Common.queryView
+                        |> Query.has [ style "padding-top" "50px" ]
+            , test "centers text" <|
+                \_ ->
+                    Common.init "/"
+                        |> Common.queryView
+                        |> Query.has
+                            [ style "display" "flex"
+                            , style "justify-content" "center"
+                            , style "width" "100%"
+                            ]
+            , test "has 20px font size" <|
+                \_ ->
+                    Common.init "/"
+                        |> Common.queryView
+                        |> Query.has
+                            [ style "font-size" "20px" ]
+            , test "contains a spinner" <|
+                \_ ->
+                    Common.init "/"
+                        |> Common.queryView
+                        |> Query.find [ class "loading" ]
+                        |> Query.has
+                            [ style "animation" "container-rotate 1568ms linear infinite"
+                            , style "height" "24px"
+                            , style "width" "24px"
+                            ]
+            , test "contains a loading message" <|
+                \_ ->
+                    Common.init "/"
+                        |> Common.queryView
+                        |> Query.find [ class "loading" ]
+                        |> Query.has
+                            [ style "margin-left" "10px"
+                            , containing [ text "loading, please wait..." ]
+                            ]
+            ]
         , describe "welcome card" <|
             let
                 hasWelcomeCard : (() -> ( Application.Model, List Effects.Effect )) -> List Test


### PR DESCRIPTION
# Existing Issue

Fixes #2935 .

# Changes proposed in this pull request

* Add a loading screen to the dashboard rather than rendering nothing when waiting for API responses

Looks very similar to the sketch in #2935:

<img width="1392" alt="Screen Shot 2020-04-13 at 3 54 16 PM" src="https://user-images.githubusercontent.com/26583442/79155418-155e6000-7d9f-11ea-9e7a-37bc1d930638.png">

# Contributor Checklist
- [x] Unit tests
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed