### PR TITLE
web: resizable sidebar

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -686,6 +686,7 @@ sampleSession =
         { isOpen = False
         , width = 275
         }
+    , draggingSideBar = False
     , notFoundImgSrc = ""
     , pipelineRunningKeyframes = ""
     , pipelines = RemoteData.NotAsked

--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -138,13 +138,7 @@ buildView session model =
             ]
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
-            [ SideBar.view
-                { expandedTeams = session.expandedTeams
-                , pipelines = session.pipelines
-                , hovered = session.hovered
-                , isSideBarOpen = session.isSideBarOpen
-                , screenSize = session.screenSize
-                }
+            [ SideBar.view session
                 (currentJob model
                     |> Maybe.map
                         (\j ->
@@ -688,7 +682,9 @@ sampleSession =
     , csrfToken = ""
     , expandedTeams = Set.empty
     , hovered = HoverState.NoHover
-    , isSideBarOpen = False
+    , sideBarState =
+        { isOpen = False
+        }
     , notFoundImgSrc = ""
     , pipelineRunningKeyframes = ""
     , pipelines = RemoteData.NotAsked

--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -684,6 +684,7 @@ sampleSession =
     , hovered = HoverState.NoHover
     , sideBarState =
         { isOpen = False
+        , width = 275
         }
     , notFoundImgSrc = ""
     , pipelineRunningKeyframes = ""

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -74,7 +74,9 @@ init flags url =
             , pipelineRunningKeyframes = flags.pipelineRunningKeyframes
             , expandedTeams = Set.empty
             , pipelines = RemoteData.NotAsked
-            , isSideBarOpen = False
+            , sideBarState =
+                { isOpen = False
+                }
             , screenSize = ScreenSize.Desktop
             , timeZone = Time.utc
             }

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -76,6 +76,7 @@ init flags url =
             , pipelines = RemoteData.NotAsked
             , sideBarState =
                 { isOpen = False
+                , width = 275
                 }
             , screenSize = ScreenSize.Desktop
             , timeZone = Time.utc

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -78,6 +78,7 @@ init flags url =
                 { isOpen = False
                 , width = 275
                 }
+            , draggingSideBar = False
             , screenSize = ScreenSize.Desktop
             , timeZone = Time.utc
             }
@@ -456,6 +457,14 @@ subscriptions model =
     , OnSideBarStateReceived
     , OnWindowResize
     ]
+        ++ (if model.session.draggingSideBar then
+                [ OnMouse
+                , OnMouseUp
+                ]
+
+            else
+                []
+           )
         ++ SubPage.subscriptions model.subModel
 
 

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -647,13 +647,7 @@ view session model =
             ]
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
-            [ SideBar.view
-                { expandedTeams = session.expandedTeams
-                , pipelines = session.pipelines
-                , hovered = session.hovered
-                , isSideBarOpen = session.isSideBarOpen
-                , screenSize = session.screenSize
-                }
+            [ SideBar.view session
                 (model.job
                     |> Maybe.map
                         (\j ->

--- a/web/elm/src/Dashboard/Footer.elm
+++ b/web/elm/src/Dashboard/Footer.elm
@@ -53,7 +53,7 @@ handleDelivery delivery ( model, effects ) =
                     , effects
                     )
 
-        Moused ->
+        Moused _ ->
             ( { model | hideFooter = False, hideFooterCounter = 0 }, effects )
 
         ClockTicked OneSecond _ ->

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -417,13 +417,7 @@ view session model =
             ]
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
-            [ SideBar.view
-                { expandedTeams = session.expandedTeams
-                , pipelines = session.pipelines
-                , hovered = session.hovered
-                , isSideBarOpen = session.isSideBarOpen
-                , screenSize = session.screenSize
-                }
+            [ SideBar.view session
                 (Just
                     { pipelineName = model.jobIdentifier.pipelineName
                     , teamName = model.jobIdentifier.teamName

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -42,6 +42,7 @@ import Message.Storage
         )
 import Process
 import Routes
+import SideBar.State exposing (SideBarState, encodeSideBarState)
 import Task
 import Time
 import Views.Styles
@@ -171,7 +172,7 @@ type Effect
     | ChangeVisibility VisibilityAction Concourse.PipelineIdentifier
     | SaveToken String
     | LoadToken
-    | SaveSideBarState Bool
+    | SaveSideBarState SideBarState
     | LoadSideBarState
     | SaveCachedJobs (List Concourse.Job)
     | LoadCachedJobs
@@ -588,8 +589,8 @@ runEffect effect key csrfToken =
         LoadToken ->
             loadFromLocalStorage tokenKey
 
-        SaveSideBarState isOpen ->
-            saveToSessionStorage ( sideBarStateKey, Json.Encode.bool isOpen )
+        SaveSideBarState state ->
+            saveToSessionStorage ( sideBarStateKey, encodeSideBarState state )
 
         LoadSideBarState ->
             loadFromSessionStorage sideBarStateKey

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -82,6 +82,7 @@ type DomID
     | PipelineWrapper Concourse.PipelineIdentifier
     | JobPreview Concourse.JobIdentifier
     | HamburgerMenu
+    | SideBarResizeHandle
     | SideBarTeam String
     | SideBarPipeline Concourse.PipelineIdentifier
     | Dashboard

--- a/web/elm/src/Message/Storage.elm
+++ b/web/elm/src/Message/Storage.elm
@@ -49,7 +49,7 @@ port receivedFromSessionStorage : (( Key, Value ) -> msg) -> Sub msg
 
 sideBarStateKey : Key
 sideBarStateKey =
-    "is_sidebar_open"
+    "side_bar_state"
 
 
 tokenKey : Key

--- a/web/elm/src/Message/Subscription.elm
+++ b/web/elm/src/Message/Subscription.elm
@@ -26,6 +26,7 @@ import Message.Storage as Storage
         , tokenKey
         )
 import Routes
+import SideBar.State exposing (SideBarState, decodeSideBarState)
 import Time
 import Url
 
@@ -83,7 +84,7 @@ type Delivery
     | ElementVisible ( String, Bool )
     | TokenSentToFly RawHttpResponse
     | TokenReceived (Result Json.Decode.Error String)
-    | SideBarStateReceived (Result Json.Decode.Error Bool)
+    | SideBarStateReceived (Result Json.Decode.Error SideBarState)
     | CachedJobsReceived (Result Json.Decode.Error (List Concourse.Job))
     | CachedPipelinesReceived (Result Json.Decode.Error (List Concourse.Pipeline))
     | CachedTeamsReceived (Result Json.Decode.Error (List Concourse.Team))
@@ -156,7 +157,7 @@ runSubscription s =
         OnSideBarStateReceived ->
             receivedFromSessionStorage <|
                 decodeStorageResponse sideBarStateKey
-                    Json.Decode.bool
+                    decodeSideBarState
                     SideBarStateReceived
 
         OnCachedJobsReceived ->

--- a/web/elm/src/Message/Subscription.elm
+++ b/web/elm/src/Message/Subscription.elm
@@ -8,7 +8,15 @@ port module Message.Subscription exposing
     )
 
 import Browser
-import Browser.Events exposing (onClick, onKeyDown, onKeyUp, onMouseMove, onResize)
+import Browser.Events
+    exposing
+        ( onClick
+        , onKeyDown
+        , onKeyUp
+        , onMouseMove
+        , onMouseUp
+        , onResize
+        )
 import Build.StepTree.Models exposing (BuildEventEnvelope)
 import Concourse exposing (decodeJob, decodePipeline, decodeTeam)
 import Concourse.BuildEvents exposing (decodeBuildEventEnvelope)
@@ -62,6 +70,7 @@ type RawHttpResponse
 type Subscription
     = OnClockTick Interval
     | OnMouse
+    | OnMouseUp
     | OnKeyDown
     | OnKeyUp
     | OnWindowResize
@@ -81,6 +90,7 @@ type Delivery
     = KeyDown Keyboard.KeyEvent
     | KeyUp Keyboard.KeyEvent
     | Moused Position
+    | MouseUp
     | ClockTicked Interval Time.Posix
     | WindowResized Float Float
     | NonHrefLinkClicked String -- must be a String because we can't parse it out too easily :(
@@ -115,6 +125,9 @@ runSubscription s =
                 [ onMouseMove (Json.Decode.map Moused decodePosition)
                 , onClick (Json.Decode.map Moused decodePosition)
                 ]
+
+        OnMouseUp ->
+            onMouseUp <| Json.Decode.succeed MouseUp
 
         OnKeyDown ->
             onKeyDown (Keyboard.decodeKeyEvent |> Json.Decode.map KeyDown)

--- a/web/elm/src/NotFound/NotFound.elm
+++ b/web/elm/src/NotFound/NotFound.elm
@@ -63,14 +63,7 @@ view session model =
             ]
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar model.route)
-            [ SideBar.view
-                { expandedTeams = session.expandedTeams
-                , pipelines = session.pipelines
-                , hovered = session.hovered
-                , isSideBarOpen = session.isSideBarOpen
-                , screenSize = session.screenSize
-                }
-                Nothing
+            [ SideBar.view session Nothing
             , Html.div [ class "notfound" ]
                 [ Html.div [ class "title" ] [ Html.text "404" ]
                 , Html.div [ class "reason" ] [ Html.text "this page was not found" ]

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -286,7 +286,7 @@ handleDelivery delivery ( model, effects ) =
                 effects
             )
 
-        Moused ->
+        Moused _ ->
             ( { model | hideLegend = False, hideLegendCounter = 0 }, effects )
 
         ClockTicked OneSecond _ ->

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -413,14 +413,7 @@ view session model =
             , Html.div
                 (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
               <|
-                [ SideBar.view
-                    { expandedTeams = session.expandedTeams
-                    , pipelines = session.pipelines
-                    , hovered = session.hovered
-                    , isSideBarOpen = session.isSideBarOpen
-                    , screenSize = session.screenSize
-                    }
-                    (Just model.pipelineLocator)
+                [ SideBar.view session (Just model.pipelineLocator)
                 , viewSubPage session model
                 ]
             ]

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -148,7 +148,7 @@ handleDelivery delivery ( model, effects ) =
                         { oldState | width = pos.x }
                 in
                 ( { model | sideBarState = newState }
-                , effects
+                , effects ++ [ Effects.GetViewportOf Dashboard ]
                 )
 
             else

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -177,8 +177,15 @@ view model currentPipeline =
                 )
             && (model.screenSize /= ScreenSize.Mobile)
     then
+        let
+            oldState =
+                model.sideBarState
+
+            newState =
+                { oldState | width = clamp 100 600 oldState.width }
+        in
         Html.div
-            (id "side-bar" :: Styles.sideBar model.sideBarState)
+            (id "side-bar" :: Styles.sideBar newState)
             ((model.pipelines
                 |> RemoteData.withDefault []
                 |> List.Extra.gatherEqualsBy .teamName
@@ -196,7 +203,7 @@ view model currentPipeline =
                     )
              )
                 ++ [ Html.div
-                        (Styles.sideBarHandle model.sideBarState
+                        (Styles.sideBarHandle newState
                             ++ [ onMouseDown <| Click SideBarResizeHandle ]
                         )
                         []

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -150,7 +150,7 @@ view model currentPipeline =
     then
         Html.div
             (id "side-bar" :: Styles.sideBar model.sideBarState)
-            (model.pipelines
+            ((model.pipelines
                 |> RemoteData.withDefault []
                 |> List.Extra.gatherEqualsBy .teamName
                 |> List.map
@@ -165,6 +165,8 @@ view model currentPipeline =
                             }
                             |> Views.viewTeam
                     )
+             )
+                ++ [ Html.div (Styles.sideBarHandle model.sideBarState) [] ]
             )
 
     else

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -149,7 +149,7 @@ view model currentPipeline =
             && (model.screenSize /= ScreenSize.Mobile)
     then
         Html.div
-            (id "side-bar" :: Styles.sideBar)
+            (id "side-bar" :: Styles.sideBar model.sideBarState)
             (model.pipelines
                 |> RemoteData.withDefault []
                 |> List.Extra.gatherEqualsBy .teamName

--- a/web/elm/src/SideBar/State.elm
+++ b/web/elm/src/SideBar/State.elm
@@ -1,0 +1,23 @@
+module SideBar.State exposing (SideBarState, decodeSideBarState, encodeSideBarState)
+
+import Json.Decode
+import Json.Decode.Extra exposing (andMap)
+import Json.Encode
+
+
+type alias SideBarState =
+    { isOpen : Bool
+    }
+
+
+encodeSideBarState : SideBarState -> Json.Encode.Value
+encodeSideBarState state =
+    Json.Encode.object
+        [ ( "is_open", state.isOpen |> Json.Encode.bool )
+        ]
+
+
+decodeSideBarState : Json.Decode.Decoder SideBarState
+decodeSideBarState =
+    Json.Decode.succeed SideBarState
+        |> andMap (Json.Decode.field "is_open" Json.Decode.bool)

--- a/web/elm/src/SideBar/State.elm
+++ b/web/elm/src/SideBar/State.elm
@@ -7,6 +7,7 @@ import Json.Encode
 
 type alias SideBarState =
     { isOpen : Bool
+    , width : Float
     }
 
 
@@ -14,6 +15,7 @@ encodeSideBarState : SideBarState -> Json.Encode.Value
 encodeSideBarState state =
     Json.Encode.object
         [ ( "is_open", state.isOpen |> Json.Encode.bool )
+        , ( "width", state.width |> Json.Encode.float )
         ]
 
 
@@ -21,3 +23,4 @@ decodeSideBarState : Json.Decode.Decoder SideBarState
 decodeSideBarState =
     Json.Decode.succeed SideBarState
         |> andMap (Json.Decode.field "is_open" Json.Decode.bool)
+        |> andMap (Json.Decode.field "width" Json.Decode.float)

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -28,11 +28,11 @@ import Html.Attributes exposing (style)
 import Views.Icon as Icon
 
 
-sideBar : List (Html.Attribute msg)
-sideBar =
+sideBar : { r | width : Float } -> List (Html.Attribute msg)
+sideBar { width } =
     [ style "border-right" <| "1px solid " ++ Colors.frame
     , style "background-color" Colors.sideBar
-    , style "width" "275px"
+    , style "width" <| String.fromFloat width ++ "px"
     , style "overflow-y" "auto"
     , style "height" "100%"
     , style "flex-shrink" "0"

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -13,6 +13,7 @@ module SideBar.Styles exposing
     , pipelineIcon
     , pipelineLink
     , sideBar
+    , sideBarHandle
     , team
     , teamHeader
     , teamIcon
@@ -40,6 +41,19 @@ sideBar { width } =
     , style "box-sizing" "border-box"
     , style "padding-bottom" "10px"
     , style "-webkit-overflow-scrolling" "touch"
+    , style "position" "relative"
+    ]
+
+
+sideBarHandle : { r | width : Float } -> List (Html.Attribute msg)
+sideBarHandle { width } =
+    [ style "position" "fixed"
+    , style "width" "10px"
+    , style "height" "100%"
+    , style "top" "0"
+    , style "left" <| String.fromFloat (width - 5) ++ "px"
+    , style "z-index" "2"
+    , style "cursor" "ew-resize"
     ]
 
 

--- a/web/elm/src/SideBar/Views.elm
+++ b/web/elm/src/SideBar/Views.elm
@@ -2,7 +2,7 @@ module SideBar.Views exposing (Pipeline, Team, viewTeam)
 
 import HoverState exposing (TooltipPosition(..))
 import Html exposing (Html)
-import Html.Attributes exposing (href, id)
+import Html.Attributes exposing (class, href, id)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import Message.Effects exposing (toHtmlID)
 import Message.Message exposing (DomID(..), Message(..))
@@ -29,7 +29,7 @@ type alias Team =
 viewTeam : Team -> Html Message
 viewTeam team =
     Html.div
-        Styles.team
+        (class "side-bar-team" :: Styles.team)
         [ Html.div
             (Styles.teamHeader
                 ++ [ onClick <| Click <| SideBarTeam team.name.text

--- a/web/elm/tests/ApplicationTests.elm
+++ b/web/elm/tests/ApplicationTests.elm
@@ -5,6 +5,7 @@ import Browser
 import Common exposing (queryView)
 import Expect
 import Message.Effects as Effects
+import Message.Message exposing (DomID(..), Message(..))
 import Message.Subscription as Subscription exposing (Delivery(..))
 import Message.TopLevelMessage as Msgs
 import Test exposing (..)
@@ -73,4 +74,17 @@ all =
                     |> .session
                     |> .csrfToken
                     |> Expect.equal "real-token"
+        , test "subscribes to mouse events when dragging the side bar handle" <|
+            \_ ->
+                Common.init "/teams/t/pipelines/p/jobs/j"
+                    |> Application.update
+                        (Msgs.Update <|
+                            Click SideBarResizeHandle
+                        )
+                    |> Tuple.first
+                    |> Application.subscriptions
+                    |> Expect.all
+                        [ Common.contains Subscription.OnMouse
+                        , Common.contains Subscription.OnMouseUp
+                        ]
         ]

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -350,6 +350,7 @@ session =
     , hovered = HoverState.NoHover
     , sideBarState =
         { isOpen = False
+        , width = 275
         }
     , screenSize = ScreenSize.Desktop
     , userState = UserState.UserStateLoggedOut

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -352,6 +352,7 @@ session =
         { isOpen = False
         , width = 275
         }
+    , draggingSideBar = False
     , screenSize = ScreenSize.Desktop
     , userState = UserState.UserStateLoggedOut
     , clusterName = ""

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -348,7 +348,9 @@ session =
     { expandedTeams = Set.empty
     , pipelines = RemoteData.NotAsked
     , hovered = HoverState.NoHover
-    , isSideBarOpen = False
+    , sideBarState =
+        { isOpen = False
+        }
     , screenSize = ScreenSize.Desktop
     , userState = UserState.UserStateLoggedOut
     , clusterName = ""

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -1840,7 +1840,7 @@ all =
                         |> Tuple.first
                         |> afterSeconds 6
                         |> Application.update
-                            (ApplicationMsgs.DeliveryReceived Moused)
+                            (ApplicationMsgs.DeliveryReceived <| Moused { x = 0, y = 0 })
                         |> Tuple.first
                         |> Common.queryView
                         |> Query.has [ id "dashboard-info" ]

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -105,7 +105,7 @@ all =
         , test "fetches the viewport of the scrollable area when the sidebar state is loaded" <|
             \_ ->
                 Common.init "/"
-                    |> Application.handleDelivery (SideBarStateReceived (Ok True))
+                    |> Application.handleDelivery (SideBarStateReceived (Ok { isOpen = True }))
                     |> Tuple.second
                     |> Common.contains (GetViewportOf Dashboard)
         , test "renders pipeline cards in a single column grid when the viewport is narrow" <|

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -105,7 +105,14 @@ all =
         , test "fetches the viewport of the scrollable area when the sidebar state is loaded" <|
             \_ ->
                 Common.init "/"
-                    |> Application.handleDelivery (SideBarStateReceived (Ok { isOpen = True }))
+                    |> Application.handleDelivery
+                        (SideBarStateReceived
+                            (Ok
+                                { isOpen = True
+                                , width = 275
+                                }
+                            )
+                        )
                     |> Tuple.second
                     |> Common.contains (GetViewportOf Dashboard)
         , test "renders pipeline cards in a single column grid when the viewport is narrow" <|

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -445,7 +445,7 @@ all =
                     \_ ->
                         Common.init "/teams/team/pipelines/pipeline"
                             |> clockTickALot 11
-                            |> Application.update (Msgs.DeliveryReceived Moused)
+                            |> Application.update (Msgs.DeliveryReceived <| Moused { x = 0, y = 0 })
                             |> Tuple.first
                             |> Common.queryView
                             |> Query.has [ id "legend" ]

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -3896,7 +3896,9 @@ session =
     , pipelineRunningKeyframes = flags.pipelineRunningKeyframes
     , expandedTeams = Set.empty
     , pipelines = RemoteData.NotAsked
-    , isSideBarOpen = False
+    , sideBarState =
+        { isOpen = False
+        }
     , screenSize = ScreenSize.Desktop
     , timeZone = Time.utc
     }

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -3900,6 +3900,7 @@ session =
         { isOpen = False
         , width = 275
         }
+    , draggingSideBar = False
     , screenSize = ScreenSize.Desktop
     , timeZone = Time.utc
     }

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -3898,6 +3898,7 @@ session =
     , pipelines = RemoteData.NotAsked
     , sideBarState =
         { isOpen = False
+        , width = 275
         }
     , screenSize = ScreenSize.Desktop
     , timeZone = Time.utc

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -149,7 +149,7 @@ hasSideBar iAmLookingAtThePage =
             }
         , test "browser saves sidebar state on click" <|
             when iHaveAnOpenSideBar_
-                >> then_ myBrowserSavesSideBarState { isOpen = True }
+                >> then_ myBrowserSavesSideBarState { isOpen = True, width = 275 }
         , test "background becomes lighter on click" <|
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheHamburgerMenu
@@ -161,7 +161,7 @@ hasSideBar iAmLookingAtThePage =
         , test "browser toggles sidebar state on click" <|
             when iHaveAnOpenSideBar_
                 >> given iClickedTheHamburgerIcon
-                >> then_ myBrowserSavesSideBarState { isOpen = False }
+                >> then_ myBrowserSavesSideBarState { isOpen = False, width = 275 }
         , test "background toggles back to dark" <|
             given iHaveAnOpenSideBar_
                 >> given iClickedTheHamburgerIcon
@@ -229,10 +229,15 @@ hasSideBar iAmLookingAtThePage =
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheSideBar
                 >> then_ iSeeItScrollsIndependently
-        , test "sidebar is 275px wide" <|
+        , test "sidebar is 275px wide by default" <|
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheSideBar
                 >> then_ iSeeItIs275PxWide
+        , test "sidebar width is determined by sidebar state" <|
+            given iHaveAnOpenSideBar_
+                >> given myBrowserReceives400PxWideSideBarState
+                >> when iAmLookingAtTheSideBar
+                >> then_ iSeeItIs400PxWide
         , test "sidebar has right padding" <|
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheSideBar
@@ -857,6 +862,10 @@ iSeeADividingLineToTheRight =
 
 iSeeItIs275PxWide =
     Query.has [ style "width" "275px", style "box-sizing" "border-box" ]
+
+
+iSeeItIs400PxWide =
+    Query.has [ style "width" "400px" ]
 
 
 iAmLookingAtTheTeam =
@@ -1635,7 +1644,13 @@ myBrowserListensForSideBarStates =
 myBrowserReadSideBarState =
     Tuple.first
         >> Application.handleDelivery
-            (Subscription.SideBarStateReceived (Ok { isOpen = True }))
+            (Subscription.SideBarStateReceived (Ok { isOpen = True, width = 275 }))
+
+
+myBrowserReceives400PxWideSideBarState =
+    Tuple.first
+        >> Application.handleDelivery
+            (Subscription.SideBarStateReceived (Ok { isOpen = True, width = 400 }))
 
 
 myBrowserFetchesSideBarState =

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -246,6 +246,10 @@ hasSideBar iAmLookingAtThePage =
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheSideBar
                 >> then_ iSeeItHasBottomPadding
+        , test "sidebar has a resize handle" <|
+            given iHaveAnOpenSideBar_
+                >> when iAmLookingAtTheSideBar
+                >> then_ iSeeItHasAResizeHandle
         , test "toggles away" <|
             given iHaveAnOpenSideBar_
                 >> given iClickedTheHamburgerIcon
@@ -479,7 +483,7 @@ hasSideBar iAmLookingAtThePage =
                 >> given myBrowserFetchedPipelinesFromMultipleTeams
                 >> given iClickedTheHamburgerIcon
                 >> when iAmLookingAtTheSideBar
-                >> then_ iSeeTwoChildren
+                >> then_ iSeeTwoTeams
         , test "sidebar has text content of second team's name" <|
             given iAmLookingAtThePage
                 >> given iAmOnANonPhoneScreen
@@ -823,6 +827,10 @@ iSeeTwoChildren =
     Query.children [] >> Query.count (Expect.equal 2)
 
 
+iSeeTwoTeams =
+    Query.children [ class "side-bar-team" ] >> Query.count (Expect.equal 2)
+
+
 iAmLookingAtThePageBelowTheTopBar =
     Tuple.first
         >> Common.queryView
@@ -970,6 +978,10 @@ iSeeItHasRightPadding =
 
 iSeeItHasBottomPadding =
     Query.has [ style "padding-bottom" "10px" ]
+
+
+iSeeItHasAResizeHandle =
+    Query.has [ style "cursor" "ew-resize" ]
 
 
 iClickedThePipelineGroup =

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -265,6 +265,11 @@ hasSideBar iAmLookingAtThePage =
             given iHaveAnOpenSideBar_
                 >> when iDragTheSideBarHandleTo 400
                 >> then_ myBrowserSavesSideBarState { isOpen = True, width = 400 }
+        , test "dragging resize handle fetches the viewport of the dashboard" <|
+            given iHaveAnOpenSideBar_
+                >> when iPressTheSideBarHandle
+                >> when iMoveMyMouseXTo 400
+                >> then_ myBrowserFetchesTheDashboardViewport
         , test "max sidebar width is 600px" <|
             given iHaveAnOpenSideBar_
                 >> given iDragTheSideBarHandleTo 700
@@ -835,21 +840,27 @@ itIsClickable domID =
 
 
 iDragTheSideBarHandleTo x =
+    iPressTheSideBarHandle
+        >> iMoveMyMouseXTo x
+        >> iReleaseTheSideBarHandle
+
+
+iPressTheSideBarHandle =
     Tuple.first
         >> Application.update
             (TopLevelMessage.Update <| Message.Click Message.SideBarResizeHandle)
-        >> Tuple.first
-        >> Application.handleDelivery
-            (Subscription.Moused { x = x, y = 0 })
-        >> Tuple.first
-        >> Application.handleDelivery
-            Subscription.MouseUp
 
 
 iMoveMyMouseXTo x =
     Tuple.first
         >> Application.handleDelivery
             (Subscription.Moused { x = x, y = 0 })
+
+
+iReleaseTheSideBarHandle =
+    Tuple.first
+        >> Application.handleDelivery
+            Subscription.MouseUp
 
 
 iClickedTheHamburgerIcon =
@@ -1715,6 +1726,11 @@ myBrowserReceives400PxWideSideBarState =
 myBrowserFetchesSideBarState =
     Tuple.second
         >> Common.contains Effects.LoadSideBarState
+
+
+myBrowserFetchesTheDashboardViewport =
+    Tuple.second
+        >> Common.contains (Effects.GetViewportOf Message.Dashboard)
 
 
 myBrowserSavesSideBarState isOpen =

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -237,7 +237,7 @@ hasSideBar iAmLookingAtThePage =
             given iHaveAnOpenSideBar_
                 >> given myBrowserReceives400PxWideSideBarState
                 >> when iAmLookingAtTheSideBar
-                >> then_ iSeeItIs400PxWide
+                >> then_ iSeeItHasWidth 400
         , test "sidebar has right padding" <|
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheSideBar
@@ -252,19 +252,29 @@ hasSideBar iAmLookingAtThePage =
                 >> then_ iSeeItHasAResizeHandle
         , test "dragging resize handle resizes sidebar" <|
             given iHaveAnOpenSideBar_
-                >> given iDragTheSideBarHandleTo400Px
+                >> given iDragTheSideBarHandleTo 400
                 >> when iAmLookingAtTheSideBar
-                >> then_ iSeeItIs400PxWide
+                >> then_ iSeeItHasWidth 400
         , test "resize handle ignores mouse events when no longer dragging" <|
             given iHaveAnOpenSideBar_
-                >> given iDragTheSideBarHandleTo400Px
-                >> given iMoveMyMouseTo500Px
+                >> given iDragTheSideBarHandleTo 400
+                >> given iMoveMyMouseXTo 500
                 >> when iAmLookingAtTheSideBar
-                >> then_ iSeeItIs400PxWide
+                >> then_ iSeeItHasWidth 400
         , test "dragging resize handle saves the side bar state" <|
             given iHaveAnOpenSideBar_
-                >> when iDragTheSideBarHandleTo400Px
+                >> when iDragTheSideBarHandleTo 400
                 >> then_ myBrowserSavesSideBarState { isOpen = True, width = 400 }
+        , test "max sidebar width is 600px" <|
+            given iHaveAnOpenSideBar_
+                >> given iDragTheSideBarHandleTo 700
+                >> when iAmLookingAtTheSideBar
+                >> then_ iSeeItHasWidth 600
+        , test "min sidebar width is 100px" <|
+            given iHaveAnOpenSideBar_
+                >> given iDragTheSideBarHandleTo 50
+                >> when iAmLookingAtTheSideBar
+                >> then_ iSeeItHasWidth 100
         , test "toggles away" <|
             given iHaveAnOpenSideBar_
                 >> given iClickedTheHamburgerIcon
@@ -824,22 +834,22 @@ itIsClickable domID =
         ]
 
 
-iDragTheSideBarHandleTo400Px =
+iDragTheSideBarHandleTo x =
     Tuple.first
         >> Application.update
             (TopLevelMessage.Update <| Message.Click Message.SideBarResizeHandle)
         >> Tuple.first
         >> Application.handleDelivery
-            (Subscription.Moused { x = 400, y = 0 })
+            (Subscription.Moused { x = x, y = 0 })
         >> Tuple.first
         >> Application.handleDelivery
             Subscription.MouseUp
 
 
-iMoveMyMouseTo500Px =
+iMoveMyMouseXTo x =
     Tuple.first
         >> Application.handleDelivery
-            (Subscription.Moused { x = 500, y = 0 })
+            (Subscription.Moused { x = x, y = 0 })
 
 
 iClickedTheHamburgerIcon =
@@ -909,8 +919,8 @@ iSeeItIs275PxWide =
     Query.has [ style "width" "275px", style "box-sizing" "border-box" ]
 
 
-iSeeItIs400PxWide =
-    Query.has [ style "width" "400px" ]
+iSeeItHasWidth width =
+    Query.has [ style "width" <| String.fromFloat width ++ "px" ]
 
 
 iAmLookingAtTheTeam =

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -250,6 +250,21 @@ hasSideBar iAmLookingAtThePage =
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheSideBar
                 >> then_ iSeeItHasAResizeHandle
+        , test "dragging resize handle resizes sidebar" <|
+            given iHaveAnOpenSideBar_
+                >> given iDragTheSideBarHandleTo400Px
+                >> when iAmLookingAtTheSideBar
+                >> then_ iSeeItIs400PxWide
+        , test "resize handle ignores mouse events when no longer dragging" <|
+            given iHaveAnOpenSideBar_
+                >> given iDragTheSideBarHandleTo400Px
+                >> given iMoveMyMouseTo500Px
+                >> when iAmLookingAtTheSideBar
+                >> then_ iSeeItIs400PxWide
+        , test "dragging resize handle saves the side bar state" <|
+            given iHaveAnOpenSideBar_
+                >> when iDragTheSideBarHandleTo400Px
+                >> then_ myBrowserSavesSideBarState { isOpen = True, width = 400 }
         , test "toggles away" <|
             given iHaveAnOpenSideBar_
                 >> given iClickedTheHamburgerIcon
@@ -809,6 +824,24 @@ itIsClickable domID =
         ]
 
 
+iDragTheSideBarHandleTo400Px =
+    Tuple.first
+        >> Application.update
+            (TopLevelMessage.Update <| Message.Click Message.SideBarResizeHandle)
+        >> Tuple.first
+        >> Application.handleDelivery
+            (Subscription.Moused { x = 400, y = 0 })
+        >> Tuple.first
+        >> Application.handleDelivery
+            Subscription.MouseUp
+
+
+iMoveMyMouseTo500Px =
+    Tuple.first
+        >> Application.handleDelivery
+            (Subscription.Moused { x = 500, y = 0 })
+
+
 iClickedTheHamburgerIcon =
     Tuple.first
         >> Application.update
@@ -858,6 +891,10 @@ iSeeTheUsualDashboardContentsScrollingIndependently =
 
 iAmLookingAtTheSideBar =
     iAmLookingAtThePageBelowTheTopBar >> Query.children [] >> Query.first
+
+
+iAmLookingAtTheSideBarHandle =
+    iAmLookingAtTheSideBar >> Query.find [ style "cursor" "ew-resize" ]
 
 
 iSeeADividingLineBelow =

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -149,7 +149,7 @@ hasSideBar iAmLookingAtThePage =
             }
         , test "browser saves sidebar state on click" <|
             when iHaveAnOpenSideBar_
-                >> then_ myBrowserSavesSideBarState True
+                >> then_ myBrowserSavesSideBarState { isOpen = True }
         , test "background becomes lighter on click" <|
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheHamburgerMenu
@@ -161,7 +161,7 @@ hasSideBar iAmLookingAtThePage =
         , test "browser toggles sidebar state on click" <|
             when iHaveAnOpenSideBar_
                 >> given iClickedTheHamburgerIcon
-                >> then_ myBrowserSavesSideBarState False
+                >> then_ myBrowserSavesSideBarState { isOpen = False }
         , test "background toggles back to dark" <|
             given iHaveAnOpenSideBar_
                 >> given iClickedTheHamburgerIcon
@@ -1635,7 +1635,7 @@ myBrowserListensForSideBarStates =
 myBrowserReadSideBarState =
     Tuple.first
         >> Application.handleDelivery
-            (Subscription.SideBarStateReceived (Ok True))
+            (Subscription.SideBarStateReceived (Ok { isOpen = True }))
 
 
 myBrowserFetchesSideBarState =

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -44,6 +44,7 @@ model =
     , hovered = HoverState.NoHover
     , sideBarState =
         { isOpen = True
+        , width = 275
         }
     , screenSize = ScreenSize.Desktop
     }

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -42,7 +42,9 @@ model =
         RemoteData.Success
             [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
     , hovered = HoverState.NoHover
-    , isSideBarOpen = True
+    , sideBarState =
+        { isOpen = True
+        }
     , screenSize = ScreenSize.Desktop
     }
 

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -46,6 +46,7 @@ model =
         { isOpen = True
         , width = 275
         }
+    , draggingSideBar = False
     , screenSize = ScreenSize.Desktop
     }
 


### PR DESCRIPTION
<!---
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!---
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes #5462  .

This is especially relevant for 6.4.0 as we try to improve the usefulness of the sidebar (and, in effect, make the sidebar more narrow with the addition of the favouriting icon).

## Changes proposed by this PR:
<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Add an invisible resize handle to the right side of the sidebar
* Store sidebar size in session storage (along with whether it's open or not)

## Notes to reviewer:
<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
