### PR TITLE
Conjur credential manager provide certificate as string

### DIFF
--- a/atc/creds/conjur/manager.go
+++ b/atc/creds/conjur/manager.go
@@ -20,6 +20,7 @@ type Manager struct {
 	ConjurApplianceUrl     string `long:"appliance-url" description:"URL of the conjur instance"`
 	ConjurAccount          string `long:"account" description:"Conjur Account"`
 	ConjurCertFile         string `long:"cert-file" description:"Cert file used if conjur instance is using a self signed cert. E.g. /path/to/conjur.pem"`
+	SSLCertificate         string `long:"ssl-certificate" description:"Cert content. This is used when deploying from bosh"`
 	ConjurAuthnLogin       string `long:"authn-login" description:"Host username. E.g host/concourse"`
 	ConjurAuthnApiKey      string `long:"authn-api-key" description:"Api key related to the host"`
 	ConjurAuthnTokenFile   string `long:"authn-token-file" description:"Token file used if conjur instance is running in k8s or iam. E.g. /path/to/token_file"`
@@ -34,6 +35,7 @@ func newConjurClient(manager *Manager) (*conjurapi.Client, error) {
 		Account:      manager.ConjurAccount,
 		ApplianceURL: manager.ConjurApplianceUrl,
 		SSLCertPath:  manager.ConjurCertFile,
+		SSLCert:      manager.SSLCertificate,
 	}
 
 	if manager.ConjurAuthnTokenFile != "" {


### PR DESCRIPTION
Signed-off-by: AndrewCopeland <andcope1995@gmail.com>

## What does this PR accomplish?
Bug Fix

Adds the ability to provide CA certificate as a string for the conjur credential manager.

closes #5701 .

## Changes proposed by this PR:
Add ability to provide the ca certificate as a string. Currently certificate must be provided as a file.

## Notes to reviewer: 
Relates to this Issue: https://github.com/concourse/concourse-bosh-release/issues/105

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [] Updated [Documentation]
- [] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
