### PR TITLE
web: behaviour: cached pipelines response can't overwrite fresh response

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -69,3 +69,7 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 #### <sub><sup><a name="5624" href="#5624">:link:</a></sup></sub> fix
 
 * Fixed a bug where fly would no longer tell you if the team you logged in with was invalid
+
+#### <sub><sup><a name="5669" href="#5669">:link:</a></sup></sub> fix
+
+* Fix an intermittent bug where some pipelines would not be immediately visible in the UI after first logging in. #5669

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -780,7 +780,7 @@ view session model =
         ]
 
 
-tooltip : { a | pipelines : Maybe (List Pipeline) } -> { b | hovered : HoverState.HoverState } -> Maybe Tooltip.Tooltip
+tooltip : { a | pipelines : FetchResult (List Pipeline) } -> { b | hovered : HoverState.HoverState } -> Maybe Tooltip.Tooltip
 tooltip model { hovered } =
     case hovered of
         HoverState.Tooltip (Message.PipelineStatusIcon _) _ ->
@@ -795,7 +795,7 @@ tooltip model { hovered } =
 
         HoverState.Tooltip (Message.VisibilityButton { teamName, pipelineName }) _ ->
             model.pipelines
-                |> Maybe.withDefault []
+                |> FetchResult.withDefault []
                 |> List.Extra.find
                     (\p ->
                         p.teamName == teamName && p.name == pipelineName

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -544,13 +544,13 @@ toConcoursePipeline p =
     }
 
 
-pipelinesChangedFrom : Maybe (List Pipeline) -> Maybe (List Pipeline) -> Bool
+pipelinesChangedFrom : FetchResult (List Pipeline) -> FetchResult (List Pipeline) -> Bool
 pipelinesChangedFrom ps qs =
     let
         project =
-            Maybe.map <| List.map (\x -> { x | stale = True })
+            FetchResult.map <| List.map (\x -> { x | stale = True })
     in
-    project ps /= project qs
+    changedFrom (project ps) (project qs)
 
 
 groupBy : (a -> comparable) -> List a -> Dict comparable (List a)

--- a/web/elm/src/Dashboard/Footer.elm
+++ b/web/elm/src/Dashboard/Footer.elm
@@ -6,6 +6,7 @@ import Concourse.PipelineStatus as PipelineStatus exposing (PipelineStatus(..))
 import Dashboard.Group.Models exposing (Pipeline)
 import Dashboard.Models exposing (Dropdown(..), FooterModel)
 import Dashboard.Styles as Styles
+import FetchResult exposing (FetchResult)
 import HoverState
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, class, download, href, id, style)
@@ -34,7 +35,7 @@ handleDelivery delivery ( model, effects ) =
                             | showHelp =
                                 if
                                     model.pipelines
-                                        |> Maybe.withDefault []
+                                        |> FetchResult.withDefault []
                                         |> List.isEmpty
                                 then
                                     False
@@ -127,7 +128,7 @@ infoBar :
     ->
         { b
             | highDensity : Bool
-            , pipelines : Maybe (List Pipeline)
+            , pipelines : FetchResult (List Pipeline)
         }
     -> Html Message
 infoBar session model =
@@ -147,7 +148,7 @@ legend :
     { a | screenSize : ScreenSize.ScreenSize }
     ->
         { b
-            | pipelines : Maybe (List Pipeline)
+            | pipelines : FetchResult (List Pipeline)
             , highDensity : Bool
         }
     -> Html Message
@@ -200,10 +201,10 @@ concourseInfo { hovered, version } =
         ]
 
 
-hideLegend : { a | pipelines : Maybe (List Pipeline) } -> Bool
+hideLegend : { a | pipelines : FetchResult (List Pipeline) } -> Bool
 hideLegend { pipelines } =
     pipelines
-        |> Maybe.withDefault []
+        |> FetchResult.withDefault []
         |> List.isEmpty
 
 

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -70,7 +70,7 @@ type alias FooterModel r =
         | hideFooter : Bool
         , hideFooterCounter : Int
         , showHelp : Bool
-        , pipelines : Maybe (List Dashboard.Group.Models.Pipeline)
+        , pipelines : FetchResult (List Dashboard.Group.Models.Pipeline)
         , dropdown : Dropdown
         , highDensity : Bool
     }

--- a/web/elm/src/Dashboard/SearchBar.elm
+++ b/web/elm/src/Dashboard/SearchBar.elm
@@ -233,7 +233,7 @@ view :
             , dropdown : Dropdown
             , teams : FetchResult (List Concourse.Team)
             , highDensity : Bool
-            , pipelines : Maybe (List Pipeline)
+            , pipelines : FetchResult (List Pipeline)
         }
     -> Html Message
 view session ({ query, dropdown, pipelines } as params) =
