### PR TITLE
Allow globs in groups

### DIFF
--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -31,7 +31,7 @@ var _ = Describe("ValidateConfig", func() {
 				},
 				{
 					Name: "some-other-group",
-					Jobs: []string{"some-empty-job"},
+					Jobs: []string{"some-empty-*"},
 				},
 			},
 
@@ -262,14 +262,14 @@ var _ = Describe("ValidateConfig", func() {
 			BeforeEach(func() {
 				config.Groups = append(config.Groups, atc.GroupConfig{
 					Name: "bogus",
-					Jobs: []string{"bogus-job"},
+					Jobs: []string{"bogus-*"},
 				})
 			})
 
 			It("returns an error", func() {
 				Expect(errorMessages).To(HaveLen(1))
 				Expect(errorMessages[0]).To(ContainSubstring("invalid groups:"))
-				Expect(errorMessages[0]).To(ContainSubstring("unknown job 'bogus-job'"))
+				Expect(errorMessages[0]).To(ContainSubstring("no jobs match 'bogus-*' for group 'bogus'"))
 			})
 		})
 
@@ -324,6 +324,21 @@ var _ = Describe("ValidateConfig", func() {
 				Expect(errorLines).To(HaveLen(2))
 				Expect(errorLines[0]).To(ContainSubstring("invalid groups:"))
 				Expect(errorLines[1]).To(ContainSubstring("group 'some-group' appears 4 times. Duplicate names are not allowed."))
+			})
+		})
+
+		Context("when a group has and invalid glob expression", func() {
+			BeforeEach(func() {
+				config.Groups = append(config.Groups, atc.GroupConfig{
+					Name: "a-group",
+					Jobs: []string{"some-bad-glob-[0-9"},
+				})
+			})
+
+			It("returns an error", func() {
+				Expect(errorMessages).To(HaveLen(1))
+				Expect(errorMessages[0]).To(ContainSubstring("invalid groups:"))
+				Expect(errorMessages[0]).To(ContainSubstring("invalid glob expression 'some-bad-glob-[0-9' for group 'a-group'"))
 			})
 		})
 	})

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -2629,6 +2629,18 @@ var _ = Describe("Team", func() {
 			Expect(job.Tags()).To(Equal([]string{"some-group"}))
 		})
 
+		It("saves tags in the jobs table based on globs", func() {
+			otherConfig.Groups[0].Jobs = []string{"*-other-job"}
+			savedPipeline, _, err := team.SavePipeline(pipelineRef, otherConfig, 0, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			job, found, err := savedPipeline.Job("some-other-job")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			Expect(job.Tags()).To(Equal([]string{"some-group"}))
+		})
+
 		It("updates tags in the jobs table", func() {
 			savedPipeline, _, err := team.SavePipeline(pipelineRef, otherConfig, 0, false)
 			Expect(err).ToNot(HaveOccurred())
@@ -2646,7 +2658,7 @@ var _ = Describe("Team", func() {
 				},
 				{
 					Name: "some-another-group",
-					Jobs: []string{"some-other-job"},
+					Jobs: []string{"*-other-job"},
 				},
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/gobuffalo/packr v1.13.7
+	github.com/gobwas/glob v0.2.3
 	github.com/gogo/googleapis v1.3.1 // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e

--- a/go.sum
+++ b/go.sum
@@ -501,6 +501,7 @@ github.com/gobuffalo/packr v1.13.7/go.mod h1:KkinLIn/n6+3tVXMwg6KkNvWwVsrRAz4ph+
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gocql/gocql v0.0.0-20200228163523-cd4b606dd2fb/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e h1:BWhy2j3IXJhjCbC68FptL43tDKIq8FladmaTs3Xs7Z8=


### PR DESCRIPTION
## What does this PR accomplish?
Allow groups to list jobs via globs rather than just strict matches. It isn't uncommon to have an `all` group which you need to remember to add any new jobs to and it is easy to forget to `fly validate-pipeline` first. With this feature, the groups could just be (quoting to prevent being seen as YAML anchor):
```yaml
- name: all
  jobs:
  - "*"
- name: deploy
  jobs:
  - deploy-*
```

Bug Fix | _Feature_ | Documentation

## Changes proposed by this PR:
When validating/saving groups that a job is in, use `glob.Glob` rather than `Lookup`/map keys which strictly check equality. Add/modify some tests to ensure behaviour is covered.

## Notes to reviewer:
There are 2 commits here - the first uses a regular expression and the second converts it to using globs. I think globs seem nicer so I would _prefer_ to use globs and just squash these 2 commits but I left it there for reference. I don't think users need/necessarily want the full power of regular expressions just for selecting groups.

On my travels I also noticed that a group can contain resources - I'm pretty sure this field only exists on the object and in validation and isn't actually persisted to the DB anywhere. Doing some manual testing specifying `resources` in the pipeline config doesn't do anything so I'm pretty sure this is dead code. I say all this to qualify why I didn't bother extending the glob based matching to resources as well 😂 

## Release Note
`groups` in a pipeline can now match jobs based on globs e.g.:
```
groups:
- name: deploy
  jobs:
  - deploy-*
```

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
