### PR TITLE
tsa: handling of SIGHUP to reload workers keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
 	github.com/concourse/baggageclaim v1.6.6
 	github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88
-	github.com/concourse/flag v1.0.0
+	github.com/concourse/flag v1.0.1-0.20200521134421-2be0b225f922
 	github.com/concourse/go-archive v1.0.1
 	github.com/concourse/retryhttp v1.0.2
 	github.com/containerd/cgroups v0.0.0-20191220161829-06e718085901 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
 	github.com/concourse/baggageclaim v1.6.6
 	github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88
-	github.com/concourse/flag v1.0.1-0.20200521134421-2be0b225f922
+	github.com/concourse/flag v1.1.0
 	github.com/concourse/go-archive v1.0.1
 	github.com/concourse/retryhttp v1.0.2
 	github.com/containerd/cgroups v0.0.0-20191220161829-06e718085901 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88/go.mod h1:7xVx6jMkg5
 github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/flag v1.0.0 h1:XG+A/Y+8kNdNDUC9T+SQ55dZ1+xYQN6LNVBg3cGJ080=
 github.com/concourse/flag v1.0.0/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
+github.com/concourse/flag v1.0.1-0.20200521134421-2be0b225f922 h1:TOZPFSUBiqxQg0C+RzMOZBnNd7r2plU1p19S7i8JJHs=
+github.com/concourse/flag v1.0.1-0.20200521134421-2be0b225f922/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/go-archive v0.0.0-20180803203406-784931698f4f/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv0NFwlpjf5CO8=
 github.com/concourse/go-archive v1.0.0/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv0NFwlpjf5CO8=
 github.com/concourse/go-archive v1.0.1 h1:6jQk0VDiE4G6lNJQ0mLZ7XmxbqI3spO4x0wgVwk4pfo=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88/go.mod h1:7xVx6jMkg5
 github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/flag v1.0.0 h1:XG+A/Y+8kNdNDUC9T+SQ55dZ1+xYQN6LNVBg3cGJ080=
 github.com/concourse/flag v1.0.0/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
