### PR TITLE
Make task vars to be interpolated from var_sources and load_var.

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -61,3 +61,7 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 #### <sub><sup><a name="5639" href="#5639">:link:</a></sup></sub> fix
 
 * Fix a bug that crashes web node when renaming a job with `old_name` equal to `name`. #5639
+
+#### <sub><sup><a name="5620" href="#5620">:link:</a></sup></sub> fix
+
+* @evanchaoli enhanced task step `vars` to support interpolation. #5620

--- a/testflight/fixtures/task_vars.yml
+++ b/testflight/fixtures/task_vars.yml
@@ -6,6 +6,7 @@ resources:
     create_files:
       task.yml: ((task_content))
       task_unwrap.yml: ((task_unwrap_content))
+      foo.txt: bar
 
 jobs:
 - name: external-task-success
@@ -28,3 +29,16 @@ jobs:
     file: unwrapped-task-resource/task.yml
     vars:
       image_resource_type: mock
+
+- name: extarnal-task-vars-from-load-var
+  plan:
+  - get: some-resource
+  - load_var: foo
+    file: some-resource/foo.txt
+  - task: process-task-definition
+    file: some-resource/task_unwrap.yml
+  - task: run
+    file: unwrapped-task-resource/task.yml
+    vars:
+      image_resource_type: mock
+      echo_text: ((.:foo))

--- a/testflight/task_vars_test.go
+++ b/testflight/task_vars_test.go
@@ -126,6 +126,13 @@ echo_text: Hello World From Command Line
 			})
 		})
 
+		Context("when vars are from load_var", func() {
+			It("successfully runs pipeline job with external task", func() {
+				execS := fly("trigger-job", "-w", "-j", pipelineName+"/extarnal-task-vars-from-load-var")
+				Expect(execS).To(gbytes.Say("bar"))
+			})
+		})
+
 	})
 
 })


### PR DESCRIPTION
Fixes #5609

# Contributor Checklist

> Are the following items included as part of this PR? If no, please say why not.

- [x] Unit tests
- [x] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
