### PR TITLE
contributing: add tiller install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -617,7 +617,11 @@ chart`][concourse-helm-chart] exists.
 With those set, go to `topgun/k8s` and run Ginkgo:
 
 ```sh
+# run the test cases serially
 ginkgo .
+
+# run the test cases with a concurrency level of 16
+ginkgo -nodes=16 .
 ```
 
 [`kind`]: https://kind.sigs.k8s.io/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -565,6 +565,43 @@ Kubernetes-related testing are all end-to-end, living under `topgun/k8s`. They
 require access to a real Kubernetes cluster with access granted through a
 properly configured `~/.kube/config` file.
 
+[`kind`] is a great choice when it comes to running a local Kubernetes cluster -
+all you need is `docker`, and the `kind` CLI. If you wish to run the tests with
+a high degree of concurrency, it's advised to have multiple kubernetes nodes.
+This can be achieved with the following `kind` config:
+
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker
+- role: worker
+```
+
+
+With the cluster up, the next step is to have a proper [Tiller] setup (the tests
+still run with Helm 2):
+
+
+```bash
+kubectl create serviceaccount \
+	--namespace kube-system \
+	tiller
+
+kubectl create clusterrolebinding \
+	tiller-cluster-rule \
+	--clusterrole=cluster-admin \
+	--serviceaccount=kube-system:tiller
+
+helm init \
+	--service-account tiller \
+	--upgrade
+```
+
+
 The tests require a few environment variables to be set:
 
 - `CONCOURSE_IMAGE_TAG` or `CONCOURSE_IMAGE_DIGEST`: the tag or digest to use
@@ -576,11 +613,15 @@ to define the postgres chart that Concourse depends on.
 - `CONCOURSE_CHART_DIR`: location in the filesystem where a copy of [`the Concourse Helm
 chart`][concourse-helm-chart] exists.
 
+
 With those set, go to `topgun/k8s` and run Ginkgo:
 
 ```sh
 ginkgo .
 ```
+
+[`kind`]: https://kind.sigs.k8s.io/
+[Tiller]: https://v2.helm.sh/docs/install/
 
 
 ### A note on `topgun`


### PR DESCRIPTION
### Why is this PR needed?

without the ability to test our changes locally, iterating on k8s-topgun could be a big barrier to most contributors who don't have access to a testing cluster / don't want to mess up other clusters. we used to also assume that the user had already properly configured Tiller, which might not be true in many cases.

### What is this PR trying to accomplish?

the end goal here is to lower the barrier to running `k8s-topgun` by making the creation of a cluster that can run `k8s-topgun` very few commands away, as well as describing how to set up tiller, a requirement for our current testing (which relies on helm 2).


### How does it accomplish that?

it does to by adding instructions that guide the user to the creation of the cluster, and set up of tiller.


### Contributor Checklist

> Are the following items included as part of this PR? If no, please say why not.

- ~Unit tests~
- ~Integration tests~
- ~Updated documentation (located at https://github.com/concourse/docs)~
- ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


### Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
