### PR TITLE
atc: behaviour: check step runs in the same context as checker

### DIFF
--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -22,7 +22,7 @@ import (
 
 type Engine interface {
 	NewBuild(db.Build) Runnable
-	NewCheck(db.Check) Runnable
+	NewCheck(context.Context, db.Check) Runnable
 	ReleaseAll(lager.Logger)
 }
 
@@ -84,12 +84,12 @@ func (engine *engine) NewBuild(build db.Build) Runnable {
 	)
 }
 
-func (engine *engine) NewCheck(check db.Check) Runnable {
+func (engine *engine) NewCheck(ctx context.Context, check db.Check) Runnable {
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctxWithCancel, cancel := context.WithCancel(ctx)
 
 	return NewCheck(
-		ctx,
+		ctxWithCancel,
 		cancel,
 		check,
 		engine.builder,

--- a/atc/engine/engine_test.go
+++ b/atc/engine/engine_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Engine", func() {
 		})
 
 		JustBeforeEach(func() {
-			check = engine.NewCheck(fakeCheck)
+			check = engine.NewCheck(context.Background(), fakeCheck)
 		})
 
 		It("returns a build", func() {

--- a/atc/engine/enginefakes/fake_engine.go
+++ b/atc/engine/enginefakes/fake_engine.go
@@ -2,6 +2,7 @@
 package enginefakes
 
 import (
+	"context"
 	"sync"
 
 	"code.cloudfoundry.org/lager"
@@ -21,10 +22,11 @@ type FakeEngine struct {
 	newBuildReturnsOnCall map[int]struct {
 		result1 engine.Runnable
 	}
-	NewCheckStub        func(db.Check) engine.Runnable
+	NewCheckStub        func(context.Context, db.Check) engine.Runnable
 	newCheckMutex       sync.RWMutex
 	newCheckArgsForCall []struct {
-		arg1 db.Check
+		arg1 context.Context
+		arg2 db.Check
 	}
 	newCheckReturns struct {
 		result1 engine.Runnable
@@ -101,16 +103,17 @@ func (fake *FakeEngine) NewBuildReturnsOnCall(i int, result1 engine.Runnable) {
 	}{result1}
 }
 
-func (fake *FakeEngine) NewCheck(arg1 db.Check) engine.Runnable {
+func (fake *FakeEngine) NewCheck(arg1 context.Context, arg2 db.Check) engine.Runnable {
 	fake.newCheckMutex.Lock()
 	ret, specificReturn := fake.newCheckReturnsOnCall[len(fake.newCheckArgsForCall)]
 	fake.newCheckArgsForCall = append(fake.newCheckArgsForCall, struct {
-		arg1 db.Check
-	}{arg1})
-	fake.recordInvocation("NewCheck", []interface{}{arg1})
+		arg1 context.Context
+		arg2 db.Check
+	}{arg1, arg2})
+	fake.recordInvocation("NewCheck", []interface{}{arg1, arg2})
 	fake.newCheckMutex.Unlock()
 	if fake.NewCheckStub != nil {
-		return fake.NewCheckStub(arg1)
+		return fake.NewCheckStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -125,17 +128,17 @@ func (fake *FakeEngine) NewCheckCallCount() int {
 	return len(fake.newCheckArgsForCall)
 }
 
-func (fake *FakeEngine) NewCheckCalls(stub func(db.Check) engine.Runnable) {
+func (fake *FakeEngine) NewCheckCalls(stub func(context.Context, db.Check) engine.Runnable) {
 	fake.newCheckMutex.Lock()
 	defer fake.newCheckMutex.Unlock()
 	fake.NewCheckStub = stub
 }
 
-func (fake *FakeEngine) NewCheckArgsForCall(i int) db.Check {
+func (fake *FakeEngine) NewCheckArgsForCall(i int) (context.Context, db.Check) {
 	fake.newCheckMutex.RLock()
 	defer fake.newCheckMutex.RUnlock()
 	argsForCall := fake.newCheckArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeEngine) NewCheckReturns(result1 engine.Runnable) {

--- a/atc/lidar/checker.go
+++ b/atc/lidar/checker.go
@@ -49,7 +49,7 @@ func (c *checker) Run(ctx context.Context) error {
 	for _, ck := range checks {
 		if _, exists := c.running.LoadOrStore(ck.ID(), true); !exists {
 			go func(check db.Check) {
-				_, span := tracing.StartSpanFollowing(
+				ctx, span := tracing.StartSpanFollowing(
 					check,
 					"checker.Run",
 					tracing.Attrs{
@@ -62,7 +62,7 @@ func (c *checker) Run(ctx context.Context) error {
 				defer span.End()
 				defer c.running.Delete(check.ID())
 
-				engineCheck := c.engine.NewCheck(check)
+				engineCheck := c.engine.NewCheck(ctx, check)
 				engineCheck.Run(c.logger.WithData(lager.Data{
 					"check": check.ID(),
 				}))

--- a/atc/scheduler/algorithm/suite_test.go
+++ b/atc/scheduler/algorithm/suite_test.go
@@ -45,8 +45,9 @@ var _ = BeforeSuite(func() {
 
 		exporter = spanSyncer.(*jaeger.Exporter)
 
-		err = tracing.ConfigureTracer(exporter)
+		tp, err := tracing.TraceProvider(exporter)
 		Expect(err).ToNot(HaveOccurred())
+		tracing.ConfigureTraceProvider(tp)
 	}
 
 	postgresRunner = postgresrunner.Runner{

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -2,7 +2,6 @@ package tracing
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/key"
@@ -129,24 +128,21 @@ func End(span trace.Span, err error) {
 	span.End()
 }
 
-// ConfigureTracer configures the sdk to use a given exporter.
+// ConfigureTraceProvider configures the sdk to use a given trace provider.
 //
 // By default, a noop tracer is registered, thus, it's safe to call StartSpan
 // and other related methods even before `ConfigureTracer` it called.
 //
-func ConfigureTracer(exporter export.SpanSyncer) error {
-	tp, err := sdktrace.NewProvider(sdktrace.WithConfig(
+func ConfigureTraceProvider(tp trace.Provider) {
+	global.SetTraceProvider(tp)
+	Configured = true
+}
+
+func TraceProvider(exporter export.SpanSyncer) (trace.Provider, error) {
+	return sdktrace.NewProvider(sdktrace.WithConfig(
 		sdktrace.Config{
 			DefaultSampler: sdktrace.AlwaysSample(),
 		}),
 		sdktrace.WithSyncer(exporter),
 	)
-	if err != nil {
-		return fmt.Errorf("failed to configure trace provider: %w", err)
-	}
-
-	global.SetTraceProvider(tp)
-	Configured = true
-
-	return nil
 }


### PR DESCRIPTION
# Why is this PR needed?

This change, while small in impact, should allow for more sophisticated tracing of the lidar package, including propagating span context into check containers (related to #5423) and propagating check-related span context into resource versions (as part of #5602).

# What is this PR trying to accomplish?

closes #5654.

# How does it accomplish that?

We were happy about the "sensing"/inspection possibilities provided by the `testtrace` package, and decided it would be worth the preliminary refactor of the `tracing.ConfigureTracer` method. This allowed us to write a pretty expressive checker test without relying too heavily on artisanal counterfeiter fakes. Overall this should improve testability of tracing-related functions for the future.

It remains to be seen whether the thread-unsafe mutation of the `tracing.Configured` variable causes any problems when running in parallel, say, on CI.

Implementation-wise, we noticed that the checker only interacted with a check step by way of an engineCheck, so adding a context parameter to the `Check` method on the `Engine` interface felt reasonable.

This change has no external user-facing impact, so it doesn't need documentation.

# Contributor Checklist

- [x] Unit tests
- [x] ~Integration tests~ change has very small scope
- [x] ~Updated documentation (located at https://github.com/concourse/docs)~
- [x] ~Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)~

# Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~