### PR TITLE
Allow rotating the encryption key via `concourse migrate`

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -277,7 +277,8 @@ func (cmd *Migration) currentDBVersion() error {
 		defaultDriverName,
 		cmd.Postgres.ConnectionString(),
 		nil,
-		encryption.NewNoEncryption(),
+		nil,
+		nil,
 	)
 
 	version, err := helper.CurrentVersion()
@@ -294,7 +295,8 @@ func (cmd *Migration) supportedDBVersion() error {
 		defaultDriverName,
 		cmd.Postgres.ConnectionString(),
 		nil,
-		encryption.NewNoEncryption(),
+		nil,
+		nil,
 	)
 
 	version, err := helper.SupportedVersion()
@@ -310,22 +312,21 @@ func (cmd *Migration) migrateDBToVersion() error {
 	version := cmd.MigrateDBToVersion
 
 	var newKey *encryption.Key
+	var oldKey *encryption.Key
+
 	if cmd.EncryptionKey.AEAD != nil {
 		newKey = encryption.NewKey(cmd.EncryptionKey.AEAD)
 	}
-
-	var strategy encryption.Strategy
-	if newKey != nil {
-		strategy = newKey
-	} else {
-		strategy = encryption.NewNoEncryption()
+	if cmd.OldEncryptionKey.AEAD != nil {
+		oldKey = encryption.NewKey(cmd.OldEncryptionKey.AEAD)
 	}
 
 	helper := migration.NewOpenHelper(
 		defaultDriverName,
 		cmd.Postgres.ConnectionString(),
 		nil,
-		strategy,
+		newKey,
+		oldKey,
 	)
 
 	err := helper.MigrateToVersion(version)

--- a/atc/db/encryption/fallback_strategy.go
+++ b/atc/db/encryption/fallback_strategy.go
@@ -1,0 +1,26 @@
+package encryption
+
+type FallbackStrategy struct {
+	main     Strategy
+	fallback Strategy
+}
+
+func NewFallbackStrategy(main, fallback Strategy) *FallbackStrategy {
+	return &FallbackStrategy{
+		main:     main,
+		fallback: fallback,
+	}
+}
+
+func (n *FallbackStrategy) Encrypt(plaintext []byte) (string, *string, error) {
+	return n.main.Encrypt(plaintext)
+}
+
+func (n *FallbackStrategy) Decrypt(text string, nonce *string) ([]byte, error) {
+	plaintext, err := n.main.Decrypt(text, nonce)
+	if err == nil {
+		return plaintext, nil
+	}
+	return n.fallback.Decrypt(text, nonce)
+}
+

--- a/atc/db/encryption/fallback_strategy_test.go
+++ b/atc/db/encryption/fallback_strategy_test.go
@@ -1,0 +1,55 @@
+package encryption_test
+
+import (
+	"github.com/concourse/concourse/atc/db/encryption"
+	"github.com/concourse/concourse/atc/db/encryption/encryptionfakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Encryption Key with Fallback", func() {
+	var (
+		key       *encryption.FallbackStrategy
+		strategy1 *encryptionfakes.FakeStrategy
+		strategy2 *encryptionfakes.FakeStrategy
+	)
+
+	BeforeEach(func() {
+		strategy1 = &encryptionfakes.FakeStrategy{}
+		strategy2 = &encryptionfakes.FakeStrategy{}
+
+		key = encryption.NewFallbackStrategy(strategy1, strategy2)
+	})
+
+	Context("when the main key is valid", func() {
+		It("decrypts plaintext using the main key", func() {
+			strategy1.DecryptReturns([]byte("plaintext"), nil)
+
+			decryptedText, err := key.Decrypt("ciphertext", nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(decryptedText).To(Equal([]byte("plaintext")))
+		})
+	})
+
+	Context("when the main key is invalid", func() {
+		It("decrypts plaintext using the fallback key", func() {
+			strategy1.DecryptReturns(nil, encryption.ErrDataIsEncrypted)
+			strategy2.DecryptReturns([]byte("plaintext"), nil)
+
+			decryptedText, err := key.Decrypt("ciphertext", nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(decryptedText).To(Equal([]byte("plaintext")))
+		})
+	})
+
+	Context("when both keys to decrypt are invalid", func() {
+		It("return with an error", func() {
+			strategy1.DecryptReturns(nil, encryption.ErrDataIsEncrypted)
+			strategy2.DecryptReturns(nil, encryption.ErrDataIsEncrypted)
+
+			_, err := key.Decrypt("ciphertext", nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+

--- a/atc/db/migration/encryption.go
+++ b/atc/db/migration/encryption.go
@@ -1,0 +1,235 @@
+package migration
+
+import (
+	"database/sql"
+	"errors"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/db/encryption"
+)
+
+var encryptedColumns = []encryptedColumn{
+	{"teams", "legacy_auth", "id"},
+	{"resources", "config", "id"},
+	{"jobs", "config", "id"},
+	{"resource_types", "config", "id"},
+	{"builds", "private_plan", "id"},
+	{"cert_cache", "cert", "domain"},
+	{"checks", "plan", "id"},
+	{"pipelines", "var_sources", "id"},
+}
+
+type encryptedColumn struct {
+	Table      string
+	Column     string
+	PrimaryKey string
+}
+
+func (self migrator) encryptPlaintext(key *encryption.Key) error {
+	logger := self.logger.Session("encrypt")
+	for _, ec := range encryptedColumns {
+		rows, err := self.db.Query(`
+			SELECT ` + ec.PrimaryKey + `, ` + ec.Column + `
+			FROM ` + ec.Table + `
+			WHERE nonce IS NULL
+			AND ` + ec.Column + ` IS NOT NULL
+		`)
+		if err != nil {
+			return err
+		}
+
+		tLog := logger.Session("table", lager.Data{
+			"table": ec.Table,
+		})
+
+		encryptedRows := 0
+
+		for rows.Next() {
+			var (
+				primaryKey interface{}
+				val        sql.NullString
+			)
+
+			err := rows.Scan(&primaryKey, &val)
+			if err != nil {
+				tLog.Error("failed-to-scan", err)
+				return err
+			}
+
+			if !val.Valid {
+				continue
+			}
+
+			rLog := tLog.Session("row", lager.Data{
+				"primary-key": primaryKey,
+			})
+
+			encrypted, nonce, err := key.Encrypt([]byte(val.String))
+			if err != nil {
+				rLog.Error("failed-to-encrypt", err)
+				return err
+			}
+
+			_, err = self.db.Exec(`
+				UPDATE `+ec.Table+`
+				SET `+ec.Column+` = $1, nonce = $2
+				WHERE `+ec.PrimaryKey+` = $3
+			`, encrypted, nonce, primaryKey)
+			if err != nil {
+				rLog.Error("failed-to-update", err)
+				return err
+			}
+
+			encryptedRows++
+		}
+
+		if encryptedRows > 0 {
+			tLog.Info("encrypted-existing-plaintext-data", lager.Data{
+				"rows": encryptedRows,
+			})
+		}
+	}
+
+	return nil
+}
+
+func (self migrator) decryptToPlaintext(oldKey *encryption.Key) error {
+	logger := self.logger.Session("decrypt")
+	for _, ec := range encryptedColumns {
+		rows, err := self.db.Query(`
+			SELECT ` + ec.PrimaryKey + `, nonce, ` + ec.Column + `
+			FROM ` + ec.Table + `
+			WHERE nonce IS NOT NULL
+		`)
+		if err != nil {
+			return err
+		}
+
+		tLog := logger.Session("table", lager.Data{
+			"table": ec.Table,
+		})
+
+		decryptedRows := 0
+
+		for rows.Next() {
+			var (
+				primaryKey interface{}
+				val, nonce string
+			)
+
+			err := rows.Scan(&primaryKey, &nonce, &val)
+			if err != nil {
+				tLog.Error("failed-to-scan", err)
+				return err
+			}
+
+			rLog := tLog.Session("row", lager.Data{
+				"primary-key": primaryKey,
+			})
+
+			decrypted, err := oldKey.Decrypt(val, &nonce)
+			if err != nil {
+				rLog.Error("failed-to-decrypt", err)
+				return err
+			}
+
+			_, err = self.db.Exec(`
+				UPDATE `+ec.Table+`
+				SET `+ec.Column+` = $1, nonce = NULL
+				WHERE `+ec.PrimaryKey+` = $2
+			`, decrypted, primaryKey)
+			if err != nil {
+				rLog.Error("failed-to-update", err)
+				return err
+			}
+
+			decryptedRows++
+		}
+
+		if decryptedRows > 0 {
+			tLog.Info("decrypted-existing-encrypted-data", lager.Data{
+				"rows": decryptedRows,
+			})
+		}
+	}
+
+	return nil
+}
+
+var ErrEncryptedWithUnknownKey = errors.New("row encrypted with neither old nor new key")
+
+func (self migrator) encryptWithNewKey(newKey *encryption.Key, oldKey *encryption.Key) error {
+	logger := self.logger.Session("rotate")
+	for _, ec := range encryptedColumns {
+		rows, err := self.db.Query(`
+			SELECT ` + ec.PrimaryKey + `, nonce, ` + ec.Column + `
+			FROM ` + ec.Table + `
+			WHERE nonce IS NOT NULL
+		`)
+		if err != nil {
+			return err
+		}
+
+		tLog := logger.Session("table", lager.Data{
+			"table": ec.Table,
+		})
+
+		encryptedRows := 0
+
+		for rows.Next() {
+			var (
+				primaryKey interface{}
+				val, nonce string
+			)
+
+			err := rows.Scan(&primaryKey, &nonce, &val)
+			if err != nil {
+				tLog.Error("failed-to-scan", err)
+				return err
+			}
+
+			rLog := tLog.Session("row", lager.Data{
+				"primary-key": primaryKey,
+			})
+
+			decrypted, err := oldKey.Decrypt(val, &nonce)
+			if err != nil {
+				_, err = newKey.Decrypt(val, &nonce)
+				if err == nil {
+					rLog.Debug("already-encrypted-with-new-key")
+					continue
+				}
+
+				logger.Error("failed-to-decrypt-with-either-key", err)
+				return ErrEncryptedWithUnknownKey
+			}
+
+			encrypted, newNonce, err := newKey.Encrypt(decrypted)
+			if err != nil {
+				rLog.Error("failed-to-encrypt", err)
+				return err
+			}
+
+			_, err = self.db.Exec(`
+				UPDATE `+ec.Table+`
+				SET `+ec.Column+` = $1, nonce = $2
+				WHERE `+ec.PrimaryKey+` = $3
+			`, encrypted, newNonce, primaryKey)
+			if err != nil {
+				rLog.Error("failed-to-update", err)
+				return err
+			}
+
+			encryptedRows++
+		}
+
+		if encryptedRows > 0 {
+			tLog.Info("re-encrypted-existing-encrypted-data", lager.Data{
+				"rows": encryptedRows,
+			})
+		}
+	}
+
+	return nil
+}
+

--- a/atc/db/migration/encryption_test.go
+++ b/atc/db/migration/encryption_test.go
@@ -1,0 +1,224 @@
+package migration_test
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"database/sql"
+
+	"code.cloudfoundry.org/lager"
+
+	"github.com/concourse/concourse/atc/db/encryption"
+	"github.com/concourse/concourse/atc/db/lock"
+	"github.com/concourse/concourse/atc/db/migration"
+	"github.com/concourse/concourse/atc/db/migration/migrationfakes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Encryption", func() {
+	var (
+		err         error
+		db          *sql.DB
+		lockDB      *sql.DB
+		lockFactory lock.LockFactory
+		bindata     *migrationfakes.FakeBindata
+		fakeLogFunc = func(logger lager.Logger, id lock.LockID) {}
+	)
+
+	BeforeEach(func() {
+		db, err = sql.Open("postgres", postgresRunner.DataSourceName())
+		Expect(err).NotTo(HaveOccurred())
+
+		lockDB, err = sql.Open("postgres", postgresRunner.DataSourceName())
+		Expect(err).NotTo(HaveOccurred())
+
+		lockFactory = lock.NewLockFactory(lockDB, fakeLogFunc, fakeLogFunc)
+
+		bindata = new(migrationfakes.FakeBindata)
+		bindata.AssetStub = asset
+	})
+
+	AfterEach(func() {
+		_ = db.Close()
+		_ = lockDB.Close()
+	})
+
+	Context("starting with unencrypted DB", func() {
+		var (
+			key *encryption.Key
+		)
+		BeforeEach(func() {
+			key = createKey("AES256Key-32Characters1234567890")
+		})
+
+		It("encrypts the database", func() {
+			migrator := migration.NewMigrator(db, lockFactory)
+
+			err := migrator.Up(nil, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			insertIntoEncryptedColumn(db, encryption.NewNoEncryption(), "test")
+
+			err = migrator.Up(key, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isEncryptedWith(db, key, "test")).To(BeTrue())
+		})
+	})
+
+	Context("starting with encrypted DB", func() {
+		var (
+			key1 *encryption.Key
+			key2 *encryption.Key
+		)
+
+		BeforeEach(func() {
+			key1 = createKey("AES256Key-32Characters1234567890")
+			key2 = createKey("AES256Key-32Characters0987654321")
+		})
+
+		Context("removing the encryption key", func() {
+			It("decrypts the database", func() {
+				migrator := migration.NewMigrator(db, lockFactory)
+
+				err := migrator.Up(key1, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				insertIntoEncryptedColumn(db, key1, "test")
+
+				err = migrator.Up(nil, key1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isEncryptedWith(db, encryption.NewNoEncryption(), "test")).To(BeTrue())
+			})
+		})
+
+		Context("rotating the encryption key", func() {
+			It("re-encrypts the database with the new key", func() {
+				migrator := migration.NewMigrator(db, lockFactory)
+
+				err := migrator.Up(key2, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				insertIntoEncryptedColumn(db, key2, "test")
+
+				err = migrator.Up(key1, key2)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isEncryptedWith(db, key1, "test")).To(BeTrue())
+			})
+
+			It("rotates the key while doing a migration", func() {
+				migrator := migration.NewMigrator(db, lockFactory)
+
+				// do all the necessary schema migrations to this particular version
+				err = migrator.Migrate(nil, nil, 1513895878)
+				Expect(err).ToNot(HaveOccurred())
+
+				insertIntoEncryptedColumnLegacy(db, key1, "test")
+
+				// the migration after this one, 1516643303 needs to re-encrypt the auth column
+				err := migrator.Up(key2, key1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isEncryptedWith(db, key2, "test")).To(BeTrue())
+			})
+		})
+	})
+
+	Context("starting with partially encrypted DB", func() {
+		var (
+			key1     *encryption.Key
+			key2     *encryption.Key
+			migrator migration.Migrator
+		)
+
+		BeforeEach(func() {
+			key1 = createKey("AES256Key-32Characters1234567890")
+			key2 = createKey("AES256Key-32Characters0987654321")
+			migrator = migration.NewMigrator(db, lockFactory)
+
+			err := migrator.Up(nil, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			insertIntoEncryptedColumn(db, encryption.NewNoEncryption(), "row1")
+			insertIntoEncryptedColumn(db, key1, "row2")
+		})
+
+		Context("adding the encryption key", func() {
+			It("encrypts the database", func() {
+				err = migrator.Up(key1, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isEncryptedWith(db, key1, "row1")).To(BeTrue())
+				Expect(isEncryptedWith(db, key1, "row2")).To(BeTrue())
+			})
+		})
+
+		Context("removing the encryption key", func() {
+			It("decrypts the database", func() {
+				err = migrator.Up(nil, key1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isEncryptedWith(db, encryption.NewNoEncryption(), "row1")).To(BeTrue())
+				Expect(isEncryptedWith(db, encryption.NewNoEncryption(), "row2")).To(BeTrue())
+			})
+		})
+
+		Context("rotating the encryption key", func() {
+			It("re-encrypts the database with the new key", func() {
+				err = migrator.Up(key2, key1)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isEncryptedWith(db, key2, "row1")).To(BeTrue())
+				Expect(isEncryptedWith(db, key2, "row2")).To(BeTrue())
+			})
+		})
+
+		Context("rotating to the same key", func() {
+			It("doesn't break", func() {
+				err = migrator.Up(key1, key1)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isEncryptedWith(db, key1, "row1")).To(BeTrue())
+				Expect(isEncryptedWith(db, key1, "row2")).To(BeTrue())
+			})
+		})
+	})
+})
+
+// used to test database versions before the column got renamed
+func insertIntoEncryptedColumnLegacy(db *sql.DB, strategy encryption.Strategy, name string) {
+	ciphertext, nonce, err := strategy.Encrypt([]byte("{}"))
+	Expect(err).ToNot(HaveOccurred())
+	_, err = db.Exec(`INSERT INTO teams(name, auth, nonce) VALUES($1, $2, $3)`, name, ciphertext, nonce)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func insertIntoEncryptedColumn(db *sql.DB, strategy encryption.Strategy, name string) {
+	ciphertext, nonce, err := strategy.Encrypt([]byte("{}"))
+	Expect(err).ToNot(HaveOccurred())
+	_, err = db.Exec(`INSERT INTO teams(name, legacy_auth, nonce) VALUES($1, $2, $3)`, name, ciphertext, nonce)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func isEncryptedWith(db *sql.DB, strategy encryption.Strategy, name string) bool {
+	var (
+		ciphertext string
+		nonce      *string
+	)
+	row := db.QueryRow(`SELECT legacy_auth, nonce FROM teams WHERE name = $1`, name)
+	err := row.Scan(&ciphertext, &nonce)
+	Expect(err).ToNot(HaveOccurred())
+
+	_, err = strategy.Decrypt(ciphertext, nonce)
+	return err == nil
+}
+
+// createKey generates an encryption.Key from a 32 characters key
+func createKey(key string) *encryption.Key {
+	k := []byte(key)
+
+	block, err := aes.NewCipher(k)
+	Expect(err).ToNot(HaveOccurred())
+
+	aesgcm, err := cipher.NewGCM(block)
+	Expect(err).ToNot(HaveOccurred())
+
+	return encryption.NewKey(aesgcm)
+}

--- a/atc/db/migration/open_helper_test.go
+++ b/atc/db/migration/open_helper_test.go
@@ -5,7 +5,6 @@ import (
 
 	"code.cloudfoundry.org/lager"
 
-	"github.com/concourse/concourse/atc/db/encryption"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/db/migration"
 	"github.com/concourse/concourse/atc/db/migration/migrationfakes"
@@ -19,7 +18,6 @@ var _ = Describe("OpenHelper", func() {
 		db          *sql.DB
 		lockDB      *sql.DB
 		lockFactory lock.LockFactory
-		strategy    encryption.Strategy
 		bindata     *migrationfakes.FakeBindata
 		openHelper  *migration.OpenHelper
 		fakeLogFunc = func(logger lager.Logger, id lock.LockID) {}
@@ -33,8 +31,7 @@ var _ = Describe("OpenHelper", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		lockFactory = lock.NewLockFactory(lockDB, fakeLogFunc, fakeLogFunc)
-		strategy = encryption.NewNoEncryption()
-		openHelper = migration.NewOpenHelper("postgres", postgresRunner.DataSourceName(), lockFactory, strategy)
+		openHelper = migration.NewOpenHelper("postgres", postgresRunner.DataSourceName(), lockFactory, nil, nil)
 
 		bindata = new(migrationfakes.FakeBindata)
 		bindata.AssetStub = asset

--- a/atc/db/open.go
+++ b/atc/db/open.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -67,14 +66,7 @@ type Tx interface {
 
 func Open(logger lager.Logger, sqlDriver string, sqlDataSource string, newKey *encryption.Key, oldKey *encryption.Key, connectionName string, lockFactory lock.LockFactory) (Conn, error) {
 	for {
-		var strategy encryption.Strategy
-		if newKey != nil {
-			strategy = newKey
-		} else {
-			strategy = encryption.NewNoEncryption()
-		}
-
-		sqlDb, err := migration.NewOpenHelper(sqlDriver, sqlDataSource, lockFactory, strategy).Open()
+		sqlDb, err := migration.NewOpenHelper(sqlDriver, sqlDataSource, lockFactory, newKey, oldKey).Open()
 		if err != nil {
 			if shouldRetry(err) {
 				logger.Error("failed-to-open-db-retrying", err)
@@ -85,24 +77,14 @@ func Open(logger lager.Logger, sqlDriver string, sqlDataSource string, newKey *e
 			return nil, err
 		}
 
-		switch {
-		case oldKey != nil && newKey == nil:
-			err = decryptToPlaintext(logger.Session("decrypt"), sqlDb, oldKey)
-		case oldKey != nil && newKey != nil:
-			err = encryptWithNewKey(logger.Session("rotate"), sqlDb, newKey, oldKey)
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		if newKey != nil {
-			err = encryptPlaintext(logger.Session("encrypt"), sqlDb, newKey)
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		listener := pq.NewDialListener(keepAliveDialer{}, sqlDataSource, time.Second, time.Minute, nil)
+
+		var strategy encryption.Strategy
+		if newKey != nil {
+			strategy = newKey
+		} else {
+			strategy = encryption.NewNoEncryption()
+		}
 
 		return &db{
 			DB: sqlDb,
@@ -124,228 +106,6 @@ func shouldRetry(err error) bool {
 	}
 
 	return false
-}
-
-type encryptedColumn struct {
-	Table      string
-	Column     string
-	PrimaryKey string
-}
-
-var encryptedColumns = []encryptedColumn{
-	{"teams", "legacy_auth", "id"},
-	{"resources", "config", "id"},
-	{"jobs", "config", "id"},
-	{"resource_types", "config", "id"},
-	{"builds", "private_plan", "id"},
-	{"cert_cache", "cert", "domain"},
-	{"checks", "plan", "id"},
-	{"pipelines", "var_sources", "id"},
-}
-
-func encryptPlaintext(logger lager.Logger, sqlDB *sql.DB, key *encryption.Key) error {
-	for _, ec := range encryptedColumns {
-		rows, err := sqlDB.Query(`
-			SELECT ` + ec.PrimaryKey + `, ` + ec.Column + `
-			FROM ` + ec.Table + `
-			WHERE nonce IS NULL
-			AND ` + ec.Column + ` IS NOT NULL
-		`)
-		if err != nil {
-			return err
-		}
-
-		tLog := logger.Session("table", lager.Data{
-			"table": ec.Table,
-		})
-
-		encryptedRows := 0
-
-		for rows.Next() {
-			var (
-				primaryKey interface{}
-				val        sql.NullString
-			)
-
-			err := rows.Scan(&primaryKey, &val)
-			if err != nil {
-				tLog.Error("failed-to-scan", err)
-				return err
-			}
-
-			if !val.Valid {
-				continue
-			}
-
-			rLog := tLog.Session("row", lager.Data{
-				"primary-key": primaryKey,
-			})
-
-			encrypted, nonce, err := key.Encrypt([]byte(val.String))
-			if err != nil {
-				rLog.Error("failed-to-encrypt", err)
-				return err
-			}
-
-			_, err = sqlDB.Exec(`
-				UPDATE `+ec.Table+`
-				SET `+ec.Column+` = $1, nonce = $2
-				WHERE `+ec.PrimaryKey+` = $3
-			`, encrypted, nonce, primaryKey)
-			if err != nil {
-				rLog.Error("failed-to-update", err)
-				return err
-			}
-
-			encryptedRows++
-		}
-
-		if encryptedRows > 0 {
-			tLog.Info("encrypted-existing-plaintext-data", lager.Data{
-				"rows": encryptedRows,
-			})
-		}
-	}
-
-	return nil
-}
-
-func decryptToPlaintext(logger lager.Logger, sqlDB *sql.DB, oldKey *encryption.Key) error {
-	for _, ec := range encryptedColumns {
-		rows, err := sqlDB.Query(`
-			SELECT ` + ec.PrimaryKey + `, nonce, ` + ec.Column + `
-			FROM ` + ec.Table + `
-			WHERE nonce IS NOT NULL
-		`)
-		if err != nil {
-			return err
-		}
-
-		tLog := logger.Session("table", lager.Data{
-			"table": ec.Table,
-		})
-
-		decryptedRows := 0
-
-		for rows.Next() {
-			var (
-				primaryKey interface{}
-				val, nonce string
-			)
-
-			err := rows.Scan(&primaryKey, &nonce, &val)
-			if err != nil {
-				tLog.Error("failed-to-scan", err)
-				return err
-			}
-
-			rLog := tLog.Session("row", lager.Data{
-				"primary-key": primaryKey,
-			})
-
-			decrypted, err := oldKey.Decrypt(val, &nonce)
-			if err != nil {
-				rLog.Error("failed-to-decrypt", err)
-				return err
-			}
-
-			_, err = sqlDB.Exec(`
-				UPDATE `+ec.Table+`
-				SET `+ec.Column+` = $1, nonce = NULL
-				WHERE `+ec.PrimaryKey+` = $2
-			`, decrypted, primaryKey)
-			if err != nil {
-				rLog.Error("failed-to-update", err)
-				return err
-			}
-
-			decryptedRows++
-		}
-
-		if decryptedRows > 0 {
-			tLog.Info("decrypted-existing-encrypted-data", lager.Data{
-				"rows": decryptedRows,
-			})
-		}
-	}
-
-	return nil
-}
-
-var ErrEncryptedWithUnknownKey = errors.New("row encrypted with neither old nor new key")
-
-func encryptWithNewKey(logger lager.Logger, sqlDB *sql.DB, newKey *encryption.Key, oldKey *encryption.Key) error {
-	for _, ec := range encryptedColumns {
-		rows, err := sqlDB.Query(`
-			SELECT ` + ec.PrimaryKey + `, nonce, ` + ec.Column + `
-			FROM ` + ec.Table + `
-			WHERE nonce IS NOT NULL
-		`)
-		if err != nil {
-			return err
-		}
-
-		tLog := logger.Session("table", lager.Data{
-			"table": ec.Table,
-		})
-
-		encryptedRows := 0
-
-		for rows.Next() {
-			var (
-				primaryKey interface{}
-				val, nonce string
-			)
-
-			err := rows.Scan(&primaryKey, &nonce, &val)
-			if err != nil {
-				tLog.Error("failed-to-scan", err)
-				return err
-			}
-
-			rLog := tLog.Session("row", lager.Data{
-				"primary-key": primaryKey,
-			})
-
-			decrypted, err := oldKey.Decrypt(val, &nonce)
-			if err != nil {
-				_, err = newKey.Decrypt(val, &nonce)
-				if err == nil {
-					rLog.Debug("already-encrypted-with-new-key")
-					continue
-				}
-
-				logger.Error("failed-to-decrypt-with-either-key", err)
-				return ErrEncryptedWithUnknownKey
-			}
-
-			encrypted, newNonce, err := newKey.Encrypt(decrypted)
-			if err != nil {
-				rLog.Error("failed-to-encrypt", err)
-				return err
-			}
-
-			_, err = sqlDB.Exec(`
-				UPDATE `+ec.Table+`
-				SET `+ec.Column+` = $1, nonce = $2
-				WHERE `+ec.PrimaryKey+` = $3
-			`, encrypted, newNonce, primaryKey)
-			if err != nil {
-				rLog.Error("failed-to-update", err)
-				return err
-			}
-
-			encryptedRows++
-		}
-
-		if encryptedRows > 0 {
-			tLog.Info("re-encrypted-existing-encrypted-data", lager.Data{
-				"rows": encryptedRows,
-			})
-		}
-	}
-
-	return nil
 }
 
 type db struct {

--- a/atc/postgresrunner/postgresrunner.go
+++ b/atc/postgresrunner/postgresrunner.go
@@ -14,7 +14,6 @@ import (
 	"code.cloudfoundry.org/lager/lagertest"
 
 	"github.com/concourse/concourse/atc/db"
-	"github.com/concourse/concourse/atc/db/encryption"
 	"github.com/concourse/concourse/atc/db/migration"
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -101,7 +100,8 @@ func (runner *Runner) MigrateToVersion(version int) {
 		"postgres",
 		runner.DataSourceName(),
 		nil,
-		encryption.NewNoEncryption(),
+		nil,
+		nil,
 	).MigrateToVersion(version)
 	Expect(err).NotTo(HaveOccurred())
 }
@@ -111,7 +111,8 @@ func (runner *Runner) TryOpenDBAtVersion(version int) (*sql.DB, error) {
 		"postgres",
 		runner.DataSourceName(),
 		nil,
-		encryption.NewNoEncryption(),
+		nil,
+		nil,
 	).OpenAtVersion(version)
 
 	if err != nil {
@@ -136,7 +137,8 @@ func (runner *Runner) OpenDB() *sql.DB {
 		"postgres",
 		runner.DataSourceName(),
 		nil,
-		encryption.NewNoEncryption(),
+		nil,
+		nil,
 	).Open()
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | **Feature** | Documentation

closes #5959 
Also useful for #5960

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* `concourse migrate` can be called with `--old-encryption-key` to rotate the encryption key (or disable encryption)
* Fixed a bug which prohibited running a migration and rotating the key (if the migration requires decrypting from the DB)

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

* `concourse migrate` can be called with `--old-encryption-key` to rotate the database encryption key as a one-time operation
* `concourse web` still accepts `--old-encryption-key`
* You should stop any ATCs prior to running this command

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [x] Documentation reviewed
- [x] Release notes reviewed
- [x] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
