### PR TITLE
fly: tell user when team is invalid

### DIFF
--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -128,24 +128,21 @@ func (command *LoginCommand) Execute(args []string) error {
 
 	fmt.Println("")
 
-	err = command.saveTarget(
+	verifyTarget, err := rc.NewAuthenticatedTarget("verify",
 		client.URL(),
+		command.TeamName,
+		command.Insecure,
 		&rc.TargetToken{
 			Type:  tokenType,
 			Value: tokenValue,
 		},
 		target.CACert(),
-	)
+		false)
 	if err != nil {
 		return err
 	}
 
-	authenticatedTarget, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
-	if err != nil {
-		return err
-	}
-
-	userInfo, err := authenticatedTarget.Client().UserInfo()
+	userInfo, err := verifyTarget.Client().UserInfo()
 	if err != nil {
 		return err
 	}
@@ -160,7 +157,14 @@ func (command *LoginCommand) Execute(args []string) error {
 		return errors.New("unable to verify role on team")
 	}
 
-	return err
+	return command.saveTarget(
+		client.URL(),
+		&rc.TargetToken{
+			Type:  tokenType,
+			Value: tokenValue,
+		},
+		target.CACert(),
+	)
 }
 
 func (command *LoginCommand) passwordGrant(client concourse.Client, username, password string) (string, string, error) {

--- a/fly/integration/login_insecure_test.go
+++ b/fly/integration/login_insecure_test.go
@@ -41,6 +41,7 @@ var _ = Describe("login -k Command", func() {
 				loginATCServer.AppendHandlers(
 					infoHandler(),
 					tokenHandler(),
+					userInfoHandler(),
 				)
 
 				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-k", "-u", "some_user", "-p", "some_pass")
@@ -71,6 +72,7 @@ var _ = Describe("login -k Command", func() {
 					loginATCServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
+						userInfoHandler(),
 					)
 
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
@@ -161,6 +163,7 @@ var _ = Describe("login -k Command", func() {
 					loginATCServer.AppendHandlers(
 						infoHandler(),
 						tokenHandler(),
+						userInfoHandler(),
 					)
 
 					tmpDir, err = ioutil.TempDir("", "fly-test")
@@ -208,6 +211,7 @@ var _ = Describe("login -k Command", func() {
 						loginATCServer.AppendHandlers(
 							infoHandler(),
 							tokenHandler(),
+							userInfoHandler(),
 						)
 
 						flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-k", "-u", "some_user", "-p", "some_pass")

--- a/fly/integration/rename_pipeline_test.go
+++ b/fly/integration/rename_pipeline_test.go
@@ -76,13 +76,13 @@ var _ = Describe("RenamePipeline", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(sess).Should(gexec.Exit(0))
-			Expect(atcServer.ReceivedRequests()).To(HaveLen(4))
+			Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
 			Expect(sess.Out).To(gbytes.Say(fmt.Sprintf("pipeline successfully renamed to %s", newName)))
 		})
 
 		Context("when the pipeline is not found", func() {
 			BeforeEach(func() {
-				atcServer.SetHandler(3, ghttp.RespondWith(http.StatusNotFound, ""))
+				atcServer.SetHandler(4, ghttp.RespondWith(http.StatusNotFound, ""))
 			})
 
 			It("returns an error", func() {
@@ -92,14 +92,14 @@ var _ = Describe("RenamePipeline", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(sess).Should(gexec.Exit(1))
-				Expect(atcServer.ReceivedRequests()).To(HaveLen(4))
+				Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
 				Expect(sess.Err).To(gbytes.Say("pipeline 'some-pipeline' not found"))
 			})
 		})
 
 		Context("when an error occurs", func() {
 			BeforeEach(func() {
-				atcServer.SetHandler(3, ghttp.RespondWith(http.StatusTeapot, ""))
+				atcServer.SetHandler(4, ghttp.RespondWith(http.StatusTeapot, ""))
 			})
 
 			It("returns an error", func() {
@@ -109,7 +109,7 @@ var _ = Describe("RenamePipeline", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(sess).Should(gexec.Exit(1))
-				Expect(atcServer.ReceivedRequests()).To(HaveLen(4))
+				Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
 				Expect(sess.Err).To(gbytes.Say("418 I'm a teapot"))
 			})
 		})

--- a/fly/integration/rename_team_test.go
+++ b/fly/integration/rename_team_test.go
@@ -62,13 +62,13 @@ var _ = Describe("RenameTeam", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(sess).Should(gexec.Exit(0))
-			Expect(atcServer.ReceivedRequests()).To(HaveLen(4))
+			Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
 			Expect(sess.Out).To(gbytes.Say(fmt.Sprintf("Team successfully renamed to %s", newName)))
 		})
 
 		Context("when the team is not found", func() {
 			BeforeEach(func() {
-				atcServer.SetHandler(3, ghttp.RespondWith(http.StatusNotFound, ""))
+				atcServer.SetHandler(4, ghttp.RespondWith(http.StatusNotFound, ""))
 			})
 
 			It("returns an error", func() {
@@ -78,7 +78,7 @@ var _ = Describe("RenameTeam", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(sess).Should(gexec.Exit(1))
-				Expect(atcServer.ReceivedRequests()).To(HaveLen(4))
+				Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
 				Expect(sess.Err).To(gbytes.Say("Team 'a-team' not found"))
 			})
 		})

--- a/fly/integration/suite_test.go
+++ b/fly/integration/suite_test.go
@@ -72,6 +72,20 @@ func tokenHandler() http.HandlerFunc {
 	)
 }
 
+func userInfoHandler() http.HandlerFunc {
+	return ghttp.CombineHandlers(
+		ghttp.VerifyRequest("GET", "/api/v1/user"),
+		ghttp.RespondWithJSONEncoded(200, map[string]interface{}{
+			"user_name": "user",
+			"teams": map[string][]string{
+				teamName:          {"owner"},
+				"some-team":       {"owner"},
+				"some-other-team": {"owner"},
+			},
+		}),
+	)
+}
+
 func token() map[string]string {
 	return map[string]string{
 		"token_type":   "Bearer",
@@ -86,6 +100,7 @@ var _ = BeforeEach(func() {
 	atcServer.AppendHandlers(
 		infoHandler(),
 		tokenHandler(),
+		userInfoHandler(),
 		infoHandler(),
 	)
 

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -65,3 +65,7 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 #### <sub><sup><a name="5620" href="#5620">:link:</a></sup></sub> fix
 
 * @evanchaoli enhanced task step `vars` to support interpolation. #5620
+
+#### <sub><sup><a name="5624" href="#5624">:link:</a></sup></sub> fix
+
+* Fixed a bug where fly would no longer tell you if the team you logged in with was invalid


### PR DESCRIPTION
## What does this PR accomplish?
closes #5624

Before 6.1.0 fly would exit 1 and display an error if the user logged in
with an invalid team. This commit brings back this behaviour.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
