### PR TITLE
Admins should be able to login to any team

### DIFF
--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -147,14 +147,15 @@ func (command *LoginCommand) Execute(args []string) error {
 		return err
 	}
 
-	teams, ok := userInfo["teams"].(map[string]interface{})
-	if ok {
-		_, ok := teams[command.TeamName]
-		if !ok {
-			return errors.New("you are not a member of '" + command.TeamName + "' or the team does not exist")
+	if !userInfo.IsAdmin {
+		if userInfo.Teams != nil {
+			_, ok := userInfo.Teams[command.TeamName]
+			if !ok {
+				return errors.New("you are not a member of '" + command.TeamName + "' or the team does not exist")
+			}
+		} else {
+			return errors.New("unable to verify role on team")
 		}
-	} else {
-		return errors.New("unable to verify role on team")
 	}
 
 	return command.saveTarget(

--- a/fly/commands/userinfo.go
+++ b/fly/commands/userinfo.go
@@ -46,18 +46,17 @@ func (command *UserinfoCommand) Execute([]string) error {
 
 	table := ui.Table{Headers: headers}
 
-	teams := userinfo["teams"].(map[string]interface{})
 	var teamRoles []string
-	for team, roles := range teams {
-		for _, role := range roles.([]interface{}) {
-			teamRoles = append(teamRoles, team+"/"+role.(string))
+	for team, roles := range userinfo.Teams {
+		for _, role := range roles {
+			teamRoles = append(teamRoles, team+"/"+role)
 		}
 	}
 
 	sort.Strings(teamRoles)
 
 	row := ui.TableRow{
-		{Contents: userinfo["user_name"].(string)},
+		{Contents: userinfo.UserName},
 		{Contents: strings.Join(teamRoles, ",")},
 	}
 

--- a/fly/integration/userinfo_test.go
+++ b/fly/integration/userinfo_test.go
@@ -28,7 +28,13 @@ var _ = Describe("Fly CLI", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/user"),
 						ghttp.RespondWithJSONEncoded(200, map[string]interface{}{
+							"sub":       "zero",
+							"name":      "test",
+							"user_id":   "test_id",
 							"user_name": "test_user",
+							"email":     "test_email",
+							"is_admin":  false,
+							"is_system": false,
 							"teams": map[string][]string{
 								"other_team": {"owner"},
 								"test_team":  {"owner", "viewer"},
@@ -65,7 +71,13 @@ var _ = Describe("Fly CLI", func() {
 
 					Eventually(sess).Should(gexec.Exit(0))
 					Expect(sess.Out.Contents()).To(MatchJSON(`{
+							"sub":       "zero",
+							"name":      "test",
+							"user_id":   "test_id",
 							"user_name": "test_user",
+							"email":     "test_email",
+							"is_admin":  false,
+							"is_system": false,
 							"teams": {
 								"other_team": ["owner"],
 								"test_team": ["owner", "viewer"]

--- a/go-concourse/concourse/client.go
+++ b/go-concourse/concourse/client.go
@@ -31,7 +31,7 @@ type Client interface {
 	ListTeams() ([]atc.Team, error)
 	FindTeam(teamName string) (Team, error)
 	Team(teamName string) Team
-	UserInfo() (map[string]interface{}, error)
+	UserInfo() (atc.UserInfo, error)
 	ListActiveUsersSince(since time.Time) ([]atc.User, error)
 	Check(checkID string) (atc.Check, bool, error)
 }

--- a/go-concourse/concourse/concoursefakes/fake_client.go
+++ b/go-concourse/concourse/concoursefakes/fake_client.go
@@ -281,16 +281,16 @@ type FakeClient struct {
 	uRLReturnsOnCall map[int]struct {
 		result1 string
 	}
-	UserInfoStub        func() (map[string]interface{}, error)
+	UserInfoStub        func() (atc.UserInfo, error)
 	userInfoMutex       sync.RWMutex
 	userInfoArgsForCall []struct {
 	}
 	userInfoReturns struct {
-		result1 map[string]interface{}
+		result1 atc.UserInfo
 		result2 error
 	}
 	userInfoReturnsOnCall map[int]struct {
-		result1 map[string]interface{}
+		result1 atc.UserInfo
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -1574,7 +1574,7 @@ func (fake *FakeClient) URLReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeClient) UserInfo() (map[string]interface{}, error) {
+func (fake *FakeClient) UserInfo() (atc.UserInfo, error) {
 	fake.userInfoMutex.Lock()
 	ret, specificReturn := fake.userInfoReturnsOnCall[len(fake.userInfoArgsForCall)]
 	fake.userInfoArgsForCall = append(fake.userInfoArgsForCall, struct {
@@ -1597,34 +1597,34 @@ func (fake *FakeClient) UserInfoCallCount() int {
 	return len(fake.userInfoArgsForCall)
 }
 
-func (fake *FakeClient) UserInfoCalls(stub func() (map[string]interface{}, error)) {
+func (fake *FakeClient) UserInfoCalls(stub func() (atc.UserInfo, error)) {
 	fake.userInfoMutex.Lock()
 	defer fake.userInfoMutex.Unlock()
 	fake.UserInfoStub = stub
 }
 
-func (fake *FakeClient) UserInfoReturns(result1 map[string]interface{}, result2 error) {
+func (fake *FakeClient) UserInfoReturns(result1 atc.UserInfo, result2 error) {
 	fake.userInfoMutex.Lock()
 	defer fake.userInfoMutex.Unlock()
 	fake.UserInfoStub = nil
 	fake.userInfoReturns = struct {
-		result1 map[string]interface{}
+		result1 atc.UserInfo
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeClient) UserInfoReturnsOnCall(i int, result1 map[string]interface{}, result2 error) {
+func (fake *FakeClient) UserInfoReturnsOnCall(i int, result1 atc.UserInfo, result2 error) {
 	fake.userInfoMutex.Lock()
 	defer fake.userInfoMutex.Unlock()
 	fake.UserInfoStub = nil
 	if fake.userInfoReturnsOnCall == nil {
 		fake.userInfoReturnsOnCall = make(map[int]struct {
-			result1 map[string]interface{}
+			result1 atc.UserInfo
 			result2 error
 		})
 	}
 	fake.userInfoReturnsOnCall[i] = struct {
-		result1 map[string]interface{}
+		result1 atc.UserInfo
 		result2 error
 	}{result1, result2}
 }

--- a/go-concourse/concourse/user.go
+++ b/go-concourse/concourse/user.go
@@ -3,18 +3,19 @@ package concourse
 import (
 	"net/http"
 
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/go-concourse/concourse/internal"
 )
 
-func (client *client) UserInfo() (map[string]interface{}, error) {
+func (client *client) UserInfo() (atc.UserInfo, error) {
 	var connection = client.connection
 
 	req, err := http.NewRequest("GET", connection.URL()+"/api/v1/user", nil)
 	if err != nil {
-		return nil, err
+		return atc.UserInfo{}, err
 	}
 
-	var userInfo map[string]interface{}
+	var userInfo atc.UserInfo
 	err = connection.SendHTTPRequest(req, false, &internal.Response{
 		Result: &userInfo,
 	})

--- a/go-concourse/concourse/user_test.go
+++ b/go-concourse/concourse/user_test.go
@@ -3,6 +3,7 @@ package concourse_test
 import (
 	"net/http"
 
+	"github.com/concourse/concourse/atc"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -11,19 +12,18 @@ import (
 
 var _ = Describe("Skymarshal Handler User", func() {
 	Describe("UserInfo", func() {
-		var expectedUserInfo map[string]interface{}
+		var expectedUserInfo atc.UserInfo
 
 		BeforeEach(func() {
 			expectedURL := "/api/v1/user"
 
-			expectedUserInfo = map[string]interface{}{
-				"email":     "test@test.com",
-				"teams":     map[string][]string{"test_team": {"owner", "viewer"}},
-				"user_id":   "test_user_id",
-				"user_name": "test_user_name",
-				"name":      "test_name",
-				"is_admin":  false,
-				"exp":       1123123,
+			expectedUserInfo = atc.UserInfo{
+				Email:    "test@test.com",
+				Teams:    map[string][]string{"test_team": {"owner", "viewer"}},
+				UserId:   "test_user_id",
+				UserName: "test_user_name",
+				Name:     "test_name",
+				IsAdmin:  false,
 			}
 
 			atcServer.AppendHandlers(
@@ -37,14 +37,13 @@ var _ = Describe("Skymarshal Handler User", func() {
 		It("returns user info", func() {
 			result, err := client.UserInfo()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result["user_id"]).To(Equal("test_user_id"))
-			Expect(result["user_name"]).To(Equal("test_user_name"))
-			Expect(result["name"]).To(Equal("test_name"))
-			Expect(result["is_admin"]).To(Equal(false))
-			Expect(result["exp"]).To(BeNumerically("==", 1123123))
-			Expect(result["email"]).To(Equal(expectedUserInfo["email"]))
-			Expect(result["teams"]).To(HaveKeyWithValue("test_team", ContainElement("owner")))
-			Expect(result["teams"]).To(HaveKeyWithValue("test_team", ContainElement("viewer")))
+			Expect(result.UserId).To(Equal("test_user_id"))
+			Expect(result.UserName).To(Equal("test_user_name"))
+			Expect(result.Name).To(Equal("test_name"))
+			Expect(result.IsAdmin).To(Equal(false))
+			Expect(result.Email).To(Equal(expectedUserInfo.Email))
+			Expect(result.Teams).To(HaveKeyWithValue("test_team", ContainElement("owner")))
+			Expect(result.Teams).To(HaveKeyWithValue("test_team", ContainElement("viewer")))
 		})
 	})
 })


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix

This PR fixes a bug where admins were no longer able to login to any team.

closes #5741

## Changes proposed by this PR:

Only check to see if the user is a part of that team if they are not an admin. 

## Notes to reviewer:
There's a small refactor to have the `UserInfo` return the `atc.UserInfo` type rather than a `map[string][]interface` which would've contained the same fields as the `atc.UserInfo` fields.

## Contributor Checklist
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
