### PR TITLE
containerd: support custom dns configuration

### DIFF
--- a/worker/backend/cni_network.go
+++ b/worker/backend/cni_network.go
@@ -223,7 +223,7 @@ func (n cniNetwork) SetupMounts(handle string) ([]specs.Mount, error) {
 func (n cniNetwork) generateResolvConfContents() []byte {
 	contents := ""
 	for _, n := range n.nameServers {
-		contents = contents + fmt.Sprintf("nameserver %s\n", n)
+		contents = contents + "nameserver " + n + "\n"
 	}
 
 	return []byte(contents)

--- a/worker/backend/cni_network.go
+++ b/worker/backend/cni_network.go
@@ -44,9 +44,9 @@ const (
 )
 
 var (
-	// nameServers is the default set of nameservers used.
+	// defaultNameServers is the default set of nameservers used.
 	//
-	nameServers = []string{"8.8.8.8"}
+	defaultNameServers = []string{"8.8.8.8"}
 
 	// defaultCNINetworkConfig is the default configuration for the CNI network
 	// created to put concourse containers into.
@@ -155,7 +155,7 @@ func NewCNINetwork(opts ...CNINetworkOpt) (*cniNetwork, error) {
 	n := &cniNetwork{
 		binariesDir: binariesDir,
 		config:      defaultCNINetworkConfig,
-		nameServers: nameServers,
+		nameServers: defaultNameServers,
 	}
 
 	for _, opt := range opts {

--- a/worker/backend/integration/integration_test.go
+++ b/worker/backend/integration/integration_test.go
@@ -352,13 +352,14 @@ func (s *IntegrationSuite) TestAttach() {
 // those NameServers should appear in the container's etc/resolv.conf
 //
 func (s *IntegrationSuite) TestCustomDNS() {
-	namespace      := "test-custom-dns"
+	namespace := "test-custom-dns"
 	requestTimeout := 3 * time.Second
 
-	cniNetworkConfig := backend.GetDefaultCNINetworkConfig()
-	cniNetworkConfig.NameServers = []string{"1.1.1.1", "1.2.3.4"}
-	networkConfigOpt := backend.WithCNINetworkConfig(cniNetworkConfig)
-	network, err := backend.NewCNINetwork(networkConfigOpt)
+	network, err := backend.NewCNINetwork(
+		backend.WithNameServers([]string{
+			"1.1.1.1", "1.2.3.4",
+		}),
+	)
 	s.NoError(err)
 
 	networkOpt := backend.WithNetwork(network)
@@ -377,7 +378,7 @@ func (s *IntegrationSuite) TestCustomDNS() {
 	handle := uuid()
 
 	container, err := customBackend.Create(garden.ContainerSpec{
-		Handle: handle,
+		Handle:     handle,
 		RootFSPath: "raw://" + s.rootfs,
 		Privileged: true,
 	})
@@ -412,7 +413,6 @@ func (s *IntegrationSuite) TestCustomDNS() {
 	expectedDNSServer := "nameserver 1.1.1.1\nnameserver 1.2.3.4\n"
 	s.Equal(expectedDNSServer, buf.String())
 }
-
 
 // TestUngracefulStop aims at validating that we're giving the process enough
 // opportunity to finish, but that at the same time, we don't wait forever.

--- a/worker/backend/integration/integration_test.go
+++ b/worker/backend/integration/integration_test.go
@@ -348,6 +348,72 @@ func (s *IntegrationSuite) TestAttach() {
 	s.NoError(err)
 }
 
+// TestCustomDNS verfies that when a network is setup with custom NameServers
+// those NameServers should appear in the container's etc/resolv.conf
+//
+func (s *IntegrationSuite) TestCustomDNS() {
+	namespace      := "test-custom-dns"
+	requestTimeout := 3 * time.Second
+
+	cniNetworkConfig := backend.GetDefaultCNINetworkConfig()
+	cniNetworkConfig.NameServers = []string{"1.1.1.1", "1.2.3.4"}
+	networkConfigOpt := backend.WithCNINetworkConfig(cniNetworkConfig)
+	network, err := backend.NewCNINetwork(networkConfigOpt)
+	s.NoError(err)
+
+	networkOpt := backend.WithNetwork(network)
+	customBackend, err := backend.New(
+		libcontainerd.New(
+			s.containerdSocket(),
+			namespace,
+			requestTimeout,
+		),
+		networkOpt,
+	)
+	s.NoError(err)
+
+	s.NoError(customBackend.Start())
+
+	handle := uuid()
+
+	container, err := customBackend.Create(garden.ContainerSpec{
+		Handle: handle,
+		RootFSPath: "raw://" + s.rootfs,
+		Privileged: true,
+	})
+	s.NoError(err)
+
+	defer func() {
+		s.NoError(customBackend.Destroy(handle))
+		customBackend.Stop()
+	}()
+
+	buf := new(buffer)
+
+	proc, err := container.Run(
+		garden.ProcessSpec{
+			Path: "/executable",
+			Args: []string{
+				"-cat",
+				"/etc/resolv.conf",
+			},
+		},
+		garden.ProcessIO{
+			Stdout: buf,
+			Stderr: buf,
+		},
+	)
+	s.NoError(err)
+
+	exitCode, err := proc.Wait()
+	s.NoError(err)
+
+	s.Equal(exitCode, 0)
+	expectedDNSServer := "nameserver 1.1.1.1\nnameserver 1.2.3.4\n"
+	s.Equal(expectedDNSServer, buf.String())
+}
+
+
 // TestUngracefulStop aims at validating that we're giving the process enough
 // opportunity to finish, but that at the same time, we don't wait forever.
 //

--- a/worker/backend/integration/sample/main.go
+++ b/worker/backend/integration/sample/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -16,6 +17,7 @@ var (
 	flagWaitForSignal = flag.String("wait-for-signal", "", "wait for a sigal (sigterm|sighup)")
 	flagHttpGet       = flag.String("http-get", "", "website to perform an HTTP GET request against")
 	flagWriteTenTimes = flag.String("write-many-times", "", "writes a string to stdout many times")
+	flagCatFile = flag.String("cat", "", "writes contents of file to stdout")
 
 	signals = map[string]os.Signal{
 		"sighup":  syscall.SIGHUP,
@@ -67,6 +69,14 @@ func writeTenTimes(content string) {
 	}
 }
 
+func catFile(pathToFile string){
+	bytes, err	:= ioutil.ReadFile(pathToFile)
+	if err != nil {
+		log.Fatal("failed to read file ", err)
+	}
+	fmt.Print(string(bytes))
+}
+
 func main() {
 	flag.Parse()
 
@@ -77,6 +87,8 @@ func main() {
 		httpGet(*flagHttpGet)
 	case *flagWriteTenTimes != "":
 		writeTenTimes(*flagWriteTenTimes)
+	case *flagCatFile != "":
+		catFile(*flagCatFile)
 	default:
 		fmt.Println(defaultMessage)
 	}

--- a/worker/backend/process_killer_test.go
+++ b/worker/backend/process_killer_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"syscall"
 	"time"
+	"fmt"
 
 	"github.com/concourse/concourse/worker/backend"
 	"github.com/concourse/concourse/worker/backend/libcontainerd/libcontainerdfakes"

--- a/worker/backend/process_killer_test.go
+++ b/worker/backend/process_killer_test.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"syscall"
 	"time"
-	"fmt"
 
 	"github.com/concourse/concourse/worker/backend"
 	"github.com/concourse/concourse/worker/backend/libcontainerd/libcontainerdfakes"

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -31,8 +31,9 @@ type GardenBackend struct {
 	UseHoudini    bool `long:"use-houdini"    description:"Use the insecure Houdini Garden backend."`
 	UseContainerd bool `long:"use-containerd" description:"Use the containerd backend. (experimental)"`
 
-	Bin    string    `long:"bin"    description:"Path to a garden backend executable (non-absolute names get resolved from $PATH)."`
-	Config flag.File `long:"config" description:"Path to a config file to use for the Garden backend. Guardian flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
+	Bin        string    `long:"bin"        description:"Path to a garden backend executable (non-absolute names get resolved from $PATH)."`
+	Config     flag.File `long:"config"     description:"Path to a config file to use for the Garden backend. Guardian flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
+	DNSServers []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
 
 	DNS DNSConfig `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 
@@ -130,6 +131,10 @@ func (cmd *WorkerCommand) gdnRunner(logger lager.Logger) (ifrit.Runner, error) {
 		// disable graph and grootfs setup; all images passed to Concourse
 		// containers are raw://
 		"--no-image-plugin",
+	}
+
+	for _, dnsServer := range cmd.Garden.DNSServers {
+		gdnServerFlags = append(gdnServerFlags, "--dns-server", dnsServer)
 	}
 
 	gdnServerFlags = append(gdnServerFlags, detectGardenFlags(logger)...)


### PR DESCRIPTION
### Existing Issue

Fixes #5138


### Changes proposed in this pull request

This PR allows users to pass a custom DNS server for use in worker containers.

It does this by making CONCOURSE_GARDEN_DNS_SERVER flag have the same functionality for `containerd` runtime as it does when using `guardian`.

### Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


### Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
