### PR TITLE
Lidar tracing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -396,10 +396,21 @@ files are created. This is to ensure that the migrations always run in order.
 There is a utility provided to generate migration files, located at
 `atc/db/migration/cli`.
 
-To generate a migration:
+To generate a migration, you have two options:
+
+#### The short way
+
+Use the `create-migration` script:
+
+```sh
+$ ./atc/scripts/create-migration my_migration_name
+# or if you want a go migration,
+$ ./atc/scripts/create-migration my_migration_name go
+```
+
+#### The long way
 
 1. Build the CLI:
-
 ```sh
 $ cd atc/db/migration
 $ go build -o mig ./cli

--- a/atc/api/jobserver/create_build.go
+++ b/atc/api/jobserver/create_build.go
@@ -1,9 +1,11 @@
 package jobserver
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
+	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/concourse/atc/api/present"
 	"github.com/concourse/concourse/atc/db"
 )
@@ -64,7 +66,13 @@ func (s *Server) CreateJobBuild(pipeline db.Pipeline) http.Handler {
 			resource, found := resources.Lookup(input.Resource)
 			if found {
 				version := resource.CurrentPinnedVersion()
-				_, _, err := s.checkFactory.TryCreateCheck(logger, resource, resourceTypes, version, true)
+				_, _, err := s.checkFactory.TryCreateCheck(
+					lagerctx.NewContext(context.Background(), logger),
+					resource,
+					resourceTypes,
+					version,
+					true,
+				)
 				if err != nil {
 					logger.Error("failed-to-create-check", err)
 				}

--- a/atc/api/resourceserver/check.go
+++ b/atc/api/resourceserver/check.go
@@ -1,10 +1,12 @@
 package resourceserver
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
 	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/present"
 	"github.com/concourse/concourse/atc/db"
@@ -45,7 +47,13 @@ func (s *Server) CheckResource(dbPipeline db.Pipeline) http.Handler {
 			return
 		}
 
-		check, created, err := s.checkFactory.TryCreateCheck(logger, dbResource, dbResourceTypes, reqBody.From, true)
+		check, created, err := s.checkFactory.TryCreateCheck(
+			lagerctx.NewContext(context.Background(), logger),
+			dbResource,
+			dbResourceTypes,
+			reqBody.From,
+			true,
+		)
 		if err != nil {
 			s.logger.Error("failed-to-create-check", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/resourceserver/check_resource_type.go
+++ b/atc/api/resourceserver/check_resource_type.go
@@ -1,10 +1,12 @@
 package resourceserver
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
 	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/api/present"
 	"github.com/concourse/concourse/atc/db"
@@ -45,7 +47,13 @@ func (s *Server) CheckResourceType(dbPipeline db.Pipeline) http.Handler {
 			return
 		}
 
-		check, created, err := s.checkFactory.TryCreateCheck(logger, dbResourceType, dbResourceTypes, reqBody.From, true)
+		check, created, err := s.checkFactory.TryCreateCheck(
+			lagerctx.NewContext(context.Background(), logger),
+			dbResourceType,
+			dbResourceTypes,
+			reqBody.From,
+			true,
+		)
 		if err != nil {
 			s.logger.Error("failed-to-create-check", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/resourceserver/check_webhook.go
+++ b/atc/api/resourceserver/check_webhook.go
@@ -1,11 +1,13 @@
 package resourceserver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/concourse/atc/api/present"
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
@@ -59,7 +61,13 @@ func (s *Server) CheckResourceWebHook(dbPipeline db.Pipeline) http.Handler {
 			return
 		}
 
-		check, created, err := s.checkFactory.TryCreateCheck(logger, dbResource, dbResourceTypes, nil, true)
+		check, created, err := s.checkFactory.TryCreateCheck(
+			lagerctx.NewContext(context.Background(), logger),
+			dbResource,
+			dbResourceTypes,
+			nil,
+			true,
+		)
 		if err != nil {
 			s.logger.Error("failed-to-create-check", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/db/check.go
+++ b/atc/db/check.go
@@ -11,7 +11,6 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/lib/pq"
-	"go.opentelemetry.io/otel/api/propagators"
 )
 
 type CheckStatus string
@@ -50,7 +49,7 @@ type Check interface {
 	AcquireTrackingLock(lager.Logger) (lock.Lock, bool, error)
 	Reload() (bool, error)
 
-	SpanContext() propagators.Supplier
+	SpanContext() SpanContext
 }
 
 var checksQuery = psql.Select(
@@ -327,7 +326,7 @@ func (c *check) SaveVersions(versions []atc.Version) error {
 	return saveVersions(c.conn, c.resourceConfigScopeID, versions)
 }
 
-func (c *check) SpanContext() propagators.Supplier {
+func (c *check) SpanContext() SpanContext {
 	return c.spanContext
 }
 

--- a/atc/db/check.go
+++ b/atc/db/check.go
@@ -11,6 +11,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/lib/pq"
+	"go.opentelemetry.io/otel/api/propagators"
 )
 
 type CheckStatus string
@@ -49,7 +50,7 @@ type Check interface {
 	AcquireTrackingLock(lager.Logger) (lock.Lock, bool, error)
 	Reload() (bool, error)
 
-	SpanContext() SpanContext
+	SpanContext() propagators.Supplier
 }
 
 var checksQuery = psql.Select(
@@ -326,7 +327,7 @@ func (c *check) SaveVersions(versions []atc.Version) error {
 	return saveVersions(c.conn, c.resourceConfigScopeID, versions)
 }
 
-func (c *check) SpanContext() SpanContext {
+func (c *check) SpanContext() propagators.Supplier {
 	return c.spanContext
 }
 

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -207,7 +207,6 @@ func (c *checkFactory) TryCreateCheck(ctx context.Context, checkable Checkable, 
 			Tags:        checkable.Tags(),
 			Timeout:     timeout.String(),
 			FromVersion: fromVersion,
-			SpanContext: map[string]string{},
 
 			VersionedResourceTypes: filteredTypes,
 		},

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -1,8 +1,7 @@
 package db_test
 
 import (
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagertest"
+	"context"
 	"errors"
 	"time"
 
@@ -55,6 +54,7 @@ var _ = Describe("CheckFactory", func() {
 				false,
 				atc.Plan{Check: &atc.CheckPlan{Name: "some-name", Type: "some-type"}},
 				metadata,
+				map[string]string{"fake": "span"},
 			)
 			Expect(created).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
@@ -85,7 +85,6 @@ var _ = Describe("CheckFactory", func() {
 			fakeResourceTypes []db.ResourceType
 			fromVersion       atc.Version
 			manuallyTriggered bool
-			logger            lager.Logger
 		)
 
 		BeforeEach(func() {
@@ -110,12 +109,10 @@ var _ = Describe("CheckFactory", func() {
 
 			fakeResourceTypes = []db.ResourceType{fakeResourceType}
 			manuallyTriggered = true
-
-			logger = lagertest.NewTestLogger("db-test")
 		})
 
 		JustBeforeEach(func() {
-			check, created, err = checkFactory.TryCreateCheck(logger, fakeResource, fakeResourceTypes, fromVersion, manuallyTriggered)
+			check, created, err = checkFactory.TryCreateCheck(context.TODO(), fakeResource, fakeResourceTypes, fromVersion, manuallyTriggered)
 		})
 
 		Context("when the resource parent type is not a custom type", func() {
@@ -325,6 +322,7 @@ var _ = Describe("CheckFactory", func() {
 				false,
 				atc.Plan{Check: &atc.CheckPlan{Name: "some-name", Type: "some-type"}},
 				metadata,
+				map[string]string{"fake": "span"},
 			)
 		})
 
@@ -353,6 +351,7 @@ var _ = Describe("CheckFactory", func() {
 					false,
 					atc.Plan{},
 					metadata,
+					map[string]string{"fake": "span"},
 				)
 				Expect(created).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
@@ -414,6 +413,7 @@ var _ = Describe("CheckFactory", func() {
 					false,
 					atc.Plan{},
 					metadata,
+					map[string]string{"fake": "span"},
 				)
 				Expect(created).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())
@@ -444,7 +444,7 @@ var _ = Describe("CheckFactory", func() {
 
 		Context("when the resources are used", func() {
 
-			BeforeEach(func(){
+			BeforeEach(func() {
 				defaultPipeline, _, err = defaultTeam.SavePipeline("default-pipeline", atc.Config{
 					Jobs: atc.JobConfigs{
 						{

--- a/atc/db/check_test.go
+++ b/atc/db/check_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Check", func() {
 			false,
 			atc.Plan{},
 			metadata,
+			map[string]string{"fake": "span"},
 		)
 		Expect(created).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
@@ -179,6 +180,7 @@ var _ = Describe("Check", func() {
 					false,
 					atc.Plan{},
 					metadata,
+					map[string]string{"fake": "span"},
 				)
 				Expect(created).To(BeTrue())
 				Expect(err).NotTo(HaveOccurred())

--- a/atc/db/dbfakes/fake_check.go
+++ b/atc/db/dbfakes/fake_check.go
@@ -9,6 +9,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/lock"
+	"go.opentelemetry.io/otel/api/propagators"
 )
 
 type FakeCheck struct {
@@ -207,15 +208,15 @@ type FakeCheck struct {
 	schemaReturnsOnCall map[int]struct {
 		result1 string
 	}
-	SpanContextStub        func() db.SpanContext
+	SpanContextStub        func() propagators.Supplier
 	spanContextMutex       sync.RWMutex
 	spanContextArgsForCall []struct {
 	}
 	spanContextReturns struct {
-		result1 db.SpanContext
+		result1 propagators.Supplier
 	}
 	spanContextReturnsOnCall map[int]struct {
-		result1 db.SpanContext
+		result1 propagators.Supplier
 	}
 	StartStub        func() error
 	startMutex       sync.RWMutex
@@ -1254,7 +1255,7 @@ func (fake *FakeCheck) SchemaReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeCheck) SpanContext() db.SpanContext {
+func (fake *FakeCheck) SpanContext() propagators.Supplier {
 	fake.spanContextMutex.Lock()
 	ret, specificReturn := fake.spanContextReturnsOnCall[len(fake.spanContextArgsForCall)]
 	fake.spanContextArgsForCall = append(fake.spanContextArgsForCall, struct {
@@ -1277,32 +1278,32 @@ func (fake *FakeCheck) SpanContextCallCount() int {
 	return len(fake.spanContextArgsForCall)
 }
 
-func (fake *FakeCheck) SpanContextCalls(stub func() db.SpanContext) {
+func (fake *FakeCheck) SpanContextCalls(stub func() propagators.Supplier) {
 	fake.spanContextMutex.Lock()
 	defer fake.spanContextMutex.Unlock()
 	fake.SpanContextStub = stub
 }
 
-func (fake *FakeCheck) SpanContextReturns(result1 db.SpanContext) {
+func (fake *FakeCheck) SpanContextReturns(result1 propagators.Supplier) {
 	fake.spanContextMutex.Lock()
 	defer fake.spanContextMutex.Unlock()
 	fake.SpanContextStub = nil
 	fake.spanContextReturns = struct {
-		result1 db.SpanContext
+		result1 propagators.Supplier
 	}{result1}
 }
 
-func (fake *FakeCheck) SpanContextReturnsOnCall(i int, result1 db.SpanContext) {
+func (fake *FakeCheck) SpanContextReturnsOnCall(i int, result1 propagators.Supplier) {
 	fake.spanContextMutex.Lock()
 	defer fake.spanContextMutex.Unlock()
 	fake.SpanContextStub = nil
 	if fake.spanContextReturnsOnCall == nil {
 		fake.spanContextReturnsOnCall = make(map[int]struct {
-			result1 db.SpanContext
+			result1 propagators.Supplier
 		})
 	}
 	fake.spanContextReturnsOnCall[i] = struct {
-		result1 db.SpanContext
+		result1 propagators.Supplier
 	}{result1}
 }
 

--- a/atc/db/dbfakes/fake_check.go
+++ b/atc/db/dbfakes/fake_check.go
@@ -9,7 +9,6 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/lock"
-	"go.opentelemetry.io/otel/api/propagators"
 )
 
 type FakeCheck struct {
@@ -208,15 +207,15 @@ type FakeCheck struct {
 	schemaReturnsOnCall map[int]struct {
 		result1 string
 	}
-	SpanContextStub        func() propagators.Supplier
+	SpanContextStub        func() db.SpanContext
 	spanContextMutex       sync.RWMutex
 	spanContextArgsForCall []struct {
 	}
 	spanContextReturns struct {
-		result1 propagators.Supplier
+		result1 db.SpanContext
 	}
 	spanContextReturnsOnCall map[int]struct {
-		result1 propagators.Supplier
+		result1 db.SpanContext
 	}
 	StartStub        func() error
 	startMutex       sync.RWMutex
@@ -1255,7 +1254,7 @@ func (fake *FakeCheck) SchemaReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeCheck) SpanContext() propagators.Supplier {
+func (fake *FakeCheck) SpanContext() db.SpanContext {
 	fake.spanContextMutex.Lock()
 	ret, specificReturn := fake.spanContextReturnsOnCall[len(fake.spanContextArgsForCall)]
 	fake.spanContextArgsForCall = append(fake.spanContextArgsForCall, struct {
@@ -1278,32 +1277,32 @@ func (fake *FakeCheck) SpanContextCallCount() int {
 	return len(fake.spanContextArgsForCall)
 }
 
-func (fake *FakeCheck) SpanContextCalls(stub func() propagators.Supplier) {
+func (fake *FakeCheck) SpanContextCalls(stub func() db.SpanContext) {
 	fake.spanContextMutex.Lock()
 	defer fake.spanContextMutex.Unlock()
 	fake.SpanContextStub = stub
 }
 
-func (fake *FakeCheck) SpanContextReturns(result1 propagators.Supplier) {
+func (fake *FakeCheck) SpanContextReturns(result1 db.SpanContext) {
 	fake.spanContextMutex.Lock()
 	defer fake.spanContextMutex.Unlock()
 	fake.SpanContextStub = nil
 	fake.spanContextReturns = struct {
-		result1 propagators.Supplier
+		result1 db.SpanContext
 	}{result1}
 }
 
-func (fake *FakeCheck) SpanContextReturnsOnCall(i int, result1 propagators.Supplier) {
+func (fake *FakeCheck) SpanContextReturnsOnCall(i int, result1 db.SpanContext) {
 	fake.spanContextMutex.Lock()
 	defer fake.spanContextMutex.Unlock()
 	fake.SpanContextStub = nil
 	if fake.spanContextReturnsOnCall == nil {
 		fake.spanContextReturnsOnCall = make(map[int]struct {
-			result1 propagators.Supplier
+			result1 db.SpanContext
 		})
 	}
 	fake.spanContextReturnsOnCall[i] = struct {
-		result1 propagators.Supplier
+		result1 db.SpanContext
 	}{result1}
 }
 

--- a/atc/db/dbfakes/fake_check_factory.go
+++ b/atc/db/dbfakes/fake_check_factory.go
@@ -2,6 +2,7 @@
 package dbfakes
 
 import (
+	"context"
 	"sync"
 
 	"code.cloudfoundry.org/lager"
@@ -41,13 +42,14 @@ type FakeCheckFactory struct {
 		result2 bool
 		result3 error
 	}
-	CreateCheckStub        func(int, bool, atc.Plan, db.CheckMetadata) (db.Check, bool, error)
+	CreateCheckStub        func(int, bool, atc.Plan, db.CheckMetadata, db.SpanContext) (db.Check, bool, error)
 	createCheckMutex       sync.RWMutex
 	createCheckArgsForCall []struct {
 		arg1 int
 		arg2 bool
 		arg3 atc.Plan
 		arg4 db.CheckMetadata
+		arg5 db.SpanContext
 	}
 	createCheckReturns struct {
 		result1 db.Check
@@ -105,10 +107,10 @@ type FakeCheckFactory struct {
 		result1 []db.Check
 		result2 error
 	}
-	TryCreateCheckStub        func(lager.Logger, db.Checkable, db.ResourceTypes, atc.Version, bool) (db.Check, bool, error)
+	TryCreateCheckStub        func(context.Context, db.Checkable, db.ResourceTypes, atc.Version, bool) (db.Check, bool, error)
 	tryCreateCheckMutex       sync.RWMutex
 	tryCreateCheckArgsForCall []struct {
-		arg1 lager.Logger
+		arg1 context.Context
 		arg2 db.Checkable
 		arg3 db.ResourceTypes
 		arg4 atc.Version
@@ -260,7 +262,7 @@ func (fake *FakeCheckFactory) CheckReturnsOnCall(i int, result1 db.Check, result
 	}{result1, result2, result3}
 }
 
-func (fake *FakeCheckFactory) CreateCheck(arg1 int, arg2 bool, arg3 atc.Plan, arg4 db.CheckMetadata) (db.Check, bool, error) {
+func (fake *FakeCheckFactory) CreateCheck(arg1 int, arg2 bool, arg3 atc.Plan, arg4 db.CheckMetadata, arg5 db.SpanContext) (db.Check, bool, error) {
 	fake.createCheckMutex.Lock()
 	ret, specificReturn := fake.createCheckReturnsOnCall[len(fake.createCheckArgsForCall)]
 	fake.createCheckArgsForCall = append(fake.createCheckArgsForCall, struct {
@@ -268,11 +270,12 @@ func (fake *FakeCheckFactory) CreateCheck(arg1 int, arg2 bool, arg3 atc.Plan, ar
 		arg2 bool
 		arg3 atc.Plan
 		arg4 db.CheckMetadata
-	}{arg1, arg2, arg3, arg4})
-	fake.recordInvocation("CreateCheck", []interface{}{arg1, arg2, arg3, arg4})
+		arg5 db.SpanContext
+	}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("CreateCheck", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.createCheckMutex.Unlock()
 	if fake.CreateCheckStub != nil {
-		return fake.CreateCheckStub(arg1, arg2, arg3, arg4)
+		return fake.CreateCheckStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -287,17 +290,17 @@ func (fake *FakeCheckFactory) CreateCheckCallCount() int {
 	return len(fake.createCheckArgsForCall)
 }
 
-func (fake *FakeCheckFactory) CreateCheckCalls(stub func(int, bool, atc.Plan, db.CheckMetadata) (db.Check, bool, error)) {
+func (fake *FakeCheckFactory) CreateCheckCalls(stub func(int, bool, atc.Plan, db.CheckMetadata, db.SpanContext) (db.Check, bool, error)) {
 	fake.createCheckMutex.Lock()
 	defer fake.createCheckMutex.Unlock()
 	fake.CreateCheckStub = stub
 }
 
-func (fake *FakeCheckFactory) CreateCheckArgsForCall(i int) (int, bool, atc.Plan, db.CheckMetadata) {
+func (fake *FakeCheckFactory) CreateCheckArgsForCall(i int) (int, bool, atc.Plan, db.CheckMetadata, db.SpanContext) {
 	fake.createCheckMutex.RLock()
 	defer fake.createCheckMutex.RUnlock()
 	argsForCall := fake.createCheckArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeCheckFactory) CreateCheckReturns(result1 db.Check, result2 bool, result3 error) {
@@ -546,11 +549,11 @@ func (fake *FakeCheckFactory) StartedChecksReturnsOnCall(i int, result1 []db.Che
 	}{result1, result2}
 }
 
-func (fake *FakeCheckFactory) TryCreateCheck(arg1 lager.Logger, arg2 db.Checkable, arg3 db.ResourceTypes, arg4 atc.Version, arg5 bool) (db.Check, bool, error) {
+func (fake *FakeCheckFactory) TryCreateCheck(arg1 context.Context, arg2 db.Checkable, arg3 db.ResourceTypes, arg4 atc.Version, arg5 bool) (db.Check, bool, error) {
 	fake.tryCreateCheckMutex.Lock()
 	ret, specificReturn := fake.tryCreateCheckReturnsOnCall[len(fake.tryCreateCheckArgsForCall)]
 	fake.tryCreateCheckArgsForCall = append(fake.tryCreateCheckArgsForCall, struct {
-		arg1 lager.Logger
+		arg1 context.Context
 		arg2 db.Checkable
 		arg3 db.ResourceTypes
 		arg4 atc.Version
@@ -574,13 +577,13 @@ func (fake *FakeCheckFactory) TryCreateCheckCallCount() int {
 	return len(fake.tryCreateCheckArgsForCall)
 }
 
-func (fake *FakeCheckFactory) TryCreateCheckCalls(stub func(lager.Logger, db.Checkable, db.ResourceTypes, atc.Version, bool) (db.Check, bool, error)) {
+func (fake *FakeCheckFactory) TryCreateCheckCalls(stub func(context.Context, db.Checkable, db.ResourceTypes, atc.Version, bool) (db.Check, bool, error)) {
 	fake.tryCreateCheckMutex.Lock()
 	defer fake.tryCreateCheckMutex.Unlock()
 	fake.TryCreateCheckStub = stub
 }
 
-func (fake *FakeCheckFactory) TryCreateCheckArgsForCall(i int) (lager.Logger, db.Checkable, db.ResourceTypes, atc.Version, bool) {
+func (fake *FakeCheckFactory) TryCreateCheckArgsForCall(i int) (context.Context, db.Checkable, db.ResourceTypes, atc.Version, bool) {
 	fake.tryCreateCheckMutex.RLock()
 	defer fake.tryCreateCheckMutex.RUnlock()
 	argsForCall := fake.tryCreateCheckArgsForCall[i]

--- a/atc/db/migration/migrations/1588860260_add_span_context_to_checks.down.sql
+++ b/atc/db/migration/migrations/1588860260_add_span_context_to_checks.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE checks DROP COLUMN span_context;
+COMMIT;

--- a/atc/db/migration/migrations/1588860260_add_span_context_to_checks.up.sql
+++ b/atc/db/migration/migrations/1588860260_add_span_context_to_checks.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE checks ADD COLUMN span_context jsonb;
+COMMIT;

--- a/atc/db/span_context.go
+++ b/atc/db/span_context.go
@@ -1,0 +1,28 @@
+package db
+
+import (
+	"context"
+
+	"github.com/concourse/concourse/tracing"
+)
+
+type SpanContext map[string]string
+
+func NewSpanContext(ctx context.Context) SpanContext {
+	sc := SpanContext{}
+	tracing.Inject(ctx, sc)
+	return sc
+}
+
+func (sc SpanContext) Get(key string) string {
+	if sc == nil {
+		return ""
+	}
+	return sc[key]
+}
+
+func (sc SpanContext) Set(key, value string) {
+	if sc != nil {
+		sc[key] = value
+	}
+}

--- a/atc/lidar/checker.go
+++ b/atc/lidar/checker.go
@@ -53,10 +53,10 @@ func (c *checker) Run(ctx context.Context) error {
 					check,
 					"checker.Run",
 					tracing.Attrs{
-						"team":                     ck.TeamName(),
-						"pipeline":                 ck.PipelineName(),
-						"check_id":                 strconv.Itoa(ck.ID()),
-						"resource_config_scope_id": strconv.Itoa(ck.ResourceConfigScopeID()),
+						"team":                     check.TeamName(),
+						"pipeline":                 check.PipelineName(),
+						"check_id":                 strconv.Itoa(check.ID()),
+						"resource_config_scope_id": strconv.Itoa(check.ResourceConfigScopeID()),
 					},
 				)
 				defer span.End()

--- a/atc/lidar/lidar.go
+++ b/atc/lidar/lidar.go
@@ -37,23 +37,3 @@ func NewRunner(
 		},
 	)
 }
-
-func NewCheckerRunner(
-	logger lager.Logger,
-	clock clock.Clock,
-	checkRunner Runner,
-	runnerInterval time.Duration,
-	notifications Notifications,
-	lockFactory lock.LockFactory,
-	componentFactory db.ComponentFactory,
-) ifrit.Runner {
-	return grouper.NewParallel(
-		os.Interrupt,
-		[]grouper.Member{
-			{
-				Name:   atc.ComponentLidarChecker,
-				Runner: NewIntervalRunner(logger, clock, checkRunner, runnerInterval, notifications, atc.ComponentLidarChecker, lockFactory, componentFactory),
-			},
-		},
-	)
-}

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -111,23 +111,14 @@ type PutPlan struct {
 }
 
 type CheckPlan struct {
-	Type        string            `json:"type"`
-	Name        string            `json:"name,omitempty"`
-	Source      Source            `json:"source"`
-	Tags        Tags              `json:"tags,omitempty"`
-	Timeout     string            `json:"timeout,omitempty"`
-	FromVersion Version           `json:"from_version,omitempty"`
-	SpanContext map[string]string `json:"span_context"`
+	Type        string  `json:"type"`
+	Name        string  `json:"name,omitempty"`
+	Source      Source  `json:"source"`
+	Tags        Tags    `json:"tags,omitempty"`
+	Timeout     string  `json:"timeout,omitempty"`
+	FromVersion Version `json:"from_version,omitempty"`
 
 	VersionedResourceTypes VersionedResourceTypes `json:"resource_types,omitempty"`
-}
-
-func (cp *CheckPlan) Get(key string) string {
-	return cp.SpanContext[key]
-}
-
-func (cp *CheckPlan) Set(key, value string) {
-	cp.SpanContext[key] = value
 }
 
 type TaskPlan struct {

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -111,14 +111,23 @@ type PutPlan struct {
 }
 
 type CheckPlan struct {
-	Type        string  `json:"type"`
-	Name        string  `json:"name,omitempty"`
-	Source      Source  `json:"source"`
-	Tags        Tags    `json:"tags,omitempty"`
-	Timeout     string  `json:"timeout,omitempty"`
-	FromVersion Version `json:"from_version,omitempty"`
+	Type        string            `json:"type"`
+	Name        string            `json:"name,omitempty"`
+	Source      Source            `json:"source"`
+	Tags        Tags              `json:"tags,omitempty"`
+	Timeout     string            `json:"timeout,omitempty"`
+	FromVersion Version           `json:"from_version,omitempty"`
+	SpanContext map[string]string `json:"span_context"`
 
 	VersionedResourceTypes VersionedResourceTypes `json:"resource_types,omitempty"`
+}
+
+func (cp *CheckPlan) Get(key string) string {
+	return cp.SpanContext[key]
+}
+
+func (cp *CheckPlan) Set(key, value string) {
+	cp.SpanContext[key] = value
 }
 
 type TaskPlan struct {


### PR DESCRIPTION
# Why is this PR needed?

There are a few recurring scenarios where concourse seems to "hang" and not give clear feedback about why. The work in this PR is focused around improving observability in the "I pushed a new commit, but my test job isn't triggering" workflow, which has sizeable overlap with the `create-and-run-new-pipeline` SLI.

# What is this PR trying to accomplish?

The end goal is to enable a single execution of the `create-and-run-new-pipeline` SLI to correspond to a single trace - failing that, it would be nice to have a collection of traces that observe the flow of execution between all the exercised components: `scanner -> checker -> scheduler -> buildstarter -> exec` to enable a (stochastic) answer to the question "why is this SLI timing out?"

related to #5547.

# How does it accomplish that?

The straightforward part is just emitting traces from the previously-less-observed components in the `lidar` package. The more interesting and subtle part is the use of span context propagation to create relationships between spans. Now the span context created by the scanner gets serialized in a `span_context` column on the `check` it creates - this context is picked up by the checker, and any resource versions it outputs are annotated with a `span_context` in a similar manner.

It still remains to create the link between the checker and scheduler/buildstarter/exec. This is a bit more subtle because there can potentially be many resource versions that "cause" a build to be scheduled. It will probably make more sense to use a `Link` than `Relationship` in opentelemetry for this purpose.

# Contributor Checklist

- [ ] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [x] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
