### PR TITLE
bugfix: fixed a bug where task_vars prevented credential-manager and …

### DIFF
--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -172,7 +172,11 @@ func validateCredParams(credMgrVars vars.Variables, config atc.Config, session l
 				var taskConfigSource exec.TaskConfigSource
 				embeddedTaskVars := []vars.Variables{credMgrVars}
 				taskConfigSource = exec.StaticConfigSource{Config: plan.TaskConfig}
-				taskConfigSource = exec.InterpolateTemplateConfigSource{ConfigSource: taskConfigSource, Vars: embeddedTaskVars}
+				taskConfigSource = exec.InterpolateTemplateConfigSource{
+					ConfigSource:  taskConfigSource,
+					Vars:          embeddedTaskVars,
+					ExpectAllKeys: true,
+				}
 				taskConfigSource = exec.ValidatingConfigSource{ConfigSource: taskConfigSource}
 				_, err = taskConfigSource.FetchConfig(context.TODO(), session, nil)
 				if err != nil {

--- a/atc/exec/task_config_source.go
+++ b/atc/exec/task_config_source.go
@@ -159,8 +159,9 @@ func (configSource OverrideParamsConfigSource) Warnings() []string {
 
 // InterpolateTemplateConfigSource represents a config source interpolated by template vars
 type InterpolateTemplateConfigSource struct {
-	ConfigSource TaskConfigSource
-	Vars         []vars.Variables
+	ConfigSource  TaskConfigSource
+	Vars          []vars.Variables
+	ExpectAllKeys bool
 }
 
 // FetchConfig returns the interpolated configuration
@@ -176,7 +177,7 @@ func (configSource InterpolateTemplateConfigSource) FetchConfig(ctx context.Cont
 	}
 
 	// process task config using the provided variables
-	byteConfig, err = vars.NewTemplateResolver(byteConfig, configSource.Vars).Resolve(true, true)
+	byteConfig, err = vars.NewTemplateResolver(byteConfig, configSource.Vars).Resolve(configSource.ExpectAllKeys, true)
 	if err != nil {
 		return atc.TaskConfig{}, fmt.Errorf("failed to interpolate task config: %s", err)
 	}

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -161,8 +161,9 @@ func (step *TaskStep) run(ctx context.Context, state RunState) error {
 		// this 2-phase strategy allows to interpolate 'vars' by cred variables.
 		if len(step.plan.Vars) > 0 {
 			taskConfigSource = InterpolateTemplateConfigSource{
-				ConfigSource: taskConfigSource,
-				Vars:         []vars.Variables{vars.StaticVariables(step.plan.Vars)},
+				ConfigSource:  taskConfigSource,
+				Vars:          []vars.Variables{vars.StaticVariables(step.plan.Vars)},
+				ExpectAllKeys: false,
 			}
 		}
 		taskVars = []vars.Variables{variables}
@@ -178,7 +179,11 @@ func (step *TaskStep) run(ctx context.Context, state RunState) error {
 	taskConfigSource = &OverrideParamsConfigSource{ConfigSource: taskConfigSource, Params: step.plan.Params}
 
 	// interpolate template vars
-	taskConfigSource = InterpolateTemplateConfigSource{ConfigSource: taskConfigSource, Vars: taskVars}
+	taskConfigSource = InterpolateTemplateConfigSource{
+		ConfigSource:  taskConfigSource,
+		Vars:          taskVars,
+		ExpectAllKeys: true,
+	}
 
 	// validate
 	taskConfigSource = ValidatingConfigSource{ConfigSource: taskConfigSource}

--- a/testflight/fixtures/task_vars.yml
+++ b/testflight/fixtures/task_vars.yml
@@ -1,4 +1,11 @@
 ---
+var_sources:
+- name: vs
+  type: dummy
+  config:
+    vars:
+      echo_text: text-from-var-source
+
 resources:
 - name: some-resource
   type: mock
@@ -30,7 +37,7 @@ jobs:
     vars:
       image_resource_type: mock
 
-- name: extarnal-task-vars-from-load-var
+- name: external-task-vars-from-load-var
   plan:
   - get: some-resource
   - load_var: foo
@@ -42,3 +49,16 @@ jobs:
     vars:
       image_resource_type: mock
       echo_text: ((.:foo))
+
+- name: task-var-is-not-used
+  plan:
+  - get: some-resource
+  - load_var: foo
+    file: some-resource/foo.txt
+  - task: process-task-definition
+    file: some-resource/task_unwrap.yml
+  - task: run
+    file: unwrapped-task-resource/task.yml
+    vars:
+      image_resource_type: mock
+      foo: bar

--- a/testflight/fixtures/task_vars.yml
+++ b/testflight/fixtures/task_vars.yml
@@ -50,11 +50,9 @@ jobs:
       image_resource_type: mock
       echo_text: ((.:foo))
 
-- name: task-var-is-not-used
+- name: task-var-is-defined-but-task-also-needs-vars-from-var-sources
   plan:
   - get: some-resource
-  - load_var: foo
-    file: some-resource/foo.txt
   - task: process-task-definition
     file: some-resource/task_unwrap.yml
   - task: run

--- a/testflight/task_vars_test.go
+++ b/testflight/task_vars_test.go
@@ -25,10 +25,11 @@ var _ = Describe("External Tasks", func() {
 	})
 
 	Context("when external task relies on template variables", func() {
-		BeforeEach(func() {
+		var taskFileContents string
 
+		BeforeEach(func(){
 			// we are testing an external task with two external variables - ((image_resource_type)) and ((echo_text))
-			taskFileContents := `---
+			taskFileContents = `---
 platform: linux
 
 image_resource:
@@ -39,6 +40,11 @@ run:
   path: echo
   args: [((echo_text))]
 `
+		})
+
+		JustBeforeEach(func() {
+
+
 			err := ioutil.WriteFile(
 				filepath.Join(fixture, "task.yml"),
 				[]byte(taskFileContents),
@@ -128,11 +134,30 @@ echo_text: Hello World From Command Line
 
 		Context("when vars are from load_var", func() {
 			It("successfully runs pipeline job with external task", func() {
-				execS := fly("trigger-job", "-w", "-j", pipelineName+"/extarnal-task-vars-from-load-var")
+				execS := fly("trigger-job", "-w", "-j", pipelineName+"/external-task-vars-from-load-var")
 				Expect(execS).To(gbytes.Say("bar"))
 			})
 		})
 
+		Context("when task vars are not used, task should get vars from var_sources", func() {
+			BeforeEach(func(){
+				taskFileContents = `---
+platform: linux
+
+image_resource:
+  type: ((image_resource_type))
+  source: {mirror_self: true}
+
+run:
+  path: echo
+  args: [((vs:echo_text))]
+`
+			})
+			It("successfully runs pipeline job with external task", func() {
+				execS := fly("trigger-job", "-w", "-j", pipelineName+"/task-var-is-not-used")
+				Expect(execS).To(gbytes.Say("text-from-var-source"))
+			})
+		})
 	})
 
 })

--- a/testflight/task_vars_test.go
+++ b/testflight/task_vars_test.go
@@ -154,7 +154,7 @@ run:
 `
 			})
 			It("successfully runs pipeline job with external task", func() {
-				execS := fly("trigger-job", "-w", "-j", pipelineName+"/task-var-is-not-used")
+				execS := fly("trigger-job", "-w", "-j", pipelineName+"/task-var-is-defined-but-task-also-needs-vars-from-var-sources")
 				Expect(execS).To(gbytes.Say("text-from-var-source"))
 			})
 		})


### PR DESCRIPTION
…var_sources from being used.

Fixes: #5753

Signed-off-by: Chao Li <chaol@vmware.com>


## Changes proposed by this PR:

Add a field `ExpectAllKeys` to `InterpolateTemplateConfigSource`, and for task_vars interpolation, use, it should not expect all keys.

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
