### PR TITLE
atc: behavior: check deeply for context.Canceled

### DIFF
--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -239,7 +240,7 @@ func (b *engineBuild) Run(logger lager.Logger) {
 }
 
 func (b *engineBuild) finish(logger lager.Logger, err error, succeeded bool) {
-	if err == context.Canceled {
+	if errors.Is(err, context.Canceled) {
 		b.saveStatus(logger, atc.StatusAborted)
 		logger.Info("aborted")
 

--- a/atc/engine/engine_test.go
+++ b/atc/engine/engine_test.go
@@ -259,6 +259,18 @@ var _ = Describe("Engine", func() {
 									Expect(fakeBuild.FinishArgsForCall(0)).To(Equal(db.BuildStatusAborted))
 								})
 							})
+
+							Context("when the build finishes with a wrapped cancelled error", func() {
+								BeforeEach(func() {
+									fakeStep.RunReturns(fmt.Errorf("but im not a wrapper: %w", context.Canceled))
+								})
+
+								It("finishes the build", func() {
+									waitGroup.Wait()
+									Expect(fakeBuild.FinishCallCount()).To(Equal(1))
+									Expect(fakeBuild.FinishArgsForCall(0)).To(Equal(db.BuildStatusAborted))
+								})
+							})
 						})
 
 						Context("when converting the plan to a step fails", func() {

--- a/atc/worker/fetcher.go
+++ b/atc/worker/fetcher.go
@@ -17,7 +17,6 @@ import (
 const GetResourceLockInterval = 5 * time.Second
 
 var ErrFailedToGetLock = errors.New("failed to get lock")
-var ErrInterrupted = errors.New("interrupted")
 
 //go:generate counterfeiter . Fetcher
 

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2 // indirect
 	github.com/gorilla/websocket v1.4.0
-	github.com/hashicorp/go-multierror v1.0.1-0.20191120192120-72917a1559e1
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/vault/api v1.0.5-0.20191108163347-bdd38fca2cff

--- a/go.sum
+++ b/go.sum
@@ -355,8 +355,8 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.0.1-0.20191120192120-72917a1559e1 h1:GykKxF7ikF21GDbvpNQDQ3unj6Vf7qBeBjVQJx6s38U=
-github.com/hashicorp/go-multierror v1.0.1-0.20191120192120-72917a1559e1/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
+github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.6.2 h1:bHM2aVXwBtBJWxHtkSrWuI4umABCUczs52eiUS9nSiw=

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -36,3 +36,7 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 #### <sub><sup><a name="5485" href="#5485">:link:</a></sup></sub> fix
 
 * Fix a bug where a Task's image or input volume(s) were redundantly streamed from another worker despite having a local copy. This would only occur if the image or input(s) were provided by a resource definition (eg. Get step).
+
+#### <sub><sup><a name="5604" href="#5604">:link:</a></sup></sub> fix
+
+* Previously, aborting a build could sometimes result in an `errored` status rather than an `aborted` status. This happened when step code wrapped the `err` return value, fooling our `==` check. We now use [`errors.Is`](https://golang.org/pkg/errors/#Is) (new in Go 1.13) to check for the error indicating the build has been aborted, so now the build should be correctly given the `aborted` status even if the step wraps the error. #5604


### PR DESCRIPTION
# Why is this PR needed?

Without this change you can't really trust the "errored" state since it can sometimes be caused by someone aborting builds with a particular build plan.

# What is this PR trying to accomplish?

fixes #5515 

# How does it accomplish that?

Making use of `errors.Is` to detect whether the build was interrupted, and bumping `go-multierror` to support `.Unwrap`.

# Contributor Checklist

- [x] Unit tests
- [ ] ~~Integration tests~~
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
