### PR TITLE
containerd: run task with the specified user

### DIFF
--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -78,7 +78,7 @@ func (c *Container) Run(
 	procSpec := containerSpec.Process
 	setupContainerdProcSpec(spec, procSpec)
 
-	err = c.rootfsManager.SetupCwd(containerSpec, procSpec.Cwd)
+	err = c.rootfsManager.SetupCwd(containerSpec.Root.Path, procSpec.Cwd)
 	if err != nil {
 		return nil, fmt.Errorf("setup cwd: %w", err)
 	}

--- a/worker/runtime/container_test.go
+++ b/worker/runtime/container_test.go
@@ -5,8 +5,8 @@ import (
 
 	"code.cloudfoundry.org/garden"
 	"github.com/concourse/concourse/worker/runtime"
-	"github.com/concourse/concourse/worker/runtime/runtimefakes"
 	"github.com/concourse/concourse/worker/runtime/libcontainerd/libcontainerdfakes"
+	"github.com/concourse/concourse/worker/runtime/runtimefakes"
 	"github.com/containerd/containerd"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
@@ -78,6 +78,7 @@ func (s *ContainerSuite) TestRunContainerSpecErr() {
 func (s *ContainerSuite) TestRunWithNonRootCwdSetupCwdFails() {
 	s.containerdContainer.SpecReturns(&specs.Spec{
 		Process: &specs.Process{},
+		Root:    &specs.Root{},
 	}, nil)
 
 	expectedErr := errors.New("setup-cwd-err")
@@ -90,6 +91,7 @@ func (s *ContainerSuite) TestRunWithNonRootCwdSetupCwdFails() {
 func (s *ContainerSuite) TestRunTaskError() {
 	s.containerdContainer.SpecReturns(&specs.Spec{
 		Process: &specs.Process{},
+		Root:    &specs.Root{},
 	}, nil)
 
 	expectedErr := errors.New("task-err")
@@ -102,6 +104,7 @@ func (s *ContainerSuite) TestRunTaskError() {
 func (s *ContainerSuite) TestRunTaskExecError() {
 	s.containerdContainer.SpecReturns(&specs.Spec{
 		Process: &specs.Process{},
+		Root:    &specs.Root{},
 	}, nil)
 
 	s.containerdContainer.TaskReturns(s.containerdTask, nil)
@@ -116,6 +119,7 @@ func (s *ContainerSuite) TestRunTaskExecError() {
 func (s *ContainerSuite) TestRunProcWaitError() {
 	s.containerdContainer.SpecReturns(&specs.Spec{
 		Process: &specs.Process{},
+		Root:    &specs.Root{},
 	}, nil)
 
 	s.containerdContainer.TaskReturns(s.containerdTask, nil)
@@ -131,6 +135,7 @@ func (s *ContainerSuite) TestRunProcWaitError() {
 func (s *ContainerSuite) TestRunProcStartError() {
 	s.containerdContainer.SpecReturns(&specs.Spec{
 		Process: &specs.Process{},
+		Root:    &specs.Root{},
 	}, nil)
 
 	s.containerdContainer.TaskReturns(s.containerdTask, nil)
@@ -146,6 +151,7 @@ func (s *ContainerSuite) TestRunProcStartError() {
 func (s *ContainerSuite) TestRunProcCloseIOError() {
 	s.containerdContainer.SpecReturns(&specs.Spec{
 		Process: &specs.Process{},
+		Root:    &specs.Root{},
 	}, nil)
 
 	s.containerdContainer.TaskReturns(s.containerdTask, nil)
@@ -161,6 +167,7 @@ func (s *ContainerSuite) TestRunProcCloseIOError() {
 func (s *ContainerSuite) TestRunProcCloseIOWithStdin() {
 	s.containerdContainer.SpecReturns(&specs.Spec{
 		Process: &specs.Process{},
+		Root:    &specs.Root{},
 	}, nil)
 
 	s.containerdContainer.TaskReturns(s.containerdTask, nil)

--- a/worker/runtime/rootfs_manager.go
+++ b/worker/runtime/rootfs_manager.go
@@ -1,9 +1,12 @@
 package runtime
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -67,4 +70,47 @@ func (r rootfsManager) SetupCwd(containerSpec *specs.Spec, cwd string) error {
 	}
 
 	return nil
+}
+
+// Mostly copied from Go's `os/user` package
+// https://github.com/golang/go/blob/f296b7a6f045325a230f77e9bda1470b1270f817/src/os/user/lookup_unix.go#L35
+func (r rootfsManager) LookupUser(containerSpec *specs.Spec, username string) (specs.User, bool, error) {
+	path := filepath.Join(containerSpec.Root.Path, "etc", "passwd")
+	file, err := os.Open(path)
+	if err != nil {
+		return specs.User{}, false, err
+	}
+	defer file.Close()
+	bs := bufio.NewScanner(file)
+	for bs.Scan() {
+		line := bs.Text()
+
+		// There's no spec for /etc/passwd or /etc/group, but we try to follow
+		// the same rules as the glibc parser, which allows comments and blank
+		// space at the beginning of a line.
+		line = strings.TrimSpace(line)
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+
+		parts := strings.Split(line, ":")
+		if len(parts) != 7 {
+			continue
+		}
+		if parts[0] != username {
+			continue
+		}
+		var (
+			uid int
+			gid int
+		)
+		if uid, err = strconv.Atoi(parts[2]); err != nil {
+			return specs.User{}, false, fmt.Errorf("invalid uid: %w", err)
+		}
+		if gid, err = strconv.Atoi(parts[3]); err != nil {
+			return specs.User{}, false, fmt.Errorf("invalid gid: %w", err)
+		}
+		return specs.User{UID: uint32(uid), GID: uint32(gid)}, true, nil
+	}
+	return specs.User{}, false, bs.Err()
 }

--- a/worker/runtime/rootfs_manager_test.go
+++ b/worker/runtime/rootfs_manager_test.go
@@ -15,27 +15,18 @@ type RootfsManagerSuite struct {
 	suite.Suite
 	*require.Assertions
 
-	rootfs              string
-	baseSpec            *specs.Spec
-	specWithUIDMappings *specs.Spec
+	rootfsPath string
 }
 
 func (s *RootfsManagerSuite) SetupTest() {
 	var err error
 
-	s.rootfs, err = ioutil.TempDir("", "rootfs-mgr")
+	s.rootfsPath, err = ioutil.TempDir("", "rootfs-mgr")
 	s.NoError(err)
-
-	s.baseSpec = &specs.Spec{
-		Root: &specs.Root{
-			Path: s.rootfs,
-		},
-		Linux: &specs.Linux{},
-	}
 }
 
 func (s *RootfsManagerSuite) TearDownTest() {
-	os.RemoveAll(s.rootfs)
+	os.RemoveAll(s.rootfsPath)
 }
 
 func (s *RootfsManagerSuite) TestSetupCwdDirAlreadyExists() {
@@ -47,11 +38,11 @@ func (s *RootfsManagerSuite) TestSetupCwdDirAlreadyExists() {
 		}),
 	)
 
-	path := filepath.Join(s.rootfs, "dir")
+	path := filepath.Join(s.rootfsPath, "dir")
 	err := os.MkdirAll(path, 0755)
 	s.NoError(err)
 
-	err = mgr.SetupCwd(s.baseSpec, "dir")
+	err = mgr.SetupCwd(s.rootfsPath, "dir")
 	s.NoError(err)
 	s.False(mkdirCalled, "does not call mkdir")
 }
@@ -59,17 +50,17 @@ func (s *RootfsManagerSuite) TestSetupCwdDirAlreadyExists() {
 func (s *RootfsManagerSuite) TestSetupCwdCreatePathsRecursivelyByDefault() {
 	mgr := runtime.NewRootfsManager()
 
-	err := mgr.SetupCwd(s.baseSpec, "/this/that")
+	err := mgr.SetupCwd(s.rootfsPath, "/this/that")
 	s.NoError(err)
 
-	finfo, err := os.Stat(filepath.Join(s.rootfs, "this", "that"))
+	finfo, err := os.Stat(filepath.Join(s.rootfsPath, "this", "that"))
 	s.NoError(err)
 	s.True(finfo.IsDir())
 }
 
 func (s *RootfsManagerSuite) TestSetupCwdWithoutIDMappings() {
 	var (
-		path, expectedPath             = "", filepath.Join(s.rootfs, "dir")
+		path, expectedPath             = "", filepath.Join(s.rootfsPath, "dir")
 		mode, expectedMode os.FileMode = 0000, 0777
 	)
 
@@ -81,7 +72,7 @@ func (s *RootfsManagerSuite) TestSetupCwdWithoutIDMappings() {
 		}),
 	)
 
-	err := mgr.SetupCwd(s.baseSpec, "dir")
+	err := mgr.SetupCwd(s.rootfsPath, "dir")
 	s.NoError(err)
 
 	s.Equal(expectedPath, path)
@@ -94,7 +85,7 @@ func (s *RootfsManagerSuite) TestLookupUserReturnsUserInfo() {
 		root:*:0:0:System Administrator:/var/root:/bin/sh
 		some_user_name:*:1:1:Some User:/var/root:/usr/bin/false
 	`)
-	actualUser, ok, err := mgr.LookupUser(s.baseSpec, "some_user_name")
+	actualUser, ok, err := mgr.LookupUser(s.rootfsPath, "some_user_name")
 	s.NoError(err)
 
 	s.True(ok)
@@ -113,7 +104,7 @@ func (s *RootfsManagerSuite) TestLookupUserUsernameNotFound() {
 		some_user_name:*:1:1:Some User:/var/root:/usr/bin/false
 	`)
 
-	_, ok, err := mgr.LookupUser(s.baseSpec, "missing_username")
+	_, ok, err := mgr.LookupUser(s.rootfsPath, "missing_username")
 	s.NoError(err)
 	s.False(ok)
 }
@@ -125,7 +116,7 @@ func (s *RootfsManagerSuite) TestLookupUserInvalidUID() {
 		some_user_name:*:NaN:0:System Administrator:/var/root:/bin/sh
 	`)
 
-	_, _, err := mgr.LookupUser(s.baseSpec, "some_user_name")
+	_, _, err := mgr.LookupUser(s.rootfsPath, "some_user_name")
 	s.Error(err)
 }
 
@@ -136,14 +127,14 @@ func (s *RootfsManagerSuite) TestLookupUserInvalidGID() {
 		some_user_name:*:0:NaN:System Administrator:/var/root:/bin/sh
 	`)
 
-	_, _, err := mgr.LookupUser(s.baseSpec, "some_user_name")
+	_, _, err := mgr.LookupUser(s.rootfsPath, "some_user_name")
 	s.Error(err)
 }
 
 func (s *RootfsManagerSuite) TestLookupUserEtcPasswdNotFound() {
 	mgr := runtime.NewRootfsManager()
 
-	_, _, err := mgr.LookupUser(s.baseSpec, "username")
+	_, _, err := mgr.LookupUser(s.rootfsPath, "username")
 	s.Error(err)
 }
 
@@ -156,15 +147,15 @@ func (s *RootfsManagerSuite) TestLookupUserIgnoreNonUserInfo() {
 
 		some_user_name:*:1:1:Some User:/var/root:/usr/bin/false
 	`)
-	_, ok, err := mgr.LookupUser(s.baseSpec, "some_user_name")
+	_, ok, err := mgr.LookupUser(s.rootfsPath, "some_user_name")
 	s.NoError(err)
 	s.True(ok)
 }
 
 func (s *RootfsManagerSuite) writeEtcPasswd(contents string) {
-	err := os.MkdirAll(filepath.Join(s.rootfs, "etc"), 0755)
+	err := os.MkdirAll(filepath.Join(s.rootfsPath, "etc"), 0755)
 	s.NoError(err)
 
-	err = ioutil.WriteFile(filepath.Join(s.rootfs, "etc", "passwd"), []byte(contents), 0755)
+	err = ioutil.WriteFile(filepath.Join(s.rootfsPath, "etc", "passwd"), []byte(contents), 0755)
 	s.NoError(err)
 }

--- a/worker/runtime/runtimefakes/fake_rootfs_manager.go
+++ b/worker/runtime/runtimefakes/fake_rootfs_manager.go
@@ -9,10 +9,26 @@ import (
 )
 
 type FakeRootfsManager struct {
-	SetupCwdStub        func(*specs.Spec, string) error
+	LookupUserStub        func(string, string) (specs.User, bool, error)
+	lookupUserMutex       sync.RWMutex
+	lookupUserArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	lookupUserReturns struct {
+		result1 specs.User
+		result2 bool
+		result3 error
+	}
+	lookupUserReturnsOnCall map[int]struct {
+		result1 specs.User
+		result2 bool
+		result3 error
+	}
+	SetupCwdStub        func(string, string) error
 	setupCwdMutex       sync.RWMutex
 	setupCwdArgsForCall []struct {
-		arg1 *specs.Spec
+		arg1 string
 		arg2 string
 	}
 	setupCwdReturns struct {
@@ -25,11 +41,78 @@ type FakeRootfsManager struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRootfsManager) SetupCwd(arg1 *specs.Spec, arg2 string) error {
+func (fake *FakeRootfsManager) LookupUser(arg1 string, arg2 string) (specs.User, bool, error) {
+	fake.lookupUserMutex.Lock()
+	ret, specificReturn := fake.lookupUserReturnsOnCall[len(fake.lookupUserArgsForCall)]
+	fake.lookupUserArgsForCall = append(fake.lookupUserArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("LookupUser", []interface{}{arg1, arg2})
+	fake.lookupUserMutex.Unlock()
+	if fake.LookupUserStub != nil {
+		return fake.LookupUserStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.lookupUserReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeRootfsManager) LookupUserCallCount() int {
+	fake.lookupUserMutex.RLock()
+	defer fake.lookupUserMutex.RUnlock()
+	return len(fake.lookupUserArgsForCall)
+}
+
+func (fake *FakeRootfsManager) LookupUserCalls(stub func(string, string) (specs.User, bool, error)) {
+	fake.lookupUserMutex.Lock()
+	defer fake.lookupUserMutex.Unlock()
+	fake.LookupUserStub = stub
+}
+
+func (fake *FakeRootfsManager) LookupUserArgsForCall(i int) (string, string) {
+	fake.lookupUserMutex.RLock()
+	defer fake.lookupUserMutex.RUnlock()
+	argsForCall := fake.lookupUserArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeRootfsManager) LookupUserReturns(result1 specs.User, result2 bool, result3 error) {
+	fake.lookupUserMutex.Lock()
+	defer fake.lookupUserMutex.Unlock()
+	fake.LookupUserStub = nil
+	fake.lookupUserReturns = struct {
+		result1 specs.User
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeRootfsManager) LookupUserReturnsOnCall(i int, result1 specs.User, result2 bool, result3 error) {
+	fake.lookupUserMutex.Lock()
+	defer fake.lookupUserMutex.Unlock()
+	fake.LookupUserStub = nil
+	if fake.lookupUserReturnsOnCall == nil {
+		fake.lookupUserReturnsOnCall = make(map[int]struct {
+			result1 specs.User
+			result2 bool
+			result3 error
+		})
+	}
+	fake.lookupUserReturnsOnCall[i] = struct {
+		result1 specs.User
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeRootfsManager) SetupCwd(arg1 string, arg2 string) error {
 	fake.setupCwdMutex.Lock()
 	ret, specificReturn := fake.setupCwdReturnsOnCall[len(fake.setupCwdArgsForCall)]
 	fake.setupCwdArgsForCall = append(fake.setupCwdArgsForCall, struct {
-		arg1 *specs.Spec
+		arg1 string
 		arg2 string
 	}{arg1, arg2})
 	fake.recordInvocation("SetupCwd", []interface{}{arg1, arg2})
@@ -50,13 +133,13 @@ func (fake *FakeRootfsManager) SetupCwdCallCount() int {
 	return len(fake.setupCwdArgsForCall)
 }
 
-func (fake *FakeRootfsManager) SetupCwdCalls(stub func(*specs.Spec, string) error) {
+func (fake *FakeRootfsManager) SetupCwdCalls(stub func(string, string) error) {
 	fake.setupCwdMutex.Lock()
 	defer fake.setupCwdMutex.Unlock()
 	fake.SetupCwdStub = stub
 }
 
-func (fake *FakeRootfsManager) SetupCwdArgsForCall(i int) (*specs.Spec, string) {
+func (fake *FakeRootfsManager) SetupCwdArgsForCall(i int) (string, string) {
 	fake.setupCwdMutex.RLock()
 	defer fake.setupCwdMutex.RUnlock()
 	argsForCall := fake.setupCwdArgsForCall[i]
@@ -89,6 +172,8 @@ func (fake *FakeRootfsManager) SetupCwdReturnsOnCall(i int, result1 error) {
 func (fake *FakeRootfsManager) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.lookupUserMutex.RLock()
+	defer fake.lookupUserMutex.RUnlock()
 	fake.setupCwdMutex.RLock()
 	defer fake.setupCwdMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
<!---
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!---
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes #5144.

## Changes proposed by this PR:
<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
Look up user info from `/etc/passwd`, and plug it into the OCI spec. This is because the OCI spec requires the `uid` and `gid` rather than just the user name.

## Notes to reviewer:
<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [ ] ~Updated [Release notes]~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
