### PR TITLE
atc/db: track last successful build id of a job

### DIFF
--- a/atc/db/migration/migrations/1593541563_add_latest_successful_build_id.down.sql
+++ b/atc/db/migration/migrations/1593541563_add_latest_successful_build_id.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    ALTER TABLE jobs DROP COLUMN latest_successful_build_id;
+COMMIT;

--- a/atc/db/migration/migrations/1593541563_add_latest_successful_build_id.up.sql
+++ b/atc/db/migration/migrations/1593541563_add_latest_successful_build_id.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    ALTER TABLE jobs ADD COLUMN latest_successful_build_id integer;
+COMMIT;


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

closes #5800

## Changes proposed by this PR:

* Add a column called `latest_successful_build_id` to the `jobs` table
* When a job finishes successfully, it logs the build ID in the new column

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
