### PR TITLE
atc: db: fix panic when old job name is unchanged

### DIFF
--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -848,7 +848,7 @@ func (t *team) updateName(tx Tx, jobs []atc.JobConfig, pipelineID int) error {
 	jobsToUpdate := []UpdateName{}
 
 	for _, job := range jobs {
-		if job.OldName != "" {
+		if job.OldName != "" && job.OldName != job.Name {
 			var count int
 			err := psql.Select("COUNT(*) as count").
 				From("jobs").

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -2088,6 +2088,22 @@ var _ = Describe("Team", func() {
 				Expect(otherUpdatedJob.ID()).To(Equal(otherJob.ID()))
 			})
 
+			It("should handle when old job has the same name as new job", func() {
+				pipeline, _, err := team.SavePipeline(pipelineName, config, 0, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				job, _, _ := pipeline.Job("some-job")
+
+				config.Jobs[0].Name = "some-job"
+				config.Jobs[0].OldName = "some-job"
+
+				updatedPipeline, _, err := team.SavePipeline(pipelineName, config, pipeline.ConfigVersion(), false)
+				Expect(err).ToNot(HaveOccurred())
+
+				updatedJob, _, _ := updatedPipeline.Job("some-job")
+				Expect(updatedJob.ID()).To(Equal(job.ID()))
+			})
+
 			It("should return an error when there is a swap with job name", func() {
 				pipeline, _, err := team.SavePipeline(pipelineName, config, 0, false)
 				Expect(err).ToNot(HaveOccurred())

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -57,3 +57,7 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 #### <sub><sup><a name="5622" href="#5622">:link:</a></sup></sub> fix
 
 * @evanchaoli enhanced to change the Web UI and `fly teams` to show teams ordering by team names, which allows users who are participated in many teams to find a specific team easily.
+
+#### <sub><sup><a name="5639" href="#5639">:link:</a></sup></sub> fix
+
+* Fix a bug that crashes web node when renaming a job with `old_name` equal to `name`. #5639


### PR DESCRIPTION
# Why is this PR needed?
Fixes https://github.com/concourse/concourse/issues/5606

# How does it accomplish that?

It filters out the jobs which need updates when the provided old job name is the same as the existing job name.

# Contributor Checklist

- [x] Unit tests
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed 
