### PR TITLE
Elm tests use Data module for identifiers

### DIFF
--- a/web/elm/tests/ApiEndpointsTests.elm
+++ b/web/elm/tests/ApiEndpointsTests.elm
@@ -1,6 +1,7 @@
 module ApiEndpointsTests exposing (testEndpoints, testToString)
 
 import Api.Endpoints as E exposing (Endpoint(..), toString)
+import Data
 import Expect
 import Test exposing (Test, describe, test)
 import Url.Builder
@@ -21,10 +22,7 @@ testEndpoints =
         , describe "Pipeline" <|
             let
                 basePipelineEndpoint =
-                    Pipeline
-                        { pipelineName = "pipeline"
-                        , teamName = "team"
-                        }
+                    Pipeline Data.pipelineId
             in
             [ test "Base" <|
                 \_ ->
@@ -77,11 +75,7 @@ testEndpoints =
         , describe "Job" <|
             let
                 baseJobEndpoint =
-                    Job
-                        { jobName = "job"
-                        , pipelineName = "pipeline"
-                        , teamName = "team"
-                        }
+                    Job Data.jobId
             in
             [ test "Base" <|
                 \_ ->
@@ -111,11 +105,12 @@ testEndpoints =
         , test "JobBuild" <|
             \_ ->
                 JobBuild
-                    { buildName = "build"
-                    , jobName = "job"
-                    , pipelineName = "pipeline"
-                    , teamName = "team"
-                    }
+                    (Data.jobBuildId
+                        |> Data.withBuildName "build"
+                        |> Data.withJobName "job"
+                        |> Data.withPipelineName "pipeline"
+                        |> Data.withTeamName "team"
+                    )
                     |> toPath
                     |> Expect.equal "/api/v1/teams/team/pipelines/pipeline/jobs/job/builds/build"
         , describe "Build" <|
@@ -168,11 +163,7 @@ testEndpoints =
         , describe "Resource" <|
             let
                 baseResourceEndpoint =
-                    Resource
-                        { resourceName = "resource"
-                        , pipelineName = "pipeline"
-                        , teamName = "team"
-                        }
+                    Resource Data.resourceId
             in
             [ test "Base" <|
                 \_ ->
@@ -208,12 +199,7 @@ testEndpoints =
         , describe "ResourceVersion" <|
             let
                 baseVersionEndpoint =
-                    ResourceVersion
-                        { versionID = 1
-                        , resourceName = "resource"
-                        , pipelineName = "pipeline"
-                        , teamName = "team"
-                        }
+                    ResourceVersion (Data.resourceVersionId 1)
             in
             [ test "InputTo" <|
                 \_ ->

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -182,12 +182,8 @@ all =
                             |> Header.update (Message.Click Message.RerunBuildButton)
                             |> Tuple.second
                             |> Common.contains
-                                (Effects.RerunJobBuild <|
-                                    { teamName = "team"
-                                    , pipelineName = "pipeline"
-                                    , jobName = "job"
-                                    , buildName = model.name
-                                    }
+                                (Effects.RerunJobBuild
+                                    (Data.longJobBuildId |> Data.withBuildName model.name)
                                 )
                 , test "archived pipeline's have no right widgets" <|
                     \_ ->
@@ -329,13 +325,7 @@ all =
                                 }
                         )
                     |> Header.changeToBuild
-                        (Models.JobBuildPage
-                            { teamName = "team"
-                            , pipelineName = "pipeline"
-                            , jobName = "job"
-                            , buildName = "1"
-                            }
-                        )
+                        (Models.JobBuildPage Data.longJobBuildId)
                     |> Tuple.first
                     |> Header.header session
                     |> Expect.all
@@ -413,7 +403,4 @@ build =
 
 jobId : Concourse.JobIdentifier
 jobId =
-    { teamName = "team"
-    , pipelineName = "pipeline"
-    , jobName = "job"
-    }
+    Data.jobId

--- a/web/elm/tests/Common.elm
+++ b/web/elm/tests/Common.elm
@@ -17,6 +17,7 @@ module Common exposing
 import Application.Application as Application
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
+import Data
 import Expect exposing (Expectation)
 import Html
 import List.Extra
@@ -156,10 +157,11 @@ myBrowserFetchedTheBuild =
                     , name = "1"
                     , job =
                         Just
-                            { teamName = "other-team"
-                            , pipelineName = "yet-another-pipeline"
-                            , jobName = "job"
-                            }
+                            (Data.jobId
+                                |> Data.withTeamName "other-team"
+                                |> Data.withPipelineName "yet-another-pipeline"
+                                |> Data.withJobName "job"
+                            )
                     , status = BuildStatusStarted
                     , duration =
                         { startedAt = Nothing

--- a/web/elm/tests/DashboardPreviewTests.elm
+++ b/web/elm/tests/DashboardPreviewTests.elm
@@ -263,7 +263,4 @@ isPaused j =
 
 jobId : Concourse.JobIdentifier
 jobId =
-    { teamName = "team"
-    , pipelineName = "pipeline"
-    , jobName = "job"
-    }
+    Data.jobId

--- a/web/elm/tests/DashboardSearchTests.elm
+++ b/web/elm/tests/DashboardSearchTests.elm
@@ -46,12 +46,7 @@ hasData =
                                 Just
                                     { id = 1
                                     , name = "1"
-                                    , job =
-                                        Just
-                                            { teamName = "team1"
-                                            , pipelineName = "pipeline"
-                                            , jobName = "job"
-                                            }
+                                    , job = Just (Data.jobId |> Data.withTeamName "team1")
                                     , status = BuildStatusStarted
                                     , duration =
                                         { startedAt = Nothing

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -705,12 +705,7 @@ all =
                                         Just
                                             { id = 0
                                             , name = "1"
-                                            , job =
-                                                Just
-                                                    { teamName = "team"
-                                                    , pipelineName = "pipeline"
-                                                    , jobName = "job"
-                                                    }
+                                            , job = Just Data.jobId
                                             , status = BuildStatusSucceeded
                                             , duration = { startedAt = Nothing, finishedAt = Nothing }
                                             , reapTime = Nothing
@@ -2113,12 +2108,7 @@ running j =
             Just
                 { id = 1
                 , name = "1"
-                , job =
-                    Just
-                        { teamName = "team"
-                        , pipelineName = "pipeline"
-                        , jobName = "job"
-                        }
+                , job = Just Data.jobId
                 , status = BuildStatusStarted
                 , duration =
                     { startedAt = Nothing
@@ -2149,12 +2139,7 @@ jobWithNameTransitionedAt jobName transitionedAt status =
         Just
             { id = 0
             , name = "0"
-            , job =
-                Just
-                    { teamName = "team"
-                    , pipelineName = "pipeline"
-                    , jobName = jobName
-                    }
+            , job = Just Data.jobId
             , status = status
             , duration =
                 { startedAt = Nothing
@@ -2168,12 +2153,7 @@ jobWithNameTransitionedAt jobName transitionedAt status =
                 (\t ->
                     { id = 1
                     , name = "1"
-                    , job =
-                        Just
-                            { teamName = "team"
-                            , pipelineName = "pipeline"
-                            , jobName = jobName
-                            }
+                    , job = Just Data.jobId
                     , status = status
                     , duration =
                         { startedAt = Nothing
@@ -2200,12 +2180,7 @@ circularJobs =
             Just
                 { id = 0
                 , name = "0"
-                , job =
-                    Just
-                        { teamName = "team"
-                        , pipelineName = "pipeline"
-                        , jobName = "jobA"
-                        }
+                , job = Just (Data.jobId |> Data.withJobName "jobA")
                 , status = BuildStatusSucceeded
                 , duration =
                     { startedAt = Nothing
@@ -2217,12 +2192,7 @@ circularJobs =
             Just
                 { id = 1
                 , name = "1"
-                , job =
-                    Just
-                        { teamName = "team"
-                        , pipelineName = "pipeline"
-                        , jobName = "jobA"
-                        }
+                , job = Just (Data.jobId |> Data.withJobName "jobA")
                 , status = BuildStatusSucceeded
                 , duration =
                     { startedAt = Nothing
@@ -2250,12 +2220,7 @@ circularJobs =
             Just
                 { id = 0
                 , name = "0"
-                , job =
-                    Just
-                        { teamName = "team"
-                        , pipelineName = "pipeline"
-                        , jobName = "jobB"
-                        }
+                , job = Just (Data.jobId |> Data.withJobName "jobB")
                 , status = BuildStatusSucceeded
                 , duration =
                     { startedAt = Nothing
@@ -2267,12 +2232,7 @@ circularJobs =
             Just
                 { id = 1
                 , name = "1"
-                , job =
-                    Just
-                        { teamName = "team"
-                        , pipelineName = "pipeline"
-                        , jobName = "jobB"
-                        }
+                , job = Just (Data.jobId |> Data.withJobName "jobB")
                 , status = BuildStatusSucceeded
                 , duration =
                     { startedAt = Nothing

--- a/web/elm/tests/DashboardTooltipTests.elm
+++ b/web/elm/tests/DashboardTooltipTests.elm
@@ -25,11 +25,7 @@ all =
                     }
                     { hovered =
                         Tooltip
-                            (VisibilityButton
-                                { teamName = Data.teamName
-                                , pipelineName = Data.pipelineName
-                                }
-                            )
+                            (VisibilityButton Data.pipelineId)
                             Data.elementPosition
                     }
                     |> Maybe.map .body
@@ -46,11 +42,7 @@ all =
                     }
                     { hovered =
                         Tooltip
-                            (VisibilityButton
-                                { teamName = Data.teamName
-                                , pipelineName = Data.pipelineName
-                                }
-                            )
+                            (VisibilityButton Data.pipelineId)
                             Data.elementPosition
                     }
                     |> Maybe.map .body
@@ -71,11 +63,7 @@ all =
                     }
                     { hovered =
                         Tooltip
-                            (PipelineStatusIcon
-                                { teamName = Data.teamName
-                                , pipelineName = Data.pipelineName
-                                }
-                            )
+                            (PipelineStatusIcon Data.pipelineId)
                             Data.elementPosition
                     }
                     |> Maybe.map .body

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -8,21 +8,38 @@ module Data exposing
     , httpUnauthorized
     , job
     , jobBuild
+    , jobBuildId
     , jobId
     , jobName
     , leftClickEvent
+    , longJobBuildId
     , pipeline
+    , pipelineId
     , pipelineName
     , resource
+    , resourceId
     , resourceName
+    , resourceVersionId
+    , shortJobId
+    , shortPipelineId
+    , shortResourceId
     , teamName
     , version
     , versionedResource
     , withArchived
+    , withBuildName
+    , withDisableManualTrigger
     , withGroups
+    , withJobName
     , withName
     , withPaused
+    , withPipelineName
     , withPublic
+    , withResourceName
+    , withShortJobId
+    , withShortPipelineId
+    , withShortResourceId
+    , withTeamName
     )
 
 import Browser.Dom
@@ -207,6 +224,36 @@ job pipelineID =
     }
 
 
+withDisableManualTrigger : Bool -> { r | disableManualTrigger : Bool } -> { r | disableManualTrigger : Bool }
+withDisableManualTrigger disableManualTrigger p =
+    { p | disableManualTrigger = disableManualTrigger }
+
+
+withTeamName : String -> { r | teamName : String } -> { r | teamName : String }
+withTeamName name p =
+    { p | teamName = name }
+
+
+withPipelineName : String -> { r | pipelineName : String } -> { r | pipelineName : String }
+withPipelineName name p =
+    { p | pipelineName = name }
+
+
+withJobName : String -> { r | jobName : String } -> { r | jobName : String }
+withJobName name p =
+    { p | jobName = name }
+
+
+withResourceName : String -> { r | resourceName : String } -> { r | resourceName : String }
+withResourceName name p =
+    { p | resourceName = name }
+
+
+withBuildName : String -> { r | buildName : String } -> { r | buildName : String }
+withBuildName name p =
+    { p | buildName = name }
+
+
 jobName =
     "job"
 
@@ -223,6 +270,23 @@ resourceName =
     "resource"
 
 
+buildName =
+    "1"
+
+
+withShortPipelineId =
+    withPipelineName "p"
+        >> withTeamName "t"
+
+
+withShortJobId =
+    withShortPipelineId >> withJobName "j"
+
+
+withShortResourceId =
+    withShortPipelineId >> withResourceName "r"
+
+
 versionedResource : String -> Int -> Concourse.VersionedResource
 versionedResource v id =
     { id = id
@@ -237,19 +301,77 @@ version v =
     Dict.fromList [ ( "version", v ) ]
 
 
+pipelineId : Concourse.PipelineIdentifier
+pipelineId =
+    { teamName = teamName
+    , pipelineName = pipelineName
+    }
+
+
+shortPipelineId : Concourse.PipelineIdentifier
+shortPipelineId =
+    pipelineId |> withShortPipelineId
+
+
 jobId : Concourse.JobIdentifier
 jobId =
-    { teamName = "t"
-    , pipelineName = "p"
-    , jobName = "j"
+    { teamName = teamName
+    , pipelineName = pipelineName
+    , jobName = jobName
+    }
+
+
+shortJobId : Concourse.JobIdentifier
+shortJobId =
+    jobId |> withShortJobId
+
+
+resourceId : Concourse.ResourceIdentifier
+resourceId =
+    { teamName = teamName
+    , pipelineName = pipelineName
+    , resourceName = resourceName
+    }
+
+
+shortResourceId : Concourse.ResourceIdentifier
+shortResourceId =
+    resourceId |> withShortResourceId
+
+
+resourceVersionId : Int -> Concourse.VersionedResourceIdentifier
+resourceVersionId v =
+    { teamName = teamName
+    , pipelineName = pipelineName
+    , resourceName = resourceName
+    , versionID = v
+    }
+
+
+
+-- jobBuildId is really shortJobBuildId, but since jobBuild returns a short jobId,
+-- it would be weird for jobBuildId to not represent jobBuild
+
+
+jobBuildId : Concourse.JobBuildIdentifier
+jobBuildId =
+    longJobBuildId |> withShortJobId
+
+
+longJobBuildId : Concourse.JobBuildIdentifier
+longJobBuildId =
+    { teamName = teamName
+    , pipelineName = pipelineName
+    , jobName = jobName
+    , buildName = buildName
     }
 
 
 jobBuild : BuildStatus.BuildStatus -> Concourse.Build
 jobBuild status =
     { id = 1
-    , name = "1"
-    , job = Just jobId
+    , name = buildName
+    , job = Just (jobId |> withShortJobId)
     , status = status
     , duration =
         { startedAt =

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -45,16 +45,13 @@ all =
         [ describe "update" <|
             let
                 someJobInfo =
-                    { jobName = "some-job"
-                    , pipelineName = "some-pipeline"
-                    , teamName = "some-team"
-                    }
+                    Data.jobId
+                        |> Data.withJobName "some-job"
+                        |> Data.withPipelineName "some-pipeline"
+                        |> Data.withTeamName "some-team"
 
                 jobInfo =
-                    { jobName = "job"
-                    , pipelineName = "pipeline"
-                    , teamName = "team"
-                    }
+                    Data.jobId
 
                 someBuild : Build
                 someBuild =
@@ -193,10 +190,7 @@ all =
                             (JobBuildsFetched <|
                                 let
                                     jobId =
-                                        { jobName = "job"
-                                        , pipelineName = "pipeline"
-                                        , teamName = "team"
-                                        }
+                                        Data.jobId
 
                                     status =
                                         BuildStatusSucceeded
@@ -499,10 +493,7 @@ all =
                         (JobBuildsFetched <|
                             let
                                 jobId =
-                                    { jobName = "job"
-                                    , pipelineName = "pipeline"
-                                    , teamName = "team"
-                                    }
+                                    Data.jobId
 
                                 status =
                                     BuildStatusSucceeded
@@ -538,10 +529,7 @@ all =
                         (JobBuildsFetched <|
                             let
                                 jobId =
-                                    { jobName = "job"
-                                    , pipelineName = "pipeline"
-                                    , teamName = "team"
-                                    }
+                                    Data.jobId
 
                                 status =
                                     BuildStatusSucceeded
@@ -596,10 +584,7 @@ all =
                         (JobBuildsFetched <|
                             let
                                 jobId =
-                                    { jobName = "job"
-                                    , pipelineName = "pipeline"
-                                    , teamName = "team"
-                                    }
+                                    Data.jobId
 
                                 status =
                                     BuildStatusSucceeded
@@ -683,10 +668,7 @@ all =
                         (JobBuildsFetched <|
                             let
                                 jobId =
-                                    { jobName = "job"
-                                    , pipelineName = "pipeline"
-                                    , teamName = "team"
-                                    }
+                                    Data.jobId
 
                                 status =
                                     BuildStatusSucceeded
@@ -763,10 +745,7 @@ all =
                 , setup =
                     let
                         jobId =
-                            { jobName = "job"
-                            , pipelineName = "pipeline"
-                            , teamName = "team"
-                            }
+                            Data.jobId
 
                         status =
                             BuildStatusSucceeded

--- a/web/elm/tests/PauseToggleTests.elm
+++ b/web/elm/tests/PauseToggleTests.elm
@@ -1,5 +1,6 @@
 module PauseToggleTests exposing (all)
 
+import Data
 import Dict
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
@@ -15,9 +16,7 @@ all =
         [ describe "when user is unauthorized" <|
             let
                 pipeline =
-                    { pipelineName = "pipeline"
-                    , teamName = "team"
-                    }
+                    Data.pipelineId
 
                 userState =
                     UserStateLoggedIn

--- a/web/elm/tests/PinMenu/PinMenuTests.elm
+++ b/web/elm/tests/PinMenu/PinMenuTests.elm
@@ -2,6 +2,7 @@ module PinMenu.PinMenuTests exposing (all)
 
 import Colors
 import Concourse
+import Data
 import Dict
 import Expect
 import HoverState
@@ -21,10 +22,7 @@ import Views.Styles
 
 init =
     Pipeline.init
-        { pipelineLocator =
-            { teamName = "team"
-            , pipelineName = "pipeline"
-            }
+        { pipelineLocator = Data.pipelineId
         , turbulenceImgSrc = ""
         , selectedGroups = []
         }
@@ -174,11 +172,7 @@ all =
                                       , onClick =
                                             GoToRoute <|
                                                 Routes.Resource
-                                                    { id =
-                                                        { teamName = "team"
-                                                        , pipelineName = "pipeline"
-                                                        , resourceName = "test"
-                                                        }
+                                                    { id = Data.resourceId |> Data.withResourceName "test"
                                                     , page = Nothing
                                                     }
                                       }
@@ -225,11 +219,7 @@ all =
                                       , onClick =
                                             GoToRoute <|
                                                 Routes.Resource
-                                                    { id =
-                                                        { teamName = "team"
-                                                        , pipelineName = "pipeline"
-                                                        , resourceName = "test"
-                                                        }
+                                                    { id = Data.resourceId |> Data.withResourceName "test"
                                                     , page = Nothing
                                                     }
                                       }

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -1263,9 +1263,9 @@ all =
 
                         domID =
                             Msgs.PipelineStatusIcon
-                                { teamName = "team"
-                                , pipelineName = "pipeline-0"
-                                }
+                                (Data.pipelineId
+                                    |> Data.withPipelineName "pipeline-0"
+                                )
                     in
                     [ test "status icon is faded sync" <|
                         \_ ->
@@ -1589,9 +1589,7 @@ all =
                 [ describe "visibility toggle" <|
                     let
                         pipelineId =
-                            { pipelineName = "pipeline"
-                            , teamName = "team"
-                            }
+                            Data.pipelineId
 
                         visibilityToggle =
                             Common.queryView
@@ -2197,11 +2195,7 @@ all =
                                        , style "opacity" "0.5"
                                        ]
                             }
-                        , hoverable =
-                            Msgs.PipelineButton
-                                { pipelineName = "pipeline"
-                                , teamName = "team"
-                                }
+                        , hoverable = Msgs.PipelineButton Data.pipelineId
                         , hoveredSelector =
                             { description = "a bright 20px square pause button with pointer cursor"
                             , selector =
@@ -2249,11 +2243,7 @@ all =
                                        , style "opacity" "0.5"
                                        ]
                             }
-                        , hoverable =
-                            Msgs.PipelineButton
-                                { pipelineName = "pipeline"
-                                , teamName = "team"
-                                }
+                        , hoverable = Msgs.PipelineButton Data.pipelineId
                         , hoveredSelector =
                             { description = "an opaque 20px square play button with pointer cursor"
                             , selector =
@@ -2286,10 +2276,7 @@ all =
                                 |> Event.expect
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton
-                                                { pipelineName = "pipeline"
-                                                , teamName = "team"
-                                                }
+                                            Msgs.PipelineButton Data.pipelineId
                                     )
                     , test "pause button turns into spinner on click" <|
                         \_ ->
@@ -2311,10 +2298,7 @@ all =
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton
-                                                { pipelineName = "pipeline"
-                                                , teamName = "team"
-                                                }
+                                            Msgs.PipelineButton Data.pipelineId
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -2336,19 +2320,10 @@ all =
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton
-                                                { pipelineName = "pipeline"
-                                                , teamName = "team"
-                                                }
+                                            Msgs.PipelineButton Data.pipelineId
                                     )
                                 |> Tuple.second
-                                |> Expect.equal
-                                    [ Effects.SendTogglePipelineRequest
-                                        { pipelineName = "pipeline"
-                                        , teamName = "team"
-                                        }
-                                        False
-                                    ]
+                                |> Expect.equal [ Effects.SendTogglePipelineRequest Data.pipelineId False ]
                     , test "all pipelines are refetched after ok toggle call" <|
                         \_ ->
                             whenOnDashboard { highDensity = False }
@@ -2365,19 +2340,11 @@ all =
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton
-                                                { pipelineName = "pipeline"
-                                                , teamName = "team"
-                                                }
+                                            Msgs.PipelineButton Data.pipelineId
                                     )
                                 |> Tuple.first
                                 |> Application.handleCallback
-                                    (Callback.PipelineToggled
-                                        { pipelineName = "pipeline"
-                                        , teamName = "team"
-                                        }
-                                        (Ok ())
-                                    )
+                                    (Callback.PipelineToggled Data.pipelineId (Ok ()))
                                 |> Tuple.second
                                 |> Expect.equal [ Effects.FetchAllPipelines ]
                     , test "401 toggle call redirects to login" <|
@@ -2395,19 +2362,11 @@ all =
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineButton
-                                                { pipelineName = "pipeline"
-                                                , teamName = "team"
-                                                }
+                                            Msgs.PipelineButton Data.pipelineId
                                     )
                                 |> Tuple.first
                                 |> Application.handleCallback
-                                    (Callback.PipelineToggled
-                                        { pipelineName = "pipeline"
-                                        , teamName = "team"
-                                        }
-                                        Data.httpUnauthorized
-                                    )
+                                    (Callback.PipelineToggled Data.pipelineId Data.httpUnauthorized)
                                 |> Tuple.second
                                 |> Expect.equal [ Effects.RedirectToLogin ]
                     ]

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -510,11 +510,7 @@ all =
                         (Update <|
                             Hover <|
                                 Just <|
-                                    JobPreview
-                                        { teamName = "team"
-                                        , pipelineName = "pipeline-0"
-                                        , jobName = "job"
-                                        }
+                                    JobPreview (Data.jobId |> Data.withPipelineName "pipeline-0")
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -532,10 +528,7 @@ all =
                         (Update <|
                             Hover <|
                                 Just <|
-                                    PipelineWrapper
-                                        { teamName = "team"
-                                        , pipelineName = "pipeline-0"
-                                        }
+                                    PipelineWrapper (Data.pipelineId |> Data.withPipelineName "pipeline-0")
                         )
                     |> Tuple.first
                     |> Common.queryView
@@ -556,8 +549,7 @@ all =
                         (Update <|
                             Hover <|
                                 Just <|
-                                    PipelineWrapper <|
-                                        { pipelineName = "pipeline-0", teamName = "team" }
+                                    PipelineWrapper (Data.pipelineId |> Data.withPipelineName "pipeline-0")
                         )
         , test "pipeline wrapper responds to mouse out" <|
             \_ ->

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -305,9 +305,9 @@ all =
                 defaultModel =
                     Pipeline.init
                         { pipelineLocator =
-                            { teamName = "some-team"
-                            , pipelineName = "some-pipeline"
-                            }
+                            Data.pipelineId
+                                |> Data.withTeamName "some-team"
+                                |> Data.withPipelineName "some-pipeline"
                         , turbulenceImgSrc = "some-turbulence-img-src"
                         , selectedGroups = []
                         }
@@ -376,12 +376,7 @@ all =
                                 )
                             )
                         |> Tuple.second
-                        |> Common.contains
-                            (Effects.FetchPipeline
-                                { teamName = "team"
-                                , pipelineName = "pipeline"
-                                }
-                            )
+                        |> Common.contains (Effects.FetchPipeline Data.pipelineId)
             , test "on one minute timer, refreshes version" <|
                 \_ ->
                     Common.init "/teams/team/pipelines/pipeline"

--- a/web/elm/tests/ResourceFeature.elm
+++ b/web/elm/tests/ResourceFeature.elm
@@ -111,26 +111,15 @@ iClickTheVersionThatIsPinned =
 
 
 pinnedVersionID =
-    { teamName = Data.teamName
-    , pipelineName = Data.pipelineName
-    , resourceName = Data.resourceName
-    , versionID = 0
-    }
+    Data.resourceVersionId 0
 
 
 unpinnedVersionID =
-    { teamName = Data.teamName
-    , pipelineName = Data.pipelineName
-    , resourceName = Data.resourceName
-    , versionID = 1
-    }
+    Data.resourceVersionId 1
 
 
 resourceID =
-    { teamName = Data.teamName
-    , pipelineName = Data.pipelineName
-    , resourceName = Data.resourceName
-    }
+    Data.resourceId
 
 
 myBrowserSendsAPinResourceRequest =

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -64,17 +64,17 @@ commentButtonBlue =
 
 teamName : String
 teamName =
-    "some-team"
+    Data.teamName
 
 
 pipelineName : String
 pipelineName =
-    "some-pipeline"
+    Data.pipelineName
 
 
 resourceName : String
 resourceName =
-    "some-resource"
+    Data.resourceName
 
 
 resourceIcon : String
@@ -84,29 +84,17 @@ resourceIcon =
 
 versionID : Models.VersionId
 versionID =
-    { teamName = teamName
-    , pipelineName = pipelineName
-    , resourceName = resourceName
-    , versionID = 1
-    }
+    Data.resourceVersionId 1
 
 
 otherVersionID : Models.VersionId
 otherVersionID =
-    { teamName = teamName
-    , pipelineName = pipelineName
-    , resourceName = resourceName
-    , versionID = 2
-    }
+    Data.resourceVersionId 2
 
 
 disabledVersionID : Models.VersionId
 disabledVersionID =
-    { teamName = teamName
-    , pipelineName = pipelineName
-    , resourceName = resourceName
-    , versionID = 3
-    }
+    Data.resourceVersionId 3
 
 
 version : String
@@ -210,7 +198,7 @@ all =
                 init
                     |> Application.view
                     |> .title
-                    |> Expect.equal "some-resource - Concourse"
+                    |> Expect.equal "resource - Concourse"
         , test "fetches time zone on page load" <|
             \_ ->
                 Application.init
@@ -251,21 +239,8 @@ all =
                         )
                     |> Tuple.second
                     |> Expect.all
-                        [ Common.contains
-                            (Effects.FetchResource
-                                { resourceName = resourceName
-                                , pipelineName = pipelineName
-                                , teamName = teamName
-                                }
-                            )
-                        , Common.contains
-                            (Effects.FetchVersionedResources
-                                { resourceName = resourceName
-                                , pipelineName = pipelineName
-                                , teamName = teamName
-                                }
-                                Nothing
-                            )
+                        [ Common.contains (Effects.FetchResource Data.resourceId)
+                        , Common.contains (Effects.FetchVersionedResources Data.resourceId Nothing)
                         ]
         , test "autorefresh respects expanded state" <|
             \_ ->
@@ -297,12 +272,7 @@ all =
                                 ( versionID
                                 , [ { id = 0
                                     , name = "some-build"
-                                    , job =
-                                        Just
-                                            { teamName = teamName
-                                            , pipelineName = pipelineName
-                                            , jobName = "some-job"
-                                            }
+                                    , job = Just Data.jobId
                                     , status = BuildStatusSucceeded
                                     , duration =
                                         { startedAt = Nothing
@@ -335,12 +305,7 @@ all =
                                 ( versionID
                                 , [ { id = 0
                                     , name = "some-build"
-                                    , job =
-                                        Just
-                                            { teamName = teamName
-                                            , pipelineName = pipelineName
-                                            , jobName = "some-job"
-                                            }
+                                    , job = Just Data.jobId
                                     , status = BuildStatusSucceeded
                                     , duration =
                                         { startedAt = Nothing
@@ -545,7 +510,7 @@ all =
                     , defineHoverBehaviour <|
                         let
                             urlPath =
-                                "/teams/some-team/pipelines/some-pipeline/resources/some-resource?since=1&limit=1"
+                                "/teams/team/pipelines/pipeline/resources/resource?since=1&limit=1"
                         in
                         { name = "left pagination chevron with previous page"
                         , setup =
@@ -1284,11 +1249,7 @@ all =
                 [ test "version pin states reflect resource pin state" <|
                     \_ ->
                         Resource.init
-                            { resourceId =
-                                { teamName = teamName
-                                , pipelineName = pipelineName
-                                , resourceName = resourceName
-                                }
+                            { resourceId = Data.resourceId
                             , paging = Nothing
                             }
                             |> Resource.handleCallback
@@ -1348,11 +1309,7 @@ all =
                 , test "switching pins puts both versions in transition states" <|
                     \_ ->
                         Resource.init
-                            { resourceId =
-                                { teamName = teamName
-                                , pipelineName = pipelineName
-                                , resourceName = resourceName
-                                }
+                            { resourceId = Data.resourceId
                             , paging = Nothing
                             }
                             |> Resource.handleCallback
@@ -1413,11 +1370,7 @@ all =
                 , test "successful PinResource call when switching shows new version pinned" <|
                     \_ ->
                         Resource.init
-                            { resourceId =
-                                { teamName = teamName
-                                , pipelineName = pipelineName
-                                , resourceName = resourceName
-                                }
+                            { resourceId = Data.resourceId
                             , paging = Nothing
                             }
                             |> Resource.handleDelivery (ClockTicked OneSecond (Time.millisToPosix 1000))
@@ -1482,11 +1435,7 @@ all =
                 , test "auto-refresh respects pin switching" <|
                     \_ ->
                         Resource.init
-                            { resourceId =
-                                { teamName = teamName
-                                , pipelineName = pipelineName
-                                , resourceName = resourceName
-                                }
+                            { resourceId = Data.resourceId
                             , paging = Nothing
                             }
                             |> Resource.handleDelivery (ClockTicked OneSecond (Time.millisToPosix 1000))
@@ -1700,13 +1649,7 @@ all =
                         |> clickToUnpin
                         |> Application.handleCallback (Callback.VersionUnpinned (Ok ()))
                         |> Tuple.second
-                        |> Expect.equal
-                            [ Effects.FetchResource
-                                { resourceName = resourceName
-                                , pipelineName = pipelineName
-                                , teamName = teamName
-                                }
-                            ]
+                        |> Expect.equal [ Effects.FetchResource Data.resourceId ]
             , describe "pin comment bar" <|
                 let
                     pinCommentBar =
@@ -2076,14 +2019,7 @@ all =
                                         |> givenTextareaFocused
                                         |> pressControlEnter
                                         |> Tuple.second
-                                        |> Expect.equal
-                                            [ Effects.SetPinComment
-                                                { teamName = teamName
-                                                , pipelineName = pipelineName
-                                                , resourceName = resourceName
-                                                }
-                                                "foo"
-                                            ]
+                                        |> Expect.equal [ Effects.SetPinComment Data.resourceId "foo" ]
                             , test "Command + Enter sends SaveComment msg" <|
                                 \_ ->
                                     init
@@ -2093,14 +2029,7 @@ all =
                                         |> givenTextareaFocused
                                         |> pressMetaEnter
                                         |> Tuple.second
-                                        |> Expect.equal
-                                            [ Effects.SetPinComment
-                                                { teamName = teamName
-                                                , pipelineName = pipelineName
-                                                , resourceName = resourceName
-                                                }
-                                                "foo"
-                                            ]
+                                        |> Expect.equal [ Effects.SetPinComment Data.resourceId "foo" ]
                             , test "blurring input triggers BlurTextArea msg" <|
                                 \_ ->
                                     textarea
@@ -2270,14 +2199,7 @@ all =
                                     |> update
                                         (Message.Message.Click Message.Message.SaveCommentButton)
                                     |> Tuple.second
-                                    |> Common.contains
-                                        (Effects.SetPinComment
-                                            { teamName = teamName
-                                            , pipelineName = pipelineName
-                                            , resourceName = resourceName
-                                            }
-                                            "foo"
-                                        )
+                                    |> Common.contains (Effects.SetPinComment Data.resourceId "foo")
                         , test "SaveComment msg does not make API call if comment has not changed" <|
                             \_ ->
                                 init
@@ -2363,13 +2285,7 @@ all =
                                     |> Tuple.first
                                     |> Application.handleCallback (CommentSet <| Ok ())
                                     |> Tuple.second
-                                    |> Common.contains
-                                        (Effects.FetchResource
-                                            { teamName = teamName
-                                            , pipelineName = pipelineName
-                                            , resourceName = resourceName
-                                            }
-                                        )
+                                    |> Common.contains (Effects.FetchResource Data.resourceId)
                         , test "on error, refetches data" <|
                             \_ ->
                                 init
@@ -2383,13 +2299,7 @@ all =
                                     |> Application.handleCallback
                                         (CommentSet <| Data.httpInternalServerError)
                                     |> Tuple.second
-                                    |> Common.contains
-                                        (Effects.FetchResource
-                                            { teamName = teamName
-                                            , pipelineName = pipelineName
-                                            , resourceName = resourceName
-                                            }
-                                        )
+                                    |> Common.contains (Effects.FetchResource Data.resourceId)
                         ]
                     ]
                 ]
@@ -2594,7 +2504,7 @@ all =
                                         , isAdmin = False
                                         , teams =
                                             Dict.fromList
-                                                [ ( "some-team"
+                                                [ ( "team"
                                                   , [ "member" ]
                                                   )
                                                 ]
@@ -2678,11 +2588,7 @@ all =
                             onSuccess
                                 >> Tuple.second
                                 >> Expect.equal
-                                    [ Effects.SetPinComment
-                                        { teamName = teamName
-                                        , pipelineName = pipelineName
-                                        , resourceName = resourceName
-                                        }
+                                    [ Effects.SetPinComment Data.resourceId
                                         "pinned by some-user at Jan 1 1970 12:00:00 AM"
                                     ]
                         ]
@@ -2999,13 +2905,7 @@ all =
                                     Message.Message.CheckButton True
                                 )
                             |> Tuple.second
-                            |> Expect.equal
-                                [ Effects.DoCheck
-                                    { resourceName = resourceName
-                                    , pipelineName = pipelineName
-                                    , teamName = teamName
-                                    }
-                                ]
+                            |> Expect.equal [ Effects.DoCheck Data.resourceId ]
                 , describe "while check is pending" <|
                     let
                         givenCheckInProgress : Application.Model -> Application.Model
@@ -3161,17 +3061,8 @@ all =
                                 )
                             |> Tuple.second
                             |> Expect.equal
-                                [ Effects.FetchResource
-                                    { resourceName = resourceName
-                                    , pipelineName = pipelineName
-                                    , teamName = teamName
-                                    }
-                                , Effects.FetchVersionedResources
-                                    { resourceName = resourceName
-                                    , pipelineName = pipelineName
-                                    , teamName = teamName
-                                    }
-                                    Nothing
+                                [ Effects.FetchResource Data.resourceId
+                                , Effects.FetchVersionedResources Data.resourceId Nothing
                                 ]
                 , test "when check resolves unsuccessfully, status is error" <|
                     \_ ->
@@ -3215,13 +3106,7 @@ all =
                                         Data.check Concourse.Errored
                                 )
                             |> Tuple.second
-                            |> Expect.equal
-                                [ Effects.FetchResource
-                                    { resourceName = resourceName
-                                    , pipelineName = pipelineName
-                                    , teamName = teamName
-                                    }
-                                ]
+                            |> Expect.equal [ Effects.FetchResource Data.resourceId ]
                 , test "when check returns 401, redirects to login" <|
                     \_ ->
                         init

--- a/web/elm/tests/SideBar/PipelineTests.elm
+++ b/web/elm/tests/SideBar/PipelineTests.elm
@@ -160,11 +160,7 @@ all =
                         |> viewPipeline { defaultState | isFavoritesSection = False }
                         |> .domID
                         |> Expect.equal
-                            (SideBarPipeline AllPipelines
-                                { teamName = "team"
-                                , pipelineName = "pipeline"
-                                }
-                            )
+                            (SideBarPipeline AllPipelines Data.pipelineId)
             ]
         , describe "when in favorites section"
             [ test "domID is for Favorites section" <|
@@ -173,11 +169,7 @@ all =
                         |> viewPipeline { defaultState | isFavoritesSection = True }
                         |> .domID
                         |> Expect.equal
-                            (SideBarPipeline Favorites
-                                { teamName = "team"
-                                , pipelineName = "pipeline"
-                                }
-                            )
+                            (SideBarPipeline Favorites Data.pipelineId)
             ]
         ]
 
@@ -192,21 +184,16 @@ viewPipeline :
     -> Views.Pipeline
 viewPipeline { active, hovered, favorited, isFavoritesSection } p =
     let
-        pipelineIdentifier =
-            { teamName = "team"
-            , pipelineName = "pipeline"
-            }
-
         hoveredDomId =
             if hovered then
-                HoverState.Hovered (SideBarPipeline AllPipelines pipelineIdentifier)
+                HoverState.Hovered (SideBarPipeline AllPipelines Data.pipelineId)
 
             else
                 HoverState.NoHover
 
         activePipeline =
             if active then
-                Just pipelineIdentifier
+                Just Data.pipelineId
 
             else
                 Nothing

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -525,11 +525,7 @@ hasSideBar iAmLookingAtThePage =
                 , selector =
                     [ style "opacity" "0.4" ]
                 }
-            , hoverable =
-                Message.SideBarPipeline AllPipelines
-                    { pipelineName = "pipeline"
-                    , teamName = "team"
-                    }
+            , hoverable = Message.SideBarPipeline AllPipelines Data.pipelineId
             , hoveredSelector =
                 { description = "light background"
                 , selector =
@@ -1164,19 +1160,6 @@ iAmLookingAtTheFirstPipelineLink =
     iAmLookingAtTheFirstPipeline >> Query.children [] >> Query.index 1
 
 
-iHoveredTheFirstPipelineLink =
-    Tuple.first
-        >> Application.update
-            (TopLevelMessage.Update <|
-                Message.Hover <|
-                    Just <|
-                        Message.SideBarPipeline AllPipelines
-                            { teamName = "team"
-                            , pipelineName = "pipeline"
-                            }
-            )
-
-
 iSeeItContainsThePipelineName =
     Query.has [ text "pipeline" ]
 
@@ -1522,10 +1505,7 @@ iHoveredThePipelineLink =
             (TopLevelMessage.Update <|
                 Message.Hover <|
                     Just <|
-                        Message.SideBarPipeline AllPipelines
-                            { pipelineName = "pipeline"
-                            , teamName = "team"
-                            }
+                        Message.SideBarPipeline AllPipelines Data.pipelineId
             )
 
 
@@ -1629,10 +1609,7 @@ iClickAPipelineLink =
                 Subscription.RouteChanged <|
                     Routes.Pipeline
                         { groups = []
-                        , id =
-                            { pipelineName = "other-pipeline"
-                            , teamName = "team"
-                            }
+                        , id = Data.pipelineId |> Data.withPipelineName "other-pipeline"
                         }
             )
 
@@ -1673,9 +1650,9 @@ iNavigateBackToThePipelinePage =
                     Routes.Pipeline
                         { groups = []
                         , id =
-                            { pipelineName = "yet-another-pipeline"
-                            , teamName = "other-team"
-                            }
+                            Data.pipelineId
+                                |> Data.withTeamName "other-team"
+                                |> Data.withPipelineName "yet-another-pipeline"
                         }
             )
 

--- a/web/elm/tests/SideBarTests.elm
+++ b/web/elm/tests/SideBarTests.elm
@@ -55,7 +55,4 @@ model =
 
 domID : DomID
 domID =
-    SideBarPipeline AllPipelines
-        { teamName = "team"
-        , pipelineName = "pipeline"
-        }
+    SideBarPipeline AllPipelines Data.pipelineId

--- a/web/elm/tests/SubPageTests.elm
+++ b/web/elm/tests/SubPageTests.elm
@@ -32,11 +32,7 @@ all =
                         (NotFoundModel
                             (notFound
                                 (Routes.Job
-                                    { id =
-                                        { teamName = "t"
-                                        , pipelineName = "p"
-                                        , jobName = "j"
-                                        }
+                                    { id = Data.shortJobId
                                     , page = Nothing
                                     }
                                 )
@@ -52,11 +48,7 @@ all =
                         (NotFoundModel
                             (notFound
                                 (Routes.Resource
-                                    { id =
-                                        { teamName = "t"
-                                        , pipelineName = "p"
-                                        , resourceName = "r"
-                                        }
+                                    { id = Data.shortResourceId
                                     , page = Nothing
                                     }
                                 )
@@ -87,10 +79,7 @@ all =
                         (NotFoundModel
                             (notFound
                                 (Routes.Pipeline
-                                    { id =
-                                        { teamName = "t"
-                                        , pipelineName = "p"
-                                        }
+                                    { id = Data.shortPipelineId
                                     , groups = []
                                     }
                                 )

--- a/web/elm/tests/TooltipTests.elm
+++ b/web/elm/tests/TooltipTests.elm
@@ -81,10 +81,7 @@ nonOverflowingViewport =
 
 domID : DomID
 domID =
-    SideBarPipeline AllPipelines
-        { teamName = "team"
-        , pipelineName = "pipeline"
-        }
+    SideBarPipeline AllPipelines Data.pipelineId
 
 
 overflowingViewport : Browser.Dom.Viewport

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -292,11 +292,7 @@ all =
                     (ApplicationMsgs.Update <|
                         Msgs.GoToRoute
                             (Routes.Resource
-                                { id =
-                                    { teamName = "t"
-                                    , pipelineName = "p"
-                                    , resourceName = "r"
-                                    }
+                                { id = Data.shortResourceId
                                 , page = Nothing
                                 }
                             )
@@ -306,11 +302,7 @@ all =
                         [ Effects.NavigateTo <|
                             Routes.toString <|
                                 Routes.Resource
-                                    { id =
-                                        { teamName = "t"
-                                        , pipelineName = "p"
-                                        , resourceName = "r"
-                                        }
+                                    { id = Data.shortResourceId
                                     , page = Nothing
                                     }
                         ]
@@ -1369,15 +1361,12 @@ all =
                         >> Tuple.first
 
                 pipelineIdentifier =
-                    { pipelineName = "p"
-                    , teamName = "t"
-                    }
+                    Data.shortPipelineId
 
                 toggleMsg =
                     ApplicationMsgs.Update <|
                         Msgs.Click <|
-                            Msgs.PipelineButton
-                                pipelineIdentifier
+                            Msgs.PipelineButton pipelineIdentifier
             in
             [ defineHoverBehaviour
                 { name = "play pipeline icon when authorized"
@@ -1412,7 +1401,7 @@ all =
                                 }
                     }
                 , hoverable =
-                    Msgs.PipelineButton { pipelineName = "p", teamName = "t" }
+                    Msgs.PipelineButton pipelineIdentifier
                 }
             , defineHoverBehaviour
                 { name = "play pipeline icon when unauthenticated"
@@ -1447,7 +1436,7 @@ all =
                                 }
                     }
                 , hoverable =
-                    Msgs.PipelineButton { pipelineName = "p", teamName = "t" }
+                    Msgs.PipelineButton pipelineIdentifier
                 }
             , defineHoverBehaviour
                 { name = "play pipeline icon when unauthorized"
@@ -1490,7 +1479,7 @@ all =
                         ]
                     }
                 , hoverable =
-                    Msgs.PipelineButton { pipelineName = "p", teamName = "t" }
+                    Msgs.PipelineButton pipelineIdentifier
                 }
             , test "clicking play button sends TogglePipelinePaused msg" <|
                 \_ ->


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

**tl;dr** this only cleans up tests - when we implement pipeline instances in the UI, we'll need to make changes to all of these tests anyway (else we'll encounter syntax errors)

Adding new fields to identifiers is a pain (as you can probably tell from this PR) because it introduces compiler errors in probably >100 tests.  Rather than each test defining its own identifiers, use default ones + helper functions (e.g. `withName "new-value"`) that transform the default values.

The motivation for this is to prepare for pipeline instances which will introduce a new parameter for identifying pipelines (and therefore also jobs, resources, and resource versions). With this change, when we add a new field to the identifier records, we'll only need to change the default values in the `Data` module.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
