### PR TITLE
web: favorite pipelines section on dashboard

### DIFF
--- a/web/assets/css/dashboard.less
+++ b/web/assets/css/dashboard.less
@@ -70,7 +70,7 @@
 
   .dashboard-team-name {
     font-size: (36px * @scale);
-    padding-right: 0.5em;
+    padding-right: 0.5rem;
   }
 
   .card {

--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -37,7 +37,7 @@ import Html.Lazy
 import Keyboard
 import Login.Login as Login
 import Maybe.Extra
-import Message.Message exposing (DomID(..), Message(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import RemoteData exposing (WebData)
 import Routes exposing (Highlight)
 import ScreenSize
@@ -89,7 +89,7 @@ main =
         Benchmark.describe "benchmark suite"
             [ Benchmark.compare "DashboardPreview.view"
                 "current"
-                (\_ -> DP.view HoverState.NoHover (DP.groupByRank sampleJobs))
+                (\_ -> DP.view AllPipelinesSection HoverState.NoHover (DP.groupByRank sampleJobs))
                 "old"
                 (\_ -> dashboardPreviewView sampleJobs)
             , Benchmark.compare "Build.view"

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -146,7 +146,7 @@ handleEvent event ( model, effects ) =
             )
 
         SelectedWorker origin output time ->
-            ( updateStep origin.id (setRunning << appendStepLog ("\u{001b}[1mselected worker: \u{001b}[0m" ++ output ++ "\n") time) model
+            ( updateStep origin.id (setRunning << appendStepLog ("\u{001B}[1mselected worker: \u{001B}[0m" ++ output ++ "\n") time) model
             , effects
             )
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -704,7 +704,7 @@ updateBody msg ( model, effects ) =
             , effects
             )
 
-        Click (PipelineButton _ pipelineId) ->
+        Click (PipelineCardPauseToggle _ pipelineId) ->
             let
                 isPaused =
                     model.pipelines
@@ -1192,7 +1192,6 @@ pipelinesView session params =
                             , pipelineJobs = params.pipelineJobs
                             , jobs = jobs
                             }
-                            favoritedPipelines
                         , Views.Styles.separator PipelineGridConstants.sectionSpacerHeight
                         , Html.div Styles.pipelineSectionHeader [ Html.text "all pipelines" ]
                         ]

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -704,7 +704,7 @@ updateBody msg ( model, effects ) =
             , effects
             )
 
-        Click (PipelineButton pipelineId) ->
+        Click (PipelineButton _ pipelineId) ->
             let
                 isPaused =
                     model.pipelines
@@ -724,7 +724,7 @@ updateBody msg ( model, effects ) =
                 Nothing ->
                     ( model, effects )
 
-        Click (VisibilityButton pipelineId) ->
+        Click (VisibilityButton _ pipelineId) ->
             let
                 isPublic =
                     model.pipelines
@@ -807,7 +807,7 @@ view session model =
 tooltip : { a | pipelines : Maybe (Dict String (List Pipeline)) } -> { b | hovered : HoverState.HoverState } -> Maybe Tooltip.Tooltip
 tooltip model { hovered } =
     case hovered of
-        HoverState.Tooltip (Message.PipelineStatusIcon _) _ ->
+        HoverState.Tooltip (Message.PipelineStatusIcon _ _) _ ->
             Just
                 { body =
                     Html.div
@@ -817,7 +817,7 @@ tooltip model { hovered } =
                 , arrow = Nothing
                 }
 
-        HoverState.Tooltip (Message.VisibilityButton pipelineId) _ ->
+        HoverState.Tooltip (Message.VisibilityButton _ pipelineId) _ ->
             model.pipelines
                 |> findPipeline pipelineId
                 |> Maybe.map

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1164,7 +1164,7 @@ pipelinesView session params =
                 else
                     let
                         offset =
-                            0
+                            PipelineGridConstants.sectionHeaderHeight
 
                         layout =
                             PipelineGrid.computeFavoritePipelinesLayout
@@ -1175,25 +1175,32 @@ pipelinesView session params =
                                 }
                                 favoritedPipelines
                     in
-                    Group.viewFavoritePipelines
-                        session
-                        { dragState = NotDragging
-                        , dropState = NotDropping
-                        , now = params.now
-                        , hovered = session.hovered
-                        , pipelineRunningKeyframes = session.pipelineRunningKeyframes
-                        , pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
-                        , pipelineLayers = params.pipelineLayers
-                        , pipelineCards = layout.pipelineCards
-                        , headers = layout.headers
-                        , groupCardsHeight = layout.height
-                        , pipelineJobs = params.pipelineJobs
-                        , jobs = jobs
-                        }
-                        favoritedPipelines
+                    Html.div []
+                        [ Html.div Styles.pipelineSectionHeader [ Html.text "favorite pipelines" ]
+                        , Group.viewFavoritePipelines
+                            session
+                            { dragState = NotDragging
+                            , dropState = NotDropping
+                            , now = params.now
+                            , hovered = session.hovered
+                            , pipelineRunningKeyframes = session.pipelineRunningKeyframes
+                            , pipelinesWithResourceErrors = params.pipelinesWithResourceErrors
+                            , pipelineLayers = params.pipelineLayers
+                            , pipelineCards = layout.pipelineCards
+                            , headers = layout.headers
+                            , groupCardsHeight = layout.height
+                            , pipelineJobs = params.pipelineJobs
+                            , jobs = jobs
+                            }
+                            favoritedPipelines
+                        , Views.Styles.separator PipelineGridConstants.sectionSpacerHeight
+                        , Html.div Styles.pipelineSectionHeader [ Html.text "all pipelines" ]
+                        ]
                         |> (\html ->
                                 ( html
                                 , layout.height
+                                    + (2 * PipelineGridConstants.sectionHeaderHeight)
+                                    + PipelineGridConstants.sectionSpacerHeight
                                 )
                            )
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1142,6 +1142,17 @@ pipelinesView session params =
             params.teams
                 |> FetchResult.withDefault []
 
+        filteredGroups =
+            Filter.filterGroups
+                { pipelineJobs = params.pipelineJobs
+                , jobs = jobs
+                , query = params.query
+                , teams = teams
+                , pipelines = pipelines
+                , dashboardView = params.dashboardView
+                }
+                |> List.sortWith (Group.ordering session)
+
         ( favoritesView, offsetHeight ) =
             if params.highDensity then
                 ( Html.text "", 0 )
@@ -1149,10 +1160,8 @@ pipelinesView session params =
             else
                 let
                     favoritedPipelines =
-                        params.pipelines
-                            |> Maybe.withDefault Dict.empty
-                            |> Dict.toList
-                            |> List.concatMap Tuple.second
+                        filteredGroups
+                            |> List.concatMap .pipelines
                             |> List.filter
                                 (\fp ->
                                     Set.member fp.id session.favoritedPipelines
@@ -1202,17 +1211,6 @@ pipelinesView session params =
                                     + PipelineGridConstants.sectionSpacerHeight
                                 )
                            )
-
-        filteredGroups =
-            Filter.filterGroups
-                { pipelineJobs = params.pipelineJobs
-                , jobs = jobs
-                , query = params.query
-                , teams = teams
-                , pipelines = pipelines
-                , dashboardView = params.dashboardView
-                }
-                |> List.sortWith (Group.ordering session)
 
         groupViews =
             filteredGroups

--- a/web/elm/src/Dashboard/DashboardPreview.elm
+++ b/web/elm/src/Dashboard/DashboardPreview.elm
@@ -9,7 +9,7 @@ import Html exposing (Html)
 import Html.Attributes exposing (attribute, class, href)
 import Html.Events exposing (onMouseEnter, onMouseLeave)
 import List.Extra
