### PR TITLE
feat: added a new event type SelectedWorker

### DIFF
--- a/atc/engine/builder/delegate_factory.go
+++ b/atc/engine/builder/delegate_factory.go
@@ -506,6 +506,17 @@ func (delegate *buildStepDelegate) Finished(logger lager.Logger, succeeded bool)
 	logger.Info("finished")
 }
 
+func (d *buildStepDelegate) SelectedWorker(logger lager.Logger, workerName string) {
+	err := d.build.SaveEvent(event.SelectedWorker{
+		Time:       time.Now().Unix(),
+		WorkerName: workerName,
+	})
+	if err != nil {
+		logger.Error("failed-to-save-selected-worker-event", err)
+		return
+	}
+}
+
 func (delegate *buildStepDelegate) Errored(logger lager.Logger, message string) {
 	err := delegate.build.SaveEvent(event.Error{
 		Message: message,

--- a/atc/engine/builder/delegate_factory.go
+++ b/atc/engine/builder/delegate_factory.go
@@ -506,9 +506,12 @@ func (delegate *buildStepDelegate) Finished(logger lager.Logger, succeeded bool)
 	logger.Info("finished")
 }
 
-func (d *buildStepDelegate) SelectedWorker(logger lager.Logger, workerName string) {
-	err := d.build.SaveEvent(event.SelectedWorker{
-		Time:       time.Now().Unix(),
+func (delegate *buildStepDelegate) SelectedWorker(logger lager.Logger, workerName string) {
+	err := delegate.build.SaveEvent(event.SelectedWorker{
+		Time: time.Now().Unix(),
+		Origin: event.Origin{
+			ID: event.OriginID(delegate.planID),
+		},
 		WorkerName: workerName,
 	})
 	if err != nil {

--- a/atc/event/events.go
+++ b/atc/event/events.go
@@ -91,8 +91,9 @@ func (Status) EventType() atc.EventType  { return EventTypeStatus }
 func (Status) Version() atc.EventVersion { return "1.0" }
 
 type SelectedWorker struct {
-	WorkerName string `json:"selected_worker"`
 	Time       int64  `json:"time"`
+	Origin     Origin `json:"origin"`
+	WorkerName string `json:"selected_worker"`
 }
 
 func (SelectedWorker) EventType() atc.EventType  { return EventTypeSelectedWorker }

--- a/atc/event/events.go
+++ b/atc/event/events.go
@@ -90,6 +90,14 @@ type Status struct {
 func (Status) EventType() atc.EventType  { return EventTypeStatus }
 func (Status) Version() atc.EventVersion { return "1.0" }
 
+type SelectedWorker struct {
+	WorkerName string `json:"selected_worker"`
+	Time       int64  `json:"time"`
+}
+
+func (SelectedWorker) EventType() atc.EventType  { return EventTypeSelectedWorker }
+func (SelectedWorker) Version() atc.EventVersion { return "1.0" }
+
 type Log struct {
 	Time    int64  `json:"time"`
 	Origin  Origin `json:"origin"`

--- a/atc/event/parser.go
+++ b/atc/event/parser.go
@@ -44,6 +44,7 @@ func init() {
 	RegisterEvent(StartPut{})
 	RegisterEvent(FinishPut{})
 	RegisterEvent(Status{})
+	RegisterEvent(SelectedWorker{})
 	RegisterEvent(Log{})
 	RegisterEvent(Error{})
 

--- a/atc/event/parser_test.go
+++ b/atc/event/parser_test.go
@@ -66,6 +66,7 @@ var _ = Describe("ParseEvent", func() {
 		Entry("StartPut", event.StartPut{}),
 		Entry("FinishPut", event.FinishPut{}),
 		Entry("Status", event.Status{}),
+		Entry("SelectedWorker", event.SelectedWorker{}),
 		Entry("Log", event.Log{}),
 		Entry("Error", event.Error{}),
 	)

--- a/atc/event/types.go
+++ b/atc/event/types.go
@@ -9,6 +9,9 @@ const (
 	// build status change (e.g. 'started', 'succeeded')
 	EventTypeStatus atc.EventType = "status"
 
+	// a step (get/put/task) selected worker
+	EventTypeSelectedWorker atc.EventType = "selected-worker"
+
 	// task execution started
 	EventTypeStartTask atc.EventType = "start-task"
 

--- a/atc/exec/build_step_delegate.go
+++ b/atc/exec/build_step_delegate.go
@@ -24,5 +24,6 @@ type BuildStepDelegate interface {
 	Initializing(lager.Logger)
 	Starting(lager.Logger)
 	Finished(lager.Logger, bool)
+	SelectedWorker(lager.Logger, string)
 	Errored(lager.Logger, string)
 }

--- a/atc/exec/execfakes/fake_build_step_delegate.go
+++ b/atc/exec/execfakes/fake_build_step_delegate.go
@@ -25,19 +25,6 @@ type FakeBuildStepDelegate struct {
 		arg1 lager.Logger
 		arg2 bool
 	}
-	ImageSourceRedactionStub        func(atc.Source) (atc.Source, error)
-	imageSourceRedactionMutex       sync.RWMutex
-	imageSourceRedactionArgsForCall []struct {
-		arg1 atc.Source
-	}
-	imageSourceRedactionReturns struct {
-		result1 atc.Source
-		result2 error
-	}
-	imageSourceRedactionReturnsOnCall map[int]struct {
-		result1 atc.Source
-		result2 error
-	}
 	ImageVersionDeterminedStub        func(db.UsedResourceCache) error
 	imageVersionDeterminedMutex       sync.RWMutex
 	imageVersionDeterminedArgsForCall []struct {
@@ -53,6 +40,25 @@ type FakeBuildStepDelegate struct {
 	initializingMutex       sync.RWMutex
 	initializingArgsForCall []struct {
 		arg1 lager.Logger
+	}
+	RedactImageSourceStub        func(atc.Source) (atc.Source, error)
+	redactImageSourceMutex       sync.RWMutex
+	redactImageSourceArgsForCall []struct {
+		arg1 atc.Source
+	}
+	redactImageSourceReturns struct {
+		result1 atc.Source
+		result2 error
+	}
+	redactImageSourceReturnsOnCall map[int]struct {
+		result1 atc.Source
+		result2 error
+	}
+	SelectedWorkerStub        func(lager.Logger, string)
+	selectedWorkerMutex       sync.RWMutex
+	selectedWorkerArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
 	}
 	StartingStub        func(lager.Logger)
 	startingMutex       sync.RWMutex
@@ -157,69 +163,6 @@ func (fake *FakeBuildStepDelegate) FinishedArgsForCall(i int) (lager.Logger, boo
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeBuildStepDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
-	fake.imageSourceRedactionMutex.Lock()
-	ret, specificReturn := fake.imageSourceRedactionReturnsOnCall[len(fake.imageSourceRedactionArgsForCall)]
-	fake.imageSourceRedactionArgsForCall = append(fake.imageSourceRedactionArgsForCall, struct {
-		arg1 atc.Source
-	}{arg1})
-	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
-	fake.imageSourceRedactionMutex.Unlock()
-	if fake.ImageSourceRedactionStub != nil {
-		return fake.ImageSourceRedactionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.imageSourceRedactionReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeBuildStepDelegate) ImageSourceRedactionCallCount() int {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	return len(fake.imageSourceRedactionArgsForCall)
-}
-
-func (fake *FakeBuildStepDelegate) ImageSourceRedactionCalls(stub func(atc.Source) (atc.Source, error)) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = stub
-}
-
-func (fake *FakeBuildStepDelegate) ImageSourceRedactionArgsForCall(i int) atc.Source {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	argsForCall := fake.imageSourceRedactionArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeBuildStepDelegate) ImageSourceRedactionReturns(result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	fake.imageSourceRedactionReturns = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeBuildStepDelegate) ImageSourceRedactionReturnsOnCall(i int, result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	if fake.imageSourceRedactionReturnsOnCall == nil {
-		fake.imageSourceRedactionReturnsOnCall = make(map[int]struct {
-			result1 atc.Source
-			result2 error
-		})
-	}
-	fake.imageSourceRedactionReturnsOnCall[i] = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeBuildStepDelegate) ImageVersionDetermined(arg1 db.UsedResourceCache) error {
 	fake.imageVersionDeterminedMutex.Lock()
 	ret, specificReturn := fake.imageVersionDeterminedReturnsOnCall[len(fake.imageVersionDeterminedArgsForCall)]
@@ -309,6 +252,101 @@ func (fake *FakeBuildStepDelegate) InitializingArgsForCall(i int) lager.Logger {
 	defer fake.initializingMutex.RUnlock()
 	argsForCall := fake.initializingArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeBuildStepDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
+	fake.redactImageSourceMutex.Lock()
+	ret, specificReturn := fake.redactImageSourceReturnsOnCall[len(fake.redactImageSourceArgsForCall)]
+	fake.redactImageSourceArgsForCall = append(fake.redactImageSourceArgsForCall, struct {
+		arg1 atc.Source
+	}{arg1})
+	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
+	fake.redactImageSourceMutex.Unlock()
+	if fake.RedactImageSourceStub != nil {
+		return fake.RedactImageSourceStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.redactImageSourceReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBuildStepDelegate) RedactImageSourceCallCount() int {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	return len(fake.redactImageSourceArgsForCall)
+}
+
+func (fake *FakeBuildStepDelegate) RedactImageSourceCalls(stub func(atc.Source) (atc.Source, error)) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = stub
+}
+
+func (fake *FakeBuildStepDelegate) RedactImageSourceArgsForCall(i int) atc.Source {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	argsForCall := fake.redactImageSourceArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeBuildStepDelegate) RedactImageSourceReturns(result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	fake.redactImageSourceReturns = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBuildStepDelegate) RedactImageSourceReturnsOnCall(i int, result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	if fake.redactImageSourceReturnsOnCall == nil {
+		fake.redactImageSourceReturnsOnCall = make(map[int]struct {
+			result1 atc.Source
+			result2 error
+		})
+	}
+	fake.redactImageSourceReturnsOnCall[i] = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBuildStepDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
+	fake.selectedWorkerMutex.Lock()
+	fake.selectedWorkerArgsForCall = append(fake.selectedWorkerArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
+	fake.selectedWorkerMutex.Unlock()
+	if fake.SelectedWorkerStub != nil {
+		fake.SelectedWorkerStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeBuildStepDelegate) SelectedWorkerCallCount() int {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	return len(fake.selectedWorkerArgsForCall)
+}
+
+func (fake *FakeBuildStepDelegate) SelectedWorkerCalls(stub func(lager.Logger, string)) {
+	fake.selectedWorkerMutex.Lock()
+	defer fake.selectedWorkerMutex.Unlock()
+	fake.SelectedWorkerStub = stub
+}
+
+func (fake *FakeBuildStepDelegate) SelectedWorkerArgsForCall(i int) (lager.Logger, string) {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	argsForCall := fake.selectedWorkerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeBuildStepDelegate) Starting(arg1 lager.Logger) {
@@ -505,12 +543,14 @@ func (fake *FakeBuildStepDelegate) Invocations() map[string][][]interface{} {
 	defer fake.erroredMutex.RUnlock()
 	fake.finishedMutex.RLock()
 	defer fake.finishedMutex.RUnlock()
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
 	fake.imageVersionDeterminedMutex.RLock()
 	defer fake.imageVersionDeterminedMutex.RUnlock()
 	fake.initializingMutex.RLock()
 	defer fake.initializingMutex.RUnlock()
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
 	fake.startingMutex.RLock()
 	defer fake.startingMutex.RUnlock()
 	fake.stderrMutex.RLock()

--- a/atc/exec/execfakes/fake_check_delegate.go
+++ b/atc/exec/execfakes/fake_check_delegate.go
@@ -25,19 +25,6 @@ type FakeCheckDelegate struct {
 		arg1 lager.Logger
 		arg2 bool
 	}
-	ImageSourceRedactionStub        func(atc.Source) (atc.Source, error)
-	imageSourceRedactionMutex       sync.RWMutex
-	imageSourceRedactionArgsForCall []struct {
-		arg1 atc.Source
-	}
-	imageSourceRedactionReturns struct {
-		result1 atc.Source
-		result2 error
-	}
-	imageSourceRedactionReturnsOnCall map[int]struct {
-		result1 atc.Source
-		result2 error
-	}
 	ImageVersionDeterminedStub        func(db.UsedResourceCache) error
 	imageVersionDeterminedMutex       sync.RWMutex
 	imageVersionDeterminedArgsForCall []struct {
@@ -54,6 +41,19 @@ type FakeCheckDelegate struct {
 	initializingArgsForCall []struct {
 		arg1 lager.Logger
 	}
+	RedactImageSourceStub        func(atc.Source) (atc.Source, error)
+	redactImageSourceMutex       sync.RWMutex
+	redactImageSourceArgsForCall []struct {
+		arg1 atc.Source
+	}
+	redactImageSourceReturns struct {
+		result1 atc.Source
+		result2 error
+	}
+	redactImageSourceReturnsOnCall map[int]struct {
+		result1 atc.Source
+		result2 error
+	}
 	SaveVersionsStub        func(db.SpanContext, []atc.Version) error
 	saveVersionsMutex       sync.RWMutex
 	saveVersionsArgsForCall []struct {
@@ -65,6 +65,12 @@ type FakeCheckDelegate struct {
 	}
 	saveVersionsReturnsOnCall map[int]struct {
 		result1 error
+	}
+	SelectedWorkerStub        func(lager.Logger, string)
+	selectedWorkerMutex       sync.RWMutex
+	selectedWorkerArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
 	}
 	StartingStub        func(lager.Logger)
 	startingMutex       sync.RWMutex
@@ -169,69 +175,6 @@ func (fake *FakeCheckDelegate) FinishedArgsForCall(i int) (lager.Logger, bool) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeCheckDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
-	fake.imageSourceRedactionMutex.Lock()
-	ret, specificReturn := fake.imageSourceRedactionReturnsOnCall[len(fake.imageSourceRedactionArgsForCall)]
-	fake.imageSourceRedactionArgsForCall = append(fake.imageSourceRedactionArgsForCall, struct {
-		arg1 atc.Source
-	}{arg1})
-	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
-	fake.imageSourceRedactionMutex.Unlock()
-	if fake.ImageSourceRedactionStub != nil {
-		return fake.ImageSourceRedactionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.imageSourceRedactionReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeCheckDelegate) ImageSourceRedactionCallCount() int {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	return len(fake.imageSourceRedactionArgsForCall)
-}
-
-func (fake *FakeCheckDelegate) ImageSourceRedactionCalls(stub func(atc.Source) (atc.Source, error)) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = stub
-}
-
-func (fake *FakeCheckDelegate) ImageSourceRedactionArgsForCall(i int) atc.Source {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	argsForCall := fake.imageSourceRedactionArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeCheckDelegate) ImageSourceRedactionReturns(result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	fake.imageSourceRedactionReturns = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCheckDelegate) ImageSourceRedactionReturnsOnCall(i int, result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	if fake.imageSourceRedactionReturnsOnCall == nil {
-		fake.imageSourceRedactionReturnsOnCall = make(map[int]struct {
-			result1 atc.Source
-			result2 error
-		})
-	}
-	fake.imageSourceRedactionReturnsOnCall[i] = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeCheckDelegate) ImageVersionDetermined(arg1 db.UsedResourceCache) error {
 	fake.imageVersionDeterminedMutex.Lock()
 	ret, specificReturn := fake.imageVersionDeterminedReturnsOnCall[len(fake.imageVersionDeterminedArgsForCall)]
@@ -323,6 +266,69 @@ func (fake *FakeCheckDelegate) InitializingArgsForCall(i int) lager.Logger {
 	return argsForCall.arg1
 }
 
+func (fake *FakeCheckDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
+	fake.redactImageSourceMutex.Lock()
+	ret, specificReturn := fake.redactImageSourceReturnsOnCall[len(fake.redactImageSourceArgsForCall)]
+	fake.redactImageSourceArgsForCall = append(fake.redactImageSourceArgsForCall, struct {
+		arg1 atc.Source
+	}{arg1})
+	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
+	fake.redactImageSourceMutex.Unlock()
+	if fake.RedactImageSourceStub != nil {
+		return fake.RedactImageSourceStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.redactImageSourceReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeCheckDelegate) RedactImageSourceCallCount() int {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	return len(fake.redactImageSourceArgsForCall)
+}
+
+func (fake *FakeCheckDelegate) RedactImageSourceCalls(stub func(atc.Source) (atc.Source, error)) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = stub
+}
+
+func (fake *FakeCheckDelegate) RedactImageSourceArgsForCall(i int) atc.Source {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	argsForCall := fake.redactImageSourceArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCheckDelegate) RedactImageSourceReturns(result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	fake.redactImageSourceReturns = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCheckDelegate) RedactImageSourceReturnsOnCall(i int, result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	if fake.redactImageSourceReturnsOnCall == nil {
+		fake.redactImageSourceReturnsOnCall = make(map[int]struct {
+			result1 atc.Source
+			result2 error
+		})
+	}
+	fake.redactImageSourceReturnsOnCall[i] = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeCheckDelegate) SaveVersions(arg1 db.SpanContext, arg2 []atc.Version) error {
 	var arg2Copy []atc.Version
 	if arg2 != nil {
@@ -387,6 +393,38 @@ func (fake *FakeCheckDelegate) SaveVersionsReturnsOnCall(i int, result1 error) {
 	fake.saveVersionsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeCheckDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
+	fake.selectedWorkerMutex.Lock()
+	fake.selectedWorkerArgsForCall = append(fake.selectedWorkerArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
+	fake.selectedWorkerMutex.Unlock()
+	if fake.SelectedWorkerStub != nil {
+		fake.SelectedWorkerStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeCheckDelegate) SelectedWorkerCallCount() int {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	return len(fake.selectedWorkerArgsForCall)
+}
+
+func (fake *FakeCheckDelegate) SelectedWorkerCalls(stub func(lager.Logger, string)) {
+	fake.selectedWorkerMutex.Lock()
+	defer fake.selectedWorkerMutex.Unlock()
+	fake.SelectedWorkerStub = stub
+}
+
+func (fake *FakeCheckDelegate) SelectedWorkerArgsForCall(i int) (lager.Logger, string) {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	argsForCall := fake.selectedWorkerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeCheckDelegate) Starting(arg1 lager.Logger) {
@@ -583,14 +621,16 @@ func (fake *FakeCheckDelegate) Invocations() map[string][][]interface{} {
 	defer fake.erroredMutex.RUnlock()
 	fake.finishedMutex.RLock()
 	defer fake.finishedMutex.RUnlock()
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
 	fake.imageVersionDeterminedMutex.RLock()
 	defer fake.imageVersionDeterminedMutex.RUnlock()
 	fake.initializingMutex.RLock()
 	defer fake.initializingMutex.RUnlock()
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
 	fake.saveVersionsMutex.RLock()
 	defer fake.saveVersionsMutex.RUnlock()
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
 	fake.startingMutex.RLock()
 	defer fake.startingMutex.RUnlock()
 	fake.stderrMutex.RLock()

--- a/atc/exec/execfakes/fake_get_delegate.go
+++ b/atc/exec/execfakes/fake_get_delegate.go
@@ -27,19 +27,6 @@ type FakeGetDelegate struct {
 		arg2 exec.ExitStatus
 		arg3 runtime.VersionResult
 	}
-	ImageSourceRedactionStub        func(atc.Source) (atc.Source, error)
-	imageSourceRedactionMutex       sync.RWMutex
-	imageSourceRedactionArgsForCall []struct {
-		arg1 atc.Source
-	}
-	imageSourceRedactionReturns struct {
-		result1 atc.Source
-		result2 error
-	}
-	imageSourceRedactionReturnsOnCall map[int]struct {
-		result1 atc.Source
-		result2 error
-	}
 	ImageVersionDeterminedStub        func(db.UsedResourceCache) error
 	imageVersionDeterminedMutex       sync.RWMutex
 	imageVersionDeterminedArgsForCall []struct {
@@ -55,6 +42,25 @@ type FakeGetDelegate struct {
 	initializingMutex       sync.RWMutex
 	initializingArgsForCall []struct {
 		arg1 lager.Logger
+	}
+	RedactImageSourceStub        func(atc.Source) (atc.Source, error)
+	redactImageSourceMutex       sync.RWMutex
+	redactImageSourceArgsForCall []struct {
+		arg1 atc.Source
+	}
+	redactImageSourceReturns struct {
+		result1 atc.Source
+		result2 error
+	}
+	redactImageSourceReturnsOnCall map[int]struct {
+		result1 atc.Source
+		result2 error
+	}
+	SelectedWorkerStub        func(lager.Logger, string)
+	selectedWorkerMutex       sync.RWMutex
+	selectedWorkerArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
 	}
 	StartingStub        func(lager.Logger)
 	startingMutex       sync.RWMutex
@@ -167,69 +173,6 @@ func (fake *FakeGetDelegate) FinishedArgsForCall(i int) (lager.Logger, exec.Exit
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeGetDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
-	fake.imageSourceRedactionMutex.Lock()
-	ret, specificReturn := fake.imageSourceRedactionReturnsOnCall[len(fake.imageSourceRedactionArgsForCall)]
-	fake.imageSourceRedactionArgsForCall = append(fake.imageSourceRedactionArgsForCall, struct {
-		arg1 atc.Source
-	}{arg1})
-	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
-	fake.imageSourceRedactionMutex.Unlock()
-	if fake.ImageSourceRedactionStub != nil {
-		return fake.ImageSourceRedactionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.imageSourceRedactionReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeGetDelegate) ImageSourceRedactionCallCount() int {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	return len(fake.imageSourceRedactionArgsForCall)
-}
-
-func (fake *FakeGetDelegate) ImageSourceRedactionCalls(stub func(atc.Source) (atc.Source, error)) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = stub
-}
-
-func (fake *FakeGetDelegate) ImageSourceRedactionArgsForCall(i int) atc.Source {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	argsForCall := fake.imageSourceRedactionArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeGetDelegate) ImageSourceRedactionReturns(result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	fake.imageSourceRedactionReturns = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeGetDelegate) ImageSourceRedactionReturnsOnCall(i int, result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	if fake.imageSourceRedactionReturnsOnCall == nil {
-		fake.imageSourceRedactionReturnsOnCall = make(map[int]struct {
-			result1 atc.Source
-			result2 error
-		})
-	}
-	fake.imageSourceRedactionReturnsOnCall[i] = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeGetDelegate) ImageVersionDetermined(arg1 db.UsedResourceCache) error {
 	fake.imageVersionDeterminedMutex.Lock()
 	ret, specificReturn := fake.imageVersionDeterminedReturnsOnCall[len(fake.imageVersionDeterminedArgsForCall)]
@@ -319,6 +262,101 @@ func (fake *FakeGetDelegate) InitializingArgsForCall(i int) lager.Logger {
 	defer fake.initializingMutex.RUnlock()
 	argsForCall := fake.initializingArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeGetDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
+	fake.redactImageSourceMutex.Lock()
+	ret, specificReturn := fake.redactImageSourceReturnsOnCall[len(fake.redactImageSourceArgsForCall)]
+	fake.redactImageSourceArgsForCall = append(fake.redactImageSourceArgsForCall, struct {
+		arg1 atc.Source
+	}{arg1})
+	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
+	fake.redactImageSourceMutex.Unlock()
+	if fake.RedactImageSourceStub != nil {
+		return fake.RedactImageSourceStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.redactImageSourceReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeGetDelegate) RedactImageSourceCallCount() int {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	return len(fake.redactImageSourceArgsForCall)
+}
+
+func (fake *FakeGetDelegate) RedactImageSourceCalls(stub func(atc.Source) (atc.Source, error)) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = stub
+}
+
+func (fake *FakeGetDelegate) RedactImageSourceArgsForCall(i int) atc.Source {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	argsForCall := fake.redactImageSourceArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeGetDelegate) RedactImageSourceReturns(result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	fake.redactImageSourceReturns = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGetDelegate) RedactImageSourceReturnsOnCall(i int, result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	if fake.redactImageSourceReturnsOnCall == nil {
+		fake.redactImageSourceReturnsOnCall = make(map[int]struct {
+			result1 atc.Source
+			result2 error
+		})
+	}
+	fake.redactImageSourceReturnsOnCall[i] = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeGetDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
+	fake.selectedWorkerMutex.Lock()
+	fake.selectedWorkerArgsForCall = append(fake.selectedWorkerArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
+	fake.selectedWorkerMutex.Unlock()
+	if fake.SelectedWorkerStub != nil {
+		fake.SelectedWorkerStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeGetDelegate) SelectedWorkerCallCount() int {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	return len(fake.selectedWorkerArgsForCall)
+}
+
+func (fake *FakeGetDelegate) SelectedWorkerCalls(stub func(lager.Logger, string)) {
+	fake.selectedWorkerMutex.Lock()
+	defer fake.selectedWorkerMutex.Unlock()
+	fake.SelectedWorkerStub = stub
+}
+
+func (fake *FakeGetDelegate) SelectedWorkerArgsForCall(i int) (lager.Logger, string) {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	argsForCall := fake.selectedWorkerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeGetDelegate) Starting(arg1 lager.Logger) {
@@ -548,12 +586,14 @@ func (fake *FakeGetDelegate) Invocations() map[string][][]interface{} {
 	defer fake.erroredMutex.RUnlock()
 	fake.finishedMutex.RLock()
 	defer fake.finishedMutex.RUnlock()
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
 	fake.imageVersionDeterminedMutex.RLock()
 	defer fake.imageVersionDeterminedMutex.RUnlock()
 	fake.initializingMutex.RLock()
 	defer fake.initializingMutex.RUnlock()
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
 	fake.startingMutex.RLock()
 	defer fake.startingMutex.RUnlock()
 	fake.stderrMutex.RLock()

--- a/atc/exec/execfakes/fake_put_delegate.go
+++ b/atc/exec/execfakes/fake_put_delegate.go
@@ -27,19 +27,6 @@ type FakePutDelegate struct {
 		arg2 exec.ExitStatus
 		arg3 runtime.VersionResult
 	}
-	ImageSourceRedactionStub        func(atc.Source) (atc.Source, error)
-	imageSourceRedactionMutex       sync.RWMutex
-	imageSourceRedactionArgsForCall []struct {
-		arg1 atc.Source
-	}
-	imageSourceRedactionReturns struct {
-		result1 atc.Source
-		result2 error
-	}
-	imageSourceRedactionReturnsOnCall map[int]struct {
-		result1 atc.Source
-		result2 error
-	}
 	ImageVersionDeterminedStub        func(db.UsedResourceCache) error
 	imageVersionDeterminedMutex       sync.RWMutex
 	imageVersionDeterminedArgsForCall []struct {
@@ -56,6 +43,19 @@ type FakePutDelegate struct {
 	initializingArgsForCall []struct {
 		arg1 lager.Logger
 	}
+	RedactImageSourceStub        func(atc.Source) (atc.Source, error)
+	redactImageSourceMutex       sync.RWMutex
+	redactImageSourceArgsForCall []struct {
+		arg1 atc.Source
+	}
+	redactImageSourceReturns struct {
+		result1 atc.Source
+		result2 error
+	}
+	redactImageSourceReturnsOnCall map[int]struct {
+		result1 atc.Source
+		result2 error
+	}
 	SaveOutputStub        func(lager.Logger, atc.PutPlan, atc.Source, atc.VersionedResourceTypes, runtime.VersionResult)
 	saveOutputMutex       sync.RWMutex
 	saveOutputArgsForCall []struct {
@@ -64,6 +64,12 @@ type FakePutDelegate struct {
 		arg3 atc.Source
 		arg4 atc.VersionedResourceTypes
 		arg5 runtime.VersionResult
+	}
+	SelectedWorkerStub        func(lager.Logger, string)
+	selectedWorkerMutex       sync.RWMutex
+	selectedWorkerArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
 	}
 	StartingStub        func(lager.Logger)
 	startingMutex       sync.RWMutex
@@ -169,69 +175,6 @@ func (fake *FakePutDelegate) FinishedArgsForCall(i int) (lager.Logger, exec.Exit
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakePutDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
-	fake.imageSourceRedactionMutex.Lock()
-	ret, specificReturn := fake.imageSourceRedactionReturnsOnCall[len(fake.imageSourceRedactionArgsForCall)]
-	fake.imageSourceRedactionArgsForCall = append(fake.imageSourceRedactionArgsForCall, struct {
-		arg1 atc.Source
-	}{arg1})
-	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
-	fake.imageSourceRedactionMutex.Unlock()
-	if fake.ImageSourceRedactionStub != nil {
-		return fake.ImageSourceRedactionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.imageSourceRedactionReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakePutDelegate) ImageSourceRedactionCallCount() int {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	return len(fake.imageSourceRedactionArgsForCall)
-}
-
-func (fake *FakePutDelegate) ImageSourceRedactionCalls(stub func(atc.Source) (atc.Source, error)) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = stub
-}
-
-func (fake *FakePutDelegate) ImageSourceRedactionArgsForCall(i int) atc.Source {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	argsForCall := fake.imageSourceRedactionArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakePutDelegate) ImageSourceRedactionReturns(result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	fake.imageSourceRedactionReturns = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakePutDelegate) ImageSourceRedactionReturnsOnCall(i int, result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	if fake.imageSourceRedactionReturnsOnCall == nil {
-		fake.imageSourceRedactionReturnsOnCall = make(map[int]struct {
-			result1 atc.Source
-			result2 error
-		})
-	}
-	fake.imageSourceRedactionReturnsOnCall[i] = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakePutDelegate) ImageVersionDetermined(arg1 db.UsedResourceCache) error {
 	fake.imageVersionDeterminedMutex.Lock()
 	ret, specificReturn := fake.imageVersionDeterminedReturnsOnCall[len(fake.imageVersionDeterminedArgsForCall)]
@@ -323,6 +266,69 @@ func (fake *FakePutDelegate) InitializingArgsForCall(i int) lager.Logger {
 	return argsForCall.arg1
 }
 
+func (fake *FakePutDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
+	fake.redactImageSourceMutex.Lock()
+	ret, specificReturn := fake.redactImageSourceReturnsOnCall[len(fake.redactImageSourceArgsForCall)]
+	fake.redactImageSourceArgsForCall = append(fake.redactImageSourceArgsForCall, struct {
+		arg1 atc.Source
+	}{arg1})
+	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
+	fake.redactImageSourceMutex.Unlock()
+	if fake.RedactImageSourceStub != nil {
+		return fake.RedactImageSourceStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.redactImageSourceReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakePutDelegate) RedactImageSourceCallCount() int {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	return len(fake.redactImageSourceArgsForCall)
+}
+
+func (fake *FakePutDelegate) RedactImageSourceCalls(stub func(atc.Source) (atc.Source, error)) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = stub
+}
+
+func (fake *FakePutDelegate) RedactImageSourceArgsForCall(i int) atc.Source {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	argsForCall := fake.redactImageSourceArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakePutDelegate) RedactImageSourceReturns(result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	fake.redactImageSourceReturns = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePutDelegate) RedactImageSourceReturnsOnCall(i int, result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	if fake.redactImageSourceReturnsOnCall == nil {
+		fake.redactImageSourceReturnsOnCall = make(map[int]struct {
+			result1 atc.Source
+			result2 error
+		})
+	}
+	fake.redactImageSourceReturnsOnCall[i] = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakePutDelegate) SaveOutput(arg1 lager.Logger, arg2 atc.PutPlan, arg3 atc.Source, arg4 atc.VersionedResourceTypes, arg5 runtime.VersionResult) {
 	fake.saveOutputMutex.Lock()
 	fake.saveOutputArgsForCall = append(fake.saveOutputArgsForCall, struct {
@@ -356,6 +362,38 @@ func (fake *FakePutDelegate) SaveOutputArgsForCall(i int) (lager.Logger, atc.Put
 	defer fake.saveOutputMutex.RUnlock()
 	argsForCall := fake.saveOutputArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
+func (fake *FakePutDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
+	fake.selectedWorkerMutex.Lock()
+	fake.selectedWorkerArgsForCall = append(fake.selectedWorkerArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
+	fake.selectedWorkerMutex.Unlock()
+	if fake.SelectedWorkerStub != nil {
+		fake.SelectedWorkerStub(arg1, arg2)
+	}
+}
+
+func (fake *FakePutDelegate) SelectedWorkerCallCount() int {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	return len(fake.selectedWorkerArgsForCall)
+}
+
+func (fake *FakePutDelegate) SelectedWorkerCalls(stub func(lager.Logger, string)) {
+	fake.selectedWorkerMutex.Lock()
+	defer fake.selectedWorkerMutex.Unlock()
+	fake.SelectedWorkerStub = stub
+}
+
+func (fake *FakePutDelegate) SelectedWorkerArgsForCall(i int) (lager.Logger, string) {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	argsForCall := fake.selectedWorkerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakePutDelegate) Starting(arg1 lager.Logger) {
@@ -552,14 +590,16 @@ func (fake *FakePutDelegate) Invocations() map[string][][]interface{} {
 	defer fake.erroredMutex.RUnlock()
 	fake.finishedMutex.RLock()
 	defer fake.finishedMutex.RUnlock()
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
 	fake.imageVersionDeterminedMutex.RLock()
 	defer fake.imageVersionDeterminedMutex.RUnlock()
 	fake.initializingMutex.RLock()
 	defer fake.initializingMutex.RUnlock()
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
 	fake.saveOutputMutex.RLock()
 	defer fake.saveOutputMutex.RUnlock()
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
 	fake.startingMutex.RLock()
 	defer fake.startingMutex.RUnlock()
 	fake.stderrMutex.RLock()

--- a/atc/exec/execfakes/fake_task_delegate.go
+++ b/atc/exec/execfakes/fake_task_delegate.go
@@ -25,19 +25,6 @@ type FakeTaskDelegate struct {
 		arg1 lager.Logger
 		arg2 exec.ExitStatus
 	}
-	ImageSourceRedactionStub        func(atc.Source) (atc.Source, error)
-	imageSourceRedactionMutex       sync.RWMutex
-	imageSourceRedactionArgsForCall []struct {
-		arg1 atc.Source
-	}
-	imageSourceRedactionReturns struct {
-		result1 atc.Source
-		result2 error
-	}
-	imageSourceRedactionReturnsOnCall map[int]struct {
-		result1 atc.Source
-		result2 error
-	}
 	ImageVersionDeterminedStub        func(db.UsedResourceCache) error
 	imageVersionDeterminedMutex       sync.RWMutex
 	imageVersionDeterminedArgsForCall []struct {
@@ -53,6 +40,25 @@ type FakeTaskDelegate struct {
 	initializingMutex       sync.RWMutex
 	initializingArgsForCall []struct {
 		arg1 lager.Logger
+	}
+	RedactImageSourceStub        func(atc.Source) (atc.Source, error)
+	redactImageSourceMutex       sync.RWMutex
+	redactImageSourceArgsForCall []struct {
+		arg1 atc.Source
+	}
+	redactImageSourceReturns struct {
+		result1 atc.Source
+		result2 error
+	}
+	redactImageSourceReturnsOnCall map[int]struct {
+		result1 atc.Source
+		result2 error
+	}
+	SelectedWorkerStub        func(lager.Logger, string)
+	selectedWorkerMutex       sync.RWMutex
+	selectedWorkerArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
 	}
 	SetTaskConfigStub        func(atc.TaskConfig)
 	setTaskConfigMutex       sync.RWMutex
@@ -162,69 +168,6 @@ func (fake *FakeTaskDelegate) FinishedArgsForCall(i int) (lager.Logger, exec.Exi
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeTaskDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
-	fake.imageSourceRedactionMutex.Lock()
-	ret, specificReturn := fake.imageSourceRedactionReturnsOnCall[len(fake.imageSourceRedactionArgsForCall)]
-	fake.imageSourceRedactionArgsForCall = append(fake.imageSourceRedactionArgsForCall, struct {
-		arg1 atc.Source
-	}{arg1})
-	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
-	fake.imageSourceRedactionMutex.Unlock()
-	if fake.ImageSourceRedactionStub != nil {
-		return fake.ImageSourceRedactionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.imageSourceRedactionReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeTaskDelegate) ImageSourceRedactionCallCount() int {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	return len(fake.imageSourceRedactionArgsForCall)
-}
-
-func (fake *FakeTaskDelegate) ImageSourceRedactionCalls(stub func(atc.Source) (atc.Source, error)) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = stub
-}
-
-func (fake *FakeTaskDelegate) ImageSourceRedactionArgsForCall(i int) atc.Source {
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
-	argsForCall := fake.imageSourceRedactionArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeTaskDelegate) ImageSourceRedactionReturns(result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	fake.imageSourceRedactionReturns = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeTaskDelegate) ImageSourceRedactionReturnsOnCall(i int, result1 atc.Source, result2 error) {
-	fake.imageSourceRedactionMutex.Lock()
-	defer fake.imageSourceRedactionMutex.Unlock()
-	fake.ImageSourceRedactionStub = nil
-	if fake.imageSourceRedactionReturnsOnCall == nil {
-		fake.imageSourceRedactionReturnsOnCall = make(map[int]struct {
-			result1 atc.Source
-			result2 error
-		})
-	}
-	fake.imageSourceRedactionReturnsOnCall[i] = struct {
-		result1 atc.Source
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeTaskDelegate) ImageVersionDetermined(arg1 db.UsedResourceCache) error {
 	fake.imageVersionDeterminedMutex.Lock()
 	ret, specificReturn := fake.imageVersionDeterminedReturnsOnCall[len(fake.imageVersionDeterminedArgsForCall)]
@@ -314,6 +257,101 @@ func (fake *FakeTaskDelegate) InitializingArgsForCall(i int) lager.Logger {
 	defer fake.initializingMutex.RUnlock()
 	argsForCall := fake.initializingArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeTaskDelegate) RedactImageSource(arg1 atc.Source) (atc.Source, error) {
+	fake.redactImageSourceMutex.Lock()
+	ret, specificReturn := fake.redactImageSourceReturnsOnCall[len(fake.redactImageSourceArgsForCall)]
+	fake.redactImageSourceArgsForCall = append(fake.redactImageSourceArgsForCall, struct {
+		arg1 atc.Source
+	}{arg1})
+	fake.recordInvocation("RedactImageSource", []interface{}{arg1})
+	fake.redactImageSourceMutex.Unlock()
+	if fake.RedactImageSourceStub != nil {
+		return fake.RedactImageSourceStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.redactImageSourceReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTaskDelegate) RedactImageSourceCallCount() int {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	return len(fake.redactImageSourceArgsForCall)
+}
+
+func (fake *FakeTaskDelegate) RedactImageSourceCalls(stub func(atc.Source) (atc.Source, error)) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = stub
+}
+
+func (fake *FakeTaskDelegate) RedactImageSourceArgsForCall(i int) atc.Source {
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	argsForCall := fake.redactImageSourceArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeTaskDelegate) RedactImageSourceReturns(result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	fake.redactImageSourceReturns = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTaskDelegate) RedactImageSourceReturnsOnCall(i int, result1 atc.Source, result2 error) {
+	fake.redactImageSourceMutex.Lock()
+	defer fake.redactImageSourceMutex.Unlock()
+	fake.RedactImageSourceStub = nil
+	if fake.redactImageSourceReturnsOnCall == nil {
+		fake.redactImageSourceReturnsOnCall = make(map[int]struct {
+			result1 atc.Source
+			result2 error
+		})
+	}
+	fake.redactImageSourceReturnsOnCall[i] = struct {
+		result1 atc.Source
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTaskDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
+	fake.selectedWorkerMutex.Lock()
+	fake.selectedWorkerArgsForCall = append(fake.selectedWorkerArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
+	fake.selectedWorkerMutex.Unlock()
+	if fake.SelectedWorkerStub != nil {
+		fake.SelectedWorkerStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeTaskDelegate) SelectedWorkerCallCount() int {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	return len(fake.selectedWorkerArgsForCall)
+}
+
+func (fake *FakeTaskDelegate) SelectedWorkerCalls(stub func(lager.Logger, string)) {
+	fake.selectedWorkerMutex.Lock()
+	defer fake.selectedWorkerMutex.Unlock()
+	fake.SelectedWorkerStub = stub
+}
+
+func (fake *FakeTaskDelegate) SelectedWorkerArgsForCall(i int) (lager.Logger, string) {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	argsForCall := fake.selectedWorkerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeTaskDelegate) SetTaskConfig(arg1 atc.TaskConfig) {
@@ -541,12 +579,14 @@ func (fake *FakeTaskDelegate) Invocations() map[string][][]interface{} {
 	defer fake.erroredMutex.RUnlock()
 	fake.finishedMutex.RLock()
 	defer fake.finishedMutex.RUnlock()
-	fake.imageSourceRedactionMutex.RLock()
-	defer fake.imageSourceRedactionMutex.RUnlock()
 	fake.imageVersionDeterminedMutex.RLock()
 	defer fake.imageVersionDeterminedMutex.RUnlock()
 	fake.initializingMutex.RLock()
 	defer fake.initializingMutex.RUnlock()
+	fake.redactImageSourceMutex.RLock()
+	defer fake.redactImageSourceMutex.RUnlock()
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
 	fake.setTaskConfigMutex.RLock()
 	defer fake.setTaskConfigMutex.RUnlock()
 	fake.startingMutex.RLock()

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -48,6 +48,7 @@ type GetDelegate interface {
 	Initializing(lager.Logger)
 	Starting(lager.Logger)
 	Finished(lager.Logger, ExitStatus, runtime.VersionResult)
+	SelectedWorker(lager.Logger, string)
 	Errored(lager.Logger, string)
 
 	UpdateVersion(lager.Logger, atc.GetPlan, runtime.VersionResult)

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -30,6 +30,7 @@ type PutDelegate interface {
 	Initializing(lager.Logger)
 	Starting(lager.Logger)
 	Finished(lager.Logger, ExitStatus, runtime.VersionResult)
+	SelectedWorker(lager.Logger, string)
 	Errored(lager.Logger, string)
 
 	SaveOutput(lager.Logger, atc.PutPlan, atc.Source, atc.VersionedResourceTypes, runtime.VersionResult)

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -66,6 +66,7 @@ type TaskDelegate interface {
 	Initializing(lager.Logger)
 	Starting(lager.Logger)
 	Finished(lager.Logger, ExitStatus)
+	SelectedWorker(lager.Logger, string)
 	Errored(lager.Logger, string)
 }
 

--- a/atc/runtime/runtimefakes/fake_starting_event_delegate.go
+++ b/atc/runtime/runtimefakes/fake_starting_event_delegate.go
@@ -9,6 +9,12 @@ import (
 )
 
 type FakeStartingEventDelegate struct {
+	SelectedWorkerStub        func(lager.Logger, string)
+	selectedWorkerMutex       sync.RWMutex
+	selectedWorkerArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+	}
 	StartingStub        func(lager.Logger)
 	startingMutex       sync.RWMutex
 	startingArgsForCall []struct {
@@ -16,6 +22,38 @@ type FakeStartingEventDelegate struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeStartingEventDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
+	fake.selectedWorkerMutex.Lock()
+	fake.selectedWorkerArgsForCall = append(fake.selectedWorkerArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
+	fake.selectedWorkerMutex.Unlock()
+	if fake.SelectedWorkerStub != nil {
+		fake.SelectedWorkerStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeStartingEventDelegate) SelectedWorkerCallCount() int {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	return len(fake.selectedWorkerArgsForCall)
+}
+
+func (fake *FakeStartingEventDelegate) SelectedWorkerCalls(stub func(lager.Logger, string)) {
+	fake.selectedWorkerMutex.Lock()
+	defer fake.selectedWorkerMutex.Unlock()
+	fake.SelectedWorkerStub = stub
+}
+
+func (fake *FakeStartingEventDelegate) SelectedWorkerArgsForCall(i int) (lager.Logger, string) {
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
+	argsForCall := fake.selectedWorkerArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeStartingEventDelegate) Starting(arg1 lager.Logger) {
@@ -52,6 +90,8 @@ func (fake *FakeStartingEventDelegate) StartingArgsForCall(i int) lager.Logger {
 func (fake *FakeStartingEventDelegate) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.selectedWorkerMutex.RLock()
+	defer fake.selectedWorkerMutex.RUnlock()
 	fake.startingMutex.RLock()
 	defer fake.startingMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -17,6 +17,7 @@ const (
 //go:generate counterfeiter . StartingEventDelegate
 type StartingEventDelegate interface {
 	Starting(lager.Logger)
+	SelectedWorker(lager.Logger, string)
 }
 
 type VersionResult struct {

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -100,13 +100,14 @@ func NewClient(pool Pool,
 	provider WorkerProvider,
 	compression compression.Compression,
 	workerPollingInterval time.Duration,
-	WorkerStatusPublishInterval time.Duration) *client {
+	workerStatusPublishInterval time.Duration,
+) *client {
 	return &client{
 		pool:                        pool,
 		provider:                    provider,
 		compression:                 compression,
 		workerPollingInterval:       workerPollingInterval,
-		workerStatusPublishInterval: WorkerStatusPublishInterval,
+		workerStatusPublishInterval: workerStatusPublishInterval,
 	}
 }
 
@@ -304,6 +305,8 @@ func (client *client) RunTaskStep(
 		return TaskResult{}, err
 	}
 
+	eventDelegate.SelectedWorker(logger, chosenWorker.Name())
+
 	// container already exited
 	exitStatusProp, _ := container.Properties()
 	code := exitStatusProp[taskExitStatusPropertyName]
@@ -427,6 +430,8 @@ func (client *client) RunGetStep(
 		return GetResult{}, err
 	}
 
+	eventDelegate.SelectedWorker(logger, chosenWorker.Name())
+
 	sign, err := resource.Signature()
 	if err != nil {
 		return GetResult{}, err
@@ -484,6 +489,8 @@ func (client *client) RunPutStep(
 	if err != nil {
 		return PutResult{}, err
 	}
+
+	eventDelegate.SelectedWorker(logger, chosenWorker.Name())
 
 	container, err := chosenWorker.FindOrCreateContainer(
 		ctx,

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -453,6 +453,8 @@ var _ = Describe("Client", func() {
 
 			It("invokes the Starting Event on the delegate", func() {
 				Expect(fakeEventDelegate.StartingCallCount()).Should((Equal(1)))
+				_, actualWorkerName := fakeEventDelegate.SelectedWorkerArgsForCall(0)
+				Expect(actualWorkerName).To(Equal(fakeChosenWorker.Name()))
 			})
 
 			It("calls Fetch on the worker", func() {
@@ -643,6 +645,8 @@ var _ = Describe("Client", func() {
 			It("chooses a worker", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(fakePool.FindOrChooseWorkerForContainerCallCount()).To(Equal(1))
+				_, actualWorkerName := fakeEventDelegate.SelectedWorkerArgsForCall(0)
+				Expect(actualWorkerName).To(Equal(fakeWorker.Name()))
 			})
 
 			It("invokes the SelectedWorker Event on the delegate", func() {
@@ -1371,6 +1375,8 @@ var _ = Describe("Client", func() {
 
 		It("invokes the SelectedWorker Event on the delegate", func() {
 			Expect(fakeEventDelegate.SelectedWorkerCallCount()).Should((Equal(1)))
+			_, actualWorkerName := fakeEventDelegate.SelectedWorkerArgsForCall(0)
+			Expect(actualWorkerName).To(Equal(fakeChosenWorker.Name()))
 		})
 
 		Context("worker is chosen", func() {

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -442,6 +442,10 @@ var _ = Describe("Client", func() {
 			Expect(actualStrategy).To(Equal(fakeStrategy))
 		})
 
+		It("invokes the SelectedWorker Event on the delegate", func() {
+			Expect(fakeEventDelegate.SelectedWorkerCallCount()).Should((Equal(1)))
+		})
+
 		Context("worker is chosen", func() {
 			BeforeEach(func() {
 				fakePool.FindOrChooseWorkerReturns(fakeChosenWorker, nil)
@@ -641,6 +645,10 @@ var _ = Describe("Client", func() {
 				Expect(fakePool.FindOrChooseWorkerForContainerCallCount()).To(Equal(1))
 			})
 
+			It("invokes the SelectedWorker Event on the delegate", func() {
+				Expect(fakeEventDelegate.SelectedWorkerCallCount()).Should((Equal(1)))
+			})
+
 			Context("when 'limit-active-tasks' strategy is chosen", func() {
 				BeforeEach(func() {
 					fakeStrategy.ModifiesActiveTasksReturns(true)
@@ -697,6 +705,10 @@ var _ = Describe("Client", func() {
 
 				It("returns the error", func() {
 					Expect(err).To(Equal(workerDisaster))
+				})
+
+				It("should not invokes the SelectedWorker Event on the delegate", func() {
+					Expect(fakeEventDelegate.SelectedWorkerCallCount()).Should((Equal(0)))
 				})
 			})
 
@@ -1355,6 +1367,10 @@ var _ = Describe("Client", func() {
 			Expect(actualContainerSpec).To(Equal(containerSpec))
 			Expect(actualWorkerSpec).To(Equal(workerSpec))
 			Expect(strategy).To(Equal(fakeStrategy))
+		})
+
+		It("invokes the SelectedWorker Event on the delegate", func() {
+			Expect(fakeEventDelegate.SelectedWorkerCallCount()).Should((Equal(1)))
 		})
 
 		Context("worker is chosen", func() {

--- a/fly/eventstream/render.go
+++ b/fly/eventstream/render.go
@@ -37,6 +37,10 @@ func Render(dst io.Writer, src eventstream.EventStream, options RenderOptions) i
 			dstImpl.SetTimestamp(e.Time)
 			fmt.Fprintf(dstImpl, "%s", e.Payload)
 
+		case event.SelectedWorker:
+			dstImpl.SetTimestamp(e.Time)
+			fmt.Fprintf(dstImpl, "\x1b[1mselected worker: %s\n", e.WorkerName)
+
 		case event.InitializeTask:
 			dstImpl.SetTimestamp(e.Time)
 			fmt.Fprintf(dstImpl, "\x1b[1minitializing\x1b[0m\n")

--- a/fly/eventstream/render.go
+++ b/fly/eventstream/render.go
@@ -39,7 +39,7 @@ func Render(dst io.Writer, src eventstream.EventStream, options RenderOptions) i
 
 		case event.SelectedWorker:
 			dstImpl.SetTimestamp(e.Time)
-			fmt.Fprintf(dstImpl, "\x1b[1mselected worker: %s\n", e.WorkerName)
+			fmt.Fprintf(dstImpl, "\x1b[1mselected worker:\x1b[0m %s\n", e.WorkerName)
 
 		case event.InitializeTask:
 			dstImpl.SetTimestamp(e.Time)

--- a/fly/eventstream/render_test.go
+++ b/fly/eventstream/render_test.go
@@ -305,7 +305,7 @@ var _ = Describe("V1.0 Renderer", func() {
 		})
 
 		It("prints the build's run script", func() {
-			Expect(out.Contents()).To(ContainSubstring("\x1b[1mselected worker: some-worker\n"))
+			Expect(out.Contents()).To(ContainSubstring("\x1b[1mselected worker:\u001B[0m some-worker\n"))
 		})
 
 		Context("and time configuration enabled", func() {

--- a/fly/eventstream/render_test.go
+++ b/fly/eventstream/render_test.go
@@ -295,4 +295,27 @@ var _ = Describe("V1.0 Renderer", func() {
 			})
 		})
 	})
+
+	Context("and a SelectedWorker event is received", func() {
+		BeforeEach(func() {
+			receivedEvents <- event.SelectedWorker{
+				Time: time.Now().Unix(),
+				WorkerName: "some-worker",
+			}
+		})
+
+		It("prints the build's run script", func() {
+			Expect(out.Contents()).To(ContainSubstring("\x1b[1mselected worker: some-worker\n"))
+		})
+
+		Context("and time configuration enabled", func() {
+			BeforeEach(func() {
+				options.ShowTimestamp = true
+			})
+
+			It("timestamp is prefixed", func() {
+				Expect(out).To(gbytes.Say(`\d{2}\:\d{2}\:\d{2}\s{2}\w*`))
+			})
+		})
+	})
 })

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -18,3 +18,7 @@
   * set_pipeline step is removed from job
   * Job that set pipeline is deleted
   * Parent pipeline is deleted
+
+#### <sub><sup><a name="5846" href="#5810">:link:</a></sup></sub> feature
+
+* @evanchaoli Enhanced build log page as well as `fly watch` to display worker name for `get/put/task` steps. #5846

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -145,6 +145,11 @@ handleEvent event ( model, effects ) =
             , effects
             )
 
+        SelectedWorker origin output time ->
+            ( updateStep origin.id (setRunning << appendStepLog ("selected worker: " ++ output ++ "\n") time) model
+            , effects
+            )
+
         Error origin message time ->
             ( updateStep origin.id (setStepError message time) model
             , effects

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -146,7 +146,7 @@ handleEvent event ( model, effects ) =
             )
 
         SelectedWorker origin output time ->
-            ( updateStep origin.id (setRunning << appendStepLog ("selected worker: " ++ output ++ "\n") time) model
+            ( updateStep origin.id (setRunning << appendStepLog ("\u{001b}[1mselected worker: \u{001b}[0m" ++ output ++ "\n") time) model
             , effects
             )
 

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -135,6 +135,7 @@ type BuildEvent
     | StartPut Origin Time.Posix
     | FinishPut Origin Int Concourse.Version Concourse.Metadata (Maybe Time.Posix)
     | Log Origin String (Maybe Time.Posix)
+    | SelectedWorker Origin String (Maybe Time.Posix)
     | Error Origin String Time.Posix
     | End
     | Opened

--- a/web/elm/src/Concourse/BuildEvents.elm
+++ b/web/elm/src/Concourse/BuildEvents.elm
@@ -86,6 +86,15 @@ decodeBuildEvent =
                                 (Json.Decode.maybe <| Json.Decode.field "time" <| Json.Decode.map dateFromSeconds Json.Decode.int)
                             )
 
+                    "selected-worker" ->
+                        Json.Decode.field
+                            "data"
+                            (Json.Decode.map3 SelectedWorker
+                                (Json.Decode.field "origin" <| Json.Decode.lazy (\_ -> decodeOrigin))
+                                (Json.Decode.field "selected_worker" Json.Decode.string)
+                                (Json.Decode.maybe <| Json.Decode.field "time" <| Json.Decode.map dateFromSeconds Json.Decode.int)
+                            )
+
                     "error" ->
                         Json.Decode.field "data" decodeErrorEvent
 


### PR DESCRIPTION
Fixes: #5795

## What does this PR accomplish?

This PR adds an opt-in feature where worker name can be injected into get/put step's metadata. 


## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note

The build log page and `fly watch` now display the worker name for `get/put/task` steps

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
