### PR TITLE
Return real JSON from "fly get-team --json"

### DIFF
--- a/fly/commands/get_team.go
+++ b/fly/commands/get_team.go
@@ -35,11 +35,7 @@ func (command *GetTeamCommand) Execute(args []string) error {
 	}
 
 	if command.JSON {
-		err := displayhelpers.JsonPrint(map[string]interface{}{
-			"name": team.Name(),
-			"id":   team.ID(),
-			"auth": team.Auth(),
-		})
+		err := displayhelpers.JsonPrint(team.ATCTeam())
 		if err != nil {
 			return err
 		}

--- a/fly/commands/get_team.go
+++ b/fly/commands/get_team.go
@@ -35,7 +35,11 @@ func (command *GetTeamCommand) Execute(args []string) error {
 	}
 
 	if command.JSON {
-		if err := displayhelpers.JsonPrint(team); err != nil {
+		err := displayhelpers.JsonPrint(map[string]interface{}{
+			"name": team.Name(),
+			"auth": team.Auth(),
+		})
+		if err != nil {
 			return err
 		}
 		return nil

--- a/fly/commands/get_team.go
+++ b/fly/commands/get_team.go
@@ -37,6 +37,7 @@ func (command *GetTeamCommand) Execute(args []string) error {
 	if command.JSON {
 		err := displayhelpers.JsonPrint(map[string]interface{}{
 			"name": team.Name(),
+			"id":   team.ID(),
 			"auth": team.Auth(),
 		})
 		if err != nil {

--- a/fly/integration/get_team_test.go
+++ b/fly/integration/get_team_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Fly CLI", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(sess).Should(gexec.Exit(0))
 
-					Expect(sess.Out.Contents()).To(MatchJSON(`{"name": "myTeam", "auth": {"owner": {"groups": [], "users": ["local:username"] }}}`))
+					Expect(sess.Out.Contents()).To(MatchJSON(`{"id": 1, "name": "myTeam", "auth": {"owner": {"groups": [], "users": ["local:username"] }}}`))
 				})
 			})
 		})

--- a/fly/integration/get_team_test.go
+++ b/fly/integration/get_team_test.go
@@ -101,6 +101,16 @@ var _ = Describe("Fly CLI", func() {
 						},
 					}))
 				})
+
+				It("produces structured JSON output if requested", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "get-team", "-n", "myTeam", "--json")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(gexec.Exit(0))
+
+					Expect(sess.Out.Contents()).To(MatchJSON(`{"name": "myTeam", "auth": {"owner": {"groups": [], "users": ["local:username"] }}}`))
+				})
 			})
 		})
 	})

