### PR TITLE
feat(atc): support "set-pipeline: self"

### DIFF
--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -97,6 +97,15 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState) error {
 	fmt.Fprintln(stderr, "\x1b[33mfollow RFC #31 for updates: https://github.com/concourse/rfcs/pull/31\x1b[0m")
 	fmt.Fprintln(stderr, "")
 
+	if step.plan.Name == "self" {
+		fmt.Fprintln(stderr, "\x1b[1;33mWARNING: 'set_pipeline: self' is experimental and subject to change!\x1b[0m")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "\x1b[33mcontribute to discussion #5732 with feedback: https://github.com/concourse/concourse/discussions/5732\x1b[0m")
+		fmt.Fprintln(stderr, "")
+
+		step.plan.Name = step.metadata.PipelineName
+	}
+
 	source := setPipelineSource{
 		ctx:    ctx,
 		logger: logger,

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -98,7 +98,7 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState) error {
 	fmt.Fprintln(stderr, "")
 
 	if step.plan.Name == "self" {
-		fmt.Fprintln(stderr, "\x1b[1;33mWARNING: 'set_pipeline: self' is experimental and subject to change!\x1b[0m")
+		fmt.Fprintln(stderr, "\x1b[1;33mWARNING: 'set_pipeline: self' is experimental and may be removed in the future!\x1b[0m")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "\x1b[33mcontribute to discussion #5732 with feedback: https://github.com/concourse/concourse/discussions/5732\x1b[0m")
 		fmt.Fprintln(stderr, "")

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -104,6 +104,8 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState) error {
 		fmt.Fprintln(stderr, "")
 
 		step.plan.Name = step.metadata.PipelineName
+		// self must be set to current team, thus ignore team.
+		step.plan.Team = ""
 	}
 
 	source := setPipelineSource{

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -349,6 +349,35 @@ jobs:
 				})
 			})
 
+			Context("when set-pipeline self", func(){
+				BeforeEach(func(){
+					spPlan = &atc.SetPipelinePlan{
+						Name: "self",
+						File: "some-resource/pipeline.yml",
+						Team: "foo-team",
+					}
+					fakeBuild.SavePipelineReturns(fakePipeline, false, nil)
+				})
+
+				It("should save the pipeline itself", func(){
+					Expect(fakeBuild.SavePipelineCallCount()).To(Equal(1))
+					name, _, _, _, _ := fakeBuild.SavePipelineArgsForCall(0)
+					Expect(name).To(Equal("some-pipeline"))
+				})
+
+				It("should save to the current team", func(){
+					Expect(fakeBuild.SavePipelineCallCount()).To(Equal(1))
+					_, teamId, _, _, _ := fakeBuild.SavePipelineArgsForCall(0)
+					Expect(teamId).To(Equal(fakeTeam.ID()))
+				})
+
+				It("should print an experimental message", func() {
+					Expect(stderr).To(gbytes.Say("WARNING: 'set_pipeline: self' is experimental"))
+					Expect(stderr).To(gbytes.Say("contribute to discussion #5732"))
+					Expect(stderr).To(gbytes.Say("discussions/5732"))
+				})
+			})
+
 			Context("when team is configured", func() {
 				var (
 					fakeUserCurrentTeam *dbfakes.FakeTeam

--- a/testflight/set-pipeline-step_test.go
+++ b/testflight/set-pipeline-step_test.go
@@ -131,4 +131,24 @@ var _ = Describe("set-pipeline Step", func() {
 			})
 		})
 	})
+
+	Context("set self", func() {
+		BeforeEach(func() {
+			pipelineName = "self-reset"
+
+			fly("set-pipeline", "-n", "-p", pipelineName, "-c", "fixtures/set-pipeline.yml", "-v", "pipeline_name=self")
+			fly("unpause-pipeline", "-p", pipelineName)
+		})
+
+		It("set the other pipeline", func() {
+			By("set-pipeline step should succeed")
+			execS := fly("trigger-job", "-w", "-j", pipelineName+"/sp")
+			Expect(execS.Out).To(gbytes.Say("setting pipeline: self-reset"))
+			Expect(execS.Out).To(gbytes.Say("done"))
+
+			By("should trigger the pipeline job successfully")
+			execS = fly("trigger-job", "-w", "-j", pipelineName+"/normal-job")
+			Expect(execS.Out).To(gbytes.Say("hello world"))
+		})
+	})
 })

--- a/testflight/set-pipeline-step_test.go
+++ b/testflight/set-pipeline-step_test.go
@@ -1,6 +1,7 @@
 package testflight_test
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -134,16 +135,15 @@ var _ = Describe("set-pipeline Step", func() {
 
 	Context("set self", func() {
 		BeforeEach(func() {
-			pipelineName = "self-reset"
-
-			fly("set-pipeline", "-n", "-p", pipelineName, "-c", "fixtures/set-pipeline.yml", "-v", "pipeline_name=self")
-			fly("unpause-pipeline", "-p", pipelineName)
+			currentFlyTarget = testflightFlyTarget
+			currentTeamName = ""
+			createdPipelineName = "self"
 		})
 
 		It("set the other pipeline", func() {
 			By("set-pipeline step should succeed")
 			execS := fly("trigger-job", "-w", "-j", pipelineName+"/sp")
-			Expect(execS.Out).To(gbytes.Say("setting pipeline: self-reset"))
+			Expect(execS.Out).To(gbytes.Say(fmt.Sprintf("setting pipeline: %s", pipelineName)))
 			Expect(execS.Out).To(gbytes.Say("done"))
 
 			By("should trigger the pipeline job successfully")


### PR DESCRIPTION
This is a substitution of #4857 as it is too out-of-date, no way to rebase, so I just start over.

In #4857, "self" is replaced with real pipeline name in the first place, which leads to a lot of interface changes. In this change, I just do that in the set_pipeline step, so this is a tiny change. I take the way because:

1. I forget what was the comment that requested me to replace "self" in the first place.
2. If we do the replacement in the first place `build_factory`, then that also requires a lot of interface changes. As this is considered as an experimental feature, could be reverted in future, it's better to constraint the change scope.
3. Also, if we replace in the first place, as we need to print warning message in set_pipeline step, then we have to add a flag in SetPipelinePlan to indicate "self" is specified, which also sounds unnecessary.

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
