### PR TITLE
atc/db/migration: changd type of id column in resource_config_version…

### DIFF
--- a/atc/db/migration/migrations/1598284990_alter_id_on_resource_config_versions_bigint.down.sql
+++ b/atc/db/migration/migrations/1598284990_alter_id_on_resource_config_versions_bigint.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE resource_config_versions ALTER COLUMN id TYPE int;
+COMMIT;

--- a/atc/db/migration/migrations/1598284990_alter_id_on_resource_config_versions_bigint.up.sql
+++ b/atc/db/migration/migrations/1598284990_alter_id_on_resource_config_versions_bigint.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE resource_config_versions ALTER COLUMN id TYPE bigint;
+COMMIT;


### PR DESCRIPTION


## What does this PR accomplish?
Bug Fix | Feature | Documentation

closes #5667  .

## Changes proposed by this PR:
Use `bigint` for `id` column.

## Notes to reviewer:
For the concern of the migration might take long time to finish, we have tested the query in CI that has 1m entries in `resource_config_verions` table. We ran the query without pausing jobs or stopping atc. It took about 14s to complete, which matches the estimate in https://github.com/concourse/concourse/issues/5667#issuecomment-679377296. And thus this fix could be shipped by next minor release.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits


## Reviewer Checklist
- [ ] Code reviewed
- [ ] PR acceptance performed
