### PR TITLE
Add recover to concourse core to prevent panic

### DIFF
--- a/atc/engine/engine_test.go
+++ b/atc/engine/engine_test.go
@@ -272,6 +272,20 @@ var _ = Describe("Engine", func() {
 									Expect(fakeBuild.FinishArgsForCall(0)).To(Equal(db.BuildStatusAborted))
 								})
 							})
+
+							Context("when the build panic", func() {
+								BeforeEach(func() {
+									fakeStep.RunStub = func(context.Context, exec.RunState) error {
+										panic("something went wrong")
+									}
+								})
+
+								It("finishes the build with error", func() {
+									waitGroup.Wait()
+									Expect(fakeBuild.FinishCallCount()).To(Equal(1))
+									Expect(fakeBuild.FinishArgsForCall(0)).To(Equal(db.BuildStatusErrored))
+								})
+							})
 						})
 
 						Context("when converting the plan to a step fails", func() {
@@ -468,6 +482,20 @@ var _ = Describe("Engine", func() {
 								waitGroup.Wait()
 								Expect(fakeCheck.FinishWithErrorCallCount()).To(Equal(1))
 								Expect(fakeCheck.FinishWithErrorArgsForCall(0)).To(Equal(fmt.Errorf("run check step: %w", errors.New("nope"))))
+							})
+						})
+
+						Context("when the check panic", func() {
+							BeforeEach(func() {
+								fakeStep.RunStub = func(context.Context, exec.RunState) error {
+									panic("something went wrong")
+								}
+							})
+
+							It("finishes the check with panic error", func() {
+								waitGroup.Wait()
+								Expect(fakeCheck.FinishWithErrorCallCount()).To(Equal(1))
+								Expect(fakeCheck.FinishWithErrorArgsForCall(0).Error()).To(ContainSubstring("something went wrong"))
 							})
 						})
 

--- a/atc/exec/in_parallel.go
+++ b/atc/exec/in_parallel.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"runtime/debug"
 	"strings"
 )
 
@@ -55,6 +57,14 @@ func (step InParallelStep) Run(ctx context.Context, state RunState) error {
 		}
 
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					err := fmt.Errorf("panic in parallel step: %v", r)
+
+					fmt.Fprintf(os.Stderr, "%s\n %s\n", err.Error(), string(debug.Stack()))
+					errs <- err
+				}
+			}()
 			defer func() {
 				<-sem
 			}()

--- a/atc/exec/in_parallel_test.go
+++ b/atc/exec/in_parallel_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/concourse/concourse/atc/exec"
 	. "github.com/concourse/concourse/atc/exec"
 	"github.com/concourse/concourse/atc/exec/build"
 	"github.com/concourse/concourse/atc/exec/execfakes"
@@ -276,5 +277,22 @@ var _ = Describe("Parallel", func() {
 				Expect(step.Succeeded()).To(BeTrue())
 			})
 		})
+	})
+
+	Describe("Panic", func() {
+		Context("when one step panic", func() {
+			BeforeEach(func() {
+				fakeStepA.SucceededReturns(false)
+				fakeStepB.RunStub = func(context.Context, exec.RunState) error {
+					panic("something went wrong")
+				}
+			})
+
+			It("returns false", func() {
+				Expect(step.Succeeded()).To(BeFalse())
+				Expect(stepErr.Error()).To(ContainSubstring("something went wrong"))
+			})
+		})
+
 	})
 })

--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -145,6 +145,20 @@ var _ = Describe("Scanner", func() {
 							It("sends a notification for the checker to run", func() {
 								Expect(fakeCheckFactory.NotifyCheckerCallCount()).To(Equal(1))
 							})
+
+							Context("when try creating a check panic", func() {
+								BeforeEach(func() {
+									fakeCheckFactory.TryCreateCheckStub = func(context.Context, db.Checkable, db.ResourceTypes, atc.Version, bool) (db.Check, bool, error) {
+										panic("something went wrong")
+									}
+								})
+
+								It("recover from the panic", func() {
+									Expect(err).ToNot(HaveOccurred())
+									Eventually(fakeResource.SetCheckSetupErrorCallCount).Should(Equal(1))
+									Eventually(fakeResource.SetCheckSetupErrorArgsForCall(0).Error).Should(ContainSubstring("something went wrong"))
+								})
+							})
 						})
 
 						Context("when the checkable has a pinned version", func() {
@@ -316,7 +330,7 @@ var _ = Describe("Scanner", func() {
 
 				Context("last check is 9 minutes ago", func() {
 					BeforeEach(func() {
-						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute*9))
+						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute * 9))
 					})
 
 					It("does not create a check", func() {
@@ -326,7 +340,7 @@ var _ = Describe("Scanner", func() {
 
 				Context("last check is 11 minutes ago", func() {
 					BeforeEach(func() {
-						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute*11))
+						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-time.Minute * 11))
 					})
 
 					It("does not create a check", func() {

--- a/atc/scheduler/runner.go
+++ b/atc/scheduler/runner.go
@@ -3,6 +3,9 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"os"
+	"runtime/debug"
+	"strconv"
 	"sync"
 	"time"
 
@@ -67,6 +70,20 @@ func (s *Runner) Run(ctx context.Context) error {
 		jLog := sLog.Session("job", lager.Data{"job": j.Name()})
 
 		go func(job db.SchedulerJob) {
+			loggerData := lager.Data{
+				"job_id":        strconv.Itoa(job.ID()),
+				"job_name":      job.Name(),
+				"pipeline_name": job.PipelineName(),
+				"team_name":     job.TeamName(),
+			}
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("panic in scheduler run %s: %v", loggerData, r)
+
+					fmt.Fprintf(os.Stderr, "%s\n %s\n", err.Error(), string(debug.Stack()))
+					jLog.Error("panic-in-scheduler-run", err)
+				}
+			}()
 			defer func() {
 				<-s.guardJobScheduling
 				s.running.Delete(job.ID())

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -1,0 +1,3 @@
+#### <sub><sup><a name="5842" href="#5842">:link:</a></sup></sub> feature
+
+* Added recover for panic error that used to crash the cluster. Now it should be less easy to panic (we hope!) and if it does, panic error could be found on Stderr and log. #5842


### PR DESCRIPTION

<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Feature 

closes #3594.

## Changes proposed by this PR:
Add `recover()` to go routines around core scheduler, lidar and build engine. It will capture the panic and log it in stderr and logger.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed