### PR TITLE
topgun/k8s: run dns proxy tests against containerd

### DIFF
--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -14,10 +14,13 @@ var _ = Describe("DNS Resolution", func() {
 		setReleaseNameAndNamespace("dp")
 	})
 
-	var setupDeployment = func(dnsProxyEnable, dnsServer string) {
+	var setupDeployment = func(useContainerd bool, dnsProxyEnable, dnsServer string) {
 		args := []string{
 			`--set=worker.replicas=1`,
 			`--set-string=concourse.worker.garden.dnsProxyEnable=` + dnsProxyEnable,
+		}
+		if useContainerd {
+			args = append(args, "--set=worker.garden.useContainerd=true")
 		}
 		if dnsServer != "" {
 			args = append(args,
@@ -52,51 +55,61 @@ var _ = Describe("DNS Resolution", func() {
 		shouldWork bool
 	}
 
-	DescribeTable("different proxy settings",
-		func(c Case) {
-			setupDeployment(c.enableDnsProxy, c.dnsServer)
+	expectedDnsProxyBehaviour := func(useContainerd bool) {
+		DescribeTable("different proxy settings",
+			func(c Case) {
+				setupDeployment(useContainerd, c.enableDnsProxy, c.dnsServer)
 
-			sess := fly.Start("execute", "-c", "tasks/dns-proxy-task.yml", "-v", "url="+c.addressFunction())
-			<-sess.Exited
+				sess := fly.Start("execute", "-c", "tasks/dns-proxy-task.yml", "-v", "url="+c.addressFunction())
+				<-sess.Exited
 
-			if !c.shouldWork {
-				Expect(sess.ExitCode()).ToNot(BeZero())
-				return
-			}
+				if !c.shouldWork {
+					Expect(sess.ExitCode()).ToNot(BeZero())
+					return
+				}
 
-			Expect(sess.ExitCode()).To(BeZero())
-		},
-		Entry("Proxy Enabled, with full service name", Case{
-			enableDnsProxy:  "true",
-			addressFunction: fullAddress,
-			shouldWork:      true,
-		}),
-		Entry("Proxy Enabled, with short service name", Case{
-			enableDnsProxy:  "true",
-			addressFunction: shortAddress,
-			shouldWork:      false,
-		}),
-		Entry("Proxy Disabled, with full service name", Case{
-			enableDnsProxy:  "false",
-			addressFunction: fullAddress,
-			shouldWork:      true,
-		}),
-		Entry("Proxy Disabled, with short service name", Case{
-			enableDnsProxy:  "false",
-			addressFunction: shortAddress,
-			shouldWork:      true,
-		}),
-		Entry("Adding extra dns server, with Proxy Disabled and full address", Case{
-			enableDnsProxy:  "false",
-			dnsServer:       "8.8.8.8",
-			addressFunction: fullAddress,
-			shouldWork:      false,
-		}),
-		Entry("Adding extra dns server, with Proxy Enabled and full address", Case{
-			enableDnsProxy:  "true",
-			dnsServer:       "8.8.8.8",
-			addressFunction: fullAddress,
-			shouldWork:      false,
-		}),
-	)
+				Expect(sess.ExitCode()).To(BeZero())
+			},
+			Entry("Proxy Enabled, with full service name", Case{
+				enableDnsProxy:  "true",
+				addressFunction: fullAddress,
+				shouldWork:      true,
+			}),
+			Entry("Proxy Enabled, with short service name", Case{
+				enableDnsProxy:  "true",
+				addressFunction: shortAddress,
+				shouldWork:      false,
+			}),
+			Entry("Proxy Disabled, with full service name", Case{
+				enableDnsProxy:  "false",
+				addressFunction: fullAddress,
+				shouldWork:      true,
+			}),
+			Entry("Proxy Disabled, with short service name", Case{
+				enableDnsProxy:  "false",
+				addressFunction: shortAddress,
+				shouldWork:      true,
+			}),
+			Entry("Adding extra dns server, with Proxy Disabled and full address", Case{
+				enableDnsProxy:  "false",
+				dnsServer:       "8.8.8.8",
+				addressFunction: fullAddress,
+				shouldWork:      false,
+			}),
+			Entry("Adding extra dns server, with Proxy Enabled and full address", Case{
+				enableDnsProxy:  "true",
+				dnsServer:       "8.8.8.8",
+				addressFunction: fullAddress,
+				shouldWork:      false,
+			}),
+		)
+	}
+
+	Context("with gdn backend", func() {
+		expectedDnsProxyBehaviour(false)
+	})
+
+	Context("with containerd backend", func() {
+		expectedDnsProxyBehaviour(true)
+	})
 })


### PR DESCRIPTION
# Why is this PR needed?

Fixes #5473.

# How does it accomplish that?

The entire DNS Proxy test suite can now be run either using `guardian` or `containerd` simply by passing a `useContainerd` flag which will set the `--use-containerd` flag on the worker.

# Reviewer Checklist

- [ ] Tests reviewed
- [ ] PR acceptance performed