### PR TITLE
topgun: behavior: fix concourse.worker.tsa.hosts

### DIFF
--- a/topgun/k8s/external_worker_test.go
+++ b/topgun/k8s/external_worker_test.go
@@ -37,7 +37,7 @@ var _ = Describe("external workers through separate deployments", func() {
 			"--set=postgresql.enabled=false",
 			"--set=web.enabled=false",
 			"--set=worker.replicas=1",
-			"--set=concourse.worker.tsa.hosts[0]="+releaseName+"-web-web."+releaseName+"-web.svc.cluster.local:"+tsaPort,
+			"--set=concourse.worker.tsa.hosts[0]="+releaseName+"-web-web-worker-gateway."+releaseName+"-web.svc.cluster.local:"+tsaPort,
 		)
 		deployConcourseChart(releaseName+"-worker", helmArgs...)
 


### PR DESCRIPTION
Fix the concourse.worker.tsa.hosts for
https://github.com/concourse/concourse-chart/pull/96

## What does this PR accomplish?
With pull request concourse/concourse-chart#96 tsa (workerGateway) k8s service is separated. `concourse.worker.tsa.hosts` is updated in tests to support this

## Changes proposed by this PR:
Update k8s test for concourse/concourse-chart#96 

## Notes to reviewer:
@taylorsilva reviews concourse/concourse-chart#96 

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
