### PR TITLE
web: behaviour: fix tooltip on pipeline names

### DIFF
--- a/web/elm/src/SideBar/Views.elm
+++ b/web/elm/src/SideBar/Views.elm
@@ -77,13 +77,14 @@ viewPipeline p =
             ++ [ href <| p.href
                , onMouseEnter <| Hover <| Just <| p.domID
                , onMouseLeave <| Hover Nothing
-               , id <| toHtmlID p.domID
                ]
         )
         [ Html.div
             (Styles.pipelineIcon p.icon)
             []
         , Html.div
-            (Styles.pipelineName p.name)
+            (id (toHtmlID p.domID)
+                :: Styles.pipelineName p.name
+            )
             [ Html.text p.name.text ]
         ]


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

It was no longer being displayed after a regression in
concourse/concourse#5778 since the dom id was being applied to the full
width of the pipeline element rather than the text element itself,
meaning the `clientWidth` never differed from the `scrollWidth`. This
results in us not knowing when the text is ellipsized.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

Place the Dom ID on the text container rather than the outer wrapper element

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
