### PR TITLE
atc: handle groups claims properly

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -231,12 +231,17 @@ func (a *access) connectorID() string {
 }
 
 func (a *access) groups() []string {
+	groups := []string{}
 	if raw, ok := a.claims()["groups"]; ok {
-		if claim, ok := raw.([]string); ok {
-			return claim
+		if rawGroups, ok := raw.([]interface{}); ok {
+			for _, rawGroup := range rawGroups {
+				if group, ok := rawGroup.(string); ok {
+					groups = append(groups, group)
+				}
+			}
 		}
 	}
-	return []string{}
+	return groups
 }
 
 func (a *access) adminTeams() []string {

--- a/atc/api/accessor/accessor_test.go
+++ b/atc/api/accessor/accessor_test.go
@@ -222,7 +222,7 @@ var _ = Describe("Accessor", func() {
 			verification.HasToken = true
 			verification.IsTokenValid = true
 			verification.RawClaims = map[string]interface{}{
-				"groups": []string{"some-group"},
+				"groups": []interface{}{"some-group"},
 				"federated_claims": map[string]interface{}{
 					"connector_id": "some-connector",
 				},
@@ -649,7 +649,7 @@ var _ = Describe("Accessor", func() {
 						"user_id":      "some-user-id",
 						"user_name":    "some-user-name",
 					},
-					"groups": []string{"some-group"},
+					"groups": []interface{}{"some-group"},
 				}
 			})
 


### PR DESCRIPTION
# Why do we need this?

Without the fix, we have teams:{} from the call to /api/v1/users when making
that request from a user whose membership to a team is determined based on
groups - given that we were performing the cast on []string rather than
[]interface, that'd fail the type assertion, always returning an empty list of
strings (thus, teams: {}).

Now with the proper casting taking place, I was able to verify that a call to
/api/v1/users indeed return the set of teams.