### PR TITLE
worker: Remove unneccesary print statement

### DIFF
--- a/worker/backend/process_killer_test.go
+++ b/worker/backend/process_killer_test.go
@@ -3,7 +3,6 @@ package backend_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"syscall"
 	"time"
@@ -68,7 +67,6 @@ func (s *ProcessKillerSuite) TestKillKillError() {
 
 func (s *ProcessKillerSuite) TestKillWaitContextDeadlineReached() {
 	err := s.killer.Kill(context.Background(), s.proc, s.signal, s.notEnoughTimeout)
-	fmt.Println(err)
 	s.True(errors.Is(err, backend.ErrGracePeriodTimeout))
 }
 


### PR DESCRIPTION
- remove fmt.Print from process_killer_test

# Why do we need this PR?
Minor - removed floating print statement so that we don't pollute test logs.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [x] Unit tests

# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
