### PR TITLE
Fix topgun failures due to auth change by updating topgun fly client auth

### DIFF
--- a/topgun/fly.go
+++ b/topgun/fly.go
@@ -3,7 +3,6 @@ package topgun
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -190,13 +189,6 @@ func FetchToken(webURL, username, password string) (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	idToken, ok := token.Extra("id_token").(string)
-	if !ok {
-		return nil, errors.New("missing id_token")
-	}
-
-	token.AccessToken = idToken
 
 	return token, nil
 }


### PR DESCRIPTION
## What does this PR accomplish?
Fix failing topgun tests
[Failing Build](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/bosh-topgun-core/builds/313)

  ```
  Unexpected error:
          <*errors.errorString | 0xc000111cc0>: {s: "not authorized"}
          not authorized
      occurred

      /tmp/build/d1c622c6/concourse/topgun/common/common.go:347
  ```

## Changes proposed by this PR:

don't use id token as access token to reflect new auth
Ref: https://github.com/concourse/concourse/pull/5897

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
