### PR TITLE
Add `aws ssm` support for `var_sources`

### DIFF
--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -731,7 +731,7 @@ func validateVarSources(c Config) error {
 		// TODO: this check should eventually be removed once all credential managers
 		// are supported in pipeline. - @evanchaoli
 		switch cm.Type {
-		case "vault", "dummy":
+		case "vault", "dummy", "ssm":
 		default:
 			return fmt.Errorf("credential manager type %s is not supported in pipeline yet", cm.Type)
 		}

--- a/atc/creds/ssm/manager.go
+++ b/atc/creds/ssm/manager.go
@@ -21,12 +21,12 @@ const DefaultPipelineSecretTemplate = "/concourse/{{.Team}}/{{.Pipeline}}/{{.Sec
 const DefaultTeamSecretTemplate = "/concourse/{{.Team}}/{{.Secret}}"
 
 type SsmManager struct {
-	AwsAccessKeyID         string `mapstructure:"access-key" long:"access-key" description:"AWS Access key ID"`
-	AwsSecretAccessKey     string `mapstructure:"secret-key" long:"secret-key" description:"AWS Secret Access Key"`
-	AwsSessionToken        string `mapstructure:"session-token" long:"session-token" description:"AWS Session Token"`
+	AwsAccessKeyID         string `mapstructure:"access_key" long:"access-key" description:"AWS Access key ID"`
+	AwsSecretAccessKey     string `mapstructure:"secret_key" long:"secret-key" description:"AWS Secret Access Key"`
+	AwsSessionToken        string `mapstructure:"session_token" long:"session-token" description:"AWS Session Token"`
 	AwsRegion              string `mapstructure:"region" long:"region" description:"AWS region to send requests to"`
-	PipelineSecretTemplate string `mapstructure:"pipeline-secret-template" long:"pipeline-secret-template" description:"AWS SSM parameter name template used for pipeline specific parameter" default:"/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"`
-	TeamSecretTemplate     string `mapstructure:"team-secret-template" long:"team-secret-template" description:"AWS SSM parameter name template used for team specific parameter" default:"/concourse/{{.Team}}/{{.Secret}}"`
+	PipelineSecretTemplate string `mapstructure:"pipeline_secret_template" long:"pipeline-secret-template" description:"AWS SSM parameter name template used for pipeline specific parameter" default:"/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"`
+	TeamSecretTemplate     string `mapstructure:"team_secret_template" long:"team-secret-template" description:"AWS SSM parameter name template used for team specific parameter" default:"/concourse/{{.Team}}/{{.Secret}}"`
 	Ssm                    *Ssm
 }
 

--- a/atc/creds/ssm/manager.go
+++ b/atc/creds/ssm/manager.go
@@ -84,7 +84,6 @@ func (manager *SsmManager) Config(config map[string]interface{}) error {
 	manager.PipelineSecretTemplate = DefaultPipelineSecretTemplate
 
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		DecodeHook:  mapstructure.StringToTimeDurationHookFunc(),
 		ErrorUnused: true,
 		Result:      &manager,
 	})

--- a/atc/creds/ssm/manager.go
+++ b/atc/creds/ssm/manager.go
@@ -1,19 +1,20 @@
 package ssm
 
 import (
-	"code.cloudfoundry.org/lager"
 	"encoding/json"
 	"errors"
+	"io/ioutil"
+	"strings"
+	"text/template"
+	"text/template/parse"
+
+	"code.cloudfoundry.org/lager"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/concourse/concourse/atc/creds"
-	"io/ioutil"
-	"strings"
-	"text/template"
-	"text/template/parse"
 )
 
 const DefaultPipelineSecretTemplate = "/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"

--- a/atc/creds/ssm/manager.go
+++ b/atc/creds/ssm/manager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/concourse/concourse/atc/creds"
-	"github.com/mitchellh/mapstructure"
 	"io/ioutil"
 	"strings"
 	"text/template"
