### PR TITLE
topgun/k8s: more flexible regex in container limits test

### DIFF
--- a/topgun/k8s/container_limits_test.go
+++ b/topgun/k8s/container_limits_test.go
@@ -82,9 +82,8 @@ func containerLimitsFail(selectorFlags ...string) {
 			<-buildSession.Exited
 			Expect(buildSession.ExitCode()).To(Equal(2))
 			Expect(buildSession).To(gbytes.Say(
-				"failed to write 1073741824 to memory.memsw.limit_in_bytes",
+				"memory.memsw.limit_in_bytes: permission denied",
 			))
-			Expect(buildSession).To(gbytes.Say("permission denied"))
 		})
 	})
 }


### PR DESCRIPTION
# Why is this PR needed?

[k8s-topgun](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-topgun) has been failing since April 17th, blocking our ability to ship a new minor version of Concourse.

# What is this PR trying to accomplish?

After investigating the output of k8s-topgun, I realized that the failure was the result of an unnecessarily-brittle test - the underlying behaviour of the system was still correct. This PR is trying to address the robustness of the test.

# How does it accomplish that?

Replace a fairly strict regex with a more flexible one that shoudl effectively verify the same behaviour. I am confident this is a reasonable pattern to use, as it is employed by testflight in a very similar scenario.

I tested this by focusing the container limits test that has been failing on master, and running:

```
fly -t ci execute \
  -c $HOME/workspace/ci/tasks/k8s-topgun.yml \
  -i concourse=. \
  -j concourse/k8s-topgun \
  --tag k8s-topgun \
  --image unit-image
```

EDIT: sorry, I forgot to mention that I patched `ci` with this first!

```diff
diff --git a/tasks/k8s-topgun.yml b/tasks/k8s-topgun.yml
index 072d512..03f4b82 100644
--- a/tasks/k8s-topgun.yml
+++ b/tasks/k8s-topgun.yml
@@ -7,8 +7,9 @@ image_resource:

 params:
   CONCOURSE_CHART_DIR:
-  CONCOURSE_IMAGE_NAME:
-  KUBE_CONFIG:
+  CONCOURSE_IMAGE_NAME: concourse/concourse-rc
+  KUBE_CONFIG: ((kube_config))
+  IN_CLUSTER: "true"

 inputs:
 - name: concourse
```

# Contributor Checklist

- [x] ~Unit tests~
- [x] Integration tests
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist

- [x] ~Code reviewed~ No code changes!
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~