### PR TITLE
fly: allow pasting long tokens into login

### DIFF
--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/go-concourse/concourse"
 	semisemanticversion "github.com/cppforlife/go-semi-semantic/version"
+	"github.com/peterh/liner"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/vito/go-interact/interact"
 	"golang.org/x/oauth2"
@@ -111,14 +113,18 @@ func (command *LoginCommand) Execute(args []string) error {
 		return err
 	}
 
+	lineReader := liner.NewLiner()
+	defer lineReader.Close()
+	lineReader.SetCtrlCAborts(true)
+
 	if semver.Compare(legacySemver) <= 0 && semver.Compare(devSemver) != 0 {
 		// Legacy Auth Support
-		tokenType, tokenValue, err = command.legacyAuth(target, command.BrowserOnly)
+		tokenType, tokenValue, err = command.legacyAuth(lineReader, target, command.BrowserOnly)
 	} else {
 		if command.Username != "" && command.Password != "" {
 			tokenType, tokenValue, err = command.passwordGrant(client, command.Username, command.Password)
 		} else {
-			tokenType, tokenValue, err = command.authCodeGrant(client.URL(), command.BrowserOnly)
+			tokenType, tokenValue, err = command.authCodeGrant(lineReader, client.URL(), command.BrowserOnly)
 		}
 	}
 
@@ -192,7 +198,7 @@ func (command *LoginCommand) passwordGrant(client concourse.Client, username, pa
 	return token.TokenType, idToken, nil
 }
 
