### PR TITLE
fly: always warn on set-pipeline if pipeline is paused

### DIFF
--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -78,11 +78,18 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 		return err
 	}
 
+	updatedConfig, found, err := atcConfig.Team.Pipeline(atcConfig.PipelineName)
+	if err != nil {
+		return err
+	}
+
+	paused := found && updatedConfig.Paused
+
 	if len(warnings) > 0 {
 		displayhelpers.ShowWarnings(warnings)
 	}
 
-	atcConfig.showPipelineUpdateResult(created, updated)
+	atcConfig.showPipelineUpdateResult(created, updated, paused)
 	return nil
 }
 
@@ -90,7 +97,7 @@ func (atcConfig ATCConfig) UnpausePipelineCommand() string {
 	return fmt.Sprintf("%s -t %s unpause-pipeline -p %s", os.Args[0], atcConfig.TargetName, atcConfig.PipelineName)
 }
 
-func (atcConfig ATCConfig) showPipelineUpdateResult(created bool, updated bool) {
+func (atcConfig ATCConfig) showPipelineUpdateResult(created bool, updated bool, paused bool) {
 	if updated {
 		fmt.Println("configuration updated")
 	} else if created {
@@ -107,13 +114,16 @@ func (atcConfig ATCConfig) showPipelineUpdateResult(created bool, updated bool) 
 
 		fmt.Println("pipeline created!")
 		fmt.Printf("you can view your pipeline here: %s\n", targetURL.ResolveReference(pipelineURL))
+	} else {
+		panic("Something really went wrong!")
+	}
+
+	if paused {
 		fmt.Println("")
 		fmt.Println("the pipeline is currently paused. to unpause, either:")
 		fmt.Println("  - run the unpause-pipeline command:")
 		fmt.Println("    " + atcConfig.UnpausePipelineCommand())
 		fmt.Println("  - click play next to the pipeline in the web ui")
-	} else {
-		panic("Something really went wrong!")
 	}
 }
 

--- a/fly/integration/set_pipeline_test.go
+++ b/fly/integration/set_pipeline_test.go
@@ -210,6 +210,9 @@ var _ = Describe("Fly CLI", func() {
 					path, err := atc.Routes.CreatePathForRoute(atc.SaveConfig, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
 					Expect(err).NotTo(HaveOccurred())
 
+					path_get, err := atc.Routes.CreatePathForRoute(atc.GetPipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+					Expect(err).NotTo(HaveOccurred())
+
 					config = atc.Config{
 						Groups: atc.GroupConfigs{},
 
@@ -250,6 +253,10 @@ var _ = Describe("Fly CLI", func() {
 							},
 						),
 					)
+
+					atcServer.RouteToHandler("GET", path_get,
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Pipeline{Name: "awesome-pipeline", Paused: false, TeamName: "main"}),
+					)
 				})
 
 				It("parses the config file and sends it to the ATC", func() {
@@ -277,7 +284,7 @@ var _ = Describe("Fly CLI", func() {
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(3))
+					}).By(4))
 				})
 
 				Context("when a non-stringy var is specified with -v", func() {
@@ -345,7 +352,7 @@ var _ = Describe("Fly CLI", func() {
 							Expect(sess.ExitCode()).To(Equal(0))
 						}).To(Change(func() int {
 							return len(atcServer.ReceivedRequests())
-						}).By(3))
+						}).By(4))
 					})
 				})
 
@@ -372,7 +379,7 @@ var _ = Describe("Fly CLI", func() {
 
 						}).To(Change(func() int {
 							return len(atcServer.ReceivedRequests())
-						}).By(3))
+						}).By(4))
 					})
 				})
 			})
@@ -431,6 +438,13 @@ this is super secure
 							},
 						),
 					)
+
+					path_get, err := atc.Routes.CreatePathForRoute(atc.GetPipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+					Expect(err).NotTo(HaveOccurred())
+
+					atcServer.RouteToHandler("GET", path_get,
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Pipeline{Name: "awesome-pipeline", Paused: false, TeamName: "main"}),
+					)
 				})
 
 				It("succeeds", func() {
@@ -452,7 +466,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(3))
+					}).By(4))
 				})
 			})
 
@@ -510,6 +524,13 @@ this is super secure
 							},
 						),
 					)
