### PR TITLE
fix go 1.15 int-to-string conversion warning

### DIFF
--- a/atc/api/auth/check_build_read_access_handler_test.go
+++ b/atc/api/auth/check_build_read_access_handler_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -262,7 +263,7 @@ var _ = Describe("CheckBuildReadAccessHandler", func() {
 						pipeline.JobReturns(fakeJob, true, nil)
 					})
 
-					It("returns "+string(status), func() {
+					It("returns "+fmt.Sprint(status), func() {
 						Expect(response.StatusCode).To(Equal(status))
 					})
 				})
@@ -294,7 +295,7 @@ var _ = Describe("CheckBuildReadAccessHandler", func() {
 					build.PipelineReturns(pipeline, true, nil)
 				})
 
-				It("returns "+string(status), func() {
+				It("returns "+fmt.Sprint(status), func() {
 					Expect(response.StatusCode).To(Equal(status))
 				})
 			})

--- a/atc/db/worker_lifecycle_test.go
+++ b/atc/db/worker_lifecycle_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Worker Lifecycle", func() {
 						err = dbBuild.Finish(s)
 						Expect(err).ToNot(HaveOccurred())
 					}
-					_, err = dbWorker.CreateContainer(db.NewBuildStepContainerOwner(dbBuild.ID(), atc.PlanID(4), defaultTeam.ID()), db.ContainerMetadata{})
+					_, err = dbWorker.CreateContainer(db.NewBuildStepContainerOwner(dbBuild.ID(), atc.PlanID("4"), defaultTeam.ID()), db.ContainerMetadata{})
 					Expect(err).ToNot(HaveOccurred())
 
 					_, found, err := workerFactory.GetWorker(atcWorker.Name)
@@ -207,7 +207,7 @@ var _ = Describe("Worker Lifecycle", func() {
 					Expect(err).ToNot(HaveOccurred())
 				}
 
-				_, err := dbWorker.CreateContainer(db.NewBuildStepContainerOwner(dbBuild.ID(), atc.PlanID(4), defaultTeam.ID()), db.ContainerMetadata{})
+				_, err := dbWorker.CreateContainer(db.NewBuildStepContainerOwner(dbBuild.ID(), atc.PlanID("4"), defaultTeam.ID()), db.ContainerMetadata{})
 				Expect(err).ToNot(HaveOccurred())
 
 				_, found, err := workerFactory.GetWorker(atcWorker.Name)
@@ -419,7 +419,7 @@ var _ = Describe("Worker Lifecycle", func() {
 						Expect(err).ToNot(HaveOccurred())
 					}
 
-					_, err = dbWorker.CreateContainer(db.NewBuildStepContainerOwner(dbBuild.ID(), atc.PlanID(4), defaultTeam.ID()), db.ContainerMetadata{})
+					_, err = dbWorker.CreateContainer(db.NewBuildStepContainerOwner(dbBuild.ID(), atc.PlanID("4"), defaultTeam.ID()), db.ContainerMetadata{})
 					Expect(err).ToNot(HaveOccurred())
 
 					_, found, err := workerFactory.GetWorker(atcWorker.Name)
@@ -453,7 +453,7 @@ var _ = Describe("Worker Lifecycle", func() {
 					Expect(err).ToNot(HaveOccurred())
 				}
 
-				_, err := dbWorker.CreateContainer(db.NewBuildStepContainerOwner(dbBuild.ID(), atc.PlanID(4), defaultTeam.ID()), db.ContainerMetadata{})
+				_, err := dbWorker.CreateContainer(db.NewBuildStepContainerOwner(dbBuild.ID(), atc.PlanID("4"), defaultTeam.ID()), db.ContainerMetadata{})
 				Expect(err).ToNot(HaveOccurred())
 
 				_, found, err := workerFactory.GetWorker(atcWorker.Name)

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -71,7 +71,7 @@ var _ = Describe("GetStep", func() {
 			PipelineName: "some-pipeline",
 		}
 
-		planID = 56
+		planID = "56"
 	)
 
 	BeforeEach(func() {

--- a/atc/exec/load_var_step_test.go
+++ b/atc/exec/load_var_step_test.go
@@ -62,7 +62,7 @@ var _ = Describe("LoadVarStep", func() {
 
 		stdout, stderr *gbytes.Buffer
 
-		planID = 56
+		planID = "56"
 	)
 
 	BeforeEach(func() {

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -105,7 +105,7 @@ jobs:
 
 		stdout, stderr *gbytes.Buffer
 
-		planID = 56
+		planID = "56"
 	)
 
 	BeforeEach(func() {

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -63,7 +63,7 @@ var _ = Describe("TaskStep", func() {
 			JobID:   12345,
 		}
 
-		planID = atc.PlanID(42)
+		planID = atc.PlanID("42")
 	)
 
 	BeforeEach(func() {
@@ -123,7 +123,7 @@ var _ = Describe("TaskStep", func() {
 
 	JustBeforeEach(func() {
 		plan := atc.Plan{
-			ID:   atc.PlanID(planID),
+			ID:   planID,
 			Task: taskPlan,
 		}
 

--- a/atc/scheduler/job_scheduling_test.go
+++ b/atc/scheduler/job_scheduling_test.go
@@ -2,6 +2,7 @@ package scheduler_test
 
 import (
 	"errors"
+	"fmt"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
@@ -271,7 +272,7 @@ func (example Example) Run() {
 	for i, build := range example.Job.Builds {
 		fakeBuild := new(dbfakes.FakeBuild)
 		fakeBuild.IDReturns(build.ID)
-		fakeBuild.NameReturns(string(build.ID))
+		fakeBuild.NameReturns(fmt.Sprint(build.ID))
 		fakeBuild.IsAbortedReturns(build.Aborted)
 		fakeBuild.RerunOfReturns(build.RerunOfBuildID)
 		fakeBuild.IsManuallyTriggeredReturns(build.ManuallyTriggered)

--- a/atc/worker/choose_task_worker_test.go
+++ b/atc/worker/choose_task_worker_test.go
@@ -236,7 +236,7 @@ func workerContainerDummy() worker.ContainerSpec {
 func containerOwnerDummy() db.ContainerOwner {
 	return db.NewBuildStepContainerOwner(
 		1234,
-		atc.PlanID(42),
+		atc.PlanID("42"),
 		123,
 	)
 }

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -528,7 +528,7 @@ var _ = Describe("Client", func() {
 			memory := uint64(1024)
 
 			buildId := 1234
-			planId := atc.PlanID(42)
+			planId := atc.PlanID("42")
 			teamId := 123
 			fakeDelegate = new(execfakes.FakeTaskDelegate)
 			fakeContainerOwner = db.NewBuildStepContainerOwner(


### PR DESCRIPTION
Go 1.15 added automated vetting in tests for this particular case, and
it's causing our unit tests to fail.

https://golang.org/doc/go1.15#vet

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

Ported #5983 over

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
