### PR TITLE
fly: fix fly login manual input on windows

### DIFF
--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -119,12 +119,13 @@ func (command *LoginCommand) Execute(args []string) error {
 	if isRawMode {
 		state, err := terminal.MakeRaw(int(os.Stdin.Fd()))
 		if err != nil {
-			return err
+			isRawMode = false
+		} else {
+			defer func() {
+				terminal.Restore(int(os.Stdin.Fd()), state)
+				fmt.Print("\r")
+			}()
 		}
-		defer func() {
-			terminal.Restore(int(os.Stdin.Fd()), state)
-			fmt.Print("\r")
-		}()
 	}
 
 	if semver.Compare(legacySemver) <= 0 && semver.Compare(devSemver) != 0 {

--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -123,7 +123,7 @@ func (command *LoginCommand) Execute(args []string) error {
 		}
 		defer func() {
 			terminal.Restore(int(os.Stdin.Fd()), state)
-			fmt.Println("\r")
+			fmt.Print("\r")
 		}()
 	}
 
@@ -139,6 +139,7 @@ func (command *LoginCommand) Execute(args []string) error {
 	}
 
 	if errors.Is(err, pty.ErrInterrupted) {
+		fmt.Println("^C\r")
 		return nil
 	}
 

--- a/fly/pty/open_raw_term_windows.go
+++ b/fly/pty/open_raw_term_windows.go
@@ -5,10 +5,12 @@ package pty
 import (
 	"io"
 	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func IsTerminal() bool {
-	return true
+	return terminal.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func OpenRawTerm() (Term, error) {

--- a/fly/pty/readline.go
+++ b/fly/pty/readline.go
@@ -8,7 +8,7 @@ import (
 var ErrInterrupted = errors.New("interrupted")
 
 const (
-	keyCtrlC = 3
+	keyCtrlC     = 3
 	keyBackspace = 127
 )
 
@@ -29,7 +29,9 @@ func ReadLine(reader io.Reader) ([]byte, error) {
 			case keyCtrlC:
 				return nil, ErrInterrupted
 			default:
-				ret = append(ret, buf[0])
+				if isPrintableChar(buf[0]) {
+					ret = append(ret, buf[0])
+				}
 			}
 			continue
 		}
@@ -40,4 +42,8 @@ func ReadLine(reader io.Reader) ([]byte, error) {
 			return ret, err
 		}
 	}
+}
+
+func isPrintableChar(b byte) bool {
+	return b >= 32
 }

--- a/fly/pty/readline.go
+++ b/fly/pty/readline.go
@@ -1,0 +1,43 @@
+package pty
+
+import (
+	"errors"
+	"io"
+)
+
+var ErrInterrupted = errors.New("interrupted")
+
+const (
+	keyCtrlC = 3
+	keyBackspace = 127
+)
+
+func ReadLine(reader io.Reader) ([]byte, error) {
+	var buf [1]byte
+	var ret []byte
+
+	for {
+		n, err := reader.Read(buf[:])
+		if n > 0 {
+			switch buf[0] {
+			case '\b', keyBackspace:
+				if len(ret) > 0 {
+					ret = ret[:len(ret)-1]
+				}
+			case '\r', '\n':
+				return ret, nil
+			case keyCtrlC:
+				return nil, ErrInterrupted
+			default:
+				ret = append(ret, buf[0])
+			}
+			continue
+		}
+		if err != nil {
+			if err == io.EOF && len(ret) > 0 {
+				return ret, nil
+			}
+			return ret, err
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,6 @@ require (
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.0.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/peterh/liner v1.2.0
 	github.com/peterhellberg/link v1.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942

--- a/go.sum
+++ b/go.sum
@@ -462,8 +462,6 @@ github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW1
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
-github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-sqlite3 v0.0.0-20160907162043-3fb7a0e792ed/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -544,8 +542,6 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.5.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
-github.com/peterh/liner v1.2.0 h1:w/UPXyl5GfahFxcTOz2j9wCIHNI+pUPr2laqpojKNCg=
-github.com/peterh/liner v1.2.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/peterhellberg/link v1.0.0 h1:mUWkiegowUXEcmlb+ybF75Q/8D2Y0BjZtR8cxoKhaQo=
 github.com/peterhellberg/link v1.0.0/go.mod h1:gtSlOT4jmkY8P47hbTc8PTgiDDWpdPbFYl75keYyBB8=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

There's more context in the first commit message, but tl;dr the library we switched to for reading in the token on stdin didn't behave so well on Windows (at least on git bash and in the test suite, seemed fine in Powershell).

The library tried to be smart about things based on the width of the terminal (because the library does smart things), but Windows was reporting that the terminal had 0 width for some reason. However, we don't really *need* a library that does smart things - we just need to read a line of text from the terminal and hide the output. 

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Ditch peterh/liner in favour of using raw mode ourselves and reading the input character-by-character, dealing with some special characters (ctrl+C, backspace, new line/carriage return).

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

This doesn't shouldn't change the behaviour noticeably on Linux/Mac OS - only on Windows.

Also, putting the terminal into raw mode on Windows Git Bash also seems to be a no-go, so the input won't be hidden there (but will be elsewhere).

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
