### PR TITLE
reduce watsjs flakiness

### DIFF
--- a/web/wats/helpers/palette.js
+++ b/web/wats/helpers/palette.js
@@ -2,9 +2,6 @@
 
 let color = require('color');
 
-// search box border
-// team name color
-
 module.exports = {
   "base00": color("#1E1D1D"),
   "base01": color("#2A2929"),
@@ -12,7 +9,7 @@ module.exports = {
   "base03": color("#504B4B"),
   "base04": color("#868585"),
 
-  "white": color("#ffffff"),
+  "white": color("#FFFFFF"),
 
   "green": color("#11C560"),
   "green2": color("#419867"),
@@ -25,5 +22,6 @@ module.exports = {
   "brown": color("#8B572A"),
   "brown2": color("#6A401C"),
   "grey": color("#9B9B9B"),
-  "grey2": color("#7A7373")
+  "grey2": color("#7A7373"),
+  "yellow": color("#F1C40F"),
 }

--- a/web/wats/helpers/web.js
+++ b/web/wats/helpers/web.js
@@ -50,7 +50,9 @@ class Web {
 
   async waitForBackgroundColor(selector, backgroundColor, {timeout = 30000} = {}) {
     await this.page.waitFor(({expectedBackground, selector}) => {
-      const background = document.querySelector(selector).style.backgroundColor;
+      const elem = document.querySelector(selector);
+      if (elem === null) return false;
+      const background = elem.style.backgroundColor;
       return background === expectedBackground;
     }, {timeout}, {
       selector,

--- a/web/wats/helpers/web.js
+++ b/web/wats/helpers/web.js
@@ -48,6 +48,16 @@ class Web {
     }, text)
   }
 
+  async waitForBackgroundColor(selector, backgroundColor, {timeout = 30000} = {}) {
+    await this.page.waitFor(({expectedBackground, selector}) => {
+      const background = document.querySelector(selector).style.backgroundColor;
+      return background === expectedBackground;
+    }, {timeout}, {
+      selector,
+      expectedBackground: backgroundColor.rgb().string(),
+    });
+  }
+
   async scrollIntoView(selector) {
     await this.page.waitFor(selector);
     await this.page.evaluate(selector => {

--- a/web/wats/package.json
+++ b/web/wats/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "test": "ava"
+    "test": "ava --serial"
   },
   "repository": "git+https://github.com/concourse/concourse.git",
   "author": "",

--- a/web/wats/test/build.js
+++ b/web/wats/test/build.js
@@ -34,11 +34,9 @@ test('shows abort hooks', async t => {
   await t.context.web.page.waitFor('button[title="Abort Build"]');
   await t.context.web.page.click('button[title="Abort Build"]');
 
-  const yellow = "rgb(241, 196, 15)";
-  const brown = "rgb(139, 87, 42)";
-  await t.context.web.page.waitFor(({yellow}) => (document.querySelector('.build-header').style.backgroundColor) !== yellow, {timeout: 60000}, {yellow});
-  const newColour = await t.context.web.page.$eval('.build-header', el => el.style.backgroundColor);
-  t.is(newColour, brown);
+  await t.context.web.waitForBackgroundColor('.build-header', palette.brown, {
+    timeout: 60000,
+  });
   await t.context.web.page.waitFor('[data-step-name="say-bye-from-step"] [data-step-state="succeeded"]');
   await t.context.web.page.waitFor('[data-step-name="say-bye-from-job"] [data-step-state="succeeded"]');
 

--- a/web/wats/test/dashboard.js
+++ b/web/wats/test/dashboard.js
@@ -21,26 +21,6 @@ test.afterEach.always(async t => {
   await t.context.finish(t);
 });
 
-async function showsPipelineState(t, setup, assertions) {
-  await t.context.fly.run('set-pipeline -n -p some-pipeline -c fixtures/states-pipeline.yml');
-  await t.context.fly.run('unpause-pipeline -p some-pipeline');
-
-  await setup(t);
-
-  await t.context.web.page.goto(t.context.web.route('/'));
-
-  const group = `.dashboard-team-group[data-team-name="${t.context.teamName}"]`;
-  await t.context.web.scrollIntoView(group);
-  await t.context.web.page.waitFor(`${group} .card`);
-  const pipeline = await t.context.web.page.$(`${group} .card`);
-  const text = await t.context.web.text(pipeline);
-
-  const banner = await t.context.web.page.$(`${group} .banner`);
-  const background = await t.context.web.computedStyle(banner, 'backgroundColor');
-
-  await assertions(t, text, color(background), group);
-};
-
 test('does not show team name when unauthenticated and team has no exposed pipelines', async t => {
   t.context.web = await Web.build(t.context.url)
   await t.context.web.page.goto(t.context.web.route('/'));
@@ -89,18 +69,27 @@ test('shows pipelines in their correct order', async t => {
   t.deepEqual(names, pipelineOrder);
 });
 
-test('auto-refreshes to reflect state changes', showsPipelineState, async t => {
+test('auto-refreshes to reflect state changes', async t => {
+  await t.context.fly.run('set-pipeline -n -p some-pipeline -c fixtures/states-pipeline.yml');
+  await t.context.fly.run('unpause-pipeline -p some-pipeline');
+
   await t.context.fly.run("trigger-job -w -j some-pipeline/passing");
-}, async (t, text, background, group) => {
-  t.deepEqual(background, palette.green);
+
+  await t.context.web.page.goto(t.context.web.route('/'));
+
+  const group = `.dashboard-team-group[data-team-name="${t.context.teamName}"]`;
+  await t.context.web.scrollIntoView(group);
+  await t.context.web.page.waitFor(`${group} .card`);
+  const pipeline = await t.context.web.page.$(`${group} .card`);
+  const text = await t.context.web.text(pipeline);
+
+  const bannerSelector = `${group} .banner`;
+
+  await t.context.web.waitForBackgroundColor(bannerSelector, palette.green);
 
   await t.throwsAsync(async () => await t.context.fly.run("trigger-job -w -j some-pipeline/failing"));
 
-  await t.context.web.page.waitFor(10000);
-
-  let newBanner = await t.context.web.page.$(`${group} .banner`);
-  let newBackground = await t.context.web.computedStyle(newBanner, 'backgroundColor');
-  t.deepEqual(color(newBackground), palette.red);
+  await t.context.web.waitForBackgroundColor(bannerSelector, palette.red);
 });
 
 test('picks up cluster name from configuration', async t => {

--- a/web/wats/test/dashboard.js
+++ b/web/wats/test/dashboard.js
@@ -94,7 +94,15 @@ test('auto-refreshes to reflect state changes', async t => {
 
 test('picks up cluster name from configuration', async t => {
   await t.context.web.page.goto(t.context.web.route('/'));
-  const clusterName = await t.context.web.page.$eval(`#top-bar-app > div:nth-child(1)`, el => el.innerText);
+
+  const clusterNameSelector = `#top-bar-app > div:nth-child(1)`;
+  await t.context.web.page.waitFor(({selector}) => {
+    return document.querySelector(selector).innerText.length > 0;
+  }, {timeout: 10000}, {
+    selector: clusterNameSelector,
+  });
+
+  const clusterName = await t.context.web.page.$eval(clusterNameSelector, el => el.innerText);
 
   t.is(clusterName, 'dev');
 });


### PR DESCRIPTION

<img width="755" alt="Screen Shot 2020-05-19 at 8 52 03 PM" src="https://user-images.githubusercontent.com/26583442/82392766-b1b8f980-9a12-11ea-8848-bc781eff3dec.png">

A light at the end of the tunnel


# Why is this PR needed?

Currently, the [watsjs job](https://ci.concourse-ci.org/teams/contributor/pipelines/prs/jobs/watsjs) in our pipelines is mostly red due to flaky tests. For a while, my automatic instinct when a wats test failed was to retrigger the build - only after failing multiple times did I look into why it failed. Recently, however, retriggering the build rarely seems to get the build to go pass.


# What is this PR trying to accomplish?

closes #5626  .


# How does it accomplish that?

* wait for changes to occur, rather than hoping they were quick enough to have already happened
* run wats tests serially

---

P.S. I'm guessing there'll still be some flakes, but hopefully they'll be much fewer

# Contributor Checklist

- [x] Integration tests

# Reviewer Checklist

- [x] Tests reviewed
- [ ] PR acceptance performed