### PR TITLE
atc/exec: don't panic on RetryStep

### DIFF
--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -1504,7 +1504,7 @@ var _ = Describe("ValidateConfig", func() {
 							Step: &atc.PutStep{
 								Name: "some-resource",
 							},
-							Attempts: -1,
+							Attempts: 0,
 						},
 					})
 
@@ -1513,7 +1513,7 @@ var _ = Describe("ValidateConfig", func() {
 
 				It("does return an error", func() {
 					Expect(errorMessages).To(HaveLen(1))
-					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].attempts: cannot be negative"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].attempts: must be greater than 0"))
 				})
 			})
 

--- a/atc/exec/retry_step.go
+++ b/atc/exec/retry_step.go
@@ -44,5 +44,8 @@ func (step *RetryStep) Run(ctx context.Context, state RunState) error {
 
 // Succeeded delegates to the last step that it ran.
 func (step *RetryStep) Succeeded() bool {
+	if step.LastAttempt == nil {
+		return false
+	}
 	return step.LastAttempt.Succeeded()
 }

--- a/atc/exec/retry_step_test.go
+++ b/atc/exec/retry_step_test.go
@@ -339,4 +339,16 @@ var _ = Describe("Retry Step", func() {
 			})
 		})
 	})
+
+	Context("when the RetryStep is given no attempts", func() {
+		BeforeEach(func() {
+			step = Retry()
+		})
+
+		Describe("Succeeded", func() {
+			It("should return false", func() {
+				Expect(step.Succeeded()).To(BeFalse())
+			})
+		})
+	})
 })

--- a/atc/exec/retry_step_test.go
+++ b/atc/exec/retry_step_test.go
@@ -40,6 +40,27 @@ var _ = Describe("Retry Step", func() {
 		step = Retry(attempt1, attempt2, attempt3)
 	})
 
+	Context("when calling succeeded before running", func() {
+		Context("when the RetryStep is given no attempts", func() {
+			BeforeEach(func() {
+				step = Retry()
+			})
+
+			Describe("Succeeded", func() {
+				It("should return false", func() {
+					Expect(step.Succeeded()).To(BeFalse())
+				})
+			})
+		})
+
+		Context("when the RetryStep is given attempts", func() {
+			Describe("Succeeded", func() {
+				It("should return false", func() {
+					Expect(step.Succeeded()).To(BeFalse())
+				})
+			})
+		})
+	})
 	Context("when attempt 1 succeeds", func() {
 		BeforeEach(func() {
 			attempt1.SucceededReturns(true)
@@ -336,18 +357,6 @@ var _ = Describe("Retry Step", func() {
 
 					Expect(attempt3.SucceededCallCount()).To(Equal(2))
 				})
-			})
-		})
-	})
-
-	Context("when the RetryStep is given no attempts", func() {
-		BeforeEach(func() {
-			step = Retry()
-		})
-
-		Describe("Succeeded", func() {
-			It("should return false", func() {
-				Expect(step.Succeeded()).To(BeFalse())
 			})
 		})
 	})

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -264,8 +264,8 @@ func (validator *StepValidator) VisitRetry(step *RetryStep) error {
 	validator.pushContext(".attempts")
 	defer validator.popContext()
 
-	if step.Attempts < 0 {
-		validator.recordError("cannot be negative")
+	if step.Attempts <= 0 {
+		validator.recordError("must be greater than 0")
 	}
 
 	return nil

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,0 +1,3 @@
+#### <sub><sup><a name="5830" href="#5830">:link:</a></sup></sub> fix
+
+* Fix a validation issue where a step can be set with 0 attempts causing the ATC to panic. #5830


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #5077  .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Step validation now disallows `attempts: 0`
* Don't panic if `RetryStep` doesn't have a `LastAttempt`

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

Prior to this fix, the panic is easy to reproduce - just set a pipeline with some step that has `attempts: 0`.

We don't have a reproducible where `RetryStep` panics even with `attempts > 0`, but this should fix that issue as well.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
