### PR TITLE
make sure version checking synchronously in testflight flaky test

### DIFF
--- a/testflight/resource_type_check_test.go
+++ b/testflight/resource_type_check_test.go
@@ -17,6 +17,9 @@ var _ = Describe("Resource-types checks", func() {
 			"fixtures/resource-types.yml",
 			"-v", "hash="+hash.String(),
 		)
+
+		checkS := fly("check-resource", "-r", inPipeline("my-resource-image"))
+		Eventually(checkS).Should(gbytes.Say("succeeded"))
 	})
 
 	It("can check the resource-type", func() {


### PR DESCRIPTION
## What does this PR accomplish?
Fix a flaky testflight test

closes #5820 .

## Changes proposed by this PR:
Run a fly `check-resource` to make sure initial version is fetched first.

## Notes to reviewer:
There are two possible cases for this test
Scenario 1
```
---- scanner run just finished (so there is a 10s interval before next tick)
---- pipeline unpaused
---- fly check-resource-type -r custom-rsource-type -f newVersion
       <------ check 1 for custom-resource-type is created.
       <------ checker got notified since it is manually triggered. 
       <------ check 1 is ran and newer version returned.
---- build triggers
        ---- get step
               ---- run a check on resource my-resource-image using custom-resource-type image with new version
---- test garanteed to pass
```

Scenario 2
```
---- pipeline unpaused
---- scanner run ticked
	---- scanner check my-resource-image
                ---- scanner check custom-resource-type
		       <---- check 1 created for custom-resource-type (will return initial version)
        <---- check 2 created for my-resource-image
(since they are normal check, check 1&2 will wait in the queue until checker run is ticked)
					

---- fly check-resource-type -r custom-resource-type -f newVersion
        <------ check 3 for custom-resource-type is created. (will return newer version)
         <------ checker got notified since it is manually triggered. 
	<------ check 1&2&3 are ran AT THE SAME TIME

--- build triggers
      ---- get step !!! 
```
In the Get step of scenario 2, the version used to run get step is based on which check of custom-resource-type finished FIRST. Since  `mock` resource will return initial version configured in source or version from check `-f`. The finishing order of check 1 and 3 decides the version that gonna be used. And since check 3 is a muanually created check it will be the top in the check list to run, which increases the chance that check 1 finished after check 3, which makes the initial version from check 1 the latest version of custom-resource-type

With 6.3 check rate limiting, in scenario 2, in a heavy load environment, there could be more checks injected before check 1 e.g. [check a, b, c, d, e ... check 1]. Remember check 3 is created manually, so it will be put in the first batch to run while check 1 is put in a second or even third batch e.g. [check3, check a, b, c] [check d, e ... check 1]. In this case the test is garanteed to fail.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits


## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] PR acceptance performed