+
+					path_get, err := atc.Routes.CreatePathForRoute(atc.GetPipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+					Expect(err).NotTo(HaveOccurred())
+
+					atcServer.RouteToHandler("GET", path_get,
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Pipeline{Name: "awesome-pipeline", Paused: false, TeamName: "main"}),
+					)
 				})
 
 				It("succeeds", func() {
@@ -533,7 +554,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(3))
+					}).By(4))
 				})
 			})
 
@@ -591,6 +612,13 @@ this is super secure
 							},
 						),
 					)
+
+					path_get, err := atc.Routes.CreatePathForRoute(atc.GetPipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+					Expect(err).NotTo(HaveOccurred())
+
+					atcServer.RouteToHandler("GET", path_get,
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Pipeline{Name: "awesome-pipeline", Paused: false, TeamName: "main"}),
+					)
 				})
 
 				It("succeeds, sending the remaining vars uninterpolated", func() {
@@ -611,7 +639,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(3))
+					}).By(4))
 				})
 
 				Context("when the --check-creds option is used", func() {
@@ -635,7 +663,7 @@ this is super secure
 								Expect(sess.ExitCode()).To(Equal(0))
 							}).To(Change(func() int {
 								return len(atcServer.ReceivedRequests())
-							}).By(3))
+							}).By(4))
 						})
 					})
 
@@ -714,6 +742,13 @@ this is super secure
 
 				atcServer.RouteToHandler("GET", path,
 					ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ConfigResponse{Config: config}, http.Header{atc.ConfigVersionHeader: {"42"}}),
+				)
+
+				path_get, err := atc.Routes.CreatePathForRoute(atc.GetPipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+				Expect(err).NotTo(HaveOccurred())
+
+				atcServer.RouteToHandler("GET", path_get,
+					ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Pipeline{Name: "awesome-pipeline", Paused: false, TeamName: "main"}),
 				)
 			})
 
@@ -831,7 +866,7 @@ this is super secure
 
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(3))
+					}).By(4))
 				})
 			})
 
@@ -945,7 +980,7 @@ this is super secure
 
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(3))
+					}).By(4))
 				})
 
 				It("bails if the user rejects the diff", func() {
@@ -990,6 +1025,12 @@ this is super secure
 								Name: "other-team",
 							}),
 						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v1/teams/other-team/pipelines/awesome-pipeline"),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Pipeline{
+								Name: "awesome-pipeline",
+							}),
+						),
 					)
 				})
 
@@ -1013,7 +1054,7 @@ this is super secure
 
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 
 				It("bails if the user rejects the configuration", func() {
@@ -1069,23 +1110,8 @@ this is super secure
 				})
 			})
 
