### PR TITLE
hack: update apt repos before install

### DIFF
--- a/hack/dlv/Dockerfile
+++ b/hack/dlv/Dockerfile
@@ -3,7 +3,7 @@ FROM concourse/concourse:local
 ENV GO111MODULE=off
 ENV EDITOR=vim
 
-RUN apt install -y vim
+RUN apt update && apt install -y vim
 RUN go get -u -v github.com/go-delve/delve/cmd/dlv
 
 ENTRYPOINT [ "dlv" ]


### PR DESCRIPTION
without performing the update to the local apt repository state that
keeps track of the possible packages to install, we can end up having
problems trying to install versions of packages that are not tracked in
the upstream repositories anymore.

this will prevent failures like the following:

	  404  Not Found [IP: 91.189.88.142 80]
	Err:5 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libpython3.5-stdlib amd64 3.5.2-2ubuntu0~16.04.9
	  404  Not Found [IP: 91.189.88.142 80]
	Err:7 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libpython3.5 amd64 3.5.2-2ubuntu0~16.04.9
	  404  Not Found [IP: 91.189.88.142 80]

