### PR TITLE
Rerun builds with baggageclaim network errors

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -64,8 +64,8 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/cppforlife/go-semi-semantic/version"
-	multierror "github.com/hashicorp/go-multierror"
-	flags "github.com/jessevdk/go-flags"
+	"github.com/hashicorp/go-multierror"
+	"github.com/jessevdk/go-flags"
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/grouper"
@@ -247,7 +247,7 @@ type RunCommand struct {
 	SystemClaimKey    string   `long:"system-claim-key" default:"aud" description:"The token claim key to use when matching system-claim-values"`
 	SystemClaimValues []string `long:"system-claim-value" default:"concourse-worker" description:"Configure which token requests should be considered 'system' requests."`
 
-	EnableBuildRerunWhenWorkerDisappears bool `long:"enable-rerun-when-worker-disappears" description:"Enable automatically build rerun when worker disappears"`
+	EnableBuildRerunWhenWorkerDisappears bool `long:"enable-rerun-when-worker-disappears" description:"Enable automatically build rerun when worker disappears or a network error occurs"`
 }
 
 type Migration struct {
@@ -1738,12 +1738,12 @@ func (cmd *RunCommand) constructLoginHandler(
 func (cmd *RunCommand) constructTokenVerifier(accessTokenFactory db.AccessTokenFactory) accessor.TokenVerifier {
 
 	validClients := []string{flyClientID}
-	for clientId, _ := range cmd.Auth.AuthFlags.Clients {
+	for clientId := range cmd.Auth.AuthFlags.Clients {
 		validClients = append(validClients, clientId)
 	}
 
 	MiB := 1024 * 1024
-	claimsCacher := accessor.NewClaimsCacher(accessTokenFactory, 1 * MiB)
+	claimsCacher := accessor.NewClaimsCacher(accessTokenFactory, 1*MiB)
 
 	return accessor.NewVerifier(claimsCacher, validClients)
 }

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -240,7 +240,7 @@ func (b *engineBuild) Run(ctx context.Context) {
 	case err = <-done:
 		logger.Debug("engine-build-done")
 		if err != nil {
-			if _, ok := err.(exec.Retriable); ok {
+			if ok := errors.As(err, &exec.Retriable{}); ok {
 				return
 			}
 		}

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -240,7 +240,7 @@ func (b *engineBuild) Run(ctx context.Context) {
 	case err = <-done:
 		logger.Debug("engine-build-done")
 		if err != nil {
-			if _, ok := err.(exec.Retriable); ok {
+			if _, ok := err.(exec.Retryable); ok {
 				return
 			}
 		}

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -240,7 +240,7 @@ func (b *engineBuild) Run(ctx context.Context) {
 	case err = <-done:
 		logger.Debug("engine-build-done")
 		if err != nil {
-			if _, ok := err.(exec.Retryable); ok {
+			if _, ok := err.(exec.Retriable); ok {
 				return
 			}
 		}

--- a/atc/exec/in_parallel.go
+++ b/atc/exec/in_parallel.go
@@ -93,8 +93,8 @@ func (step InParallelStep) Run(ctx context.Context, state RunState) error {
 		return ctx.Err()
 	}
 
-	if merr, ok := result.(*multierror.Error); ok {
-		return fmt.Errorf("one or more parallel steps errored:\n%w", merr)
+	if result != nil {
+		return result
 	}
 
 	return nil

--- a/atc/exec/in_parallel.go
+++ b/atc/exec/in_parallel.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
-	"strings"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 // InParallelStep is a step of steps to run in parallel.
@@ -77,14 +78,14 @@ func (step InParallelStep) Run(ctx context.Context, state RunState) error {
 		executedSteps++
 	}
 
-	var errorMessages []string
+	var result error
 	for i := 0; i < executedSteps; i++ {
 		err := <-errs
 		if err != nil && !errors.Is(err, context.Canceled) {
 			// The Run context being cancelled only means that one or more steps failed, not
 			// in_parallel itself. If we return context.Canceled error messages the step will
 			// be marked as errored instead of failed, and therefore they should be ignored.
-			errorMessages = append(errorMessages, err.Error())
+			result = multierror.Append(result, err)
 		}
 	}
 
@@ -92,8 +93,8 @@ func (step InParallelStep) Run(ctx context.Context, state RunState) error {
 		return ctx.Err()
 	}
 
-	if len(errorMessages) > 0 {
-		return fmt.Errorf("one or more parallel steps errored:\n%s", strings.Join(errorMessages, "\n"))
+	if merr, ok := result.(*multierror.Error); ok {
+		return fmt.Errorf("one or more parallel steps errored:\n%w", merr)
 	}
 
 	return nil

--- a/atc/exec/on_abort.go
+++ b/atc/exec/on_abort.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 )
 
 // OnAbortStep will run one step, and then a second step if the first step
@@ -31,7 +32,7 @@ func (o OnAbortStep) Run(ctx context.Context, state RunState) error {
 		return nil
 	}
 
-	if stepRunErr == context.Canceled {
+	if errors.Is(stepRunErr, context.Canceled) {
 		// run only on abort, not timeout
 		o.hook.Run(context.Background(), state)
 	}

--- a/atc/exec/on_error.go
+++ b/atc/exec/on_error.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/go-multierror"
 )
@@ -37,11 +38,11 @@ func (o OnErrorStep) Run(ctx context.Context, state RunState) error {
 	errs = multierror.Append(errs, stepRunErr)
 
 	// for all errors that aren't caused by an Abort, run the hook
-	if stepRunErr != context.Canceled {
+	if ok := errors.Is(stepRunErr, context.Canceled); !ok {
 		err := o.hook.Run(context.Background(), state)
 		if err != nil {
 			// This causes to return both the errors as expected.
-			errs = multierror.Append(errs, stepRunErr)
+			errs = multierror.Append(errs, err)
 		}
 	}
 

--- a/atc/exec/on_error.go
+++ b/atc/exec/on_error.go
@@ -38,7 +38,7 @@ func (o OnErrorStep) Run(ctx context.Context, state RunState) error {
 	errs = multierror.Append(errs, stepRunErr)
 
 	// for all errors that aren't caused by an Abort, run the hook
-	if ok := errors.Is(stepRunErr, context.Canceled); !ok {
+	if !errors.Is(stepRunErr, context.Canceled) {
 		err := o.hook.Run(context.Background(), state)
 		if err != nil {
 			// This causes to return both the errors as expected.

--- a/atc/exec/retry_error_step.go
+++ b/atc/exec/retry_error_step.go
@@ -42,7 +42,7 @@ func (step RetryErrorStep) Run(ctx context.Context, state RunState) error {
 	logger := lagerctx.FromContext(ctx)
 	runErr := step.Step.Run(ctx, state)
 	if runErr != nil && step.toRetry(logger, runErr) {
-		logger.Info("retryable", lager.Data{"error": runErr.Error()})
+		logger.Info("retriable", lager.Data{"error": runErr.Error()})
 		step.delegate.Errored(logger, fmt.Sprintf("%s, will retry ...", runErr.Error()))
 		runErr = Retriable{runErr}
 	}

--- a/atc/exec/retry_error_step.go
+++ b/atc/exec/retry_error_step.go
@@ -51,11 +51,12 @@ func (step RetryErrorStep) Run(ctx context.Context, state RunState) error {
 
 func (step RetryErrorStep) toRetry(logger lager.Logger, err error) bool {
 	var urlError *url.Error
+	var netError net.Error
 	if errors.As(err, &transport.WorkerMissingError{}) || errors.As(err, &transport.WorkerUnreachableError{}) || errors.As(err, &urlError) {
 		logger.Debug("retry-error",
 			lager.Data{"err_type": reflect.TypeOf(err).String(), "err": err.Error()})
 		return true
-	} else if _, ok := err.(net.Error); ok || regexp.MustCompile(`worker .+ disappeared`).MatchString(err.Error()) {
+	} else if errors.As(err, &netError) || regexp.MustCompile(`worker .+ disappeared`).MatchString(err.Error()) {
 		logger.Debug("retry-error",
 			lager.Data{"err_type": reflect.TypeOf(err).String(), "err": err})
 		return true

--- a/atc/exec/retry_error_step.go
+++ b/atc/exec/retry_error_step.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"reflect"
 	"regexp"
@@ -55,7 +54,7 @@ func (step RetryErrorStep) toRetry(logger lager.Logger, err error) bool {
 	var unreachable *transport.WorkerUnreachableError
 	var netOpErr *net.OpError
 	re := regexp.MustCompile(`worker .+ disappeared`)
-	if ok := errors.As(err, &transportErr) || errors.As(err, &unreachable); ok {
+	if ok := errors.As(err, &transportErr) || errors.As(err, &unreachable) || errors.As(err, &netOpErr); ok {
 		logger.Debug("retry-error",
 			lager.Data{"err_type": reflect.TypeOf(err).String(), "err": err.Error()})
 		return true
@@ -63,11 +62,6 @@ func (step RetryErrorStep) toRetry(logger lager.Logger, err error) bool {
 		logger.Debug("retry-error",
 			lager.Data{"err_type": reflect.TypeOf(err).String(), "err": err})
 		return true
-	} else if errors.Is(err, io.EOF) || errors.As(err, &netOpErr) {
-		logger.Debug("retry-error",
-			lager.Data{"err_type": reflect.TypeOf(err).String(), "err": err.Error()})
-		return true
-
 	}
 	return false
 }

--- a/atc/exec/retry_error_step.go
+++ b/atc/exec/retry_error_step.go
@@ -53,7 +53,7 @@ func (step RetryErrorStep) toRetry(logger lager.Logger, err error) bool {
 	var transportErr *transport.WorkerMissingError
 	var unreachable *transport.WorkerUnreachableError
 	re := regexp.MustCompile(`worker .+ disappeared`)
-	if ok := errors.As(err, transportErr) || errors.As(err, unreachable); ok {
+	if ok := errors.As(err, &transportErr) || errors.As(err, &unreachable); ok {
 		logger.Debug("retry-error",
 			lager.Data{"err_type": reflect.TypeOf(err).String(), "err": err.Error()})
 		return true

--- a/atc/exec/retry_error_step_test.go
+++ b/atc/exec/retry_error_step_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 
 	. "github.com/concourse/concourse/atc/exec"
@@ -91,17 +90,6 @@ var _ = Describe("RetryErrorStep", func() {
 				Expect(fakeDelegate.ErroredCallCount()).To(Equal(1))
 				_, message := fakeDelegate.ErroredArgsForCall(0)
 				Expect(message).To(Equal(fmt.Sprintf("%s, will retry ...", cause.Error())))
-			})
-		})
-
-		Context("when eof error happened", func() {
-			cause := io.EOF
-			BeforeEach(func() {
-				fakeStep.RunReturns(cause)
-			})
-
-			It("should return retriable", func() {
-				Expect(runErr).To(Equal(Retriable{cause}))
 			})
 		})
 

--- a/atc/exec/retry_error_step_test.go
+++ b/atc/exec/retry_error_step_test.go
@@ -82,7 +82,7 @@ var _ = Describe("RetryErrorStep", func() {
 				fakeStep.RunReturns(cause)
 			})
 
-			It("should return retryable", func() {
+			It("should return retriable", func() {
 				Expect(runErr).To(Equal(Retriable{cause}))
 			})
 

--- a/atc/exec/retry_error_step_test.go
+++ b/atc/exec/retry_error_step_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 
 	. "github.com/concourse/concourse/atc/exec"
 	"github.com/concourse/concourse/atc/exec/build"
@@ -93,7 +94,18 @@ var _ = Describe("RetryErrorStep", func() {
 			})
 		})
 
-		Context("when net.OpError error happened", func() {
+		Context("when url.Error error happened", func() {
+			cause := &url.Error{Op: "error", URL: "err", Err: errors.New("error")}
+			BeforeEach(func() {
+				fakeStep.RunReturns(cause)
+			})
+
+			It("should return retriable", func() {
+				Expect(runErr).To(Equal(Retriable{cause}))
+			})
+		})
+
+		Context("when net.Error error happened", func() {
 			cause := &net.OpError{Op: "read", Net: "test", Source: nil, Addr: nil, Err: errors.New("test")}
 			BeforeEach(func() {
 				fakeStep.RunReturns(cause)

--- a/atc/exec/retry_error_step_test.go
+++ b/atc/exec/retry_error_step_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 
 	. "github.com/concourse/concourse/atc/exec"
 	"github.com/concourse/concourse/atc/exec/build"
@@ -99,7 +100,18 @@ var _ = Describe("RetryErrorStep", func() {
 				fakeStep.RunReturns(cause)
 			})
 
-			It("should return retryable", func() {
+			It("should return retriable", func() {
+				Expect(runErr).To(Equal(Retriable{cause}))
+			})
+		})
+
+		Context("when net.OpError error happened", func() {
+			cause := &net.OpError{Op: "read", Net: "test", Source: nil, Addr: nil, Err: errors.New("test")}
+			BeforeEach(func() {
+				fakeStep.RunReturns(cause)
+			})
+
+			It("should return retriable", func() {
 				Expect(runErr).To(Equal(Retriable{cause}))
 			})
 		})

--- a/atc/exec/retry_error_step_test.go
+++ b/atc/exec/retry_error_step_test.go
@@ -83,7 +83,7 @@ var _ = Describe("RetryErrorStep", func() {
 			})
 
 			It("should return retryable", func() {
-				Expect(runErr).To(Equal(Retryable{cause}))
+				Expect(runErr).To(Equal(Retriable{cause}))
 			})
 
 			It("logs 'timeout exceeded'", func() {
@@ -100,7 +100,7 @@ var _ = Describe("RetryErrorStep", func() {
 			})
 
 			It("should return retryable", func() {
-				Expect(runErr).To(Equal(Retryable{cause}))
+				Expect(runErr).To(Equal(Retriable{cause}))
 			})
 		})
 

--- a/atc/exec/retry_error_step_test.go
+++ b/atc/exec/retry_error_step_test.go
@@ -102,12 +102,6 @@ var _ = Describe("RetryErrorStep", func() {
 			It("should return retryable", func() {
 				Expect(runErr).To(Equal(Retryable{cause}))
 			})
-
-			It("logs 'timeout exceeded'", func() {
-				Expect(fakeDelegate.ErroredCallCount()).To(Equal(1))
-				_, message := fakeDelegate.ErroredArgsForCall(0)
-				Expect(message).To(Equal(fmt.Sprintf("%s, will retry ...", cause.Error())))
-			})
 		})
 
 		Context("when the inner step returns any other error", func() {

--- a/atc/exec/timeout_step.go
+++ b/atc/exec/timeout_step.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -38,7 +39,7 @@ func (ts *TimeoutStep) Run(ctx context.Context, state RunState) error {
 	defer cancel()
 
 	err = ts.step.Run(timeoutCtx, state)
-	if err == context.DeadlineExceeded {
+	if errors.Is(err, context.DeadlineExceeded) {
 		ts.timedOut = true
 		return nil
 	}

--- a/atc/exec/try_step.go
+++ b/atc/exec/try_step.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 )
 
 // TryStep wraps another step, ignores its errors, and always succeeds.
@@ -22,7 +23,7 @@ func Try(step Step) Step {
 // error.
 func (ts *TryStep) Run(ctx context.Context, state RunState) error {
 	err := ts.step.Run(ctx, state)
-	if err == context.Canceled {
+	if errors.Is(err, context.Canceled) {
 		ts.aborted = true
 		// propagate aborts but not timeouts
 		return err


### PR DESCRIPTION
Signed-off-by: kirillbilchenko <kirya7@gmail.com>

<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes # .

## Changes proposed by this PR:
Add case to cover issue like this `Put "/volumes/a2dc0c2a-5057-4d0e-794f-ae7607ce8638/stream-in?path=.": EOF` which causing all job to fail
## Notes to reviewer:
Added test to cover this io.EOF case.

## Release Note

* The `--enable-rerun-when-worker-disappears` flag now supports rerunning builds after any network error from the ATC to the worker's baggageclaim. Such network errors are common when the worker disappears.
* Builds will now be rerun when this flag is enabled and the failing step is a nested step (e.g. within an `in_parallel`)

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
