### PR TITLE
fly: Include archive flag

### DIFF
--- a/fly/commands/internal/flaghelpers/completion.go
+++ b/fly/commands/internal/flaghelpers/completion.go
@@ -23,7 +23,7 @@ func parseFlags() flyCommand {
 	}()
 
 	var fly flyCommand
-	parser := flags.NewParser(&fly, flags.HelpFlag|flags.PassDoubleDash)
+	parser := flags.NewParser(&fly, flags.HelpFlag|flags.PassDoubleDash|flags.IgnoreUnknown)
 	parser.NamespaceDelimiter = "-"
 	parser.Parse()
 

--- a/fly/commands/pipelines.go
+++ b/fly/commands/pipelines.go
@@ -109,8 +109,9 @@ func (command *PipelinesCommand) buildHeader() []string {
 	}
 
 	if command.IncludeArchived {
-		headers = append(headers, "archived", "last updated")
+		headers = append(headers, "archived")
 	}
+	headers = append(headers, "last updated")
 
 	return headers
 }

--- a/fly/commands/pipelines.go
+++ b/fly/commands/pipelines.go
@@ -12,8 +12,9 @@ import (
 )
 
 type PipelinesCommand struct {
-	All  bool `short:"a"  long:"all" description:"Show pipelines across all teams"`
-	Json bool `long:"json" description:"Print command result as JSON"`
+	All             bool `short:"a"  long:"all" description:"Show pipelines across all teams"`
+	IncludeArchived bool `long:"include-archived" description:"Show archived pipelines"`
+	Json            bool `long:"json" description:"Print command result as JSON"`
 }
 
 func (command *PipelinesCommand) Execute([]string) error {
@@ -27,26 +28,19 @@ func (command *PipelinesCommand) Execute([]string) error {
 		return err
 	}
 
-	var headers []string
 	var unfilteredPipelines []atc.Pipeline
 
 	if command.All {
 		unfilteredPipelines, err = target.Client().ListPipelines()
-		headers = []string{"name", "team", "paused", "public", "last updated"}
 	} else {
 		unfilteredPipelines, err = target.Team().ListPipelines()
-		headers = []string{"name", "paused", "public", "last updated"}
 	}
 	if err != nil {
 		return err
 	}
 
-	pipelines := []atc.Pipeline{}
-	for _, p := range unfilteredPipelines {
-		if !p.Archived {
-			pipelines = append(pipelines, p)
-		}
-	}
+	headers := command.buildHeader()
+	pipelines := command.filterPipelines(unfilteredPipelines)
 
 	if command.Json {
 		err = displayhelpers.JsonPrint(pipelines)
@@ -78,6 +72,16 @@ func (command *PipelinesCommand) Execute([]string) error {
 			publicColumn.Contents = "no"
 		}
 
+		var archivedColumn ui.TableCell
+		if command.IncludeArchived {
+			if p.Archived {
+				archivedColumn.Contents = "yes"
+				archivedColumn.Color = ui.OnColor
+			} else {
+				archivedColumn.Contents = "no"
+			}
+		}
+
 		row := ui.TableRow{}
 		row = append(row, ui.TableCell{Contents: p.Name})
 		if command.All {
@@ -85,10 +89,44 @@ func (command *PipelinesCommand) Execute([]string) error {
 		}
 		row = append(row, pausedColumn)
 		row = append(row, publicColumn)
+		if command.IncludeArchived {
+			row = append(row, archivedColumn)
+		}
 		row = append(row, ui.TableCell{Contents: time.Unix(p.LastUpdated, 0).String()})
 
 		table.Data = append(table.Data, row)
 	}
 
 	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+}
+
+func (command *PipelinesCommand) buildHeader() []string {
+	var headers []string
+	if command.All {
+		headers = []string{"name", "team", "paused", "public"}
+	} else {
+		headers = []string{"name", "paused", "public"}
+	}
+
+	if command.IncludeArchived {
+		headers = append(headers, "archived", "last updated")
+	}
+
+	return headers
+}
+
+func (command *PipelinesCommand) filterPipelines(unfilteredPipelines []atc.Pipeline) []atc.Pipeline {
+	pipelines := make([]atc.Pipeline, 0)
+
+	if !command.IncludeArchived {
+		for _, p := range unfilteredPipelines {
+			if !p.Archived {
+				pipelines = append(pipelines, p)
+			}
+		}
+	} else {
+		pipelines = unfilteredPipelines
+	}
+
+	return pipelines
 }

--- a/fly/integration/pipelines_test.go
+++ b/fly/integration/pipelines_test.go
@@ -21,10 +21,16 @@ var _ = Describe("Fly CLI", func() {
 			flyCmd *exec.Cmd
 		)
 
+		JustBeforeEach(func() {
+			flyCmd.Args = append([]string{flyCmd.Args[0], "--print-table-headers"}, flyCmd.Args[1:]...)
+		})
+
 		Context("when pipelines are returned from the API", func() {
+			BeforeEach(func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "pipelines")
+			})
 			Context("when no --all flag is given", func() {
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", targetName, "pipelines")
 					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
@@ -85,7 +91,7 @@ var _ = Describe("Fly CLI", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(sess).Should(gexec.Exit(0))
 
-					Expect(sess.Out).To(PrintTable(ui.Table{
+					Expect(sess.Out).To(PrintTableWithHeaders(ui.Table{
 						Headers: ui.TableRow{
 							{Contents: "name", Color: color.New(color.Bold)},
 							{Contents: "paused", Color: color.New(color.Bold)},
@@ -111,7 +117,7 @@ var _ = Describe("Fly CLI", func() {
 
 			Context("when --all is specified", func() {
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", targetName, "pipelines", "--all")
+					flyCmd.Args = append(flyCmd.Args, "--all")
 					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/pipelines"),
@@ -193,7 +199,7 @@ var _ = Describe("Fly CLI", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(sess).Should(gexec.Exit(0))
 
-					Expect(sess.Out).To(PrintTable(ui.Table{
+					Expect(sess.Out).To(PrintTableWithHeaders(ui.Table{
 						Headers: ui.TableRow{
 							{Contents: "name", Color: color.New(color.Bold)},
 							{Contents: "team", Color: color.New(color.Bold)},
@@ -221,73 +227,38 @@ var _ = Describe("Fly CLI", func() {
 			})
 
 			Context("when --include-archived is specified", func() {
-				Context("when --all flag is given", func() {
-
-					It("includes archived pipelines in the output", func() {
-						flyCmd = exec.Command(flyPath, "-t", targetName, "pipelines", "--include-archived", "--all")
-						atcServer.AppendHandlers(
-							ghttp.CombineHandlers(
-								ghttp.VerifyRequest("GET", "/api/v1/pipelines"),
-								ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
-									{Name: "pipeline-1-longer", Paused: false, Public: false, TeamName: "test", LastUpdated: 1},
-									{Name: "archived-pipeline", Paused: true, Archived: true, Public: true, TeamName: "main", LastUpdated: 1},
-								}),
-							),
-						)
-
-						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-						Expect(err).NotTo(HaveOccurred())
-						Eventually(sess).Should(gexec.Exit(0))
-
-						Expect(sess.Out).To(PrintTable(ui.Table{
-							Headers: ui.TableRow{
-								{Contents: "name", Color: color.New(color.Bold)},
-								{Contents: "team", Color: color.New(color.Bold)},
-								{Contents: "paused", Color: color.New(color.Bold)},
-								{Contents: "public", Color: color.New(color.Bold)},
-								{Contents: "archived", Color: color.New(color.Bold)},
-								{Contents: "last updated", Color: color.New(color.Bold)},
-							},
-							Data: []ui.TableRow{
-								{{Contents: "pipeline-1-longer"}, {Contents: "test"}, {Contents: "no"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
-								{{Contents: "archived-pipeline"}, {Contents: "main"}, {Contents: "yes"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "yes"}, {Contents: time.Unix(1, 0).String()}},
-							},
-						}))
-					})
+				BeforeEach(func() {
+					flyCmd.Args = append(flyCmd.Args, "--include-archived")
 				})
-				Context("when no --all flag is given", func() {
 
-					It("includes archived pipelines in the output", func() {
-						flyCmd = exec.Command(flyPath, "-t", targetName, "pipelines", "--include-archived")
-						atcServer.AppendHandlers(
-							ghttp.CombineHandlers(
-								ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
-								ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
-									{Name: "pipeline-1-longer", Paused: false, Public: false, TeamName: "main", LastUpdated: 1},
-									{Name: "archived-pipeline", Paused: true, Archived: true, Public: true, TeamName: "main", LastUpdated: 1},
-								}),
-							),
-						)
+				It("includes archived pipelines in the output", func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
+							ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
+								{Name: "pipeline-1-longer", Paused: false, Public: false, TeamName: "main", LastUpdated: 1},
+								{Name: "archived-pipeline", Paused: true, Archived: true, Public: true, TeamName: "main", LastUpdated: 1},
+							}),
+						),
+					)
 
-						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-						Expect(err).NotTo(HaveOccurred())
-						Eventually(sess).Should(gexec.Exit(0))
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(gexec.Exit(0))
 
-						Expect(sess.Out).To(PrintTable(ui.Table{
-							Headers: ui.TableRow{
-								{Contents: "name", Color: color.New(color.Bold)},
-								{Contents: "team", Color: color.New(color.Bold)},
-								{Contents: "paused", Color: color.New(color.Bold)},
-								{Contents: "public", Color: color.New(color.Bold)},
-								{Contents: "archived", Color: color.New(color.Bold)},
-								{Contents: "last updated", Color: color.New(color.Bold)},
-							},
-							Data: []ui.TableRow{
-								{{Contents: "pipeline-1-longer"}, {Contents: "no"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
-								{{Contents: "archived-pipeline"}, {Contents: "yes"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "yes"}, {Contents: time.Unix(1, 0).String()}},
-							},
-						}))
-					})
+					Expect(sess.Out).To(PrintTableWithHeaders(ui.Table{
+						Headers: ui.TableRow{
+							{Contents: "name", Color: color.New(color.Bold)},
+							{Contents: "paused", Color: color.New(color.Bold)},
+							{Contents: "public", Color: color.New(color.Bold)},
+							{Contents: "archived", Color: color.New(color.Bold)},
+							{Contents: "last updated", Color: color.New(color.Bold)},
+						},
+						Data: []ui.TableRow{
+							{{Contents: "pipeline-1-longer"}, {Contents: "no"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "archived-pipeline"}, {Contents: "yes"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "yes"}, {Contents: time.Unix(1, 0).String()}},
+						},
+					}))
 				})
 			})
 

--- a/fly/integration/pipelines_test.go
+++ b/fly/integration/pipelines_test.go
@@ -264,8 +264,6 @@ var _ = Describe("Fly CLI", func() {
 
 			Context("completion", func() {
 				BeforeEach(func() {
-					flyCmd = exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "some-")
-					flyCmd.Env = append(os.Environ(), "GO_FLAGS_COMPLETION=1")
 					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
@@ -277,8 +275,21 @@ var _ = Describe("Fly CLI", func() {
 						),
 					)
 				})
-
 				It("returns all matching pipelines", func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "some-")
+					flyCmd.Env = append(os.Environ(), "GO_FLAGS_COMPLETION=1")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(gexec.Exit(0))
+					Eventually(sess.Out).Should(gbytes.Say("some-pipeline-1"))
+					Eventually(sess.Out).Should(gbytes.Say("some-pipeline-2"))
+					Eventually(sess.Out).ShouldNot(gbytes.Say("another-pipeline"))
+				})
+				It("works with other application level flags", func() {
+					flyCmd = exec.Command(flyPath, "--verbose", "-t", targetName, "get-pipeline", "-p", "some-")
+					flyCmd.Env = append(os.Environ(), "GO_FLAGS_COMPLETION=1")
+
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(sess).Should(gexec.Exit(0))

--- a/fly/integration/print_table_matcher_test.go
+++ b/fly/integration/print_table_matcher_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 type PrintTableMatcher struct {
-	table ui.Table
+	table        ui.Table
+	printHeaders bool
 
 	actual   string
 	expected string
@@ -20,6 +21,10 @@ type PrintTableMatcher struct {
 
 func PrintTable(table ui.Table) *PrintTableMatcher {
 	return &PrintTableMatcher{table: table}
+}
+
+func PrintTableWithHeaders(table ui.Table) *PrintTableMatcher {
+	return &PrintTableMatcher{table: table, printHeaders: true}
 }
 
 func (matcher *PrintTableMatcher) Match(actual interface{}) (bool, error) {
@@ -49,7 +54,7 @@ func (matcher *PrintTableMatcher) Match(actual interface{}) (bool, error) {
 		return false, err
 	}
 
-	err = matcher.table.Render(buf, false)
+	err = matcher.table.Render(buf, matcher.printHeaders)
 	if err != nil {
 		return false, err
 	}

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -12,3 +12,7 @@
 #### <sub><sup><a name="5782" href="#5782">:link:</a></sup></sub> fix
 
 * The sidebar can now be expanded in the UI - no more long pipeline names being cut off! #5782
+
+#### <sub><sup><a name="5390" href="#5390">:link:</a></sup></sub> fix
+
+* Add `--include-archive` flag for `fly pipelines` command.

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -15,4 +15,4 @@
 
 #### <sub><sup><a name="5390" href="#5390">:link:</a></sup></sub> fix
 
-* Add `--include-archive` flag for `fly pipelines` command.
+* Add `--include-archived` flag for `fly pipelines` command. #5673

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -13,6 +13,6 @@
 
 * The sidebar can now be expanded in the UI - no more long pipeline names being cut off! #5782
 
-#### <sub><sup><a name="5390" href="#5390">:link:</a></sup></sub> fix
+#### <sub><sup><a name="5390" href="#5390">:link:</a></sup></sub> feature
 
 * Add `--include-archived` flag for `fly pipelines` command. #5673


### PR DESCRIPTION
## What does this PR accomplish?
Feature

closes #5390 .

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] ~Updated [Documentation]~
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [x] Release notes reviewed
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