-import Message.Message exposing (DomID(..), Message(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes
 
 
@@ -53,8 +53,12 @@ viewJob hovered job =
     in
     Html.div
         (attribute "data-tooltip" job.name
-            :: Styles.jobPreview job (HoverState.isHovered (JobPreview jobId) hovered)
-            ++ [ onMouseEnter <| Hover <| Just <| JobPreview jobId
+            :: Styles.jobPreview job
+                (HoverState.isHovered
+                    (JobPreview AllPipelinesSection jobId)
+                    hovered
+                )
+            ++ [ onMouseEnter <| Hover <| Just <| JobPreview AllPipelinesSection jobId
                , onMouseLeave <| Hover Nothing
                ]
         )

--- a/web/elm/src/Dashboard/DashboardPreview.elm
+++ b/web/elm/src/Dashboard/DashboardPreview.elm
@@ -13,20 +13,20 @@ import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes
 
 
-view : HoverState.HoverState -> List (List Concourse.Job) -> Html Message
-view hovered layers =
+view : PipelinesSection -> HoverState.HoverState -> List (List Concourse.Job) -> Html Message
+view section hovered layers =
     Html.div
         (class "pipeline-grid" :: Styles.pipelinePreviewGrid)
-        (List.map (viewJobLayer hovered) layers)
+        (List.map (viewJobLayer section hovered) layers)
 
 
-viewJobLayer : HoverState.HoverState -> List Concourse.Job -> Html Message
-viewJobLayer hovered jobs =
-    Html.div [ class "parallel-grid" ] (List.map (viewJob hovered) jobs)
+viewJobLayer : PipelinesSection -> HoverState.HoverState -> List Concourse.Job -> Html Message
+viewJobLayer section hovered jobs =
+    Html.div [ class "parallel-grid" ] (List.map (viewJob section hovered) jobs)
 
 
-viewJob : HoverState.HoverState -> Concourse.Job -> Html Message
-viewJob hovered job =
+viewJob : PipelinesSection -> HoverState.HoverState -> Concourse.Job -> Html Message
+viewJob section hovered job =
     let
         latestBuild : Maybe Concourse.Build
         latestBuild =
@@ -55,10 +55,10 @@ viewJob hovered job =
         (attribute "data-tooltip" job.name
             :: Styles.jobPreview job
                 (HoverState.isHovered
-                    (JobPreview AllPipelinesSection jobId)
+                    (JobPreview section jobId)
                     hovered
                 )
-            ++ [ onMouseEnter <| Hover <| Just <| JobPreview AllPipelinesSection jobId
+            ++ [ onMouseEnter <| Hover <| Just <| JobPreview section jobId
                , onMouseLeave <| Hover Nothing
                ]
         )

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -447,11 +447,12 @@ headerView { x, y, width, height } header =
         , style "width" <| String.fromFloat width ++ "px"
         , style "height" <| String.fromFloat height ++ "px"
         , style "font-size" "18px"
-        , style "padding-left" "0.5em"
+        , style "padding-left" "0.5rem"
         , style "padding-top" "17.5px"
         , style "box-sizing" "border-box"
         , style "text-overflow" "ellipsis"
         , style "overflow" "hidden"
         , style "white-space" "nowrap"
+        , style "font-weight" Views.Styles.fontWeightBold
         ]
         [ Html.text header ]

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -346,7 +346,7 @@ pipelineCardView session params section { bounds, pipeline } teamName =
              , style "height" "100%"
              , attribute "data-pipeline-name" pipeline.name
              ]
-                ++ (if not pipeline.stale then
+                ++ (if section == AllPipelinesSection && not pipeline.stale then
                         [ attribute
                             "ondragstart"
                             "event.dataTransfer.setData('text/plain', '');"

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -139,9 +139,8 @@ viewFavoritePipelines :
         , pipelineJobs : Dict ( String, String ) (List Concourse.JobIdentifier)
         , jobs : Dict ( String, String, String ) Concourse.Job
         }
-    -> List Pipeline
     -> Html Message
-viewFavoritePipelines session params g =
+viewFavoritePipelines session params =
     let
         pipelineCardViews =
             params.pipelineCards

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -24,7 +24,7 @@ import Html.Keyed
 import Json.Decode
 import Maybe.Extra
 import Message.Effects as Effects
-import Message.Message exposing (DomID(..), DropTarget(..), Message(..))
+import Message.Message exposing (DomID(..), DropTarget(..), Message(..), PipelinesSection(..))
 import Ordering exposing (Ordering)
 import Set exposing (Set)
 import Time
@@ -73,6 +73,7 @@ view session params g =
                         (\{ bounds, pipeline } ->
                             pipelineCardView session
                                 params
+                                AllPipelinesSection
                                 { bounds = bounds, pipeline = pipeline }
                                 g.teamName
                                 |> (\html -> ( String.fromInt pipeline.id, html ))
@@ -148,6 +149,7 @@ viewFavoritePipelines session params g =
                     (\{ bounds, pipeline } ->
                         pipelineCardView session
                             params
+                            FavoritesSection
                             { bounds = bounds, pipeline = pipeline }
                             pipeline.teamName
                             |> (\html -> ( String.fromInt pipeline.id, html ))
@@ -275,13 +277,14 @@ pipelineCardView :
             , pipelineJobs : Dict ( String, String ) (List Concourse.JobIdentifier)
             , jobs : Dict ( String, String, String ) Concourse.Job
         }
+    -> PipelinesSection
     ->
         { bounds : PipelineGrid.Bounds
         , pipeline : Pipeline
         }
     -> String
     -> Html Message
-pipelineCardView session params { bounds, pipeline } teamName =
+pipelineCardView session params section { bounds, pipeline } teamName =
     Html.div
         ([ class "pipeline-wrapper"
          , style "position" "absolute"
@@ -393,6 +396,7 @@ pipelineCardView session params { bounds, pipeline } teamName =
                 , pipelineRunningKeyframes = params.pipelineRunningKeyframes
                 , userState = session.userState
                 , favoritedPipelines = session.favoritedPipelines
+                , section = section
                 }
             ]
         ]

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -328,7 +328,7 @@ pipelineCardView session params { bounds, pipeline } teamName =
                             []
                 in
                 case HoverState.hoveredElement params.hovered of
-                    Just (JobPreview jobID) ->
+                    Just (JobPreview _ jobID) ->
                         hoverStyle jobID
 
                     Just (PipelineWrapper pipelineID) ->

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -450,7 +450,7 @@ headerView { x, y, width, height } header =
         , style "width" <| String.fromFloat width ++ "px"
         , style "height" <| String.fromFloat height ++ "px"
         , style "font-size" "18px"
-        , style "padding-left" "0.5rem"
+        , style "padding-left" "12.5px"
         , style "padding-top" "17.5px"
         , style "box-sizing" "border-box"
         , style "text-overflow" "ellipsis"

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -28,7 +28,7 @@ import Html.Attributes
         )
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import Message.Effects as Effects
-import Message.Message exposing (DomID(..), Message(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes
 import Set exposing (Set)
 import Time
@@ -311,7 +311,7 @@ footerView userState favoritedPipelines pipeline now hovered existingJobs =
                     status == PipelineStatus.PipelineStatusPaused
                 , pipeline = pipelineId
                 , isToggleHovered =
-                    HoverState.isHovered (PipelineButton pipelineId) hovered
+                    HoverState.isHovered (PipelineButton AllPipelinesSection pipelineId) hovered
                 , isToggleLoading = pipeline.isToggleLoading
                 , tooltipPosition = Views.Styles.Above
                 , margin = "0"
@@ -329,14 +329,14 @@ footerView userState favoritedPipelines pipeline now hovered existingJobs =
                             , userState = userState
                             }
                 , isHovered =
-                    HoverState.isHovered (VisibilityButton pipelineId) hovered
+                    HoverState.isHovered (VisibilityButton AllPipelinesSection pipelineId) hovered
                 , isVisibilityLoading = pipeline.isVisibilityLoading
                 }
 
         favoritedIcon =
             favoritedView
                 { isFavorited = Set.member pipeline.id favoritedPipelines
-                , isHovered = HoverState.isHovered (PipelineCardFavoritedIcon pipeline.id) hovered
+                , isHovered = HoverState.isHovered (PipelineCardFavoritedIcon AllPipelinesSection pipeline.id) hovered
                 , pipelineId = pipeline.id
                 }
     in
@@ -376,8 +376,8 @@ pipelineStatusView pipeline status now =
                 Icon.icon
                     { sizePx = 20, image = Assets.PipelineStatusIconJobsDisabled }
                     ([ style "opacity" "0.5"
-                     , id <| Effects.toHtmlID <| PipelineStatusIcon pipelineId
-                     , onMouseEnter <| Hover <| Just <| PipelineStatusIcon pipelineId
+                     , id <| Effects.toHtmlID <| PipelineStatusIcon AllPipelinesSection pipelineId
+                     , onMouseEnter <| Hover <| Just <| PipelineStatusIcon AllPipelinesSection pipelineId
                      ]
                         ++ Styles.pipelineStatusIcon
                     )
@@ -423,10 +423,10 @@ favoritedView { isFavorited, isHovered, pipelineId } =
             { isFavorited = isFavorited
             , isHovered = isHovered
             }
-            ++ [ onMouseEnter <| Hover <| Just <| PipelineCardFavoritedIcon pipelineId
+            ++ [ onMouseEnter <| Hover <| Just <| PipelineCardFavoritedIcon AllPipelinesSection pipelineId
                , onMouseLeave <| Hover Nothing
-               , id <| Effects.toHtmlID <| PipelineCardFavoritedIcon pipelineId
-               , onClick <| Click <| PipelineCardFavoritedIcon pipelineId
+               , id <| Effects.toHtmlID <| PipelineCardFavoritedIcon AllPipelinesSection pipelineId
+               , onClick <| Click <| PipelineCardFavoritedIcon AllPipelinesSection pipelineId
                ]
         )
         []
@@ -445,7 +445,7 @@ visibilityView { public, pipelineId, isClickable, isHovered, isVisibilityLoading
         Spinner.hoverableSpinner
             { sizePx = 20
             , margin = "0"
-            , hoverable = Just <| VisibilityButton pipelineId
+            , hoverable = Just <| VisibilityButton AllPipelinesSection pipelineId
             }
 
     else
@@ -455,12 +455,12 @@ visibilityView { public, pipelineId, isClickable, isHovered, isVisibilityLoading
                 , isClickable = isClickable
                 , isHovered = isHovered
                 }
-                ++ [ onMouseEnter <| Hover <| Just <| VisibilityButton pipelineId
+                ++ [ onMouseEnter <| Hover <| Just <| VisibilityButton AllPipelinesSection pipelineId
                    , onMouseLeave <| Hover Nothing
-                   , id <| Effects.toHtmlID <| VisibilityButton pipelineId
+                   , id <| Effects.toHtmlID <| VisibilityButton AllPipelinesSection pipelineId
                    ]
                 ++ (if isClickable then
-                        [ onClick <| Click <| VisibilityButton pipelineId ]
+                        [ onClick <| Click <| VisibilityButton AllPipelinesSection pipelineId ]
 
                     else
                         []

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -156,7 +156,7 @@ pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, favo
 
           else
             bodyView section hovered layers
-        , footerView userState favoritedPipelines pipeline now hovered existingJobs
+        , footerView userState favoritedPipelines pipeline section now hovered existingJobs
         ]
 
 
@@ -289,11 +289,12 @@ footerView :
     UserState
     -> Set Concourse.DatabaseID
     -> Pipeline
+    -> PipelinesSection
     -> Maybe Time.Posix
     -> HoverState.HoverState
     -> List Concourse.Job
     -> Html Message
-footerView userState favoritedPipelines pipeline now hovered existingJobs =
+footerView userState favoritedPipelines pipeline section now hovered existingJobs =
     let
         spacer =
             Html.div [ style "width" "12px" ] []
@@ -312,11 +313,12 @@ footerView userState favoritedPipelines pipeline now hovered existingJobs =
                     status == PipelineStatus.PipelineStatusPaused
                 , pipeline = pipelineId
                 , isToggleHovered =
-                    HoverState.isHovered (PipelineButton AllPipelinesSection pipelineId) hovered
+                    HoverState.isHovered (PipelineButton section pipelineId) hovered
                 , isToggleLoading = pipeline.isToggleLoading
                 , tooltipPosition = Views.Styles.Above
                 , margin = "0"
                 , userState = userState
+                , section = section
                 }
 
         visibilityButton =
@@ -330,20 +332,22 @@ footerView userState favoritedPipelines pipeline now hovered existingJobs =
                             , userState = userState
                             }
                 , isHovered =
-                    HoverState.isHovered (VisibilityButton AllPipelinesSection pipelineId) hovered
+                    HoverState.isHovered (VisibilityButton section pipelineId) hovered
                 , isVisibilityLoading = pipeline.isVisibilityLoading
+                , section = section
                 }
 
         favoritedIcon =
             favoritedView
                 { isFavorited = Set.member pipeline.id favoritedPipelines
-                , isHovered = HoverState.isHovered (PipelineCardFavoritedIcon AllPipelinesSection pipeline.id) hovered
+                , isHovered = HoverState.isHovered (PipelineCardFavoritedIcon section pipeline.id) hovered
                 , pipelineId = pipeline.id
+                , section = section
                 }
     in
     Html.div
         (class "card-footer" :: Styles.pipelineCardFooter)
-        [ pipelineStatusView pipeline status now
+        [ pipelineStatusView section pipeline status now
         , Html.div
             [ style "display" "flex" ]
           <|
@@ -357,8 +361,8 @@ footerView userState favoritedPipelines pipeline now hovered existingJobs =
         ]
 
 
-pipelineStatusView : Pipeline -> PipelineStatus.PipelineStatus -> Maybe Time.Posix -> Html Message
-pipelineStatusView pipeline status now =
+pipelineStatusView : PipelinesSection -> Pipeline -> PipelineStatus.PipelineStatus -> Maybe Time.Posix -> Html Message
+pipelineStatusView section pipeline status now =
     let
         pipelineId =
             { pipelineName = pipeline.name
@@ -377,8 +381,8 @@ pipelineStatusView pipeline status now =
                 Icon.icon
                     { sizePx = 20, image = Assets.PipelineStatusIconJobsDisabled }
                     ([ style "opacity" "0.5"
-                     , id <| Effects.toHtmlID <| PipelineStatusIcon AllPipelinesSection pipelineId
-                     , onMouseEnter <| Hover <| Just <| PipelineStatusIcon AllPipelinesSection pipelineId
+                     , id <| Effects.toHtmlID <| PipelineStatusIcon section pipelineId
+                     , onMouseEnter <| Hover <| Just <| PipelineStatusIcon section pipelineId
                      ]
                         ++ Styles.pipelineStatusIcon
                     )
@@ -416,18 +420,19 @@ favoritedView :
     { isFavorited : Bool
     , isHovered : Bool
     , pipelineId : Concourse.DatabaseID
+    , section : PipelinesSection
     }
     -> Html Message
-favoritedView { isFavorited, isHovered, pipelineId } =
+favoritedView { isFavorited, isHovered, pipelineId, section } =
     Html.div
         (Styles.favoritedToggle
             { isFavorited = isFavorited
             , isHovered = isHovered
             }
-            ++ [ onMouseEnter <| Hover <| Just <| PipelineCardFavoritedIcon AllPipelinesSection pipelineId
+            ++ [ onMouseEnter <| Hover <| Just <| PipelineCardFavoritedIcon section pipelineId
                , onMouseLeave <| Hover Nothing
-               , id <| Effects.toHtmlID <| PipelineCardFavoritedIcon AllPipelinesSection pipelineId
-               , onClick <| Click <| PipelineCardFavoritedIcon AllPipelinesSection pipelineId
+               , id <| Effects.toHtmlID <| PipelineCardFavoritedIcon section pipelineId
+               , onClick <| Click <| PipelineCardFavoritedIcon section pipelineId
                ]
         )
         []
@@ -439,14 +444,15 @@ visibilityView :
     , isClickable : Bool
     , isHovered : Bool
     , isVisibilityLoading : Bool
+    , section : PipelinesSection
     }
     -> Html Message
-visibilityView { public, pipelineId, isClickable, isHovered, isVisibilityLoading } =
+visibilityView { public, pipelineId, isClickable, isHovered, isVisibilityLoading, section } =
     if isVisibilityLoading then
         Spinner.hoverableSpinner
             { sizePx = 20
             , margin = "0"
-            , hoverable = Just <| VisibilityButton AllPipelinesSection pipelineId
+            , hoverable = Just <| VisibilityButton section pipelineId
             }
 
     else
@@ -456,12 +462,12 @@ visibilityView { public, pipelineId, isClickable, isHovered, isVisibilityLoading
                 , isClickable = isClickable
                 , isHovered = isHovered
                 }
-                ++ [ onMouseEnter <| Hover <| Just <| VisibilityButton AllPipelinesSection pipelineId
+                ++ [ onMouseEnter <| Hover <| Just <| VisibilityButton section pipelineId
                    , onMouseLeave <| Hover Nothing
-                   , id <| Effects.toHtmlID <| VisibilityButton AllPipelinesSection pipelineId
+                   , id <| Effects.toHtmlID <| VisibilityButton section pipelineId
                    ]
                 ++ (if isClickable then
-                        [ onClick <| Click <| VisibilityButton AllPipelinesSection pipelineId ]
+                        [ onClick <| Click <| VisibilityButton section pipelineId ]
 
                     else
                         []

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -114,9 +114,10 @@ pipelineView :
     , resourceError : Bool
     , existingJobs : List Concourse.Job
     , layers : List (List Concourse.Job)
+    , section : PipelinesSection
     }
     -> Html Message
-pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, favoritedPipelines, resourceError, existingJobs, layers } =
+pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, favoritedPipelines, resourceError, existingJobs, layers, section } =
     let
         bannerStyle =
             if pipeline.stale then
@@ -154,7 +155,7 @@ pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, favo
             previewPlaceholder
 
           else
-            bodyView hovered layers
+            bodyView section hovered layers
         , footerView userState favoritedPipelines pipeline now hovered existingJobs
         ]
 
@@ -277,11 +278,11 @@ headerView pipeline resourceError =
         ]
 
 
-bodyView : HoverState.HoverState -> List (List Concourse.Job) -> Html Message
-bodyView hovered layers =
+bodyView : PipelinesSection -> HoverState.HoverState -> List (List Concourse.Job) -> Html Message
+bodyView section hovered layers =
     Html.div
         (class "card-body" :: Styles.pipelineCardBody)
-        [ DashboardPreview.view hovered layers ]
+        [ DashboardPreview.view section hovered layers ]
 
 
 footerView :

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -313,12 +313,12 @@ footerView userState favoritedPipelines pipeline section now hovered existingJob
                     status == PipelineStatus.PipelineStatusPaused
                 , pipeline = pipelineId
                 , isToggleHovered =
-                    HoverState.isHovered (PipelineButton section pipelineId) hovered
+                    HoverState.isHovered (PipelineCardPauseToggle section pipelineId) hovered
                 , isToggleLoading = pipeline.isToggleLoading
                 , tooltipPosition = Views.Styles.Above
                 , margin = "0"
                 , userState = userState
-                , section = section
+                , domID = PipelineCardPauseToggle section pipelineId
                 }
 
         visibilityButton =

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -134,7 +134,7 @@ pipelineView { now, pipeline, hovered, pipelineRunningKeyframes, userState, favo
     in
     Html.div
         (Styles.pipelineCard
-            ++ (if not pipeline.stale then
+            ++ (if section == AllPipelinesSection && not pipeline.stale then
                     [ style "cursor" "move" ]
 
                 else

--- a/web/elm/src/Dashboard/PipelineGrid.elm
+++ b/web/elm/src/Dashboard/PipelineGrid.elm
@@ -1,7 +1,9 @@
 module Dashboard.PipelineGrid exposing
     ( Bounds
     , DropArea
+    , Header
     , PipelineCard
+    , computeFavoritePipelinesLayout
     , computeLayout
     )
 
@@ -9,9 +11,16 @@ import Concourse
 import Dashboard.Drag exposing (dragPipeline)
 import Dashboard.Group.Models exposing (Group, Pipeline)
 import Dashboard.Models exposing (DragState(..), DropState(..))
-import Dashboard.PipelineGrid.Constants exposing (cardHeight, cardWidth, padding)
+import Dashboard.PipelineGrid.Constants
+    exposing
+        ( cardHeight
+        , cardWidth
+        , headerHeight
+        , padding
+        )
 import Dashboard.PipelineGrid.Layout as Layout
 import Dict exposing (Dict)
+import List.Extra
 import Message.Message exposing (DomID(..), DropTarget(..), Message(..))
 import UserState exposing (UserState(..))
 
@@ -33,6 +42,12 @@ type alias PipelineCard =
 type alias DropArea =
     { bounds : Bounds
     , target : DropTarget
+    }
+
+
+type alias Header =
+    { bounds : Bounds
+    , header : String
     }
 
 
@@ -188,6 +203,120 @@ computeLayout params g =
     in
     { pipelineCards = pipelineCards
     , dropAreas = dropAreas
+    , height = totalCardsHeight
+    }
+
+
+computeFavoritePipelinesLayout :
+    { pipelineLayers : Dict ( String, String ) (List (List Concourse.JobIdentifier))
+    , viewportWidth : Float
+    , viewportHeight : Float
+    , scrollTop : Float
+    }
+    -> List Pipeline
+    ->
+        { pipelineCards : List PipelineCard
+        , headers : List Header
+        , height : Float
+        }
+computeFavoritePipelinesLayout params pipelines =
+    let
+        numColumns =
+            max 1 (floor (params.viewportWidth / (cardWidth + padding)))
+
+        rowHeight =
+            cardHeight + headerHeight
+
+        isVisible_ =
+            isVisible params.viewportHeight params.scrollTop rowHeight
+
+        cards =
+            pipelines
+                |> previewSizes params.pipelineLayers
+                |> List.map Layout.cardSize
+                |> Layout.layout numColumns
+
+        numRows =
+            cards
+                |> List.map (\c -> c.row + c.spannedRows - 1)
+                |> List.maximum
+                |> Maybe.withDefault 1
+
+        totalCardsHeight =
+            toFloat numRows * rowHeight
+
+        cardBounds =
+            boundsForCell
+                { colGap = padding
+                , rowGap = headerHeight
+                , offsetX = padding
+                , offsetY = headerHeight
+                }
+
+        pipelineCards =
+            cards
+                |> List.map2 Tuple.pair pipelines
+                |> List.filter (\( _, card ) -> isVisible_ card)
+                |> List.map
+                    (\( pipeline, card ) ->
+                        { pipeline = pipeline
+                        , bounds = cardBounds card
+                        }
+                    )
+
+        headers =
+            pipelineCards
+                |> List.Extra.groupWhile
+                    (\c1 c2 ->
+                        (c1.pipeline.teamName == c2.pipeline.teamName)
+                            && (c1.bounds.y == c2.bounds.y)
+                    )
+                |> List.map
+                    (\( c, cs ) ->
+                        ( c
+                        , case List.Extra.last cs of
+                            Nothing ->
+                                c
+
+                            Just tail ->
+                                tail
+                        )
+                    )
+                |> List.foldl
+                    (\( first, last ) ( prevTeam, headers_ ) ->
+                        let
+                            curTeam =
+                                first.pipeline.teamName
+
+                            header =
+                                case prevTeam of
+                                    Nothing ->
+                                        curTeam
+
+                                    Just prevTeam_ ->
+                                        if prevTeam_ == curTeam then
+                                            curTeam ++ " (continued)"
+
+                                        else
+                                            curTeam
+                        in
+                        ( Just curTeam
+                        , { header = header
+                          , bounds =
+                                { x = first.bounds.x
+                                , y = first.bounds.y - headerHeight
+                                , width = last.bounds.x + cardWidth - first.bounds.x
+                                , height = headerHeight
+                                }
+                          }
+                            :: headers_
+                        )
+                    )
+                    ( Nothing, [] )
+                |> Tuple.second
+    in
+    { pipelineCards = pipelineCards
+    , headers = headers
     , height = totalCardsHeight
     }
 

--- a/web/elm/src/Dashboard/PipelineGrid/Constants.elm
+++ b/web/elm/src/Dashboard/PipelineGrid/Constants.elm
@@ -3,6 +3,8 @@ module Dashboard.PipelineGrid.Constants exposing
     , cardWidth
     , headerHeight
     , padding
+    , sectionHeaderHeight
+    , sectionSpacerHeight
     )
 
 
@@ -24,3 +26,13 @@ padding =
 headerHeight : number
 headerHeight =
     60
+
+
+sectionHeaderHeight : number
+sectionHeaderHeight =
+    70
+
+
+sectionSpacerHeight : number
+sectionSpacerHeight =
+    30

--- a/web/elm/src/Dashboard/PipelineGrid/Layout.elm
+++ b/web/elm/src/Dashboard/PipelineGrid/Layout.elm
@@ -1,4 +1,4 @@
-module Dashboard.PipelineGrid.Layout exposing (cardSize, layout)
+module Dashboard.PipelineGrid.Layout exposing (Card, cardSize, layout)
 
 
 type alias GridSpan =
@@ -6,8 +6,8 @@ type alias GridSpan =
 
 
 type alias Card =
-    { width : GridSpan
-    , height : GridSpan
+    { spannedColumns : GridSpan
+    , spannedRows : GridSpan
     , column : Int
     , row : Int
     }
@@ -63,7 +63,7 @@ layout numColumns cardSizes =
                         else
                             max rowHeight h
                 in
-                { cards = { width = w, height = h, column = newColumn, row = newRow } :: cards
+                { cards = { spannedColumns = w, spannedRows = h, column = newColumn, row = newRow } :: cards
                 , column = newColumn + w
                 , row = newRow
                 , rowHeight = newRowHeight

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -888,6 +888,5 @@ pipelineSectionHeader : List (Html.Attribute msg)
 pipelineSectionHeader =
     [ style "font-size" "22px"
     , style "font-weight" Views.Styles.fontWeightBold
-    , style "padding" "30px 0 10px 25px"
-    , style "margin-left" "0.5rem"
+    , style "padding" "30px 0 10px 37.5px"
     ]

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -40,6 +40,7 @@ module Dashboard.Styles exposing
     , pipelineCardTransitionAgeStale
     , pipelineName
     , pipelinePreviewGrid
+    , pipelineSectionHeader
     , pipelineStatusIcon
     , previewPlaceholder
     , resourceErrorTriangle
@@ -880,4 +881,13 @@ loadingView =
     , style "align-items" "center"
     , style "width" "100%"
     , style "height" "100%"
+    ]
+
+
+pipelineSectionHeader : List (Html.Attribute msg)
+pipelineSectionHeader =
+    [ style "font-size" "22px"
+    , style "font-weight" Views.Styles.fontWeightBold
+    , style "padding" "30px 0 10px 25px"
+    , style "margin-left" "0.5rem"
     ]

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -1,9 +1,9 @@
 port module Message.Effects exposing
     ( Effect(..)
+    , pipelinesSectionName
     , renderPipeline
     , renderSvgIcon
     , runEffect
-    , sideBarSectionName
     , stickyHeaderConfig
     , toHtmlID
     )
@@ -24,7 +24,7 @@ import Message.Callback exposing (Callback(..))
 import Message.Message
     exposing
         ( DomID(..)
-        , SideBarSection(..)
+        , PipelinesSection(..)
         , VersionToggleAction(..)
         , VisibilityAction(..)
         )
@@ -653,13 +653,13 @@ runEffect effect key csrfToken =
             syncTextareaHeight (toHtmlID domID)
 
 
-sideBarSectionName : SideBarSection -> String
-sideBarSectionName section =
+pipelinesSectionName : PipelinesSection -> String
+pipelinesSectionName section =
     case section of
-        Favorites ->
+        FavoritesSection ->
             "Favorites"
 
-        AllPipelines ->
+        AllPipelinesSection ->
             "AllPipelines"
 
 
@@ -667,10 +667,10 @@ toHtmlID : DomID -> String
 toHtmlID domId =
     case domId of
         SideBarTeam section t ->
-            sideBarSectionName section ++ "_" ++ Base64.encode t
+            pipelinesSectionName section ++ "_" ++ Base64.encode t
 
         SideBarPipeline section p ->
-            sideBarSectionName section ++ "_" ++ Base64.encode p.teamName ++ "_" ++ Base64.encode p.pipelineName
+            pipelinesSectionName section ++ "_" ++ Base64.encode p.teamName ++ "_" ++ Base64.encode p.pipelineName
 
         PipelineStatusIcon p ->
             Base64.encode p.teamName

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -672,14 +672,18 @@ toHtmlID domId =
         SideBarPipeline section p ->
             pipelinesSectionName section ++ "_" ++ Base64.encode p.teamName ++ "_" ++ Base64.encode p.pipelineName
 
-        PipelineStatusIcon p ->
-            Base64.encode p.teamName
+        PipelineStatusIcon section p ->
+            pipelinesSectionName section
+                ++ "_"
+                ++ Base64.encode p.teamName
                 ++ "_"
                 ++ Base64.encode p.pipelineName
                 ++ "_status"
 
-        VisibilityButton p ->
-            Base64.encode p.teamName
+        VisibilityButton section p ->
+            pipelinesSectionName section
+                ++ "_"
+                ++ Base64.encode p.teamName
                 ++ "_"
                 ++ Base64.encode p.pipelineName
                 ++ "_visibility"

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -2,7 +2,7 @@ module Message.Message exposing
     ( DomID(..)
     , DropTarget(..)
     , Message(..)
-    , SideBarSection(..)
+    , PipelinesSection(..)
     , VersionId
     , VersionToggleAction(..)
     , VisibilityAction(..)
@@ -87,16 +87,16 @@ type DomID
     | JobPreview Concourse.JobIdentifier
     | HamburgerMenu
     | SideBarResizeHandle
-    | SideBarTeam SideBarSection String
-    | SideBarPipeline SideBarSection Concourse.PipelineIdentifier
+    | SideBarTeam PipelinesSection String
+    | SideBarPipeline PipelinesSection Concourse.PipelineIdentifier
     | SideBarFavoritedIcon DatabaseID
     | Dashboard
     | DashboardGroup String
 
 
-type SideBarSection
-    = Favorites
-    | AllPipelines
+type PipelinesSection
+    = FavoritesSection
+    | AllPipelinesSection
 
 
 type VersionToggleAction

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -62,10 +62,10 @@ type DomID
     | PinMenuDropDown String
     | PinButton VersionId
     | PinBar
-    | PipelineStatusIcon Concourse.PipelineIdentifier
-    | PipelineButton Concourse.PipelineIdentifier
-    | VisibilityButton Concourse.PipelineIdentifier
-    | PipelineCardFavoritedIcon DatabaseID
+    | PipelineStatusIcon PipelinesSection Concourse.PipelineIdentifier
+    | PipelineButton PipelinesSection Concourse.PipelineIdentifier
+    | VisibilityButton PipelinesSection Concourse.PipelineIdentifier
+    | PipelineCardFavoritedIcon PipelinesSection DatabaseID
     | FooterCliIcon Cli.Cli
     | WelcomeCardCliIcon Cli.Cli
     | CopyTokenButton
@@ -84,7 +84,7 @@ type DomID
     | VersionToggle VersionId
     | BuildTab Int String
     | PipelineWrapper Concourse.PipelineIdentifier
-    | JobPreview Concourse.JobIdentifier
+    | JobPreview PipelinesSection Concourse.JobIdentifier
     | HamburgerMenu
     | SideBarResizeHandle
     | SideBarTeam PipelinesSection String

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -63,7 +63,8 @@ type DomID
     | PinButton VersionId
     | PinBar
     | PipelineStatusIcon PipelinesSection Concourse.PipelineIdentifier
-    | PipelineButton PipelinesSection Concourse.PipelineIdentifier
+    | PipelineCardPauseToggle PipelinesSection Concourse.PipelineIdentifier
+    | TopBarPauseToggle Concourse.PipelineIdentifier
     | VisibilityButton PipelinesSection Concourse.PipelineIdentifier
     | PipelineCardFavoritedIcon PipelinesSection DatabaseID
     | FooterCliIcon Cli.Cli

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -403,11 +403,13 @@ view session model =
                             , isToggleHovered =
                                 HoverState.isHovered
                                     (PipelineButton AllPipelinesSection model.pipelineLocator)
+                                    -- TODO: pick a diff. domID
                                     session.hovered
                             , isToggleLoading = model.isToggleLoading
                             , tooltipPosition = Views.Styles.Below
                             , margin = "17px"
                             , userState = session.userState
+                            , section = AllPipelinesSection
                             }
                         ]
                 , Login.view session.userState model <| displayPaused

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -329,7 +329,7 @@ update msg ( model, effects ) =
         SetGroups groups ->
             ( model, effects ++ [ NavigateTo <| getNextUrl groups model ] )
 
-        Click (PipelineButton _ pipelineIdentifier) ->
+        Click (TopBarPauseToggle pipelineIdentifier) ->
             let
                 paused =
                     model.pipeline |> RemoteData.map .paused
@@ -402,14 +402,13 @@ view session model =
                             , isPaused = isPaused model.pipeline
                             , isToggleHovered =
                                 HoverState.isHovered
-                                    (PipelineButton AllPipelinesSection model.pipelineLocator)
-                                    -- TODO: pick a diff. domID
+                                    (TopBarPauseToggle model.pipelineLocator)
                                     session.hovered
                             , isToggleLoading = model.isToggleLoading
                             , tooltipPosition = Views.Styles.Below
                             , margin = "17px"
                             , userState = session.userState
-                            , section = AllPipelinesSection
+                            , domID = TopBarPauseToggle model.pipelineLocator
                             }
                         ]
                 , Login.view session.userState model <| displayPaused

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -38,7 +38,7 @@ import Keyboard
 import Login.Login as Login
 import Message.Callback exposing (Callback(..))
 import Message.Effects exposing (Effect(..))
-import Message.Message exposing (DomID(..), Message(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Message.Subscription
     exposing
         ( Delivery(..)
@@ -329,7 +329,7 @@ update msg ( model, effects ) =
         SetGroups groups ->
             ( model, effects ++ [ NavigateTo <| getNextUrl groups model ] )
 
-        Click (PipelineButton pipelineIdentifier) ->
+        Click (PipelineButton _ pipelineIdentifier) ->
             let
                 paused =
                     model.pipeline |> RemoteData.map .paused
@@ -402,7 +402,7 @@ view session model =
                             , isPaused = isPaused model.pipeline
                             , isToggleHovered =
                                 HoverState.isHovered
-                                    (PipelineButton model.pipelineLocator)
+                                    (PipelineButton AllPipelinesSection model.pipelineLocator)
                                     session.hovered
                             , isToggleLoading = model.isToggleLoading
                             , tooltipPosition = Views.Styles.Below

--- a/web/elm/src/SideBar/Pipeline.elm
+++ b/web/elm/src/SideBar/Pipeline.elm
@@ -3,7 +3,7 @@ module SideBar.Pipeline exposing (pipeline)
 import Assets
 import Concourse
 import HoverState
-import Message.Message exposing (DomID(..), Message(..), SideBarSection(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes
 import Set exposing (Set)
 import SideBar.Styles as Styles
@@ -42,10 +42,10 @@ pipeline params p =
         domID =
             SideBarPipeline
                 (if params.isFavoritesSection then
-                    Favorites
+                    FavoritesSection
 
                  else
-                    AllPipelines
+                    AllPipelinesSection
                 )
                 pipelineId
 

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -30,6 +30,7 @@ import SideBar.Team as Team
 import SideBar.Views as Views
 import Tooltip
 import Views.Icon as Icon
+import Views.Styles
 
 
 type alias Model m =
@@ -329,7 +330,7 @@ favoritedPipelinesSection model currentPipeline =
                             |> Views.viewTeam
                     )
             )
-        , Styles.separator
+        , Views.Styles.separator 10
         ]
 
 

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -19,7 +19,7 @@ import Html.Events exposing (onClick, onMouseDown, onMouseEnter, onMouseLeave)
 import List.Extra
 import Message.Callback exposing (Callback(..))
 import Message.Effects as Effects
-import Message.Message exposing (DomID(..), Message(..), SideBarSection(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Message.Subscription exposing (Delivery(..))
 import RemoteData exposing (RemoteData(..), WebData)
 import ScreenSize exposing (ScreenSize(..))
@@ -78,7 +78,7 @@ update message model =
 
         Click (SideBarTeam section teamName) ->
             case section of
-                AllPipelines ->
+                AllPipelinesSection ->
                     ( { model
                         | expandedTeamsInAllPipelines =
                             toggle teamName model.expandedTeamsInAllPipelines
@@ -86,7 +86,7 @@ update message model =
                     , []
                     )
 
-                Favorites ->
+                FavoritesSection ->
                     ( { model
                         | collapsedTeamsInFavorites =
                             toggle teamName model.collapsedTeamsInFavorites

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -106,7 +106,7 @@ update message model =
             , [ Effects.SaveFavoritedPipelines <| favoritedPipelines ]
             )
 
-        Click (PipelineCardFavoritedIcon pipelineID) ->
+        Click (PipelineCardFavoritedIcon _ pipelineID) ->
             let
                 favoritedPipelines =
                     toggle pipelineID model.favoritedPipelines

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -13,7 +13,6 @@ module SideBar.Styles exposing
     , pipelineIcon
     , pipelineName
     , sectionHeader
-    , separator
     , sideBar
     , sideBarHandle
     , starPadding
@@ -337,12 +336,3 @@ tooltipBody =
     , style "align-items" "center"
     , style "height" "30px"
     ]
-
-
-separator : Html.Html msg
-separator =
-    Html.div
-        [ style "border-bottom" "1px solid black"
-        , style "margin-top" "10px"
-        ]
-        []

--- a/web/elm/src/SideBar/Team.elm
+++ b/web/elm/src/SideBar/Team.elm
@@ -3,7 +3,7 @@ module SideBar.Team exposing (team)
 import Assets
 import Concourse
 import HoverState
-import Message.Message exposing (DomID(..), Message(..), SideBarSection(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Set exposing (Set)
 import SideBar.Pipeline as Pipeline
 import SideBar.Styles as Styles
@@ -32,10 +32,10 @@ team session t =
         domID =
             SideBarTeam
                 (if session.isFavoritesSection then
-                    Favorites
+                    FavoritesSection
 
                  else
-                    AllPipelines
+                    AllPipelinesSection
                 )
                 t.name
 

--- a/web/elm/src/Views/PauseToggle.elm
+++ b/web/elm/src/Views/PauseToggle.elm
@@ -21,6 +21,7 @@ view :
         , margin : String
         , userState : UserState
         , tooltipPosition : Styles.TooltipPosition
+        , section : PipelinesSection
     }
     -> Html Message
 view params =
@@ -38,12 +39,12 @@ view params =
     else
         Html.div
             (Styles.pauseToggle params.margin
-                ++ [ onMouseEnter <| Hover <| Just <| PipelineButton AllPipelinesSection params.pipeline
+                ++ [ onMouseEnter <| Hover <| Just <| PipelineButton params.section params.pipeline
                    , onMouseLeave <| Hover Nothing
                    , class "pause-toggle"
                    ]
                 ++ (if isClickable then
-                        [ onClick <| Click <| PipelineButton AllPipelinesSection params.pipeline ]
+                        [ onClick <| Click <| PipelineButton params.section params.pipeline ]
 
                     else
                         []

--- a/web/elm/src/Views/PauseToggle.elm
+++ b/web/elm/src/Views/PauseToggle.elm
@@ -5,7 +5,7 @@ import Concourse
 import Html exposing (Html)
 import Html.Attributes exposing (class)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
-import Message.Message exposing (DomID(..), Message(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import UserState exposing (UserState(..))
 import Views.Icon as Icon
 import Views.Spinner as Spinner
@@ -38,12 +38,12 @@ view params =
     else
         Html.div
             (Styles.pauseToggle params.margin
-                ++ [ onMouseEnter <| Hover <| Just <| PipelineButton params.pipeline
+                ++ [ onMouseEnter <| Hover <| Just <| PipelineButton AllPipelinesSection params.pipeline
                    , onMouseLeave <| Hover Nothing
                    , class "pause-toggle"
                    ]
                 ++ (if isClickable then
-                        [ onClick <| Click <| PipelineButton params.pipeline ]
+                        [ onClick <| Click <| PipelineButton AllPipelinesSection params.pipeline ]
 
                     else
                         []

--- a/web/elm/src/Views/PauseToggle.elm
+++ b/web/elm/src/Views/PauseToggle.elm
@@ -21,7 +21,7 @@ view :
         , margin : String
         , userState : UserState
         , tooltipPosition : Styles.TooltipPosition
-        , section : PipelinesSection
+        , domID : DomID
     }
     -> Html Message
 view params =
@@ -39,12 +39,12 @@ view params =
     else
         Html.div
             (Styles.pauseToggle params.margin
-                ++ [ onMouseEnter <| Hover <| Just <| PipelineButton params.section params.pipeline
+                ++ [ onMouseEnter <| Hover <| Just <| params.domID
                    , onMouseLeave <| Hover Nothing
                    , class "pause-toggle"
                    ]
                 ++ (if isClickable then
-                        [ onClick <| Click <| PipelineButton params.section params.pipeline ]
+                        [ onClick <| Click <| params.domID ]
 
                     else
                         []

--- a/web/elm/src/Views/Styles.elm
+++ b/web/elm/src/Views/Styles.elm
@@ -15,6 +15,7 @@ module Views.Styles exposing
     , pauseToggle
     , pauseToggleIcon
     , pauseToggleTooltip
+    , separator
     , topBar
     )
 
@@ -242,3 +243,12 @@ pauseToggleTooltip ttp =
     , style "right" "-150%"
     , style "z-index" "1"
     ]
+
+
+separator : Float -> Html.Html msg
+separator topMargin =
+    Html.div
+        [ style "border-bottom" "1px solid black"
+        , style "margin-top" <| String.fromFloat topMargin ++ "px"
+        ]
+        []

--- a/web/elm/tests/DashboardPreviewTests.elm
+++ b/web/elm/tests/DashboardPreviewTests.elm
@@ -6,14 +6,17 @@ import Common exposing (defineHoverBehaviour, isColorWithStripes, queryView)
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Dashboard.DashboardPreview as DP
+import DashboardTests exposing (whenOnDashboard)
 import Data
 import Expect
 import Message.Callback as Callback
-import Message.Message exposing (DomID(..), PipelinesSection(..))
-import Message.TopLevelMessage exposing (TopLevelMessage)
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
+import Message.Subscription as Subscription
+import Message.TopLevelMessage exposing (TopLevelMessage(..))
+import Set
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (class, containing, style, text)
+import Test.Html.Selector exposing (class, containing, id, style, text)
 import Time
 import Url
 
@@ -164,6 +167,45 @@ all =
                         { thick = Colors.abortedFaded
                         , thin = Colors.aborted
                         }
+        , describe "preview in favorites section" <|
+            let
+                dashboardWithJobInFavoritesSection =
+                    dashboardWithJob
+                        >> Application.handleDelivery
+                            (Subscription.FavoritedPipelinesReceived <| Ok <| Set.singleton 0)
+                        >> Tuple.first
+
+                findJobPreviewInFavoritesSection =
+                    queryView
+                        >> Query.find [ id "dashboard-favorite-pipelines" ]
+                        >> Query.find [ class "card", containing [ text "pipeline" ] ]
+                        >> Query.find [ class "parallel-grid" ]
+                        >> Query.children []
+                        >> Query.first
+            in
+            [ defineHoverBehaviour
+                { name = "pending job"
+                , setup = dashboardWithJobInFavoritesSection job
+                , query = findJobPreviewInFavoritesSection
+                , unhoveredSelector =
+                    { description = "light grey background"
+                    , selector = [ style "background-color" Colors.pending ]
+                    }
+                , hoverable = JobPreview FavoritesSection jobId
+                , hoveredSelector =
+                    { description = "dark grey background"
+                    , selector = [ style "background-color" Colors.pendingFaded ]
+                    }
+                }
+            , test "hovering over job preview in favorites section does not highlight in all pipelines section" <|
+                \_ ->
+                    dashboardWithJob job
+                        |> Application.update
+                            (Update <| Hover <| Just (JobPreview FavoritesSection jobId))
+                        |> Tuple.first
+                        |> findJobPreview
+                        |> Query.has [ style "background-color" Colors.pending ]
+            ]
         ]
 
 
@@ -174,7 +216,7 @@ viewJob =
 
 dashboardWithJob : Concourse.Job -> Application.Model
 dashboardWithJob j =
-    Common.init "/"
+    whenOnDashboard { highDensity = False }
         |> Application.handleCallback
             (Callback.AllJobsFetched <|
                 Ok

--- a/web/elm/tests/DashboardPreviewTests.elm
+++ b/web/elm/tests/DashboardPreviewTests.elm
@@ -9,7 +9,7 @@ import Dashboard.DashboardPreview as DP
 import Data
 import Expect
 import Message.Callback as Callback
-import Message.Message exposing (DomID(..))
+import Message.Message exposing (DomID(..), PipelinesSection(..))
 import Message.TopLevelMessage exposing (TopLevelMessage)
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
@@ -51,7 +51,7 @@ all =
                 { description = "light grey background"
                 , selector = [ style "background-color" Colors.pending ]
                 }
-            , hoverable = JobPreview jobId
+            , hoverable = JobPreview AllPipelinesSection jobId
             , hoveredSelector =
                 { description = "dark grey background"
                 , selector = [ style "background-color" Colors.pendingFaded ]

--- a/web/elm/tests/DashboardSearchTests.elm
+++ b/web/elm/tests/DashboardSearchTests.elm
@@ -4,11 +4,14 @@ import Application.Application as Application
 import Common exposing (queryView)
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
+import DashboardTests exposing (whenOnDashboard)
 import Data
 import Expect exposing (Expectation)
 import Message.Callback as Callback
 import Message.Message
+import Message.Subscription as Subscription
 import Message.TopLevelMessage as Msgs
+import Set
 import Test exposing (Test)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (class, id, style, text)
@@ -35,18 +38,23 @@ it desc expectationFunc model =
 hasData : Test
 hasData =
     describe "dashboard search"
-        (Common.init "/"
+        (whenOnDashboard { highDensity = False }
             |> Application.handleCallback
                 (Callback.AllJobsFetched <|
                     Ok
                         [ { name = "job"
-                          , pipelineName = "pipeline"
+                          , pipelineName = "pipeline1"
                           , teamName = "team1"
                           , nextBuild =
                                 Just
                                     { id = 1
                                     , name = "1"
-                                    , job = Just (Data.jobId |> Data.withTeamName "team1")
+                                    , job =
+                                        Just
+                                            (Data.jobId
+                                                |> Data.withTeamName "team1"
+                                                |> Data.withPipelineName "pipeline1"
+                                            )
                                     , status = BuildStatusStarted
                                     , duration =
                                         { startedAt = Nothing
@@ -76,8 +84,8 @@ hasData =
             |> Application.handleCallback
                 (Callback.AllPipelinesFetched <|
                     Ok
-                        [ Data.pipeline "team1" 0 |> Data.withName "pipeline"
-                        , Data.pipeline "team1" 1 |> Data.withName "other-pipeline"
+                        [ Data.pipeline "team1" 0 |> Data.withName "pipeline1"
+                        , Data.pipeline "team1" 1 |> Data.withName "pipeline2"
                         ]
                 )
             |> Tuple.first
@@ -131,7 +139,7 @@ hasData =
                     [ it "shows the running pipeline" <|
                         queryView
                             >> Query.find [ class "card" ]
-                            >> Query.has [ text "pipeline" ]
+                            >> Query.has [ text "pipeline1" ]
                     ]
                 ]
             ]
@@ -183,6 +191,24 @@ hasData =
                     , style "font-size" "13px"
                     , style "margin-top" "20px"
                     ]
+        , context "when there are favorited pipelines"
+            (Application.handleDelivery
+                (Subscription.FavoritedPipelinesReceived <|
+                    Ok <|
+                        Set.fromList [ 0, 1 ]
+                )
+            )
+            [ it "applies the filter to the favorites section" <|
+                Tuple.first
+                    >> Application.update
+                        (Msgs.Update <|
+                            Message.Message.FilterMsg "pipeline1"
+                        )
+                    >> Tuple.first
+                    >> queryView
+                    >> Query.find [ id "dashboard-favorite-pipelines" ]
+                    >> Query.hasNot [ text "pipeline2" ]
+            ]
         ]
 
 

--- a/web/elm/tests/DashboardTooltipTests.elm
+++ b/web/elm/tests/DashboardTooltipTests.elm
@@ -6,7 +6,7 @@ import Dict
 import Expect
 import HoverState exposing (HoverState(..))
 import Html
-import Message.Message exposing (DomID(..))
+import Message.Message exposing (DomID(..), PipelinesSection(..))
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (text)

--- a/web/elm/tests/DashboardTooltipTests.elm
+++ b/web/elm/tests/DashboardTooltipTests.elm
@@ -25,7 +25,7 @@ all =
                     }
                     { hovered =
                         Tooltip
-                            (VisibilityButton Data.pipelineId)
+                            (VisibilityButton AllPipelinesSection Data.pipelineId)
                             Data.elementPosition
                     }
                     |> Maybe.map .body
@@ -42,7 +42,7 @@ all =
                     }
                     { hovered =
                         Tooltip
-                            (VisibilityButton Data.pipelineId)
+                            (VisibilityButton AllPipelinesSection Data.pipelineId)
                             Data.elementPosition
                     }
                     |> Maybe.map .body
@@ -63,7 +63,7 @@ all =
                     }
                     { hovered =
                         Tooltip
-                            (PipelineStatusIcon Data.pipelineId)
+                            (PipelineStatusIcon AllPipelinesSection Data.pipelineId)
                             Data.elementPosition
                     }
                     |> Maybe.map .body

--- a/web/elm/tests/PauseToggleTests.elm
+++ b/web/elm/tests/PauseToggleTests.elm
@@ -2,7 +2,7 @@ module PauseToggleTests exposing (all)
 
 import Data
 import Dict
-import Message.Message exposing (PipelinesSection(..))
+import Message.Message exposing (DomID(..), PipelinesSection(..))
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (containing, style, tag, text)
@@ -39,7 +39,7 @@ all =
                         , margin = ""
                         , userState = userState
                         , tooltipPosition = Styles.Above
-                        , section = AllPipelinesSection
+                        , domID = PipelineCardPauseToggle AllPipelinesSection pipeline
                         }
                         |> Query.fromHtml
                         |> Query.has [ style "opacity" "0.2" ]
@@ -53,7 +53,7 @@ all =
                         , margin = ""
                         , userState = userState
                         , tooltipPosition = Styles.Above
-                        , section = AllPipelinesSection
+                        , domID = PipelineCardPauseToggle AllPipelinesSection pipeline
                         }
                         |> Query.fromHtml
                         |> Query.has
@@ -81,7 +81,7 @@ all =
                         , margin = ""
                         , userState = userState
                         , tooltipPosition = Styles.Below
-                        , section = AllPipelinesSection
+                        , domID = PipelineCardPauseToggle AllPipelinesSection pipeline
                         }
                         |> Query.fromHtml
                         |> Query.has

--- a/web/elm/tests/PauseToggleTests.elm
+++ b/web/elm/tests/PauseToggleTests.elm
@@ -2,6 +2,7 @@ module PauseToggleTests exposing (all)
 
 import Data
 import Dict
+import Message.Message exposing (PipelinesSection(..))
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (containing, style, tag, text)
@@ -38,6 +39,7 @@ all =
                         , margin = ""
                         , userState = userState
                         , tooltipPosition = Styles.Above
+                        , section = AllPipelinesSection
                         }
                         |> Query.fromHtml
                         |> Query.has [ style "opacity" "0.2" ]
@@ -51,6 +53,7 @@ all =
                         , margin = ""
                         , userState = userState
                         , tooltipPosition = Styles.Above
+                        , section = AllPipelinesSection
                         }
                         |> Query.fromHtml
                         |> Query.has
@@ -78,6 +81,7 @@ all =
                         , margin = ""
                         , userState = userState
                         , tooltipPosition = Styles.Below
+                        , section = AllPipelinesSection
                         }
                         |> Query.fromHtml
                         |> Query.has

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -38,7 +38,7 @@ import Expect exposing (Expectation)
 import Html.Attributes as Attr
 import Message.Callback as Callback
 import Message.Effects as Effects
-import Message.Message as Msgs exposing (PipelinesSection(..))
+import Message.Message as Msgs exposing (DomID(..), PipelinesSection(..))
 import Message.Subscription exposing (Delivery(..), Interval(..))
 import Message.TopLevelMessage as ApplicationMsgs
 import Set
@@ -2296,7 +2296,7 @@ all =
                                        ]
                             }
                         , hoverable =
-                            Msgs.PipelineButton FavoritesSection
+                            Msgs.PipelineCardPauseToggle FavoritesSection
                                 { pipelineName = "pipeline"
                                 , teamName = "team"
                                 }

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -1592,7 +1592,8 @@ all =
 
                         visibilityToggle =
                             Common.queryView
-                                >> Query.find [ class "card-footer" ]
+                                >> Query.findAll [ class "card-footer" ]
+                                >> Query.first
                                 >> Query.children []
                                 >> Query.index -1
                                 >> Query.children []
@@ -1669,6 +1670,35 @@ all =
                                                 Msgs.Hide
                                                 pipelineId
                                             ]
+                            , defineHoverBehaviour
+                                { name = "open eye toggle in favorites section"
+                                , setup =
+                                    whenOnDashboard { highDensity = False }
+                                        |> Application.handleDelivery
+                                            (Message.Subscription.FavoritedPipelinesReceived <| Ok <| Set.singleton 0)
+                                        |> Tuple.first
+                                        |> setup
+                                        |> Tuple.first
+                                , query = visibilityToggle
+                                , unhoveredSelector =
+                                    { description = "faded 20px square"
+                                    , selector =
+                                        openEye
+                                            ++ [ style "opacity" "0.5"
+                                               , style "cursor" "pointer"
+                                               ]
+                                    }
+                                , hoverable =
+                                    Msgs.VisibilityButton FavoritesSection pipelineId
+                                , hoveredSelector =
+                                    { description = "bright 20px square"
+                                    , selector =
+                                        openEye
+                                            ++ [ style "opacity" "1"
+                                               , style "cursor" "pointer"
+                                               ]
+                                    }
+                                }
                             , defineHoverBehaviour
                                 { name = "visibility spinner"
                                 , setup =
@@ -2217,6 +2247,59 @@ all =
                                        ]
                             }
                         , hoverable = Msgs.PipelineButton Data.pipelineId
+                        , hoveredSelector =
+                            { description = "a bright 20px square pause button with pointer cursor"
+                            , selector =
+                                iconSelector
+                                    { size = "20px"
+                                    , image = Assets.PauseIcon
+                                    }
+                                    ++ [ style "cursor" "pointer"
+                                       , style "opacity" "1"
+                                       ]
+                            }
+                        }
+                    , defineHoverBehaviour
+                        { name = "pause button in favorites section"
+                        , setup =
+                            whenOnDashboard { highDensity = False }
+                                |> givenDataAndUser
+                                    (apiData [ ( "team", [] ) ])
+                                    (userWithRoles [ ( "team", [ "owner" ] ) ])
+                                |> Tuple.first
+                                |> Application.handleCallback
+                                    (Callback.AllPipelinesFetched <|
+                                        Ok
+                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+                                    )
+                                |> Tuple.first
+                                |> Application.handleDelivery
+                                    (Message.Subscription.FavoritedPipelinesReceived <| Ok <| Set.singleton 0)
+                                |> Tuple.first
+                        , query =
+                            Common.queryView
+                                >> Query.findAll [ class "card-footer" ]
+                                >> Query.first
+                                >> Query.children []
+                                >> Query.index -1
+                                >> Query.children []
+                                >> Query.index 0
+                        , unhoveredSelector =
+                            { description = "a faded 20px square pause button with pointer cursor"
+                            , selector =
+                                iconSelector
+                                    { size = "20px"
+                                    , image = Assets.PauseIcon
+                                    }
+                                    ++ [ style "cursor" "pointer"
+                                       , style "opacity" "0.5"
+                                       ]
+                            }
+                        , hoverable =
+                            Msgs.PipelineButton FavoritesSection
+                                { pipelineName = "pipeline"
+                                , teamName = "team"
+                                }
                         , hoveredSelector =
                             { description = "a bright 20px square pause button with pointer cursor"
                             , selector =

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -1291,7 +1291,7 @@ all =
                                     )
 
                         domID =
-                            Msgs.PipelineStatusIcon
+                            Msgs.PipelineStatusIcon AllPipelinesSection
                                 (Data.pipelineId
                                     |> Data.withPipelineName "pipeline-0"
                                 )
@@ -2276,7 +2276,7 @@ all =
                                        , style "opacity" "0.5"
                                        ]
                             }
-                        , hoverable = Msgs.PipelineButton Data.pipelineId
+                        , hoverable = Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
                         , hoveredSelector =
                             { description = "a bright 20px square pause button with pointer cursor"
                             , selector =
@@ -2377,7 +2377,7 @@ all =
                                        , style "opacity" "0.5"
                                        ]
                             }
-                        , hoverable = Msgs.PipelineButton Data.pipelineId
+                        , hoverable = Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
                         , hoveredSelector =
                             { description = "an opaque 20px square play button with pointer cursor"
                             , selector =
@@ -2410,7 +2410,7 @@ all =
                                 |> Event.expect
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
                                     )
                     , test "pause button turns into spinner on click" <|
                         \_ ->
@@ -2432,7 +2432,7 @@ all =
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -2454,7 +2454,7 @@ all =
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
                                     )
                                 |> Tuple.second
                                 |> Expect.equal [ Effects.SendTogglePipelineRequest Data.pipelineId False ]
@@ -2474,7 +2474,7 @@ all =
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
                                     )
                                 |> Tuple.first
                                 |> Application.handleCallback
@@ -2496,7 +2496,7 @@ all =
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
                                     )
                                 |> Tuple.first
                                 |> Application.handleCallback

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -2412,7 +2412,8 @@ all =
 
                         favoritedToggle =
                             Common.queryView
-                                >> Query.find [ class "card-footer" ]
+                                >> Query.findAll [ class "card-footer" ]
+                                >> Query.first
                                 >> Query.children []
                                 >> Query.index -1
                                 >> Query.children []

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -38,7 +38,7 @@ import Expect exposing (Expectation)
 import Html.Attributes as Attr
 import Message.Callback as Callback
 import Message.Effects as Effects
-import Message.Message as Msgs
+import Message.Message as Msgs exposing (PipelinesSection(..))
 import Message.Subscription exposing (Delivery(..), Interval(..))
 import Message.TopLevelMessage as ApplicationMsgs
 import Set
@@ -1629,7 +1629,7 @@ all =
                                                ]
                                     }
                                 , hoverable =
