### PR TITLE
Add worker flag to configure container network pool

### DIFF
--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -40,6 +40,8 @@ type WorkerCommand struct {
 	HealthcheckBindPort uint16        `long:"healthcheck-bind-port"  default:"8888"     description:"Port on which to listen for health checking requests."`
 	HealthCheckTimeout  time.Duration `long:"healthcheck-timeout"    default:"5s"       description:"HTTP timeout for the full duration of health checking."`
 
+	ContainerNetworkPool string `long:"container-network-pool" description:"Network range to use for dynamically allocated container subnets."`
+
 	SweepInterval               time.Duration `long:"sweep-interval" default:"30s" description:"Interval on which containers and volumes will be garbage collected from the worker."`
 	VolumeSweeperMaxInFlight    uint16        `long:"volume-sweeper-max-in-flight" default:"3" description:"Maximum number of volumes which can be swept in parallel."`
 	ContainerSweeperMaxInFlight uint16        `long:"container-sweeper-max-in-flight" default:"5" description:"Maximum number of containers which can be swept in parallel."`

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -34,8 +34,7 @@ type GardenBackend struct {
 	Bin        string    `long:"bin"        description:"Path to a garden backend executable (non-absolute names get resolved from $PATH)."`
 	Config     flag.File `long:"config"     description:"Path to a config file to use for the Garden backend. Guardian flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
 	DNSServers []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
-
-	DNS DNSConfig `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
+	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
 }
@@ -135,6 +134,10 @@ func (cmd *WorkerCommand) gdnRunner(logger lager.Logger) (ifrit.Runner, error) {
 
 	for _, dnsServer := range cmd.Garden.DNSServers {
 		gdnServerFlags = append(gdnServerFlags, "--dns-server", dnsServer)
+	}
+
+	if cmd.ContainerNetworkPool != "" {
+		gdnServerFlags = append(gdnServerFlags, "--network-pool", cmd.ContainerNetworkPool)
 	}
 
 	gdnServerFlags = append(gdnServerFlags, detectGardenFlags(logger)...)


### PR DESCRIPTION
# Existing Issue
Fixes #5140  .

# Changes proposed in this pull request
add `container-network-pool` flag to worker command. It will be passed to garden server flag `network-pool` or containerd cni network config.

The env var will be `CONCOURSE_CONTAINER_NETWORK_POOL`

# Contributor Checklist
- [ ] Unit tests
- [ ] Integration tests (if applicable)
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] Bosh release update
- [ ] Concoures chart update
