### PR TITLE
Allow set_pipeline can be used across teams

### DIFF
--- a/atc/config.go
+++ b/atc/config.go
@@ -433,6 +433,8 @@ type PlanConfig struct {
 	// name of 'set_pipeline'
 	SetPipeline string   `json:"set_pipeline,omitempty"`
 	VarFiles    []string `json:"var_files,omitempty"`
+	// team of 'set_pipeline', only valid for main team
+	Team string `json:"team,omitempty"`
 
 	// config path, e.g. foo/build.yml. Multiple steps might have this field, e.g. Task step and SetPipeline step.
 	File string `json:"file,omitempty"`

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -130,7 +130,42 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState) error {
 		return nil
 	}
 
-	team := step.teamFactory.GetByID(step.metadata.TeamID)
+	var team db.Team
+	if step.plan.Team == "" {
+		team = step.teamFactory.GetByID(step.metadata.TeamID)
+	} else {
+		currentTeam, found, err := step.teamFactory.FindTeam(step.metadata.TeamName)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("team %s not found", step.metadata.TeamName)
+		}
+
+		targetTeam, found, err := step.teamFactory.FindTeam(step.plan.Team)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("team %s not found", step.plan.Team)
+		}
+
+		permitted := false
+		if targetTeam.ID() == currentTeam.ID() {
+			permitted = true
+		}
+		if currentTeam.Admin() {
+			permitted = true
+		}
+		if !permitted {
+			return fmt.Errorf(
+				"only %s team can set another team's pipeline",
+				atc.DefaultTeamName,
+			)
+		}
+
+		team = targetTeam
+	}
 
 	fromVersion := db.ConfigVersion(0)
 	pipeline, found, err := team.Pipeline(step.plan.Name)

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -134,6 +134,11 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState) error {
 	if step.plan.Team == "" {
 		team = step.teamFactory.GetByID(step.metadata.TeamID)
 	} else {
+		fmt.Fprintln(stderr, "\x1b[1;33mWARNING: specifying the team in a set_pipeline step is experimental and may be removed in the future!\x1b[0m")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "\x1b[33mcontribute to discussion #5731 with feedback: https://github.com/concourse/concourse/discussions/5731\x1b[0m")
+		fmt.Fprintln(stderr, "")
+
 		currentTeam, found, err := step.teamFactory.FindTeam(step.metadata.TeamName)
 		if err != nil {
 			return err

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -94,14 +94,7 @@ jobs:
 
 		credVarsTracker vars.CredVarsTracker
 
-		stepMetadata = exec.StepMetadata{
-			TeamID:       123,
-			TeamName:     "some-team",
-			BuildID:      42,
-			BuildName:    "some-build",
-			PipelineID:   4567,
-			PipelineName: "some-pipeline",
-		}
+		stepMetadata exec.StepMetadata
 
 		stdout, stderr *gbytes.Buffer
 
@@ -135,7 +128,18 @@ jobs:
 		fakeTeam = new(dbfakes.FakeTeam)
 		fakePipeline = new(dbfakes.FakePipeline)
 
-		fakeTeam.NameReturns("some-team")
+		stepMetadata = exec.StepMetadata{
+			TeamID:       123,
+			TeamName:     "some-team",
+			BuildID:      42,
+			BuildName:    "some-build",
+			PipelineID:   4567,
+			PipelineName: "some-pipeline",
+		}
+
+		fakeTeam.IDReturns(stepMetadata.TeamID)
+		fakeTeam.NameReturns(stepMetadata.TeamName)
+
 		fakePipeline.NameReturns("some-pipeline")
 		fakeTeamFactory.GetByIDReturns(fakeTeam)
 
@@ -303,6 +307,111 @@ jobs:
 					Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
 					_, succeeded := fakeDelegate.FinishedArgsForCall(0)
 					Expect(succeeded).To(BeTrue())
+				})
+			})
+
+			Context("when team is configured", func() {
+				var (
+					fakeUserCurrentTeam *dbfakes.FakeTeam
+				)
+
+				BeforeEach(func() {
+					fakeUserCurrentTeam = new(dbfakes.FakeTeam)
+					fakeUserCurrentTeam.IDReturns(111)
+					fakeUserCurrentTeam.NameReturns("main")
+					fakeUserCurrentTeam.AdminReturns(false)
+
+					stepMetadata.TeamID = fakeUserCurrentTeam.ID()
+					stepMetadata.TeamName = fakeUserCurrentTeam.Name()
+					fakeTeamFactory.FindTeamReturnsOnCall(
+						0,
+						fakeUserCurrentTeam, true, nil,
+					)
+				})
+
+				Context("when team is set to the empty string", func() {
+					BeforeEach(func() {
+						fakeTeam.PipelineReturns(fakePipeline, true, nil)
+						fakeTeam.SavePipelineReturns(fakePipeline, false, nil)
+						spPlan.Team = ""
+					})
+
+					It("should finish successfully", func() {
+						Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
+						_, succeeded := fakeDelegate.FinishedArgsForCall(0)
+						Expect(succeeded).To(BeTrue())
+					})
+				})
+
+				Context("when team does not exist", func() {
+					BeforeEach(func() {
+						spPlan.Team = "not-found"
+						fakeTeamFactory.FindTeamReturnsOnCall(
+							1,
+							nil, false, nil,
+						)
+					})
+
+					It("should return error", func() {
+						Expect(stepErr).To(HaveOccurred())
+						Expect(stepErr.Error()).To(Equal("team not-found not found"))
+					})
+				})
+
+				Context("when team exists", func() {
+					Context("when the target team is the current team", func() {
+						BeforeEach(func() {
+							spPlan.Team = fakeUserCurrentTeam.Name()
+							fakeTeamFactory.FindTeamReturnsOnCall(
+								1,
+								fakeUserCurrentTeam, true, nil,
+							)
+
+							fakeUserCurrentTeam.PipelineReturns(fakePipeline, true, nil)
+							fakeUserCurrentTeam.SavePipelineReturns(fakePipeline, false, nil)
+						})
+
+						It("should finish successfully", func() {
+							Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
+							_, succeeded := fakeDelegate.FinishedArgsForCall(0)
+							Expect(succeeded).To(BeTrue())
+						})
+					})
+
+					Context("when the team is not the current team", func() {
+						BeforeEach(func() {
+							spPlan.Team = fakeTeam.Name()
+							fakeTeamFactory.FindTeamReturnsOnCall(
+								1,
+								fakeTeam, true, nil,
+							)
+						})
+
+						Context("when the current team is an admin team", func() {
+							BeforeEach(func() {
+								fakeUserCurrentTeam.AdminReturns(true)
+
+								fakeTeam.PipelineReturns(fakePipeline, true, nil)
+								fakeTeam.SavePipelineReturns(fakePipeline, false, nil)
+							})
+
+							It("should finish successfully", func() {
+								Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
+								_, succeeded := fakeDelegate.FinishedArgsForCall(0)
+								Expect(succeeded).To(BeTrue())
+							})
+						})
+
+						Context("when the current team is not an admin team", func() {
+							It("should return error", func() {
+
+								Expect(stepErr).To(HaveOccurred())
+								Expect(stepErr.Error()).To(Equal(
+									"only main team can set another team's pipeline",
+								))
+							})
+						})
+					})
 				})
 			})
 		})

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -376,6 +376,12 @@ jobs:
 							_, succeeded := fakeDelegate.FinishedArgsForCall(0)
 							Expect(succeeded).To(BeTrue())
 						})
