### PR TITLE
hack: add opencensus agent when jaeger is enabled

### DIFF
--- a/hack/oc-agent/config.yml
+++ b/hack/oc-agent/config.yml
@@ -1,0 +1,7 @@
+receivers:
+  jaeger:
+    collector_http_port: 14268
+exporters:
+  jaeger:
+    service_name: atc
+    collector_endpoint: http://jaeger:14268/api/traces

--- a/hack/overrides/jaeger.yml
+++ b/hack/overrides/jaeger.yml
@@ -13,7 +13,14 @@ services:
   web:
     environment:
       CONCOURSE_TRACING_JAEGER_COMPONENT: atc
-      CONCOURSE_TRACING_JAEGER_ENDPOINT: http://jaeger:14268/api/traces
+      CONCOURSE_TRACING_JAEGER_ENDPOINT: http://oc-agent:14268/api/traces
+
+  oc-agent:
+    image: omnition/opencensus-agent:0.1.11
+    volumes:
+    - ./hack/oc-agent:/etc/config
+    command:
+      - --config=/etc/config/config.yml
 
   jaeger:
     image: jaegertracing/all-in-one:1.14


### PR DESCRIPTION
<!---
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!---
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
A mild improvement to developer experience.

## Changes proposed by this PR:
<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

Let's start exercising the opencensus agent, which is good at adapting to other tracing backends. This change adds it as a pass-through middleman but should have no other notable impact on dev workflows.

## Notes to reviewer:
<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

To verify, it should be enough to `docker-compose -f docker-compose.yml -f hack/overrides/jaeger.yml up -d`, see the opencensus agent running and still see traces properly displayed in jaeger.

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] ~Added tests (Unit and/or Integration)~
- [x] ~Updated [Documentation]~
- [x] ~Updated [Release notes]~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [x] ~Code reviewed~
- [x] ~Tests reviewed~
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)~
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
