### PR TITLE
[WIP] Allow pipeline to specify custom header bar color

### DIFF
--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -45,6 +45,9 @@ var _ = Describe("Pipelines API", func() {
 				Resources: []string{"resource3", "resource4"},
 			},
 		})
+		publicPipeline.DisplayReturns(atc.DisplayConfig{
+			HeaderColor: "#FFFFFF",
+		})
 		publicPipeline.LastUpdatedReturns(time.Unix(1, 0))
 
 		anotherPublicPipeline = new(dbfakes.FakePipeline)
@@ -131,7 +134,10 @@ var _ = Describe("Pipelines API", func() {
 							"jobs": ["job3", "job4"],
 							"resources": ["resource3", "resource4"]
 						}
-					]
+					],
+					"display": {
+						"header_color": "#FFFFFF"
+					}
 				},
 				{
 					"id": 2,
@@ -140,7 +146,8 @@ var _ = Describe("Pipelines API", func() {
 					"public": true,
 					"archived": false,
 					"team_name": "another",
-					"last_updated": 1
+					"last_updated": 1,
+					"display": {}
 				}
 			]`))
 		})
@@ -283,7 +290,8 @@ var _ = Describe("Pipelines API", func() {
 								"jobs": ["job1", "job2"],
 								"resources": ["resource1", "resource2"]
 							}
-						]
+						],
+						"display": {}
 					},
 					{
 						"id": 1,
@@ -299,7 +307,10 @@ var _ = Describe("Pipelines API", func() {
 								"jobs": ["job3", "job4"],
 								"resources": ["resource3", "resource4"]
 							}
-						]
+						],
+						"display": {
+							"header_color": "#FFFFFF"
+						}
 					}
 				]`))
 			})
@@ -387,6 +398,9 @@ var _ = Describe("Pipelines API", func() {
 					Resources: []string{"resource3", "resource4"},
 				},
 			})
+			fakePipeline.DisplayReturns(atc.DisplayConfig{
+				HeaderColor: "#FFFFFF",
+			})
 			fakePipeline.LastUpdatedReturns(time.Unix(1, 0))
 		})
 
