### PR TITLE
added tracing to load_var and set_pipeline.

### DIFF
--- a/atc/exec/load_var_step.go
+++ b/atc/exec/load_var_step.go
@@ -17,6 +17,7 @@ import (
 	"github.com/concourse/concourse/atc/exec/artifact"
 	"github.com/concourse/concourse/atc/exec/build"
 	"github.com/concourse/concourse/atc/worker"
+	"github.com/concourse/concourse/tracing"
 )
 
 // LoadVarStep loads a value from a file and sets it as a build-local var.
@@ -65,6 +66,22 @@ func (err InvalidLocalVarFile) Error() string {
 }
 
 func (step *LoadVarStep) Run(ctx context.Context, state RunState) error {
+	ctx, span := tracing.StartSpan(ctx, "load_var", tracing.Attrs{
+		"team":     step.metadata.TeamName,
+		"pipeline": step.metadata.PipelineName,
+		"job":      step.metadata.JobName,
+		"build":    step.metadata.BuildName,
+		"name":     step.plan.Name,
+		"file":     step.plan.File,
+	})
+
+	err := step.run(ctx, state)
+	tracing.End(span, err)
+
+	return err
+}
+
+func (step *LoadVarStep) run(ctx context.Context, state RunState) error {
 	logger := lagerctx.FromContext(ctx)
 	logger = logger.Session("load-var-step", lager.Data{
 		"step-name": step.plan.Name,

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -60,7 +60,7 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 
 #### <sub><sup><a name="5622" href="#5622">:link:</a></sup></sub> fix
 
-* @evanchaoli enhanced to change the Web UI and `fly teams` to show teams ordering by team names, which allows users who are participated in many teams to find a specific team easily.
+* @evanchaoli enhanced to change the Web UI and `fly teams` to show teams ordering by team names, which allows users who are participated in many teams to find a specific team easily. #5622
 
 #### <sub><sup><a name="5639" href="#5639">:link:</a></sup></sub> fix
 
@@ -85,3 +85,7 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 #### <sub><sup><a name="5572" href="#5572">:link:</a></sup></sub> feature
 
 * Add tracing to allow users and developers to observe volume streaming from source to destination volumes.  #5579
+
+#### <sub><sup><a name="5706" href="#5706">:link:</a></sup></sub> fix
+
+* Steps `load_var` and `set_pipeline` missed tracing, @evanchaoli added tracing to these steps. #5706

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -86,6 +86,6 @@ Currently the only API action that can be limited in this way is `ListAllJobs` -
 
 * Add tracing to allow users and developers to observe volume streaming from source to destination volumes.  #5579
 
-#### <sub><sup><a name="5706" href="#5706">:link:</a></sup></sub> fix
+#### <sub><sup><a name="5706" href="#5706">:link:</a></sup></sub> feature
 
-* Steps `load_var` and `set_pipeline` missed tracing, @evanchaoli added tracing to these steps. #5706
+* @evanchaoli added spans for the `load_var` and `set_pipeline` steps when [distributed tracing](https://concourse-ci.org/tracing.html) is enabled. #5706


### PR DESCRIPTION
## What does this PR accomplish?

To add tracing to steps `load_var` and `set_pipeline`.

## Changes proposed by this PR:

This is a tiny change, just added tracing to steps `load_var` and `set_pipeline` similar to `get/put/task/check` steps.

## Notes to reviewer:

NA

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] ~Added tests (Unit and/or Integration)~
- [ ] Updated [Documentation]
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] ~Tests reviewed~
- [ ] Documentation reviewed
- [x] Release notes reviewed
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
