### PR TITLE
web: behaviour: fresh data over stale

### DIFF
--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -460,14 +460,19 @@ handleDeliveryBody delivery ( model, effects ) =
             ( model, effects ++ [ GetViewportOf Dashboard AlwaysShow ] )
 
         CachedPipelinesReceived (Ok pipelines) ->
-            let
-                newPipelines =
-                    pipelines
-                        |> List.map (toDashboardPipeline True (model.jobsError == Just Disabled))
-                        |> Just
-            in
-            if newPipelines |> pipelinesChangedFrom model.pipelines then
-                ( { model | pipelines = newPipelines }, effects )
+            if model.pipelines == Nothing then
+                ( { model
+                    | pipelines =
+                        pipelines
+                            |> List.map
+                                (toDashboardPipeline
+                                    True
+                                    (model.jobsError == Just Disabled)
+                                )
+                            |> Just
+                  }
+                , effects
+                )
 
             else
                 ( model, effects )

--- a/web/elm/tests/DashboardCacheTests.elm
+++ b/web/elm/tests/DashboardCacheTests.elm
@@ -211,6 +211,23 @@ all =
                         )
                     |> Tuple.second
                     |> Common.contains (SaveCachedPipelines [ Data.pipeline "team" 0 ])
+        , test "ignores cached pipelines if we've already fetched from network" <|
+            \_ ->
+                Common.init "/"
+                    |> Application.handleCallback
+                        (AllPipelinesFetched <|
+                            Ok <|
+                                [ Data.pipeline "team" 0 ]
+                        )
+                    |> Tuple.first
+                    |> Application.handleDelivery
+                        (CachedPipelinesReceived <|
+                            Ok <|
+                                []
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.has [ class "pipeline-wrapper", containing [ text "pipeline-0" ] ]
         , test "does not save pipelines to cache when fetched with no change" <|
             \_ ->
                 Common.init "/"


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #5669.

## Changes proposed by this PR:

In the old model of `FetchResult`, there were three distinct states for the entire set of pipelines -- `None`, `Cached` and `Fetched`. However, part of the work done in #5529 was preliminary refactoring to allow each pipeline to have its own `.stale` state. This would be important for implementing #5556. However, I kinda got it wrong by just reusing the `changedFrom` funtion. This way ensures that stale data cannot overwrite fresh data -- the only way stale data results in a UI change is if there was previously no data at all!

## Notes to reviewer:

For manual verification, I found it valuable to inject some slowness to the interactions with localStorage. This makes the reproduction steps described by @aoldershaw in #5669 very consistent.

```diff
diff --git a/web/public/elm-setup.js b/web/public/elm-setup.js
index 3f06b583a..0a2983fef 100644
--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -110,7 +110,8 @@ app.ports.tooltipHd.subscribe(function (pipelineInfo) {
   title.parentNode.setAttribute('data-tooltip', pipelineName);
 });
 
-app.ports.saveToLocalStorage.subscribe(function(params) {
+app.ports.saveToLocalStorage.subscribe(async function(params) {
+  await new Promise(r => setTimeout(r, 2000));
   if (!params || params.length !== 2) {
     return;
   }
@@ -134,7 +135,8 @@ app.ports.saveToSessionStorage.subscribe(function(params) {
   }
 });
 
-app.ports.loadFromLocalStorage.subscribe(function(key) {
+app.ports.loadFromLocalStorage.subscribe(async function(key) {
+  await new Promise(r => setTimeout(r, 1000));
   const value = localStorage.getItem(key);
   if (value === null) {
     return;
```

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] ~Updated [Documentation]~
- [x] ~Updated [Release notes]~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
