### PR TITLE
atc/db: write operations to an archived pipeline fail

### DIFF
--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -1480,7 +1480,19 @@ var _ = Describe("Jobs API", func() {
 						fakeJob.DisableManualTriggerReturns(false)
 					})
 
-					Context("when triggering the build fails", func() {
+					Context("when triggering the build fails due to a db conflict", func() {
+						BeforeEach(func() {
+							conflict := new(dbfakes.FakeConflict)
+							conflict.ConflictReturns("some conflict")
+							fakeJob.CreateBuildReturns(nil, conflict)
+						})
+						It("returns a 409", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusConflict))
+							body, _ := ioutil.ReadAll(response.Body)
+							Expect(body).To(Equal([]byte("some conflict\n")))
+						})
+					})
+					Context("when triggering the build fails with an unexpected error", func() {
 						BeforeEach(func() {
 							fakeJob.CreateBuildReturns(nil, errors.New("nopers"))
 						})

--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -2560,6 +2560,20 @@ var _ = Describe("Jobs API", func() {
 						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
 					})
 				})
+
+				Context("when scheduling fails due to a db conflict", func() {
+					BeforeEach(func() {
+						conflict := new(dbfakes.FakeConflict)
+						conflict.ConflictReturns("some conflict")
+						fakeJob.RequestScheduleReturns(conflict)
+					})
+
+					It("returns a 409 and an error", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusConflict))
+						body, _ := ioutil.ReadAll(response.Body)
+						Expect(body).To(Equal([]byte("some conflict\n")))
+					})
+				})
 			})
 		})
 

--- a/atc/api/jobserver/create_build.go
+++ b/atc/api/jobserver/create_build.go
@@ -33,6 +33,11 @@ func (s *Server) CreateJobBuild(pipeline db.Pipeline) http.Handler {
 		}
 
 		build, err := job.CreateBuild()
+		if conflict, ok := err.(db.Conflict); ok {
+			logger.Error("failed-to-create-job-build", err)
+			http.Error(w, conflict.Conflict(), http.StatusConflict)
+			return
+		}
 		if err != nil {
 			logger.Error("failed-to-create-job-build", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/jobserver/schedule_job.go
+++ b/atc/api/jobserver/schedule_job.go
@@ -25,6 +25,11 @@ func (s *Server) ScheduleJob(pipeline db.Pipeline) http.Handler {
 		}
 
 		err = job.RequestSchedule()
+		if conflict, ok := err.(db.Conflict); ok {
+			logger.Error("failed-to-schedule-job", err)
+			http.Error(w, conflict.Conflict(), http.StatusConflict)
+			return
+		}
 		if err != nil {
 			logger.Error("failed-to-schedule-job", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/pipelineserver/archive_test.go
+++ b/atc/api/pipelineserver/archive_test.go
@@ -92,4 +92,25 @@ var _ = Describe("Archive Handler", func() {
 			Expect(body).To(Equal([]byte("endpoint is not enabled\n")))
 		})
 	})
+
+	Context("when the endpoint is not enabled", func() {
+		BeforeEach(func() {
+			server = pipelineserver.NewServer(
+				fakeLogger,
+				new(dbfakes.FakeTeamFactory),
+				new(dbfakes.FakePipelineFactory),
+				"",
+				false, /* enableArchivePipeline */
+			)
+			handler = server.ArchivePipeline(dbPipeline)
+		})
+
+		It("responds with status Forbidden", func() {
+			handler.ServeHTTP(recorder, request)
+
+			Expect(recorder.Code).To(Equal(http.StatusForbidden))
+			body, _ := ioutil.ReadAll(recorder.Body)
+			Expect(body).To(Equal([]byte("endpoint is not enabled\n")))
+		})
+	})
 })

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -1307,6 +1307,25 @@ var _ = Describe("Resources API", func() {
 					})
 				})
 
