### PR TITLE
Allow `fly set-pipeline` to take configuration from stdin

### DIFF
--- a/atc/path_flag.go
+++ b/atc/path_flag.go
@@ -2,6 +2,9 @@ package atc
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -12,6 +15,21 @@ type PathFlag string
 
 func (path *PathFlag) UnmarshalFlag(value string) error {
 	if value == "" {
+		return nil
+	}
+
+	if value == "-" {
+		tempf, err := ioutil.TempFile("", "fly-set-pipeline")
+		if err != nil {
+			return fmt.Errorf("failed to create a temp file")
+		}
+		defer tempf.Close()
+
+		_, err = io.Copy(tempf, os.Stdin)
+		if err != nil {
+			return fmt.Errorf("failed to write temp file: %s", err.Error())
+		}
+		*path = PathFlag(tempf.Name())
 		return nil
 	}
 

--- a/atc/path_flag.go
+++ b/atc/path_flag.go
@@ -6,10 +6,13 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/jessevdk/go-flags"
 )
+
+const tempFilePattern = "___dash-stdin-path-flag___"
 
 type PathFlag string
 
@@ -18,8 +21,8 @@ func (path *PathFlag) UnmarshalFlag(value string) error {
 		return nil
 	}
 
-	if value == "-" {
-		tempf, err := ioutil.TempFile("", "fly-set-pipeline")
+	if value == "-" && runtime.GOOS != "windows" {
+		tempf, err := ioutil.TempFile("", tempFilePattern)
 		if err != nil {
 			return fmt.Errorf("failed to create a temp file")
 		}
@@ -59,4 +62,8 @@ func (path *PathFlag) Complete(match string) []flags.Completion {
 	}
 
 	return comps
+}
+
+func (path *PathFlag) FromStdin() bool {
+	return strings.Index(string(*path), tempFilePattern) >= 0
 }

--- a/atc/path_flag.go
+++ b/atc/path_flag.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/jessevdk/go-flags"
@@ -21,7 +20,13 @@ func (path *PathFlag) UnmarshalFlag(value string) error {
 		return nil
 	}
 
-	if value == "-" && runtime.GOOS != "windows" {
+	if value == "-" {
+		_, err := os.Stat("/dev/stdin")
+		if err == nil {
+			*path = PathFlag("/dev/stdin")
+			return nil
+		}
+
 		tempf, err := ioutil.TempFile("", tempFilePattern)
 		if err != nil {
 			return fmt.Errorf("failed to create a temp file")
@@ -65,5 +70,5 @@ func (path *PathFlag) Complete(match string) []flags.Completion {
 }
 
 func (path *PathFlag) FromStdin() bool {
-	return strings.Index(string(*path), tempFilePattern) >= 0
+	return *path == "/dev/stdin" || strings.Index(string(*path), tempFilePattern) >= 0
 }

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -5,7 +5,6 @@ import (
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/commands/internal/setpipelinehelpers"
 	"github.com/concourse/concourse/fly/commands/internal/templatehelpers"
-	"github.com/concourse/concourse/fly/pty"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/mgutz/ansi"
@@ -78,7 +77,7 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 		PipelineName:     pipelineName,
 		TargetName:       Fly.Target,
 		Target:           target.Client().URL(),
-		SkipInteraction:  command.SkipInteractive || !pty.IsTerminal(),
+		SkipInteraction:  command.SkipInteractive || command.Config.FromStdin(),
 		CheckCredentials: command.CheckCredentials,
 		CommandWarnings:  warnings,
 	}

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -5,6 +5,7 @@ import (
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/commands/internal/setpipelinehelpers"
 	"github.com/concourse/concourse/fly/commands/internal/templatehelpers"
+	"github.com/concourse/concourse/fly/pty"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/mgutz/ansi"
@@ -17,7 +18,7 @@ type SetPipelineCommand struct {
 	CheckCredentials bool `long:"check-creds"  description:"Validate credential variables against credential manager"`
 
 	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline"  required:"true"  description:"Pipeline to configure"`
-	Config   atc.PathFlag             `short:"c"  long:"config"    required:"true"  description:"Pipeline configuration file"`
+	Config   atc.PathFlag             `short:"c"  long:"config"    required:"true"  description:"Pipeline configuration file, \"-\" stands for stdin"`
 
 	Var     []flaghelpers.VariablePairFlag     `short:"v"  long:"var"       value-name:"[NAME=STRING]"  description:"Specify a string value to set for a variable in the pipeline"`
 	YAMLVar []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"  value-name:"[NAME=YAML]"    description:"Specify a YAML value to set for a variable in the pipeline"`
@@ -77,7 +78,7 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 		PipelineName:     pipelineName,
 		TargetName:       Fly.Target,
 		Target:           target.Client().URL(),
-		SkipInteraction:  command.SkipInteractive,
+		SkipInteraction:  command.SkipInteractive || !pty.IsTerminal(),
 		CheckCredentials: command.CheckCredentials,
 		CommandWarnings:  warnings,
 	}

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -9,6 +9,7 @@
 #### <sub><sup><a name="5810" href="#5810">:link:</a></sup></sub> feature
 
 * Reduce the allowed character set for Concourse valid identifiers. Only prints warnings instead of errors as a first step. #5810
+
 * Add `--team` flag for `fly pause-pipeline` command. #5917
 * Add `--team` flag for `fly hide-pipeline` command. #5917
 

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -9,7 +9,6 @@
 #### <sub><sup><a name="5810" href="#5810">:link:</a></sup></sub> feature
 
 * Reduce the allowed character set for Concourse valid identifiers. Only prints warnings instead of errors as a first step. #5810
-
 * Add `--team` flag for `fly pause-pipeline` command. #5917
 * Add `--team` flag for `fly hide-pipeline` command. #5917
 


### PR DESCRIPTION
feat: allow set-pipeline to take configure from stdin. this would make pipeline migration from one cluster to the other easier.

## What does this PR accomplish?

With this feature a user may migrate a pipeline from one cluster to the other with a single line command:

```bash
$ fly -t <target1> gp -p <pipeline-name> | fly -t <target2> sp -c - -p <pipeline-name> -n
```

## Changes proposed by this PR:

Modified `PathFlag` to accept `-`. When `-` is given, it generate a temp file by reading from stdin.

## Notes to reviewer:

I see a couple of problems with this implementation:

1. The second `fly sp` must be given `-n`, otherwise `apply configuration? [yN]: bailing out`. As the question/answer is done by @vito's packet `interaction`, I wonder if @vito has idea with that.

2. `set-pipeline` command actually takes multiple `PathFlag`, `-c`, `-l`, only at most a single flag can use `-`, but it seems no way to restrict that.

Maybe we only add description about `-` to `-c`?

## Release Note

The `--config` flag of the `fly set-pipeline` command now supports `-` for reading pipeline config from stdin

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
