### PR TITLE
Add a max in flight to resource checking

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -141,10 +141,12 @@ type RunCommand struct {
 
 	EnableGlobalResources bool `long:"enable-global-resources" description:"Enable equivalent resources across pipelines and teams to share a single version history."`
 
+	ComponentRunnerInterval time.Duration `long:"component-runner-interval" default:"10s" description:"Interval on which runners are kicked off for builds, locks, scans, and checks"`
+
 	LidarScannerInterval time.Duration `long:"lidar-scanner-interval" default:"1m" description:"Interval on which the resource scanner will run to see if new checks need to be scheduled"`
 	LidarCheckerInterval time.Duration `long:"lidar-checker-interval" default:"10s" description:"Interval on which the resource checker runs any scheduled checks"`
 
-	ComponentRunnerInterval time.Duration `long:"component-runner-interval" default:"10s" description:"Interval on which runners are kicked off for builds, locks, scans, and checks"`
+	ResourceCheckingMaxInFlight uint64 `long:"resource-checking-max-in-flight" default:"32" description:"Maximum number of resources to be checked at the same time"`
 
 	GlobalResourceCheckTimeout          time.Duration `long:"global-resource-check-timeout" default:"1h" description:"Time limit on checking for new versions of resources."`
 	ResourceCheckingInterval            time.Duration `long:"resource-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources."`
@@ -952,6 +954,7 @@ func (cmd *RunCommand) constructBackendMembers(
 				logger.Session(atc.ComponentLidarChecker),
 				dbCheckFactory,
 				engine,
+				cmd.ResourceCheckingMaxInFlight,
 			),
 			cmd.ComponentRunnerInterval,
 			bus,

--- a/atc/lidar/checker.go
+++ b/atc/lidar/checker.go
@@ -16,12 +16,15 @@ func NewChecker(
 	logger lager.Logger,
 	checkFactory db.CheckFactory,
 	engine engine.Engine,
+	resourceCheckingMaxInFlight uint64,
 ) *checker {
+	newGuardResourceChecking := make(chan struct{}, resourceCheckingMaxInFlight)
 	return &checker{
-		logger:       logger,
-		checkFactory: checkFactory,
-		engine:       engine,
-		running:      &sync.Map{},
+		logger:                logger,
+		checkFactory:          checkFactory,
+		engine:                engine,
+		running:               &sync.Map{},
+		guardResourceChecking: newGuardResourceChecking,
 	}
 }
 
@@ -31,7 +34,8 @@ type checker struct {
 	checkFactory db.CheckFactory
 	engine       engine.Engine
 
-	running *sync.Map
+	guardResourceChecking chan struct{}
+	running               *sync.Map
 }
 
 func (c *checker) Run(ctx context.Context) error {
@@ -48,7 +52,13 @@ func (c *checker) Run(ctx context.Context) error {
 
 	for _, ck := range checks {
 		if _, exists := c.running.LoadOrStore(ck.ID(), true); !exists {
+			c.guardResourceChecking <- struct{}{}
+
 			go func(check db.Check) {
+				defer func() {
+					<-c.guardResourceChecking
+				}()
+
 				_, span := tracing.StartSpanFollowing(
 					check,
 					"checker.Run",

--- a/atc/lidar/checker_test.go
+++ b/atc/lidar/checker_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Checker", func() {
 			logger,
 			fakeCheckFactory,
 			fakeEngine,
+			10,
 		)
 	})
 


### PR DESCRIPTION
## What does this PR accomplish?
Adding a max in flight to resource checking will allow for less spiky behaviour during resource checking intervals. 

This is sort of a temporary fix, where the underlying problem of how the checker is structured will result in spiky behaviour due to the fact that it grabs all the started checks from the database and schedules them all at once. 

This spiky behaviour is tuned down by adding a max in flight, where there can only be a maximum number of checks that happen at once rather than an infinite amount. Having no upper bound to the number of checks that can happen at once can cause problems in large environments where there are thousands of resources, where users will see huge spikes in load. 

closes #4624.

## Changes proposed by this PR:
Adds a max in flight to the number of resource checks that happen at once. This number is configurable but I have yet to find a sane default. If it is too low, users will complain about their resource checks being slow. But if it is too high then it will not help mitigate the load balancing.

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
