### PR TITLE
fly: add --team flag to unpause-pipeline

### DIFF
--- a/fly/commands/unpause_pipeline.go
+++ b/fly/commands/unpause_pipeline.go
@@ -6,11 +6,13 @@ import (
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type UnpausePipelineCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" description:"Pipeline to unpause"`
 	All      bool                     `short:"a" long:"all"      description:"Unpause all pipelines"`
+	Team     string                   `long:"team"              description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *UnpausePipelineCommand) Validate() error {
@@ -41,13 +43,24 @@ func (command *UnpausePipelineCommand) Execute(args []string) error {
 		return err
 	}
 
+	var team concourse.Team
+
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team)
+		if err != nil {
+			return err
+		}
+	} else {
+		team = target.Team()
+	}
+
 	var pipelineNames []string
 	if string(command.Pipeline) != "" {
 		pipelineNames = []string{string(command.Pipeline)}
 	}
 
 	if command.All {
-		pipelines, err := target.Team().ListPipelines()
+		pipelines, err := team.ListPipelines()
 		if err != nil {
 			return err
 		}
@@ -58,7 +71,7 @@ func (command *UnpausePipelineCommand) Execute(args []string) error {
 	}
 
 	for _, pipelineName := range pipelineNames {
-		found, err := target.Team().UnpausePipeline(pipelineName)
+		found, err := team.UnpausePipeline(pipelineName)
 		if err != nil {
 			return err
 		}

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -114,6 +114,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
 			Entry("unpause-job command returns an error",
 				exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+			Entry("unpause-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "unpause-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -140,6 +142,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "other-team")),
 			Entry("unpause-job command returns an error",
 				exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "other-team")),
+			Entry("unpause-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "unpause-pipeline", "-p", "pipeline", "--team", "other-team")),
 		)
 	})
 })


### PR DESCRIPTION
# Why is this PR needed?
Currently the only way for users to unpause pipelines from different teams with Fly is to create multiple targets. See #5215 

# What is this PR trying to accomplish?
Allow unpausing pipelines in teams other than the default configured for the target.

# How does it accomplish that?
Adds `--team` flag to `unpause-pipeline` command which overrides the default configured for the target.

# Contributor Checklist
- [ ] Unit tests
- [x] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