-github.com/concourse/flag v1.0.1-0.20200521134421-2be0b225f922 h1:TOZPFSUBiqxQg0C+RzMOZBnNd7r2plU1p19S7i8JJHs=
-github.com/concourse/flag v1.0.1-0.20200521134421-2be0b225f922/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
+github.com/concourse/flag v1.1.0 h1:d2l91vIK6lwfIC7uNLb3i51tZtaWCTokh80VoE6T/RU=
+github.com/concourse/flag v1.1.0/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/go-archive v0.0.0-20180803203406-784931698f4f/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv0NFwlpjf5CO8=
 github.com/concourse/go-archive v1.0.0/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv0NFwlpjf5CO8=
 github.com/concourse/go-archive v1.0.1 h1:6jQk0VDiE4G6lNJQ0mLZ7XmxbqI3spO4x0wgVwk4pfo=

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -149,13 +149,13 @@ func (cmd *TSACommand) Runner(args []string) (ifrit.Runner, error) {
 	// For now it only reload the TSACommand.AuthorizedKeys but any
 	// other configuration could be added
 	go func() {
+		// Set up channel on which to send signal notifications.
+		// We must use a buffered channel or risk missing the signal
+		// if we're not ready to receive when the signal is sent.
+		c := make(chan os.Signal, 1)
+		defer close(c)
+		signal.Notify(c, syscall.SIGHUP)
 		for {
-
-			// Set up channel on which to send signal notifications.
-			// We must use a buffered channel or risk missing the signal
-			// if we're not ready to receive when the signal is sent.
-			c := make(chan os.Signal, 1)
-			signal.Notify(c, syscall.SIGHUP)
 
 			// Block until a signal is received.
 			_ = <-c

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -13,6 +13,9 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
+	"os/signal"
+	"syscall"
+
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/skymarshal/token"
@@ -141,6 +144,46 @@ func (cmd *TSACommand) Runner(args []string) (ifrit.Runner, error) {
 		httpClient:        httpClient,
 		sessionTeam:       sessionAuthTeam,
 	}
+	// Starts a goroutine that his purpose is to basically listen to the
+	// SIGUSR1 syscall to then reload the config.
+	// For now it only reload the TSACommand.AuthorizedKeys but any
+	// other configuration could be added
+	go func() {
+		for {
+
+			// Set up channel on which to send signal notifications.
+			// We must use a buffered channel or risk missing the signal
+			// if we're not ready to receive when the signal is sent.
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, syscall.SIGUSR1)
+
+			// Block until a signal is received.
+			_ = <-c
+
+			logger.Info("reloading-config")
+
+			err := cmd.AuthorizedKeys.Reload()
+			if err != nil {
+				logger.Error("failed to reload authorized keys file : %s", err)
+				continue
+			}
+
+			teamAuthorizedKeys, err = cmd.loadTeamAuthorizedKeys()
+			if err != nil {
+				logger.Error("failed to load team authorized keys : %s", err)
+				continue
+			}
+
+			// compute again the config so it's updated
+			config, err := cmd.configureSSHServer(sessionAuthTeam, cmd.AuthorizedKeys.Keys, teamAuthorizedKeys)
+			if err != nil {
+				logger.Error("failed to configure SSH server: %s", err)
+				continue
+			}
+
+			server.config = config
+		}
+	}()
 
 	return serverRunner{logger, server, listenAddr}, nil
 }

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -145,7 +145,7 @@ func (cmd *TSACommand) Runner(args []string) (ifrit.Runner, error) {
 		sessionTeam:       sessionAuthTeam,
 	}
 	// Starts a goroutine that his purpose is to basically listen to the
-	// SIGUSR1 syscall to then reload the config.
+	// SIGHUP syscall to then reload the config.
 	// For now it only reload the TSACommand.AuthorizedKeys but any
 	// other configuration could be added
 	go func() {
@@ -155,7 +155,7 @@ func (cmd *TSACommand) Runner(args []string) (ifrit.Runner, error) {
 			// We must use a buffered channel or risk missing the signal
 			// if we're not ready to receive when the signal is sent.
 			c := make(chan os.Signal, 1)
-			signal.Notify(c, syscall.SIGUSR1)
+			signal.Notify(c, syscall.SIGHUP)
 
 			// Block until a signal is received.
 			_ = <-c

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -146,16 +146,16 @@ func (cmd *TSACommand) Runner(args []string) (ifrit.Runner, error) {
 	}
 	// Starts a goroutine whose purpose is to listen to the
 	// SIGHUP syscall and reload configuration upon receiving the signal.
- 	// For now it only reloads the TSACommand.AuthorizedKeys but
+	// For now it only reloads the TSACommand.AuthorizedKeys but
 	// other configuration can potentially be added.
 	go func() {
 		reloadWorkerKeys := make(chan os.Signal, 1)
-		defer close(c)
-		signal.Notify(c, syscall.SIGHUP)
+		defer close(reloadWorkerKeys)
+		signal.Notify(reloadWorkerKeys, syscall.SIGHUP)
 		for {
 
 			// Block until a signal is received.
-			<-c
+			<-reloadWorkerKeys
 
 			logger.Info("reloading-config")
 


### PR DESCRIPTION
# Why is this PR needed?

This pull request fix the issue #1105 by adding TSA support for reloading authorized keys without restart based on signal `SIGUSR1`

As described in #1105 and #3551 it is really handy for HA purpose to be able to add worker keys without having to restart a Concourse web/TSA process.

It also rely on this pull request that have been merged https://github.com/concourse/flag/pull/5

# What is this PR trying to accomplish?


Provide a solution for user to dynamically add or remove worker keys without having to restart Concourse.

closes #1105 .


# How does it accomplish that?

I choose to use signal `SIGHUP` that any user can send with the following command:

```
kill -s SIGHUP <PID of Concourse web>
```

The implementation is really simple and for a user point of view it's really easy to send this signal to concourse when you update any authorized keys file.
Signal usage have been inspired by Concourse worker process https://concourse-ci.org/concourse-worker.html#restarting-a-worker


# Contributor Checklist

- [ ] Unit tests
- [ ] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

Let's discuss about those points if the technical solution is approved.

# Reviewer Checklist


- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) 
      and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text). 
