### PR TITLE
atc: Optimize db queries

### DIFF
--- a/atc/db/versions_db.go
+++ b/atc/db/versions_db.go
@@ -32,7 +32,7 @@ func NewVersionsDB(conn Conn, limitRows int, cache *gocache.Cache) VersionsDB {
 	}
 }
 
-func (versions VersionsDB) IsFirstOccurrence(ctx context.Context, jobID int, inputName string, versionMD5 ResourceVersion) (bool, error) {
+func (versions VersionsDB) IsFirstOccurrence(ctx context.Context, jobID int, inputName string, versionMD5 ResourceVersion, resourceId int) (bool, error) {
 	var exists bool
 	err := versions.conn.QueryRowContext(ctx, `
 		WITH builds_of_job AS (
@@ -44,7 +44,8 @@ func (versions VersionsDB) IsFirstOccurrence(ctx context.Context, jobID int, inp
 			JOIN builds_of_job b ON b.id = i.build_id
 			WHERE i.name = $2
 			AND i.version_md5 = $3
-		)`, jobID, inputName, versionMD5).
+			AND i.resource_id = $4
+		)`, jobID, inputName, versionMD5, resourceId).
 		Scan(&exists)
 	if err != nil {
 		return false, err

--- a/atc/scheduler/algorithm/compute.go
+++ b/atc/scheduler/algorithm/compute.go
@@ -96,7 +96,7 @@ func (a *Algorithm) candidatesToInputMapping(ctx context.Context, mapping db.Inp
 				ResolveError: resolveErr,
 			}
 		} else {
-			firstOcc, err := a.versionsDB.IsFirstOccurrence(ctx, input.JobID, input.Name, candidates[input.Name].Version)
+			firstOcc, err := a.versionsDB.IsFirstOccurrence(ctx, input.JobID, input.Name, candidates[input.Name].Version, input.ResourceID)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
# What is this PR trying to accomplish?

Improve the efficiency of queries in order to lower database CPU usage. This PR tackles a couple of vectors that could be the cause of some db slowness that was noticed on the concourse's team `hush-house` deployment.

closes #5577 

# How does it accomplish that?

* Update `FirstOccurrence()`  query to use the index available in the `build_resource_config_version_inputs` table
* Rewrite the query for deleting any old build image resource caches when finishing a build in order to speed up its performance

# Contributor Checklist

> Are the following items included as part of this PR? If no, please say why not.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