-                                    Msgs.VisibilityButton pipelineId
+                                    Msgs.VisibilityButton AllPipelinesSection pipelineId
                                 , hoveredSelector =
                                     { description = "bright 20px square"
                                     , selector =
@@ -1649,7 +1649,7 @@ all =
                                         |> Event.expect
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                             , test "click has HidePipeline effect" <|
@@ -1660,7 +1660,7 @@ all =
                                         |> Application.update
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.second
@@ -1678,7 +1678,7 @@ all =
                                         |> Application.update
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.first
@@ -1693,7 +1693,7 @@ all =
                                         ]
                                     }
                                 , hoverable =
-                                    Msgs.VisibilityButton pipelineId
+                                    Msgs.VisibilityButton AllPipelinesSection pipelineId
                                 , hoveredSelector =
                                     { description = "20px spinner"
                                     , selector =
@@ -1712,7 +1712,7 @@ all =
                                         |> Application.update
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.first
@@ -1733,7 +1733,7 @@ all =
                                         |> Application.update
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.first
@@ -1754,7 +1754,7 @@ all =
                                         |> Application.update
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.first
@@ -1786,7 +1786,7 @@ all =
                                                ]
                                     }
                                 , hoverable =
-                                    Msgs.VisibilityButton pipelineId
+                                    Msgs.VisibilityButton AllPipelinesSection pipelineId
                                 , hoveredSelector =
                                     { description = "faded 20px square"
                                     , selector =
@@ -1824,7 +1824,7 @@ all =
                                                ]
                                     }
                                 , hoverable =
