### PR TITLE
automatically fill system-claim-values

### DIFF
--- a/cmd/concourse/concourse_test.go
+++ b/cmd/concourse/concourse_test.go
@@ -122,10 +122,12 @@ var _ = Describe("Web Command", func() {
 					args = append(args, "--tsa-client-id", "tsa-client-id")
 				})
 
-				It("errors", func() {
-					Eventually(concourseRunner.Err()).Should(
-						gbytes.Say("at least one systemClaimValue must be equal to tsa-client-id"),
-					)
+				It("starts atc", func() {
+					Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("atc.listening"))
+				})
+
+				It("starts tsa", func() {
+					Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("tsa.listening"))
 				})
 
 				Context("with system-claim-key is not set to 'aud'", func() {

--- a/cmd/concourse/concourse_test.go
+++ b/cmd/concourse/concourse_test.go
@@ -13,13 +13,13 @@ import (
 	"strconv"
 
 	"github.com/concourse/concourse/atc/postgresrunner"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/ginkgomon"
 	"golang.org/x/crypto/ssh"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Web Command", func() {
@@ -45,12 +45,12 @@ var _ = Describe("Web Command", func() {
 
 		concourseRunner = ginkgomon.New(ginkgomon.Config{
 			Command:       concourseCommand,
-			Name:          "tsa",
+			Name:          "web",
 			StartCheck:    "atc.cmd.start",
 			AnsiColorCode: "32m",
 		})
 
-		concourseProcess = ginkgomon.Invoke(concourseRunner)
+		concourseProcess = ifrit.Background(concourseRunner)
 
 		// workaround to avoid panic due to registering http handlers multiple times
 		http.DefaultServeMux = new(http.ServeMux)
@@ -97,8 +97,6 @@ var _ = Describe("Web Command", func() {
 					"--tsa-bind-port", strconv.Itoa(2222+GinkgoParallelNode()),
 					"--client-id", "client-id",
 					"--client-secret", "client-secret",
-					"--tsa-client-id", "tsa-client-id",
-					"--tsa-client-secret", "tsa-client-secret",
 					"--tsa-token-url", "http://localhost/token",
 				)
 			})
@@ -111,12 +109,76 @@ var _ = Describe("Web Command", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("ATC should start up", func() {
+			It("starts atc", func() {
 				Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("atc.listening"))
 			})
 
-			It("TSA should start up", func() {
+			It("starts tsa", func() {
 				Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("tsa.listening"))
+			})
+
+			Context("with tsa-client-id specified", func() {
+				BeforeEach(func() {
+					args = append(args, "--tsa-client-id", "tsa-client-id")
+				})
+
+				It("errors", func() {
+					Eventually(concourseRunner.Err()).Should(
+						gbytes.Say("at least one systemClaimValue must be equal to tsa-client-id"),
+					)
+				})
+
+				Context("with system-claim-key is not set to 'aud'", func() {
+					BeforeEach(func() {
+						args = append(args, "--system-claim-key", "not-aud")
+					})
+
+					It("starts atc", func() {
+						Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("atc.listening"))
+					})
+
+					It("starts tsa", func() {
+						Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("tsa.listening"))
+					})
+				})
+
+				Context("with system-claim-key set to 'aud'", func() {
+					BeforeEach(func() {
+						args = append(args, "--system-claim-key", "aud")
+					})
+
+					Context("when the system claim values does not contain the client id", func() {
+						BeforeEach(func() {
+							args = append(args,
+								"--system-claim-value", "system-claim-value-1",
+								"--system-claim-value", "system-claim-value-2",
+							)
+						})
+
+						It("errors", func() {
+							Eventually(concourseRunner.Err()).Should(
+								gbytes.Say("at least one systemClaimValue must be equal to tsa-client-id"),
+							)
+						})
+					})
+
+					Context("when the system claim values contain the client id", func() {
+						BeforeEach(func() {
+							args = append(args,
+								"--system-claim-value", "tsa-client-id",
+								"--system-claim-value", "system-claim-value-1",
+							)
+						})
+
+						It("starts atc", func() {
+							Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("atc.listening"))
+						})
+
+						It("starts tsa", func() {
+							Eventually(concourseRunner.Buffer(), "30s", "2s").Should(gbytes.Say("tsa.listening"))
+						})
+					})
+				})
 			})
 		})
 	})

