### PR TITLE
feature: support vault okta backend auth

### DIFF
--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/lager"
+	"github.com/hashicorp/go-rootcerts"
 	vaultapi "github.com/hashicorp/vault/api"
 )
 

--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/hashicorp/go-rootcerts"
 	vaultapi "github.com/hashicorp/vault/api"
 )
 
@@ -94,7 +93,7 @@ func (ac *APIClient) Login() (time.Duration, error) {
 	client := ac.client()
 	loginPath := path.Join("auth", ac.authConfig.Backend, "login")
 
-	if ac.authConfig.Backend == "ldap" {
+	if ac.authConfig.Backend == "ldap" || ac.authConfig.Backend == "okta" {
 		username, ok := ac.loginParams()["username"].(string)
 		if !ok {
 			err := fmt.Errorf("failed to assert username as string")


### PR DESCRIPTION

This PR allows you to use the [Vault Okta Auth Backend](https://www.vaultproject.io/docs/auth/okta)  for authenticating to vault.  Like the [previous PR for Vault LDAP](https://github.com/concourse/concourse/pull/3884) using the okta backend works differently from a REST convention standpoint.  

As this is a one line change that is only adding behavior to something that requires a lot of integration tests, I believe the reasoning given in https://github.com/concourse/concourse/pull/3884 would also apply here.



# Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
