### PR TITLE
Remind people they need JS to run the browser app

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -67,6 +67,7 @@
     </style>
   </head>
   <body>
+    <noscript>You don’t appear to have JavaScript enabled. This web UI won’t work without it!</noscript>
     <div id="elm-app-embed"></div>
     <script>
       window.elmFlags = {


### PR DESCRIPTION
Some people don't have JavaScript enabled all the time, this PR tells them they need it to use rather than showing a blank screen.

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