@@ -246,7 +246,7 @@ view session ({ query, dropdown, pipelines } as params) =
 
         noPipelines =
             pipelines
-                |> Maybe.withDefault []
+                |> FetchResult.withDefault []
                 |> List.isEmpty
     in
     if noPipelines then
@@ -304,7 +304,7 @@ viewDropdownItems :
             | query : String
             , dropdown : Dropdown
             , teams : FetchResult (List Concourse.Team)
-            , pipelines : Maybe (List Pipeline)
+            , pipelines : FetchResult (List Pipeline)
         }
     -> List (Html Message)
 viewDropdownItems { screenSize } ({ dropdown } as model) =
@@ -328,7 +328,7 @@ viewDropdownItems { screenSize } ({ dropdown } as model) =
             ]
 
 
-dropdownOptions : { a | query : String, teams : FetchResult (List Concourse.Team), pipelines : Maybe (List Pipeline) } -> List String
+dropdownOptions : { a | query : String, teams : FetchResult (List Concourse.Team), pipelines : FetchResult (List Pipeline) } -> List String
 dropdownOptions { query, teams, pipelines } =
     case String.trim query of
         "" ->
@@ -352,7 +352,7 @@ dropdownOptions { query, teams, pipelines } =
                     |> Set.fromList
                 )
                 (pipelines
-                    |> Maybe.withDefault []
+                    |> FetchResult.withDefault []
                     |> List.map .teamName
                     |> Set.fromList
                 )

--- a/web/elm/src/FetchResult.elm
+++ b/web/elm/src/FetchResult.elm
@@ -2,6 +2,7 @@ module FetchResult exposing
     ( FetchResult(..)
     , changedFrom
     , map
+    , value
     , withDefault
     )
 

--- a/web/elm/tests/DashboardCacheTests.elm
+++ b/web/elm/tests/DashboardCacheTests.elm
@@ -211,6 +211,23 @@ all =
                         )
                     |> Tuple.second
                     |> Common.contains (SaveCachedPipelines [ Data.pipeline "team" 0 ])
+        , test "ignores cached pipelines if we've already fetched from network" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (AllPipelinesFetched <|
+                            Ok <|
+                                [ Data.pipeline "team" 0 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (CachedPipelinesReceived <|
+                            Ok <|
+                                []
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.has [ class "pipeline-wrapper", containing [ text "pipeline-0" ] ]
         , test "does not save pipelines to cache when fetched with no change" <|
             \_ ->
                 Common.init "/"

--- a/web/elm/tests/DashboardTooltipTests.elm
+++ b/web/elm/tests/DashboardTooltipTests.elm
@@ -3,6 +3,7 @@ module DashboardTooltipTests exposing (all)
 import Dashboard.Dashboard as Dashboard
 import Data
 import Expect
+import FetchResult exposing (FetchResult(..))
 import HoverState exposing (HoverState(..))
 import Html
 import Message.Message exposing (DomID(..))
@@ -18,7 +19,7 @@ all =
             \_ ->
                 Dashboard.tooltip
                     { pipelines =
-                        Just
+                        Fetched
                             [ Data.dashboardPipeline 0 True ]
                     }
                     { hovered =
@@ -38,7 +39,7 @@ all =
             \_ ->
                 Dashboard.tooltip
                     { pipelines =
-                        Just
+                        Fetched
                             [ Data.dashboardPipeline 0 False ]
                     }
                     { hovered =
@@ -62,7 +63,7 @@ all =
                 in
                 Dashboard.tooltip
                     { pipelines =
-                        Just
+                        Fetched
                             [ { p | jobsDisabled = True } ]
                     }
                     { hovered =


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix

A bug was introduced in #5529 (in particular, d196102f510f0cd4c2e58690a81507e75d4bbe31) such that if the cached pipeline result comes in after the response from the network (seems to happen pretty frequently when running locally), the cached data will overwrite the fresh data. This can result in no pipelines being displayed when you first login (at least until 5 seconds later).

I've been able to reproduce this pretty frequently by:
1. setting a pipeline that isn't exposed
1. logging out
1. refreshing (probably optional)
1. logging in
1. pipeline won't appear for 5 seconds

## Changes proposed by this PR:

* Change `Dashboard.Model.pipelines` from a `Maybe (List Pipeline)` to a `FetchResult (List Pipeline)`
  * This essentially reverts part of d196102f510f0cd4c2e58690a81507e75d4bbe31, but leaves the addition of the `.stale` field. This feels a bit weird as it's possible to have a model where `.stale` is `False` for all pipelines, but `model.pipelines` is `Cached`, but it feels like an okay compromise for not having to thread `isCached` everywhere
* `pipelinesChangedFrom` returns `False` when comparing `Fetched` to `Cached`


## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [x] PR acceptance performed