### PR TITLE
Retry on 503 when concurrent request control enabled

### DIFF
--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -10,6 +10,7 @@ module Dashboard.Models exposing
 import Concourse
 import Dashboard.Group.Models
 import Dict exposing (Dict)
+import Message.Effects exposing (Effect(..))
 import FetchResult exposing (FetchResult)
 import Login.Login as Login
 import Time
@@ -39,6 +40,7 @@ type alias Model =
             , viewportHeight : Float
             , scrollTop : Float
             , pipelineJobs : Dict ( String, String ) (List Concourse.JobIdentifier)
+            , effectsToRetry : List Effect
             }
         )
 


### PR DESCRIPTION
Fixes #5466 


# How does it accomplish that?
cherry picking from same fix of 5.5.x https://github.com/concourse/concourse/pull/5483/commits/da38f56362d57cfde318326909269624974b786c

The differences are
1. The retry logic is for ListAllJobs endpoint only
2. The retry will be added to the retry pool only when there is no same retry exists. Without doing this the size of pool keep increased with same FetchJobs effect and every second all of them will be executed.


# Contributor Checklist
- [ ] Unit tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [x] PR acceptance performed