@@ -452,7 +466,10 @@ var _ = Describe("Pipelines API", func() {
 								"jobs": ["job3", "job4"],
 								"resources": ["resource3", "resource4"]
 							}
-						]
+						],
+						"display": {
+							"header_color": "#FFFFFF"
+						}
 					}`))
 			})
 		})

--- a/atc/api/present/pipeline.go
+++ b/atc/api/present/pipeline.go
@@ -14,6 +14,7 @@ func Pipeline(savedPipeline db.Pipeline) atc.Pipeline {
 		Public:      savedPipeline.Public(),
 		Archived:    savedPipeline.Archived(),
 		Groups:      savedPipeline.Groups(),
+		Display:     savedPipeline.Display(),
 		LastUpdated: savedPipeline.LastUpdated().Unix(),
 	}
 }

--- a/atc/config.go
+++ b/atc/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Resources     ResourceConfigs  `json:"resources,omitempty"`
 	ResourceTypes ResourceTypes    `json:"resource_types,omitempty"`
 	Jobs          JobConfigs       `json:"jobs,omitempty"`
+	Display       DisplayConfig    `json:"display,omitempty"`
 }
 
 func UnmarshalConfig(payload []byte, config interface{}) error {
@@ -32,6 +33,7 @@ func UnmarshalConfig(payload []byte, config interface{}) error {
 		Resources     interface{} `json:"resources,omitempty"`
 		ResourceTypes interface{} `json:"resource_types,omitempty"`
 		Jobs          interface{} `json:"jobs,omitempty"`
+		Display       interface{} `json:"display,omitempty"`
 	}
 
 	var stripped skeletonConfig
@@ -195,6 +197,10 @@ type ResourceType struct {
 	CheckSetupError      string `json:"check_setup_error,omitempty"`
 	CheckError           string `json:"check_error,omitempty"`
 	UniqueVersionHistory bool   `json:"unique_version_history,omitempty"`
+}
+
+type DisplayConfig struct {
+	HeaderColor string `json:"header_color,omitempty"`
 }
 
 type ResourceTypes []ResourceType

--- a/atc/db/dbfakes/fake_pipeline.go
+++ b/atc/db/dbfakes/fake_pipeline.go
@@ -168,6 +168,16 @@ type FakePipeline struct {
 	destroyReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DisplayStub        func() atc.DisplayConfig
+	displayMutex       sync.RWMutex
+	displayArgsForCall []struct {
+	}
+	displayReturns struct {
+		result1 atc.DisplayConfig
+	}
+	displayReturnsOnCall map[int]struct {
+		result1 atc.DisplayConfig
+	}
 	ExposeStub        func() error
 	exposeMutex       sync.RWMutex
 	exposeArgsForCall []struct {
@@ -1286,6 +1296,58 @@ func (fake *FakePipeline) DestroyReturnsOnCall(i int, result1 error) {
 	}
 	fake.destroyReturnsOnCall[i] = struct {
 		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) Display() atc.DisplayConfig {
+	fake.displayMutex.Lock()
+	ret, specificReturn := fake.displayReturnsOnCall[len(fake.displayArgsForCall)]
+	fake.displayArgsForCall = append(fake.displayArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Display", []interface{}{})
+	fake.displayMutex.Unlock()
+	if fake.DisplayStub != nil {
+		return fake.DisplayStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.displayReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakePipeline) DisplayCallCount() int {
+	fake.displayMutex.RLock()
+	defer fake.displayMutex.RUnlock()
+	return len(fake.displayArgsForCall)
+}
+
+func (fake *FakePipeline) DisplayCalls(stub func() atc.DisplayConfig) {
+	fake.displayMutex.Lock()
+	defer fake.displayMutex.Unlock()
+	fake.DisplayStub = stub
+}
+
+func (fake *FakePipeline) DisplayReturns(result1 atc.DisplayConfig) {
+	fake.displayMutex.Lock()
+	defer fake.displayMutex.Unlock()
+	fake.DisplayStub = nil
+	fake.displayReturns = struct {
+		result1 atc.DisplayConfig
+	}{result1}
+}
+
+func (fake *FakePipeline) DisplayReturnsOnCall(i int, result1 atc.DisplayConfig) {
+	fake.displayMutex.Lock()
+	defer fake.displayMutex.Unlock()
+	fake.DisplayStub = nil
+	if fake.displayReturnsOnCall == nil {
+		fake.displayReturnsOnCall = make(map[int]struct {
+			result1 atc.DisplayConfig
+		})
+	}
+	fake.displayReturnsOnCall[i] = struct {
+		result1 atc.DisplayConfig
 	}{result1}
 }
 
@@ -3083,6 +3145,8 @@ func (fake *FakePipeline) Invocations() map[string][][]interface{} {
 	defer fake.deleteBuildEventsByBuildIDsMutex.RUnlock()
 	fake.destroyMutex.RLock()
 	defer fake.destroyMutex.RUnlock()
+	fake.displayMutex.RLock()
+	defer fake.displayMutex.RUnlock()
 	fake.exposeMutex.RLock()
 	defer fake.exposeMutex.RUnlock()
 	fake.getBuildsWithVersionAsInputMutex.RLock()

--- a/atc/db/migration/migrations/1597434416_add_pipeline_display_info.down.sql
+++ b/atc/db/migration/migrations/1597434416_add_pipeline_display_info.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    ALTER TABLE pipelines DROP COLUMN display;
+COMMIT;

--- a/atc/db/migration/migrations/1597434416_add_pipeline_display_info.up.sql
+++ b/atc/db/migration/migrations/1597434416_add_pipeline_display_info.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    ALTER TABLE pipelines ADD COLUMN display jsonb;
+COMMIT;

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -44,6 +44,7 @@ type Pipeline interface {
 	ParentBuildID() int
 	Groups() atc.GroupConfigs
 	VarSources() atc.VarSourceConfigs
+	Display() atc.DisplayConfig
 	ConfigVersion() ConfigVersion
 	Config() (atc.Config, error)
 	Public() bool
@@ -107,6 +108,7 @@ type pipeline struct {
 	parentBuildID int
 	groups        atc.GroupConfigs
 	varSources    atc.VarSourceConfigs
+	display       atc.DisplayConfig
 	configVersion ConfigVersion
 	paused        bool
 	public        bool
@@ -125,6 +127,7 @@ var pipelinesQuery = psql.Select(`
 		p.name,
 		p.groups,
 		p.var_sources,
