### PR TITLE
hack: fix dlv installation

### DIFF
--- a/hack/dlv/Dockerfile
+++ b/hack/dlv/Dockerfile
@@ -1,5 +1,6 @@
 FROM concourse/concourse:local
 
+ENV GO111MODULE=off
 ENV EDITOR=vim
 
 RUN apt install -y vim


### PR DESCRIPTION
### Why do we need this PR?

the way that we're currently asking `dlv` to be installed (via `go get`
in a directory that is module aware), it's as if we were making dlv a
dependency of concourse, which is not really what we want.

```
#6 5.952 github.com/go-delve/delve/pkg/terminal
#6 5.967 # github.com/go-delve/delve/pkg/terminal
#6 5.967 /go/pkg/mod/github.com/go-delve/delve@v1.4.0/pkg/terminal/command.go:959:28: cannot use ([]rune)(args) (type []rune) as type string in argument to argv.Argv
#6 5.967 /go/pkg/mod/github.com/go-delve/delve@v1.4.0/pkg/terminal/command.go:959:36: undefined: argv.ParseEnv
#6 5.967 /go/pkg/mod/github.com/go-delve/delve@v1.4.0/pkg/terminal/command.go:960:3: cannot use func literal (type func([]rune, map[string]string) ([]rune, error)) as type argv.Expander in argument to argv.Argv
------
failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c go get -u -v github.com/go-delve/delve/cmd/dlv]: runc did not terminate sucessfully
```


### Changes proposed in this pull request

as explained in an issue in dlv's repo (see [1]), this can be fixed by
turning go modules off during the installation.

[1]: https://github.com/go-delve/delve/issues/1991#issuecomment-609706835

to verify that the proposed approach works:

1. bring concourse up (`docker-compose up -d --build`)
2. trace `web` (`./hack/trace web`)
  - you should see `dlv` being properly build, and then the repl showing up

### Contributor Checklist

- ~Unit tests~
- ~Integration tests (if applicable)~
- ~Updated documentation (located at https://github.com/concourse/docs)~
- ~Updated release notes (located at https://github.com/concourse/concoure/tree/master/release-notes)~


### Reviewer Checklist

- [x] Code reviewed

