### PR TITLE
TSA uses concourse's gclient with a configurable timeout instead of the cloudfoundry/gardent/client

### DIFF
--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -18,3 +18,7 @@
   * set_pipeline step is removed from job
   * Job that set pipeline is deleted
   * Parent pipeline is deleted
+
+#### <sub><sup><a name="5146" href="#5146">:link:</a></sup></sub> feature
+
+* Refactor TSA to use Concourse's gclient which has a configurable timeout Issue: #5146 PR: #5845

--- a/tsa/cmd/tsa/register_test.go
+++ b/tsa/cmd/tsa/register_test.go
@@ -433,7 +433,8 @@ var _ = Describe("Register", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusTeapot))
 
 				By("exiting successfully")
-				Eventually(registerErr).Should(Receive(BeNil()))
+				// https://golang.org/src/net/http/transport.go -> IdleConnTimeout is 90s in the DefaultTransport used by gclient.BasicGardenClientWithRequestTimeout
+				Eventually(registerErr, time.Second*100).Should(Receive(BeNil()))
 			})
 
 			Context("with a drain timeout", func() {

--- a/tsa/cmd/tsa/suite_test.go
+++ b/tsa/cmd/tsa/suite_test.go
@@ -55,6 +55,8 @@ var (
 	heartbeatInterval = 1 * time.Second
 	tsaProcess        ifrit.Process
 
+	gardenRequestTimeout = 3 * time.Second
+
 	gardenAddr  string
 	fakeBackend *gfakes.FakeBackend
 
@@ -158,6 +160,7 @@ var _ = BeforeEach(func() {
 		"--client-secret", "some-client-secret",
 		"--token-url", authServer.URL()+"/token",
 		"--atc-url", atcServer.URL(),
+		"--garden-request-timeout", gardenRequestTimeout.String(),
 		"--heartbeat-interval", heartbeatInterval.String(),
 	)
 

--- a/tsa/heartbeater.go
+++ b/tsa/heartbeater.go
@@ -10,11 +10,11 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/clock"
-	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/baggageclaim"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/worker/gclient"
 	"github.com/tedsuo/rata"
 )
 
@@ -28,7 +28,7 @@ type Heartbeater struct {
 	interval    time.Duration
 	cprInterval time.Duration
 
-	gardenClient       garden.Client
+	gardenClient       gclient.Client
 	baggageclaimClient baggageclaim.Client
 
 	atcEndpointPicker EndpointPicker
@@ -42,7 +42,7 @@ func NewHeartbeater(
 	clock clock.Clock,
 	interval time.Duration,
 	cprInterval time.Duration,
-	gardenClient garden.Client,
+	gardenClient gclient.Client,
 	baggageclaimClient baggageclaim.Client,
 	atcEndpointPicker EndpointPicker,
 	httpClient *http.Client,

--- a/tsa/heartbeater_test.go
+++ b/tsa/heartbeater_test.go
@@ -8,13 +8,14 @@ import (
 
 	"code.cloudfoundry.org/clock/fakeclock"
 	"code.cloudfoundry.org/garden"
-	"code.cloudfoundry.org/garden/gardenfakes"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/baggageclaim"
 	"github.com/concourse/baggageclaim/baggageclaimfakes"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/worker/gclient"
+	"github.com/concourse/concourse/atc/worker/gclient/gclientfakes"
 	. "github.com/concourse/concourse/tsa"
 	"github.com/concourse/concourse/tsa/tsafakes"
 	. "github.com/onsi/ginkgo"
@@ -42,7 +43,7 @@ var _ = Describe("Heartbeater", func() {
 		resourceTypes  []atc.WorkerResourceType
 
 		expectedWorker         atc.Worker
-		fakeGardenClient       *gardenfakes.FakeClient
+		fakeGardenClient       *gclientfakes.FakeClient
 		fakeBaggageclaimClient *baggageclaimfakes.FakeClient
 		fakeATC1               *ghttp.Server
 		fakeATC2               *ghttp.Server
@@ -130,7 +131,7 @@ var _ = Describe("Heartbeater", func() {
 			},
 		)
 
-		fakeGardenClient = new(gardenfakes.FakeClient)
+		fakeGardenClient = new(gclientfakes.FakeClient)
 		fakeBaggageclaimClient = new(baggageclaimfakes.FakeClient)
 
 		clientWriter = gbytes.NewBuffer()
@@ -181,12 +182,12 @@ var _ = Describe("Heartbeater", func() {
 
 	Context("when Garden returns containers and Baggageclaim returns volumes", func() {
 		BeforeEach(func() {
-			containers := make(chan []garden.Container, 4)
+			containers := make(chan []gclient.Container, 4)
 			volumes := make(chan []baggageclaim.Volume, 4)
 
-			containers <- []garden.Container{
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
+			containers <- []gclient.Container{
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
 			}
 
 			volumes <- []baggageclaim.Volume{
@@ -195,12 +196,12 @@ var _ = Describe("Heartbeater", func() {
 				new(baggageclaimfakes.FakeVolume),
 			}
 
-			containers <- []garden.Container{
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
+			containers <- []gclient.Container{
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
 			}
 
 			volumes <- []baggageclaim.Volume{
@@ -208,21 +209,21 @@ var _ = Describe("Heartbeater", func() {
 				new(baggageclaimfakes.FakeVolume),
 			}
 
-			containers <- []garden.Container{
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
+			containers <- []gclient.Container{
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
 			}
 
 			volumes <- []baggageclaim.Volume{
 				new(baggageclaimfakes.FakeVolume),
 			}
 
-			containers <- []garden.Container{
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
-				new(gardenfakes.FakeContainer),
+			containers <- []gclient.Container{
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
+				new(gclientfakes.FakeContainer),
 			}
 
 			volumes <- []baggageclaim.Volume{}
@@ -230,7 +231,7 @@ var _ = Describe("Heartbeater", func() {
 			close(containers)
 			close(volumes)
 
-			fakeGardenClient.ContainersStub = func(garden.Properties) ([]garden.Container, error) {
+			fakeGardenClient.ContainersStub = func(garden.Properties) ([]gclient.Container, error) {
 				return <-containers, nil
 			}
 

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -52,7 +52,8 @@ type TSACommand struct {
 	TokenURL     flag.URL `long:"token-url" required:"true" description:"Token endpoint of the auth server"`
 	Scopes       []string `long:"scope" description:"Scopes to request from the auth server"`
 
-	HeartbeatInterval time.Duration `long:"heartbeat-interval" default:"30s" description:"interval on which to heartbeat workers to the ATC"`
+	HeartbeatInterval    time.Duration `long:"heartbeat-interval" default:"30s" description:"interval on which to heartbeat workers to the ATC"`
+	GardenRequestTimeout time.Duration `long:"garden-request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
 
 	ClusterName    string `long:"cluster-name" description:"A name for this Concourse cluster, to be displayed on the dashboard page."`
 	LogClusterName bool   `long:"log-cluster-name" description:"Log cluster name."`
@@ -135,14 +136,15 @@ func (cmd *TSACommand) Runner(args []string) (ifrit.Runner, error) {
 	httpClient := oauth2.NewClient(ctx, idTokenSource)
 
 	server := &server{
-		logger:            logger,
-		heartbeatInterval: cmd.HeartbeatInterval,
-		cprInterval:       1 * time.Second,
-		atcEndpointPicker: atcEndpointPicker,
-		forwardHost:       cmd.PeerAddress,
-		config:            config,
-		httpClient:        httpClient,
-		sessionTeam:       sessionAuthTeam,
+		logger:               logger,
+		heartbeatInterval:    cmd.HeartbeatInterval,
+		cprInterval:          1 * time.Second,
+		atcEndpointPicker:    atcEndpointPicker,
+		forwardHost:          cmd.PeerAddress,
+		config:               config,
+		httpClient:           httpClient,
+		sessionTeam:          sessionAuthTeam,
+		gardenRequestTimeout: cmd.GardenRequestTimeout,
 	}
 	// Starts a goroutine whose purpose is to listen to the
 	// SIGHUP syscall and reload configuration upon receiving the signal.

--- a/tsa/tsacmd/remote_cli.go
+++ b/tsa/tsacmd/remote_cli.go
@@ -75,9 +75,8 @@ func (req forwardWorkerRequest) Handle(ctx context.Context, state ConnState, cha
 		req.server.heartbeatInterval,
 		req.server.cprInterval,
 		gclient.BasicGardenClientWithRequestTimeout(
-			logger.Session("garden-connection"),
-			// TODO Don't hardcode this
-			time.Minute*5,
+			lagerctx.WithSession(ctx, "garden-connection"),
+			req.server.gardenRequestTimeout,
 			gardenURL(worker.GardenAddr),
 		),
 		bclient.NewWithHTTPClient(worker.BaggageclaimURL, &http.Client{

--- a/tsa/tsacmd/server.go
+++ b/tsa/tsacmd/server.go
@@ -20,14 +20,15 @@ import (
 const maxForwards = 2
 
 type server struct {
-	logger            lager.Logger
-	atcEndpointPicker tsa.EndpointPicker
-	heartbeatInterval time.Duration
-	cprInterval       time.Duration
-	forwardHost       string
-	config            *ssh.ServerConfig
-	httpClient        *http.Client
-	sessionTeam       *sessionTeam
+	logger               lager.Logger
+	atcEndpointPicker    tsa.EndpointPicker
+	heartbeatInterval    time.Duration
+	cprInterval          time.Duration
+	gardenRequestTimeout time.Duration
+	forwardHost          string
+	config               *ssh.ServerConfig
+	httpClient           *http.Client
+	sessionTeam          *sessionTeam
 }
 
 type sessionTeam struct {


### PR DESCRIPTION
closes #5146 

## Changes proposed by this PR:
- tsa uses the concourse/gclient rather than cloudfoundry/garden 

## Notes to reviewer:
Since the gclient used by the TSA is used for heartbeating, I assumed its safe that it won't have explicit keep-alive configured. Furthermore, there is keepalive logic on the [TSA client](https://github.com/concourse/concourse/blob/master/tsa/keepalive.go) for the underlying ssh connection from the worker.

With the default heartbeat interval, I observed the keepalive timer resetting indefinitely using ` netstat -nto | grep GARDEN_PORT_ON_THE_WEB` on the web node 

Also, tried to pull the gclient into a more common path (eg. root of the repo) since it is used by atc, worker & tsa. However, it unfortunately has a bunch of dependencies on `atc/worker` at the moment and hence I felt it didn't make sense to move it until that is addressed. The changes can be seen on [move-glclient-to-root](https://github.com/concourse/concourse/tree/move-glclient-to-root)

## Release Note
Refactor TSA to use Concourse's gclient which has a configurable timeout Issue: #5146 PR: #5845

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
