### PR TITLE
Fly execute: pass worker tags to input.

### DIFF
--- a/atc/api/artifactserver/create.go
+++ b/atc/api/artifactserver/create.go
@@ -23,6 +23,7 @@ func (s *Server) CreateArtifact(team db.Team) http.Handler {
 		workerSpec := worker.WorkerSpec{
 			TeamID:   team.ID(),
 			Platform: r.FormValue("platform"),
+			Tags:     r.Form["tags"],
 		}
 
 		volumeSpec := worker.VolumeSpec{

--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -66,6 +66,7 @@ func (command *ExecuteCommand) Execute(args []string) error {
 		command.InputsFrom,
 		command.IncludeIgnored,
 		taskConfig.Platform,
+		command.Tags,
 	)
 	if err != nil {
 		return err

--- a/fly/commands/internal/executehelpers/inputs.go
+++ b/fly/commands/internal/executehelpers/inputs.go
@@ -31,6 +31,7 @@ func DetermineInputs(
 	inputsFrom flaghelpers.JobFlag,
 	includeIgnored bool,
 	platform string,
+	tags []string,
 ) ([]Input, map[string]string, *atc.ImageResource, atc.VersionedResourceTypes, error) {
 	inputMappings := ConvertInputMappings(userInputMappings)
 
@@ -74,7 +75,7 @@ func DetermineInputs(
 		}
 	}
 
-	inputsFromLocal, err := GenerateLocalInputs(fact, team, localInputMappings, includeIgnored, platform)
+	inputsFromLocal, err := GenerateLocalInputs(fact, team, localInputMappings, includeIgnored, platform, tags)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -158,6 +159,7 @@ func GenerateLocalInputs(
 	inputMappings []flaghelpers.InputPairFlag,
 	includeIgnored bool,
 	platform string,
+	tags []string,
 ) (map[string]Input, error) {
 	inputs := map[string]Input{}
 
@@ -170,7 +172,7 @@ func GenerateLocalInputs(
 		path := mapping.Path
 
 		prog.Go("uploading "+name, func(bar *mpb.Bar) error {
-			artifact, err := Upload(bar, team, path, includeIgnored, platform)
+			artifact, err := Upload(bar, team, path, includeIgnored, platform, tags)
 			if err != nil {
 				return err
 			}

--- a/fly/commands/internal/executehelpers/uploads.go
+++ b/fly/commands/internal/executehelpers/uploads.go
@@ -12,7 +12,7 @@ import (
 	"github.com/vbauerster/mpb/v4"
 )
 
-func Upload(bar *mpb.Bar, team concourse.Team, path string, includeIgnored bool, platform string) (atc.WorkerArtifact, error) {
+func Upload(bar *mpb.Bar, team concourse.Team, path string, includeIgnored bool, platform string, tags []string) (atc.WorkerArtifact, error) {
 	files := getFiles(path, includeIgnored)
 
 	archiveStream, archiveWriter := io.Pipe()
@@ -21,7 +21,7 @@ func Upload(bar *mpb.Bar, team concourse.Team, path string, includeIgnored bool,
 		archiveWriter.CloseWithError(tgzfs.Compress(archiveWriter, path, files...))
 	}()
 
-	return team.CreateArtifact(bar.ProxyReader(archiveStream), platform)
+	return team.CreateArtifact(bar.ProxyReader(archiveStream), platform, tags)
 }
 
 func getFiles(dir string, includeIgnored bool) []string {

--- a/go-concourse/concourse/artifacts.go
+++ b/go-concourse/concourse/artifacts.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tedsuo/rata"
 )
 
-func (team *team) CreateArtifact(src io.Reader, platform string) (atc.WorkerArtifact, error) {
+func (team *team) CreateArtifact(src io.Reader, platform string, tags []string) (atc.WorkerArtifact, error) {
 	var artifact atc.WorkerArtifact
 
 	params := rata.Params{
@@ -22,7 +22,7 @@ func (team *team) CreateArtifact(src io.Reader, platform string) (atc.WorkerArti
 		Header:      http.Header{"Content-Type": {"application/octet-stream"}},
 		RequestName: atc.CreateArtifact,
 		Params:      params,
-		Query:       url.Values{"platform": {platform}},
+		Query:       url.Values{"platform": {platform}, "tags": tags},
 		Body:        src,
 	}, &internal.Response{
 		Result: &artifact,

--- a/go-concourse/concourse/artifacts_test.go
+++ b/go-concourse/concourse/artifacts_test.go
@@ -27,7 +27,7 @@ var _ = Describe("ArtifactRepository", func() {
 			})
 
 			It("errors", func() {
-				_, err := team.CreateArtifact(bytes.NewBufferString("some-contents"), "some-platform")
+				_, err := team.CreateArtifact(bytes.NewBufferString("some-contents"), "some-platform", []string{"some-tags"})
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -45,7 +45,7 @@ var _ = Describe("ArtifactRepository", func() {
 			})
 
 			It("returns json", func() {
-				artifact, err := team.CreateArtifact(bytes.NewBufferString("some-contents"), "some-platform")
+				artifact, err := team.CreateArtifact(bytes.NewBufferString("some-contents"), "some-platform", []string{"some-tags"})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(artifact.ID).To(Equal(17))
 			})

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -148,11 +148,12 @@ type FakeTeam struct {
 		result1 int64
 		result2 error
 	}
-	CreateArtifactStub        func(io.Reader, string) (atc.WorkerArtifact, error)
+	CreateArtifactStub        func(io.Reader, string, []string) (atc.WorkerArtifact, error)
 	createArtifactMutex       sync.RWMutex
 	createArtifactArgsForCall []struct {
 		arg1 io.Reader
 		arg2 string
+		arg3 []string
 	}
 	createArtifactReturns struct {
 		result1 atc.WorkerArtifact
@@ -1334,17 +1335,23 @@ func (fake *FakeTeam) ClearTaskCacheReturnsOnCall(i int, result1 int64, result2 
 	}{result1, result2}
 }
 
-func (fake *FakeTeam) CreateArtifact(arg1 io.Reader, arg2 string) (atc.WorkerArtifact, error) {
+func (fake *FakeTeam) CreateArtifact(arg1 io.Reader, arg2 string, arg3 []string) (atc.WorkerArtifact, error) {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
+	}
 	fake.createArtifactMutex.Lock()
 	ret, specificReturn := fake.createArtifactReturnsOnCall[len(fake.createArtifactArgsForCall)]
 	fake.createArtifactArgsForCall = append(fake.createArtifactArgsForCall, struct {
 		arg1 io.Reader
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("CreateArtifact", []interface{}{arg1, arg2})
+		arg3 []string
+	}{arg1, arg2, arg3Copy})
+	fake.recordInvocation("CreateArtifact", []interface{}{arg1, arg2, arg3Copy})
 	fake.createArtifactMutex.Unlock()
 	if fake.CreateArtifactStub != nil {
-		return fake.CreateArtifactStub(arg1, arg2)
+		return fake.CreateArtifactStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1359,17 +1366,17 @@ func (fake *FakeTeam) CreateArtifactCallCount() int {
 	return len(fake.createArtifactArgsForCall)
 }
 
-func (fake *FakeTeam) CreateArtifactCalls(stub func(io.Reader, string) (atc.WorkerArtifact, error)) {
+func (fake *FakeTeam) CreateArtifactCalls(stub func(io.Reader, string, []string) (atc.WorkerArtifact, error)) {
 	fake.createArtifactMutex.Lock()
 	defer fake.createArtifactMutex.Unlock()
 	fake.CreateArtifactStub = stub
 }
 
-func (fake *FakeTeam) CreateArtifactArgsForCall(i int) (io.Reader, string) {
+func (fake *FakeTeam) CreateArtifactArgsForCall(i int) (io.Reader, string, []string) {
 	fake.createArtifactMutex.RLock()
 	defer fake.createArtifactMutex.RUnlock()
 	argsForCall := fake.createArtifactArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeTeam) CreateArtifactReturns(result1 atc.WorkerArtifact, result2 error) {

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -71,7 +71,7 @@ type Team interface {
 	Builds(page Page) ([]atc.Build, Pagination, error)
 	OrderingPipelines(pipelineNames []string) error
 
-	CreateArtifact(io.Reader, string) (atc.WorkerArtifact, error)
+	CreateArtifact(io.Reader, string, []string) (atc.WorkerArtifact, error)
 	GetArtifact(int) (io.ReadCloser, error)
 }
 


### PR DESCRIPTION
closes #5672.

When issuing `fly execute` and selecting a platform
where there are *only* tagged worker the command fails
because DetermineInputs does not pass along the tags
specified in the command and thus, at the end of the chain,
SelectWorkers will return that no worker satisfy the
request (because the are no untagged workers).

This commit passes the worker tags along the chain so that
the input can be set up.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>

- [X] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [X] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
