### PR TITLE
web: behaviour: convert scrollToId to use a port

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -24,6 +24,9 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 
 * Close Worker's registration connection to the TSA on application level keepalive failure
 * Add 5 second timeout for keepalive operation
+#### <sub><sup><a name="5457" href="#5457">:link:</a></sup></sub> fix
+
+* Improve consistency of auto-scrolling to highlighted logs. #5457
 
 #### <sub><sup><a name="5452" href="#4081">:link:</a></sup></sub> fix
 

--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -766,6 +766,7 @@ sampleModel =
             , highlight = Routes.HighlightNothing
             }
     , autoScroll = True
+    , isScrollToIdInProgress = False
     , previousKeyPress = Nothing
     , isTriggerBuildKeyDown = False
     , showHelp = False

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -454,7 +454,11 @@ update msg ( model, effects ) =
             ( model, effects ++ [ NavigateTo <| Routes.toString <| route ] )
 
         Scrolled { scrollHeight, scrollTop, clientHeight } ->
-            ( { model | autoScroll = scrollHeight == scrollTop + clientHeight }
+            ( { model
+                | autoScroll =
+                    (scrollHeight == scrollTop + clientHeight)
+                        && not model.isScrollToIdInProgress
+              }
             , effects
             )
 
@@ -478,7 +482,7 @@ getScrollBehavior model =
                 NoScroll
 
         Routes.HighlightNothing ->
-            if model.autoScroll && not model.isScrollToIdInProgress then
+            if model.autoScroll then
                 if model.hasLoadedYet then
                     case model.status of
                         BuildStatusSucceeded ->

--- a/web/elm/src/Build/Models.elm
+++ b/web/elm/src/Build/Models.elm
@@ -25,6 +25,7 @@ type alias Model =
             (ShortcutsModel
                 { shiftDown : Bool
                 , highlight : Highlight
+                , isScrollToIdInProgress : Bool
                 , authorized : Bool
                 , output : CurrentOutput
                 , prep : Maybe Concourse.BuildPrep

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -15,7 +15,6 @@ import Message.Message
         , VersionToggleAction
         , VisibilityAction
         )
-import Message.ScrollDirection exposing (ScrollDirection)
 import Time
 
 

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -64,7 +64,6 @@ type Callback
     | AllPipelinesFetched (Fetched (List Concourse.Pipeline))
     | GotViewport DomID TooltipPolicy (Result Browser.Dom.Error Browser.Dom.Viewport)
     | GotElement (Result Browser.Dom.Error Browser.Dom.Element)
-    | ScrollCompleted ScrollDirection String
 
 
 type TooltipPolicy

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -11,7 +11,7 @@ import Api
 import Api.Endpoints as Endpoints
 import Assets
 import Base64
-import Browser.Dom exposing (Element, Viewport, getElement, getViewport, getViewportOf, setViewportOf)
+import Browser.Dom exposing (Viewport, getElement, getViewport, getViewportOf, setViewportOf)
 import Browser.Navigation as Navigation
 import Concourse exposing (encodeJob, encodePipeline, encodeTeam)
 import Concourse.BuildStatus exposing (BuildStatus)
@@ -659,11 +659,6 @@ toHtmlID domId =
 
         _ ->
             ""
-
-
-scrollToIdPadding : Float
-scrollToIdPadding =
-    60
 
 
 scroll : ScrollDirection -> String -> Cmd Callback

--- a/web/elm/src/Message/Subscription.elm
+++ b/web/elm/src/Message/Subscription.elm
@@ -42,6 +42,9 @@ port reportIsVisible : (( String, Bool ) -> msg) -> Sub msg
 port rawHttpResponse : (String -> msg) -> Sub msg
 
 
+port scrolledToId : (( String, String ) -> msg) -> Sub msg
+
+
 type RawHttpResponse
     = Success
     | Timeout
@@ -64,6 +67,7 @@ type Subscription
     | OnCachedJobsReceived
     | OnCachedPipelinesReceived
     | OnCachedTeamsReceived
+    | OnScrolledToId
 
 
 type Delivery
@@ -83,6 +87,7 @@ type Delivery
     | CachedJobsReceived (Result Json.Decode.Error (List Concourse.Job))
     | CachedPipelinesReceived (Result Json.Decode.Error (List Concourse.Pipeline))
     | CachedTeamsReceived (Result Json.Decode.Error (List Concourse.Team))
+    | ScrolledToId ( String, String )
     | Noop
 
 
@@ -177,6 +182,9 @@ runSubscription s =
 
         OnTokenSentToFly ->
             rawHttpResponse (decodeHttpResponse >> TokenSentToFly)
+
+        OnScrolledToId ->
+            scrolledToId ScrolledToId
 
 
 decodeStorageResponse : Storage.Key -> Json.Decode.Decoder a -> (Result Json.Decode.Error a -> Delivery) -> ( Storage.Key, Storage.Value ) -> Delivery

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -425,9 +425,6 @@ all =
                                 ]
                         )
                     |> Tuple.first
