### PR TITLE
 use the configured resolv.conf for containerd

### DIFF
--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -74,9 +74,6 @@ var _ = Describe("DNS Resolution", func() {
 	expectedDnsProxyBehaviour := func(runtime string) {
 		DescribeTable("different proxy settings",
 			func(c Case) {
-				if runtime == containerdRuntime && c.enableDnsProxy == "false" {
-					Skip("Skip test until https://github.com/concourse/concourse/issues/5967 is resolv'ed :P")
-				}
 				setupDeployment(runtime, c.enableDnsProxy, c.dnsServer)
 
 				sess := fly.Start("execute", "-c", "tasks/dns-proxy-task.yml", "-v", "url="+c.addressFunction())

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -491,7 +491,7 @@ func (s *IntegrationSuite) TestCustomDNS() {
 	s.NoError(err)
 
 	s.Equal(exitCode, 0)
-	expectedDNSServer := "nameserver 1.1.1.1\nnameserver 1.2.3.4\n"
+	expectedDNSServer := "nameserver 1.1.1.1\nnameserver 1.2.3.4"
 	s.Equal(expectedDNSServer, buf.String())
 }
 

--- a/worker/runtime/resolvconf_parser.go
+++ b/worker/runtime/resolvconf_parser.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"code.cloudfoundry.org/localip"
+)
+
+// Parse resolve.conf file from the provided path.
+// implementation is based on guardian's implementation
+// here: https://github.com/cloudfoundry/guardian/blob/master/kawasaki/dns/resolv_compiler.go
+func ParseHostResolveConf(path string) ([]string, error) {
+
+	resolvConf, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read host's resolv.conf: %w", err)
+	}
+
+	resolvContents := string(resolvConf)
+
+	loopbackNameserver := regexp.MustCompile(`^\s*nameserver\s+127\.0\.0\.\d+\s*$`)
+	if loopbackNameserver.MatchString(resolvContents) {
+		ip, err := localip.LocalIP()
+		if err != nil {
+			return nil, err
+		}
+		return []string{"nameserver " + ip}, nil
+	}
+
+	var entries []string
+
+	for _, resolvEntry := range strings.Split(strings.TrimSpace(resolvContents), "\n") {
+		if resolvEntry == "" {
+			continue
+		}
+
+		if !strings.HasPrefix(resolvEntry, "nameserver") {
+			entries = append(entries, strings.TrimSpace(resolvEntry))
+			continue
+		}
+
+		pattern := regexp.MustCompile(`127\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
+		if !pattern.MatchString(strings.TrimSpace(resolvEntry)) {
+			nameserverFields := strings.Fields(resolvEntry)
+			if len(nameserverFields) != 2 {
+				continue
+			}
+			entries = append(entries, strings.Join(nameserverFields, " "))
+		}
+	}
+
+	return entries, nil
+}

--- a/worker/runtime/resolvconf_parser_test.go
+++ b/worker/runtime/resolvconf_parser_test.go
@@ -1,0 +1,49 @@
+package runtime_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"code.cloudfoundry.org/localip"
+	"github.com/concourse/concourse/worker/runtime"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ResolveconfParserSuite struct {
+	suite.Suite
+	*require.Assertions
+}
+
+func (s *ResolveconfParserSuite) TestParseHostResolvConf() {
+	file := `
+nameserver 8.8.8.8
+nameserver 127.0.0.16
+nameserver something 9.9.9.9
+search something
+`
+
+	tmpDir, _ := ioutil.TempDir("", "test-resolv")
+	defer os.RemoveAll(tmpDir)
+	ioutil.WriteFile(path.Join(tmpDir, "resolv.conf"), []byte(file), 0644)
+
+	entries, err := runtime.ParseHostResolveConf(path.Join(tmpDir, "resolv.conf"))
+	s.NoError(err)
+
+	s.Equal([]string{"nameserver 8.8.8.8", "search something"}, entries)
+}
+
+func (s *ResolveconfParserSuite) TestParseHostResolvConfWithLoopback() {
+	file := `nameserver 127.0.0.1`
+
+	tmpDir, _ := ioutil.TempDir("", "test-resolv-noloopback")
+	defer os.RemoveAll(tmpDir)
+	ioutil.WriteFile(path.Join(tmpDir, "resolv.conf"), []byte(file), 0644)
+
+	entries, err := runtime.ParseHostResolveConf(path.Join(tmpDir, "resolv.conf"))
+	s.NoError(err)
+
+	ip, _ := localip.LocalIP()
+	s.Equal([]string{"nameserver " + ip}, entries)
+}

--- a/worker/runtime/suite_test.go
+++ b/worker/runtime/suite_test.go
@@ -18,4 +18,5 @@ func TestSuite(t *testing.T) {
 	suite.Run(t, &RootfsManagerSuite{Assertions: require.New(t)})
 	suite.Run(t, &UserNamespaceSuite{Assertions: require.New(t)})
 	suite.Run(t, &TimeoutLockSuite{Assertions: require.New(t)})
+	suite.Run(t, &ResolveconfParserSuite{Assertions: require.New(t)})
 }

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -152,7 +152,7 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 
 	dnsServers := cmd.Containerd.DNSServers
 	if cmd.Containerd.DNS.Enable {
- 		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
+		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
 The nameserver values could come from manually defined properties
 or the host itself

Revert "k8s topgun: behaviour: skip containerd dns tests"
This reverts commit 0b03e84c5a1109855351787fd74296430efbcc14.

Signed-off-by: Bishoy Youssef <byoussef@pivotal.io>
Co-authored-by: Vikram Yadav <vyadav@pivotal.io>

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
Feature

closes #5967  .

## Changes proposed by this PR:
The resolv.conf is injected into the containers created by containerd on a worker. The approach is similar to Garden behaviour: https://github.com/cloudfoundry/guardian/blob/ca905e542c224efde27f5c2070ac6c6f9bc37c0c/kawasaki/resolv.go#L30.

When setting the configuration, the priority is given to the configuration provided by the user by setting `concourse_garden_dns_servers` property. If the user doesn't set this property, we use the worker host's dns configuration inside the container.

## Notes to reviewer:
We couldn't run the topgun tests locally so please make sure the topgun tests passed for this PR on CI.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