-			Context("when the server says this is the first time it's creating the pipeline", func() {
-				Context("when the user doesn't mention paused", func() {
-					BeforeEach(func() {
-						path, err := atc.Routes.CreatePathForRoute(atc.SaveConfig, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
-						Expect(err).NotTo(HaveOccurred())
-
-						atcServer.RouteToHandler("PUT", path, ghttp.CombineHandlers(
-							ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
-							func(w http.ResponseWriter, r *http.Request) {
-								config := getConfig(r)
-								Expect(config).To(MatchYAML(payload))
-							},
-							ghttp.RespondWith(http.StatusCreated, "{}"),
-						))
-						config.Resources[0].Name = "updated-name"
-					})
-
+			Context("when the pipeline is paused", func() {
+				AssertSuccessWithPausedPipelineHelp := func(expectCreationMessage bool) {
 					It("succeeds and prints an error message to help the user", func() {
 						Expect(func() {
 							flyCmd := exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "awesome-pipeline", "-c", configFile.Name())
@@ -1099,10 +1125,12 @@ this is super secure
 							Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
 							yes(stdin)
 
-							pipelineURL := urljoiner.Join(atcServer.URL(), "teams/main/pipelines", "awesome-pipeline")
+							if expectCreationMessage {
+								pipelineURL := urljoiner.Join(atcServer.URL(), "teams/main/pipelines", "awesome-pipeline")
 
-							Eventually(sess).Should(gbytes.Say("pipeline created!"))
-							Eventually(sess).Should(gbytes.Say(fmt.Sprintf("you can view your pipeline here: %s", pipelineURL)))
+								Eventually(sess).Should(gbytes.Say("pipeline created!"))
+								Eventually(sess).Should(gbytes.Say(fmt.Sprintf("you can view your pipeline here: %s", pipelineURL)))
+							}
 
 							Eventually(sess).Should(gbytes.Say("the pipeline is currently paused. to unpause, either:"))
 							Eventually(sess).Should(gbytes.Say("  - run the unpause-pipeline command:"))
@@ -1113,8 +1141,60 @@ this is super secure
 							Expect(sess.ExitCode()).To(Equal(0))
 						}).To(Change(func() int {
 							return len(atcServer.ReceivedRequests())
-						}).By(3))
+						}).By(4))
 					})
+				}
+				
+				Context("when updating an existing pipeline", func(){
+					BeforeEach(func() {
+						path, err := atc.Routes.CreatePathForRoute(atc.SaveConfig, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+						Expect(err).NotTo(HaveOccurred())
+
+						path_get, err := atc.Routes.CreatePathForRoute(atc.GetPipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+						Expect(err).NotTo(HaveOccurred())
+
+						atcServer.RouteToHandler("PUT", path, ghttp.CombineHandlers(
+							ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
+							func(w http.ResponseWriter, r *http.Request) {
+								config := getConfig(r)
+								Expect(config).To(MatchYAML(payload))
+							},
+							ghttp.RespondWith(http.StatusOK, "{}"),
+						))
+
+						atcServer.RouteToHandler("GET", path_get, ghttp.RespondWithJSONEncoded(http.StatusOK,
+							atc.Pipeline{Name: "awesome-pipeline", Paused: true, TeamName: "main"}))
+						
+						config.Resources[0].Name = "updated-name"
+					})
+
+					AssertSuccessWithPausedPipelineHelp(false)
+				})
+
+				Context("when the pipeline is being created for the first time", func() {
+					BeforeEach(func() {
+						path, err := atc.Routes.CreatePathForRoute(atc.SaveConfig, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+						Expect(err).NotTo(HaveOccurred())
+
+						path_get, err := atc.Routes.CreatePathForRoute(atc.GetPipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+						Expect(err).NotTo(HaveOccurred())
+
+						atcServer.RouteToHandler("PUT", path, ghttp.CombineHandlers(
+							ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
+							func(w http.ResponseWriter, r *http.Request) {
+								config := getConfig(r)
+								Expect(config).To(MatchYAML(payload))
+							},
+							ghttp.RespondWith(http.StatusCreated, "{}"),
+						))
+
+						atcServer.RouteToHandler("GET", path_get, ghttp.RespondWithJSONEncoded(http.StatusOK,
+							atc.Pipeline{Name: "awesome-pipeline", Paused: true, TeamName: "main"}))
+						
+						config.Resources[0].Name = "updated-name"
+					})
+
+					AssertSuccessWithPausedPipelineHelp(true)
 				})
 			})
 
@@ -1159,7 +1239,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(3))
+					}).By(4))
 				})
 			})
 


### PR DESCRIPTION

## What does this PR accomplish?

Feature: The `fly set-pipeline` command printed a helpful hint about the pipeline being paused, on initial pipeline creation. Some users have reported being confused when they missed this message, tried to update a pipeline later on, and did not see builds running. That might happen because the pipeline was always paused, or because they didn't realize somebody else had paused it at some point in the several months since they last thought about it. This PR causes the helpful hint to be shown whenever the configuration of a paused pipeline is successfully created _or updated_.

## Changes proposed by this PR:

This is limited to the client side in `fly`. The `showPipelineUpdateResult` helper gets an extra flag `paused` to tweak its behavior depending on whether or not the pipeline is paused, and this controls the printed text in the obvious way. To determine the status, we make a call to `atc.GetPipeline`, which returns the `Paused` state (among other things), as this is not otherwise available from the `atc.SaveConfig` return.

Most of the delta is test changes, which are
1. Boilerplate addition of stub GetPipeline handlers, and accounting for it being invoked on successful paths.
2. Testing the actual functionality, in the `"when the pipeline is paused"` context block.

## Notes to reviewer:

I think the immediate invocation of GetPipeline just after SaveConfig _should_ be OK, but I'm a little worried there might be a data race.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [X] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [X] [Signed] all commits
- [X] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation] -- I don't believe this is documentable, and I didn't find existing docs that included `set-pipeline` output verbatim in the changed scenario
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
