### PR TITLE
atc: structure: check step runs in the same context as checker

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"time"
 
-	export "go.opentelemetry.io/otel/sdk/export/trace"
-
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse"

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	export "go.opentelemetry.io/otel/sdk/export/trace"
+
 	"code.cloudfoundry.org/clock"
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse"

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -22,7 +22,7 @@ import (
 
 type Engine interface {
 	NewBuild(db.Build) Runnable
-	NewCheck(db.Check) Runnable
+	NewCheck(context.Context, db.Check) Runnable
 	ReleaseAll(lager.Logger)
 }
 
@@ -84,12 +84,12 @@ func (engine *engine) NewBuild(build db.Build) Runnable {
 	)
 }
 
-func (engine *engine) NewCheck(check db.Check) Runnable {
+func (engine *engine) NewCheck(ctx context.Context, check db.Check) Runnable {
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctxWithCancel, cancel := context.WithCancel(ctx)
 
 	return NewCheck(
-		ctx,
+		ctxWithCancel,
 		cancel,
 		check,
 		engine.builder,

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -22,14 +22,14 @@ import (
 
 type Engine interface {
 	NewBuild(db.Build) Runnable
-	NewCheck(context.Context, db.Check) Runnable
+	NewCheck(db.Check) Runnable
 	ReleaseAll(lager.Logger)
 }
 
 //go:generate counterfeiter . Runnable
 
 type Runnable interface {
-	Run(logger lager.Logger)
+	Run(context.Context, context.CancelFunc)
 }
 
 //go:generate counterfeiter . StepBuilder
@@ -70,12 +70,7 @@ func (engine *engine) ReleaseAll(logger lager.Logger) {
 }
 
 func (engine *engine) NewBuild(build db.Build) Runnable {
-
-	ctx, cancel := context.WithCancel(context.Background())
-
 	return NewBuild(
-		ctx,
-		cancel,
 		build,
 		engine.builder,
 		engine.release,
@@ -84,13 +79,8 @@ func (engine *engine) NewBuild(build db.Build) Runnable {
 	)
 }
 
-func (engine *engine) NewCheck(ctx context.Context, check db.Check) Runnable {
-
-	ctxWithCancel, cancel := context.WithCancel(ctx)
-
+func (engine *engine) NewCheck(check db.Check) Runnable {
 	return NewCheck(
-		ctxWithCancel,
-		cancel,
 		check,
 		engine.builder,
 		engine.release,
@@ -100,8 +90,6 @@ func (engine *engine) NewCheck(ctx context.Context, check db.Check) Runnable {
 }
 
 func NewBuild(
-	ctx context.Context,
-	cancel func(),
 	build db.Build,
 	builder StepBuilder,
 	release chan bool,
@@ -109,9 +97,6 @@ func NewBuild(
 	waitGroup *sync.WaitGroup,
 ) Runnable {
 	return &engineBuild{
-		ctx:    ctx,
-		cancel: cancel,
-
 		build:   build,
 		builder: builder,
 
@@ -122,9 +107,6 @@ func NewBuild(
 }
 
 type engineBuild struct {
-	ctx    context.Context
-	cancel func()
-
 	build   db.Build
 	builder StepBuilder
 
@@ -135,11 +117,11 @@ type engineBuild struct {
 	pipelineCredMgrs []creds.Manager
 }
 
-func (b *engineBuild) Run(logger lager.Logger) {
+func (b *engineBuild) Run(ctx context.Context, cancel context.CancelFunc) {
 	b.waitGroup.Add(1)
 	defer b.waitGroup.Done()
 
-	logger = logger.WithData(lager.Data{
+	logger := lagerctx.FromContext(ctx).WithData(lager.Data{
 		"build":    b.build.ID(),
 		"pipeline": b.build.PipelineName(),
 		"job":      b.build.JobName(),
@@ -182,7 +164,7 @@ func (b *engineBuild) Run(logger lager.Logger) {
 
 	defer notifier.Close()
 
-	ctx, span := tracing.StartSpan(b.ctx, "build", tracing.Attrs{
+	ctx, span := tracing.StartSpan(ctx, "build", tracing.Attrs{
 		"team":     b.build.TeamName(),
 		"pipeline": b.build.PipelineName(),
 		"job":      b.build.JobName(),
@@ -219,7 +201,7 @@ func (b *engineBuild) Run(logger lager.Logger) {
 		case <-noleak:
 		case <-notifier.Notify():
 			logger.Info("aborting")
-			b.cancel()
+			cancel()
 		}
 	}()
 
@@ -316,8 +298,6 @@ func (b *engineBuild) clearRunState() {
 }
 
 func NewCheck(
-	ctx context.Context,
-	cancel func(),
 	check db.Check,
 	builder StepBuilder,
 	release chan bool,
@@ -325,9 +305,6 @@ func NewCheck(
 	waitGroup *sync.WaitGroup,
 ) Runnable {
 	return &engineCheck{
-		ctx:    ctx,
-		cancel: cancel,
-
 		check:   check,
 		builder: builder,
 
@@ -338,9 +315,6 @@ func NewCheck(
 }
 
 type engineCheck struct {
-	ctx    context.Context
-	cancel func()
-
 	check   db.Check
 	builder StepBuilder
 
@@ -349,11 +323,11 @@ type engineCheck struct {
 	waitGroup     *sync.WaitGroup
 }
 
-func (c *engineCheck) Run(logger lager.Logger) {
+func (c *engineCheck) Run(ctx context.Context, cancel context.CancelFunc) {
 	c.waitGroup.Add(1)
 	defer c.waitGroup.Done()
 
-	logger = logger.WithData(lager.Data{
+	logger := lagerctx.FromContext(ctx).WithData(lager.Data{
 		"check": c.check.ID(),
 	})
 
@@ -393,7 +367,7 @@ func (c *engineCheck) Run(logger lager.Logger) {
 
 	done := make(chan error)
 	go func() {
-		ctx := lagerctx.NewContext(c.ctx, logger)
+		ctx := lagerctx.NewContext(ctx, logger)
 		done <- step.Run(ctx, state)
 	}()
 

--- a/atc/engine/engine_test.go
+++ b/atc/engine/engine_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Engine", func() {
 		})
 
 		JustBeforeEach(func() {
-			check = engine.NewCheck(fakeCheck)
+			check = engine.NewCheck(context.Background(), fakeCheck)
 		})
 
 		It("returns a build", func() {

--- a/atc/engine/enginefakes/fake_engine.go
+++ b/atc/engine/enginefakes/fake_engine.go
@@ -2,7 +2,6 @@
 package enginefakes
 
 import (
-	"context"
 	"sync"
 
 	"code.cloudfoundry.org/lager"
@@ -22,11 +21,10 @@ type FakeEngine struct {
 	newBuildReturnsOnCall map[int]struct {
 		result1 engine.Runnable
 	}
-	NewCheckStub        func(context.Context, db.Check) engine.Runnable
+	NewCheckStub        func(db.Check) engine.Runnable
 	newCheckMutex       sync.RWMutex
 	newCheckArgsForCall []struct {
-		arg1 context.Context
-		arg2 db.Check
+		arg1 db.Check
 	}
 	newCheckReturns struct {
 		result1 engine.Runnable
@@ -103,17 +101,16 @@ func (fake *FakeEngine) NewBuildReturnsOnCall(i int, result1 engine.Runnable) {
 	}{result1}
 }
 
-func (fake *FakeEngine) NewCheck(arg1 context.Context, arg2 db.Check) engine.Runnable {
+func (fake *FakeEngine) NewCheck(arg1 db.Check) engine.Runnable {
 	fake.newCheckMutex.Lock()
 	ret, specificReturn := fake.newCheckReturnsOnCall[len(fake.newCheckArgsForCall)]
 	fake.newCheckArgsForCall = append(fake.newCheckArgsForCall, struct {
-		arg1 context.Context
-		arg2 db.Check
-	}{arg1, arg2})
-	fake.recordInvocation("NewCheck", []interface{}{arg1, arg2})
+		arg1 db.Check
+	}{arg1})
+	fake.recordInvocation("NewCheck", []interface{}{arg1})
 	fake.newCheckMutex.Unlock()
 	if fake.NewCheckStub != nil {
-		return fake.NewCheckStub(arg1, arg2)
+		return fake.NewCheckStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -128,17 +125,17 @@ func (fake *FakeEngine) NewCheckCallCount() int {
 	return len(fake.newCheckArgsForCall)
 }
 
-func (fake *FakeEngine) NewCheckCalls(stub func(context.Context, db.Check) engine.Runnable) {
+func (fake *FakeEngine) NewCheckCalls(stub func(db.Check) engine.Runnable) {
 	fake.newCheckMutex.Lock()
 	defer fake.newCheckMutex.Unlock()
 	fake.NewCheckStub = stub
 }
 
-func (fake *FakeEngine) NewCheckArgsForCall(i int) (context.Context, db.Check) {
+func (fake *FakeEngine) NewCheckArgsForCall(i int) db.Check {
 	fake.newCheckMutex.RLock()
 	defer fake.newCheckMutex.RUnlock()
 	argsForCall := fake.newCheckArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
 func (fake *FakeEngine) NewCheckReturns(result1 engine.Runnable) {

--- a/atc/engine/enginefakes/fake_engine.go
+++ b/atc/engine/enginefakes/fake_engine.go
@@ -2,6 +2,7 @@
 package enginefakes
 
 import (
+	"context"
 	"sync"
 
 	"code.cloudfoundry.org/lager"
@@ -21,10 +22,11 @@ type FakeEngine struct {
 	newBuildReturnsOnCall map[int]struct {
 		result1 engine.Runnable
 	}
-	NewCheckStub        func(db.Check) engine.Runnable
+	NewCheckStub        func(context.Context, db.Check) engine.Runnable
 	newCheckMutex       sync.RWMutex
 	newCheckArgsForCall []struct {
-		arg1 db.Check
+		arg1 context.Context
+		arg2 db.Check
 	}
 	newCheckReturns struct {
 		result1 engine.Runnable
@@ -101,16 +103,17 @@ func (fake *FakeEngine) NewBuildReturnsOnCall(i int, result1 engine.Runnable) {
 	}{result1}
 }
 
-func (fake *FakeEngine) NewCheck(arg1 db.Check) engine.Runnable {
+func (fake *FakeEngine) NewCheck(arg1 context.Context, arg2 db.Check) engine.Runnable {
 	fake.newCheckMutex.Lock()
 	ret, specificReturn := fake.newCheckReturnsOnCall[len(fake.newCheckArgsForCall)]
 	fake.newCheckArgsForCall = append(fake.newCheckArgsForCall, struct {
-		arg1 db.Check
-	}{arg1})
-	fake.recordInvocation("NewCheck", []interface{}{arg1})
+		arg1 context.Context
+		arg2 db.Check
+	}{arg1, arg2})
+	fake.recordInvocation("NewCheck", []interface{}{arg1, arg2})
 	fake.newCheckMutex.Unlock()
 	if fake.NewCheckStub != nil {
-		return fake.NewCheckStub(arg1)
+		return fake.NewCheckStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -125,17 +128,17 @@ func (fake *FakeEngine) NewCheckCallCount() int {
 	return len(fake.newCheckArgsForCall)
 }
 
-func (fake *FakeEngine) NewCheckCalls(stub func(db.Check) engine.Runnable) {
+func (fake *FakeEngine) NewCheckCalls(stub func(context.Context, db.Check) engine.Runnable) {
 	fake.newCheckMutex.Lock()
 	defer fake.newCheckMutex.Unlock()
 	fake.NewCheckStub = stub
 }
 
-func (fake *FakeEngine) NewCheckArgsForCall(i int) db.Check {
+func (fake *FakeEngine) NewCheckArgsForCall(i int) (context.Context, db.Check) {
 	fake.newCheckMutex.RLock()
 	defer fake.newCheckMutex.RUnlock()
 	argsForCall := fake.newCheckArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeEngine) NewCheckReturns(result1 engine.Runnable) {

--- a/atc/engine/enginefakes/fake_runnable.go
+++ b/atc/engine/enginefakes/fake_runnable.go
@@ -2,31 +2,33 @@
 package enginefakes
 
 import (
+	"context"
 	"sync"
 
-	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/engine"
 )
 
 type FakeRunnable struct {
-	RunStub        func(lager.Logger)
+	RunStub        func(context.Context, context.CancelFunc)
 	runMutex       sync.RWMutex
 	runArgsForCall []struct {
-		arg1 lager.Logger
+		arg1 context.Context
+		arg2 context.CancelFunc
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRunnable) Run(arg1 lager.Logger) {
+func (fake *FakeRunnable) Run(arg1 context.Context, arg2 context.CancelFunc) {
 	fake.runMutex.Lock()
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
-		arg1 lager.Logger
-	}{arg1})
-	fake.recordInvocation("Run", []interface{}{arg1})
+		arg1 context.Context
+		arg2 context.CancelFunc
+	}{arg1, arg2})
+	fake.recordInvocation("Run", []interface{}{arg1, arg2})
 	fake.runMutex.Unlock()
 	if fake.RunStub != nil {
-		fake.RunStub(arg1)
+		fake.RunStub(arg1, arg2)
 	}
 }
 
@@ -36,17 +38,17 @@ func (fake *FakeRunnable) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
-func (fake *FakeRunnable) RunCalls(stub func(lager.Logger)) {
+func (fake *FakeRunnable) RunCalls(stub func(context.Context, context.CancelFunc)) {
 	fake.runMutex.Lock()
 	defer fake.runMutex.Unlock()
 	fake.RunStub = stub
 }
 
-func (fake *FakeRunnable) RunArgsForCall(i int) lager.Logger {
+func (fake *FakeRunnable) RunArgsForCall(i int) (context.Context, context.CancelFunc) {
 	fake.runMutex.RLock()
 	defer fake.runMutex.RUnlock()
 	argsForCall := fake.runArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeRunnable) Invocations() map[string][][]interface{} {

--- a/atc/lidar/checker.go
+++ b/atc/lidar/checker.go
@@ -49,7 +49,7 @@ func (c *checker) Run(ctx context.Context) error {
 	for _, ck := range checks {
 		if _, exists := c.running.LoadOrStore(ck.ID(), true); !exists {
 			go func(check db.Check) {
-				_, span := tracing.StartSpanFollowing(
+				ctx, span := tracing.StartSpanFollowing(
 					check,
 					"checker.Run",
 					tracing.Attrs{
@@ -62,7 +62,7 @@ func (c *checker) Run(ctx context.Context) error {
 				defer span.End()
 				defer c.running.Delete(check.ID())
 
-				engineCheck := c.engine.NewCheck(check)
+				engineCheck := c.engine.NewCheck(ctx, check)
 				engineCheck.Run(c.logger.WithData(lager.Data{
 					"check": check.ID(),
 				}))

--- a/atc/scheduler/algorithm/suite_test.go
+++ b/atc/scheduler/algorithm/suite_test.go
@@ -45,8 +45,9 @@ var _ = BeforeSuite(func() {
 
 		exporter = spanSyncer.(*jaeger.Exporter)
 
-		err = tracing.ConfigureTracer(exporter)
+		tp, err := tracing.TraceProvider(exporter)
 		Expect(err).ToNot(HaveOccurred())
+		tracing.ConfigureTraceProvider(tp)
 	}
 
 	postgresRunner = postgresrunner.Runner{

--- a/atc/scheduler/algorithm/suite_test.go
+++ b/atc/scheduler/algorithm/suite_test.go
@@ -45,8 +45,7 @@ var _ = BeforeSuite(func() {
 
 		exporter = spanSyncer.(*jaeger.Exporter)
 
-		tp, err := tracing.TraceProvider(exporter)
-		Expect(err).ToNot(HaveOccurred())
+		tp := tracing.TraceProvider(exporter)
 		tracing.ConfigureTraceProvider(tp)
 	}
 

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -25,6 +25,31 @@ import (
 //
 var Configured bool
 
+type Config struct {
+	Jaeger      Jaeger
+	Stackdriver Stackdriver
+}
+
+func (c Config) Prepare() error {
+	switch {
+	case c.Jaeger.IsConfigured():
+		exp, err := c.Jaeger.Exporter()
+		if err != nil {
+			return err
+		}
+
+		ConfigureTracer(exp)
+	case c.Stackdriver.IsConfigured():
+		exp, err := c.Stackdriver.Exporter()
+		if err != nil {
+			return err
+		}
+
+		ConfigureTracer(exp)
+	}
+	return nil
+}
+
 // StartSpan creates a span, giving back a context that has itself added as the
 // parent span.
 //

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -76,4 +76,25 @@ var _ = Describe("Tracer", func() {
 
 	})
 
+	Describe("Prepare", func() {
+		BeforeEach(func() {
+			tracing.Configured = false
+		})
+
+		It("configures tracing if jaeger flags are provided", func() {
+			c := tracing.Config{
+				Jaeger: tracing.Jaeger{
+					Endpoint: "http://jaeger:14268/api/traces",
+				},
+			}
+			c.Prepare()
+			Expect(tracing.Configured).To(BeTrue())
+		})
+
+		It("does not configure tracing if no flags are provided", func() {
+			c := tracing.Config{}
+			c.Prepare()
+			Expect(tracing.Configured).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
## What does this PR accomplish?

Refactor - closes #5654.

## Changes proposed by this PR:

Some interesting refactors around the tracing package allowed us to make more effective use of the testtrace package from opentelemetry. Hopefully this will assist tracing-related testing efforts in the future.

Having the correct context available for the check step should unblock efforts to propagate span context into check containers (#5423) or resource versions (#5602).

## Notes to reviewer:

Commit messages are fairly thorough.

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] ~Updated [Documentation]~
- [x] ~Updated [Release notes]~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~