### PR TITLE
web: behaviour: add tooltip to sync icon

### DIFF
--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -434,9 +434,15 @@ view model =
     in
     { title = title ++ " - Concourse"
     , body =
-        [ Tooltip.view model.session
-        , Html.map Update body
-        ]
+        List.map (Html.map Update)
+            [ SubPage.tooltip model.subModel model.session
+                |> Maybe.map (Tooltip.view model.session)
+                |> Maybe.withDefault (Html.text "")
+            , SideBar.tooltip model.session
+                |> Maybe.map (Tooltip.view model.session)
+                |> Maybe.withDefault (Html.text "")
+            , body
+            ]
     }
 
 

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -47,7 +47,7 @@ import Http
 import List.Extra
 import Login.Login as Login
 import Maybe.Extra
-import Message.Callback exposing (Callback(..), TooltipPolicy(..))
+import Message.Callback exposing (Callback(..))
 import Message.Effects as Effects exposing (Effect(..))
 import Message.Message exposing (DomID(..), Message(..))
 import Message.ScrollDirection as ScrollDirection
@@ -316,11 +316,10 @@ handleDelivery session delivery ( model, effects ) =
                         HoverState.Hovered (FirstOccurrenceGetStepLabel stepID) ->
                             [ GetViewportOf
                                 (FirstOccurrenceGetStepLabel stepID)
-                                AlwaysShow
                             ]
 
                         HoverState.Hovered (StepState stepID) ->
-                            [ GetViewportOf (StepState stepID) AlwaysShow ]
+                            [ GetViewportOf (StepState stepID) ]
 
                         _ ->
                             []

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -8,6 +8,7 @@ module Build.Build exposing
     , handleDelivery
     , init
     , subscriptions
+    , tooltip
     , update
     , view
     )
@@ -24,6 +25,7 @@ import Build.Shortcuts as Shortcuts
 import Build.StepTree.Models as STModels
 import Build.StepTree.StepTree as StepTree
 import Build.Styles as Styles
+import Colors
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import DateFormat
@@ -58,6 +60,7 @@ import SideBar.SideBar as SideBar
 import StrictEvents exposing (onScroll)
 import String
 import Time
+import Tooltip
 import UpdateMsg exposing (UpdateMsg)
 import Views.Icon as Icon
 import Views.LoadingIndicator as LoadingIndicator
@@ -662,6 +665,26 @@ view session model =
             , viewBuildPage session model
             ]
         ]
+
+
+tooltip : Model -> { a | hovered : HoverState.HoverState } -> Maybe Tooltip.Tooltip
+tooltip _ { hovered } =
+    case hovered of
+        HoverState.Tooltip (FirstOccurrenceGetStepLabel _) _ ->
+            Just
+                { body =
+                    Html.div
+                        Styles.firstOccurrenceTooltip
+                        [ Html.text "new version" ]
+                , attachPosition =
+                    { direction = Tooltip.Top
+                    , alignment = Tooltip.Start
+                    }
+                , arrow = Just { size = 5, color = Colors.tooltipBackground }
+                }
+
+        _ ->
+            Nothing
 
 
 breadcrumbs : Model -> Html Message

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -230,12 +230,9 @@ stepStatusIcon =
     ]
 
 
-firstOccurrenceTooltip : Float -> Float -> List (Html.Attribute msg)
-firstOccurrenceTooltip bottom left =
-    [ style "position" "fixed"
-    , style "left" <| String.fromFloat left ++ "px"
-    , style "bottom" <| String.fromFloat bottom ++ "px"
-    , style "background-color" Colors.tooltipBackground
+firstOccurrenceTooltip : List (Html.Attribute msg)
+firstOccurrenceTooltip =
+    [ style "background-color" Colors.tooltipBackground
     , style "padding" "5px"
     , style "z-index" "100"
     , style "width" "6em"
@@ -244,12 +241,9 @@ firstOccurrenceTooltip bottom left =
         ++ Application.Styles.disableInteraction
 
 
-firstOccurrenceTooltipArrow : Float -> Float -> Float -> List (Html.Attribute msg)
-firstOccurrenceTooltipArrow bottom left width =
-    [ style "position" "fixed"
-    , style "left" <| String.fromFloat (left + width / 2) ++ "px"
-    , style "bottom" <| String.fromFloat bottom ++ "px"
-    , style "margin-bottom" "-5px"
+firstOccurrenceTooltipArrow : List (Html.Attribute msg)
+firstOccurrenceTooltipArrow =
+    [ style "margin-bottom" "-5px"
     , style "margin-left" "-5px"
     , style "width" "0"
     , style "height" "0"

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -8,7 +8,6 @@ module Build.Styles exposing
     , durationTooltipArrow
     , errorLog
     , firstOccurrenceTooltip
-    , firstOccurrenceTooltipArrow
     , header
     , historyItem
     , metadataCell
@@ -239,19 +238,6 @@ firstOccurrenceTooltip =
     , style "pointer-events" "none"
     ]
         ++ Application.Styles.disableInteraction
-
-
-firstOccurrenceTooltipArrow : List (Html.Attribute msg)
-firstOccurrenceTooltipArrow =
-    [ style "margin-bottom" "-5px"
-    , style "margin-left" "-5px"
-    , style "width" "0"
-    , style "height" "0"
-    , style "border-top" <| "5px solid " ++ Colors.tooltipBackground
-    , style "border-left" "5px solid transparent"
-    , style "border-right" "5px solid transparent"
-    , style "z-index" "100"
-    ]
 
 
 durationTooltip : List (Html.Attribute msg)

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -780,8 +780,8 @@ view session model =
         ]
 
 
-tooltip : Model -> { a | hovered : HoverState.HoverState } -> Maybe Tooltip.Tooltip
-tooltip _ { hovered } =
+tooltip : { a | pipelines : Maybe (List Pipeline) } -> { b | hovered : HoverState.HoverState } -> Maybe Tooltip.Tooltip
+tooltip model { hovered } =
     case hovered of
         HoverState.Tooltip (Message.PipelineStatusIcon _) _ ->
             Just
@@ -792,6 +792,33 @@ tooltip _ { hovered } =
                 , attachPosition = { direction = Tooltip.Top, alignment = Tooltip.Start }
                 , arrow = Nothing
                 }
+
+        HoverState.Tooltip (Message.VisibilityButton { teamName, pipelineName }) _ ->
+            model.pipelines
+                |> Maybe.withDefault []
+                |> List.Extra.find
+                    (\p ->
+                        p.teamName == teamName && p.name == pipelineName
+                    )
+                |> Maybe.map
+                    (\p ->
+                        { body =
+                            Html.div
+                                Styles.visibilityTooltip
+                                [ Html.text <|
+                                    if p.public then
+                                        "hide pipeline"
+
+                                    else
+                                        "expose pipeline"
+                                ]
+                        , attachPosition =
+                            { direction = Tooltip.Top
+                            , alignment = Tooltip.End
+                            }
+                        , arrow = Nothing
+                        }
+                    )
 
         _ ->
             Nothing

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -662,6 +662,9 @@ updateBody msg ( model, effects ) =
                 _ ->
                     ( model, effects )
 
+        Hover (Just domID) ->
+            ( model, effects ++ [ GetViewportOf domID ] )
+
         Click LogoutButton ->
             ( { model
                 | teams = None

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -54,7 +54,7 @@ import Html.Events
 import Http
 import List.Extra
 import Login.Login as Login
-import Message.Callback exposing (Callback(..), TooltipPolicy(..))
+import Message.Callback exposing (Callback(..))
 import Message.Effects exposing (Effect(..), toHtmlID)
 import Message.Message as Message
     exposing
@@ -118,7 +118,7 @@ init searchType =
       , LoadCachedJobs
       , LoadCachedPipelines
       , LoadCachedTeams
-      , GetViewportOf Dashboard AlwaysShow
+      , GetViewportOf Dashboard
       ]
     )
 
@@ -405,7 +405,7 @@ handleCallback callback ( model, effects ) =
             , effects
             )
 
