### PR TITLE
Add new default values Guardian network-pool and max-containers

### DIFF
--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -52,6 +53,10 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 	}
 
 	gdnServerFlags = append(gdnServerFlags, detectGuardianFlags(logger)...)
+	gdnServerFlags = append(gdnServerFlags,
+		"--max-containers", strconv.Itoa(cmd.Guardian.MaxContainers),
+		"--network-pool", cmd.Guardian.NetworkPool,
+	)
 
 	if cmd.Guardian.DNS.Enable {
 		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
@@ -104,6 +109,7 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 	return grouper.NewParallel(os.Interrupt, members), nil
 }
 
+// This won't detect flags listed in the GuardianRuntime struct
 func detectGuardianFlags(logger lager.Logger) []string {
 	env := os.Environ()
 

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -53,22 +53,6 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 
 	gdnServerFlags = append(gdnServerFlags, detectGuardianFlags(logger)...)
 
-	networkPoolSet := false
-	for _, gdnServerFlag := range gdnServerFlags {
-		if gdnServerFlag == "--network-pool" {
-			networkPoolSet = true
-			break
-		}
-	}
-	if !networkPoolSet {
-		// If network-pool is unset Guardian defaults to 10.80.0.0/22 which allows 1024 addresses implicitly limiting a
-		// Guardian worker to 250 containers (4 addresses per container). This is true even if max-containers is set to
-		// a higher value.
-		// We set network-pool to 10.80.0.0/16 to increase the allowable addresses significantly ensuring the container
-		// count is only limited by the explicit max-containers flag.
-		gdnServerFlags = append(gdnServerFlags, "--network-pool", "10.80.0.0/16")
-	}
-
 	if cmd.Guardian.DNS.Enable {
 		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
 		if err != nil {

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -53,6 +53,22 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 
 	gdnServerFlags = append(gdnServerFlags, detectGuardianFlags(logger)...)
 
+	networkPoolSet := false
+	for _, gdnServerFlag := range gdnServerFlags {
+		if gdnServerFlag == "--network-pool" {
+			networkPoolSet = true
+			break
+		}
+	}
+	if !networkPoolSet {
+		// If network-pool is unset Guardian defaults to 10.80.0.0/22 which allows 1024 addresses implicitly limiting a
+		// Guardian worker to 250 containers (4 addresses per container). This is true even if max-containers is set to
+		// a higher value.
+		// We set network-pool to 10.80.0.0/16 to increase the allowable addresses significantly ensuring the container
+		// count is only limited by the explicit max-containers flag.
+		gdnServerFlags = append(gdnServerFlags, "--network-pool", "10.80.0.0/16")
+	}
+
 	if cmd.Guardian.DNS.Enable {
 		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
 		if err != nil {

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -31,11 +31,11 @@ type GuardianRuntime struct {
 	Bin            string        `long:"bin"        description:"Path to a garden server executable (non-absolute names get resolved from $PATH)."`
 	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Garden backend. Guardian flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
+	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 
 	//Guardian specific flags - these are passed along as-is to the gdn binary as options. The defaults have been defined to suite Concourse.
 	MaxContainers  int           `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`
 	NetworkPool    string        `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
-	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 }
 
 type ContainerdRuntime struct {

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -47,7 +47,7 @@ type ContainerdRuntime struct {
 	DNS                DNSConfig `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 	DNSServers         []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
 	RestrictedNetworks []string  `long:"restricted-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
-	MaxContainers      int       `long:"max-containers" default:"0" description:"Max container capacity. 0 means no limit."`
+	MaxContainers      int       `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`
 	NetworkPool        string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
 }
 

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -31,6 +31,10 @@ type GuardianRuntime struct {
 	Bin            string        `long:"bin"        description:"Path to a garden server executable (non-absolute names get resolved from $PATH)."`
 	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Garden backend. Guardian flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
+
+	//Guardian specific flags - these are passed along as-is to the gdn binary as options. The defaults have been defined to suite Concourse.
+	MaxContainers  int           `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`
+	NetworkPool    string        `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 }
 


### PR DESCRIPTION
## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Feature

Part of https://github.com/concourse/concourse/issues/5985

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
If `--network-pool` is unset Guardian defaults to `10.80.0.0/22` which allows 1024 addresses, implicitly limiting a
Guardian worker to 250 containers (4 addresses reserved per container). This is true even if max-containers is set to
a higher value.

We set network-pool to `10.80.0.0/16` to increase the allowable addresses significantly ensuring the container
count is only limited by the explicit max-containers flag. If a user passes a custom value we use that instead.

**Update**
* Exposing both flags as options in the worker command now.
* Defaulting the maximum container limit to 250 to avoid stamping herd problem.
* Defaulting containerd max-container value to do the same.

More details on reasoning in an issue [comment](https://github.com/concourse/concourse/issues/5985#issuecomment-692202317).

## Notes to reviewer:
Inspecting processes running on a Guardian worker without having set `CONCOURSE_GARDEN_NETWORK_POOL` shows the following.
![Screen Shot 2020-09-01 at 5 01 18 PM](https://user-images.githubusercontent.com/5854091/91906007-74047780-ec75-11ea-8750-221d53159ce2.png)


When passing a custom value of `10.80.0.0/20`:
![Screen Shot 2020-09-01 at 5 05 17 PM](https://user-images.githubusercontent.com/5854091/91905973-63540180-ec75-11ea-9d74-35dcec8ce27a.png)

**Related PRs**
https://github.com/concourse/concourse-chart/pull/150
https://github.com/concourse/concourse-bosh-release/pull/121

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