+
+						It("should print an experimental message", func() {
+							Expect(stderr).To(gbytes.Say("WARNING: specifying the team"))
+							Expect(stderr).To(gbytes.Say("contribute to discussion #5731"))
+							Expect(stderr).To(gbytes.Say("discussions/5731"))
+						})
 					})
 
 					Context("when the team is not the current team", func() {

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -211,6 +211,7 @@ type TaskPlan struct {
 type SetPipelinePlan struct {
 	Name     string                 `json:"name"`
 	File     string                 `json:"file"`
+	Team     string                 `json:"team,omitempty"`
 	Vars     map[string]interface{} `json:"vars,omitempty"`
 	VarFiles []string               `json:"var_files,omitempty"`
 }

--- a/atc/public_plan.go
+++ b/atc/public_plan.go
@@ -262,8 +262,10 @@ func (plan TaskPlan) Public() *json.RawMessage {
 func (plan SetPipelinePlan) Public() *json.RawMessage {
 	return enc(struct {
 		Name string `json:"name"`
+		Team string `json:"team"`
 	}{
 		Name: plan.Name,
+		Team: plan.Team,
 	})
 }
 

--- a/atc/public_plan_test.go
+++ b/atc/public_plan_test.go
@@ -354,6 +354,7 @@ var _ = Describe("Plan", func() {
 						ID: "37",
 						SetPipeline: &atc.SetPipelinePlan{
 							Name:     "some-pipeline",
+							Team:     "some-team",
 							File:     "some-file",
 							VarFiles: []string{"vf"},
 							Vars:     map[string]interface{}{"k1": "v1"},
@@ -621,7 +622,8 @@ var _ = Describe("Plan", func() {
 	{
 	  "id": "37",
 	  "set_pipeline": {
-		"name": "some-pipeline"
+		"name": "some-pipeline",
+		"team": "some-team"
 	  }
 	}
   ]

--- a/atc/scheduler/factory/build_factory.go
+++ b/atc/scheduler/factory/build_factory.go
@@ -281,6 +281,7 @@ func (factory *buildFactory) basePlan(
 		plan = factory.planFactory.NewPlan(atc.SetPipelinePlan{
 			Name:     name,
 			File:     planConfig.File,
+			Team:     planConfig.Team,
 			Vars:     planConfig.Vars,
 			VarFiles: planConfig.VarFiles,
 		})

--- a/testflight/fixtures/set-pipeline.yml
+++ b/testflight/fixtures/set-pipeline.yml
@@ -1,0 +1,37 @@
+---
+resources:
+- name: some-resource
+  type: mock
+  source:
+    create_files:
+      pipeline.yml: |
+        ---
+        jobs:
+        - name: normal-job
+          public: true
+          plan:
+          - task: a-task
+            config:
+              platform: linux
+              image_resource:
+                type: mock
+                source: {mirror_self: true}
+              run:
+                path: echo
+                args: ["hello world"]
+      name.yml: |
+        ---
+        name: somebody
+
+jobs:
+- name: sp
+  public: true
+  plan:
+    - get: some-resource
+    - set_pipeline: ((pipeline_name))
+      team: ((team_name))
+      file: some-resource/pipeline.yml
+      var_files:
+      - some-resource/name.yml
+      vars:
+        greetings: hello

--- a/testflight/set-pipeline-step_test.go
+++ b/testflight/set-pipeline-step_test.go
@@ -8,14 +8,15 @@ import (
 )
 
 var _ = Describe("set-pipeline Step", func() {
-	const (
-		createdPipelineName = "created-pipeline"
+	var (
+		createdPipelineName string
+		currentTeamName     string
+		currentFlyTarget    string
 	)
 
-	var (
-		currentTeamName  string
-		currentFlyTarget string
-	)
+	BeforeEach(func() {
+		createdPipelineName = randomPipelineName()
+	})
 
 	JustBeforeEach(func() {
 		withFlyTarget(currentFlyTarget, func() {
@@ -52,7 +53,7 @@ var _ = Describe("set-pipeline Step", func() {
 
 			By("set-pipeline step should succeed")
 			execS = fly("trigger-job", "-w", "-j", pipelineName+"/sp")
-			Expect(execS.Out).To(gbytes.Say("setting pipeline: created-pipeline"))
+			Expect(execS.Out).To(gbytes.Say("setting pipeline: " + createdPipelineName))
 			Expect(execS.Out).To(gbytes.Say("done"))
 
 			By("should trigger the second pipeline job successfully")
@@ -79,7 +80,7 @@ var _ = Describe("set-pipeline Step", func() {
 			By("set-pipeline step should succeed")
 			withFlyTarget(adminFlyTarget, func() {
 				execS := fly("trigger-job", "-w", "-j", pipelineName+"/sp")
-				Expect(execS.Out).To(gbytes.Say("setting pipeline: created-pipeline"))
+				Expect(execS.Out).To(gbytes.Say("setting pipeline: " + createdPipelineName))
 				Expect(execS.Out).To(gbytes.Say("done"))
 			})
 

--- a/testflight/set-pipeline-step_test.go
+++ b/testflight/set-pipeline-step_test.go
@@ -1,89 +1,29 @@
 package testflight_test
 
 import (
-	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 )
 
 var _ = Describe("set-pipeline Step", func() {
 	const (
-		pipelineName       = "first-sp"
-		secondPipelineName = "second-sp"
+		createdPipelineName = "created-pipeline"
 	)
 
-	const pipelineContent = `---
-resources:
-- name: some-resource
-  type: mock
-  source:
-    create_files:
-      pipeline.yml: |
-        ---
-        jobs:
-        - name: normal-job
-          public: true
-          plan:
-          - task: a-task
-            config:
-              platform: linux
-              image_resource:
-                type: mock
-                source: {mirror_self: true}
-              run:
-                path: echo
-                args: ["hello world"]
-      name.yml: |
-        ---
-        name: somebody
-
-jobs:
-- name: sp
-  public: true
-  plan:
-    - get: some-resource
-    - set_pipeline: %s
-      team: ((team_name))
-      file: some-resource/pipeline.yml
-      var_files:
-      - some-resource/name.yml
-      vars:
-        greetings: hello`
-
 	var (
-		fixture          string
 		currentTeamName  string
 		currentFlyTarget string
 	)
 
-	BeforeEach(func() {
-		fixture = filepath.Join(tmp, "fixture")
-
-		err := os.MkdirAll(fixture, 0755)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	JustBeforeEach(func() {
-		err := ioutil.WriteFile(
-			filepath.Join(fixture, pipelineName+".yml"),
-			[]byte(fmt.Sprintf(pipelineContent, secondPipelineName)),
-			0755,
-		)
-		Expect(err).NotTo(HaveOccurred())
-
 		withFlyTarget(currentFlyTarget, func() {
-			fly(
-				"set-pipeline", "-n",
-				"-p", pipelineName,
-				"-c", fixture+"/"+pipelineName+".yml",
+			setAndUnpausePipeline(
+				"fixtures/set-pipeline.yml",
 				"-v", "team_name="+currentTeamName,
+				"-v", "pipeline_name="+createdPipelineName,
 			)
-			fly("unpause-pipeline", "-p", pipelineName)
 		})
 	})
 
@@ -100,23 +40,23 @@ jobs:
 		})
 
 		AfterEach(func() {
-			fly("destroy-pipeline", "-n", "-p", secondPipelineName)
+			fly("destroy-pipeline", "-n", "-p", createdPipelineName)
 		})
 
 		It("sets the other pipeline", func() {
 			By("second pipeline should initially not exist")
-			execS := spawnFly("get-pipeline", "-p", secondPipelineName)
+			execS := spawnFly("get-pipeline", "-p", createdPipelineName)
 			<-execS.Exited
 			Expect(execS).To(gexec.Exit(1))
 			Expect(execS.Err).To(gbytes.Say("pipeline not found"))
 
 			By("set-pipeline step should succeed")
 			execS = fly("trigger-job", "-w", "-j", pipelineName+"/sp")
-			Expect(execS.Out).To(gbytes.Say("setting pipeline: second-sp"))
+			Expect(execS.Out).To(gbytes.Say("setting pipeline: created-pipeline"))
 			Expect(execS.Out).To(gbytes.Say("done"))
 
 			By("should trigger the second pipeline job successfully")
-			execS = fly("trigger-job", "-w", "-j", secondPipelineName+"/normal-job")
+			execS = fly("trigger-job", "-w", "-j", createdPipelineName+"/normal-job")
 			Expect(execS.Out).To(gbytes.Say("hello world"))
 		})
 	})
@@ -130,7 +70,7 @@ jobs:
 		It("sets the other pipeline", func() {
 			By("second pipeline should initially not exist")
 			withFlyTarget(testflightFlyTarget, func() {
-				execS := spawnFly("get-pipeline", "-p", secondPipelineName)
+				execS := spawnFly("get-pipeline", "-p", createdPipelineName)
 				<-execS.Exited
 				Expect(execS).To(gexec.Exit(1))
 				Expect(execS.Err).To(gbytes.Say("pipeline not found"))
@@ -139,20 +79,20 @@ jobs:
 			By("set-pipeline step should succeed")
 			withFlyTarget(adminFlyTarget, func() {
 				execS := fly("trigger-job", "-w", "-j", pipelineName+"/sp")
-				Expect(execS.Out).To(gbytes.Say("setting pipeline: second-sp"))
+				Expect(execS.Out).To(gbytes.Say("setting pipeline: created-pipeline"))
 				Expect(execS.Out).To(gbytes.Say("done"))
 			})
 
 			By("should trigger the second pipeline job successfully")
 			withFlyTarget(testflightFlyTarget, func() {
-				execS := fly("trigger-job", "-w", "-j", secondPipelineName+"/normal-job")
+				execS := fly("trigger-job", "-w", "-j", createdPipelineName+"/normal-job")
 				Expect(execS.Out).To(gbytes.Say("hello world"))
 			})
 		})
 
 		AfterEach(func() {
 			withFlyTarget(testflightFlyTarget, func() {
-				fly("destroy-pipeline", "-n", "-p", secondPipelineName)
+				fly("destroy-pipeline", "-n", "-p", createdPipelineName)
 			})
 		})
 	})
@@ -166,7 +106,7 @@ jobs:
 		It("fails to set the other pipeline", func() {
 			By("second pipeline should initially not exist")
 			withFlyTarget(adminFlyTarget, func() {
-				execS := spawnFly("get-pipeline", "-p", secondPipelineName)
+				execS := spawnFly("get-pipeline", "-p", createdPipelineName)
 				<-execS.Exited
 				Expect(execS).To(gexec.Exit(1))
 				Expect(execS.Err).To(gbytes.Say("pipeline not found"))
@@ -183,7 +123,7 @@ jobs:
 
 			By("second pipeline should still not exist")
 			withFlyTarget(adminFlyTarget, func() {
-				execS := spawnFly("get-pipeline", "-p", secondPipelineName)
+				execS := spawnFly("get-pipeline", "-p", createdPipelineName)
 				<-execS.Exited
 				Expect(execS).To(gexec.Exit(1))
 				Expect(execS.Err).To(gbytes.Say("pipeline not found"))


### PR DESCRIPTION
## What does this PR accomplish?

Feature

## Changes proposed by this PR:

Allow "team" parameter to be used for "set_pipeline" steps

- Omitting the parameter uses the current team
- Specifying it targets a particular team
- Specifying it requires the team to be an Admin team (main)

We currently use the [`concourse-pipeline-resource`](https://github.com/concourse/concourse-pipeline-resource) to manage a few pipelines for other teams.

It would be more elegant if this could be done via the `set_pipeline` step. We currently have a local user for each of our tenant teams, for this purpose.

Pertains to https://github.com/concourse/rfcs/pull/31:

- Requested: https://github.com/concourse/rfcs/pull/31#issuecomment-601621064
- Vito comments: https://github.com/concourse/rfcs/pull/31#issuecomment-625273371

I think admin teams (main) be able to set pipelines is reasonable.

### Examples

Set the pipeline `pipeline` of the current team
```
      - set_pipeline: pipeline
        file: pipeline/pipeline.yml
```

Set the pipeline `pipeline` of the team `another-team`
```
      - set_pipeline: pipeline
        team: another-team
        file: pipeline/pipeline.yml
```

This can only be done by the `main` team (or any team with `admin=t` in the database, which is only the `main` team)

## Notes to reviewer:

I have only written unit tests, I have not written an integration test

I have not updated the release notes yet

I have not raised a docs PR yet

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