-        GotViewport Dashboard _ (Ok viewport) ->
+        GotViewport Dashboard (Ok viewport) ->
             ( { model
                 | viewportWidth = viewport.viewport.width
                 , viewportHeight = viewport.viewport.height
@@ -454,10 +454,10 @@ handleDeliveryBody delivery ( model, effects ) =
             ( { model | now = Just time, effectsToRetry = [] }, model.effectsToRetry )
 
         WindowResized _ _ ->
-            ( model, effects ++ [ GetViewportOf Dashboard AlwaysShow ] )
+            ( model, effects ++ [ GetViewportOf Dashboard ] )
 
         SideBarStateReceived _ ->
-            ( model, effects ++ [ GetViewportOf Dashboard AlwaysShow ] )
+            ( model, effects ++ [ GetViewportOf Dashboard ] )
 
         CachedPipelinesReceived (Ok pipelines) ->
             let
@@ -721,7 +721,7 @@ updateBody msg ( model, effects ) =
                     ( model, effects )
 
         Click HamburgerMenu ->
-            ( model, effects ++ [ GetViewportOf Dashboard AlwaysShow ] )
+            ( model, effects ++ [ GetViewportOf Dashboard ] )
 
         Scrolled scrollState ->
             ( { model | scrollTop = scrollState.scrollTop }, effects )

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -4,6 +4,7 @@ module Dashboard.Dashboard exposing
     , handleDelivery
     , init
     , subscriptions
+    , tooltip
     , update
     , view
     )
@@ -73,6 +74,7 @@ import ScreenSize exposing (ScreenSize(..))
 import SideBar.SideBar as SideBar
 import StrictEvents exposing (onScroll)
 import Time
+import Tooltip
 import UserState
 import Views.Spinner as Spinner
 import Views.Styles
@@ -776,6 +778,23 @@ view session model =
             ]
         , Footer.view session model
         ]
+
+
+tooltip : Model -> { a | hovered : HoverState.HoverState } -> Maybe Tooltip.Tooltip
+tooltip _ { hovered } =
+    case hovered of
+        HoverState.Tooltip (Message.PipelineStatusIcon _) _ ->
+            Just
+                { body =
+                    Html.div
+                        Styles.jobsDisabledTooltip
+                        [ Html.text "automatic job monitoring disabled" ]
+                , attachPosition = { direction = Tooltip.Top, alignment = Tooltip.Start }
+                , arrow = Nothing
+                }
+
+        _ ->
+            Nothing
 
 
 topBar : Session -> Model -> Html Message

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -10,9 +10,9 @@ module Dashboard.Models exposing
 import Concourse
 import Dashboard.Group.Models
 import Dict exposing (Dict)
-import Message.Effects exposing (Effect(..))
 import FetchResult exposing (FetchResult)
 import Login.Login as Login
+import Message.Effects exposing (Effect(..))
 import Time
 
 

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -15,8 +15,18 @@ import Dashboard.Styles as Styles
 import Duration
 import HoverState
 import Html exposing (Html)
-import Html.Attributes exposing (attribute, class, classList, draggable, href, style)
+import Html.Attributes
+    exposing
+        ( attribute
+        , class
+        , classList
+        , draggable
+        , href
+        , id
+        , style
+        )
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
+import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..))
 import Routes
 import Time
@@ -293,7 +303,12 @@ footerView userState pipeline now hovered existingJobs =
             [ if pipeline.jobsDisabled then
                 Icon.icon
                     { sizePx = 20, image = Assets.PipelineStatusIconJobsDisabled }
-                    (style "opacity" "0.5" :: Styles.pipelineStatusIcon)
+                    ([ style "opacity" "0.5"
+                     , id <| Effects.toHtmlID <| PipelineStatusIcon pipelineId
+                     , onMouseEnter <| Hover <| Just <| PipelineStatusIcon pipelineId
+                     ]
+                        ++ Styles.pipelineStatusIcon
+                    )
 
               else if pipeline.stale then
                 Icon.icon

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -393,6 +393,7 @@ visibilityView { public, pipelineId, isClickable, isHovered, isVisibilityLoading
                 }
                 ++ [ onMouseEnter <| Hover <| Just <| VisibilityButton pipelineId
                    , onMouseLeave <| Hover Nothing
+                   , id <| Effects.toHtmlID <| VisibilityButton pipelineId
                    ]
                 ++ (if isClickable then
                         [ onClick <| Click <| VisibilityButton pipelineId ]
@@ -401,21 +402,7 @@ visibilityView { public, pipelineId, isClickable, isHovered, isVisibilityLoading
                         []
                    )
             )
-            (if isClickable && isHovered then
-                [ Html.div
-                    Styles.visibilityTooltip
-                    [ Html.text <|
-                        if public then
-                            "hide pipeline"
-
-                        else
-                            "expose pipeline"
-                    ]
-                ]
-
-             else
-                []
-            )
+            []
 
 
 sinceTransitionText : PipelineStatus.StatusDetails -> Time.Posix -> String

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -14,6 +14,7 @@ module Dashboard.Styles exposing
     , infoItem
     , jobPreview
     , jobPreviewLink
+    , jobsDisabledTooltip
     , legend
     , legendItem
     , legendSeparator
@@ -766,6 +767,17 @@ visibilityTooltip =
     , style "margin-bottom" "5px"
     , style "right" "-150%"
     ]
+
+
+jobsDisabledTooltip : List (Html.Attribute msg)
+jobsDisabledTooltip =
+    [ style "background-color" Colors.tooltipBackground
+    , style "padding" "2.5px"
+    , style "z-index" "100"
+    , style "margin-bottom" "5px"
+    , style "pointer-events" "none"
+    ]
+        ++ Application.Styles.disableInteraction
 
 
 jobPreview : Concourse.Job -> Bool -> List (Html.Attribute msg)

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -759,13 +759,9 @@ visibilityToggle { public, isClickable, isHovered } =
 
 visibilityTooltip : List (Html.Attribute msg)
 visibilityTooltip =
