### PR TITLE
Re-introduce mutex timeouts

### DIFF
--- a/atc/db/lock/lock_test.go
+++ b/atc/db/lock/lock_test.go
@@ -41,7 +41,12 @@ var _ = Describe("Locks", func() {
 
 		logger = lagertest.NewTestLogger("test")
 
-		lockFactory = lock.NewLockFactory(postgresRunner.OpenSingleton(), fakeLogFunc, fakeLogFunc)
+		lockFactory = lock.NewLockFactoryWithTimeout(
+			postgresRunner.OpenSingleton(),
+			fakeLogFunc,
+			fakeLogFunc,
+			time.Second,
+		)
 
 		dbConn = postgresRunner.OpenConn()
 		teamFactory = db.NewTeamFactory(dbConn, lockFactory)
@@ -86,7 +91,7 @@ var _ = Describe("Locks", func() {
 
 			fakeLockDB.AcquireStub = func(id lock.LockID) (bool, error) {
 				select {
-				case <-time.After(11 * time.Second):
+				case <-time.After(2 * time.Second):
 				case <-done:
 				}
 				return true, nil
@@ -150,7 +155,12 @@ var _ = Describe("Locks", func() {
 			var lockFactory2 lock.LockFactory
 
 			BeforeEach(func() {
-				lockFactory2 = lock.NewLockFactory(postgresRunner.OpenSingleton(), fakeLogFunc, fakeLogFunc)
+				lockFactory2 = lock.NewLockFactoryWithTimeout(
+					postgresRunner.OpenSingleton(),
+					fakeLogFunc,
+					fakeLogFunc,
+					time.Second,
+				)
 			})
 
 			It("does not acquire the lock", func() {

--- a/atc/db/lock/lock_test.go
+++ b/atc/db/lock/lock_test.go
@@ -76,6 +76,36 @@ var _ = Describe("Locks", func() {
 			Expect(acquired).To(BeFalse())
 		})
 
+		It("Acquire times out acquiring the mutex lock", func() {
+
+			done := make(chan struct{})
+			readyToAcquire := make(chan struct{})
+
+			fakeLockDB := new(lockfakes.FakeLockDB)
+			factory := lock.NewTestLockFactory(fakeLockDB)
+
+			fakeLockDB.AcquireStub = func(id lock.LockID) (bool, error) {
+				select {
+				case <-time.After(11 * time.Second):
+				case <-done:
+				}
+				return true, nil
+			}
+
+			go func() {
+				close(readyToAcquire)
+				_, acquired, err := factory.Acquire(logger, lock.LockID{42})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(acquired).To(BeTrue())
+			}()
+
+			<-readyToAcquire
+			_, acquired, err := factory.Acquire(logger, lock.LockID{420000})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(acquired).To(BeFalse())
+			close(done)
+		})
+
 		It("Acquire accepts list of ids", func() {
 			var acquired bool
 			var err error

--- a/atc/db/lock/mutex.go
+++ b/atc/db/lock/mutex.go
@@ -1,0 +1,45 @@
+package lock
+
+import "time"
+
+func NewMutex(timeout time.Duration) *mutex {
+	return &mutex{
+		c:  make(chan struct{}, 1),
+		to: timeout,
+	}
+}
+
+type mutex struct {
+	c  chan struct{}
+	to time.Duration
+}
+
+func (m *mutex) Unlock() {
+	<-m.c
+}
+
+func (m *mutex) Lock() bool {
+	return m.LockWithTimeout(m.to)
+}
+
+func (m *mutex) LockWithTimeout(timeout time.Duration) bool {
+	if timeout > 0 {
+		return m.lockWithTimeout(timeout)
+	} else {
+		return m.lockIndefinitely()
+	}
+}
+
+func (m *mutex) lockWithTimeout(timeout time.Duration) bool {
+	select {
+	case m.c <- struct{}{}:
+		return true
+	case <-time.After(timeout):
+	}
+	return false
+}
+
+func (m *mutex) lockIndefinitely() bool {
+	m.c <- struct{}{}
+	return true
+}

--- a/atc/db/lock/mutex_test.go
+++ b/atc/db/lock/mutex_test.go
@@ -1,0 +1,181 @@
+package lock_test
+
+import (
+	"time"
+
+	"github.com/concourse/concourse/atc/db/lock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Mutex", func() {
+
+	var mutex interface {
+		Unlock()
+		Lock() bool
+		LockWithTimeout(timeout time.Duration) bool
+	}
+
+	Context("when a default timeout is provided", func() {
+
+		BeforeEach(func() {
+			mutex = lock.NewMutex(time.Millisecond)
+		})
+
+		Context("when using the defaults", func() {
+			It("times out acquiring the lock", func() {
+				ready := make(chan struct{})
+				done := make(chan struct{})
+
+				go func() {
+					acquired := mutex.Lock()
+					Expect(acquired).To(BeTrue())
+					close(ready)
+				}()
+
+				go func() {
+					<-ready
+					acquired := mutex.Lock()
+					Expect(acquired).To(BeFalse())
+					close(done)
+				}()
+
+				Eventually(done).Should(BeClosed())
+			})
+		})
+
+		Context("overriding the defaults", func() {
+			It("waits to acquire the lock", func() {
+				ready := make(chan struct{})
+				done := make(chan struct{})
+
+				go func() {
+					acquired := mutex.Lock()
+					Expect(acquired).To(BeTrue())
+					close(ready)
+				}()
+
+				go func() {
+					<-ready
+					mutex.LockWithTimeout(0)
+					close(done)
+				}()
+
+				Consistently(done).ShouldNot(Receive())
+			})
+
+			It("eventually acquires a lock after its been released", func() {
+				ready := make(chan struct{})
+				waiting := make(chan struct{})
+				unlock := make(chan struct{})
+				done := make(chan struct{})
+
+				go func() {
+					acquired := mutex.Lock()
+					Expect(acquired).To(BeTrue())
+					close(ready)
+
+					<-unlock
+					mutex.Unlock()
+				}()
+
+				go func() {
+					<-ready
+					acquired := mutex.LockWithTimeout(0)
+					close(waiting)
+
+					Expect(acquired).To(BeTrue())
+					close(done)
+				}()
+
+				Consistently(waiting).ShouldNot(Receive())
+
+				close(unlock)
+
+				Eventually(done).Should(BeClosed())
+			})
+		})
+	})
+
+	Context("when there is no default timeout", func() {
+
+		BeforeEach(func() {
+			mutex = lock.NewMutex(0)
+		})
+
+		Context("when using the defaults", func() {
+			It("waits to acquire the lock", func() {
+				ready := make(chan struct{})
+				done := make(chan struct{})
+
+				go func() {
+					acquired := mutex.Lock()
+					Expect(acquired).To(BeTrue())
+					close(ready)
+				}()
+
+				go func() {
+					<-ready
+					mutex.Lock()
+					close(done)
+				}()
+
+				Consistently(done).ShouldNot(Receive())
+			})
+
+			It("eventually acquires a lock after its been released", func() {
+				ready := make(chan struct{})
+				waiting := make(chan struct{})
+				unlock := make(chan struct{})
+				done := make(chan struct{})
+
+				go func() {
+					acquired := mutex.Lock()
+					Expect(acquired).To(BeTrue())
+					close(ready)
+
+					<-unlock
+					mutex.Unlock()
+				}()
+
+				go func() {
+					<-ready
+					acquired := mutex.Lock()
+					close(waiting)
+
+					Expect(acquired).To(BeTrue())
+					close(done)
+				}()
+
+				Consistently(waiting).ShouldNot(Receive())
+
+				close(unlock)
+
+				Eventually(done).Should(BeClosed())
+			})
+		})
+
+		Context("overriding the defaults", func() {
+			It("times out acquiring the lock", func() {
+				ready := make(chan struct{})
+				done := make(chan struct{})
+
+				go func() {
+					acquired := mutex.Lock()
+					Expect(acquired).To(BeTrue())
+					close(ready)
+				}()
+
+				go func() {
+					<-ready
+					acquired := mutex.LockWithTimeout(time.Millisecond)
+					Expect(acquired).To(BeFalse())
+					close(done)
+				}()
+
+				Eventually(done).Should(BeClosed())
+			})
+		})
+	})
+})

--- a/atc/db/notifications_bus.go
+++ b/atc/db/notifications_bus.go
@@ -2,8 +2,10 @@ package db
 
 import (
 	"database/sql"
-	"sync"
+	"errors"
+	"time"
 
+	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/lib/pq"
 )
 
@@ -14,20 +16,27 @@ type NotificationsBus interface {
 	Close() error
 }
 
+type Mutex interface {
+	Unlock()
+	Lock() bool
+	LockWithTimeout(timeout time.Duration) bool
+}
+
 type notificationsBus struct {
 	listener *pq.Listener
 	conn     *sql.DB
 
 	notifications  map[string]map[chan bool]struct{}
-	notificationsL sync.Mutex
+	notificationsL Mutex
 }
 
-func NewNotificationsBus(listener *pq.Listener, conn *sql.DB) NotificationsBus {
+func NewNotificationsBus(listener *pq.Listener, conn *sql.DB, timeout time.Duration) NotificationsBus {
 	bus := &notificationsBus{
 		listener: listener,
 		conn:     conn,
 
-		notifications: make(map[string]map[chan bool]struct{}),
+		notifications:  make(map[string]map[chan bool]struct{}),
+		notificationsL: lock.NewMutex(timeout),
 	}
 
 	go bus.wait()
@@ -45,40 +54,46 @@ func (bus *notificationsBus) Notify(channel string) error {
 }
 
 func (bus *notificationsBus) Listen(channel string) (chan bool, error) {
-	bus.notificationsL.Lock()
-	defer bus.notificationsL.Unlock()
+	if bus.notificationsL.Lock() {
+		defer bus.notificationsL.Unlock()
 
-	if len(bus.notifications[channel]) == 0 {
-		err := bus.listener.Listen(channel)
-		if err != nil {
-			return nil, err
+		if len(bus.notifications[channel]) == 0 {
+			err := bus.listener.Listen(channel)
+			if err != nil {
+				return nil, err
+			}
 		}
+
+		notify := make(chan bool, 1)
+
+		sinks, found := bus.notifications[channel]
+		if !found {
+			sinks = map[chan bool]struct{}{}
+			bus.notifications[channel] = sinks
+		}
+
+		sinks[notify] = struct{}{}
+
+		return notify, nil
 	}
 
-	notify := make(chan bool, 1)
-
-	sinks, found := bus.notifications[channel]
-	if !found {
-		sinks = map[chan bool]struct{}{}
-		bus.notifications[channel] = sinks
-	}
-
-	sinks[notify] = struct{}{}
-
-	return notify, nil
+	return nil, errors.New("timeout")
 }
 
 func (bus *notificationsBus) Unlisten(channel string, notify chan bool) error {
-	bus.notificationsL.Lock()
-	defer bus.notificationsL.Unlock()
+	if bus.notificationsL.Lock() {
+		defer bus.notificationsL.Unlock()
 
-	delete(bus.notifications[channel], notify)
+		delete(bus.notifications[channel], notify)
 
-	if len(bus.notifications[channel]) == 0 {
-		return bus.listener.Unlisten(channel)
+		if len(bus.notifications[channel]) == 0 {
+			return bus.listener.Unlisten(channel)
+		}
+
+		return nil
 	}
 
-	return nil
+	return errors.New("timeout")
 }
 
 func (bus *notificationsBus) wait() {
@@ -89,36 +104,48 @@ func (bus *notificationsBus) wait() {
 			break
 		}
 
-		bus.notificationsL.Lock()
-
 		if notification != nil {
-			// alert any relevant listeners of notification being received
-			// (nonblocking)
-			for sink := range bus.notifications[notification.Channel] {
-				select {
-				case sink <- true:
-					// notified of message being received (or queued up)
-				default:
-					// already had notification queued up; no need to handle it twice
-				}
-			}
+			bus.handleNotification(notification)
 		} else {
-			// alert all listeners of connection break so they can check for things
-			// they may have missed
-			for _, sinks := range bus.notifications {
-				for sink := range sinks {
-					select {
-					case sink <- false:
-						// notify that connection was lost, so listener can check for
-						// things that may have changed while connection was lost
-					default:
-						// already had notification queued up; no need to check for
-						// anything missed since something will be notified anyway
-					}
+			bus.handleReconnect()
+		}
+	}
+}
+
+func (bus *notificationsBus) handleNotification(notification *pq.Notification) {
+	if bus.notificationsL.Lock() {
+		defer bus.notificationsL.Unlock()
+
+		// alert any relevant listeners of notification being received
+		// (nonblocking)
+		for sink := range bus.notifications[notification.Channel] {
+			select {
+			case sink <- true:
+				// notified of message being received (or queued up)
+			default:
+				// already had notification queued up; no need to handle it twice
+			}
+		}
+	}
+}
+
+func (bus *notificationsBus) handleReconnect() {
+	if bus.notificationsL.Lock() {
+		defer bus.notificationsL.Unlock()
+
+		// alert all listeners of connection break so they can check for things
+		// they may have missed
+		for _, sinks := range bus.notifications {
+			for sink := range sinks {
+				select {
+				case sink <- false:
+					// notify that connection was lost, so listener can check for
+					// things that may have changed while connection was lost
+				default:
+					// already had notification queued up; no need to check for
+					// anything missed since something will be notified anyway
 				}
 			}
 		}
-
-		bus.notificationsL.Unlock()
 	}
 }

--- a/atc/db/open.go
+++ b/atc/db/open.go
@@ -65,6 +65,10 @@ type Tx interface {
 }
 
 func Open(logger lager.Logger, sqlDriver string, sqlDataSource string, newKey *encryption.Key, oldKey *encryption.Key, connectionName string, lockFactory lock.LockFactory) (Conn, error) {
+	return OpenWithBusTimeout(logger, sqlDriver, sqlDataSource, newKey, oldKey, connectionName, lockFactory, 0)
+}
+
+func OpenWithBusTimeout(logger lager.Logger, sqlDriver string, sqlDataSource string, newKey *encryption.Key, oldKey *encryption.Key, connectionName string, lockFactory lock.LockFactory, timeout time.Duration) (Conn, error) {
 	for {
 		var strategy encryption.Strategy
 		if newKey != nil {
@@ -106,7 +110,7 @@ func Open(logger lager.Logger, sqlDriver string, sqlDataSource string, newKey *e
 		return &db{
 			DB: sqlDb,
 
-			bus:        NewNotificationsBus(listener, sqlDb),
+			bus:        NewNotificationsBus(listener, sqlDb, timeout),
 			encryption: strategy,
 			name:       connectionName,
 		}, nil


### PR DESCRIPTION
Fixes #5385

This PR allows users to configure two different timeouts:
- The `NotificationTimeout`, for when listening for pub/sub messages from postgres
- The `LockTimeout`, for when acquiring locks from postgres

This features is marked as experimental, and the default behaviour is preserved from previous versions of concourse (no timeout).