### PR TITLE
containerd integration: fix some setup flakiness

### DIFF
--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -67,7 +67,7 @@ func (s *IntegrationSuite) SetupSuite() {
 	s.startContainerd()
 
 	retries := 0
-	for retries < 10 {
+	for retries < 100 {
 		c, err := containerd.New(s.containerdSocket(), containerd.WithTimeout(100*time.Millisecond))
 		if err != nil {
 			retries++

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -13,11 +13,9 @@ import (
 	"code.cloudfoundry.org/garden"
 	"github.com/concourse/concourse/worker/runtime"
 	"github.com/concourse/concourse/worker/runtime/libcontainerd"
-	"github.com/concourse/concourse/worker/workercmd"
 	"github.com/containerd/containerd"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/tedsuo/ifrit"
 )
 
 type IntegrationSuite struct {
@@ -26,7 +24,7 @@ type IntegrationSuite struct {
 
 	gardenBackend     runtime.GardenBackend
 	client            *libcontainerd.Client
-	containerdProcess ifrit.Process
+	containerdProcess *exec.Cmd
 	rootfs            string
 	stderr            bytes.Buffer
 	stdout            bytes.Buffer
@@ -38,9 +36,10 @@ func (s *IntegrationSuite) containerdSocket() string {
 }
 
 func (s *IntegrationSuite) startContainerd() {
-	command := exec.Command("/usr/local/concourse/bin/containerd",
+	command := exec.Command("containerd",
 		"--address="+s.containerdSocket(),
-		"--root="+filepath.Join(s.tmpDir, "containerd"),
+		"--root="+filepath.Join(s.tmpDir, "root"),
+		"--state="+filepath.Join(s.tmpDir, "state"),
 	)
 
 	command.Stdout = &s.stdout
@@ -49,7 +48,15 @@ func (s *IntegrationSuite) startContainerd() {
 		Pdeathsig: syscall.SIGKILL,
 	}
 
-	s.containerdProcess = ifrit.Invoke(workercmd.CmdRunner{command})
+	err := command.Start()
+	s.NoError(err)
+
+	s.containerdProcess = command
+}
+
+func (s *IntegrationSuite) stopContainerd() {
+	s.NoError(s.containerdProcess.Process.Signal(syscall.SIGTERM))
+	s.NoError(s.containerdProcess.Wait())
 }
 
 func (s *IntegrationSuite) SetupSuite() {
@@ -71,16 +78,17 @@ func (s *IntegrationSuite) SetupSuite() {
 		return
 	}
 
+	s.stopContainerd()
+	s.NoError(os.RemoveAll(s.tmpDir))
+
 	fmt.Println("STDOUT:", s.stdout.String())
 	fmt.Println("STDERR:", s.stderr.String())
 	s.Fail("timed out waiting for containerd to start")
 }
 
 func (s *IntegrationSuite) TearDownSuite() {
-	s.containerdProcess.Signal(syscall.SIGTERM)
-	<-s.containerdProcess.Wait()
-
-	os.RemoveAll(s.tmpDir)
+	s.stopContainerd()
+	s.NoError(os.RemoveAll(s.tmpDir))
 }
 
 func (s *IntegrationSuite) SetupTest() {


### PR DESCRIPTION
# Why is this PR needed?

The `containerd-integration` build seems to be kind of flaky - I'm guessing the 1 second timeout is just too short when the worker is running multiple things.

# What is this PR trying to accomplish?

Bump the 1 second timeout to 10 seconds, and also clean up the process and tmpdir if starting fails. (TearDownSuite won't run if StartUpSuite failed.)

**note**: I also changed the `containerd` path to just `containerd` instead of an absolute path and passed a `--state` flag pointing to our tmpdir, in the interest of making these tests easier to run on a Linux dev machine, but that effort hasn't paid off since the tests need to be run as `root` anyway. :/ If this passes in CI as-is I think it'd be worth merging anyway but I may be missing some other reason for hardcoding the path. Happy to back it out since it's not technically required though.

# Contributor Checklist

- [ ] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)


# Reviewer Checklist

- [ ] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
