### PR TITLE
Implement ability to mount parts of the worker filesystem. Fixes #5495

### DIFF
--- a/atc/engine/builder/builder.go
+++ b/atc/engine/builder/builder.go
@@ -1,0 +1,500 @@
+package builder
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"code.cloudfoundry.org/lager"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/creds"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/exec"
+	"github.com/concourse/concourse/vars"
+)
+
+const supportedSchema = "exec.v2"
+
+//go:generate counterfeiter . StepFactory
+
+type StepFactory interface {
+	GetStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.GetDelegate) exec.Step
+	PutStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.PutDelegate) exec.Step
+	TaskStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.TaskDelegate, atc.UnsafeWorkerOverrides) exec.Step
+	CheckStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, exec.CheckDelegate) exec.Step
+	SetPipelineStep(atc.Plan, exec.StepMetadata, exec.BuildStepDelegate) exec.Step
+	LoadVarStep(atc.Plan, exec.StepMetadata, exec.BuildStepDelegate) exec.Step
+	ArtifactInputStep(atc.Plan, db.Build, exec.BuildStepDelegate) exec.Step
+	ArtifactOutputStep(atc.Plan, db.Build, exec.BuildStepDelegate) exec.Step
+}
+
+//go:generate counterfeiter . DelegateFactory
+
+type DelegateFactory interface {
+	GetDelegate(db.Build, atc.PlanID, vars.CredVarsTracker) exec.GetDelegate
+	PutDelegate(db.Build, atc.PlanID, vars.CredVarsTracker) exec.PutDelegate
+	TaskDelegate(db.Build, atc.PlanID, vars.CredVarsTracker) exec.TaskDelegate
+	CheckDelegate(db.Check, atc.PlanID, vars.CredVarsTracker) exec.CheckDelegate
+	BuildStepDelegate(db.Build, atc.PlanID, vars.CredVarsTracker) exec.BuildStepDelegate
+}
+
+func NewStepBuilder(
+	stepFactory StepFactory,
+	delegateFactory DelegateFactory,
+	externalURL string,
+	secrets creds.Secrets,
+	varSourcePool creds.VarSourcePool,
+	redactSecrets bool,
+	workerOverrides atc.UnsafeWorkerOverrides,
+) *stepBuilder {
+	return &stepBuilder{
+		stepFactory:     stepFactory,
+		delegateFactory: delegateFactory,
+		externalURL:     externalURL,
+		globalSecrets:   secrets,
+		varSourcePool:   varSourcePool,
+		redactSecrets:   redactSecrets,
+		workerOverrides: workerOverrides,
+	}
+}
+
+type stepBuilder struct {
+	stepFactory     StepFactory
+	delegateFactory DelegateFactory
+	externalURL     string
+	globalSecrets   creds.Secrets
+	varSourcePool   creds.VarSourcePool
+	redactSecrets   bool
+	workerOverrides atc.UnsafeWorkerOverrides
+}
+
+func (builder *stepBuilder) BuildStep(logger lager.Logger, build db.Build) (exec.Step, error) {
+	if build == nil {
+		return exec.IdentityStep{}, errors.New("must provide a build")
+	}
+
+	if build.Schema() != supportedSchema {
+		return exec.IdentityStep{}, errors.New("schema not supported")
+	}
+
+	var credVarsTracker vars.CredVarsTracker
+
+	// "fly execute" generated build will have no pipeline.
+	if build.PipelineID() == 0 {
+		globalVars := creds.NewVariables(builder.globalSecrets, build.TeamName(), build.PipelineName(), false)
+		credVarsTracker = vars.NewCredVarsTracker(globalVars, builder.redactSecrets)
+	} else {
+		pipeline, found, err := build.Pipeline()
+		if err != nil {
+			return exec.IdentityStep{}, errors.New(fmt.Sprintf("failed to find pipeline: %s", err.Error()))
+		}
+		if !found {
+			return exec.IdentityStep{}, errors.New("pipeline not found")
+		}
+
+		varss, err := pipeline.Variables(logger, builder.globalSecrets, builder.varSourcePool)
+		if err != nil {
+			return exec.IdentityStep{}, err
+		}
+		credVarsTracker = vars.NewCredVarsTracker(varss, builder.redactSecrets)
+	}
+
+	return builder.buildStep(build, build.PrivatePlan(), credVarsTracker), nil
+}
+
+func (builder *stepBuilder) BuildStepErrored(logger lager.Logger, build db.Build, err error) {
+	builder.delegateFactory.BuildStepDelegate(build, build.PrivatePlan().ID, nil).Errored(logger, err.Error())
+}
+
+func (builder *stepBuilder) CheckStep(logger lager.Logger, check db.Check) (exec.Step, error) {
+
+	if check == nil {
+		return exec.IdentityStep{}, errors.New("must provide a check")
+	}
+
+	if check.Schema() != supportedSchema {
+		return exec.IdentityStep{}, errors.New("schema not supported")
+	}
+
+	pipeline, found, err := check.Pipeline()
+	if err != nil {
+		return exec.IdentityStep{}, errors.New(fmt.Sprintf("failed to find pipeline: %s", err.Error()))
+	}
+	if !found {
+		return exec.IdentityStep{}, errors.New("pipeline not found")
+	}
+
+	varss, err := pipeline.Variables(logger, builder.globalSecrets, builder.varSourcePool)
+	if err != nil {
+		return exec.IdentityStep{}, fmt.Errorf("failed to create pipeline variables: %s", err.Error())
+	}
+	credVarsTracker := vars.NewCredVarsTracker(varss, builder.redactSecrets)
+	return builder.buildCheckStep(check, check.Plan(), credVarsTracker), nil
+}
+
+func (builder *stepBuilder) buildStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+	if plan.Aggregate != nil {
+		return builder.buildAggregateStep(build, plan, credVarsTracker)
+	}
+
+	if plan.InParallel != nil {
+		return builder.buildParallelStep(build, plan, credVarsTracker)
+	}
+
+	if plan.Do != nil {
+		return builder.buildDoStep(build, plan, credVarsTracker)
+	}
+
+	if plan.Timeout != nil {
+		return builder.buildTimeoutStep(build, plan, credVarsTracker)
+	}
+
+	if plan.Try != nil {
+		return builder.buildTryStep(build, plan, credVarsTracker)
+	}
+
+	if plan.OnAbort != nil {
+		return builder.buildOnAbortStep(build, plan, credVarsTracker)
+	}
+
+	if plan.OnError != nil {
+		return builder.buildOnErrorStep(build, plan, credVarsTracker)
+	}
+
+	if plan.OnSuccess != nil {
+		return builder.buildOnSuccessStep(build, plan, credVarsTracker)
+	}
+
+	if plan.OnFailure != nil {
+		return builder.buildOnFailureStep(build, plan, credVarsTracker)
+	}
+
+	if plan.Ensure != nil {
+		return builder.buildEnsureStep(build, plan, credVarsTracker)
+	}
+
+	if plan.Task != nil {
+		return builder.buildTaskStep(build, plan, credVarsTracker)
+	}
+
+	if plan.SetPipeline != nil {
+		return builder.buildSetPipelineStep(build, plan, credVarsTracker)
+	}
+
+	if plan.LoadVar != nil {
+		return builder.buildLoadVarStep(build, plan, credVarsTracker)
+	}
+
+	if plan.Get != nil {
+		return builder.buildGetStep(build, plan, credVarsTracker)
+	}
+
+	if plan.Put != nil {
+		return builder.buildPutStep(build, plan, credVarsTracker)
+	}
+
+	if plan.Retry != nil {
+		return builder.buildRetryStep(build, plan, credVarsTracker)
+	}
+
+	if plan.ArtifactInput != nil {
+		return builder.buildArtifactInputStep(build, plan, credVarsTracker)
+	}
+
+	if plan.ArtifactOutput != nil {
+		return builder.buildArtifactOutputStep(build, plan, credVarsTracker)
+	}
+
+	return exec.IdentityStep{}
+}
+
+func (builder *stepBuilder) buildAggregateStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	agg := exec.AggregateStep{}
+
+	for _, innerPlan := range *plan.Aggregate {
+		innerPlan.Attempts = plan.Attempts
+		step := builder.buildStep(build, innerPlan, credVarsTracker)
+		agg = append(agg, step)
+	}
+
+	return agg
+}
+
+func (builder *stepBuilder) buildParallelStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	var steps []exec.Step
+
+	for _, innerPlan := range plan.InParallel.Steps {
+		innerPlan.Attempts = plan.Attempts
+		step := builder.buildStep(build, innerPlan, credVarsTracker)
+		steps = append(steps, step)
+	}
+
+	return exec.InParallel(steps, plan.InParallel.Limit, plan.InParallel.FailFast)
+}
+
+func (builder *stepBuilder) buildDoStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	var step exec.Step = exec.IdentityStep{}
+
+	for i := len(*plan.Do) - 1; i >= 0; i-- {
+		innerPlan := (*plan.Do)[i]
+		innerPlan.Attempts = plan.Attempts
+		previous := builder.buildStep(build, innerPlan, credVarsTracker)
+		step = exec.OnSuccess(previous, step)
+	}
+
+	return step
+}
+
+func (builder *stepBuilder) buildTimeoutStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+	innerPlan := plan.Timeout.Step
+	innerPlan.Attempts = plan.Attempts
+	step := builder.buildStep(build, innerPlan, credVarsTracker)
+	return exec.Timeout(step, plan.Timeout.Duration)
+}
+
+func (builder *stepBuilder) buildTryStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+	innerPlan := plan.Try.Step
+	innerPlan.Attempts = plan.Attempts
+	step := builder.buildStep(build, innerPlan, credVarsTracker)
+	return exec.Try(step)
+}
+
+func (builder *stepBuilder) buildOnAbortStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+	plan.OnAbort.Step.Attempts = plan.Attempts
+	step := builder.buildStep(build, plan.OnAbort.Step, credVarsTracker)
+	plan.OnAbort.Next.Attempts = plan.Attempts
+	next := builder.buildStep(build, plan.OnAbort.Next, credVarsTracker)
+	return exec.OnAbort(step, next)
+}
+
+func (builder *stepBuilder) buildOnErrorStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+	plan.OnError.Step.Attempts = plan.Attempts
+	step := builder.buildStep(build, plan.OnError.Step, credVarsTracker)
+	plan.OnError.Next.Attempts = plan.Attempts
+	next := builder.buildStep(build, plan.OnError.Next, credVarsTracker)
+	return exec.OnError(step, next)
+}
+
+func (builder *stepBuilder) buildOnSuccessStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+	plan.OnSuccess.Step.Attempts = plan.Attempts
+	step := builder.buildStep(build, plan.OnSuccess.Step, credVarsTracker)
+	plan.OnSuccess.Next.Attempts = plan.Attempts
+	next := builder.buildStep(build, plan.OnSuccess.Next, credVarsTracker)
+	return exec.OnSuccess(step, next)
+}
+
+func (builder *stepBuilder) buildOnFailureStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+	plan.OnFailure.Step.Attempts = plan.Attempts
+	step := builder.buildStep(build, plan.OnFailure.Step, credVarsTracker)
+	plan.OnFailure.Next.Attempts = plan.Attempts
+	next := builder.buildStep(build, plan.OnFailure.Next, credVarsTracker)
+	return exec.OnFailure(step, next)
+}
+
+func (builder *stepBuilder) buildEnsureStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+	plan.Ensure.Step.Attempts = plan.Attempts
+	step := builder.buildStep(build, plan.Ensure.Step, credVarsTracker)
+	plan.Ensure.Next.Attempts = plan.Attempts
+	next := builder.buildStep(build, plan.Ensure.Next, credVarsTracker)
+	return exec.Ensure(step, next)
+}
+
+func (builder *stepBuilder) buildRetryStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+	steps := []exec.Step{}
+
+	for index, innerPlan := range *plan.Retry {
+		innerPlan.Attempts = append(plan.Attempts, index+1)
+
+		step := builder.buildStep(build, innerPlan, credVarsTracker)
+		steps = append(steps, step)
+	}
+
+	return exec.Retry(steps...)
+}
+
+func (builder *stepBuilder) buildGetStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	containerMetadata := builder.containerMetadata(
+		build,
+		db.ContainerTypeGet,
+		plan.Get.Name,
+		plan.Attempts,
+	)
+
+	stepMetadata := builder.stepMetadata(
+		build,
+		builder.externalURL,
+	)
+
+	return builder.stepFactory.GetStep(
+		plan,
+		stepMetadata,
+		containerMetadata,
+		builder.delegateFactory.GetDelegate(build, plan.ID, credVarsTracker),
+	)
+}
+
+func (builder *stepBuilder) buildPutStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	containerMetadata := builder.containerMetadata(
+		build,
+		db.ContainerTypePut,
+		plan.Put.Name,
+		plan.Attempts,
+	)
+
+	stepMetadata := builder.stepMetadata(
+		build,
+		builder.externalURL,
+	)
+
+	return builder.stepFactory.PutStep(
+		plan,
+		stepMetadata,
+		containerMetadata,
+		builder.delegateFactory.PutDelegate(build, plan.ID, credVarsTracker),
+	)
+}
+
+func (builder *stepBuilder) buildCheckStep(check db.Check, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	containerMetadata := db.ContainerMetadata{
+		Type: db.ContainerTypeCheck,
+	}
+
+	stepMetadata := exec.StepMetadata{
+		TeamID:                check.TeamID(),
+		TeamName:              check.TeamName(),
+		PipelineID:            check.PipelineID(),
+		PipelineName:          check.PipelineName(),
+		ResourceConfigScopeID: check.ResourceConfigScopeID(),
+		ResourceConfigID:      check.ResourceConfigID(),
+		BaseResourceTypeID:    check.BaseResourceTypeID(),
+		ExternalURL:           builder.externalURL,
+	}
+
+	return builder.stepFactory.CheckStep(
+		plan,
+		stepMetadata,
+		containerMetadata,
+		builder.delegateFactory.CheckDelegate(check, plan.ID, credVarsTracker),
+	)
+}
+
+func (builder *stepBuilder) buildTaskStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	containerMetadata := builder.containerMetadata(
+		build,
+		db.ContainerTypeTask,
+		plan.Task.Name,
+		plan.Attempts,
+	)
+
+	stepMetadata := builder.stepMetadata(
+		build,
+		builder.externalURL,
+	)
+
+	return builder.stepFactory.TaskStep(
+		plan,
+		stepMetadata,
+		containerMetadata,
+		builder.delegateFactory.TaskDelegate(build, plan.ID, credVarsTracker),
+		builder.workerOverrides,
+	)
+}
+
+func (builder *stepBuilder) buildSetPipelineStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	stepMetadata := builder.stepMetadata(
+		build,
+		builder.externalURL,
+	)
+
+	return builder.stepFactory.SetPipelineStep(
+		plan,
+		stepMetadata,
+		builder.delegateFactory.BuildStepDelegate(build, plan.ID, credVarsTracker),
+	)
+}
+
+func (builder *stepBuilder) buildLoadVarStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	stepMetadata := builder.stepMetadata(
+		build,
+		builder.externalURL,
+	)
+
+	return builder.stepFactory.LoadVarStep(
+		plan,
+		stepMetadata,
+		builder.delegateFactory.BuildStepDelegate(build, plan.ID, credVarsTracker),
+	)
+}
+
+func (builder *stepBuilder) buildArtifactInputStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	return builder.stepFactory.ArtifactInputStep(
+		plan,
+		build,
+		builder.delegateFactory.BuildStepDelegate(build, plan.ID, credVarsTracker),
+	)
+}
+
+func (builder *stepBuilder) buildArtifactOutputStep(build db.Build, plan atc.Plan, credVarsTracker vars.CredVarsTracker) exec.Step {
+
+	return builder.stepFactory.ArtifactOutputStep(
+		plan,
+		build,
+		builder.delegateFactory.BuildStepDelegate(build, plan.ID, credVarsTracker),
+	)
+}
+
+func (builder *stepBuilder) containerMetadata(
+	build db.Build,
+	containerType db.ContainerType,
+	stepName string,
+	attempts []int,
+) db.ContainerMetadata {
+	attemptStrs := []string{}
+	for _, a := range attempts {
+		attemptStrs = append(attemptStrs, strconv.Itoa(a))
+	}
+
+	return db.ContainerMetadata{
+		Type: containerType,
+
+		PipelineID: build.PipelineID(),
+		JobID:      build.JobID(),
+		BuildID:    build.ID(),
+
+		PipelineName: build.PipelineName(),
+		JobName:      build.JobName(),
+		BuildName:    build.Name(),
+
+		StepName: stepName,
+		Attempt:  strings.Join(attemptStrs, "."),
+	}
+}
+
+func (builder *stepBuilder) stepMetadata(
+	build db.Build,
+	externalURL string,
+) exec.StepMetadata {
+	return exec.StepMetadata{
+		BuildID:      build.ID(),
+		BuildName:    build.Name(),
+		TeamID:       build.TeamID(),
+		TeamName:     build.TeamName(),
+		JobID:        build.JobID(),
+		JobName:      build.JobName(),
+		PipelineID:   build.PipelineID(),
+		PipelineName: build.PipelineName(),
+		ExternalURL:  externalURL,
+	}
+}

