### PR TITLE
Add missing transaction rollbacks

### DIFF
--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -535,6 +535,8 @@ func (j *job) GetNextBuildInputs() ([]BuildInput, error) {
 		return nil, err
 	}
 
+	defer tx.Rollback()
+
 	buildInputs, err := j.getNextBuildInputs(tx)
 	if err != nil {
 		return nil, err

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -734,6 +734,8 @@ func (p *pipeline) LoadDebugVersionsDB() (*atc.DebugVersionsDB, error) {
 		return nil, err
 	}
 
+	defer tx.Rollback()
+
 	rows, err := psql.Select("v.id, v.check_order, r.id, v.resource_config_scope_id, o.build_id, b.job_id").
 		From("build_resource_config_version_outputs o").
 		Join("builds b ON b.id = o.build_id").

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -631,6 +631,8 @@ func (r *resource) UnpinVersion() error {
 		return err
 	}
 
+	defer tx.Rollback()
+
 	results, err := psql.Delete("resource_pins").
 		Where(sq.Eq{"resource_pins.resource_id": r.id}).
 		RunWith(tx).

--- a/atc/db/volume_repository.go
+++ b/atc/db/volume_repository.go
@@ -150,6 +150,8 @@ func (repository *volumeRepository) RemoveMissingVolumes(gracePeriod time.Durati
 		return 0, err
 	}
 
+	defer tx.Rollback()
+
 	// Setting the foreign key constraint to deferred, meaning that the foreign
 	// key constraint will not be executed until the end of the transaction. This
 	// allows the gc query to remove any parent volumes as long as the child


### PR DESCRIPTION
# Why is this PR needed?

There are a few db methods that are missing tx.Rollback() to ensure that the queries will be rolled back if one of the queries fail within the transaction. The places that @aoldershaw found were Resource.UnpinVersion, Job.GetNextBuildInputs, VolumeRepository.RemoveMissingVolumes and Pipeline.LoadDebugVersionsDB.

# What is this PR trying to accomplish?

Adds the missing rollbacks to methods that open a transaction but did not add a transaction rollback in case the method fails in the middle of the transaction. Some of these methods only have select queries so the rollback is technically not necessary but I added it to keep it consistent and safe in case there are future refactors that add any queries that modify data.

closes #5557.

# Contributor Checklist

> Are the following items included as part of this PR? If no, please say why not.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
