### PR TITLE
web: behaviour: text change for resources `checked successfully`

### DIFF
--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -1104,7 +1104,7 @@ checkSection ({ checkStatus, checkSetupError, checkError } as model) =
         checkMessage =
             case checkStatus of
                 Models.FailingToCheck ->
-                    "checking failed"
+                    "check failed"
 
                 Models.CheckPending ->
                     "check pending"
@@ -1113,7 +1113,7 @@ checkSection ({ checkStatus, checkSetupError, checkError } as model) =
                     "check in progress"
 
                 Models.CheckingSuccessfully ->
-                    "checking successfully"
+                    "checked successfully"
 
         stepBody =
             if failingToCheck then

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -2917,7 +2917,7 @@ all =
                             |> Tuple.first
                             |> checkBar UserStateLoggedOut
                             |> Query.find [ tag "h3" ]
-                            |> Query.has [ text "checking successfully" ]
+                            |> Query.has [ text "checked successfully" ]
                 ]
             , describe "when authorized" <|
                 let


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix

## Changes proposed by this PR:
A quick text changed for `checking successfully`

## Contributor Checklist
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] PR acceptance performed
