### PR TITLE
atc: Allow OPA integration to return reasons for failures (breaking change)

### DIFF
--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/gc/gcfakes"
+	"github.com/concourse/concourse/atc/policy"
 	"github.com/concourse/concourse/atc/worker/workerfakes"
 	"github.com/concourse/concourse/atc/wrappa"
 
@@ -159,7 +160,7 @@ var _ = BeforeEach(func() {
 	checkWorkerTeamAccessHandlerFactory := auth.NewCheckWorkerTeamAccessHandlerFactory(dbWorkerFactory)
 
 	fakePolicyChecker = new(policycheckerfakes.FakePolicyChecker)
-	fakePolicyChecker.CheckReturns(true, nil)
+	fakePolicyChecker.CheckReturns(policy.PassedPolicyCheck(), nil)
 
 	apiWrapper := wrappa.MultiWrappa{
 		wrappa.NewPolicyCheckWrappa(logger, fakePolicyChecker),

--- a/atc/api/policychecker/checker.go
+++ b/atc/api/policychecker/checker.go
@@ -2,10 +2,11 @@ package policychecker
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
+
 	"sigs.k8s.io/yaml"
-	"encoding/json"
 
 	"github.com/concourse/concourse/atc/api/accessor"
 	"github.com/concourse/concourse/atc/policy"
@@ -14,7 +15,7 @@ import (
 //go:generate counterfeiter . PolicyChecker
 
 type PolicyChecker interface {
-	Check(string, accessor.Access, *http.Request) (bool, error)
+	Check(string, accessor.Access, *http.Request) (policy.PolicyCheckOutput, error)
 }
 
 type checker struct {
@@ -28,22 +29,22 @@ func NewApiPolicyChecker(policyChecker *policy.Checker) PolicyChecker {
 	return &checker{policyChecker: policyChecker}
 }
 
-func (c *checker) Check(action string, acc accessor.Access, req *http.Request) (bool, error) {
+func (c *checker) Check(action string, acc accessor.Access, req *http.Request) (policy.PolicyCheckOutput, error) {
 	// Ignore self invoked API calls.
 	if acc.IsSystem() {
-		return true, nil
+		return policy.PassedPolicyCheck(), nil
 	}
 
 	// Actions in black will not go through policy check.
 	if c.policyChecker.ShouldSkipAction(action) {
-		return true, nil
+		return policy.PassedPolicyCheck(), nil
 	}
 
 	// Only actions with specified http method will go through policy check.
 	// But actions in white list will always go through policy check.
 	if !c.policyChecker.ShouldCheckHttpMethod(req.Method) &&
 		!c.policyChecker.ShouldCheckAction(action) {
-		return true, nil
+		return policy.PassedPolicyCheck(), nil
 	}
 
 	team := req.FormValue(":team_name")
@@ -60,7 +61,7 @@ func (c *checker) Check(action string, acc accessor.Access, req *http.Request) (
 	case "application/json", "text/vnd.yaml", "text/yaml", "text/x-yaml", "application/x-yaml":
 		body, err := ioutil.ReadAll(req.Body)
 		if err != nil {
-			return false, err
+			return policy.FailedPolicyCheck(), err
 		} else if body != nil && len(body) > 0 {
 			if ct == "application/json" {
 				err = json.Unmarshal(body, &input.Data)
@@ -68,7 +69,7 @@ func (c *checker) Check(action string, acc accessor.Access, req *http.Request) (
 				err = yaml.Unmarshal(body, &input.Data)
 			}
 			if err != nil {
-				return false, err
+				return policy.FailedPolicyCheck(), err
 			}
 
 			req.Body = ioutil.NopCloser(bytes.NewBuffer(body))

--- a/atc/api/policychecker/policycheckerfakes/fake_policy_checker.go
+++ b/atc/api/policychecker/policycheckerfakes/fake_policy_checker.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/concourse/concourse/atc/api/accessor"
 	"github.com/concourse/concourse/atc/api/policychecker"
+	"github.com/concourse/concourse/atc/policy"
 )
 
 type FakePolicyChecker struct {
-	CheckStub        func(string, accessor.Access, *http.Request) (bool, error)
+	CheckStub        func(string, accessor.Access, *http.Request) (policy.PolicyCheckOutput, error)
 	checkMutex       sync.RWMutex
 	checkArgsForCall []struct {
 		arg1 string
@@ -18,18 +19,18 @@ type FakePolicyChecker struct {
 		arg3 *http.Request
 	}
 	checkReturns struct {
-		result1 bool
+		result1 policy.PolicyCheckOutput
 		result2 error
 	}
 	checkReturnsOnCall map[int]struct {
-		result1 bool
+		result1 policy.PolicyCheckOutput
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakePolicyChecker) Check(arg1 string, arg2 accessor.Access, arg3 *http.Request) (bool, error) {
+func (fake *FakePolicyChecker) Check(arg1 string, arg2 accessor.Access, arg3 *http.Request) (policy.PolicyCheckOutput, error) {
 	fake.checkMutex.Lock()
 	ret, specificReturn := fake.checkReturnsOnCall[len(fake.checkArgsForCall)]
 	fake.checkArgsForCall = append(fake.checkArgsForCall, struct {
@@ -55,7 +56,7 @@ func (fake *FakePolicyChecker) CheckCallCount() int {
 	return len(fake.checkArgsForCall)
 }
 
-func (fake *FakePolicyChecker) CheckCalls(stub func(string, accessor.Access, *http.Request) (bool, error)) {
+func (fake *FakePolicyChecker) CheckCalls(stub func(string, accessor.Access, *http.Request) (policy.PolicyCheckOutput, error)) {
 	fake.checkMutex.Lock()
 	defer fake.checkMutex.Unlock()
 	fake.CheckStub = stub
@@ -68,28 +69,28 @@ func (fake *FakePolicyChecker) CheckArgsForCall(i int) (string, accessor.Access,
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakePolicyChecker) CheckReturns(result1 bool, result2 error) {
+func (fake *FakePolicyChecker) CheckReturns(result1 policy.PolicyCheckOutput, result2 error) {
 	fake.checkMutex.Lock()
 	defer fake.checkMutex.Unlock()
 	fake.CheckStub = nil
 	fake.checkReturns = struct {
-		result1 bool
+		result1 policy.PolicyCheckOutput
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakePolicyChecker) CheckReturnsOnCall(i int, result1 bool, result2 error) {
+func (fake *FakePolicyChecker) CheckReturnsOnCall(i int, result1 policy.PolicyCheckOutput, result2 error) {
 	fake.checkMutex.Lock()
 	defer fake.checkMutex.Unlock()
 	fake.CheckStub = nil
 	if fake.checkReturnsOnCall == nil {
 		fake.checkReturnsOnCall = make(map[int]struct {
-			result1 bool
+			result1 policy.PolicyCheckOutput
 			result2 error
 		})
 	}
 	fake.checkReturnsOnCall[i] = struct {
-		result1 bool
+		result1 policy.PolicyCheckOutput
 		result2 error
 	}{result1, result2}
 }

--- a/atc/policy/opa/opa_test.go
+++ b/atc/policy/opa/opa_test.go
@@ -1,13 +1,14 @@
 package opa_test
 
 import (
-	"code.cloudfoundry.org/lager/lagertest"
 	"fmt"
-	"github.com/concourse/concourse/atc/policy"
-	"github.com/concourse/concourse/atc/policy/opa"
 	"net/http"
 	"net/http/httptest"
 	"time"
+
+	"code.cloudfoundry.org/lager/lagertest"
+	"github.com/concourse/concourse/atc/policy"
+	"github.com/concourse/concourse/atc/policy/opa"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,10 +17,10 @@ import (
 var _ = Describe("Policy checker", func() {
 
 	var (
-		logger = lagertest.NewTestLogger("opa-test")
+		logger  = lagertest.NewTestLogger("opa-test")
 		fakeOpa *httptest.Server
-		agent policy.Agent
-		err error
+		agent   policy.Agent
+		err     error
 	)
 
 	AfterEach(func() {
@@ -30,7 +31,7 @@ var _ = Describe("Policy checker", func() {
 
 	JustBeforeEach(func() {
 		fakeOpa.Start()
-		agent, err = (&opa.OpaConfig{fakeOpa.URL, time.Second*2}).NewAgent(logger)
+		agent, err = (&opa.OpaConfig{fakeOpa.URL, time.Second * 2}).NewAgent(logger)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(agent).ToNot(BeNil())
 	})
@@ -42,38 +43,54 @@ var _ = Describe("Policy checker", func() {
 			}))
 		})
 
-		It("should pass", func() {
-			pass, err := agent.Check(policy.PolicyCheckInput{})
+		It("should be allowed", func() {
+			result, err := agent.Check(policy.PolicyCheckInput{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pass).To(BeTrue())
+			Expect(result.Allowed).To(BeTrue())
 		})
 	})
 
-	Context("when OPA returns pass", func() {
+	Context("when OPA returns allowed", func() {
 		BeforeEach(func() {
 			fakeOpa = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprint(w, `{"result": true}`)
+				fmt.Fprint(w, `{"result": {"allowed": true }}`)
 			}))
 		})
 
-		It("should pass", func() {
-			pass, err := agent.Check(policy.PolicyCheckInput{})
+		It("should be allowed", func() {
+			result, err := agent.Check(policy.PolicyCheckInput{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pass).To(BeTrue())
+			Expect(result.Allowed).To(BeTrue())
 		})
 	})
 
-	Context("when OPA returns not-pass", func() {
+	Context("when OPA returns not-allowed", func() {
 		BeforeEach(func() {
 			fakeOpa = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				fmt.Fprint(w, `{"result": false}`)
+				fmt.Fprint(w, `{"result": {"allowed": false }}`)
 			}))
 		})
 
-		It("should not pass", func() {
-			pass, err := agent.Check(policy.PolicyCheckInput{})
+		It("should not be allowed and return reasons", func() {
+			result, err := agent.Check(policy.PolicyCheckInput{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pass).To(BeFalse())
+			Expect(result.Allowed).To(BeFalse())
+			Expect(result.Reasons).To(BeEmpty())
+		})
+	})
+
+	Context("when OPA returns not-allowed with reasons", func() {
+		BeforeEach(func() {
+			fakeOpa = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"result": {"allowed": false, "reasons": ["a policy says you can't do that"]}}`)
+			}))
+		})
+
+		It("should not be allowed and return reasons", func() {
+			result, err := agent.Check(policy.PolicyCheckInput{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Allowed).To(BeFalse())
+			Expect(result.Reasons).To(ConsistOf("a policy says you can't do that"))
 		})
 	})
 
@@ -88,10 +105,10 @@ var _ = Describe("Policy checker", func() {
 		})
 
 		It("should return error", func() {
-			pass, err := agent.Check(policy.PolicyCheckInput{})
+			result, err := agent.Check(policy.PolicyCheckInput{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(MatchRegexp("connection refused"))
-			Expect(pass).To(BeFalse())
+			Expect(result.Allowed).To(BeFalse())
 		})
 	})
 
@@ -101,10 +118,10 @@ var _ = Describe("Policy checker", func() {
 		})
 
 		It("should return error", func() {
-			pass, err := agent.Check(policy.PolicyCheckInput{})
+			result, err := agent.Check(policy.PolicyCheckInput{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("opa returned status: 404"))
-			Expect(pass).To(BeFalse())
+			Expect(result.Allowed).To(BeFalse())
 		})
 	})
 
@@ -116,10 +133,10 @@ var _ = Describe("Policy checker", func() {
 		})
 
 		It("should return error", func() {
-			pass, err := agent.Check(policy.PolicyCheckInput{})
+			result, err := agent.Check(policy.PolicyCheckInput{})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("opa returned bad response: invalid character 'h' looking for beginning of value"))
-			Expect(pass).To(BeFalse())
+			Expect(result.Allowed).To(BeFalse())
 		})
 	})
 })

--- a/atc/policy/policyfakes/fake_agent.go
+++ b/atc/policy/policyfakes/fake_agent.go
@@ -8,24 +8,24 @@ import (
 )
 
 type FakeAgent struct {
-	CheckStub        func(policy.PolicyCheckInput) (bool, error)
+	CheckStub        func(policy.PolicyCheckInput) (policy.PolicyCheckOutput, error)
 	checkMutex       sync.RWMutex
 	checkArgsForCall []struct {
 		arg1 policy.PolicyCheckInput
 	}
 	checkReturns struct {
-		result1 bool
+		result1 policy.PolicyCheckOutput
 		result2 error
 	}
 	checkReturnsOnCall map[int]struct {
-		result1 bool
+		result1 policy.PolicyCheckOutput
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeAgent) Check(arg1 policy.PolicyCheckInput) (bool, error) {
+func (fake *FakeAgent) Check(arg1 policy.PolicyCheckInput) (policy.PolicyCheckOutput, error) {
 	fake.checkMutex.Lock()
 	ret, specificReturn := fake.checkReturnsOnCall[len(fake.checkArgsForCall)]
 	fake.checkArgsForCall = append(fake.checkArgsForCall, struct {
@@ -49,7 +49,7 @@ func (fake *FakeAgent) CheckCallCount() int {
 	return len(fake.checkArgsForCall)
 }
 
-func (fake *FakeAgent) CheckCalls(stub func(policy.PolicyCheckInput) (bool, error)) {
+func (fake *FakeAgent) CheckCalls(stub func(policy.PolicyCheckInput) (policy.PolicyCheckOutput, error)) {
 	fake.checkMutex.Lock()
 	defer fake.checkMutex.Unlock()
 	fake.CheckStub = stub
@@ -62,28 +62,28 @@ func (fake *FakeAgent) CheckArgsForCall(i int) policy.PolicyCheckInput {
 	return argsForCall.arg1
 }
 
-func (fake *FakeAgent) CheckReturns(result1 bool, result2 error) {
+func (fake *FakeAgent) CheckReturns(result1 policy.PolicyCheckOutput, result2 error) {
 	fake.checkMutex.Lock()
 	defer fake.checkMutex.Unlock()
 	fake.CheckStub = nil
 	fake.checkReturns = struct {
-		result1 bool
+		result1 policy.PolicyCheckOutput
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeAgent) CheckReturnsOnCall(i int, result1 bool, result2 error) {
+func (fake *FakeAgent) CheckReturnsOnCall(i int, result1 policy.PolicyCheckOutput, result2 error) {
 	fake.checkMutex.Lock()
 	defer fake.checkMutex.Unlock()
 	fake.CheckStub = nil
 	if fake.checkReturnsOnCall == nil {
 		fake.checkReturnsOnCall = make(map[int]struct {
-			result1 bool
+			result1 policy.PolicyCheckOutput
 			result2 error
 		})
 	}
 	fake.checkReturnsOnCall[i] = struct {
-		result1 bool
+		result1 policy.PolicyCheckOutput
 		result2 error
 	}{result1, result2}
 }

--- a/hack/opa/policy.rego
+++ b/hack/opa/policy.rego
@@ -1,8 +1,24 @@
 package concourse
 
-# replace with 'false' to add rules
-default allow = true
+default decision = {"allowed": true}
 
-# allow {
-#   input.action == "ListContainers"
-# }
+# uncomment to include deny rules
+#decision = {"allowed": false, "reasons": reasons} {
+#  count(deny) > 0
+#  reasons := deny
+#}
+
+deny["cannot use docker-image types"] {
+  input.action == "UseImage"
+  input.data.image_type == "docker-image"
+}
+
+deny["cannot run privileged tasks"] {
+  input.action == "SaveConfig"
+  input.data.jobs[_].plan[_].privileged
+}
+
+deny["cannot use privileged resource types"] {
+  input.action == "SaveConfig"
+  input.data.resource_types[_].privileged
+}

--- a/hack/overrides/opa.yml
+++ b/hack/overrides/opa.yml
@@ -8,11 +8,11 @@ version: '3'
 services:
   web:
     environment:
-      CONCOURSE_OPA_URL: http://opa:8181/v1/data/concourse/allow
+      CONCOURSE_OPA_URL: http://opa:8181/v1/data/concourse/decision
       CONCOURSE_POLICY_CHECK_FILTER_HTTP_METHODS: PUT,POST
 
       # uncomment to configure
-      # CONCOURSE_POLICY_CHECK_FILTER_ACTION: ListWorkers,ListContainers,UseImage
+      # CONCOURSE_POLICY_CHECK_FILTER_ACTION: ListWorkers,ListContainers,UseImage,SaveConfig
       # CONCOURSE_POLICY_CHECK_FILTER_ACTION_SKIP: PausePipeline,UnpausePipeline
 
   opa:


### PR DESCRIPTION
Feature

## Changes proposed by this PR:
Allow OPA documents to include an `allowed` and a `reasons` field that
gives a bit more feedback to the user about why something failed. This
allows OPA operators to write rules that are self explanatory as to why
things are getting denied.

Fly does not appear to print the full error message currently but this
works for the UI.

## Notes to reviewer:
This represents a breaking change to the OPA API (if you can call it that) - the document returned will no longer just be a boolean and will instead be objects (though the reasons are optional, it will need to be an object of at least `{ "allowed": true/false }`

I figured whilst this feature was new was probably the time to break the contract between Concourse and OPA though rather than later when it has general opt-in 😁

I'm also happy to write some documentation for the OPA feature at some point too 😄 

I used the following Rego:
```
package concourse

decision = {"allowed": true} {
  count(deny) == 0
}

decision = {"allowed": false, "reasons": reasons} {
  count(deny) > 0
  reasons := deny
}

deny["cannot use busybox"] {
  input.action = "UseImage"
  input.data.image_source.repository == "busybox"
}

deny["cannot use docker-image types"] {
  input.action = "UseImage"
  input.data.image_type == "docker-image"
}
```

Which in the UI produces the following output when trying to run a task with the `busybox` image from a `docker-image` resource:
![Screenshot 2020-08-18 at 00 11 21](https://user-images.githubusercontent.com/14118619/90453004-67194d00-e0e7-11ea-8366-d6d0d7b507b7.png)


## Release Note
Operators using the OPA integration can now return reasons why a check failed. This is a breaking change and existing policies will need to be re-written to return an object `{}` containing an `allowed` and `reasons` fields. `allowed` is the original boolean value and `reasons` is an array of strings.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
