### PR TITLE
Send a notification to the build tracker when a build starts

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -375,6 +375,11 @@ func (b *build) Start(plan atc.Plan) (bool, error) {
 		return false, err
 	}
 
+	err = b.conn.Bus().Notify(atc.ComponentBuildTracker)
+	if err != nil {
+		return false, err
+	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
# Why is this PR needed?

Fixes #5612

There has been some noticeable slowness to the starting of builds after a change was made to the scheduler where it is no longer responsible to start the build that it scheduled 3a6a9b8#diff-ec5d156bedf6973365a4b99c7af3d828L197. This means that after a build is marked as `started` by the scheduler 

https://github.com/concourse/concourse/blob/c57de700a5a038ed7db3fe27f109cb0a7eda725f/atc/scheduler/buildstarter.go#L216-L220

it will have to wait for the next tick of the `build tracker` before the build is "actually" started (actually started as in the steps are run).

https://github.com/concourse/concourse/blob/c57de700a5a038ed7db3fe27f109cb0a7eda725f/atc/builds/tracker.go#L56-L60

The build tracker runs on it's own 10 second interval so users can see an extra 10 second delay after their build has technically started before any steps are run.

# What is this PR trying to accomplish?

This PR is trying to get rid of that delay between the time that the build is started by the scheduler and the build tracker starting to run the steps of the build.

closes #5612.

# How does it accomplish that?

A notification will be sent to the build tracker whenever a build is started. This will kick off the build tracker to run every time the scheduler starts a build. I manually tested triggering a build with and without this change and without the notification, I saw builds taking approximately 20 seconds to complete.

![Screen Shot 2020-05-20 at 3 05 23 PM](https://user-images.githubusercontent.com/19290703/82487827-e8435280-9aac-11ea-8ad5-69ebfbe56c77.png)

Rather than with this change, the build completes within 2 seconds.

![Screen Shot 2020-05-20 at 2 59 07 PM](https://user-images.githubusercontent.com/19290703/82487856-f2fde780-9aac-11ea-8868-fdc87f3b66be.png)

# Contributor Checklist

> Are the following items included as part of this PR? If no, please say why not.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

> This section is intended for the core maintainers only, to track review progress.

> Please do not fill out this section.

- [x] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
