### PR TITLE
fly: admins can login to any team that exists

### DIFF
--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -981,6 +981,39 @@ jobs:
 							})
 						})
 					})
+
+					Context("there is a problem fetching the team", func() {
+						BeforeEach(func() {
+							request.Header.Set("Content-Type", "application/json")
+
+							payload, err := json.Marshal(pipelineConfig)
+							Expect(err).NotTo(HaveOccurred())
+
+							request.Body = gbytes.BufferWithBytes(payload)
+						})
+
+						Context("when the team is not found", func() {
+							BeforeEach(func() {
+								dbTeamFactory.FindTeamReturns(nil, false, nil)
+							})
+
+							It("returns 404", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+							})
+						})
+
+						Context("when finding the team fails", func() {
+							BeforeEach(func() {
+								dbTeamFactory.FindTeamReturns(nil, false, errors.New("failed"))
+							})
+
+							It("returns 500", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+							})
+						})
+					})
+
+
 				})
 
 				Context("when the Content-Type is unsupported", func() {

--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -101,7 +101,7 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 
 	if !found {
 		session.Debug("team-not-found")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #5939 

## Changes proposed by this PR:
Before this PR admins could log into any teams, even those that
don't exist. If the admin did log into a team that did not exist they
would get unclear error messages when running other commands that then
tried to target the non-existant team (e.g. HTTP 500 error from
set-pipeline command).

Now an admin will know if they successfully logged into another team or
not.

The `SaveConfig` endpoint will now return a 404 when the team is not found. It previously returned 500. It's sibling endpoint, `GetConfig`, already returned 404 in this situation, so this actually brings `SaveConfig` inline with `GetConfig`.

## Notes to reviewer:


## Release Note
Previously admins could log into any team, even if the team did not exist. Admins can still log into any team but now fly verifies that the team exists before saving the target to `.flyrc`.

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
