### PR TITLE
worker: Fix flakey container sweeper test

### DIFF
--- a/worker/container_sweeper_test.go
+++ b/worker/container_sweeper_test.go
@@ -20,7 +20,7 @@ import (
 
 var _ = Describe("Container Sweeper", func() {
 	const (
-		sweepInterval              = 50 * time.Millisecond
+		sweepInterval              = 1 * time.Second
 		maxInFlight                = uint16(1)
 		gardenClientTimeoutRequest = 5 * time.Millisecond
 	)


### PR DESCRIPTION
Co-authored-by: Rui Yang <ryang@pivotal.io>

<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
Fixes flakey container sweeper test by increasing sweeper timeout to 1sec. for tests.

We set the timeout to 500MS but it failed at 190th run. We arte setting it to 1 sec. just to be on safer side.

closes #5174 .

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