+		p.display,
 		p.nonce,
 		p.version,
 		p.team_id,
@@ -155,6 +158,7 @@ func (p *pipeline) ParentBuildID() int       { return p.parentBuildID }
 func (p *pipeline) Groups() atc.GroupConfigs { return p.groups }
 
 func (p *pipeline) VarSources() atc.VarSourceConfigs { return p.varSources }
+func (p *pipeline) Display() atc.DisplayConfig       { return p.display }
 func (p *pipeline) ConfigVersion() ConfigVersion     { return p.configVersion }
 func (p *pipeline) Public() bool                     { return p.public }
 func (p *pipeline) Paused() bool                     { return p.paused }
@@ -268,6 +272,7 @@ func (p *pipeline) Config() (atc.Config, error) {
 		Resources:     resources.Configs(),
 		ResourceTypes: resourceTypes.Configs(),
 		Jobs:          jobConfigs,
+		Display:       p.Display(),
 	}
 
 	return config, nil

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -49,6 +49,9 @@ var _ = Describe("Pipeline", func() {
 					},
 				},
 			},
+			Display: atc.DisplayConfig{
+				HeaderColor: "#FFFFFF",
+			},
 			Jobs: atc.JobConfigs{
 				{
 					Name: "job-name",

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -375,6 +375,11 @@ func savePipeline(
 		return 0, false, err
 	}
 
+	displayPayload, err := json.Marshal(config.Display)
+	if err != nil {
+		return 0, false, err
+	}
+
 	var pipelineID int
 	if !existingConfig {
 		err = psql.Insert("pipelines").
@@ -382,6 +387,7 @@ func savePipeline(
 				"name":            pipelineName,
 				"groups":          groupsPayload,
 				"var_sources":     encryptedVarSourcesPayload,
+				"display":         displayPayload,
 				"nonce":           nonce,
 				"version":         sq.Expr("nextval('config_version_seq')"),
 				"ordering":        sq.Expr("currval('pipelines_id_seq')"),
@@ -403,6 +409,7 @@ func savePipeline(
 			Set("archived", false).
 			Set("groups", groupsPayload).
 			Set("var_sources", encryptedVarSourcesPayload).
+			Set("display", displayPayload).
 			Set("nonce", nonce).
 			Set("version", sq.Expr("nextval('config_version_seq')")).
 			Set("last_updated", sq.Expr("now()")).
@@ -1221,13 +1228,14 @@ func scanPipeline(p *pipeline, scan scannable) error {
 	var (
 		groups        sql.NullString
 		varSources    sql.NullString
+		display       sql.NullString
 		nonce         sql.NullString
 		nonceStr      *string
 		lastUpdated   pq.NullTime
 		parentJobID   sql.NullInt64
 		parentBuildID sql.NullInt64
 	)
-	err := scan.Scan(&p.id, &p.name, &groups, &varSources, &nonce, &p.configVersion, &p.teamID, &p.teamName, &p.paused, &p.public, &p.archived, &lastUpdated, &parentJobID, &parentBuildID)
+	err := scan.Scan(&p.id, &p.name, &groups, &varSources, &display, &nonce, &p.configVersion, &p.teamID, &p.teamName, &p.paused, &p.public, &p.archived, &lastUpdated, &parentJobID, &parentBuildID)
 	if err != nil {
 		return err
 	}
@@ -1248,6 +1256,16 @@ func scanPipeline(p *pipeline, scan scannable) error {
 
 	if nonce.Valid {
 		nonceStr = &nonce.String
+	}
+
+	if display.Valid {
+		var displayConfig atc.DisplayConfig
+		err = json.Unmarshal([]byte(display.String), &displayConfig)
+		if err != nil {
+			return err
+		}
+
+		p.display = displayConfig
 	}
 
 	if varSources.Valid {

--- a/atc/pipeline.go
+++ b/atc/pipeline.go
@@ -1,14 +1,15 @@
 package atc
 
 type Pipeline struct {
-	ID          int          `json:"id"`
-	Name        string       `json:"name"`
-	Paused      bool         `json:"paused"`
-	Public      bool         `json:"public"`
-	Archived    bool         `json:"archived"`
-	Groups      GroupConfigs `json:"groups,omitempty"`
-	TeamName    string       `json:"team_name"`
-	LastUpdated int64        `json:"last_updated,omitempty"`
+	ID          int           `json:"id"`
+	Name        string        `json:"name"`
+	Paused      bool          `json:"paused"`
+	Public      bool          `json:"public"`
+	Archived    bool          `json:"archived"`
+	Groups      GroupConfigs  `json:"groups,omitempty"`
+	TeamName    string        `json:"team_name"`
+	Display     DisplayConfig `json:"display,omitempty"`
+	LastUpdated int64         `json:"last_updated,omitempty"`
 }
 
 type RenameRequest struct {

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -19,6 +19,7 @@ module Concourse exposing
     , CheckStatus(..)
     , ClusterInfo
     , DatabaseID
+    , Display
     , HookedPlan
     , Job
     , JobBuildIdentifier
@@ -72,6 +73,7 @@ import Dict exposing (Dict)
 import Json.Decode
 import Json.Decode.Extra exposing (andMap)
 import Json.Encode
+import Json.Encode.Extra
 import Time
 
 
@@ -698,6 +700,7 @@ type alias Pipeline =
     , public : Bool
     , teamName : TeamName
     , groups : List PipelineGroup
+    , display : Display
     }
 
 
@@ -706,6 +709,10 @@ type alias PipelineGroup =
     , jobs : List String
     , resources : List String
     }
+
+
+type alias Display =
+    { headerColor : Maybe String }
 
 
 encodePipeline : Pipeline -> Json.Encode.Value
@@ -718,6 +725,7 @@ encodePipeline pipeline =
         , ( "public", pipeline.public |> Json.Encode.bool )
         , ( "team_name", pipeline.teamName |> Json.Encode.string )
         , ( "groups", pipeline.groups |> Json.Encode.list encodePipelineGroup )
+        , ( "display", pipeline.display |> encodeDisplay )
         ]
 
 
@@ -731,6 +739,7 @@ decodePipeline =
         |> andMap (Json.Decode.field "public" Json.Decode.bool)
         |> andMap (Json.Decode.field "team_name" Json.Decode.string)
         |> andMap (defaultTo [] <| Json.Decode.field "groups" (Json.Decode.list decodePipelineGroup))
+        |> andMap (Json.Decode.field "display" decodeDisplay)
 
 
 encodePipelineGroup : PipelineGroup -> Json.Encode.Value
@@ -748,6 +757,18 @@ decodePipelineGroup =
         |> andMap (Json.Decode.field "name" Json.Decode.string)
         |> andMap (defaultTo [] <| Json.Decode.field "jobs" <| Json.Decode.list Json.Decode.string)
         |> andMap (defaultTo [] <| Json.Decode.field "resources" <| Json.Decode.list Json.Decode.string)
+
+
+encodeDisplay : Display -> Json.Encode.Value
+encodeDisplay display =
+    Json.Encode.object
+        [ ( "header_color", display.headerColor |> Json.Encode.Extra.maybe Json.Encode.string ) ]
+
+
+decodeDisplay : Json.Decode.Decoder Display
+decodeDisplay =
+    Json.Decode.succeed Display
+        |> andMap (Json.Decode.maybe (Json.Decode.field "header_color" Json.Decode.string))
 
 
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -571,6 +571,7 @@ toConcoursePipeline p =
     , paused = p.paused
     , archived = p.archived
     , groups = []
+    , display = Concourse.Display Maybe.Nothing
     }
 
 

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -413,6 +413,9 @@ view session model =
                 , Login.view session.userState model <| displayPaused
                 ]
             , Html.div
+                (id "top-bar-color" :: Views.Styles.topBarColor (headerColor <| model.pipeline))
+                []
+            , Html.div
                 (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
               <|
                 [ SideBar.view session (Just model.pipelineLocator)
@@ -435,6 +438,16 @@ isPaused p =
 isArchived : WebData Concourse.Pipeline -> Bool
 isArchived p =
     RemoteData.withDefault False (RemoteData.map .archived p)
+
+
+headerColor : WebData Concourse.Pipeline -> Maybe String
+headerColor pipeline =
+    case pipeline of
+        RemoteData.Success p ->
+            p.display.headerColor
+
+        _ ->
+            Nothing
 
 
 viewSubPage :

--- a/web/elm/src/Views/Styles.elm
+++ b/web/elm/src/Views/Styles.elm
@@ -16,6 +16,7 @@ module Views.Styles exposing
     , pauseToggleIcon
     , pauseToggleTooltip
     , topBar
+    , topBarColor
     )
 
 import Assets
@@ -66,48 +67,54 @@ pageIncludingTopBar =
 
 pageBelowTopBar : Routes.Route -> List (Html.Attribute msg)
 pageBelowTopBar route =
-    style "padding-top" "54px"
-        :: (case route of
-                Routes.FlySuccess _ _ ->
-                    [ style "height" "100%" ]
+    case route of
+        Routes.FlySuccess _ _ ->
+            [ style "height" "100%"
+            , style "padding-top" "54px"
+            ]
 
-                Routes.Resource _ ->
-                    [ style "box-sizing" "border-box"
-                    , style "height" "100%"
-                    , style "display" "flex"
-                    ]
+        Routes.Resource _ ->
+            [ style "box-sizing" "border-box"
+            , style "height" "100%"
+            , style "padding-top" "54px"
+            , style "display" "flex"
+            ]
 
-                Routes.Pipeline _ ->
-                    [ style "box-sizing" "border-box"
-                    , style "height" "100%"
-                    , style "display" "flex"
-                    ]
+        Routes.Pipeline _ ->
+            [ style "box-sizing" "border-box"
+            , style "height" "100%"
+            , style "padding-top" "90px"
+            , style "display" "flex"
+            ]
 
-                Routes.Dashboard _ ->
-                    [ style "box-sizing" "border-box"
-                    , style "display" "flex"
-                    , style "height" "100%"
-                    , style "padding-bottom" "50px"
-                    ]
+        Routes.Dashboard _ ->
+            [ style "box-sizing" "border-box"
+            , style "display" "flex"
+            , style "height" "100%"
+            , style "padding-top" "54px"
+            , style "padding-bottom" "50px"
+            ]
 
-                Routes.Build _ ->
-                    [ style "box-sizing" "border-box"
-                    , style "height" "100%"
-                    , style "display" "flex"
-                    ]
+        Routes.Build _ ->
+            [ style "box-sizing" "border-box"
+            , style "height" "100%"
+            , style "padding-top" "54px"
+            , style "display" "flex"
+            ]
 
-                Routes.OneOffBuild _ ->
-                    [ style "box-sizing" "border-box"
-                    , style "height" "100%"
-                    , style "display" "flex"
-                    ]
+        Routes.OneOffBuild _ ->
+            [ style "box-sizing" "border-box"
+            , style "height" "100%"
+            , style "padding-top" "54px"
+            , style "display" "flex"
+            ]
 
-                Routes.Job _ ->
-                    [ style "box-sizing" "border-box"
-                    , style "height" "100%"
-                    , style "display" "flex"
-                    ]
-           )
+        Routes.Job _ ->
+            [ style "box-sizing" "border-box"
+            , style "height" "100%"
+            , style "padding-top" "54px"
+            , style "display" "flex"
+            ]
 
 
 topBar : Bool -> List (Html.Attribute msg)
@@ -125,6 +132,26 @@ topBar isPaused =
 
         else
             Colors.frame
+    , style "border-bottom" <| "1px solid " ++ Colors.frame
+    ]
+
+
+topBarColor : Maybe String -> List (Html.Attribute msg)
+topBarColor color =
+    [ style "position" "fixed"
+    , style "top" "54px"
+    , style "width" "100%"
+    , style "height" "36px"
+    , style "z-index" "999"
+    , style "display" "flex"
+    , style "justify-content" "space-between"
+    , style "background-color" <|
+        case color of
+            Just clr ->
+                clr
+
+            Nothing ->
+                Colors.frame
     , style "border-bottom" <| "1px solid " ++ Colors.frame
     ]
 

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -164,6 +164,7 @@ pipeline team id =
     , archived = False
     , public = True
     , teamName = team
+    , display = { headerColor = Nothing }
     , groups = []
     }
 

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -522,12 +522,12 @@ all =
                         |> Query.each
                             (Query.has [ style "display" "inline-block" ])
             , describe "top bar positioning"
-                [ testTopBarPositioning "Dashboard" "/"
-                , testTopBarPositioning "Pipeline" "/teams/team/pipelines/pipeline"
-                , testTopBarPositioning "Job" "/teams/team/pipelines/pipeline/jobs/job"
-                , testTopBarPositioning "Build" "/teams/team/pipelines/pipeline/jobs/job/builds/build"
-                , testTopBarPositioning "Resource" "/teams/team/pipelines/pipeline/resources/resource"
-                , testTopBarPositioning "FlySuccess" "/fly_success"
+                [ testTopBarPositioning "Dashboard" "/" "54px"
+                , testTopBarPositioning "Pipeline" "/teams/team/pipelines/pipeline" "90px"
+                , testTopBarPositioning "Job" "/teams/team/pipelines/pipeline/jobs/job" "54px"
+                , testTopBarPositioning "Build" "/teams/team/pipelines/pipeline/jobs/job/builds/build" "54px"
+                , testTopBarPositioning "Resource" "/teams/team/pipelines/pipeline/resources/resource" "54px"
+                , testTopBarPositioning "FlySuccess" "/fly_success" "54px"
                 ]
             , rspecStyleDescribe "when on job page"
                 (Common.init "/teams/team/pipeline/pipeline/jobs/job/builds/1")
@@ -683,8 +683,8 @@ givenMultiplePinnedResources =
         >> Tuple.first
 
 
-testTopBarPositioning : String -> String -> Test
-testTopBarPositioning pageName url =
+testTopBarPositioning : String -> String -> String -> Test
+testTopBarPositioning pageName url topPadding =
     describe pageName
         [ test "whole page fills the whole screen" <|
             \_ ->
@@ -700,7 +700,7 @@ testTopBarPositioning pageName url =
                     |> Common.queryView
                     |> Query.find [ id "page-below-top-bar" ]
                     |> Query.has
-                        [ style "padding-top" "54px"
+                        [ style "padding-top" topPadding
                         , style "height" "100%"
                         ]
         ]


### PR DESCRIPTION
## What does this PR accomplish?
Allows users to quickly identify a particular pipeline visually for when pipelines are shown on dashboards and the structure may not be enough to differentiate them.
Bug Fix | _Feature_ | Documentation


## Changes proposed by this PR:
Adds a `display` config to the pipeline YAML and stores this in a `jsonb` column in the DB. This config is exposed via API and frontend renders it as a colored bar below main top bar in pipeline view.

Looks like this:
![Screenshot 2020-08-27 at 14 42 07](https://user-images.githubusercontent.com/14118619/91450064-c7d92000-e873-11ea-9394-16b75f1bc2d3.png)


## Notes to reviewer:
The user need attempting to be met here is "as an engineer with lots of similar pipelines on a monitor, I want to quickly identify which pipeline is which." I'm not particularly tied to the UI bar element as a means to do this but _something_ that serves this purpose would be useful - especially as instanced pipelines will make it much more common to have very similar looking pipelines that color may assist in differentiating between.

Most of this PR is useful if we want to provide any custom display stuff for a pipeline (e.g. a description) so even if the UI bit is nasty (it kinda is), it would be good to discuss if there is a useful next step for this work that could reuse a lot of the `DisplayConfig` stuff in the ATC.

This is a draft as I just want to gather feedback. Some `fly` tests are failing and the UX is a bit nasty where it says
```
display configuration has been added:
      + {}
```
which would be preferable to fix. 


## Alternatives
Some other designs I tried for reference.
![Screenshot 2020-08-21 at 13 23 57](https://user-images.githubusercontent.com/14118619/91450674-75e4ca00-e874-11ea-9d13-64465d6e12ad.png)
![Screenshot 2020-08-21 at 13 25 51](https://user-images.githubusercontent.com/14118619/91450693-7b421480-e874-11ea-8c2d-daacf4c8e6df.png)


## Release Note
N/A draft

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
