### PR TITLE
Pass user roles to policy checker for API calls

### DIFF
--- a/atc/api/policychecker/checker.go
+++ b/atc/api/policychecker/checker.go
@@ -46,12 +46,14 @@ func (c *checker) Check(action string, acc accessor.Access, req *http.Request) (
 		return true, nil
 	}
 
+	team := req.FormValue(":team_name")
 	input := policy.PolicyCheckInput{
-		HttpMethod:     req.Method,
-		Action:         action,
-		User:           acc.Claims().UserName,
-		Team:           req.FormValue(":team_name"),
-		Pipeline:       req.FormValue(":pipeline_name"),
+		HttpMethod: req.Method,
+		Action:     action,
+		User:       acc.Claims().UserName,
+		Roles:      acc.TeamRoles()[team],
+		Team:       team,
+		Pipeline:   req.FormValue(":pipeline_name"),
 	}
 
 	switch ct := req.Header.Get("Content-type"); ct {

--- a/atc/api/policychecker/checker_test.go
+++ b/atc/api/policychecker/checker_test.go
@@ -147,6 +147,9 @@ var _ = Describe("PolicyChecker", func() {
 
 			Context("when every is ok", func() {
 				BeforeEach(func() {
+					fakeAccess.TeamRolesReturns(map[string][]string{
+						"some-team": []string{"some-role"},
+					})
 					fakeAccess.ClaimsReturns(accessor.Claims{UserName: "some-user"})
 					body := bytes.NewBuffer([]byte("a: b"))
 					fakeRequest = httptest.NewRequest("PUT", "/something?:team_name=some-team&:pipeline_name=some-pipeline", body)
@@ -169,6 +172,7 @@ var _ = Describe("PolicyChecker", func() {
 						Action:         "some-action",
 						User:           "some-user",
 						Team:           "some-team",
+						Roles:          []string{"some-role"},
 						Pipeline:       "some-pipeline",
 						Data:           map[string]interface{}{"a": "b"},
 					}))

--- a/atc/policy/checker.go
+++ b/atc/policy/checker.go
@@ -30,6 +30,7 @@ type PolicyCheckInput struct {
 	Action         string      `json:"action"`
 	User           string      `json:"user,omitempty"`
 	Team           string      `json:"team,omitempty"`
+	Roles          []string    `json:"roles,omitempty"`
 	Pipeline       string      `json:"pipeline,omitempty"`
 	Data           interface{} `json:"data,omitempty"`
 }


### PR DESCRIPTION
## What does this PR accomplish?

Feature

## Changes proposed by this PR:
Passing in the roles of the current user into the policy checks for API calls allows for a policy server like OPA to implement even more fine grained controls such as "owners can create pipelines with privileged containers but members cannot." This should allow for even more customisable roles without burdening Concourse itself with supporting all these use cases.

## Notes to reviewer:
Should be pretty simple. I tested this with a team with a `member` and an `owner` and the correct Rego to deny members creating privileged containers and it worked as expected.

## Release Note
The user's team roles will now be passed to the policy checker for all API checks

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
