### PR TITLE
support dns proxy in containerd

### DIFF
--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -13,6 +13,8 @@ import (
 
 	"code.cloudfoundry.org/garden/server"
 	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/localip"
+	concourseCmd "github.com/concourse/concourse/cmd"
 	containerd "github.com/concourse/concourse/worker/backend"
 	"github.com/concourse/concourse/worker/backend/libcontainerd"
 	"github.com/tedsuo/ifrit"
@@ -132,18 +134,43 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 		Pdeathsig: syscall.SIGKILL,
 	}
 
+	members := grouper.Members{}
+
+	dnsServers := cmd.Garden.DNSServers
+	if cmd.Garden.DNS.Enable {
+		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
+		if err != nil {
+			return nil, err
+		}
+
+		lip, err := localip.LocalIP()
+		if err != nil {
+			return nil, err
+		}
+
+		dnsServers = append(dnsServers, lip)
+
+		members = append(members, grouper.Member{
+			Name: "dns-proxy",
+			Runner: concourseCmd.NewLoggingRunner(
+				logger.Session("dns-proxy-runner"),
+				dnsProxyRunner,
+			),
+		})
+	}
+
 	backendRunner, err := containerdGardenServerRunner(
 		logger,
 		cmd.bindAddr(),
 		sock,
 		cmd.Garden.RequestTimeout,
-		cmd.Garden.DNSServers,
+		dnsServers,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("containerd garden server runner: %w", err)
 	}
 
-	return grouper.NewParallel(os.Interrupt, grouper.Members{
+	members = append(members, grouper.Members{
 		{
 			Name:   "containerd",
 			Runner: CmdRunner{command},
@@ -152,5 +179,7 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 			Name:   "containerd-backend",
 			Runner: backendRunner,
 		},
-	}), nil
+	}...)
+
+	return grouper.NewParallel(os.Interrupt, members), nil
 }


### PR DESCRIPTION
### Existing Issue

Fixes #5139 



### Changes proposed in this pull request

When CONCOURSE_GARDEN_DNS_ENABLE flag is set on the worker while running containerd as a backend, a proxy DNS server will be run, and added to the list of DNS servers for a container.

Note:
Given that topgun/k8s already tests all of the possible scenarios involving configuring DNS servers, we rely on that suite for ensuring that this is properly done - there might be other possibilities for 
making this not rely on the topgun suite though - please let us knowif you have any ideas!

See https://github.com/concourse/concourse/blob/fab3de1722a2ce998d3710bd066453594f24ec57/topgun/k8s/dns_proxy_test.go

**UPDATE**: Issue #5473 opened to address the testing

### Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


### Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 


cc @muntac 
