### PR TITLE
Tracing for Image Streaming

### DIFF
--- a/atc/worker/artifact_source.go
+++ b/atc/worker/artifact_source.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/compression"
 	"github.com/concourse/concourse/atc/runtime"
+	"github.com/concourse/concourse/tracing"
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -60,6 +61,14 @@ func (source *artifactSource) StreamTo(
 	logger lager.Logger,
 	destination ArtifactDestination,
 ) error {
+	ctx, span := tracing.StartSpan(ctx, "artifactSource.StreamTo", nil)
+	defer span.End()
+
+	_, outSpan := tracing.StartSpan(ctx, "volume.StreamOut", tracing.Attrs{
+		"origin-volume": source.volume.Handle(),
+		"origin-worker": source.volume.WorkerName(),
+	})
+	defer outSpan.End()
 	out, err := source.volume.StreamOut(ctx, ".", source.compression.Encoding())
 	if err != nil {
 		return err

--- a/atc/worker/artifact_source.go
+++ b/atc/worker/artifact_source.go
@@ -70,17 +70,17 @@ func (source *artifactSource) StreamTo(
 	})
 	defer outSpan.End()
 	out, err := source.volume.StreamOut(ctx, ".", source.compression.Encoding())
+
 	if err != nil {
+		tracing.End(outSpan, err)
 		return err
 	}
 
 	defer out.Close()
 
 	err = destination.StreamIn(ctx, ".", source.compression.Encoding(), out)
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return err
 }
 
 // TODO: figure out if we want logging before and after streams, I remove logger from private methods

--- a/atc/worker/image/image.go
+++ b/atc/worker/image/image.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"github.com/concourse/concourse/tracing"
 	"io"
 	"net/url"
 	"path"
@@ -77,6 +78,9 @@ func (i *imageProvidedByPreviousStepOnDifferentWorker) FetchForContainer(
 	logger lager.Logger,
 	container db.CreatingContainer,
 ) (worker.FetchedImage, error) {
+	ctx, span := tracing.StartSpan(ctx, "imageProvidedByPreviousStepOnDifferentWorker.FetchForContainer", tracing.Attrs{"container_id": container.Handle()})
+	defer span.End()
+
 	imageVolume, err := i.volumeClient.FindOrCreateVolumeForContainer(
 		logger,
 		worker.VolumeSpec{

--- a/atc/worker/volume.go
+++ b/atc/worker/volume.go
@@ -91,8 +91,11 @@ func (v *volume) StreamIn(ctx context.Context, path string, encoding baggageclai
 		"destination-volume": v.Handle(),
 		"destination-worker": v.WorkerName(),
 	})
-	defer span.End()
-	return v.bcVolume.StreamIn(ctx, path, encoding, tarStream)
+
+	err := v.bcVolume.StreamIn(ctx, path, encoding, tarStream)
+	tracing.End(span, err)
+
+	return err
 }
 
 func (v *volume) StreamOut(ctx context.Context, path string, encoding baggageclaim.Encoding) (io.ReadCloser, error) {

--- a/atc/worker/volume.go
+++ b/atc/worker/volume.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"github.com/concourse/concourse/tracing"
 	"io"
 
 	"code.cloudfoundry.org/lager"
@@ -86,6 +87,11 @@ func (v *volume) SetPrivileged(privileged bool) error {
 }
 
 func (v *volume) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, tarStream io.Reader) error {
+	_, span := tracing.StartSpan(ctx, "volume.StreamIn", tracing.Attrs{
+		"destination-volume": v.Handle(),
+		"destination-worker": v.WorkerName(),
+	})
+	defer span.End()
 	return v.bcVolume.StreamIn(ctx, path, encoding, tarStream)
 }
 

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -69,3 +69,7 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 #### <sub><sup><a name="5624" href="#5624">:link:</a></sup></sub> fix
 
 * Fixed a bug where fly would no longer tell you if the team you logged in with was invalid
+
+#### <sub><sup><a name="5572" href="#5572">:link:</a></sup></sub> feature
+
+* Add tracing to allow users and developers to observe volume streaming from source to destination volumes.  #5579

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -144,7 +144,7 @@ func End(span trace.Span, err error) {
 	if err != nil {
 		span.SetStatus(codes.Internal)
 		span.SetAttributes(
-			key.New("error").String(err.Error()),
+			key.New("error-message").String(err.Error()),
 		)
 	}
 


### PR DESCRIPTION
Fixes #5572 

# Why is this PR needed? 

See #5572 

# Contributor Checklist
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 

# Instruction for Acceptance Test
- Update the `docker-compose.yml` with two diff. workers to use diff. tags (e.g we used `workerb` in the following example)
- Run `docker-compose -f docker-compose.yml -f hack/overrides/jaeger.yml up --build -d` 
- You can use the following `pipeline.yml` for testing
```pipeline.yml
---
resources:
  - name: my-image
    type: registry-image
    source:
      repository: busybox

jobs:
  - name: create-and-consume
    public: true
    plan:
      - get: my-image
      - task: make-a-file
        tags: [workerb]
        image: my-image
        config:
          platform: linux
          run:
            path: sh
            args:
              - -exc
              - ls -la; echo "Created a file on $(date)" > ./files/created_file
          outputs:
            - name: files
      - task: consume-the-file
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          inputs:
            - name: files
          run:
            path: cat
            args:
              - ./files/created_file
```
- Check jaeger UI on port `25000`
