### PR TITLE
tasks scheduling: metrics: enhance TasksWaiting metric.

### DIFF
--- a/atc/metric/emitter/prometheus_test.go
+++ b/atc/metric/emitter/prometheus_test.go
@@ -187,7 +187,6 @@ var _ = Describe("PrometheusEmitter", func() {
 		}
 	})
 
-
 	JustBeforeEach(func() {
 		prometheusEmitter, err = prometheusConfig.NewEmitter()
 	})
@@ -196,6 +195,11 @@ var _ = Describe("PrometheusEmitter", func() {
 		prometheusEmitter.Emit(logger, metric.Event{
 			Name:  "tasks waiting",
 			Value: 4,
+			Attributes: map[string]string{
+				"teamId":     "42",
+				"workerTags": "tester",
+				"platform":   "darwin",
+			},
 		})
 
 		res, _ := http.Get(fmt.Sprintf("http://%s:%s/metrics", prometheusConfig.BindIP, prometheusConfig.BindPort))
@@ -203,7 +207,7 @@ var _ = Describe("PrometheusEmitter", func() {
 		body, _ := ioutil.ReadAll(res.Body)
 
 		Expect(res.StatusCode).To(Equal(http.StatusOK))
-		Expect(string(body)).To(ContainSubstring("concourse_tasks_waiting 4"))
+		Expect(string(body)).To(ContainSubstring("concourse_tasks_waiting{platform=\"darwin\",teamId=\"42\",workerTags=\"tester\"} 4"))
 		Expect(err).To(BeNil())
 	})
 })

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -30,8 +30,6 @@ var JobsScheduling = &Gauge{}
 var BuildsStarted = &Counter{}
 var BuildsRunning = &Gauge{}
 
-var TasksWaiting = &Gauge{}
-
 var ChecksFinishedWithError = &Counter{}
 var ChecksFinishedWithSuccess = &Counter{}
 var ChecksQueueSize = &Gauge{}
@@ -40,6 +38,34 @@ var ChecksEnqueued = &Counter{}
 
 var ConcurrentRequests = map[string]*Gauge{}
 var ConcurrentRequestsLimitHit = map[string]*Counter{}
+
+type TasksWaitingLabels struct {
+	TeamId     string
+	WorkerTags string
+	Platform   string
+}
+
+var TasksWaiting = map[TasksWaitingLabels]*Gauge{}
+
+type TasksWaitingDuration struct {
+	Labels   TasksWaitingLabels
+	Duration time.Duration
+}
+
+func (event TasksWaitingDuration) Emit(logger lager.Logger) {
+	emit(
+		logger.Session("tasks-waiting-duration"),
+		Event{
+			Name:  "tasks waiting duration",
+			Value: event.Duration.Seconds(),
+			Attributes: map[string]string{
+				"teamId":     event.Labels.TeamId,
+				"workerTags": event.Labels.WorkerTags,
+				"platform":   event.Labels.Platform,
+			},
+		},
+	)
+}
 
 type BuildCollectorDuration struct {
 	Duration time.Duration

--- a/atc/metric/periodic.go
+++ b/atc/metric/periodic.go
@@ -165,13 +165,20 @@ func tick(logger lager.Logger) {
 		)
 	}
 
