### PR TITLE
Skip failing k8s topgun tests for containerd without a dns proxy or dns servers configured

### DIFF
--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -74,6 +74,9 @@ var _ = Describe("DNS Resolution", func() {
 	expectedDnsProxyBehaviour := func(runtime string) {
 		DescribeTable("different proxy settings",
 			func(c Case) {
+				if runtime == containerdRuntime && c.enableDnsProxy == "false" {
+					Skip("Skip test until https://github.com/concourse/concourse/issues/5967 is resolv'ed :P")
+				}
 				setupDeployment(runtime, c.enableDnsProxy, c.dnsServer)
 
 				sess := fly.Start("execute", "-c", "tasks/dns-proxy-task.yml", "-v", "url="+c.addressFunction())

--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -2,6 +2,7 @@ package k8s_test
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -48,14 +49,14 @@ var _ = Describe("DNS Resolution", func() {
 		}
 		switch {
 		case runtime == containerdRuntime:
-			args = append(args, `--set-string=concourse.worker.containerd.dnsProxyEnable=` + dnsProxyEnable)
+			args = append(args, `--set-string=concourse.worker.containerd.dnsProxyEnable=`+dnsProxyEnable)
 			if dnsServer != "" {
 				args = append(args,
 					`--set=worker.env[0].name=CONCOURSE_CONTAINERD_DNS_SERVER`,
 					`--set=worker.env[0].value=`+dnsServer)
 			}
 		case runtime == guardianRuntime:
-			args = append(args, `--set-string=concourse.worker.garden.dnsProxyEnable=` + dnsProxyEnable)
+			args = append(args, `--set-string=concourse.worker.garden.dnsProxyEnable=`+dnsProxyEnable)
 			if dnsServer != "" {
 				args = append(args,
 					`--set=worker.env[0].name=CONCOURSE_GARDEN_DNS_SERVER`,


### PR DESCRIPTION
## What does this PR accomplish?
skip containerd dns tests which have dns proxy disabled and don't
specify dns servers to resolve in cluster addresses.

These tests should be un-skipped once
https://github.com/concourse/concourse/issues/5967 is closed

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
