### PR TITLE
Edit pr template to include new release note generation process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 <!--
 Hi there! Thanks for submitting a pull request to Concourse!
+
+Please ensure your PR title is appropriate because it will be used to generate
+the release note.
+
 To help us review your PR, please fill in the following information.
 -->
 
@@ -24,6 +28,13 @@ Leave a message to whoever is going to review this PR.
 Mainly, pointers to review the PR, and how they can test it.
 -->
 
+## Release Note
+<!--
+If needed, you can leave a detailed description here which will be used to
+generate the release note for the next version of Concourse. The title of the
+PR will also be pulled into the release note.
+-->
+
 ## Contributor Checklist
 <!--
 Most of the PRs should have the following added to them,
@@ -33,14 +44,13 @@ this doesn't apply to all PRs, so it is helpful to tell us what you did.
 - [ ] [Signed] all commits
 - [ ] Added tests (Unit and/or Integration)
 - [ ] Updated [Documentation]
-- [ ] Updated [Release notes]
+- [ ] Added release note (Optional)
 
 [Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
 [Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
 [Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
 [Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
 [Documentation]: https://github.com/concourse/docs
-[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes
 
 ## Reviewer Checklist
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,15 +2,18 @@
 Hi there! Thanks for submitting a pull request to Concourse!
 
 The title of your pull request will be used to generate the release notes.
-Please make if a brief sentence that describes the PR in the imperative form.
-Please refrain from adding prefixes like 'feature:', and don't include a period
-at the end. We will edit the title if needed so don't worry about getting it
-perfect!
+Please provide a brief sentence that describes the PR, using the [imperative
+mood]. Please refrain from adding prefixes like 'feature:', and don't include a
+period at the end.
 
 Examples: "Add feature to doohickey", "Fix panic during spline reticulation"
 
+We will edit the title if needed so don't worry about getting it perfect!
+
 To help us review your PR, please fill in the following information.
 -->
+
+[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
 
 ## What does this PR accomplish?
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,12 @@
 <!--
 Hi there! Thanks for submitting a pull request to Concourse!
 
-Please ensure your PR title is appropriate because it will be used to generate
-the release note.
+The title of your pull request will be used to generate the release notes.
+Please make if a brief sentence that describes the PR in the imperative form.
+Please refrain from adding prefixes like 'feature:', and don't include a period
+at the end. (Thank you!)
+
+Examples: "Add feature to doohickey", "Fix panic during spline reticulation"
 
 To help us review your PR, please fill in the following information.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,8 @@ Hi there! Thanks for submitting a pull request to Concourse!
 The title of your pull request will be used to generate the release notes.
 Please make if a brief sentence that describes the PR in the imperative form.
 Please refrain from adding prefixes like 'feature:', and don't include a period
-at the end. (Thank you!)
+at the end. We will edit the title if needed so don't worry about getting it
+perfect!
 
 Examples: "Add feature to doohickey", "Fix panic during spline reticulation"
 


### PR DESCRIPTION
## What does this PR accomplish?

Documentation

Edited the pr template to respect the new release note generation process. The title will be used to generate the release note for each pull request and the author also has the option of adding a description to the release note for the changes made in the pr under the `## Release Note` header.

#5768 

## Contributor Checklist
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
