### PR TITLE
6.4.x: atc: ignore unknown step fields when reading from DB

### DIFF
--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -279,11 +279,11 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 			}
 		}
 
-		stepConfig := job.StepConfig()
+		step := job.Step()
 
 		validator := atc.NewStepValidator(c, []string{identifier, ".plan"})
 
-		_ = stepConfig.Visit(validator)
+		_ = validator.Validate(step)
 
 		for _, warning := range validator.Warnings {
 			warnings = append(warnings, ConfigWarning{

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -1,6 +1,7 @@
 package configvalidate_test
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/concourse/concourse/atc"
@@ -1667,6 +1668,106 @@ var _ = Describe("ValidateConfig", func() {
 					Expect(errorMessages).To(HaveLen(1))
 					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[1].load_var(a-var): repeated name"))
 				})
+			})
+
+			Describe("checking for unknown fields", func() {
+				basicStep := func() atc.StepConfig {
+					return &atc.TaskStep{
+						Name:       "task",
+						ConfigPath: "some-file",
+					}
+				}
+
+				stepWithUnknownFields := func() atc.Step {
+					return atc.Step{
+						Config:        basicStep(),
+						UnknownFields: map[string]*json.RawMessage{"bogus": nil},
+					}
+				}
+
+				for _, test := range []struct {
+					name   string
+					config atc.StepConfig
+				}{
+					{
+						name: "on_success",
+						config: &atc.OnSuccessStep{
+							Step: basicStep(),
+							Hook: stepWithUnknownFields(),
+						},
+					},
+					{
+						name: "on_failure",
+						config: &atc.OnFailureStep{
+							Step: basicStep(),
+							Hook: stepWithUnknownFields(),
+						},
+					},
+					{
+						name: "on_error",
+						config: &atc.OnErrorStep{
+							Step: basicStep(),
+							Hook: stepWithUnknownFields(),
+						},
+					},
+					{
+						name: "on_abort",
+						config: &atc.OnAbortStep{
+							Step: basicStep(),
+							Hook: stepWithUnknownFields(),
+						},
+					},
+					{
+						name: "ensure",
+						config: &atc.EnsureStep{
+							Step: basicStep(),
+							Hook: stepWithUnknownFields(),
+						},
+					},
+					{
+						name: "try",
+						config: &atc.TryStep{
+							Step: stepWithUnknownFields(),
+						},
+					},
+					{
+						name: "do[0]",
+						config: &atc.DoStep{
+							Steps: []atc.Step{stepWithUnknownFields()},
+						},
+					},
+					{
+						name: "in_parallel.steps[0]",
+						config: &atc.InParallelStep{
+							Config: atc.InParallelConfig{
+								Steps: []atc.Step{stepWithUnknownFields()},
+							},
+						},
+					},
+					{
+						name: "aggregate[0]",
+						config: &atc.AggregateStep{
+							Steps: []atc.Step{stepWithUnknownFields()},
+						},
+					},
+				} {
+					test := test
+
+					Context("when an "+test.name+" step has unknown fields", func() {
+						BeforeEach(func() {
+							job.PlanSequence = append(job.PlanSequence, atc.Step{
+								Config: test.config,
+							})
+
+							config.Jobs = append(config.Jobs, job)
+						})
+
+						It("returns an error", func() {
+							Expect(errorMessages).To(HaveLen(1))
+							Expect(errorMessages[0]).To(ContainSubstring(`jobs.some-other-job.plan.do[0].` + test.name + `: unknown fields ["bogus"]`))
+						})
+					})
+				}
 			})
 		})
 

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -1670,104 +1670,23 @@ var _ = Describe("ValidateConfig", func() {
 				})
 			})
 
-			Describe("checking for unknown fields", func() {
-				basicStep := func() atc.StepConfig {
-					return &atc.TaskStep{
-						Name:       "task",
-						ConfigPath: "some-file",
-					}
-				}
-
-				stepWithUnknownFields := func() atc.Step {
-					return atc.Step{
-						Config:        basicStep(),
+			Context("when a step has unknown fields", func() {
+				BeforeEach(func() {
+					job.PlanSequence = append(job.PlanSequence, atc.Step{
+						Config: &atc.TaskStep{
+							Name:       "task",
+							ConfigPath: "some-file",
+						},
 						UnknownFields: map[string]*json.RawMessage{"bogus": nil},
-					}
-				}
-
-				for _, test := range []struct {
-					name   string
-					config atc.StepConfig
-				}{
-					{
-						name: "on_success",
-						config: &atc.OnSuccessStep{
-							Step: basicStep(),
-							Hook: stepWithUnknownFields(),
-						},
-					},
-					{
-						name: "on_failure",
-						config: &atc.OnFailureStep{
-							Step: basicStep(),
-							Hook: stepWithUnknownFields(),
-						},
-					},
-					{
-						name: "on_error",
-						config: &atc.OnErrorStep{
-							Step: basicStep(),
-							Hook: stepWithUnknownFields(),
-						},
-					},
-					{
-						name: "on_abort",
-						config: &atc.OnAbortStep{
-							Step: basicStep(),
-							Hook: stepWithUnknownFields(),
-						},
-					},
-					{
-						name: "ensure",
-						config: &atc.EnsureStep{
-							Step: basicStep(),
-							Hook: stepWithUnknownFields(),
-						},
-					},
-					{
-						name: "try",
-						config: &atc.TryStep{
-							Step: stepWithUnknownFields(),
-						},
-					},
-					{
-						name: "do[0]",
-						config: &atc.DoStep{
-							Steps: []atc.Step{stepWithUnknownFields()},
-						},
-					},
-					{
-						name: "in_parallel.steps[0]",
-						config: &atc.InParallelStep{
-							Config: atc.InParallelConfig{
-								Steps: []atc.Step{stepWithUnknownFields()},
-							},
-						},
-					},
-					{
-						name: "aggregate[0]",
-						config: &atc.AggregateStep{
-							Steps: []atc.Step{stepWithUnknownFields()},
-						},
-					},
-				} {
-					test := test
-
-					Context("when an "+test.name+" step has unknown fields", func() {
-						BeforeEach(func() {
-							job.PlanSequence = append(job.PlanSequence, atc.Step{
-								Config: test.config,
-							})
-
-							config.Jobs = append(config.Jobs, job)
-						})
-
-						It("returns an error", func() {
-							Expect(errorMessages).To(HaveLen(1))
-							Expect(errorMessages[0]).To(ContainSubstring(`jobs.some-other-job.plan.do[0].` + test.name + `: unknown fields ["bogus"]`))
-						})
 					})
-				}
+
+					config.Jobs = append(config.Jobs, job)
+				})
+
+				It("returns an error", func() {
+					Expect(errorMessages).To(HaveLen(1))
+					Expect(errorMessages[0]).To(ContainSubstring(`jobs.some-other-job.plan.do[0]: unknown fields ["bogus"]`))
+				})
 			})
 		})
 

--- a/atc/job_config.go
+++ b/atc/job_config.go
@@ -29,6 +29,10 @@ type BuildLogRetention struct {
 	Days                   int `json:"days,omitempty"`
 }
 
+func (config JobConfig) Step() Step {
+	return Step{Config: config.StepConfig()}
+}
+
 func (config JobConfig) StepConfig() StepConfig {
 	var step StepConfig = &DoStep{
 		Steps: config.PlanSequence,


### PR DESCRIPTION
Sibling PR to #5878 for the 6.4.x release branch

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
