### PR TITLE
Skip yarn benchmark until dependency is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "build-elm": "cd web/elm && elm make --optimize --output ../public/elm.js src/Main.elm && uglifyjs ../public/elm.js --compress \"pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe\" | uglifyjs --mangle --output=../public/elm.min.js",
     "build-elm-debug": "cd web/elm && elm make --debug --output ../public/elm.js src/Main.elm && uglifyjs < ../public/elm.js > ../public/elm.min.js",
     "update-mdi-svg": "./hack/update-mdi-svg \"node_modules/@mdi/svg/svg\" | tr -d '\n' > web/public/mdi-svg.min.js",
-    "benchmark": "cd web/elm && elm make --optimize --output /tmp/benchmark.html benchmarks/Benchmarks.elm && node benchmarks/benchmark.js /tmp/benchmark.html"
+    "benchmark": "echo skipping benchmarks until https://github.com/elm-explorations/benchmark/issues/21 is fixed"
   }
 }

--- a/web/elm/elm.json
+++ b/web/elm/elm.json
@@ -1,8 +1,7 @@
 {
     "type": "application",
     "source-directories": [
-        "src",
-        "benchmarks"
+        "src"
     ],
     "elm-version": "0.19.1",
     "dependencies": {
@@ -20,7 +19,6 @@
             "elm-community/json-extra": "4.0.0",
             "elm-community/list-extra": "8.1.0",
             "elm-community/maybe-extra": "5.0.0",
-            "elm-explorations/benchmark": "1.0.1",
             "fapian/elm-html-aria": "1.4.0",
             "krisajenkins/remotedata": "5.0.0",
             "matthewsj/elm-ordering": "2.0.0",
@@ -30,10 +28,8 @@
         },
         "indirect": {
             "BrianHicks/elm-trend": "2.1.2",
-            "Skinney/murmur3": "2.0.8",
             "elm/regex": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "mdgriffith/style-elements": "5.0.1",
             "rtfeldman/elm-iso8601-date-strings": "1.1.2"
         }
     },


### PR DESCRIPTION
## What does this PR accomplish?
The `Skinney/murmur3` elm dependency was moved to `robinheghan/murmur3` which caused our elm compiling to break - https://github.com/robinheghan/murmur3/issues/5. We decided to remove the elm dependency `elm-explorations/benchmark` that uses that package until it gets fixed. We created an issue in the dependency here
https://github.com/elm-explorations/benchmark/issues/21. Once it is fixed we can restore it back to before.

## Contributor Checklist
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
