### PR TITLE
Fix empty worker tags

### DIFF
--- a/atc/worker/worker.go
+++ b/atc/worker/worker.go
@@ -764,8 +764,14 @@ func (worker *gardenWorker) Uptime() time.Duration {
 
 func (worker *gardenWorker) tagsMatch(tags []string) bool {
 	workerTags := worker.dbWorker.Tags()
-	if len(workerTags) > 0 && len(tags) == 0 {
-		return false
+	if len(tags) == 0 {
+		// If worker only has an empty tag due to user specifying "" instead of []
+		if len(workerTags) == 1 && workerTags[0] == "" {
+			return true
+		}
+		if len(workerTags) > 0 {
+			return false
+		}
 	}
 
 insert_coin:

--- a/atc/worker/worker_test.go
+++ b/atc/worker/worker_test.go
@@ -563,9 +563,40 @@ var _ = Describe("Worker", func() {
 				})
 			})
 
-			Context("when the worker has no tags", func() {
+			Context("when no tags are specified", func() {
+				BeforeEach(func() {
+					spec.Tags = []string{}
+				})
+
+				It("returns true", func() {
+					Expect(satisfies).To(BeFalse())
+				})
+			})
+
+			Context("when empty tags are specified", func() {
+				BeforeEach(func() {
+					spec.Tags = []string{""}
+				})
+
+				It("returns true", func() {
+					Expect(satisfies).To(BeFalse())
+				})
+			})
+
+			Context("when the worker has no tags and no requested tags", func() {
 				BeforeEach(func() {
 					tags = []string{}
+					spec.Tags = []string{}
+				})
+
+				It("returns true", func() {
+					Expect(satisfies).To(BeTrue())
+				})
+			})
+
+			Context("when the worker has an empty tag and no requested tags", func() {
+				BeforeEach(func() {
+					tags = []string{""}
 					spec.Tags = []string{}
 				})
 


### PR DESCRIPTION
Empty worker tags should be treated the same as not having any tags at all
This makes having the CONCOURSE_TAGS being unset equivalent to CONCOURSE_TAGS being set and empty

This change should probably be handled in the environment variable wiring, but it's getting late and there's a lot of magic going on in there

## What does this PR accomplish?

Bug Fix

closes #6056 

## Changes proposed by this PR:
If the tags list has length 1, but the only item is the empty string, then don't fail the match

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
