### PR TITLE
atc: structure: Make algorithm.Compute take only InputConfigs

### DIFF
--- a/atc/scheduler/algorithm/compute.go
+++ b/atc/scheduler/algorithm/compute.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/tracing"
 )
@@ -27,9 +26,7 @@ type Algorithm struct {
 func (a *Algorithm) Compute(
 	ctx context.Context,
 	job db.Job,
-	inputs []atc.JobInput,
-	resources db.Resources,
-	relatedJobs NameToIDMap,
+	inputConfigs InputConfigs,
 ) (db.InputMapping, bool, bool, error) {
 	ctx, span := tracing.StartSpan(ctx, "Algorithm.Compute", tracing.Attrs{
 		"pipeline": job.PipelineName(),
@@ -37,7 +34,7 @@ func (a *Algorithm) Compute(
 	})
 	defer span.End()
 
-	resolvers, err := constructResolvers(a.versionsDB, job, inputs, resources, relatedJobs)
+	resolvers, err := constructResolvers(a.versionsDB, inputConfigs)
 	if err != nil {
 		return nil, false, false, fmt.Errorf("construct resolvers: %w", err)
 	}

--- a/atc/scheduler/algorithm/firstoccurrence_test.go
+++ b/atc/scheduler/algorithm/firstoccurrence_test.go
@@ -246,17 +246,22 @@ var _ = Describe("Resolve", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(found).To(BeTrue())
 
-		jobInputs := []atc.JobInput{
-			{
-				Name:     "some-input",
-				Resource: "r1",
+		resource, found, err := pipeline.Resource("r1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+
+		inputConfigs := algorithm.InputConfigs{
+			algorithm.InputConfig{
+				Name:       "some-input",
+				ResourceID: resource.ID(),
+				JobID:      job.ID(),
 			},
 		}
 
 		algorithm := algorithm.New(versionsDB)
 
 		var ok bool
-		inputMapping, ok, _, err = algorithm.Compute(context.Background(), job, jobInputs, dbResources, map[string]int{"j1": 1})
+		inputMapping, ok, _, err = algorithm.Compute(context.Background(), job, inputConfigs)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ok).To(BeTrue())
 	})

--- a/atc/scheduler/algorithm/input_config.go
+++ b/atc/scheduler/algorithm/input_config.go
@@ -1,0 +1,69 @@
+package algorithm
+
+import (
+	"errors"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+)
+
+type InputConfigs []InputConfig
+
+type InputConfig struct {
+	Name            string
+	Passed          db.JobSet
+	UseEveryVersion bool
+	PinnedVersion   atc.Version
+	ResourceID      int
+	JobID           int
+}
+
+func (a *Algorithm) CreateInputConfigs(
+	jobID int,
+	jobInputs []atc.JobInput,
+	resources db.Resources,
+	relatedJobs NameToIDMap,
+) (InputConfigs, error) {
+
+	inputConfigs := InputConfigs{}
+	for _, input := range jobInputs {
+		resource, found := resources.Lookup(input.Resource)
+		if !found {
+			return nil, errors.New("input resource not found")
+		}
+
+		inputConfig := InputConfig{
+			Name:       input.Name,
+			ResourceID: resource.ID(),
+			JobID:      jobID,
+		}
+
+		var pinnedVersion atc.Version
+		if resource.CurrentPinnedVersion() != nil {
+			pinnedVersion = resource.CurrentPinnedVersion()
+		}
+
+		if input.Version != nil && input.Version.Pinned != nil {
+			pinnedVersion = input.Version.Pinned
+		}
+
+		inputConfig.PinnedVersion = pinnedVersion
+
+		if inputConfig.PinnedVersion == nil {
+			if input.Version != nil {
+				inputConfig.UseEveryVersion = input.Version.Every
+			}
+		}
+
+		jobs := db.JobSet{}
+		for _, passedJobName := range input.Passed {
+			jobID := relatedJobs[passedJobName]
+			jobs[jobID] = true
+		}
+
+		inputConfig.Passed = jobs
+		inputConfigs = append(inputConfigs, inputConfig)
+	}
+
+	return inputConfigs, nil
+}

--- a/atc/scheduler/algorithm/input_config_test.go
+++ b/atc/scheduler/algorithm/input_config_test.go
@@ -1,0 +1,104 @@
+package algorithm_test
+
+import (
+	"errors"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbfakes"
+	. "github.com/concourse/concourse/atc/scheduler/algorithm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Inputs", func() {
+	var (
+		algorithm         Algorithm
+		fakeResource      *dbfakes.FakeResource
+		expectedResources db.Resources
+		expectedJobIDs    NameToIDMap
+
+		Latest   = &atc.VersionConfig{Latest: true}
+		Every    = &atc.VersionConfig{Every: true}
+		Version1 = atc.Version{"ver": "v1"}
+		Version2 = atc.Version{"ver": "v2"}
+		PinnedV1 = &atc.VersionConfig{Pinned: Version1}
+	)
+
+	BeforeEach(func() {
+		algorithm = Algorithm{}
+		fakeResource = new(dbfakes.FakeResource)
+		fakeResource.NameReturns("some-resource")
+
+		expectedResources = db.Resources{fakeResource}
+		expectedJobIDs = NameToIDMap{"j1": 1}
+	})
+
+	DescribeTable("CreateInputConfigs",
+		func(
+			jobVersion *atc.VersionConfig,
+			resourcePinnedVersion atc.Version,
+			expectedUseEveryVersion bool,
+			expectedPinnedVersion atc.Version,
+		) {
+			if resourcePinnedVersion != nil {
+				fakeResource.CurrentPinnedVersionReturns(resourcePinnedVersion)
+			}
+
+			jobInput := atc.JobInput{
+				Name: "a", Resource: fakeResource.Name(), Trigger: true, Version: jobVersion,
+			}
+			inputConfigs, err := algorithm.CreateInputConfigs(1, []atc.JobInput{jobInput}, expectedResources, expectedJobIDs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inputConfigs).To(HaveLen(1))
+			Expect(inputConfigs[0].UseEveryVersion).To(Equal(expectedUseEveryVersion))
+			Expect(inputConfigs[0].PinnedVersion).To(Equal(expectedPinnedVersion))
+		},
+		Entry("no job version, no resource version", nil, nil, false, nil),
+		Entry("no job version, resource version pinned", nil, Version1, false, Version1),
+		Entry("job version latest, no resource version", Latest, nil, false, nil),
+		Entry("job version latest, resource version pinned", Latest, Version1, false, Version1),
+		Entry("job version every, no resource version", Every, nil, true, nil),
+		Entry("job version every, resource version pinned", Every, Version1, false, Version1),
+		Entry("job version pinned, no resource version", PinnedV1, nil, false, Version1),
+		Entry("job version pinned, resource version pinned", PinnedV1, Version2, false, Version1),
+	)
+
+	Describe("when no matching resource exists", func() {
+		It("returns the error", func() {
+			jobInput := atc.JobInput{
+				Name: "a", Resource: "foo", Trigger: true,
+			}
+			inputConfigs, err := algorithm.CreateInputConfigs(1, []atc.JobInput{jobInput}, expectedResources, expectedJobIDs)
+			Expect(inputConfigs).To(BeNil())
+			Expect(err).To(Equal(errors.New("input resource not found")))
+		})
+	})
+
+	Describe("passed jobs", func() {
+		Context("when there are no passed constraints", func() {
+			It("returns an empty set of jobs", func() {
+				jobInput := atc.JobInput{
+					Name: "a", Resource: fakeResource.Name(), Trigger: true, Passed: []string{},
+				}
+				inputConfigs, err := algorithm.CreateInputConfigs(1, []atc.JobInput{jobInput}, expectedResources, expectedJobIDs)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(inputConfigs).To(HaveLen(1))
+				Expect(inputConfigs[0].Passed).To(Equal(db.JobSet{}))
+			})
+		})
+		Context("when there are passed jobs", func() {
+			It("returns a job set marking that job as passed", func() {
+				expectedJobIDs = NameToIDMap{"j1": 1, "j2": 2}
+				jobInput := atc.JobInput{
+					Name: "a", Resource: fakeResource.Name(), Trigger: true, Passed: []string{"j1", "j2"},
+				}
+				inputConfigs, err := algorithm.CreateInputConfigs(1, []atc.JobInput{jobInput}, expectedResources, expectedJobIDs)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(inputConfigs).To(HaveLen(1))
+				Expect(inputConfigs[0].Passed).To(Equal(db.JobSet{1: true, 2: true}))
+			})
+		})
+	})
+})

--- a/atc/scheduler/build.go
+++ b/atc/scheduler/build.go
@@ -44,7 +44,12 @@ func (m *manualTriggerBuild) IsReadyToDetermineInputs(logger lager.Logger) bool 
 }
 
 func (m *manualTriggerBuild) BuildInputs(ctx context.Context) ([]db.BuildInput, bool, error) {
-	inputMapping, resolved, hasNextInputs, err := m.algorithm.Compute(ctx, m.job, m.jobInputs, m.resources, m.relatedJobIDs)
+	inputConfigs, err := m.algorithm.CreateInputConfigs(m.job.ID(), m.jobInputs, m.resources, m.relatedJobIDs)
+	if err != nil {
+		return nil, false, fmt.Errorf("input configs: %w", err)
+	}
+
+	inputMapping, resolved, hasNextInputs, err := m.algorithm.Compute(ctx, m.job, inputConfigs)
 	if err != nil {
 		return nil, false, fmt.Errorf("compute inputs: %w", err)
 	}

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -278,7 +278,9 @@ var _ = Describe("BuildStarter", func() {
 
 							It("computes the next inputs for the right job and versions", func() {
 								Expect(fakeAlgorithm.ComputeCallCount()).To(Equal(1))
-								_, actualJob, actualInputs, _, actualRelatedJobs := fakeAlgorithm.ComputeArgsForCall(0)
+								actualJobId, actualInputs, _, actualRelatedJobs := fakeAlgorithm.CreateInputConfigsArgsForCall(0)
+								_, actualJob, _ := fakeAlgorithm.ComputeArgsForCall(0)
+								Expect(actualJobId).To(Equal(job.ID()))
 								Expect(actualJob.Name()).To(Equal(job.Name()))
 								Expect(actualRelatedJobs).To(Equal(relatedJobs))
 								Expect(actualInputs).To(Equal(jobInputs))

--- a/atc/scheduler/scheduler_test.go
+++ b/atc/scheduler/scheduler_test.go
@@ -115,7 +115,9 @@ var _ = Describe("Scheduler", func() {
 
 				It("computed the inputs", func() {
 					Expect(fakeAlgorithm.ComputeCallCount()).To(Equal(1))
-					_, actualJob, actualInputs, resources, relatedJobs := fakeAlgorithm.ComputeArgsForCall(0)
+					actualJobId, actualInputs, resources, relatedJobs := fakeAlgorithm.CreateInputConfigsArgsForCall(0)
+					_, actualJob, _ := fakeAlgorithm.ComputeArgsForCall(0)
+					Expect(actualJobId).To(Equal(fakeJob.ID()))
 					Expect(actualJob.Name()).To(Equal(fakeJob.Name()))
 					Expect(resources).To(Equal(expectedResources))
 					Expect(relatedJobs).To(Equal(expectedJobIDs))

--- a/atc/scheduler/schedulerfakes/fake_algorithm.go
+++ b/atc/scheduler/schedulerfakes/fake_algorithm.go
@@ -12,14 +12,12 @@ import (
 )
 
 type FakeAlgorithm struct {
-	ComputeStub        func(context.Context, db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) (db.InputMapping, bool, bool, error)
+	ComputeStub        func(context.Context, db.Job, algorithm.InputConfigs) (db.InputMapping, bool, bool, error)
 	computeMutex       sync.RWMutex
 	computeArgsForCall []struct {
 		arg1 context.Context
 		arg2 db.Job
-		arg3 []atc.JobInput
-		arg4 db.Resources
-		arg5 algorithm.NameToIDMap
+		arg3 algorithm.InputConfigs
 	}
 	computeReturns struct {
 		result1 db.InputMapping
@@ -33,29 +31,38 @@ type FakeAlgorithm struct {
 		result3 bool
 		result4 error
 	}
+	CreateInputConfigsStub        func(int, []atc.JobInput, db.Resources, algorithm.NameToIDMap) (algorithm.InputConfigs, error)
+	createInputConfigsMutex       sync.RWMutex
+	createInputConfigsArgsForCall []struct {
+		arg1 int
+		arg2 []atc.JobInput
+		arg3 db.Resources
+		arg4 algorithm.NameToIDMap
+	}
+	createInputConfigsReturns struct {
+		result1 algorithm.InputConfigs
+		result2 error
+	}
+	createInputConfigsReturnsOnCall map[int]struct {
+		result1 algorithm.InputConfigs
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAlgorithm) Compute(arg1 context.Context, arg2 db.Job, arg3 []atc.JobInput, arg4 db.Resources, arg5 algorithm.NameToIDMap) (db.InputMapping, bool, bool, error) {
-	var arg3Copy []atc.JobInput
-	if arg3 != nil {
-		arg3Copy = make([]atc.JobInput, len(arg3))
-		copy(arg3Copy, arg3)
-	}
+func (fake *FakeAlgorithm) Compute(arg1 context.Context, arg2 db.Job, arg3 algorithm.InputConfigs) (db.InputMapping, bool, bool, error) {
 	fake.computeMutex.Lock()
 	ret, specificReturn := fake.computeReturnsOnCall[len(fake.computeArgsForCall)]
 	fake.computeArgsForCall = append(fake.computeArgsForCall, struct {
 		arg1 context.Context
 		arg2 db.Job
-		arg3 []atc.JobInput
-		arg4 db.Resources
-		arg5 algorithm.NameToIDMap
-	}{arg1, arg2, arg3Copy, arg4, arg5})
-	fake.recordInvocation("Compute", []interface{}{arg1, arg2, arg3Copy, arg4, arg5})
+		arg3 algorithm.InputConfigs
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("Compute", []interface{}{arg1, arg2, arg3})
 	fake.computeMutex.Unlock()
 	if fake.ComputeStub != nil {
-		return fake.ComputeStub(arg1, arg2, arg3, arg4, arg5)
+		return fake.ComputeStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
@@ -70,17 +77,17 @@ func (fake *FakeAlgorithm) ComputeCallCount() int {
 	return len(fake.computeArgsForCall)
 }
 
-func (fake *FakeAlgorithm) ComputeCalls(stub func(context.Context, db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) (db.InputMapping, bool, bool, error)) {
+func (fake *FakeAlgorithm) ComputeCalls(stub func(context.Context, db.Job, algorithm.InputConfigs) (db.InputMapping, bool, bool, error)) {
 	fake.computeMutex.Lock()
 	defer fake.computeMutex.Unlock()
 	fake.ComputeStub = stub
 }
 
-func (fake *FakeAlgorithm) ComputeArgsForCall(i int) (context.Context, db.Job, []atc.JobInput, db.Resources, algorithm.NameToIDMap) {
+func (fake *FakeAlgorithm) ComputeArgsForCall(i int) (context.Context, db.Job, algorithm.InputConfigs) {
 	fake.computeMutex.RLock()
 	defer fake.computeMutex.RUnlock()
 	argsForCall := fake.computeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeAlgorithm) ComputeReturns(result1 db.InputMapping, result2 bool, result3 bool, result4 error) {
@@ -115,11 +122,84 @@ func (fake *FakeAlgorithm) ComputeReturnsOnCall(i int, result1 db.InputMapping, 
 	}{result1, result2, result3, result4}
 }
 
+func (fake *FakeAlgorithm) CreateInputConfigs(arg1 int, arg2 []atc.JobInput, arg3 db.Resources, arg4 algorithm.NameToIDMap) (algorithm.InputConfigs, error) {
+	var arg2Copy []atc.JobInput
+	if arg2 != nil {
+		arg2Copy = make([]atc.JobInput, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.createInputConfigsMutex.Lock()
+	ret, specificReturn := fake.createInputConfigsReturnsOnCall[len(fake.createInputConfigsArgsForCall)]
+	fake.createInputConfigsArgsForCall = append(fake.createInputConfigsArgsForCall, struct {
+		arg1 int
+		arg2 []atc.JobInput
+		arg3 db.Resources
+		arg4 algorithm.NameToIDMap
+	}{arg1, arg2Copy, arg3, arg4})
+	fake.recordInvocation("CreateInputConfigs", []interface{}{arg1, arg2Copy, arg3, arg4})
+	fake.createInputConfigsMutex.Unlock()
+	if fake.CreateInputConfigsStub != nil {
+		return fake.CreateInputConfigsStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.createInputConfigsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeAlgorithm) CreateInputConfigsCallCount() int {
+	fake.createInputConfigsMutex.RLock()
+	defer fake.createInputConfigsMutex.RUnlock()
+	return len(fake.createInputConfigsArgsForCall)
+}
+
+func (fake *FakeAlgorithm) CreateInputConfigsCalls(stub func(int, []atc.JobInput, db.Resources, algorithm.NameToIDMap) (algorithm.InputConfigs, error)) {
+	fake.createInputConfigsMutex.Lock()
+	defer fake.createInputConfigsMutex.Unlock()
+	fake.CreateInputConfigsStub = stub
+}
+
+func (fake *FakeAlgorithm) CreateInputConfigsArgsForCall(i int) (int, []atc.JobInput, db.Resources, algorithm.NameToIDMap) {
+	fake.createInputConfigsMutex.RLock()
+	defer fake.createInputConfigsMutex.RUnlock()
+	argsForCall := fake.createInputConfigsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeAlgorithm) CreateInputConfigsReturns(result1 algorithm.InputConfigs, result2 error) {
+	fake.createInputConfigsMutex.Lock()
+	defer fake.createInputConfigsMutex.Unlock()
+	fake.CreateInputConfigsStub = nil
+	fake.createInputConfigsReturns = struct {
+		result1 algorithm.InputConfigs
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeAlgorithm) CreateInputConfigsReturnsOnCall(i int, result1 algorithm.InputConfigs, result2 error) {
+	fake.createInputConfigsMutex.Lock()
+	defer fake.createInputConfigsMutex.Unlock()
+	fake.CreateInputConfigsStub = nil
+	if fake.createInputConfigsReturnsOnCall == nil {
+		fake.createInputConfigsReturnsOnCall = make(map[int]struct {
+			result1 algorithm.InputConfigs
+			result2 error
+		})
+	}
+	fake.createInputConfigsReturnsOnCall[i] = struct {
+		result1 algorithm.InputConfigs
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeAlgorithm) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.computeMutex.RLock()
 	defer fake.computeMutex.RUnlock()
+	fake.createInputConfigsMutex.RLock()
+	defer fake.createInputConfigsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
# Why is this PR needed?

There is a lot of logic going on inside the Algorithm.Compute method which makes it hard to decompose and test small things such as adding new `version` conditions (as part of fixing #5456).



# What is this PR trying to accomplish?

Make it easier to understand the precedence of `version` flags and pinning between resources and job inputs.

# How does it accomplish that?

Extract the logic around which is the correct pinned version and whether to be using every version into a separate, testable method. Add a set of table tests for the different set of inputs so we can easily and readably see what the expected outcomes of multiple configuration options are.

There is _one_ functional change in this PR which is that when a pinned version is set on an `InputConfig`, the `UseEveryVersion` flag is no longer explicitly set. This shouldn't be an issue as pinned versions take precedence over `version: every` and we now have tests if we ever want to change this behaviour.

# Notes
* This is my first foray into this codebase and I don't write a lot of Golang (that might be obvious) so feedback is more than welcome.
* Not a massive fan of table testing usually but seemed right given this is basically a matrix multiplication of possible configurations.
* Should this be in the algorithm package? Should it just be moved up into the scheduler package? The way `Scheduler` and `BuildStarter` interact means there's some duplicate code and so I stuck it in the `Algorithm` class since they both already had the same instance of that.


# Contributor Checklist

> Are the following items included as part of this PR? If no, please say why not.

- [x] Unit tests
- [ ] ~Integration tests~ Hoping for a no-op to user-facing behaviour
- [ ] ~Updated documentation (located at https://github.com/concourse/docs)~ Not relevant, internal only
- [ ] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~ Not relevant, internal only


# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
