### PR TITLE
Remove duplicate migrations that not postgres 9.5 friendly

### DIFF
--- a/atc/db/migration/migrations/1583868323_add_pipelines_last_update.down.sql
+++ b/atc/db/migration/migrations/1583868323_add_pipelines_last_update.down.sql
@@ -1,4 +1,2 @@
 BEGIN;
-  ALTER TABLE pipelines
-    DROP COLUMN "last_updated";
 COMMIT;

--- a/atc/db/migration/migrations/1583868323_add_pipelines_last_update.up.sql
+++ b/atc/db/migration/migrations/1583868323_add_pipelines_last_update.up.sql
@@ -1,4 +1,2 @@
 BEGIN;
-  ALTER TABLE pipelines
-    ADD COLUMN If NOT EXISTS "last_updated" timestamp with time zone NOT NULL DEFAULT '1970-01-01 00:00:00';
 COMMIT;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: postgres
+    image: postgres:${POSTGRES_TAG:-latest}
     shm_size: 1gb
     ports:
     - 6543:5432


### PR DESCRIPTION
# Existing Issue
Fixes #5391.

# Why do we need this PR?
To support postgres 9.5


# Changes proposed in this pull request
The migration that caused the syntax error is a duplicate to fix an earlier migration error. We could just remove the migration.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
