### PR TITLE
skymarshal: bcrypt client secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
 	github.com/concourse/baggageclaim v1.6.5
-	github.com/concourse/dex v0.0.0-20191211162806-d04c1742d527
+	github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88
 	github.com/concourse/flag v1.0.0
 	github.com/concourse/go-archive v1.0.1
 	github.com/concourse/retryhttp v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/concourse/baggageclaim v1.6.5 h1:nqUNImvNPagFWLpjmYM3K/iUtXcgjWCXGUVE
 github.com/concourse/baggageclaim v1.6.5/go.mod h1:XEX/nfW5iJQwJVLUh1AxyqtFRLeyM+iZLeKMUEloiKc=
 github.com/concourse/dex v0.0.0-20191211162806-d04c1742d527 h1:Ep+u+I/PBlINJF63aUHBao80GgfLqaz5aWFw/pLiavw=
 github.com/concourse/dex v0.0.0-20191211162806-d04c1742d527/go.mod h1:7xVx6jMkg5UoaGhDHp3mGdETzdVSTY8dOEG1v6ixNQc=
+github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88 h1:8BK+Qq51oMwD2CzjAbbMKlAjcXM/PHnAjuRkzZvFmZ4=
+github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88/go.mod h1:7xVx6jMkg5UoaGhDHp3mGdETzdVSTY8dOEG1v6ixNQc=
 github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/flag v1.0.0 h1:XG+A/Y+8kNdNDUC9T+SQ55dZ1+xYQN6LNVBg3cGJ080=
 github.com/concourse/flag v1.0.0/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=

--- a/skymarshal/dexserver/dexserver_test.go
+++ b/skymarshal/dexserver/dexserver_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Dex Server", func() {
 			})
 		})
 
-		Context("when clients are configured", func() {
+		Context("when clients are configured in plain text", func() {
 			BeforeEach(func() {
 				config.Clients = map[string]string{
 					"some-client-id": "some-client-secret",
@@ -189,12 +189,30 @@ var _ = Describe("Dex Server", func() {
 				config.RedirectURL = "http://example.com"
 			})
 
-			It("should contain the configured clients", func() {
+			It("should contain the configured clients with a bcrypted secret", func() {
 				clients, err := storage.ListClients()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clients).To(HaveLen(1))
 				Expect(clients[0].ID).To(Equal("some-client-id"))
-				Expect(clients[0].Secret).To(Equal("some-client-secret"))
+				Expect(bcrypt.CompareHashAndPassword([]byte(clients[0].Secret), []byte("some-client-secret"))).NotTo(HaveOccurred())
+				Expect(clients[0].RedirectURIs).To(ContainElement("http://example.com"))
+			})
+		})
+
+		Context("when clients are configured in bcrypt format", func() {
+			BeforeEach(func() {
+				config.Clients = map[string]string{
+					"some-client-id": "$2a$10$3veRX245rLrpOKrgu7jIyOEKF5Km5tY86bZql6/oTMssgPO/6XJju",
+				}
+				config.RedirectURL = "http://example.com"
+			})
+
+			It("should contain the configured clients with the given secret", func() {
+				clients, err := storage.ListClients()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clients).To(HaveLen(1))
+				Expect(clients[0].ID).To(Equal("some-client-id"))
+				Expect(clients[0].Secret).To(Equal("$2a$10$3veRX245rLrpOKrgu7jIyOEKF5Km5tY86bZql6/oTMssgPO/6XJju"))
 				Expect(clients[0].RedirectURIs).To(ContainElement("http://example.com"))
 			})
 		})


### PR DESCRIPTION
Fixes #5428 

- you can now configure dex with bcrypted client secrets
- if they are in plaintext concourse will bcrypt them and then pass them to dex.

corresponding dex commit:
https://github.com/concourse/dex/commit/dcbe94f