--- a/cmd/concourse/web.go
+++ b/cmd/concourse/web.go
@@ -118,22 +118,42 @@ func (cmd *WebCommand) populateSharedFlags() error {
 	cmd.RunCommand.Auth.AuthFlags.Clients[cmd.TSACommand.ClientID] = cmd.TSACommand.ClientSecret
 	cmd.RunCommand.Auth.AuthFlags.Clients[cmd.RunCommand.Server.ClientID] = cmd.RunCommand.Server.ClientSecret
 
-	if cmd.TSACommand.ClientID != "" {
-		if cmd.RunCommand.SystemClaimKey == "aud" {
-			found := false
-			for _, val := range cmd.RunCommand.SystemClaimValues {
-				if val == cmd.TSACommand.ClientID {
-					found = true
-				}
+	// if we're using the 'aud' as the SystemClaimKey then we want to validate
+	// that the SystemClaimValues contains our TSA Client. If it's not 'aud' then
+	// we can't validate anything
+	if cmd.RunCommand.SystemClaimKey == "aud" {
+
+		// if we're using the default SystemClaimValues then override these values
+		// to make sure they include the TSA ClientID
+		if len(cmd.RunCommand.SystemClaimValues) == 1 {
+			if cmd.RunCommand.SystemClaimValues[0] == "concourse-worker" {
+				cmd.RunCommand.SystemClaimValues = []string{cmd.TSACommand.ClientID}
 			}
-			if !found {
-				return errors.New("at least one systemClaimValue must be equal to tsa-client-id")
-			}
+		}
+
+		if err := cmd.validateSystemClaimValues(); err != nil {
+			return err
 		}
 	}
 
 	cmd.TSACommand.ClusterName = cmd.RunCommand.Server.ClusterName
 	cmd.TSACommand.LogClusterName = cmd.RunCommand.LogClusterName
+
+	return nil
+}
+
+func (cmd *WebCommand) validateSystemClaimValues() error {
+
+	found := false
+	for _, val := range cmd.RunCommand.SystemClaimValues {
+		if val == cmd.TSACommand.ClientID {
+			found = true
+		}
+	}
+
+	if !found {
+		return errors.New("at least one systemClaimValue must be equal to tsa-client-id")
+	}
 
 	return nil
 }

--- a/cmd/concourse/web.go
+++ b/cmd/concourse/web.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -116,6 +117,20 @@ func (cmd *WebCommand) populateSharedFlags() error {
 
 	cmd.RunCommand.Auth.AuthFlags.Clients[cmd.TSACommand.ClientID] = cmd.TSACommand.ClientSecret
 	cmd.RunCommand.Auth.AuthFlags.Clients[cmd.RunCommand.Server.ClientID] = cmd.RunCommand.Server.ClientSecret
+
+	if cmd.TSACommand.ClientID != "" {
+		if cmd.RunCommand.SystemClaimKey == "aud" {
+			found := false
+			for _, val := range cmd.RunCommand.SystemClaimValues {
+				if val == cmd.TSACommand.ClientID {
+					found = true
+				}
+			}
+			if !found {
+				return errors.New("at least one systemClaimValue must be equal to tsa-client-id")
+			}
+		}
+	}
 
 	cmd.TSACommand.ClusterName = cmd.RunCommand.Server.ClusterName
 	cmd.TSACommand.LogClusterName = cmd.RunCommand.LogClusterName


### PR DESCRIPTION
ps.: this should be cherry-picked to `master`

# Why is this PR needed?

The `system-claim-key` and `system-claim-value` flags exist so you can tell concourse which requests should have 'system' privileges. These system privileges grant access to perform various actions required by the TSA, mainly around the lifecycle of workers.

By default we grant these 'system' privileges to any request presenting a token that was issued using the `concourse-worker` client (the token will have the `aud` claim set to `concourse-worker`). 

If a user wants to change the `tsa-client-id` then they probably won't know that they need to change the `system-claim-value` as well. So we automagically configure it for them behind the scenes.
