### PR TITLE
atc/db: structure: don't differentiate between pinning sources

### DIFF
--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -1524,7 +1524,7 @@ var _ = Describe("Jobs API", func() {
 							BeforeEach(func() {
 								fakeResource = new(dbfakes.FakeResource)
 								fakeResource.NameReturns("some-input")
-								fakeResource.CurrentPinnedVersionReturns(atc.Version{"some": "version"})
+								fakeResource.PinnedVersionReturns(atc.Version{"some": "version"})
 
 								fakePipeline.ResourcesReturns([]db.Resource{fakeResource}, nil)
 							})

--- a/atc/api/jobserver/create_build.go
+++ b/atc/api/jobserver/create_build.go
@@ -65,7 +65,7 @@ func (s *Server) CreateJobBuild(pipeline db.Pipeline) http.Handler {
 		for _, input := range inputs {
 			resource, found := resources.Lookup(input.Resource)
 			if found {
-				version := resource.CurrentPinnedVersion()
+				version := resource.PinnedVersion()
 				_, _, err := s.checkFactory.TryCreateCheck(
 					lagerctx.NewContext(context.Background(), logger),
 					resource,

--- a/atc/api/present/resource.go
+++ b/atc/api/present/resource.go
@@ -37,13 +37,8 @@ func Resource(resource db.Resource, showCheckError bool, teamName string) atc.Re
 		atcResource.LastChecked = resource.LastCheckEndTime().Unix()
 	}
 
-	if resource.ConfigPinnedVersion() != nil {
-		atcResource.PinnedVersion = resource.ConfigPinnedVersion()
-		atcResource.PinnedInConfig = true
-	} else if resource.APIPinnedVersion() != nil {
-		atcResource.PinnedVersion = resource.APIPinnedVersion()
-		atcResource.PinnedInConfig = false
-	}
+	atcResource.PinnedVersion = resource.PinnedVersion()
+	atcResource.PinnedInConfig = resource.PinnedInConfig()
 
 	return atcResource
 }

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -1038,7 +1038,8 @@ var _ = Describe("Resources API", func() {
 						resource1.NameReturns("resource-1")
 						resource1.TypeReturns("type-1")
 						resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
-						resource1.ConfigPinnedVersionReturns(atc.Version{"version": "v1"})
+						resource1.PinnedVersionReturns(atc.Version{"version": "v1"})
+						resource1.PinnedInConfigReturns(true)
 
 						fakePipeline.ResourceReturns(resource1, true, nil)
 					})
@@ -1080,7 +1081,7 @@ var _ = Describe("Resources API", func() {
 						resource1.NameReturns("resource-1")
 						resource1.TypeReturns("type-1")
 						resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
-						resource1.APIPinnedVersionReturns(atc.Version{"version": "v1"})
+						resource1.PinnedVersionReturns(atc.Version{"version": "v1"})
 
 						fakePipeline.ResourceReturns(resource1, true, nil)
 					})
@@ -1119,7 +1120,7 @@ var _ = Describe("Resources API", func() {
 						resource1.NameReturns("resource-1")
 						resource1.TypeReturns("type-1")
 						resource1.LastCheckEndTimeReturns(time.Unix(1513364881, 0))
-						resource1.APIPinnedVersionReturns(atc.Version{"version": "v1"})
+						resource1.PinnedVersionReturns(atc.Version{"version": "v1"})
 						resource1.PinCommentReturns("a pin comment")
 						fakePipeline.ResourceReturns(resource1, true, nil)
 					})

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -30,7 +30,7 @@ type Checkable interface {
 	CheckEvery() string
 	CheckTimeout() string
 	LastCheckEndTime() time.Time
-	CurrentPinnedVersion() atc.Version
+	PinnedVersion() atc.Version
 
 	HasWebhook() bool
 

--- a/atc/db/dbfakes/fake_checkable.go
+++ b/atc/db/dbfakes/fake_checkable.go
@@ -30,16 +30,6 @@ type FakeCheckable struct {
 	checkTimeoutReturnsOnCall map[int]struct {
 		result1 string
 	}
-	CurrentPinnedVersionStub        func() atc.Version
-	currentPinnedVersionMutex       sync.RWMutex
-	currentPinnedVersionArgsForCall []struct {
-	}
-	currentPinnedVersionReturns struct {
-		result1 atc.Version
-	}
-	currentPinnedVersionReturnsOnCall map[int]struct {
-		result1 atc.Version
-	}
 	HasWebhookStub        func() bool
 	hasWebhookMutex       sync.RWMutex
 	hasWebhookArgsForCall []struct {
@@ -69,6 +59,16 @@ type FakeCheckable struct {
 	}
 	nameReturnsOnCall map[int]struct {
 		result1 string
+	}
+	PinnedVersionStub        func() atc.Version
+	pinnedVersionMutex       sync.RWMutex
+	pinnedVersionArgsForCall []struct {
+	}
+	pinnedVersionReturns struct {
+		result1 atc.Version
+	}
+	pinnedVersionReturnsOnCall map[int]struct {
+		result1 atc.Version
 	}
 	PipelineStub        func() (db.Pipeline, bool, error)
 	pipelineMutex       sync.RWMutex
@@ -297,58 +297,6 @@ func (fake *FakeCheckable) CheckTimeoutReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeCheckable) CurrentPinnedVersion() atc.Version {
-	fake.currentPinnedVersionMutex.Lock()
-	ret, specificReturn := fake.currentPinnedVersionReturnsOnCall[len(fake.currentPinnedVersionArgsForCall)]
-	fake.currentPinnedVersionArgsForCall = append(fake.currentPinnedVersionArgsForCall, struct {
-	}{})
-	fake.recordInvocation("CurrentPinnedVersion", []interface{}{})
-	fake.currentPinnedVersionMutex.Unlock()
-	if fake.CurrentPinnedVersionStub != nil {
-		return fake.CurrentPinnedVersionStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.currentPinnedVersionReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeCheckable) CurrentPinnedVersionCallCount() int {
-	fake.currentPinnedVersionMutex.RLock()
-	defer fake.currentPinnedVersionMutex.RUnlock()
-	return len(fake.currentPinnedVersionArgsForCall)
-}
-
-func (fake *FakeCheckable) CurrentPinnedVersionCalls(stub func() atc.Version) {
-	fake.currentPinnedVersionMutex.Lock()
-	defer fake.currentPinnedVersionMutex.Unlock()
-	fake.CurrentPinnedVersionStub = stub
-}
-
-func (fake *FakeCheckable) CurrentPinnedVersionReturns(result1 atc.Version) {
-	fake.currentPinnedVersionMutex.Lock()
-	defer fake.currentPinnedVersionMutex.Unlock()
-	fake.CurrentPinnedVersionStub = nil
-	fake.currentPinnedVersionReturns = struct {
-		result1 atc.Version
-	}{result1}
-}
-
-func (fake *FakeCheckable) CurrentPinnedVersionReturnsOnCall(i int, result1 atc.Version) {
-	fake.currentPinnedVersionMutex.Lock()
-	defer fake.currentPinnedVersionMutex.Unlock()
-	fake.CurrentPinnedVersionStub = nil
-	if fake.currentPinnedVersionReturnsOnCall == nil {
-		fake.currentPinnedVersionReturnsOnCall = make(map[int]struct {
-			result1 atc.Version
-		})
-	}
-	fake.currentPinnedVersionReturnsOnCall[i] = struct {
-		result1 atc.Version
-	}{result1}
-}
-
 func (fake *FakeCheckable) HasWebhook() bool {
 	fake.hasWebhookMutex.Lock()
 	ret, specificReturn := fake.hasWebhookReturnsOnCall[len(fake.hasWebhookArgsForCall)]
@@ -502,6 +450,58 @@ func (fake *FakeCheckable) NameReturnsOnCall(i int, result1 string) {
 	}
 	fake.nameReturnsOnCall[i] = struct {
 		result1 string
+	}{result1}
+}
+
+func (fake *FakeCheckable) PinnedVersion() atc.Version {
+	fake.pinnedVersionMutex.Lock()
+	ret, specificReturn := fake.pinnedVersionReturnsOnCall[len(fake.pinnedVersionArgsForCall)]
+	fake.pinnedVersionArgsForCall = append(fake.pinnedVersionArgsForCall, struct {
+	}{})
+	fake.recordInvocation("PinnedVersion", []interface{}{})
+	fake.pinnedVersionMutex.Unlock()
+	if fake.PinnedVersionStub != nil {
+		return fake.PinnedVersionStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.pinnedVersionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeCheckable) PinnedVersionCallCount() int {
+	fake.pinnedVersionMutex.RLock()
+	defer fake.pinnedVersionMutex.RUnlock()
+	return len(fake.pinnedVersionArgsForCall)
+}
+
+func (fake *FakeCheckable) PinnedVersionCalls(stub func() atc.Version) {
+	fake.pinnedVersionMutex.Lock()
+	defer fake.pinnedVersionMutex.Unlock()
+	fake.PinnedVersionStub = stub
+}
+
+func (fake *FakeCheckable) PinnedVersionReturns(result1 atc.Version) {
+	fake.pinnedVersionMutex.Lock()
+	defer fake.pinnedVersionMutex.Unlock()
+	fake.PinnedVersionStub = nil
+	fake.pinnedVersionReturns = struct {
+		result1 atc.Version
+	}{result1}
+}
+
+func (fake *FakeCheckable) PinnedVersionReturnsOnCall(i int, result1 atc.Version) {
+	fake.pinnedVersionMutex.Lock()
+	defer fake.pinnedVersionMutex.Unlock()
+	fake.PinnedVersionStub = nil
+	if fake.pinnedVersionReturnsOnCall == nil {
+		fake.pinnedVersionReturnsOnCall = make(map[int]struct {
+			result1 atc.Version
+		})
+	}
+	fake.pinnedVersionReturnsOnCall[i] = struct {
+		result1 atc.Version
 	}{result1}
 }
 
@@ -1110,14 +1110,14 @@ func (fake *FakeCheckable) Invocations() map[string][][]interface{} {
 	defer fake.checkEveryMutex.RUnlock()
 	fake.checkTimeoutMutex.RLock()
 	defer fake.checkTimeoutMutex.RUnlock()
-	fake.currentPinnedVersionMutex.RLock()
-	defer fake.currentPinnedVersionMutex.RUnlock()
 	fake.hasWebhookMutex.RLock()
 	defer fake.hasWebhookMutex.RUnlock()
 	fake.lastCheckEndTimeMutex.RLock()
 	defer fake.lastCheckEndTimeMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
+	fake.pinnedVersionMutex.RLock()
+	defer fake.pinnedVersionMutex.RUnlock()
 	fake.pipelineMutex.RLock()
 	defer fake.pipelineMutex.RUnlock()
 	fake.pipelineIDMutex.RLock()

--- a/atc/db/dbfakes/fake_created_container.go
+++ b/atc/db/dbfakes/fake_created_container.go
@@ -21,18 +21,6 @@ type FakeCreatedContainer struct {
 		result1 db.DestroyingContainer
 		result2 error
 	}
-	DiscontinueStub        func() (db.DestroyingContainer, error)
-	discontinueMutex       sync.RWMutex
-	discontinueArgsForCall []struct {
-	}
-	discontinueReturns struct {
-		result1 db.DestroyingContainer
-		result2 error
-	}
-	discontinueReturnsOnCall map[int]struct {
-		result1 db.DestroyingContainer
-		result2 error
-	}
 	HandleStub        func() string
 	handleMutex       sync.RWMutex
 	handleArgsForCall []struct {
@@ -157,61 +145,6 @@ func (fake *FakeCreatedContainer) DestroyingReturnsOnCall(i int, result1 db.Dest
 		})
 	}
 	fake.destroyingReturnsOnCall[i] = struct {
-		result1 db.DestroyingContainer
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCreatedContainer) Discontinue() (db.DestroyingContainer, error) {
-	fake.discontinueMutex.Lock()
-	ret, specificReturn := fake.discontinueReturnsOnCall[len(fake.discontinueArgsForCall)]
-	fake.discontinueArgsForCall = append(fake.discontinueArgsForCall, struct {
-	}{})
-	fake.recordInvocation("Discontinue", []interface{}{})
-	fake.discontinueMutex.Unlock()
-	if fake.DiscontinueStub != nil {
-		return fake.DiscontinueStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.discontinueReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeCreatedContainer) DiscontinueCallCount() int {
-	fake.discontinueMutex.RLock()
-	defer fake.discontinueMutex.RUnlock()
-	return len(fake.discontinueArgsForCall)
-}
-
-func (fake *FakeCreatedContainer) DiscontinueCalls(stub func() (db.DestroyingContainer, error)) {
-	fake.discontinueMutex.Lock()
-	defer fake.discontinueMutex.Unlock()
-	fake.DiscontinueStub = stub
-}
-
-func (fake *FakeCreatedContainer) DiscontinueReturns(result1 db.DestroyingContainer, result2 error) {
-	fake.discontinueMutex.Lock()
-	defer fake.discontinueMutex.Unlock()
-	fake.DiscontinueStub = nil
-	fake.discontinueReturns = struct {
-		result1 db.DestroyingContainer
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCreatedContainer) DiscontinueReturnsOnCall(i int, result1 db.DestroyingContainer, result2 error) {
-	fake.discontinueMutex.Lock()
-	defer fake.discontinueMutex.Unlock()
-	fake.DiscontinueStub = nil
-	if fake.discontinueReturnsOnCall == nil {
-		fake.discontinueReturnsOnCall = make(map[int]struct {
-			result1 db.DestroyingContainer
-			result2 error
-		})
-	}
-	fake.discontinueReturnsOnCall[i] = struct {
 		result1 db.DestroyingContainer
 		result2 error
 	}{result1, result2}
@@ -586,8 +519,6 @@ func (fake *FakeCreatedContainer) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.destroyingMutex.RLock()
 	defer fake.destroyingMutex.RUnlock()
-	fake.discontinueMutex.RLock()
-	defer fake.discontinueMutex.RUnlock()
 	fake.handleMutex.RLock()
 	defer fake.handleMutex.RUnlock()
 	fake.iDMutex.RLock()

--- a/atc/db/dbfakes/fake_destroying_container.go
+++ b/atc/db/dbfakes/fake_destroying_container.go
@@ -40,16 +40,6 @@ type FakeDestroyingContainer struct {
 	iDReturnsOnCall map[int]struct {
 		result1 int
 	}
-	IsDiscontinuedStub        func() bool
-	isDiscontinuedMutex       sync.RWMutex
-	isDiscontinuedArgsForCall []struct {
-	}
-	isDiscontinuedReturns struct {
-		result1 bool
-	}
-	isDiscontinuedReturnsOnCall map[int]struct {
-		result1 bool
-	}
 	MetadataStub        func() db.ContainerMetadata
 	metadataMutex       sync.RWMutex
 	metadataArgsForCall []struct {
@@ -243,58 +233,6 @@ func (fake *FakeDestroyingContainer) IDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeDestroyingContainer) IsDiscontinued() bool {
-	fake.isDiscontinuedMutex.Lock()
-	ret, specificReturn := fake.isDiscontinuedReturnsOnCall[len(fake.isDiscontinuedArgsForCall)]
-	fake.isDiscontinuedArgsForCall = append(fake.isDiscontinuedArgsForCall, struct {
-	}{})
-	fake.recordInvocation("IsDiscontinued", []interface{}{})
-	fake.isDiscontinuedMutex.Unlock()
-	if fake.IsDiscontinuedStub != nil {
-		return fake.IsDiscontinuedStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.isDiscontinuedReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeDestroyingContainer) IsDiscontinuedCallCount() int {
-	fake.isDiscontinuedMutex.RLock()
-	defer fake.isDiscontinuedMutex.RUnlock()
-	return len(fake.isDiscontinuedArgsForCall)
-}
-
-func (fake *FakeDestroyingContainer) IsDiscontinuedCalls(stub func() bool) {
-	fake.isDiscontinuedMutex.Lock()
-	defer fake.isDiscontinuedMutex.Unlock()
-	fake.IsDiscontinuedStub = stub
-}
-
-func (fake *FakeDestroyingContainer) IsDiscontinuedReturns(result1 bool) {
-	fake.isDiscontinuedMutex.Lock()
-	defer fake.isDiscontinuedMutex.Unlock()
-	fake.IsDiscontinuedStub = nil
-	fake.isDiscontinuedReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *FakeDestroyingContainer) IsDiscontinuedReturnsOnCall(i int, result1 bool) {
-	fake.isDiscontinuedMutex.Lock()
-	defer fake.isDiscontinuedMutex.Unlock()
-	fake.IsDiscontinuedStub = nil
-	if fake.isDiscontinuedReturnsOnCall == nil {
-		fake.isDiscontinuedReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isDiscontinuedReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
-}
-
 func (fake *FakeDestroyingContainer) Metadata() db.ContainerMetadata {
 	fake.metadataMutex.Lock()
 	ret, specificReturn := fake.metadataReturnsOnCall[len(fake.metadataArgsForCall)]
@@ -460,8 +398,6 @@ func (fake *FakeDestroyingContainer) Invocations() map[string][][]interface{} {
 	defer fake.handleMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
-	fake.isDiscontinuedMutex.RLock()
-	defer fake.isDiscontinuedMutex.RUnlock()
 	fake.metadataMutex.RLock()
 	defer fake.metadataMutex.RUnlock()
 	fake.stateMutex.RLock()

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -10,16 +10,6 @@ import (
 )
 
 type FakeResource struct {
-	APIPinnedVersionStub        func() atc.Version
-	aPIPinnedVersionMutex       sync.RWMutex
-	aPIPinnedVersionArgsForCall []struct {
-	}
-	aPIPinnedVersionReturns struct {
-		result1 atc.Version
-	}
-	aPIPinnedVersionReturnsOnCall map[int]struct {
-		result1 atc.Version
-	}
 	CheckErrorStub        func() error
 	checkErrorMutex       sync.RWMutex
 	checkErrorArgsForCall []struct {
@@ -59,26 +49,6 @@ type FakeResource struct {
 	}
 	checkTimeoutReturnsOnCall map[int]struct {
 		result1 string
-	}
-	ConfigPinnedVersionStub        func() atc.Version
-	configPinnedVersionMutex       sync.RWMutex
-	configPinnedVersionArgsForCall []struct {
-	}
-	configPinnedVersionReturns struct {
-		result1 atc.Version
-	}
-	configPinnedVersionReturnsOnCall map[int]struct {
-		result1 atc.Version
-	}
-	CurrentPinnedVersionStub        func() atc.Version
-	currentPinnedVersionMutex       sync.RWMutex
-	currentPinnedVersionArgsForCall []struct {
-	}
-	currentPinnedVersionReturns struct {
-		result1 atc.Version
-	}
-	currentPinnedVersionReturnsOnCall map[int]struct {
-		result1 atc.Version
 	}
 	DisableVersionStub        func(int) error
 	disableVersionMutex       sync.RWMutex
@@ -194,6 +164,26 @@ type FakeResource struct {
 	pinVersionReturnsOnCall map[int]struct {
 		result1 bool
 		result2 error
+	}
+	PinnedInConfigStub        func() bool
+	pinnedInConfigMutex       sync.RWMutex
+	pinnedInConfigArgsForCall []struct {
+	}
+	pinnedInConfigReturns struct {
+		result1 bool
+	}
+	pinnedInConfigReturnsOnCall map[int]struct {
+		result1 bool
+	}
+	PinnedVersionStub        func() atc.Version
+	pinnedVersionMutex       sync.RWMutex
+	pinnedVersionArgsForCall []struct {
+	}
+	pinnedVersionReturns struct {
+		result1 atc.Version
+	}
+	pinnedVersionReturnsOnCall map[int]struct {
+		result1 atc.Version
 	}
 	PipelineStub        func() (db.Pipeline, bool, error)
 	pipelineMutex       sync.RWMutex
@@ -444,58 +434,6 @@ type FakeResource struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeResource) APIPinnedVersion() atc.Version {
-	fake.aPIPinnedVersionMutex.Lock()
-	ret, specificReturn := fake.aPIPinnedVersionReturnsOnCall[len(fake.aPIPinnedVersionArgsForCall)]
-	fake.aPIPinnedVersionArgsForCall = append(fake.aPIPinnedVersionArgsForCall, struct {
-	}{})
-	fake.recordInvocation("APIPinnedVersion", []interface{}{})
-	fake.aPIPinnedVersionMutex.Unlock()
-	if fake.APIPinnedVersionStub != nil {
-		return fake.APIPinnedVersionStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.aPIPinnedVersionReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeResource) APIPinnedVersionCallCount() int {
-	fake.aPIPinnedVersionMutex.RLock()
-	defer fake.aPIPinnedVersionMutex.RUnlock()
-	return len(fake.aPIPinnedVersionArgsForCall)
-}
-
-func (fake *FakeResource) APIPinnedVersionCalls(stub func() atc.Version) {
-	fake.aPIPinnedVersionMutex.Lock()
-	defer fake.aPIPinnedVersionMutex.Unlock()
-	fake.APIPinnedVersionStub = stub
-}
-
-func (fake *FakeResource) APIPinnedVersionReturns(result1 atc.Version) {
-	fake.aPIPinnedVersionMutex.Lock()
-	defer fake.aPIPinnedVersionMutex.Unlock()
-	fake.APIPinnedVersionStub = nil
-	fake.aPIPinnedVersionReturns = struct {
-		result1 atc.Version
-	}{result1}
-}
-
-func (fake *FakeResource) APIPinnedVersionReturnsOnCall(i int, result1 atc.Version) {
-	fake.aPIPinnedVersionMutex.Lock()
-	defer fake.aPIPinnedVersionMutex.Unlock()
-	fake.APIPinnedVersionStub = nil
-	if fake.aPIPinnedVersionReturnsOnCall == nil {
-		fake.aPIPinnedVersionReturnsOnCall = make(map[int]struct {
-			result1 atc.Version
-		})
-	}
-	fake.aPIPinnedVersionReturnsOnCall[i] = struct {
-		result1 atc.Version
-	}{result1}
-}
-
 func (fake *FakeResource) CheckError() error {
 	fake.checkErrorMutex.Lock()
 	ret, specificReturn := fake.checkErrorReturnsOnCall[len(fake.checkErrorArgsForCall)]
@@ -701,110 +639,6 @@ func (fake *FakeResource) CheckTimeoutReturnsOnCall(i int, result1 string) {
 	}
 	fake.checkTimeoutReturnsOnCall[i] = struct {
 		result1 string
-	}{result1}
-}
-
-func (fake *FakeResource) ConfigPinnedVersion() atc.Version {
-	fake.configPinnedVersionMutex.Lock()
-	ret, specificReturn := fake.configPinnedVersionReturnsOnCall[len(fake.configPinnedVersionArgsForCall)]
-	fake.configPinnedVersionArgsForCall = append(fake.configPinnedVersionArgsForCall, struct {
-	}{})
-	fake.recordInvocation("ConfigPinnedVersion", []interface{}{})
-	fake.configPinnedVersionMutex.Unlock()
-	if fake.ConfigPinnedVersionStub != nil {
-		return fake.ConfigPinnedVersionStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.configPinnedVersionReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeResource) ConfigPinnedVersionCallCount() int {
-	fake.configPinnedVersionMutex.RLock()
-	defer fake.configPinnedVersionMutex.RUnlock()
-	return len(fake.configPinnedVersionArgsForCall)
-}
-
-func (fake *FakeResource) ConfigPinnedVersionCalls(stub func() atc.Version) {
-	fake.configPinnedVersionMutex.Lock()
-	defer fake.configPinnedVersionMutex.Unlock()
-	fake.ConfigPinnedVersionStub = stub
-}
-
-func (fake *FakeResource) ConfigPinnedVersionReturns(result1 atc.Version) {
-	fake.configPinnedVersionMutex.Lock()
-	defer fake.configPinnedVersionMutex.Unlock()
-	fake.ConfigPinnedVersionStub = nil
-	fake.configPinnedVersionReturns = struct {
-		result1 atc.Version
-	}{result1}
-}
-
-func (fake *FakeResource) ConfigPinnedVersionReturnsOnCall(i int, result1 atc.Version) {
-	fake.configPinnedVersionMutex.Lock()
-	defer fake.configPinnedVersionMutex.Unlock()
-	fake.ConfigPinnedVersionStub = nil
-	if fake.configPinnedVersionReturnsOnCall == nil {
-		fake.configPinnedVersionReturnsOnCall = make(map[int]struct {
-			result1 atc.Version
-		})
-	}
-	fake.configPinnedVersionReturnsOnCall[i] = struct {
-		result1 atc.Version
-	}{result1}
-}
-
-func (fake *FakeResource) CurrentPinnedVersion() atc.Version {
-	fake.currentPinnedVersionMutex.Lock()
-	ret, specificReturn := fake.currentPinnedVersionReturnsOnCall[len(fake.currentPinnedVersionArgsForCall)]
-	fake.currentPinnedVersionArgsForCall = append(fake.currentPinnedVersionArgsForCall, struct {
-	}{})
-	fake.recordInvocation("CurrentPinnedVersion", []interface{}{})
-	fake.currentPinnedVersionMutex.Unlock()
-	if fake.CurrentPinnedVersionStub != nil {
-		return fake.CurrentPinnedVersionStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.currentPinnedVersionReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeResource) CurrentPinnedVersionCallCount() int {
-	fake.currentPinnedVersionMutex.RLock()
-	defer fake.currentPinnedVersionMutex.RUnlock()
-	return len(fake.currentPinnedVersionArgsForCall)
-}
-
-func (fake *FakeResource) CurrentPinnedVersionCalls(stub func() atc.Version) {
-	fake.currentPinnedVersionMutex.Lock()
-	defer fake.currentPinnedVersionMutex.Unlock()
-	fake.CurrentPinnedVersionStub = stub
-}
-
-func (fake *FakeResource) CurrentPinnedVersionReturns(result1 atc.Version) {
-	fake.currentPinnedVersionMutex.Lock()
-	defer fake.currentPinnedVersionMutex.Unlock()
-	fake.CurrentPinnedVersionStub = nil
-	fake.currentPinnedVersionReturns = struct {
-		result1 atc.Version
-	}{result1}
-}
-
-func (fake *FakeResource) CurrentPinnedVersionReturnsOnCall(i int, result1 atc.Version) {
-	fake.currentPinnedVersionMutex.Lock()
-	defer fake.currentPinnedVersionMutex.Unlock()
-	fake.CurrentPinnedVersionStub = nil
-	if fake.currentPinnedVersionReturnsOnCall == nil {
-		fake.currentPinnedVersionReturnsOnCall = make(map[int]struct {
-			result1 atc.Version
-		})
-	}
-	fake.currentPinnedVersionReturnsOnCall[i] = struct {
-		result1 atc.Version
 	}{result1}
 }
 
@@ -1405,6 +1239,110 @@ func (fake *FakeResource) PinVersionReturnsOnCall(i int, result1 bool, result2 e
 		result1 bool
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeResource) PinnedInConfig() bool {
+	fake.pinnedInConfigMutex.Lock()
+	ret, specificReturn := fake.pinnedInConfigReturnsOnCall[len(fake.pinnedInConfigArgsForCall)]
+	fake.pinnedInConfigArgsForCall = append(fake.pinnedInConfigArgsForCall, struct {
+	}{})
+	fake.recordInvocation("PinnedInConfig", []interface{}{})
+	fake.pinnedInConfigMutex.Unlock()
+	if fake.PinnedInConfigStub != nil {
+		return fake.PinnedInConfigStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.pinnedInConfigReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeResource) PinnedInConfigCallCount() int {
+	fake.pinnedInConfigMutex.RLock()
+	defer fake.pinnedInConfigMutex.RUnlock()
+	return len(fake.pinnedInConfigArgsForCall)
+}
+
+func (fake *FakeResource) PinnedInConfigCalls(stub func() bool) {
+	fake.pinnedInConfigMutex.Lock()
+	defer fake.pinnedInConfigMutex.Unlock()
+	fake.PinnedInConfigStub = stub
+}
+
+func (fake *FakeResource) PinnedInConfigReturns(result1 bool) {
+	fake.pinnedInConfigMutex.Lock()
+	defer fake.pinnedInConfigMutex.Unlock()
+	fake.PinnedInConfigStub = nil
+	fake.pinnedInConfigReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeResource) PinnedInConfigReturnsOnCall(i int, result1 bool) {
+	fake.pinnedInConfigMutex.Lock()
+	defer fake.pinnedInConfigMutex.Unlock()
+	fake.PinnedInConfigStub = nil
+	if fake.pinnedInConfigReturnsOnCall == nil {
+		fake.pinnedInConfigReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.pinnedInConfigReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeResource) PinnedVersion() atc.Version {
+	fake.pinnedVersionMutex.Lock()
+	ret, specificReturn := fake.pinnedVersionReturnsOnCall[len(fake.pinnedVersionArgsForCall)]
+	fake.pinnedVersionArgsForCall = append(fake.pinnedVersionArgsForCall, struct {
+	}{})
+	fake.recordInvocation("PinnedVersion", []interface{}{})
+	fake.pinnedVersionMutex.Unlock()
+	if fake.PinnedVersionStub != nil {
+		return fake.PinnedVersionStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.pinnedVersionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeResource) PinnedVersionCallCount() int {
+	fake.pinnedVersionMutex.RLock()
+	defer fake.pinnedVersionMutex.RUnlock()
+	return len(fake.pinnedVersionArgsForCall)
+}
+
+func (fake *FakeResource) PinnedVersionCalls(stub func() atc.Version) {
+	fake.pinnedVersionMutex.Lock()
+	defer fake.pinnedVersionMutex.Unlock()
+	fake.PinnedVersionStub = stub
+}
+
+func (fake *FakeResource) PinnedVersionReturns(result1 atc.Version) {
+	fake.pinnedVersionMutex.Lock()
+	defer fake.pinnedVersionMutex.Unlock()
+	fake.PinnedVersionStub = nil
+	fake.pinnedVersionReturns = struct {
+		result1 atc.Version
+	}{result1}
+}
+
+func (fake *FakeResource) PinnedVersionReturnsOnCall(i int, result1 atc.Version) {
+	fake.pinnedVersionMutex.Lock()
+	defer fake.pinnedVersionMutex.Unlock()
+	fake.PinnedVersionStub = nil
+	if fake.pinnedVersionReturnsOnCall == nil {
+		fake.pinnedVersionReturnsOnCall = make(map[int]struct {
+			result1 atc.Version
+		})
+	}
+	fake.pinnedVersionReturnsOnCall[i] = struct {
+		result1 atc.Version
+	}{result1}
 }
 
 func (fake *FakeResource) Pipeline() (db.Pipeline, bool, error) {
@@ -2597,8 +2535,6 @@ func (fake *FakeResource) WebhookTokenReturnsOnCall(i int, result1 string) {
 func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.aPIPinnedVersionMutex.RLock()
-	defer fake.aPIPinnedVersionMutex.RUnlock()
 	fake.checkErrorMutex.RLock()
 	defer fake.checkErrorMutex.RUnlock()
 	fake.checkEveryMutex.RLock()
@@ -2607,10 +2543,6 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.checkSetupErrorMutex.RUnlock()
 	fake.checkTimeoutMutex.RLock()
 	defer fake.checkTimeoutMutex.RUnlock()
-	fake.configPinnedVersionMutex.RLock()
-	defer fake.configPinnedVersionMutex.RUnlock()
-	fake.currentPinnedVersionMutex.RLock()
-	defer fake.currentPinnedVersionMutex.RUnlock()
 	fake.disableVersionMutex.RLock()
 	defer fake.disableVersionMutex.RUnlock()
 	fake.enableVersionMutex.RLock()
@@ -2633,6 +2565,10 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.pinCommentMutex.RUnlock()
 	fake.pinVersionMutex.RLock()
 	defer fake.pinVersionMutex.RUnlock()
+	fake.pinnedInConfigMutex.RLock()
+	defer fake.pinnedInConfigMutex.RUnlock()
+	fake.pinnedVersionMutex.RLock()
+	defer fake.pinnedVersionMutex.RUnlock()
 	fake.pipelineMutex.RLock()
 	defer fake.pipelineMutex.RUnlock()
 	fake.pipelineIDMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_cache_factory.go
+++ b/atc/db/dbfakes/fake_resource_cache_factory.go
@@ -27,17 +27,17 @@ type FakeResourceCacheFactory struct {
 		result1 db.UsedResourceCache
 		result2 error
 	}
-	FindResourceCacheByIdStub        func(int) (db.UsedResourceCache, bool, error)
-	findResourceCacheByIdMutex       sync.RWMutex
-	findResourceCacheByIdArgsForCall []struct {
+	FindResourceCacheByIDStub        func(int) (db.UsedResourceCache, bool, error)
+	findResourceCacheByIDMutex       sync.RWMutex
+	findResourceCacheByIDArgsForCall []struct {
 		arg1 int
 	}
-	findResourceCacheByIdReturns struct {
+	findResourceCacheByIDReturns struct {
 		result1 db.UsedResourceCache
 		result2 bool
 		result3 error
 	}
-	findResourceCacheByIdReturnsOnCall map[int]struct {
+	findResourceCacheByIDReturnsOnCall map[int]struct {
 		result1 db.UsedResourceCache
 		result2 bool
 		result3 error
@@ -140,65 +140,65 @@ func (fake *FakeResourceCacheFactory) FindOrCreateResourceCacheReturnsOnCall(i i
 }
 
 func (fake *FakeResourceCacheFactory) FindResourceCacheByID(arg1 int) (db.UsedResourceCache, bool, error) {
-	fake.findResourceCacheByIdMutex.Lock()
-	ret, specificReturn := fake.findResourceCacheByIdReturnsOnCall[len(fake.findResourceCacheByIdArgsForCall)]
-	fake.findResourceCacheByIdArgsForCall = append(fake.findResourceCacheByIdArgsForCall, struct {
+	fake.findResourceCacheByIDMutex.Lock()
+	ret, specificReturn := fake.findResourceCacheByIDReturnsOnCall[len(fake.findResourceCacheByIDArgsForCall)]
+	fake.findResourceCacheByIDArgsForCall = append(fake.findResourceCacheByIDArgsForCall, struct {
 		arg1 int
 	}{arg1})
 	fake.recordInvocation("FindResourceCacheByID", []interface{}{arg1})
-	fake.findResourceCacheByIdMutex.Unlock()
-	if fake.FindResourceCacheByIdStub != nil {
-		return fake.FindResourceCacheByIdStub(arg1)
+	fake.findResourceCacheByIDMutex.Unlock()
+	if fake.FindResourceCacheByIDStub != nil {
+		return fake.FindResourceCacheByIDStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findResourceCacheByIdReturns
+	fakeReturns := fake.findResourceCacheByIDReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
-func (fake *FakeResourceCacheFactory) FindResourceCacheByIdCallCount() int {
-	fake.findResourceCacheByIdMutex.RLock()
-	defer fake.findResourceCacheByIdMutex.RUnlock()
-	return len(fake.findResourceCacheByIdArgsForCall)
+func (fake *FakeResourceCacheFactory) FindResourceCacheByIDCallCount() int {
+	fake.findResourceCacheByIDMutex.RLock()
+	defer fake.findResourceCacheByIDMutex.RUnlock()
+	return len(fake.findResourceCacheByIDArgsForCall)
 }
 
-func (fake *FakeResourceCacheFactory) FindResourceCacheByIdCalls(stub func(int) (db.UsedResourceCache, bool, error)) {
-	fake.findResourceCacheByIdMutex.Lock()
-	defer fake.findResourceCacheByIdMutex.Unlock()
-	fake.FindResourceCacheByIdStub = stub
+func (fake *FakeResourceCacheFactory) FindResourceCacheByIDCalls(stub func(int) (db.UsedResourceCache, bool, error)) {
+	fake.findResourceCacheByIDMutex.Lock()
+	defer fake.findResourceCacheByIDMutex.Unlock()
+	fake.FindResourceCacheByIDStub = stub
 }
 
-func (fake *FakeResourceCacheFactory) FindResourceCacheByIdArgsForCall(i int) int {
-	fake.findResourceCacheByIdMutex.RLock()
-	defer fake.findResourceCacheByIdMutex.RUnlock()
-	argsForCall := fake.findResourceCacheByIdArgsForCall[i]
+func (fake *FakeResourceCacheFactory) FindResourceCacheByIDArgsForCall(i int) int {
+	fake.findResourceCacheByIDMutex.RLock()
+	defer fake.findResourceCacheByIDMutex.RUnlock()
+	argsForCall := fake.findResourceCacheByIDArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeResourceCacheFactory) FindResourceCacheByIdReturns(result1 db.UsedResourceCache, result2 bool, result3 error) {
-	fake.findResourceCacheByIdMutex.Lock()
-	defer fake.findResourceCacheByIdMutex.Unlock()
-	fake.FindResourceCacheByIdStub = nil
-	fake.findResourceCacheByIdReturns = struct {
+func (fake *FakeResourceCacheFactory) FindResourceCacheByIDReturns(result1 db.UsedResourceCache, result2 bool, result3 error) {
+	fake.findResourceCacheByIDMutex.Lock()
+	defer fake.findResourceCacheByIDMutex.Unlock()
+	fake.FindResourceCacheByIDStub = nil
+	fake.findResourceCacheByIDReturns = struct {
 		result1 db.UsedResourceCache
 		result2 bool
 		result3 error
 	}{result1, result2, result3}
 }
 
-func (fake *FakeResourceCacheFactory) FindResourceCacheByIdReturnsOnCall(i int, result1 db.UsedResourceCache, result2 bool, result3 error) {
-	fake.findResourceCacheByIdMutex.Lock()
-	defer fake.findResourceCacheByIdMutex.Unlock()
-	fake.FindResourceCacheByIdStub = nil
-	if fake.findResourceCacheByIdReturnsOnCall == nil {
-		fake.findResourceCacheByIdReturnsOnCall = make(map[int]struct {
+func (fake *FakeResourceCacheFactory) FindResourceCacheByIDReturnsOnCall(i int, result1 db.UsedResourceCache, result2 bool, result3 error) {
+	fake.findResourceCacheByIDMutex.Lock()
+	defer fake.findResourceCacheByIDMutex.Unlock()
+	fake.FindResourceCacheByIDStub = nil
+	if fake.findResourceCacheByIDReturnsOnCall == nil {
+		fake.findResourceCacheByIDReturnsOnCall = make(map[int]struct {
 			result1 db.UsedResourceCache
 			result2 bool
 			result3 error
 		})
 	}
-	fake.findResourceCacheByIdReturnsOnCall[i] = struct {
+	fake.findResourceCacheByIDReturnsOnCall[i] = struct {
 		result1 db.UsedResourceCache
 		result2 bool
 		result3 error
@@ -339,8 +339,8 @@ func (fake *FakeResourceCacheFactory) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.findOrCreateResourceCacheMutex.RLock()
 	defer fake.findOrCreateResourceCacheMutex.RUnlock()
-	fake.findResourceCacheByIdMutex.RLock()
-	defer fake.findResourceCacheByIdMutex.RUnlock()
+	fake.findResourceCacheByIDMutex.RLock()
+	defer fake.findResourceCacheByIDMutex.RUnlock()
 	fake.resourceCacheMetadataMutex.RLock()
 	defer fake.resourceCacheMetadataMutex.RUnlock()
 	fake.updateResourceCacheMetadataMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_type.go
+++ b/atc/db/dbfakes/fake_resource_type.go
@@ -50,16 +50,6 @@ type FakeResourceType struct {
 	checkTimeoutReturnsOnCall map[int]struct {
 		result1 string
 	}
-	CurrentPinnedVersionStub        func() atc.Version
-	currentPinnedVersionMutex       sync.RWMutex
-	currentPinnedVersionArgsForCall []struct {
-	}
-	currentPinnedVersionReturns struct {
-		result1 atc.Version
-	}
-	currentPinnedVersionReturnsOnCall map[int]struct {
-		result1 atc.Version
-	}
 	HasWebhookStub        func() bool
 	hasWebhookMutex       sync.RWMutex
 	hasWebhookArgsForCall []struct {
@@ -119,6 +109,16 @@ type FakeResourceType struct {
 	}
 	paramsReturnsOnCall map[int]struct {
 		result1 atc.Params
+	}
+	PinnedVersionStub        func() atc.Version
+	pinnedVersionMutex       sync.RWMutex
+	pinnedVersionArgsForCall []struct {
+	}
+	pinnedVersionReturns struct {
+		result1 atc.Version
+	}
+	pinnedVersionReturnsOnCall map[int]struct {
+		result1 atc.Version
 	}
 	PipelineStub        func() (db.Pipeline, bool, error)
 	pipelineMutex       sync.RWMutex
@@ -493,58 +493,6 @@ func (fake *FakeResourceType) CheckTimeoutReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) CurrentPinnedVersion() atc.Version {
-	fake.currentPinnedVersionMutex.Lock()
-	ret, specificReturn := fake.currentPinnedVersionReturnsOnCall[len(fake.currentPinnedVersionArgsForCall)]
-	fake.currentPinnedVersionArgsForCall = append(fake.currentPinnedVersionArgsForCall, struct {
-	}{})
-	fake.recordInvocation("CurrentPinnedVersion", []interface{}{})
-	fake.currentPinnedVersionMutex.Unlock()
-	if fake.CurrentPinnedVersionStub != nil {
-		return fake.CurrentPinnedVersionStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.currentPinnedVersionReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeResourceType) CurrentPinnedVersionCallCount() int {
-	fake.currentPinnedVersionMutex.RLock()
-	defer fake.currentPinnedVersionMutex.RUnlock()
-	return len(fake.currentPinnedVersionArgsForCall)
-}
-
-func (fake *FakeResourceType) CurrentPinnedVersionCalls(stub func() atc.Version) {
-	fake.currentPinnedVersionMutex.Lock()
-	defer fake.currentPinnedVersionMutex.Unlock()
-	fake.CurrentPinnedVersionStub = stub
-}
-
-func (fake *FakeResourceType) CurrentPinnedVersionReturns(result1 atc.Version) {
-	fake.currentPinnedVersionMutex.Lock()
-	defer fake.currentPinnedVersionMutex.Unlock()
-	fake.CurrentPinnedVersionStub = nil
-	fake.currentPinnedVersionReturns = struct {
-		result1 atc.Version
-	}{result1}
-}
-
-func (fake *FakeResourceType) CurrentPinnedVersionReturnsOnCall(i int, result1 atc.Version) {
-	fake.currentPinnedVersionMutex.Lock()
-	defer fake.currentPinnedVersionMutex.Unlock()
-	fake.CurrentPinnedVersionStub = nil
-	if fake.currentPinnedVersionReturnsOnCall == nil {
-		fake.currentPinnedVersionReturnsOnCall = make(map[int]struct {
-			result1 atc.Version
-		})
-	}
-	fake.currentPinnedVersionReturnsOnCall[i] = struct {
-		result1 atc.Version
-	}{result1}
-}
-
 func (fake *FakeResourceType) HasWebhook() bool {
 	fake.hasWebhookMutex.Lock()
 	ret, specificReturn := fake.hasWebhookReturnsOnCall[len(fake.hasWebhookArgsForCall)]
@@ -854,6 +802,58 @@ func (fake *FakeResourceType) ParamsReturnsOnCall(i int, result1 atc.Params) {
 	}
 	fake.paramsReturnsOnCall[i] = struct {
 		result1 atc.Params
+	}{result1}
+}
+
+func (fake *FakeResourceType) PinnedVersion() atc.Version {
+	fake.pinnedVersionMutex.Lock()
+	ret, specificReturn := fake.pinnedVersionReturnsOnCall[len(fake.pinnedVersionArgsForCall)]
+	fake.pinnedVersionArgsForCall = append(fake.pinnedVersionArgsForCall, struct {
+	}{})
+	fake.recordInvocation("PinnedVersion", []interface{}{})
+	fake.pinnedVersionMutex.Unlock()
+	if fake.PinnedVersionStub != nil {
+		return fake.PinnedVersionStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.pinnedVersionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeResourceType) PinnedVersionCallCount() int {
+	fake.pinnedVersionMutex.RLock()
+	defer fake.pinnedVersionMutex.RUnlock()
+	return len(fake.pinnedVersionArgsForCall)
+}
+
+func (fake *FakeResourceType) PinnedVersionCalls(stub func() atc.Version) {
+	fake.pinnedVersionMutex.Lock()
+	defer fake.pinnedVersionMutex.Unlock()
+	fake.PinnedVersionStub = stub
+}
+
+func (fake *FakeResourceType) PinnedVersionReturns(result1 atc.Version) {
+	fake.pinnedVersionMutex.Lock()
+	defer fake.pinnedVersionMutex.Unlock()
+	fake.PinnedVersionStub = nil
+	fake.pinnedVersionReturns = struct {
+		result1 atc.Version
+	}{result1}
+}
+
+func (fake *FakeResourceType) PinnedVersionReturnsOnCall(i int, result1 atc.Version) {
+	fake.pinnedVersionMutex.Lock()
+	defer fake.pinnedVersionMutex.Unlock()
+	fake.PinnedVersionStub = nil
+	if fake.pinnedVersionReturnsOnCall == nil {
+		fake.pinnedVersionReturnsOnCall = make(map[int]struct {
+			result1 atc.Version
+		})
+	}
+	fake.pinnedVersionReturnsOnCall[i] = struct {
+		result1 atc.Version
 	}{result1}
 }
 
@@ -1677,8 +1677,6 @@ func (fake *FakeResourceType) Invocations() map[string][][]interface{} {
 	defer fake.checkSetupErrorMutex.RUnlock()
 	fake.checkTimeoutMutex.RLock()
 	defer fake.checkTimeoutMutex.RUnlock()
-	fake.currentPinnedVersionMutex.RLock()
-	defer fake.currentPinnedVersionMutex.RUnlock()
 	fake.hasWebhookMutex.RLock()
 	defer fake.hasWebhookMutex.RUnlock()
 	fake.iDMutex.RLock()
@@ -1691,6 +1689,8 @@ func (fake *FakeResourceType) Invocations() map[string][][]interface{} {
 	defer fake.nameMutex.RUnlock()
 	fake.paramsMutex.RLock()
 	defer fake.paramsMutex.RUnlock()
+	fake.pinnedVersionMutex.RLock()
+	defer fake.pinnedVersionMutex.RUnlock()
 	fake.pipelineMutex.RLock()
 	defer fake.pipelineMutex.RUnlock()
 	fake.pipelineIDMutex.RLock()

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -93,8 +93,7 @@ var _ = Describe("Resource", func() {
 				case "some-resource":
 					Expect(r.Type()).To(Equal("registry-image"))
 					Expect(r.Source()).To(Equal(atc.Source{"some": "repository"}))
-					Expect(r.ConfigPinnedVersion()).To(Equal(atc.Version{"ref": "abcdef"}))
-					Expect(r.CurrentPinnedVersion()).To(Equal(r.ConfigPinnedVersion()))
+					Expect(r.PinnedVersion()).To(Equal(atc.Version{"ref": "abcdef"}))
 					Expect(r.HasWebhook()).To(BeTrue())
 				case "some-other-resource":
 					Expect(r.Type()).To(Equal("git"))
@@ -1480,6 +1479,7 @@ var _ = Describe("Resource", func() {
 			resource      db.Resource
 			resourceScope db.ResourceConfigScope
 			resID         int
+			version       atc.Version
 		)
 
 		BeforeEach(func() {
@@ -1510,7 +1510,8 @@ var _ = Describe("Resource", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			resConf, found, err := resourceScope.FindVersion(atc.Version{"version": "v1"})
+			version = atc.Version{"version": "v1"}
+			resConf, found, err := resourceScope.FindVersion(version)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 			resID = resConf.ID()
@@ -1529,8 +1530,8 @@ var _ = Describe("Resource", func() {
 				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(resource.CurrentPinnedVersion()).To(Equal(resource.APIPinnedVersion()))
-				pinnedVersion = resource.APIPinnedVersion()
+				pinnedVersion = version
+				Expect(resource.PinnedVersion()).To(Equal(pinnedVersion))
 			})
 
 			It("returns not found and does not update anything", func() {
@@ -1538,7 +1539,7 @@ var _ = Describe("Resource", func() {
 				Expect(found).To(BeFalse())
 				Expect(err).To(HaveOccurred())
 
-				Expect(resource.APIPinnedVersion()).To(Equal(pinnedVersion))
+				Expect(resource.PinnedVersion()).To(Equal(pinnedVersion))
 			})
 		})
 
@@ -1592,9 +1593,8 @@ var _ = Describe("Resource", func() {
 			})
 
 			Context("when the resource is not pinned", func() {
-				It("sets the api pinned version", func() {
-					Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
-					Expect(resource.CurrentPinnedVersion()).To(Equal(resource.APIPinnedVersion()))
+				It("sets the pinned version", func() {
+					Expect(resource.PinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 				})
 			})
 
@@ -1615,8 +1615,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("switch the pin to given version", func() {
-					Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v3"}))
-					Expect(resource.CurrentPinnedVersion()).To(Equal(resource.APIPinnedVersion()))
+					Expect(resource.PinnedVersion()).To(Equal(atc.Version{"version": "v3"}))
 				})
 			})
 
@@ -1676,9 +1675,8 @@ var _ = Describe("Resource", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("sets the api pinned version to nil", func() {
-					Expect(resource.APIPinnedVersion()).To(BeNil())
-					Expect(resource.CurrentPinnedVersion()).To(BeNil())
+				It("sets the pinned version to nil", func() {
+					Expect(resource.PinnedVersion()).To(BeNil())
 				})
 
 				It("unsets the pin comment", func() {

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -43,7 +43,7 @@ type ResourceType interface {
 	CheckSetupError() error
 	CheckError() error
 	UniqueVersionHistory() bool
-	CurrentPinnedVersion() atc.Version
+	PinnedVersion() atc.Version
 	ResourceConfigScopeID() int
 
 	HasWebhook() bool
@@ -196,7 +196,7 @@ func (t *resourceType) UniqueVersionHistory() bool    { return t.uniqueVersionHi
 func (t *resourceType) ResourceConfigScopeID() int    { return t.resourceConfigScopeID }
 
 func (t *resourceType) Version() atc.Version              { return t.version }
-func (t *resourceType) CurrentPinnedVersion() atc.Version { return nil }
+func (t *resourceType) PinnedVersion() atc.Version { return nil }
 
 func (t *resourceType) HasWebhook() bool {
 	return false

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -1794,7 +1794,7 @@ var _ = Describe("Team", func() {
 			reloaded, err := resource.Reload()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reloaded).To(BeTrue())
-			Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
+			Expect(resource.PinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 
 			config.Resources[0].Version = atc.Version{
 				"version": "v2",
@@ -1806,8 +1806,7 @@ var _ = Describe("Team", func() {
 			resource, found, err = savedPipeline.Resource("some-resource")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
-			Expect(resource.ConfigPinnedVersion()).To(Equal(atc.Version{"version": "v2"}))
-			Expect(resource.APIPinnedVersion()).To(BeNil())
+			Expect(resource.PinnedVersion()).To(Equal(atc.Version{"version": "v2"}))
 		})
 
 		It("clears out config pinned version when it is removed", func() {
@@ -1821,8 +1820,7 @@ var _ = Describe("Team", func() {
 			resource, found, err := pipeline.Resource("some-resource")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
-			Expect(resource.ConfigPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
-			Expect(resource.APIPinnedVersion()).To(BeNil())
+			Expect(resource.PinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 
 			config.Resources[0].Version = nil
 
@@ -1832,8 +1830,7 @@ var _ = Describe("Team", func() {
 			resource, found, err = savedPipeline.Resource("some-resource")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
-			Expect(resource.ConfigPinnedVersion()).To(BeNil())
-			Expect(resource.APIPinnedVersion()).To(BeNil())
+			Expect(resource.PinnedVersion()).To(BeNil())
 		})
 
 		It("does not clear the api pinned version when resaving pipeline config", func() {
@@ -1875,7 +1872,7 @@ var _ = Describe("Team", func() {
 			reloaded, err := resource.Reload()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reloaded).To(BeTrue())
-			Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
+			Expect(resource.PinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 
 			savedPipeline, _, err := team.SavePipeline(pipelineName, config, pipeline.ConfigVersion(), false)
 			Expect(err).ToNot(HaveOccurred())
@@ -1883,7 +1880,7 @@ var _ = Describe("Team", func() {
 			resource, found, err = savedPipeline.Resource("some-resource")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
-			Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
+			Expect(resource.PinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 		})
 
 		It("marks resource as inactive if it is no longer in config", func() {

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -125,7 +125,7 @@ func (s *scanner) check(ctx context.Context, checkable db.Checkable, resourceTyp
 		return nil
 	}
 
-	version := checkable.CurrentPinnedVersion()
+	version := checkable.PinnedVersion()
 
 	_, created, err := s.checkFactory.TryCreateCheck(lagerctx.NewContext(spanCtx, s.logger), checkable, resourceTypes, version, false)
 	if err != nil {

--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Scanner", func() {
 
 						Context("when the checkable has a pinned version", func() {
 							BeforeEach(func() {
-								fakeResource.CurrentPinnedVersionReturns(atc.Version{"some": "version"})
+								fakeResource.PinnedVersionReturns(atc.Version{"some": "version"})
 							})
 
 							It("creates a check", func() {
@@ -170,7 +170,7 @@ var _ = Describe("Scanner", func() {
 
 						Context("when the checkable does not have a pinned version", func() {
 							BeforeEach(func() {
-								fakeResource.CurrentPinnedVersionReturns(nil)
+								fakeResource.PinnedVersionReturns(nil)
 							})
 
 							It("creates a check", func() {
@@ -316,7 +316,7 @@ var _ = Describe("Scanner", func() {
 
 				Context("last check is 9 minutes ago", func() {
 					BeforeEach(func() {
-						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute*9))
+						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute * 9))
 					})
 
 					It("does not create a check", func() {
@@ -326,7 +326,7 @@ var _ = Describe("Scanner", func() {
 
 				Context("last check is 11 minutes ago", func() {
 					BeforeEach(func() {
-						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute*11))
+						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute * 11))
 					})
 
 					It("does not create a check", func() {


### PR DESCRIPTION
Rather than setting one of these fields to nil and then nil checking in
CurrentPinnedVersion, only the pinned version needs storing. A flag for
if the source of the pinning is config is kept for the `api/present`
package to use for the UI

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns page]: https://github.com/concourse/concourse/wiki/Anti-Patterns


# Why is this PR needed?
Simplify the contract of the `db/resource` package slightly to remove `ConfigPinnedVersion` and `ApiPinnedVersion` in favour of `PinnedVersion`

# What is this PR trying to accomplish?
Now that config pinned versions are in the DB and fetched the same way, there is not real need to store both the config pinned version and the API pinned version where at least one is always nil. The `api/present` package needs to know which one was pinned to set a `pinned_in_config` flag so just expose a boolean from the `db/resource` package to match what `api/present` expects.

This is prep work to do a little tidy up as part of implementing #5456 


# How does it accomplish that?
Remove `ApiPinnedVersion` and `ConfigPinnedVersion` from `db/resource` package in favour of just the `PinnedVersion` and a boolean flag for `PinnedInConfig`

`PinnedVersion()` then replaces `CurrentPinnedVersion()` which means we only have to do logic about which version is pinned once in this class.


# Contributor Checklist
- [x] Unit tests
- [ ] ~Integration tests~
- [ ] ~Updated documentation (located at https://github.com/concourse/docs)~
- [ ] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~


# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
