### PR TITLE
Dockerfile: set key env vars after generating keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,12 @@ RUN concourse generate-key -t rsa -b 1024 -f /concourse-keys/session_signing_key
 RUN concourse generate-key -t ssh -b 1024 -f /concourse-keys/tsa_host_key
 RUN concourse generate-key -t ssh -b 1024 -f /concourse-keys/worker_key
 RUN cp /concourse-keys/worker_key.pub /concourse-keys/authorized_worker_keys
+
+# 'web' keys
+ENV CONCOURSE_SESSION_SIGNING_KEY     /concourse-keys/session_signing_key
+ENV CONCOURSE_TSA_AUTHORIZED_KEYS     /concourse-keys/authorized_worker_keys
+ENV CONCOURSE_TSA_HOST_KEY            /concourse-keys/tsa_host_key
+
+# 'worker' keys
+ENV CONCOURSE_TSA_PUBLIC_KEY          /concourse-keys/tsa_host_key.pub
+ENV CONCOURSE_TSA_WORKER_PRIVATE_KEY  /concourse-keys/worker_key


### PR DESCRIPTION
# Why is this PR needed?

The dev image, upon which we base our image for testing, sets some environment
variables pointing to various keys. This is done as a convenience for images
layered on top, but it doesn't really make sense because these environment
variables are actually set to point to nonexistent paths.

# What is this PR trying to accomplish?

The idea here is to pave the way for creating images where the key-generation
and configuration-setting are done in the opposite order.

# How does it accomplish that?

This change should have no impact for the moment -- it sets environment
variables that, at this point, are already set. In general it makes more
sense to generate the keys before pointing to them with environment variables.
Once we switch to a stricter version of go-flags, this change will be necessary
to prevent the `concourse generate-key` commands from failing.

# Contributor Checklist

- [x] ~Unit tests~
- [x] ~Integration tests~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist

- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] PR acceptance performed - do a docker build!
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~