### PR TITLE
atc: behavior: try named var sources before global ones

### DIFF
--- a/atc/creds/kubernetes/secrets.go
+++ b/atc/creds/kubernetes/secrets.go
@@ -25,20 +25,20 @@ type Secrets struct {
 func (secrets Secrets) NewSecretLookupPaths(teamName string, pipelineName string, allowRootPath bool) []creds.SecretLookupPath {
 	lookupPaths := []creds.SecretLookupPath{}
 	if len(pipelineName) > 0 {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+":"+pipelineName+"."))
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+"/"+pipelineName+"."))
 	}
-	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+":"))
+	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+teamName+"/"))
 	if allowRootPath {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+":"))
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(secrets.namespacePrefix+"/"))
 	}
 	return lookupPaths
 }
 
 // Get retrieves the value and expiration of an individual secret
 func (secrets Secrets) Get(secretPath string) (interface{}, *time.Time, bool, error) {
-	parts := strings.Split(secretPath, ":")
+	parts := strings.Split(secretPath, "/")
 	if len(parts) != 2 {
-		return nil, nil, false, fmt.Errorf("unable to split kubernetes secret path into [namespace]:[secret]: %s", secretPath)
+		return nil, nil, false, fmt.Errorf("unable to split kubernetes secret path into [namespace]/[secret]: %s", secretPath)
 	}
 
 	var namespace = parts[0]

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -1096,9 +1096,10 @@ func (p *pipeline) getBuildsFrom(tx Tx, col string) (map[string]Build, error) {
 func (p *pipeline) Variables(logger lager.Logger, globalSecrets creds.Secrets, varSourcePool creds.VarSourcePool) (vars.Variables, error) {
 	globalVars := creds.NewVariables(globalSecrets, p.TeamName(), p.Name(), false)
 	namedVarsMap := vars.NamedVariables{}
+
 	// It's safe to add NamedVariables to allVars via an array here, because
 	// a map is passed by reference.
-	allVars := vars.NewMultiVars([]vars.Variables{globalVars, namedVarsMap})
+	allVars := vars.NewMultiVars([]vars.Variables{namedVarsMap, globalVars})
 
 	orderedVarSources, err := p.varSources.OrderByDependency()
 	if err != nil {


### PR DESCRIPTION
# Why is this PR needed?

Global credential managers are currently queried before pipeline-level var sources, which doesn't seem right. Normally it should just find nothing (since named vars have a `:` in their secret path, making it an unlikely match) - however the Kubernetes secret manager actually uses `:` internally so it would choke on any named var source.

# What is this PR trying to accomplish?

fixes #5413

# How does it accomplish that?

* Swap the order, so that pipeline-level var sources are tried first. I think this should be fine and may have been the original intention - paging @evanchaoli just to make sure I haven't missed anything here!
* Switch the K8s secret manager from `:` for `/` for clarity. This should actually have no user impact, because the K8s secret manager was constructing its own strings using a `:` as a separator - we just switched it to `/`.

# Contributor Checklist

- [x] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