@@ -73,27 +72,6 @@ func (manager *SsmManager) Init(log lager.Logger) error {
 
 	manager.Ssm = &Ssm{
 		api: ssm.New(session),
-	}
-
-	return nil
-}
-
-func (manager *SsmManager) Config(config map[string]interface{}) error {
-	// apply defaults
-	manager.TeamSecretTemplate = DefaultTeamSecretTemplate
-	manager.PipelineSecretTemplate = DefaultPipelineSecretTemplate
-
-	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ErrorUnused: true,
-		Result:      &manager,
-	})
-	if err != nil {
-		return err
-	}
-
-	err = decoder.Decode(config)
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/atc/creds/ssm/manager_factory.go
+++ b/atc/creds/ssm/manager_factory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/concourse/concourse/atc/creds"
 	flags "github.com/jessevdk/go-flags"
+	"github.com/mitchellh/mapstructure"
 )
 
 type ssmManagerFactory struct{}
@@ -31,9 +32,20 @@ func (factory *ssmManagerFactory) NewInstance(config interface{}) (creds.Manager
 	if c, ok := config.(map[string]interface{}); !ok {
 		return nil, fmt.Errorf("invalid aws ssm config format")
 	} else {
-		manager := &SsmManager{}
+		manager := &SsmManager{
+			TeamSecretTemplate: DefaultTeamSecretTemplate,
+			PipelineSecretTemplate : DefaultPipelineSecretTemplate,
+		}
 
-		err := manager.Config(c)
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			ErrorUnused: true,
+			Result:      &manager,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		err = decoder.Decode(c)
 		if err != nil {
 			return nil, err
 		}

--- a/atc/creds/ssm/manager_factory.go
+++ b/atc/creds/ssm/manager_factory.go
@@ -1,6 +1,7 @@
 package ssm
 
 import (
+	"fmt"
 	"github.com/concourse/concourse/atc/creds"
 	flags "github.com/jessevdk/go-flags"
 )
@@ -26,6 +27,17 @@ func (factory *ssmManagerFactory) AddConfig(group *flags.Group) creds.Manager {
 	return manager
 }
 
-func (factory *ssmManagerFactory) NewInstance(interface{}) (creds.Manager, error) {
-	return &SsmManager{}, nil
+func (factory *ssmManagerFactory) NewInstance(config interface{}) (creds.Manager, error) {
+	if c, ok := config.(map[string]interface{}); !ok {
+		return nil, fmt.Errorf("invalid aws ssm config format")
+	} else {
+		manager := &SsmManager{}
+
+		err := manager.Config(c)
+		if err != nil {
+			return nil, err
+		}
+
+		return manager, nil
+	}
 }

--- a/atc/creds/ssm/manager_factory.go
+++ b/atc/creds/ssm/manager_factory.go
@@ -1,7 +1,6 @@
 package ssm
 
 import (
-	"fmt"
 	"github.com/concourse/concourse/atc/creds"
 	flags "github.com/jessevdk/go-flags"
 	"github.com/mitchellh/mapstructure"
@@ -29,27 +28,23 @@ func (factory *ssmManagerFactory) AddConfig(group *flags.Group) creds.Manager {
 }
 
 func (factory *ssmManagerFactory) NewInstance(config interface{}) (creds.Manager, error) {
-	if c, ok := config.(map[string]interface{}); !ok {
-		return nil, fmt.Errorf("invalid aws ssm config format")
-	} else {
-		manager := &SsmManager{
-			TeamSecretTemplate: DefaultTeamSecretTemplate,
-			PipelineSecretTemplate : DefaultPipelineSecretTemplate,
-		}
-
-		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-			ErrorUnused: true,
-			Result:      &manager,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		err = decoder.Decode(c)
-		if err != nil {
-			return nil, err
-		}
-
-		return manager, nil
+	manager := &SsmManager{
+		TeamSecretTemplate:     DefaultTeamSecretTemplate,
+		PipelineSecretTemplate: DefaultPipelineSecretTemplate,
 	}
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused: true,
+		Result:      &manager,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = decoder.Decode(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return manager, nil
 }


### PR DESCRIPTION
[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns page]: https://github.com/concourse/concourse/wiki/Anti-Patterns


# Why is this PR needed?

The `var_sources` only supports `dummy` and `vault` and I've the need to support `aws ssm`.

# What is this PR trying to accomplish?

This PR adds `aws ssm` support for `var_sources`

# How does it accomplish that?

I followed the guidelines that @vito gave me in discord and followed the approached used for Vault.

This is my first time doing go so be kind 😅 

# Contributor Checklist

- [ ] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
