### PR TITLE
Fix build reaper missing builds due to pagination

### DIFF
--- a/atc/api/builds_test.go
+++ b/atc/api/builds_test.go
@@ -200,8 +200,6 @@ var _ = Describe("Builds API", func() {
 
 					teamName, page := dbBuildFactory.VisibleBuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						From:  0,
-						To:    0,
 						Limit: 100,
 					}))
 					Expect(teamName).To(ConsistOf("some-team"))
@@ -218,8 +216,8 @@ var _ = Describe("Builds API", func() {
 
 					_, page := dbBuildFactory.VisibleBuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						From:  2,
-						To:    3,
+						From:  db.NewIntPtr(2),
+						To:    db.NewIntPtr(3),
 						Limit: 8,
 					}))
 				})
@@ -288,8 +286,8 @@ var _ = Describe("Builds API", func() {
 			Context("when next/previous pages are available", func() {
 				BeforeEach(func() {
 					dbBuildFactory.VisibleBuildsReturns(returnedBuilds, db.Pagination{
-						Newer: &db.Page{From: 4, Limit: 2},
-						Older: &db.Page{To: 3, Limit: 2},
+						Newer: &db.Page{From: db.NewIntPtr(4), Limit: 2},
+						Older: &db.Page{To: db.NewIntPtr(3), Limit: 2},
 					}, nil)
 				})
 
@@ -339,8 +337,6 @@ var _ = Describe("Builds API", func() {
 
 					_, page := dbBuildFactory.VisibleBuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						From:  0,
-						To:    0,
 						Limit: 100,
 					}))
 				})
@@ -356,8 +352,8 @@ var _ = Describe("Builds API", func() {
 
 					_, page := dbBuildFactory.VisibleBuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						From:  2,
-						To:    3,
+						From:  db.NewIntPtr(2),
+						To:    db.NewIntPtr(3),
 						Limit: 8,
 					}))
 				})
