### PR TITLE
k8s/topgun: update prometheus dependencies and disable worker

### DIFF
--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"time"
 
+	. "github.com/concourse/concourse/topgun"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -19,10 +20,13 @@ var _ = Describe("Prometheus integration", func() {
 		prometheusReleaseName = releaseName + "-prom"
 
 		deployConcourseChart(releaseName,
-			"--set=worker.replicas=1",
-			"--set=concourse.worker.ephemeral=true",
-			"--set=concourse.web.prometheus.enabled=true",
-			"--set=concourse.worker.baggageclaim.driver=detect")
+			"--set=worker.enabled=false",
+			"--set=concourse.web.prometheus.enabled=true")
+
+		Run(nil,
+			"helm", "dependency", "update",
+			path.Join(Environment.HelmChartsDir, "stable/prometheus"),
+		)
 
 		helmDeploy(prometheusReleaseName,
 			namespace,


### PR DESCRIPTION
### Why is this PR needed?

With `stable/prometheus` going from having `kube-state-metrics` embedded in its set of templates to a separate dependency, `k8s-topgun` started failing:
```
Error: found in requirements.yaml, but missing in charts/ directory: kube-state-metrics
```

Without this PR, we can't have `k8s-topgun` running without having the version of `helm/charts` pinned to an old commit, which would force us to have that commit hardcoded in the release branches, as well as the main pipeline.

### What is this PR trying to accomplish?

It tries to make the installation of `prometheus` possible regardless of how its dependencies are set up (either through `requirements.yaml` - the new way of doing thing -, or the old one - embedded). 



### How does it accomplish that?

It does so by running `helm dependency update` before running `helm install`.

Given that such command will not fail in case of `requirements.yaml` not existing (which would be true for older versions of the `helm/charts` repo), it's safe to always do it.

### Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
