### PR TITLE
Add feature of resource version reaper.

### DIFF
--- a/atc/db/migration/migrations/1598925992_add_index_to_resource_config_tables_on_check_order.down.sql
+++ b/atc/db/migration/migrations/1598925992_add_index_to_resource_config_tables_on_check_order.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  DROP INDEX resource_config_scope_check_order_idx;
+COMMIT;

--- a/atc/db/migration/migrations/1598925992_add_index_to_resource_config_tables_on_check_order.up.sql
+++ b/atc/db/migration/migrations/1598925992_add_index_to_resource_config_tables_on_check_order.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  CREATE INDEX resource_config_scope_check_order_idx ON resource_config_versions (resource_config_scope_id, check_order desc);
+COMMIT;

--- a/atc/db/version_reaper.go
+++ b/atc/db/version_reaper.go
@@ -1,0 +1,124 @@
+package db
+
+import (
+	"code.cloudfoundry.org/lager"
+	"context"
+	"database/sql"
+	sq "github.com/Masterminds/squirrel"
+)
+
+type resourceVersionReaper struct {
+	conn                   Conn
+	logger                 lager.Logger
+	maxVersionsPerResource int
+}
+
+func NewResourceVersionReaper(logger lager.Logger, conn Conn, maxVersionsPerResource int) *resourceVersionReaper {
+	return &resourceVersionReaper{
+		conn:                   conn,
+		logger:                 logger,
+		maxVersionsPerResource: maxVersionsPerResource,
+	}
+}
+
+func (r *resourceVersionReaper) ReapVersions(ctx context.Context) error {
+	rcsIds, err := r.getResourceConfigScopesToReap(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rcsId := range rcsIds {
+		checkOrder, err := r.getLastCheckOrderToRetain(ctx, rcsId)
+		if err != nil {
+			return nil
+		}
+
+		if checkOrder == 0 {
+			continue
+		}
+
+		n, err := r.deleteVersions(ctx, rcsId, checkOrder)
+		if err != nil {
+			r.logger.Error("failed-to-delete-verions", err, lager.Data{"resource-config-scope-id": rcsId})
+			continue
+		}
+		r.logger.Info("deleted-versions", lager.Data{"resource-config-scope-id": rcsId, "deleted-versions": n})
+	}
+
+	return nil
+}
+
+// getResourceConfigScopesToReap return a list of resource_config_scope_id who
+// has more than maxVersionsPerResource versions.
+func (r *resourceVersionReaper) getResourceConfigScopesToReap(ctx context.Context) ([]int, error) {
+	rows, err := psql.Select("count(*) a", "resource_config_scope_id").
+		From("resource_config_versions").
+		Where(sq.NotEq{
+			"check_order": 0,
+		}).
+		Having(sq.Gt{
+			"count(*)": r.maxVersionsPerResource,
+		}).
+		OrderBy("a DESC").
+		RunWith(r.conn).
+		QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	rcsIds := []int{}
+	for rows.Next() {
+		var count, rcsId int
+		err = rows.Scan(&count, &rcsId)
+		if err != nil {
+			return nil, err
+		}
+
+		rcsIds = append(rcsIds, rcsId)
+	}
+
+	return rcsIds, nil
+}
+
+// getLastCheckOrderToRetain return a check_order of specified resource_config_scope_id.
+// Versions whose check_order are smaller than returned check_order can be deleted.
+func (r *resourceVersionReaper) getLastCheckOrderToRetain(ctx context.Context, rcsId int) (int, error) {
+	var checkOrder int
+	err := r.conn.QueryRowContext(ctx, `
+		SELECT check_order
+		FROM (
+			SELECT check_order
+			FROM resource_config_versions
+			WHERE resource_config_scope_id = $1 and check_order != 0
+            ORDER BY check_order DESC
+            LIMIT $2
+        ) AS rcv
+		ORDER BY check_order
+		LIMIT 1`, rcsId, r.maxVersionsPerResource).Scan(&checkOrder)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return checkOrder, nil
+}
+
+// deleteVersions deletes unpinned versions whose check_order are smaller than lastCheckOrderToRetain.
+func (r *resourceVersionReaper) deleteVersions(ctx context.Context, rcsId int, lastCheckOrderToRetain int) (int64, error) {
+	result, err := r.conn.ExecContext(ctx, `
+		DELETE FROM resource_config_versions
+        WHERE resource_config_scope_id = $1 and check_order < $2 and check_order != 0 and version not in (
+			SELECT version
+			FROM resource_pins
+			WHERE resource_id in (
+				SELECT resource_id
+				FROM resource_config_scopes
+				WHERE id = $1
+			)
+        )`, rcsId, lastCheckOrderToRetain)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/atc/db/version_reaper.go
+++ b/atc/db/version_reaper.go
@@ -56,6 +56,7 @@ func (r *resourceVersionReaper) getResourceConfigScopesToReap(ctx context.Contex
 		Where(sq.NotEq{
 			"check_order": 0,
 		}).
+		GroupBy("resource_config_scope_id").
 		Having(sq.Gt{
 			"count(*)": r.maxVersionsPerResource,
 		}).

--- a/atc/gc/version_reaper.go
+++ b/atc/gc/version_reaper.go
@@ -15,10 +15,6 @@ type versionReaper struct {
 }
 
 func NewVersionReaper(conn db.Conn, maxVersionsPerResource int) *versionReaper {
-	if maxVersionsPerResource < 100 {
-		maxVersionsPerResource = 100
-	}
-
 	return &versionReaper{
 		conn:                   conn,
 		maxVersionsPerResource: maxVersionsPerResource,

--- a/atc/gc/version_reaper.go
+++ b/atc/gc/version_reaper.go
@@ -1,0 +1,42 @@
+package gc
+
+import (
+	"context"
+	"github.com/concourse/concourse/atc/db"
+	"time"
+
+	"code.cloudfoundry.org/lager/lagerctx"
+	"github.com/concourse/concourse/atc/metric"
+)
+
+type versionReaper struct {
+	conn                   db.Conn
+	maxVersionsPerResource int
+}
+
+func NewVersionReaper(conn db.Conn, maxVersionsPerResource int) *versionReaper {
+	if maxVersionsPerResource < 100 {
+		maxVersionsPerResource = 100
+	}
+
+	return &versionReaper{
+		conn:                   conn,
+		maxVersionsPerResource: maxVersionsPerResource,
+	}
+}
+
+func (r *versionReaper) Run(ctx context.Context) error {
+	logger := lagerctx.FromContext(ctx).Session("version-reaper")
+
+	start := time.Now()
+	defer func() {
+		metric.VersionReaperDuration{
+			Duration: time.Since(start),
+		}.Emit(logger)
+	}()
+
+	logger.Debug("start")
+	defer logger.Debug("done")
+
+	return db.NewResourceVersionReaper(logger, r.conn, r.maxVersionsPerResource).ReapVersions(ctx)
+}

--- a/atc/gc/version_reaper_test.go
+++ b/atc/gc/version_reaper_test.go
@@ -1,0 +1,90 @@
+package gc_test
+
+import (
+	"code.cloudfoundry.org/lager/lagerctx"
+	"context"
+	"fmt"
+	sq "github.com/Masterminds/squirrel"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/gc"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("VersionReaper", func() {
+	var (
+		maxVersionsToRetain int
+		resourceConfigScopeId int
+	)
+
+	BeforeEach(func(){
+
+		resource, found, err := defaultPipeline.Resource("some-resource")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(found).To(BeTrue())
+
+		resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
+		Expect(err).NotTo(HaveOccurred())
+
+		resourceConfigScopeId = resourceScope.ID()
+	})
+
+	JustBeforeEach(func(){
+		ctx := lagerctx.NewContext(context.Background(), logger)
+		err := gc.NewVersionReaper(dbConn, maxVersionsToRetain).Run(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("when version count not exceed the cap", func(){
+		BeforeEach(func(){
+			maxVersionsToRetain = 101
+			for i := 0; i < 66; i ++ {
+				insertVersion(i, resourceConfigScopeId)
+			}
+		})
+		It("should not delete any version", func(){
+			Expect(versionCount(resourceConfigScopeId, true)).To(Equal(1))
+			Expect(versionCount(resourceConfigScopeId, false)).To(Equal(65))
+		})
+	})
+
+	Context("when version count exceeds the cap", func(){
+		BeforeEach(func(){
+			maxVersionsToRetain = 101
+			for i := 0; i < 200; i ++ {
+				insertVersion(i, resourceConfigScopeId)
+			}
+		})
+		It("should not delete any version", func(){
+			Expect(versionCount(resourceConfigScopeId, true)).To(Equal(1))
+			Expect(versionCount(resourceConfigScopeId, false)).To(Equal(maxVersionsToRetain))
+		})
+	})
+})
+
+func insertVersion(index int, resourceConfigScopeId int) {
+	var versionMD5 string
+	version := fmt.Sprintf(`{"some":"version-%d"}`, index)
+	err = psql.Insert("resource_config_versions").
+		Columns("version", "version_md5", "metadata", "check_order", "resource_config_scope_id").
+		Values(version, sq.Expr(fmt.Sprintf("md5('%s')", version)), `null`, index, resourceConfigScopeId).
+		Suffix("RETURNING version_md5").
+		RunWith(dbConn).QueryRow().Scan(&versionMD5)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func versionCount(resourceConfigScopeId int, zeroCheckOrder bool) int {
+	var count int
+	builder := psql.Select("count(*)").
+		From("resource_config_versions").
+		Where(sq.Eq{"resource_config_scope_id": resourceConfigScopeId})
+	if zeroCheckOrder {
+		builder = builder.Where(sq.Eq{"check_order": 0})
+	} else {
+		builder = builder.Where(sq.Gt{"check_order": 0})
+	}
+	err := builder.RunWith(dbConn).QueryRow().Scan(&count)
+	Expect(err).ToNot(HaveOccurred())
+	return count
+}

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -51,6 +51,20 @@ func (event BuildCollectorDuration) Emit(logger lager.Logger) {
 	)
 }
 
+type VersionReaperDuration struct {
+	Duration time.Duration
+}
+
+func (event VersionReaperDuration) Emit(logger lager.Logger) {
+	Metrics.emit(
+		logger.Session("gc-version-reaper-duration"),
+		Event{
+			Name:  "gc: version reaper duration (ms)",
+			Value: ms(event.Duration),
+		},
+	)
+}
+
 type WorkerCollectorDuration struct {
 	Duration time.Duration
 }


### PR DESCRIPTION
## What does this PR accomplish?

Concourse doesn't have a mechanism to reap resource versions, so that table `resource_config_versions` keeps growing unless some pipeline is destroyed.

On one of our clusters, the PG database crashed due to a memory issue. From the PG logs, I identified that a resource had 0.5M versions, so I had to destroy the pipeline in order to clean up those versions. Then I further dig into table `resource_config_versions` of the cluster, many resources have more than 100K versions.

Retain all versions of a resource seems to not make a lot of sense. It feels to me that retaining 1000 versions per resource should be good enough.

This PR adds a resource version reaper that will allow cluster administrator to configure `max-versions-per-resource`. If set to 0, then this feature is opt-out.

## Changes proposed by this PR:

My algorithm includes 3 steps:

1. Get all `resource-config-scope-id` who has more than `max-versions-per-resource` versions.
2. For each such `resource-config-scope-id`, get `check_order` of #`max-versions-per-resource` version.
3. Delete versions whose `check_order` are smaller than `check_order` from step 2. Pinned version will not be deleted.

## Notes to reviewer:

I haven't run tests yet, but I have tested all SQL statements  in `db/version_reaper.go` that are main algorithm. Once the algorithm is confirmed by Concourse dev team, I'll add unit test cases and run tests.

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