-	emit(
-		logger.Session("tasks-waiting"),
-		Event{
-			Name:  "tasks waiting",
-			Value: TasksWaiting.Max(),
-		},
-	)
+	for labels, gauge := range TasksWaiting {
+		emit(
+			logger.Session("tasks-waiting"),
+			Event{
+				Name:  "tasks waiting",
+				Value: gauge.Max(),
+				Attributes: map[string]string{
+					"teamId":     labels.TeamId,
+					"workerTags": labels.WorkerTags,
+					"platform":   labels.Platform,
+				},
+			},
+		)
+	}
 
 	emit(
 		logger.Session("checks-finished-with-error"),

--- a/atc/metric/periodic_test.go
+++ b/atc/metric/periodic_test.go
@@ -142,10 +142,17 @@ var _ = Describe("Periodic emission of metrics", func() {
 	})
 
 	Context("limit-active-tasks metrics", func() {
+		labels := metric.TasksWaitingLabels{
+			TeamId:     "42",
+			WorkerTags: "tester",
+			Platform:   "darwin",
+		}
+
 		BeforeEach(func() {
 			gauge := &metric.Gauge{}
 			gauge.Set(123)
-			metric.TasksWaiting = gauge
+
+			metric.TasksWaiting[labels] = gauge
 		})
 		It("emits", func() {
 			Eventually(emitter.EmitCallCount).Should(BeNumerically(">=", 1))
@@ -155,6 +162,11 @@ var _ = Describe("Periodic emission of metrics", func() {
 						MatchFields(IgnoreExtras, Fields{
 							"Name":  Equal("tasks waiting"),
 							"Value": Equal(float64(123)),
+							"Attributes": Equal(map[string]string{
+								"teamId":     labels.TeamId,
+								"workerTags": labels.WorkerTags,
+								"platform":   labels.Platform,
+							}),
 						}),
 					),
 				),

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/garden"
@@ -586,6 +587,12 @@ func (client *client) chooseTaskWorker(
 	workerStatusPublishTicker := time.NewTicker(client.workerStatusPublishInterval)
 	defer workerStatusPublishTicker.Stop()
 
+	tasksWaitingLabels := metric.TasksWaitingLabels{
+		TeamId:     strconv.Itoa(workerSpec.TeamID),
+		WorkerTags: strings.Join(containerSpec.Tags, "_"),
+		Platform:   workerSpec.Platform,
+	}
+
 	for {
 		if chosenWorker, err = client.pool.FindOrChooseWorkerForContainer(
 			ctx,
@@ -631,6 +638,10 @@ func (client *client) chooseTaskWorker(
 			if elapsed > 0 {
 				message := fmt.Sprintf("Found a free worker after waiting %s.\n", elapsed.Round(1*time.Second))
 				writeOutputMessage(logger, outputWriter, message)
+				metric.TasksWaitingDuration{
+					Labels:   tasksWaitingLabels,
+					Duration: elapsed,
+				}.Emit(logger)
 			}
 
 			return chosenWorker, err
@@ -643,8 +654,12 @@ func (client *client) chooseTaskWorker(
 
 		// Increase task waiting only once
 		if elapsed == 0 {
-			metric.TasksWaiting.Inc()
-			defer metric.TasksWaiting.Dec()
+			_, ok := metric.TasksWaiting[tasksWaitingLabels]
+			if !ok {
+				metric.TasksWaiting[tasksWaitingLabels] = &metric.Gauge{}
+			}
+			metric.TasksWaiting[tasksWaitingLabels].Inc()
+			defer metric.TasksWaiting[tasksWaitingLabels].Dec()
 		}
 
 		elapsed = waitForWorker(logger,

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -26,3 +26,10 @@
 #### <sub><sup><a name="5146" href="#5146">:link:</a></sup></sub> feature
 
 * Refactor TSA to use Concourse's gclient which has a configurable timeout Issue: #5146 PR: #5845
+
+#### <sub><sup><a name="5981" href="#5981">:link:</a></sup></sub> feature
+
+* Enhance `task_waiting` metric to export labels in Prometheus for: platform, worker tags and team of the tasks awaiting execution.
+
+  A new metric called `tasks_wait_duration_bucket` is also added to express as quantiles the average time spent by tasks awaiting execution. PR: #5981
+  ![Example graph for the task wait time histograms.](https://user-images.githubusercontent.com/40891147/89990749-189d2600-dc83-11ea-8fde-ae579fdb0a0a.png)


### PR DESCRIPTION
## What does this PR accomplish?

When exporting the Prometheus metric `tasks_waiting` assigns labels to easily distinguish which sets of workers the tasks are awaiting execution on.

Feature

## Changes proposed by this PR:

The `TasksWaiting` metric is now assigned labels for:

 * Team ID

 * Worker tags: when multiple tags are defined they are joined

 * Platform

of the tasks that are waiting to be executed.

Since one of the most interesting aspect of the metric is to be able to AutoScale the workers instances, the added labels allow for a more specific scaling since they differentiate the groups the workers might belong to.

Also add metric to track the amount of time the tasks spend waiting to be executed.

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
