### PR TITLE
Fix typo with ComponentRunnerInterval env

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -137,7 +137,7 @@ type RunCommand struct {
 	LidarScannerInterval time.Duration `long:"lidar-scanner-interval" default:"1m" description:"Interval on which the resource scanner will run to see if new checks need to be scheduled"`
 	LidarCheckerInterval time.Duration `long:"lidar-checker-interval" default:"10s" description:"Interval on which the resource checker runs any scheduled checks"`
 
-	ComponentRunnerInterval time.Duration `long:"runner-interval" default:"10s" description:"Interval on which runners are kicked off for builds, locks, scans, and checks"`
+	ComponentRunnerInterval time.Duration `long:"component-runner-interval" default:"10s" description:"Interval on which runners are kicked off for builds, locks, scans, and checks"`
 
 	GlobalResourceCheckTimeout time.Duration `long:"global-resource-check-timeout" default:"1h" description:"Time limit on checking for new versions of resources."`
 	ResourceCheckingInterval   time.Duration `long:"resource-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources."`


### PR DESCRIPTION
Signed-off-by: TJ Higgins <tj@architect.io>

# Why do we need this PR?
Fixing a typo I noticed from my pr to add ComponentRunnerInterval  https://github.com/concourse/concourse/pull/5342. Sorry!

# Reviewer Checklist
- [x] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [x] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
