### PR TITLE
topgun: fix creds mgmt tests

### DIFF
--- a/topgun/k8s/kubernetes_creds_mgmt_test.go
+++ b/topgun/k8s/kubernetes_creds_mgmt_test.go
@@ -68,6 +68,15 @@ var _ = Describe("Kubernetes credential management", func() {
 			By("creating a namespace made by the user instead of the chart")
 			Run(nil, "kubectl", "create", "namespace", releaseName+"-main")
 
+			By("binding the role that grants access to the secrets in our newly created namespace ")
+			Run(nil,
+				"kubectl", "create",
+				"--namespace", releaseName+"-main",
+				"rolebinding", "rb",
+				"--clusterrole", releaseName+"-web",
+				"--serviceaccount", releaseName+":"+releaseName+"-web",
+			)
+
 			deployConcourseChart(releaseName, "--set=worker.replicas=1",
 				"--set=concourse.web.secretCacheEnabled=true",
 				"--set=concourse.web.secretCacheDuration=600",


### PR DESCRIPTION

### Why is this PR needed?

we're currently unable to ship due to `k8s-topgun` failing.

![Screenshot from 2020-04-29 13-54-38](https://user-images.githubusercontent.com/3574444/80715932-0ed12780-8ac5-11ea-9e2b-3a1079107a08.png)

part of that is the fact that the tests that relate to credential management are not 
up to date with the expectations of the chart. fixing that would then let us move on
with 6.1.x, and continue to have our PRs to that repo being properly tested.

### What is this PR trying to accomplish?

it tries to fix part of the failures that we're currently seeing - that part being
the cred mgmt tests.


### How does it accomplish that?

there are a set of tests in that suite that requires the user to provide
their own namespaces for the teams that the `web` nodes are supposed to
retrieve credentials from:

	1. create namespace
	2. tell concourse that team & pipeline credentials should come
	from that specific namespace
	3. put secrets in that namespace
	4. have `web` nodes reading secrets from that namespace

now, despite the user having the ability to do all of those first 3
steps, the 4th is something that the `web` node on its own, using its
own credentials (by means of it serviceAccount token).

internally, kubernetes will check if that serviceAccount can do what it
wants (fetch secrets from that namespace) by verifying which roles are
bound to it.

previously, the thing (rolebinding) that would bind the role (ability to
read secrets from the namespace) to the actor (serviceAccount) was
created by default by the chart, but we changed that (see note 1) to be
more flexible.

this means that the test should reflect the new need of the user
providing the rolebinding.

note 1: https://github.com/concourse/concourse-chart/pull/4



### Contributor Checklist

> Are the following items included as part of this PR? If no, please say why not.

- [ ] ~Unit tests~
- [x] Integration tests
- [ ] ~Updated documentation (located at https://github.com/concourse/docs)~
- [ ] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


### Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