-    [ style "position" "absolute"
-    , style "background-color" Colors.tooltipBackground
-    , style "bottom" "100%"
+    [ style "background-color" Colors.tooltipBackground
     , style "white-space" "nowrap"
     , style "padding" "2.5px"
-    , style "margin-bottom" "5px"
-    , style "right" "-150%"
     ]
 
 
@@ -773,11 +769,7 @@ jobsDisabledTooltip : List (Html.Attribute msg)
 jobsDisabledTooltip =
     [ style "background-color" Colors.tooltipBackground
     , style "padding" "2.5px"
-    , style "z-index" "100"
-    , style "margin-bottom" "5px"
-    , style "pointer-events" "none"
     ]
-        ++ Application.Styles.disableInteraction
 
 
 jobPreview : Concourse.Job -> Bool -> List (Html.Attribute msg)

--- a/web/elm/src/FlySuccess/FlySuccess.elm
+++ b/web/elm/src/FlySuccess/FlySuccess.elm
@@ -3,6 +3,7 @@ module FlySuccess.FlySuccess exposing
     , handleDelivery
     , init
     , subscriptions
+    , tooltip
     , update
     , view
     )
@@ -27,6 +28,7 @@ import Message.Subscription as Subscription
         )
 import Message.TopLevelMessage exposing (TopLevelMessage(..))
 import Routes
+import Tooltip
 import UserState exposing (UserState)
 import Views.Icon as Icon
 import Views.Styles
@@ -152,6 +154,11 @@ view userState model =
                 ]
             ]
         ]
+
+
+tooltip : Model -> a -> Maybe Tooltip.Tooltip
+tooltip _ _ =
+    Nothing
 
 
 body : Model -> List (Html Message)

--- a/web/elm/src/HoverState.elm
+++ b/web/elm/src/HoverState.elm
@@ -5,6 +5,7 @@ module HoverState exposing
     , isHovered
     )
 
+import Browser.Dom
 import Message.Message exposing (DomID)
 
 
@@ -17,7 +18,7 @@ type HoverState
     = NoHover
     | Hovered DomID
     | TooltipPending DomID
-    | Tooltip DomID TooltipPosition
+    | Tooltip DomID Browser.Dom.Element
 
 
 hoveredElement : HoverState -> Maybe DomID

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -8,6 +8,7 @@ module Job.Job exposing
     , handleDelivery
     , init
     , subscriptions
+    , tooltip
     , update
     , view
     )
@@ -56,6 +57,7 @@ import Routes
 import SideBar.SideBar as SideBar
 import StrictEvents exposing (onLeftClick)
 import Time
+import Tooltip
 import UpdateMsg exposing (UpdateMsg)
 import Views.BuildDuration as BuildDuration
 import Views.DictView as DictView
@@ -430,6 +432,11 @@ view session model =
             , viewMainJobsSection session model
             ]
         ]
+
+
+tooltip : Model -> a -> Maybe Tooltip.Tooltip
+tooltip _ _ =
+    Nothing
 
 
 viewMainJobsSection : Session -> Model -> Html Message

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -1,7 +1,4 @@
-module Message.Callback exposing
-    ( Callback(..)
-    , TooltipPolicy(..)
-    )
+module Message.Callback exposing (Callback(..))
 
 import Browser.Dom
 import Concourse
@@ -61,10 +58,5 @@ type Callback
     | BuildAborted (Fetched ())
     | VisibilityChanged VisibilityAction Concourse.PipelineIdentifier (Fetched ())
     | AllPipelinesFetched (Fetched (List Concourse.Pipeline))
-    | GotViewport DomID TooltipPolicy (Result Browser.Dom.Error Browser.Dom.Viewport)
+    | GotViewport DomID (Result Browser.Dom.Error Browser.Dom.Viewport)
     | GotElement (Result Browser.Dom.Error Browser.Dom.Element)
-
-
-type TooltipPolicy
-    = AlwaysShow
-    | OnlyShowWhenOverflowing

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -19,7 +19,7 @@ import Concourse.Pagination exposing (Page)
 import Json.Decode
 import Json.Encode
 import Maybe exposing (Maybe)
-import Message.Callback exposing (Callback(..), TooltipPolicy(..))
+import Message.Callback exposing (Callback(..))
 import Message.Message
     exposing
         ( DomID(..)
@@ -182,7 +182,7 @@ type Effect
     | SaveCachedTeams (List Concourse.Team)
     | LoadCachedTeams
     | DeleteCachedTeams
-    | GetViewportOf DomID TooltipPolicy
+    | GetViewportOf DomID
     | GetElement DomID
     | SyncTextareaHeight DomID
 
@@ -621,9 +621,9 @@ runEffect effect key csrfToken =
         DeleteCachedTeams ->
             deleteFromLocalStorage teamsKey
 
-        GetViewportOf domID tooltipPolicy ->
+        GetViewportOf domID ->
             Browser.Dom.getViewportOf (toHtmlID domID)
-                |> Task.attempt (GotViewport domID tooltipPolicy)
+                |> Task.attempt (GotViewport domID)
 
         GetElement domID ->
             Browser.Dom.getElement (toHtmlID domID)

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -642,6 +642,12 @@ toHtmlID domId =
         SideBarPipeline p ->
             Base64.encode p.teamName ++ "_" ++ Base64.encode p.pipelineName
 
+        PipelineStatusIcon p ->
+            Base64.encode p.teamName
+                ++ "_"
+                ++ Base64.encode p.pipelineName
+                ++ "_icon"
+
         FirstOccurrenceGetStepLabel stepID ->
             stepID ++ "_first_occurrence"
 

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -646,7 +646,13 @@ toHtmlID domId =
             Base64.encode p.teamName
                 ++ "_"
                 ++ Base64.encode p.pipelineName
-                ++ "_icon"
+                ++ "_status"
+
+        VisibilityButton p ->
+            Base64.encode p.teamName
+                ++ "_"
+                ++ Base64.encode p.pipelineName
+                ++ "_visibility"
 
         FirstOccurrenceGetStepLabel stepID ->
             stepID ++ "_first_occurrence"

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -60,6 +60,7 @@ type DomID
     | PinMenuDropDown String
     | PinButton VersionId
     | PinBar
+    | PipelineStatusIcon Concourse.PipelineIdentifier
     | PipelineButton Concourse.PipelineIdentifier
     | VisibilityButton Concourse.PipelineIdentifier
     | FooterCliIcon Cli.Cli

--- a/web/elm/src/NotFound/NotFound.elm
+++ b/web/elm/src/NotFound/NotFound.elm
@@ -3,6 +3,7 @@ module NotFound.NotFound exposing
     , handleDelivery
     , init
     , subscriptions
+    , tooltip
     , view
     )
 
@@ -23,6 +24,7 @@ import Message.TopLevelMessage exposing (TopLevelMessage(..))
 import NotFound.Model exposing (Model)
 import Routes
 import SideBar.SideBar as SideBar
+import Tooltip
 import Views.Styles
 import Views.TopBar as TopBar
 
@@ -82,6 +84,11 @@ view session model =
                 ]
             ]
         ]
+
+
+tooltip : Model -> a -> Maybe Tooltip.Tooltip
+tooltip _ _ =
+    Nothing
 
 
 subscriptions : List Subscription

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -8,6 +8,7 @@ module Pipeline.Pipeline exposing
     , handleDelivery
     , init
     , subscriptions
+    , tooltip
     , update
     , view
     )
