### PR TITLE
Custom background image

### DIFF
--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -45,6 +45,9 @@ var _ = Describe("Pipelines API", func() {
 				Resources: []string{"resource3", "resource4"},
 			},
 		})
+		publicPipeline.DisplayReturns(&atc.DisplayConfig{
+			BackgroundImage: "background.jpg",
+		})
 		publicPipeline.LastUpdatedReturns(time.Unix(1, 0))
 
 		anotherPublicPipeline = new(dbfakes.FakePipeline)
@@ -131,7 +134,10 @@ var _ = Describe("Pipelines API", func() {
 							"jobs": ["job3", "job4"],
 							"resources": ["resource3", "resource4"]
 						}
-					]
+					],
+					"display": {
+						"background_image": "background.jpg"
+					}
 				},
 				{
 					"id": 2,
@@ -299,7 +305,10 @@ var _ = Describe("Pipelines API", func() {
 								"jobs": ["job3", "job4"],
 								"resources": ["resource3", "resource4"]
 							}
-						]
+						],
+						"display": {
+							"background_image": "background.jpg"
+						}
 					}
 				]`))
 			})
@@ -387,6 +396,9 @@ var _ = Describe("Pipelines API", func() {
 					Resources: []string{"resource3", "resource4"},
 				},
 			})
+			fakePipeline.DisplayReturns(&atc.DisplayConfig{
+				BackgroundImage: "background.jpg",
+			})
 			fakePipeline.LastUpdatedReturns(time.Unix(1, 0))
 		})
 
@@ -452,7 +464,10 @@ var _ = Describe("Pipelines API", func() {
 								"jobs": ["job3", "job4"],
 								"resources": ["resource3", "resource4"]
 							}
-						]
+						],
+						"display": {
+							"background_image": "background.jpg"
+						}
 					}`))
 			})
 		})

--- a/atc/api/present/pipeline.go
+++ b/atc/api/present/pipeline.go
@@ -14,6 +14,7 @@ func Pipeline(savedPipeline db.Pipeline) atc.Pipeline {
 		Public:      savedPipeline.Public(),
 		Archived:    savedPipeline.Archived(),
 		Groups:      savedPipeline.Groups(),
+		Display:     savedPipeline.Display(),
 		LastUpdated: savedPipeline.LastUpdated().Unix(),
 	}
 }

--- a/atc/config.go
+++ b/atc/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Resources     ResourceConfigs  `json:"resources,omitempty"`
 	ResourceTypes ResourceTypes    `json:"resource_types,omitempty"`
 	Jobs          JobConfigs       `json:"jobs,omitempty"`
