### PR TITLE
Update k8s-topgun for Helm v3

### DIFF
--- a/topgun/k8s/external_postgres_test.go
+++ b/topgun/k8s/external_postgres_test.go
@@ -40,7 +40,7 @@ var _ = Describe("External PostgreSQL", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(pgReleaseName)
+		helmDestroy(pgReleaseName, namespace)
 		cleanup(releaseName, namespace)
 	})
 

--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Prometheus integration", func() {
 	})
 
 	AfterEach(func() {
-		helmDestroy(prometheusReleaseName)
+		helmDestroy(prometheusReleaseName, namespace)
 		cleanup(releaseName, namespace)
 	})
 


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

closes #5219 .

## Changes proposed by this PR:
* Behaviour around namespaces changed in Helm 3.
* Every helm command is now scoped to a namespace just like kubectl.
* We now need to specify the namespace in each helm command.
* as of helm 3.2.0, we can add `--create-namespace` to the `helm upgrade` command which will allow helm to create the namespace if it doesn't exist, following the same behaviour that was in helm2 versions.
* Tiller is no longer required either, the `init` command was removed because of this.

## Notes to reviewer:
This PR depends on https://github.com/concourse/concourse-chart/pull/146 and https://github.com/concourse/ci/pull/375.
This PR should be merged once we have migrated topgun cluster to use helm3.

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
