### PR TITLE
Enforce SetPipeline policy check in set_pipeline step

### DIFF
--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -180,6 +180,7 @@ func (factory *coreStepFactory) SetPipelineStep(
 		factory.teamFactory,
 		factory.buildFactory,
 		factory.client,
+		delegateFactory.policyChecker,
 	)
 
 	spStep = exec.LogError(spStep, delegateFactory)

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -3,6 +3,7 @@ package exec_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 
 	. "github.com/onsi/ginkgo"
@@ -18,6 +19,8 @@ import (
 	"github.com/concourse/concourse/atc/exec/build"
 	"github.com/concourse/concourse/atc/exec/build/buildfakes"
 	"github.com/concourse/concourse/atc/exec/execfakes"
+	"github.com/concourse/concourse/atc/policy"
+	"github.com/concourse/concourse/atc/policy/policyfakes"
 	"github.com/concourse/concourse/atc/worker/workerfakes"
 	"github.com/concourse/concourse/vars"
 	"github.com/onsi/gomega/gbytes"
@@ -92,6 +95,10 @@ jobs:
 
 		fakeDelegate        *execfakes.FakeSetPipelineStepDelegate
 		fakeDelegateFactory *execfakes.FakeSetPipelineStepDelegateFactory
+
+		filter      policy.Filter
+		fakeAgent   *policyfakes.FakeAgent
+		fakeChecker policy.Checker
 
 		fakeWorkerClient *workerfakes.FakeClient
 
@@ -172,6 +179,16 @@ jobs:
 		fakeTeamFactory.GetByIDReturns(fakeTeam)
 		fakeBuildFactory.BuildReturns(fakeBuild, true, nil)
 
+		filter = policy.Filter{
+			Actions: []string{exec.ActionRunSetPipeline},
+		}
+
+		fakeAgent = new(policyfakes.FakeAgent)
+		fakeAgent.CheckReturns(policy.PassedPolicyCheck(), nil)
+		fakePolicyAgentFactory.NewAgentReturns(fakeAgent, nil)
+
+		fakeChecker, _ = policy.Initialize(testLogger, "some-cluster", "some-version", filter)
+
 		fakeWorkerClient = new(workerfakes.FakeClient)
 
 		spPlan = &atc.SetPipelinePlan{
@@ -199,6 +216,7 @@ jobs:
 			fakeTeamFactory,
 			fakeBuildFactory,
 			fakeWorkerClient,
+			fakeChecker,
 		)
 
 		stepOk, stepErr = spStep.Run(ctx, state)
@@ -542,6 +560,49 @@ jobs:
 								))
 							})
 						})
+					})
+				})
+			})
+
+			Context("when policy checker enabled", func() {
+				Context("policy check errors", func() {
+					BeforeEach(func() {
+						result := policy.FailedPolicyCheck()
+						fakeAgent.CheckReturns(result, fmt.Errorf("unexpected error"))
+					})
+
+					It("should return error", func() {
+						Expect(stepErr).To(HaveOccurred())
+						Expect(stepErr.Error()).To(Equal("error checking policy enforcement"))
+					})
+				})
+
+				Context("policy check fails", func() {
+					BeforeEach(func() {
+						result := policy.FailedPolicyCheck()
+						result.Reasons = append(result.Reasons, "foo", "bar")
+						fakeAgent.CheckReturns(result, nil)
+					})
+
+					It("should return error", func() {
+						Expect(stepErr).To(HaveOccurred())
+						Expect(stepErr.Error()).To(Equal("policy check failed for set_pipeline: foo, bar"))
+					})
+				})
+
+				Context("policy check succeeds", func() {
+					BeforeEach(func() {
+						fakeBuild.PipelineReturns(fakePipeline, true, nil)
+						fakeBuild.SavePipelineReturns(fakePipeline, false, nil)
+						spPlan.Team = ""
+					})
+
+					It("should finish successfully", func() {
+						_, teamID, _, _, _ := fakeBuild.SavePipelineArgsForCall(0)
+						Expect(teamID).To(Equal(fakeTeam.ID()))
+						Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
+						_, succeeded := fakeDelegate.FinishedArgsForCall(0)
+						Expect(succeeded).To(BeTrue())
 					})
 				})
 			})


### PR DESCRIPTION
Signed-off-by: Chris Ludden <chris.ludden@gmail.com>

## What does this PR accomplish?

Bug Fix - adds policy check to `set_pipeline` step

closes #5931.

## Changes proposed by this PR:
Enforces `SaveConfig` policy check (when enabled) in `set_pipeline` step

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
