### PR TITLE
Sort team by name on the UI.

### DIFF
--- a/atc/db/pipeline_factory.go
+++ b/atc/db/pipeline_factory.go
@@ -35,7 +35,7 @@ func (f *pipelineFactory) VisiblePipelines(teamNames []string) ([]Pipeline, erro
 
 	rows, err := pipelinesQuery.
 		Where(sq.Eq{"t.name": teamNames}).
-		OrderBy("team_id ASC", "ordering ASC").
+		OrderBy("t.name ASC", "ordering ASC").
 		RunWith(tx).
 		Query()
 	if err != nil {
@@ -50,7 +50,7 @@ func (f *pipelineFactory) VisiblePipelines(teamNames []string) ([]Pipeline, erro
 	rows, err = pipelinesQuery.
 		Where(sq.NotEq{"t.name": teamNames}).
 		Where(sq.Eq{"public": true}).
-		OrderBy("team_id ASC", "ordering ASC").
+		OrderBy("t.name ASC", "ordering ASC").
 		RunWith(tx).
 		Query()
 	if err != nil {
@@ -72,7 +72,7 @@ func (f *pipelineFactory) VisiblePipelines(teamNames []string) ([]Pipeline, erro
 
 func (f *pipelineFactory) AllPipelines() ([]Pipeline, error) {
 	rows, err := pipelinesQuery.
-		OrderBy("team_id ASC", "ordering ASC").
+		OrderBy("t.name ASC", "ordering ASC").
 		RunWith(f.conn).
 		Query()
 	if err != nil {

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -545,7 +545,7 @@ func (t *team) PublicPipelines() ([]Pipeline, error) {
 			"team_id": t.id,
 			"public":  true,
 		}).
-		OrderBy("team_id ASC", "ordering ASC").
+		OrderBy("t.name ASC", "ordering ASC").
 		RunWith(t.conn).
 		Query()
 	if err != nil {

--- a/atc/db/team_factory.go
+++ b/atc/db/team_factory.go
@@ -112,7 +112,7 @@ func (factory *teamFactory) FindTeam(teamName string) (Team, bool, error) {
 func (factory *teamFactory) GetTeams() ([]Team, error) {
 	rows, err := psql.Select("id, name, admin, auth").
 		From("teams").
-		OrderBy("id ASC").
+		OrderBy("name ASC").
 		RunWith(factory.conn).
 		Query()
 	if err != nil {

--- a/atc/db/team_factory_test.go
+++ b/atc/db/team_factory_test.go
@@ -149,10 +149,10 @@ var _ = Describe("Team Factory", func() {
 			It("returns both teams", func() {
 				Expect(teams).To(HaveLen(2))
 
-				Expect(teams[0].Name()).To(Equal(atcTeam.Name))
-				Expect(teams[0].Auth()).To(Equal(atcTeam.Auth))
+				Expect(teams[0].Name()).To(Equal("some-other-team"))
 
-				Expect(teams[1].Name()).To(Equal("some-other-team"))
+				Expect(teams[1].Name()).To(Equal(atcTeam.Name))
+				Expect(teams[1].Auth()).To(Equal(atcTeam.Auth))
 			})
 		})
 	})

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -41,7 +41,10 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 
 * Previously, aborting a build could sometimes result in an `errored` status rather than an `aborted` status. This happened when step code wrapped the `err` return value, fooling our `==` check. We now use [`errors.Is`](https://golang.org/pkg/errors/#Is) (new in Go 1.13) to check for the error indicating the build has been aborted, so now the build should be correctly given the `aborted` status even if the step wraps the error. #5604
 
-
 #### <sub><sup><a name="5596" href="#5595">:link:</a></sup></sub> fix
  
 * @lbenedix and @shyamz-22 improved the way auth config for teams are validated. Now operators cannot start a web node with an empty `--main-team-config` file, and `fly set-team` will fail if it would result in a team with no possible members. This prevents scenarios where users can get [accidentally locked out](https://github.com/concourse/concourse/issues/5595) of concourse. #5596
+
+#### <sub><sup><a name="5622" href="#5622">:link:</a></sup></sub> fix
+
+* @evanchaoli enhanced to change the Web UI and `fly teams` to show teams ordering by team names, which allows users who are participated in many teams to find a specific team easily.


### PR DESCRIPTION
# Why is this PR needed?

Per https://github.com/concourse/concourse/discussions/5412#discussioncomment-7929, the UI shows teams in order of creation time, which doesn't make much sense, because nobody would remember when teams are created, so that such order roughly equals to random order.

Some users might be many teams, such "random" team order makes users hard to find a team on the UI.

# What is this PR trying to accomplish?

To sort teams on the UI by team name.

# How does it accomplish that?

Just changing order by team id to order by team name.

There is already an index on team name, thus order by team name should not hurt sql query performance.

# Contributor Checklist

> Are the following items included as part of this PR? If no, please say why not.

- [x] Unit tests
- [x] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
