### PR TITLE
feat(atc): add data manipulation functions to load_var

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -226,6 +226,7 @@ func (visitor *planVisitor) VisitLoadVar(step *atc.LoadVarStep) error {
 		File:   step.File,
 		Format: step.Format,
 		Reveal: step.Reveal,
+		AddVars: step.AddVars,
 	})
 
 	return nil

--- a/atc/config.go
+++ b/atc/config.go
@@ -300,3 +300,8 @@ func DefaultSSHConfig() ssh.Config {
 		},
 	}
 }
+
+type AddVarConfig struct {
+	Name string `json:"name"`
+	Expr string `json:"expr"`
+}

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -217,10 +217,11 @@ type SetPipelinePlan struct {
 }
 
 type LoadVarPlan struct {
-	Name   string `json:"name"`
-	File   string `json:"file"`
-	Format string `json:"format,omitempty"`
-	Reveal bool   `json:"reveal,omitempty"`
+	Name    string         `json:"name"`
+	File    string         `json:"file"`
+	Format  string         `json:"format,omitempty"`
+	Reveal  bool           `json:"reveal,omitempty"`
+	AddVars []AddVarConfig `json:"adds,omitempty"`
 }
 
 type RetryPlan []Plan

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -350,10 +350,11 @@ func (step *SetPipelineStep) Visit(v StepVisitor) error {
 }
 
 type LoadVarStep struct {
-	Name   string `json:"load_var"`
-	File   string `json:"file,omitempty"`
-	Format string `json:"format,omitempty"`
-	Reveal bool   `json:"reveal,omitempty"`
+	Name    string         `json:"load_var"`
+	File    string         `json:"file,omitempty"`
+	Format  string         `json:"format,omitempty"`
+	Reveal  bool           `json:"reveal,omitempty"`
+	AddVars []AddVarConfig `json:"adds,omitempty"`
 }
 
 func (step *LoadVarStep) Visit(v StepVisitor) error {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Masterminds/squirrel v1.1.0
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
 	github.com/NYTimes/gziphandler v1.1.1
+	github.com/PaesslerAG/gval v1.0.1
 	github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a
 	github.com/aws/aws-sdk-go v1.25.18
 	github.com/caarlos0/env v3.5.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,9 @@ github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cq
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
+github.com/PaesslerAG/gval v1.0.1 h1:QnCvok0w0Y3uZNxmNmC6GZ0cuBl+jH0tu/rBMT8pso4=
+github.com/PaesslerAG/gval v1.0.1/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=

--- a/vars/eval/eval.go
+++ b/vars/eval/eval.go
@@ -1,0 +1,47 @@
+package eval
+
+import (
+	"fmt"
+	"github.com/PaesslerAG/gval"
+	"regexp"
+	"strconv"
+)
+
+func VarEval(expr string, data interface{}) (interface{}, error) {
+	value, err := gval.Evaluate(
+		expr,
+		data,
+		gval.Full(),
+		gval.Function("strlen", strlen),
+		gval.Function("len", arrlen),
+		gval.Function("rematch", rematch),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func strlen(args ...interface{}) (interface{}, error) {
+	length := len(args[0].(string))
+	return strconv.Itoa(length), nil
+}
+
+func arrlen(args ...interface{}) (interface{}, error) {
+	length := len(args[0].([]interface{}))
+	return strconv.Itoa(length), nil
+}
+
+func rematch(args ...interface{}) (interface{}, error) {
+	str := args[0].(string)
+	expr := args[1].(string)
+	re, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	result := re.FindAllStringSubmatch(str, 1)
+	if result == nil {
+		return nil, fmt.Errorf("no match")
+	}
+	return result[0][1], nil
+}

--- a/vars/template.go
+++ b/vars/template.go
@@ -17,6 +17,7 @@ type Template struct {
 type EvaluateOpts struct {
 	ExpectAllKeys     bool
 	ExpectAllVarsUsed bool
+	PlainText         bool
 }
 
 func NewTemplate(bytes []byte) Template {
@@ -29,6 +30,14 @@ func (t Template) ExtraVarNames() []string {
 
 func (t Template) Evaluate(vars Variables, opts EvaluateOpts) ([]byte, error) {
 	var obj interface{}
+
+	if opts.PlainText {
+		obj, err := t.interpolateRoot(string(t.bytes), newVarsTracker(vars, opts.ExpectAllKeys, opts.ExpectAllVarsUsed))
+		if err != nil {
+			return []byte{}, err
+		}
+		return []byte(obj.(string)), nil
+	}
 
 	err := yaml.Unmarshal(t.bytes, &obj)
 	if err != nil {


### PR DESCRIPTION

## What does this PR accomplish?

The `load_var` step make a pipeline to be able to load variables at run-time. But a new problem I have seen is that, sometime, users need to some simple manipulations on loaded vars, then they have to add a task to do so, which makes pipeline massive. 

This PR adds some data manipulation functions to load_var. See my test pipeline:

```yaml
var_sources:
- name: vs
  type: dummy
  config:
    vars:
      vs_var: hello

jobs:
- name: myjob
  plan:
  - task: generate-data
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: 
          repository: busybox
      outputs:
      - name: out
      run:
        path: sh
        args:
        - -exc
        - |
         echo '{"foo": "bar", "arr": ["1", "2", "3"]}' > out/data.json
         echo '<release-note>some feature released</release-note>' > out/release.txt

  - load_var: data
    file: out/data.json
    adds:
    - name: statement
      expr: foo + " is bar" # basic string concat, where foo is a field in loaded var "data"
    - name: arrlen
      expr: len(arr)  # get length of an array, where arr is a field in loaded var "data"
    - name: from_vs
      expr: |
        "((vs:vs_var))" + " world" # vars from var_source can also be used

  - load_var: release
    file: out/release.txt
    adds:
    - name: note
      expr: rematch( "((.:release))", "<release-note>(.*)</release-note>" ) # regexp match, this help extract sub-string, e.g. extract release-note from PR description

  - task: show-vars
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: 
          repository: busybox
      outputs:
      - name: out
      run:
        path: sh
        args:
        - -exc
        - |
         echo __((.:data.foo))__
         echo __((.:data-statement))__
         echo The array has ((.:data-arrlen)) items__
         echo __((.:data-from_vs))__
         echo '__((.:release-note))__'
```

And see screen shot of a build of the pipeline:

![load_var_add](https://user-images.githubusercontent.com/18585861/88991841-5eb5c980-d314-11ea-977c-e735a8528390.png)


## Changes proposed by this PR:

Add a param `adds` to `load_var` step, an add contains a name and a expression, where the expression will be evaluated to a string, and inject a new var `<load_var name>-<add name>`.


## Notes to reviewer:

1. This is an initial version for review. If people buy in this idea, more data manipulation functions can be supported.
2. The package `eval` added in this PR can be used for https://github.com/concourse/rfcs/pull/66

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
