### PR TITLE
Optimize team roles computation in API

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -42,6 +42,8 @@ type access struct {
 	systemClaimKey    string
 	systemClaimValues []string
 	teams             []db.Team
+	teamRoles         map[string][]string
+	isAdmin           bool
 }
 
 func NewAccessor(
@@ -51,77 +53,42 @@ func NewAccessor(
 	systemClaimValues []string,
 	teams []db.Team,
 ) *access {
-	return &access{
+	a := &access{
 		verification:      verification,
 		requiredRole:      requiredRole,
 		systemClaimKey:    systemClaimKey,
 		systemClaimValues: systemClaimValues,
 		teams:             teams,
 	}
+	a.computeTeamRoles()
+	return a
 }
 
-func (a *access) HasToken() bool {
-	return a.verification.HasToken
-}
 
-func (a *access) IsAuthenticated() bool {
-	return a.verification.IsTokenValid
-}
-
-func (a *access) IsAuthorized(teamName string) bool {
-
-	if a.IsAdmin() {
-		return true
-	}
-
-	for _, team := range a.TeamNames() {
-		if team == teamName {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (a *access) TeamNames() []string {
-
-	teamNames := []string{}
-
-	isAdmin := a.IsAdmin()
+func (a *access) computeTeamRoles() {
+	a.teamRoles = map[string][]string{}
 
 	for _, team := range a.teams {
-		if isAdmin || a.hasRequiredRole(team.Auth()) {
-			teamNames = append(teamNames, team.Name())
+		roles := a.rolesForTeam(team.Auth())
+		if len(roles) > 0 {
+			a.teamRoles[team.Name()] = roles
+		}
+		if team.Admin() && contains(roles, OwnerRole) {
+			a.isAdmin = true
 		}
 	}
-
-	return teamNames
 }
 
-func (a *access) hasRequiredRole(auth atc.TeamAuth) bool {
-	for _, teamRole := range a.rolesForTeam(auth) {
-		if a.hasPermission(teamRole) {
+func contains(arr []string, val string) bool {
+	for _, v := range arr {
+		if v == val {
 			return true
 		}
 	}
 	return false
-}
-
-func (a *access) teamRoles() map[string][]string {
-
-	teamRoles := map[string][]string{}
-
-	for _, team := range a.teams {
-		if roles := a.rolesForTeam(team.Auth()); len(roles) > 0 {
-			teamRoles[team.Name()] = roles
-		}
-	}
-
-	return teamRoles
 }
 
 func (a *access) rolesForTeam(auth atc.TeamAuth) []string {
-
 	roleSet := map[string]bool{}
 
 	groups := a.groups()
@@ -169,19 +136,45 @@ func (a *access) rolesForTeam(auth atc.TeamAuth) []string {
 	return roles
 }
 
-func (a *access) hasPermission(role string) bool {
-	switch a.requiredRole {
-	case OwnerRole:
-		return role == OwnerRole
-	case MemberRole:
-		return role == OwnerRole || role == MemberRole
-	case OperatorRole:
-		return role == OwnerRole || role == MemberRole || role == OperatorRole
-	case ViewerRole:
-		return role == OwnerRole || role == MemberRole || role == OperatorRole || role == ViewerRole
-	default:
-		return false
+func (a *access) HasToken() bool {
+	return a.verification.HasToken
+}
+
+func (a *access) IsAuthenticated() bool {
+	return a.verification.IsTokenValid
+}
+
+func (a *access) IsAuthorized(teamName string) bool {
+	return a.isAdmin || a.hasPermission(a.teamRoles[teamName])
+}
+
+func (a *access) TeamNames() []string {
+	teamNames := []string{}
+	for _, team := range a.teams {
+		if a.isAdmin || a.hasPermission(a.teamRoles[team.Name()]) {
+			teamNames = append(teamNames, team.Name())
+		}
 	}
+
+	return teamNames
+}
+
+func (a *access) hasPermission(roles []string) bool {
+	for _, role := range roles {
+		switch a.requiredRole {
+		case OwnerRole:
+			return role == OwnerRole
+		case MemberRole:
+			return role == OwnerRole || role == MemberRole
+		case OperatorRole:
+			return role == OwnerRole || role == MemberRole || role == OperatorRole
+		case ViewerRole:
+			return role == OwnerRole || role == MemberRole || role == OperatorRole || role == ViewerRole
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 func (a *access) claims() map[string]interface{} {
@@ -244,30 +237,8 @@ func (a *access) groups() []string {
 	return groups
 }
 
-func (a *access) adminTeams() []string {
-	var adminTeams []string
-
-	for _, team := range a.teams {
-		if team.Admin() {
-			adminTeams = append(adminTeams, team.Name())
-		}
-	}
-	return adminTeams
-}
-
 func (a *access) IsAdmin() bool {
-
-	teamRoles := a.teamRoles()
-
-	for _, adminTeam := range a.adminTeams() {
-		for _, role := range teamRoles[adminTeam] {
-			if role == "owner" {
-				return true
-			}
-		}
-	}
-
-	return false
+	return a.isAdmin
 }
 
 func (a *access) IsSystem() bool {
@@ -282,7 +253,7 @@ func (a *access) IsSystem() bool {
 }
 
 func (a *access) TeamRoles() map[string][]string {
-	return a.teamRoles()
+	return a.teamRoles
 }
 
 func (a *access) Claims() Claims {

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -82,52 +82,18 @@ var _ = Describe("Teams API", func() {
 					"groups": []string{}, "users": []string{"local:username"},
 				},
 			})
+
+			fakeAccess.IsAuthorizedReturnsOnCall(0, true)
+			fakeAccess.IsAuthorizedReturnsOnCall(1, false)
+			fakeAccess.IsAuthorizedReturnsOnCall(2, true)
 		})
 
-		Context("when the requester is an admin", func() {
+		Context("when the database call succeeds", func() {
 			BeforeEach(func() {
-				fakeAccess.IsAdminReturns(true)
-
-				dbTeamFactory.GetTeamsReturns([]db.Team{fakeTeamOne, fakeTeamTwo, fakeTeamThree}, nil)
-
-			})
-
-			It("should return all teams", func() {
-				body, err := ioutil.ReadAll(response.Body)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(body).To(MatchJSON(`[
- 					{
- 						"id": 5,
- 						"name": "avengers",
-						"auth": { "owner":{"users":["local:username"],"groups":[]}}
- 					},
- 					{
- 						"id": 9,
- 						"name": "aliens",
-						"auth": { "owner":{"users":["local:username"],"groups":[]}}
-					},
- 					{
- 						"id": 22,
- 						"name": "predators",
-						"auth": { "owner":{"users":["local:username"],"groups":[]}}
-					}
- 				]`))
-			})
-		})
-
-		Context("when the requester is NOT an admin", func() {
-			BeforeEach(func() {
-				fakeAccess.IsAdminReturns(false)
-
-				fakeAccess.IsAuthorizedReturnsOnCall(0, true)
-				fakeAccess.IsAuthorizedReturnsOnCall(1, false)
-				fakeAccess.IsAuthorizedReturnsOnCall(2, true)
-
 				dbTeamFactory.GetTeamsReturns([]db.Team{fakeTeamOne, fakeTeamTwo, fakeTeamThree}, nil)
 			})
 
-			It("should return only the teams the user is authorized for", func() {
+			It("should return the teams the user is authorized for", func() {
 				body, err := ioutil.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -146,7 +112,7 @@ var _ = Describe("Teams API", func() {
 			})
 		})
 
-		Context("when the database returns an error", func() {
+		Context("when the database call returns an error", func() {
 			var disaster error
 
 			BeforeEach(func() {

--- a/atc/api/teamserver/list.go
+++ b/atc/api/teamserver/list.go
@@ -22,7 +22,7 @@ func (s *Server) ListTeams(w http.ResponseWriter, r *http.Request) {
 	acc := accessor.GetAccessor(r)
 	presentedTeams := make([]atc.Team, 0)
 	for _, team := range teams {
-		if acc.IsAdmin() || acc.IsAuthorized(team.Name()) {
+		if acc.IsAuthorized(team.Name()) {
 			presentedTeams = append(presentedTeams, present.Team(team))
 		}
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #5912 .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Precompute team roles once when we construct the accessor, rather than every time we try to check if a user has access to a team

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

Opening a separate PR from #5897 since this is an independent change, and we are going to have a discussion about auth in general soon, so the approach is kind of up in the air.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