@@ -53,6 +54,7 @@ import SideBar.SideBar as SideBar
 import StrictEvents exposing (onLeftClickOrShiftLeftClick)
 import Svg
 import Svg.Attributes as SvgAttributes
+import Tooltip
 import UpdateMsg exposing (UpdateMsg)
 import Views.PauseToggle as PauseToggle
 import Views.Styles
@@ -423,6 +425,11 @@ view session model =
                 ]
             ]
         ]
+
+
+tooltip : Model -> a -> Maybe Tooltip.Tooltip
+tooltip _ _ =
+    Nothing
 
 
 isPaused : WebData Concourse.Pipeline -> Bool

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -7,6 +7,7 @@ module Resource.Resource exposing
     , handleDelivery
     , init
     , subscriptions
+    , tooltip
     , update
     , versions
     , view
@@ -84,6 +85,7 @@ import StrictEvents
 import Svg
 import Svg.Attributes as SvgAttributes
 import Time
+import Tooltip
 import UpdateMsg exposing (UpdateMsg)
 import UserState exposing (UserState(..))
 import Views.DictView as DictView
@@ -881,6 +883,11 @@ view session model =
                     ]
             ]
         ]
+
+
+tooltip : Model -> a -> Maybe Tooltip.Tooltip
+tooltip _ _ =
+    Nothing
 
 
 header : Session -> Model -> Html Message

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -15,7 +15,7 @@ import Html exposing (Html)
 import Html.Attributes exposing (id)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import List.Extra
-import Message.Callback exposing (Callback(..), TooltipPolicy(..))
+import Message.Callback exposing (Callback(..))
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..))
 import Message.Subscription exposing (Delivery(..))
@@ -70,7 +70,6 @@ update message model =
             ( model
             , [ Effects.GetViewportOf
                     (SideBarPipeline pipelineID)
-                    OnlyShowWhenOverflowing
               ]
             )
 
@@ -78,7 +77,6 @@ update message model =
             ( model
             , [ Effects.GetViewportOf
                     (SideBarTeam teamName)
-                    OnlyShowWhenOverflowing
               ]
             )
 

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -3,11 +3,13 @@ module SideBar.SideBar exposing
     , hamburgerMenu
     , handleCallback
     , handleDelivery
+    , tooltip
     , update
     , view
     )
 
 import Assets
+import Colors
 import Concourse
 import EffectTransformer exposing (ET)
 import HoverState
@@ -159,6 +161,27 @@ view model currentPipeline =
 
     else
         Html.text ""
+
+
+tooltip : Model m -> Maybe Tooltip.Tooltip
+tooltip { hovered } =
+    case hovered of
+        HoverState.Tooltip (SideBarTeam teamName) _ ->
+            Just
+                { body = Html.div Styles.tooltipBody [ Html.text teamName ]
+                , attachPosition = { direction = Tooltip.Right, alignment = Tooltip.Middle 30 }
+                , arrow = Just { size = 15, color = Colors.frame }
+                }
+
+        HoverState.Tooltip (SideBarPipeline pipelineID) _ ->
+            Just
+                { body = Html.div Styles.tooltipBody [ Html.text pipelineID.pipelineName ]
+                , attachPosition = { direction = Tooltip.Right, alignment = Tooltip.Middle 30 }
+                , arrow = Just { size = 15, color = Colors.frame }
+                }
+
+        _ ->
+            Nothing
 
 
 hamburgerMenu :

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -251,13 +251,9 @@ pipelineIcon opacity =
     ]
 
 
-tooltip : Float -> Float -> List (Html.Attribute msg)
-tooltip top left =
-    [ style "position" "fixed"
-    , style "left" <| String.fromFloat left ++ "px"
-    , style "top" <| String.fromFloat top ++ "px"
-    , style "margin-top" "-15px"
-    , style "z-index" "1"
+tooltip : List (Html.Attribute msg)
+tooltip =
+    [ style "z-index" "1"
     , style "display" "flex"
     ]
 

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -18,7 +18,6 @@ module SideBar.Styles exposing
     , teamIcon
     , teamName
     , tooltip
-    , tooltipArrow
     , tooltipBody
     )
 
@@ -258,14 +257,6 @@ tooltip =
     ]
 
 
-tooltipArrow : List (Html.Attribute msg)
-tooltipArrow =
-    [ style "border-right" <| "15px solid " ++ Colors.frame
-    , style "border-top" "15px solid transparent"
-    , style "border-bottom" "15px solid transparent"
-    ]
-
-
 tooltipBody : List (Html.Attribute msg)
 tooltipBody =
     [ style "background-color" Colors.frame
@@ -273,4 +264,5 @@ tooltipBody =
     , style "font-size" "12px"
     , style "display" "flex"
     , style "align-items" "center"
+    , style "height" "30px"
     ]

--- a/web/elm/src/SubPage/SubPage.elm
+++ b/web/elm/src/SubPage/SubPage.elm
@@ -5,6 +5,7 @@ module SubPage.SubPage exposing
     , handleNotFound
     , init
     , subscriptions
+    , tooltip
     , update
     , urlUpdate
     , view
@@ -34,6 +35,7 @@ import Pipeline.Pipeline as Pipeline
 import Resource.Models
 import Resource.Resource as Resource
 import Routes
+import Tooltip
 import UpdateMsg exposing (UpdateMsg)
 
 
@@ -349,6 +351,31 @@ view ({ userState } as session) mdl =
             ( FlySuccess.documentTitle
             , FlySuccess.view userState model
             )
+
+
+tooltip : Model -> Session -> Maybe Tooltip.Tooltip
+tooltip mdl =
+    case mdl of
+        BuildModel model ->
+            Build.tooltip model
+
+        JobModel model ->
+            Job.tooltip model
+
+        PipelineModel model ->
+            Pipeline.tooltip model
+
+        ResourceModel model ->
+            Resource.tooltip model
+
+        DashboardModel model ->
+            Dashboard.tooltip model
+
+        NotFoundModel model ->
+            NotFound.tooltip model
+
+        FlySuccessModel model ->
+            FlySuccess.tooltip model
 
 
 subscriptions : Model -> List Subscription

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -2,6 +2,7 @@ module Tooltip exposing (Model, handleCallback, view)
 
 import Browser.Dom
 import Build.Styles
+import Dashboard.Styles
 import EffectTransformer exposing (ET)
 import HoverState exposing (TooltipPosition(..))
 import Html exposing (Html)
@@ -175,6 +176,13 @@ view { hovered } =
                 [ Html.div SideBar.Styles.tooltipArrow []
                 , Html.div SideBar.Styles.tooltipBody [ Html.text pipelineID.pipelineName ]
                 ]
+
+        HoverState.Tooltip (Message.PipelineStatusIcon _) target ->
+            Html.div
+                (Dashboard.Styles.jobsDisabledTooltip
+                    ++ position { direction = Top, alignment = Start } target Nothing Nothing
+                )
+                [ Html.text "automatic job monitoring disabled" ]
 
         _ ->
             Html.text ""

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -1,9 +1,11 @@
 module Tooltip exposing (Model, handleCallback, view)
 
+import Browser.Dom
 import Build.Styles
 import EffectTransformer exposing (ET)
 import HoverState exposing (TooltipPosition(..))
 import Html exposing (Html)