-                    |> Application.handleCallback
-                        (Callback.ScrollCompleted (ScrollDirection.ToId "stepid:1") "build-body")
-                    |> Tuple.first
                     |> Application.handleDelivery
                         (EventsReceived <| Ok [])
                     |> Tuple.second

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -429,6 +429,147 @@ all =
                         (EventsReceived <| Ok [])
                     |> Tuple.second
                     |> Common.notContains (Effects.Scroll (ScrollDirection.ToId "stepid:1") "build-body")
+        , test "auto-scroll disallowed before scrolled to highlighted line" <|
+            \_ ->
+                Application.init
+                    flags
+                    { protocol = Url.Http
+                    , host = ""
+                    , port_ = Nothing
+                    , path = "/teams/t/pipelines/p/jobs/j/builds/1"
+                    , query = Nothing
+                    , fragment = Just "Lstepid:1"
+                    }
+                    |> Tuple.first
+                    |> fetchBuild BuildStatusStarted
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.PlanAndResourcesFetched 1 <|
+                            Ok <|
+                                ( { id = "stepid"
+                                  , step =
+                                        Concourse.BuildStepTask
+                                            "step"
+                                  }
+                                , { inputs = [], outputs = [] }
+                                )
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (EventsReceived <|
+                            Ok <|
+                                [ { url = eventsUrl
+                                  , data =
+                                        STModels.StartTask
+                                            { source = "stdout"
+                                            , id = "stepid"
+                                            }
+                                            (Time.millisToPosix 0)
+                                  }
+                                , { url = eventsUrl
+                                  , data =
+                                        STModels.Log
+                                            { source = "stdout"
+                                            , id = "stepid"
+                                            }
+                                            "log message"
+                                            Nothing
+                                  }
+                                ]
+                        )
+                    |> Tuple.first
+                    |> Application.update
+                        (Msgs.Update <|
+                            Message.Message.Scrolled
+                                { scrollHeight = 20
+                                , scrollTop = 10
+                                , clientHeight = 10
+                                }
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (EventsReceived <| Ok [])
+                    |> Tuple.second
+                    |> Common.notContains (Effects.Scroll ScrollDirection.ToBottom "build-body")
+        , test "auto-scroll allowed after scrolled to highlighted line" <|
+            \_ ->
+                Application.init
+                    flags
+                    { protocol = Url.Http
+                    , host = ""
+                    , port_ = Nothing
+                    , path = "/teams/t/pipelines/p/jobs/j/builds/1"
+                    , query = Nothing
+                    , fragment = Just "Lstepid:1"
+                    }
+                    |> Tuple.first
+                    |> fetchBuild BuildStatusStarted
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.PlanAndResourcesFetched 1 <|
+                            Ok <|
+                                ( { id = "stepid"
+                                  , step =
+                                        Concourse.BuildStepTask
+                                            "step"
+                                  }
+                                , { inputs = [], outputs = [] }
+                                )
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (EventsReceived <|
+                            Ok <|
+                                [ { url = eventsUrl
+                                  , data =
+                                        STModels.StartTask
+                                            { source = "stdout"
+                                            , id = "stepid"
+                                            }
+                                            (Time.millisToPosix 0)
+                                  }
+                                , { url = eventsUrl
+                                  , data =
+                                        STModels.Log
+                                            { source = "stdout"
+                                            , id = "stepid"
+                                            }
+                                            "log message"
+                                            Nothing
+                                  }
+                                ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (Subscription.ScrolledToId ( "Lstepid:1", "build-body" ))
+                    |> Tuple.first
+                    |> Application.update
+                        (Msgs.Update <|
+                            Message.Message.Scrolled
+                                { scrollHeight = 20
+                                , scrollTop = 10
+                                , clientHeight = 10
+                                }
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (EventsReceived <| Ok [])
+                    |> Tuple.second
+                    |> Common.contains (Effects.Scroll ScrollDirection.ToBottom "build-body")
+        , test "subscribes to scrolled to id completion" <|
+            \_ ->
+                Application.init
+                    flags
+                    { protocol = Url.Http
+                    , host = ""
+                    , port_ = Nothing
+                    , path = "/teams/t/pipelines/p/jobs/j/builds/1"
+                    , query = Nothing
+                    , fragment = Just "Lstepid:1"
+                    }
+                    |> Tuple.first
+                    |> Application.subscriptions
+                    |> Common.contains Subscription.OnScrolledToId
         , describe "page title"
             [ test "with a job build" <|
                 \_ ->

--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -187,8 +187,27 @@ app.ports.syncTextareaHeight.subscribe(function(id) {
 	  setTimeout(attemptToSyncHeight, 50);
 	}
   }, 0);
-})
+});
 
