### PR TITLE
Remove unnecessary updates to the resource's `check_error` value

### DIFF
--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -263,7 +263,10 @@ func (r *resource) SetCheckSetupError(cause error) error {
 	if cause == nil {
 		_, err = psql.Update("resources").
 			Set("check_error", nil).
-			Where(sq.Eq{"id": r.ID()}).
+			Where(sq.And{
+				sq.Eq{"id": r.ID()},
+				sq.NotEq{"check_error": nil},
+			}).
 			RunWith(r.conn).
 			Exec()
 	} else {


### PR DESCRIPTION
## What does this PR accomplish?
Feature

This PR makes it so that we will only update the check error to nil if the check error is not already nil. This will help reduce the amount of work that the database will need to do in order to update the check error for every resource. This query is run within `SetCheckSetupError`

https://github.com/concourse/concourse/blob/d32357aeee93f6a650644dd81094b31a93a8bdae/atc/db/resource.go#L260-L278

which is called by every resource that is checked through the lidar scanner

https://github.com/concourse/concourse/blob/40d2c5af96af67b7ad15d13fe43d9d6badf1c846/atc/lidar/scanner.go#L93

In our large Concourse deployment called `hush-house`, I found that this query ranked 4th on the queries that the database spent the most total time on.

![Screen Shot 2020-08-14 at 3 06 15 PM](https://user-images.githubusercontent.com/19290703/90295184-3ec6ef80-de56-11ea-9f20-a8c008b4921b.png)

Even though the average time taken to run the query is only approximately 3 ms, the number of calls is large enough to cause the database to spend a lot of time running this query. I'm guessing it is because most of the time, the check error value is nil and the value in the database is also nil but we were still running the `UPDATE` query to set it to nil regardless of the existing value. Hopefully with this change, it will help reduce the amount of work spent on this query.

## Changes proposed by this PR:
Only update the resource `check_error` to nil if it is not already nil.

## Release Note
The query will only update the resource check error to `NULL` if it is not already `NULL`.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
