### PR TITLE
Fix ordering of max in flight check

### DIFF
--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -934,7 +934,7 @@ func (j *job) getRunningBuildsBySerialGroup(tx Tx, serialGroups []string) ([]Bui
 }
 
 func (j *job) getNextPendingBuildBySerialGroup(tx Tx, serialGroups []string) (Build, bool, error) {
-	row := buildsQuery.Options(`DISTINCT ON (b.id)`).
+	row := buildsQuery.
 		Join(`jobs_serial_groups jsg ON j.id = jsg.job_id`).
 		Where(sq.Eq{
 			"jsg.serial_group":    serialGroups,
@@ -942,7 +942,7 @@ func (j *job) getNextPendingBuildBySerialGroup(tx Tx, serialGroups []string) (Bu
 			"j.paused":            false,
 			"j.inputs_determined": true,
 			"j.pipeline_id":       j.pipelineID}).
-		OrderBy("b.id ASC").
+		OrderBy("COALESCE(b.rerun_of, b.id) ASC, b.id ASC").
 		Limit(1).
 		RunWith(tx).
 		QueryRow()

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -934,7 +934,7 @@ func (j *job) getRunningBuildsBySerialGroup(tx Tx, serialGroups []string) ([]Bui
 }
 
 func (j *job) getNextPendingBuildBySerialGroup(tx Tx, serialGroups []string) (Build, bool, error) {
-	row := buildsQuery.
+	subQuery, params, err := buildsQuery.Options(`DISTINCT ON (b.id)`).
 		Join(`jobs_serial_groups jsg ON j.id = jsg.job_id`).
 		Where(sq.Eq{
 			"jsg.serial_group":    serialGroups,
@@ -942,13 +942,18 @@ func (j *job) getNextPendingBuildBySerialGroup(tx Tx, serialGroups []string) (Bu
 			"j.paused":            false,
 			"j.inputs_determined": true,
 			"j.pipeline_id":       j.pipelineID}).
-		OrderBy("COALESCE(b.rerun_of, b.id) ASC, b.id ASC").
-		Limit(1).
-		RunWith(tx).
-		QueryRow()
+		ToSql()
+	if err != nil {
+		return nil, false, err
+	}
+
+	row := tx.QueryRow(`
+			SELECT * FROM (`+subQuery+`) j
+			ORDER BY COALESCE(rerun_of, id) ASC, id ASC
+			LIMIT 1`, params...)
 
 	build := newEmptyBuild(j.conn, j.lockFactory)
-	err := scanBuild(build, row, j.conn.EncryptionStrategy())
+	err = scanBuild(build, row, j.conn.EncryptionStrategy())
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, false, nil

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -68,3 +68,7 @@
 #### <sub><sup><a name="5479" href="#5479">:link:</a></sup></sub> feature
 
 * Updated a migration that adds a column to the pipelines table. The syntax initially used is not supported by Postgres 9.5 which is still supported. Removed the unsupported syntax so users using Postgres 9.5 can run the migration. Our CI pipeline has also been updated to ensure we run our tests on Postgres 9.5. #5479
+
+#### <sub><sup><a name="5452" href="#5452">:link:</a></sup></sub> fix
+
+* We fixed a bug where if you create a new build and then trigger a rerun build, both the builds will be stuck in pending state. #5452


### PR DESCRIPTION
# Existing Issue

Fixes #5452.

# Why do we need this PR?
There is a bug where if you create a new pending build and then trigger a rerun pending build, all the builds will be stuck in pending state. This is because the ordering of the builds that are scheduled are different than the ordering of the builds that are used to check if the job has reached max in flight. The pending builds are scheduled in the same order as the algorithm where it takes into account rerun builds and orders them in the order of the build it is a rerun of. For example, if you have three pending builds that were created in this order, 5, 6.1, 2.1, where 6.1 and 2.1 are reruns, we will schedule them in the order 2.1, 5, 6.1. This is because we schedule builds from oldest -> latest and since 2.1 is a rerun of 2, it gets scheduled first. Then 5 is scheduled because it is older than the build 6.1 was a rerun of. This is the part of the query that takes care of this ordering.

https://github.com/concourse/concourse/blob/3d7c18cc7d7efeabd6f3b062ddc662aa39c4bc88/atc/db/job.go#L630

With the scheduler ordering the pending builds that it needs to schedule in this format, the max in flight check currently orders them just by build ID in ascending format. 

https://github.com/concourse/concourse/blob/3d7c18cc7d7efeabd6f3b062ddc662aa39c4bc88/atc/db/job.go#L945

With the max in flight check ordering it in build ID, the same example as before with pending builds 5, 6.1 and 2.1 created in this order, the max in flight check would have determined build 5 to be the next pending build. But the next pending build according to the scheduler is 2.1 so then it compares if the next pending build according to the scheduler (build 2.1) to the next pending build according to the max in flight check (build 5). Since they are different, it returns max in flight reached.

https://github.com/concourse/concourse/blob/3d7c18cc7d7efeabd6f3b062ddc662aa39c4bc88/atc/db/job.go#L844

# Changes proposed in this pull request
I made a change that orders the max in flight check for the next pending build the same way as the scheduler orders it's pending build. This will ensure that both definitions of what the "next pending build" is will be the same.

I didn't add any tests because this is an edge case that can't be properly written as a unit test since it involves certain conditions on multiple components. However, I did do manual testing with one job and creating a new pending build first and then a rerun build. I observed it be stuck in pending state before this change and after the change, is able to start.

# Contributor Checklist
> Are the following items included as part of this PR? Please delete checkbox items that don't apply.
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
> This section is intended for the core maintainers only, to track review progress. Please do not
> fill out this section.
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
