### PR TITLE
Changing "$target" to "ci" in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ as `booklit.yml`, [target your Concourse
 instance](https://concourse-ci.org/fly.html#fly-login), and then run:
 
 ```sh
-fly -t $target set-pipeline -p booklit -c booklit.yml
+fly -t ci set-pipeline -p booklit -c booklit.yml
 ```
 
 These pipeline files are self-contained, maximizing portability from one


### PR DESCRIPTION
Per issue: https://github.com/concourse/concourse/issues/5636

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns page]: https://github.com/concourse/concourse/wiki/Anti-Patterns

# Why is this PR needed?
The onboarding documentation is harder to follow without the change in this PR

# What is this PR trying to accomplish?
Making the onboarding documentation easier to follow

closes #5636

# How does it accomplish that?
Changes the relevant section of the readme

# Contributor Checklist

No tests are included, since the readme isn't a tested section of the repo

- [ ] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 