+	Display       *DisplayConfig   `json:"display,omitempty"`
 }
 
 func UnmarshalConfig(payload []byte, config interface{}) error {
@@ -32,6 +33,7 @@ func UnmarshalConfig(payload []byte, config interface{}) error {
 		Resources     interface{} `json:"resources,omitempty"`
 		ResourceTypes interface{} `json:"resource_types,omitempty"`
 		Jobs          interface{} `json:"jobs,omitempty"`
+		Display       interface{} `json:"display,omitempty"`
 	}
 
 	var stripped skeletonConfig
@@ -195,6 +197,10 @@ type ResourceType struct {
 	CheckSetupError      string `json:"check_setup_error,omitempty"`
 	CheckError           string `json:"check_error,omitempty"`
 	UniqueVersionHistory bool   `json:"unique_version_history,omitempty"`
+}
+
+type DisplayConfig struct {
+	BackgroundImage string `json:"background_image,omitempty"`
 }
 
 type ResourceTypes []ResourceType

--- a/atc/config_diff_test.go
+++ b/atc/config_diff_test.go
@@ -1,0 +1,219 @@
+package atc_test
+
+import (
+	. "github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("Config diff", func() {
+	Describe("job config", func() {
+		var job JobConfig
+		BeforeEach(func() {
+			job = JobConfig{
+				Name: "some-job",
+				PlanSequence: []Step{
+					Step{
+						Config: &GetStep{
+							Name:     "some-name",
+							Resource: "some-resource",
+							Trigger:  true,
+						},
+					},
+				},
+			}
+		})
+
+		Context("when there are no jobs", func() {
+			It("does not print anything about jobs", func() {
+				buffer := NewBuffer()
+				diff := Config{}.Diff(buffer, Config{})
+				Expect(diff).To(BeFalse())
+				Consistently(buffer).ShouldNot(Say("jobs"))
+			})
+		})
+
+		Context("when a job is added", func() {
+			It("says config has been added", func() {
+				buffer := NewBuffer()
+				newConfig := Config{
+					Jobs: []JobConfig{job},
+				}
+				diff := Config{}.Diff(buffer, newConfig)
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("job some-job has been added:"))
+				Eventually(buffer).Should(Say(`\+.*name: some-job`))
+				Eventually(buffer).Should(Say(`\+.*plan:`))
+				Eventually(buffer).Should(Say(`\+.*- get: some-name`))
+				Eventually(buffer).Should(Say(`\+.*  resource: some-resource`))
+				Eventually(buffer).Should(Say(`\+.*  trigger: true`))
+			})
+		})
+
+		Context("when display config is removed", func() {
+			It("says config has been removed", func() {
+				buffer := NewBuffer()
+				oldConfig := Config{
+					Jobs: []JobConfig{job},
+				}
+				diff := oldConfig.Diff(buffer, Config{})
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("job some-job has been removed:"))
+				Eventually(buffer).Should(Say(`-.*name: some-job`))
+				Eventually(buffer).Should(Say(`-.*plan:`))
+				Eventually(buffer).Should(Say(`-.*- get: some-name`))
+				Eventually(buffer).Should(Say(`-.*  resource: some-resource`))
+				Eventually(buffer).Should(Say(`-.*  trigger: true`))
+			})
+		})
+
+		Context("when there are no jobs to change", func() {
+			It("says there are no changes to apply", func() {
+				oldConfig := Config{
+					Jobs: []JobConfig{job},
+				}
+				newConfig := Config{
+					Jobs: []JobConfig{job},
+				}
+
+				diff := oldConfig.Diff(GinkgoWriter, newConfig)
+				Expect(diff).To(BeFalse())
+			})
+		})
+
+		Context("when a single field changes", func() {
+			It("removes the field if it has a default value", func() {
+				oldConfig := Config{
+					Jobs: []JobConfig{job},
+				}
+				newJob := JobConfig{
+					Name: "some-job",
+					PlanSequence: []Step{
+						Step{
+							Config: &GetStep{
+								Name:     "some-name",
+								Resource: "some-resource",
+								Trigger:  false,
+							},
+						},
+					},
+				}
+				newConfig := Config{
+					Jobs: []JobConfig{newJob},
+				}
+
+				buffer := NewBuffer()
+				diff := oldConfig.Diff(buffer, newConfig)
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("job some-job has changed:"))
+				Eventually(buffer).Should(Say(`-.* trigger: true`))
+			})
+
+			It("replaces the field if it does not have a default value", func() {
+				oldConfig := Config{
+					Jobs: []JobConfig{job},
+				}
+				newJob := JobConfig{
+					Name: "some-job",
+					PlanSequence: []Step{
+						Step{
+							Config: &GetStep{
+								Name:     "some-name",
+								Resource: "some-other-resource",
+								Trigger:  true,
+							},
+						},
+					},
+				}
+				newConfig := Config{
+					Jobs: []JobConfig{newJob},
+				}
+
+				buffer := NewBuffer()
+				diff := oldConfig.Diff(buffer, newConfig)
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("job some-job has changed:"))
+				Eventually(buffer).Should(Say(`-.* resource: some-resource`))
+				Eventually(buffer).Should(Say(`\+.* resource: some-other-resource`))
+			})
+		})
+	})
+
+	Describe("display config", func() {
+		var display DisplayConfig
+		BeforeEach(func() {
+			display = DisplayConfig{
+				BackgroundImage: "some-background.jpg",
+			}
+		})
+		Context("when there is no display config", func() {
+			It("does not print anything about display config", func() {
+				buffer := NewBuffer()
+				diff := Config{}.Diff(buffer, Config{})
+				Expect(diff).To(BeFalse())
+				Consistently(buffer).ShouldNot(Say("display"))
+			})
+		})
+
+		Context("when display config is added", func() {
+			It("says config has been added", func() {
+				buffer := NewBuffer()
+				newConfig := Config{
+					Display: &display,
+				}
+				diff := Config{}.Diff(buffer, newConfig)
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("display configuration has been added:"))
+				Eventually(buffer).Should(Say(`\+.*background_image: some-background.jpg`))
+			})
+		})
+
+		Context("when display config is removed", func() {
+			It("says config has been removed", func() {
+				buffer := NewBuffer()
+				oldConfig := Config{
+					Display: &display,
+				}
+				diff := oldConfig.Diff(buffer, Config{})
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("display configuration has been removed:"))
+				Eventually(buffer).Should(Say(`-.*background_image: some-background.jpg`))
+			})
+		})
+
+		Context("when there is no display config to change", func() {
+			It("says there are no changes to apply", func() {
+				oldConfig := Config{
+					Display: &display,
+				}
+				newConfig := Config{
+					Display: &display,
+				}
+
+				diff := oldConfig.Diff(GinkgoWriter, newConfig)
+				Expect(diff).To(BeFalse())
+			})
+		})
+
+		Context("when the background changes", func() {
+			It("replaces the background", func() {
+				oldConfig := Config{
+					Display: &display,
+				}
+				newConfig := Config{
+					Display: &DisplayConfig{
+						BackgroundImage: "some-other-background.jpg",
+					},
+				}
+
+				buffer := NewBuffer()
+				diff := oldConfig.Diff(buffer, newConfig)
+				Expect(diff).To(BeTrue())
+				Eventually(buffer).Should(Say("display configuration has changed:"))
+				Eventually(buffer).Should(Say("-.*background_image: some-background.jpg"))
+				Eventually(buffer).Should(Say(`\+.*background_image: some-other-background.jpg`))
+			})
+		})
+	})
+})

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -3,6 +3,7 @@ package configvalidate
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/concourse/concourse/atc"
@@ -54,6 +55,12 @@ func Validate(c Config) ([]ConfigWarning, []string) {
 		errorMessages = append(errorMessages, formatErr("jobs", jobsErr))
 	}
 	warnings = append(warnings, jobWarnings...)
