### PR TITLE
feat(load_var): add format trim and make it default

### DIFF
--- a/atc/exec/load_var_step.go
+++ b/atc/exec/load_var_step.go
@@ -175,6 +175,8 @@ func (step *LoadVarStep) fetchVars(
 		if err != nil {
 			return nil, InvalidLocalVarFile{file, "yaml", err}
 		}
+	case "trim":
+		value = strings.TrimSpace(string(fileContent))
 	case "raw":
 		value = string(fileContent)
 	default:
@@ -197,12 +199,12 @@ func (step *LoadVarStep) fileFormat(file string) (string, error) {
 		return format, nil
 	}
 
-	return "raw", nil
+	return "trim", nil
 }
 
 func (step *LoadVarStep) isValidFormat(format string) bool {
 	switch format {
-	case "raw", "yml", "yaml", "json":
+	case "raw", "trim", "yml", "yaml", "json":
 		return true
 	}
 	return false


### PR DESCRIPTION
## What does this PR accomplish?

Some resource types as well as tasks generate output files with tailing "\n", for example https://github.com/concourse/docker-image-resource#in-fetch-the-image-from-the-registry all output files have tailing "\n".

When `load_var` reads file as `raw` format, tailing "\n" may make following steps hard to use the var. For example:

```yaml
- load_var: image_repo
  file: image/repository

- load_var: image_tag
  file: image/tag

- some-step:
   params:
      uri: ((.:image_repo)):((.:image_tag))
```

The `uri` expects an image uri, like `some-image:some-tag`, but as `load_var` carries tailing newlines, `uri` will actually be `some-image:\nsome-tag\n". 

## Changes proposed by this PR:

Add a params `trim_raw` to `load_var` step, if true, then trim heading and trailing spaces of content reading from file.



## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
