### PR TITLE
Add flag ` --ignore-event-parsing-errors` to `fly watch` to ignore event parsing errors when an unknown event type or version is encountered. 

### DIFF
--- a/fly/commands/watch.go
+++ b/fly/commands/watch.go
@@ -12,10 +12,11 @@ import (
 )
 
 type WatchCommand struct {
-	Job       flaghelpers.JobFlag `short:"j" long:"job"         value-name:"PIPELINE/JOB"  description:"Watches builds of the given job"`
-	Build     string              `short:"b" long:"build"                                  description:"Watches a specific build"`
-	Url       string              `short:"u" long:"url"                                    description:"URL for the build or job to watch"`
-	Timestamp bool                `short:"t" long:"timestamps"                             description:"Print with local timestamp"`
+	Job                      flaghelpers.JobFlag `short:"j" long:"job"         value-name:"PIPELINE/JOB"  description:"Watches builds of the given job"`
+	Build                    string              `short:"b" long:"build"                                  description:"Watches a specific build"`
+	Url                      string              `short:"u" long:"url"                                    description:"URL for the build or job to watch"`
+	Timestamp                bool                `short:"t" long:"timestamps"                             description:"Print with local timestamp"`
+	IgnoreEventParsingErrors bool                `long:"ignore-event-parsing-errors"                      description:"Ignore event parsing errors"`
 }
 
 func getBuildIDFromURL(target rc.Target, urlParam string) (int, error) {
@@ -103,7 +104,10 @@ func (command *WatchCommand) Execute(args []string) error {
 		return err
 	}
 
-	renderOptions := eventstream.RenderOptions{ShowTimestamp: command.Timestamp}
+	renderOptions := eventstream.RenderOptions{
+		ShowTimestamp:            command.Timestamp,
+		IgnoreEventParsingErrors: command.IgnoreEventParsingErrors,
+	}
 
 	exitCode := eventstream.Render(os.Stdout, eventSource, renderOptions)
 

--- a/fly/eventstream/render.go
+++ b/fly/eventstream/render.go
@@ -26,20 +26,13 @@ func Render(dst io.Writer, src eventstream.EventStream, options RenderOptions) i
 		if err != nil {
 			if err == io.EOF {
 				return exitStatus
-			} else if _, ok := err.(event.UnknownEventTypeError); ok && options.IgnoreEventParsingErrors {
-				dstImpl.SetTimestamp(0)
-				fmt.Fprintf(dstImpl, "failed to parse next event: %s\n", ui.ErroredColor.Sprint(err))
-				continue
-			} else if _, ok := err.(event.UnknownEventVersionError); ok && options.IgnoreEventParsingErrors {
-				dstImpl.SetTimestamp(0)
-				fmt.Fprintf(dstImpl, "failed to parse next event: %s\n", ui.ErroredColor.Sprint(err))
+			} else if options.IgnoreEventParsingErrors && isEventParseError(err) {
 				continue
 			} else {
 				dstImpl.SetTimestamp(0)
-				fmt.Fprintf(dstImpl, "failed to parse next event: %s\n", err)
+				fmt.Fprintf(dstImpl, "failed to parse next event: %s\n", ui.ErroredColor.Sprint(err))
 				return 255
 			}
-
 		}
 
 		switch e := ev.(type) {
@@ -108,4 +101,13 @@ func Render(dst io.Writer, src eventstream.EventStream, options RenderOptions) i
 			return exitStatus
 		}
 	}
+}
+
+func isEventParseError(err error) bool {
+	if _, ok := err.(event.UnknownEventTypeError); ok {
+		return true
+	} else if _, ok := err.(event.UnknownEventVersionError); ok {
+		return true
+	}
+	return false
 }

--- a/fly/eventstream/render_test.go
+++ b/fly/eventstream/render_test.go
@@ -348,10 +348,6 @@ var _ = Describe("V1.0 Renderer", func() {
 			BeforeEach(func() {
 				options.IgnoreEventParsingErrors = true
 			})
-			It("prints the build's run script", func() {
-				Expect(out.Contents()).To(ContainSubstring("failed to parse next event"))
-			})
-
 			It("exits with 0 exit code", func() {
 				Expect(exitStatus).To(Equal(0))
 			})
@@ -361,8 +357,3 @@ var _ = Describe("V1.0 Renderer", func() {
 	})
 
 })
-
-type someNewEvent struct{}
-
-func (someNewEvent) EventType() atc.EventType  { return "some-new-event" }
-func (someNewEvent) Version() atc.EventVersion { return "1.0" }

--- a/fly/eventstream/render_test.go
+++ b/fly/eventstream/render_test.go
@@ -296,10 +296,10 @@ var _ = Describe("V1.0 Renderer", func() {
 		})
 	})
 
-	Context("and a SelectedWorker event is received", func() {
+	Context("when a SelectedWorker event is received", func() {
 		BeforeEach(func() {
 			receivedEvents <- event.SelectedWorker{
-				Time: time.Now().Unix(),
+				Time:       time.Now().Unix(),
 				WorkerName: "some-worker",
 			}
 		})
@@ -318,4 +318,51 @@ var _ = Describe("V1.0 Renderer", func() {
 			})
 		})
 	})
+
+	Context("when an UnknownEventTypeError or UnknownEventVersionError is received", func() {
+
+		BeforeEach(func() {
+			errors := make(chan error, 100)
+
+			stream.NextEventStub = func() (atc.Event, error) {
+				select {
+				case ev := <-errors:
+					return nil, ev
+				default:
+					return nil, io.EOF
+				}
+			}
+			errors <- event.UnknownEventTypeError{"some-event"}
+			errors <- event.UnknownEventVersionError{Type: "some-bad-version-event"}
+		})
+
+		It("prints the build's run script", func() {
+			Expect(out.Contents()).To(ContainSubstring("failed to parse next event"))
+		})
+
+		It("exits with 255 exit code", func() {
+			Expect(exitStatus).To(Equal(255))
+		})
+
+		Context("when IgnoreEventParsingErrors is configured", func() {
+			BeforeEach(func() {
+				options.IgnoreEventParsingErrors = true
+			})
+			It("prints the build's run script", func() {
+				Expect(out.Contents()).To(ContainSubstring("failed to parse next event"))
+			})
+
+			It("exits with 0 exit code", func() {
+				Expect(exitStatus).To(Equal(0))
+			})
+
+		})
+
+	})
+
 })
+
+type someNewEvent struct{}
+
+func (someNewEvent) EventType() atc.EventType  { return "some-new-event" }
+func (someNewEvent) Version() atc.EventVersion { return "1.0" }


### PR DESCRIPTION
## What does this PR accomplish?
Feature
closes #5938 

## Changes proposed by this PR:
adding a toggle flag to `fly watch` that ignores parsing errors
of type;
- UnknownEventTypeError 
- UnknownEventVersionError

This prevents issues if a user were to trigger jobs on a version of
Concourse and then downgrade/upgrade Concourse to a version where an
event type is not recognized causing fly to bail. In such scenarios, the
user would have to determine the correct fly version to use to correctly
parse the build events, which seems quite cumbersome.

## Notes to reviewer:
For testing, easiest method is to trigger a job in a pipeline, edit a record in the build_events_X table with a bogus event and attempt to `fly watch` the build 

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
