### PR TITLE
web: style changes to resizable sidebar

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -4,3 +4,7 @@
 
 [static vars]: https://concourse-ci.org/vars.html#static-vars
 [dynamic vars]: https://concourse-ci.org/vars.html#dynamic-vars
+
+#### <sub><sup><a name="5782" href="#5782">:link:</a></sup></sub> fix
+
+* The sidebar can now be expanded in the UI - no more long pipeline names being cut off! #5782

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -11,11 +11,13 @@ module Application.Application exposing
     )
 
 import Application.Models exposing (Session)
+import Application.Styles as Styles
 import Browser
 import Concourse
 import EffectTransformer exposing (ET)
 import HoverState
 import Html
+import Html.Attributes exposing (id, style)
 import Http
 import Message.Callback exposing (Callback(..))
 import Message.Effects as Effects exposing (Effect(..))
@@ -445,7 +447,17 @@ view model =
             , SideBar.tooltip model.session
                 |> Maybe.map (Tooltip.view model.session)
                 |> Maybe.withDefault (Html.text "")
-            , body
+            , Html.div
+                (id "page-wrapper"
+                    :: style "height" "100%"
+                    :: (if model.session.draggingSideBar then
+                            Styles.disableInteraction
+
+                        else
+                            []
+                       )
+                )
+                [ body ]
             ]
     }
 

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -53,7 +53,7 @@ sideBarHandle { width } =
     , style "top" "0"
     , style "left" <| String.fromFloat (width - 5) ++ "px"
     , style "z-index" "2"
-    , style "cursor" "ew-resize"
+    , style "cursor" "col-resize"
     ]
 
 

--- a/web/elm/tests/ApplicationTests.elm
+++ b/web/elm/tests/ApplicationTests.elm
@@ -10,7 +10,7 @@ import Message.Subscription as Subscription exposing (Delivery(..))
 import Message.TopLevelMessage as Msgs
 import Test exposing (..)
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (style)
+import Test.Html.Selector exposing (id, style)
 import Url
 
 
@@ -87,4 +87,37 @@ all =
                         [ Common.contains Subscription.OnMouse
                         , Common.contains Subscription.OnMouseUp
                         ]
+        , test "cannot select text when dragging sidebar" <|
+            \_ ->
+                Common.init "/teams/t/pipelines/p/jobs/j"
+                    |> Application.update
+                        (Msgs.Update <|
+                            Click SideBarResizeHandle
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.has
+                        [ style "user-select" "none"
+                        , style "-ms-user-select" "none"
+                        , style "-moz-user-select" "none"
+                        , style "-khtml-user-select" "none"
+                        , style "-webkit-user-select" "none"
+                        , style "-webkit-touch-callout" "none"
+                        ]
+        , test "can select text when not dragging sidebar" <|
+            \_ ->
+                Common.init "/teams/t/pipelines/p/jobs/j"
+                    |> Common.queryView
+                    |> Query.hasNot [ style "user-select" "none" ]
+        , test "page-wrapper fills height" <|
+            \_ ->
+                Common.init "/teams/t/pipelines/p/jobs/j"
+                    |> Application.update
+                        (Msgs.Update <|
+                            Click SideBarResizeHandle
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ id "page-wrapper" ]
+                    |> Query.has [ style "height" "100%" ]
         ]

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -914,10 +914,6 @@ iAmLookingAtTheSideBar =
     iAmLookingAtThePageBelowTheTopBar >> Query.children [] >> Query.first
 
 
-iAmLookingAtTheSideBarHandle =
-    iAmLookingAtTheSideBar >> Query.find [ style "cursor" "ew-resize" ]
-
-
 iSeeADividingLineBelow =
     Query.has [ style "border-bottom" <| "1px solid " ++ Colors.frame ]
 
@@ -1039,7 +1035,7 @@ iSeeItHasBottomPadding =
 
 
 iSeeItHasAResizeHandle =
-    Query.has [ style "cursor" "ew-resize" ]
+    Query.has [ style "cursor" "col-resize" ]
 
 
 iClickedThePipelineGroup =


### PR DESCRIPTION
<!---
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?

* Minor style changes that were bothering me:
  * Change the cursor from `ew-resize` to `col-resize`
  * Disable highlighting when resizing sidebar
* Added release note in #5782

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [x] Release notes reviewed
- [x] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
