### PR TITLE
Enable fly validate-pipeline to accept "--enable-across-step"

### DIFF
--- a/fly/commands/internal/validatepipelinehelpers/validate.go
+++ b/fly/commands/internal/validatepipelinehelpers/validate.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func Validate(yamlTemplate templatehelpers.YamlTemplateWithParams, strict bool, output bool) error {
+func Validate(yamlTemplate templatehelpers.YamlTemplateWithParams, strict bool, output bool, enableAcrossStep bool) error {
 	evaluatedTemplate, err := yamlTemplate.Evaluate(true, strict)
 	if err != nil {
 		return err
@@ -30,6 +30,10 @@ func Validate(yamlTemplate templatehelpers.YamlTemplateWithParams, strict bool, 
 		if err := yaml.Unmarshal([]byte(evaluatedTemplate), &unmarshalledTemplate); err != nil {
 			return err
 		}
+	}
+
+	if enableAcrossStep {
+		atc.EnableAcrossStep = true
 	}
 
 	warnings, errorMessages := configvalidate.Validate(unmarshalledTemplate)

--- a/fly/commands/internal/validatepipelinehelpers/validate.go
+++ b/fly/commands/internal/validatepipelinehelpers/validate.go
@@ -1,7 +1,9 @@
 package validatepipelinehelpers
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/concourse/concourse/atc"
 
 	"github.com/concourse/concourse/atc/configvalidate"
@@ -45,7 +47,7 @@ func Validate(yamlTemplate templatehelpers.YamlTemplateWithParams, strict bool, 
 	}
 
 	if len(errorMessages) > 0 || (strict && len(warnings) > 0) {
-		displayhelpers.Failf("configuration invalid")
+		return errors.New("configuration invalid")
 	}
 
 	if output {

--- a/fly/commands/internal/validatepipelinehelpers/validate_test.go
+++ b/fly/commands/internal/validatepipelinehelpers/validate_test.go
@@ -20,6 +20,7 @@ var _ = Describe("Validate Pipeline", func() {
 		var tmpdir string
 		var goodPipeline templatehelpers.YamlTemplateWithParams
 		var dupkeyPipeline templatehelpers.YamlTemplateWithParams
+		var goodAcrossPipeline templatehelpers.YamlTemplateWithParams
 
 		BeforeEach(func() {
 			var err error
@@ -90,8 +91,41 @@ resource_types:
 			)
 			Expect(err).NotTo(HaveOccurred())
 
+			err = ioutil.WriteFile(
+				filepath.Join(tmpdir, "good-across-pipeline.yml"),
+				[]byte(`---
+resource_types:
+- name: foo
+  type: registry-image
+  source:
+    repository: foo/foo
+- name: bar
+  type: registry-image
+  source:
+    repository: bar/bar
+jobs:
+- name: hello-world
+  plan:
+  - task: say-hello
+    across:
+    - var: foo_version
+      values: ["2.4", "2.5"]
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source: {repository: ubuntu, tag: "foo-((foo))"}
+      run:
+        path: echo
+        args: ["Hello, world!"]
+`),
+				0644,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
 			goodPipeline = templatehelpers.NewYamlTemplateWithParams(atc.PathFlag(filepath.Join(tmpdir, "good-pipeline.yml")), nil, nil, nil)
 			dupkeyPipeline = templatehelpers.NewYamlTemplateWithParams(atc.PathFlag(filepath.Join(tmpdir, "dupkey-pipeline.yml")), nil, nil, nil)
+			goodAcrossPipeline = templatehelpers.NewYamlTemplateWithParams(atc.PathFlag(filepath.Join(tmpdir, "good-across-pipeline.yml")), nil, nil, nil)
 		})
 
 		AfterEach(func() {
@@ -99,24 +133,32 @@ resource_types:
 		})
 
 		It("validates a good pipeline", func() {
-			err := validatepipelinehelpers.Validate(goodPipeline, false, false)
+			err := validatepipelinehelpers.Validate(goodPipeline, false, false, false)
 			Expect(err).To(BeNil())
 		})
 		It("validates a good pipeline with strict", func() {
-			err := validatepipelinehelpers.Validate(goodPipeline, true, false)
+			err := validatepipelinehelpers.Validate(goodPipeline, true, false, false)
 			Expect(err).To(BeNil())
 		})
 		It("validates a good pipeline with output", func() {
-			err := validatepipelinehelpers.Validate(goodPipeline, true, true)
+			err := validatepipelinehelpers.Validate(goodPipeline, true, true, false)
 			Expect(err).To(BeNil())
 		})
 		It("do not fail validating a pipeline with repeated resource types (probably should but for compat doesn't)", func() {
-			err := validatepipelinehelpers.Validate(dupkeyPipeline, false, false)
+			err := validatepipelinehelpers.Validate(dupkeyPipeline, false, false, false)
 			Expect(err).To(BeNil())
 		})
 		It("fail validating a pipeline with repeated resource types with strict", func() {
-			err := validatepipelinehelpers.Validate(dupkeyPipeline, true, false)
+			err := validatepipelinehelpers.Validate(dupkeyPipeline, true, false, false)
 			Expect(err).ToNot(BeNil())
+		})
+		It("fail validating a pipeline using experimental `across` without the command flag enabling it", func() {
+			err := validatepipelinehelpers.Validate(goodAcrossPipeline, false, false, false)
+			Expect(err).ToNot(BeNil())
+		})
+		It("validates a pipeline using experimental `across` when the command flag enabling it is present", func() {
+			err := validatepipelinehelpers.Validate(goodAcrossPipeline, false, false, true)
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/fly/commands/validate_pipeline.go
+++ b/fly/commands/validate_pipeline.go
@@ -17,9 +17,10 @@ import (
 )
 
 type ValidatePipelineCommand struct {
-	Config atc.PathFlag `short:"c" long:"config" required:"true"        description:"Pipeline configuration file"`
-	Strict bool         `short:"s" long:"strict"                        description:"Fail on warnings"`
-	Output bool         `short:"o" long:"output"                        description:"Output templated pipeline to stdout"`
+	Config           atc.PathFlag `short:"c" long:"config" required:"true"  description:"Pipeline configuration file"`
+	Strict           bool         `short:"s" long:"strict"                  description:"Fail on warnings"`
+	Output           bool         `short:"o" long:"output"                  description:"Output templated pipeline to stdout"`
+	EnableAcrossStep bool         `long:"enable-across-step"                description:"Enable the experimental across step to be used in jobs. The API is subject to change."`
 
 	Var     []flaghelpers.VariablePairFlag     `short:"v"  long:"var"       value-name:"[NAME=STRING]"  description:"Specify a string value to set for a variable in the pipeline"`
 	YAMLVar []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"  value-name:"[NAME=YAML]"    description:"Specify a YAML value to set for a variable in the pipeline"`
@@ -29,5 +30,5 @@ type ValidatePipelineCommand struct {
 
 func (command *ValidatePipelineCommand) Execute(args []string) error {
 	yamlTemplate := templatehelpers.NewYamlTemplateWithParams(command.Config, command.VarsFrom, command.Var, command.YAMLVar)
-	return validatepipelinehelpers.Validate(yamlTemplate, command.Strict, command.Output)
+	return validatepipelinehelpers.Validate(yamlTemplate, command.Strict, command.Output, command.EnableAcrossStep)
 }


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix: closes #6026

Feature: polishes support of `across` from #5887.


## Changes proposed by this PR:

Two changes were made:

First, this adds the flag `--enable-across-step` to fly's `validate-pipeline` command in order to validate pipelines using `across` steps.

Second, in order to support testing of error conditions during validation, `validatepipelinehelpers.Validate` no longer calls `os.Exit(1)` (via `displayhelpers.Failf()`) when errors are encountered during parsing. Instead, it returns an error and relies on `main.handleError()` to do the right thing with it.

<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

Please take a look at #6026 which explains the problem being addressed here. There's test coverage added to `fly/commands/internal/validatepipelinehelpers/validate_test.go` which should also help understand the impact.


## Release Note

Enable `fly validate-pipeline` to accept `--enable-across-step` and recognize `across` as a valid step.


## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~ (`across`, an experimental feature, is not documented yet)
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
