### PR TITLE
Support SAML 2.0 as an auth backend

### DIFF
--- a/skymarshal/skycmd/saml_flags.go
+++ b/skymarshal/skycmd/saml_flags.go
@@ -1,0 +1,82 @@
+package skycmd
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/concourse/dex/connector/saml"
+	"github.com/concourse/flag"
+	multierror "github.com/hashicorp/go-multierror"
+)
+
+func init() {
+	RegisterConnector(&Connector{
+		id:         "saml",
+		config:     &SAMLFlags{},
+		teamConfig: &SAMLTeamFlags{},
+	})
+}
+
+type SAMLFlags struct {
+	DisplayName        string      `long:"display-name" description:"The auth provider name displayed to users on the login page"`
+	SsoURL             string      `long:"sso-url" description:"(Required) SSO URL used for POST value"`
+	CACert             flag.File   `long:"ca-cert" description:"(Required) CA Certificate"`
+	UsernameAttr       string      `long:"username-attr" default:"name" description:"The user name indicates which claim to use to map an external user name to a Concourse user name."`
+	EmailAttr          string      `long:"email-attr" default:"email" description:"The email indicates which claim to use to map an external user email to a Concourse user email."`
+	GroupsAttr         string      `long:"groups-attr" default:"groups" description:"The groups key indicates which attribute to use to map external groups to Concourse teams."`
+	GroupsDelim        string      `long:"groups-delim" description:"If specified, groups are returned as string, this delimiter will be used to split the group string."`
+	NameIDPolicyFormat string      `long:"name-id-policy-format" description:"Requested format of the NameID. The NameID value is is mapped to the ID Token 'sub' claim."`
+	InsecureSkipVerify bool        `long:"skip-ssl-validation" description:"Skip SSL validation"`
+}
+
+func (flag *SAMLFlags) Name() string {
+	if flag.DisplayName != "" {
+		return flag.DisplayName
+	}
+	return "SAML"
+}
+
+func (flag *SAMLFlags) Validate() error {
+	var errs *multierror.Error
+
+	if flag.SsoURL == "" {
+		errs = multierror.Append(errs, errors.New("Missing sso-url"))
+	}
+
+	if flag.CACert == "" {
+		errs = multierror.Append(errs, errors.New("Missing ca-cert"))
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func (flag *SAMLFlags) Serialize(redirectURI string) ([]byte, error) {
+	if err := flag.Validate(); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(saml.Config{
+		SSOURL:                          flag.SsoURL,
+		CA:                              flag.CACert.Path(),
+		InsecureSkipSignatureValidation: flag.InsecureSkipVerify,
+		UsernameAttr:                    flag.UsernameAttr,
+		EmailAttr:                       flag.EmailAttr,
+		GroupsAttr:                      flag.GroupsAttr,
+		GroupsDelim:                     flag.GroupsDelim,
+		NameIDPolicyFormat:              flag.NameIDPolicyFormat,
+		RedirectURI:                     redirectURI,
+	})
+}
+
+type SAMLTeamFlags struct {
+	Users  []string `json:"users" long:"user" description:"A whitelisted SAML user" value-name:"USERNAME"`
+	Groups []string `json:"groups" long:"group" description:"A whitelisted SAML group" value-name:"GROUP_NAME"`
+}
+
+func (flag *SAMLTeamFlags) GetUsers() []string {
+	return flag.Users
+}
+
+func (flag *SAMLTeamFlags) GetGroups() []string {
+	return flag.Groups
+}

--- a/skymarshal/skycmd/saml_flags.go
+++ b/skymarshal/skycmd/saml_flags.go
@@ -21,6 +21,8 @@ type SAMLFlags struct {
 	DisplayName        string      `long:"display-name" description:"The auth provider name displayed to users on the login page"`
 	SsoURL             string      `long:"sso-url" description:"(Required) SSO URL used for POST value"`
 	CACert             flag.File   `long:"ca-cert" description:"(Required) CA Certificate"`
+	EntityIssuer       string      `long:"entity-issuer" description:"Manually specify dex's Issuer value."`
+	SsoIssuer          string      `long:"sso-issuer" description:"Issuer value expected in the SAML response."`
 	UsernameAttr       string      `long:"username-attr" default:"name" description:"The user name indicates which claim to use to map an external user name to a Concourse user name."`
 	EmailAttr          string      `long:"email-attr" default:"email" description:"The email indicates which claim to use to map an external user email to a Concourse user email."`
 	GroupsAttr         string      `long:"groups-attr" default:"groups" description:"The groups key indicates which attribute to use to map external groups to Concourse teams."`
@@ -58,6 +60,8 @@ func (flag *SAMLFlags) Serialize(redirectURI string) ([]byte, error) {
 	return json.Marshal(saml.Config{
 		SSOURL:                          flag.SsoURL,
 		CA:                              flag.CACert.Path(),
+		EntityIssuer:                    flag.EntityIssuer,
+		SSOIssuer:                       flag.SsoIssuer,
 		InsecureSkipSignatureValidation: flag.InsecureSkipVerify,
 		UsernameAttr:                    flag.UsernameAttr,
 		EmailAttr:                       flag.EmailAttr,


### PR DESCRIPTION
## What does this PR accomplish?

Feature

addresses #1036

## Changes proposed by this PR:

[concourse/dex](https://github.com/concourse/dex) already includes the saml connector, this PR simply adds the skycmd flags required to enable saml authentication.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [ ] Added release note (Optional)

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
