### PR TITLE
Check if version exists before using it as a candidate

### DIFF
--- a/atc/db/versions_db.go
+++ b/atc/db/versions_db.go
@@ -212,6 +212,24 @@ func (versions VersionsDB) SuccessfulBuildOutputs(ctx context.Context, buildID i
 	return algorithmOutputs, nil
 }
 
+func (versions VersionsDB) VersionExists(ctx context.Context, resourceID int, versionMD5 ResourceVersion) (bool, error) {
+	var exists bool
+	err := versions.conn.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM resource_config_versions v
+			JOIN resources r ON r.resource_config_scope_id = v.resource_config_scope_id
+			WHERE r.id = $1
+			AND v.version_md5 = $2
+		)`, resourceID, versionMD5).
+		Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+
+	return exists, nil
+}
+
 func (versions VersionsDB) FindVersionOfResource(ctx context.Context, resourceID int, v atc.Version) (ResourceVersion, bool, error) {
 	versionJSON, err := json.Marshal(v)
 	if err != nil {

--- a/atc/scheduler/algorithm/algorithm_test.go
+++ b/atc/scheduler/algorithm/algorithm_test.go
@@ -3175,4 +3175,70 @@ var _ = DescribeTable("Input resolving",
 			},
 		},
 	}),
+
+	Entry("if the chosen version for an input with passed constraints does not exist, it will not select that version", Example{
+		DB: DB{
+			BuildInputs: []DBRow{
+				{Job: "another-job", BuildID: 100, Resource: "resource-x", Version: "rxv1", CheckOrder: 1},
+				{Job: "another-job", BuildID: 101, Resource: "resource-x", Version: "rxv2", CheckOrder: 2, DoNotInsertVersion: true},
+			},
+			Resources: []DBRow{
+				{Resource: "resource-x", Version: "rxv1", CheckOrder: 1},
+			},
+		},
+
+		Inputs: Inputs{
+			{
+				Name:     "resource-x",
+				Resource: "resource-x",
+				Passed:   []string{"another-job"},
+			},
+		},
+
+		Result: Result{
+			OK: true,
+			Values: map[string]string{
+				"resource-x": "rxv1",
+			},
+		},
+	}),
+
+	Entry("if there are multiple inputs with the same passed constraint job and the chosen version from a build does not exist, it will not use that build", Example{
+		DB: DB{
+			BuildInputs: []DBRow{
+				{Job: "another-job", BuildID: 100, Resource: "resource-x", Version: "rxv1", CheckOrder: 1},
+				{Job: "another-job", BuildID: 101, Resource: "resource-x", Version: "rxv2", CheckOrder: 2},
+
+				{Job: "another-job", BuildID: 100, Resource: "resource-y", Version: "ryv1", CheckOrder: 1},
+				{Job: "another-job", BuildID: 101, Resource: "resource-y", Version: "ryv2", CheckOrder: 2, DoNotInsertVersion: true},
+			},
+
+			Resources: []DBRow{
+				{Resource: "resource-x", Version: "rxv1", CheckOrder: 1},
+				{Resource: "resource-x", Version: "rxv2", CheckOrder: 2},
+				{Resource: "resource-y", Version: "ryv1", CheckOrder: 1},
+			},
+		},
+
+		Inputs: Inputs{
+			{
+				Name:     "resource-x",
+				Resource: "resource-x",
+				Passed:   []string{"another-job"},
+			},
+			{
+				Name:     "resource-y",
+				Resource: "resource-y",
+				Passed:   []string{"another-job"},
+			},
+		},
+
+		Result: Result{
+			OK: true,
+			Values: map[string]string{
+				"resource-x": "rxv1",
+				"resource-y": "ryv1",
+			},
+		},
+	}),
 )

--- a/atc/scheduler/algorithm/group_resolver.go
+++ b/atc/scheduler/algorithm/group_resolver.go
@@ -256,6 +256,18 @@ outputs:
 				continue
 			}
 
+			if candidate == nil {
+				exists, err := r.vdb.VersionExists(ctx, output.ResourceID, output.Version)
+				if err != nil {
+					tracing.End(span, err)
+					return false, err
+				}
+
+				if !exists {
+					break outputs
+				}
+			}
+
 			// if this doesn't work out, restore it to either nil or the
 			// candidate *without* the job vouching for it
 			restore[c] = candidate

--- a/atc/scheduler/algorithm/table_helpers_test.go
+++ b/atc/scheduler/algorithm/table_helpers_test.go
@@ -44,6 +44,7 @@ type DBRow struct {
 	RerunOfBuildID        int
 	BuildStatus           string
 	NoResourceConfigScope bool
+	DoNotInsertVersion    bool
 }
 
 type Example struct {
@@ -762,7 +763,7 @@ func (s setupDB) insertRowVersion(resources map[string]atc.ResourceConfig, row D
 		},
 	}
 
-	if row.NoResourceConfigScope {
+	if row.NoResourceConfigScope || row.DoNotInsertVersion {
 		// there's no version to insert if it has no scope
 		return
 	}


### PR DESCRIPTION
## What does this PR accomplish?

It increases stability of the algorithm when trying to compute a version for it's inputs. When we determine a set of versions within the algorithm, we should only be using versions that exists in the `resource_config_versions` table. For the pinned and individual resolvers, we compute our version for the input using the `resource_config_versions` table so we will only compute a version that already exists. For the group resolver, we use the successful build outputs table so we might end up computing a version that exists in the `successful_build_outputs` but not in the `resource_config_versions` table.

closes #5655 

## Changes proposed by this PR:
Before we set a version as a candidate for an input, we will do a check to see if that version exists in the `resource_config_versions` table. This will ensure that we only set a version as a candidate if it exists.

## Notes to reviewer:
The number of extra queries to the database that this change adds depending on the run of the algorithm. For example, if the algorithm is determining versions for a set of three inputs, if the versions that it chose the first time are all viable then this query will only be run three times (once for each input). But if the algorithm has to run through multiple builds which results in it setting multiple versions as a candidate for the input, that can result in us running this query for however many times we set the version as a candidate. The point I'm trying to make is that this change has the possibility of adding on to the load of the algorithm, and the scale of it depends on the amount of times that it needs to reset the version on a candidate. That being said, the query itself should be fairly lightweight. When we ran the query to check if a version exists on a large deployment, it ran in 0.05 ms. The following is the result of the explain analyze.
```
Result  (cost=17.04..17.05 rows=1 width=1) (actual time=0.033..0.033 rows=1 loops=1)
  InitPlan 1 (returns $1)
    ->  Nested Loop  (cost=0.96..17.04 rows=1 width=0) (actual time=0.033..0.033 rows=1 loops=1)
          ->  Index Scan using resources_pkey on resources r  (cost=0.41..8.46 rows=1 width=4) (actual time=0.013..0.013 rows=1 loops=1)
                Index Cond: (id = 79654)
          ->  Index Only Scan using resource_config_scope_id_and_version_md5_unique on resource_config_versions v  (cost=0.55..8.57 rows=1 width=4) (actual time=0.018..0.018 rows=1 loops=1)
                Index Cond: ((resource_config_scope_id = r.resource_config_scope_id) AND (version_md5 = '3895ed6ba0e0a864a2bc7eed3c72ad3e'::text))
                Heap Fetches: 0
Planning time: 0.379 ms
Execution time: 0.054 ms
```

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
