### PR TITLE
Return error when a step only contains modifiers

### DIFF
--- a/atc/steps.go
+++ b/atc/steps.go
@@ -18,6 +18,7 @@ type Step struct {
 // ErrNoStepConfigured is returned when a step does not have any keys that
 // indicate its step type.
 var ErrNoStepConfigured = errors.New("no step configured")
+var ErrNoCoreStepDeclared = errors.New("no core step type declared (e.g. get, put, task, etc.)")
 
 // UnmarshalJSON unmarshals step configuration in multiple passes, determining
 // precedence by the order of StepDetectors listed in the StepPrecedence
@@ -92,7 +93,7 @@ func (step *Step) UnmarshalJSON(data []byte) error {
 	}
 
 	if !coreStepDeclared {
-		return errors.New("no core step type declared (e.g. get, put, task, etc.)")
+		return ErrNoCoreStepDeclared
 	}
 
 	if len(deferred) != 0 {

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -172,8 +172,8 @@ type StepWrapper interface {
 	// Wrap is called during (Step).UnmarshalJSON whenever an 'inner' step is
 	// parsed.
 	//
-	// Modifier step types should implement this by assigning a `json:"-"` tag to
-	// an internal field of type StepConfig in their struct.
+	// Modifier step types should implement this function by assigning to an
+	// internal field, that has a `json:"-"` tag, the passed in StepConfig.
 	Wrap(StepConfig)
 
 	// Unwrap is called during (Step).MarshalJSON and must return the wrapped

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -172,8 +172,8 @@ type StepWrapper interface {
 	// Wrap is called during (Step).UnmarshalJSON whenever an 'inner' step is
 	// parsed.
 	//
-	// Modifier step types should implement this function by assigning to an
-	// internal field, that has a `json:"-"` tag, the passed in StepConfig.
+	// Modifier step types should implement this function by assigning the
+	// passed in StepConfig to an internal field that has a `json:"-"` tag.
 	Wrap(StepConfig)
 
 	// Unwrap is called during (Step).MarshalJSON and must return the wrapped

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -441,3 +441,15 @@ func rawMessage(s string) *json.RawMessage {
 	raw := json.RawMessage(s)
 	return &raw
 }
+
+func (s *StepsSuite) TestModifierOnlyStepsAreInvalid() {
+	ConfigYAML := `
+			attempts: 2
+		`
+	cleanIndents := strings.ReplaceAll(ConfigYAML, "\t", "")
+
+	var step atc.Step
+	actualErr := yaml.Unmarshal([]byte(cleanIndents), &step)
+	s.Error(actualErr)
+	s.Contains(actualErr.Error(), "no core step type declared (e.g. get, put, task, etc.)")
+}


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #5869

## Changes proposed by this PR:
A small change to the json parsing logic used when parsing steps in a job plan. Basically adding a bool flag to let us know if a step contains any core step types or not. If none are found then an error is returned.

Now a user will get:
```
$ cat pipeline.yml
jobs:
- name: job
  plan:
  - attempts: 1
$ fly -t dev sp -p hope-this-doesnt-panic -c pipeline.yml
error: error unmarshaling JSON: while decoding JSON: no core step type declared (e.g. get, put, task, etc.)
```

## Notes to reviewer:
If you use an old version of fly you'll only get the error after hitting the API when trying to set the pipeline. If you recompile fly based on this branch then fly will catch the error locally.

**Open question:** The original issue is about a panic. This PR prevents the panic from happening now but there could still be other ways that a `Step` could be constructed with nils. Should we wrap these cases in `recovers`?
This is where the panic happens when you have a step that only contains a `RetryStep`(`attempts`). The `RetryStep.Step` field is nil, resulting in the panic. **What do you think??**
```go
// VisitRetry recurses through to the wrapped step.
func (recursor StepRecursor) VisitRetry(step *RetryStep) error {
	return step.Step.Visit(recursor)
}
```

## Contributor Checklist
- [x] Followed [Code of conduct]♥️, [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
