### PR TITLE
Add timeout flag to fly hijack

### DIFF
--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -363,7 +363,7 @@ func (command *HijackCommand) chooseContainer(target rc.Target, team concourse.T
 
 	start := time.Now()
 	currentTime := start
-	for currentTime.Sub(start).Seconds() < timeout.Seconds() {
+	for currentTime.Sub(start).Seconds() <= timeout.Seconds() {
 		if command.Handle != "" {
 			chosenContainer, err = team.GetContainer(command.Handle)
 			if err == nil {

--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -31,7 +31,7 @@ type HijackCommand struct {
 	StepName       string                   `short:"s" long:"step"                              description:"Name of step to hijack (e.g. build, unit, resource name)"`
 	StepType       string                   `          long:"step-type"                         description:"Type of step to hijack (e.g. get, put, task)"`
 	Attempt        string                   `short:"a" long:"attempt" value-name:"N[,N,...]"    description:"Attempt number of step to hijack."`
-	TimeOut        string                   `short:"o" long:"timeout"                           description:"Time to wait for container."`
+	Timeout        time.Duration            `short:"o" long:"timeout"                           description:"Time to wait for container."`
 	PositionalArgs struct {
 		Command []string `positional-arg-name:"command" description:"The command to run in the container (default: bash)"`
 	} `positional-args:"yes"`
@@ -359,10 +359,7 @@ func locateContainer(client concourse.Client, fingerprint *containerFingerprint)
 func (command *HijackCommand) chooseContainer(target rc.Target, team concourse.Team) (atc.Container, error) {
 	var err error
 	chosenContainer := atc.Container{}
-	timeout, err := time.ParseDuration(fmt.Sprintf("%s", command.TimeOut))
-	if err != nil {
-		return chosenContainer, err
-	}
+	timeout := command.Timeout
 
 	start := time.Now()
 	currentTime := start
@@ -397,7 +394,7 @@ func (command *HijackCommand) chooseContainer(target rc.Target, team concourse.T
 			} else if len(hijackableContainers) > 1 {
 
 				// timeout flag was set, assume container selection criteria is concise enough for 1 container
-				if command.TimeOut != "" {
+				if command.Timeout != time.Duration(0) {
 					currentTime = time.Now()
 					continue
 				}


### PR DESCRIPTION
# Why is this PR needed?

It may take some time for a job to reach a specific step/task but its duration may be very short. Timeout flag allows for accessing the container without needing to run `fly hijack` within a very specific window of time.

# What is this PR trying to accomplish?

Reduces time needed to wait for step/task to become available. Especially when the step/task passes and gets cleaned up.

# How does it accomplish that?

Loops the logic for identifying containers, but when `--timeout/-o` flag is specified, it does not allow the user to interactively choose the container. Selection must be as specific as possible (e.g. only one container that matches selection criteria)

# Contributor Checklist

- [ ] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
