### PR TITLE
fly: add team option to destroy-pipeline command

### DIFF
--- a/fly/commands/destroy_pipeline.go
+++ b/fly/commands/destroy_pipeline.go
@@ -3,15 +3,17 @@ package commands
 import (
 	"fmt"
 
-	"github.com/concourse/concourse/fly/rc"
-	"github.com/vito/go-interact/interact"
-
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
+	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/go-concourse/concourse"
+	"github.com/vito/go-interact/interact"
 )
 
 type DestroyPipelineCommand struct {
 	Pipeline        flaghelpers.PipelineFlag `short:"p"  long:"pipeline" required:"true" description:"Pipeline to destroy"`
 	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Destroy the pipeline without confirmation"`
+
+	Team string `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *DestroyPipelineCommand) Validate() error {
@@ -35,6 +37,17 @@ func (command *DestroyPipelineCommand) Execute(args []string) error {
 		return err
 	}
 
+	var team concourse.Team
+
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team)
+		if err != nil {
+			return err
+		}
+	} else {
+		team = target.Team()
+	}
+
 	pipelineName := string(command.Pipeline)
 	fmt.Printf("!!! this will remove all data for pipeline `%s`\n\n", pipelineName)
 
@@ -47,7 +60,7 @@ func (command *DestroyPipelineCommand) Execute(args []string) error {
 		}
 	}
 
-	found, err := target.Team().DeletePipeline(pipelineName)
+	found, err := team.DeletePipeline(pipelineName)
 	if err != nil {
 		return err
 	}

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -122,6 +122,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "unpause-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
 			Entry("set-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", "doesnotexist")),
+			Entry("destroy-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -156,6 +158,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "unpause-pipeline", "-p", "pipeline", "--team", "other-team")),
 			Entry("set-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", "other-team")),
+			Entry("destroy-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", "other-team")),
 		)
 	})
 })


### PR DESCRIPTION
Allow for users to destroying pipelines for different teams
without switching targets

concourse/concourse#5215

Signed-off-by: Ka Hin Ng <kang@pivotal.io>

<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Feature

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
* Add `--team` flag for `fly destroy-pipeline` command.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