+app.ports.scrollToId.subscribe(function(params) {
+  if (!params || params.length !== 2) {
+    return;
+  }
+  const [parentId, toId] = params;
+  const padding = 10;
+  const interval = setInterval(function() {
+    const parentElem = document.getElementById(parentId);
+    if (parentElem == null) {
+      return;
+    }
+    const elem = document.getElementById(toId);
+    if (elem == null) {
+      return;
+    }
+    parentElem.scrollTop = elem.offsetTop - padding;
+    clearInterval(interval);
+  }, 20);
+});
 
 app.ports.openEventStream.subscribe(function(config) {
   var buffer = [];

--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -205,6 +205,7 @@ app.ports.scrollToId.subscribe(function(params) {
       return;
     }
     parentElem.scrollTop = elem.offsetTop - padding;
+    app.ports.scrolledToId.send([parentId, toId]);
     clearInterval(interval);
   }, 20);
 });

--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -1,7 +1,7 @@
 const renderingModulePromise = import('./index.mjs');
 
 const node = document.getElementById("elm-app-embed");
-if (node == null) {
+if (node === null) {
   throw "missing #elm-app-embed";
 }
 
@@ -80,15 +80,15 @@ app.ports.tooltip.subscribe(function (pipelineInfo) {
   const pipelineTeamName = pipelineInfo[1];
 
   const team = document.getElementById(pipelineTeamName);
-  if (team == null) {
+  if (team === null) {
     return;
   }
   const card = team.querySelector(`.card[data-pipeline-name="${pipelineName}"]`);
-  if (card == null) {
+  if (card === null) {
     return;
   }
   const title = card.querySelector('.dashboard-pipeline-name');
-  if(title == null || title.offsetWidth >= title.scrollWidth) {
+  if(title === null || title.offsetWidth >= title.scrollWidth) {
     return;
   }
   title.parentNode.setAttribute('data-tooltip', pipelineName);
@@ -99,12 +99,12 @@ app.ports.tooltipHd.subscribe(function (pipelineInfo) {
   var pipelineTeamName = pipelineInfo[1];
 
   const card = document.querySelector(`.card[data-pipeline-name="${pipelineName}"][data-team-name="${pipelineTeamName}"]`);
-  if (card == null) {
+  if (card === null) {
     return;
   }
   const title = card.querySelector('.dashboardhd-pipeline-name');
 
-  if(title == null || title.offsetWidth >= title.scrollWidth){
+  if(title === null || title.offsetWidth >= title.scrollWidth){
     return;
   }
   title.parentNode.setAttribute('data-tooltip', pipelineName);
@@ -172,7 +172,7 @@ window.addEventListener('storage', function(event) {
 app.ports.syncTextareaHeight.subscribe(function(id) {
   const attemptToSyncHeight = () => {
     const elem = document.getElementById(id);
-    if (elem == null) {
+    if (elem === null) {
       return false;
     }
     elem.style.height = "auto";
@@ -197,11 +197,11 @@ app.ports.scrollToId.subscribe(function(params) {
   const padding = 10;
   const interval = setInterval(function() {
     const parentElem = document.getElementById(parentId);
-    if (parentElem == null) {
+    if (parentElem === null) {
       return;
     }
     const elem = document.getElementById(toId);
-    if (elem == null) {
+    if (elem === null) {
       return;
     }
     parentElem.scrollTop = elem.offsetTop - padding;

--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -205,7 +205,7 @@ app.ports.scrollToId.subscribe(function(params) {
       return;
     }
     parentElem.scrollTop = elem.offsetTop - padding;
-    app.ports.scrolledToId.send([parentId, toId]);
+    setTimeout(() => app.ports.scrolledToId.send([parentId, toId]), 50)
     clearInterval(interval);
   }, 20);
 });


### PR DESCRIPTION
# Existing Issue

Fixes #5454 .

# Changes proposed in this pull request

* Add `scrollToId` port that periodically checks if the parent and target element exist, and once both do, scrolls the target to the top of the parent
* Remove now unused `ScrollCompleted` callback

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

# Additional Context

With concourse/concourse#5275, I had attempted to fix scrolling to IDs
on the build page. While this sometimes worked, if it takes a long time
to render the log lines (common when there are many log lines), we would
fail to scroll since the ID did not yet exist on the page.

To fix this, revert the `scrollToId` behaviour to before
495904da500188d89a9c9e62071d4ac0e3205ed7 i.e. use ports for this. Note
that the behaviour isn't exactly the same - rather than using
`scrollIntoView`, which moves the top of the element to the top of the
screen, set the `scrollTop` of the parent to `offsetTop` (minus some
padding so it's not right at the top). This is because the step has a
sticky header, so if we moved the log line right to the top, it would be
hidden behind this header.