### PR TITLE
db: behaviour: save disable_manual_trigger on job

### DIFF
--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -84,6 +84,10 @@ var _ = Describe("Job", func() {
 				{
 					Name: "job-2",
 				},
+				{
+					Name: "non-triggerable-job",
+					DisableManualTrigger: true,
+				},
 			},
 			Resources: atc.ResourceConfigs{
 				{
@@ -127,6 +131,26 @@ var _ = Describe("Job", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(otherJob.Public()).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("DisableManualTrigger", func() {
+		Context("when the config has disable_manual_trigger set to true", func() {
+			It("returns true", func() {
+				nonTriggerableJob, found, err := pipeline.Job("non-triggerable-job")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+				Expect(nonTriggerableJob.DisableManualTrigger()).To(BeTrue())
+			})
+		})
+
+		Context("when the config does not have disable_manual_trigger set", func() {
+			It("returns false", func() {
+				otherJob, found, err := pipeline.Job("some-other-job")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+				Expect(otherJob.DisableManualTrigger()).To(BeFalse())
 			})
 		})
 	})

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -1062,9 +1062,9 @@ func saveJob(tx Tx, job atc.JobConfig, pipelineID int, groups []string) (int, er
 
 	var jobID int
 	err = psql.Insert("jobs").
-		Columns("name", "pipeline_id", "config", "public", "max_in_flight", "interruptible", "active", "nonce", "tags").
-		Values(job.Name, pipelineID, encryptedPayload, job.Public, job.MaxInFlight(), job.Interruptible, true, nonce, pq.Array(groups)).
-		Suffix("ON CONFLICT (name, pipeline_id) DO UPDATE SET config = EXCLUDED.config, public = EXCLUDED.public, max_in_flight = EXCLUDED.max_in_flight, interruptible = EXCLUDED.interruptible, active = EXCLUDED.active, nonce = EXCLUDED.nonce, tags = EXCLUDED.tags").
+		Columns("name", "pipeline_id", "config", "public", "max_in_flight", "disable_manual_trigger", "interruptible", "active", "nonce", "tags").
+		Values(job.Name, pipelineID, encryptedPayload, job.Public, job.MaxInFlight(), job.DisableManualTrigger, job.Interruptible, true, nonce, pq.Array(groups)).
+		Suffix("ON CONFLICT (name, pipeline_id) DO UPDATE SET config = EXCLUDED.config, public = EXCLUDED.public, max_in_flight = EXCLUDED.max_in_flight, disable_manual_trigger = EXCLUDED.disable_manual_trigger, interruptible = EXCLUDED.interruptible, active = EXCLUDED.active, nonce = EXCLUDED.nonce, tags = EXCLUDED.tags").
 		Suffix("RETURNING id").
 		RunWith(tx).
 		QueryRow().


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #5906.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
Very small change to a query, and added a test -- this feature seems to have regressed in #4933 when we did some refactoring of the database. While there _was_ a wats acceptance test covering this, I still think a DB test is much more economical.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->
If you use the pipeline in the linked issue you should see that the code on master allows you to trigger the job, whereas with this change you will get the expected 409 Conflict when you attempt to trigger the job.

## Release Note

Fixed the [`disable_manual_trigger:`](https://concourse-ci.org/jobs.html#schema.job.disable_manual_trigger) field on jobs -- since v6.0.0 it had no effect and jobs with this setting could actually still be manually triggered.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] ~Updated [Documentation]~
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
