### PR TITLE
worker: prefix containerd specific flags with CONCOURSE_CONTAINERD

### DIFF
--- a/hack/overrides/containerd.yml
+++ b/hack/overrides/containerd.yml
@@ -8,4 +8,4 @@ version: '3'
 services:
   worker:
     environment:
-      CONCOURSE_GARDEN_USE_CONTAINERD: "true"
+      CONCOURSE_RUNTIME: containerd

--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -41,20 +41,20 @@ var _ = Describe("DNS Resolution", func() {
 	const containerdRuntime = "containerd"
 	const guardianRuntime = "guardian"
 
-	var setupDeployment = func(runtimeType string, dnsProxyEnable, dnsServer string) {
+	var setupDeployment = func(runtime string, dnsProxyEnable, dnsServer string) {
 		args := []string{
 			`--set=worker.replicas=1`,
-			`--set-string=concourse.worker.runtime.type=` + runtimeType,
+			`--set-string=concourse.worker.runtime=` + runtime,
 		}
 		switch {
-		case runtimeType == containerdRuntime:
+		case runtime == containerdRuntime:
 			args = append(args, `--set-string=concourse.worker.containerd.dnsProxyEnable=` + dnsProxyEnable)
 			if dnsServer != "" {
 				args = append(args,
 					`--set=worker.env[0].name=CONCOURSE_CONTAINERD_DNS_SERVER`,
 					`--set=worker.env[0].value=`+dnsServer)
 			}
-		case runtimeType == guardianRuntime:
+		case runtime == guardianRuntime:
 			args = append(args, `--set-string=concourse.worker.garden.dnsProxyEnable=` + dnsProxyEnable)
 			if dnsServer != "" {
 				args = append(args,
@@ -62,7 +62,7 @@ var _ = Describe("DNS Resolution", func() {
 					`--set=worker.env[0].value=`+dnsServer)
 			}
 		default:
-			fmt.Errorf("Invalid runtime type %s. Test aborted.", runtimeType)
+			fmt.Errorf("Invalid runtime type %s. Test aborted.", runtime)
 			return
 		}
 
@@ -70,10 +70,10 @@ var _ = Describe("DNS Resolution", func() {
 		atc = waitAndLogin(namespace, releaseName+"-web")
 	}
 
-	expectedDnsProxyBehaviour := func(runtimeType string) {
+	expectedDnsProxyBehaviour := func(runtime string) {
 		DescribeTable("different proxy settings",
 			func(c Case) {
-				setupDeployment(runtimeType, c.enableDnsProxy, c.dnsServer)
+				setupDeployment(runtime, c.enableDnsProxy, c.dnsServer)
 
 				sess := fly.Start("execute", "-c", "tasks/dns-proxy-task.yml", "-v", "url="+c.addressFunction())
 				<-sess.Exited

--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -37,28 +38,42 @@ var _ = Describe("DNS Resolution", func() {
 		shouldWork bool
 	}
 
-	var setupDeployment = func(useContainerd bool, dnsProxyEnable, dnsServer string) {
+	const containerdRuntime = "containerd"
+	const guardianRuntime = "guardian"
+
+	var setupDeployment = func(runtimeType string, dnsProxyEnable, dnsServer string) {
 		args := []string{
 			`--set=worker.replicas=1`,
-			`--set-string=concourse.worker.garden.dnsProxyEnable=` + dnsProxyEnable,
+			`--set-string=concourse.worker.runtime.type=` + runtimeType,
 		}
-		if useContainerd {
-			args = append(args, "--set=worker.garden.useContainerd=true")
-		}
-		if dnsServer != "" {
-			args = append(args,
-				`--set=worker.env[0].name=CONCOURSE_GARDEN_DNS_SERVER`,
-				`--set=worker.env[0].value=`+dnsServer)
+		switch {
+		case runtimeType == containerdRuntime:
+			args = append(args, `--set-string=concourse.worker.containerd.dnsProxyEnable=` + dnsProxyEnable)
+			if dnsServer != "" {
+				args = append(args,
+					`--set=worker.env[0].name=CONCOURSE_CONTAINERD_DNS_SERVER`,
+					`--set=worker.env[0].value=`+dnsServer)
+			}
+		case runtimeType == guardianRuntime:
+			args = append(args, `--set-string=concourse.worker.garden.dnsProxyEnable=` + dnsProxyEnable)
+			if dnsServer != "" {
+				args = append(args,
+					`--set=worker.env[0].name=CONCOURSE_GARDEN_DNS_SERVER`,
+					`--set=worker.env[0].value=`+dnsServer)
+			}
+		default:
+			fmt.Errorf("Invalid runtime type %s. Test aborted.", runtimeType)
+			return
 		}
 
 		deployConcourseChart(releaseName, args...)
 		atc = waitAndLogin(namespace, releaseName+"-web")
 	}
 
-	expectedDnsProxyBehaviour := func(useContainerd bool) {
+	expectedDnsProxyBehaviour := func(runtimeType string) {
 		DescribeTable("different proxy settings",
 			func(c Case) {
-				setupDeployment(useContainerd, c.enableDnsProxy, c.dnsServer)
+				setupDeployment(runtimeType, c.enableDnsProxy, c.dnsServer)
 
 				sess := fly.Start("execute", "-c", "tasks/dns-proxy-task.yml", "-v", "url="+c.addressFunction())
 				<-sess.Exited
@@ -106,10 +121,10 @@ var _ = Describe("DNS Resolution", func() {
 	}
 
 	Context("with gdn backend", func() {
-		expectedDnsProxyBehaviour(false)
+		expectedDnsProxyBehaviour(guardianRuntime)
 	})
 
 	Context("with containerd backend", func() {
-		expectedDnsProxyBehaviour(true)
+		expectedDnsProxyBehaviour(containerdRuntime)
 	})
 })

--- a/worker/integration/integration_test.go
+++ b/worker/integration/integration_test.go
@@ -44,7 +44,7 @@ func (s *WorkerRunnerSuite) BeforeTest(suiteName, testName string) {
 
 func (s *WorkerRunnerSuite) TestWorkDirIsCreated() {
 	s.wrkcmd.WorkDir = "somedir"
-	s.wrkcmd.Runtime.Type = "containerd"
+	s.wrkcmd.Runtime = "containerd"
 
 	_, err := s.wrkcmd.Runner([]string{})
 	s.NoError(err)

--- a/worker/integration/integration_test.go
+++ b/worker/integration/integration_test.go
@@ -44,7 +44,7 @@ func (s *WorkerRunnerSuite) BeforeTest(suiteName, testName string) {
 
 func (s *WorkerRunnerSuite) TestWorkDirIsCreated() {
 	s.wrkcmd.WorkDir = "somedir"
-	s.wrkcmd.Garden.UseContainerd = true
+	s.wrkcmd.Runtime.Type = "containerd"
 
 	_, err := s.wrkcmd.Runner([]string{})
 	s.NoError(err)

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -123,8 +123,8 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 		return nil, err
 	}
 
-	if cmd.Garden.Config.Path() != "" {
-		config = cmd.Garden.Config.Path()
+	if cmd.Containerd.Config.Path() != "" {
+		config = cmd.Containerd.Config.Path()
 	} else {
 		err := writeDefaultContainerdConfig(config)
 		if err != nil {
@@ -132,8 +132,8 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 		}
 	}
 
-	if cmd.Garden.Bin != "" {
-		bin = cmd.Garden.Bin
+	if cmd.Containerd.Bin != "" {
+		bin = cmd.Containerd.Bin
 	}
 
 	command := exec.Command(bin,
@@ -150,9 +150,9 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 
 	members := grouper.Members{}
 
-	dnsServers := cmd.Garden.DNSServers
-	if cmd.Garden.DNS.Enable {
-		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
+	dnsServers := cmd.Containerd.DNSServers
+	if cmd.Containerd.DNS.Enable {
+ 		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
 		if err != nil {
 			return nil, err
 		}
@@ -177,11 +177,11 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 		logger,
 		cmd.bindAddr(),
 		sock,
-		cmd.Garden.RequestTimeout,
+		cmd.Containerd.RequestTimeout,
 		dnsServers,
-		cmd.ContainerNetworkPool,
-		cmd.Garden.MaxContainers,
-		cmd.Garden.DenyNetworks,
+		cmd.Containerd.NetworkPool,
+		cmd.Containerd.MaxContainers,
+		cmd.Containerd.DenyNetworks,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("containerd garden server runner: %w", err)

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -181,7 +181,7 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 		dnsServers,
 		cmd.Containerd.NetworkPool,
 		cmd.Containerd.MaxContainers,
-		cmd.Containerd.DenyNetworks,
+		cmd.Containerd.RestrictedNetworks,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("containerd garden server runner: %w", err)

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -104,9 +104,6 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 	return grouper.NewParallel(os.Interrupt, members), nil
 }
 
-// For historical reasons this is "CONCOURSE_GARDEN_" instead of "CONCOURSE_GUARDIAN_"
-var guardianEnvPrefix = "CONCOURSE_GARDEN_"
-
 func detectGuardianFlags(logger lager.Logger) []string {
 	env := os.Environ()
 

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -17,7 +17,8 @@ import (
 	"github.com/tedsuo/ifrit/grouper"
 )
 
-// This runs Guardian using the gdn binary
+// This prepares the Guardian runtime using the gdn binary.
+// The gdn binary exposes Guardian's functionality via a Garden server.
 func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, error) {
 	depotDir := filepath.Join(cmd.WorkDir.Path(), "depot")
 
@@ -30,9 +31,7 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 
 	members := grouper.Members{}
 
-	gdnFlags := []string{}
-
-	gdnServerFlags := []string{
+	gdnFlags := []string{
 		"--bind-ip", cmd.BindIP.IP.String(),
 		"--bind-port", fmt.Sprintf("%d", cmd.BindPort),
 
@@ -46,9 +45,9 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 		"--no-image-plugin",
 	}
 
-	gdnServerFlags = append(gdnServerFlags, detectGardenFlags(logger)...)
+	gdnFlags = append(gdnFlags, detectGuardianFlags(logger)...)
 
-	if cmd.Garden.DNS.Enable {
+	if cmd.Guardian.DNS.Enable {
 		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
 		if err != nil {
 			return nil, err
@@ -67,18 +66,18 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 			),
 		})
 
-		gdnServerFlags = append(gdnServerFlags, "--dns-server", lip)
+		gdnFlags = append(gdnFlags, "--dns-server", lip)
 
 		// must permit access to host network in order for DNS proxy address to be
 		// reachable
-		gdnServerFlags = append(gdnServerFlags, "--allow-host-access")
+		gdnFlags = append(gdnFlags, "--allow-host-access")
 	}
 
-	gdnArgs := append(gdnFlags, append([]string{"server"}, gdnServerFlags...)...)
+	gdnArgs := append([]string{"server"}, gdnFlags...)
 
 	bin := "gdn"
-	if cmd.Garden.Bin != "" {
-		bin = cmd.Garden.Bin
+	if cmd.Guardian.Bin != "" {
+		bin = cmd.Guardian.Bin
 	}
 
 	gdnCmd := exec.Command(bin, gdnArgs...)
@@ -99,9 +98,10 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 	return grouper.NewParallel(os.Interrupt, members), nil
 }
 
-var gardenEnvPrefix = "CONCOURSE_GARDEN_"
+// For historical reasons this is "CONCOURSE_GARDEN_" instead of "CONCOURSE_GUARDIAN_"
+var guardianEnvPrefix = "CONCOURSE_GARDEN_"
 
-func detectGardenFlags(logger lager.Logger) []string {
+func detectGuardianFlags(logger lager.Logger) []string {
 	env := os.Environ()
 
 	flags := []string{}
@@ -115,11 +115,11 @@ func detectGardenFlags(logger lager.Logger) []string {
 		name := spl[0]
 		val := spl[1]
 
-		if !strings.HasPrefix(name, gardenEnvPrefix) {
+		if !strings.HasPrefix(name, guardianEnvPrefix) {
 			continue
 		}
 
-		strip := strings.Replace(name, gardenEnvPrefix, "", 1)
+		strip := strings.Replace(name, guardianEnvPrefix, "", 1)
 		flag := flagify(strip)
 
 		logger.Info("forwarding-garden-env-var", lager.Data{

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -33,10 +32,6 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 
 	gdnFlags := []string{}
 
-	if cmd.Garden.Config.Path() != "" {
-		gdnFlags = append(gdnFlags, "--config", cmd.Garden.Config.Path())
-	}
-
 	gdnServerFlags := []string{
 		"--bind-ip", cmd.BindIP.IP.String(),
 		"--bind-port", fmt.Sprintf("%d", cmd.BindPort),
@@ -49,22 +44,6 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 		// disable graph and grootfs setup; all images passed to Concourse
 		// containers are raw://
 		"--no-image-plugin",
-	}
-
-	for _, dnsServer := range cmd.Garden.DNSServers {
-		gdnServerFlags = append(gdnServerFlags, "--dns-server", dnsServer)
-	}
-
-	for _, denyNetwork := range cmd.Garden.DenyNetworks {
-		gdnServerFlags = append(gdnServerFlags, "--deny-network", denyNetwork)
-	}
-
-	if cmd.ContainerNetworkPool != "" {
-		gdnServerFlags = append(gdnServerFlags, "--network-pool", cmd.ContainerNetworkPool)
-	}
-
-	if cmd.Garden.MaxContainers != 0 {
-		gdnServerFlags = append(gdnServerFlags, "--max-containers", strconv.Itoa(cmd.Garden.MaxContainers))
 	}
 
 	gdnServerFlags = append(gdnServerFlags, detectGardenFlags(logger)...)

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -48,9 +48,11 @@ type WorkerCommand struct {
 
 	ConnectionDrainTimeout time.Duration `long:"connection-drain-timeout" default:"1h" description:"Duration after which a worker should give up draining forwarded connections on shutdown."`
 
-	Garden GardenBackend `group:"Garden Configuration" namespace:"garden"`
+	// This refers to flags relevant to the operation of the Guardian runtime.
+	// For historical reasons it is namespaced under "garden" i.e. CONCOURSE_GARDEN instead of "guardian" i.e. CONCOURSE_GUARDIAN
+	Guardian GuardianRuntime `group:"Guardian Configuration" namespace:"garden"`
 
-	Containerd ContainerdBackend `group:"Containerd Configuration" namespace:"containerd"`
+	Containerd ContainerdRuntime `group:"Containerd Configuration" namespace:"containerd"`
 
 	Runtime Runtime `group:"Runtime Configuration" namespace:"runtime"`
 
@@ -111,7 +113,7 @@ func (cmd *WorkerCommand) Runner(args []string) (ifrit.Runner, error) {
 
 	gardenClient := gclient.BasicGardenClientWithRequestTimeout(
 		logger.Session("garden-connection"),
-		cmd.Garden.RequestTimeout,
+		cmd.Guardian.RequestTimeout,
 		cmd.gardenURL(),
 	)
 

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -48,13 +48,13 @@ type WorkerCommand struct {
 
 	ConnectionDrainTimeout time.Duration `long:"connection-drain-timeout" default:"1h" description:"Duration after which a worker should give up draining forwarded connections on shutdown."`
 
+	Runtime Runtime `group:"Runtime Configuration" namespace:"runtime"`
+
 	// This refers to flags relevant to the operation of the Guardian runtime.
 	// For historical reasons it is namespaced under "garden" i.e. CONCOURSE_GARDEN instead of "guardian" i.e. CONCOURSE_GUARDIAN
 	Guardian GuardianRuntime `group:"Guardian Configuration" namespace:"garden"`
 
 	Containerd ContainerdRuntime `group:"Containerd Configuration" namespace:"containerd"`
-
-	Runtime Runtime `group:"Runtime Configuration" namespace:"runtime"`
 
 	ExternalGardenURL flag.URL `long:"external-garden-url" description:"API endpoint of an externally managed Garden server to use instead of running the embedded Garden server."`
 
@@ -81,7 +81,7 @@ func (cmd *WorkerCommand) Runner(args []string) (ifrit.Runner, error) {
 
 	logger, _ := cmd.Logger.Logger("worker")
 
-	atcWorker, gardenRunner, err := cmd.gardenRunner(logger.Session("garden"))
+	atcWorker, gardenServerRunner, err := cmd.gardenServerRunner(logger.Session("garden"))
 	if err != nil {
 		return nil, err
 	}
@@ -155,10 +155,10 @@ func (cmd *WorkerCommand) Runner(args []string) (ifrit.Runner, error) {
 
 	var members grouper.Members
 
-	if !cmd.gardenIsExternal() {
+	if !cmd.gardenServerIsExternal() {
 		members = append(members, grouper.Member{
 			Name:   "garden",
-			Runner: concourseCmd.NewLoggingRunner(logger.Session("garden-runner"), gardenRunner),
+			Runner: concourseCmd.NewLoggingRunner(logger.Session("garden-runner"), gardenServerRunner),
 		})
 	}
 
@@ -213,12 +213,12 @@ func (cmd *WorkerCommand) Runner(args []string) (ifrit.Runner, error) {
 	return grouper.NewParallel(os.Interrupt, members), nil
 }
 
-func (cmd *WorkerCommand) gardenIsExternal() bool {
+func (cmd *WorkerCommand) gardenServerIsExternal() bool {
 	return cmd.ExternalGardenURL.URL != nil
 }
 
 func (cmd *WorkerCommand) gardenAddr() string {
-	if cmd.gardenIsExternal() {
+	if cmd.gardenServerIsExternal() {
 		return cmd.ExternalGardenURL.URL.Host
 	}
 

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -40,8 +40,6 @@ type WorkerCommand struct {
 	HealthcheckBindPort uint16        `long:"healthcheck-bind-port"  default:"8888"     description:"Port on which to listen for health checking requests."`
 	HealthCheckTimeout  time.Duration `long:"healthcheck-timeout"    default:"5s"       description:"HTTP timeout for the full duration of health checking."`
 
-	ContainerNetworkPool string `long:"container-network-pool" description:"Network range to use for dynamically allocated container subnets."`
-
 	SweepInterval               time.Duration `long:"sweep-interval" default:"30s" description:"Interval on which containers and volumes will be garbage collected from the worker."`
 	VolumeSweeperMaxInFlight    uint16        `long:"volume-sweeper-max-in-flight" default:"3" description:"Maximum number of volumes which can be swept in parallel."`
 	ContainerSweeperMaxInFlight uint16        `long:"container-sweeper-max-in-flight" default:"5" description:"Maximum number of containers which can be swept in parallel."`

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -48,7 +48,7 @@ type WorkerCommand struct {
 
 	ConnectionDrainTimeout time.Duration `long:"connection-drain-timeout" default:"1h" description:"Duration after which a worker should give up draining forwarded connections on shutdown."`
 
-	Runtime Runtime `group:"Runtime Configuration" namespace:"runtime"`
+	RuntimeConfiguration `group:"Runtime Configuration"`
 
 	// This refers to flags relevant to the operation of the Guardian runtime.
 	// For historical reasons it is namespaced under "garden" i.e. CONCOURSE_GARDEN instead of "guardian" i.e. CONCOURSE_GUARDIAN

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -54,6 +54,8 @@ type WorkerCommand struct {
 
 	Containerd ContainerdBackend `group:"Containerd Configuration" namespace:"containerd"`
 
+	Runtime Runtime `group:"Runtime Configuration" namespace:"runtime"`
+
 	ExternalGardenURL flag.URL `long:"external-garden-url" description:"API endpoint of an externally managed Garden server to use instead of running the embedded Garden server."`
 
 	Baggageclaim baggageclaimcmd.BaggageclaimCommand `group:"Baggageclaim Configuration" namespace:"baggageclaim"`

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -52,6 +52,8 @@ type WorkerCommand struct {
 
 	Garden GardenBackend `group:"Garden Configuration" namespace:"garden"`
 
+	Containerd ContainerdBackend `group:"Containerd Configuration" namespace:"containerd"`
+
 	ExternalGardenURL flag.URL `long:"external-garden-url" description:"API endpoint of an externally managed Garden server to use instead of running the embedded Garden server."`
 
 	Baggageclaim baggageclaimcmd.BaggageclaimCommand `group:"Baggageclaim Configuration" namespace:"baggageclaim"`

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -25,15 +25,26 @@ type Certs struct {
 type GardenBackend struct {
 	UseHoudini    bool `long:"use-houdini"    description:"Use the insecure Houdini Garden backend."`
 	UseContainerd bool `long:"use-containerd" description:"Use the containerd backend. (experimental)"`
-
 	Bin            string        `long:"bin"        description:"Path to a garden backend executable (non-absolute names get resolved from $PATH)."`
 	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Garden backend. Guardian flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
 	DNSServers     []string      `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 	DenyNetworks   []string      `long:"deny-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
-
 	MaxContainers int `long:"max-containers" default:"0" description:"Max container capacity. 0 means no limit."`
+}
+
+type ContainerdBackend struct {
+	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Containerd binary."`
+	Bin            string        `long:"bin"        description:"Path to a containerd executable (non-absolute names get resolved from $PATH)."`
+	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
+
+	//TODO can this be simplifed to just a bool rather than struct with a bool?
+	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
+	DNSServers     []string      `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
+	DenyNetworks   []string      `long:"deny-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
+	MaxContainers int `long:"max-containers" default:"0" description:"Max container capacity. 0 means no limit."`
+	NetworkPool string `long:"network-pool" description:"Network range to use for dynamically allocated container subnets."`
 }
 
 func (cmd WorkerCommand) LessenRequirements(prefix string, command *flags.Command) {

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -23,21 +23,21 @@ type Certs struct {
 }
 
 type Runtime struct {
-	Type string `long:"type" default:"guardian" description:"Runtime to use with the worker. Possible values: guardian, containerd, houdini. Please note that Houdini is insecure and doesn't run 'tasks' in containers"`
+	Type string `long:"type" default:"guardian" description:"Runtime to use with the worker. Possible values: guardian, containerd, houdini. Please note that Houdini is insecure and doesn't run 'tasks' in containers."`
 }
 
-type GardenBackend struct {
+type GuardianRuntime struct {
 	Bin            string        `long:"bin"        description:"Path to a garden backend executable (non-absolute names get resolved from $PATH)."`
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
 }
 
-type ContainerdBackend struct {
+type ContainerdRuntime struct {
 	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Containerd binary."`
 	Bin            string        `long:"bin"        description:"Path to a containerd executable (non-absolute names get resolved from $PATH)."`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
 
-	//TODO can this be simplifed to just a bool rather than struct with a bool?
+	//TODO can DNSConfig be simplifed to just a bool rather than struct with a bool?
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 	DNSServers     []string      `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
 	DenyNetworks   []string      `long:"deny-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
@@ -124,7 +124,7 @@ func (cmd *WorkerCommand) checkRoot() error {
 }
 
 func (cmd *WorkerCommand) dnsProxyRunner(logger lager.Logger) (ifrit.Runner, error) {
-	server, err := cmd.Garden.DNS.Server()
+	server, err := cmd.Guardian.DNS.Server()
 	if err != nil {
 		return nil, err
 	}

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -43,7 +43,7 @@ type ContainerdRuntime struct {
 	DNSServers         []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
 	RestrictedNetworks []string  `long:"restricted-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
 	MaxContainers      int       `long:"max-containers" default:"0" description:"Max container capacity. 0 means no limit."`
-	NetworkPool        string    `long:"network-pool" description:"Network range to use for dynamically allocated container subnets."`
+	NetworkPool        string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
 }
 
 const containerdRuntime = "containerd"

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -28,12 +28,8 @@ type Runtime struct {
 
 type GardenBackend struct {
 	Bin            string        `long:"bin"        description:"Path to a garden backend executable (non-absolute names get resolved from $PATH)."`
-	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Garden backend. Guardian flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
-	DNSServers     []string      `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
-	DenyNetworks   []string      `long:"deny-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
-	MaxContainers int `long:"max-containers" default:"0" description:"Max container capacity. 0 means no limit."`
 }
 
 type ContainerdBackend struct {

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -93,14 +93,14 @@ func (cmd *WorkerCommand) gardenServerRunner(logger lager.Logger) (atc.Worker, i
 	var runner ifrit.Runner
 
 	switch {
-	case cmd.RuntimeConfiguration.Runtime == houdiniRuntime:
+	case cmd.Runtime == houdiniRuntime:
 		runner, err = cmd.houdiniRunner(logger)
-	case cmd.RuntimeConfiguration.Runtime == containerdRuntime:
+	case cmd.Runtime == containerdRuntime:
 		runner, err = cmd.containerdRunner(logger)
-	case cmd.RuntimeConfiguration.Runtime == guardianRuntime:
+	case cmd.Runtime == guardianRuntime:
 		runner, err = cmd.guardianRunner(logger)
 	default:
-		err = fmt.Errorf("unsupported Runtime :%s", cmd.RuntimeConfiguration.Runtime)
+		err = fmt.Errorf("unsupported Runtime :%s", cmd.Runtime)
 	}
 
 	if err != nil {
@@ -221,20 +221,20 @@ const containerdEnvPrefix = "CONCOURSE_CONTAINERD_"
 // Checks if runtime specific flags provided match the selected runtime type
 func (cmd *WorkerCommand) verifyRuntimeFlags() error {
 	switch {
-	case cmd.RuntimeConfiguration.Runtime == houdiniRuntime:
+	case cmd.Runtime == houdiniRuntime:
 		if cmd.hasFlags(guardianEnvPrefix)  || cmd.hasFlags(containerdEnvPrefix) {
 			return fmt.Errorf("cannot use %s or %s environment variables with Houdini", guardianEnvPrefix, containerdEnvPrefix)
 		}
-	case cmd.RuntimeConfiguration.Runtime == containerdRuntime:
+	case cmd.Runtime == containerdRuntime:
 		if cmd.hasFlags(guardianEnvPrefix) {
 			return fmt.Errorf("cannot use %s environment variables with Containerd", guardianEnvPrefix)
 		}
-	case cmd.RuntimeConfiguration.Runtime == guardianRuntime:
+	case cmd.Runtime == guardianRuntime:
 		if cmd.hasFlags(containerdEnvPrefix) {
 			return fmt.Errorf("cannot use %s environment variables with Guardian", containerdEnvPrefix)
 		}
 	default:
-		return fmt.Errorf("unsupported Runtime :%s", cmd.RuntimeConfiguration.Runtime)
+		return fmt.Errorf("unsupported Runtime :%s", cmd.Runtime)
 	}
 
 	return nil

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -29,6 +29,7 @@ type Runtime struct {
 
 type GuardianRuntime struct {
 	Bin            string        `long:"bin"        description:"Path to a garden server executable (non-absolute names get resolved from $PATH)."`
+	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Garden backend. Guardian flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 }

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -38,11 +38,11 @@ type ContainerdRuntime struct {
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
 
 	//TODO can DNSConfig be simplifed to just a bool rather than struct with a bool?
-	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
-	DNSServers     []string      `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
-	DenyNetworks   []string      `long:"deny-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
-	MaxContainers int `long:"max-containers" default:"0" description:"Max container capacity. 0 means no limit."`
-	NetworkPool string `long:"network-pool" description:"Network range to use for dynamically allocated container subnets."`
+	DNS                DNSConfig `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
+	DNSServers         []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
+	RestrictedNetworks []string  `long:"restricted-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
+	MaxContainers      int       `long:"max-containers" default:"0" description:"Max container capacity. 0 means no limit."`
+	NetworkPool        string    `long:"network-pool" description:"Network range to use for dynamically allocated container subnets."`
 }
 
 func (cmd WorkerCommand) LessenRequirements(prefix string, command *flags.Command) {

--- a/worker/workercmd/worker_nonlinux.go
+++ b/worker/workercmd/worker_nonlinux.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tedsuo/ifrit"
 )
 
-type Runtime struct {
+type RuntimeConfiguration struct {
 }
 
 type GuardianRuntime struct {

--- a/worker/workercmd/worker_nonlinux.go
+++ b/worker/workercmd/worker_nonlinux.go
@@ -15,11 +15,11 @@ import (
 type Runtime struct {
 }
 
-type GardenBackend struct {
-	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
+type GuardianRuntime struct {
+	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 }
 
-type ContainerdBackend struct {
+type ContainerdRuntime struct {
 }
 
 type Certs struct{}
@@ -29,7 +29,7 @@ func (cmd WorkerCommand) LessenRequirements(prefix string, command *flags.Comman
 	command.FindOptionByLongName(prefix + "baggageclaim-volumes").Required = false
 }
 
-func (cmd *WorkerCommand) gardenRunner(logger lager.Logger) (atc.Worker, ifrit.Runner, error) {
+func (cmd *WorkerCommand) gardenServerRunner(logger lager.Logger) (atc.Worker, ifrit.Runner, error) {
 	worker := cmd.Worker.Worker()
 	worker.Platform = runtime.GOOS
 	var err error

--- a/worker/workercmd/worker_nonlinux.go
+++ b/worker/workercmd/worker_nonlinux.go
@@ -12,6 +12,9 @@ import (
 	"github.com/tedsuo/ifrit"
 )
 
+type Runtime struct {
+}
+
 type GardenBackend struct {
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
 }

--- a/worker/workercmd/worker_nonlinux.go
+++ b/worker/workercmd/worker_nonlinux.go
@@ -16,6 +16,9 @@ type GardenBackend struct {
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
 }
 
+type ContainerdBackend struct {
+}
+
 type Certs struct{}
 
 func (cmd WorkerCommand) LessenRequirements(prefix string, command *flags.Command) {


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | Feature | Documentation

closes #5407.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

`containerd` specific flags have been put under their own namespace and are now prefixed with `CONCOURSE_CONTAINERD` to prevent confusing them with Guardian flags and features.

Guardian flags will still be prefixed with `CONCOURSE_GARDEN`. However, this PR changes many internal references to the terms Garden, Guardian, server, and backend to reduce ambiguity for developers.

Corresponding update to Helm chart: https://github.com/concourse/concourse-chart/pull/131
Corresponding update to BOSH release: https://github.com/concourse/concourse-bosh-release/pull/112
Corresponding updates to CI:
https://github.com/concourse/ci/pull/356
https://github.com/concourse/ci/pull/357

Remaining TODO:
- [x] Prevent mixed usage of containerd and guardian flags
- [x] Update Helm chart
- [x] Update BOSH release
- [x] Update containerd topgun/k8s test
- [x] Update CI `ignored-in-binary` and `ignored-in-distribution` lists to be compatible with updated binary, helm chart, and bosh release 

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->
We recommend going over individual commits and commit descriptions while reviewing.
 
## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
