### PR TITLE
release-notes: structure: update 6.4.0 release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -783,4 +783,3 @@ pushed commits without the signature.
 [helm-charts]: https://github.com/helm/charts/blob/master/README.md
 [fav-commit]: https://dhwthompson.com/2019/my-favourite-git-commit
 [sb-changes]: https://medium.com/@kentbeck_7670/bs-changes-e574bc396aaa
-

--- a/release-notes/v6.4.0.md
+++ b/release-notes/v6.4.0.md
@@ -35,7 +35,7 @@
 
 #### <sub><sup><a name="5770" href="#5770">:link:</a></sup></sub> fix
 
-* `fly login` now accepts arbitrarily long tokens when pasting the token manually into the console. Previously, the limit was OS dependent (with OSX having a relatively small maximum length of 1024 characters). This has been a long-standing issue, but it became most noticable after 6.1.0 which significantly increased the size of tokens. Note that pasted token is now hidden in the console output. #5770
+* `fly login` now accepts arbitrarily long tokens when pasting the token manually into the console. Previously, the limit was OS dependent (with OSX having a relatively small maximum length of 1024 characters). This has been a long-standing issue, but it became most noticeable after 6.1.0 which significantly increased the size of tokens. Note that the pasted token is now hidden in the console output. #5770
 
 #### <sub><sup><a name="5390" href="#5390">:link:</a></sup></sub> feature
 
@@ -47,7 +47,7 @@
 
 #### <sub><sup><a name="5504" href="#5504">:link:</a></sup></sub> feature
 
-* Refactor existing step structure to simplify introducing new steps. The primary user facing change is step validation messages are different. PR: #5504
+* Refactor existing step structure to simplify introducing new steps. The primary user facing change are different step validation messages. PR: #5504
 
 #### <sub><sup><a name="5729" href="#5729">:link:</a></sup></sub> feature
 
@@ -55,7 +55,7 @@
 
 #### <sub><sup><a name="5034" href="#5034">:link:</a></sup></sub> feature
 
-* @evanchaoli added [OPA](https://www.openpolicyagent.org/) integration to Concourse to enable policy enforcement. The [RFC #41](https://github.com/concourse/rfcs/pull/41) for the integration is still in progress so is considered 'experimental'. PR: #5034
+* @evanchaoli added [OPA](https://www.openpolicyagent.org/) integration to Concourse to enable policy enforcement. The [RFC #41](https://github.com/concourse/rfcs/pull/41) for the integration is still in progress so it is considered 'experimental'. PR: #5034
 
 #### <sub><sup><a name="5144" href="#5144">:link:</a></sup></sub> feature
 

--- a/release-notes/v6.4.0.md
+++ b/release-notes/v6.4.0.md
@@ -40,3 +40,23 @@
 #### <sub><sup><a name="5390" href="#5390">:link:</a></sup></sub> feature
 
 * Add `--team` flag for `fly set-pipelines` command #5805
+
+#### <sub><sup><a name="5855" href="#5855">:link:</a></sup></sub> fix
+
+* Fix tooltip on pipeline names. PR: #5855
+
+#### <sub><sup><a name="5504" href="#5504">:link:</a></sup></sub> feature
+
+* Refactor existing step structure to simplify introducing new steps. The primary user facing change is step validation messages are different. PR: #5504
+
+#### <sub><sup><a name="5729" href="#5729">:link:</a></sup></sub> feature
+
+* @tlwr updated the `set_pipeline` step to be used across teams. This is 'experimental' for now, please share your feedback in the [thread](https://github.com/concourse/concourse/discussions/5731). PR: #5729
+
+#### <sub><sup><a name="5034" href="#5034">:link:</a></sup></sub> feature
+
+* @evanchaoli added [OPA](https://www.openpolicyagent.org/) integration to Concourse to enable policy enforcement. The [RFC #41](https://github.com/concourse/rfcs/pull/41) for the integration is still in progress so is considered 'experimental'. PR: #5034
+
+#### <sub><sup><a name="5144" href="#5144">:link:</a></sup></sub> feature
+
+* Add support for task.run.user field in containerd runtime. Issue: #5144 PR: #5704


### PR DESCRIPTION
## Contributor Checklist
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