--- a/go-concourse/concourse/build_inputs.go
+++ b/go-concourse/concourse/build_inputs.go
@@ -12,7 +12,7 @@ func (team *team) BuildInputsForJob(pipelineName string, jobName string) ([]atc.
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"job_name":      jobName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var buildInputs []atc.BuildInput
@@ -38,7 +38,7 @@ func (team *team) BuildsWithVersionAsInput(pipelineName string, resourceName str
 		"pipeline_name":              pipelineName,
 		"resource_name":              resourceName,
 		"resource_config_version_id": strconv.Itoa(resourceVersionID),
-		"team_name":                  team.name,
+		"team_name":                  team.Name(),
 	}
 
 	var builds []atc.Build

--- a/go-concourse/concourse/build_outputs_of.go
+++ b/go-concourse/concourse/build_outputs_of.go
@@ -10,7 +10,7 @@ import (
 
 func (team *team) BuildsWithVersionAsOutput(pipelineName string, resourceName string, resourceVersionID int) ([]atc.Build, bool, error) {
 	params := rata.Params{
-		"team_name":                  team.name,
+		"team_name":                  team.Name(),
 		"pipeline_name":              pipelineName,
 		"resource_name":              resourceName,
 		"resource_config_version_id": strconv.Itoa(resourceVersionID),

--- a/go-concourse/concourse/builds.go
+++ b/go-concourse/concourse/builds.go
@@ -39,7 +39,7 @@ func (team *team) CreateJobBuild(pipelineName string, jobName string) (atc.Build
 	params := rata.Params{
 		"job_name":      jobName,
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var build atc.Build
@@ -58,7 +58,7 @@ func (team *team) RerunJobBuild(pipelineName string, jobName string, buildName s
 		"build_name":    buildName,
 		"job_name":      jobName,
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var build atc.Build
@@ -77,7 +77,7 @@ func (team *team) JobBuild(pipelineName, jobName, buildName string) (atc.Build, 
 		"job_name":      jobName,
 		"build_name":    buildName,
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var build atc.Build
@@ -163,7 +163,7 @@ func (team *team) Builds(page Page) ([]atc.Build, Pagination, error) {
 	headers := http.Header{}
 
 	params := rata.Params{
-		"team_name": team.name,
+		"team_name": team.Name(),
 	}
 
 	err := team.connection.Send(internal.Request{

--- a/go-concourse/concourse/check_resource.go
+++ b/go-concourse/concourse/check_resource.go
@@ -15,7 +15,7 @@ func (team *team) CheckResource(pipelineName string, resourceName string, versio
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"resource_name": resourceName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var check atc.Check

--- a/go-concourse/concourse/check_resource_type.go
+++ b/go-concourse/concourse/check_resource_type.go
@@ -15,7 +15,7 @@ func (team *team) CheckResourceType(pipelineName string, resourceTypeName string
 	params := rata.Params{
 		"pipeline_name":      pipelineName,
 		"resource_type_name": resourceTypeName,
-		"team_name":          team.name,
+		"team_name":          team.Name(),
 	}
 
 	var check atc.Check

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -10,6 +10,16 @@ import (
 )
 
 type FakeTeam struct {
+	ATCTeamStub        func() atc.Team
+	aTCTeamMutex       sync.RWMutex
+	aTCTeamArgsForCall []struct {
+	}
+	aTCTeamReturns struct {
+		result1 atc.Team
+	}
+	aTCTeamReturnsOnCall map[int]struct {
+		result1 atc.Team
+	}
 	ArchivePipelineStub        func(string) (bool, error)
 	archivePipelineMutex       sync.RWMutex
 	archivePipelineArgsForCall []struct {
@@ -756,6 +766,58 @@ type FakeTeam struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeTeam) ATCTeam() atc.Team {
+	fake.aTCTeamMutex.Lock()
+	ret, specificReturn := fake.aTCTeamReturnsOnCall[len(fake.aTCTeamArgsForCall)]
+	fake.aTCTeamArgsForCall = append(fake.aTCTeamArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ATCTeam", []interface{}{})
+	fake.aTCTeamMutex.Unlock()
+	if fake.ATCTeamStub != nil {
+		return fake.ATCTeamStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.aTCTeamReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeTeam) ATCTeamCallCount() int {
+	fake.aTCTeamMutex.RLock()
+	defer fake.aTCTeamMutex.RUnlock()
+	return len(fake.aTCTeamArgsForCall)
+}
+
+func (fake *FakeTeam) ATCTeamCalls(stub func() atc.Team) {
+	fake.aTCTeamMutex.Lock()
+	defer fake.aTCTeamMutex.Unlock()
+	fake.ATCTeamStub = stub
+}
+
+func (fake *FakeTeam) ATCTeamReturns(result1 atc.Team) {
+	fake.aTCTeamMutex.Lock()
+	defer fake.aTCTeamMutex.Unlock()
+	fake.ATCTeamStub = nil
+	fake.aTCTeamReturns = struct {
+		result1 atc.Team
+	}{result1}
+}
+
+func (fake *FakeTeam) ATCTeamReturnsOnCall(i int, result1 atc.Team) {
+	fake.aTCTeamMutex.Lock()
+	defer fake.aTCTeamMutex.Unlock()
+	fake.ATCTeamStub = nil
+	if fake.aTCTeamReturnsOnCall == nil {
+		fake.aTCTeamReturnsOnCall = make(map[int]struct {
+			result1 atc.Team
+		})
+	}
+	fake.aTCTeamReturnsOnCall[i] = struct {
+		result1 atc.Team
+	}{result1}
 }
 
 func (fake *FakeTeam) ArchivePipeline(arg1 string) (bool, error) {
@@ -4051,6 +4113,8 @@ func (fake *FakeTeam) VersionedResourceTypesReturnsOnCall(i int, result1 atc.Ver
 func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.aTCTeamMutex.RLock()
+	defer fake.aTCTeamMutex.RUnlock()
 	fake.archivePipelineMutex.RLock()
 	defer fake.archivePipelineMutex.RUnlock()
 	fake.authMutex.RLock()

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -348,6 +348,16 @@ type FakeTeam struct {
 		result1 bool
 		result2 error
 	}
+	IDStub        func() int
+	iDMutex       sync.RWMutex
+	iDArgsForCall []struct {
+	}
+	iDReturns struct {
+		result1 int
+	}
+	iDReturnsOnCall map[int]struct {
+		result1 int
+	}
 	JobStub        func(string, string) (atc.Job, bool, error)
 	jobMutex       sync.RWMutex
 	jobArgsForCall []struct {
@@ -2243,6 +2253,58 @@ func (fake *FakeTeam) HidePipelineReturnsOnCall(i int, result1 bool, result2 err
 	}{result1, result2}
 }
 
+func (fake *FakeTeam) ID() int {
+	fake.iDMutex.Lock()
+	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
+	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ID", []interface{}{})
+	fake.iDMutex.Unlock()
+	if fake.IDStub != nil {
+		return fake.IDStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.iDReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeTeam) IDCallCount() int {
+	fake.iDMutex.RLock()
+	defer fake.iDMutex.RUnlock()
+	return len(fake.iDArgsForCall)
+}
+
+func (fake *FakeTeam) IDCalls(stub func() int) {
+	fake.iDMutex.Lock()
+	defer fake.iDMutex.Unlock()
+	fake.IDStub = stub
+}
+
+func (fake *FakeTeam) IDReturns(result1 int) {
+	fake.iDMutex.Lock()
+	defer fake.iDMutex.Unlock()
+	fake.IDStub = nil
+	fake.iDReturns = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeTeam) IDReturnsOnCall(i int, result1 int) {
+	fake.iDMutex.Lock()
+	defer fake.iDMutex.Unlock()
+	fake.IDStub = nil
+	if fake.iDReturnsOnCall == nil {
+		fake.iDReturnsOnCall = make(map[int]struct {
+			result1 int
+		})
+	}
+	fake.iDReturnsOnCall[i] = struct {
+		result1 int
+	}{result1}
+}
+
 func (fake *FakeTeam) Job(arg1 string, arg2 string) (atc.Job, bool, error) {
 	fake.jobMutex.Lock()
 	ret, specificReturn := fake.jobReturnsOnCall[len(fake.jobArgsForCall)]
@@ -4035,6 +4097,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.getContainerMutex.RUnlock()
 	fake.hidePipelineMutex.RLock()
 	defer fake.hidePipelineMutex.RUnlock()
+	fake.iDMutex.RLock()
+	defer fake.iDMutex.RUnlock()
 	fake.jobMutex.RLock()
 	defer fake.jobMutex.RUnlock()
 	fake.jobBuildMutex.RLock()

--- a/go-concourse/concourse/configs.go
+++ b/go-concourse/concourse/configs.go
@@ -17,7 +17,7 @@ import (
 func (team *team) PipelineConfig(pipelineName string) (atc.Config, string, bool, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var configResponse atc.ConfigResponse
@@ -58,7 +58,7 @@ type setConfigResponse struct {
 func (team *team) CreateOrUpdatePipelineConfig(pipelineName string, configVersion string, passedConfig []byte, checkCredentials bool) (bool, bool, []ConfigWarning, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	queryParams := url.Values{}

--- a/go-concourse/concourse/containers.go
+++ b/go-concourse/concourse/containers.go
@@ -13,7 +13,7 @@ func (team *team) ListContainers(queryList map[string]string) ([]atc.Container, 
 	urlValues := url.Values{}
 
 	params := rata.Params{
-		"team_name": team.name,
+		"team_name": team.Name(),
 	}
 	for k, v := range queryList {
 		urlValues[k] = []string{v}
@@ -33,7 +33,7 @@ func (team *team) GetContainer(handle string) (atc.Container, error) {
 
 	params := rata.Params{
 		"id":        handle,
-		"team_name": team.name,
+		"team_name": team.Name(),
 	}
 
 	err := team.connection.Send(internal.Request{

--- a/go-concourse/concourse/jobs.go
+++ b/go-concourse/concourse/jobs.go
@@ -12,7 +12,7 @@ import (
 func (team *team) ListJobs(pipelineName string) ([]atc.Job, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var jobs []atc.Job
@@ -41,7 +41,7 @@ func (team *team) Job(pipelineName, jobName string) (atc.Job, bool, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"job_name":      jobName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var job atc.Job
@@ -65,7 +65,7 @@ func (team *team) JobBuilds(pipelineName string, jobName string, page Page) ([]a
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"job_name":      jobName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var builds []atc.Build
@@ -98,7 +98,7 @@ func (team *team) PauseJob(pipelineName string, jobName string) (bool, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"job_name":      jobName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	err := team.connection.Send(internal.Request{
@@ -120,7 +120,7 @@ func (team *team) UnpauseJob(pipelineName string, jobName string) (bool, error) 
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"job_name":      jobName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	err := team.connection.Send(internal.Request{
@@ -142,7 +142,7 @@ func (team *team) ScheduleJob(pipelineName string, jobName string) (bool, error)
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"job_name":      jobName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	err := team.connection.Send(internal.Request{
@@ -162,7 +162,7 @@ func (team *team) ScheduleJob(pipelineName string, jobName string) (bool, error)
 
 func (team *team) ClearTaskCache(pipelineName string, jobName string, stepName string, cachePath string) (int64, error) {
 	params := rata.Params{
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 		"pipeline_name": pipelineName,
 		"job_name":      jobName,
 		"step_name":     stepName,

--- a/go-concourse/concourse/pipelines.go
+++ b/go-concourse/concourse/pipelines.go
@@ -14,7 +14,7 @@ import (
 func (team *team) Pipeline(pipelineName string) (atc.Pipeline, bool, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var pipeline atc.Pipeline
@@ -37,7 +37,7 @@ func (team *team) Pipeline(pipelineName string) (atc.Pipeline, bool, error) {
 
 func (team *team) OrderingPipelines(pipelines []string) error {
 	params := rata.Params{
-		"team_name": team.name,
+		"team_name": team.Name(),
 	}
 
 	buffer := &bytes.Buffer{}
@@ -58,7 +58,7 @@ func (team *team) OrderingPipelines(pipelines []string) error {
 
 func (team *team) ListPipelines() ([]atc.Pipeline, error) {
 	params := rata.Params{
-		"team_name": team.name,
+		"team_name": team.Name(),
 	}
 
 	var pipelines []atc.Pipeline
@@ -96,7 +96,7 @@ func (team *team) CreatePipelineBuild(pipelineName string, plan atc.Plan) (atc.B
 		RequestName: atc.CreatePipelineBuild,
 		Body:        buffer,
 		Params: rata.Params{
-			"team_name":     team.name,
+			"team_name":     team.Name(),
 			"pipeline_name": pipelineName,
 		},
 		Header: http.Header{
@@ -135,7 +135,7 @@ func (team *team) HidePipeline(pipelineName string) (bool, error) {
 func (team *team) managePipeline(pipelineName string, endpoint string) (bool, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 	err := team.connection.Send(internal.Request{
 		RequestName: endpoint,
@@ -155,7 +155,7 @@ func (team *team) managePipeline(pipelineName string, endpoint string) (bool, er
 func (team *team) RenamePipeline(pipelineName, name string) (bool, []ConfigWarning, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	jsonBytes, err := json.Marshal(atc.RenameRequest{NewName: name})
@@ -186,7 +186,7 @@ func (team *team) RenamePipeline(pipelineName, name string) (bool, []ConfigWarni
 func (team *team) PipelineBuilds(pipelineName string, page Page) ([]atc.Build, Pagination, bool, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var builds []atc.Build

--- a/go-concourse/concourse/resource.go
+++ b/go-concourse/concourse/resource.go
@@ -10,7 +10,7 @@ func (team *team) Resource(pipelineName string, resourceName string) (atc.Resour
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"resource_name": resourceName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var resource atc.Resource
@@ -33,7 +33,7 @@ func (team *team) Resource(pipelineName string, resourceName string) (atc.Resour
 func (team *team) ListResources(pipelineName string) ([]atc.Resource, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var resources []atc.Resource

--- a/go-concourse/concourse/resourceversions.go
+++ b/go-concourse/concourse/resourceversions.go
@@ -16,7 +16,7 @@ func (team *team) ResourceVersions(pipelineName string, resourceName string, pag
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"resource_name": resourceName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var resourceVersions []atc.ResourceVersion
@@ -66,7 +66,7 @@ func (team *team) UnpinResource(pipelineName string, resourceName string) (bool,
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"resource_name": resourceName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	err := team.connection.Send(internal.Request{
@@ -88,7 +88,7 @@ func (team *team) SetPinComment(pipelineName string, resourceName string, commen
 	params := rata.Params{
 		"pipeline_name": pipelineName,
 		"resource_name": resourceName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	pinComment := atc.SetPinCommentRequestBody{
@@ -126,7 +126,7 @@ func (team *team) sendResourceVersion(pipelineName string, resourceName string, 
 		"pipeline_name":              pipelineName,
 		"resource_name":              resourceName,
 		"resource_config_version_id": strconv.Itoa(resourceVersionID),
-		"team_name":                  team.name,
+		"team_name":                  team.Name(),
 	}
 
 	err := team.connection.Send(internal.Request{

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -11,7 +11,7 @@ import (
 
 type Team interface {
 	Name() string
-
+    ID() int
 	Auth() atc.TeamAuth
 
 	CreateOrUpdate(team atc.Team) (atc.Team, bool, bool, []ConfigWarning, error)
@@ -77,6 +77,7 @@ type Team interface {
 
 type team struct {
 	name       string
+	id         int
 	connection internal.Connection //Deprecated
 	httpAgent  internal.HTTPAgent
 	auth       atc.TeamAuth
@@ -86,13 +87,17 @@ func (team *team) Name() string {
 	return team.name
 }
 
+func (team *team) ID() int {
+	return team.id
+}
+
+func (team *team) Auth() atc.TeamAuth {
+	return team.auth
+}
+
 func (client *client) Team(name string) Team {
 	return &team{
 		name:       name,
 		connection: client.connection,
 	}
-}
-
-func (team *team) Auth() atc.TeamAuth {
-	return team.auth
 }

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -13,6 +13,7 @@ type Team interface {
 	Name() string
     ID() int
 	Auth() atc.TeamAuth
+	ATCTeam() atc.Team
 
 	CreateOrUpdate(team atc.Team) (atc.Team, bool, bool, []ConfigWarning, error)
 	RenameTeam(teamName, name string) (bool, []ConfigWarning, error)
@@ -76,28 +77,30 @@ type Team interface {
 }
 
 type team struct {
-	name       string
-	id         int
+	atcTeam    atc.Team
 	connection internal.Connection //Deprecated
 	httpAgent  internal.HTTPAgent
-	auth       atc.TeamAuth
 }
 
 func (team *team) Name() string {
-	return team.name
+	return team.atcTeam.Name
 }
 
 func (team *team) ID() int {
-	return team.id
+	return team.atcTeam.ID
 }
 
 func (team *team) Auth() atc.TeamAuth {
-	return team.auth
+	return team.atcTeam.Auth
+}
+
+func (team *team) ATCTeam() atc.Team {
+	return team.atcTeam
 }
 
 func (client *client) Team(name string) Team {
 	return &team{
-		name:       name,
+		atcTeam:    atc.Team{Name: name},
 		connection: client.connection,
 	}
 }

--- a/go-concourse/concourse/teams.go
+++ b/go-concourse/concourse/teams.go
@@ -24,7 +24,7 @@ type setTeamResponse struct {
 // CreateOrUpdate creates or updates team teamName with the settings provided in passedTeam.
 // passedTeam should reflect the desired state of team's configuration.
 func (team *team) CreateOrUpdate(passedTeam atc.Team) (atc.Team, bool, bool, []ConfigWarning, error) {
-	params := rata.Params{"team_name": team.name}
+	params := rata.Params{"team_name": team.Name()}
 
 	buffer := &bytes.Buffer{}
 	err := json.NewEncoder(buffer).Encode(passedTeam)
@@ -137,11 +137,9 @@ func (client *client) FindTeam(teamName string) (Team, error) {
 			return nil, err
 		}
 		return &team{
-			name:       atcTeam.Name,
-			id:         atcTeam.ID,
+			atcTeam:    atcTeam,
 			connection: client.connection,
 			httpAgent:  client.httpAgent,
-			auth:       atcTeam.Auth,
 		}, nil
 	case http.StatusForbidden:
 		return nil, fmt.Errorf("you do not have a role on team '%s'", teamName)

--- a/go-concourse/concourse/teams.go
+++ b/go-concourse/concourse/teams.go
@@ -138,6 +138,7 @@ func (client *client) FindTeam(teamName string) (Team, error) {
 		}
 		return &team{
 			name:       atcTeam.Name,
+			id:         atcTeam.ID,
 			connection: client.connection,
 			httpAgent:  client.httpAgent,
 			auth:       atcTeam.Auth,

--- a/go-concourse/concourse/teams_test.go
+++ b/go-concourse/concourse/teams_test.go
@@ -41,7 +41,7 @@ var _ = Describe("ATC Handler Teams", func() {
 			It("returns the requested team", func() {
 				team, err := client.FindTeam(teamName)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(team.Name()).To(Equal(teamName))
+				Expect(team.Name(),).To(Equal(teamName))
 				Expect(team.Auth()).To(Equal(expectedAuth))
 			})
 		})

--- a/go-concourse/concourse/teams_test.go
+++ b/go-concourse/concourse/teams_test.go
@@ -41,7 +41,7 @@ var _ = Describe("ATC Handler Teams", func() {
 			It("returns the requested team", func() {
 				team, err := client.FindTeam(teamName)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(team.Name(),).To(Equal(teamName))
+				Expect(team.Name()).To(Equal(teamName))
 				Expect(team.Auth()).To(Equal(expectedAuth))
 			})
 		})

--- a/go-concourse/concourse/version_resource_types.go
+++ b/go-concourse/concourse/version_resource_types.go
@@ -9,7 +9,7 @@ import (
 func (team *team) VersionedResourceTypes(pipelineName string) (atc.VersionedResourceTypes, bool, error) {
 	params := rata.Params{
 		"pipeline_name": pipelineName,
-		"team_name":     team.name,
+		"team_name":     team.Name(),
 	}
 
 	var versionedResourceTypes atc.VersionedResourceTypes

--- a/go-concourse/concourse/volumes.go
+++ b/go-concourse/concourse/volumes.go
@@ -10,7 +10,7 @@ func (team *team) ListVolumes() ([]atc.Volume, error) {
 	var volumes []atc.Volume
 
 	params := rata.Params{
-		"team_name": team.name,
+		"team_name": team.Name(),
 	}
 	err := team.connection.Send(internal.Request{
 		RequestName: atc.ListVolumes,


### PR DESCRIPTION

## What does this PR accomplish?

Bug Fix

## Changes proposed by this PR:

This is documented, implemented-ish, and tested-ish, but didn't work: doing `fly -t tgt get-team --team-name foo --json` would always produce the syntactically-valid but boring response `{}`. This is because the code uses the go-concourse `Team` object, which has no data members and so does very little of interest when serialized.

There was originally a test for the YAML-formatted output, but that did not run for the reasons described in 2e5d954, and there were no tests for JSON. That commit also changed the test to look at the tabular format. It appears tests of the JSON path were accidentally skipped over in the refactoring.

We now synthesize a JSON object with team and auth contents, plus the team ID (originally discarded in `go-concourse` but now stashed for this purpose). That means the output will match the elements in `fly teams`.

## Notes to reviewer:

I added `.ID()` to the go-concourse `Team`, as a quick way to get this information through. In `get_team.go` I just make a little map with the desired data, which happens to mirror ATC's definition of `Team`. I feel a bit bad about not just using `atc.Team` properly, but was wary of getting caught up in too much messing about with refactoring of the different `Team`/`team` objects. Happy to give a stab at that if it seems worthwhile.

The changes in go-concourse/concourse/concoursefakes/fake_team.go are just whatever `go generate` did, and should be completely boilerplate.

## Release Note
The `--json` flag on `fly get-team` is meant to yield a structured JSON representation of the team data, including auth details, but instead just gave `{}`. Now it works as intended.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [X] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [X] [Signed] all commits
- [X] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation] - I didn't change this because it's already documented to work this way
- [X] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