--- a/atc/engine/builder/step_factory.go
+++ b/atc/engine/builder/step_factory.go
@@ -1,0 +1,217 @@
+package builder
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"path/filepath"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/lock"
+	"github.com/concourse/concourse/atc/exec"
+	"github.com/concourse/concourse/atc/resource"
+	"github.com/concourse/concourse/atc/worker"
+)
+
+type stepFactory struct {
+	pool                            worker.Pool
+	client                          worker.Client
+	resourceFactory                 resource.ResourceFactory
+	teamFactory                     db.TeamFactory
+	resourceCacheFactory            db.ResourceCacheFactory
+	resourceConfigFactory           db.ResourceConfigFactory
+	defaultLimits                   atc.ContainerLimits
+	strategy                        worker.ContainerPlacementStrategy
+	lockFactory                     lock.LockFactory
+	enableRerunWhenWorkerDisappears bool
+}
+
+func NewStepFactory(
+	pool worker.Pool,
+	client worker.Client,
+	resourceFactory resource.ResourceFactory,
+	teamFactory db.TeamFactory,
+	resourceCacheFactory db.ResourceCacheFactory,
+	resourceConfigFactory db.ResourceConfigFactory,
+	defaultLimits atc.ContainerLimits,
+	strategy worker.ContainerPlacementStrategy,
+	lockFactory lock.LockFactory,
+	enableRerunWhenWorkerDisappears bool,
+) *stepFactory {
+	return &stepFactory{
+		pool:                            pool,
+		client:                          client,
+		resourceFactory:                 resourceFactory,
+		teamFactory:                     teamFactory,
+		resourceCacheFactory:            resourceCacheFactory,
+		resourceConfigFactory:           resourceConfigFactory,
+		defaultLimits:                   defaultLimits,
+		strategy:                        strategy,
+		lockFactory:                     lockFactory,
+		enableRerunWhenWorkerDisappears: enableRerunWhenWorkerDisappears,
+	}
+}
+
+func (factory *stepFactory) GetStep(
+	plan atc.Plan,
+	stepMetadata exec.StepMetadata,
+	containerMetadata db.ContainerMetadata,
+	delegate exec.GetDelegate,
+) exec.Step {
+	containerMetadata.WorkingDirectory = resource.ResourcesDir("get")
+
+	getStep := exec.NewGetStep(
+		plan.ID,
+		*plan.Get,
+		stepMetadata,
+		containerMetadata,
+		factory.resourceFactory,
+		factory.resourceCacheFactory,
+		factory.strategy,
+		delegate,
+		factory.client,
+	)
+
+	getStep = exec.LogError(getStep, delegate)
+	if factory.enableRerunWhenWorkerDisappears {
+		getStep = exec.RetryError(getStep, delegate)
+	}
+	return getStep
+}
+
+func (factory *stepFactory) PutStep(
+	plan atc.Plan,
+	stepMetadata exec.StepMetadata,
+	containerMetadata db.ContainerMetadata,
+	delegate exec.PutDelegate,
+) exec.Step {
+	containerMetadata.WorkingDirectory = resource.ResourcesDir("put")
+
+	putStep := exec.NewPutStep(
+		plan.ID,
+		*plan.Put,
+		stepMetadata,
+		containerMetadata,
+		factory.resourceFactory,
+		factory.resourceConfigFactory,
+		factory.strategy,
+		factory.client,
+		delegate,
+	)
+
+	putStep = exec.LogError(putStep, delegate)
+	if factory.enableRerunWhenWorkerDisappears {
+		putStep = exec.RetryError(putStep, delegate)
+	}
+	return putStep
+}
+
+func (factory *stepFactory) CheckStep(
+	plan atc.Plan,
+	stepMetadata exec.StepMetadata,
+	containerMetadata db.ContainerMetadata,
+	delegate exec.CheckDelegate,
+) exec.Step {
+	containerMetadata.WorkingDirectory = resource.ResourcesDir("check")
+	// TODO (runtime/#4957): Placement Strategy should be abstracted out from step factory or step level concern
+	checkStep := exec.NewCheckStep(
+		plan.ID,
+		*plan.Check,
+		stepMetadata,
+		factory.resourceFactory,
+		containerMetadata,
+		worker.NewRandomPlacementStrategy(),
+		factory.pool,
+		delegate,
+		factory.client,
+	)
+
+	return checkStep
+}
+
+func (factory *stepFactory) TaskStep(
+	plan atc.Plan,
+	stepMetadata exec.StepMetadata,
+	containerMetadata db.ContainerMetadata,
+	delegate exec.TaskDelegate,
+	workerOverrides atc.UnsafeWorkerOverrides,
+) exec.Step {
+	sum := sha1.Sum([]byte(plan.Task.Name))
+	containerMetadata.WorkingDirectory = filepath.Join("/tmp", "build", fmt.Sprintf("%x", sum[:4]))
+
+	taskStep := exec.NewTaskStep(
+		plan.ID,
+		*plan.Task,
+		factory.defaultLimits,
+		stepMetadata,
+		containerMetadata,
+		factory.strategy,
+		factory.client,
+		delegate,
+		factory.lockFactory,
+		workerOverrides,
+	)
+
+	taskStep = exec.LogError(taskStep, delegate)
+	if factory.enableRerunWhenWorkerDisappears {
+		taskStep = exec.RetryError(taskStep, delegate)
+	}
+	return taskStep
+}
+
+func (factory *stepFactory) SetPipelineStep(
+	plan atc.Plan,
+	stepMetadata exec.StepMetadata,
+	delegate exec.BuildStepDelegate,
+) exec.Step {
+	spStep := exec.NewSetPipelineStep(
+		plan.ID,
+		*plan.SetPipeline,
+		stepMetadata,
+		delegate,
+		factory.teamFactory,
+		factory.client,
+	)
+
+	spStep = exec.LogError(spStep, delegate)
+	if factory.enableRerunWhenWorkerDisappears {
+		spStep = exec.RetryError(spStep, delegate)
+	}
+	return spStep
+}
+
+func (factory *stepFactory) LoadVarStep(
+	plan atc.Plan,
+	stepMetadata exec.StepMetadata,
+	delegate exec.BuildStepDelegate,
+) exec.Step {
+	loadVarStep := exec.NewLoadVarStep(
+		plan.ID,
+		*plan.LoadVar,
+		stepMetadata,
+		delegate,
+		factory.client,
+	)
+
+	loadVarStep = exec.LogError(loadVarStep, delegate)
+	if factory.enableRerunWhenWorkerDisappears {
+		loadVarStep = exec.RetryError(loadVarStep, delegate)
+	}
+	return loadVarStep
+}
+
+func (factory *stepFactory) ArtifactInputStep(
+	plan atc.Plan,
+	build db.Build,
+	delegate exec.BuildStepDelegate,
+) exec.Step {
+	return exec.NewArtifactInputStep(plan, build, factory.client, delegate)
+}
+
+func (factory *stepFactory) ArtifactOutputStep(
+	plan atc.Plan,
+	build db.Build,
+	delegate exec.BuildStepDelegate,
+) exec.Step {
+	return exec.NewArtifactOutputStep(plan, build, factory.client, delegate)
+}