+import Html.Attributes exposing (style)
 import Message.Callback exposing (Callback(..))
 import Message.Effects as Effects
 import Message.Message as Message exposing (DomID(..))
@@ -14,12 +16,28 @@ type alias Model m =
     { m | hovered : HoverState.HoverState }
 
 
-type TooltipPolicy
+type TooltipCondition
     = AlwaysShow
     | OnlyShowWhenOverflowing
 
 
-policy : DomID -> TooltipPolicy
+type alias AttachPosition =
+    { direction : Direction
+    , alignment : Alignment
+    }
+
+
+type Direction
+    = Top
+    | Right
+
+
+type Alignment
+    = Start
+    | Middle
+
+
+policy : DomID -> TooltipCondition
 policy domID =
     case domID of
         SideBarPipeline _ ->
@@ -30,6 +48,63 @@ policy domID =
 
         _ ->
             AlwaysShow
+
+
+position : AttachPosition -> Browser.Dom.Element -> Maybe Float -> Maybe Float -> List (Html.Attribute msg)
+position { direction, alignment } { element, viewport } w h =
+    let
+        target =
+            element
+
+        vertical =
+            case ( direction, alignment, h ) of
+                ( Top, _, _ ) ->
+                    [ style "bottom" <| String.fromFloat (viewport.height - target.y) ++ "px" ]
+
+                ( Right, Start, _ ) ->
+                    [ style "top" <| String.fromFloat target.y ++ "px" ]
+
+                ( Right, Middle, Just height ) ->
+                    [ style "top" <| String.fromFloat (target.y + (target.height - height) / 2) ++ "px" ]
+
+                -- ( Right, End, _ ) ->
+                --     [ style "bottom" <| String.fromFloat (viewport.height - target.y - target.height) ++ "px" ]
+                -- ( Bottom, _, _ ) ->
+                --     [ style "top" <| String.fromFloat (target.y + target.height) ++ "px" ]
+                -- ( Left, Start, _ ) ->
+                --     [ style "top" <| String.fromFloat target.y ++ "px" ]
+                -- ( Left, Middle, Just height ) ->
+                --     [ style "top" <| String.fromFloat (target.y + (target.height - height) / 2) ++ "px" ]
+                -- ( Left, End, _ ) ->
+                --     [ style "bottom" <| String.fromFloat (viewport.height - target.y - target.height) ++ "px" ]
+                _ ->
+                    []
+
+        horizontal =
+            case ( direction, alignment, w ) of
+                ( Top, Start, _ ) ->
+                    [ style "left" <| String.fromFloat target.x ++ "px" ]
+
+                ( Top, Middle, Just width ) ->
+                    [ style "left" <| String.fromFloat (target.x + (target.width - width) / 2) ++ "px" ]
+
+                -- ( Top, End, _ ) ->
+                --     [ style "right" <| String.fromFloat (target.x + target.width) ++ "px" ]
+                ( Right, _, _ ) ->
+                    [ style "left" <| String.fromFloat (target.x + target.width) ++ "px" ]
+
+                -- ( Bottom, Start, _ ) ->
+                --     [ style "left" <| String.fromFloat target.x ++ "px" ]
+                -- ( Bottom, Middle, Just width ) ->
+                --     [ style "left" <| String.fromFloat (target.x + (target.width - width) / 2) ++ "px" ]
+                -- ( Bottom, End, _ ) ->
+                --     [ style "right" <| String.fromFloat (target.x + target.width) ++ "px" ]
+                -- ( Left, _, _ ) ->
+                --     [ style "right" <| String.fromFloat (viewport.width - target.x) ++ "px" ]
+                _ ->
+                    []
+    in
+    style "position" "fixed" :: vertical ++ horizontal
 
 
 handleCallback : Callback -> ET (Model m)
@@ -52,27 +127,10 @@ handleCallback callback ( model, effects ) =
                 _ ->
                     ( model, effects )
 
-        GotElement (Ok { element, viewport }) ->
+        GotElement (Ok element) ->
             case model.hovered of
-                HoverState.TooltipPending (Message.FirstOccurrenceGetStepLabel stepID) ->
-                    ( { model
-                        | hovered =
-                            HoverState.Tooltip (Message.FirstOccurrenceGetStepLabel stepID) <|
-                                Bottom
-                                    (viewport.height - element.y)
-                                    element.x
-                                    element.width
-                      }
-                    , effects
-                    )
-
                 HoverState.TooltipPending domID ->
-                    ( { model
-                        | hovered =
-                            HoverState.Tooltip domID <|
-                                Top (element.y + (element.height / 2))
-                                    (element.x + element.width)
-                      }
+                    ( { model | hovered = HoverState.Tooltip domID element }
                     , effects
                     )
 
@@ -86,28 +144,36 @@ handleCallback callback ( model, effects ) =
 view : Model m -> Html msg
 view { hovered } =
     case hovered of
-        HoverState.Tooltip (Message.FirstOccurrenceGetStepLabel _) (Bottom b l w) ->
+        HoverState.Tooltip (Message.FirstOccurrenceGetStepLabel _) target ->
             Html.div []
                 [ Html.div
-                    (Build.Styles.firstOccurrenceTooltip b l)
+                    (Build.Styles.firstOccurrenceTooltip
+                        ++ position { direction = Top, alignment = Start } target Nothing Nothing
+                    )
                     [ Html.text "new version" ]
                 , Html.div
-                    (Build.Styles.firstOccurrenceTooltipArrow b l w)
+                    (Build.Styles.firstOccurrenceTooltipArrow
+                        ++ position { direction = Top, alignment = Middle } target (Just 5) Nothing
+                    )
                     []
                 ]
 
-        HoverState.Tooltip (Message.SideBarTeam teamName) (Top t l) ->
+        HoverState.Tooltip (Message.SideBarTeam teamName) target ->
             Html.div
-                (SideBar.Styles.tooltip t l)
+                (SideBar.Styles.tooltip
+                    ++ position { direction = Right, alignment = Middle } target Nothing (Just 30)
+                )
                 [ Html.div SideBar.Styles.tooltipArrow []
                 , Html.div SideBar.Styles.tooltipBody [ Html.text teamName ]
                 ]
 
-        HoverState.Tooltip (Message.SideBarPipeline { pipelineName }) (Top t l) ->
+        HoverState.Tooltip (Message.SideBarPipeline pipelineID) target ->
             Html.div
-                (SideBar.Styles.tooltip t l)
+                (SideBar.Styles.tooltip
+                    ++ position { direction = Right, alignment = Middle } target Nothing (Just 30)
+                )
                 [ Html.div SideBar.Styles.tooltipArrow []
-                , Html.div SideBar.Styles.tooltipBody [ Html.text pipelineName ]
+                , Html.div SideBar.Styles.tooltipBody [ Html.text pipelineID.pipelineName ]
                 ]
 
         _ ->

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -28,6 +28,13 @@ type alias Tooltip =
     }
 
 
