### PR TITLE
Update go mod with latest changes in concourse/dex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
 	github.com/concourse/baggageclaim v1.7.0
-	github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88
+	github.com/concourse/dex v0.0.0-20200730150203-821b48abfd88
 	github.com/concourse/flag v1.1.0
 	github.com/concourse/go-archive v1.0.1
 	github.com/concourse/retryhttp v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -114,14 +114,11 @@ github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e/go.mod h1:P
 github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 h1:9j2KbUEQn5E7MEV3enSrkJTrBC0iDbosW5gXX+Z+dLE=
 github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2/go.mod h1:0a+Ghg38uB86Dx+de84dFSkILTnBHzCpFMRnjHgSzi4=
 github.com/cockroachdb/cmux v0.0.0-20170110192607-30d10be49292/go.mod h1:qRiX68mZX1lGBkTWyp3CLcenw9I94W2dLeRvMzcn9N4=
-github.com/concourse/baggageclaim v1.6.6 h1:wQyJgf41L522Vl1Z6L+LueoCLKia+/XqhrtTz0yrHRI=
-github.com/concourse/baggageclaim v1.6.6/go.mod h1:UdvVE2W8LgXcCz0ZdKBwUbpKZ0KN4Fx1OeY1xtZOUvY=
+github.com/concourse/baggageclaim v1.7.0 h1:6l7xUOiQ770+GEpbmS+XjmcZOWW7RPT/4T2GSj22tiU=
 github.com/concourse/baggageclaim v1.7.0/go.mod h1:UdvVE2W8LgXcCz0ZdKBwUbpKZ0KN4Fx1OeY1xtZOUvY=
-github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88 h1:8BK+Qq51oMwD2CzjAbbMKlAjcXM/PHnAjuRkzZvFmZ4=
-github.com/concourse/dex v0.0.0-20200417202922-dcbe94f28c88/go.mod h1:7xVx6jMkg5UoaGhDHp3mGdETzdVSTY8dOEG1v6ixNQc=
+github.com/concourse/dex v0.0.0-20200730150203-821b48abfd88 h1:RGcAW/U9rGy82zm8IQMqdvUuLcESgisSTb03Yb48zZo=
+github.com/concourse/dex v0.0.0-20200730150203-821b48abfd88/go.mod h1:7xVx6jMkg5UoaGhDHp3mGdETzdVSTY8dOEG1v6ixNQc=
 github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
-github.com/concourse/flag v1.0.0 h1:XG+A/Y+8kNdNDUC9T+SQ55dZ1+xYQN6LNVBg3cGJ080=
-github.com/concourse/flag v1.0.0/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/flag v1.1.0 h1:d2l91vIK6lwfIC7uNLb3i51tZtaWCTokh80VoE6T/RU=
 github.com/concourse/flag v1.1.0/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=
 github.com/concourse/go-archive v0.0.0-20180803203406-784931698f4f/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv0NFwlpjf5CO8=
@@ -746,6 +743,7 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

## Changes proposed by this PR:
Update to use latest version of concourse/dex that fixes concourse/dex#7

Anyone using gitlab to configure their teams will need to update their team config's if they were defined using Gitlab users. If teams were defined with Gitlab groups then no changes are needed.

## Notes to reviewer:


## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] ~Added tests (Unit and/or Integration)~
- [ ] ~Updated [Documentation]~
- [ ] ~Updated [Release notes]~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

cc @taylorsilva 