### PR TITLE
Use atc.TaskEnv type in task step

### DIFF
--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -182,7 +182,7 @@ var factoryTests = []PlannerTest{
 			},
 			ConfigPath:        "some-task-file",
 			Vars:              atc.Params{"some": "vars"},
-			Params:            atc.Params{"SOME": "PARAMS"},
+			Params:            atc.TaskEnv{"SOME": "PARAMS"},
 			Tags:              atc.Tags{"tag-1", "tag-2"},
 			InputMapping:      map[string]string{"generic": "specific"},
 			OutputMapping:     map[string]string{"specific": "generic"},
@@ -419,12 +419,12 @@ var factoryTests = []PlannerTest{
 			},
 			Vars: []atc.AcrossVarConfig{
 				{
-					Var: "var1",
-					Values: []interface{}{"a1", "a2"},
+					Var:         "var1",
+					Values:      []interface{}{"a1", "a2"},
 					MaxInFlight: &atc.MaxInFlightConfig{All: true},
 				},
 				{
-					Var: "var2",
+					Var:    "var2",
 					Values: []interface{}{"b1", "b2"},
 				},
 			},

--- a/atc/creds/task_validation.go
+++ b/atc/creds/task_validation.go
@@ -5,21 +5,21 @@ import (
 	"github.com/concourse/concourse/vars"
 )
 
-type TaskParamsValidator struct {
+type TaskEnvValidator struct {
 	variablesResolver vars.Variables
-	rawTaskParams     atc.Params
+	rawTaskEnv        atc.TaskEnv
 }
 
-func NewTaskParamsValidator(variables vars.Variables, params atc.Params) TaskParamsValidator {
-	return TaskParamsValidator{
+func NewTaskEnvValidator(variables vars.Variables, params atc.TaskEnv) TaskEnvValidator {
+	return TaskEnvValidator{
 		variablesResolver: variables,
-		rawTaskParams:     params,
+		rawTaskEnv:        params,
 	}
 }
 
-func (s TaskParamsValidator) Validate() error {
+func (s TaskEnvValidator) Validate() error {
 	var params atc.TaskEnv
-	return evaluate(s.variablesResolver, s.rawTaskParams, &params)
+	return evaluate(s.variablesResolver, s.rawTaskEnv, &params)
 }
 
 type TaskVarsValidator struct {

--- a/atc/exec/task_config_source.go
+++ b/atc/exec/task_config_source.go
@@ -2,11 +2,8 @@ package exec
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math"
-	"strconv"
 	"strings"
 
 	"code.cloudfoundry.org/lager"
@@ -111,7 +108,7 @@ func (configSource FileConfigSource) Warnings() []string {
 // OverrideParamsConfigSource is used to override params in a config source
 type OverrideParamsConfigSource struct {
 	ConfigSource TaskConfigSource
-	Params       atc.Params
+	Params       atc.TaskEnv
 	WarningList  []string
 }
 
@@ -132,22 +129,7 @@ func (configSource *OverrideParamsConfigSource) FetchConfig(ctx context.Context,
 			configSource.WarningList = append(configSource.WarningList, fmt.Sprintf("%s was defined in pipeline but missing from task file", key))
 		}
 
-		switch v := val.(type) {
-		case string:
-			taskConfig.Params[key] = v
-		case float64:
-			if math.Floor(v) == v {
-				taskConfig.Params[key] = strconv.FormatInt(int64(v), 10)
-			} else {
-				taskConfig.Params[key] = strconv.FormatFloat(v, 'f', -1, 64)
-			}
-		default:
-			bs, err := json.Marshal(val)
-			if err != nil {
-				return atc.TaskConfig{}, err
-			}
-			taskConfig.Params[key] = string(bs)
-		}
+		taskConfig.Params[key] = val
 	}
 
 	return taskConfig, nil

--- a/atc/exec/task_config_source_test.go
+++ b/atc/exec/task_config_source_test.go
@@ -244,7 +244,7 @@ run: {path: a/file}
 			config       atc.TaskConfig
 			configSource TaskConfigSource
 
-			overrideParams atc.Params
+			overrideParams atc.TaskEnv
 
 			fetchedConfig atc.TaskConfig
 			fetchErr      error
@@ -261,7 +261,7 @@ run: {path: a/file}
 				},
 			}
 
-			overrideParams = atc.Params{"PARAM": "B", "EXTRA_PARAM": "C"}
+			overrideParams = atc.TaskEnv{"PARAM": "B", "EXTRA_PARAM": "C"}
 		})
 
 		Context("when there are no params to override", func() {
@@ -316,31 +316,6 @@ run: {path: a/file}
 				Expect(configSource.Warnings()).To(HaveLen(1))
 				Expect(configSource.Warnings()[0]).To(ContainSubstring("EXTRA_PARAM was defined in pipeline but missing from task file"))
 			})
-
-			Context("when params have int or float values", func() {
-				BeforeEach(func() {
-					overrideParams["int-val"] = float64(1059262)
-					overrideParams["float-val"] = float64(1059262.987345987)
-					configSource = &OverrideParamsConfigSource{
-						ConfigSource: StaticConfigSource{Config: &config},
-						Params:       overrideParams,
-					}
-				})
-
-				JustBeforeEach(func() {
-					fetchedConfig, fetchErr = configSource.FetchConfig(context.TODO(), logger, repo)
-				})
-
-				It("succeeds", func() {
-					Expect(fetchErr).NotTo(HaveOccurred())
-				})
-
-				It("processes them correctly", func() {
-					Expect(fetchedConfig.Params).To(HaveKeyWithValue("int-val", "1059262"))
-					Expect(fetchedConfig.Params).To(HaveKeyWithValue("float-val", "1059262.987345987"))
-				})
-			})
-
 		})
 	})
 
