### PR TITLE
fly: behaviour: fix manual token input on zero-column terminals

### DIFF
--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -291,11 +291,16 @@ type tcpKeepAliveListener struct {
 func waitForTokenInput(lineReader *liner.State, tokenChannel chan string, errorChannel chan error) {
 	fmt.Println()
 
+	passwordPromptSupported := liner.TerminalSupported()
 	for {
 		var token string
 		var err error
-		if liner.TerminalSupported() {
+		if passwordPromptSupported {
 			token, err = lineReader.PasswordPrompt("or enter token manually (input hidden): ")
+			if err != nil && err != liner.ErrPromptAborted && err != io.EOF {
+				passwordPromptSupported = false
+				continue
+			}
 		} else {
 			token, err = lineReader.Prompt("or enter token manually: ")
 		}


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

Our unit test suite was failing on our darwin and windows workers due to
the following error message: https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/unit/builds/323#L5eea6b9f:103

```
error: liner: function not supported in this terminal
```

This occurs in the liner package when running the `PasswordPrompt` when
one of the following occurs:

1. the terminal isn't supported (which we were already covering)
2. the number of columns is 0

Rather than trying to infer from the error message (which is generally
considered bad practice and could be brittle), fallback to the
non-password prompt on any error (that isn't a Ctrl+C or EOF).

Note that I haven't actually tested this since I'm not sure how to
simulate a zero-width terminal

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