+
+	displayWarnings, displayErr := validateDisplay(c)
+	if displayErr != nil {
+		errorMessages = append(errorMessages, formatErr("display config", displayErr))
+	}
+	warnings = append(warnings, displayWarnings...)
 
 	return warnings, errorMessages
 }
@@ -385,4 +392,29 @@ func validateVarSources(c Config) ([]ConfigWarning, error) {
 	}
 
 	return warnings, compositeErr(errorMessages)
+}
+
+func validateDisplay(c Config) ([]ConfigWarning, error) {
+	var warnings []ConfigWarning
+
+	if c.Display == nil {
+		return warnings, nil
+	}
+
+	url, err := url.Parse(c.Display.BackgroundImage)
+
+	if err != nil {
+		return warnings, fmt.Errorf("background_image is not a valid URL: %s", c.Display.BackgroundImage)
+	}
+
+	switch url.Scheme {
+	case "https":
+	case "http":
+	case "":
+		break
+	default:
+		return warnings, fmt.Errorf("background_image scheme must be either http, https or relative")
+	}
+
+	return warnings, nil
 }

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -2059,4 +2059,58 @@ var _ = Describe("ValidateConfig", func() {
 			})
 		})
 	})
+
+	Describe("validating display config", func() {
+		Context("when the background image is a valid http URL", func() {
+			BeforeEach(func() {
+				config.Display = &atc.DisplayConfig{
+					BackgroundImage: "http://example.com/image.jpg",
+				}
+			})
+
+			It("does not return an error", func() {
+				Expect(errorMessages).To(HaveLen(0))
+			})
+		})
+
+		Context("when the background image is a valid relative URL", func() {
+			BeforeEach(func() {
+				config.Display = &atc.DisplayConfig{
+					BackgroundImage: "public/images/image.jpg",
+				}
+			})
+
+			It("does not return an error", func() {
+				Expect(errorMessages).To(HaveLen(0))
+			})
+		})
+
+		Context("when the background image uses an unsupported scheme", func() {
+			BeforeEach(func() {
+				config.Display = &atc.DisplayConfig{
+					BackgroundImage: "data:image/png;base64, iVBORw0KGgoA",
+				}
+			})
+
+			It("returns an error", func() {
+				Expect(errorMessages).To(HaveLen(1))
+				Expect(errorMessages[0]).To(ContainSubstring("invalid display config:"))
+				Expect(errorMessages[0]).To(ContainSubstring("background_image scheme must be either http, https or relative"))
+			})
+		})
+
+		Context("when the background image is an invalid URL", func() {
+			BeforeEach(func() {
+				config.Display = &atc.DisplayConfig{
+					BackgroundImage: "://example.com",
+				}
+			})
+
+			It("returns an error", func() {
+				Expect(errorMessages).To(HaveLen(1))
+				Expect(errorMessages[0]).To(ContainSubstring("invalid display config:"))
+				Expect(errorMessages[0]).To(ContainSubstring("background_image is not a valid URL: ://example.com"))
+			})
+		})
+	})
 })

