### PR TITLE
cmd: structure: increase timeout for system claim error test

### DIFF
--- a/cmd/concourse/concourse_test.go
+++ b/cmd/concourse/concourse_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/concourse/concourse/atc/postgresrunner"
 	"github.com/onsi/gomega/gbytes"
@@ -145,7 +146,7 @@ var _ = Describe("Web Command", func() {
 				})
 
 				It("errors", func() {
-					Eventually(concourseRunner.Err()).Should(
+					Eventually(concourseRunner.Err(), 5*time.Second).Should(
 						gbytes.Say("at least one systemClaimValue must be equal to tsa-client-id"),
 					)
 				})


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | Feature | Documentation

No code change, just resolving a flaky test.

## Changes proposed by this PR:

Whenever this test flakes, it seems like a timing issue, so let's be a bit more generous.

## Notes to reviewer:
I've noticed this test flaking for a while now, and it's integrating across a wide boundary -- I think it's OK to simply make it a bit more permissive.

On the other hand, it's a very small piece of validation logic that is being tested, which would be a natural candidate for a unit test. We may have a bit of a separation problem here.

On the other _other_ hand, we're going to revisit configuration soon so it might make sense to pay down this pre-existing tech debt later when we're doing the right thing anyway.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] ~Updated [Documentation]~
- [x] ~Updated [Release notes]~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
- [x] ~Code reviewed~
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
