### PR TITLE
[5.5.x] web: behaviour: do not pile on dashboard API calls

### DIFF
--- a/release-notes/v5.5.11.md
+++ b/release-notes/v5.5.11.md
@@ -1,4 +1,7 @@
-#### <sub><sup><a name="v5511-note-1" href="#5511-note-1">:link:</a></sup></sub> feature
+#### <sub><sup><a name="5427" href="#5427">:link:</a></sup></sub> feature
 
 * Add loading indicator on dashboard while awaiting initial API response. #5427
 
+#### <sub><sup><a name="5472" href="#5472">:link:</a></sup></sub> fix
+
+* The dashboard page refreshes its data every 5 seconds. Until now, it was possible (especially for admin users) for the dashboard to initiate an ever-growing number of API calls, unnecessarily consuming browser, network and API resources. Now the dashboard will not initiate a request for more data until the previous request finishes. #5472

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -102,6 +102,7 @@ init flags =
       , query = Routes.extractQuery flags.searchType
       , isUserMenuExpanded = False
       , dropdown = Hidden
+      , isDataLoading = True
       }
     , [ FetchData
       , PinTeamNames Message.Effects.stickyHeaderConfig
@@ -118,6 +119,7 @@ handleCallback msg ( model, effects ) =
             ( { model
                 | state =
                     RemoteData.Failure (Turbulence model.turbulencePath)
+                , isDataLoading = False
               }
             , effects
             )
@@ -159,6 +161,7 @@ handleCallback msg ( model, effects ) =
                     , highDensity = False
                     , version = apiData.version
                     , userState = userState
+                    , isDataLoading = False
                   }
                 , effects
                     ++ [ ModifyUrl <|
@@ -172,6 +175,7 @@ handleCallback msg ( model, effects ) =
                     | groups = groups
                     , version = apiData.version
                     , userState = userState
+                    , isDataLoading = False
                   }
                 , effects
                 )
@@ -267,7 +271,16 @@ handleDeliveryBody delivery ( model, effects ) =
             )
 
         ClockTicked FiveSeconds _ ->
-            ( model, effects ++ [ FetchData, FetchPipelines ] )
+            ( { model | isDataLoading = True }
+            , effects
+                ++ FetchPipelines
+                :: (if model.isDataLoading then
+                        []
+
+                    else
+                        [ FetchData ]
+                   )
+            )
 
         _ ->
             ( model, effects )

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -30,6 +30,7 @@ type alias Model =
             , userState : UserState.UserState
             , highDensity : Bool
             , query : String
+            , isDataLoading : Bool
             }
         )
 

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -3535,6 +3535,9 @@ all =
         , test "auto refreshes data every five seconds" <|
             \_ ->
                 Common.init "/"
+                    |> givenDataUnauthenticated
+                        (oneTeamOnePipeline "team")
+                    |> Tuple.first
                     |> Application.update
                         (ApplicationMsgs.DeliveryReceived <|
                             ClockTicked FiveSeconds <|
@@ -3543,6 +3546,37 @@ all =
                     |> Tuple.second
                     |> List.member Effects.FetchData
                     |> Expect.true "should refresh data"
+        , test "does not pile on API requests" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.update
+                        (ApplicationMsgs.DeliveryReceived <|
+                            ClockTicked FiveSeconds <|
+                                Time.millisToPosix 0
+                        )
+                    |> Tuple.second
+                    |> List.member Effects.FetchData
+                    |> Expect.false "should not pile on requests"
+        , test "does not pile on API requests after the first" <|
+            \_ ->
+                Common.init "/"
+                    |> givenDataUnauthenticated
+                        (oneTeamOnePipeline "team")
+                    |> Tuple.first
+                    |> Application.update
+                        (ApplicationMsgs.DeliveryReceived <|
+                            ClockTicked FiveSeconds <|
+                                Time.millisToPosix 0
+                        )
+                    |> Tuple.first
+                    |> Application.update
+                        (ApplicationMsgs.DeliveryReceived <|
+                            ClockTicked FiveSeconds <|
+                                Time.millisToPosix 0
+                        )
+                    |> Tuple.second
+                    |> List.member Effects.FetchData
+                    |> Expect.false "should not pile on requests"
         ]
 
 


### PR DESCRIPTION
Fixes #5424. This is a backport of (part of) the functionality in #5023, and I have duplicated the release note from that feature.

# Changes proposed in this pull request

* pretty straightforward - add a flag to the Dashboard model - on every 5 seconds this flag is set to `True`, and every time an `APIDataFetched` callback returns it is set to `False`.
* This means that you will never have two `FetchData` effects in flight at the same time

Similar to https://github.com/concourse/concourse/pull/5023#issue-362785585, I patched my `ListAllJobs` endpoint so it sleeps for an extra 10 seconds.

Before this patch:
<img width="719" alt="Screen Shot 2020-04-20 at 3 06 29 PM" src="https://user-images.githubusercontent.com/22056320/79790670-18ff6300-831a-11ea-81d1-ee559f4a9436.png">

After this patch:
<img width="721" alt="Screen Shot 2020-04-20 at 3 10 37 PM" src="https://user-images.githubusercontent.com/22056320/79790679-1dc41700-831a-11ea-8edb-9d9fbcb4ba8b.png">

# Contributor Checklist
- [x] Unit tests
- [x] ~Integration tests (if applicable)~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~