### PR TITLE
Speed up querying for unencrypted builds 

### DIFF
--- a/atc/db/migration/migrations/1595347367_add_index_for_unencrypted_private_plans_to_builds.down.sql
+++ b/atc/db/migration/migrations/1595347367_add_index_for_unencrypted_private_plans_to_builds.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  DROP INDEX unencrypted_private_plans_build_idx;
+COMMIT;

--- a/atc/db/migration/migrations/1595347367_add_index_for_unencrypted_private_plans_to_builds.up.sql
+++ b/atc/db/migration/migrations/1595347367_add_index_for_unencrypted_private_plans_to_builds.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  CREATE INDEX unencrypted_private_plans_build_idx ON builds (id, private_plan) WHERE nonce IS NULL AND private_plan IS NOT NULL;
+COMMIT;


### PR DESCRIPTION
## What does this PR accomplish?
This index will help speed up the query that is run when we encrypt any plain text in the database. The query that I am referring to is this

https://github.com/concourse/concourse/blob/785b3ccadf83396e1a85026d8eb9dbf72c529d57/atc/db/open.go#L148-L153

which is currently being run whenever the web nodes start up and need to open a connection to the database. The specific query that this index speeds up is `SELECT id, private_plan FROM builds WHERE nonce IS NULL AND private_plan IS NOT NULL;`. If I run an explain analyze on it on our large scale environment, it takes approximately 1 minute to complete. 

```
Seq Scan on builds  (cost=0.00..401990.09 rows=1 width=36) (actual time=73848.522..73848.522 rows=0 loops=1)
  Filter: ((nonce IS NULL) AND (private_plan IS NOT NULL))
  Rows Removed by Filter: 4445258
Planning time: 1.491 ms
Execution time: 73848.566 ms
```

But after I added the index it takes around 0.02 ms to complete.

```
Index Only Scan using builds_id_private_plan_idx on builds  (cost=0.12..6.07 rows=1 width=36) (actual time=0.002..0.002 rows=0 loops=1)
  Heap Fetches: 0
Planning time: 0.447 ms
Execution time: 0.026 ms
```

closes #5899.

## Release Note

If your environment had a large number of builds and an encrypted database, you might have noticed your web node being slow to start up. An index was added to help speed up the querying of unencrypted builds which is run during the web startup. 

## Contributor Checklist
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
