### PR TITLE
Prevent potential deadlock after pipeline deletion

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -918,6 +918,7 @@ func (cmd *RunCommand) backendComponents(
 	dbPipelineFactory := db.NewPipelineFactory(dbConn, lockFactory)
 	dbJobFactory := db.NewJobFactory(dbConn, lockFactory)
 	dbCheckableCounter := db.NewCheckableCounter(dbConn)
+	dbPipelineLifecycle := db.NewPipelineLifecycle(dbConn, lockFactory)
 
 	alg := algorithm.New(db.NewVersionsDB(dbConn, algorithmLimitRows, schedulerCache))
 
@@ -1065,6 +1066,7 @@ func (cmd *RunCommand) backendComponents(
 			},
 			Runnable: gc.NewBuildLogCollector(
 				dbPipelineFactory,
+				dbPipelineLifecycle,
 				500,
 				gc.NewBuildLogRetentionCalculator(
 					cmd.DefaultBuildLogsToRetain,

--- a/atc/db/db_suite_test.go
+++ b/atc/db/db_suite_test.go
@@ -201,6 +201,11 @@ var _ = BeforeEach(func() {
 	logger = lagertest.NewTestLogger("test")
 })
 
+func destroy(d interface{ Destroy() error }) {
+	err := d.Destroy()
+	Expect(err).ToNot(HaveOccurred())
+}
+
 var _ = AfterEach(func() {
 	err := dbConn.Close()
 	Expect(err).NotTo(HaveOccurred())

--- a/atc/db/dbfakes/fake_pipeline_lifecycle.go
+++ b/atc/db/dbfakes/fake_pipeline_lifecycle.go
@@ -18,6 +18,16 @@ type FakePipelineLifecycle struct {
 	archiveAbandonedPipelinesReturnsOnCall map[int]struct {
 		result1 error
 	}
+	RemoveBuildEventsForDeletedPipelinesStub        func() error
+	removeBuildEventsForDeletedPipelinesMutex       sync.RWMutex
+	removeBuildEventsForDeletedPipelinesArgsForCall []struct {
+	}
+	removeBuildEventsForDeletedPipelinesReturns struct {
+		result1 error
+	}
+	removeBuildEventsForDeletedPipelinesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -74,11 +84,65 @@ func (fake *FakePipelineLifecycle) ArchiveAbandonedPipelinesReturnsOnCall(i int,
 	}{result1}
 }
 
+func (fake *FakePipelineLifecycle) RemoveBuildEventsForDeletedPipelines() error {
+	fake.removeBuildEventsForDeletedPipelinesMutex.Lock()
+	ret, specificReturn := fake.removeBuildEventsForDeletedPipelinesReturnsOnCall[len(fake.removeBuildEventsForDeletedPipelinesArgsForCall)]
+	fake.removeBuildEventsForDeletedPipelinesArgsForCall = append(fake.removeBuildEventsForDeletedPipelinesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("RemoveBuildEventsForDeletedPipelines", []interface{}{})
+	fake.removeBuildEventsForDeletedPipelinesMutex.Unlock()
+	if fake.RemoveBuildEventsForDeletedPipelinesStub != nil {
+		return fake.RemoveBuildEventsForDeletedPipelinesStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.removeBuildEventsForDeletedPipelinesReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakePipelineLifecycle) RemoveBuildEventsForDeletedPipelinesCallCount() int {
+	fake.removeBuildEventsForDeletedPipelinesMutex.RLock()
+	defer fake.removeBuildEventsForDeletedPipelinesMutex.RUnlock()
+	return len(fake.removeBuildEventsForDeletedPipelinesArgsForCall)
+}
+
+func (fake *FakePipelineLifecycle) RemoveBuildEventsForDeletedPipelinesCalls(stub func() error) {
+	fake.removeBuildEventsForDeletedPipelinesMutex.Lock()
+	defer fake.removeBuildEventsForDeletedPipelinesMutex.Unlock()
+	fake.RemoveBuildEventsForDeletedPipelinesStub = stub
+}
+
+func (fake *FakePipelineLifecycle) RemoveBuildEventsForDeletedPipelinesReturns(result1 error) {
+	fake.removeBuildEventsForDeletedPipelinesMutex.Lock()
+	defer fake.removeBuildEventsForDeletedPipelinesMutex.Unlock()
+	fake.RemoveBuildEventsForDeletedPipelinesStub = nil
+	fake.removeBuildEventsForDeletedPipelinesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipelineLifecycle) RemoveBuildEventsForDeletedPipelinesReturnsOnCall(i int, result1 error) {
+	fake.removeBuildEventsForDeletedPipelinesMutex.Lock()
+	defer fake.removeBuildEventsForDeletedPipelinesMutex.Unlock()
+	fake.RemoveBuildEventsForDeletedPipelinesStub = nil
+	if fake.removeBuildEventsForDeletedPipelinesReturnsOnCall == nil {
+		fake.removeBuildEventsForDeletedPipelinesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.removeBuildEventsForDeletedPipelinesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakePipelineLifecycle) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.archiveAbandonedPipelinesMutex.RLock()
 	defer fake.archiveAbandonedPipelinesMutex.RUnlock()
+	fake.removeBuildEventsForDeletedPipelinesMutex.RLock()
+	defer fake.removeBuildEventsForDeletedPipelinesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/atc/db/migration/migrations/1597342429_add_deleted_pipelines_table.down.sql
+++ b/atc/db/migration/migrations/1597342429_add_deleted_pipelines_table.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+    DROP TABLE IF EXISTS deleted_pipelines;
+
+    CREATE OR REPLACE FUNCTION on_pipeline_delete() RETURNS TRIGGER AS $$
+    BEGIN
+        EXECUTE format('DROP TABLE IF EXISTS pipeline_build_events_%s', OLD.id);
+        RETURN NULL;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    DROP TRIGGER IF EXISTS pipeline_build_events_delete_trigger ON pipelines;
+    CREATE TRIGGER pipeline_build_events_delete_trigger AFTER DELETE on pipelines FOR EACH ROW EXECUTE PROCEDURE on_pipeline_delete();
+COMMIT;

--- a/atc/db/migration/migrations/1597342429_add_deleted_pipelines_table.up.sql
+++ b/atc/db/migration/migrations/1597342429_add_deleted_pipelines_table.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+    DROP TRIGGER IF EXISTS pipeline_build_events_delete_trigger ON pipelines;
+    DROP FUNCTION IF EXISTS on_pipeline_delete();
+
+	CREATE TABLE deleted_pipelines (
+        id integer NOT NULL,
+        deleted_at timestamp without time zone DEFAULT now() NOT NULL
+	);
+COMMIT;

--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -110,6 +110,10 @@ func (p *pipelineLifecycle) RemoveBuildEventsForDeletedPipelines() error {
 
 	rows.Close()
 
+	if len(idsToDelete) == 0 {
+		return nil
+	}
+
 	for _, id := range idsToDelete {
 		_, err = p.conn.Exec(fmt.Sprintf("DROP TABLE IF EXISTS pipeline_build_events_%d", id))
 		if err != nil {

--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc/db/lock"
@@ -11,6 +12,7 @@ import (
 
 type PipelineLifecycle interface {
 	ArchiveAbandonedPipelines() error
+	RemoveBuildEventsForDeletedPipelines() error
 }
 
 func NewPipelineLifecycle(conn Conn, lockFactory lock.LockFactory) PipelineLifecycle {
@@ -83,6 +85,44 @@ func archivePipelines(tx Tx, conn Conn, lockFactory lock.LockFactory, rows *sql.
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (p *pipelineLifecycle) RemoveBuildEventsForDeletedPipelines() error {
+	rows, err := psql.Select("id").
+		From("deleted_pipelines").
+		RunWith(p.conn).
+		Query()
+	if err != nil {
+		return err
+	}
+
+	var idsToDelete []int
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return err
+		}
+		idsToDelete = append(idsToDelete, id)
+	}
+
+	rows.Close()
+
+	for _, id := range idsToDelete {
+		_, err = p.conn.Exec(fmt.Sprintf("DROP TABLE IF EXISTS pipeline_build_events_%d", id))
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = psql.Delete("deleted_pipelines").
+		Where(sq.Eq{"id": idsToDelete}).
+		RunWith(p.conn).
+		Exec()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/atc/db/pipeline_lifecycle_test.go
+++ b/atc/db/pipeline_lifecycle_test.go
@@ -1,6 +1,8 @@
 package db_test
 
 import (
+	"fmt"
+
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 
@@ -10,70 +12,124 @@ import (
 
 var _ = Describe("PipelineLifecycle", func() {
 	var (
-		pl            db.PipelineLifecycle
-		childPipeline db.Pipeline
-		err           error
+		pl  db.PipelineLifecycle
+		err error
 	)
 
 	BeforeEach(func() {
 		pl = db.NewPipelineLifecycle(dbConn, lockFactory)
 	})
 
-	JustBeforeEach(func() {
-		err = pl.ArchiveAbandonedPipelines()
-		Expect(err).NotTo(HaveOccurred())
+	Describe("ArchiveAbandonedPipelines", func() {
+		JustBeforeEach(func() {
+			err = pl.ArchiveAbandonedPipelines()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("child pipeline is set by a job in a pipeline", func() {
+			var (
+				childPipeline db.Pipeline
+			)
+
+			BeforeEach(func() {
+				build, _ := defaultJob.CreateBuild()
+				childPipeline, _, _ = build.SavePipeline("child-pipeline", defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false)
+				build.Finish(db.BuildStatusSucceeded)
+			})
+
+			Context("parent pipeline is destroyed", func() {
+				BeforeEach(func() {
+					defaultPipeline.Destroy()
+				})
+
+				It("should archive all child pipelines", func() {
+					childPipeline.Reload()
+					Expect(childPipeline.Archived()).To(BeTrue())
+				})
+			})
+
+			Context("parent pipeline is archived", func() {
+				BeforeEach(func() {
+					defaultPipeline.Archive()
+				})
+
+				It("should archive all child pipelines", func() {
+					childPipeline.Reload()
+					Expect(childPipeline.Archived()).To(BeTrue())
+				})
+			})
+
+			Context("job is removed from the parent pipeline", func() {
+				BeforeEach(func() {
+					defaultPipelineConfig.Jobs = atc.JobConfigs{
+						{
+							Name: "a-different-job",
+						},
+					}
+					defaultTeam.SavePipeline("default-pipeline", defaultPipelineConfig, defaultPipeline.ConfigVersion(), false)
+				})
+
+				It("archives all child pipelines set by the deleted job", func() {
+					childPipeline.Reload()
+					Expect(childPipeline.Archived()).To(BeTrue())
+				})
+			})
+		})
+
+		Context("pipeline does not have a parent job and build ID", func() {
+			It("Should not archive the pipeline", func() {
+				defaultPipeline.Reload()
+				Expect(defaultPipeline.Archived()).To(BeFalse())
+			})
+		})
 	})
 
-	Context("child pipeline is set by a job in a pipeline", func() {
+	Describe("RemoveBuildEventsForDeletedPipelines", func() {
+		var (
+			pipeline1 db.Pipeline
+			pipeline2 db.Pipeline
+		)
+
 		BeforeEach(func() {
-			build, _ := defaultJob.CreateBuild()
-			childPipeline, _, _ = build.SavePipeline("child-pipeline", defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false)
-			build.Finish(db.BuildStatusSucceeded)
+			pipeline1 = defaultPipeline
+			pipeline2, _, _ = defaultTeam.SavePipeline("pipeline2", defaultPipelineConfig, 0, false)
 		})
 
-		Context("parent pipeline is destroyed", func() {
-			BeforeEach(func() {
-				defaultPipeline.Destroy()
-			})
+		pipelineBuildEventsExists := func(id int) bool {
+			var exists bool
+			err = dbConn.QueryRow(fmt.Sprintf("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'pipeline_build_events_%d')", id)).Scan(&exists)
+			Expect(err).ToNot(HaveOccurred())
 
-			It("should archive all child pipelines", func() {
-				childPipeline.Reload()
-				Expect(childPipeline.Archived()).To(BeTrue())
-			})
+			return exists
+		}
+
+		It("drops the pipeline_build_events_x table for each deleted pipeline", func() {
+			pipeline1.Destroy()
+			pipeline2.Destroy()
+
+			err := pl.RemoveBuildEventsForDeletedPipelines()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(pipelineBuildEventsExists(pipeline1.ID())).To(BeFalse())
+			Expect(pipelineBuildEventsExists(pipeline2.ID())).To(BeFalse())
 		})
 
-		Context("parent pipeline is archived", func() {
-			BeforeEach(func() {
-				defaultPipeline.Archive()
-			})
+		It("clears the deleted_pipelines table", func() {
+			pipeline1.Destroy()
+			pl.RemoveBuildEventsForDeletedPipelines()
 
-			It("should archive all child pipelines", func() {
-				childPipeline.Reload()
-				Expect(childPipeline.Archived()).To(BeTrue())
-			})
+			var count int
+			err := dbConn.QueryRow("SELECT COUNT(*) FROM deleted_pipelines").Scan(&count)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(count).To(Equal(0))
 		})
 
-		Context("job is removed from the parent pipeline", func() {
-			BeforeEach(func() {
-				defaultPipelineConfig.Jobs = atc.JobConfigs{
-					{
-						Name: "a-different-job",
-					},
-				}
-				defaultTeam.SavePipeline("default-pipeline", defaultPipelineConfig, defaultPipeline.ConfigVersion(), false)
-			})
+		It("is resilient to pipeline_build_events_x tables not existing", func() {
+			pipeline1.Destroy()
+			dbConn.Exec(fmt.Sprintf("DROP TABLE pipeline_build_events_%d", pipeline1.ID()))
 
-			It("archives all child pipelines set by the deleted job", func() {
-				childPipeline.Reload()
-				Expect(childPipeline.Archived()).To(BeTrue())
-			})
-		})
-	})
-
-	Context("pipeline does not have a parent job and build ID", func() {
-		It("Should not archive the pipeline", func() {
-			defaultPipeline.Reload()
-			Expect(defaultPipeline.Archived()).To(BeFalse())
+			err := pl.RemoveBuildEventsForDeletedPipelines()
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -1203,6 +1204,15 @@ var _ = Describe("Pipeline", func() {
 			_, found, err = team.Pipeline(pipeline.Name())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeFalse())
+		})
+
+		It("marks the pipeline ID in the deleted_pipelines table", func() {
+			pipeline.Destroy()
+
+			var exists bool
+			err := dbConn.QueryRow(fmt.Sprintf("SELECT EXISTS (SELECT 1 FROM deleted_pipelines WHERE id = %d)", pipeline.ID())).Scan(&exists)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue(), "did not mark the pipeline id in deleted_pipelines")
 		})
 	})
 

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -1207,7 +1207,7 @@ var _ = Describe("Pipeline", func() {
 		})
 
 		It("marks the pipeline ID in the deleted_pipelines table", func() {
-			pipeline.Destroy()
+			destroy(pipeline)
 
 			var exists bool
 			err := dbConn.QueryRow(fmt.Sprintf("SELECT EXISTS (SELECT 1 FROM deleted_pipelines WHERE id = %d)", pipeline.ID())).Scan(&exists)

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -41,16 +41,8 @@ var _ = Describe("Team", func() {
 
 	Describe("Delete", func() {
 		var err error
-		var otherTeamPipeline db.Pipeline
 
 		BeforeEach(func() {
-			otherTeamPipeline, _, err = otherTeam.SavePipeline("fake-pipeline", atc.Config{
-				Jobs: atc.JobConfigs{
-					{Name: "job-name"},
-				},
-			}, db.ConfigVersion(1), false)
-			Expect(err).ToNot(HaveOccurred())
-
 			err = otherTeam.Delete()
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -65,13 +57,6 @@ var _ = Describe("Team", func() {
 		It("drops the team_build_events_ID table", func() {
 			var exists bool
 			err := dbConn.QueryRow(fmt.Sprintf("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'team_build_events_%d')", otherTeam.ID())).Scan(&exists)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(exists).To(BeFalse())
-		})
-
-		It("drops the teams pipeline_build_events_ID table", func() {
-			var exists bool
-			err := dbConn.QueryRow(fmt.Sprintf("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'pipeline_build_events_%d')", otherTeamPipeline.ID())).Scan(&exists)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(exists).To(BeFalse())
 		})


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #5287  .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Remove `pipeline_build_events_delete_trigger`, which previously dropped the `pipeline_build_events_x` table when the corresponding pipeline was deleted
  * Instead, deleting a pipeline marks it as deleted in a new `deleted_pipelines` table
* Modify the build log collector to drop the `pipeline_build_events_x` table for each pipeline that is marked as deleted in `deleted_pipelines`

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

The motivation for this change is elaborated more in https://github.com/concourse/concourse/issues/5287#issuecomment-673472967, but essentially, having only one place where build events are deleted removes the risk of deadlocking here.

An alternative approach we considered was to compare the list of all (non-deleted) pipelines to the list of `pipeline_build_events_x` tables that are still around to determine which to delete. This would mean we wouldn't have to maintain the `deleted_pipelines` table. We went with the `deleted_pipelines` approach because it enables us to make decisions about *when* to remove pipeline build events for deleted pipelines. For instance, an operator may wish to keep build events around for 1 week after a pipeline is deleted. We don't currently support this, but it's a possibility with the chosen approach. Also, it kind of felt weird querying the list of tables in Postgres. Happy to reconsider the approach taken, though.

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