@@ -433,7 +408,7 @@ run: {path: a/file}
 		})
 
 		Context("when expect all keys", func() {
-			BeforeEach(func(){
+			BeforeEach(func() {
 				expectAllKeys = true
 			})
 
@@ -455,7 +430,7 @@ run: {path: a/file}
 		})
 
 		Context("when not expect all keys", func() {
-			BeforeEach(func(){
+			BeforeEach(func() {
 				expectAllKeys = false
 				taskVars = atc.Params{}
 			})

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -225,7 +225,7 @@ type TaskPlan struct {
 	Config     *TaskConfig `json:"config,omitempty"`
 	Vars       Params      `json:"vars,omitempty"`
 
-	Params            Params            `json:"params,omitempty"`
+	Params            TaskEnv           `json:"params,omitempty"`
 	InputMapping      map[string]string `json:"input_mapping,omitempty"`
 	OutputMapping     map[string]string `json:"output_mapping,omitempty"`
 	ImageArtifactName string            `json:"image,omitempty"`

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -340,7 +340,7 @@ type TaskStep struct {
 	Privileged        bool              `json:"privileged,omitempty"`
 	ConfigPath        string            `json:"file,omitempty"`
 	Config            *TaskConfig       `json:"config,omitempty"`
-	Params            Params            `json:"params,omitempty"`
+	Params            TaskEnv           `json:"params,omitempty"`
 	Vars              Params            `json:"vars,omitempty"`
 	Tags              Tags              `json:"tags,omitempty"`
 	InputMapping      map[string]string `json:"input_mapping,omitempty"`

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -90,11 +90,35 @@ var factoryTests = []StepTest{
 			},
 			ConfigPath:        "some-task-file",
 			Vars:              atc.Params{"some": "vars"},
-			Params:            atc.Params{"SOME": "PARAMS"},
+			Params:            atc.TaskEnv{"SOME": "PARAMS"},
 			Tags:              []string{"tag-1", "tag-2"},
 			InputMapping:      map[string]string{"generic": "specific"},
 			OutputMapping:     map[string]string{"specific": "generic"},
 			ImageArtifactName: "some-image",
+		},
+	},
+	{
+		Title: "task step with non-string params",
+
+		ConfigYAML: `
+			task: some-task
+			file: some-task-file
+			params:
+			  NUMBER: 42
+			  FLOAT: 1.5
+			  BOOL: yes
+			  OBJECT: {foo: bar}
+		`,
+
+		StepConfig: &atc.TaskStep{
+			Name:       "some-task",
+			ConfigPath: "some-task-file",
+			Params: atc.TaskEnv{
+				"NUMBER": "42",
+				"FLOAT":  "1.5",
+				"BOOL":   "true",
+				"OBJECT": `{"foo":"bar"}`,
+			},
 		},
 	},
 	{


### PR DESCRIPTION
## What does this PR accomplish?

Refactor

## Changes proposed by this PR:

Rather than parsing task step `params:` into an `atc.Params` type and converting values to strings when the step runs, parse into an `atc.TaskEnv` type which already handles the string conversion and is a bit more clear as to what the data is used for.

`atc.TaskEnv` was introduced a while back but could not be integrated at this level because we had one big `atc.PlanConfig` type and we couldn't change the `params:` field only for the task step. Now that it has its own `atc.TaskStep` type (#5504), this is easy!

## Notes to reviewer:

This also fixes a subtle bug with `fly set-pipeline --check-creds`; previously we would actually validate `params:` *twice* if `file:` was set. Now we only validate it once. The main goal of this PR is the refactor, I just noticed this issue along the way and fixed it.

This change should have no impact but I haven't manually verified so.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
