### PR TITLE
release-notes: structure: update 6.4.x

### DIFF
--- a/release-notes/v6.4.0.md
+++ b/release-notes/v6.4.0.md
@@ -1,6 +1,6 @@
 #### <sub><sup><a name="5833" href="#5833">:link:</a></sup></sub> feature
 
-* Added a way of renaming pipeline resources while preserving version history by updating the resource name (as well as any reference in steps) and specifying its old name as [**`old_name`**](https://concourse-ci.org/resources.html#schema.resource.old_name). After the pipeline has been configured, the `old_name` field can be removed. #5833
+* @mouellet added a way of renaming pipeline resources while preserving version history by updating the resource name (as well as any reference in steps) and specifying its old name as [**`old_name`**](https://concourse-ci.org/resources.html#schema.resource.old_name). After the pipeline has been configured, the `old_name` field can be removed. #5833
 
 #### <sub><sup><a name="5777" href="#5777">:link:</a></sup></sub> feature
 
@@ -51,7 +51,7 @@
 
 #### <sub><sup><a name="5504" href="#5504">:link:</a></sup></sub> feature
 
-* Refactor existing step structure to simplify introducing new steps. The primary user facing change are different step validation messages. PR: #5504
+* Refactor existing step structure to simplify introducing new steps. The primary user facing changes are stricter validation and slightly different step validation messages. Previously, fields that were not part of a step wouldn't have failed validation,however, now they will. This will impact stateful actions such as `set-pipeline`. PR: #5504, #5878
 
 #### <sub><sup><a name="5729" href="#5729">:link:</a></sup></sub> feature
 


### PR DESCRIPTION
- add attribution for community PRs

## What does this PR accomplish?
Update 6.4.x release notes and shoutout for community PRs

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