+				Context("when the pipeline is archived", func() {
+					BeforeEach(func() {
+						fakeResource := new(dbfakes.FakeResource)
+						fakePipeline.ResourceReturns(fakeResource, true, nil)
+						fakeResourceTypes := db.ResourceTypes{}
+						fakePipeline.ResourceTypesReturns(fakeResourceTypes, nil)
+
+						conflict := new(dbfakes.FakeConflict)
+						conflict.ConflictReturns("archived pipeline error")
+						dbCheckFactory.TryCreateCheckReturns(nil, false, conflict)
+					})
+
+					It("returns 409", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusConflict))
+						body, _ := ioutil.ReadAll(response.Body)
+						Expect(body).To(Equal([]byte("archived pipeline error\n")))
+					})
+				})
+
 				Context("when looking up the resource types succeeds", func() {
 					var fakeResourceTypes db.ResourceTypes
 

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -596,6 +596,25 @@ var _ = Describe("Resources API", func() {
 				})
 			})
 
+			Context("when the pipeline is archived", func() {
+				BeforeEach(func() {
+					fakeResource := new(dbfakes.FakeResource)
+					fakePipeline.ResourceReturns(fakeResource, true, nil)
+					fakeResourceTypes := db.ResourceTypes{}
+					fakePipeline.ResourceTypesReturns(fakeResourceTypes, nil)
+
+					conflict := new(dbfakes.FakeConflict)
+					conflict.ConflictReturns("archived pipeline error")
+					dbCheckFactory.TryCreateCheckReturns(nil, false, conflict)
+				})
+
+				It("returns 409 and an error", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusConflict))
+					body, _ := ioutil.ReadAll(response.Body)
+					Expect(body).To(Equal([]byte("archived pipeline error\n")))
+				})
+			})
+
 			Context("when the resource is not found", func() {
 				BeforeEach(func() {
 					fakePipeline.ResourceReturns(nil, false, nil)

--- a/atc/api/resourceserver/check.go
+++ b/atc/api/resourceserver/check.go
@@ -46,6 +46,11 @@ func (s *Server) CheckResource(dbPipeline db.Pipeline) http.Handler {
 		}
 
 		check, created, err := s.checkFactory.TryCreateCheck(logger, dbResource, dbResourceTypes, reqBody.From, true)
+		if conflict, ok := err.(db.Conflict); ok {
+			s.logger.Error("failed-to-create-check", err)
+			http.Error(w, conflict.Conflict(), http.StatusConflict)
+			return
+		}
 		if err != nil {
 			s.logger.Error("failed-to-create-check", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/resourceserver/check_resource_type.go
+++ b/atc/api/resourceserver/check_resource_type.go
@@ -46,6 +46,12 @@ func (s *Server) CheckResourceType(dbPipeline db.Pipeline) http.Handler {
 		}
 
 		check, created, err := s.checkFactory.TryCreateCheck(logger, dbResourceType, dbResourceTypes, reqBody.From, true)
+		if conflict, ok := err.(db.Conflict); ok {
+			s.logger.Error("failed-to-create-check", err)
+			w.WriteHeader(http.StatusConflict)
+			http.Error(w, conflict.Conflict(), http.StatusConflict)
+			return
+		}
 		if err != nil {
 			s.logger.Error("failed-to-create-check", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -160,6 +160,9 @@ func (c *checkFactory) TryCreateCheck(logger lager.Logger, checkable Checkable, 
 	if !found {
 		return nil, false, fmt.Errorf("pipeline not found")
 	}
+	if pp.Archived() {
+		return nil, false, conflict("resources part of an archived pipeline cannot be checked")
+	}
 
 	varss, err := pp.Variables(logger, c.secrets, c.varSourcePool)
 	if err != nil {

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -896,6 +896,17 @@ func (j *job) RequestSchedule() error {
 
 	defer tx.Rollback()
 
+	pipeline, ok, err := j.pipeline(tx)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrPipelineDisappeared
+	}
+	if pipeline.Archived() {
+		return conflict("jobs part of an archived pipeline cannot be scheduled")
+	}
+
 	err = requestSchedule(tx, j.id)
 	if err != nil {
 		return err

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -2267,4 +2267,28 @@ var _ = Describe("Job", func() {
 			}))
 		})
 	})
+
+	Describe("CreateBuild", func() {
+		Context("when a pipeline is archived", func() {
+			It("fails to create a build", func() {
+				err := pipeline.Archive()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = job.CreateBuild()
+				conflict, ok := err.(db.Conflict)
+				Expect(ok).To(BeTrue(), "error was not a db.Conflict")
+				Expect(conflict.Conflict()).To(Equal("jobs part of an archived pipeline cannot be triggered"))
+			})
+		})
+
+		Context("when a pipeline does not exist", func() {
+			It("returns an error", func() {
+				err := pipeline.Destroy()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = job.CreateBuild()
+				Expect(err).To(MatchError("pipeline disappeared"))
+			})
+		})
+	})
 })

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -2291,4 +2291,28 @@ var _ = Describe("Job", func() {
 			})
 		})
 	})