+
+-- Many tooltips, especially in crowded parts of the UI, have an extra
+-- triangular piece sticking out that points to the tooltip's target. Online
+-- this element is variously called a 'tail' or an 'arrow', with 'arrow'
+-- predominating.
+
+
 type alias Arrow =
     { size : Float
     , color : String

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -89,14 +89,6 @@ position { direction, alignment } { element, viewport } =
                 ( Right, End ) ->
                     [ style "bottom" <| String.fromFloat (viewport.height - target.y - target.height) ++ "px" ]
 
-        -- ( Bottom, _ ) ->
-        --     [ style "top" <| String.fromFloat (target.y + target.height) ++ "px" ]
-        -- ( Left, Start ) ->
-        --     [ style "top" <| String.fromFloat target.y ++ "px" ]
-        -- ( Left, Middle height ) ->
-        --     [ style "top" <| String.fromFloat (target.y + (target.height - height) / 2) ++ "px" ]
-        -- ( Left, End ) ->
-        --     [ style "bottom" <| String.fromFloat (viewport.height - target.y - target.height) ++ "px" ]
         horizontal =
             case ( direction, alignment ) of
                 ( Top, Start ) ->
@@ -110,15 +102,6 @@ position { direction, alignment } { element, viewport } =
 
                 ( Right, _ ) ->
                     [ style "left" <| String.fromFloat (target.x + target.width) ++ "px" ]
-
-        -- ( Bottom, Start ) ->
-        --     [ style "left" <| String.fromFloat target.x ++ "px" ]
-        -- ( Bottom, Middle width ) ->
-        --     [ style "left" <| String.fromFloat (target.x + (target.width - width) / 2) ++ "px" ]
-        -- ( Bottom, End ) ->
-        --     [ style "right" <| String.fromFloat (target.x + target.width) ++ "px" ]
-        -- ( Left, _ ) ->
-        --     [ style "right" <| String.fromFloat (viewport.width - target.x) ++ "px" ]
     in
     [ style "position" "fixed", style "z-index" "100" ] ++ vertical ++ horizontal
 

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -53,6 +53,7 @@ type Direction
 type Alignment
     = Start
     | Middle Float
+    | End
 
 
 policy : DomID -> TooltipCondition
@@ -85,8 +86,9 @@ position { direction, alignment } { element, viewport } =
                 ( Right, Middle height ) ->
                     [ style "top" <| String.fromFloat (target.y + (target.height - height) / 2) ++ "px" ]
 
-        -- ( Right, End ) ->
-        --     [ style "bottom" <| String.fromFloat (viewport.height - target.y - target.height) ++ "px" ]
+                ( Right, End ) ->
+                    [ style "bottom" <| String.fromFloat (viewport.height - target.y - target.height) ++ "px" ]
+
         -- ( Bottom, _ ) ->
         --     [ style "top" <| String.fromFloat (target.y + target.height) ++ "px" ]
         -- ( Left, Start ) ->
@@ -103,8 +105,9 @@ position { direction, alignment } { element, viewport } =
                 ( Top, Middle width ) ->
                     [ style "left" <| String.fromFloat (target.x + (target.width - width) / 2) ++ "px" ]
 
-                -- ( Top, End ) ->
-                --     [ style "right" <| String.fromFloat (target.x + target.width) ++ "px" ]
+                ( Top, End ) ->
+                    [ style "right" <| String.fromFloat (viewport.width - target.x - target.width) ++ "px" ]
+
                 ( Right, _ ) ->
                     [ style "left" <| String.fromFloat (target.x + target.width) ++ "px" ]
 

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -3141,10 +3141,7 @@ all =
                                 )
                             >> Tuple.second
                             >> Common.contains
-                                (Effects.GetViewportOf
-                                    firstOccurrenceLabelID
-                                    Callback.AlwaysShow
-                                )
+                                (Effects.GetViewportOf firstOccurrenceLabelID)
                     , test "mousing off yellow label triggers Hover message" <|
                         fetchPlanWithGetStepWithFirstOccurrence
                             >> hoverFirstOccurrenceLabel
@@ -3190,7 +3187,7 @@ all =
                             )
                         >> Tuple.first
                         >> Application.handleCallback
