### PR TITLE
Allow the fly http transport to use client certificates

### DIFF
--- a/fly/commands/sync.go
+++ b/fly/commands/sync.go
@@ -10,14 +10,18 @@ import (
 	"github.com/vbauerster/mpb/v4/decor"
 
 	"github.com/concourse/concourse"
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
 )
 
 type SyncCommand struct {
-	Force  bool   `long:"force" short:"f" description:"Sync even if versions already match."`
-	ATCURL string `long:"concourse-url" short:"c" description:"Concourse URL to sync with"`
+	Force          bool         `long:"force" short:"f" description:"Sync even if versions already match."`
+	ATCURL         string       `long:"concourse-url" short:"c" description:"Concourse URL to sync with"`
+	CACert         atc.PathFlag `long:"ca-cert" description:"Path to Concourse PEM-encoded CA certificate file."`
+	ClientCertPath atc.PathFlag `long:"client-certificate" description:"Path to a PEM-encoded client certificate file."`
+	ClientKeyPath  atc.PathFlag `long:"client-key" description:"Path to a PEM-encoded client key file."`
 }
 
 func (command *SyncCommand) Execute(args []string) error {
@@ -32,7 +36,9 @@ func (command *SyncCommand) Execute(args []string) error {
 			command.ATCURL,
 			"",
 			false,
-			"",
+			string(command.CACert),
+			string(command.ClientCertPath),
+			string(command.ClientKeyPath),
 			Fly.Verbose,
 		)
 	}