--- a/atc/engine/builder_test.go
+++ b/atc/engine/builder_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Builder", func() {
 				"http://example.com",
 				fakeRateLimiter,
 				fakePolicyChecker,
+				atc.UnsafeWorkerOverrides{},
 			)
 
 			planFactory = atc.NewPlanFactory(123)

--- a/atc/engine/enginefakes/fake_core_step_factory.go
+++ b/atc/engine/enginefakes/fake_core_step_factory.go
@@ -110,6 +110,8 @@ type FakeCoreStepFactory struct {
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
 		arg4 engine.DelegateFactory
+		arg5 exec.TaskDelegate
+		arg6 atc.UnsafeWorkerOverrides
 	}
 	taskStepReturns struct {
 		result1 exec.Step
@@ -556,7 +558,7 @@ func (fake *FakeCoreStepFactory) SetPipelineStepReturnsOnCall(i int, result1 exe
 	}{result1}
 }
 
-func (fake *FakeCoreStepFactory) TaskStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 engine.DelegateFactory) exec.Step {
+func (fake *FakeCoreStepFactory) TaskStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 engine.DelegateFactory, arg5 atc.UnsafeWorkerOverrides) exec.Step {
 	fake.taskStepMutex.Lock()
 	ret, specificReturn := fake.taskStepReturnsOnCall[len(fake.taskStepArgsForCall)]
 	fake.taskStepArgsForCall = append(fake.taskStepArgsForCall, struct {
@@ -564,7 +566,8 @@ func (fake *FakeCoreStepFactory) TaskStep(arg1 atc.Plan, arg2 exec.StepMetadata,
 		arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
 		arg4 engine.DelegateFactory
-	}{arg1, arg2, arg3, arg4})
+		arg5 atc.UnsafeWorkerOverrides
+	}{arg1, arg2, arg3, arg4, arg5})
 	fake.recordInvocation("TaskStep", []interface{}{arg1, arg2, arg3, arg4})
 	fake.taskStepMutex.Unlock()
 	if fake.TaskStepStub != nil {

--- a/atc/task.go
+++ b/atc/task.go
@@ -47,11 +47,16 @@ type ImageResource struct {
 	Tags    Tags    `json:"tags,omitempty"`
 }
 
+// UnsafeWorkerOverrides encapsulates configuration applied to all workers,
+// which breaks the isolation between workload and worker.
+type UnsafeWorkerOverrides struct {
+	BindMounts map[string]string `json:"bind-mounts,omitempty"`
+}
+
 func (ir *ImageResource) ApplySourceDefaults(resourceTypes VersionedResourceTypes) {
 	if ir == nil {
 		return
 	}
-
 	parentType, found := resourceTypes.Lookup(ir.Type)
 	if found {
 		ir.Source = parentType.Defaults.Merge(ir.Source)

--- a/atc/worker/holepunch_mount.go
+++ b/atc/worker/holepunch_mount.go
@@ -1,0 +1,15 @@
+package worker
+
+import "code.cloudfoundry.org/garden"
+
+type HolepunchMount struct {
+	FromPath, ToPath string
+}
+
+func (m *HolepunchMount) VolumeOn(worker Worker) (garden.BindMount, bool, error) {
+	return garden.BindMount{
+		SrcPath: m.FromPath,
+		DstPath: m.ToPath,
+		Mode:    garden.BindMountModeRW,
+	}, true, nil
+}


### PR DESCRIPTION
<!---
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!---
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes #5495, #5674.

## Changes proposed by this PR:
As discussed in #5495, a new option is added to ATC to apply additional bind mounts to all task steps. This should allow people who _do_ trust their workloads with access to the workers, to do so. 

This is necessary for access to attached peripherals (such as GPUs or hardware testbeds), and then also kids like me who run concourse on a single box and just want to yeet artifacts to disk.


## Notes to reviewer:
Basically adding a `--mount-holepunch "workerpath:containerpath"` should create the corresponding bind mount in all task step executions.

Reading the checklist below ... what do

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [X] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [X] [Signed] all commits
- [X] Added tests (**Unit** and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
