### PR TITLE
web: behaviour: recover from turbulence view

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -61,4 +61,7 @@
 
 * Add loading indicator on dashboard while awaiting initial API/cache response. #5458
 
+#### <sub><sup><a name="5496" href="#5496">:link:</a></sup></sub> fix
+
+* Allow the dashboard to recover from the "show turbulence" view if any API call fails once, but starts working afterward. This will prevent users from needing to refresh the page after closing their laptop or in the presence of network flakiness. #5496
 

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -11,8 +11,6 @@ import Dashboard.Group.Models
 import Dict exposing (Dict)
 import FetchResult exposing (FetchResult)
 import Login.Login as Login
-import Message.Effects exposing (Effect)
-import Set exposing (Set)
 import Time
 
 

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -11,14 +11,15 @@ import Dashboard.Group.Models
 import Dict exposing (Dict)
 import FetchResult exposing (FetchResult)
 import Login.Login as Login
+import Message.Effects exposing (Effect)
+import Set exposing (Set)
 import Time
 
 
 type alias Model =
     FooterModel
         (Login.Model
-            { showTurbulence : Bool
-            , now : Maybe Time.Posix
+            { now : Maybe Time.Posix
             , highDensity : Bool
             , query : String
             , pipelinesWithResourceErrors : Dict ( String, String ) Bool
@@ -31,6 +32,10 @@ type alias Model =
             , isTeamsRequestFinished : Bool
             , isPipelinesRequestFinished : Bool
             , isResourcesRequestFinished : Bool
+            , isJobsErroring : Bool
+            , isTeamsErroring : Bool
+            , isResourcesErroring : Bool
+            , isPipelinesErroring : Bool
             , viewportWidth : Float
             , viewportHeight : Float
             , scrollTop : Float

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -147,6 +147,19 @@ flags =
     }
 
 
+internalServerError : Http.Error
+internalServerError =
+    Http.BadStatus
+        { url = "http://example.com"
+        , status =
+            { code = 500
+            , message = "internal server error"
+            }
+        , headers = Dict.empty
+        , body = ""
+        }
+
+
 all : Test
 all =
     describe "Dashboard"
@@ -258,60 +271,93 @@ all =
                         )
                     |> Tuple.second
                     |> Expect.equal [ Effects.RedirectToLogin ]
+        , test "shows turbulence view if the all teams call gives a bad status error" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllTeamsFetched <| Err internalServerError)
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.has [ text "experiencing turbulence" ]
+        , test "recovers from turbulence view if all teams call succeeds" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllTeamsFetched <| Err internalServerError)
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllTeamsFetched <| Ok [])
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.hasNot [ text "experiencing turbulence" ]
         , test "shows turbulence view if the all resources call gives a bad status error" <|
             \_ ->
                 Common.init "/"
                     |> Application.handleCallback
-                        (Callback.AllResourcesFetched <|
-                            Err <|
-                                Http.BadStatus
-                                    { url = "http://example.com"
-                                    , status =
-                                        { code = 500
-                                        , message = "internal server error"
-                                        }
-                                    , headers = Dict.empty
-                                    , body = ""
-                                    }
-                        )
+                        (Callback.AllResourcesFetched <| Err internalServerError)
                     |> Tuple.first
                     |> Common.queryView
                     |> Query.has [ text "experiencing turbulence" ]
+        , test "recovers from turbulence view if all resources call succeeds" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllResourcesFetched <| Err internalServerError)
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllResourcesFetched <| Ok [])
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.hasNot [ text "experiencing turbulence" ]
         , test "shows turbulence view if the all jobs call gives a bad status error" <|
             \_ ->
                 Common.init "/"
                     |> Application.handleCallback
