### PR TITLE
Remove private_plan from index

### DIFF
--- a/atc/db/migration/migrations/1595347367_add_index_for_unencrypted_private_plans_to_builds.up.sql
+++ b/atc/db/migration/migrations/1595347367_add_index_for_unencrypted_private_plans_to_builds.up.sql
@@ -1,3 +1,3 @@
 BEGIN;
-  CREATE INDEX unencrypted_private_plans_build_idx ON builds (id, private_plan) WHERE nonce IS NULL AND private_plan IS NOT NULL;
+  CREATE INDEX unencrypted_private_plans_build_idx ON builds (id) WHERE nonce IS NULL AND private_plan IS NOT NULL;
 COMMIT;


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!
To help us review your PR, please fill in the following information.
-->

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #5948 .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Remove `private_plan` from index in existing migration
  * When the `private_plan` was of moderate size (>2700 bytes), scheduling would error as the plan would not fit in the index (since the btree maximum size is 2704 bytes)
  * The query won't be quite as fast since we can't just use the index, but it should still be faster than having no index since we don't need to scan the builds table

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Updated [Release notes]

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs
[Release notes]: https://github.com/concourse/concourse/tree/master/release-notes

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