-                                    Msgs.VisibilityButton pipelineId
+                                    Msgs.VisibilityButton AllPipelinesSection pipelineId
                                 , hoveredSelector =
                                     { description = "bright 20px square"
                                     , selector =
@@ -1844,7 +1844,7 @@ all =
                                         |> Event.expect
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                             , test "click has ExposePipeline effect" <|
@@ -1855,7 +1855,7 @@ all =
                                         |> Application.update
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.second
@@ -1873,7 +1873,7 @@ all =
                                         |> Application.update
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.first
@@ -1888,7 +1888,7 @@ all =
                                         ]
                                     }
                                 , hoverable =
-                                    Msgs.VisibilityButton pipelineId
+                                    Msgs.VisibilityButton AllPipelinesSection pipelineId
                                 , hoveredSelector =
                                     { description = "20px spinner"
                                     , selector =
@@ -1907,7 +1907,7 @@ all =
                                         |> Application.update
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.first
@@ -1928,7 +1928,7 @@ all =
                                         |> Application.update
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
-                                                    Msgs.VisibilityButton
+                                                    Msgs.VisibilityButton AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.first
@@ -1960,7 +1960,7 @@ all =
                                                ]
                                     }
                                 , hoverable =
-                                    Msgs.VisibilityButton pipelineId
+                                    Msgs.VisibilityButton AllPipelinesSection pipelineId
                                 , hoveredSelector =
                                     { description = "faded 20px square"
                                     , selector =
@@ -2436,7 +2436,7 @@ all =
                                                ]
                                     }
                                 , hoverable =
