### PR TITLE
hack: add opa override and no-op setup

### DIFF
--- a/hack/opa/policy.rego
+++ b/hack/opa/policy.rego
@@ -1,0 +1,8 @@
+package concourse
+
+# replace with 'false' to add rules
+default allow = true
+
+# allow {
+#   input.action == "ListContainers"
+# }

--- a/hack/overrides/opa.yml
+++ b/hack/overrides/opa.yml
@@ -1,0 +1,27 @@
+# opa.yml - a docker-compose override that adds 'opa' to the stack.
+#
+# ref: https://www.openpolicyagent.org/
+# ref: https://docs.docker.com/compose/extends/
+#
+version: '3'
+
+services:
+  web:
+    environment:
+      CONCOURSE_OPA_URL: http://opa:8181/v1/data/concourse/allow
+      CONCOURSE_POLICY_CHECK_FILTER_HTTP_METHODS: PUT,POST
+
+      # uncomment to configure
+      # CONCOURSE_POLICY_CHECK_FILTER_ACTION: ListWorkers,ListContainers,UseImage
+      # CONCOURSE_POLICY_CHECK_FILTER_ACTION_SKIP: PausePipeline,UnpausePipeline
+
+  opa:
+    image: openpolicyagent/opa
+    command:
+    - run
+    - --server
+    - --log-level=debug
+    - --watch
+    - /concourse-opa
+    volumes:
+    - ./hack/opa:/concourse-opa


### PR DESCRIPTION
<!---
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!---
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | Feature | Documentation

closes # .

## Changes proposed by this PR:
<!---
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!---
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!---
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!---
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
