### PR TITLE
atc: ensure claims LRU cache is safe for concurrent use

### DIFF
--- a/atc/api/accessor/claims_cacher_test.go
+++ b/atc/api/accessor/claims_cacher_test.go
@@ -76,6 +76,14 @@ var _ = Describe("ClaimsCacher", func() {
 		_, _, err := claimsCacher.GetAccessToken("token")
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("fetches claims from the DB concurrently", func() {
+		// this is designed purely to trigger the race detector
+		go claimsCacher.GetAccessToken("token1")
+		go claimsCacher.GetAccessToken("token2")
+		go claimsCacher.GetAccessToken("token3")
+		Eventually(fakeAccessTokenFetcher.GetAccessTokenCallCount).Should(Equal(3))
+	})
 })
 
 func stringWithLen(l int) string {


### PR DESCRIPTION

## What does this PR accomplish?

Bug Fix

We saw a panic in concourse `v6.5.0` related to the new claims cache. It appears the claims cache makes use of a non-concurrent safe structure.

## Changes proposed by this PR:

* This adds a test that can trip the race detector when tests are run with `-race`
* Adds a lock to serialise access to the LRU cache to make it safe (and pass the test)

## Notes to reviewer:

I'm confident there is a problem here, however this may not be the correct place for the lock.

## Release Note

Avoid potential race in access token caching

## Contributor Checklist


- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