-                                    Msgs.PipelineCardFavoritedIcon pipelineId
+                                    Msgs.PipelineCardFavoritedIcon AllPipelinesSection pipelineId
                                 , hoveredSelector =
                                     { description = "bright 20px square"
                                     , selector =
@@ -2457,6 +2457,7 @@ all =
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
                                                     Msgs.PipelineCardFavoritedIcon
+                                                        AllPipelinesSection
                                                         pipelineId
                                             )
                             , test "click has FavoritedPipeline effect" <|
@@ -2468,6 +2469,7 @@ all =
                                             (ApplicationMsgs.Update <|
                                                 Msgs.Click <|
                                                     Msgs.PipelineCardFavoritedIcon
+                                                        AllPipelinesSection
                                                         pipelineId
                                             )
                                         |> Tuple.second

--- a/web/elm/tests/PipelineGridLayoutTests.elm
+++ b/web/elm/tests/PipelineGridLayoutTests.elm
@@ -40,13 +40,13 @@ all =
                 \_ ->
                     layout 2 [ ( 1, 1 ), ( 1, 1 ) ]
                         |> Expect.equal
-                            [ { width = 1
-                              , height = 1
+                            [ { spannedColumns = 1
+                              , spannedRows = 1
                               , column = 1
                               , row = 1
                               }
-                            , { width = 1
-                              , height = 1
+                            , { spannedColumns = 1
+                              , spannedRows = 1
                               , column = 2
                               , row = 1
                               }
@@ -55,13 +55,13 @@ all =
                 \_ ->
                     layout 1 [ ( 1, 1 ), ( 1, 1 ) ]
                         |> Expect.equal
-                            [ { width = 1
-                              , height = 1
+                            [ { spannedColumns = 1
+                              , spannedRows = 1
                               , column = 1
                               , row = 1
                               }
-                            , { width = 1
-                              , height = 1
+                            , { spannedColumns = 1
+                              , spannedRows = 1
                               , column = 1
                               , row = 2
                               }
@@ -70,13 +70,13 @@ all =
                 \_ ->
                     layout 2 [ ( 2, 1 ), ( 1, 1 ) ]
                         |> Expect.equal
-                            [ { width = 2
-                              , height = 1
+                            [ { spannedColumns = 2
+                              , spannedRows = 1
                               , column = 1
                               , row = 1
                               }
-                            , { width = 1
-                              , height = 1
+                            , { spannedColumns = 1
+                              , spannedRows = 1
                               , column = 1
                               , row = 2
                               }
@@ -85,13 +85,13 @@ all =
                 \_ ->
                     layout 2 [ ( 1, 1 ), ( 2, 1 ) ]
                         |> Expect.equal
-                            [ { width = 1
-                              , height = 1
+                            [ { spannedColumns = 1
+                              , spannedRows = 1
                               , column = 1
                               , row = 1
                               }
-                            , { width = 2
-                              , height = 1
+                            , { spannedColumns = 2
+                              , spannedRows = 1
                               , column = 1
                               , row = 2
                               }
@@ -100,8 +100,8 @@ all =
                 \_ ->
                     layout 1 [ ( 2, 1 ) ]
                         |> Expect.equal
-                            [ { width = 2
-                              , height = 1
+                            [ { spannedColumns = 2
+                              , spannedRows = 1
                               , column = 1
                               , row = 1
                               }
@@ -110,33 +110,33 @@ all =
                 \_ ->
                     layout 1 [ ( 1, 2 ), ( 1, 1 ) ]
                         |> Expect.equal
-                            [ { width = 1
-                              , height = 2
+                            [ { spannedColumns = 1
+                              , spannedRows = 2
                               , column = 1
                               , row = 1
                               }
-                            , { width = 1
-                              , height = 1
+                            , { spannedColumns = 1
+                              , spannedRows = 1
                               , column = 1
                               , row = 3
                               }
                             ]
-            , test "the height of a row is the height of the tallest card in the row" <|
+            , test "the spannedRows of a row is the spannedRows of the tallest card in the row" <|
                 \_ ->
                     layout 2 [ ( 1, 2 ), ( 1, 1 ), ( 1, 1 ) ]
                         |> Expect.equal
-                            [ { width = 1
-                              , height = 2
+                            [ { spannedColumns = 1
+                              , spannedRows = 2
                               , column = 1
                               , row = 1
                               }
-                            , { width = 1
-                              , height = 1
+                            , { spannedColumns = 1
+                              , spannedRows = 1
                               , column = 2
                               , row = 1
                               }
-                            , { width = 1
-                              , height = 1
+                            , { spannedColumns = 1
+                              , spannedRows = 1
                               , column = 1
                               , row = 3
                               }

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -857,7 +857,7 @@ all =
                         |> Application.handleCallback
                             (Callback.GotViewport Dashboard <|
                                 Ok <|
-                                    viewportWithSize 300 200
+                                    viewportWithSize 300 600
                             )
                         |> Tuple.first
                         |> gotFavoritedPipelines [ 0, 1 ]

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -8,7 +8,7 @@ import Expect
 import Json.Encode as Encode
 import Message.Callback as Callback
 import Message.Effects exposing (Effect(..))
-import Message.Message exposing (DomID(..), Message(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Message.Subscription as Subscription exposing (Delivery(..))
 import Message.TopLevelMessage exposing (TopLevelMessage(..))
 import Set

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -622,6 +622,30 @@ all =
                         |> Query.find [ class "dashboard-team-pipelines" ]
                         |> Query.findAll [ class "drop-area" ]
                         |> Query.count (Expect.equal 2)
+            , test "renders the final drop area to the right of the last card" <|
+                \_ ->
+                    Common.init "/"
+                        |> Application.handleCallback
+                            (Callback.AllPipelinesFetched <|
+                                Ok [ Data.pipeline "team" 0 ]
+                            )
+                        |> Tuple.first
+                        |> Application.handleCallback
+                            (Callback.GotViewport Dashboard <|
+                                Ok <|
+                                    viewportWithSize 600 200
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find [ class "dashboard-team-pipelines" ]
+                        |> Query.findAll [ class "drop-area" ]
+                        |> Query.index -1
+                        |> hasBounds
+                            { x = 272 + 25
+                            , y = 0
+                            , width = 272 + 25
+                            , height = 268
+                            }
             , test "renders the drop area up one row when the card breaks the row, but there is space for a smaller card" <|
                 \_ ->
                     Common.init "/"

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -511,7 +511,7 @@ all =
                         (Update <|
                             Hover <|
                                 Just <|
-                                    JobPreview (Data.jobId |> Data.withPipelineName "pipeline-0")
+                                    JobPreview AllPipelinesSection (Data.jobId |> Data.withPipelineName "pipeline-0")
                         )
                     |> Tuple.first
                     |> Common.queryView

--- a/web/elm/tests/SideBar/PipelineTests.elm
+++ b/web/elm/tests/SideBar/PipelineTests.elm
@@ -8,7 +8,7 @@ import Data
 import Expect
 import HoverState exposing (TooltipPosition(..))
 import Html exposing (Html)
-import Message.Message exposing (DomID(..), Message, SideBarSection(..))
+import Message.Message exposing (DomID(..), Message, PipelinesSection(..))
 import Set
 import SideBar.Pipeline as Pipeline
 import SideBar.Styles as Styles

--- a/web/elm/tests/SideBar/PipelineTests.elm
+++ b/web/elm/tests/SideBar/PipelineTests.elm
@@ -160,7 +160,7 @@ all =
                         |> viewPipeline { defaultState | isFavoritesSection = False }
                         |> .domID
                         |> Expect.equal
-                            (SideBarPipeline AllPipelines Data.pipelineId)
+                            (SideBarPipeline AllPipelinesSection Data.pipelineId)
             ]
         , describe "when in favorites section"
             [ test "domID is for Favorites section" <|
@@ -169,7 +169,7 @@ all =
                         |> viewPipeline { defaultState | isFavoritesSection = True }
                         |> .domID
                         |> Expect.equal
-                            (SideBarPipeline Favorites Data.pipelineId)
+                            (SideBarPipeline FavoritesSection Data.pipelineId)
             ]
         ]
 
@@ -186,7 +186,7 @@ viewPipeline { active, hovered, favorited, isFavoritesSection } p =
     let
         hoveredDomId =
             if hovered then
-                HoverState.Hovered (SideBarPipeline AllPipelines Data.pipelineId)
+                HoverState.Hovered (SideBarPipeline AllPipelinesSection Data.pipelineId)
 
             else
                 HoverState.NoHover

--- a/web/elm/tests/SideBar/TeamTests.elm
+++ b/web/elm/tests/SideBar/TeamTests.elm
@@ -5,7 +5,7 @@ import Data
 import Expect
 import HoverState exposing (TooltipPosition(..))
 import Html exposing (Html)
-import Message.Message exposing (DomID(..), Message, SideBarSection(..))
+import Message.Message exposing (DomID(..), Message, PipelinesSection(..))
 import Set
 import SideBar.Styles as Styles
 import SideBar.Team as Team
@@ -285,7 +285,7 @@ all =
                     team { defaultState | isFavoritesSection = False }
                         |> .name
                         |> .domID
-                        |> Expect.equal (SideBarTeam AllPipelines "team")
+                        |> Expect.equal (SideBarTeam AllPipelinesSection "team")
             ]
         , describe "when in favorites section"
             [ test "domID is for Favorites section" <|
@@ -293,7 +293,7 @@ all =
                     team { defaultState | isFavoritesSection = True }
                         |> .name
                         |> .domID
-                        |> Expect.equal (SideBarTeam Favorites "team")
+                        |> Expect.equal (SideBarTeam FavoritesSection "team")
             ]
         ]
 
@@ -310,7 +310,7 @@ team { active, expanded, hovered, hasFavorited, isFavoritesSection } =
     let
         hoveredDomId =
             if hovered then
-                HoverState.Hovered (SideBarTeam AllPipelines "team")
+                HoverState.Hovered (SideBarTeam AllPipelinesSection "team")
 
             else
                 HoverState.NoHover

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -525,7 +525,7 @@ hasSideBar iAmLookingAtThePage =
                 , selector =
                     [ style "opacity" "0.4" ]
                 }
-            , hoverable = Message.SideBarPipeline AllPipelines Data.pipelineId
+            , hoverable = Message.SideBarPipeline AllPipelinesSection Data.pipelineId
             , hoveredSelector =
                 { description = "light background"
                 , selector =
@@ -1508,7 +1508,7 @@ iHoveredThePipelineLink =
             (TopLevelMessage.Update <|
                 Message.Hover <|
                     Just <|
-                        Message.SideBarPipeline AllPipelines Data.pipelineId
+                        Message.SideBarPipeline AllPipelinesSection Data.pipelineId
             )
 
 

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -22,8 +22,8 @@ import Expect
 import Html.Attributes as Attr
 import Http
 import Message.Callback as Callback
-import Message.Effects as Effects exposing (sideBarSectionName)
-import Message.Message as Message exposing (SideBarSection(..))
+import Message.Effects as Effects exposing (pipelinesSectionName)
+import Message.Message as Message exposing (PipelinesSection(..))
 import Message.Subscription as Subscription
 import Message.TopLevelMessage as TopLevelMessage
 import Routes
@@ -380,7 +380,7 @@ hasSideBar iAmLookingAtThePage =
         , test "team header is clickable" <|
             given iHaveAnOpenSideBar_
                 >> when iAmLookingAtTheTeamHeader
-                >> then_ (itIsClickable <| Message.SideBarTeam AllPipelines "team")
+                >> then_ (itIsClickable <| Message.SideBarTeam AllPipelinesSection "team")
         , test "there is a minus icon when group is clicked" <|
             given iHaveAnOpenSideBar_
                 >> given iClickedThePipelineGroup
@@ -1039,7 +1039,7 @@ iSeeItEllipsizesLongText =
 iSeeItHasAValidTeamId =
     Query.has
         [ id <|
-            (sideBarSectionName AllPipelines
+            (pipelinesSectionName AllPipelinesSection
                 ++ "_"
                 ++ Base64.encode "team"
             )
@@ -1049,7 +1049,7 @@ iSeeItHasAValidTeamId =
 iSeeItHasAValidPipelineId =
     Query.has
         [ id <|
-            (sideBarSectionName AllPipelines
+            (pipelinesSectionName AllPipelinesSection
                 ++ "_"
                 ++ Base64.encode "team"
                 ++ "_"
@@ -1103,7 +1103,10 @@ iSeeFilledStarIcon =
 iClickedThePipelineGroup =
     Tuple.first
         >> Application.update
-            (TopLevelMessage.Update <| Message.Click <| Message.SideBarTeam AllPipelines "team")
+            (TopLevelMessage.Update <|
+                Message.Click <|
+                    Message.SideBarTeam AllPipelinesSection "team"
+            )
 
 
 iClickedTheFirstPipelineStar =
@@ -1539,7 +1542,7 @@ iClickedTheOtherPipelineGroup =
         >> Application.update
             (TopLevelMessage.Update <|
                 Message.Click <|
-                    Message.SideBarTeam AllPipelines "other-team"
+                    Message.SideBarTeam AllPipelinesSection "other-team"
             )
 
 

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -55,4 +55,4 @@ model =
 
 domID : DomID
 domID =
-    SideBarPipeline AllPipelines Data.pipelineId
+    SideBarPipeline AllPipelinesSection Data.pipelineId

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -6,7 +6,7 @@ import Data
 import Expect
 import HoverState
 import Message.Effects as Effects
-import Message.Message exposing (DomID(..), Message(..), SideBarSection(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import RemoteData
 import ScreenSize
 import Set

--- a/web/elm/tests/TooltipTests.elm
+++ b/web/elm/tests/TooltipTests.elm
@@ -81,7 +81,7 @@ nonOverflowingViewport =
 
 domID : DomID
 domID =
-    SideBarPipeline AllPipelines Data.pipelineId
+    SideBarPipeline AllPipelinesSection Data.pipelineId
 
 
 overflowingViewport : Browser.Dom.Viewport

--- a/web/elm/tests/TooltipTests.elm
+++ b/web/elm/tests/TooltipTests.elm
@@ -7,7 +7,7 @@ import Expect
 import HoverState exposing (TooltipPosition(..))
 import Message.Callback as Callback
 import Message.Effects as Effects
-import Message.Message exposing (DomID(..), Message(..), SideBarSection(..))
+import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Test exposing (Test, describe, test)
 import Tooltip
 

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -1366,7 +1366,8 @@ all =
                 toggleMsg =
                     ApplicationMsgs.Update <|
                         Msgs.Click <|
-                            Msgs.PipelineButton pipelineIdentifier
+                            Msgs.TopBarPauseToggle
+                                pipelineIdentifier
             in
             [ defineHoverBehaviour
                 { name = "play pipeline icon when authorized"
@@ -1401,7 +1402,7 @@ all =
                                 }
                     }
                 , hoverable =
-                    Msgs.PipelineButton pipelineIdentifier
+                    Msgs.TopBarPauseToggle pipelineIdentifier
                 }
             , defineHoverBehaviour
                 { name = "play pipeline icon when unauthenticated"
@@ -1436,7 +1437,7 @@ all =
                                 }
                     }
                 , hoverable =
-                    Msgs.PipelineButton pipelineIdentifier
+                    Msgs.TopBarPauseToggle pipelineIdentifier
                 }
             , defineHoverBehaviour
                 { name = "play pipeline icon when unauthorized"
@@ -1479,7 +1480,7 @@ all =
                         ]
                     }
                 , hoverable =
-                    Msgs.PipelineButton pipelineIdentifier
+                    Msgs.TopBarPauseToggle pipelineIdentifier
                 }
             , test "clicking play button sends TogglePipelinePaused msg" <|
                 \_ ->


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

closes #5439  .

## Changes proposed by this PR:

* Create a new favorite pipelines section on dashboard
  * Pipeline cards in favorites section don't support drag and drop
  * The cards appear in the same order as they do in the all pipelines section (so, reordering in all pipelines will also change the order in the favorite pipelines section)

## Notes to reviewer:

Lazy rendering makes this ~kinda~ really brutal

Also, this is branched off of #5904 (issue/5436)

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
- [x] Code reviewed
- [x] Tests reviewed
- [x] PR acceptance performed