@@ -421,8 +417,8 @@ var _ = Describe("Builds API", func() {
 			Context("when next/previous pages are available", func() {
 				BeforeEach(func() {
 					dbBuildFactory.VisibleBuildsReturns(returnedBuilds, db.Pagination{
-						Newer: &db.Page{From: 4, Limit: 2},
-						Older: &db.Page{To: 3, Limit: 2},
+						Newer: &db.Page{From: db.NewIntPtr(4), Limit: 2},
+						Older: &db.Page{To: db.NewIntPtr(3), Limit: 2},
 					}, nil)
 				})
 

--- a/atc/api/builds_test.go
+++ b/atc/api/builds_test.go
@@ -200,8 +200,8 @@ var _ = Describe("Builds API", func() {
 
 					teamName, page := dbBuildFactory.VisibleBuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						Since: 0,
-						Until: 0,
+						From:  0,
+						To:    0,
 						Limit: 100,
 					}))
 					Expect(teamName).To(ConsistOf("some-team"))
@@ -210,7 +210,7 @@ var _ = Describe("Builds API", func() {
 
 			Context("when all the params are passed", func() {
 				BeforeEach(func() {
-					queryParams = "?since=2&until=3&limit=8"
+					queryParams = "?from=2&to=3&limit=8"
 				})
 
 				It("passes them through", func() {
@@ -218,8 +218,8 @@ var _ = Describe("Builds API", func() {
 
 					_, page := dbBuildFactory.VisibleBuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						Since: 2,
-						Until: 3,
+						From:  2,
+						To:    3,
 						Limit: 8,
 					}))
 				})
@@ -288,15 +288,15 @@ var _ = Describe("Builds API", func() {
 			Context("when next/previous pages are available", func() {
 				BeforeEach(func() {
 					dbBuildFactory.VisibleBuildsReturns(returnedBuilds, db.Pagination{
-						Previous: &db.Page{Until: 4, Limit: 2},
-						Next:     &db.Page{Since: 3, Limit: 2},
+						Newer: &db.Page{From: 4, Limit: 2},
+						Older: &db.Page{To: 3, Limit: 2},
 					}, nil)
 				})
 
 				It("returns Link headers per rfc5988", func() {
 					Expect(response.Header["Link"]).To(ConsistOf([]string{
-						fmt.Sprintf(`<%s/api/v1/builds?until=4&limit=2>; rel="previous"`, externalURL),
-						fmt.Sprintf(`<%s/api/v1/builds?since=3&limit=2>; rel="next"`, externalURL),
+						fmt.Sprintf(`<%s/api/v1/builds?from=4&limit=2>; rel="previous"`, externalURL),
+						fmt.Sprintf(`<%s/api/v1/builds?to=3&limit=2>; rel="next"`, externalURL),
 					}))
 				})
 			})
@@ -339,8 +339,8 @@ var _ = Describe("Builds API", func() {
 
 					_, page := dbBuildFactory.VisibleBuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						Since: 0,
-						Until: 0,
+						From:  0,
+						To:    0,
 						Limit: 100,
 					}))
 				})
@@ -348,7 +348,7 @@ var _ = Describe("Builds API", func() {
 
 			Context("when all the params are passed", func() {
 				BeforeEach(func() {
-					queryParams = "?since=2&until=3&limit=8"
+					queryParams = "?from=2&to=3&limit=8"
 				})
 
 				It("passes them through", func() {
@@ -356,8 +356,8 @@ var _ = Describe("Builds API", func() {
 
 					_, page := dbBuildFactory.VisibleBuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						Since: 2,
-						Until: 3,
+						From:  2,
+						To:    3,
 						Limit: 8,
 					}))
 				})
@@ -421,15 +421,15 @@ var _ = Describe("Builds API", func() {
 			Context("when next/previous pages are available", func() {
 				BeforeEach(func() {
 					dbBuildFactory.VisibleBuildsReturns(returnedBuilds, db.Pagination{
-						Previous: &db.Page{Until: 4, Limit: 2},
-						Next:     &db.Page{Since: 3, Limit: 2},
+						Newer: &db.Page{From: 4, Limit: 2},
+						Older: &db.Page{To: 3, Limit: 2},
 					}, nil)
 				})
 
 				It("returns Link headers per rfc5988", func() {
 					Expect(response.Header["Link"]).To(ConsistOf([]string{
-						fmt.Sprintf(`<%s/api/v1/builds?until=4&limit=2>; rel="previous"`, externalURL),
-						fmt.Sprintf(`<%s/api/v1/builds?since=3&limit=2>; rel="next"`, externalURL),
+						fmt.Sprintf(`<%s/api/v1/builds?from=4&limit=2>; rel="previous"`, externalURL),
+						fmt.Sprintf(`<%s/api/v1/builds?to=3&limit=2>; rel="next"`, externalURL),
 					}))
 				})
 			})

--- a/atc/api/buildserver/list.go
+++ b/atc/api/buildserver/list.go
@@ -18,8 +18,8 @@ func (s *Server) ListBuilds(w http.ResponseWriter, r *http.Request) {
 
 	var (
 		err     error
-		until   int
-		since   int
+		from    int
+		to      int
 		limit   int
 		useDate bool
 	)
@@ -29,20 +29,19 @@ func (s *Server) ListBuilds(w http.ResponseWriter, r *http.Request) {
 		useDate = true
 	}
 
-	urlUntil := r.FormValue(atc.PaginationQueryUntil)
-	until, _ = strconv.Atoi(urlUntil)
+	urlFrom := r.FormValue(atc.PaginationQueryFrom)
+	from, _ = strconv.Atoi(urlFrom)
 
-	urlSince := r.FormValue(atc.PaginationQuerySince)
-	since, _ = strconv.Atoi(urlSince)
+	urlTo := r.FormValue(atc.PaginationQueryTo)
+	to, _ = strconv.Atoi(urlTo)
 
 	urlLimit := r.FormValue(atc.PaginationQueryLimit)
-
 	limit, _ = strconv.Atoi(urlLimit)
 	if limit == 0 {
 		limit = atc.PaginationAPIDefaultLimit
 	}
 
-	page := db.Page{Until: until, Since: since, Limit: limit, UseDate: useDate}
+	page := db.Page{From: from, To: to, Limit: limit, UseDate: useDate}
 
 	var builds []db.Build
 	var pagination db.Pagination
@@ -60,12 +59,12 @@ func (s *Server) ListBuilds(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if pagination.Next != nil {
-		s.addNextLink(w, *pagination.Next)
+	if pagination.Older != nil {
+		s.addNextLink(w, *pagination.Older)
 	}
 
-	if pagination.Previous != nil {
-		s.addPreviousLink(w, *pagination.Previous)
+	if pagination.Newer != nil {
+		s.addPreviousLink(w, *pagination.Newer)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -88,8 +87,8 @@ func (s *Server) addNextLink(w http.ResponseWriter, page db.Page) {
 	w.Header().Add("Link", fmt.Sprintf(
 		`<%s/api/v1/builds?%s=%d&%s=%d>; rel="%s"`,
 		s.externalURL,
-		atc.PaginationQuerySince,
-		page.Since,
+		atc.PaginationQueryTo,
+		page.To,
 		atc.PaginationQueryLimit,
 		page.Limit,
 		atc.LinkRelNext,
@@ -100,8 +99,8 @@ func (s *Server) addPreviousLink(w http.ResponseWriter, page db.Page) {
 	w.Header().Add("Link", fmt.Sprintf(
 		`<%s/api/v1/builds?%s=%d&%s=%d>; rel="%s"`,
 		s.externalURL,
-		atc.PaginationQueryUntil,
-		page.Until,
+		atc.PaginationQueryFrom,
+		page.From,
 		atc.PaginationQueryLimit,
 		page.Limit,
 		atc.LinkRelPrevious,

--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -1237,8 +1237,6 @@ var _ = Describe("Jobs API", func() {
 
 						page := fakeJob.BuildsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
-							From:  0,
-							To:    0,
 							Limit: 100,
 						}))
 					})
@@ -1254,8 +1252,8 @@ var _ = Describe("Jobs API", func() {
 
 						page := fakeJob.BuildsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
-							From:  2,
-							To:    3,
+							From:  db.NewIntPtr(2),
+							To:    db.NewIntPtr(3),
 							Limit: 8,
 						}))
 					})
@@ -1364,8 +1362,8 @@ var _ = Describe("Jobs API", func() {
 					Context("when next/previous pages are available", func() {
 						BeforeEach(func() {
 							fakeJob.BuildsReturns(returnedBuilds, db.Pagination{
-								Newer: &db.Page{From: 4, Limit: 2},
-								Older: &db.Page{To: 2, Limit: 2},
+								Newer: &db.Page{From: db.NewIntPtr(4), Limit: 2},
+								Older: &db.Page{To: db.NewIntPtr(2), Limit: 2},
 							}, nil)
 						})
 

--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -1237,8 +1237,8 @@ var _ = Describe("Jobs API", func() {
 
 						page := fakeJob.BuildsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
-							Since: 0,
-							Until: 0,
+							From:  0,
+							To:    0,
 							Limit: 100,
 						}))
 					})
@@ -1246,7 +1246,7 @@ var _ = Describe("Jobs API", func() {
 
 				Context("when all the params are passed", func() {
 					BeforeEach(func() {
-						queryParams = "?since=2&until=3&limit=8"
+						queryParams = "?from=2&to=3&limit=8"
 					})
 
 					It("passes them through", func() {
@@ -1254,8 +1254,8 @@ var _ = Describe("Jobs API", func() {
 
 						page := fakeJob.BuildsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
-							Since: 2,
-							Until: 3,
+							From:  2,
+							To:    3,
 							Limit: 8,
 						}))
 					})
@@ -1364,15 +1364,15 @@ var _ = Describe("Jobs API", func() {
 					Context("when next/previous pages are available", func() {
 						BeforeEach(func() {
 							fakeJob.BuildsReturns(returnedBuilds, db.Pagination{
-								Previous: &db.Page{Until: 4, Limit: 2},
-								Next:     &db.Page{Since: 2, Limit: 2},
+								Newer: &db.Page{From: 4, Limit: 2},
+								Older: &db.Page{To: 2, Limit: 2},
 							}, nil)
 						})
 
 						It("returns Link headers per rfc5988", func() {
 							Expect(response.Header["Link"]).To(ConsistOf([]string{
-								fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/builds?until=4&limit=2>; rel="previous"`, externalURL),
-								fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/builds?since=2&limit=2>; rel="next"`, externalURL),
+								fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/builds?from=4&limit=2>; rel="previous"`, externalURL),
+								fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/builds?to=2&limit=2>; rel="next"`, externalURL),
 							}))
 						})
 					})

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1696,8 +1696,8 @@ var _ = Describe("Pipelines API", func() {
 
 					page := fakePipeline.BuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						Since: 0,
-						Until: 0,
+						From:  0,
+						To:    0,
 						Limit: 100,
 					}))
 				})
@@ -1705,7 +1705,7 @@ var _ = Describe("Pipelines API", func() {
 
 			Context("when all the params are passed", func() {
 				BeforeEach(func() {
-					queryParams = "?since=2&until=3&limit=8"
+					queryParams = "?from=2&to=3&limit=8"
 				})
 
 				It("passes them through", func() {
@@ -1713,8 +1713,8 @@ var _ = Describe("Pipelines API", func() {
 
 					page := fakePipeline.BuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						Since: 2,
-						Until: 3,
+						From:  2,
+						To:    3,
 						Limit: 8,
 					}))
 				})
@@ -1794,15 +1794,15 @@ var _ = Describe("Pipelines API", func() {
 				Context("when next/previous pages are available", func() {
 					BeforeEach(func() {
 						fakePipeline.BuildsReturns(returnedBuilds, db.Pagination{
-							Previous: &db.Page{Until: 4, Limit: 2},
-							Next:     &db.Page{Since: 2, Limit: 2},
+							Newer: &db.Page{From: 4, Limit: 2},
+							Older: &db.Page{To: 2, Limit: 2},
 						}, nil)
 					})
 
 					It("returns Link headers per rfc5988", func() {
 						Expect(response.Header["Link"]).To(ConsistOf([]string{
-							fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/builds?until=4&limit=2>; rel="previous"`, externalURL),
-							fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/builds?since=2&limit=2>; rel="next"`, externalURL),
+							fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/builds?from=4&limit=2>; rel="previous"`, externalURL),
+							fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/builds?to=2&limit=2>; rel="next"`, externalURL),
 						}))
 					})
 				})

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1696,8 +1696,6 @@ var _ = Describe("Pipelines API", func() {
 
 					page := fakePipeline.BuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						From:  0,
-						To:    0,
 						Limit: 100,
 					}))
 				})
@@ -1713,8 +1711,8 @@ var _ = Describe("Pipelines API", func() {
 
 					page := fakePipeline.BuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						From:  2,
-						To:    3,
+						From:  db.NewIntPtr(2),
+						To:    db.NewIntPtr(3),
 						Limit: 8,
 					}))
 				})
@@ -1794,8 +1792,8 @@ var _ = Describe("Pipelines API", func() {
 				Context("when next/previous pages are available", func() {
 					BeforeEach(func() {
 						fakePipeline.BuildsReturns(returnedBuilds, db.Pagination{
-							Newer: &db.Page{From: 4, Limit: 2},
-							Older: &db.Page{To: 2, Limit: 2},
+							Newer: &db.Page{From: db.NewIntPtr(4), Limit: 2},
+							Older: &db.Page{To: db.NewIntPtr(2), Limit: 2},
 						}, nil)
 					})
 

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -713,8 +713,6 @@ var _ = Describe("Teams API", func() {
 
 					page := fakeTeam.BuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						From:  0,
-						To:    0,
 						Limit: 100,
 					}))
 				})
@@ -730,8 +728,8 @@ var _ = Describe("Teams API", func() {
 
 					page := fakeTeam.BuildsArgsForCall(0)
 					Expect(page).To(Equal(db.Page{
-						From:  2,
-						To:    3,
+						From:  db.NewIntPtr(2),
+						To:    db.NewIntPtr(3),
 						Limit: 8,
 					}))
 				})
@@ -811,8 +809,8 @@ var _ = Describe("Teams API", func() {
 				Context("when next/previous pages are available", func() {
 					BeforeEach(func() {
 						fakeTeam.BuildsReturns(returnedBuilds, db.Pagination{
-							Newer: &db.Page{From: 4, Limit: 2},
-							Older: &db.Page{To: 2, Limit: 2},
+							Newer: &db.Page{From: db.NewIntPtr(4), Limit: 2},
+							Older: &db.Page{To: db.NewIntPtr(2), Limit: 2},
 						}, nil)
 					})
 

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Teams API", func() {
 			response *http.Response
 			teamAuth atc.TeamAuth
 			atcTeam  atc.Team
-			path string
+			path     string
 		)
 
 		BeforeEach(func() {
@@ -272,130 +272,130 @@ var _ = Describe("Teams API", func() {
 			path = fmt.Sprintf("%s/api/v1/teams/some-team", server.URL)
 		})
 
-			JustBeforeEach(func() {
-				var err error
-				request, err := http.NewRequest("PUT", path, jsonEncode(atcTeam))
-				Expect(err).NotTo(HaveOccurred())
+		JustBeforeEach(func() {
+			var err error
+			request, err := http.NewRequest("PUT", path, jsonEncode(atcTeam))
+			Expect(err).NotTo(HaveOccurred())
 
-				response, err = client.Do(request)
-				Expect(err).NotTo(HaveOccurred())
-			})
+			response, err = client.Do(request)
+			Expect(err).NotTo(HaveOccurred())
+		})
 
-			authorizedTeamTests := func() {
-				Context("when the team exists", func() {
+		authorizedTeamTests := func() {
+			Context("when the team exists", func() {
+				BeforeEach(func() {
+					atcTeam = atc.Team{
+						Auth: atc.TeamAuth{
+							"owner": map[string][]string{
+								"users": []string{"local:username"},
+							},
+						},
+					}
+					dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+				})
+
+				It("updates provider auth", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+					Expect(fakeTeam.UpdateProviderAuthCallCount()).To(Equal(1))
+
+					updatedProviderAuth := fakeTeam.UpdateProviderAuthArgsForCall(0)
+					Expect(updatedProviderAuth).To(Equal(atcTeam.Auth))
+				})
+
+				Context("when updating provider auth fails", func() {
+					BeforeEach(func() {
+						fakeTeam.UpdateProviderAuthReturns(errors.New("stop trying to make fetch happen"))
+					})
+
+					It("returns 500 Internal Server error", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					})
+				})
+				Context("when provider auth is empty", func() {
+					BeforeEach(func() {
+						atcTeam = atc.Team{}
+						dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+					})
+
+					It("does not update provider auth", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+						Expect(fakeTeam.UpdateProviderAuthCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when provider auth is invalid", func() {
 					BeforeEach(func() {
 						atcTeam = atc.Team{
 							Auth: atc.TeamAuth{
-								"owner": map[string][]string{
-									"users": []string{"local:username"},
+								"owner": {
+									//"users": []string{},
+									//"groups": []string{},
 								},
 							},
 						}
 						dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
 					})
 
-					It("updates provider auth", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
-						Expect(fakeTeam.UpdateProviderAuthCallCount()).To(Equal(1))
-
-						updatedProviderAuth := fakeTeam.UpdateProviderAuthArgsForCall(0)
-						Expect(updatedProviderAuth).To(Equal(atcTeam.Auth))
-					})
-
-					Context("when updating provider auth fails", func() {
-						BeforeEach(func() {
-							fakeTeam.UpdateProviderAuthReturns(errors.New("stop trying to make fetch happen"))
-						})
-
-						It("returns 500 Internal Server error", func() {
-							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
-						})
-					})
-					Context("when provider auth is empty", func() {
-						BeforeEach(func() {
-							atcTeam = atc.Team{}
-							dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
-						})
-
-						It("does not update provider auth", func() {
-							Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-							Expect(fakeTeam.UpdateProviderAuthCallCount()).To(Equal(0))
-						})
-					})
-
-					Context("when provider auth is invalid", func() {
-						BeforeEach(func() {
-							atcTeam = atc.Team{
-								Auth: atc.TeamAuth{
-									"owner": {
-										//"users": []string{},
-										//"groups": []string{},
-									},
-								},
-							}
-							dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
-						})
-
-						It("does not update provider auth", func() {
-							Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-							Expect(fakeTeam.UpdateProviderAuthCallCount()).To(Equal(0))
-						})
+					It("does not update provider auth", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+						Expect(fakeTeam.UpdateProviderAuthCallCount()).To(Equal(0))
 					})
 				})
-			}
+			})
+		}
 
-			Context("when the requester team is authorized as an admin team", func() {
+		Context("when the requester team is authorized as an admin team", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+				fakeAccess.IsAuthenticatedReturns(true)
+				fakeAccess.IsAdminReturns(true)
+			})
+
+			authorizedTeamTests()
+
+			Context("when the team is not found", func() {
 				BeforeEach(func() {
-					fakeAccess.IsAuthenticatedReturns(true)
-					fakeAccess.IsAuthenticatedReturns(true)
-					fakeAccess.IsAdminReturns(true)
+					dbTeamFactory.FindTeamReturns(nil, false, nil)
+					dbTeamFactory.CreateTeamReturns(fakeTeam, nil)
 				})
 
-				authorizedTeamTests()
+				It("creates the team", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusCreated))
+					Expect(dbTeamFactory.CreateTeamCallCount()).To(Equal(1))
 
-				Context("when the team is not found", func() {
+					createdTeam := dbTeamFactory.CreateTeamArgsForCall(0)
+					Expect(createdTeam).To(Equal(atc.Team{
+						Name: "some-team",
+						Auth: teamAuth,
+					}))
+				})
+
+				It("delete the teams in cache", func() {
+					Expect(dbTeamFactory.NotifyCacherCallCount()).To(Equal(1))
+				})
+
+				Context("when it fails to create team", func() {
 					BeforeEach(func() {
-						dbTeamFactory.FindTeamReturns(nil, false, nil)
-						dbTeamFactory.CreateTeamReturns(fakeTeam, nil)
+						dbTeamFactory.CreateTeamReturns(nil, errors.New("it is never going to happen"))
 					})
 
-					It("creates the team", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusCreated))
-						Expect(dbTeamFactory.CreateTeamCallCount()).To(Equal(1))
-
-						createdTeam := dbTeamFactory.CreateTeamArgsForCall(0)
-						Expect(createdTeam).To(Equal(atc.Team{
-							Name: "some-team",
-							Auth: teamAuth,
-						}))
+					It("returns a 500 Internal Server error", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
 					})
 
-					It("delete the teams in cache", func() {
-						Expect(dbTeamFactory.NotifyCacherCallCount()).To(Equal(1))
+					It("does not delete the teams in cache", func() {
+						Expect(dbTeamFactory.NotifyCacherCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when the team's name is an invalid identifier", func() {
+					BeforeEach(func() {
+						path = fmt.Sprintf("%s/api/v1/teams/_some-team", server.URL)
+						fakeTeam.NameReturns("_some-team")
 					})
 
-					Context("when it fails to create team", func() {
-						BeforeEach(func() {
-							dbTeamFactory.CreateTeamReturns(nil, errors.New("it is never going to happen"))
-						})
-
-						It("returns a 500 Internal Server error", func() {
-							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
-						})
-
-						It("does not delete the teams in cache", func() {
-							Expect(dbTeamFactory.NotifyCacherCallCount()).To(Equal(0))
-						})
-					})
-
-					Context("when the team's name is an invalid identifier", func() {
-						BeforeEach(func() {
-							path = fmt.Sprintf("%s/api/v1/teams/_some-team", server.URL)
-							fakeTeam.NameReturns("_some-team")
-						})
-
-						It("returns a warning in the response body", func() {
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+					It("returns a warning in the response body", func() {
+						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 								{
 									"warnings": [
 										{
@@ -408,162 +408,52 @@ var _ = Describe("Teams API", func() {
 										"name": "_some-team"
 									}
 								}`))
-						})
-					})
-				})
-			})
-
-			Context("when the requester team is authorized as the team being set", func() {
-				BeforeEach(func() {
-					fakeAccess.IsAuthenticatedReturns(true)
-					fakeAccess.IsAuthorizedReturns(true)
-				})
-
-				authorizedTeamTests()
-
-				Context("when the team is not found", func() {
-					BeforeEach(func() {
-						dbTeamFactory.FindTeamReturns(nil, false, nil)
-						dbTeamFactory.CreateTeamReturns(fakeTeam, nil)
-					})
-
-					It("does not create the team", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusForbidden))
-						Expect(dbTeamFactory.CreateTeamCallCount()).To(Equal(0))
 					})
 				})
 			})
 		})
 
-		Describe("DELETE /api/v1/teams/:team_name", func() {
-			var request *http.Request
-			var response *http.Response
-
-			var teamName string
-
+		Context("when the requester team is authorized as the team being set", func() {
 			BeforeEach(func() {
-				teamName = "team venture"
-
-				fakeTeam.IDReturns(2)
-				fakeTeam.NameReturns(teamName)
+				fakeAccess.IsAuthenticatedReturns(true)
+				fakeAccess.IsAuthorizedReturns(true)
 			})
 
-			Context("when the requester is authenticated for some admin team", func() {
-				JustBeforeEach(func() {
-					path := fmt.Sprintf("%s/api/v1/teams/%s", server.URL, teamName)
+			authorizedTeamTests()
 
-					var err error
-					request, err = http.NewRequest("DELETE", path, nil)
-					Expect(err).NotTo(HaveOccurred())
-
-					response, err = client.Do(request)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
+			Context("when the team is not found", func() {
 				BeforeEach(func() {
-					fakeAccess.IsAuthenticatedReturns(true)
-					fakeAccess.IsAdminReturns(true)
+					dbTeamFactory.FindTeamReturns(nil, false, nil)
+					dbTeamFactory.CreateTeamReturns(fakeTeam, nil)
 				})
 
-				Context("when there's a problem finding teams", func() {
-					BeforeEach(func() {
-						dbTeamFactory.FindTeamReturns(nil, false, errors.New("a dingo ate my baby!"))
-					})
-
-					It("returns 500 Internal Server Error", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
-					})
-				})
-
-				Context("when team exists", func() {
-					BeforeEach(func() {
-						dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
-					})
-
-					It("returns 204 No Content", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusNoContent))
-					})
-
-					It("receives the correct team name", func() {
-						Expect(dbTeamFactory.FindTeamCallCount()).To(Equal(1))
-						Expect(dbTeamFactory.FindTeamArgsForCall(0)).To(Equal(teamName))
-					})
-					It("deletes the team from the DB", func() {
-						Expect(fakeTeam.DeleteCallCount()).To(Equal(1))
-						//TODO delete the build events via a table drop rather
-					})
-
-					Context("when trying to delete the admin team", func() {
-						BeforeEach(func() {
-							teamName = atc.DefaultTeamName
-							fakeTeam.AdminReturns(true)
-							dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
-							dbTeamFactory.GetTeamsReturns([]db.Team{fakeTeam}, nil)
-						})
-
-						It("returns 403 Forbidden and backs off", func() {
-							Expect(response.StatusCode).To(Equal(http.StatusForbidden))
-							Expect(fakeTeam.DeleteCallCount()).To(Equal(0))
-						})
-					})
-
-					Context("when there's a problem deleting the team", func() {
-						BeforeEach(func() {
-							fakeTeam.DeleteReturns(errors.New("disaster"))
-						})
-
-						It("returns 500 Internal Server Error", func() {
-							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
-						})
-					})
-				})
-
-				Context("when team does not exist", func() {
-					BeforeEach(func() {
-						dbTeamFactory.FindTeamReturns(nil, false, nil)
-					})
-
-					It("returns 404 Not Found", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusNotFound))
-					})
-				})
-			})
-
-			Context("when the requester belongs to a non-admin team", func() {
-				JustBeforeEach(func() {
-					path := fmt.Sprintf("%s/api/v1/teams/%s", server.URL, "non-admin-team")
-
-					var err error
-					request, err = http.NewRequest("DELETE", path, nil)
-					Expect(err).NotTo(HaveOccurred())
-
-					response, err = client.Do(request)
-					Expect(err).NotTo(HaveOccurred())
-
-				})
-
-				BeforeEach(func() {
-					fakeAccess.IsAuthenticatedReturns(true)
-					fakeAccess.IsAdminReturns(false)
-				})
-
-				It("returns 403 forbidden", func() {
+				It("does not create the team", func() {
 					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+					Expect(dbTeamFactory.CreateTeamCallCount()).To(Equal(0))
 				})
 			})
 		})
+	})
 
-		Describe("PUT /api/v1/teams/:team_name/rename", func() {
-			var response *http.Response
-			var requestBody string
-			var teamName string
+	Describe("DELETE /api/v1/teams/:team_name", func() {
+		var request *http.Request
+		var response *http.Response
 
+		var teamName string
+
+		BeforeEach(func() {
+			teamName = "team venture"
+
+			fakeTeam.IDReturns(2)
+			fakeTeam.NameReturns(teamName)
+		})
+
+		Context("when the requester is authenticated for some admin team", func() {
 			JustBeforeEach(func() {
-				request, err := http.NewRequest(
-					"PUT",
-					server.URL+"/api/v1/teams/"+teamName+"/rename",
-					bytes.NewBufferString(requestBody),
-				)
+				path := fmt.Sprintf("%s/api/v1/teams/%s", server.URL, teamName)
+
+				var err error
+				request, err = http.NewRequest("DELETE", path, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				response, err = client.Do(request)
@@ -571,44 +461,154 @@ var _ = Describe("Teams API", func() {
 			})
 
 			BeforeEach(func() {
-				requestBody = `{"name":"some-new-name"}`
-				fakeTeam.IDReturns(2)
+				fakeAccess.IsAuthenticatedReturns(true)
+				fakeAccess.IsAdminReturns(true)
 			})
 
-			Context("when authenticated", func() {
+			Context("when there's a problem finding teams", func() {
 				BeforeEach(func() {
-					fakeAccess.IsAuthenticatedReturns(true)
+					dbTeamFactory.FindTeamReturns(nil, false, errors.New("a dingo ate my baby!"))
 				})
-				Context("when requester belongs to an admin team", func() {
+
+				It("returns 500 Internal Server Error", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+				})
+			})
+
+			Context("when team exists", func() {
+				BeforeEach(func() {
+					dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+				})
+
+				It("returns 204 No Content", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusNoContent))
+				})
+
+				It("receives the correct team name", func() {
+					Expect(dbTeamFactory.FindTeamCallCount()).To(Equal(1))
+					Expect(dbTeamFactory.FindTeamArgsForCall(0)).To(Equal(teamName))
+				})
+				It("deletes the team from the DB", func() {
+					Expect(fakeTeam.DeleteCallCount()).To(Equal(1))
+					//TODO delete the build events via a table drop rather
+				})
+
+				Context("when trying to delete the admin team", func() {
 					BeforeEach(func() {
-						teamName = "a-team"
-						fakeTeam.NameReturns(teamName)
-						fakeAccess.IsAdminReturns(true)
+						teamName = atc.DefaultTeamName
+						fakeTeam.AdminReturns(true)
 						dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+						dbTeamFactory.GetTeamsReturns([]db.Team{fakeTeam}, nil)
 					})
 
-					It("constructs teamDB with provided team name", func() {
-						Expect(dbTeamFactory.FindTeamCallCount()).To(Equal(1))
-						Expect(dbTeamFactory.FindTeamArgsForCall(0)).To(Equal("a-team"))
+					It("returns 403 Forbidden and backs off", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+						Expect(fakeTeam.DeleteCallCount()).To(Equal(0))
+					})
+				})
+
+				Context("when there's a problem deleting the team", func() {
+					BeforeEach(func() {
+						fakeTeam.DeleteReturns(errors.New("disaster"))
 					})
 
-					It("renames the team to the name provided", func() {
-						Expect(fakeTeam.RenameCallCount()).To(Equal(1))
-						Expect(fakeTeam.RenameArgsForCall(0)).To(Equal("some-new-name"))
+					It("returns 500 Internal Server Error", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					})
+				})
+			})
+
+			Context("when team does not exist", func() {
+				BeforeEach(func() {
+					dbTeamFactory.FindTeamReturns(nil, false, nil)
+				})
+
+				It("returns 404 Not Found", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+				})
+			})
+		})
+
+		Context("when the requester belongs to a non-admin team", func() {
+			JustBeforeEach(func() {
+				path := fmt.Sprintf("%s/api/v1/teams/%s", server.URL, "non-admin-team")
+
+				var err error
+				request, err = http.NewRequest("DELETE", path, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				response, err = client.Do(request)
+				Expect(err).NotTo(HaveOccurred())
+
+			})
+
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+				fakeAccess.IsAdminReturns(false)
+			})
+
+			It("returns 403 forbidden", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+			})
+		})
+	})
+
+	Describe("PUT /api/v1/teams/:team_name/rename", func() {
+		var response *http.Response
+		var requestBody string
+		var teamName string
+
+		JustBeforeEach(func() {
+			request, err := http.NewRequest(
+				"PUT",
+				server.URL+"/api/v1/teams/"+teamName+"/rename",
+				bytes.NewBufferString(requestBody),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err = client.Do(request)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		BeforeEach(func() {
+			requestBody = `{"name":"some-new-name"}`
+			fakeTeam.IDReturns(2)
+		})
+
+		Context("when authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+			})
+			Context("when requester belongs to an admin team", func() {
+				BeforeEach(func() {
+					teamName = "a-team"
+					fakeTeam.NameReturns(teamName)
+					fakeAccess.IsAdminReturns(true)
+					dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+				})
+
+				It("constructs teamDB with provided team name", func() {
+					Expect(dbTeamFactory.FindTeamCallCount()).To(Equal(1))
+					Expect(dbTeamFactory.FindTeamArgsForCall(0)).To(Equal("a-team"))
+				})
+
+				It("renames the team to the name provided", func() {
+					Expect(fakeTeam.RenameCallCount()).To(Equal(1))
+					Expect(fakeTeam.RenameArgsForCall(0)).To(Equal("some-new-name"))
+				})
+
+				It("returns 200", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+				})
+
+				Context("when a warning occurs", func() {
+
+					BeforeEach(func() {
+						requestBody = `{"name":"_some-new-name"}`
 					})
 
-					It("returns 200", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
-					})
-
-					Context("when a warning occurs", func() {
-
-						BeforeEach(func() {
-							requestBody = `{"name":"_some-new-name"}`
-						})
-
-						It("returns a warning in the response body", func() {
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+					It("returns a warning in the response body", func() {
+						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"warnings": [
 								{
@@ -617,172 +617,172 @@ var _ = Describe("Teams API", func() {
 								}
 								]
 							}`))
-						})
-					})
-				})
-
-				Context("when requester belongs to the team", func() {
-					BeforeEach(func() {
-						teamName = "a-team"
-						fakeTeam.NameReturns(teamName)
-						fakeAccess.IsAuthorizedReturns(true)
-						dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
-					})
-
-					It("constructs teamDB with provided team name", func() {
-						Expect(dbTeamFactory.FindTeamCallCount()).To(Equal(1))
-						Expect(dbTeamFactory.FindTeamArgsForCall(0)).To(Equal("a-team"))
-					})
-
-					It("renames the team to the name provided", func() {
-						Expect(fakeTeam.RenameCallCount()).To(Equal(1))
-						Expect(fakeTeam.RenameArgsForCall(0)).To(Equal("some-new-name"))
-					})
-
-					It("returns 200", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
-					})
-				})
-
-				Context("when requester does not belong to the team", func() {
-					BeforeEach(func() {
-						teamName = "a-team"
-						fakeTeam.NameReturns(teamName)
-						fakeAccess.IsAuthorizedReturns(false)
-						dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
-					})
-
-					It("returns 403 Forbidden", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusForbidden))
-						Expect(fakeTeam.RenameCallCount()).To(Equal(0))
 					})
 				})
 			})
 
-			Context("when not authenticated", func() {
+			Context("when requester belongs to the team", func() {
 				BeforeEach(func() {
-					fakeAccess.IsAuthenticatedReturns(false)
+					teamName = "a-team"
+					fakeTeam.NameReturns(teamName)
+					fakeAccess.IsAuthorizedReturns(true)
+					dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
 				})
 
-				It("returns 401 Unauthorized", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				It("constructs teamDB with provided team name", func() {
+					Expect(dbTeamFactory.FindTeamCallCount()).To(Equal(1))
+					Expect(dbTeamFactory.FindTeamArgsForCall(0)).To(Equal("a-team"))
+				})
+
+				It("renames the team to the name provided", func() {
+					Expect(fakeTeam.RenameCallCount()).To(Equal(1))
+					Expect(fakeTeam.RenameArgsForCall(0)).To(Equal("some-new-name"))
+				})
+
+				It("returns 200", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
+				})
+			})
+
+			Context("when requester does not belong to the team", func() {
+				BeforeEach(func() {
+					teamName = "a-team"
+					fakeTeam.NameReturns(teamName)
+					fakeAccess.IsAuthorizedReturns(false)
+					dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+				})
+
+				It("returns 403 Forbidden", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
 					Expect(fakeTeam.RenameCallCount()).To(Equal(0))
 				})
 			})
 		})
 
-		Describe("GET /api/v1/teams/:team_name/builds", func() {
-			var (
-				response    *http.Response
-				queryParams string
-				teamName    string
-			)
-
+		Context("when not authenticated", func() {
 			BeforeEach(func() {
-				teamName = "some-team"
+				fakeAccess.IsAuthenticatedReturns(false)
 			})
 
-			JustBeforeEach(func() {
-				var err error
+			It("returns 401 Unauthorized", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(fakeTeam.RenameCallCount()).To(Equal(0))
+			})
+		})
+	})
 
-				response, err = client.Get(server.URL + "/api/v1/teams/" + teamName + "/builds" + queryParams)
-				Expect(err).NotTo(HaveOccurred())
+	Describe("GET /api/v1/teams/:team_name/builds", func() {
+		var (
+			response    *http.Response
+			queryParams string
+			teamName    string
+		)
+
+		BeforeEach(func() {
+			teamName = "some-team"
+		})
+
+		JustBeforeEach(func() {
+			var err error
+
+			response, err = client.Get(server.URL + "/api/v1/teams/" + teamName + "/builds" + queryParams)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when not authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(false)
+				dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
 			})
 
-			Context("when not authenticated", func() {
+			It("returns 401", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+				Expect(fakeTeam.BuildsCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when authenticated", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+				dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+			})
+
+			Context("when no params are passed", func() {
+				It("does not set defaults for since and until", func() {
+					Expect(fakeTeam.BuildsCallCount()).To(Equal(1))
+
+					page := fakeTeam.BuildsArgsForCall(0)
+					Expect(page).To(Equal(db.Page{
+						From:  0,
+						To:    0,
+						Limit: 100,
+					}))
+				})
+			})
+
+			Context("when all the params are passed", func() {
 				BeforeEach(func() {
-					fakeAccess.IsAuthenticatedReturns(false)
-					dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+					queryParams = "?from=2&to=3&limit=8"
 				})
 
-				It("returns 401", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
-					Expect(fakeTeam.BuildsCallCount()).To(Equal(0))
+				It("passes them through", func() {
+					Expect(fakeTeam.BuildsCallCount()).To(Equal(1))
+
+					page := fakeTeam.BuildsArgsForCall(0)
+					Expect(page).To(Equal(db.Page{
+						From:  2,
+						To:    3,
+						Limit: 8,
+					}))
 				})
 			})
 
-			Context("when authenticated", func() {
+			Context("when getting the builds succeeds", func() {
+				var returnedBuilds []db.Build
+
 				BeforeEach(func() {
-					fakeAccess.IsAuthenticatedReturns(true)
-					dbTeamFactory.FindTeamReturns(fakeTeam, true, nil)
+					queryParams = "?since=5&limit=2"
+
+					build1 := new(dbfakes.FakeBuild)
+					build1.IDReturns(4)
+					build1.NameReturns("2")
+					build1.JobNameReturns("some-job")
+					build1.PipelineNameReturns("some-pipeline")
+					build1.TeamNameReturns("some-team")
+					build1.StatusReturns(db.BuildStatusStarted)
+					build1.StartTimeReturns(time.Unix(1, 0))
+					build1.EndTimeReturns(time.Unix(100, 0))
+
+					build2 := new(dbfakes.FakeBuild)
+					build2.IDReturns(2)
+					build2.NameReturns("1")
+					build2.JobNameReturns("some-job")
+					build2.PipelineNameReturns("some-pipeline")
+					build2.TeamNameReturns("some-team")
+					build2.StatusReturns(db.BuildStatusSucceeded)
+					build2.StartTimeReturns(time.Unix(101, 0))
+					build2.EndTimeReturns(time.Unix(200, 0))
+
+					returnedBuilds = []db.Build{build1, build2}
+					fakeTeam.BuildsReturns(returnedBuilds, db.Pagination{}, nil)
 				})
 
-				Context("when no params are passed", func() {
-					It("does not set defaults for since and until", func() {
-						Expect(fakeTeam.BuildsCallCount()).To(Equal(1))
-
-						page := fakeTeam.BuildsArgsForCall(0)
-						Expect(page).To(Equal(db.Page{
-							Since: 0,
-							Until: 0,
-							Limit: 100,
-						}))
-					})
+				It("returns 200 OK", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusOK))
 				})
 
-				Context("when all the params are passed", func() {
-					BeforeEach(func() {
-						queryParams = "?since=2&until=3&limit=8"
-					})
-
-					It("passes them through", func() {
-						Expect(fakeTeam.BuildsCallCount()).To(Equal(1))
-
-						page := fakeTeam.BuildsArgsForCall(0)
-						Expect(page).To(Equal(db.Page{
-							Since: 2,
-							Until: 3,
-							Limit: 8,
-						}))
-					})
+				It("returns Content-Type 'application/json'", func() {
+					expectedHeaderEntries := map[string]string{
+						"Content-Type": "application/json",
+					}
+					Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 				})
 
-				Context("when getting the builds succeeds", func() {
-					var returnedBuilds []db.Build
+				It("returns the builds", func() {
+					body, err := ioutil.ReadAll(response.Body)
+					Expect(err).NotTo(HaveOccurred())
 
-					BeforeEach(func() {
-						queryParams = "?since=5&limit=2"
-
-						build1 := new(dbfakes.FakeBuild)
-						build1.IDReturns(4)
-						build1.NameReturns("2")
-						build1.JobNameReturns("some-job")
-						build1.PipelineNameReturns("some-pipeline")
-						build1.TeamNameReturns("some-team")
-						build1.StatusReturns(db.BuildStatusStarted)
-						build1.StartTimeReturns(time.Unix(1, 0))
-						build1.EndTimeReturns(time.Unix(100, 0))
-
-						build2 := new(dbfakes.FakeBuild)
-						build2.IDReturns(2)
-						build2.NameReturns("1")
-						build2.JobNameReturns("some-job")
-						build2.PipelineNameReturns("some-pipeline")
-						build2.TeamNameReturns("some-team")
-						build2.StatusReturns(db.BuildStatusSucceeded)
-						build2.StartTimeReturns(time.Unix(101, 0))
-						build2.EndTimeReturns(time.Unix(200, 0))
-
-						returnedBuilds = []db.Build{build1, build2}
-						fakeTeam.BuildsReturns(returnedBuilds, db.Pagination{}, nil)
-					})
-
-					It("returns 200 OK", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusOK))
-					})
-
-					It("returns Content-Type 'application/json'", func() {
-						expectedHeaderEntries := map[string]string{
-							"Content-Type": "application/json",
-						}
-						Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
-					})
-
-					It("returns the builds", func() {
-						body, err := ioutil.ReadAll(response.Body)
-						Expect(err).NotTo(HaveOccurred())
-
-						Expect(body).To(MatchJSON(`[
+					Expect(body).To(MatchJSON(`[
 					{
 						"id": 4,
 						"name": "2",
@@ -806,34 +806,34 @@ var _ = Describe("Teams API", func() {
 						"end_time": 200
 					}
 				]`))
-					})
-
-					Context("when next/previous pages are available", func() {
-						BeforeEach(func() {
-							fakeTeam.BuildsReturns(returnedBuilds, db.Pagination{
-								Previous: &db.Page{Until: 4, Limit: 2},
-								Next:     &db.Page{Since: 2, Limit: 2},
-							}, nil)
-						})
-
-						It("returns Link headers per rfc5988", func() {
-							Expect(response.Header["Link"]).To(ConsistOf([]string{
-								fmt.Sprintf(`<%s/api/v1/teams/some-team/builds?until=4&limit=2>; rel="previous"`, externalURL),
-								fmt.Sprintf(`<%s/api/v1/teams/some-team/builds?since=2&limit=2>; rel="next"`, externalURL),
-							}))
-						})
-					})
 				})
 
-				Context("when getting the build fails", func() {
+				Context("when next/previous pages are available", func() {
 					BeforeEach(func() {
-						fakeTeam.BuildsReturns(nil, db.Pagination{}, errors.New("oh no!"))
+						fakeTeam.BuildsReturns(returnedBuilds, db.Pagination{
+							Newer: &db.Page{From: 4, Limit: 2},
+							Older: &db.Page{To: 2, Limit: 2},
+						}, nil)
 					})
 
-					It("returns 404 Not Found", func() {
-						Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+					It("returns Link headers per rfc5988", func() {
+						Expect(response.Header["Link"]).To(ConsistOf([]string{
+							fmt.Sprintf(`<%s/api/v1/teams/some-team/builds?from=4&limit=2>; rel="previous"`, externalURL),
+							fmt.Sprintf(`<%s/api/v1/teams/some-team/builds?to=2&limit=2>; rel="next"`, externalURL),
+						}))
 					})
+				})
+			})
+
+			Context("when getting the build fails", func() {
+				BeforeEach(func() {
+					fakeTeam.BuildsReturns(nil, db.Pagination{}, errors.New("oh no!"))
+				})
+
+				It("returns 404 Not Found", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 				})
 			})
 		})
 	})
+})

--- a/atc/api/teamserver/list_builds.go
+++ b/atc/api/teamserver/list_builds.go
@@ -26,19 +26,23 @@ func (s *Server) ListTeamBuilds(w http.ResponseWriter, r *http.Request) {
 	timestamps := r.FormValue(atc.PaginationQueryTimestamps)
 
 	urlFrom := r.FormValue(atc.PaginationQueryFrom)
-	from, _ = strconv.Atoi(urlFrom)
-
 	urlTo := r.FormValue(atc.PaginationQueryTo)
-	to, _ = strconv.Atoi(urlTo)
 
 	urlLimit := r.FormValue(atc.PaginationQueryLimit)
-
 	limit, _ = strconv.Atoi(urlLimit)
 	if limit == 0 {
 		limit = atc.PaginationAPIDefaultLimit
 	}
 
-	page := db.Page{From: from, To: to, Limit: limit}
+	page := db.Page{Limit: limit}
+	if urlFrom != "" {
+		from, _ = strconv.Atoi(urlFrom)
+		page.From = db.NewIntPtr(from)
+	}
+	if urlTo != "" {
+		to, _ = strconv.Atoi(urlTo)
+		page.To = db.NewIntPtr(to)
+	}
 
 	team, found, err := s.teamFactory.FindTeam(teamName)
 	if err != nil {
@@ -92,7 +96,7 @@ func (s *Server) addNextLink(w http.ResponseWriter, teamName string, page db.Pag
 		s.externalURL,
 		teamName,
 		atc.PaginationQueryTo,
-		page.To,
+		*page.To,
 		atc.PaginationQueryLimit,
 		page.Limit,
 		atc.LinkRelNext,
@@ -105,7 +109,7 @@ func (s *Server) addPreviousLink(w http.ResponseWriter, teamName string, page db
 		s.externalURL,
 		teamName,
 		atc.PaginationQueryFrom,
-		page.From,
+		*page.From,
 		atc.PaginationQueryLimit,
 		page.Limit,
 		atc.LinkRelPrevious,

--- a/atc/api/teamserver/list_builds.go
+++ b/atc/api/teamserver/list_builds.go
@@ -13,8 +13,8 @@ import (
 
 func (s *Server) ListTeamBuilds(w http.ResponseWriter, r *http.Request) {
 	var (
-		until      int
-		since      int
+		from       int
+		to         int
 		limit      int
 		builds     []db.Build
 		pagination db.Pagination
@@ -25,11 +25,11 @@ func (s *Server) ListTeamBuilds(w http.ResponseWriter, r *http.Request) {
 	teamName := r.FormValue(":team_name")
 	timestamps := r.FormValue(atc.PaginationQueryTimestamps)
 
-	urlUntil := r.FormValue(atc.PaginationQueryUntil)
-	until, _ = strconv.Atoi(urlUntil)
+	urlFrom := r.FormValue(atc.PaginationQueryFrom)
+	from, _ = strconv.Atoi(urlFrom)
 
-	urlSince := r.FormValue(atc.PaginationQuerySince)
-	since, _ = strconv.Atoi(urlSince)
+	urlTo := r.FormValue(atc.PaginationQueryTo)
+	to, _ = strconv.Atoi(urlTo)
 
 	urlLimit := r.FormValue(atc.PaginationQueryLimit)
 
@@ -38,7 +38,7 @@ func (s *Server) ListTeamBuilds(w http.ResponseWriter, r *http.Request) {
 		limit = atc.PaginationAPIDefaultLimit
 	}
 
-	page := db.Page{Until: until, Since: since, Limit: limit}
+	page := db.Page{From: from, To: to, Limit: limit}
 
 	team, found, err := s.teamFactory.FindTeam(teamName)
 	if err != nil {
@@ -62,12 +62,12 @@ func (s *Server) ListTeamBuilds(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if pagination.Next != nil {
-		s.addNextLink(w, teamName, *pagination.Next)
+	if pagination.Older != nil {
+		s.addNextLink(w, teamName, *pagination.Older)
 	}
 
-	if pagination.Previous != nil {
-		s.addPreviousLink(w, teamName, *pagination.Previous)
+	if pagination.Newer != nil {
+		s.addPreviousLink(w, teamName, *pagination.Newer)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -91,8 +91,8 @@ func (s *Server) addNextLink(w http.ResponseWriter, teamName string, page db.Pag
 		`<%s/api/v1/teams/%s/builds?%s=%d&%s=%d>; rel="%s"`,
 		s.externalURL,
 		teamName,
-		atc.PaginationQuerySince,
-		page.Since,
+		atc.PaginationQueryTo,
+		page.To,
 		atc.PaginationQueryLimit,
 		page.Limit,
 		atc.LinkRelNext,
@@ -104,8 +104,8 @@ func (s *Server) addPreviousLink(w http.ResponseWriter, teamName string, page db
 		`<%s/api/v1/teams/%s/builds?%s=%d&%s=%d>; rel="%s"`,
 		s.externalURL,
 		teamName,
-		atc.PaginationQueryUntil,
-		page.Until,
+		atc.PaginationQueryFrom,
+		page.From,
 		atc.PaginationQueryLimit,
 		page.Limit,
 		atc.LinkRelPrevious,

--- a/atc/api/versions_test.go
+++ b/atc/api/versions_test.go
@@ -229,8 +229,6 @@ var _ = Describe("Versions API", func() {
 
 						page, versionFilter := fakeResource.VersionsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
-							From:  0,
-							To:    0,
 							Limit: 100,
 						}))
 						Expect(versionFilter).To(Equal(atc.Version{}))
@@ -247,8 +245,8 @@ var _ = Describe("Versions API", func() {
 
 						page, versionFilter := fakeResource.VersionsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
-							From:  5,
-							To:    7,
+							From:  db.NewIntPtr(5),
+							To:    db.NewIntPtr(7),
 							Limit: 8,
 						}))
 						Expect(versionFilter).To(Equal(atc.Version{
@@ -402,8 +400,8 @@ var _ = Describe("Versions API", func() {
 						BeforeEach(func() {
 							fakePipeline.NameReturns("some-pipeline")
 							fakeResource.VersionsReturns(returnedVersions, db.Pagination{
-								Newer: &db.Page{From: 4, Limit: 2},
-								Older: &db.Page{To: 2, Limit: 2},
+								Newer: &db.Page{From: db.NewIntPtr(4), Limit: 2},
+								Older: &db.Page{To: db.NewIntPtr(2), Limit: 2},
 							}, true, nil)
 						})
 

--- a/atc/api/versions_test.go
+++ b/atc/api/versions_test.go
@@ -229,8 +229,6 @@ var _ = Describe("Versions API", func() {
 
 						page, versionFilter := fakeResource.VersionsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
-							Since: 0,
-							Until: 0,
 							From:  0,
 							To:    0,
 							Limit: 100,
@@ -241,7 +239,7 @@ var _ = Describe("Versions API", func() {
 
 				Context("when all the params are passed", func() {
 					BeforeEach(func() {
-						queryParams = "?since=2&until=3&from=5&to=7&limit=8&filter=ref:foo&filter=some-ref:blah"
+						queryParams = "?from=5&to=7&limit=8&filter=ref:foo&filter=some-ref:blah"
 					})
 
 					It("passes them through", func() {
@@ -249,8 +247,6 @@ var _ = Describe("Versions API", func() {
 
 						page, versionFilter := fakeResource.VersionsArgsForCall(0)
 						Expect(page).To(Equal(db.Page{
-							Since: 2,
-							Until: 3,
 							From:  5,
 							To:    7,
 							Limit: 8,
@@ -406,15 +402,15 @@ var _ = Describe("Versions API", func() {
 						BeforeEach(func() {
 							fakePipeline.NameReturns("some-pipeline")
 							fakeResource.VersionsReturns(returnedVersions, db.Pagination{
-								Previous: &db.Page{Until: 4, Limit: 2},
-								Next:     &db.Page{Since: 2, Limit: 2},
+								Newer: &db.Page{From: 4, Limit: 2},
+								Older: &db.Page{To: 2, Limit: 2},
 							}, true, nil)
 						})
 
 						It("returns Link headers per rfc5988", func() {
 							Expect(response.Header["Link"]).To(ConsistOf([]string{
-								fmt.Sprintf(`<%s/api/v1/teams/a-team/pipelines/some-pipeline/resources/some-resource/versions?until=4&limit=2>; rel="previous"`, externalURL),
-								fmt.Sprintf(`<%s/api/v1/teams/a-team/pipelines/some-pipeline/resources/some-resource/versions?since=2&limit=2>; rel="next"`, externalURL),
+								fmt.Sprintf(`<%s/api/v1/teams/a-team/pipelines/some-pipeline/resources/some-resource/versions?from=4&limit=2>; rel="previous"`, externalURL),
+								fmt.Sprintf(`<%s/api/v1/teams/a-team/pipelines/some-pipeline/resources/some-resource/versions?to=2&limit=2>; rel="next"`, externalURL),
 							}))
 						})
 					})

--- a/atc/db/build_factory_test.go
+++ b/atc/db/build_factory_test.go
@@ -527,11 +527,23 @@ var _ = Describe("BuildFactory", func() {
 			Expect(started).To(BeTrue())
 		})
 
-		Describe("with a future date as Page.Since", func() {
+		It("returns builds started in the given timespan", func() {
+			page := db.Page{
+				Limit:   10,
+				From:    int(time.Now().Unix() - 10000),
+				To:      int(time.Now().Unix() + 10),
+				UseDate: true,
+			}
+			builds, _, err := buildFactory.AllBuilds(page)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(builds)).To(Equal(2))
+		})
+
+		Describe("with a future date as Page.From", func() {
 			It("should return nothing", func() {
 				page := db.Page{
 					Limit:   10,
-					Since:   int(time.Now().Unix() + 10),
+					From:    int(time.Now().Unix() + 10),
 					UseDate: true,
 				}
 				builds, _, err := buildFactory.AllBuilds(page)
@@ -540,11 +552,11 @@ var _ = Describe("BuildFactory", func() {
 			})
 		})
 
-		Describe("with a very old date as Page.Until", func() {
+		Describe("with a very old date as Page.To", func() {
 			It("should return nothing", func() {
 				page := db.Page{
 					Limit:   10,
-					Until:   int(time.Now().Unix() - 10000),
+					To:      int(time.Now().Unix() - 10000),
 					UseDate: true,
 				}
 				builds, _, err := buildFactory.AllBuilds(page)

--- a/atc/db/build_factory_test.go
+++ b/atc/db/build_factory_test.go
@@ -530,8 +530,8 @@ var _ = Describe("BuildFactory", func() {
 		It("returns builds started in the given timespan", func() {
 			page := db.Page{
 				Limit:   10,
-				From:    int(time.Now().Unix() - 10000),
-				To:      int(time.Now().Unix() + 10),
+				From:    db.NewIntPtr(int(time.Now().Unix() - 10000)),
+				To:      db.NewIntPtr(int(time.Now().Unix() + 10)),
 				UseDate: true,
 			}
 			builds, _, err := buildFactory.AllBuilds(page)
@@ -543,7 +543,7 @@ var _ = Describe("BuildFactory", func() {
 			It("should return nothing", func() {
 				page := db.Page{
 					Limit:   10,
-					From:    int(time.Now().Unix() + 10),
+					From:    db.NewIntPtr(int(time.Now().Unix() + 10)),
 					UseDate: true,
 				}
 				builds, _, err := buildFactory.AllBuilds(page)
@@ -556,7 +556,7 @@ var _ = Describe("BuildFactory", func() {
 			It("should return nothing", func() {
 				page := db.Page{
 					Limit:   10,
-					To:      int(time.Now().Unix() - 10000),
+					To:      db.NewIntPtr(int(time.Now().Unix() - 10000)),
 					UseDate: true,
 				}
 				builds, _, err := buildFactory.AllBuilds(page)

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -373,47 +373,47 @@ var _ = Describe("Job", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildsPage).To(Equal([]db.Build{builds[9], builds[8]}))
 				Expect(pagination.Newer).To(BeNil())
-				Expect(pagination.Older).To(Equal(&db.Page{To: builds[7].ID(), Limit: 2}))
+				Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(builds[7].ID()), Limit: 2}))
 			})
 		})
 
 		Context("with a to that places it in the middle of the builds", func() {
 			It("returns the builds, with previous/next pages", func() {
-				buildsPage, pagination, err := someJob.Builds(db.Page{To: builds[6].ID(), Limit: 2})
+				buildsPage, pagination, err := someJob.Builds(db.Page{To: db.NewIntPtr(builds[6].ID()), Limit: 2})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildsPage).To(Equal([]db.Build{builds[6], builds[5]}))
-				Expect(pagination.Newer).To(Equal(&db.Page{From: builds[7].ID(), Limit: 2}))
-				Expect(pagination.Older).To(Equal(&db.Page{To: builds[4].ID(), Limit: 2}))
+				Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(builds[7].ID()), Limit: 2}))
+				Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(builds[4].ID()), Limit: 2}))
 			})
 		})
 
 		Context("with a to that places it at the end of the builds", func() {
 			It("returns the builds, with previous/next pages", func() {
-				buildsPage, pagination, err := someJob.Builds(db.Page{To: builds[1].ID(), Limit: 2})
+				buildsPage, pagination, err := someJob.Builds(db.Page{To: db.NewIntPtr(builds[1].ID()), Limit: 2})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildsPage).To(Equal([]db.Build{builds[1], builds[0]}))
-				Expect(pagination.Newer).To(Equal(&db.Page{From: builds[2].ID(), Limit: 2}))
+				Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(builds[2].ID()), Limit: 2}))
 				Expect(pagination.Older).To(BeNil())
 			})
 		})
 
 		Context("with a from that places it in the middle of the builds", func() {
 			It("returns the builds, with previous/next pages", func() {
-				buildsPage, pagination, err := someJob.Builds(db.Page{From: builds[6].ID(), Limit: 2})
+				buildsPage, pagination, err := someJob.Builds(db.Page{From: db.NewIntPtr(builds[6].ID()), Limit: 2})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildsPage).To(Equal([]db.Build{builds[7], builds[6]}))
-				Expect(pagination.Newer).To(Equal(&db.Page{From: builds[8].ID(), Limit: 2}))
-				Expect(pagination.Older).To(Equal(&db.Page{To: builds[5].ID(), Limit: 2}))
+				Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(builds[8].ID()), Limit: 2}))
+				Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(builds[5].ID()), Limit: 2}))
 			})
 		})
 
 		Context("with a from that places it at the beginning of the builds", func() {
 			It("returns the builds, with previous/next pages", func() {
-				buildsPage, pagination, err := someJob.Builds(db.Page{From: builds[8].ID(), Limit: 2})
+				buildsPage, pagination, err := someJob.Builds(db.Page{From: db.NewIntPtr(builds[8].ID()), Limit: 2})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildsPage).To(Equal([]db.Build{builds[9], builds[8]}))
 				Expect(pagination.Newer).To(BeNil())
-				Expect(pagination.Older).To(Equal(&db.Page{To: builds[7].ID(), Limit: 2}))
+				Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(builds[7].ID()), Limit: 2}))
 			})
 		})
 	})
@@ -488,7 +488,7 @@ var _ = Describe("Job", func() {
 			Context("only to", func() {
 				It("returns only those before to", func() {
 					returnedBuilds, _, err := job.BuildsWithTime(db.Page{
-						To:    int(builds[2].StartTime().Unix()),
+						To:    db.NewIntPtr(int(builds[2].StartTime().Unix())),
 						Limit: 50,
 					})
 
@@ -500,7 +500,7 @@ var _ = Describe("Job", func() {
 			Context("only from", func() {
 				It("returns only those after from", func() {
 					returnedBuilds, _, err := job.BuildsWithTime(db.Page{
-						From:  int(builds[1].StartTime().Unix()),
+						From:  db.NewIntPtr(int(builds[1].StartTime().Unix())),
 						Limit: 50,
 					})
 
@@ -512,8 +512,8 @@ var _ = Describe("Job", func() {
 			Context("from and to", func() {
 				It("returns only elements in the range", func() {
 					returnedBuilds, _, err := job.BuildsWithTime(db.Page{
-						From:  int(builds[1].StartTime().Unix()),
-						To:    int(builds[2].StartTime().Unix()),
+						From:  db.NewIntPtr(int(builds[1].StartTime().Unix())),
+						To:    db.NewIntPtr(int(builds[2].StartTime().Unix())),
 						Limit: 50,
 					})
 					Expect(err).NotTo(HaveOccurred())

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Job", func() {
 					Name: "job-2",
 				},
 				{
-					Name: "non-triggerable-job",
+					Name:                 "non-triggerable-job",
 					DisableManualTrigger: true,
 				},
 			},
@@ -367,53 +367,53 @@ var _ = Describe("Job", func() {
 			})
 		})
 
-		Context("with no since/until", func() {
+		Context("with no from/to", func() {
 			It("returns the first page, with the given limit, and a next page", func() {
 				buildsPage, pagination, err := someJob.Builds(db.Page{Limit: 2})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildsPage).To(Equal([]db.Build{builds[9], builds[8]}))
-				Expect(pagination.Previous).To(BeNil())
-				Expect(pagination.Next).To(Equal(&db.Page{Since: builds[8].ID(), Limit: 2}))
+				Expect(pagination.Newer).To(BeNil())
+				Expect(pagination.Older).To(Equal(&db.Page{To: builds[7].ID(), Limit: 2}))
 			})
 		})
 
-		Context("with a since that places it in the middle of the builds", func() {
+		Context("with a to that places it in the middle of the builds", func() {
 			It("returns the builds, with previous/next pages", func() {
-				buildsPage, pagination, err := someJob.Builds(db.Page{Since: builds[6].ID(), Limit: 2})
+				buildsPage, pagination, err := someJob.Builds(db.Page{To: builds[6].ID(), Limit: 2})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(buildsPage).To(Equal([]db.Build{builds[5], builds[4]}))
-				Expect(pagination.Previous).To(Equal(&db.Page{Until: builds[5].ID(), Limit: 2}))
-				Expect(pagination.Next).To(Equal(&db.Page{Since: builds[4].ID(), Limit: 2}))
+				Expect(buildsPage).To(Equal([]db.Build{builds[6], builds[5]}))
+				Expect(pagination.Newer).To(Equal(&db.Page{From: builds[7].ID(), Limit: 2}))
+				Expect(pagination.Older).To(Equal(&db.Page{To: builds[4].ID(), Limit: 2}))
 			})
 		})
 
-		Context("with a since that places it at the end of the builds", func() {
+		Context("with a to that places it at the end of the builds", func() {
 			It("returns the builds, with previous/next pages", func() {
-				buildsPage, pagination, err := someJob.Builds(db.Page{Since: builds[2].ID(), Limit: 2})
+				buildsPage, pagination, err := someJob.Builds(db.Page{To: builds[1].ID(), Limit: 2})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildsPage).To(Equal([]db.Build{builds[1], builds[0]}))
-				Expect(pagination.Previous).To(Equal(&db.Page{Until: builds[1].ID(), Limit: 2}))
-				Expect(pagination.Next).To(BeNil())
+				Expect(pagination.Newer).To(Equal(&db.Page{From: builds[2].ID(), Limit: 2}))
+				Expect(pagination.Older).To(BeNil())
 			})
 		})
 
-		Context("with an until that places it in the middle of the builds", func() {
+		Context("with a from that places it in the middle of the builds", func() {
 			It("returns the builds, with previous/next pages", func() {
-				buildsPage, pagination, err := someJob.Builds(db.Page{Until: builds[6].ID(), Limit: 2})
+				buildsPage, pagination, err := someJob.Builds(db.Page{From: builds[6].ID(), Limit: 2})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(buildsPage).To(Equal([]db.Build{builds[8], builds[7]}))
-				Expect(pagination.Previous).To(Equal(&db.Page{Until: builds[8].ID(), Limit: 2}))
-				Expect(pagination.Next).To(Equal(&db.Page{Since: builds[7].ID(), Limit: 2}))
+				Expect(buildsPage).To(Equal([]db.Build{builds[7], builds[6]}))
+				Expect(pagination.Newer).To(Equal(&db.Page{From: builds[8].ID(), Limit: 2}))
+				Expect(pagination.Older).To(Equal(&db.Page{To: builds[5].ID(), Limit: 2}))
 			})
 		})
 
-		Context("with a until that places it at the beginning of the builds", func() {
+		Context("with a from that places it at the beginning of the builds", func() {
 			It("returns the builds, with previous/next pages", func() {
-				buildsPage, pagination, err := someJob.Builds(db.Page{Until: builds[7].ID(), Limit: 2})
+				buildsPage, pagination, err := someJob.Builds(db.Page{From: builds[8].ID(), Limit: 2})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(buildsPage).To(Equal([]db.Build{builds[9], builds[8]}))
-				Expect(pagination.Previous).To(BeNil())
-				Expect(pagination.Next).To(Equal(&db.Page{Since: builds[8].ID(), Limit: 2}))
+				Expect(pagination.Newer).To(BeNil())
+				Expect(pagination.Older).To(Equal(&db.Page{To: builds[7].ID(), Limit: 2}))
 			})
 		})
 	})
@@ -485,10 +485,10 @@ var _ = Describe("Job", func() {
 		})
 
 		Context("when providing boundaries", func() {
-			Context("only until", func() {
-				It("returns only those after until", func() {
+			Context("only to", func() {
+				It("returns only those before to", func() {
 					returnedBuilds, _, err := job.BuildsWithTime(db.Page{
-						Until: int(builds[2].StartTime().Unix()),
+						To:    int(builds[2].StartTime().Unix()),
 						Limit: 50,
 					})
 
@@ -497,10 +497,10 @@ var _ = Describe("Job", func() {
 				})
 			})
 
-			Context("only since", func() {
-				It("returns only those before since", func() {
+			Context("only from", func() {
+				It("returns only those after from", func() {
 					returnedBuilds, _, err := job.BuildsWithTime(db.Page{
-						Since: int(builds[1].StartTime().Unix()),
+						From:  int(builds[1].StartTime().Unix()),
 						Limit: 50,
 					})
 
@@ -509,11 +509,11 @@ var _ = Describe("Job", func() {
 				})
 			})
 
-			Context("since and until", func() {
+			Context("from and to", func() {
 				It("returns only elements in the range", func() {
 					returnedBuilds, _, err := job.BuildsWithTime(db.Page{
-						Until: int(builds[2].StartTime().Unix()),
-						Since: int(builds[1].StartTime().Unix()),
+						From:  int(builds[1].StartTime().Unix()),
+						To:    int(builds[2].StartTime().Unix()),
 						Limit: 50,
 					})
 					Expect(err).NotTo(HaveOccurred())

--- a/atc/db/pagination.go
+++ b/atc/db/pagination.go
@@ -1,9 +1,6 @@
 package db
 
 type Page struct {
-	Since int // exclusive
-	Until int // exclusive
-
 	From int // inclusive
 	To   int // inclusive
 
@@ -12,6 +9,7 @@ type Page struct {
 }
 
 type Pagination struct {
-	Previous *Page
-	Next     *Page
+	Newer *Page
+	Older *Page
 }
+

--- a/atc/db/pagination.go
+++ b/atc/db/pagination.go
@@ -1,8 +1,8 @@
 package db
 
 type Page struct {
-	From int // inclusive
-	To   int // inclusive
+	From *int // inclusive
+	To   *int // inclusive
 
 	Limit   int
 	UseDate bool
@@ -13,3 +13,6 @@ type Pagination struct {
 	Older *Page
 }
 
+func NewIntPtr(i int) *int {
+	return &i
+}

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -2061,7 +2061,7 @@ var _ = Describe("Pipeline", func() {
 			Context("only to", func() {
 				It("returns only those before and including to", func() {
 					returnedBuilds, _, err := pipeline.BuildsWithTime(db.Page{
-						To:    int(builds[2].StartTime().Unix()),
+						To:    db.NewIntPtr(int(builds[2].StartTime().Unix())),
 						Limit: 50,
 					})
 
@@ -2073,7 +2073,7 @@ var _ = Describe("Pipeline", func() {
 			Context("only from", func() {
 				It("returns only those after from", func() {
 					returnedBuilds, _, err := pipeline.BuildsWithTime(db.Page{
-						From:  int(builds[1].StartTime().Unix()),
+						From:  db.NewIntPtr(int(builds[1].StartTime().Unix())),
 						Limit: 50,
 					})
 
@@ -2085,8 +2085,8 @@ var _ = Describe("Pipeline", func() {
 			Context("from and to", func() {
 				It("returns only elements in the range", func() {
 					returnedBuilds, _, err := pipeline.BuildsWithTime(db.Page{
-						From:  int(builds[1].StartTime().Unix()),
-						To:    int(builds[2].StartTime().Unix()),
+						From:  db.NewIntPtr(int(builds[1].StartTime().Unix())),
+						To:    db.NewIntPtr(int(builds[2].StartTime().Unix())),
 						Limit: 50,
 					})
 					Expect(err).NotTo(HaveOccurred())

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -2058,10 +2058,10 @@ var _ = Describe("Pipeline", func() {
 
 		Context("when providing boundaries", func() {
 
-			Context("only until", func() {
-				It("returns only those after until", func() {
+			Context("only to", func() {
+				It("returns only those before and including to", func() {
 					returnedBuilds, _, err := pipeline.BuildsWithTime(db.Page{
-						Until: int(builds[2].StartTime().Unix()),
+						To:    int(builds[2].StartTime().Unix()),
 						Limit: 50,
 					})
 
@@ -2070,10 +2070,10 @@ var _ = Describe("Pipeline", func() {
 				})
 			})
 
-			Context("only since", func() {
-				It("returns only those before since", func() {
+			Context("only from", func() {
+				It("returns only those after from", func() {
 					returnedBuilds, _, err := pipeline.BuildsWithTime(db.Page{
-						Since: int(builds[1].StartTime().Unix()),
+						From:  int(builds[1].StartTime().Unix()),
 						Limit: 50,
 					})
 
@@ -2082,11 +2082,11 @@ var _ = Describe("Pipeline", func() {
 				})
 			})
 
-			Context("since and until", func() {
+			Context("from and to", func() {
 				It("returns only elements in the range", func() {
 					returnedBuilds, _, err := pipeline.BuildsWithTime(db.Page{
-						Until: int(builds[2].StartTime().Unix()),
-						Since: int(builds[1].StartTime().Unix()),
+						From:  int(builds[1].StartTime().Unix()),
+						To:    int(builds[2].StartTime().Unix()),
 						Limit: 50,
 					})
 					Expect(err).NotTo(HaveOccurred())

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -413,7 +413,7 @@ func (r *resource) Versions(page Page, versionFilter atc.Version) ([]atc.Resourc
 	}
 
 	var rows *sql.Rows
-	if page.From != 0 {
+	if page.From != nil {
 		rows, err = tx.Query(fmt.Sprintf(`
 			SELECT sub.*
 				FROM (
@@ -424,18 +424,18 @@ func (r *resource) Versions(page Page, versionFilter atc.Version) ([]atc.Resourc
 				LIMIT $3
 			) sub
 			ORDER BY sub.check_order DESC
-		`, query), r.id, page.From, page.Limit, filterJSON)
+		`, query), r.id, *page.From, page.Limit, filterJSON)
 		if err != nil {
 			return nil, Pagination{}, false, err
 		}
-	} else if page.To != 0 {
+	} else if page.To != nil {
 		rows, err = tx.Query(fmt.Sprintf(`
 			%s
 				AND version @> $4
 				AND v.check_order <= (SELECT check_order FROM resource_config_versions WHERE id = $2)
 			ORDER BY v.check_order DESC
 			LIMIT $3
-		`, query), r.id, page.To, page.Limit, filterJSON)
+		`, query), r.id, *page.To, page.Limit, filterJSON)
 		if err != nil {
 			return nil, Pagination{}, false, err
 		}
@@ -515,7 +515,7 @@ func (r *resource) Versions(page Page, versionFilter atc.Version) ([]atc.Resourc
 		return nil, Pagination{}, false, err
 	} else if err == nil {
 		pagination.Older = &Page{
-			To:    olderRCVId,
+			To:    &olderRCVId,
 			Limit: page.Limit,
 		}
 	}
@@ -532,7 +532,7 @@ func (r *resource) Versions(page Page, versionFilter atc.Version) ([]atc.Resourc
 		return nil, Pagination{}, false, err
 	} else if err == nil {
 		pagination.Newer = &Page{
-			From:  newerRCVId,
+			From:  &newerRCVId,
 			Limit: page.Limit,
 		}
 	}

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -1168,59 +1168,59 @@ var _ = Describe("Resource", func() {
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[8].Version))
 					Expect(pagination.Newer).To(BeNil())
-					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[7].ID, Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(resourceVersions[7].ID), Limit: 2}))
 				})
 			})
 
 			Context("with a to that places it in the middle of the versions", func() {
 				It("returns the versions, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{To: resourceVersions[6].ID, Limit: 2}, nil)
+					historyPage, pagination, found, err := resource.Versions(db.Page{To: db.NewIntPtr(resourceVersions[6].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[6].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[5].Version))
-					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[7].ID, Limit: 2}))
-					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[4].ID, Limit: 2}))
+					Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(resourceVersions[7].ID), Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(resourceVersions[4].ID), Limit: 2}))
 				})
 			})
 
 			Context("with a to that places it to the oldest version", func() {
 				It("returns the versions, with no next page", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{To: resourceVersions[1].ID, Limit: 2}, nil)
+					historyPage, pagination, found, err := resource.Versions(db.Page{To: db.NewIntPtr(resourceVersions[1].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[1].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[0].Version))
-					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[2].ID, Limit: 2}))
+					Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(resourceVersions[2].ID), Limit: 2}))
 					Expect(pagination.Older).To(BeNil())
 				})
 			})
 
 			Context("with a from that places it in the middle of the versions", func() {
 				It("returns the versions, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{From: resourceVersions[6].ID, Limit: 2}, nil)
+					historyPage, pagination, found, err := resource.Versions(db.Page{From: db.NewIntPtr(resourceVersions[6].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[7].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[6].Version))
-					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[8].ID, Limit: 2}))
-					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[5].ID, Limit: 2}))
+					Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(resourceVersions[8].ID), Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(resourceVersions[5].ID), Limit: 2}))
 				})
 			})
 
 			Context("with a from that places it at the beginning of the most recent versions", func() {
 				It("returns the versions, with no previous page", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{From: resourceVersions[8].ID, Limit: 2}, nil)
+					historyPage, pagination, found, err := resource.Versions(db.Page{From: db.NewIntPtr(resourceVersions[8].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[8].Version))
 					Expect(pagination.Newer).To(BeNil())
-					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[7].ID, Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(resourceVersions[7].ID), Limit: 2}))
 				})
 			})
 
@@ -1390,27 +1390,27 @@ var _ = Describe("Resource", func() {
 
 			Context("with from", func() {
 				It("returns the versions, with previous/next pages including from", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{From: resourceVersions[1].ID, Limit: 2}, nil)
+					historyPage, pagination, found, err := resource.Versions(db.Page{From: db.NewIntPtr(resourceVersions[1].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[2].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[1].Version))
-					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[3].ID, Limit: 2}))
-					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[0].ID, Limit: 2}))
+					Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(resourceVersions[3].ID), Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(resourceVersions[0].ID), Limit: 2}))
 				})
 			})
 
 			Context("with to", func() {
 				It("returns the builds, with previous/next pages including to", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{To: resourceVersions[2].ID, Limit: 2}, nil)
+					historyPage, pagination, found, err := resource.Versions(db.Page{To: db.NewIntPtr(resourceVersions[2].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[2].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[1].Version))
-					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[3].ID, Limit: 2}))
-					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[0].ID, Limit: 2}))
+					Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(resourceVersions[3].ID), Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(resourceVersions[0].ID), Limit: 2}))
 				})
 			})
 		})

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -1159,7 +1159,7 @@ var _ = Describe("Resource", func() {
 				Expect(reloaded).To(BeTrue())
 			})
 
-			Context("with no since/until", func() {
+			Context("with no from/to", func() {
 				It("returns the first page, with the given limit, and a next page", func() {
 					historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
@@ -1167,60 +1167,60 @@ var _ = Describe("Resource", func() {
 					Expect(len(historyPage)).To(Equal(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[8].Version))
-					Expect(pagination.Previous).To(BeNil())
-					Expect(pagination.Next).To(Equal(&db.Page{Since: resourceVersions[8].ID, Limit: 2}))
+					Expect(pagination.Newer).To(BeNil())
+					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[7].ID, Limit: 2}))
 				})
 			})
 
-			Context("with a since that places it in the middle of the builds", func() {
-				It("returns the builds, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Since: resourceVersions[6].ID, Limit: 2}, nil)
+			Context("with a to that places it in the middle of the versions", func() {
+				It("returns the versions, with previous/next pages", func() {
+					historyPage, pagination, found, err := resource.Versions(db.Page{To: resourceVersions[6].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
-					Expect(historyPage[0].Version).To(Equal(resourceVersions[5].Version))
-					Expect(historyPage[1].Version).To(Equal(resourceVersions[4].Version))
-					Expect(pagination.Previous).To(Equal(&db.Page{Until: resourceVersions[5].ID, Limit: 2}))
-					Expect(pagination.Next).To(Equal(&db.Page{Since: resourceVersions[4].ID, Limit: 2}))
+					Expect(historyPage[0].Version).To(Equal(resourceVersions[6].Version))
+					Expect(historyPage[1].Version).To(Equal(resourceVersions[5].Version))
+					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[7].ID, Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[4].ID, Limit: 2}))
 				})
 			})
 
-			Context("with a since that places it at the end of the builds", func() {
-				It("returns the builds, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Since: resourceVersions[2].ID, Limit: 2}, nil)
+			Context("with a to that places it to the oldest version", func() {
+				It("returns the versions, with no next page", func() {
+					historyPage, pagination, found, err := resource.Versions(db.Page{To: resourceVersions[1].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[1].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[0].Version))
-					Expect(pagination.Previous).To(Equal(&db.Page{Until: resourceVersions[1].ID, Limit: 2}))
-					Expect(pagination.Next).To(BeNil())
+					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[2].ID, Limit: 2}))
+					Expect(pagination.Older).To(BeNil())
 				})
 			})
 
-			Context("with an until that places it in the middle of the builds", func() {
-				It("returns the builds, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Until: resourceVersions[6].ID, Limit: 2}, nil)
+			Context("with a from that places it in the middle of the versions", func() {
+				It("returns the versions, with previous/next pages", func() {
+					historyPage, pagination, found, err := resource.Versions(db.Page{From: resourceVersions[6].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
-					Expect(historyPage[0].Version).To(Equal(resourceVersions[8].Version))
-					Expect(historyPage[1].Version).To(Equal(resourceVersions[7].Version))
-					Expect(pagination.Previous).To(Equal(&db.Page{Until: resourceVersions[8].ID, Limit: 2}))
-					Expect(pagination.Next).To(Equal(&db.Page{Since: resourceVersions[7].ID, Limit: 2}))
+					Expect(historyPage[0].Version).To(Equal(resourceVersions[7].Version))
+					Expect(historyPage[1].Version).To(Equal(resourceVersions[6].Version))
+					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[8].ID, Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[5].ID, Limit: 2}))
 				})
 			})
 
-			Context("with a until that places it at the beginning of the builds", func() {
-				It("returns the builds, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Until: resourceVersions[7].ID, Limit: 2}, nil)
+			Context("with a from that places it at the beginning of the most recent versions", func() {
+				It("returns the versions, with no previous page", func() {
+					historyPage, pagination, found, err := resource.Versions(db.Page{From: resourceVersions[8].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[9].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[8].Version))
-					Expect(pagination.Previous).To(BeNil())
-					Expect(pagination.Next).To(Equal(&db.Page{Since: resourceVersions[8].ID, Limit: 2}))
+					Expect(pagination.Newer).To(BeNil())
+					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[7].ID, Limit: 2}))
 				})
 			})
 
@@ -1373,7 +1373,7 @@ var _ = Describe("Resource", func() {
 				// ids ordered by check order now: [3, 2, 4, 1]
 			})
 
-			Context("with no since/until", func() {
+			Context("with no from/to", func() {
 				It("returns versions ordered by check order", func() {
 					historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 4}, nil)
 					Expect(err).ToNot(HaveOccurred())
@@ -1383,60 +1383,34 @@ var _ = Describe("Resource", func() {
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[2].Version))
 					Expect(historyPage[2].Version).To(Equal(resourceVersions[1].Version))
 					Expect(historyPage[3].Version).To(Equal(resourceVersions[0].Version))
-					Expect(pagination.Previous).To(BeNil())
-					Expect(pagination.Next).To(BeNil())
-				})
-			})
-
-			Context("with a since", func() {
-				It("returns the builds, with previous/next pages excluding since", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Since: 3, Limit: 2}, nil)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-					Expect(historyPage).To(HaveLen(2))
-					Expect(historyPage[0].Version).To(Equal(resourceVersions[2].Version))
-					Expect(historyPage[1].Version).To(Equal(resourceVersions[1].Version))
-					Expect(pagination.Previous).To(Equal(&db.Page{Until: 2, Limit: 2}))
-					Expect(pagination.Next).To(Equal(&db.Page{Since: 4, Limit: 2}))
+					Expect(pagination.Newer).To(BeNil())
+					Expect(pagination.Older).To(BeNil())
 				})
 			})
 
 			Context("with from", func() {
-				It("returns the builds, with previous/next pages including from", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{From: 2, Limit: 2}, nil)
+				It("returns the versions, with previous/next pages including from", func() {
+					historyPage, pagination, found, err := resource.Versions(db.Page{From: resourceVersions[1].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[2].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[1].Version))
-					Expect(pagination.Previous).To(Equal(&db.Page{Until: 2, Limit: 2}))
-					Expect(pagination.Next).To(Equal(&db.Page{Since: 4, Limit: 2}))
-				})
-			})
-
-			Context("with a until", func() {
-				It("returns the builds, with previous/next pages excluding until", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Until: 1, Limit: 2}, nil)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-					Expect(historyPage).To(HaveLen(2))
-					Expect(historyPage[0].Version).To(Equal(resourceVersions[2].Version))
-					Expect(historyPage[1].Version).To(Equal(resourceVersions[1].Version))
-					Expect(pagination.Previous).To(Equal(&db.Page{Until: 2, Limit: 2}))
-					Expect(pagination.Next).To(Equal(&db.Page{Since: 4, Limit: 2}))
+					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[3].ID, Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[0].ID, Limit: 2}))
 				})
 			})
 
 			Context("with to", func() {
 				It("returns the builds, with previous/next pages including to", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{To: 4, Limit: 2}, nil)
+					historyPage, pagination, found, err := resource.Versions(db.Page{To: resourceVersions[2].ID, Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
 					Expect(historyPage[0].Version).To(Equal(resourceVersions[2].Version))
 					Expect(historyPage[1].Version).To(Equal(resourceVersions[1].Version))
-					Expect(pagination.Previous).To(Equal(&db.Page{Until: 2, Limit: 2}))
-					Expect(pagination.Next).To(Equal(&db.Page{Since: 4, Limit: 2}))
+					Expect(pagination.Newer).To(Equal(&db.Page{From: resourceVersions[3].ID, Limit: 2}))
+					Expect(pagination.Older).To(Equal(&db.Page{To: resourceVersions[0].ID, Limit: 2}))
 				})
 			})
 		})
@@ -1474,7 +1448,7 @@ var _ = Describe("Resource", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(historyPage).To(BeNil())
-				Expect(pagination).To(Equal(db.Pagination{Previous: nil, Next: nil}))
+				Expect(pagination).To(Equal(db.Pagination{Newer: nil, Older: nil}))
 			})
 		})
 	})

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -1131,7 +1131,7 @@ var _ = Describe("Team", func() {
 				Expect(builds[1]).To(Equal(allBuilds[3]))
 
 				Expect(pagination.Newer).To(BeNil())
-				Expect(pagination.Older).To(Equal(&db.Page{To: allBuilds[2].ID(), Limit: 2}))
+				Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(allBuilds[2].ID()), Limit: 2}))
 
 				builds, pagination, err = team.PrivateAndPublicBuilds(*pagination.Older)
 				Expect(err).ToNot(HaveOccurred())
@@ -1141,8 +1141,8 @@ var _ = Describe("Team", func() {
 				Expect(builds[0]).To(Equal(allBuilds[2]))
 				Expect(builds[1]).To(Equal(allBuilds[1]))
 
-				Expect(pagination.Newer).To(Equal(&db.Page{From: allBuilds[3].ID(), Limit: 2}))
-				Expect(pagination.Older).To(Equal(&db.Page{To: allBuilds[0].ID(), Limit: 2}))
+				Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(allBuilds[3].ID()), Limit: 2}))
+				Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(allBuilds[0].ID()), Limit: 2}))
 
 				builds, pagination, err = team.PrivateAndPublicBuilds(*pagination.Older)
 				Expect(err).ToNot(HaveOccurred())
@@ -1150,7 +1150,7 @@ var _ = Describe("Team", func() {
 				Expect(len(builds)).To(Equal(1))
 				Expect(builds[0]).To(Equal(allBuilds[0]))
 
-				Expect(pagination.Newer).To(Equal(&db.Page{From: allBuilds[1].ID(), Limit: 2}))
+				Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(allBuilds[1].ID()), Limit: 2}))
 				Expect(pagination.Older).To(BeNil())
 
 				builds, pagination, err = team.PrivateAndPublicBuilds(*pagination.Newer)
@@ -1159,8 +1159,8 @@ var _ = Describe("Team", func() {
 				Expect(len(builds)).To(Equal(2))
 				Expect(builds[0]).To(Equal(allBuilds[2]))
 				Expect(builds[1]).To(Equal(allBuilds[1]))
-				Expect(pagination.Newer).To(Equal(&db.Page{From: allBuilds[3].ID(), Limit: 2}))
-				Expect(pagination.Older).To(Equal(&db.Page{To: allBuilds[0].ID(), Limit: 2}))
+				Expect(pagination.Newer).To(Equal(&db.Page{From: db.NewIntPtr(allBuilds[3].ID()), Limit: 2}))
+				Expect(pagination.Older).To(Equal(&db.Page{To: db.NewIntPtr(allBuilds[0].ID()), Limit: 2}))
 			})
 
 			Context("when there are builds that belong to different teams", func() {
@@ -1305,7 +1305,7 @@ var _ = Describe("Team", func() {
 			Context("only to", func() {
 				It("returns only those before to", func() {
 					returnedBuilds, _, err := team.BuildsWithTime(db.Page{
-						To:    int(builds[2].StartTime().Unix()),
+						To:    db.NewIntPtr(int(builds[2].StartTime().Unix())),
 						Limit: 50,
 					})
 
@@ -1317,7 +1317,7 @@ var _ = Describe("Team", func() {
 			Context("only from", func() {
 				It("returns only those after from", func() {
 					returnedBuilds, _, err := team.BuildsWithTime(db.Page{
-						From:  int(builds[1].StartTime().Unix()),
+						From:  db.NewIntPtr(int(builds[1].StartTime().Unix())),
 						Limit: 50,
 					})
 
@@ -1329,8 +1329,8 @@ var _ = Describe("Team", func() {
 			Context("from and to", func() {
 				It("returns only elements in the range", func() {
 					returnedBuilds, _, err := team.BuildsWithTime(db.Page{
-						From:  int(builds[1].StartTime().Unix()),
-						To:    int(builds[2].StartTime().Unix()),
+						From:  db.NewIntPtr(int(builds[1].StartTime().Unix())),
+						To:    db.NewIntPtr(int(builds[2].StartTime().Unix())),
 						Limit: 50,
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -1397,7 +1397,7 @@ var _ = Describe("Team", func() {
 		Context("when limiting the range of build ids", func() {
 			Context("specifying only from", func() {
 				It("returns all builds after and including the specified id", func() {
-					builds, _, err := team.Builds(db.Page{Limit: 50, From: secondBuild.ID()})
+					builds, _, err := team.Builds(db.Page{Limit: 50, From: db.NewIntPtr(secondBuild.ID())})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(builds).To(ConsistOf(secondBuild, thirdBuild))
 				})
@@ -1405,7 +1405,7 @@ var _ = Describe("Team", func() {
 
 			Context("specifying only to", func() {
 				It("returns all builds before and including the specified id", func() {
-					builds, _, err := team.Builds(db.Page{Limit: 50, To: secondBuild.ID()})
+					builds, _, err := team.Builds(db.Page{Limit: 50, To: db.NewIntPtr(secondBuild.ID())})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(builds).To(ConsistOf(oneOffBuild, build, secondBuild))
 				})
@@ -1413,7 +1413,7 @@ var _ = Describe("Team", func() {
 
 			Context("specifying both from and to", func() {
 				It("returns all builds within range of ids", func() {
-					builds, _, err := team.Builds(db.Page{Limit: 50, From: build.ID(), To: thirdBuild.ID()})
+					builds, _, err := team.Builds(db.Page{Limit: 50, From: db.NewIntPtr(build.ID()), To: db.NewIntPtr(thirdBuild.ID())})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(builds).To(ConsistOf(build, secondBuild, thirdBuild))
 				})
@@ -1421,7 +1421,7 @@ var _ = Describe("Team", func() {
 
 			Context("specifying from greater than the biggest ID in the database", func() {
 				It("returns no rows error", func() {
-					builds, _, err := team.Builds(db.Page{Limit: 50, From: thirdBuild.ID() + 1})
+					builds, _, err := team.Builds(db.Page{Limit: 50, From: db.NewIntPtr(thirdBuild.ID() + 1)})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(builds).To(BeEmpty())
 				})
@@ -1429,7 +1429,7 @@ var _ = Describe("Team", func() {
 
 			Context("specifying invalid boundaries", func() {
 				It("should fail", func() {
-					_, _, err := team.Builds(db.Page{Limit: 50, From: thirdBuild.ID(), To: secondBuild.ID()})
+					_, _, err := team.Builds(db.Page{Limit: 50, From: db.NewIntPtr(thirdBuild.ID()), To: db.NewIntPtr(secondBuild.ID())})
 					Expect(err).To(HaveOccurred())
 				})
 			})

--- a/atc/gc/build_log_collector.go
+++ b/atc/gc/build_log_collector.go
@@ -94,7 +94,7 @@ func (br *buildLogCollector) reapLogsOfJob(pipeline db.Pipeline,
 
 	from := job.FirstLoggedBuildID()
 	limit := br.batchSize
-	page := &db.Page{From: from, Limit: limit}
+	page := &db.Page{From: &from, Limit: limit}
 	for page != nil {
 		builds, pagination, err := job.Builds(*page)
 		if err != nil {

--- a/atc/gc/build_log_collector_test.go
+++ b/atc/gc/build_log_collector_test.go
@@ -107,11 +107,13 @@ var _ = Describe("BuildLogCollector", func() {
 					)
 				})
 				BeforeEach(func() {
+					page1 := db.Page{From: 5, Limit: 5}
+					page2 := db.Page{From: 10, Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sbDrained(10, true), sbDrained(9, false), sbDrained(8, false), sbDrained(7, true), sbDrained(6, false)}, db.Pagination{}, nil
-						} else if page == (db.Page{Until: 10, Limit: 5}) {
-							return []db.Build{sbDrained(11, true)}, db.Pagination{}, nil
+						if page == page1 {
+							return []db.Build{sbDrained(9, false), sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, true)}, db.Pagination{Newer: &page2}, nil
+						} else if page == (db.Page{From: 10, Limit: 5}) {
+							return []db.Build{sbDrained(11, true), sbDrained(10, true)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
 						return []db.Build{}, db.Pagination{}, nil
@@ -137,7 +139,7 @@ var _ = Describe("BuildLogCollector", func() {
 				It("should reap builds which have been drained", func() {
 					Expect(fakePipeline.DeleteBuildEventsByBuildIDsCallCount()).To(Equal(1))
 
-					Expect(fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)).To(ConsistOf(7))
+					Expect(fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)).To(ConsistOf(7, 5))
 				})
 
 				It("should update first logged build id to the earliest non-drained build", func() {
@@ -158,10 +160,12 @@ var _ = Describe("BuildLogCollector", func() {
 						buildLogRetainCalc,
 						false,
 					)
+					page1 := db.Page{From: 5, Limit: 5}
+					page2 := db.Page{From: 10, Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sbDrained(9, true), sbDrained(8, false), sbDrained(7, false), sbDrained(6, true), sbDrained(5, false)}, db.Pagination{}, nil
-						} else if page == (db.Page{Until: 9, Limit: 5}) {
+						if page == page1 {
+							return []db.Build{sbDrained(9, true), sbDrained(8, false), sbDrained(7, false), sbDrained(6, true), sbDrained(5, false)}, db.Pagination{Newer: &page2}, nil
+						} else if page == page2 {
 							return []db.Build{sbDrained(10, true)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -189,8 +193,8 @@ var _ = Describe("BuildLogCollector", func() {
 
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sbDrained(8, false), sbDrained(7, true), sbDrained(6, false)}, db.Pagination{}, nil
+						if page == (db.Page{From: 5, Limit: 5}) {
+							return []db.Build{sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, false)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
 						return []db.Build{}, db.Pagination{}, nil
@@ -218,8 +222,8 @@ var _ = Describe("BuildLogCollector", func() {
 
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sbDrained(8, false), sbDrained(7, true), sbDrained(6, false)}, db.Pagination{}, nil
+						if page == (db.Page{From: 5, Limit: 5}) {
+							return []db.Build{sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, false)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
 						return []db.Build{}, db.Pagination{}, nil
@@ -241,17 +245,19 @@ var _ = Describe("BuildLogCollector", func() {
 					fakeJob.ConfigReturns(atc.JobConfig{
 						BuildLogsToRetain: 3,
 					}, nil)
+					page1 := db.Page{From: 5, Limit: 5}
+					page2 := db.Page{From: 10, Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
+						if page == page1 {
 							return []db.Build{
-								sb(10),
 								runningBuild(9),
 								runningBuild(8),
 								sb(7),
 								sb(6),
-							}, db.Pagination{}, nil
-						} else if page == (db.Page{Until: 10, Limit: 5}) {
-							return []db.Build{sb(11)}, db.Pagination{}, nil
+								sb(5),
+							}, db.Pagination{Newer: &page2}, nil
+						} else if page == page2 {
+							return []db.Build{sb(10)}, db.Pagination{}, nil
 						} else {
 							Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
 						}
@@ -271,20 +277,20 @@ var _ = Describe("BuildLogCollector", func() {
 				It("reaps only not-running builds", func() {
 					Expect(fakePipeline.DeleteBuildEventsByBuildIDsCallCount()).To(Equal(1))
 					actualBuildIDs := fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)
-					Expect(actualBuildIDs).To(ConsistOf(6))
+					Expect(actualBuildIDs).To(ConsistOf(5))
 				})
 
 				It("updates FirstLoggedBuildID to earliest non-reaped build", func() {
 					Expect(fakeJob.UpdateFirstLoggedBuildIDCallCount()).To(Equal(1))
 					actualNewFirstLoggedBuildID := fakeJob.UpdateFirstLoggedBuildIDArgsForCall(0)
-					Expect(actualNewFirstLoggedBuildID).To(Equal(7))
+					Expect(actualNewFirstLoggedBuildID).To(Equal(6))
 				})
 			})
 
 			Context("when no builds need to be reaped", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
+						if page == (db.Page{From: 5, Limit: 5}) {
 							return []db.Build{runningBuild(5)}, db.Pagination{}, nil
 						} else {
 							Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -347,8 +353,8 @@ var _ = Describe("BuildLogCollector", func() {
 			Context("when only count is set", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sbTime(7, time.Now().Add(-23*time.Hour)), sbTime(6, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
+						if page == (db.Page{From: 5, Limit: 5}) {
+							return []db.Build{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
 						return nil, db.Pagination{}, nil
@@ -371,17 +377,15 @@ var _ = Describe("BuildLogCollector", func() {
 
 					Expect(fakePipeline.DeleteBuildEventsByBuildIDsCallCount()).To(Equal(1))
 					actualBuildIDs := fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)
-					Expect(actualBuildIDs).To(ConsistOf(6))
+					Expect(actualBuildIDs).To(ConsistOf(5))
 				})
 			})
 
 			Context("when only date is set", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sbTime(7, time.Now().Add(-23*time.Hour)), sbTime(6, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
-						} else if page == (db.Page{Limit: 1}) {
-							return []db.Build{sbTime(7, time.Now().Add(-23*time.Hour))}, db.Pagination{}, nil
+						if page == (db.Page{From: 5, Limit: 5}) {
+							return []db.Build{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
 						return nil, db.Pagination{}, nil
@@ -409,8 +413,8 @@ var _ = Describe("BuildLogCollector", func() {
 			Context("when count and date are set > 0", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sbTime(7, time.Now().Add(-23*time.Hour)), sbTime(6, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
+						if page == (db.Page{From: 5, Limit: 5}) {
+							return []db.Build{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
 						return nil, db.Pagination{}, nil
@@ -433,15 +437,15 @@ var _ = Describe("BuildLogCollector", func() {
 
 					Expect(fakePipeline.DeleteBuildEventsByBuildIDsCallCount()).To(Equal(1))
 					actualBuildIDs := fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)
-					Expect(actualBuildIDs).To(ConsistOf(6))
+					Expect(actualBuildIDs).To(ConsistOf(5))
 				})
 			})
 
 			Context("when only date is set", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sbTime(7, time.Now().Add(-23*time.Hour)), sbTime(6, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
+						if page == (db.Page{From: 5, Limit: 5}) {
+							return []db.Build{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
 						return nil, db.Pagination{}, nil
@@ -464,7 +468,7 @@ var _ = Describe("BuildLogCollector", func() {
 
 					Expect(fakePipeline.DeleteBuildEventsByBuildIDsCallCount()).To(Equal(1))
 					actualBuildIDs := fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)
-					Expect(actualBuildIDs).To(ConsistOf(6))
+					Expect(actualBuildIDs).To(ConsistOf(5))
 				})
 			})
 
@@ -478,12 +482,15 @@ var _ = Describe("BuildLogCollector", func() {
 						},
 					}, nil)
 
+					page1 := db.Page{From: 5, Limit: 5}
+					page2 := db.Page{From: 10, Limit: 5}
+					page3 := db.Page{From: 15, Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sb(9), successBuild(8), sb(7), reapedBuild(6), reapedBuild(5)}, db.Pagination{}, nil
-						} else if page == (db.Page{Until: 9, Limit: 5}) {
-							return []db.Build{sb(14), successBuild(13), sb(12), sb(11), sb(10)}, db.Pagination{}, nil
-						} else if page == (db.Page{Until: 14, Limit: 5}) {
+						if page == page1 {
+							return []db.Build{sb(9), successBuild(8), sb(7), reapedBuild(6), reapedBuild(5)}, db.Pagination{Newer: &page2}, nil
+						} else if page == page2 {
+							return []db.Build{sb(14), successBuild(13), sb(12), sb(11), sb(10)}, db.Pagination{Newer: &page3}, nil
+						} else if page == page3 {
 							return []db.Build{sb(18), sb(17), sb(16), sb(15)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -527,12 +534,15 @@ var _ = Describe("BuildLogCollector", func() {
 						},
 					}, nil)
 
+					page1 := db.Page{From: 5, Limit: 5}
+					page2 := db.Page{From: 10, Limit: 5}
+					page3 := db.Page{From: 15, Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 4, Limit: 5}) {
-							return []db.Build{sb(9), successBuild(8), sb(7), reapedBuild(6), reapedBuild(5)}, db.Pagination{}, nil
-						} else if page == (db.Page{Until: 9, Limit: 5}) {
-							return []db.Build{sb(14), successBuild(13), successBuild(12), sb(11), successBuild(10)}, db.Pagination{}, nil
-						} else if page == (db.Page{Until: 14, Limit: 5}) {
+						if page == page1 {
+							return []db.Build{sb(9), successBuild(8), sb(7), reapedBuild(6), reapedBuild(5)}, db.Pagination{Newer: &page2}, nil
+						} else if page == page2 {
+							return []db.Build{sb(14), successBuild(13), successBuild(12), sb(11), successBuild(10)}, db.Pagination{Newer: &page3}, nil
+						} else if page == page3 {
 							return []db.Build{successBuild(18), sb(17), sb(16), successBuild(15)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -570,58 +580,89 @@ var _ = Describe("BuildLogCollector", func() {
 			})
 		})
 
-		Context("when FirstLoggedBuildID == 1", func() {
-			var fakeJob *dbfakes.FakeJob
+		Context("when the FirstLoggedBuildID has an value", func() {
+			Context("when all the logs get reaped", func() {
+				var fakeJob *dbfakes.FakeJob
 
-			BeforeEach(func() {
-				fakeJob = new(dbfakes.FakeJob)
-				fakeJob.NameReturns("job-1")
-				fakeJob.FirstLoggedBuildIDReturns(1)
-				fakeJob.ConfigReturns(atc.JobConfig{
-					BuildLogsToRetain: 10,
-				}, nil)
-
-				fakePipeline.JobsReturns([]db.Job{fakeJob}, nil)
-			})
-
-			Context("when we install a custom build log retention calculator", func() {
 				BeforeEach(func() {
-					buildLogRetainCalc = NewBuildLogRetentionCalculator(3, 3, 0, 0)
+					fakeJob = new(dbfakes.FakeJob)
+					fakeJob.NameReturns("job-1")
+					fakeJob.FirstLoggedBuildIDReturns(5)
+					fakeJob.ConfigReturns(atc.JobConfig{
+						BuildLogRetention: &atc.BuildLogRetention{
+							Days: 1,
+						},
+					}, nil)
 
-					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{Until: 0, Limit: 5}) {
-							return []db.Build{sb(4), sb(3), sb(2), sb(1)}, db.Pagination{}, nil
-						}
+					fakePipeline.JobsReturns([]db.Job{fakeJob}, nil)
 
-						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
-						return nil, db.Pagination{}, nil
-					}
+					yesterday := time.Now().Add(-30 * time.Hour)
 
-					fakePipeline.DeleteBuildEventsByBuildIDsReturns(nil)
-					fakeJob.UpdateFirstLoggedBuildIDReturns(nil)
+					fakeJob.BuildsReturns([]db.Build{sbTime(9, yesterday), sbTime(8, yesterday), sbTime(7, yesterday), sbTime(6, yesterday), sbTime(5, yesterday)}, db.Pagination{}, nil)
 				})
 
-				It("uses build log calculator", func() {
+				It("FirstLoggedBuildID doesn't get reset to 0", func() {
 					Expect(buildLogCollector.Run(context.TODO())).NotTo(HaveOccurred())
 					Expect(fakePipeline.DeleteBuildEventsByBuildIDsCallCount()).To(Equal(1))
-					Expect(fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)).To(ConsistOf(1))
+					Expect(fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)).To(ConsistOf(9, 8, 7, 6, 5))
+					Expect(fakeJob.UpdateFirstLoggedBuildIDCallCount()).To(Equal(0))
 				})
 			})
 
-			Context("when getting the job builds fails", func() {
-				var disaster error
+			Context("when FirstLoggedBuildID == 1", func() {
+				var fakeJob *dbfakes.FakeJob
 
 				BeforeEach(func() {
-					disaster = errors.New("major malfunction")
+					fakeJob = new(dbfakes.FakeJob)
+					fakeJob.NameReturns("job-1")
+					fakeJob.FirstLoggedBuildIDReturns(1)
+					fakeJob.ConfigReturns(atc.JobConfig{
+						BuildLogsToRetain: 10,
+					}, nil)
 
-					fakeJob.BuildsReturns(nil, db.Pagination{}, disaster)
+					fakePipeline.JobsReturns([]db.Job{fakeJob}, nil)
 				})
 
-				It("returns the error", func() {
-					err := buildLogCollector.Run(context.TODO())
-					Expect(err).To(Equal(disaster))
+				Context("when we install a custom build log retention calculator", func() {
+					BeforeEach(func() {
+						buildLogRetainCalc = NewBuildLogRetentionCalculator(3, 3, 0, 0)
+
+						fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
+							if page == (db.Page{From: 1, Limit: 5}) {
+								return []db.Build{sb(4), sb(3), sb(2), sb(1)}, db.Pagination{}, nil
+							}
+
+							Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
+							return nil, db.Pagination{}, nil
+						}
+
+						fakePipeline.DeleteBuildEventsByBuildIDsReturns(nil)
+						fakeJob.UpdateFirstLoggedBuildIDReturns(nil)
+					})
+
+					It("uses build log calculator", func() {
+						Expect(buildLogCollector.Run(context.TODO())).NotTo(HaveOccurred())
+						Expect(fakePipeline.DeleteBuildEventsByBuildIDsCallCount()).To(Equal(1))
+						Expect(fakePipeline.DeleteBuildEventsByBuildIDsArgsForCall(0)).To(ConsistOf(1))
+					})
+				})
+
+				Context("when getting the job builds fails", func() {
+					var disaster error
+
+					BeforeEach(func() {
+						disaster = errors.New("major malfunction")
+
+						fakeJob.BuildsReturns(nil, db.Pagination{}, disaster)
+					})
+
+					It("returns the error", func() {
+						err := buildLogCollector.Run(context.TODO())
+						Expect(err).To(Equal(disaster))
+					})
 				})
 			})
+
 		})
 
 		Context("when the job says retain 0 builds", func() {
@@ -683,6 +724,7 @@ var _ = Describe("BuildLogCollector", func() {
 			Expect(err).To(Equal(disaster))
 		})
 	})
+
 })
 
 func sb(id int) db.Build {

--- a/atc/gc/build_log_collector_test.go
+++ b/atc/gc/build_log_collector_test.go
@@ -107,12 +107,10 @@ var _ = Describe("BuildLogCollector", func() {
 					)
 				})
 				BeforeEach(func() {
-					page1 := db.Page{From: 5, Limit: 5}
-					page2 := db.Page{From: 10, Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == page1 {
-							return []db.Build{sbDrained(9, false), sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, true)}, db.Pagination{Newer: &page2}, nil
-						} else if page == (db.Page{From: 10, Limit: 5}) {
+						if *page.From == 5 {
+							return []db.Build{sbDrained(9, false), sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, true)}, db.Pagination{Newer: &db.Page{From: db.NewIntPtr(10), Limit: 5}}, nil
+						} else if *page.From == 10 {
 							return []db.Build{sbDrained(11, true), sbDrained(10, true)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -160,12 +158,10 @@ var _ = Describe("BuildLogCollector", func() {
 						buildLogRetainCalc,
 						false,
 					)
-					page1 := db.Page{From: 5, Limit: 5}
-					page2 := db.Page{From: 10, Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == page1 {
-							return []db.Build{sbDrained(9, true), sbDrained(8, false), sbDrained(7, false), sbDrained(6, true), sbDrained(5, false)}, db.Pagination{Newer: &page2}, nil
-						} else if page == page2 {
+						if *page.From == 5 {
+							return []db.Build{sbDrained(9, true), sbDrained(8, false), sbDrained(7, false), sbDrained(6, true), sbDrained(5, false)}, db.Pagination{Newer: &db.Page{From: db.NewIntPtr(10), Limit: 5}}, nil
+						} else if *page.From == 10 {
 							return []db.Build{sbDrained(10, true)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -193,7 +189,7 @@ var _ = Describe("BuildLogCollector", func() {
 
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{From: 5, Limit: 5}) {
+						if *page.From == 5 {
 							return []db.Build{sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, false)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -222,7 +218,7 @@ var _ = Describe("BuildLogCollector", func() {
 
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{From: 5, Limit: 5}) {
+						if *page.From == 5 {
 							return []db.Build{sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, false)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -245,18 +241,16 @@ var _ = Describe("BuildLogCollector", func() {
 					fakeJob.ConfigReturns(atc.JobConfig{
 						BuildLogsToRetain: 3,
 					}, nil)
-					page1 := db.Page{From: 5, Limit: 5}
-					page2 := db.Page{From: 10, Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == page1 {
+						if *page.From == 5 {
 							return []db.Build{
 								runningBuild(9),
 								runningBuild(8),
 								sb(7),
 								sb(6),
 								sb(5),
-							}, db.Pagination{Newer: &page2}, nil
-						} else if page == page2 {
+							}, db.Pagination{Newer: &db.Page{From: db.NewIntPtr(10), Limit: 5}}, nil
+						} else if *page.From == 10 {
 							return []db.Build{sb(10)}, db.Pagination{}, nil
 						} else {
 							Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -290,7 +284,7 @@ var _ = Describe("BuildLogCollector", func() {
 			Context("when no builds need to be reaped", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{From: 5, Limit: 5}) {
+						if *page.From == 5 {
 							return []db.Build{runningBuild(5)}, db.Pagination{}, nil
 						} else {
 							Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -353,7 +347,7 @@ var _ = Describe("BuildLogCollector", func() {
 			Context("when only count is set", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{From: 5, Limit: 5}) {
+						if *page.From == 5 {
 							return []db.Build{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -384,7 +378,7 @@ var _ = Describe("BuildLogCollector", func() {
 			Context("when only date is set", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{From: 5, Limit: 5}) {
+						if *page.From == 5 {
 							return []db.Build{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -413,7 +407,7 @@ var _ = Describe("BuildLogCollector", func() {
 			Context("when count and date are set > 0", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{From: 5, Limit: 5}) {
+						if *page.From == 5 {
 							return []db.Build{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -444,7 +438,7 @@ var _ = Describe("BuildLogCollector", func() {
 			Context("when only date is set", func() {
 				BeforeEach(func() {
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == (db.Page{From: 5, Limit: 5}) {
+						if *page.From == 5 {
 							return []db.Build{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -482,15 +476,15 @@ var _ = Describe("BuildLogCollector", func() {
 						},
 					}, nil)
 
-					page1 := db.Page{From: 5, Limit: 5}
-					page2 := db.Page{From: 10, Limit: 5}
-					page3 := db.Page{From: 15, Limit: 5}
+					page1 := db.Page{From: db.NewIntPtr(5), Limit: 5}
+					page2 := db.Page{From: db.NewIntPtr(10), Limit: 5}
+					page3 := db.Page{From: db.NewIntPtr(15), Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == page1 {
+						if *page.From == *page1.From {
 							return []db.Build{sb(9), successBuild(8), sb(7), reapedBuild(6), reapedBuild(5)}, db.Pagination{Newer: &page2}, nil
-						} else if page == page2 {
+						} else if *page.From == *page2.From {
 							return []db.Build{sb(14), successBuild(13), sb(12), sb(11), sb(10)}, db.Pagination{Newer: &page3}, nil
-						} else if page == page3 {
+						} else if *page.From == *page3.From {
 							return []db.Build{sb(18), sb(17), sb(16), sb(15)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -534,15 +528,15 @@ var _ = Describe("BuildLogCollector", func() {
 						},
 					}, nil)
 
-					page1 := db.Page{From: 5, Limit: 5}
-					page2 := db.Page{From: 10, Limit: 5}
-					page3 := db.Page{From: 15, Limit: 5}
+					page1 := db.Page{From: db.NewIntPtr(5), Limit: 5}
+					page2 := db.Page{From: db.NewIntPtr(10), Limit: 5}
+					page3 := db.Page{From: db.NewIntPtr(15), Limit: 5}
 					fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-						if page == page1 {
+						if *page.From == *page1.From {
 							return []db.Build{sb(9), successBuild(8), sb(7), reapedBuild(6), reapedBuild(5)}, db.Pagination{Newer: &page2}, nil
-						} else if page == page2 {
+						} else if *page.From == *page2.From {
 							return []db.Build{sb(14), successBuild(13), successBuild(12), sb(11), successBuild(10)}, db.Pagination{Newer: &page3}, nil
-						} else if page == page3 {
+						} else if *page.From == *page3.From {
 							return []db.Build{successBuild(18), sb(17), sb(16), successBuild(15)}, db.Pagination{}, nil
 						}
 						Fail(fmt.Sprintf("Builds called with unexpected argument: page=%#v", page))
@@ -628,7 +622,7 @@ var _ = Describe("BuildLogCollector", func() {
 						buildLogRetainCalc = NewBuildLogRetentionCalculator(3, 3, 0, 0)
 
 						fakeJob.BuildsStub = func(page db.Page) ([]db.Build, db.Pagination, error) {
-							if page == (db.Page{From: 1, Limit: 5}) {
+							if *page.From == 1 {
 								return []db.Build{sb(4), sb(3), sb(2), sb(1)}, db.Pagination{}, nil
 							}
 

--- a/atc/pagination.go
+++ b/atc/pagination.go
@@ -5,8 +5,6 @@ const (
 	LinkRelPrevious = "previous"
 
 	PaginationQueryTimestamps = "timestamps"
-	PaginationQuerySince      = "since"
-	PaginationQueryUntil      = "until"
 	PaginationQueryFrom       = "from"
 	PaginationQueryTo         = "to"
 	PaginationQueryLimit      = "limit"

--- a/fly/commands/builds.go
+++ b/fly/commands/builds.go
@@ -250,14 +250,14 @@ func (command *BuildsCommand) validateBuildArguments(timeSince time.Time, page c
 		if err != nil {
 			return page, errors.New("Since time should be in the format: " + inputTimeLayout)
 		}
-		page.Since = int(timeSince.Unix())
+		page.From = int(timeSince.Unix())
 	}
 	if command.Until != "" {
 		timeUntil, err = time.ParseInLocation(inputTimeLayout, command.Until, time.Now().Location())
 		if err != nil {
 			return page, errors.New("Until time should be in the format: " + inputTimeLayout)
 		}
-		page.Until = int(timeUntil.Unix())
+		page.To = int(timeUntil.Unix())
 	}
 	if timeSince.After(timeUntil) && command.Since != "" && command.Until != "" {
 		return page, errors.New("Cannot have --since after --until")

--- a/fly/commands/helpers_test.go
+++ b/fly/commands/helpers_test.go
@@ -220,8 +220,8 @@ var _ = Describe("Helper Functions", func() {
 
 						client.BuildsStub = func(page concourse.Page) ([]atc.Build, concourse.Pagination, error) {
 							var builds []atc.Build
-							if page.Since != 0 {
-								builds = allBuilds[page.Since : page.Since+page.Limit]
+							if page.To != 0 {
+								builds = allBuilds[page.To : page.To+page.Limit]
 							} else {
 								builds = allBuilds[0:page.Limit]
 							}
@@ -229,11 +229,11 @@ var _ = Describe("Helper Functions", func() {
 							pagination := concourse.Pagination{
 								Previous: &concourse.Page{
 									Limit: page.Limit,
-									Until: builds[0].ID,
+									From:  builds[0].ID,
 								},
 								Next: &concourse.Page{
 									Limit: page.Limit,
-									Since: builds[len(builds)-1].ID,
+									To:    builds[len(builds)-1].ID,
 								},
 							}
 

--- a/fly/integration/builds_test.go
+++ b/fly/integration/builds_test.go
@@ -449,7 +449,7 @@ var _ = Describe("Fly CLI", func() {
 					cmdArgs = append(cmdArgs, "--since", since.Format(timeLayout))
 					cmdArgs = append(cmdArgs, "--until", until.Format(timeLayout))
 
-					queryParams = fmt.Sprintf("limit=50&since=%d&until=%d&timestamps=true", since.Unix(), until.Unix())
+					queryParams = fmt.Sprintf("limit=50&from=%d&to=%d&timestamps=true", since.Unix(), until.Unix())
 				})
 
 				It("returns the builds correctly", func() {
@@ -820,7 +820,7 @@ var _ = Describe("Fly CLI", func() {
 				until = time.Date(2020, 11, 2, 0, 0, 0, 0, time.Now().Location())
 
 				expectedURL = "/api/v1/builds"
-				queryParams = fmt.Sprintf("limit=50&since=%d&until=%d&timestamps=true", since.Unix(), until.Unix())
+				queryParams = fmt.Sprintf("limit=50&from=%d&to=%d&timestamps=true", since.Unix(), until.Unix())
 				returnedStatusCode = http.StatusOK
 				returnedBuilds = []atc.Build{
 					{
@@ -969,7 +969,7 @@ var _ = Describe("Fly CLI", func() {
 					cmdArgs = append(cmdArgs, "--since", since.Format(timeLayout))
 					cmdArgs = append(cmdArgs, "--until", until.Format(timeLayout))
 
-					queryParams = fmt.Sprintf("limit=50&since=%d&until=%d&timestamps=true", since.Unix(), until.Unix())
+					queryParams = fmt.Sprintf("limit=50&from=%d&to=%d&timestamps=true", since.Unix(), until.Unix())
 				})
 
 				It("returns the builds correctly", func() {

--- a/go-concourse/concourse/builds_test.go
+++ b/go-concourse/concourse/builds_test.go
@@ -271,7 +271,7 @@ var _ = Describe("ATC Handler Builds", func() {
 			builds, pagination, clientErr = client.Builds(page)
 		})
 
-		Context("when since, until, and limit are 0", func() {
+		Context("when from, to, and limit are 0", func() {
 			BeforeEach(func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -287,31 +287,31 @@ var _ = Describe("ATC Handler Builds", func() {
 			})
 		})
 
-		Context("when since is specified", func() {
+		Context("when from is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Since: 24}
+				page = concourse.Page{From: 24}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "since=24"),
+						ghttp.VerifyRequest("GET", expectedURL, "from=24"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
 			})
 
-			It("calls to get all builds since that id", func() {
+			It("calls to get all builds from that id", func() {
 				Expect(clientErr).NotTo(HaveOccurred())
 				Expect(builds).To(Equal(expectedBuilds))
 			})
 		})
 
-		Context("when since and limit is specified", func() {
+		Context("when from and limit is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Since: 24, Limit: 5}
+				page = concourse.Page{From: 24, Limit: 5}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "since=24&limit=5"),
+						ghttp.VerifyRequest("GET", expectedURL, "from=24&limit=5"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
@@ -323,31 +323,31 @@ var _ = Describe("ATC Handler Builds", func() {
 			})
 		})
 
-		Context("when until is specified", func() {
+		Context("when to is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Until: 26}
+				page = concourse.Page{To: 26}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "until=26"),
+						ghttp.VerifyRequest("GET", expectedURL, "to=26"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
 			})
 
-			It("calls to get all builds until that id", func() {
+			It("calls to get all builds to that id", func() {
 				Expect(clientErr).NotTo(HaveOccurred())
 				Expect(builds).To(Equal(expectedBuilds))
 			})
 		})
 
-		Context("when until and limit is specified", func() {
+		Context("when to and limit is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Until: 26, Limit: 15}
+				page = concourse.Page{To: 26, Limit: 15}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "until=26&limit=15"),
+						ghttp.VerifyRequest("GET", expectedURL, "to=26&limit=15"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
@@ -359,19 +359,19 @@ var _ = Describe("ATC Handler Builds", func() {
 			})
 		})
 
-		Context("when since and until are both specified", func() {
+		Context("when from and to are both specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Since: 24, Until: 26}
+				page = concourse.Page{From: 24, To: 26}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "until=26&since=24"),
+						ghttp.VerifyRequest("GET", expectedURL, "to=26&from=24"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
 			})
 
-			It("sends both the since and the until", func() {
+			It("sends both the from and the to", func() {
 				Expect(clientErr).NotTo(HaveOccurred())
 				Expect(builds).To(Equal(expectedBuilds))
 			})
@@ -402,8 +402,8 @@ var _ = Describe("ATC Handler Builds", func() {
 							ghttp.VerifyRequest("GET", expectedURL),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds, http.Header{
 								"Link": []string{
-									`<http://some-url.com/api/v1/builds?since=452&limit=123>; rel="previous"`,
-									`<http://some-url.com/api/v1/builds?until=254&limit=456>; rel="next"`,
+									`<http://some-url.com/api/v1/builds?from=452&limit=123>; rel="previous"`,
+									`<http://some-url.com/api/v1/builds?to=254&limit=456>; rel="next"`,
 								},
 							}),
 						),
@@ -412,8 +412,8 @@ var _ = Describe("ATC Handler Builds", func() {
 
 				It("returns the pagination data from the header", func() {
 					Expect(clientErr).ToNot(HaveOccurred())
-					Expect(pagination.Previous).To(Equal(&concourse.Page{Since: 452, Limit: 123}))
-					Expect(pagination.Next).To(Equal(&concourse.Page{Until: 254, Limit: 456}))
+					Expect(pagination.Previous).To(Equal(&concourse.Page{From: 452, Limit: 123}))
+					Expect(pagination.Next).To(Equal(&concourse.Page{To: 254, Limit: 456}))
 				})
 			})
 		})
@@ -498,7 +498,7 @@ var _ = Describe("ATC Handler Builds", func() {
 			builds, pagination, teamErr = team.Builds(page)
 		})
 
-		Context("when since, until, and limit are 0", func() {
+		Context("when from, to, and limit are 0", func() {
 			BeforeEach(func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -514,31 +514,31 @@ var _ = Describe("ATC Handler Builds", func() {
 			})
 		})
 
-		Context("when since is specified", func() {
+		Context("when from is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Since: 24}
+				page = concourse.Page{From: 24}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "since=24"),
+						ghttp.VerifyRequest("GET", expectedURL, "from=24"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
 			})
 
-			It("calls to get all builds since that id", func() {
+			It("calls to get all builds from that id", func() {
 				Expect(teamErr).NotTo(HaveOccurred())
 				Expect(builds).To(Equal(expectedBuilds))
 			})
 		})
 
-		Context("when since and limit is specified", func() {
+		Context("when from and limit is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Since: 24, Limit: 5}
+				page = concourse.Page{From: 24, Limit: 5}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "since=24&limit=5"),
+						ghttp.VerifyRequest("GET", expectedURL, "from=24&limit=5"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
@@ -550,31 +550,31 @@ var _ = Describe("ATC Handler Builds", func() {
 			})
 		})
 
-		Context("when until is specified", func() {
+		Context("when to is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Until: 26}
+				page = concourse.Page{To: 26}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "until=26"),
+						ghttp.VerifyRequest("GET", expectedURL, "to=26"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
 			})
 
-			It("calls to get all builds until that id", func() {
+			It("calls to get all builds to that id", func() {
 				Expect(teamErr).NotTo(HaveOccurred())
 				Expect(builds).To(Equal(expectedBuilds))
 			})
 		})
 
-		Context("when until and limit is specified", func() {
+		Context("when to and limit is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Until: 26, Limit: 15}
+				page = concourse.Page{To: 26, Limit: 15}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "until=26&limit=15"),
+						ghttp.VerifyRequest("GET", expectedURL, "to=26&limit=15"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
@@ -586,19 +586,19 @@ var _ = Describe("ATC Handler Builds", func() {
 			})
 		})
 
-		Context("when since and until are both specified", func() {
+		Context("when from and to are both specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Since: 24, Until: 26}
+				page = concourse.Page{From: 24, To: 26}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "until=26&since=24"),
+						ghttp.VerifyRequest("GET", expectedURL, "to=26&from=24"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds),
 					),
 				)
 			})
 
-			It("sends both the since and the until", func() {
+			It("sends both the from and the to", func() {
 				Expect(teamErr).NotTo(HaveOccurred())
 				Expect(builds).To(Equal(expectedBuilds))
 			})
@@ -627,8 +627,8 @@ var _ = Describe("ATC Handler Builds", func() {
 							ghttp.VerifyRequest("GET", expectedURL),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds, http.Header{
 								"Link": []string{
-									`<http://some-url.com/api/v1/builds?since=452&limit=123>; rel="previous"`,
-									`<http://some-url.com/api/v1/builds?until=254&limit=456>; rel="next"`,
+									`<http://some-url.com/api/v1/builds?from=452&limit=123>; rel="previous"`,
+									`<http://some-url.com/api/v1/builds?to=254&limit=456>; rel="next"`,
 								},
 							}),
 						),
@@ -637,8 +637,8 @@ var _ = Describe("ATC Handler Builds", func() {
 
 				It("returns the pagination data from the header", func() {
 					Expect(teamErr).ToNot(HaveOccurred())
-					Expect(pagination.Previous).To(Equal(&concourse.Page{Since: 452, Limit: 123}))
-					Expect(pagination.Next).To(Equal(&concourse.Page{Until: 254, Limit: 456}))
+					Expect(pagination.Previous).To(Equal(&concourse.Page{From: 452, Limit: 123}))
+					Expect(pagination.Next).To(Equal(&concourse.Page{To: 254, Limit: 456}))
 				})
 			})
 		})

--- a/go-concourse/concourse/jobs_test.go
+++ b/go-concourse/concourse/jobs_test.go
@@ -185,7 +185,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 			)
 		})
 
-		Context("when since, until, and limit are 0", func() {
+		Context("when from, to, and limit are 0", func() {
 			BeforeEach(func() {
 				expectedURL = fmt.Sprint("/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/builds")
 			})
@@ -198,14 +198,14 @@ var _ = Describe("ATC Handler Jobs", func() {
 			})
 		})
 
-		Context("when since is specified", func() {
+		Context("when from is specified", func() {
 			BeforeEach(func() {
 				expectedURL = fmt.Sprint("/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/builds")
-				expectedQuery = fmt.Sprint("since=24")
+				expectedQuery = fmt.Sprint("from=24")
 			})
 
-			It("calls to get all builds since that id", func() {
-				builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{Since: 24})
+			It("calls to get all builds from that id", func() {
+				builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{From: 24})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(builds).To(Equal(expectedBuilds))
@@ -213,11 +213,11 @@ var _ = Describe("ATC Handler Jobs", func() {
 
 			Context("and limit is specified", func() {
 				BeforeEach(func() {
-					expectedQuery = fmt.Sprint("since=24&limit=5")
+					expectedQuery = fmt.Sprint("from=24&limit=5")
 				})
 
 				It("appends limit to the url", func() {
-					builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{Since: 24, Limit: 5})
+					builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{From: 24, Limit: 5})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(builds).To(Equal(expectedBuilds))
@@ -225,14 +225,14 @@ var _ = Describe("ATC Handler Jobs", func() {
 			})
 		})
 
-		Context("when until is specified", func() {
+		Context("when to is specified", func() {
 			BeforeEach(func() {
 				expectedURL = fmt.Sprint("/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/builds")
-				expectedQuery = fmt.Sprint("until=26")
+				expectedQuery = fmt.Sprint("to=26")
 			})
 
-			It("calls to get all builds until that id", func() {
-				builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{Until: 26})
+			It("calls to get all builds to that id", func() {
+				builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{To: 26})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(builds).To(Equal(expectedBuilds))
@@ -240,11 +240,11 @@ var _ = Describe("ATC Handler Jobs", func() {
 
 			Context("and limit is specified", func() {
 				BeforeEach(func() {
-					expectedQuery = fmt.Sprint("until=26&limit=15")
+					expectedQuery = fmt.Sprint("to=26&limit=15")
 				})
 
 				It("appends limit to the url", func() {
-					builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{Until: 26, Limit: 15})
+					builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{To: 26, Limit: 15})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(builds).To(Equal(expectedBuilds))
@@ -252,14 +252,14 @@ var _ = Describe("ATC Handler Jobs", func() {
 			})
 		})
 
-		Context("when since and until are both specified", func() {
+		Context("when from and to are both specified", func() {
 			BeforeEach(func() {
 				expectedURL = fmt.Sprint("/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/builds")
-				expectedQuery = fmt.Sprint("until=26&since=24")
+				expectedQuery = fmt.Sprint("to=26&from=24")
 			})
 
-			It("sends both the since and the until", func() {
-				builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{Since: 24, Until: 26})
+			It("sends both the from and the to", func() {
+				builds, _, found, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{From: 24, To: 26})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(builds).To(Equal(expectedBuilds))
@@ -314,8 +314,8 @@ var _ = Describe("ATC Handler Jobs", func() {
 							ghttp.VerifyRequest("GET", expectedURL),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds, http.Header{
 								"Link": []string{
-									`<http://some-url.com/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/builds?since=452&limit=123>; rel="previous"`,
-									`<http://some-url.com/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/builds?until=254&limit=456>; rel="next"`,
+									`<http://some-url.com/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/builds?from=452&limit=123>; rel="previous"`,
+									`<http://some-url.com/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/builds?to=254&limit=456>; rel="next"`,
 								},
 							}),
 						),
@@ -326,8 +326,8 @@ var _ = Describe("ATC Handler Jobs", func() {
 					_, pagination, _, err := team.JobBuilds("mypipeline", "myjob", concourse.Page{})
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(pagination.Previous).To(Equal(&concourse.Page{Since: 452, Limit: 123}))
-					Expect(pagination.Next).To(Equal(&concourse.Page{Until: 254, Limit: 456}))
+					Expect(pagination.Previous).To(Equal(&concourse.Page{From: 452, Limit: 123}))
+					Expect(pagination.Next).To(Equal(&concourse.Page{To: 254, Limit: 456}))
 				})
 			})
 		})

--- a/go-concourse/concourse/pagination.go
+++ b/go-concourse/concourse/pagination.go
@@ -43,8 +43,8 @@ func paginationFromHeaders(header http.Header) (Pagination, error) {
 }
 
 type Page struct {
-	Since      int
-	Until      int
+	From       int
+	To         int
 	Limit      int
 	Timestamps bool
 }
@@ -57,8 +57,8 @@ func pageFromURI(uri string) (Page, error) {
 		return Page{}, err
 	}
 	params := url.Query()
-	page.Since, _ = strconv.Atoi(params.Get("since"))
-	page.Until, _ = strconv.Atoi(params.Get("until"))
+	page.From, _ = strconv.Atoi(params.Get("from"))
+	page.To, _ = strconv.Atoi(params.Get("to"))
 	page.Limit, _ = strconv.Atoi(params.Get("limit"))
 
 	return page, nil
@@ -66,12 +66,12 @@ func pageFromURI(uri string) (Page, error) {
 
 func (p Page) QueryParams() url.Values {
 	queryParams := url.Values{}
-	if p.Until > 0 {
-		queryParams.Add("until", strconv.Itoa(p.Until))
+	if p.From > 0 {
+		queryParams.Add("from", strconv.Itoa(p.From))
 	}
 
-	if p.Since > 0 {
-		queryParams.Add("since", strconv.Itoa(p.Since))
+	if p.To > 0 {
+		queryParams.Add("to", strconv.Itoa(p.To))
 	}
 
 	if p.Limit > 0 {

--- a/go-concourse/concourse/pipelines_test.go
+++ b/go-concourse/concourse/pipelines_test.go
@@ -602,7 +602,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 			)
 		})
 
-		Context("when since, until, and limit are 0", func() {
+		Context("when from, to, and limit are 0", func() {
 			BeforeEach(func() {
 			})
 
@@ -614,13 +614,13 @@ var _ = Describe("ATC Handler Pipelines", func() {
 			})
 		})
 
-		Context("when since is specified", func() {
+		Context("when from is specified", func() {
 			BeforeEach(func() {
-				expectedQuery = fmt.Sprint("since=24")
+				expectedQuery = fmt.Sprint("from=24")
 			})
 
-			It("calls to get all builds since that id", func() {
-				builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{Since: 24})
+			It("calls to get all builds from that id", func() {
+				builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{From: 24})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(builds).To(Equal(expectedBuilds))
@@ -628,11 +628,11 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 			Context("and limit is specified", func() {
 				BeforeEach(func() {
-					expectedQuery = fmt.Sprint("since=24&limit=5")
+					expectedQuery = fmt.Sprint("from=24&limit=5")
 				})
 
 				It("appends limit to the url", func() {
-					builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{Since: 24, Limit: 5})
+					builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{From: 24, Limit: 5})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(builds).To(Equal(expectedBuilds))
@@ -640,13 +640,13 @@ var _ = Describe("ATC Handler Pipelines", func() {
 			})
 		})
 
-		Context("when until is specified", func() {
+		Context("when to is specified", func() {
 			BeforeEach(func() {
-				expectedQuery = fmt.Sprint("until=26")
+				expectedQuery = fmt.Sprint("to=26")
 			})
 
-			It("calls to get all builds until that id", func() {
-				builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{Until: 26})
+			It("calls to get all builds to that id", func() {
+				builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{To: 26})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(builds).To(Equal(expectedBuilds))
@@ -654,11 +654,11 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 			Context("and limit is specified", func() {
 				BeforeEach(func() {
-					expectedQuery = fmt.Sprint("until=26&limit=15")
+					expectedQuery = fmt.Sprint("to=26&limit=15")
 				})
 
 				It("appends limit to the url", func() {
-					builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{Until: 26, Limit: 15})
+					builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{To: 26, Limit: 15})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(builds).To(Equal(expectedBuilds))
@@ -666,13 +666,13 @@ var _ = Describe("ATC Handler Pipelines", func() {
 			})
 		})
 
-		Context("when since and until are both specified", func() {
+		Context("when from and to are both specified", func() {
 			BeforeEach(func() {
-				expectedQuery = fmt.Sprint("until=26&since=24")
+				expectedQuery = fmt.Sprint("to=26&from=24")
 			})
 
-			It("sends both since and until", func() {
-				builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{Since: 24, Until: 26})
+			It("sends both from and to", func() {
+				builds, _, found, err := team.PipelineBuilds("mypipeline", concourse.Page{From: 24, To: 26})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(builds).To(Equal(expectedBuilds))
@@ -721,8 +721,8 @@ var _ = Describe("ATC Handler Pipelines", func() {
 							ghttp.VerifyRequest("GET", expectedURL),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuilds, http.Header{
 								"Link": []string{
-									`<http://some-url.com/api/v1/teams/some-team/pipelines/some-pipeline/builds?since=452&limit=123>; rel="previous"`,
-									`<http://some-url.com/api/v1/teams/some-team/pipelines/some-pipeline/builds?until=254&limit=456>; rel="next"`,
+									`<http://some-url.com/api/v1/teams/some-team/pipelines/some-pipeline/builds?from=452&limit=123>; rel="previous"`,
+									`<http://some-url.com/api/v1/teams/some-team/pipelines/some-pipeline/builds?to=254&limit=456>; rel="next"`,
 								},
 							}),
 						),
@@ -733,8 +733,8 @@ var _ = Describe("ATC Handler Pipelines", func() {
 					_, pagination, _, err := team.PipelineBuilds("mypipeline", concourse.Page{})
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(pagination.Previous).To(Equal(&concourse.Page{Since: 452, Limit: 123}))
-					Expect(pagination.Next).To(Equal(&concourse.Page{Until: 254, Limit: 456}))
+					Expect(pagination.Previous).To(Equal(&concourse.Page{From: 452, Limit: 123}))
+					Expect(pagination.Next).To(Equal(&concourse.Page{To: 254, Limit: 456}))
 				})
 			})
 		})

--- a/go-concourse/concourse/resourceversions_test.go
+++ b/go-concourse/concourse/resourceversions_test.go
@@ -44,7 +44,7 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			versions, pagination, found, clientErr = team.ResourceVersions("mypipeline", "myresource", page, filter)
 		})
 
-		Context("when since, until, and limit are 0", func() {
+		Context("when from, to, and limit are 0", func() {
 			BeforeEach(func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -61,32 +61,32 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			})
 		})
 
-		Context("when since is specified", func() {
+		Context("when from is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Since: 24}
+				page = concourse.Page{From: 24}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "since=24"),
+						ghttp.VerifyRequest("GET", expectedURL, "from=24"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedVersions),
 					),
 				)
 			})
 
-			It("calls to get all versions since that id", func() {
+			It("calls to get all versions from that id", func() {
 				Expect(clientErr).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(versions).To(Equal(expectedVersions))
 			})
 		})
 
-		Context("when since and limit is specified", func() {
+		Context("when from and limit is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Since: 24, Limit: 5}
+				page = concourse.Page{From: 24, Limit: 5}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "since=24&limit=5"),
+						ghttp.VerifyRequest("GET", expectedURL, "from=24&limit=5"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedVersions),
 					),
 				)
@@ -99,32 +99,32 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			})
 		})
 
-		Context("when until is specified", func() {
+		Context("when to is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Until: 26}
+				page = concourse.Page{To: 26}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "until=26"),
+						ghttp.VerifyRequest("GET", expectedURL, "to=26"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedVersions),
 					),
 				)
 			})
 
-			It("calls to get all versions until that id", func() {
+			It("calls to get all versions to that id", func() {
 				Expect(clientErr).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(versions).To(Equal(expectedVersions))
 			})
 		})
 
-		Context("when until and limit is specified", func() {
+		Context("when to and limit is specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Until: 26, Limit: 15}
+				page = concourse.Page{To: 26, Limit: 15}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "until=26&limit=15"),
+						ghttp.VerifyRequest("GET", expectedURL, "to=26&limit=15"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedVersions),
 					),
 				)
@@ -137,19 +137,19 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			})
 		})
 
-		Context("when since and until are both specified", func() {
+		Context("when from and to are both specified", func() {
 			BeforeEach(func() {
-				page = concourse.Page{Since: 24, Until: 26}
+				page = concourse.Page{From: 24, To: 26}
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "until=26&since=24"),
+						ghttp.VerifyRequest("GET", expectedURL, "to=26&from=24"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedVersions),
 					),
 				)
 			})
 
-			It("sends both since and the until", func() {
+			It("sends both from and the to", func() {
 				Expect(clientErr).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(versions).To(Equal(expectedVersions))
@@ -215,8 +215,8 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 							ghttp.VerifyRequest("GET", expectedURL),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, expectedVersions, http.Header{
 								"Link": []string{
-									`<http://some-url.com/api/v1/teams/some-team/pipelines/mypipeline/resources/myresource/versions?since=452&limit=123>; rel="previous"`,
-									`<http://some-url.com/api/v1/teams/some-team/pipelines/mypipeline/resources/myresource/versions?until=254&limit=456>; rel="next"`,
+									`<http://some-url.com/api/v1/teams/some-team/pipelines/mypipeline/resources/myresource/versions?from=452&limit=123>; rel="previous"`,
+									`<http://some-url.com/api/v1/teams/some-team/pipelines/mypipeline/resources/myresource/versions?to=254&limit=456>; rel="next"`,
 								},
 							}),
 						),
@@ -225,8 +225,8 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 
 				It("returns the pagination data from the header", func() {
 					Expect(clientErr).ToNot(HaveOccurred())
-					Expect(pagination.Previous).To(Equal(&concourse.Page{Since: 452, Limit: 123}))
-					Expect(pagination.Next).To(Equal(&concourse.Page{Until: 254, Limit: 456}))
+					Expect(pagination.Previous).To(Equal(&concourse.Page{From: 452, Limit: 123}))
+					Expect(pagination.Next).To(Equal(&concourse.Page{To: 254, Limit: 456}))
 				})
 			})
 		})

--- a/web/elm/src/Api/Pagination.elm
+++ b/web/elm/src/Api/Pagination.elm
@@ -39,20 +39,17 @@ params : Maybe Page -> List Url.Builder.QueryParameter
 params p =
     case p of
         Just { direction, limit } ->
-            [ Url.Builder.int "limit" limit
-            , case direction of
-                Since since ->
-                    Url.Builder.int "since" since
-
-                Until until ->
-                    Url.Builder.int "limit" until
-
+            (case direction of
                 From from ->
-                    Url.Builder.int "limit" from
+                    [ Url.Builder.int "from" from ]
 
                 To to ->
-                    Url.Builder.int "limit" to
-            ]
+                    [ Url.Builder.int "to" to ]
+
+                ToMostRecent ->
+                    []
+            )
+                ++ [ Url.Builder.int "limit" limit ]
 
         Nothing ->
             []
@@ -149,7 +146,4 @@ parsePage url =
                         }
                     )
     in
-    tryDirection Until "until"
-        |> orElse (tryDirection Since "since")
-        |> orElse (tryDirection From "from")
-        |> orElse (tryDirection To "to")
+    tryDirection From "from" |> orElse (tryDirection To "to")

--- a/web/elm/src/Concourse/Pagination.elm
+++ b/web/elm/src/Concourse/Pagination.elm
@@ -7,6 +7,7 @@ module Concourse.Pagination exposing
     , chevronLeft
     , chevronRight
     , equal
+    , isPreviousPage
     )
 
 import Assets
@@ -39,23 +40,19 @@ type Direction
     | ToMostRecent
 
 
-
---directionEqual : Direction -> Direction -> Bool
---directionEqual d1 d2 =
---    case ( d1, d2 ) of
---        ( From p1, From p2 ) ->
---            p1 == p2
---
---        ( To p1, To p2 ) ->
---            p1 == p2
---
---        ( _, _ ) ->
---            False
-
-
 equal : Page -> Page -> Bool
 equal =
     (==)
+
+
+isPreviousPage : Page -> Bool
+isPreviousPage p =
+    case p.direction of
+        From _ ->
+            True
+
+        _ ->
+            False
 
 
 chevronContainer : List (Html.Attribute msg)

--- a/web/elm/src/Concourse/Pagination.elm
+++ b/web/elm/src/Concourse/Pagination.elm
@@ -34,34 +34,28 @@ type alias Page =
 
 
 type Direction
-    = Since Int
-    | Until Int
-    | From Int
+    = From Int
     | To Int
+    | ToMostRecent
 
 
-directionEqual : Direction -> Direction -> Bool
-directionEqual d1 d2 =
-    case ( d1, d2 ) of
-        ( Since p1, Since p2 ) ->
-            p1 == p2
 
-        ( Until p1, Until p2 ) ->
-            p1 == p2
-
-        ( From p1, From p2 ) ->
-            p1 == p2
-
-        ( To p1, To p2 ) ->
-            p1 == p2
-
-        ( _, _ ) ->
-            False
+--directionEqual : Direction -> Direction -> Bool
+--directionEqual d1 d2 =
+--    case ( d1, d2 ) of
+--        ( From p1, From p2 ) ->
+--            p1 == p2
+--
+--        ( To p1, To p2 ) ->
+--            p1 == p2
+--
+--        ( _, _ ) ->
+--            False
 
 
 equal : Page -> Page -> Bool
-equal one two =
-    directionEqual one.direction two.direction
+equal =
+    (==)
 
 
 chevronContainer : List (Html.Attribute msg)

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -24,7 +24,7 @@ type Callback
     | GotCurrentTime Time.Posix
     | GotCurrentTimeZone Time.Zone
     | BuildTriggered (Fetched Concourse.Build)
-    | JobBuildsFetched (Fetched (Paginated Concourse.Build))
+    | JobBuildsFetched (Fetched ( Page, Paginated Concourse.Build ))
     | JobFetched (Fetched Concourse.Job)
     | JobsFetched (Fetched Json.Encode.Value)
     | PipelineFetched (Fetched Concourse.Pipeline)
@@ -35,7 +35,7 @@ type Callback
     | ResourcesFetched (Fetched Json.Encode.Value)
     | BuildResourcesFetched (Fetched ( Int, Concourse.BuildResources ))
     | ResourceFetched (Fetched Concourse.Resource)
-    | VersionedResourcesFetched (Fetched ( Maybe Page, Paginated Concourse.VersionedResource ))
+    | VersionedResourcesFetched (Fetched ( Page, Paginated Concourse.VersionedResource ))
     | ClusterInfoFetched (Fetched Concourse.ClusterInfo)
     | PausedToggled (Fetched ())
     | InputToFetched (Fetched ( VersionId, List Concourse.Build ))

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -228,6 +228,7 @@ runEffect effect key csrfToken =
                 (Just page)
                 Concourse.decodeBuild
                 |> Api.request
+                |> Task.map (\b -> ( page, b ))
                 |> Task.attempt JobBuildsFetched
 
         FetchResource id ->
@@ -248,7 +249,7 @@ runEffect effect key csrfToken =
                 (Just page)
                 Concourse.decodeVersionedResource
                 |> Api.request
-                |> Task.map (\b -> ( Just page, b ))
+                |> Task.map (\b -> ( page, b ))
                 |> Task.attempt VersionedResourcesFetched
 
         FetchResources id ->

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -123,10 +123,10 @@ stickyHeaderConfig =
 type Effect
     = FetchJob Concourse.JobIdentifier
     | FetchJobs Concourse.PipelineIdentifier
-    | FetchJobBuilds Concourse.JobIdentifier (Maybe Page)
+    | FetchJobBuilds Concourse.JobIdentifier Page
     | FetchResource Concourse.ResourceIdentifier
     | FetchCheck Int
-    | FetchVersionedResources Concourse.ResourceIdentifier (Maybe Page)
+    | FetchVersionedResources Concourse.ResourceIdentifier Page
     | FetchResources Concourse.PipelineIdentifier
     | FetchBuildResources Concourse.BuildId
     | FetchPipeline Concourse.PipelineIdentifier
@@ -225,7 +225,7 @@ runEffect effect key csrfToken =
         FetchJobBuilds id page ->
             Api.paginatedGet
                 (Endpoints.JobBuildsList |> Endpoints.Job id)
-                page
+                (Just page)
                 Concourse.decodeBuild
                 |> Api.request
                 |> Task.attempt JobBuildsFetched
@@ -242,13 +242,13 @@ runEffect effect key csrfToken =
                 |> Api.request
                 |> Task.attempt Checked
 
-        FetchVersionedResources id paging ->
+        FetchVersionedResources id page ->
             Api.paginatedGet
                 (Endpoints.ResourceVersionsList |> Endpoints.Resource id)
-                paging
+                (Just page)
                 Concourse.decodeVersionedResource
                 |> Api.request
-                |> Task.map (\b -> ( paging, b ))
+                |> Task.map (\b -> ( Just page, b ))
                 |> Task.attempt VersionedResourcesFetched
 
         FetchResources id ->

--- a/web/elm/src/Resource/Models.elm
+++ b/web/elm/src/Resource/Models.elm
@@ -37,7 +37,7 @@ type alias Model =
         , pinnedVersion : PinnedVersion
         , now : Maybe Time.Posix
         , resourceIdentifier : Concourse.ResourceIdentifier
-        , currentPage : Maybe Page
+        , currentPage : Page
         , versions : Paginated Version
         , pinCommentLoading : Bool
         , textAreaFocused : Bool

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -299,9 +299,6 @@ handleCallback callback session ( model, effects ) =
 
         VersionedResourcesFetched (Ok ( requestedPage, paginated )) ->
             let
-                fetchedPage =
-                    permalink paginated.content
-
                 resourceVersions =
                     { pagination = paginated.pagination
                     , content =
@@ -802,20 +799,6 @@ updateVersion versionID updateFunc model =
             model.versions
     in
     { model | versions = { resourceVersions | content = newVersionsContent } }
-
-
-permalink : List Concourse.VersionedResource -> Page
-permalink versionedResources =
-    case List.head versionedResources of
-        Nothing ->
-            { direction = Concourse.Pagination.ToMostRecent
-            , limit = 100
-            }
-
-        Just version ->
-            { direction = Concourse.Pagination.To version.id
-            , limit = List.length versionedResources
-            }
 
 
 documentTitle : Model -> String

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -18,6 +18,7 @@ module Routes exposing
 
 import Concourse
 import Concourse.Pagination as Pagination exposing (Direction(..))
+import Api.Pagination
 import Dict
 import Maybe.Extra
 import Url
@@ -130,17 +131,17 @@ oneOffBuild =
 
 
 parsePage : Maybe Int -> Maybe Int -> Maybe Int -> Maybe Pagination.Page
-parsePage since until limit =
-    case ( since, until, limit ) of
-        ( Nothing, Just u, Just l ) ->
+parsePage from to limit =
+    case ( from, to, limit ) of
+        ( Nothing, Just t, Just l ) ->
             Just
-                { direction = Pagination.Until u
+                { direction = Pagination.To t
                 , limit = l
                 }
 
-        ( Just s, Nothing, Just l ) ->
+        ( Just f, Nothing, Just l ) ->
             Just
-                { direction = Pagination.Since s
+                { direction = Pagination.From f
                 , limit = l
                 }
 
@@ -151,14 +152,14 @@ parsePage since until limit =
 resource : Parser (Route -> a) a
 resource =
     let
-        resourceHelper teamName pipelineName resourceName since until limit =
+        resourceHelper teamName pipelineName resourceName from to limit =
             Resource
                 { id =
                     { teamName = teamName
                     , pipelineName = pipelineName
                     , resourceName = resourceName
                     }
-                , page = parsePage since until limit
+                , page = parsePage from to limit
                 }
     in
     map resourceHelper
@@ -168,8 +169,8 @@ resource =
             </> string
             </> s "resources"
             </> string
-            <?> Query.int "since"
-            <?> Query.int "until"
+            <?> Query.int "from"
+            <?> Query.int "to"
             <?> Query.int "limit"
         )
 
@@ -177,14 +178,14 @@ resource =
 job : Parser (Route -> a) a
 job =
     let
-        jobHelper teamName pipelineName jobName since until limit =
+        jobHelper teamName pipelineName jobName from to limit =
             Job
                 { id =
                     { teamName = teamName
                     , pipelineName = pipelineName
                     , jobName = jobName
                     }
-                , page = parsePage since until limit
+                , page = parsePage from to limit
                 }
     in
     map jobHelper
@@ -194,8 +195,8 @@ job =
             </> string
             </> s "jobs"
             </> string
-            <?> Query.int "since"
-            <?> Query.int "until"
+            <?> Query.int "from"
+            <?> Query.int "to"
             <?> Query.int "limit"
         )
 
@@ -371,29 +372,6 @@ sitemap =
         ]
 
 
-pageToQueryParams : Maybe Pagination.Page -> List Builder.QueryParameter
-pageToQueryParams page =
-    case page of
-        Nothing ->
-            []
-
-        Just { direction, limit } ->
-            [ case direction of
-                Since id ->
-                    Builder.int "since" id
-
-                Until id ->
-                    Builder.int "until" id
-
-                From id ->
-                    Builder.int "from" id
-
-                To id ->
-                    Builder.int "to" id
-            , Builder.int "limit" limit
-            ]
-
-
 toString : Route -> String
 toString route =
     case route of
@@ -420,7 +398,7 @@ toString route =
                 , "jobs"
                 , id.jobName
                 ]
-                (pageToQueryParams page)
+                (Api.Pagination.params page)
 
         Resource { id, page } ->
             Builder.absolute
@@ -431,7 +409,7 @@ toString route =
                 , "resources"
                 , id.resourceName
                 ]
-                (pageToQueryParams page)
+                (Api.Pagination.params page)
 
         OneOffBuild { id, highlight } ->
             Builder.absolute

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1750,7 +1750,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -1794,7 +1794,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -1847,7 +1847,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -1888,7 +1888,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -1929,7 +1929,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -1971,7 +1971,7 @@ all =
                                             { previousPage = Nothing
                                             , nextPage =
                                                 Just
-                                                    { direction = Until 1
+                                                    { direction = To 1
                                                     , limit = 100
                                                     }
                                             }
@@ -2053,7 +2053,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -2067,7 +2067,7 @@ all =
                         >> Tuple.second
                         >> Expect.equal
                             [ Effects.FetchBuildHistory Data.shortJobId
-                                (Just { direction = Until 1, limit = 100 })
+                                (Just { direction = To 1, limit = 100 })
                             ]
                 , test "scrolling to last build while fetching fetches no more" <|
                     givenBuildFetched
@@ -2079,7 +2079,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -2112,7 +2112,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -2128,7 +2128,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 2
+                                                { direction = To 2
                                                 , limit = 100
                                                 }
                                         }
@@ -2150,7 +2150,7 @@ all =
                         >> Tuple.second
                         >> Common.notContains
                             (Effects.FetchBuildHistory Data.shortJobId
-                                (Just { direction = Until 2, limit = 100 })
+                                (Just { direction = To 2, limit = 100 })
                             )
                 , test "if build is present in history, checks its visibility" <|
                     givenBuildFetched
@@ -2162,7 +2162,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -2182,7 +2182,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -2205,7 +2205,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 1
+                                                { direction = To 1
                                                 , limit = 100
                                                 }
                                         }
@@ -2231,7 +2231,7 @@ all =
                                         { previousPage = Nothing
                                         , nextPage =
                                             Just
-                                                { direction = Until 2
+                                                { direction = To 2
                                                 , limit = 100
                                                 }
                                         }
@@ -2253,7 +2253,7 @@ all =
                         >> Tuple.second
                         >> Expect.equal
                             [ Effects.FetchBuildHistory Data.shortJobId
-                                (Just { direction = Until 2, limit = 100 })
+                                (Just { direction = To 2, limit = 100 })
                             ]
                 , test "trigger build button is styled as a box of the color of the build status" <|
                     givenHistoryAndDetailsFetched

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -209,12 +209,14 @@ all =
                                         ]
                                 in
                                 Ok
-                                    { pagination =
-                                        { previousPage = Nothing
-                                        , nextPage = Nothing
-                                        }
-                                    , content = builds
-                                    }
+                                    ( Job.startingPage
+                                    , { pagination =
+                                            { previousPage = Nothing
+                                            , nextPage = Nothing
+                                            }
+                                      , content = builds
+                                      }
+                                    )
                             )
                         >> Tuple.first
                         >> queryView
@@ -512,12 +514,14 @@ all =
                                     ]
                             in
                             Ok
-                                { pagination =
-                                    { previousPage = Nothing
-                                    , nextPage = Nothing
-                                    }
-                                , content = builds
-                                }
+                                ( Job.startingPage
+                                , { pagination =
+                                        { previousPage = Nothing
+                                        , nextPage = Nothing
+                                        }
+                                  , content = builds
+                                  }
+                                )
                         )
                     >> Tuple.first
                     >> queryView
@@ -548,12 +552,14 @@ all =
                                     ]
                             in
                             Ok
-                                { pagination =
-                                    { previousPage = Nothing
-                                    , nextPage = Nothing
-                                    }
-                                , content = builds
-                                }
+                                ( Job.startingPage
+                                , { pagination =
+                                        { previousPage = Nothing
+                                        , nextPage = Nothing
+                                        }
+                                  , content = builds
+                                  }
+                                )
                         )
                     >> Tuple.first
                     >> queryView
@@ -603,12 +609,14 @@ all =
                                     ]
                             in
                             Ok
-                                { pagination =
-                                    { previousPage = Nothing
-                                    , nextPage = Nothing
-                                    }
-                                , content = builds
-                                }
+                                ( Job.startingPage
+                                , { pagination =
+                                        { previousPage = Nothing
+                                        , nextPage = Nothing
+                                        }
+                                  , content = builds
+                                  }
+                                )
                         )
                     >> Tuple.first
                     >> queryView
@@ -687,12 +695,14 @@ all =
                                     ]
                             in
                             Ok
-                                { pagination =
-                                    { previousPage = Nothing
-                                    , nextPage = Nothing
-                                    }
-                                , content = builds
-                                }
+                                ( Job.startingPage
+                                , { pagination =
+                                        { previousPage = Nothing
+                                        , nextPage = Nothing
+                                        }
+                                  , content = builds
+                                  }
+                                )
                         )
                     >> Tuple.first
                     >> queryView
@@ -772,12 +782,14 @@ all =
                         |> Application.handleCallback
                             (JobBuildsFetched <|
                                 Ok
-                                    { pagination =
-                                        { previousPage = Just prevPage
-                                        , nextPage = Nothing
-                                        }
-                                    , content = builds
-                                    }
+                                    ( Job.startingPage
+                                    , { pagination =
+                                            { previousPage = Just prevPage
+                                            , nextPage = Nothing
+                                            }
+                                      , content = builds
+                                      }
+                                    )
                             )
                         |> Tuple.first
                 , query =
@@ -833,6 +845,30 @@ all =
                     }
                 , hoverable = Message.Message.PreviousPageButton
                 }
+            , test "pagination previous page loads most recent page if less than 100 entries" <|
+                \_ ->
+                    init { disabled = False, paused = False } ()
+                        |> Application.handleCallback
+                            (JobBuildsFetched <|
+                                Ok
+                                    ( { direction = From 1, limit = 100 }
+                                    , { pagination =
+                                            { previousPage = Nothing
+                                            , nextPage = Nothing
+                                            }
+                                      , content = []
+                                      }
+                                    )
+                            )
+                        |> Tuple.second
+                        |> Common.contains
+                            (Effects.FetchJobBuilds
+                                { teamName = "team"
+                                , pipelineName = "pipeline"
+                                , jobName = "job"
+                                }
+                                Job.startingPage
+                            )
             , describe "When fetching builds"
                 [ test "says no builds" <|
                     \_ ->
@@ -840,12 +876,14 @@ all =
                             |> Application.handleCallback
                                 (JobBuildsFetched <|
                                     Ok
-                                        { pagination =
-                                            { previousPage = Nothing
-                                            , nextPage = Nothing
-                                            }
-                                        , content = []
-                                        }
+                                        ( Job.startingPage
+                                        , { pagination =
+                                                { previousPage = Nothing
+                                                , nextPage = Nothing
+                                                }
+                                          , content = []
+                                          }
+                                        )
                                 )
                             |> Tuple.first
                             |> queryView
@@ -877,12 +915,14 @@ all =
                             Job.handleCallback
                                 (JobBuildsFetched <|
                                     Ok
-                                        { content = [ someBuild ]
-                                        , pagination =
-                                            { previousPage = Nothing
-                                            , nextPage = Nothing
-                                            }
-                                        }
+                                        ( Job.startingPage
+                                        , { content = [ someBuild ]
+                                          , pagination =
+                                                { previousPage = Nothing
+                                                , nextPage = Nothing
+                                                }
+                                          }
+                                        )
                                 )
                                 ( defaultModel, [] )
             , test "JobBuildsFetched error" <|
@@ -1012,12 +1052,14 @@ all =
                     >> Application.handleCallback
                         (Callback.JobBuildsFetched <|
                             Ok
-                                { content = [ someBuild ]
-                                , pagination =
-                                    { nextPage = Nothing
-                                    , previousPage = Nothing
-                                    }
-                                }
+                                ( Job.startingPage
+                                , { content = [ someBuild ]
+                                  , pagination =
+                                        { nextPage = Nothing
+                                        , previousPage = Nothing
+                                        }
+                                  }
+                                )
                         )
                     >> Tuple.first
                     >> Application.update
@@ -1039,12 +1081,14 @@ all =
                     >> Application.handleCallback
                         (Callback.JobBuildsFetched <|
                             Ok
-                                { content = [ someBuild ]
-                                , pagination =
-                                    { nextPage = Nothing
-                                    , previousPage = Nothing
-                                    }
-                                }
+                                ( Job.startingPage
+                                , { content = [ someBuild ]
+                                  , pagination =
+                                        { nextPage = Nothing
+                                        , previousPage = Nothing
+                                        }
+                                  }
+                                )
                         )
                     >> Tuple.first
                     >> Application.update

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -739,7 +739,7 @@ all =
             , defineHoverBehaviour <|
                 let
                     urlPath =
-                        "/teams/team/pipelines/pipeline/jobs/job?since=1&limit=1"
+                        "/teams/team/pipelines/pipeline/jobs/job?from=1&limit=1"
                 in
                 { name = "left pagination chevron with previous page"
                 , setup =
@@ -764,7 +764,7 @@ all =
                             ]
 
                         prevPage =
-                            { direction = Since 1
+                            { direction = From 1
                             , limit = 1
                             }
                     in
@@ -773,8 +773,7 @@ all =
                             (JobBuildsFetched <|
                                 Ok
                                     { pagination =
-                                        { previousPage =
-                                            Just prevPage
+                                        { previousPage = Just prevPage
                                         , nextPage = Nothing
                                         }
                                     , content = builds
@@ -854,25 +853,24 @@ all =
                 ]
             , test "JobBuildsFetched" <|
                 \_ ->
-                    let
-                        bwr =
-                            defaultModel.buildsWithResources
-                    in
                     Expect.equal
                         { defaultModel
                             | currentPage =
-                                Just
-                                    { direction = Concourse.Pagination.Since 124
-                                    , limit = 1
-                                    }
+                                { direction = Concourse.Pagination.To 123
+                                , limit = 1
+                                }
                             , buildsWithResources =
-                                { bwr
-                                    | content =
+                                RemoteData.Success
+                                    { content =
                                         [ { build = someBuild
                                           , resources = Nothing
                                           }
                                         ]
-                                }
+                                    , pagination =
+                                        { previousPage = Nothing
+                                        , nextPage = Nothing
+                                        }
+                                    }
                         }
                     <|
                         Tuple.first <|
@@ -1006,7 +1004,7 @@ all =
                         )
                     >> Tuple.second
                     >> Expect.all
-                        [ Common.contains (Effects.FetchJobBuilds jobInfo Nothing)
+                        [ Common.contains (Effects.FetchJobBuilds jobInfo { direction = ToMostRecent, limit = 100 })
                         , Common.contains (Effects.FetchJob jobInfo)
                         ]
             , test "on one-second timer, updates build timestamps" <|

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -3,9 +3,9 @@ module JobTests exposing (all)
 import Application.Application as Application
 import Assets
 import Common exposing (defineHoverBehaviour, queryView)
-import Concourse exposing (Build, BuildId, Job)
+import Concourse exposing (Build)
 import Concourse.BuildStatus exposing (BuildStatus(..))
-import Concourse.Pagination exposing (Direction(..))
+import Concourse.Pagination exposing (Direction(..), Paginated)
 import DashboardTests exposing (darkGrey, iconSelector, middleGrey)
 import Data
 import Dict
@@ -43,98 +43,6 @@ all : Test
 all =
     describe "Job"
         [ describe "update" <|
-            let
-                someJobInfo =
-                    Data.jobId
-                        |> Data.withJobName "some-job"
-                        |> Data.withPipelineName "some-pipeline"
-                        |> Data.withTeamName "some-team"
-
-                jobInfo =
-                    Data.jobId
-
-                someBuild : Build
-                someBuild =
-                    { id = 123
-                    , name = "45"
-                    , job = Just someJobInfo
-                    , status = BuildStatusSucceeded
-                    , duration =
-                        { startedAt = Just <| Time.millisToPosix 0
-                        , finishedAt = Just <| Time.millisToPosix 0
-                        }
-                    , reapTime = Just <| Time.millisToPosix 0
-                    }
-
-                someJob : Concourse.Job
-                someJob =
-                    { name = "some-job"
-                    , pipelineName = "some-pipeline"
-                    , teamName = "some-team"
-                    , nextBuild = Nothing
-                    , finishedBuild = Just someBuild
-                    , transitionBuild = Nothing
-                    , paused = False
-                    , disableManualTrigger = False
-                    , inputs = []
-                    , outputs = []
-                    , groups = []
-                    }
-
-                defaultModel : Job.Model
-                defaultModel =
-                    Job.init
-                        { jobId = someJobInfo
-                        , paging = Nothing
-                        }
-                        |> Tuple.first
-
-                csrfToken : String
-                csrfToken =
-                    "csrf_token"
-
-                flags : Application.Flags
-                flags =
-                    { turbulenceImgSrc = ""
-                    , notFoundImgSrc = ""
-                    , csrfToken = csrfToken
-                    , authToken = ""
-                    , pipelineRunningKeyframes = ""
-                    }
-
-                init :
-                    { disabled : Bool, paused : Bool }
-                    -> ()
-                    -> Application.Model
-                init { disabled, paused } _ =
-                    Common.init "/teams/team/pipelines/pipeline/jobs/job"
-                        |> Application.handleCallback
-                            (JobFetched <|
-                                Ok
-                                    { name = "job"
-                                    , pipelineName = "pipeline"
-                                    , teamName = "team"
-                                    , nextBuild = Nothing
-                                    , finishedBuild = Just someBuild
-                                    , transitionBuild = Nothing
-                                    , paused = paused
-                                    , disableManualTrigger = disabled
-                                    , inputs = []
-                                    , outputs = []
-                                    , groups = []
-                                    }
-                            )
-                        |> Tuple.first
-
-                loadingIndicatorSelector : List Selector.Selector
-                loadingIndicatorSelector =
-                    [ style "animation"
-                        "container-rotate 1568ms linear infinite"
-                    , style "height" "14px"
-                    , style "width" "14px"
-                    , style "margin" "7px"
-                    ]
-            in
             [ describe "while page is loading"
                 [ test "title includes job name" <|
                     \_ ->
@@ -188,35 +96,7 @@ all =
                     init { disabled = False, paused = False }
                         >> Application.handleCallback
                             (JobBuildsFetched <|
-                                let
-                                    jobId =
-                                        Data.jobId
-
-                                    status =
-                                        BuildStatusSucceeded
-
-                                    builds =
-                                        [ { id = 0
-                                          , name = "0"
-                                          , job = Just jobId
-                                          , status = status
-                                          , duration =
-                                                { startedAt = Nothing
-                                                , finishedAt = Nothing
-                                                }
-                                          , reapTime = Nothing
-                                          }
-                                        ]
-                                in
-                                Ok
-                                    ( Job.startingPage
-                                    , { pagination =
-                                            { previousPage = Nothing
-                                            , nextPage = Nothing
-                                            }
-                                      , content = builds
-                                      }
-                                    )
+                                Ok ( Job.startingPage, buildsWithEmptyPagination )
                             )
                         >> Tuple.first
                         >> queryView
@@ -493,35 +373,7 @@ all =
                 init { disabled = False, paused = False }
                     >> Application.handleCallback
                         (JobBuildsFetched <|
-                            let
-                                jobId =
-                                    Data.jobId
-
-                                status =
-                                    BuildStatusSucceeded
-
-                                builds =
-                                    [ { id = 0
-                                      , name = "0"
-                                      , job = Just jobId
-                                      , status = status
-                                      , duration =
-                                            { startedAt = Nothing
-                                            , finishedAt = Nothing
-                                            }
-                                      , reapTime = Nothing
-                                      }
-                                    ]
-                            in
-                            Ok
-                                ( Job.startingPage
-                                , { pagination =
-                                        { previousPage = Nothing
-                                        , nextPage = Nothing
-                                        }
-                                  , content = builds
-                                  }
-                                )
+                            Ok ( Job.startingPage, buildsWithEmptyPagination )
                         )
                     >> Tuple.first
                     >> queryView
@@ -531,35 +383,7 @@ all =
                 init { disabled = False, paused = False }
                     >> Application.handleCallback
                         (JobBuildsFetched <|
-                            let
-                                jobId =
-                                    Data.jobId
-
-                                status =
-                                    BuildStatusSucceeded
-
-                                builds =
-                                    [ { id = 0
-                                      , name = "0"
-                                      , job = Just jobId
-                                      , status = status
-                                      , duration =
-                                            { startedAt = Nothing
-                                            , finishedAt = Nothing
-                                            }
-                                      , reapTime = Nothing
-                                      }
-                                    ]
-                            in
-                            Ok
-                                ( Job.startingPage
-                                , { pagination =
-                                        { previousPage = Nothing
-                                        , nextPage = Nothing
-                                        }
-                                  , content = builds
-                                  }
-                                )
+                            Ok ( Job.startingPage, buildsWithEmptyPagination )
                         )
                     >> Tuple.first
                     >> queryView
@@ -588,35 +412,7 @@ all =
                 init { disabled = False, paused = False }
                     >> Application.handleCallback
                         (JobBuildsFetched <|
-                            let
-                                jobId =
-                                    Data.jobId
-
-                                status =
-                                    BuildStatusSucceeded
-
-                                builds =
-                                    [ { id = 0
-                                      , name = "0"
-                                      , job = Just jobId
-                                      , status = status
-                                      , duration =
-                                            { startedAt = Nothing
-                                            , finishedAt = Nothing
-                                            }
-                                      , reapTime = Nothing
-                                      }
-                                    ]
-                            in
-                            Ok
-                                ( Job.startingPage
-                                , { pagination =
-                                        { previousPage = Nothing
-                                        , nextPage = Nothing
-                                        }
-                                  , content = builds
-                                  }
-                                )
+                            Ok ( Job.startingPage, buildsWithEmptyPagination )
                         )
                     >> Tuple.first
                     >> queryView
@@ -674,35 +470,7 @@ all =
                 init { disabled = False, paused = False }
                     >> Application.handleCallback
                         (JobBuildsFetched <|
-                            let
-                                jobId =
-                                    Data.jobId
-
-                                status =
-                                    BuildStatusSucceeded
-
-                                builds =
-                                    [ { id = 0
-                                      , name = "0"
-                                      , job = Just jobId
-                                      , status = status
-                                      , duration =
-                                            { startedAt = Nothing
-                                            , finishedAt = Nothing
-                                            }
-                                      , reapTime = Nothing
-                                      }
-                                    ]
-                            in
-                            Ok
-                                ( Job.startingPage
-                                , { pagination =
-                                        { previousPage = Nothing
-                                        , nextPage = Nothing
-                                        }
-                                  , content = builds
-                                  }
-                                )
+                            Ok ( Job.startingPage, buildsWithEmptyPagination )
                         )
                     >> Tuple.first
                     >> queryView
@@ -754,25 +522,6 @@ all =
                 { name = "left pagination chevron with previous page"
                 , setup =
                     let
-                        jobId =
-                            Data.jobId
-
-                        status =
-                            BuildStatusSucceeded
-
-                        builds =
-                            [ { id = 0
-                              , name = "0"
-                              , job = Just jobId
-                              , status = status
-                              , duration =
-                                    { startedAt = Nothing
-                                    , finishedAt = Nothing
-                                    }
-                              , reapTime = Nothing
-                              }
-                            ]
-
                         prevPage =
                             { direction = From 1
                             , limit = 1
@@ -847,11 +596,15 @@ all =
                 }
             , test "pagination previous page loads most recent page if less than 100 entries" <|
                 \_ ->
+                    let
+                        previousPage =
+                            { direction = From 1, limit = 100 }
+                    in
                     init { disabled = False, paused = False } ()
                         |> Application.handleCallback
                             (JobBuildsFetched <|
                                 Ok
-                                    ( { direction = From 1, limit = 100 }
+                                    ( previousPage
                                     , { pagination =
                                             { previousPage = Nothing
                                             , nextPage = Nothing
@@ -1112,3 +865,112 @@ darkGreen =
 brightGreen : String
 brightGreen =
     "#11c560"
+
+
+someJobInfo : Concourse.JobIdentifier
+someJobInfo =
+    Data.jobId
+        |> Data.withJobName "some-job"
+        |> Data.withPipelineName "some-pipeline"
+        |> Data.withTeamName "some-team"
+
+
+someBuild : Build
+someBuild =
+    { id = 123
+    , name = "45"
+    , job = Just someJobInfo
+    , status = BuildStatusSucceeded
+    , duration =
+        { startedAt = Just <| Time.millisToPosix 0
+        , finishedAt = Just <| Time.millisToPosix 0
+        }
+    , reapTime = Just <| Time.millisToPosix 0
+    }
+
+
+jobInfo : Concourse.JobIdentifier
+jobInfo =
+    Data.jobId
+
+
+builds : List Build
+builds =
+    [ { id = 0
+      , name = "0"
+      , job = Just jobInfo
+      , status = BuildStatusSucceeded
+      , duration =
+            { startedAt = Nothing
+            , finishedAt = Nothing
+            }
+      , reapTime = Nothing
+      }
+    ]
+
+
+buildsWithEmptyPagination : Paginated Build
+buildsWithEmptyPagination =
+    { content = builds
+    , pagination =
+        { previousPage = Nothing
+        , nextPage = Nothing
+        }
+    }
+
+
+someJob : Concourse.Job
+someJob =
+    { name = "some-job"
+    , pipelineName = "some-pipeline"
+    , teamName = "some-team"
+    , nextBuild = Nothing
+    , finishedBuild = Just someBuild
+    , transitionBuild = Nothing
+    , paused = False
+    , disableManualTrigger = False
+    , inputs = []
+    , outputs = []
+    , groups = []
+    }
+
+
+defaultModel : Job.Model
+defaultModel =
+    Job.init
+        { jobId = someJobInfo
+        , paging = Nothing
+        }
+        |> Tuple.first
+
+
+init : { disabled : Bool, paused : Bool } -> () -> Application.Model
+init { disabled, paused } _ =
+    Common.init "/teams/team/pipelines/pipeline/jobs/job"
+        |> Application.handleCallback
+            (JobFetched <|
+                Ok
+                    { name = "job"
+                    , pipelineName = "pipeline"
+                    , teamName = "team"
+                    , nextBuild = Nothing
+                    , finishedBuild = Just someBuild
+                    , transitionBuild = Nothing
+                    , paused = paused
+                    , disableManualTrigger = disabled
+                    , inputs = []
+                    , outputs = []
+                    , groups = []
+                    }
+            )
+        |> Tuple.first
+
+
+loadingIndicatorSelector : List Selector.Selector
+loadingIndicatorSelector =
+    [ style "animation"
+        "container-rotate 1568ms linear infinite"
+    , style "height" "14px"
+    , style "width" "14px"
+    , style "margin" "7px"
+    ]

--- a/web/elm/tests/PaginationTests.elm
+++ b/web/elm/tests/PaginationTests.elm
@@ -29,7 +29,7 @@ all =
                         |> Api.Pagination.parseLinks
                         |> Expect.equal
                             { previousPage =
-                                Just { direction = Until 1, limit = 2 }
+                                Just { direction = From 1, limit = 2 }
                             , nextPage = Nothing
                             }
             , test "with a Link rel=\"next\" present" <|
@@ -39,7 +39,7 @@ all =
                         |> Expect.equal
                             { previousPage = Nothing
                             , nextPage =
-                                Just { direction = Since 1, limit = 2 }
+                                Just { direction = To 1, limit = 2 }
                             }
             , test "with a Link rel=\"previous\" and a Link rel=\"next\" present" <|
                 \_ ->
@@ -47,9 +47,9 @@ all =
                         |> Api.Pagination.parseLinks
                         |> Expect.equal
                             { previousPage =
-                                Just { direction = Until 1, limit = 2 }
+                                Just { direction = From 3, limit = 2 }
                             , nextPage =
-                                Just { direction = Since 3, limit = 4 }
+                                Just { direction = To 1, limit = 4 }
                             }
             , test "with malformed link header" <|
                 \_ ->
@@ -76,7 +76,7 @@ withPreviousLink : Dict String String
 withPreviousLink =
     Dict.fromList
         [ ( "Link"
-          , "<https://example.com/previous?until=1&limit=2>; rel=\"previous\""
+          , "<https://example.com/previous?from=1&limit=2>; rel=\"previous\""
           )
         ]
 
@@ -85,7 +85,7 @@ withNextLink : Dict String String
 withNextLink =
     Dict.fromList
         [ ( "Link"
-          , "<https://example.com/next?since=1&limit=2>; rel=\"next\""
+          , "<https://example.com/next?to=1&limit=2>; rel=\"next\""
           )
         ]
 
@@ -94,8 +94,8 @@ withPreviousAndNextLink : Dict String String
 withPreviousAndNextLink =
     Dict.fromList
         [ ( "link"
-          , "<https://example.com/previous?until=1&limit=2>; rel=\"previous\""
-                ++ ", <https://example.com/next?since=3&limit=4>; rel=\"next\""
+          , "<https://example.com/previous?from=3&limit=2>; rel=\"previous\""
+                ++ ", <https://example.com/next?to=1&limit=4>; rel=\"next\""
           )
         ]
 

--- a/web/elm/tests/ResourceFeature.elm
+++ b/web/elm/tests/ResourceFeature.elm
@@ -10,6 +10,7 @@ import Message.Callback as Callback
 import Message.Effects as Effects
 import Message.Message as Message exposing (DomID(..))
 import Message.TopLevelMessage exposing (TopLevelMessage(..))
+import Resource.Resource as Resource
 import Test exposing (Test, describe, test)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
@@ -56,7 +57,7 @@ theResourceIsAlreadyPinned =
         >> Application.handleCallback
             (Callback.VersionedResourcesFetched <|
                 Ok
-                    ( Nothing
+                    ( Resource.startingPage
                     , { content =
                             [ Data.versionedResource pinnedVersion 0
                             , Data.versionedResource notThePinnedVersion 1

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -10,7 +10,6 @@ import Concourse.Pagination exposing (Direction(..), Page, Pagination)
 import DashboardTests
     exposing
         ( almostBlack
-        , darkGrey
         , iconSelector
         , middleGrey
         )
@@ -19,7 +18,6 @@ import Dict
 import Expect exposing (..)
 import HoverState
 import Html.Attributes as Attr
-import Http
 import Keyboard
 import Message.Callback as Callback exposing (Callback(..))
 import Message.Effects as Effects
@@ -55,11 +53,6 @@ import Time
 import Url
 import UserState exposing (UserState(..))
 import Views.Styles
-
-
-commentButtonBlue : String
-commentButtonBlue =
-    "#196ac8"
 
 
 teamName : String
@@ -115,16 +108,6 @@ disabledVersion =
 purpleHex : String
 purpleHex =
     "#5c3bd1"
-
-
-fadedBlackHex : String
-fadedBlackHex =
-    "#1e1d1d80"
-
-
-almostWhiteHex : String
-almostWhiteHex =
-    "#e6e7e8"
 
 
 lightGreyHex : String
@@ -575,11 +558,13 @@ all =
                         }
                     , test "pagination previous loads most recent if less than 100 entries" <|
                         \_ ->
+                            let
+                                previousPage =
+                                    { direction = From 1, limit = 100 }
+                            in
                             init
                                 |> givenResourceIsNotPinned
-                                |> givenVersionsWithPages
-                                     { direction = From 1, limit = 100 }
-                                    { nextPage = Nothing, previousPage = Nothing }
+                                |> givenVersionsWithPages previousPage emptyPagination
                                 |> Tuple.second
                                 |> Common.contains
                                     (Effects.FetchVersionedResources
@@ -1309,10 +1294,7 @@ all =
                                                   , enabled = False
                                                   }
                                                 ]
-                                          , pagination =
-                                                { previousPage = Nothing
-                                                , nextPage = Nothing
-                                                }
+                                          , pagination = emptyPagination
                                           }
                                         )
                                 )
@@ -1369,10 +1351,7 @@ all =
                                                   , enabled = False
                                                   }
                                                 ]
-                                          , pagination =
-                                                { previousPage = Nothing
-                                                , nextPage = Nothing
-                                                }
+                                          , pagination = emptyPagination
                                           }
                                         )
                                 )
@@ -1431,10 +1410,7 @@ all =
                                                   , enabled = False
                                                   }
                                                 ]
-                                          , pagination =
-                                                { previousPage = Nothing
-                                                , nextPage = Nothing
-                                                }
+                                          , pagination = emptyPagination
                                           }
                                         )
                                 )
@@ -1496,10 +1472,7 @@ all =
                                                   , enabled = False
                                                   }
                                                 ]
-                                          , pagination =
-                                                { previousPage = Nothing
-                                                , nextPage = Nothing
-                                                }
+                                          , pagination = emptyPagination
                                           }
                                         )
                                 )
@@ -3503,6 +3476,11 @@ clickToDisable vid =
         >> Tuple.first
 
 
+emptyPagination : Pagination
+emptyPagination =
+    { nextPage = Nothing, previousPage = Nothing }
+
+
 givenVersionsWithPages : Page -> Concourse.Pagination.Pagination -> Application.Model -> ( Application.Model, List Effects.Effect )
 givenVersionsWithPages requestedPage pagination =
     Application.handleCallback
@@ -3534,10 +3512,7 @@ givenVersionsWithPages requestedPage pagination =
 
 givenVersionsWithoutPagination : Application.Model -> Application.Model
 givenVersionsWithoutPagination =
-    givenVersionsWithPages Resource.startingPage
-        { previousPage = Nothing
-        , nextPage = Nothing
-        }
+    givenVersionsWithPages Resource.startingPage emptyPagination
         >> Tuple.first
 
 
@@ -3707,11 +3682,6 @@ hasCheckbox =
 purpleOutlineSelector : List Selector
 purpleOutlineSelector =
     [ style "border" <| "1px solid " ++ purpleHex ]
-
-
-redOutlineSelector : List Selector
-redOutlineSelector =
-    [ style "border" <| "1px solid " ++ failureRed ]
 
 
 findLast : List Selector -> Query.Single msg -> Query.Single msg

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -6,7 +6,7 @@ import Assets
 import Common exposing (defineHoverBehaviour, queryView)
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
-import Concourse.Pagination exposing (Direction(..))
+import Concourse.Pagination exposing (Direction(..), Page)
 import DashboardTests
     exposing
         ( almostBlack
@@ -240,7 +240,10 @@ all =
                     |> Tuple.second
                     |> Expect.all
                         [ Common.contains (Effects.FetchResource Data.resourceId)
-                        , Common.contains (Effects.FetchVersionedResources Data.resourceId Nothing)
+                        , Common.contains
+                            (Effects.FetchVersionedResources Data.resourceId
+                                Resource.startingPage
+                            )
                         ]
         , test "autorefresh respects expanded state" <|
             \_ ->
@@ -510,7 +513,7 @@ all =
                     , defineHoverBehaviour <|
                         let
                             urlPath =
-                                "/teams/team/pipelines/pipeline/resources/resource?since=1&limit=1"
+                                "/teams/team/pipelines/pipeline/resources/resource?from=100&limit=1"
                         in
                         { name = "left pagination chevron with previous page"
                         , setup =
@@ -3062,7 +3065,7 @@ all =
                             |> Tuple.second
                             |> Expect.equal
                                 [ Effects.FetchResource Data.resourceId
-                                , Effects.FetchVersionedResources Data.resourceId Nothing
+                                , Effects.FetchVersionedResources Data.resourceId Resource.startingPage
                                 ]
                 , test "when check resolves unsuccessfully, status is error" <|
                     \_ ->
@@ -3543,12 +3546,12 @@ givenVersionsWithPagination =
                   , pagination =
                         { previousPage =
                             Just
-                                { direction = Since 1
+                                { direction = From 100
                                 , limit = 1
                                 }
                         , nextPage =
                             Just
-                                { direction = Since 100
+                                { direction = To 1
                                 , limit = 1
                                 }
                         }


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #5977 

## Changes proposed by this PR:

Since/until used to be chronologically right to left, they're replaced by from/to which is now chronologically left to right:

Given we have build ids: `1, 2, 3, 4, 5, 6, 7`
`since=4` would give us: `3, 2, 1` and `until=4` would give: `7, 6, 5`
`from=4` would give us: `7, 6, 5, 4` and `to=4` would give: `4, 3, 2, 1`

- replace since/until with from/to in atc, go-concourse, and web (fly keeps it as it's used in different meaning there)
- from/to are now int pointers to differentiate between default value `nil`, and explicit `0`
- as a result of above changes, build reaper no longer misses builds
- fixed the left chevron always directing to the starting page for resource versions and job builds page
- fixed edge case where the left chevron would lead to 

## Notes to reviewer:
Reviewing commit by commit is probably better

## Release Note
- Fixed the build reaper missing builds
- Fixed pagination bugs on the resource version and job builds pages

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
