### PR TITLE
Enable secret cache for var_source.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -548,6 +548,7 @@ func (cmd *RunCommand) Runner(positionalArguments []string) (ifrit.Runner, error
 
 	cmd.varSourcePool = creds.NewVarSourcePool(
 		logger.Session("var-source-pool"),
+		cmd.CredentialManagement,
 		5*time.Minute,
 		1*time.Minute,
 		clock.NewClock(),
@@ -1283,12 +1284,7 @@ func (cmd *RunCommand) secretManager(logger lager.Logger) (creds.Secrets, error)
 		break
 	}
 
-	result := secretsFactory.NewSecrets()
-	result = creds.NewRetryableSecrets(result, cmd.CredentialManagement.RetryConfig)
-	if cmd.CredentialManagement.CacheConfig.Enabled {
-		result = creds.NewCachedSecrets(result, cmd.CredentialManagement.CacheConfig)
-	}
-	return result, nil
+	return cmd.CredentialManagement.NewSecrets(secretsFactory), nil
 }
 
 func (cmd *RunCommand) newKey() *encryption.Key {

--- a/atc/creds/manager.go
+++ b/atc/creds/manager.go
@@ -27,6 +27,16 @@ type CredentialManagementConfig struct {
 	CacheConfig SecretCacheConfig
 }
 
+// NewSecrets creates a Secrets object from secretsFactory based on configs.
+func (c CredentialManagementConfig) NewSecrets(secretsFactory SecretsFactory) Secrets {
+	result := secretsFactory.NewSecrets()
+	result = NewRetryableSecrets(result, c.RetryConfig)
+	if c.CacheConfig.Enabled {
+		result = NewCachedSecrets(result, c.CacheConfig)
+	}
+	return result
+}
+
 type HealthResponse struct {
 	Response interface{} `json:"response,omitempty"`
 	Error    string      `json:"error,omitempty"`

--- a/atc/creds/pool_test.go
+++ b/atc/creds/pool_test.go
@@ -17,11 +17,12 @@ import (
 
 var _ = Context("pool", func() {
 	var (
-		logger           lager.Logger
-		factory          creds.ManagerFactory
-		varSourcePool    creds.VarSourcePool
-		config1, config2 map[string]interface{}
-		fakeClock        *fakeclock.FakeClock
+		logger               lager.Logger
+		factory              creds.ManagerFactory
+		credentialManagement creds.CredentialManagementConfig
+		varSourcePool        creds.VarSourcePool
+		config1, config2     map[string]interface{}
+		fakeClock            *fakeclock.FakeClock
 	)
 
 	BeforeEach(func() {
@@ -37,11 +38,24 @@ var _ = Context("pool", func() {
 		}
 
 		fakeClock = fakeclock.NewFakeClock(time.Now())
+
+		credentialManagement = creds.CredentialManagementConfig{
+			RetryConfig: creds.SecretRetryConfig{
+				Attempts: 5,
+				Interval: time.Second,
+			},
+			CacheConfig: creds.SecretCacheConfig{
+				Enabled:          true,
+				Duration:         time.Minute,
+				DurationNotFound: time.Minute,
+				PurgeInterval:    time.Minute * 10,
+			},
+		}
 	})
 
 	Context("FindOrCreate", func() {
 		BeforeEach(func() {
-			varSourcePool = creds.NewVarSourcePool(logger, 5*time.Minute, time.Minute, fakeClock)
+			varSourcePool = creds.NewVarSourcePool(logger, credentialManagement, 5*time.Minute, time.Minute, fakeClock)
 		})
 
 		AfterEach(func() {
@@ -172,7 +186,7 @@ var _ = Context("pool", func() {
 		var err error
 
 		BeforeEach(func() {
-			varSourcePool = creds.NewVarSourcePool(logger, 7*time.Second, 1*time.Second, fakeClock)
+			varSourcePool = creds.NewVarSourcePool(logger, credentialManagement, 7*time.Second, 1*time.Second, fakeClock)
 		})
 
 		It("cleans up all var sources", func() {
@@ -194,7 +208,7 @@ var _ = Context("pool", func() {
 		var err error
 
 		BeforeEach(func() {
-			varSourcePool = creds.NewVarSourcePool(logger, 7*time.Second, 1*time.Second, fakeClock)
+			varSourcePool = creds.NewVarSourcePool(logger, credentialManagement, 7*time.Second, 1*time.Second, fakeClock)
 		})
 
 		AfterEach(func() {

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -2106,7 +2106,19 @@ var _ = Describe("Pipeline", func() {
 		)
 
 		BeforeEach(func() {
-			pool = creds.NewVarSourcePool(logger, 1*time.Minute, 1*time.Second, clock.NewClock())
+			credentialManagement := creds.CredentialManagementConfig{
+				RetryConfig: creds.SecretRetryConfig{
+					Attempts: 5,
+					Interval: time.Second,
+				},
+				CacheConfig: creds.SecretCacheConfig{
+					Enabled:          true,
+					Duration:         time.Minute,
+					DurationNotFound: time.Minute,
+					PurgeInterval:    time.Minute * 10,
+				},
+			}
+			pool = creds.NewVarSourcePool(logger, credentialManagement, 1*time.Minute, 1*time.Second, clock.NewClock())
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
## What does this PR accomplish?

Secret fetch has retry and cache abilities, but unfortunately those abilities don't work for `var_sources`. I missed them when I developed `var_sources`. This PR is to enable retry and cache for `var_sources`.

## Notes to reviewer:

I have tested the code change locally.

## Release Note

Enable secret fetch retry and cache for `var_sources`.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