--- a/fly/commands/sync.go
+++ b/fly/commands/sync.go
@@ -19,6 +19,7 @@ import (
 type SyncCommand struct {
 	Force          bool         `long:"force" short:"f" description:"Sync even if versions already match."`
 	ATCURL         string       `long:"concourse-url" short:"c" description:"Concourse URL to sync with"`
+	Insecure       bool         `short:"k" long:"insecure" description:"Skip verification of the endpoint's SSL certificate"`
 	CACert         atc.PathFlag `long:"ca-cert" description:"Path to Concourse PEM-encoded CA certificate file."`
 	ClientCertPath atc.PathFlag `long:"client-certificate" description:"Path to a PEM-encoded client certificate file."`
 	ClientKeyPath  atc.PathFlag `long:"client-key" description:"Path to a PEM-encoded client key file."`
@@ -35,7 +36,7 @@ func (command *SyncCommand) Execute(args []string) error {
 			"dummy",
 			command.ATCURL,
 			"",
-			false,
+			command.Insecure,
 			string(command.CACert),
 			string(command.ClientCertPath),
 			string(command.ClientKeyPath),

--- a/fly/rc/rcfakes/fake_target.go
+++ b/fly/rc/rcfakes/fake_target.go
@@ -30,6 +30,36 @@ type FakeTarget struct {
 	clientReturnsOnCall map[int]struct {
 		result1 concourse.Client
 	}
+	ClientCertPathStub        func() string
+	clientCertPathMutex       sync.RWMutex
+	clientCertPathArgsForCall []struct {
+	}
+	clientCertPathReturns struct {
+		result1 string
+	}
+	clientCertPathReturnsOnCall map[int]struct {
+		result1 string
+	}
+	ClientCertificateStub        func() []tls.Certificate
+	clientCertificateMutex       sync.RWMutex
+	clientCertificateArgsForCall []struct {
+	}
+	clientCertificateReturns struct {
+		result1 []tls.Certificate
+	}
+	clientCertificateReturnsOnCall map[int]struct {
+		result1 []tls.Certificate
+	}
+	ClientKeyPathStub        func() string
+	clientKeyPathMutex       sync.RWMutex
+	clientKeyPathArgsForCall []struct {
+	}
+	clientKeyPathReturns struct {
+		result1 string
+	}
+	clientKeyPathReturnsOnCall map[int]struct {
+		result1 string
+	}
 	FindTeamStub        func(string) (concourse.Team, error)
 	findTeamMutex       sync.RWMutex
 	findTeamArgsForCall []struct {
@@ -257,6 +287,162 @@ func (fake *FakeTarget) ClientReturnsOnCall(i int, result1 concourse.Client) {
 	}
 	fake.clientReturnsOnCall[i] = struct {
 		result1 concourse.Client
+	}{result1}
+}
+
+func (fake *FakeTarget) ClientCertPath() string {
+	fake.clientCertPathMutex.Lock()
+	ret, specificReturn := fake.clientCertPathReturnsOnCall[len(fake.clientCertPathArgsForCall)]
+	fake.clientCertPathArgsForCall = append(fake.clientCertPathArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ClientCertPath", []interface{}{})
+	fake.clientCertPathMutex.Unlock()
+	if fake.ClientCertPathStub != nil {
+		return fake.ClientCertPathStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.clientCertPathReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeTarget) ClientCertPathCallCount() int {
+	fake.clientCertPathMutex.RLock()
+	defer fake.clientCertPathMutex.RUnlock()
+	return len(fake.clientCertPathArgsForCall)
+}
+
+func (fake *FakeTarget) ClientCertPathCalls(stub func() string) {
+	fake.clientCertPathMutex.Lock()
+	defer fake.clientCertPathMutex.Unlock()
+	fake.ClientCertPathStub = stub
+}
+
+func (fake *FakeTarget) ClientCertPathReturns(result1 string) {
+	fake.clientCertPathMutex.Lock()
+	defer fake.clientCertPathMutex.Unlock()
+	fake.ClientCertPathStub = nil
+	fake.clientCertPathReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeTarget) ClientCertPathReturnsOnCall(i int, result1 string) {
+	fake.clientCertPathMutex.Lock()
+	defer fake.clientCertPathMutex.Unlock()
+	fake.ClientCertPathStub = nil
+	if fake.clientCertPathReturnsOnCall == nil {
+		fake.clientCertPathReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.clientCertPathReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeTarget) ClientCertificate() []tls.Certificate {
+	fake.clientCertificateMutex.Lock()
+	ret, specificReturn := fake.clientCertificateReturnsOnCall[len(fake.clientCertificateArgsForCall)]
+	fake.clientCertificateArgsForCall = append(fake.clientCertificateArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ClientCertificate", []interface{}{})
+	fake.clientCertificateMutex.Unlock()
+	if fake.ClientCertificateStub != nil {
+		return fake.ClientCertificateStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.clientCertificateReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeTarget) ClientCertificateCallCount() int {
+	fake.clientCertificateMutex.RLock()
+	defer fake.clientCertificateMutex.RUnlock()
+	return len(fake.clientCertificateArgsForCall)
+}
+
+func (fake *FakeTarget) ClientCertificateCalls(stub func() []tls.Certificate) {
+	fake.clientCertificateMutex.Lock()
+	defer fake.clientCertificateMutex.Unlock()
+	fake.ClientCertificateStub = stub
+}
+
+func (fake *FakeTarget) ClientCertificateReturns(result1 []tls.Certificate) {
+	fake.clientCertificateMutex.Lock()
+	defer fake.clientCertificateMutex.Unlock()
+	fake.ClientCertificateStub = nil
+	fake.clientCertificateReturns = struct {
+		result1 []tls.Certificate
+	}{result1}
+}
+
+func (fake *FakeTarget) ClientCertificateReturnsOnCall(i int, result1 []tls.Certificate) {
+	fake.clientCertificateMutex.Lock()
+	defer fake.clientCertificateMutex.Unlock()
+	fake.ClientCertificateStub = nil
+	if fake.clientCertificateReturnsOnCall == nil {
+		fake.clientCertificateReturnsOnCall = make(map[int]struct {
+			result1 []tls.Certificate
+		})
+	}
+	fake.clientCertificateReturnsOnCall[i] = struct {
+		result1 []tls.Certificate
+	}{result1}
+}
+
+func (fake *FakeTarget) ClientKeyPath() string {
+	fake.clientKeyPathMutex.Lock()
+	ret, specificReturn := fake.clientKeyPathReturnsOnCall[len(fake.clientKeyPathArgsForCall)]
+	fake.clientKeyPathArgsForCall = append(fake.clientKeyPathArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ClientKeyPath", []interface{}{})
+	fake.clientKeyPathMutex.Unlock()
+	if fake.ClientKeyPathStub != nil {
+		return fake.ClientKeyPathStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.clientKeyPathReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeTarget) ClientKeyPathCallCount() int {
+	fake.clientKeyPathMutex.RLock()
+	defer fake.clientKeyPathMutex.RUnlock()
+	return len(fake.clientKeyPathArgsForCall)
+}
+
+func (fake *FakeTarget) ClientKeyPathCalls(stub func() string) {
+	fake.clientKeyPathMutex.Lock()
+	defer fake.clientKeyPathMutex.Unlock()
+	fake.ClientKeyPathStub = stub
+}
+
+func (fake *FakeTarget) ClientKeyPathReturns(result1 string) {
+	fake.clientKeyPathMutex.Lock()
+	defer fake.clientKeyPathMutex.Unlock()
+	fake.ClientKeyPathStub = nil
+	fake.clientKeyPathReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeTarget) ClientKeyPathReturnsOnCall(i int, result1 string) {
+	fake.clientKeyPathMutex.Lock()
+	defer fake.clientKeyPathMutex.Unlock()
+	fake.ClientKeyPathStub = nil
+	if fake.clientKeyPathReturnsOnCall == nil {
+		fake.clientKeyPathReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.clientKeyPathReturnsOnCall[i] = struct {
+		result1 string
 	}{result1}
 }
 
@@ -870,6 +1056,12 @@ func (fake *FakeTarget) Invocations() map[string][][]interface{} {
 	defer fake.cACertMutex.RUnlock()
 	fake.clientMutex.RLock()
 	defer fake.clientMutex.RUnlock()
+	fake.clientCertPathMutex.RLock()
+	defer fake.clientCertPathMutex.RUnlock()
+	fake.clientCertificateMutex.RLock()
+	defer fake.clientCertificateMutex.RUnlock()
+	fake.clientKeyPathMutex.RLock()
+	defer fake.clientKeyPathMutex.RUnlock()
 	fake.findTeamMutex.RLock()
 	defer fake.findTeamMutex.RUnlock()
 	fake.isWorkerVersionCompatibleMutex.RLock()

--- a/fly/rc/target.go
+++ b/fly/rc/target.go
@@ -539,15 +539,27 @@ func loadCACertPool(caCert string) (cert *x509.CertPool, err error) {
 
 func loadClientCertificate(clientCertificateLocation string, clientKeyLocation string) (cert []tls.Certificate, err error) {
 	if clientCertificateLocation == "" {
-		return []tls.Certificate{}, nil
-	} else {
-		clientCertData, err := tls.LoadX509KeyPair(clientCertificateLocation, clientKeyLocation)
-		if err != nil {
+		if clientKeyLocation != "" {
+			err = errors.New("A client key may not be declared without defining a client certificate")
+
 			return []tls.Certificate{}, err
 		}
 
-		cert = []tls.Certificate{clientCertData}
+		return []tls.Certificate{}, nil
 	}
+
+	if clientCertificateLocation != "" && clientKeyLocation == "" {
+		err = errors.New("A client certificate may not be declared without defining a client key")
+
+		return []tls.Certificate{}, err
+	}
+
+	clientCertData, err := tls.LoadX509KeyPair(clientCertificateLocation, clientKeyLocation)
+	if err != nil {
+		return []tls.Certificate{}, err
+	}
+
+	cert = []tls.Certificate{clientCertData}
 
 	return cert, nil
 }

--- a/fly/rc/target.go
+++ b/fly/rc/target.go
@@ -47,6 +47,9 @@ type Target interface {
 	Team() concourse.Team
 	FindTeam(string) (concourse.Team, error)
 	CACert() string
+	ClientCertPath() string
+	ClientKeyPath() string
+	ClientCertificate() []tls.Certificate
 	Validate() error
 	ValidateWithWarningOnly() error
 	TLSConfig() *tls.Config
@@ -59,14 +62,17 @@ type Target interface {
 }
 
 type target struct {
-	name      TargetName
-	teamName  string
-	caCert    string
-	tlsConfig *tls.Config
-	client    concourse.Client
-	url       string
-	token     *TargetToken
-	info      atc.Info
+	name              TargetName
+	teamName          string
+	caCert            string
+	clientCertPath    string
+	clientKeyPath     string
+	clientCertificate []tls.Certificate
+	tlsConfig         *tls.Config
+	client            concourse.Client
+	url               string
+	token             *TargetToken
+	info              atc.Info
 }
 
 func NewTarget(
@@ -76,22 +82,29 @@ func NewTarget(
 	token *TargetToken,
 	caCert string,
 	caCertPool *x509.CertPool,
+	clientCertPath string,
+	clientKeyPath string,
+	clientCertificate []tls.Certificate,
 	insecure bool,
 	client concourse.Client,
 ) *target {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: insecure,
 		RootCAs:            caCertPool,
+		Certificates:       clientCertificate,
 	}
 
 	return &target{
-		name:      name,
-		teamName:  teamName,
-		url:       url,
-		token:     token,
-		caCert:    caCert,
-		tlsConfig: tlsConfig,
-		client:    client,
+		name:              name,
+		teamName:          teamName,
+		url:               url,
+		token:             token,
+		caCert:            caCert,
+		clientCertPath:    clientCertPath,
+		clientKeyPath:     clientKeyPath,
+		clientCertificate: clientCertificate,
+		tlsConfig:         tlsConfig,
+		client:            client,
 	}
 }
 
@@ -112,6 +125,8 @@ func LoadTargetFromURL(url, team string, tracing bool) (Target, TargetName, erro
 }
 
 func LoadTarget(selectedTarget TargetName, tracing bool) (Target, error) {
+	var clientCertificate []tls.Certificate
+
 	targetProps, err := selectTarget(selectedTarget)
 	if err != nil {
 		return nil, err
@@ -122,7 +137,12 @@ func LoadTarget(selectedTarget TargetName, tracing bool) (Target, error) {
 		return nil, err
 	}
 
-	httpClient := defaultHttpClient(targetProps.Token, targetProps.Insecure, caCertPool)
+	clientCertificate, err = loadClientCertificate(targetProps.ClientCertPath, targetProps.ClientKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := defaultHttpClient(targetProps.Token, targetProps.Insecure, caCertPool, clientCertificate)
 	client := concourse.NewClient(targetProps.API, httpClient, tracing)
 
 	return NewTarget(
@@ -132,6 +152,9 @@ func LoadTarget(selectedTarget TargetName, tracing bool) (Target, error) {
 		targetProps.Token,
 		targetProps.CACert,
 		caCertPool,
+		targetProps.ClientCertPath,
+		targetProps.ClientKeyPath,
+		clientCertificate,
 		targetProps.Insecure,
 		client,
 	), nil
@@ -142,6 +165,8 @@ func LoadUnauthenticatedTarget(
 	teamName string,
 	insecure bool,
 	caCert string,
+	clientCertPath string,
+	clientKeyPath string,
 	tracing bool,
 ) (Target, error) {
 	targetProps, err := selectTarget(selectedTarget)
@@ -166,7 +191,19 @@ func LoadUnauthenticatedTarget(
 		return nil, err
 	}
 
-	httpClient := &http.Client{Transport: transport(insecure, caCertPool)}
+	var clientCertificate []tls.Certificate
+
+	if clientCertPath == "" && clientKeyPath == "" {
+		clientCertPath = targetProps.ClientCertPath
+		clientKeyPath = targetProps.ClientKeyPath
+	}
+
+	clientCertificate, err = loadClientCertificate(clientCertPath, clientKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{Transport: transport(insecure, caCertPool, clientCertificate)}
 
 	return NewTarget(
 		selectedTarget,
@@ -175,6 +212,9 @@ func LoadUnauthenticatedTarget(
 		targetProps.Token,
 		caCert,
 		caCertPool,
+		clientCertPath,
+		clientKeyPath,
+		clientCertificate,
 		targetProps.Insecure,
 		concourse.NewClient(targetProps.API, httpClient, tracing),
 	), nil
@@ -186,6 +226,8 @@ func NewUnauthenticatedTarget(
 	teamName string,
 	insecure bool,
 	caCert string,
+	clientCertPath string,
+	clientKeyPath string,
 	tracing bool,
 ) (Target, error) {
 	caCertPool, err := loadCACertPool(caCert)
@@ -193,7 +235,13 @@ func NewUnauthenticatedTarget(
 		return nil, err
 	}
 
-	httpClient := &http.Client{Transport: transport(insecure, caCertPool)}
+	var clientCertificate []tls.Certificate
+	clientCertificate, err = loadClientCertificate(clientCertPath, clientKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{Transport: transport(insecure, caCertPool, clientCertificate)}
 	client := concourse.NewClient(url, httpClient, tracing)
 	return NewTarget(
 		name,
@@ -202,6 +250,9 @@ func NewUnauthenticatedTarget(
 		nil,
 		caCert,
 		caCertPool,
+		clientCertPath,
+		clientKeyPath,
+		clientCertificate,
 		insecure,
 		client,
 	), nil
@@ -214,13 +265,22 @@ func NewAuthenticatedTarget(
 	insecure bool,
 	token *TargetToken,
 	caCert string,
+	clientCertPath string,
+	clientKeyPath string,
 	tracing bool,
 ) (Target, error) {
 	caCertPool, err := loadCACertPool(caCert)
 	if err != nil {
 		return nil, err
 	}
-	httpClient := defaultHttpClient(token, insecure, caCertPool)
+
+	var clientCertificate []tls.Certificate
+	clientCertificate, err = loadClientCertificate(clientCertPath, clientKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := defaultHttpClient(token, insecure, caCertPool, clientCertificate)
 	client := concourse.NewClient(url, httpClient, tracing)
 
 	return NewTarget(
@@ -230,6 +290,9 @@ func NewAuthenticatedTarget(
 		token,
 		caCert,
 		caCertPool,
+		clientCertPath,
+		clientKeyPath,
+		clientCertificate,
 		insecure,
 		client,
 	), nil
@@ -243,13 +306,22 @@ func NewBasicAuthTarget(
 	username string,
 	password string,
 	caCert string,
+	clientCertPath string,
+	clientKeyPath string,
 	tracing bool,
 ) (Target, error) {
 	caCertPool, err := loadCACertPool(caCert)
 	if err != nil {
 		return nil, err
 	}
-	httpClient := basicAuthHttpClient(username, password, insecure, caCertPool)
+
+	var clientCertificate []tls.Certificate
+	clientCertificate, err = loadClientCertificate(clientCertPath, clientKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := basicAuthHttpClient(username, password, insecure, caCertPool, clientCertificate)
 	client := concourse.NewClient(url, httpClient, tracing)
 
 	return NewTarget(
@@ -259,6 +331,9 @@ func NewBasicAuthTarget(
 		nil,
 		caCert,
 		caCertPool,
+		clientCertPath,
+		clientKeyPath,
+		clientCertificate,
 		insecure,
 		client,
 	), nil
@@ -282,6 +357,18 @@ func (t *target) CACert() string {
 
 func (t *target) TLSConfig() *tls.Config {
 	return t.tlsConfig
+}
+
+func (t *target) ClientCertPath() string {
+	return t.clientCertPath
+}
+
+func (t *target) ClientKeyPath() string {
+	return t.clientKeyPath
+}
+
+func (t *target) ClientCertificate() []tls.Certificate {
+	return t.clientCertificate
 }
 
 func (t *target) URL() string {
@@ -403,7 +490,7 @@ func (t *target) getInfo() (atc.Info, error) {
 	return t.info, err
 }
 
-func defaultHttpClient(token *TargetToken, insecure bool, caCertPool *x509.CertPool) *http.Client {
+func defaultHttpClient(token *TargetToken, insecure bool, caCertPool *x509.CertPool, clientCertificate []tls.Certificate) *http.Client {
 	var oAuthToken *oauth2.Token
 	if token != nil {
 		oAuthToken = &oauth2.Token{
@@ -412,7 +499,7 @@ func defaultHttpClient(token *TargetToken, insecure bool, caCertPool *x509.CertP
 		}
 	}
 
-	transport := transport(insecure, caCertPool)
+	transport := transport(insecure, caCertPool, clientCertificate)
 
 	if token != nil {
 		transport = &oauth2.Transport{
@@ -450,28 +537,45 @@ func loadCACertPool(caCert string) (cert *x509.CertPool, err error) {
 	return pool, nil
 }
 
+func loadClientCertificate(clientCertificateLocation string, clientKeyLocation string) (cert []tls.Certificate, err error) {
+	if clientCertificateLocation == "" {
+		return []tls.Certificate{}, nil
+	} else {
+		clientCertData, err := tls.LoadX509KeyPair(clientCertificateLocation, clientKeyLocation)
+		if err != nil {
+			return []tls.Certificate{}, err
+		}
+
+		cert = []tls.Certificate{clientCertData}
+	}
+
+	return cert, nil
+}
+
 func basicAuthHttpClient(
 	username string,
 	password string,
 	insecure bool,
 	caCertPool *x509.CertPool,
+	clientCertificate []tls.Certificate,
 ) *http.Client {
 	return &http.Client{
 		Transport: basicAuthTransport{
 			username: username,
 			password: password,
-			base:     transport(insecure, caCertPool),
+			base:     transport(insecure, caCertPool, clientCertificate),
 		},
 	}
 }
 
-func transport(insecure bool, caCertPool *x509.CertPool) http.RoundTripper {
+func transport(insecure bool, caCertPool *x509.CertPool, clientCertificate []tls.Certificate) http.RoundTripper {
 	var transport http.RoundTripper
 
 	transport = &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: insecure,
 			RootCAs:            caCertPool,
+			Certificates:       clientCertificate,
 		},
 		Dial: (&net.Dialer{
 			Timeout: 10 * time.Second,

--- a/fly/rc/target_test.go
+++ b/fly/rc/target_test.go
@@ -104,6 +104,7 @@ AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 				Expect((*base).TLSClientConfig).To(Equal(&tls.Config{
 					InsecureSkipVerify: true,
 					RootCAs:            nil,
+					Certificates:       []tls.Certificate{},
 				}))
 			})
 		})
@@ -154,6 +155,7 @@ AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 				Expect((*base).TLSClientConfig).To(Equal(&tls.Config{
 					InsecureSkipVerify: false,
 					RootCAs:            expectedCaCertPool,
+					Certificates:       []tls.Certificate{},
 				}))
 			})
 		})
@@ -170,6 +172,9 @@ AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 				nil,
 				"ca-cert",
 				nil,
+				"",
+				"",
+				[]tls.Certificate{},
 				true,
 				fakeClient,
 			).FindTeam("the-team")

--- a/fly/rc/target_test.go
+++ b/fly/rc/target_test.go
@@ -163,12 +163,8 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 		})
 
 		Context("when there is ca-cert", func() {
-			type targetDetailsYAML struct {
-				Targets map[rc.TargetName]rc.TargetProps
-			}
-
 			BeforeEach(func() {
-				flyrcConfig := targetDetailsYAML{
+				flyrcConfig := rc.RC{
 					Targets: map[rc.TargetName]rc.TargetProps{
 						"some-target": {
 							API:      "http://concourse.com",
@@ -214,10 +210,6 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 		})
 
 		Context("when there is a client certificate path and a client key path", func() {
-			type targetDetailsYAML struct {
-				Targets map[rc.TargetName]rc.TargetProps
-			}
-
 			BeforeEach(func() {
 				certPath := filepath.Join(userHomeDir(), "client.pem")
 				keyPath := filepath.Join(userHomeDir(), "client.key")
@@ -229,7 +221,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 				err = ioutil.WriteFile(keyPath, []byte(clientKey), 0600)
 				Expect(err).ToNot(HaveOccurred())
 
-				flyrcConfig := targetDetailsYAML{
+				flyrcConfig := rc.RC{
 					Targets: map[rc.TargetName]rc.TargetProps{
 						"some-target": {
 							API:            "http://concourse.com",
@@ -267,17 +259,13 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 		})
 
 		Context("when there is a client certificate path, but no client key path", func() {
-			type targetDetailsYAML struct {
-				Targets map[rc.TargetName]rc.TargetProps
-			}
-
 			BeforeEach(func() {
 				certPath := filepath.Join(userHomeDir(), "client.pem")
 
 				err := ioutil.WriteFile(certPath, []byte(clientCert), 0600)
 				Expect(err).ToNot(HaveOccurred())
 
-				flyrcConfig := targetDetailsYAML{
+				flyrcConfig := rc.RC{
 					Targets: map[rc.TargetName]rc.TargetProps{
 						"some-target": {
 							API:            "http://concourse.com",
@@ -303,17 +291,13 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 		})
 
 		Context("when there is a client key path, but no client certificate path", func() {
-			type targetDetailsYAML struct {
-				Targets map[rc.TargetName]rc.TargetProps
-			}
-
 			BeforeEach(func() {
 				keyPath := filepath.Join(userHomeDir(), "client.key")
 
 				err := ioutil.WriteFile(keyPath, []byte(clientKey), 0600)
 				Expect(err).ToNot(HaveOccurred())
 
-				flyrcConfig := targetDetailsYAML{
+				flyrcConfig := rc.RC{
 					Targets: map[rc.TargetName]rc.TargetProps{
 						"some-target": {
 							API:           "http://concourse.com",

--- a/fly/rc/target_test.go
+++ b/fly/rc/target_test.go
@@ -35,6 +35,59 @@ AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 -----END CERTIFICATE-----
 `
 
+	const clientCert = `-----BEGIN CERTIFICATE-----
+MIIDZTCCAk2gAwIBAgIUX7Uw88QRy27mQJqKLoCypKgEwyQwDQYJKoZIhvcNAQEL
+BQAwQjELMAkGA1UEBhMCWFgxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UE
+CgwTRGVmYXVsdCBDb21wYW55IEx0ZDAeFw0yMDA4MjYxMzQyMzVaFw0yMDA5MjUx
+MzQyMzVaMEIxCzAJBgNVBAYTAlhYMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAa
+BgNVBAoME0RlZmF1bHQgQ29tcGFueSBMdGQwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCnN888R5+LZQ2ngGDpcNuFLwxgIewZCSJizWlXDfGNgQZ7g/rX
+jsTDfsax9t5cFafvh3fC2eR5GCddNIggsA8DFEwss7e1b0bljDesqtRlXLofH0Q6
+Crgj9gbzorsRqLjbLNpuKD7qTeuyaaI/ofRn4blu6hx8T2r0DRgNRlTcSz/0GByK
+xg99aH4BmTSM6VRtkxOoXnRmTbe8EJeeva7nNAqIpQzGTnhOvEOnQsfM1wpgASS3
+dvQxgZi9vFPqg/bbdSYzBm1SctOXpHHERR5pgZCxP2vV6ZSxMH9cyw6jiYmSXzCq
+6GCRyP3ofIZi0oI/Csa10Z1l26v0ZLOJdGKtAgMBAAGjUzBRMB0GA1UdDgQWBBQV
+UGnNB+GFX6Rs3eKrWjIHSgEcFTAfBgNVHSMEGDAWgBQVUGnNB+GFX6Rs3eKrWjIH
+SgEcFTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBGqpQ+8FX5
+uCYd7PPeD1WNoKlIeA2FfX+SJcCFJY4MdqtjBFPTtUCMD3medXezujjwQeVR8Cup
+HK+3O/YEG/bNayqA8nZBF2tNGeNHXNl6iSYV1UjKvELUvh5S5QRrvrbNTmUJuSsL
+WHhU/KEi/FYPeOzQEGxR7meRJWggBM57b9s81W+I+XrJ71wfaYiI70GbKeRoHWA0
+gnhXZV7MBiEgNSHOGaavjkF22E2At40XHWL87dUJZVMp4SEu/e4XJeWvum21VDrs
+mlR/qNacLCRV2kECu+9YEtT//lb5njdHkMMeXmYp4lrNpCuXzbAWpRo8VER6RQ2Q
+6vNmvRoBV5G1
+-----END CERTIFICATE-----
+`
+
+	const clientKey = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCnN888R5+LZQ2n
+gGDpcNuFLwxgIewZCSJizWlXDfGNgQZ7g/rXjsTDfsax9t5cFafvh3fC2eR5GCdd
+NIggsA8DFEwss7e1b0bljDesqtRlXLofH0Q6Crgj9gbzorsRqLjbLNpuKD7qTeuy
+aaI/ofRn4blu6hx8T2r0DRgNRlTcSz/0GByKxg99aH4BmTSM6VRtkxOoXnRmTbe8
+EJeeva7nNAqIpQzGTnhOvEOnQsfM1wpgASS3dvQxgZi9vFPqg/bbdSYzBm1SctOX
+pHHERR5pgZCxP2vV6ZSxMH9cyw6jiYmSXzCq6GCRyP3ofIZi0oI/Csa10Z1l26v0
+ZLOJdGKtAgMBAAECggEABX72Frsb6U729exoQwPskyIKvBYhVmlQcgLiVXQl3krB
+VcnusqsEmJBQI4VDpa8oh9zh+MuEkN5UXOHfH4Pp2mYOYuG9Rf9USzMimVA8DuDP
+VTqH2YiEqNnrPJK6p0fuW3XL8BbuinDpMEH8jS7bg5aNq7GSIhvSHhdYFQecvmjF
+JRhQCcp/kvy7YgCG+Eg9bNYyGTKjx7WEWxY0BtF4saqiGN3l8T4gGHMdk/RBCkPZ
+QG69V0FyC5iAi07J/x9eNSIwuq4egzzdraklnaLcrsSEOvjvTDl9+xUEESFW/OTO
+b6RD5uGahhjJoX+WCOX01E7EN2EP1QgU+Fookq4YWQKBgQDSbIyRjQokH/DnNon/
+Fn8/cChz1vPgMDHojRP/pxk/gMC8Jcp0JrpKFMZcPphkuc5O6rjf8BExUncESXec
+uAcr9+G/TS1fA8eRpgFS3gmSwmQsJHRiNprhyGKM6WOhIa1Oi5ku6ZGZZf/GGaEA
+Fv2jqV1RanVxwU3mNW8rP7V/6wKBgQDLb5olPo/IfBf9oP9nwhiWK1ZPErICdiH7
+UtADDCTZhAE9VNSOvf78PduEKXVDKUWj5IaSgaijIj6edcYbCmRjqzG5g1choyAY
+hZ/hAUX3X6nA1lc/ND/v7epVjZ8I7vzf72VRfDpTNdnjoRMzhR4c1HpKfdZwzTXT
+AWFWRaAZxwKBgGmUY3eIb+UuTZ6Fg/oE3LYE3Zc57EW5iOEpIDavLgDp5krBH3Lm
+F6SiBeE02xv3CqgYJ8jc2JOJ0APLpQNyZs7N4mwtGi3JZLIUvCdLFzyW4tIvPGIn
+CdFtzNztIbswfZeifarHMPHp9sr8AwdbgcpDaXo3U1RPbHmsp+noXnYfAoGBAMp9
+OyD3NIaJfheluJK+T1qpqC7snOJ2UzylIQbnf4ZCLjmtxiSOWM8ZgvX5jg5bdkW7
+oXcSN5io7UssTxN7NJFARS4x3PhONhQybQC5E7s2LPEUZ6MxjrJyTVz6qeFqf6kl
+z+Nbk3Jfl5FLMqGFToPDujWLK3b7yydLqGcGxmThAoGBALrluhB3186MZsZGPccc
+gEyHgI3smYf7BBSlkOOj3Ws8tckiVv0WXKmk8kpB2H4Z49l1vkqT0fqLdZGioUCT
+pOyP4gMpJpf2MofQq96Ng4GFSoSl7i52olbd7e6P6IGP01AAwwlmF64dl5oGk4hW
+Lfkzl8ebb+tt0XFMUFc42WNr
+-----END PRIVATE KEY-----
+`
+
 	var (
 		tmpDir string
 		flyrc  string
@@ -157,6 +210,131 @@ AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 					RootCAs:            expectedCaCertPool,
 					Certificates:       []tls.Certificate{},
 				}))
+			})
+		})
+
+		Context("when there is a client certificate path and a client key path", func() {
+			type targetDetailsYAML struct {
+				Targets map[rc.TargetName]rc.TargetProps
+			}
+
+			BeforeEach(func() {
+				certPath := filepath.Join(userHomeDir(), "client.pem")
+				keyPath := filepath.Join(userHomeDir(), "client.key")
+
+				err := ioutil.WriteFile(certPath, []byte(clientCert), 0600)
+
+				Expect(err).ToNot(HaveOccurred())
+
+				err = ioutil.WriteFile(keyPath, []byte(clientKey), 0600)
+				Expect(err).ToNot(HaveOccurred())
+
+				flyrcConfig := targetDetailsYAML{
+					Targets: map[rc.TargetName]rc.TargetProps{
+						"some-target": {
+							API:            "http://concourse.com",
+							ClientCertPath: certPath,
+							ClientKeyPath:  keyPath,
+							TeamName:       "some-team",
+							Token: &rc.TargetToken{
+								Type:  "Bearer",
+								Value: "some-token",
+							},
+						},
+					},
+				}
+				flyrcContents, err := yaml.Marshal(flyrcConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+			})
+
+			It("loads target with correct transport", func() {
+				target, err := rc.LoadTarget("some-target", false)
+				Expect(err).NotTo(HaveOccurred())
+				transport, ok := target.Client().HTTPClient().Transport.(*oauth2.Transport)
+				Expect(ok).To(BeTrue())
+				base, ok := (*transport).Base.(*http.Transport)
+				Expect(ok).To(BeTrue())
+
+				expectedX509Cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
+
+				Expect((*base).TLSClientConfig).To(Equal(&tls.Config{
+					InsecureSkipVerify: false,
+					Certificates:       []tls.Certificate{expectedX509Cert},
+				}))
+			})
+		})
+
+		Context("when there is a client certificate path, but no client key path", func() {
+			type targetDetailsYAML struct {
+				Targets map[rc.TargetName]rc.TargetProps
+			}
+
+			BeforeEach(func() {
+				certPath := filepath.Join(userHomeDir(), "client.pem")
+
+				err := ioutil.WriteFile(certPath, []byte(clientCert), 0600)
+				Expect(err).ToNot(HaveOccurred())
+
+				flyrcConfig := targetDetailsYAML{
+					Targets: map[rc.TargetName]rc.TargetProps{
+						"some-target": {
+							API:            "http://concourse.com",
+							ClientCertPath: certPath,
+							TeamName:       "some-team",
+							Token: &rc.TargetToken{
+								Type:  "Bearer",
+								Value: "some-token",
+							},
+						},
+					},
+				}
+				flyrcContents, err := yaml.Marshal(flyrcConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+			})
+
+			It("warns the user and exits with failure", func() {
+				_, err := rc.LoadTarget("some-target", false)
+				Expect(err).Should(MatchError("A client certificate may not be declared without defining a client key"))
+			})
+		})
+
+		Context("when there is a client key path, but no client certificate path", func() {
+			type targetDetailsYAML struct {
+				Targets map[rc.TargetName]rc.TargetProps
+			}
+
+			BeforeEach(func() {
+				keyPath := filepath.Join(userHomeDir(), "client.key")
+
+				err := ioutil.WriteFile(keyPath, []byte(clientKey), 0600)
+				Expect(err).ToNot(HaveOccurred())
+
+				flyrcConfig := targetDetailsYAML{
+					Targets: map[rc.TargetName]rc.TargetProps{
+						"some-target": {
+							API:           "http://concourse.com",
+							ClientKeyPath: keyPath,
+							TeamName:      "some-team",
+							Token: &rc.TargetToken{
+								Type:  "Bearer",
+								Value: "some-token",
+							},
+						},
+					},
+				}
+				flyrcContents, err := yaml.Marshal(flyrcConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+			})
+
+			It("warns the user and exits with failure", func() {
+				_, err := rc.LoadTarget("some-target", false)
+				Expect(err).Should(MatchError("A client key may not be declared without defining a client certificate"))
 			})
 		})
 	})

--- a/fly/rc/targets.go
+++ b/fly/rc/targets.go
@@ -33,11 +33,13 @@ type RC struct {
 }
 
 type TargetProps struct {
-	API      string       `json:"api"`
-	TeamName string       `json:"team"`
-	Insecure bool         `json:"insecure,omitempty"`
-	Token    *TargetToken `json:"token,omitempty"`
-	CACert   string       `json:"ca_cert,omitempty"`
+	API            string       `json:"api"`
+	TeamName       string       `json:"team"`
+	Insecure       bool         `json:"insecure,omitempty"`
+	Token          *TargetToken `json:"token,omitempty"`
+	CACert         string       `json:"ca_cert,omitempty"`
+	ClientCertPath string       `json:"client_cert_path,omitempty"`
+	ClientKeyPath  string       `json:"client_key_path,omitempty"`
 }
 
 type TargetToken struct {
@@ -121,6 +123,8 @@ func SaveTarget(
 	teamName string,
 	token *TargetToken,
 	caCert string,
+	clientCertPath string,
+	clientKeyPath string,
 ) error {
 	flyTargets, err := LoadTargets()
 	if err != nil {
@@ -134,6 +138,8 @@ func SaveTarget(
 	newInfo.Token = token
 	newInfo.TeamName = teamName
 	newInfo.CACert = caCert
+	newInfo.ClientCertPath = clientCertPath
+	newInfo.ClientKeyPath = clientKeyPath
 
 	flyTargets[targetName] = newInfo
 	return writeTargets(flyrc, flyTargets)

--- a/fly/rc/targets_test.go
+++ b/fly/rc/targets_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Targets", func() {
 			})
 
 			It("creates any new file with 0600 permissions", func() {
-				err := rc.SaveTarget("foo", "url", false, "main", nil, "")
+				err := rc.SaveTarget("foo", "url", false, "main", nil, "", "", "")
 				Expect(err).ToNot(HaveOccurred())
 				fi, statErr := os.Stat(flyrc)
 				Expect(statErr).To(BeNil())
@@ -191,7 +191,7 @@ var _ = Describe("Targets", func() {
 				})
 
 				It("preserves those permissions", func() {
-					err := rc.SaveTarget("foo", "url", false, "main", nil, "")
+					err := rc.SaveTarget("foo", "url", false, "main", nil, "", "", "")
 					Expect(err).ToNot(HaveOccurred())
 					fi, statErr := os.Stat(flyrc)
 					Expect(statErr).To(BeNil())
@@ -211,6 +211,8 @@ var _ = Describe("Targets", func() {
 						false,
 						"main",
 						nil,
+						"",
+						"",
 						"",
 					)
 					Expect(err).ToNot(HaveOccurred())
@@ -235,6 +237,8 @@ var _ = Describe("Targets", func() {
 						"main",
 						nil,
 						rsaCertPEM,
+						"",
+						"",
 					)
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -260,6 +264,8 @@ var _ = Describe("Targets", func() {
 						"main",
 						nil,
 						"",
+						"",
+						"",
 					)
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -282,6 +288,8 @@ var _ = Describe("Targets", func() {
 						true,
 						"main",
 						nil,
+						"",
+						"",
 						"",
 					)
 					Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## What does this PR accomplish?

This PR adds the ability to declare client certificates when using the `login` command for use by fly's http transport.

This stems from the fact our Concourse deployment is imposed some security requirements that are not fulfilled natively by Concourse's authentication mechanisms. With client certificates attached to every request, this allows us to _pre-authenticate_ requests at the proxy or load-balancer level before requests reach ATC without having to resort to more traditional techniques like IP allow-lists.

Just to be clear, this feature is useful as-is without anything being implemented in ATC.

This works towards fulfilling some of the asks in #578 .

## Changes proposed by this PR:

This PR does mainly two things:

- It adds the ability to tack-on client certificates to the http transport for consumption by a middleman before ATC
- It takes care of storing the settings in `.flyrc`

## Notes to reviewer:

It could be debated how the client-cert should be stored or be made reference to. I made the call to store the path at which the key-cert pair is made available and let the user deal with properly securing that file. That said, it could also be stored whole in `.flyrc`.

~Depending on how the review shakes out, I'll fill out the documentation afterwards.~

Weee documentation!

~As for tests, I'll need help.~ 

~Ok so it seems I've fixed the tests that were already there, but still need to write new tests for the new feature.~

Weee tests!

## Release Note

No idea, halp.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
