### PR TITLE
atc/db: less cryptic error message

### DIFF
--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -142,7 +142,7 @@ func (c *checkFactory) TryCreateCheck(logger lager.Logger, checkable Checkable, 
 	parentType, found := resourceTypes.Parent(checkable)
 	if found {
 		if parentType.Version() == nil {
-			return nil, false, fmt.Errorf("resource's parent type '%s' has no version", parentType.Name())
+			return nil, false, fmt.Errorf("resource type '%s' has no version", parentType.Name())
 		}
 	}
 

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -3,7 +3,6 @@ package db
 import (
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -143,7 +142,7 @@ func (c *checkFactory) TryCreateCheck(logger lager.Logger, checkable Checkable, 
 	parentType, found := resourceTypes.Parent(checkable)
 	if found {
 		if parentType.Version() == nil {
-			return nil, false, errors.New("parent type has no version")
+			return nil, false, fmt.Errorf("resource's parent type '%s' has no version", parentType.Name())
 		}
 	}
 

--- a/testflight/custom_resource_check_test.go
+++ b/testflight/custom_resource_check_test.go
@@ -16,7 +16,7 @@ var _ = Describe("When a resource type depends on another resource type", func()
 		check := spawnFly("check-resource", "-r", inPipeline("recursive-custom-resource"), "--shallow")
 		<-check.Exited
 		Expect(check).To(gexec.Exit(1))
-		Expect(check.Err).To(gbytes.Say("parent type has no version"))
+		Expect(check.Err).To(gbytes.Say("resource's parent type '.*' has no version"))
 	})
 
 	It("can be checked recursively", func() {

--- a/testflight/custom_resource_check_test.go
+++ b/testflight/custom_resource_check_test.go
@@ -16,7 +16,7 @@ var _ = Describe("When a resource type depends on another resource type", func()
 		check := spawnFly("check-resource", "-r", inPipeline("recursive-custom-resource"), "--shallow")
 		<-check.Exited
 		Expect(check).To(gexec.Exit(1))
-		Expect(check.Err).To(gbytes.Say("resource's parent type '.*' has no version"))
+		Expect(check.Err).To(gbytes.Say("resource type '.*' has no version"))
 	})
 
 	It("can be checked recursively", func() {

--- a/testflight/resource_type_test.go
+++ b/testflight/resource_type_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			checkResource := spawnFly("check-resource", "-r", inPipeline("my-resource"), "--shallow")
 			<-checkResource.Exited
 			Expect(checkResource).To(gexec.Exit(1))
-			Expect(checkResource.Err).To(gbytes.Say("resource's parent type '.*' has no version"))
+			Expect(checkResource.Err).To(gbytes.Say("resource type '.*' has no version"))
 		})
 	})
 

--- a/testflight/resource_type_test.go
+++ b/testflight/resource_type_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 			checkResource := spawnFly("check-resource", "-r", inPipeline("my-resource"), "--shallow")
 			<-checkResource.Exited
 			Expect(checkResource).To(gexec.Exit(1))
-			Expect(checkResource.Err).To(gbytes.Say("parent type has no version"))
+			Expect(checkResource.Err).To(gbytes.Say("resource's parent type '.*' has no version"))
 		})
 	})
 


### PR DESCRIPTION
# Why is this PR needed?

When a resource's parent type has no version you see this error on the resource's page:

```
parent type has no version
```

Noticed this error message myself and it wasn't clear to me what was
wrong. Someone on discord also mentioned that the error message was not
helpful with their troubleshooting.
<img width="724" alt="Screen Shot 2020-05-05 at 11 12 07 AM" src="https://user-images.githubusercontent.com/4583837/81083471-a1593880-8ec2-11ea-9c97-e4c1c0449dd3.png">
This error message should guide the user to look at the likely source of
the error: the parent resource type's config.

# What is this PR trying to accomplish?

Change the error message when no parent type exists to:

```
resource's parent type 'name-of-parent-resource-type' has no version
```

# Contributor Checklist

> Are the following items included as part of this PR? If no, please say why not.

- [ ] ~Unit tests~
- [x] Integration tests
- [ ] ~Updated documentation (located at https://github.com/concourse/docs)~
- [ ] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


# Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
