### PR TITLE
atc: structure: fix NewEmitter structure by adding checks field

### DIFF
--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -61,7 +61,7 @@ func (config *NewRelicConfig) IsConfigured() bool {
 
 func (config *NewRelicConfig) NewEmitter() (metric.Emitter, error) {
 	client := &http.Client{
-		Transport: &http.Transport{},
+		Transport: &http.Transport{ Proxy: http.ProxyFromEnvironment },
 		Timeout:   time.Minute,
 	}
 
@@ -72,6 +72,7 @@ func (config *NewRelicConfig) NewEmitter() (metric.Emitter, error) {
 		prefix:             config.ServicePrefix,
 		containers:         new(stats),
 		volumes:            new(stats),
+		checks:             new(stats),
 		BatchSize:          int(config.BatchSize),
 		BatchDuration:      config.BatchDuration,
 		DisableCompression: config.DisableCompression,

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -69,3 +69,11 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 #### <sub><sup><a name="5624" href="#5624">:link:</a></sup></sub> fix
 
 * Fixed a bug where fly would no longer tell you if the team you logged in with was invalid
+
+#### <sub><sup><a name="newrelic-checks-fix" href="#newrelic-checks-fix">:link:</a></sup></sub> fix
+
+* Fixed a bug "invalid memory address or nil pointer dereference" in NewRelic emitter
+
+#### <sub><sup><a name="5222" href="#5222">:link:</a></sup></sub> feature
+
+* Proxy support for NewRelic emitter


### PR DESCRIPTION
checks field was not initialized so "checks delete" event causes an error "invalid memory address or nil pointer dereference"

<!---
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!---
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | Feature | Documentation

* Bug Fix: checks field was not initialized so "checks delete" event causes an error "invalid memory address or nil pointer dereference"
* Feature: Proxy support for NewRelic emitter

closes: #5222 

## Changes proposed by this PR:
<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
