### PR TITLE
valid identifiers

### DIFF
--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -317,11 +317,11 @@ var _ = Describe("Config API", func() {
 								"warnings": [
 									{
 										"type": "invalid_identifier",
-										"message": "pipeline: '_pipeline' is not a valid identifier"
+										"message": "pipeline: '_pipeline' is not a valid identifier: must start with a lowercase letter"
 									},
 									{
 										"type": "invalid_identifier",
-										"message": "team: '_team' is not a valid identifier"
+										"message": "team: '_team' is not a valid identifier: must start with a lowercase letter"
 									}
 								]
 							}`))

--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -293,6 +293,41 @@ var _ = Describe("Config API", func() {
 				fakeAccess.IsAuthorizedReturns(true)
 			})
 
+			Context("when an identifier is invalid", func() {
+
+				BeforeEach(func() {
+					var err error
+					request, err = requestGenerator.CreateRequest(atc.SaveConfig, rata.Params{
+						"team_name":     "_team",
+						"pipeline_name": "_pipeline",
+					}, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					request.Header.Set("Content-Type", "application/json")
+
+					payload, err := json.Marshal(pipelineConfig)
+					Expect(err).NotTo(HaveOccurred())
+
+					request.Body = gbytes.BufferWithBytes(payload)
+				})
+
+				It("returns warnings in the response body", func() {
+					Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							{
+								"warnings": [
+									{
+										"type": "invalid_identifier",
+										"message": "'_pipeline' is not a valid [pipeline] identifier"
+									},
+									{
+										"type": "invalid_identifier",
+										"message": "'_team' is not a valid [team] identifier"
+									}
+								]
+							}`))
+				})
+			})
+
 			Context("when a config version is specified", func() {
 				BeforeEach(func() {
 					request.Header.Set(atc.ConfigVersionHeader, "42")

--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -317,11 +317,11 @@ var _ = Describe("Config API", func() {
 								"warnings": [
 									{
 										"type": "invalid_identifier",
-										"message": "'_pipeline' is not a valid [pipeline] identifier"
+										"message": "pipeline: '_pipeline' is not a valid identifier"
 									},
 									{
 										"type": "invalid_identifier",
-										"message": "'_team' is not a valid [team] identifier"
+										"message": "team: '_team' is not a valid identifier"
 									}
 								]
 							}`))

--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -3,7 +3,6 @@ package configserver
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -70,19 +69,15 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pipelineName := rata.Param(r, "pipeline_name")
-	if err := atc.ValidateIdentifier(pipelineName, "pipeline"); err != nil {
-		var got *atc.InvalidIdentifierError
-		if errors.As(err, &got) {
-			warnings = append(warnings, got.ConfigWarning())
-		}
+	warning := atc.ValidateIdentifier(pipelineName, "pipeline")
+	if warning != nil {
+		warnings = append(warnings, *warning)
 	}
 
 	teamName := rata.Param(r, "team_name")
-	if err := atc.ValidateIdentifier(teamName, "team"); err != nil {
-		var got *atc.InvalidIdentifierError
-		if errors.As(err, &got) {
-			warnings = append(warnings, got.ConfigWarning())
-		}
+	warning = atc.ValidateIdentifier(teamName, "team")
+	if warning != nil {
+		warnings = append(warnings, *warning)
 	}
 
 	if checkCredentials {

--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -69,7 +69,22 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pipelineName := rata.Param(r, "pipeline_name")
+	err := atc.ValidateIdentifier(pipelineName, "pipeline")
+	if err != nil {
+		warnings = append(warnings, atc.ConfigWarning{
+			Type:    "invalid_identifier",
+			Message: err.Error(),
+		})
+	}
+
 	teamName := rata.Param(r, "team_name")
+	err = atc.ValidateIdentifier(teamName, "team")
+	if err != nil {
+		warnings = append(warnings, atc.ConfigWarning{
+			Type:    "invalid_identifier",
+			Message: err.Error(),
+		})
+	}
 
 	if checkCredentials {
 		variables := creds.NewVariables(s.secretManager, teamName, pipelineName, false)

--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -3,6 +3,7 @@ package configserver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -69,21 +70,19 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pipelineName := rata.Param(r, "pipeline_name")
-	err := atc.ValidateIdentifier(pipelineName, "pipeline")
-	if err != nil {
-		warnings = append(warnings, atc.ConfigWarning{
-			Type:    "invalid_identifier",
-			Message: err.Error(),
-		})
+	if err := atc.ValidateIdentifier(pipelineName, "pipeline"); err != nil {
+		var got *atc.InvalidIdentifierError
+		if errors.As(err, &got) {
+			warnings = append(warnings, got.ConfigWarning())
+		}
 	}
 
 	teamName := rata.Param(r, "team_name")
-	err = atc.ValidateIdentifier(teamName, "team")
-	if err != nil {
-		warnings = append(warnings, atc.ConfigWarning{
-			Type:    "invalid_identifier",
-			Message: err.Error(),
-		})
+	if err := atc.ValidateIdentifier(teamName, "team"); err != nil {
+		var got *atc.InvalidIdentifierError
+		if errors.As(err, &got) {
+			warnings = append(warnings, got.ConfigWarning())
+		}
 	}
 
 	if checkCredentials {

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1546,11 +1546,16 @@ var _ = Describe("Pipelines API", func() {
 
 	Describe("PUT /api/v1/teams/:team_name/pipelines/:pipeline_name/rename", func() {
 		var response *http.Response
+		var requestBody string
+
+		BeforeEach(func() {
+			requestBody = `{"name":"some-new-name"}`
+		})
 
 		JustBeforeEach(func() {
 			var err error
 
-			request, err := http.NewRequest("PUT", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/rename", bytes.NewBufferString(`{"name":"some-new-name"}`))
+			request, err := http.NewRequest("PUT", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/rename", bytes.NewBufferString(requestBody))
 			Expect(err).NotTo(HaveOccurred())
 
 			response, err = client.Do(request)
@@ -1579,13 +1584,32 @@ var _ = Describe("Pipelines API", func() {
 					Expect(pipelineName).To(Equal("a-pipeline"))
 				})
 
-				It("returns 204", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusNoContent))
+				It("returns 200", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
 				})
 
 				It("renames the pipeline to the name provided", func() {
 					Expect(dbPipeline.RenameCallCount()).To(Equal(1))
 					Expect(dbPipeline.RenameArgsForCall(0)).To(Equal("some-new-name"))
+				})
+
+				Context("when a warning occurs", func() {
+
+					BeforeEach(func() {
+						requestBody = `{"name":"_some-new-name"}`
+					})
+
+					It("returns a waring in the response body", func() {
+						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							{
+								"warnings": [
+									{
+										"type": "invalid_identifier",
+										"message": "'_some-new-name' is not a valid [pipeline] identifier"
+									}
+								]
+							}`))
+					})
 				})
 
 				Context("when an error occurs on update", func() {

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1605,7 +1605,7 @@ var _ = Describe("Pipelines API", func() {
 								"warnings": [
 									{
 										"type": "invalid_identifier",
-										"message": "pipeline: '_some-new-name' is not a valid identifier"
+										"message": "pipeline: '_some-new-name' is not a valid identifier: must start with a lowercase letter"
 									}
 								]
 							}`))

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1605,7 +1605,7 @@ var _ = Describe("Pipelines API", func() {
 								"warnings": [
 									{
 										"type": "invalid_identifier",
-										"message": "'_some-new-name' is not a valid [pipeline] identifier"
+										"message": "pipeline: '_some-new-name' is not a valid identifier"
 									}
 								]
 							}`))

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1599,7 +1599,7 @@ var _ = Describe("Pipelines API", func() {
 						requestBody = `{"name":"_some-new-name"}`
 					})
 
-					It("returns a waring in the response body", func() {
+					It("returns a warning in the response body", func() {
 						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"warnings": [

--- a/atc/api/pipelineserver/rename.go
+++ b/atc/api/pipelineserver/rename.go
@@ -3,7 +3,6 @@ package pipelineserver
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -46,22 +45,10 @@ func (s *Server) RenamePipeline(pipeline db.Pipeline) http.Handler {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		s.writeResponse(w, atc.SaveConfigResponse{Warnings: warnings})
+		err = json.NewEncoder(w).Encode(atc.SaveConfigResponse{Warnings: warnings})
+		if err != nil {
+			s.logger.Error("failed-to-encode-response", err)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 	})
-}
-
-func (s *Server) writeResponse(w http.ResponseWriter, response atc.SaveConfigResponse) {
-	responseJSON, err := json.Marshal(response)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "failed to generate error response: %s", err)
-		return
-	}
-
-	_, err = w.Write(responseJSON)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 }

--- a/atc/api/pipelineserver/rename.go
+++ b/atc/api/pipelineserver/rename.go
@@ -2,7 +2,6 @@ package pipelineserver
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"net/http"
 
@@ -30,11 +29,9 @@ func (s *Server) RenamePipeline(pipeline db.Pipeline) http.Handler {
 		}
 
 		var warnings []atc.ConfigWarning
-		if err = atc.ValidateIdentifier(rename.NewName, "pipeline"); err != nil {
-			var got *atc.InvalidIdentifierError
-			if errors.As(err, &got) {
-				warnings = append(warnings, got.ConfigWarning())
-			}
+		warning := atc.ValidateIdentifier(rename.NewName, "pipeline")
+		if warning != nil {
+			warnings = append(warnings, *warning)
 		}
 
 		err = pipeline.Rename(rename.NewName)

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -290,6 +290,7 @@ var _ = Describe("Teams API", func() {
 			response *http.Response
 			teamAuth atc.TeamAuth
 			atcTeam  atc.Team
+			path string
 		)
 
 		BeforeEach(func() {
@@ -302,11 +303,10 @@ var _ = Describe("Teams API", func() {
 				},
 			}
 			atcTeam = atc.Team{Auth: teamAuth}
+			path = fmt.Sprintf("%s/api/v1/teams/some-team", server.URL)
 		})
 
 			JustBeforeEach(func() {
-				path := fmt.Sprintf("%s/api/v1/teams/some-team", server.URL)
-
 				var err error
 				request, err := http.NewRequest("PUT", path, jsonEncode(atcTeam))
 				Expect(err).NotTo(HaveOccurred())
@@ -419,6 +419,29 @@ var _ = Describe("Teams API", func() {
 
 						It("does not delete the teams in cache", func() {
 							Expect(dbTeamFactory.NotifyCacherCallCount()).To(Equal(0))
+						})
+					})
+
+					Context("when the team's name is an invalid identifier", func() {
+						BeforeEach(func() {
+							path = fmt.Sprintf("%s/api/v1/teams/_some-team", server.URL)
+							fakeTeam.NameReturns("_some-team")
+						})
+
+						It("returns a waring in the response body", func() {
+							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+								{
+									"warnings": [
+										{
+											"type": "invalid_identifier",
+											"message": "'_some-team' is not a valid [team] identifier"
+										}
+									],
+									"team": {
+										"id": 5,
+										"name": "_some-team"
+									}
+								}`))
 						})
 					})
 				})
@@ -566,13 +589,14 @@ var _ = Describe("Teams API", func() {
 
 		Describe("PUT /api/v1/teams/:team_name/rename", func() {
 			var response *http.Response
+			var requestBody string
 			var teamName string
 
 			JustBeforeEach(func() {
 				request, err := http.NewRequest(
 					"PUT",
 					server.URL+"/api/v1/teams/"+teamName+"/rename",
-					bytes.NewBufferString(`{"name":"some-new-name"}`),
+					bytes.NewBufferString(requestBody),
 				)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -581,6 +605,7 @@ var _ = Describe("Teams API", func() {
 			})
 
 			BeforeEach(func() {
+				requestBody = `{"name":"some-new-name"}`
 				fakeTeam.IDReturns(2)
 			})
 
@@ -606,8 +631,27 @@ var _ = Describe("Teams API", func() {
 						Expect(fakeTeam.RenameArgsForCall(0)).To(Equal("some-new-name"))
 					})
 
-					It("returns 204 no content", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusNoContent))
+					It("returns 200", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusOK))
+					})
+
+					Context("when a warning occurs", func() {
+
+						BeforeEach(func() {
+							requestBody = `{"name":"_some-new-name"}`
+						})
+
+						It("returns a waring in the response body", func() {
+							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							{
+								"warnings": [
+								{
+									"type": "invalid_identifier",
+									"message": "'_some-new-name' is not a valid [team] identifier"
+								}
+								]
+							}`))
+						})
 					})
 				})
 
@@ -629,8 +673,8 @@ var _ = Describe("Teams API", func() {
 						Expect(fakeTeam.RenameArgsForCall(0)).To(Equal("some-new-name"))
 					})
 
-					It("returns 204 no content", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusNoContent))
+					It("returns 200", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusOK))
 					})
 				})
 

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -434,7 +434,7 @@ var _ = Describe("Teams API", func() {
 									"warnings": [
 										{
 											"type": "invalid_identifier",
-											"message": "'_some-team' is not a valid [team] identifier"
+											"message": "team: '_some-team' is not a valid identifier"
 										}
 									],
 									"team": {
@@ -647,7 +647,7 @@ var _ = Describe("Teams API", func() {
 								"warnings": [
 								{
 									"type": "invalid_identifier",
-									"message": "'_some-new-name' is not a valid [team] identifier"
+									"message": "team: '_some-new-name' is not a valid identifier"
 								}
 								]
 							}`))

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -434,7 +434,7 @@ var _ = Describe("Teams API", func() {
 									"warnings": [
 										{
 											"type": "invalid_identifier",
-											"message": "team: '_some-team' is not a valid identifier"
+											"message": "team: '_some-team' is not a valid identifier: must start with a lowercase letter"
 										}
 									],
 									"team": {
@@ -647,7 +647,7 @@ var _ = Describe("Teams API", func() {
 								"warnings": [
 								{
 									"type": "invalid_identifier",
-									"message": "team: '_some-new-name' is not a valid identifier"
+									"message": "team: '_some-new-name' is not a valid identifier: must start with a lowercase letter"
 								}
 								]
 							}`))

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -428,7 +428,7 @@ var _ = Describe("Teams API", func() {
 							fakeTeam.NameReturns("_some-team")
 						})
 
-						It("returns a waring in the response body", func() {
+						It("returns a warning in the response body", func() {
 							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 								{
 									"warnings": [
@@ -641,7 +641,7 @@ var _ = Describe("Teams API", func() {
 							requestBody = `{"name":"_some-new-name"}`
 						})
 
-						It("returns a waring in the response body", func() {
+						It("returns a warning in the response body", func() {
 							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"warnings": [

--- a/atc/api/teamserver/rename.go
+++ b/atc/api/teamserver/rename.go
@@ -2,6 +2,7 @@ package teamserver
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -37,12 +38,11 @@ func (s *Server) RenameTeam(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var warnings []atc.ConfigWarning
-	err = atc.ValidateIdentifier(rename.NewName, "team")
-	if err != nil {
-		warnings = append(warnings, atc.ConfigWarning{
-			Type:    "invalid_identifier",
-			Message: err.Error(),
-		})
+	if err = atc.ValidateIdentifier(rename.NewName, "team"); err != nil {
+		var got *atc.InvalidIdentifierError
+		if errors.As(err, &got) {
+			warnings = append(warnings, got.ConfigWarning())
+		}
 	}
 
 	team, found, err := s.teamFactory.FindTeam(teamName)

--- a/atc/api/teamserver/set.go
+++ b/atc/api/teamserver/set.go
@@ -11,6 +11,12 @@ import (
 	"github.com/concourse/concourse/atc/api/present"
 )
 
+type SetTeamResponse struct {
+	Errors   []string            `json:"errors,omitempty"`
+	Warnings []atc.ConfigWarning `json:"warnings,omitempty"`
+	Team     atc.Team            `json:"team"`
+}
+
 func (s *Server) SetTeam(w http.ResponseWriter, r *http.Request) {
 	hLog := s.logger.Session("set-team")
 
@@ -48,6 +54,7 @@ func (s *Server) SetTeam(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	response := SetTeamResponse{}
 	if found {
 		hLog.Debug("updating-credentials")
 		err = team.UpdateProviderAuth(atcTeam.Auth)
@@ -61,6 +68,16 @@ func (s *Server) SetTeam(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	} else if acc.IsAdmin() {
 		hLog.Debug("creating team")
+
+		var warnings []atc.ConfigWarning
+		err = atc.ValidateIdentifier(atcTeam.Name, "team")
+		if err != nil {
+			warnings = append(warnings, atc.ConfigWarning{
+				Type:    "invalid_identifier",
+				Message: err.Error(),
+			})
+		}
+		response.Warnings = warnings
 
 		team, err = s.teamFactory.CreateTeam(atcTeam)
 		if err != nil {
@@ -82,7 +99,9 @@ func (s *Server) SetTeam(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = json.NewEncoder(w).Encode(present.Team(team))
+	response.Team = present.Team(team)
+
+	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
 		hLog.Error("failed-to-encode-team", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/teamserver/set.go
+++ b/atc/api/teamserver/set.go
@@ -2,6 +2,7 @@ package teamserver
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"code.cloudfoundry.org/lager"
@@ -70,12 +71,11 @@ func (s *Server) SetTeam(w http.ResponseWriter, r *http.Request) {
 		hLog.Debug("creating team")
 
 		var warnings []atc.ConfigWarning
-		err = atc.ValidateIdentifier(atcTeam.Name, "team")
-		if err != nil {
-			warnings = append(warnings, atc.ConfigWarning{
-				Type:    "invalid_identifier",
-				Message: err.Error(),
-			})
+		if err = atc.ValidateIdentifier(atcTeam.Name, "team"); err != nil {
+			var got *atc.InvalidIdentifierError
+			if errors.As(err, &got) {
+				warnings = append(warnings, got.ConfigWarning())
+			}
 		}
 		response.Warnings = warnings
 

--- a/atc/api/teamserver/set.go
+++ b/atc/api/teamserver/set.go
@@ -2,7 +2,6 @@ package teamserver
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 
 	"code.cloudfoundry.org/lager"
@@ -70,14 +69,10 @@ func (s *Server) SetTeam(w http.ResponseWriter, r *http.Request) {
 	} else if acc.IsAdmin() {
 		hLog.Debug("creating team")
 
-		var warnings []atc.ConfigWarning
-		if err = atc.ValidateIdentifier(atcTeam.Name, "team"); err != nil {
-			var got *atc.InvalidIdentifierError
-			if errors.As(err, &got) {
-				warnings = append(warnings, got.ConfigWarning())
-			}
+		warning := atc.ValidateIdentifier(atcTeam.Name, "team")
+		if warning != nil {
+			response.Warnings = append(response.Warnings, *warning)
 		}
-		response.Warnings = warnings
 
 		team, err = s.teamFactory.CreateTeam(atcTeam)
 		if err != nil {

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -77,11 +77,9 @@ func validateGroups(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("groups.%s", group.Name)
 		}
 
-		if err := ValidateIdentifier(group.Name, identifier); err != nil {
-			var got *atc.InvalidIdentifierError
-			if errors.As(err, &got) {
-				warnings = append(warnings, got.ConfigWarning())
-			}
+		warning := ValidateIdentifier(group.Name, identifier)
+		if warning != nil {
+			warnings = append(warnings, *warning)
 		}
 
 		if val, ok := groupNames[group.Name]; ok {
@@ -142,11 +140,9 @@ func validateResources(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("resources.%s", resource.Name)
 		}
 
-		if err := ValidateIdentifier(resource.Name, identifier); err != nil {
-			var got *atc.InvalidIdentifierError
-			if errors.As(err, &got) {
-				warnings = append(warnings, got.ConfigWarning())
-			}
+		warning := ValidateIdentifier(resource.Name, identifier)
+		if warning != nil {
+			warnings = append(warnings, *warning)
 		}
 
 		if other, exists := names[resource.Name]; exists {
@@ -186,11 +182,9 @@ func validateResourceTypes(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("resource_types.%s", resourceType.Name)
 		}
 
-		if err := ValidateIdentifier(resourceType.Name, identifier); err != nil {
-			var got *atc.InvalidIdentifierError
-			if errors.As(err, &got) {
-				warnings = append(warnings, got.ConfigWarning())
-			}
+		warning := ValidateIdentifier(resourceType.Name, identifier)
+		if warning != nil {
+			warnings = append(warnings, *warning)
 		}
 
 		if other, exists := names[resourceType.Name]; exists {
@@ -261,11 +255,9 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("jobs.%s", job.Name)
 		}
 
-		if err := ValidateIdentifier(job.Name, identifier); err != nil {
-			var got *atc.InvalidIdentifierError
-			if errors.As(err, &got) {
-				warnings = append(warnings, got.ConfigWarning())
-			}
+		warning := ValidateIdentifier(job.Name, identifier)
+		if warning != nil {
+			warnings = append(warnings, *warning)
 		}
 
 		if other, exists := names[job.Name]; exists {
@@ -356,11 +348,9 @@ func validateVarSources(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("var_sources.%s", cm.Name)
 		}
 
-		if err := ValidateIdentifier(cm.Name, identifier); err != nil {
-			var got *atc.InvalidIdentifierError
-			if errors.As(err, &got) {
-				warnings = append(warnings, got.ConfigWarning())
-			}
+		warning := ValidateIdentifier(cm.Name, identifier)
+		if warning != nil {
+			warnings = append(warnings, *warning)
 		}
 
 		if factory, exists := creds.ManagerFactories()[cm.Type]; exists {

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -327,12 +327,7 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 
 		_ = validator.Validate(step)
 
-		for _, warning := range validator.Warnings {
-			warnings = append(warnings, ConfigWarning{
-				Type:    "pipeline",
-				Message: warning,
-			})
-		}
+		warnings = append(warnings, validator.Warnings...)
 
 		errorMessages = append(errorMessages, validator.Errors...)
 	}

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -3,7 +3,6 @@ package configvalidate
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/concourse/concourse/atc"
@@ -59,13 +58,6 @@ func Validate(c Config) ([]ConfigWarning, []string) {
 	return warnings, errorMessages
 }
 
-func validateIdentifier(identifier string) error {
-	if identifier != "" && !regexp.MustCompile(`^\p{L}[\p{L}\d\-.]*$`).MatchString(identifier) {
-		return fmt.Errorf("'%s' is not a valid identifier", identifier)
-	}
-	return nil
-}
-
 func validateGroups(c Config) ([]ConfigWarning, error) {
 	var warnings []ConfigWarning
 	var errorMessages []string
@@ -78,7 +70,7 @@ func validateGroups(c Config) ([]ConfigWarning, error) {
 	}
 
 	for _, group := range c.Groups {
-		if err := validateIdentifier(group.Name); err != nil {
+		if err := ValidateIdentifier(group.Name); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),
@@ -136,7 +128,7 @@ func validateResources(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, resource := range c.Resources {
-		if err := validateIdentifier(resource.Name); err != nil {
+		if err := ValidateIdentifier(resource.Name); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),
@@ -180,7 +172,7 @@ func validateResourceTypes(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, resourceType := range c.ResourceTypes {
-		if err := validateIdentifier(resourceType.Name); err != nil {
+		if err := ValidateIdentifier(resourceType.Name); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),
@@ -255,7 +247,7 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, job := range c.Jobs {
-		if err := validateIdentifier(job.Name); err != nil {
+		if err := ValidateIdentifier(job.Name); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),
@@ -350,7 +342,7 @@ func validateVarSources(c Config) ([]ConfigWarning, error) {
 	names := map[string]interface{}{}
 
 	for _, cm := range c.VarSources {
-		if err := validateIdentifier(cm.Name); err != nil {
+		if err := ValidateIdentifier(cm.Name); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -69,12 +69,19 @@ func validateGroups(c Config) ([]ConfigWarning, error) {
 		jobsGrouped[job.Name] = false
 	}
 
-	for _, group := range c.Groups {
-		if err := ValidateIdentifier(group.Name, "group"); err != nil {
-			warnings = append(warnings, ConfigWarning{
-				Type:    "invalid_identifier",
-				Message: err.Error(),
-			})
+	for i, group := range c.Groups {
+		var identifier string
+		if group.Name == "" {
+			identifier = fmt.Sprintf("groups[%d]", i)
+		} else {
+			identifier = fmt.Sprintf("groups.%s", group.Name)
+		}
+
+		if err := ValidateIdentifier(group.Name, identifier); err != nil {
+			var got *atc.InvalidIdentifierError
+			if errors.As(err, &got) {
+				warnings = append(warnings, got.ConfigWarning())
+			}
 		}
 
 		if val, ok := groupNames[group.Name]; ok {
@@ -128,18 +135,18 @@ func validateResources(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, resource := range c.Resources {
-		if err := ValidateIdentifier(resource.Name, "resource"); err != nil {
-			warnings = append(warnings, ConfigWarning{
-				Type:    "invalid_identifier",
-				Message: err.Error(),
-			})
-		}
-
 		var identifier string
 		if resource.Name == "" {
 			identifier = fmt.Sprintf("resources[%d]", i)
 		} else {
 			identifier = fmt.Sprintf("resources.%s", resource.Name)
+		}
+
+		if err := ValidateIdentifier(resource.Name, identifier); err != nil {
+			var got *atc.InvalidIdentifierError
+			if errors.As(err, &got) {
+				warnings = append(warnings, got.ConfigWarning())
+			}
 		}
 
 		if other, exists := names[resource.Name]; exists {
@@ -172,18 +179,18 @@ func validateResourceTypes(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, resourceType := range c.ResourceTypes {
-		if err := ValidateIdentifier(resourceType.Name, "resource_type"); err != nil {
-			warnings = append(warnings, ConfigWarning{
-				Type:    "invalid_identifier",
-				Message: err.Error(),
-			})
-		}
-
 		var identifier string
 		if resourceType.Name == "" {
 			identifier = fmt.Sprintf("resource_types[%d]", i)
 		} else {
 			identifier = fmt.Sprintf("resource_types.%s", resourceType.Name)
+		}
+
+		if err := ValidateIdentifier(resourceType.Name, identifier); err != nil {
+			var got *atc.InvalidIdentifierError
+			if errors.As(err, &got) {
+				warnings = append(warnings, got.ConfigWarning())
+			}
 		}
 
 		if other, exists := names[resourceType.Name]; exists {
@@ -247,18 +254,18 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, job := range c.Jobs {
-		if err := ValidateIdentifier(job.Name, "job"); err != nil {
-			warnings = append(warnings, ConfigWarning{
-				Type:    "invalid_identifier",
-				Message: err.Error(),
-			})
-		}
-
 		var identifier string
 		if job.Name == "" {
 			identifier = fmt.Sprintf("jobs[%d]", i)
 		} else {
 			identifier = fmt.Sprintf("jobs.%s", job.Name)
+		}
+
+		if err := ValidateIdentifier(job.Name, identifier); err != nil {
+			var got *atc.InvalidIdentifierError
+			if errors.As(err, &got) {
+				warnings = append(warnings, got.ConfigWarning())
+			}
 		}
 
 		if other, exists := names[job.Name]; exists {
@@ -341,12 +348,19 @@ func validateVarSources(c Config) ([]ConfigWarning, error) {
 
 	names := map[string]interface{}{}
 
-	for _, cm := range c.VarSources {
-		if err := ValidateIdentifier(cm.Name, "var_source"); err != nil {
-			warnings = append(warnings, ConfigWarning{
-				Type:    "invalid_identifier",
-				Message: err.Error(),
-			})
+	for i, cm := range c.VarSources {
+		var identifier string
+		if cm.Name == "" {
+			identifier = fmt.Sprintf("var_sources[%d]", i)
+		} else {
+			identifier = fmt.Sprintf("var_sources.%s", cm.Name)
+		}
+
+		if err := ValidateIdentifier(cm.Name, identifier); err != nil {
+			var got *atc.InvalidIdentifierError
+			if errors.As(err, &got) {
+				warnings = append(warnings, got.ConfigWarning())
+			}
 		}
 
 		if factory, exists := creds.ManagerFactories()[cm.Type]; exists {

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -238,6 +238,13 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, job := range c.Jobs {
+		if err := validateIdentifier(job.Name); err != nil {
+			warnings = append(warnings, ConfigWarning{
+				Type:    "invalid_identifier",
+				Message: err.Error(),
+			})
+		}
+
 		var identifier string
 		if job.Name == "" {
 			identifier = fmt.Sprintf("jobs[%d]", i)

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -70,7 +70,7 @@ func validateGroups(c Config) ([]ConfigWarning, error) {
 	}
 
 	for _, group := range c.Groups {
-		if err := ValidateIdentifier(group.Name); err != nil {
+		if err := ValidateIdentifier(group.Name, "group"); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),
@@ -128,7 +128,7 @@ func validateResources(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, resource := range c.Resources {
-		if err := ValidateIdentifier(resource.Name); err != nil {
+		if err := ValidateIdentifier(resource.Name, "resource"); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),
@@ -172,7 +172,7 @@ func validateResourceTypes(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, resourceType := range c.ResourceTypes {
-		if err := ValidateIdentifier(resourceType.Name); err != nil {
+		if err := ValidateIdentifier(resourceType.Name, "resource_type"); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),
@@ -247,7 +247,7 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	for i, job := range c.Jobs {
-		if err := ValidateIdentifier(job.Name); err != nil {
+		if err := ValidateIdentifier(job.Name, "job"); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),
@@ -342,7 +342,7 @@ func validateVarSources(c Config) ([]ConfigWarning, error) {
 	names := map[string]interface{}{}
 
 	for _, cm := range c.VarSources {
-		if err := ValidateIdentifier(cm.Name); err != nil {
+		if err := ValidateIdentifier(cm.Name, "var_source"); err != nil {
 			warnings = append(warnings, ConfigWarning{
 				Type:    "invalid_identifier",
 				Message: err.Error(),

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -138,6 +138,24 @@ var _ = Describe("ValidateConfig", func() {
 				}))
 			})
 		})
+
+		Context("when a var source has an invalid identifier", func() {
+			BeforeEach(func() {
+				config.VarSources = append(config.VarSources, atc.VarSourceConfig{
+					Name:   "_some-var-source",
+					Type:   "dummy",
+					Config: "",
+				})
+			})
+
+			It("returns a warning", func() {
+				Expect(warnings).To(HaveLen(1))
+				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
+					Type:    "invalid_identifier",
+					Message: "'_some-var-source' is not a valid identifier",
+				}))
+			})
+		})
 	})
 
 	Describe("invalid groups", func() {

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -132,7 +132,7 @@ var _ = Describe("ValidateConfig", func() {
 				Expect(warnings).To(HaveLen(1))
 				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
 					Type:    "invalid_identifier",
-					Message: "'_some-group' is not a valid identifier",
+					Message: "'_some-group' is not a valid [group] identifier",
 				}))
 			})
 		})
@@ -152,7 +152,7 @@ var _ = Describe("ValidateConfig", func() {
 				Expect(warnings).To(HaveLen(1))
 				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
 					Type:    "invalid_identifier",
-					Message: "'some_resource' is not a valid identifier",
+					Message: "'some_resource' is not a valid [resource] identifier",
 				}))
 			})
 		})
@@ -172,7 +172,7 @@ var _ = Describe("ValidateConfig", func() {
 				Expect(warnings).To(HaveLen(1))
 				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
 					Type:    "invalid_identifier",
-					Message: "'_some-resource-type' is not a valid identifier",
+					Message: "'_some-resource-type' is not a valid [resource_type] identifier",
 				}))
 			})
 		})
@@ -190,7 +190,7 @@ var _ = Describe("ValidateConfig", func() {
 				Expect(warnings).To(HaveLen(1))
 				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
 					Type:    "invalid_identifier",
-					Message: "'_some-var-source' is not a valid identifier",
+					Message: "'_some-var-source' is not a valid [var_source] identifier",
 				}))
 			})
 		})
@@ -206,7 +206,7 @@ var _ = Describe("ValidateConfig", func() {
 				Expect(warnings).To(HaveLen(1))
 				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
 					Type:    "invalid_identifier",
-					Message: "'_some-job' is not a valid identifier",
+					Message: "'_some-job' is not a valid [job] identifier",
 				}))
 			})
 		})

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -119,6 +119,24 @@ var _ = Describe("ValidateConfig", func() {
 	})
 
 	Describe("invalid identifiers", func() {
+
+		Context("when a group has an invalid identifier", func() {
+			BeforeEach(func() {
+				config.Groups = append(config.Groups, atc.GroupConfig{
+					Name: "_some-group",
+					Jobs: []string{"some-job"},
+				})
+			})
+
+			It("returns a warning", func() {
+				Expect(warnings).To(HaveLen(1))
+				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
+					Type:    "invalid_identifier",
+					Message: "'_some-group' is not a valid identifier",
+				}))
+			})
+		})
+
 		Context("when a resource has an invalid identifier", func() {
 			BeforeEach(func() {
 				config.Resources = append(config.Resources, atc.ResourceConfig{

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -130,10 +130,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			It("returns a warning", func() {
 				Expect(warnings).To(HaveLen(1))
-				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
-					Type:    "invalid_identifier",
-					Message: "'_some-group' is not a valid [group] identifier",
-				}))
+				Expect(warnings[0].Message).To(ContainSubstring("'_some-group' is not a valid identifier"))
 			})
 		})
 
@@ -150,10 +147,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			It("returns a warning", func() {
 				Expect(warnings).To(HaveLen(1))
-				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
-					Type:    "invalid_identifier",
-					Message: "'some_resource' is not a valid [resource] identifier",
-				}))
+				Expect(warnings[0].Message).To(ContainSubstring("'some_resource' is not a valid identifier"))
 			})
 		})
 
@@ -170,10 +164,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			It("returns a warning", func() {
 				Expect(warnings).To(HaveLen(1))
-				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
-					Type:    "invalid_identifier",
-					Message: "'_some-resource-type' is not a valid [resource_type] identifier",
-				}))
+				Expect(warnings[0].Message).To(ContainSubstring("'_some-resource-type' is not a valid identifier"))
 			})
 		})
 
@@ -188,10 +179,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			It("returns a warning", func() {
 				Expect(warnings).To(HaveLen(1))
-				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
-					Type:    "invalid_identifier",
-					Message: "'_some-var-source' is not a valid [var_source] identifier",
-				}))
+				Expect(warnings[0].Message).To(ContainSubstring("'_some-var-source' is not a valid identifier"))
 			})
 		})
 
@@ -204,10 +192,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			It("returns a warning", func() {
 				Expect(warnings).To(HaveLen(1))
-				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
-					Type:    "invalid_identifier",
-					Message: "'_some-job' is not a valid [job] identifier",
-				}))
+				Expect(warnings[0].Message).To(ContainSubstring("'_some-job' is not a valid identifier"))
 			})
 		})
 

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -157,6 +157,26 @@ var _ = Describe("ValidateConfig", func() {
 			})
 		})
 
+		Context("when a resource type has an invalid identifier", func() {
+			BeforeEach(func() {
+				config.ResourceTypes = append(config.ResourceTypes, atc.ResourceType{
+					Name: "_some-resource-type",
+					Type: "some-type",
+					Source: atc.Source{
+						"source-config": "some-value",
+					},
+				})
+			})
+
+			It("returns a warning", func() {
+				Expect(warnings).To(HaveLen(1))
+				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
+					Type:    "invalid_identifier",
+					Message: "'_some-resource-type' is not a valid identifier",
+				}))
+			})
+		})
+
 		Context("when a var source has an invalid identifier", func() {
 			BeforeEach(func() {
 				config.VarSources = append(config.VarSources, atc.VarSourceConfig{

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -210,6 +210,49 @@ var _ = Describe("ValidateConfig", func() {
 				}))
 			})
 		})
+
+		Context("when a step has an invalid identifier", func() {
+			var job atc.JobConfig
+
+			BeforeEach(func() {
+				job.PlanSequence = append(job.PlanSequence, atc.Step{
+					Config: &atc.GetStep{
+						Name: "_get-step",
+					},
+				})
+				job.PlanSequence = append(job.PlanSequence, atc.Step{
+					Config: &atc.TaskStep{
+						Name: "_task-step",
+					},
+				})
+				job.PlanSequence = append(job.PlanSequence, atc.Step{
+					Config: &atc.PutStep{
+						Name: "_put-step",
+					},
+				})
+				job.PlanSequence = append(job.PlanSequence, atc.Step{
+					Config: &atc.SetPipelineStep{
+						Name: "_set-pipeline-step",
+					},
+				})
+				job.PlanSequence = append(job.PlanSequence, atc.Step{
+					Config: &atc.LoadVarStep{
+						Name: "_load-var-step",
+					},
+				})
+
+				config.Jobs = append(config.Jobs, job)
+			})
+
+			It("returns a warning", func() {
+				Expect(warnings).To(HaveLen(5))
+				Expect(warnings[0].Message).To(ContainSubstring("'_get-step' is not a valid identifier"))
+				Expect(warnings[1].Message).To(ContainSubstring("'_task-step' is not a valid identifier"))
+				Expect(warnings[2].Message).To(ContainSubstring("'_put-step' is not a valid identifier"))
+				Expect(warnings[3].Message).To(ContainSubstring("'_set-pipeline-step' is not a valid identifier"))
+				Expect(warnings[4].Message).To(ContainSubstring("'_load-var-step' is not a valid identifier"))
+			})
+		})
 	})
 
 	Describe("invalid groups", func() {

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -156,6 +156,22 @@ var _ = Describe("ValidateConfig", func() {
 				}))
 			})
 		})
+
+		Context("when a job has an invalid identifier", func() {
+			BeforeEach(func() {
+				config.Jobs = append(config.Jobs, atc.JobConfig{
+					Name: "_some-job",
+				})
+			})
+
+			It("returns a warning", func() {
+				Expect(warnings).To(HaveLen(1))
+				Expect(warnings[0]).To(Equal(atc.ConfigWarning{
+					Type:    "invalid_identifier",
+					Message: "'_some-job' is not a valid identifier",
+				}))
+			})
+		})
 	})
 
 	Describe("invalid groups", func() {

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -10,8 +10,13 @@ type ConfigWarning struct {
 	Message string `json:"message"`
 }
 
-func ValidateIdentifier(identifier string) error {
-	if identifier != "" && !regexp.MustCompile(`^\p{L}[\p{L}\d\-.]*$`).MatchString(identifier) {
+var validIdentifiers = regexp.MustCompile(`^\p{L}[\p{L}\d\-.]*$`)
+
+func ValidateIdentifier(identifier string, context ...string) error {
+	if identifier != "" && !validIdentifiers.MatchString(identifier) {
+		if context != nil {
+			return fmt.Errorf("'%s' is not a valid %s identifier", identifier, context)
+		}
 		return fmt.Errorf("'%s' is not a valid identifier", identifier)
 	}
 	return nil

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -11,35 +11,13 @@ type ConfigWarning struct {
 	Message string `json:"message"`
 }
 
-type InvalidIdentifierError struct {
-	Identifier string
-	Context    []string
-}
-
-func (e *InvalidIdentifierError) Error() string {
-	return fmt.Sprintf("'%s' is not a valid identifier", e.Identifier)
-}
-
-func (e *InvalidIdentifierError) ConfigWarning() ConfigWarning {
-	warning := ConfigWarning{
-		Type:    "invalid_identifier",
-		Message: e.Error(),
-	}
-
-	if e.Context != nil {
-		warning.Message = fmt.Sprintf("%s: %s", strings.Join(e.Context, ""), e.Error())
-	}
-
-	return warning
-}
-
 var validIdentifiers = regexp.MustCompile(`^[\p{Ll}\p{Lt}\p{Lm}\p{Lo}][\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-.]*$`)
 
-func ValidateIdentifier(identifier string, context ...string) error {
+func ValidateIdentifier(identifier string, context ...string) *ConfigWarning {
 	if identifier != "" && !validIdentifiers.MatchString(identifier) {
-		return &InvalidIdentifierError{
-			Identifier: identifier,
-			Context:    context,
+		return &ConfigWarning{
+			Type:    "invalid_identifier",
+			Message: fmt.Sprintf("%s: %s", strings.Join(context, ""), fmt.Sprintf("'%s' is not a valid identifier", identifier)),
 		}
 	}
 	return nil

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -1,6 +1,18 @@
 package atc
 
+import (
+	"fmt"
+	"regexp"
+)
+
 type ConfigWarning struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`
+}
+
+func ValidateIdentifier(identifier string) error {
+	if identifier != "" && !regexp.MustCompile(`^\p{L}[\p{L}\d\-.]*$`).MatchString(identifier) {
+		return fmt.Errorf("'%s' is not a valid identifier", identifier)
+	}
+	return nil
 }

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -12,12 +12,20 @@ type ConfigWarning struct {
 }
 
 var validIdentifiers = regexp.MustCompile(`^[\p{Ll}\p{Lt}\p{Lm}\p{Lo}][\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-.]*$`)
+var startsWithLetter = regexp.MustCompile(`^[^\p{Ll}\p{Lt}\p{Lm}\p{Lo}]`)
+var invalidCharacter = regexp.MustCompile(`([^\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-.])`)
 
 func ValidateIdentifier(identifier string, context ...string) *ConfigWarning {
 	if identifier != "" && !validIdentifiers.MatchString(identifier) {
+		var reason string
+		if startsWithLetter.MatchString(identifier) {
+			reason = "must start with a lowercase letter"
+		} else if invalidChar := invalidCharacter.Find([]byte(identifier[1:])); invalidChar != nil {
+			reason = fmt.Sprintf("illegal character '%s'", invalidChar)
+		}
 		return &ConfigWarning{
 			Type:    "invalid_identifier",
-			Message: fmt.Sprintf("%s: %s", strings.Join(context, ""), fmt.Sprintf("'%s' is not a valid identifier", identifier)),
+			Message: fmt.Sprintf("%s: %s", strings.Join(context, ""), fmt.Sprintf("'%s' is not a valid identifier: %s", identifier, reason)),
 		}
 	}
 	return nil

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -33,7 +33,7 @@ func (e *InvalidIdentifierError) ConfigWarning() ConfigWarning {
 	return warning
 }
 
-var validIdentifiers = regexp.MustCompile(`^\p{L}[\p{L}\d\-.]*$`)
+var validIdentifiers = regexp.MustCompile(`^[\p{Ll}\p{Lt}\p{Lm}\p{Lo}][\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-.]*$`)
 
 func ValidateIdentifier(identifier string, context ...string) error {
 	if identifier != "" && !validIdentifiers.MatchString(identifier) {

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -1,0 +1,52 @@
+package atc_test
+
+import (
+	"github.com/concourse/concourse/atc"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ValidateIdentifier", func() {
+	Context("when an identifier starts with valid letter", func() {
+		It("runs without error", func() {
+			err := atc.ValidateIdentifier("something")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when an identifier starts with a number", func() {
+		It("returns an error", func() {
+			err := atc.ValidateIdentifier("1something")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when an identifier starts with an hyphen", func() {
+		It("returns an error", func() {
+			err := atc.ValidateIdentifier("-something")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when an identifier starts with an underscore", func() {
+		It("returns an error", func() {
+			err := atc.ValidateIdentifier("_something")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when an identifier starts with an period", func() {
+		It("returns an error", func() {
+			err := atc.ValidateIdentifier(".something")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when an identifier contains multilingual characters", func() {
+		It("runs without error", func() {
+			err := atc.ValidateIdentifier("ひらがな")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -49,4 +49,15 @@ var _ = Describe("ValidateIdentifier", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+
+	Describe("ValidateIdentifier with context", func() {
+		Context("when an identifier is invalid", func() {
+			It("returns an error with context", func() {
+				err := atc.ValidateIdentifier("_something", "pipeline")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("'_something' is not a valid [pipeline] identifier"))
+			})
+		})
+
+	})
 })

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -8,47 +8,73 @@ import (
 )
 
 var _ = Describe("ValidateIdentifier", func() {
-	Context("when an identifier starts with valid letter", func() {
-		It("runs without error", func() {
-			err := atc.ValidateIdentifier("something")
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
+	type testCase struct {
+		description string
+		identifier  string
+		errors      bool
+	}
 
-	Context("when an identifier starts with a number", func() {
-		It("returns an error", func() {
-			err := atc.ValidateIdentifier("1something")
-			Expect(err).To(HaveOccurred())
-		})
-	})
+	for _, test := range []testCase{
+		{
+			description: "starts with a valid letter",
+			identifier:  "something",
+			errors:      false,
+		},
+		{
+			description: "contains multilingual characters",
+			identifier:  "ひらがな",
+			errors:      false,
+		},
+		{
+			description: "starts with a number",
+			identifier:  "1something",
+			errors:      true,
+		},
+		{
+			description: "starts with hyphen",
+			identifier:  "-something",
+			errors:      true,
+		},
+		{
+			description: "starts with period",
+			identifier:  ".something",
+			errors:      true,
+		},
+		{
+			description: "starts with an uppercase letter",
+			identifier:  "Something",
+			errors:      true,
+		},
+		{
+			description: "contains an underscore",
+			identifier:  "some_thing",
+			errors:      true,
+		},
+		{
+			description: "contains an uppercase letter",
+			identifier:  "someThing",
+			errors:      true,
+		},
+	} {
+		test := test
 
-	Context("when an identifier starts with an hyphen", func() {
-		It("returns an error", func() {
-			err := atc.ValidateIdentifier("-something")
-			Expect(err).To(HaveOccurred())
+		Context("when an identifier "+test.description, func() {
+			var it string
+			if test.errors {
+				it = "returns an error"
+			} else {
+				it = "runs without error"
+			}
+			It(it, func() {
+				err := atc.ValidateIdentifier(test.identifier)
+				if test.errors {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			})
 		})
-	})
-
-	Context("when an identifier starts with an underscore", func() {
-		It("returns an error", func() {
-			err := atc.ValidateIdentifier("_something")
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Context("when an identifier starts with an period", func() {
-		It("returns an error", func() {
-			err := atc.ValidateIdentifier(".something")
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Context("when an identifier contains multilingual characters", func() {
-		It("runs without error", func() {
-			err := atc.ValidateIdentifier("ひらがな")
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
+	}
 
 	Describe("ValidateIdentifier with context", func() {
 		Context("when an identifier is invalid", func() {

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -11,6 +11,7 @@ var _ = Describe("ValidateIdentifier", func() {
 	type testCase struct {
 		description string
 		identifier  string
+		message     string
 		warning     bool
 	}
 
@@ -28,31 +29,37 @@ var _ = Describe("ValidateIdentifier", func() {
 		{
 			description: "starts with a number",
 			identifier:  "1something",
+			message:     "must start with a lowercase letter",
 			warning:     true,
 		},
 		{
 			description: "starts with hyphen",
 			identifier:  "-something",
+			message:     "must start with a lowercase letter",
 			warning:     true,
 		},
 		{
 			description: "starts with period",
 			identifier:  ".something",
+			message:     "must start with a lowercase letter",
 			warning:     true,
 		},
 		{
 			description: "starts with an uppercase letter",
 			identifier:  "Something",
+			message:     "must start with a lowercase letter",
 			warning:     true,
 		},
 		{
 			description: "contains an underscore",
 			identifier:  "some_thing",
+			message:     "illegal character '_'",
 			warning:     true,
 		},
 		{
 			description: "contains an uppercase letter",
 			identifier:  "someThing",
+			message:     "illegal character 'T'",
 			warning:     true,
 		},
 	} {
@@ -69,6 +76,7 @@ var _ = Describe("ValidateIdentifier", func() {
 				warning := atc.ValidateIdentifier(test.identifier)
 				if test.warning {
 					Expect(warning).NotTo(BeNil())
+					Expect(warning.Message).To(ContainSubstring(test.message))
 				} else {
 					Expect(warning).To(BeNil())
 				}

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -55,7 +55,7 @@ var _ = Describe("ValidateIdentifier", func() {
 			It("returns an error with context", func() {
 				err := atc.ValidateIdentifier("_something", "pipeline")
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("'_something' is not a valid [pipeline] identifier"))
+				Expect(err.Error()).To(ContainSubstring("'_something' is not a valid identifier"))
 			})
 		})
 

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -11,66 +11,66 @@ var _ = Describe("ValidateIdentifier", func() {
 	type testCase struct {
 		description string
 		identifier  string
-		errors      bool
+		warning     bool
 	}
 
 	for _, test := range []testCase{
 		{
 			description: "starts with a valid letter",
 			identifier:  "something",
-			errors:      false,
+			warning:     false,
 		},
 		{
 			description: "contains multilingual characters",
 			identifier:  "ひらがな",
-			errors:      false,
+			warning:     false,
 		},
 		{
 			description: "starts with a number",
 			identifier:  "1something",
-			errors:      true,
+			warning:     true,
 		},
 		{
 			description: "starts with hyphen",
 			identifier:  "-something",
-			errors:      true,
+			warning:     true,
 		},
 		{
 			description: "starts with period",
 			identifier:  ".something",
-			errors:      true,
+			warning:     true,
 		},
 		{
 			description: "starts with an uppercase letter",
 			identifier:  "Something",
-			errors:      true,
+			warning:     true,
 		},
 		{
 			description: "contains an underscore",
 			identifier:  "some_thing",
-			errors:      true,
+			warning:     true,
 		},
 		{
 			description: "contains an uppercase letter",
 			identifier:  "someThing",
-			errors:      true,
+			warning:     true,
 		},
 	} {
 		test := test
 
 		Context("when an identifier "+test.description, func() {
 			var it string
-			if test.errors {
-				it = "returns an error"
+			if test.warning {
+				it = "returns a warning"
 			} else {
-				it = "runs without error"
+				it = "runs without warning"
 			}
 			It(it, func() {
-				err := atc.ValidateIdentifier(test.identifier)
-				if test.errors {
-					Expect(err).To(HaveOccurred())
+				warning := atc.ValidateIdentifier(test.identifier)
+				if test.warning {
+					Expect(warning).NotTo(BeNil())
 				} else {
-					Expect(err).NotTo(HaveOccurred())
+					Expect(warning).To(BeNil())
 				}
 			})
 		})
@@ -79,11 +79,10 @@ var _ = Describe("ValidateIdentifier", func() {
 	Describe("ValidateIdentifier with context", func() {
 		Context("when an identifier is invalid", func() {
 			It("returns an error with context", func() {
-				err := atc.ValidateIdentifier("_something", "pipeline")
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("'_something' is not a valid identifier"))
+				warning := atc.ValidateIdentifier("_something", "pipeline")
+				Expect(warning).NotTo(BeNil())
+				Expect(warning.Message).To(ContainSubstring("'_something' is not a valid identifier"))
 			})
 		})
-
 	})
 })

--- a/atc/integration/integration_suite_test.go
+++ b/atc/integration/integration_suite_test.go
@@ -131,7 +131,7 @@ func login(atcURL, username, password string) concourse.Client {
 
 func setupTeam(atcURL string, team atc.Team) {
 	ccClient := login(atcURL, "test", "test")
-	createdTeam, _, _, err := ccClient.Team(team.Name).CreateOrUpdate(team)
+	createdTeam, _, _, _, err := ccClient.Team(team.Name).CreateOrUpdate(team)
 
 	Expect(err).ToNot(HaveOccurred())
 	Expect(createdTeam.Name).To(Equal(team.Name))

--- a/atc/integration/rbac_test.go
+++ b/atc/integration/rbac_test.go
@@ -134,7 +134,7 @@ jobs:
 					}
 
 					ccClient := login(atcURL, "o-user", "o-user")
-					createdTeam, _, _, err := ccClient.Team(team.Name).CreateOrUpdate(team)
+					createdTeam, _, _, _, err := ccClient.Team(team.Name).CreateOrUpdate(team)
 
 					Expect(err).ToNot(HaveOccurred())
 					Expect(createdTeam.Name).To(Equal(team.Name))

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -100,6 +100,11 @@ func (validator *StepValidator) VisitGet(step *GetStep) error {
 	validator.pushContext(fmt.Sprintf(".get(%s)", step.Name))
 	defer validator.popContext()
 
+	err := ValidateIdentifier(step.Name)
+	if err != nil {
+		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: err.Error()})
+	}
+
 	if validator.seenGetName[step.Name] {
 		validator.recordError("repeated name")
 	}
@@ -153,6 +158,11 @@ func (validator *StepValidator) VisitPut(step *PutStep) error {
 	validator.pushContext(".put(%s)", step.Name)
 	defer validator.popContext()
 
+	err := ValidateIdentifier(step.Name)
+	if err != nil {
+		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: err.Error()})
+	}
+
 	resourceName := step.ResourceName()
 
 	_, found := validator.config.Resources.Lookup(resourceName)
@@ -167,6 +177,11 @@ func (validator *StepValidator) VisitSetPipeline(step *SetPipelineStep) error {
 	validator.pushContext(".set_pipeline(%s)", step.Name)
 	defer validator.popContext()
 
+	err := ValidateIdentifier(step.Name)
+	if err != nil {
+		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: err.Error()})
+	}
+
 	if step.File == "" {
 		validator.recordError("no file specified")
 	}
@@ -177,6 +192,11 @@ func (validator *StepValidator) VisitSetPipeline(step *SetPipelineStep) error {
 func (validator *StepValidator) VisitLoadVar(step *LoadVarStep) error {
 	validator.pushContext(".load_var(%s)", step.Name)
 	defer validator.popContext()
+
+	err := ValidateIdentifier(step.Name)
+	if err != nil {
+		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: err.Error()})
+	}
 
 	if validator.seenLoadVarName[step.Name] {
 		validator.recordError("repeated name")

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -1,6 +1,7 @@
 package atc
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -62,9 +63,11 @@ func (validator *StepValidator) VisitTask(plan *TaskStep) error {
 	validator.pushContext(fmt.Sprintf(".task(%s)", plan.Name))
 	defer validator.popContext()
 
-	err := ValidateIdentifier(plan.Name)
-	if err != nil {
-		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
+	if err := ValidateIdentifier(plan.Name, validator.context...); err != nil {
+		var got *InvalidIdentifierError
+		if errors.As(err, &got) {
+			validator.recordWarning(got.ConfigWarning())
+		}
 	}
 
 	if plan.Config == nil && plan.ConfigPath == "" {
@@ -105,9 +108,11 @@ func (validator *StepValidator) VisitGet(step *GetStep) error {
 	validator.pushContext(fmt.Sprintf(".get(%s)", step.Name))
 	defer validator.popContext()
 
-	err := ValidateIdentifier(step.Name)
-	if err != nil {
-		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
+	if err := ValidateIdentifier(step.Name, validator.context...); err != nil {
+		var got *InvalidIdentifierError
+		if errors.As(err, &got) {
+			validator.recordWarning(got.ConfigWarning())
+		}
 	}
 
 	if validator.seenGetName[step.Name] {
@@ -163,9 +168,11 @@ func (validator *StepValidator) VisitPut(step *PutStep) error {
 	validator.pushContext(".put(%s)", step.Name)
 	defer validator.popContext()
 
-	err := ValidateIdentifier(step.Name)
-	if err != nil {
-		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
+	if err := ValidateIdentifier(step.Name, validator.context...); err != nil {
+		var got *InvalidIdentifierError
+		if errors.As(err, &got) {
+			validator.recordWarning(got.ConfigWarning())
+		}
 	}
 
 	resourceName := step.ResourceName()
@@ -182,9 +189,11 @@ func (validator *StepValidator) VisitSetPipeline(step *SetPipelineStep) error {
 	validator.pushContext(".set_pipeline(%s)", step.Name)
 	defer validator.popContext()
 
-	err := ValidateIdentifier(step.Name)
-	if err != nil {
-		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
+	if err := ValidateIdentifier(step.Name, validator.context...); err != nil {
+		var got *InvalidIdentifierError
+		if errors.As(err, &got) {
+			validator.recordWarning(got.ConfigWarning())
+		}
 	}
 
 	if step.File == "" {
@@ -198,9 +207,11 @@ func (validator *StepValidator) VisitLoadVar(step *LoadVarStep) error {
 	validator.pushContext(".load_var(%s)", step.Name)
 	defer validator.popContext()
 
-	err := ValidateIdentifier(step.Name)
-	if err != nil {
-		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
+	if err := ValidateIdentifier(step.Name, validator.context...); err != nil {
+		var got *InvalidIdentifierError
+		if errors.As(err, &got) {
+			validator.recordWarning(got.ConfigWarning())
+		}
 	}
 
 	if validator.seenLoadVarName[step.Name] {

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -1,7 +1,6 @@
 package atc
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -63,11 +62,9 @@ func (validator *StepValidator) VisitTask(plan *TaskStep) error {
 	validator.pushContext(fmt.Sprintf(".task(%s)", plan.Name))
 	defer validator.popContext()
 
-	if err := ValidateIdentifier(plan.Name, validator.context...); err != nil {
-		var got *InvalidIdentifierError
-		if errors.As(err, &got) {
-			validator.recordWarning(got.ConfigWarning())
-		}
+	warning := ValidateIdentifier(plan.Name, validator.context...)
+	if warning != nil {
+		validator.recordWarning(*warning)
 	}
 
 	if plan.Config == nil && plan.ConfigPath == "" {
@@ -108,11 +105,9 @@ func (validator *StepValidator) VisitGet(step *GetStep) error {
 	validator.pushContext(fmt.Sprintf(".get(%s)", step.Name))
 	defer validator.popContext()
 
-	if err := ValidateIdentifier(step.Name, validator.context...); err != nil {
-		var got *InvalidIdentifierError
-		if errors.As(err, &got) {
-			validator.recordWarning(got.ConfigWarning())
-		}
+	warning := ValidateIdentifier(step.Name, validator.context...)
+	if warning != nil {
+		validator.recordWarning(*warning)
 	}
 
 	if validator.seenGetName[step.Name] {
@@ -168,11 +163,9 @@ func (validator *StepValidator) VisitPut(step *PutStep) error {
 	validator.pushContext(".put(%s)", step.Name)
 	defer validator.popContext()
 
-	if err := ValidateIdentifier(step.Name, validator.context...); err != nil {
-		var got *InvalidIdentifierError
-		if errors.As(err, &got) {
-			validator.recordWarning(got.ConfigWarning())
-		}
+	warning := ValidateIdentifier(step.Name, validator.context...)
+	if warning != nil {
+		validator.recordWarning(*warning)
 	}
 
 	resourceName := step.ResourceName()
@@ -189,11 +182,9 @@ func (validator *StepValidator) VisitSetPipeline(step *SetPipelineStep) error {
 	validator.pushContext(".set_pipeline(%s)", step.Name)
 	defer validator.popContext()
 
-	if err := ValidateIdentifier(step.Name, validator.context...); err != nil {
-		var got *InvalidIdentifierError
-		if errors.As(err, &got) {
-			validator.recordWarning(got.ConfigWarning())
-		}
+	warning := ValidateIdentifier(step.Name, validator.context...)
+	if warning != nil {
+		validator.recordWarning(*warning)
 	}
 
 	if step.File == "" {
@@ -207,11 +198,9 @@ func (validator *StepValidator) VisitLoadVar(step *LoadVarStep) error {
 	validator.pushContext(".load_var(%s)", step.Name)
 	defer validator.popContext()
 
-	if err := ValidateIdentifier(step.Name, validator.context...); err != nil {
-		var got *InvalidIdentifierError
-		if errors.As(err, &got) {
-			validator.recordWarning(got.ConfigWarning())
-		}
+	warning := ValidateIdentifier(step.Name, validator.context...)
+	if warning != nil {
+		validator.recordWarning(*warning)
 	}
 
 	if validator.seenLoadVarName[step.Name] {

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -78,7 +78,7 @@ func (validator *StepValidator) VisitTask(plan *TaskStep) error {
 	if plan.Config != nil && (plan.Config.RootfsURI != "" || plan.Config.ImageResource != nil) && plan.ImageArtifactName != "" {
 		validator.recordWarning(ConfigWarning{
 			Type:    "pipeline",
-			Message: "specifies image: on the step but also specifies an image under config: - the image: on the step takes precedence",
+			Message: validator.annotate("specifies image: on the step but also specifies an image under config: - the image: on the step takes precedence"),
 		})
 	}
 
@@ -265,7 +265,7 @@ func (validator *StepValidator) VisitAggregate(step *AggregateStep) error {
 
 	validator.recordWarning(ConfigWarning{
 		Type:    "pipeline",
-		Message: "the aggregate step is deprecated and will be removed in a future version",
+		Message: validator.annotate("the aggregate step is deprecated and will be removed in a future version"),
 	})
 
 	for i, sub := range step.Steps {

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -62,6 +62,11 @@ func (validator *StepValidator) VisitTask(plan *TaskStep) error {
 	validator.pushContext(fmt.Sprintf(".task(%s)", plan.Name))
 	defer validator.popContext()
 
+	err := ValidateIdentifier(plan.Name)
+	if err != nil {
+		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
+	}
+
 	if plan.Config == nil && plan.ConfigPath == "" {
 		validator.recordError("must specify either `file:` or `config:`")
 	}
@@ -102,7 +107,7 @@ func (validator *StepValidator) VisitGet(step *GetStep) error {
 
 	err := ValidateIdentifier(step.Name)
 	if err != nil {
-		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: err.Error()})
+		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
 	}
 
 	if validator.seenGetName[step.Name] {
@@ -160,7 +165,7 @@ func (validator *StepValidator) VisitPut(step *PutStep) error {
 
 	err := ValidateIdentifier(step.Name)
 	if err != nil {
-		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: err.Error()})
+		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
 	}
 
 	resourceName := step.ResourceName()
@@ -179,7 +184,7 @@ func (validator *StepValidator) VisitSetPipeline(step *SetPipelineStep) error {
 
 	err := ValidateIdentifier(step.Name)
 	if err != nil {
-		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: err.Error()})
+		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
 	}
 
 	if step.File == "" {
@@ -195,7 +200,7 @@ func (validator *StepValidator) VisitLoadVar(step *LoadVarStep) error {
 
 	err := ValidateIdentifier(step.Name)
 	if err != nil {
-		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: err.Error()})
+		validator.recordWarning(ConfigWarning{Type: "invalid_identifier", Message: validator.annotate(err.Error())})
 	}
 
 	if validator.seenLoadVarName[step.Name] {

--- a/fly/commands/archive_pipeline.go
+++ b/fly/commands/archive_pipeline.go
@@ -19,7 +19,8 @@ type ArchivePipelineCommand struct {
 }
 
 func (command *ArchivePipelineCommand) Validate() error {
-	return command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
+	return err
 }
 
 func (command *ArchivePipelineCommand) Execute(args []string) error {

--- a/fly/commands/builds.go
+++ b/fly/commands/builds.go
@@ -150,7 +150,7 @@ func (command *BuildsCommand) validateJobBuilds(builds []atc.Build, currentTeam 
 }
 
 func (command *BuildsCommand) validatePipelineBuilds(builds []atc.Build, currentTeam concourse.Team, page concourse.Page) ([]atc.Build, error) {
-	err := command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
 	if err != nil {
 		return nil, err
 	}

--- a/fly/commands/checklist.go
+++ b/fly/commands/checklist.go
@@ -14,7 +14,8 @@ type ChecklistCommand struct {
 }
 
 func (command *ChecklistCommand) Validate() error {
-	return command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
+	return err
 }
 
 func (command *ChecklistCommand) Execute([]string) error {

--- a/fly/commands/destroy_pipeline.go
+++ b/fly/commands/destroy_pipeline.go
@@ -15,7 +15,8 @@ type DestroyPipelineCommand struct {
 }
 
 func (command *DestroyPipelineCommand) Validate() error {
-	return command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
+	return err
 }
 
 func (command *DestroyPipelineCommand) Execute(args []string) error {

--- a/fly/commands/expose_pipeline.go
+++ b/fly/commands/expose_pipeline.go
@@ -13,7 +13,8 @@ type ExposePipelineCommand struct {
 }
 
 func (command *ExposePipelineCommand) Validate() error {
-	return command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
+	return err
 }
 
 func (command *ExposePipelineCommand) Execute(args []string) error {

--- a/fly/commands/get_pipeline.go
+++ b/fly/commands/get_pipeline.go
@@ -22,7 +22,8 @@ type GetPipelineCommand struct {
 }
 
 func (command *GetPipelineCommand) Validate() error {
-	return command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
+	return err
 }
 
 func (command *GetPipelineCommand) Execute(args []string) error {

--- a/fly/commands/hide_pipeline.go
+++ b/fly/commands/hide_pipeline.go
@@ -13,7 +13,8 @@ type HidePipelineCommand struct {
 }
 
 func (command *HidePipelineCommand) Validate() error {
-	return command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
+	return err
 }
 
 func (command *HidePipelineCommand) Execute(args []string) error {

--- a/fly/commands/internal/displayhelpers/error_handling.go
+++ b/fly/commands/internal/displayhelpers/error_handling.go
@@ -35,11 +35,18 @@ func ShowWarnings(warnings []concourse.ConfigWarning) {
 	fmt.Fprintln(ui.Stderr, "")
 	PrintDeprecationWarningHeader()
 
+	warningTypes := make(map[string]bool)
 	for _, warning := range warnings {
+		warningTypes[warning.Type] = true
 		fmt.Fprintf(ui.Stderr, "  - %s\n", warning.Message)
 	}
 
 	fmt.Fprintln(ui.Stderr, "")
+
+	if warningTypes["invalid_identifier"] {
+		fmt.Fprintln(ui.Stderr, "identifier schema documentation: https://concourse-ci.org/config-basics.html#schema.identifier")
+		fmt.Fprintln(ui.Stderr, "")
+	}
 }
 
 func Failf(message string, args ...interface{}) {

--- a/fly/commands/internal/flaghelpers/pipeline_flag.go
+++ b/fly/commands/internal/flaghelpers/pipeline_flag.go
@@ -8,15 +8,24 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type PipelineFlag string
 
-func (flag *PipelineFlag) Validate() error {
+func (flag *PipelineFlag) Validate() ([]concourse.ConfigWarning, error) {
 	if strings.Contains(string(*flag), "/") {
-		return errors.New("pipeline name cannot contain '/'")
+		return nil, errors.New("pipeline name cannot contain '/'")
 	}
-	return atc.ValidateIdentifier(string(*flag), "pipeline")
+
+	var warnings []concourse.ConfigWarning
+	if warning := atc.ValidateIdentifier(string(*flag), "pipeline"); warning != nil {
+		warnings = append(warnings, concourse.ConfigWarning{
+			Type:    warning.Type,
+			Message: warning.Message,
+		})
+	}
+	return warnings, nil
 }
 
 func (flag *PipelineFlag) Complete(match string) []flags.Completion {

--- a/fly/commands/internal/flaghelpers/pipeline_flag.go
+++ b/fly/commands/internal/flaghelpers/pipeline_flag.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/rc"
 )
 
@@ -15,7 +16,7 @@ func (flag *PipelineFlag) Validate() error {
 	if strings.Contains(string(*flag), "/") {
 		return errors.New("pipeline name cannot contain '/'")
 	}
-	return nil
+	return atc.ValidateIdentifier(string(*flag), "pipeline")
 }
 
 func (flag *PipelineFlag) Complete(match string) []flags.Completion {

--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vito/go-interact/interact"
 
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/configvalidate"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/templatehelpers"
 	"github.com/concourse/concourse/fly/rc"
@@ -23,6 +24,7 @@ type ATCConfig struct {
 	Target           string
 	SkipInteraction  bool
 	CheckCredentials bool
+	CommandWarnings  []concourse.ConfigWarning
 }
 
 func (atcConfig ATCConfig) ApplyConfigInteraction() bool {
@@ -54,6 +56,18 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 	err = yaml.Unmarshal([]byte(evaluatedTemplate), &newConfig)
 	if err != nil {
 		return err
+	}
+
+	configWarnings, _ := configvalidate.Validate(newConfig)
+	for _, w := range configWarnings {
+		atcConfig.CommandWarnings = append(atcConfig.CommandWarnings, concourse.ConfigWarning{
+			Type:    w.Type,
+			Message: w.Message,
+		})
+	}
+
+	if len(atcConfig.CommandWarnings) > 0 {
+		displayhelpers.ShowWarnings(atcConfig.CommandWarnings)
 	}
 
 	diffExists := diff(existingConfig, newConfig)

--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -66,11 +66,11 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 		})
 	}
 
+	diffExists := diff(existingConfig, newConfig)
+
 	if len(atcConfig.CommandWarnings) > 0 {
 		displayhelpers.ShowWarnings(atcConfig.CommandWarnings)
 	}
-
-	diffExists := diff(existingConfig, newConfig)
 
 	if !diffExists {
 		fmt.Println("no changes to apply")

--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -21,7 +21,7 @@ func (command *OrderPipelinesCommand) Validate() ([]string, error) {
 	var pipelines []string
 
 	for _, p := range command.Pipelines {
-		err := p.Validate()
+		_, err := p.Validate()
 		if err != nil {
 			return nil, err
 		}

--- a/fly/commands/pause_pipeline.go
+++ b/fly/commands/pause_pipeline.go
@@ -14,7 +14,8 @@ type PausePipelineCommand struct {
 }
 
 func (command *PausePipelineCommand) Validate() error {
-	return command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
+	return err
 }
 
 func (command *PausePipelineCommand) Execute(args []string) error {

--- a/fly/commands/rename_pipeline.go
+++ b/fly/commands/rename_pipeline.go
@@ -14,12 +14,13 @@ type RenamePipelineCommand struct {
 }
 
 func (command *RenamePipelineCommand) Validate() error {
-	err := command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
 	if err != nil {
 		return err
 	}
 
-	return command.Name.Validate()
+	_, err = command.Name.Validate()
+	return err
 }
 
 func (command *RenamePipelineCommand) Execute([]string) error {

--- a/fly/commands/rename_pipeline.go
+++ b/fly/commands/rename_pipeline.go
@@ -41,9 +41,13 @@ func (command *RenamePipelineCommand) Execute([]string) error {
 	oldName := string(command.Pipeline)
 	newName := string(command.Name)
 
-	found, err := target.Team().RenamePipeline(oldName, newName)
+	found, warnings, err := target.Team().RenamePipeline(oldName, newName)
 	if err != nil {
 		return err
+	}
+
+	if len(warnings) > 0 {
+		displayhelpers.ShowWarnings(warnings)
 	}
 
 	if !found {

--- a/fly/commands/rename_team.go
+++ b/fly/commands/rename_team.go
@@ -26,9 +26,13 @@ func (command *RenameTeamCommand) Execute([]string) error {
 
 	teamName := command.Team.Name()
 
-	found, err := target.Team().RenameTeam(teamName, command.NewTeamName)
+	found, warnings, err := target.Team().RenameTeam(teamName, command.NewTeamName)
 	if err != nil {
 		return err
+	}
+
+	if len(warnings) > 0 {
+		displayhelpers.ShowWarnings(warnings)
 	}
 
 	if !found {

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -1,8 +1,6 @@
 package commands
 
 import (
-	"errors"
-
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/commands/internal/setpipelinehelpers"
@@ -30,20 +28,16 @@ type SetPipelineCommand struct {
 }
 
 func (command *SetPipelineCommand) Validate() ([]concourse.ConfigWarning, error) {
-	if err := command.Pipeline.Validate(); err != nil {
-		var warnings []concourse.ConfigWarning
-		var got *atc.InvalidIdentifierError
-		if errors.As(err, &got) {
-			warning := got.ConfigWarning()
+	warnings, err := command.Pipeline.Validate()
+	if command.Team != "" {
+		if warning := atc.ValidateIdentifier(command.Team, "team"); warning != nil {
 			warnings = append(warnings, concourse.ConfigWarning{
 				Type:    warning.Type,
 				Message: warning.Message,
 			})
-			return warnings, nil
 		}
-		return nil, err
 	}
-	return nil, nil
+	return warnings, err
 }
 
 func (command *SetPipelineCommand) Execute(args []string) error {

--- a/fly/commands/set_team.go
+++ b/fly/commands/set_team.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -33,20 +32,14 @@ type SetTeamCommand struct {
 }
 
 func (command *SetTeamCommand) Validate() ([]concourse.ConfigWarning, error) {
-	if err := atc.ValidateIdentifier(command.Team.Name(), "team"); err != nil {
-		var warnings []concourse.ConfigWarning
-		var got *atc.InvalidIdentifierError
-		if errors.As(err, &got) {
-			warning := got.ConfigWarning()
-			warnings = append(warnings, concourse.ConfigWarning{
-				Type:    warning.Type,
-				Message: warning.Message,
-			})
-			return warnings, nil
-		}
-		return nil, err
+	var warnings []concourse.ConfigWarning
+	if warning := atc.ValidateIdentifier(command.Team.Name(), "team"); warning != nil {
+		warnings = append(warnings, concourse.ConfigWarning{
+			Type:    warning.Type,
+			Message: warning.Message,
+		})
 	}
-	return nil, nil
+	return warnings, nil
 }
 
 func (command *SetTeamCommand) Execute([]string) error {

--- a/fly/commands/set_team.go
+++ b/fly/commands/set_team.go
@@ -97,9 +97,13 @@ func (command *SetTeamCommand) Execute([]string) error {
 
 	team := atc.Team{Auth: authRoles}
 
-	_, created, updated, err := target.Client().Team(teamName).CreateOrUpdate(team)
+	_, created, updated, warnings, err := target.Client().Team(teamName).CreateOrUpdate(team)
 	if err != nil {
 		return err
+	}
+
+	if len(warnings) > 0 {
+		displayhelpers.ShowWarnings(warnings)
 	}
 
 	if created {

--- a/fly/commands/unpause_pipeline.go
+++ b/fly/commands/unpause_pipeline.go
@@ -16,7 +16,8 @@ type UnpausePipelineCommand struct {
 }
 
 func (command *UnpausePipelineCommand) Validate() error {
-	return command.Pipeline.Validate()
+	_, err := command.Pipeline.Validate()
+	return err
 }
 
 func (command *UnpausePipelineCommand) Execute(args []string) error {

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -189,7 +189,7 @@ type FakeTeam struct {
 		result1 atc.Build
 		result2 error
 	}
-	CreateOrUpdateStub        func(atc.Team) (atc.Team, bool, bool, error)
+	CreateOrUpdateStub        func(atc.Team) (atc.Team, bool, bool, []concourse.ConfigWarning, error)
 	createOrUpdateMutex       sync.RWMutex
 	createOrUpdateArgsForCall []struct {
 		arg1 atc.Team
@@ -198,13 +198,15 @@ type FakeTeam struct {
 		result1 atc.Team
 		result2 bool
 		result3 bool
-		result4 error
+		result4 []concourse.ConfigWarning
+		result5 error
 	}
 	createOrUpdateReturnsOnCall map[int]struct {
 		result1 atc.Team
 		result2 bool
 		result3 bool
-		result4 error
+		result4 []concourse.ConfigWarning
+		result5 error
 	}
 	CreateOrUpdatePipelineConfigStub        func(string, string, []byte, bool) (bool, bool, []concourse.ConfigWarning, error)
 	createOrUpdatePipelineConfigMutex       sync.RWMutex
@@ -574,7 +576,7 @@ type FakeTeam struct {
 		result3 bool
 		result4 error
 	}
-	RenamePipelineStub        func(string, string) (bool, error)
+	RenamePipelineStub        func(string, string) (bool, []concourse.ConfigWarning, error)
 	renamePipelineMutex       sync.RWMutex
 	renamePipelineArgsForCall []struct {
 		arg1 string
@@ -582,13 +584,15 @@ type FakeTeam struct {
 	}
 	renamePipelineReturns struct {
 		result1 bool
-		result2 error
+		result2 []concourse.ConfigWarning
+		result3 error
 	}
 	renamePipelineReturnsOnCall map[int]struct {
 		result1 bool
-		result2 error
+		result2 []concourse.ConfigWarning
+		result3 error
 	}
-	RenameTeamStub        func(string, string) (bool, error)
+	RenameTeamStub        func(string, string) (bool, []concourse.ConfigWarning, error)
 	renameTeamMutex       sync.RWMutex
 	renameTeamArgsForCall []struct {
 		arg1 string
@@ -596,11 +600,13 @@ type FakeTeam struct {
 	}
 	renameTeamReturns struct {
 		result1 bool
-		result2 error
+		result2 []concourse.ConfigWarning
+		result3 error
 	}
 	renameTeamReturnsOnCall map[int]struct {
 		result1 bool
-		result2 error
+		result2 []concourse.ConfigWarning
+		result3 error
 	}
 	RerunJobBuildStub        func(string, string, string) (atc.Build, error)
 	rerunJobBuildMutex       sync.RWMutex
@@ -1519,7 +1525,7 @@ func (fake *FakeTeam) CreateJobBuildReturnsOnCall(i int, result1 atc.Build, resu
 	}{result1, result2}
 }
 
-func (fake *FakeTeam) CreateOrUpdate(arg1 atc.Team) (atc.Team, bool, bool, error) {
+func (fake *FakeTeam) CreateOrUpdate(arg1 atc.Team) (atc.Team, bool, bool, []concourse.ConfigWarning, error) {
 	fake.createOrUpdateMutex.Lock()
 	ret, specificReturn := fake.createOrUpdateReturnsOnCall[len(fake.createOrUpdateArgsForCall)]
 	fake.createOrUpdateArgsForCall = append(fake.createOrUpdateArgsForCall, struct {
@@ -1531,10 +1537,10 @@ func (fake *FakeTeam) CreateOrUpdate(arg1 atc.Team) (atc.Team, bool, bool, error
 		return fake.CreateOrUpdateStub(arg1)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3, ret.result4
+		return ret.result1, ret.result2, ret.result3, ret.result4, ret.result5
 	}
 	fakeReturns := fake.createOrUpdateReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4, fakeReturns.result5
 }
 
 func (fake *FakeTeam) CreateOrUpdateCallCount() int {
@@ -1543,7 +1549,7 @@ func (fake *FakeTeam) CreateOrUpdateCallCount() int {
 	return len(fake.createOrUpdateArgsForCall)
 }
 
-func (fake *FakeTeam) CreateOrUpdateCalls(stub func(atc.Team) (atc.Team, bool, bool, error)) {
+func (fake *FakeTeam) CreateOrUpdateCalls(stub func(atc.Team) (atc.Team, bool, bool, []concourse.ConfigWarning, error)) {
 	fake.createOrUpdateMutex.Lock()
 	defer fake.createOrUpdateMutex.Unlock()
 	fake.CreateOrUpdateStub = stub
@@ -1556,7 +1562,7 @@ func (fake *FakeTeam) CreateOrUpdateArgsForCall(i int) atc.Team {
 	return argsForCall.arg1
 }
 
-func (fake *FakeTeam) CreateOrUpdateReturns(result1 atc.Team, result2 bool, result3 bool, result4 error) {
+func (fake *FakeTeam) CreateOrUpdateReturns(result1 atc.Team, result2 bool, result3 bool, result4 []concourse.ConfigWarning, result5 error) {
 	fake.createOrUpdateMutex.Lock()
 	defer fake.createOrUpdateMutex.Unlock()
 	fake.CreateOrUpdateStub = nil
@@ -1564,11 +1570,12 @@ func (fake *FakeTeam) CreateOrUpdateReturns(result1 atc.Team, result2 bool, resu
 		result1 atc.Team
 		result2 bool
 		result3 bool
-		result4 error
-	}{result1, result2, result3, result4}
+		result4 []concourse.ConfigWarning
+		result5 error
+	}{result1, result2, result3, result4, result5}
 }
 
-func (fake *FakeTeam) CreateOrUpdateReturnsOnCall(i int, result1 atc.Team, result2 bool, result3 bool, result4 error) {
+func (fake *FakeTeam) CreateOrUpdateReturnsOnCall(i int, result1 atc.Team, result2 bool, result3 bool, result4 []concourse.ConfigWarning, result5 error) {
 	fake.createOrUpdateMutex.Lock()
 	defer fake.createOrUpdateMutex.Unlock()
 	fake.CreateOrUpdateStub = nil
@@ -1577,15 +1584,17 @@ func (fake *FakeTeam) CreateOrUpdateReturnsOnCall(i int, result1 atc.Team, resul
 			result1 atc.Team
 			result2 bool
 			result3 bool
-			result4 error
+			result4 []concourse.ConfigWarning
+			result5 error
 		})
 	}
 	fake.createOrUpdateReturnsOnCall[i] = struct {
 		result1 atc.Team
 		result2 bool
 		result3 bool
-		result4 error
-	}{result1, result2, result3, result4}
+		result4 []concourse.ConfigWarning
+		result5 error
+	}{result1, result2, result3, result4, result5}
 }
 
 func (fake *FakeTeam) CreateOrUpdatePipelineConfig(arg1 string, arg2 string, arg3 []byte, arg4 bool) (bool, bool, []concourse.ConfigWarning, error) {
@@ -3253,7 +3262,7 @@ func (fake *FakeTeam) PipelineConfigReturnsOnCall(i int, result1 atc.Config, res
 	}{result1, result2, result3, result4}
 }
 
-func (fake *FakeTeam) RenamePipeline(arg1 string, arg2 string) (bool, error) {
+func (fake *FakeTeam) RenamePipeline(arg1 string, arg2 string) (bool, []concourse.ConfigWarning, error) {
 	fake.renamePipelineMutex.Lock()
 	ret, specificReturn := fake.renamePipelineReturnsOnCall[len(fake.renamePipelineArgsForCall)]
 	fake.renamePipelineArgsForCall = append(fake.renamePipelineArgsForCall, struct {
@@ -3266,10 +3275,10 @@ func (fake *FakeTeam) RenamePipeline(arg1 string, arg2 string) (bool, error) {
 		return fake.RenamePipelineStub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
 	fakeReturns := fake.renamePipelineReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeTeam) RenamePipelineCallCount() int {
@@ -3278,7 +3287,7 @@ func (fake *FakeTeam) RenamePipelineCallCount() int {
 	return len(fake.renamePipelineArgsForCall)
 }
 
-func (fake *FakeTeam) RenamePipelineCalls(stub func(string, string) (bool, error)) {
+func (fake *FakeTeam) RenamePipelineCalls(stub func(string, string) (bool, []concourse.ConfigWarning, error)) {
 	fake.renamePipelineMutex.Lock()
 	defer fake.renamePipelineMutex.Unlock()
 	fake.RenamePipelineStub = stub
@@ -3291,33 +3300,36 @@ func (fake *FakeTeam) RenamePipelineArgsForCall(i int) (string, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeTeam) RenamePipelineReturns(result1 bool, result2 error) {
+func (fake *FakeTeam) RenamePipelineReturns(result1 bool, result2 []concourse.ConfigWarning, result3 error) {
 	fake.renamePipelineMutex.Lock()
 	defer fake.renamePipelineMutex.Unlock()
 	fake.RenamePipelineStub = nil
 	fake.renamePipelineReturns = struct {
 		result1 bool
-		result2 error
-	}{result1, result2}
+		result2 []concourse.ConfigWarning
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeTeam) RenamePipelineReturnsOnCall(i int, result1 bool, result2 error) {
+func (fake *FakeTeam) RenamePipelineReturnsOnCall(i int, result1 bool, result2 []concourse.ConfigWarning, result3 error) {
 	fake.renamePipelineMutex.Lock()
 	defer fake.renamePipelineMutex.Unlock()
 	fake.RenamePipelineStub = nil
 	if fake.renamePipelineReturnsOnCall == nil {
 		fake.renamePipelineReturnsOnCall = make(map[int]struct {
 			result1 bool
-			result2 error
+			result2 []concourse.ConfigWarning
+			result3 error
 		})
 	}
 	fake.renamePipelineReturnsOnCall[i] = struct {
 		result1 bool
-		result2 error
-	}{result1, result2}
+		result2 []concourse.ConfigWarning
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeTeam) RenameTeam(arg1 string, arg2 string) (bool, error) {
+func (fake *FakeTeam) RenameTeam(arg1 string, arg2 string) (bool, []concourse.ConfigWarning, error) {
 	fake.renameTeamMutex.Lock()
 	ret, specificReturn := fake.renameTeamReturnsOnCall[len(fake.renameTeamArgsForCall)]
 	fake.renameTeamArgsForCall = append(fake.renameTeamArgsForCall, struct {
@@ -3330,10 +3342,10 @@ func (fake *FakeTeam) RenameTeam(arg1 string, arg2 string) (bool, error) {
 		return fake.RenameTeamStub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
 	fakeReturns := fake.renameTeamReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeTeam) RenameTeamCallCount() int {
@@ -3342,7 +3354,7 @@ func (fake *FakeTeam) RenameTeamCallCount() int {
 	return len(fake.renameTeamArgsForCall)
 }
 
-func (fake *FakeTeam) RenameTeamCalls(stub func(string, string) (bool, error)) {
+func (fake *FakeTeam) RenameTeamCalls(stub func(string, string) (bool, []concourse.ConfigWarning, error)) {
 	fake.renameTeamMutex.Lock()
 	defer fake.renameTeamMutex.Unlock()
 	fake.RenameTeamStub = stub
@@ -3355,30 +3367,33 @@ func (fake *FakeTeam) RenameTeamArgsForCall(i int) (string, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeTeam) RenameTeamReturns(result1 bool, result2 error) {
+func (fake *FakeTeam) RenameTeamReturns(result1 bool, result2 []concourse.ConfigWarning, result3 error) {
 	fake.renameTeamMutex.Lock()
 	defer fake.renameTeamMutex.Unlock()
 	fake.RenameTeamStub = nil
 	fake.renameTeamReturns = struct {
 		result1 bool
-		result2 error
-	}{result1, result2}
+		result2 []concourse.ConfigWarning
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeTeam) RenameTeamReturnsOnCall(i int, result1 bool, result2 error) {
+func (fake *FakeTeam) RenameTeamReturnsOnCall(i int, result1 bool, result2 []concourse.ConfigWarning, result3 error) {
 	fake.renameTeamMutex.Lock()
 	defer fake.renameTeamMutex.Unlock()
 	fake.RenameTeamStub = nil
 	if fake.renameTeamReturnsOnCall == nil {
 		fake.renameTeamReturnsOnCall = make(map[int]struct {
 			result1 bool
-			result2 error
+			result2 []concourse.ConfigWarning
+			result3 error
 		})
 	}
 	fake.renameTeamReturnsOnCall[i] = struct {
 		result1 bool
-		result2 error
-	}{result1, result2}
+		result2 []concourse.ConfigWarning
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeTeam) RerunJobBuild(arg1 string, arg2 string, arg3 string) (atc.Build, error) {

--- a/go-concourse/concourse/pipelines.go
+++ b/go-concourse/concourse/pipelines.go
@@ -152,7 +152,7 @@ func (team *team) managePipeline(pipelineName string, endpoint string) (bool, er
 	}
 }
 
-func (team *team) RenamePipeline(pipelineName, name string) (bool, error) {
+func (team *team) RenamePipeline(pipelineName, name string) (bool, []ConfigWarning, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"team_name":     team.name,
@@ -160,22 +160,26 @@ func (team *team) RenamePipeline(pipelineName, name string) (bool, error) {
 
 	jsonBytes, err := json.Marshal(atc.RenameRequest{NewName: name})
 	if err != nil {
-		return false, err
+		return false, []ConfigWarning{}, err
 	}
 
+	var response setConfigResponse
 	err = team.connection.Send(internal.Request{
 		RequestName: atc.RenamePipeline,
 		Params:      params,
 		Body:        bytes.NewBuffer(jsonBytes),
 		Header:      http.Header{"Content-Type": []string{"application/json"}},
-	}, nil)
+	}, &internal.Response{
+		Result: &response,
+	})
+
 	switch err.(type) {
 	case nil:
-		return true, nil
+		return true, response.Warnings, nil
 	case internal.ResourceNotFoundError:
-		return false, nil
+		return false, []ConfigWarning{}, nil
 	default:
-		return false, err
+		return false, []ConfigWarning{}, err
 	}
 }
 

--- a/go-concourse/concourse/pipelines_test.go
+++ b/go-concourse/concourse/pipelines_test.go
@@ -439,23 +439,60 @@ var _ = Describe("ATC Handler Pipelines", func() {
 	})
 
 	Describe("RenamePipeline", func() {
-		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline/rename"
+		var (
+			expectedURL         string
+			expectedRequestBody string
+			expectedResponse    atc.SaveConfigResponse
+		)
+
+		BeforeEach(func() {
+			expectedURL = "/api/v1/teams/some-team/pipelines/mypipeline/rename"
+			expectedRequestBody = `{"name":"newpipelinename"}`
+			expectedResponse = atc.SaveConfigResponse{
+				Errors:   nil,
+				Warnings: []atc.ConfigWarning{},
+			}
+		})
 
 		Context("when the pipeline exists", func() {
-			BeforeEach(func() {
+			JustBeforeEach(func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("PUT", expectedURL),
-						ghttp.VerifyJSON(`{"name":"newpipelinename"}`),
-						ghttp.RespondWith(http.StatusNoContent, ""),
+						ghttp.VerifyJSON(expectedRequestBody),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedResponse),
 					),
 				)
 			})
 
 			It("renames the pipeline when called", func() {
-				renamed, err := team.RenamePipeline("mypipeline", "newpipelinename")
+				renamed, _, err := team.RenamePipeline("mypipeline", "newpipelinename")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(renamed).To(BeTrue())
+			})
+
+			Context("when the pipeline identifier is invalid", func() {
+
+				BeforeEach(func() {
+					expectedRequestBody = `{"name":"_newpipelinename"}`
+					expectedResponse = atc.SaveConfigResponse{
+						Errors: nil,
+						Warnings: []atc.ConfigWarning{
+							{
+								Type:    "invalid_identifier",
+								Message: "pipeline: '_newpipelinename' is not a valid identifier",
+							},
+						},
+					}
+				})
+
+				It("returns a warning", func() {
+					renamed, warnings, err := team.RenamePipeline("mypipeline", "_newpipelinename")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(renamed).To(BeTrue())
+					Expect(warnings).To(HaveLen(1))
+					Expect(warnings[0].Message).To(ContainSubstring("pipeline: '_newpipelinename' is not a valid identifier"))
+				})
 			})
 		})
 
@@ -467,7 +504,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 			})
 
 			It("returns false and no error", func() {
-				renamed, err := team.RenamePipeline("mypipeline", "newpipelinename")
+				renamed, _, err := team.RenamePipeline("mypipeline", "newpipelinename")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(renamed).To(BeFalse())
 			})
@@ -481,7 +518,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 			})
 
 			It("returns an error", func() {
-				renamed, err := team.RenamePipeline("mypipeline", "newpipelinename")
+				renamed, _, err := team.RenamePipeline("mypipeline", "newpipelinename")
 				Expect(err).To(MatchError(ContainSubstring("418 I'm a teapot")))
 				Expect(renamed).To(BeFalse())
 			})

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -14,8 +14,8 @@ type Team interface {
 
 	Auth() atc.TeamAuth
 
-	CreateOrUpdate(team atc.Team) (atc.Team, bool, bool, error)
-	RenameTeam(teamName, name string) (bool, error)
+	CreateOrUpdate(team atc.Team) (atc.Team, bool, bool, []ConfigWarning, error)
+	RenameTeam(teamName, name string) (bool, []ConfigWarning, error)
 	DestroyTeam(teamName string) error
 
 	Pipeline(name string) (atc.Pipeline, bool, error)
@@ -26,7 +26,7 @@ type Team interface {
 	UnpausePipeline(pipelineName string) (bool, error)
 	ExposePipeline(pipelineName string) (bool, error)
 	HidePipeline(pipelineName string) (bool, error)
-	RenamePipeline(pipelineName, name string) (bool, error)
+	RenamePipeline(pipelineName, name string) (bool, []ConfigWarning, error)
 	ListPipelines() ([]atc.Pipeline, error)
 	PipelineConfig(pipelineName string) (atc.Config, string, bool, error)
 	CreateOrUpdatePipelineConfig(pipelineName string, configVersion string, passedConfig []byte, checkCredentials bool) (bool, bool, []ConfigWarning, error)

--- a/go-concourse/concourse/teams.go
+++ b/go-concourse/concourse/teams.go
@@ -15,20 +15,26 @@ import (
 
 var ErrDestroyRefused = errors.New("not-permitted-to-destroy-as-requested")
 
+type setTeamResponse struct {
+	Errors   []string        `json:"errors,omitempty"`
+	Warnings []ConfigWarning `json:"warnings,omitempty"`
+	Team     atc.Team        `json:"team"`
+}
+
 // CreateOrUpdate creates or updates team teamName with the settings provided in passedTeam.
 // passedTeam should reflect the desired state of team's configuration.
-func (team *team) CreateOrUpdate(passedTeam atc.Team) (atc.Team, bool, bool, error) {
+func (team *team) CreateOrUpdate(passedTeam atc.Team) (atc.Team, bool, bool, []ConfigWarning, error) {
 	params := rata.Params{"team_name": team.name}
 
 	buffer := &bytes.Buffer{}
 	err := json.NewEncoder(buffer).Encode(passedTeam)
 	if err != nil {
-		return atc.Team{}, false, false, fmt.Errorf("Unable to marshal plan: %s", err)
+		return atc.Team{}, false, false, []ConfigWarning{}, fmt.Errorf("Unable to marshal plan: %s", err)
 	}
 
-	var savedTeam atc.Team
+	var result setTeamResponse
 	response := internal.Response{
-		Result: &savedTeam,
+		Result: &result,
 	}
 	err = team.connection.Send(internal.Request{
 		RequestName: atc.SetTeam,
@@ -40,7 +46,7 @@ func (team *team) CreateOrUpdate(passedTeam atc.Team) (atc.Team, bool, bool, err
 	}, &response)
 
 	if err != nil {
-		return savedTeam, false, false, err
+		return result.Team, false, false, []ConfigWarning{}, err
 	}
 
 	var created, updated bool
@@ -50,7 +56,7 @@ func (team *team) CreateOrUpdate(passedTeam atc.Team) (atc.Team, bool, bool, err
 		updated = true
 	}
 
-	return savedTeam, created, updated, nil
+	return result.Team, created, updated, result.Warnings, nil
 }
 
 // DestroyTeam destroys the team with the name given as argument.
@@ -71,29 +77,33 @@ func (team *team) DestroyTeam(teamName string) error {
 	return err
 }
 
-func (team *team) RenameTeam(teamName, name string) (bool, error) {
+func (team *team) RenameTeam(teamName, name string) (bool, []ConfigWarning, error) {
 	params := rata.Params{
 		"team_name": teamName,
 	}
 
 	jsonBytes, err := json.Marshal(atc.RenameRequest{NewName: name})
 	if err != nil {
-		return false, err
+		return false, []ConfigWarning{}, err
 	}
 
+	var response setConfigResponse
 	err = team.connection.Send(internal.Request{
 		RequestName: atc.RenameTeam,
 		Params:      params,
 		Body:        bytes.NewBuffer(jsonBytes),
 		Header:      http.Header{"Content-Type": []string{"application/json"}},
-	}, nil)
+	}, &internal.Response{
+		Result: &response,
+	})
+
 	switch err.(type) {
 	case nil:
-		return true, nil
+		return true, response.Warnings, nil
 	case internal.ResourceNotFoundError:
-		return false, nil
+		return false, []ConfigWarning{}, nil
 	default:
-		return false, err
+		return false, []ConfigWarning{}, err
 	}
 }
 

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -6,3 +6,6 @@
 
 * Added recover for panic error that used to crash the cluster. Now it should be less easy to panic (we hope!) and if it does, panic error could be found on Stderr and log. #5842
 
+#### <sub><sup><a name="5810" href="#5810">:link:</a></sup></sub> feature
+
+* Reduce the allowed character set for Concourse valid identifiers. Only prints warnings instead of errors as a first step. #5810


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes #5810.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
`fly` commands print warnings when `team`s, `pipeline`s, `job`s, `step`s, `group`s, `resource`s, `resource_type`s or `var_source`s identifier are not valid (see [rfc#40](https://github.com/concourse/rfcs/blob/master/040-valid-identifiers) for spec).

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
