### PR TITLE
feat(atc): allows to specify a registry-mirror url to ATC, and expose the url to resources via environment variable.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -129,6 +129,8 @@ type RunCommand struct {
 
 	ExternalURL flag.URL `long:"external-url" description:"URL used to reach any ATC from the outside world."`
 
+	RegistryMirrorURL flag.URL `long:"registry-mirror-url" description:"URL of a registry mirror"`
+
 	Postgres flag.PostgresConfig `group:"PostgreSQL Configuration" namespace:"postgres"`
 
 	ConcurrentRequestLimits   map[wrappa.LimitedRoute]int `long:"concurrent-request-limit" description:"Limit the number of concurrent requests to an API endpoint (Example: ListAllJobs:5)"`
@@ -1581,6 +1583,7 @@ func (cmd *RunCommand) constructEngine(
 		stepFactory,
 		builder.NewDelegateFactory(),
 		cmd.ExternalURL.String(),
+		cmd.RegistryMirrorURL.String(),
 		secretManager,
 		cmd.varSourcePool,
 		cmd.EnableRedactSecrets,

--- a/atc/engine/builder/builder.go
+++ b/atc/engine/builder/builder.go
@@ -43,27 +43,30 @@ func NewStepBuilder(
 	stepFactory StepFactory,
 	delegateFactory DelegateFactory,
 	externalURL string,
+	registryMirrorURL string,
 	secrets creds.Secrets,
 	varSourcePool creds.VarSourcePool,
 	redactSecrets bool,
 ) *stepBuilder {
 	return &stepBuilder{
-		stepFactory:     stepFactory,
-		delegateFactory: delegateFactory,
-		externalURL:     externalURL,
-		globalSecrets:   secrets,
-		varSourcePool:   varSourcePool,
-		redactSecrets:   redactSecrets,
+		stepFactory:       stepFactory,
+		delegateFactory:   delegateFactory,
+		externalURL:       externalURL,
+		registryMirrorURL: registryMirrorURL,
+		globalSecrets:     secrets,
+		varSourcePool:     varSourcePool,
+		redactSecrets:     redactSecrets,
 	}
 }
 
 type stepBuilder struct {
-	stepFactory     StepFactory
-	delegateFactory DelegateFactory
-	externalURL     string
-	globalSecrets   creds.Secrets
-	varSourcePool   creds.VarSourcePool
-	redactSecrets   bool
+	stepFactory       StepFactory
+	delegateFactory   DelegateFactory
+	externalURL       string
+	registryMirrorURL string
+	globalSecrets     creds.Secrets
+	varSourcePool     creds.VarSourcePool
+	redactSecrets     bool
 }
 
 func (builder *stepBuilder) BuildStep(logger lager.Logger, build db.Build) (exec.Step, error) {
@@ -325,6 +328,7 @@ func (builder *stepBuilder) buildGetStep(build db.Build, plan atc.Plan, credVars
 	stepMetadata := builder.stepMetadata(
 		build,
 		builder.externalURL,
+		builder.registryMirrorURL,
 	)
 
 	return builder.stepFactory.GetStep(
@@ -347,6 +351,7 @@ func (builder *stepBuilder) buildPutStep(build db.Build, plan atc.Plan, credVars
 	stepMetadata := builder.stepMetadata(
 		build,
 		builder.externalURL,
+		builder.registryMirrorURL,
 	)
 
 	return builder.stepFactory.PutStep(
@@ -394,6 +399,7 @@ func (builder *stepBuilder) buildTaskStep(build db.Build, plan atc.Plan, credVar
 	stepMetadata := builder.stepMetadata(
 		build,
 		builder.externalURL,
+		builder.registryMirrorURL,
 	)
 
 	return builder.stepFactory.TaskStep(
@@ -409,6 +415,7 @@ func (builder *stepBuilder) buildSetPipelineStep(build db.Build, plan atc.Plan, 
 	stepMetadata := builder.stepMetadata(
 		build,
 		builder.externalURL,
+		builder.registryMirrorURL,
 	)
 
 	return builder.stepFactory.SetPipelineStep(
@@ -423,6 +430,7 @@ func (builder *stepBuilder) buildLoadVarStep(build db.Build, plan atc.Plan, cred
 	stepMetadata := builder.stepMetadata(
 		build,
 		builder.externalURL,
+		builder.registryMirrorURL,
 	)
 
 	return builder.stepFactory.LoadVarStep(
@@ -480,16 +488,18 @@ func (builder *stepBuilder) containerMetadata(
 func (builder *stepBuilder) stepMetadata(
 	build db.Build,
 	externalURL string,
+	registryMirrorURL string,
 ) exec.StepMetadata {
 	return exec.StepMetadata{
-		BuildID:      build.ID(),
-		BuildName:    build.Name(),
-		TeamID:       build.TeamID(),
-		TeamName:     build.TeamName(),
-		JobID:        build.JobID(),
-		JobName:      build.JobName(),
-		PipelineID:   build.PipelineID(),
-		PipelineName: build.PipelineName(),
-		ExternalURL:  externalURL,
+		BuildID:           build.ID(),
+		BuildName:         build.Name(),
+		TeamID:            build.TeamID(),
+		TeamName:          build.TeamName(),
+		JobID:             build.JobID(),
+		JobName:           build.JobName(),
+		PipelineID:        build.PipelineID(),
+		PipelineName:      build.PipelineName(),
+		ExternalURL:       externalURL,
+		RegistryMirrorURL: registryMirrorURL,
 	}
 }

--- a/atc/exec/step_metadata.go
+++ b/atc/exec/step_metadata.go
@@ -17,6 +17,7 @@ type StepMetadata struct {
 	ResourceConfigID      int
 	BaseResourceTypeID    int
 	ExternalURL           string
+	RegistryMirrorURL     string
 }
 
 func (metadata StepMetadata) Env() []string {
@@ -56,6 +57,10 @@ func (metadata StepMetadata) Env() []string {
 
 	if metadata.ExternalURL != "" {
 		env = append(env, "ATC_EXTERNAL_URL="+metadata.ExternalURL)
+	}
+
+	if metadata.RegistryMirrorURL != "" {
+		env = append(env, "REGISTRY_MIRROR_URL="+metadata.RegistryMirrorURL)
 	}
 
 	return env


### PR DESCRIPTION

## What does this PR accomplish?

My ultimate goal is to make `registry-image` to transparently pull images from a mirror that is configured to ATC. To archive that, we need to:

1. Add a flag to `concourse web` to configure a registry mirror URL.
2. Expose the mirror URL to resource's `check/get/put` via environment variable.
3. Enhance `registry-image` resource type to check the environment variable, if there is a mirror passing from env, then pull from the mirror first and if pulling from mirror fails, then fail back to original registry.

## Changes proposed by this PR:

This PR is addressing 1&2. 

## Notes to reviewer:

This PR is calling for review of the idea, no tests have been done yet. If the idea is acceptable, then I will add test cases and run tests.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