+
+	Describe("RequestSchedule", func() {
+		Context("when a pipeline is archived", func() {
+			It("fails to request schedule", func() {
+				err := pipeline.Archive()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = job.RequestSchedule()
+				conflict, ok := err.(db.Conflict)
+				Expect(ok).To(BeTrue(), "error was not a db.Conflict")
+				Expect(conflict.Conflict()).To(Equal("jobs part of an archived pipeline cannot be scheduled"))
+			})
+		})
+
+		Context("when a pipeline does not exist", func() {
+			It("returns an error", func() {
+				err := pipeline.Destroy()
+				Expect(err).ToNot(HaveOccurred())
+
+				err = job.RequestSchedule()
+				Expect(err).To(MatchError("pipeline disappeared"))
+			})
+		})
+	})
 })

--- a/atc/db/pipeline_ref.go
+++ b/atc/db/pipeline_ref.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+
 	sq "github.com/Masterminds/squirrel"
 
 	"github.com/concourse/concourse/atc/db/lock"
@@ -42,13 +43,17 @@ func (r pipelineRef) PipelineName() string {
 }
 
 func (r pipelineRef) Pipeline() (Pipeline, bool, error) {
+	return r.pipeline(r.conn)
+}
+
+func (r pipelineRef) pipeline(runner sq.BaseRunner) (Pipeline, bool, error) {
 	if r.PipelineID() == 0 {
 		return nil, false, nil
 	}
 
 	row := pipelinesQuery.
 		Where(sq.Eq{"p.id": r.PipelineID()}).
-		RunWith(r.conn).
+		RunWith(runner).
 		QueryRow()
 
 	pipeline := newPipeline(r.conn, r.lockFactory)

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -283,7 +283,9 @@ var _ = Describe("Pipeline", func() {
 		Context("when the pipeline is unpaused", func() {
 			It("pauses the pipeline", func() {
 				err := pipeline.Unpause()
-				Expect(err.Error()).To(ContainSubstring("conflict error: archived pipelines cannot be unpaused"))
+				conflict, ok := err.(db.Conflict)
+				Expect(ok).To(BeTrue(), "error was not a db.Conflict")
+				Expect(conflict.Conflict()).To(Equal("archived pipelines cannot be unpaused"))
 				Expect(pipeline.Paused()).To(BeTrue(), "pipeline was not paused")
 			})
 		})

--- a/atc/integration/archiving_test.go
+++ b/atc/integration/archiving_test.go
@@ -87,6 +87,16 @@ var _ = Describe("ATC Integration Test", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("jobs part of an archived pipeline cannot be triggered"))
 		})
+
+		It("fails to schedule a job", func() {
+			givenAPipeline(client, "pipeline")
+			whenIArchiveIt(client, "pipeline")
+
+			_, err := client.Team("main").ScheduleJob("pipeline", "job-name")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("jobs part of an archived pipeline cannot be scheduled"))
+		})
 	})
 
 	Context("when the archiving pipeline endpoint is not enabled", func() {

--- a/atc/integration/archiving_test.go
+++ b/atc/integration/archiving_test.go
@@ -106,6 +106,7 @@ func whenIUnpauseIt(client concourse.Client, pipelineName string) {
 func whenIArchiveIt(client concourse.Client, pipelineName string) {
 	_, err := client.Team("main").ArchivePipeline(pipelineName)
 	Expect(err).ToNot(HaveOccurred())
+	return response
 }
 
 func getPipeline(client concourse.Client, pipelineName string) atc.Pipeline {


### PR DESCRIPTION
Existing Issue

Fixes #5430 .

# Changes proposed in this pull request

* Return a 409 HTTP status code for certain write operations on archived pipelines
* Return a db.Conflict error at the db level for these operations
* TODO: handle 409s in fly to print nicer error messages

# Contributor Checklist
- [x] Unit tests
- [x] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
