### PR TITLE
atc: trace check & build creation

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -29,6 +29,8 @@ type BuildInput struct {
 
 	FirstOccurrence bool
 	ResolveError    string
+
+	SpanContext SpanContext
 }
 
 type BuildOutput struct {

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -985,7 +985,7 @@ func (b *build) SaveOutput(
 		return err
 	}
 
-	newVersion, err := saveResourceVersion(tx, resourceConfigScope.ID(), version, metadata)
+	newVersion, err := saveResourceVersion(tx, resourceConfigScope.ID(), version, metadata, nil)
 	if err != nil {
 		return err
 	}

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Build", func() {
 			resourceConfigScope1, err := resource1.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = resourceConfigScope1.SaveVersions([]atc.Version{
+			err = resourceConfigScope1.SaveVersions(nil, []atc.Version{
 				{"ver": "1"},
 				{"ver": "2"},
 			})
@@ -269,7 +269,7 @@ var _ = Describe("Build", func() {
 			resourceConfigScope2, err := resource2.SetResourceConfig(atc.Source{"some": "other-source"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = resourceConfigScope2.SaveVersions([]atc.Version{
+			err = resourceConfigScope2.SaveVersions(nil, []atc.Version{
 				{"ver": "1"},
 				{"ver": "2"},
 				{"ver": "3"},
@@ -869,7 +869,7 @@ var _ = Describe("Build", func() {
 			var rcv db.ResourceConfigVersion
 
 			BeforeEach(func() {
-				err := resourceConfigScope.SaveVersions([]atc.Version{{"some": "version"}})
+				err := resourceConfigScope.SaveVersions(nil, []atc.Version{{"some": "version"}})
 				Expect(err).ToNot(HaveOccurred())
 
 				var found bool
@@ -1079,7 +1079,7 @@ var _ = Describe("Build", func() {
 			_, err = resource2.SetResourceConfig(atc.Source{"some": "source-2"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = resourceConfigScope1.SaveVersions([]atc.Version{
+			err = resourceConfigScope1.SaveVersions(nil, []atc.Version{
 				{"ver": "1"},
 				{"ver": "2"},
 			})
@@ -1436,7 +1436,7 @@ var _ = Describe("Build", func() {
 					resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
 					Expect(err).NotTo(HaveOccurred())
 
-					err = resourceConfigScope.SaveVersions([]atc.Version{{"version": "v5"}})
+					err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "v5"}})
 					Expect(err).NotTo(HaveOccurred())
 
 					rcv, found, err = resourceConfigScope.FindVersion(atc.Version{"version": "v5"})
@@ -1826,7 +1826,7 @@ var _ = Describe("Build", func() {
 					resourceConfig1, err := resource1.SetResourceConfig(atc.Source{"some": "source-1"}, atc.VersionedResourceTypes{})
 					Expect(err).NotTo(HaveOccurred())
 
-					err = resourceConfig1.SaveVersions([]atc.Version{{"version": "v1"}})
+					err = resourceConfig1.SaveVersions(nil, []atc.Version{{"version": "v1"}})
 					Expect(err).NotTo(HaveOccurred())
 
 					version, found, err := resourceConfig1.FindVersion(atc.Version{"version": "v1"})
@@ -1968,7 +1968,7 @@ var _ = Describe("Build", func() {
 				resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = resourceConfigScope.SaveVersions([]atc.Version{
+				err = resourceConfigScope.SaveVersions(nil, []atc.Version{
 					{"version": "v1"},
 					{"version": "v2"},
 					{"version": "v3"},
@@ -1982,7 +1982,7 @@ var _ = Describe("Build", func() {
 				otherResourceConfigScope, err = otherResource.SetResourceConfig(atc.Source{"some": "other-source"}, atc.VersionedResourceTypes{})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = otherResourceConfigScope.SaveVersions([]atc.Version{atc.Version{"version": "v1"}})
+				err = otherResourceConfigScope.SaveVersions(nil, []atc.Version{atc.Version{"version": "v1"}})
 				Expect(err).ToNot(HaveOccurred())
 
 				versions, _, found, err = resource.Versions(db.Page{Limit: 3}, nil)
@@ -2231,7 +2231,7 @@ var _ = Describe("Build", func() {
 				resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = resourceConfigScope.SaveVersions([]atc.Version{
+				err = resourceConfigScope.SaveVersions(nil, []atc.Version{
 					{"version": "v1"},
 					{"version": "v2"},
 					{"version": "v3"},
@@ -2245,7 +2245,7 @@ var _ = Describe("Build", func() {
 				otherResourceConfigScope, err = otherResource.SetResourceConfig(atc.Source{"some": "other-source"}, atc.VersionedResourceTypes{})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = otherResourceConfigScope.SaveVersions([]atc.Version{atc.Version{"version": "v1"}})
+				err = otherResourceConfigScope.SaveVersions(nil, []atc.Version{atc.Version{"version": "v1"}})
 				Expect(err).ToNot(HaveOccurred())
 
 				versions, _, found, err = resource.Versions(db.Page{Limit: 3}, nil)
@@ -2507,7 +2507,7 @@ var _ = Describe("Build", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updated).To(BeTrue())
 
-				err = resourceConfigScope2.SaveVersions([]atc.Version{
+				err = resourceConfigScope2.SaveVersions(nil, []atc.Version{
 					{"ver": "1"},
 				})
 				Expect(err).ToNot(HaveOccurred())

--- a/atc/db/check.go
+++ b/atc/db/check.go
@@ -45,7 +45,7 @@ type Check interface {
 	Finish() error
 	FinishWithError(err error) error
 
-	SaveVersions([]atc.Version) error
+	SaveVersions(SpanContext, []atc.Version) error
 	AllCheckables() ([]Checkable, error)
 	AcquireTrackingLock(lager.Logger) (lock.Lock, bool, error)
 	Reload() (bool, error)
@@ -323,7 +323,7 @@ func (c *check) AllCheckables() ([]Checkable, error) {
 	return checkables, nil
 }
 
-func (c *check) SaveVersions(versions []atc.Version) error {
+func (c *check) SaveVersions(spanContext SpanContext, versions []atc.Version) error {
 	return saveVersions(c.conn, c.resourceConfigScopeID, versions)
 }
 

--- a/atc/db/check.go
+++ b/atc/db/check.go
@@ -324,7 +324,7 @@ func (c *check) AllCheckables() ([]Checkable, error) {
 }
 
 func (c *check) SaveVersions(spanContext SpanContext, versions []atc.Version) error {
-	return saveVersions(c.conn, c.resourceConfigScopeID, versions)
+	return saveVersions(c.conn, c.resourceConfigScopeID, versions, spanContext)
 }
 
 func (c *check) SpanContext() propagators.Supplier {

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -235,7 +235,7 @@ var _ = Describe("CheckFactory", func() {
 								Context("when fetching the latest version returns a version", func() {
 
 									BeforeEach(func() {
-										err = resourceConfigScope.SaveVersions([]atc.Version{{"some": "version"}})
+										err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"some": "version"}})
 										Expect(err).NotTo(HaveOccurred())
 									})
 

--- a/atc/db/check_test.go
+++ b/atc/db/check_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Check", func() {
 
 	Describe("SaveVersions", func() {
 		JustBeforeEach(func() {
-			err = check.SaveVersions([]atc.Version{{"some": "version"}})
+			err = check.SaveVersions(nil, []atc.Version{{"some": "version"}})
 		})
 
 		It("succeeds", func() {

--- a/atc/db/check_test.go
+++ b/atc/db/check_test.go
@@ -229,11 +229,11 @@ var _ = Describe("Check", func() {
 		})
 
 		It("does not update span context for pre-existing versions", func() {
-			err := check.SaveVersions(
+			check.SaveVersions(
 				map[string]string{"new": "span"},
 				[]atc.Version{{"some": "version"}},
 			)
-			version, _, err := resourceConfigScope.LatestVersion()
+			version, _, _ := resourceConfigScope.LatestVersion()
 			Expect(version.SpanContext()).To(HaveKeyWithValue("fake", Equal("span")))
 		})
 	})

--- a/atc/db/dbfakes/fake_build.go
+++ b/atc/db/dbfakes/fake_build.go
@@ -10,6 +10,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/lock"
+	"go.opentelemetry.io/otel/api/propagators"
 )
 
 type FakeBuild struct {
@@ -509,6 +510,16 @@ type FakeBuild struct {
 	}
 	setInterceptibleReturnsOnCall map[int]struct {
 		result1 error
+	}
+	SpanContextStub        func() propagators.Supplier
+	spanContextMutex       sync.RWMutex
+	spanContextArgsForCall []struct {
+	}
+	spanContextReturns struct {
+		result1 propagators.Supplier
+	}
+	spanContextReturnsOnCall map[int]struct {
+		result1 propagators.Supplier
 	}
 	StartStub        func(atc.Plan) (bool, error)
 	startMutex       sync.RWMutex
@@ -3002,6 +3013,58 @@ func (fake *FakeBuild) SetInterceptibleReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeBuild) SpanContext() propagators.Supplier {
+	fake.spanContextMutex.Lock()
+	ret, specificReturn := fake.spanContextReturnsOnCall[len(fake.spanContextArgsForCall)]
+	fake.spanContextArgsForCall = append(fake.spanContextArgsForCall, struct {
+	}{})
+	fake.recordInvocation("SpanContext", []interface{}{})
+	fake.spanContextMutex.Unlock()
+	if fake.SpanContextStub != nil {
+		return fake.SpanContextStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.spanContextReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeBuild) SpanContextCallCount() int {
+	fake.spanContextMutex.RLock()
+	defer fake.spanContextMutex.RUnlock()
+	return len(fake.spanContextArgsForCall)
+}
+
+func (fake *FakeBuild) SpanContextCalls(stub func() propagators.Supplier) {
+	fake.spanContextMutex.Lock()
+	defer fake.spanContextMutex.Unlock()
+	fake.SpanContextStub = stub
+}
+
+func (fake *FakeBuild) SpanContextReturns(result1 propagators.Supplier) {
+	fake.spanContextMutex.Lock()
+	defer fake.spanContextMutex.Unlock()
+	fake.SpanContextStub = nil
+	fake.spanContextReturns = struct {
+		result1 propagators.Supplier
+	}{result1}
+}
+
+func (fake *FakeBuild) SpanContextReturnsOnCall(i int, result1 propagators.Supplier) {
+	fake.spanContextMutex.Lock()
+	defer fake.spanContextMutex.Unlock()
+	fake.SpanContextStub = nil
+	if fake.spanContextReturnsOnCall == nil {
+		fake.spanContextReturnsOnCall = make(map[int]struct {
+			result1 propagators.Supplier
+		})
+	}
+	fake.spanContextReturnsOnCall[i] = struct {
+		result1 propagators.Supplier
+	}{result1}
+}
+
 func (fake *FakeBuild) Start(arg1 atc.Plan) (bool, error) {
 	fake.startMutex.Lock()
 	ret, specificReturn := fake.startReturnsOnCall[len(fake.startArgsForCall)]
@@ -3364,6 +3427,8 @@ func (fake *FakeBuild) Invocations() map[string][][]interface{} {
 	defer fake.setDrainedMutex.RUnlock()
 	fake.setInterceptibleMutex.RLock()
 	defer fake.setInterceptibleMutex.RUnlock()
+	fake.spanContextMutex.RLock()
+	defer fake.spanContextMutex.RUnlock()
 	fake.startMutex.RLock()
 	defer fake.startMutex.RUnlock()
 	fake.startTimeMutex.RLock()

--- a/atc/db/dbfakes/fake_check.go
+++ b/atc/db/dbfakes/fake_check.go
@@ -187,10 +187,11 @@ type FakeCheck struct {
 	resourceConfigScopeIDReturnsOnCall map[int]struct {
 		result1 int
 	}
-	SaveVersionsStub        func([]atc.Version) error
+	SaveVersionsStub        func(db.SpanContext, []atc.Version) error
 	saveVersionsMutex       sync.RWMutex
 	saveVersionsArgsForCall []struct {
-		arg1 []atc.Version
+		arg1 db.SpanContext
+		arg2 []atc.Version
 	}
 	saveVersionsReturns struct {
 		result1 error
@@ -1138,21 +1139,22 @@ func (fake *FakeCheck) ResourceConfigScopeIDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeCheck) SaveVersions(arg1 []atc.Version) error {
-	var arg1Copy []atc.Version
-	if arg1 != nil {
-		arg1Copy = make([]atc.Version, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *FakeCheck) SaveVersions(arg1 db.SpanContext, arg2 []atc.Version) error {
+	var arg2Copy []atc.Version
+	if arg2 != nil {
+		arg2Copy = make([]atc.Version, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.saveVersionsMutex.Lock()
 	ret, specificReturn := fake.saveVersionsReturnsOnCall[len(fake.saveVersionsArgsForCall)]
 	fake.saveVersionsArgsForCall = append(fake.saveVersionsArgsForCall, struct {
-		arg1 []atc.Version
-	}{arg1Copy})
-	fake.recordInvocation("SaveVersions", []interface{}{arg1Copy})
+		arg1 db.SpanContext
+		arg2 []atc.Version
+	}{arg1, arg2Copy})
+	fake.recordInvocation("SaveVersions", []interface{}{arg1, arg2Copy})
 	fake.saveVersionsMutex.Unlock()
 	if fake.SaveVersionsStub != nil {
-		return fake.SaveVersionsStub(arg1)
+		return fake.SaveVersionsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -1167,17 +1169,17 @@ func (fake *FakeCheck) SaveVersionsCallCount() int {
 	return len(fake.saveVersionsArgsForCall)
 }
 
-func (fake *FakeCheck) SaveVersionsCalls(stub func([]atc.Version) error) {
+func (fake *FakeCheck) SaveVersionsCalls(stub func(db.SpanContext, []atc.Version) error) {
 	fake.saveVersionsMutex.Lock()
 	defer fake.saveVersionsMutex.Unlock()
 	fake.SaveVersionsStub = stub
 }
 
-func (fake *FakeCheck) SaveVersionsArgsForCall(i int) []atc.Version {
+func (fake *FakeCheck) SaveVersionsArgsForCall(i int) (db.SpanContext, []atc.Version) {
 	fake.saveVersionsMutex.RLock()
 	defer fake.saveVersionsMutex.RUnlock()
 	argsForCall := fake.saveVersionsArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeCheck) SaveVersionsReturns(result1 error) {

--- a/atc/db/dbfakes/fake_job.go
+++ b/atc/db/dbfakes/fake_job.go
@@ -2,6 +2,7 @@
 package dbfakes
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -132,9 +133,10 @@ type FakeJob struct {
 	disableManualTriggerReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	EnsurePendingBuildExistsStub        func() error
+	EnsurePendingBuildExistsStub        func(context.Context) error
 	ensurePendingBuildExistsMutex       sync.RWMutex
 	ensurePendingBuildExistsArgsForCall []struct {
+		arg1 context.Context
 	}
 	ensurePendingBuildExistsReturns struct {
 		result1 error
@@ -1024,15 +1026,16 @@ func (fake *FakeJob) DisableManualTriggerReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
-func (fake *FakeJob) EnsurePendingBuildExists() error {
+func (fake *FakeJob) EnsurePendingBuildExists(arg1 context.Context) error {
 	fake.ensurePendingBuildExistsMutex.Lock()
 	ret, specificReturn := fake.ensurePendingBuildExistsReturnsOnCall[len(fake.ensurePendingBuildExistsArgsForCall)]
 	fake.ensurePendingBuildExistsArgsForCall = append(fake.ensurePendingBuildExistsArgsForCall, struct {
-	}{})
-	fake.recordInvocation("EnsurePendingBuildExists", []interface{}{})
+		arg1 context.Context
+	}{arg1})
+	fake.recordInvocation("EnsurePendingBuildExists", []interface{}{arg1})
 	fake.ensurePendingBuildExistsMutex.Unlock()
 	if fake.EnsurePendingBuildExistsStub != nil {
-		return fake.EnsurePendingBuildExistsStub()
+		return fake.EnsurePendingBuildExistsStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -1047,10 +1050,17 @@ func (fake *FakeJob) EnsurePendingBuildExistsCallCount() int {
 	return len(fake.ensurePendingBuildExistsArgsForCall)
 }
 
-func (fake *FakeJob) EnsurePendingBuildExistsCalls(stub func() error) {
+func (fake *FakeJob) EnsurePendingBuildExistsCalls(stub func(context.Context) error) {
 	fake.ensurePendingBuildExistsMutex.Lock()
 	defer fake.ensurePendingBuildExistsMutex.Unlock()
 	fake.EnsurePendingBuildExistsStub = stub
+}
+
+func (fake *FakeJob) EnsurePendingBuildExistsArgsForCall(i int) context.Context {
+	fake.ensurePendingBuildExistsMutex.RLock()
+	defer fake.ensurePendingBuildExistsMutex.RUnlock()
+	argsForCall := fake.ensurePendingBuildExistsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeJob) EnsurePendingBuildExistsReturns(result1 error) {

--- a/atc/db/dbfakes/fake_resource_config_scope.go
+++ b/atc/db/dbfakes/fake_resource_config_scope.go
@@ -96,10 +96,11 @@ type FakeResourceConfigScope struct {
 	resourceConfigReturnsOnCall map[int]struct {
 		result1 db.ResourceConfig
 	}
-	SaveVersionsStub        func([]atc.Version) error
+	SaveVersionsStub        func(db.SpanContext, []atc.Version) error
 	saveVersionsMutex       sync.RWMutex
 	saveVersionsArgsForCall []struct {
-		arg1 []atc.Version
+		arg1 db.SpanContext
+		arg2 []atc.Version
 	}
 	saveVersionsReturns struct {
 		result1 error
@@ -546,21 +547,22 @@ func (fake *FakeResourceConfigScope) ResourceConfigReturnsOnCall(i int, result1 
 	}{result1}
 }
 
-func (fake *FakeResourceConfigScope) SaveVersions(arg1 []atc.Version) error {
-	var arg1Copy []atc.Version
-	if arg1 != nil {
-		arg1Copy = make([]atc.Version, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *FakeResourceConfigScope) SaveVersions(arg1 db.SpanContext, arg2 []atc.Version) error {
+	var arg2Copy []atc.Version
+	if arg2 != nil {
+		arg2Copy = make([]atc.Version, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.saveVersionsMutex.Lock()
 	ret, specificReturn := fake.saveVersionsReturnsOnCall[len(fake.saveVersionsArgsForCall)]
 	fake.saveVersionsArgsForCall = append(fake.saveVersionsArgsForCall, struct {
-		arg1 []atc.Version
-	}{arg1Copy})
-	fake.recordInvocation("SaveVersions", []interface{}{arg1Copy})
+		arg1 db.SpanContext
+		arg2 []atc.Version
+	}{arg1, arg2Copy})
+	fake.recordInvocation("SaveVersions", []interface{}{arg1, arg2Copy})
 	fake.saveVersionsMutex.Unlock()
 	if fake.SaveVersionsStub != nil {
-		return fake.SaveVersionsStub(arg1)
+		return fake.SaveVersionsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -575,17 +577,17 @@ func (fake *FakeResourceConfigScope) SaveVersionsCallCount() int {
 	return len(fake.saveVersionsArgsForCall)
 }
 
-func (fake *FakeResourceConfigScope) SaveVersionsCalls(stub func([]atc.Version) error) {
+func (fake *FakeResourceConfigScope) SaveVersionsCalls(stub func(db.SpanContext, []atc.Version) error) {
 	fake.saveVersionsMutex.Lock()
 	defer fake.saveVersionsMutex.Unlock()
 	fake.SaveVersionsStub = stub
 }
 
-func (fake *FakeResourceConfigScope) SaveVersionsArgsForCall(i int) []atc.Version {
+func (fake *FakeResourceConfigScope) SaveVersionsArgsForCall(i int) (db.SpanContext, []atc.Version) {
 	fake.saveVersionsMutex.RLock()
 	defer fake.saveVersionsMutex.RUnlock()
 	argsForCall := fake.saveVersionsArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeResourceConfigScope) SaveVersionsReturns(result1 error) {

--- a/atc/db/dbfakes/fake_resource_config_version.go
+++ b/atc/db/dbfakes/fake_resource_config_version.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/concourse/concourse/atc/db"
+	"go.opentelemetry.io/otel/api/propagators"
 )
 
 type FakeResourceConfigVersion struct {
@@ -59,6 +60,16 @@ type FakeResourceConfigVersion struct {
 	}
 	resourceConfigScopeReturnsOnCall map[int]struct {
 		result1 db.ResourceConfigScope
+	}
+	SpanContextStub        func() propagators.Supplier
+	spanContextMutex       sync.RWMutex
+	spanContextArgsForCall []struct {
+	}
+	spanContextReturns struct {
+		result1 propagators.Supplier
+	}
+	spanContextReturnsOnCall map[int]struct {
+		result1 propagators.Supplier
 	}
 	VersionStub        func() db.Version
 	versionMutex       sync.RWMutex
@@ -337,6 +348,58 @@ func (fake *FakeResourceConfigVersion) ResourceConfigScopeReturnsOnCall(i int, r
 	}{result1}
 }
 
+func (fake *FakeResourceConfigVersion) SpanContext() propagators.Supplier {
+	fake.spanContextMutex.Lock()
+	ret, specificReturn := fake.spanContextReturnsOnCall[len(fake.spanContextArgsForCall)]
+	fake.spanContextArgsForCall = append(fake.spanContextArgsForCall, struct {
+	}{})
+	fake.recordInvocation("SpanContext", []interface{}{})
+	fake.spanContextMutex.Unlock()
+	if fake.SpanContextStub != nil {
+		return fake.SpanContextStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.spanContextReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeResourceConfigVersion) SpanContextCallCount() int {
+	fake.spanContextMutex.RLock()
+	defer fake.spanContextMutex.RUnlock()
+	return len(fake.spanContextArgsForCall)
+}
+
+func (fake *FakeResourceConfigVersion) SpanContextCalls(stub func() propagators.Supplier) {
+	fake.spanContextMutex.Lock()
+	defer fake.spanContextMutex.Unlock()
+	fake.SpanContextStub = stub
+}
+
+func (fake *FakeResourceConfigVersion) SpanContextReturns(result1 propagators.Supplier) {
+	fake.spanContextMutex.Lock()
+	defer fake.spanContextMutex.Unlock()
+	fake.SpanContextStub = nil
+	fake.spanContextReturns = struct {
+		result1 propagators.Supplier
+	}{result1}
+}
+
+func (fake *FakeResourceConfigVersion) SpanContextReturnsOnCall(i int, result1 propagators.Supplier) {
+	fake.spanContextMutex.Lock()
+	defer fake.spanContextMutex.Unlock()
+	fake.SpanContextStub = nil
+	if fake.spanContextReturnsOnCall == nil {
+		fake.spanContextReturnsOnCall = make(map[int]struct {
+			result1 propagators.Supplier
+		})
+	}
+	fake.spanContextReturnsOnCall[i] = struct {
+		result1 propagators.Supplier
+	}{result1}
+}
+
 func (fake *FakeResourceConfigVersion) Version() db.Version {
 	fake.versionMutex.Lock()
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
@@ -402,6 +465,8 @@ func (fake *FakeResourceConfigVersion) Invocations() map[string][][]interface{} 
 	defer fake.reloadMutex.RUnlock()
 	fake.resourceConfigScopeMutex.RLock()
 	defer fake.resourceConfigScopeMutex.RUnlock()
+	fake.spanContextMutex.RLock()
+	defer fake.spanContextMutex.RUnlock()
 	fake.versionMutex.RLock()
 	defer fake.versionMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -1239,6 +1239,7 @@ var _ = Describe("Job", func() {
 			job                 db.Job
 			resourceConfigScope db.ResourceConfigScope
 			resource            db.Resource
+			spanContext         db.SpanContext
 		)
 
 		BeforeEach(func() {
@@ -1307,11 +1308,15 @@ var _ = Describe("Job", func() {
 			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = resourceConfigScope.SaveVersions([]atc.Version{
-				{"version": "v1"},
-				{"version": "v2"},
-				{"version": "v3"},
-			})
+			spanContext = db.SpanContext{"fake": "version"}
+			err = resourceConfigScope.SaveVersions(
+				spanContext,
+				[]atc.Version{
+					{"version": "v1"},
+					{"version": "v2"},
+					{"version": "v3"},
+				},
+			)
 			Expect(err).NotTo(HaveOccurred())
 
 			reversions, _, found, err := resource.Versions(db.Page{Limit: 3}, nil)
@@ -1388,18 +1393,21 @@ var _ = Describe("Job", func() {
 						ResourceID:      resource.ID(),
 						Version:         atc.Version{"version": "v1"},
 						FirstOccurrence: false,
+						SpanContext:     spanContext,
 					},
 					{
 						Name:            "some-input-2",
 						ResourceID:      resource.ID(),
 						Version:         atc.Version{"version": "v2"},
 						FirstOccurrence: false,
+						SpanContext:     spanContext,
 					},
 					{
 						Name:            "some-input-3",
 						ResourceID:      resource.ID(),
 						Version:         atc.Version{"version": "v3"},
 						FirstOccurrence: false,
+						SpanContext:     spanContext,
 					},
 				}
 
@@ -1446,7 +1454,7 @@ var _ = Describe("Job", func() {
 			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = resourceConfigScope.SaveVersions([]atc.Version{
+			err = resourceConfigScope.SaveVersions(nil, []atc.Version{
 				{"version": "v1"},
 				{"version": "v2"},
 				{"version": "v3"},
@@ -2255,7 +2263,7 @@ var _ = Describe("Job", func() {
 					resourceConfigScope, err := pinnedResource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
 					Expect(err).ToNot(HaveOccurred())
 
-					err = resourceConfigScope.SaveVersions([]atc.Version{
+					err = resourceConfigScope.SaveVersions(nil, []atc.Version{
 						{"api": "pinned"},
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -2382,7 +2390,7 @@ var _ = Describe("Job", func() {
 				resourceConfigScope, err := pinnedResource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = resourceConfigScope.SaveVersions([]atc.Version{
+				err = resourceConfigScope.SaveVersions(nil, []atc.Version{
 					{"some": "version"},
 				})
 				Expect(err).NotTo(HaveOccurred())

--- a/atc/db/migration/migrations/1590417946_add_span_context_to_resource_config_versions.down.sql
+++ b/atc/db/migration/migrations/1590417946_add_span_context_to_resource_config_versions.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE resource_config_versions DROP COLUMN span_context;
+COMMIT;

--- a/atc/db/migration/migrations/1590417946_add_span_context_to_resource_config_versions.up.sql
+++ b/atc/db/migration/migrations/1590417946_add_span_context_to_resource_config_versions.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE resource_config_versions ADD COLUMN span_context jsonb;
+COMMIT;

--- a/atc/db/migration/migrations/1590517222_add_span_context_to_builds.down.sql
+++ b/atc/db/migration/migrations/1590517222_add_span_context_to_builds.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE builds DROP COLUMN span_context;
+COMMIT;

--- a/atc/db/migration/migrations/1590517222_add_span_context_to_builds.up.sql
+++ b/atc/db/migration/migrations/1590517222_add_span_context_to_builds.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE builds ADD COLUMN span_context jsonb;
+COMMIT;

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -707,14 +707,14 @@ var _ = Describe("Pipeline", func() {
 				Expect(found).To(BeFalse())
 
 				By("including saved versioned resources of the current pipeline")
-				err = resourceConfigScope.SaveVersions([]atc.Version{atc.Version{"version": "1"}})
+				err = resourceConfigScope.SaveVersions(nil, []atc.Version{atc.Version{"version": "1"}})
 				Expect(err).ToNot(HaveOccurred())
 
 				savedVR1, found, err := resourceConfigScope.LatestVersion()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 
-				err = resourceConfigScope.SaveVersions([]atc.Version{atc.Version{"version": "2"}})
+				err = resourceConfigScope.SaveVersions(nil, []atc.Version{atc.Version{"version": "2"}})
 				Expect(err).ToNot(HaveOccurred())
 
 				savedVR2, found, err := resourceConfigScope.LatestVersion()
@@ -759,7 +759,7 @@ var _ = Describe("Pipeline", func() {
 				}))
 
 				By("not including saved versioned resources of other pipelines")
-				err = otherPipelineResourceConfigScope.SaveVersions([]atc.Version{atc.Version{"version": "1"}})
+				err = otherPipelineResourceConfigScope.SaveVersions(nil, []atc.Version{atc.Version{"version": "1"}})
 				Expect(err).ToNot(HaveOccurred())
 
 				_, found, err = otherPipelineResourceConfigScope.LatestVersion()
@@ -1072,14 +1072,14 @@ var _ = Describe("Pipeline", func() {
 			Expect(found).To(BeFalse())
 
 			By("including saved versioned resources of the current pipeline")
-			err = resourceConfigScope.SaveVersions([]atc.Version{{"version": "1"}})
+			err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "1"}})
 			Expect(err).ToNot(HaveOccurred())
 
 			savedVR1, found, err := resourceConfigScope.LatestVersion()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			err = resourceConfigScope.SaveVersions([]atc.Version{{"version": "2"}})
+			err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "2"}})
 			Expect(err).ToNot(HaveOccurred())
 
 			savedVR2, found, err := resourceConfigScope.LatestVersion()
@@ -1093,7 +1093,7 @@ var _ = Describe("Pipeline", func() {
 			_, _, err = otherDBPipeline.Resource("some-other-resource")
 			Expect(err).ToNot(HaveOccurred())
 
-			err = otherPipelineResourceConfigScope.SaveVersions([]atc.Version{{"version": "1"}, {"version": "2"}, {"version": "3"}})
+			err = otherPipelineResourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "1"}, {"version": "2"}, {"version": "3"}})
 			Expect(err).ToNot(HaveOccurred())
 
 			otherPipelineSavedVR, found, err := otherPipelineResourceConfigScope.LatestVersion()
@@ -1137,7 +1137,7 @@ var _ = Describe("Pipeline", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("populating resource versions")
-			err = resourceConfigScope.SaveVersions([]atc.Version{
+			err = resourceConfigScope.SaveVersions(nil, []atc.Version{
 				{
 					"key": "value",
 				},
@@ -1504,7 +1504,7 @@ var _ = Describe("Pipeline", func() {
 			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = resourceConfigScope.SaveVersions([]atc.Version{atc.Version{"version": "v1"}})
+			err = resourceConfigScope.SaveVersions(nil, []atc.Version{atc.Version{"version": "v1"}})
 			Expect(err).ToNot(HaveOccurred())
 
 			err = job.SaveNextInputMapping(db.InputMapping{
@@ -1528,7 +1528,7 @@ var _ = Describe("Pipeline", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			err = resourceConfigScope.SaveVersions([]atc.Version{
+			err = resourceConfigScope.SaveVersions(nil, []atc.Version{
 				{"version": "v2"},
 				{"version": "v3"},
 				{"version": "v4"},
@@ -1656,7 +1656,7 @@ var _ = Describe("Pipeline", func() {
 			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = resourceConfigScope.SaveVersions([]atc.Version{
+			err = resourceConfigScope.SaveVersions(nil, []atc.Version{
 				{"version": "v3"},
 				{"version": "v4"},
 			})
@@ -1864,7 +1864,7 @@ var _ = Describe("Pipeline", func() {
 			resourceTypeScope, err := resourceType.SetResourceConfig(atc.Source{"some": "type-source"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = resourceTypeScope.SaveVersions([]atc.Version{
+			err = resourceTypeScope.SaveVersions(nil, []atc.Version{
 				atc.Version{"version": "1"},
 				atc.Version{"version": "2"},
 			})
@@ -1873,12 +1873,12 @@ var _ = Describe("Pipeline", func() {
 			otherResourceTypeScope, err := otherResourceType.SetResourceConfig(atc.Source{"some": "other-type-source"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = otherResourceTypeScope.SaveVersions([]atc.Version{
+			err = otherResourceTypeScope.SaveVersions(nil, []atc.Version{
 				atc.Version{"version": "3"},
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = otherResourceTypeScope.SaveVersions([]atc.Version{
+			err = otherResourceTypeScope.SaveVersions(nil, []atc.Version{
 				atc.Version{"version": "3"},
 				atc.Version{"version": "5"},
 			})
@@ -1916,7 +1916,7 @@ var _ = Describe("Pipeline", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			version := atc.Version{"version": "1"}
-			err = resourceConfig.SaveVersions([]atc.Version{
+			err = resourceConfig.SaveVersions(nil, []atc.Version{
 				version,
 			})
 			Expect(err).ToNot(HaveOccurred())

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -307,7 +307,7 @@ func (r *resource) SaveUncheckedVersion(version atc.Version, metadata ResourceCo
 		return false, err
 	}
 
-	newVersion, err := saveResourceVersion(tx, resourceConfigScope.ID(), version, metadata)
+	newVersion, err := saveResourceVersion(tx, resourceConfigScope.ID(), version, metadata, nil)
 	if err != nil {
 		return false, err
 	}

--- a/atc/db/resource_cache_lifecycle_test.go
+++ b/atc/db/resource_cache_lifecycle_test.go
@@ -358,7 +358,7 @@ var _ = Describe("ResourceCacheLifecycle", func() {
 
 				_ = createResourceCacheWithUser(db.ForContainer(container.ID()))
 
-				err = resourceConfigScope.SaveVersions([]atc.Version{{"some": "version"}})
+				err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"some": "version"}})
 				Expect(err).ToNot(HaveOccurred())
 
 				resourceConfigVersion, found, err := resourceConfigScope.FindVersion(atc.Version{"some": "version"})

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -26,7 +26,7 @@ type ResourceConfigScope interface {
 	ResourceConfig() ResourceConfig
 	CheckError() error
 
-	SaveVersions(versions []atc.Version) error
+	SaveVersions(SpanContext, []atc.Version) error
 	FindVersion(atc.Version) (ResourceConfigVersion, bool, error)
 	LatestVersion() (ResourceConfigVersion, bool, error)
 
@@ -66,8 +66,8 @@ func (r *resourceConfigScope) CheckError() error              { return r.checkEr
 // In the case of a check resource from an older version, the versions
 // that already exist in the DB will be re-ordered using
 // incrementCheckOrder to input the correct check order
-func (r *resourceConfigScope) SaveVersions(versions []atc.Version) error {
-	return saveVersions(r.conn, r.ID(), versions, nil)
+func (r *resourceConfigScope) SaveVersions(spanContext SpanContext, versions []atc.Version) error {
+	return saveVersions(r.conn, r.ID(), versions, spanContext)
 }
 
 func saveVersions(conn Conn, rcsID int, versions []atc.Version, spanContext SpanContext) error {

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Resource Config Scope", func() {
 
 		// XXX: Can make test more resilient if there is a method that gives all versions by descending check order
 		It("ensures versioned resources have the correct check_order", func() {
-			err := resourceScope.SaveVersions(originalVersionSlice)
+			err := resourceScope.SaveVersions(nil, originalVersionSlice)
 			Expect(err).ToNot(HaveOccurred())
 
 			latestVR, found, err := resourceScope.LatestVersion()
@@ -100,7 +100,7 @@ var _ = Describe("Resource Config Scope", func() {
 				{"ref": "v3"},
 			}
 
-			err = resourceScope.SaveVersions(pretendCheckResults)
+			err = resourceScope.SaveVersions(nil, pretendCheckResults)
 			Expect(err).ToNot(HaveOccurred())
 
 			latestVR, found, err = resourceScope.LatestVersion()
@@ -120,7 +120,7 @@ var _ = Describe("Resource Config Scope", func() {
 					{"ref": "v3"},
 				}
 
-				err := resourceScope.SaveVersions(originalVersionSlice)
+				err := resourceScope.SaveVersions(nil, originalVersionSlice)
 				Expect(err).ToNot(HaveOccurred())
 
 				latestVR, found, err := resourceScope.LatestVersion()
@@ -132,7 +132,7 @@ var _ = Describe("Resource Config Scope", func() {
 			})
 
 			It("does not change the check order", func() {
-				err := resourceScope.SaveVersions(newVersionSlice)
+				err := resourceScope.SaveVersions(nil, newVersionSlice)
 				Expect(err).ToNot(HaveOccurred())
 
 				latestVR, found, err := resourceScope.LatestVersion()
@@ -145,7 +145,7 @@ var _ = Describe("Resource Config Scope", func() {
 
 			Context("when a new version is added", func() {
 				It("requests schedule on the jobs that use the resource", func() {
-					err := resourceScope.SaveVersions(originalVersionSlice)
+					err := resourceScope.SaveVersions(nil, originalVersionSlice)
 					Expect(err).ToNot(HaveOccurred())
 
 					job, found, err := pipeline.Job("some-job")
@@ -158,7 +158,7 @@ var _ = Describe("Resource Config Scope", func() {
 						{"ref": "v0"},
 						{"ref": "v3"},
 					}
-					err = resourceScope.SaveVersions(newVersions)
+					err = resourceScope.SaveVersions(nil, newVersions)
 					Expect(err).ToNot(HaveOccurred())
 
 					found, err = job.Reload()
@@ -169,7 +169,7 @@ var _ = Describe("Resource Config Scope", func() {
 				})
 
 				It("does not request schedule on the jobs that use the resource but through passed constraints", func() {
-					err := resourceScope.SaveVersions(originalVersionSlice)
+					err := resourceScope.SaveVersions(nil, originalVersionSlice)
 					Expect(err).ToNot(HaveOccurred())
 
 					job, found, err := pipeline.Job("downstream-job")
@@ -182,7 +182,7 @@ var _ = Describe("Resource Config Scope", func() {
 						{"ref": "v0"},
 						{"ref": "v3"},
 					}
-					err = resourceScope.SaveVersions(newVersions)
+					err = resourceScope.SaveVersions(nil, newVersions)
 					Expect(err).ToNot(HaveOccurred())
 
 					found, err = job.Reload()
@@ -193,7 +193,7 @@ var _ = Describe("Resource Config Scope", func() {
 				})
 
 				It("does not request schedule on the jobs that do not use the resource", func() {
-					err := resourceScope.SaveVersions(originalVersionSlice)
+					err := resourceScope.SaveVersions(nil, originalVersionSlice)
 					Expect(err).ToNot(HaveOccurred())
 
 					job, found, err := pipeline.Job("some-other-job")
@@ -206,7 +206,7 @@ var _ = Describe("Resource Config Scope", func() {
 						{"ref": "v0"},
 						{"ref": "v3"},
 					}
-					err = resourceScope.SaveVersions(newVersions)
+					err = resourceScope.SaveVersions(nil, newVersions)
 					Expect(err).ToNot(HaveOccurred())
 
 					found, err = job.Reload()
@@ -229,7 +229,7 @@ var _ = Describe("Resource Config Scope", func() {
 					{"ref": "v3"},
 				}
 
-				err := resourceScope.SaveVersions(originalVersionSlice)
+				err := resourceScope.SaveVersions(nil, originalVersionSlice)
 				Expect(err).ToNot(HaveOccurred())
 
 				var found bool
@@ -244,7 +244,7 @@ var _ = Describe("Resource Config Scope", func() {
 			})
 
 			It("disabled versions do not affect fetching the latest version", func() {
-				err := resourceScope.SaveVersions([]atc.Version{{"version": "1"}})
+				err := resourceScope.SaveVersions(nil, []atc.Version{{"version": "1"}})
 				Expect(err).ToNot(HaveOccurred())
 
 				savedRCV, found, err := resourceScope.LatestVersion()
@@ -271,7 +271,7 @@ var _ = Describe("Resource Config Scope", func() {
 			})
 
 			It("saving versioned resources updates the latest versioned resource", func() {
-				err := resourceScope.SaveVersions([]atc.Version{{"ref": "4"}, {"ref": "5"}})
+				err := resourceScope.SaveVersions(nil, []atc.Version{{"ref": "4"}, {"ref": "5"}})
 				Expect(err).ToNot(HaveOccurred())
 
 				savedVR, found, err := resourceScope.LatestVersion()
@@ -290,7 +290,7 @@ var _ = Describe("Resource Config Scope", func() {
 				{"ref": "v3"},
 			}
 
-			err := resourceScope.SaveVersions(originalVersionSlice)
+			err := resourceScope.SaveVersions(nil, originalVersionSlice)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Resource", func() {
 			resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
 			Expect(err).NotTo(HaveOccurred())
 
-			err = resourceScope.SaveVersions([]atc.Version{
+			err = resourceScope.SaveVersions(nil, []atc.Version{
 				{"disabled": "version"},
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -876,7 +876,7 @@ var _ = Describe("Resource", func() {
 				resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = resourceScope.SaveVersions([]atc.Version{version})
+				err = resourceScope.SaveVersions(nil, []atc.Version{version})
 				Expect(err).ToNot(HaveOccurred())
 
 				var found bool
@@ -1003,7 +1003,7 @@ var _ = Describe("Resource", func() {
 					{"ref": "v2", "commit": "v2"},
 				}
 
-				err = resourceScope.SaveVersions(originalVersionSlice)
+				err = resourceScope.SaveVersions(nil, originalVersionSlice)
 				Expect(err).ToNot(HaveOccurred())
 
 				resourceVersions = make([]atc.ResourceVersion, 0)
@@ -1124,7 +1124,7 @@ var _ = Describe("Resource", func() {
 					{"ref": "v9"},
 				}
 
-				err = resourceScope.SaveVersions(originalVersionSlice)
+				err = resourceScope.SaveVersions(nil, originalVersionSlice)
 				Expect(err).ToNot(HaveOccurred())
 
 				resourceVersions = make([]atc.ResourceVersion, 0)
@@ -1242,7 +1242,7 @@ var _ = Describe("Resource", func() {
 					resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
 					Expect(err).ToNot(HaveOccurred())
 
-					err = resourceScope.SaveVersions([]atc.Version{resourceVersions[9].Version})
+					err = resourceScope.SaveVersions(nil, []atc.Version{resourceVersions[9].Version})
 					Expect(err).ToNot(HaveOccurred())
 
 					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, atc.Version{})
@@ -1333,7 +1333,7 @@ var _ = Describe("Resource", func() {
 					{"ref": "v4"}, // id: 3, check_order: 3
 				}
 
-				err = resourceScope.SaveVersions(originalVersionSlice)
+				err = resourceScope.SaveVersions(nil, originalVersionSlice)
 				Expect(err).ToNot(HaveOccurred())
 
 				secondVersionSlice := []atc.Version{
@@ -1342,7 +1342,7 @@ var _ = Describe("Resource", func() {
 					{"ref": "v4"}, // id: 3, check_order: 6
 				}
 
-				err = resourceScope.SaveVersions(secondVersionSlice)
+				err = resourceScope.SaveVersions(nil, secondVersionSlice)
 				Expect(err).ToNot(HaveOccurred())
 
 				for i := 1; i < 5; i++ {
@@ -1503,7 +1503,7 @@ var _ = Describe("Resource", func() {
 			resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = resourceScope.SaveVersions([]atc.Version{
+			err = resourceScope.SaveVersions(nil, []atc.Version{
 				atc.Version{"version": "v1"},
 				atc.Version{"version": "v2"},
 				atc.Version{"version": "v3"},
@@ -1711,7 +1711,7 @@ var _ = Describe("Resource", func() {
 				resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
 				Expect(err).ToNot(HaveOccurred())
 
-				err = resourceScope.SaveVersions([]atc.Version{
+				err = resourceScope.SaveVersions(nil, []atc.Version{
 					atc.Version{"version": "v1"},
 					atc.Version{"version": "v2"},
 					atc.Version{"version": "v3"},

--- a/atc/db/resource_type_test.go
+++ b/atc/db/resource_type_test.go
@@ -371,7 +371,7 @@ var _ = Describe("ResourceType", func() {
 
 		Context("when the resource type has proper versions", func() {
 			BeforeEach(func() {
-				err := resourceTypeScope.SaveVersions([]atc.Version{
+				err := resourceTypeScope.SaveVersions(nil, []atc.Version{
 					atc.Version{"version": "1"},
 					atc.Version{"version": "2"},
 				})

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -1777,7 +1777,7 @@ var _ = Describe("Team", func() {
 			rc, err := resource.SetResourceConfig(atc.Source{"source-config": "some-value"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = rc.SaveVersions([]atc.Version{
+			err = rc.SaveVersions(nil, []atc.Version{
 				atc.Version{"version": "v1"},
 				atc.Version{"version": "v2"},
 			})
@@ -1858,7 +1858,7 @@ var _ = Describe("Team", func() {
 			rc, err := resource.SetResourceConfig(atc.Source{"source-config": "some-value"}, atc.VersionedResourceTypes{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = rc.SaveVersions([]atc.Version{
+			err = rc.SaveVersions(nil, []atc.Version{
 				atc.Version{"version": "v1"},
 				atc.Version{"version": "v2"},
 			})

--- a/atc/db/volume_test.go
+++ b/atc/db/volume_test.go
@@ -449,8 +449,8 @@ var _ = Describe("Volume", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			resourceConfigScope.SaveVersions([]atc.Version{atc.Version{"some": "version"}})
-			resourceConfigScope.SaveVersions([]atc.Version{atc.Version{"some-custom-type": "version"}})
+			resourceConfigScope.SaveVersions(nil, []atc.Version{atc.Version{"some": "version"}})
+			resourceConfigScope.SaveVersions(nil, []atc.Version{atc.Version{"some-custom-type": "version"}})
 
 			creatingContainer, err := defaultWorker.CreateContainer(db.NewBuildStepContainerOwner(build.ID(), "some-plan", defaultTeam.ID()), db.ContainerMetadata{
 				Type:     "get",

--- a/atc/engine/builder/delegate_factory.go
+++ b/atc/engine/builder/delegate_factory.go
@@ -316,8 +316,8 @@ type checkDelegate struct {
 	clock       clock.Clock
 }
 
-func (d *checkDelegate) SaveVersions(versions []atc.Version) error {
-	return d.check.SaveVersions(versions)
+func (d *checkDelegate) SaveVersions(spanContext db.SpanContext, versions []atc.Version) error {
+	return d.check.SaveVersions(spanContext, versions)
 }
 
 type discardCloser struct {

--- a/atc/engine/builder/delegate_factory_test.go
+++ b/atc/engine/builder/delegate_factory_test.go
@@ -306,12 +306,12 @@ var _ = Describe("DelegateFactory", func() {
 
 		Describe("SaveVersions", func() {
 			JustBeforeEach(func() {
-				Expect(delegate.SaveVersions(versions)).To(Succeed())
+				Expect(delegate.SaveVersions(nil, versions)).To(Succeed())
 			})
 
 			It("saves an event", func() {
 				Expect(fakeCheck.SaveVersionsCallCount()).To(Equal(1))
-				actualVersions := fakeCheck.SaveVersionsArgsForCall(0)
+				_, actualVersions := fakeCheck.SaveVersionsArgsForCall(0)
 				Expect(actualVersions).To(Equal(versions))
 			})
 		})

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -166,7 +166,7 @@ func (b *engineBuild) Run(ctx context.Context) {
 
 	defer notifier.Close()
 
-	ctx, span := tracing.StartSpan(ctx, "build", tracing.Attrs{
+	ctx, span := tracing.StartSpanFollowing(ctx, b.build, "build", tracing.Attrs{
 		"team":     b.build.TeamName(),
 		"pipeline": b.build.PipelineName(),
 		"job":      b.build.JobName(),

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -32,7 +32,7 @@ type CheckStep struct {
 type CheckDelegate interface {
 	BuildStepDelegate
 
-	SaveVersions([]atc.Version) error
+	SaveVersions(db.SpanContext, []atc.Version) error
 }
 
 func NewCheckStep(
@@ -136,7 +136,7 @@ func (step *CheckStep) Run(ctx context.Context, state RunState) error {
 		return fmt.Errorf("run check step: %w", err)
 	}
 
-	err = step.delegate.SaveVersions(result.Versions)
+	err = step.delegate.SaveVersions(db.NewSpanContext(ctx), result.Versions)
 	if err != nil {
 		return fmt.Errorf("save versions: %w", err)
 	}

--- a/atc/exec/execfakes/fake_check_delegate.go
+++ b/atc/exec/execfakes/fake_check_delegate.go
@@ -41,10 +41,11 @@ type FakeCheckDelegate struct {
 	initializingArgsForCall []struct {
 		arg1 lager.Logger
 	}
-	SaveVersionsStub        func([]atc.Version) error
+	SaveVersionsStub        func(db.SpanContext, []atc.Version) error
 	saveVersionsMutex       sync.RWMutex
 	saveVersionsArgsForCall []struct {
-		arg1 []atc.Version
+		arg1 db.SpanContext
+		arg2 []atc.Version
 	}
 	saveVersionsReturns struct {
 		result1 error
@@ -246,21 +247,22 @@ func (fake *FakeCheckDelegate) InitializingArgsForCall(i int) lager.Logger {
 	return argsForCall.arg1
 }
 
-func (fake *FakeCheckDelegate) SaveVersions(arg1 []atc.Version) error {
-	var arg1Copy []atc.Version
-	if arg1 != nil {
-		arg1Copy = make([]atc.Version, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *FakeCheckDelegate) SaveVersions(arg1 db.SpanContext, arg2 []atc.Version) error {
+	var arg2Copy []atc.Version
+	if arg2 != nil {
+		arg2Copy = make([]atc.Version, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.saveVersionsMutex.Lock()
 	ret, specificReturn := fake.saveVersionsReturnsOnCall[len(fake.saveVersionsArgsForCall)]
 	fake.saveVersionsArgsForCall = append(fake.saveVersionsArgsForCall, struct {
-		arg1 []atc.Version
-	}{arg1Copy})
-	fake.recordInvocation("SaveVersions", []interface{}{arg1Copy})
+		arg1 db.SpanContext
+		arg2 []atc.Version
+	}{arg1, arg2Copy})
+	fake.recordInvocation("SaveVersions", []interface{}{arg1, arg2Copy})
 	fake.saveVersionsMutex.Unlock()
 	if fake.SaveVersionsStub != nil {
-		return fake.SaveVersionsStub(arg1)
+		return fake.SaveVersionsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -275,17 +277,17 @@ func (fake *FakeCheckDelegate) SaveVersionsCallCount() int {
 	return len(fake.saveVersionsArgsForCall)
 }
 
-func (fake *FakeCheckDelegate) SaveVersionsCalls(stub func([]atc.Version) error) {
+func (fake *FakeCheckDelegate) SaveVersionsCalls(stub func(db.SpanContext, []atc.Version) error) {
 	fake.saveVersionsMutex.Lock()
 	defer fake.saveVersionsMutex.Unlock()
 	fake.SaveVersionsStub = stub
 }
 
-func (fake *FakeCheckDelegate) SaveVersionsArgsForCall(i int) []atc.Version {
+func (fake *FakeCheckDelegate) SaveVersionsArgsForCall(i int) (db.SpanContext, []atc.Version) {
 	fake.saveVersionsMutex.RLock()
 	defer fake.saveVersionsMutex.RUnlock()
 	argsForCall := fake.saveVersionsArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeCheckDelegate) SaveVersionsReturns(result1 error) {

--- a/atc/lidar/checker.go
+++ b/atc/lidar/checker.go
@@ -51,6 +51,7 @@ func (c *checker) Run(ctx context.Context) error {
 		if _, exists := c.running.LoadOrStore(ck.ID(), true); !exists {
 			go func(check db.Check) {
 				spanCtx, span := tracing.StartSpanFollowing(
+					ctx,
 					check,
 					"checker.Run",
 					tracing.Attrs{

--- a/atc/lidar/checker_test.go
+++ b/atc/lidar/checker_test.go
@@ -23,12 +23,6 @@ type Checker interface {
 	Run(context.Context) error
 }
 
-type testTraceProvider struct{}
-
-func (ttp *testTraceProvider) Tracer(name string) trace.Tracer {
-	return testtrace.NewTracer()
-}
-
 var _ = Describe("Checker", func() {
 	var (
 		err error
@@ -75,7 +69,7 @@ var _ = Describe("Checker", func() {
 			)
 
 			BeforeEach(func() {
-				tracing.ConfigureTraceProvider(&testTraceProvider{})
+				tracing.ConfigureTraceProvider(&tracing.TestTraceProvider{})
 				fakeCheck := new(dbfakes.FakeCheck)
 				fakeCheck.IDReturns(1)
 				var ctx context.Context

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -20,6 +20,10 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
  
 * @shyamz-22, @HannesHasselbring and @tenjaa added a metric for the amount of tasks that are currently waiting to be scheduled when using the `limit-active-tasks` placement strategy. #5448
 
+#### <sub><sup><a name="5659" href="#5659">:link:</a></sup></sub> feature
+
+* When [distributed tracing](https://concourse-ci.org/tracing.html) is configured, Concourse will now emit spans for several of its backend operations, including resource scanning, check execution, and job scheduling. These spans will be appropriately linked when viewed in a tracing tool like Jaeger, allowing operators to better observe the events that occur between resource checking and build execution. #5659
+
 #### <sub><sup><a name="5082" href="#5082">:link:</a></sup></sub> fix
 
 * Close Worker's registration connection to the TSA on application level keepalive failure

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/propagators"
@@ -13,10 +14,15 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-type TestTraceProvider struct{}
+type TestTraceProvider struct {
+	tracer *testtrace.Tracer
+}
 
 func (tp *TestTraceProvider) Tracer(name string) trace.Tracer {
-	return testtrace.NewTracer()
+	if tp.tracer == nil {
+		tp.tracer = testtrace.NewTracer()
+	}
+	return tp.tracer
 }
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 go.opentelemetry.io/otel/api/trace.Tracer
@@ -92,20 +98,7 @@ func StartSpan(
 	component string,
 	attrs Attrs,
 ) (context.Context, trace.Span) {
-	if !Configured {
-		return ctx, trace.NoopSpan{}
-	}
-
-	ctx, span := global.TraceProvider().Tracer("concourse").Start(
-		ctx,
-		component,
-	)
-
-	if len(attrs) != 0 {
-		span.SetAttributes(keyValueSlice(attrs)...)
-	}
-
-	return ctx, span
+	return startSpan(ctx, component, attrs)
 }
 
 func FromContext(ctx context.Context) trace.Span {
@@ -120,20 +113,66 @@ type WithSpanContext interface {
 	SpanContext() propagators.Supplier
 }
 
-func StartSpanFollowing(following WithSpanContext, component string, attrs Attrs) (context.Context, trace.Span) {
-	if !Configured {
-		return context.Background(), trace.NoopSpan{}
+func StartSpanFollowing(
+	ctx context.Context,
+	following WithSpanContext,
+	component string,
+	attrs Attrs,
+) (context.Context, trace.Span) {
+	supplier := following.SpanContext()
+	var spanContext core.SpanContext
+	if supplier == nil {
+		spanContext = core.EmptySpanContext()
+	} else {
+		spanContext, _ = propagators.TraceContext{}.Extract(
+			context.TODO(),
+			following.SpanContext(),
+		)
 	}
 
-	spanContext, _ := propagators.TraceContext{}.Extract(
+	return startSpan(
+		ctx,
+		component,
+		attrs,
+		trace.FollowsFrom(spanContext),
+	)
+}
+
+func StartSpanLinkedToFollowing(
+	linked context.Context,
+	following WithSpanContext,
+	component string,
+	attrs Attrs,
+) (context.Context, trace.Span) {
+	followingSpanContext, _ := propagators.TraceContext{}.Extract(
 		context.TODO(),
 		following.SpanContext(),
 	)
+	linkedSpanContext := trace.SpanFromContext(linked).SpanContext()
 
-	ctx, span := global.TraceProvider().Tracer("concourse").Start(
+	return startSpan(
 		context.Background(),
 		component,
-		trace.FollowsFrom(spanContext),
+		attrs,
+		trace.FollowsFrom(followingSpanContext),
+		trace.LinkedTo(linkedSpanContext),
+	)
+}
+
+func startSpan(
+	ctx context.Context,
+	component string,
+	attrs Attrs,
+	opts ...trace.StartOption,
+) (context.Context, trace.Span) {
+	if !Configured {
+		return ctx, trace.NoopSpan{}
+	}
+
+	ctx, span := global.TraceProvider().Tracer("concourse").Start(
+		ctx,
+		component,
+		opts...,
 	)
 
 	if len(attrs) != 0 {

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -7,10 +7,17 @@ import (
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/propagators"
 	"go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/api/trace/testtrace"
 	export "go.opentelemetry.io/otel/sdk/export/trace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/grpc/codes"
 )
+
+type TestTraceProvider struct{}
+
+func (tp *TestTraceProvider) Tracer(name string) trace.Tracer {
+	return testtrace.NewTracer()
+}
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 go.opentelemetry.io/otel/api/trace.Tracer
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 go.opentelemetry.io/otel/api/trace.Provider


### PR DESCRIPTION
Branched from #5666, please review it first.

# Why is this PR needed?

Adding tracing to these components will enable end-to-end observability of the lidar & scheduler
components, which will be helpful for debugging and large-scale timing/performance measurements.

# What is this PR trying to accomplish?

closes #5602.

# How does it accomplish that?

* adds `span_context` column to `resource_config_versions` table
* propagate the span context for a check into new versions (leaving old versions alone)
* adds `span_context` column to `builds` table
* link the span context for a build to the span contexts for each of the versions that _caused_ that build

# Contributor Checklist

- [x] Unit tests
- [x] ~Integration tests~
- [x] Updated documentation (located at https://github.com/concourse/docs) - concourse/docs#335
- [x] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

# Reviewer Checklist

- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~