-                            (Callback.GotViewport firstOccurrenceLabelID Callback.AlwaysShow <|
+                            (Callback.GotViewport firstOccurrenceLabelID <|
                                 Ok
                                     { scene =
                                         { width = 1
@@ -3378,10 +3375,7 @@ all =
                             )
                         >> Tuple.second
                         >> Common.contains
-                            (Effects.GetViewportOf
-                                (Message.Message.StepState "plan")
-                                Callback.AlwaysShow
-                            )
+                            (Effects.GetViewportOf <| Message.Message.StepState "plan")
                 , test "finished task lists initialization duration in tooltip" <|
                     fetchPlanWithGetStep
                         >> Application.handleDelivery
@@ -3423,9 +3417,7 @@ all =
                             )
                         >> Tuple.first
                         >> Application.handleCallback
-                            (Callback.GotViewport (Message.Message.StepState "plan")
-                                Callback.AlwaysShow
-                             <|
+                            (Callback.GotViewport (Message.Message.StepState "plan") <|
                                 Ok
                                     { scene =
                                         { width = 1
@@ -3510,9 +3502,7 @@ all =
                             )
                         >> Tuple.first
                         >> Application.handleCallback
-                            (Callback.GotViewport (Message.Message.StepState "plan")
-                                Callback.AlwaysShow
-                             <|
+                            (Callback.GotViewport (Message.Message.StepState "plan") <|
                                 Ok
                                     { scene =
                                         { width = 1

--- a/web/elm/tests/DashboardTooltipTests.elm
+++ b/web/elm/tests/DashboardTooltipTests.elm
@@ -1,0 +1,81 @@
+module DashboardTooltipTests exposing (all)
+
+import Dashboard.Dashboard as Dashboard
+import Data
+import Expect
+import HoverState exposing (HoverState(..))
+import Html
+import Message.Message exposing (DomID(..))
+import Test exposing (Test, describe, test)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (text)
+
+
+all : Test
+all =
+    describe "tooltip"
+        [ test "says 'hide' when an exposed pipeline is hovered" <|
+            \_ ->
+                Dashboard.tooltip
+                    { pipelines =
+                        Just
+                            [ Data.dashboardPipeline 0 True ]
+                    }
+                    { hovered =
+                        Tooltip
+                            (VisibilityButton
+                                { teamName = Data.teamName
+                                , pipelineName = Data.pipelineName
+                                }
+                            )
+                            Data.elementPosition
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "hide" ]
+        , test "says 'expose' when a hidden pipeline is hovered" <|
+            \_ ->
+                Dashboard.tooltip
+                    { pipelines =
+                        Just
+                            [ Data.dashboardPipeline 0 False ]
+                    }
+                    { hovered =
+                        Tooltip
+                            (VisibilityButton
+                                { teamName = Data.teamName
+                                , pipelineName = Data.pipelineName
+                                }
+                            )
+                            Data.elementPosition
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "expose" ]
+        , test "says 'disabled' when a pipeline with jobs disabled is hovered" <|
+            \_ ->
+                let
+                    p =
+                        Data.dashboardPipeline 0 True
+                in
+                Dashboard.tooltip
+                    { pipelines =
+                        Just
+                            [ { p | jobsDisabled = True } ]
+                    }
+                    { hovered =
+                        Tooltip
+                            (PipelineStatusIcon
+                                { teamName = Data.teamName
+                                , pipelineName = Data.pipelineName
+                                }
+                            )
+                            Data.elementPosition
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "disabled" ]
+        ]

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -1,5 +1,7 @@
 module Data exposing
     ( check
+    , dashboardPipeline
+    , elementPosition
     , httpInternalServerError
     , httpNotFound
     , httpNotImplemented
@@ -22,8 +24,10 @@ module Data exposing
     , withPublic
     )
 
+import Browser.Dom
 import Concourse
 import Concourse.BuildStatus as BuildStatus
+import Dashboard.Group.Models
 import Dict exposing (Dict)
 import Http
 import Time
@@ -144,6 +148,21 @@ pipeline team id =
     }
 
 
+dashboardPipeline : Int -> Bool -> Dashboard.Group.Models.Pipeline
+dashboardPipeline id public =
+    { id = id
+    , name = pipelineName
+    , teamName = teamName
+    , public = public
+    , isToggleLoading = False
+    , isVisibilityLoading = False
+    , paused = False
+    , archived = False
+    , stale = False
+    , jobsDisabled = False
+    }
+
+
 withPaused : Bool -> { r | paused : Bool } -> { r | paused : Bool }
 withPaused paused p =
     { p | paused = paused }
@@ -245,4 +264,25 @@ jobBuild status =
                 Just <| Time.millisToPosix 0
         }
     , reapTime = Nothing
+    }
+
+
+elementPosition : Browser.Dom.Element
+elementPosition =
+    { scene =
+        { width = 0
+        , height = 0
+        }
+    , viewport =
+        { width = 0
+        , height = 0
+        , x = 0
+        , y = 0
+        }
+    , element =
+        { x = 0
+        , y = 0
+        , width = 1
+        , height = 1
+        }
     }

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -1250,6 +1250,12 @@ all =
                                     (Callback.AllJobsFetched <|
                                         Data.httpNotImplemented
                                     )
+
+                        domID =
+                            Msgs.PipelineStatusIcon
+                                { teamName = "team"
+                                , pipelineName = "pipeline-0"
+                                }
                     in
                     [ test "status icon is faded sync" <|
                         \_ ->
@@ -1266,6 +1272,30 @@ all =
                                            , style "opacity" "0.5"
                                            ]
                                     )
+                    , test "status icon is hoverable" <|
+                        \_ ->
+                            setup
+                                |> Tuple.first
+                                |> Common.queryView
+                                |> findStatusIcon
+                                |> Event.simulate Event.mouseEnter
+                                |> Event.expect
+                                    (ApplicationMsgs.Update <|
+                                        Msgs.Hover <|
+                                            Just domID
+                                    )
+                    , test "hovering status icon sends location request" <|
+                        \_ ->
+                            setup
+                                |> Tuple.first
+                                |> Application.update
+                                    (ApplicationMsgs.Update <|
+                                        Msgs.Hover <|
+                                            Just domID
+                                    )
+                                |> Tuple.second
+                                |> Common.contains
+                                    (Effects.GetViewportOf domID)
                     , test "status text says 'no data'" <|
                         \_ ->
                             setup

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -1562,21 +1562,6 @@ all =
                                 }
                                 ++ [ style "background-size" "contain" ]
 
-                        tooltipAbove tooltipText =
-                            [ style "position" "relative"
-                            , containing
-                                [ tag "div"
-                                , containing [ text tooltipText ]
-                                , style "background-color" "#9b9b9b"
-                                , style "position" "absolute"
-                                , style "bottom" "100%"
-                                , style "white-space" "nowrap"
-                                , style "padding" "2.5px"
-                                , style "margin-bottom" "5px"
-                                , style "right" "-150%"
-                                ]
-                            ]
-
                         openEyeClickable setup =
                             [ defineHoverBehaviour
                                 { name = "open eye toggle"
@@ -1602,7 +1587,6 @@ all =
                                             ++ [ style "opacity" "1"
                                                , style "cursor" "pointer"
                                                ]
-                                            ++ tooltipAbove "hide pipeline"
                                     }
                                 }
                             , test "has click handler" <|
@@ -1798,7 +1782,6 @@ all =
                                             ++ [ style "opacity" "1"
                                                , style "cursor" "pointer"
                                                ]
-                                            ++ tooltipAbove "expose pipeline"
                                     }
                                 }
                             , test "has click handler" <|

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -1296,6 +1296,60 @@ all =
                                 |> Tuple.second
                                 |> Common.contains
                                     (Effects.GetViewportOf domID)
+                    , test "hovering status icon shows tooltip" <|
+                        \_ ->
+                            setup
+                                |> Tuple.first
+                                |> Application.update
+                                    (ApplicationMsgs.Update <|
+                                        Msgs.Hover <|
+                                            Just domID
+                                    )
+                                |> Tuple.first
+                                |> Application.handleCallback
+                                    (Callback.GotViewport domID
+                                        (Ok
+                                            { scene =
+                                                { width = 1
+                                                , height = 0
+                                                }
+                                            , viewport =
+                                                { width = 1
+                                                , height = 0
+                                                , x = 0
+                                                , y = 0
+                                                }
+                                            }
+                                        )
+                                    )
+                                |> Tuple.first
+                                |> Application.handleCallback
+                                    (Callback.GotElement <|
+                                        Ok
+                                            { scene =
+                                                { width = 0
+                                                , height = 0
+                                                }
+                                            , viewport =
+                                                { width = 0
+                                                , height = 0
+                                                , x = 0
+                                                , y = 0
+                                                }
+                                            , element =
+                                                { x = 0
+                                                , y = 0
+                                                , width = 1
+                                                , height = 1
+                                                }
+                                            }
+                                    )
+                                |> Tuple.first
+                                |> Common.queryView
+                                |> Query.has
+                                    [ style "position" "fixed"
+                                    , containing [ text "automatic job monitoring disabled" ]
+                                    ]
                     , test "status text says 'no data'" <|
                         \_ ->
                             setup

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -88,26 +88,26 @@ all =
                     , fragment = Nothing
                     }
                     |> Tuple.second
-                    |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
+                    |> Common.contains (GetViewportOf Dashboard)
         , test "fetches the viewport of the scrollable area when the window is resized" <|
             \_ ->
                 Common.init "/"
                     |> Application.handleDelivery
                         (Subscription.WindowResized 800 600)
                     |> Tuple.second
-                    |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
+                    |> Common.contains (GetViewportOf Dashboard)
         , test "fetches the viewport of the scrollable area when the sidebar is opened" <|
             \_ ->
                 Common.init "/"
                     |> Application.update (Update <| Click HamburgerMenu)
                     |> Tuple.second
-                    |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
+                    |> Common.contains (GetViewportOf Dashboard)
         , test "fetches the viewport of the scrollable area when the sidebar state is loaded" <|
             \_ ->
                 Common.init "/"
                     |> Application.handleDelivery (SideBarStateReceived (Ok True))
                     |> Tuple.second
-                    |> Common.contains (GetViewportOf Dashboard Callback.AlwaysShow)
+                    |> Common.contains (GetViewportOf Dashboard)
         , test "renders pipeline cards in a single column grid when the viewport is narrow" <|
             \_ ->
                 Common.init "/"
@@ -117,7 +117,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 300 600
                         )