--- a/atc/db/dbfakes/fake_pipeline.go
+++ b/atc/db/dbfakes/fake_pipeline.go
@@ -168,6 +168,16 @@ type FakePipeline struct {
 	destroyReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DisplayStub        func() *atc.DisplayConfig
+	displayMutex       sync.RWMutex
+	displayArgsForCall []struct {
+	}
+	displayReturns struct {
+		result1 *atc.DisplayConfig
+	}
+	displayReturnsOnCall map[int]struct {
+		result1 *atc.DisplayConfig
+	}
 	ExposeStub        func() error
 	exposeMutex       sync.RWMutex
 	exposeArgsForCall []struct {
@@ -1286,6 +1296,58 @@ func (fake *FakePipeline) DestroyReturnsOnCall(i int, result1 error) {
 	}
 	fake.destroyReturnsOnCall[i] = struct {
 		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) Display() *atc.DisplayConfig {
+	fake.displayMutex.Lock()
+	ret, specificReturn := fake.displayReturnsOnCall[len(fake.displayArgsForCall)]
+	fake.displayArgsForCall = append(fake.displayArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Display", []interface{}{})
+	fake.displayMutex.Unlock()
+	if fake.DisplayStub != nil {
+		return fake.DisplayStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.displayReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakePipeline) DisplayCallCount() int {
+	fake.displayMutex.RLock()
+	defer fake.displayMutex.RUnlock()
+	return len(fake.displayArgsForCall)
+}
+
+func (fake *FakePipeline) DisplayCalls(stub func() *atc.DisplayConfig) {
+	fake.displayMutex.Lock()
+	defer fake.displayMutex.Unlock()
+	fake.DisplayStub = stub
+}
+
+func (fake *FakePipeline) DisplayReturns(result1 *atc.DisplayConfig) {
+	fake.displayMutex.Lock()
+	defer fake.displayMutex.Unlock()
+	fake.DisplayStub = nil
+	fake.displayReturns = struct {
+		result1 *atc.DisplayConfig
+	}{result1}
+}
+
+func (fake *FakePipeline) DisplayReturnsOnCall(i int, result1 *atc.DisplayConfig) {
+	fake.displayMutex.Lock()
+	defer fake.displayMutex.Unlock()
+	fake.DisplayStub = nil
+	if fake.displayReturnsOnCall == nil {
+		fake.displayReturnsOnCall = make(map[int]struct {
+			result1 *atc.DisplayConfig
+		})
+	}
+	fake.displayReturnsOnCall[i] = struct {
+		result1 *atc.DisplayConfig
 	}{result1}
 }
 
@@ -3083,6 +3145,8 @@ func (fake *FakePipeline) Invocations() map[string][][]interface{} {
 	defer fake.deleteBuildEventsByBuildIDsMutex.RUnlock()
 	fake.destroyMutex.RLock()
 	defer fake.destroyMutex.RUnlock()
+	fake.displayMutex.RLock()
+	defer fake.displayMutex.RUnlock()
 	fake.exposeMutex.RLock()
 	defer fake.exposeMutex.RUnlock()
 	fake.getBuildsWithVersionAsInputMutex.RLock()

--- a/atc/db/migration/migrations/1599738693_add_pipeline_display_info.down.sql
+++ b/atc/db/migration/migrations/1599738693_add_pipeline_display_info.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    ALTER TABLE pipelines DROP COLUMN display;
+COMMIT;

--- a/atc/db/migration/migrations/1599738693_add_pipeline_display_info.up.sql
+++ b/atc/db/migration/migrations/1599738693_add_pipeline_display_info.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+    ALTER TABLE pipelines ADD COLUMN display jsonb;
+COMMIT;

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -44,6 +44,7 @@ type Pipeline interface {
 	ParentBuildID() int
 	Groups() atc.GroupConfigs
 	VarSources() atc.VarSourceConfigs
+	Display() *atc.DisplayConfig
 	ConfigVersion() ConfigVersion
 	Config() (atc.Config, error)
 	Public() bool
@@ -107,6 +108,7 @@ type pipeline struct {
 	parentBuildID int
 	groups        atc.GroupConfigs
 	varSources    atc.VarSourceConfigs
+	display       *atc.DisplayConfig
 	configVersion ConfigVersion
 	paused        bool
 	public        bool
@@ -125,6 +127,7 @@ var pipelinesQuery = psql.Select(`
 		p.name,
 		p.groups,
 		p.var_sources,
+		p.display,
 		p.nonce,
 		p.version,
 		p.team_id,
@@ -155,6 +158,7 @@ func (p *pipeline) ParentBuildID() int       { return p.parentBuildID }
 func (p *pipeline) Groups() atc.GroupConfigs { return p.groups }
 
 func (p *pipeline) VarSources() atc.VarSourceConfigs { return p.varSources }
+func (p *pipeline) Display() *atc.DisplayConfig      { return p.display }
 func (p *pipeline) ConfigVersion() ConfigVersion     { return p.configVersion }
 func (p *pipeline) Public() bool                     { return p.public }
 func (p *pipeline) Paused() bool                     { return p.paused }
@@ -268,6 +272,7 @@ func (p *pipeline) Config() (atc.Config, error) {
 		Resources:     resources.Configs(),
 		ResourceTypes: resourceTypes.Configs(),
 		Jobs:          jobConfigs,
+		Display:       p.Display(),
 	}
 
 	return config, nil

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -50,6 +50,9 @@ var _ = Describe("Pipeline", func() {
 					},
 				},
 			},
+			Display: &atc.DisplayConfig{
+				BackgroundImage: "background.jpg",
+			},
 			Jobs: atc.JobConfigs{
 				{
 					Name: "job-name",

--- a/atc/pipeline.go
+++ b/atc/pipeline.go
@@ -1,14 +1,15 @@
 package atc
 
 type Pipeline struct {
-	ID          int          `json:"id"`
-	Name        string       `json:"name"`
-	Paused      bool         `json:"paused"`
-	Public      bool         `json:"public"`
-	Archived    bool         `json:"archived"`
-	Groups      GroupConfigs `json:"groups,omitempty"`
-	TeamName    string       `json:"team_name"`
-	LastUpdated int64        `json:"last_updated,omitempty"`
+	ID          int            `json:"id"`
+	Name        string         `json:"name"`
+	Paused      bool           `json:"paused"`
+	Public      bool           `json:"public"`
+	Archived    bool           `json:"archived"`
+	Groups      GroupConfigs   `json:"groups,omitempty"`
+	TeamName    string         `json:"team_name"`
+	Display     *DisplayConfig `json:"display,omitempty"`
+	LastUpdated int64          `json:"last_updated,omitempty"`
 }
 
 type RenameRequest struct {

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -74,6 +74,7 @@ import Dict exposing (Dict)
 import Json.Decode
 import Json.Decode.Extra exposing (andMap)
 import Json.Encode
+import Json.Encode.Extra
 import Time
 
 
@@ -818,6 +819,7 @@ type alias Pipeline =
     , public : Bool
     , teamName : TeamName
     , groups : List PipelineGroup
+    , backgroundImage : Maybe String
     }
 
 
@@ -838,6 +840,7 @@ encodePipeline pipeline =
         , ( "public", pipeline.public |> Json.Encode.bool )
         , ( "team_name", pipeline.teamName |> Json.Encode.string )
         , ( "groups", pipeline.groups |> Json.Encode.list encodePipelineGroup )
+        , ( "display", Json.Encode.object [ ( "background_image", pipeline.backgroundImage |> Json.Encode.Extra.maybe Json.Encode.string ) ] )
         ]
 
 
@@ -851,6 +854,7 @@ decodePipeline =
         |> andMap (Json.Decode.field "public" Json.Decode.bool)
         |> andMap (Json.Decode.field "team_name" Json.Decode.string)
         |> andMap (defaultTo [] <| Json.Decode.field "groups" (Json.Decode.list decodePipelineGroup))
+        |> andMap (Json.Decode.maybe (Json.Decode.at [ "display", "background_image" ] Json.Decode.string))
 
 
 encodePipelineGroup : PipelineGroup -> Json.Encode.Value

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -571,6 +571,7 @@ toConcoursePipeline p =
     , paused = p.paused
     , archived = p.archived
     , groups = []
+    , backgroundImage = Maybe.Nothing
     }
 
 

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -454,6 +454,33 @@ isArchived p =
     RemoteData.withDefault False (RemoteData.map .archived p)
 
 
+backgroundImage : WebData Concourse.Pipeline -> List (Html.Attribute msg)
+backgroundImage pipeline =
+    case pipeline of
+        RemoteData.Success p ->
+            case p.backgroundImage of
+                Just bg ->
+                    [ style "background-image" <|
+                        "url(\""
+                            ++ bg
+                            ++ "\")"
+                    , style "background-repeat" "no-repeat"
+                    , style "background-size" "cover"
+                    , style "background-position" "center"
+                    , style "opacity" "30%"
+                    , style "filter" "grayscale(1)"
+                    , style "width" "100%"
+                    , style "height" "100%"
+                    , style "position" "absolute"
+                    ]
+
+                _ ->
+                    []
+
+        _ ->
+            []
+
+
 viewSubPage :
     { a | hovered : HoverState.HoverState, version : String }
     -> Model
@@ -467,8 +494,12 @@ viewSubPage session model =
         , style "flex-grow" "1"
         ]
         [ viewGroupsBar session model
-        , Html.div [ class "pipeline-content" ]
-            [ Svg.svg
+        , Html.div
+            [ class "pipeline-content" ]
+            [ Html.div
+                (id "pipeline-background" :: backgroundImage model.pipeline)
+                []
+            , Svg.svg
                 [ SvgAttributes.class "pipeline-graph test" ]
                 []
             , Html.div

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -458,24 +458,9 @@ backgroundImage : WebData Concourse.Pipeline -> List (Html.Attribute msg)
 backgroundImage pipeline =
     case pipeline of
         RemoteData.Success p ->
-            case p.backgroundImage of
-                Just bg ->
-                    [ style "background-image" <|
-                        "url(\""
-                            ++ bg
-                            ++ "\")"
-                    , style "background-repeat" "no-repeat"
-                    , style "background-size" "cover"
-                    , style "background-position" "center"
-                    , style "opacity" "30%"
-                    , style "filter" "grayscale(1)"
-                    , style "width" "100%"
-                    , style "height" "100%"
-                    , style "position" "absolute"
-                    ]
-
-                _ ->
-                    []
+            p.backgroundImage
+                |> Maybe.map Styles.pipelineBackground
+                |> Maybe.withDefault []
 
         _ ->
             []

--- a/web/elm/src/Pipeline/Styles.elm
+++ b/web/elm/src/Pipeline/Styles.elm
@@ -4,6 +4,7 @@ module Pipeline.Styles exposing
     , groupItem
     , groupsBar
     , pauseToggle
+    , pipelineBackground
     )
 
 import Assets
@@ -76,4 +77,21 @@ cliIcon cli =
     , style "background-position" "50% 50%"
     , style "background-size" "contain"
     , style "display" "inline-block"
+    ]
+
+
+pipelineBackground : String -> List (Html.Attribute msg)
+pipelineBackground bg =
+    [ style "background-image" <|
+        "url(\""
+            ++ bg
+            ++ "\")"
+    , style "background-repeat" "no-repeat"
+    , style "background-size" "cover"
+    , style "background-position" "center"
+    , style "opacity" "30%"
+    , style "filter" "grayscale(1)"
+    , style "width" "100%"
+    , style "height" "100%"
+    , style "position" "absolute"
     ]

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -27,6 +27,7 @@ module Data exposing
     , version
     , versionedResource
     , withArchived
+    , withBackgroundImage
     , withBuildName
     , withDisableManualTrigger
     , withGroups
@@ -165,6 +166,7 @@ pipeline team id =
     , public = True
     , teamName = team
     , groups = []
+    , backgroundImage = Maybe.Nothing
     }
 
 
@@ -206,6 +208,11 @@ withName name p =
 withGroups : List Concourse.PipelineGroup -> { r | groups : List Concourse.PipelineGroup } -> { r | groups : List Concourse.PipelineGroup }
 withGroups groups p =
     { p | groups = groups }
+
+
+withBackgroundImage : String -> { r | backgroundImage : Maybe String } -> { r | backgroundImage : Maybe String }
+withBackgroundImage bg p =
+    { p | backgroundImage = Just bg }
 
 
 job : Int -> Concourse.Job

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -4,6 +4,7 @@ import Application.Application as Application
 import Assets
 import Char
 import Common exposing (defineHoverBehaviour, queryView)
+import Concourse
 import Concourse.Cli exposing (Cli(..))
 import DashboardTests exposing (iconSelector)
 import Data
@@ -301,6 +302,29 @@ all =
                     |> Application.view
                     |> .title
                     |> Expect.equal "pipelineName - Concourse"
+        , test "pipeline background should be set from display config" <|
+            \_ ->
+                Common.init "/teams/team/pipelines/pipelineName"
+                    |> Application.handleCallback
+                        (Callback.PipelineFetched
+                            (Ok <|
+                                (Data.pipeline "team" 0
+                                    |> Data.withName "pipeline"
+                                    |> Data.withBackgroundImage "some-background.jpg"
+                                )
+                            )
+                        )
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ id "pipeline-background" ]
+                    |> Query.has
+                        [ style "background-image" "url(\"some-background.jpg\")"
+                        , style "background-repeat" "no-repeat"
+                        , style "background-size" "cover"
+                        , style "background-position" "center"
+                        , style "opacity" "30%"
+                        , style "filter" "grayscale(1)"
+                        ]
         , describe "update" <|
             let
                 defaultModel : Pipeline.Model


### PR DESCRIPTION
## What does this PR accomplish?
Allows users to quickly identify a particular pipeline visually for when pipelines are shown on dashboards and the structure may not be enough to differentiate them.
Bug Fix | _Feature- | Documentation

closes #1756
Replaces #6020 

## Changes proposed by this PR:
Allow users to specify a custom background image which is put at 30% opacity, grayscaled and blended into existing background. This allows for some level of pipeline customisation without creating too many visual problems for the UI. Uses the CSS property `background-image: url('blah')` so either hyperlinks or `data:image/png;base64` etc. strings can be used. Background is rendered on update by Elm so can be hot-reloaded. 

Examples:
![Screenshot 2020-09-10 at 14 14 47](https://user-images.githubusercontent.com/14118619/92734302-553a6b00-f370-11ea-9b09-9bf05037ef2f.png)
![plane](https://user-images.githubusercontent.com/14118619/92734347-5ff50000-f370-11ea-9f14-f6af5a9c6f94.gif)


## Notes to reviewer:
I made the `Display` field a pointer so that a missing field wouldn't be included in the JSON output but this means some `Maybe` work has to happen in the frontend to deal with this. I think this isn't _too_ bad but felt like more work that it should have been?

I added some tests to the config diff-ing stuff as I was having trouble getting it to work right. I only covered `jobs` from the existing behaviour as all the other keys largely use the same codepaths and then I added new tests for the new display behaviour. Display is the first field in the pipeline config that is not a slice of some sort so doesn't match the current model of "equivalent item" hence I had to write some custom diff/render stuff to deal with it.

## Release Note
Pipeline authors can now include a custom `background_image` under the `display` key in pipeline config e.g:
```yaml
display:
  background_image: https://avatars1.githubusercontent.com/u/7809479?s=400&v=4
```

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
