### PR TITLE
web/wats: add timeout to tests

### DIFF
--- a/web/wats/test/build.js
+++ b/web/wats/test/build.js
@@ -48,6 +48,7 @@ test('shows abort hooks', async t => {
 });
 
 test('can be switched between', async t => {
+  t.timeout(300000) // 5 minutes
   await t.context.fly.run('set-pipeline -n -p some-pipeline -c fixtures/states-pipeline.yml');
   await t.context.fly.run('unpause-pipeline -p some-pipeline');
 

--- a/web/wats/test/dashboard.js
+++ b/web/wats/test/dashboard.js
@@ -70,6 +70,7 @@ test('shows pipelines in their correct order', async t => {
 });
 
 test('auto-refreshes to reflect state changes', async t => {
+  t.timeout(300000) // 5 minutes
   await t.context.fly.run('set-pipeline -n -p some-pipeline -c fixtures/states-pipeline.yml');
   await t.context.fly.run('unpause-pipeline -p some-pipeline');
 

--- a/web/wats/test/login.js
+++ b/web/wats/test/login.js
@@ -15,6 +15,7 @@ test.beforeEach(async t => {
   context.web = await Web.build(url, username, password);
   context.succeeded = false;
   t.context = context;
+  t.timeout(300000) // 5 minutes
 });
 
 test.afterEach(async t => {

--- a/web/wats/test/resource.js
+++ b/web/wats/test/resource.js
@@ -19,6 +19,7 @@ const versionInPinBarSelector = '#pin-bar table';
 const topBarPinIconSelector = '#pin-icon';
 
 test('can unpin from top bar when pinned version is not in the versions list', async t => {
+  t.timeout(30000) // 5 minutes
   await setupPipeline(t);
   await pinVersion(t);
   await resetVersionsList(t);

--- a/web/wats/test/smoke.js
+++ b/web/wats/test/smoke.js
@@ -16,6 +16,8 @@ test.afterEach.always(async t => {
 });
 
 test('running pipelines', async t => {
+  t.timeout(300000) // 5 minutes
+
   await t.context.fly.run('set-pipeline -n -p some-pipeline -c fixtures/smoke-pipeline.yml');
   await t.context.fly.run('unpause-pipeline -p some-pipeline');
 
@@ -45,6 +47,7 @@ test('running one-off builds', async t => {
 });
 
 test('reaching the internet', async t => {
+  t.timeout(300000) // 5 minutes
   await t.context.fly.run('set-pipeline -n -p some-pipeline -c fixtures/smoke-internet-pipeline.yml');
   await t.context.fly.run('unpause-pipeline -p some-pipeline');
 


### PR DESCRIPTION
Tests that triggers a job and watch it will block until the build finishes, this leads to the tests never terminating if the build gets stuck in pending (e.g. resource fails to check).

## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

## Changes proposed by this PR:
Add a timeout of 5 minutes to tests that use `fly trigger-job -w`

## Notes to reviewer:
The `reaching the internet` smoke test should no longer hang forever if the build is stuck in pending (due to the registry-image resource not being able to reach the internet).

docker-compose.yml to create a worker without external internet access:
```
services:
  db:
    networks:
      - no-internet
    ...

  web:
    networks:
      - no-internet
      - internet
    ...

  worker:
    networks:
      - no-internet
    ...

networks:
  no-internet:
    driver: bridge
    internal: true
  internet:
    driver: bridge
```

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