-                        (Callback.AllJobsFetched <|
-                            Err <|
-                                Http.BadStatus
-                                    { url = "http://example.com"
-                                    , status =
-                                        { code = 500
-                                        , message = "internal server error"
-                                        }
-                                    , headers = Dict.empty
-                                    , body = ""
-                                    }
-                        )
+                        (Callback.AllJobsFetched <| Err internalServerError)
                     |> Tuple.first
                     |> Common.queryView
                     |> Query.has [ text "experiencing turbulence" ]
+        , test "recovers from turbulence view if all jobs call succeeds" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllJobsFetched <| Err internalServerError)
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllJobsFetched <| Ok [])
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.hasNot [ text "experiencing turbulence" ]
         , test "shows turbulence view if the all pipelines call gives a bad status error" <|
             \_ ->
                 Common.init "/"
                     |> Application.handleCallback
-                        (Callback.AllPipelinesFetched <|
-                            Err <|
-                                Http.BadStatus
-                                    { url = "http://example.com"
-                                    , status =
-                                        { code = 500
-                                        , message = "internal server error"
-                                        }
-                                    , headers = Dict.empty
-                                    , body = ""
-                                    }
-                        )
+                        (Callback.AllPipelinesFetched <| Err internalServerError)
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.has [ text "experiencing turbulence" ]
+        , test "recovers from turbulence view if all pipelines call succeeds" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <| Err internalServerError)
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <| Ok [])
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.hasNot [ text "experiencing turbulence" ]
+        , test "does not recover from turbulence view if some endpoints are still errored" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (Callback.AllJobsFetched <| Err internalServerError)
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <| Err internalServerError)
+                    |> Tuple.first
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched <| Ok [])
                     |> Tuple.first
                     |> Common.queryView
                     |> Query.has [ text "experiencing turbulence" ]

--- a/web/elm/tests/DragAndDropTests.elm
+++ b/web/elm/tests/DragAndDropTests.elm
@@ -166,15 +166,6 @@ all =
                 >> given iDropThePipelineCard
                 >> when orderPipelinesFails
                 >> then_ myBrowserMakesTheFetchPipelinesAPICall
-        , test "failed to fetch team's pipelines displays turbulence view" <|
-            given
-                iVisitedTheDashboard
-                >> given myBrowserFetchedTwoPipelines
-                >> given iAmDraggingTheFirstPipelineCard
-                >> given iAmDraggingOverTheThirdDropArea
-                >> given iDropThePipelineCard
-                >> when dashboardFailsToRefreshPipelines
-                >> then_ iSeeTheTurbulenceView
         ]
 
 
@@ -341,12 +332,6 @@ iSeeASpinner =
 
 iSeeAllCardsHaveOpacity =
     Query.each (Query.has [ style "opacity" "0.5" ])
-
-
-iSeeTheTurbulenceView =
-    Tuple.first
-        >> Common.queryView
-        >> Query.has [ text "experiencing turbulence" ]
 
 
 iDoNotSeeASpinner =


### PR DESCRIPTION
# Why is this PR needed?

If any network request fails once, the dashboard will be stuck in the
"show turbulence" page view forever (until you refresh the page). This
happens fairly frequently to me at least - if you have the dashboard
open, close your laptop for a little, and come back, the page will be
unusable due to the turbulence view.

# What is this PR trying to accomplish?

Allow the turbulence view to disappear if all of the once failing network requests start succeeding.

# How does it accomplish that?

Rather than just keeping track of whether we should display the turbulence view (which was previously never unset), keep track of whether each endpoint is failing. If any of the endpoints are still failing, display the turbulence view.

One change is that the dashboard no longer considers the "team pipelines" endpoint response for displaying the show turbulence view - if it ever errors, we'd still be stuck in the turbulence view forever (since nothing would trigger another `FetchPipelines` effect). I'd also argue that displaying turbulence if this endpoint fails is not that valuable - if there is truly turbulence, the next API calls (in < 5 seconds) will display this.

# Contributor Checklist

- [x] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist

- [x] Code reviewed
- [x] Tests reviewed
- [x] Release notes reviewed
- [x] PR acceptance performed