@@ -149,7 +149,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 650 200
                         )
@@ -181,13 +181,13 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 650 200
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport LoginButton Callback.AlwaysShow <|
+                        (Callback.GotViewport LoginButton <|
                             Ok <|
                                 viewportWithSize 100 50
                         )
@@ -225,7 +225,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 600 300
                         )
@@ -264,7 +264,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 950 300
                         )
@@ -296,7 +296,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 600 500
                         )
@@ -336,7 +336,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 300 600
                         )
@@ -352,7 +352,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 300 200
                         )
@@ -399,7 +399,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 600 250
                         )
@@ -431,7 +431,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 600 250
                         )
@@ -457,7 +457,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 300 200
                         )
@@ -474,7 +474,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.handleCallback
-                        (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                        (Callback.GotViewport Dashboard <|
                             Ok <|
                                 viewportWithSize 300 200
                         )
@@ -574,7 +574,7 @@ all =
                             )
                         |> Tuple.first
                         |> Application.handleCallback
-                            (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                            (Callback.GotViewport Dashboard <|
                                 Ok <|
                                     viewportWithSize 600 500
                             )
@@ -614,7 +614,7 @@ all =
                             )
                         |> Tuple.first
                         |> Application.handleCallback
-                            (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                            (Callback.GotViewport Dashboard <|
                                 Ok <|
                                     viewportWithSize 300 200
                             )
@@ -638,7 +638,7 @@ all =
                             )
                         |> Tuple.first
                         |> Application.handleCallback
-                            (Callback.GotViewport Dashboard Callback.AlwaysShow <|
+                            (Callback.GotViewport Dashboard <|
                                 Ok <|
                                     viewportWithSize 600 500
                             )

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -5,7 +5,6 @@ import Common
 import Data
 import Expect
 import HoverState
-import Message.Callback as Callback exposing (TooltipPolicy(..))
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..))
 import RemoteData
@@ -25,7 +24,7 @@ all =
                         |> SideBar.update (Hover <| Just domID)
                         |> Tuple.second
                         |> Common.contains
-                            (Effects.GetViewportOf domID OnlyShowWhenOverflowing)
+                            (Effects.GetViewportOf domID)
             , test "does not ask browser for viewport otherwise" <|
                 \_ ->
                     model

--- a/web/elm/tests/TooltipTests.elm
+++ b/web/elm/tests/TooltipTests.elm
@@ -59,7 +59,7 @@ all =
                         (Callback.GotElement <| Ok elementPosition)
                     |> Tuple.first
                     |> .hovered
-                    |> Expect.equal (HoverState.Tooltip domID (Top 0.5 1))
+                    |> Expect.equal (HoverState.Tooltip domID elementPosition)
         ]
 
 

--- a/web/elm/tests/TooltipTests.elm
+++ b/web/elm/tests/TooltipTests.elm
@@ -19,7 +19,7 @@ all =
                 \_ ->
                     ( { hovered = HoverState.Hovered domID }, [] )
                         |> Tooltip.handleCallback
-                            (Callback.GotViewport domID Callback.OnlyShowWhenOverflowing <|
+                            (Callback.GotViewport domID <|
                                 Ok overflowingViewport
                             )
                         |> Tuple.first
@@ -29,7 +29,7 @@ all =
                 \_ ->
                     ( { hovered = HoverState.Hovered domID }, [] )
                         |> Tooltip.handleCallback
-                            (Callback.GotViewport domID Callback.OnlyShowWhenOverflowing <|
+                            (Callback.GotViewport domID <|
                                 Ok overflowingViewport
                             )
                         |> Tuple.second
@@ -38,7 +38,7 @@ all =
                 \_ ->
                     ( { hovered = HoverState.Hovered domID }, [] )
                         |> Tooltip.handleCallback
-                            (Callback.GotViewport domID Callback.OnlyShowWhenOverflowing <|
+                            (Callback.GotViewport domID <|
                                 Ok nonOverflowingViewport
                             )
                         |> Tuple.first
@@ -47,13 +47,11 @@ all =
             ]
         , test "AlwaysShow callback with non-overflowing viewport gets element" <|
             \_ ->
-                ( { hovered = HoverState.Hovered domID }, [] )
+                ( { hovered = HoverState.Hovered Dashboard }, [] )
                     |> Tooltip.handleCallback
-                        (Callback.GotViewport domID Callback.AlwaysShow <|
-                            Ok nonOverflowingViewport
-                        )
+                        (Callback.GotViewport Dashboard <| Ok nonOverflowingViewport)
                     |> Tuple.second
-                    |> Common.contains (Effects.GetElement domID)
+                    |> Common.contains (Effects.GetElement Dashboard)
         , test "callback with tooltip position turns pending -> tooltip" <|
             \_ ->
                 ( { hovered = HoverState.TooltipPending domID }, [] )

--- a/web/elm/tests/TooltipTests.elm
+++ b/web/elm/tests/TooltipTests.elm
@@ -2,6 +2,7 @@ module TooltipTests exposing (all)
 
 import Browser.Dom
 import Common
+import Data
 import Expect
 import HoverState exposing (TooltipPosition(..))
 import Message.Callback as Callback
@@ -56,32 +57,11 @@ all =
             \_ ->
                 ( { hovered = HoverState.TooltipPending domID }, [] )
                     |> Tooltip.handleCallback
-                        (Callback.GotElement <| Ok elementPosition)
+                        (Callback.GotElement <| Ok Data.elementPosition)
                     |> Tuple.first
                     |> .hovered
-                    |> Expect.equal (HoverState.Tooltip domID elementPosition)
+                    |> Expect.equal (HoverState.Tooltip domID Data.elementPosition)
         ]
-
-
-elementPosition : Browser.Dom.Element
-elementPosition =
-    { scene =
-        { width = 0
-        , height = 0
-        }
-    , viewport =
-        { width = 0
-        , height = 0
-        , x = 0
-        , y = 0
-        }
-    , element =
-        { x = 0
-        , y = 0
-        , width = 1
-        , height = 1
-        }
-    }
 
 
 nonOverflowingViewport : Browser.Dom.Viewport


### PR DESCRIPTION
# Why is this PR needed?

When the `ListAllJobs` endpoint is disabled, the 'sync' icon that appears on pipeline cards is just _begging_ to be clicked, but it's not clickable. This will very-probably frustrate users.

# What is this PR trying to accomplish?

Add an explanatory tooltip when hovering over the icon.

closes concourse/concourse#5578.

# How does it accomplish that?

Use the functions from the `Tooltip` module, and refactor the other tooltips in the Dashboard modules to follow suit.

At least for now (@matthewpereira may jump in and change this requirement), the style matches the current visibility tooltip:

<img width="278" alt="Screen Shot 2020-05-13 at 4 21 19 PM" src="https://user-images.githubusercontent.com/22056320/81861225-ea9a2f80-9535-11ea-89f8-30d9a1ae65a4.png">


# Contributor Checklist

- [x] Unit tests
- [x] ~Integration tests~
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~