### PR TITLE
add release note for task vars fix

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,0 +1,6 @@
+#### <sub><sup><a name="5758" href="#5758">:link:</a></sup></sub> fix
+
+* @evanchaoli fixed a regression that prevented using both [static vars] and [dynamic vars] simultaneously in a task. #5758
+
+[static vars]: https://concourse-ci.org/vars.html#static-vars
+[dynamic vars]: https://concourse-ci.org/vars.html#dynamic-vars


### PR DESCRIPTION
## What does this PR accomplish?

To avoid an additional review cycle in #5758 (which did not have a release note), I added one here.

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