-func (command *LoginCommand) authCodeGrant(targetUrl string, browserOnly bool) (string, string, error) {
+func (command *LoginCommand) authCodeGrant(lineReader *liner.State, targetUrl string, browserOnly bool) (string, string, error) {
 
 	var tokenStr string
 
@@ -213,10 +219,6 @@ func (command *LoginCommand) authCodeGrant(targetUrl string, browserOnly bool) (
 	openURL = fmt.Sprintf("%s/login?fly_port=%s", targetUrl, port)
 
 	fmt.Printf("  %s\n", openURL)
-	if !browserOnly {
-		fmt.Println("")
-		fmt.Printf("or enter token manually: ")
-	}
 
 	if command.OpenBrowser {
 		// try to open the browser window, but don't get all hung up if it
@@ -225,7 +227,7 @@ func (command *LoginCommand) authCodeGrant(targetUrl string, browserOnly bool) (
 	}
 
 	if !browserOnly {
-		go waitForTokenInput(stdinChannel, errorChannel)
+		go waitForTokenInput(lineReader, stdinChannel, errorChannel)
 	}
 
 	select {
@@ -286,22 +288,33 @@ type tcpKeepAliveListener struct {
 	*net.TCPListener
 }
 
-func waitForTokenInput(tokenChannel chan string, errorChannel chan error) {
-	for {
-		var tokenType string
-		var tokenValue string
-		count, err := fmt.Scanf("%s %s", &tokenType, &tokenValue)
-		if err != nil {
-			if count != 2 {
-				fmt.Println("token must be of the format 'TYPE VALUE', e.g. 'Bearer ...'")
-				continue
-			}
+func waitForTokenInput(lineReader *liner.State, tokenChannel chan string, errorChannel chan error) {
+	fmt.Println()
 
+	for {
+		var token string
+		var err error
+		if liner.TerminalSupported() {
+			token, err = lineReader.PasswordPrompt("or enter token manually (input hidden): ")
+		} else {
+			token, err = lineReader.Prompt("or enter token manually: ")
+		}
+		token = strings.TrimSpace(token)
+		if len(token) == 0 && err == io.EOF {
+			return
+		}
+		if err != nil && err != io.EOF {
 			errorChannel <- err
 			return
 		}
 
-		tokenChannel <- tokenType + " " + tokenValue
+		parts := strings.Split(token, " ")
+		if len(parts) != 2 {
+			fmt.Println("token must be of the format 'TYPE VALUE', e.g. 'Bearer ...'")
+			continue
+		}
+
+		tokenChannel <- token
 		break
 	}
 }
@@ -327,7 +340,7 @@ func (command *LoginCommand) saveTarget(url string, token *rc.TargetToken, caCer
 	return nil
 }
 
-func (command *LoginCommand) legacyAuth(target rc.Target, browserOnly bool) (string, string, error) {
+func (command *LoginCommand) legacyAuth(lineReader *liner.State, target rc.Target, browserOnly bool) (string, string, error) {
 
 	httpClient := target.Client().HTTPClient()
 
@@ -409,11 +422,6 @@ func (command *LoginCommand) legacyAuth(target rc.Target, browserOnly bool) (str
 		fmt.Println("")
 		fmt.Printf("    %s", theURL)
 
-		if !browserOnly {
-			fmt.Println("")
-			fmt.Printf("or enter token manually: ")
-		}
-
 		if command.OpenBrowser {
 			// try to open the browser window, but don't get all hung up if it
 			// fails, since we already printed about it.
@@ -421,7 +429,7 @@ func (command *LoginCommand) legacyAuth(target rc.Target, browserOnly bool) (str
 		}
 
 		if !browserOnly {
-			go waitForTokenInput(stdinChannel, errorChannel)
+			go waitForTokenInput(lineReader, stdinChannel, errorChannel)
 		}
 
 		select {

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.0.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/peterh/liner v1.2.0
 	github.com/peterhellberg/link v1.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942

--- a/go.sum
+++ b/go.sum
@@ -462,6 +462,8 @@ github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW1
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
+github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-sqlite3 v0.0.0-20160907162043-3fb7a0e792ed/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -542,6 +544,8 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.5.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
+github.com/peterh/liner v1.2.0 h1:w/UPXyl5GfahFxcTOz2j9wCIHNI+pUPr2laqpojKNCg=
+github.com/peterh/liner v1.2.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/peterhellberg/link v1.0.0 h1:mUWkiegowUXEcmlb+ybF75Q/8D2Y0BjZtR8cxoKhaQo=
 github.com/peterhellberg/link v1.0.0/go.mod h1:gtSlOT4jmkY8P47hbTc8PTgiDDWpdPbFYl75keYyBB8=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -16,3 +16,7 @@
 #### <sub><sup><a name="5390" href="#5390">:link:</a></sup></sub> feature
 
 * Add `--include-archived` flag for `fly pipelines` command. #5673
+
+#### <sub><sup><a name="5770" href="#5770">:link:</a></sup></sub> fix
+
+* `fly login` now accepts arbitrarily long tokens when pasting the token manually into the console. Previously, the limit was OS dependent (with OSX having a relatively small maximum length of 1024 characters). This has been a long-standing issue, but it became most noticable after 6.1.0 which significantly increased the size of tokens. Note that pasted token is now hidden in the console output. #5770


### PR DESCRIPTION
## What does this PR accomplish?
<!---
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #5717 .

## Changes proposed by this PR:
<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

On OSX, there's some magic constant of 1024 characters, which is the
length of some TTY buffer. Not sure of the specifics, but essentially
you weren't able to paste tokens longer than 1024 characters in `fly
login` for the "or enter token manually" option.

Rather than doing a `fmt.Scanf`, use a module that enables raw mode and
doesn't impose any limits on the line length. It was surprisingly
difficult to find a module that did what I wanted in a nice way.

* vito/go-interact depends on golang.org/x/crypto/ssh/terminal which
  imposes a seemingly arbitrary line length limit of 4096. We could
  remove this limit, but then we'd need to maintain a fork.
* chzyer/readline is *really* slow when pasting long text. I think it
  re-renders for every character instead of recognizing that we're in
  paste mode
* tcnksm/go-input seemed to have the same 1024 character limit (despite
  using raw mode?)

Eventually I landed on peterh/liner, which works pretty nicely. It
renders the text in a single line (and trims what's not in the "frame")
by default - there is a MultiLineMode, but it seemed pretty finicky.

@vito recommended just using a password input, since we probably
shouldn't be printing it anyway. Where it's supported, use that -
elsewhere (e.g. in tests), use the regular prompt.

## Notes to reviewer:
<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
