### PR TITLE
fly/exec: only upload current directory if it's an input

### DIFF
--- a/fly/commands/internal/executehelpers/inputs.go
+++ b/fly/commands/internal/executehelpers/inputs.go
@@ -44,16 +44,34 @@ func DetermineInputs(
 		return nil, nil, nil, nil, err
 	}
 
-	if len(localInputMappings) == 0 && inputsFrom.PipelineName == "" && inputsFrom.JobName == "" {
+	if inputsFrom.PipelineName == "" && inputsFrom.JobName == "" {
 		wd, err := os.Getwd()
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
 
-		localInputMappings = append(localInputMappings, flaghelpers.InputPairFlag{
-			Name: filepath.Base(wd),
-			Path: ".",
-		})
+		required := false
+		for _, input := range taskInputs {
+			if input.Name == filepath.Base(wd) {
+				required = true
+				break
+			}
+		}
+
+		provided := false
+		for _, input := range localInputMappings {
+			if input.Name == filepath.Base(wd) {
+				provided = true
+				break
+			}
+		}
+
+		if required && !provided {
+			localInputMappings = append(localInputMappings, flaghelpers.InputPairFlag{
+				Name: filepath.Base(wd),
+				Path: ".",
+			})
+		}
 	}
 
 	inputsFromLocal, err := GenerateLocalInputs(fact, team, localInputMappings, includeIgnored, platform)


### PR DESCRIPTION
[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?

**Bug Fix** | Feature | Documentation

closes #4828

## Changes proposed by this PR:

Upload the current directory if:

- the name of the current directory matches one of the input names
- the input was not provided by a `--input NAME=PATH` flag as well

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
