### PR TITLE
Add flag to concourse worker to overwrite init binary path

### DIFF
--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -141,6 +141,12 @@ func NewGardenBackend(client libcontainerd.Client, opts ...GardenBackendOpt) (b 
 		b.userNamespace = NewUserNamespace()
 	}
 
+	// Because the garden server is created programmatically in the integration tests, add
+	// a sane default path
+	if b.initBinPath == "" {
+		b.initBinPath = bespec.DefaultInitBinPath
+	}
+
 	return b, nil
 }
 

--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -2,6 +2,8 @@ package spec
 
 import "github.com/opencontainers/runtime-spec/specs-go"
 
+const DefaultInitBinPath = "/usr/local/concourse/bin/init"
+
 var (
 	DefaultContainerMounts = []specs.Mount{
 		{

--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -3,16 +3,7 @@ package spec
 import "github.com/opencontainers/runtime-spec/specs-go"
 
 var (
-	InitMount = specs.Mount{
-		Source:      "/usr/local/concourse/bin/init",
-		Destination: "/tmp/gdn-init",
-		Type:        "bind",
-		Options:     []string{"bind"},
-	}
-
-	AnyContainerMounts = []specs.Mount{
-		InitMount, // ours
-
+	DefaultContainerMounts = []specs.Mount{
 		{
 			Destination: "/proc",
 			Type:        "proc",
@@ -63,3 +54,17 @@ var (
 		},
 	}
 )
+
+func AnyContainerMounts(initBinPath string) []specs.Mount {
+	return append(
+		[]specs.Mount{
+			{
+				Source:      initBinPath,
+				Destination: "/tmp/gdn-init",
+				Type:        "bind",
+				Options:     []string{"bind"},
+			},
+		},
+		DefaultContainerMounts...,
+	)
+}

--- a/worker/runtime/spec/spec.go
+++ b/worker/runtime/spec/spec.go
@@ -19,7 +19,7 @@ const baseCgroupsPath = "garden"
 
 // OciSpec converts a given `garden` container specification to an OCI spec.
 //
-func OciSpec(gdn garden.ContainerSpec, maxUid, maxGid uint32) (oci *specs.Spec, err error) {
+func OciSpec(initBinPath string, gdn garden.ContainerSpec, maxUid, maxGid uint32) (oci *specs.Spec, err error) {
 	if gdn.Handle == "" {
 		err = fmt.Errorf("handle must be specified")
 		return
@@ -45,7 +45,7 @@ func OciSpec(gdn garden.ContainerSpec, maxUid, maxGid uint32) (oci *specs.Spec, 
 	cgroupsPath := OciCgroupsPath(baseCgroupsPath, gdn.Handle, gdn.Privileged)
 
 	oci = merge(
-		defaultGardenOciSpec(gdn.Privileged, maxUid, maxGid),
+		defaultGardenOciSpec(initBinPath, gdn.Privileged, maxUid, maxGid),
 		&specs.Spec{
 			Version:  specs.Version,
 			Hostname: gdn.Handle,
@@ -202,7 +202,7 @@ func envWithDefaultPath(env []string, privileged bool) []string {
 // ps.: this spec is NOT completed - it must be merged with more properties to
 // form a properly working container.
 //
-func defaultGardenOciSpec(privileged bool, maxUid, maxGid uint32) *specs.Spec {
+func defaultGardenOciSpec(initBinPath string, privileged bool, maxUid, maxGid uint32) *specs.Spec {
 	var (
 		namespaces   = OciNamespaces(privileged)
 		capabilities = OciCapabilities(privileged)
@@ -227,7 +227,7 @@ func defaultGardenOciSpec(privileged bool, maxUid, maxGid uint32) *specs.Spec {
 			UIDMappings: OciIDMappings(privileged, maxUid),
 			GIDMappings: OciIDMappings(privileged, maxGid),
 		},
-		Mounts: AnyContainerMounts,
+		Mounts: AnyContainerMounts(initBinPath),
 	}
 
 	if !privileged {

--- a/worker/runtime/spec/spec_test.go
+++ b/worker/runtime/spec/spec_test.go
@@ -83,7 +83,7 @@ func (s *SpecSuite) TestContainerSpecValidations() {
 		},
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			_, err := spec.OciSpec(tc.spec, dummyMaxUid, dummyMaxGid)
+			_, err := spec.OciSpec(spec.DefaultInitBinPath, tc.spec, dummyMaxUid, dummyMaxGid)
 			s.Error(err)
 		})
 	}
@@ -360,7 +360,7 @@ func (s *SpecSuite) TestContainerSpec() {
 			check: func(oci *specs.Spec) {
 				s.Equal("/", oci.Process.Cwd)
 				s.Equal([]string{"/tmp/gdn-init"}, oci.Process.Args)
-				s.Equal(oci.Mounts, spec.AnyContainerMounts)
+				s.Equal(oci.Mounts, spec.AnyContainerMounts(spec.DefaultInitBinPath))
 
 				s.Equal(minimalContainerSpec.Handle, oci.Hostname)
 				s.Equal(spec.AnyContainerDevices, oci.Linux.Resources.Devices)
@@ -500,7 +500,7 @@ func (s *SpecSuite) TestContainerSpec() {
 		},
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			actual, err := spec.OciSpec(tc.gdn, dummyMaxUid, dummyMaxGid)
+			actual, err := spec.OciSpec(spec.DefaultInitBinPath, tc.gdn, dummyMaxUid, dummyMaxGid)
 			s.NoError(err)
 
 			tc.check(actual)

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -31,6 +31,7 @@ func containerdGardenServerRunner(
 	networkPool string,
 	maxContainers int,
 	restrictedNetworks []string,
+	initBin string,
 ) (ifrit.Runner, error) {
 	const (
 		graceTime = 0
@@ -66,6 +67,7 @@ func containerdGardenServerRunner(
 		runtime.WithNetwork(cniNetwork),
 		runtime.WithRequestTimeout(requestTimeout),
 		runtime.WithMaxContainers(maxContainers),
+		runtime.WithInitBinPath(initBin),
 	)
 
 	gardenBackend, err := runtime.NewGardenBackend(
@@ -182,6 +184,7 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 		cmd.Containerd.NetworkPool,
 		cmd.Containerd.MaxContainers,
 		cmd.Containerd.RestrictedNetworks,
+		cmd.Containerd.InitBin,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("containerd garden server runner: %w", err)

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"code.cloudfoundry.org/garden/server"
 	"code.cloudfoundry.org/lager"
@@ -21,75 +20,8 @@ import (
 	"github.com/tedsuo/ifrit/grouper"
 )
 
-// TODO This constructor could use refactoring using the functional options pattern.
-func containerdGardenServerRunner(
-	logger lager.Logger,
-	bindAddr,
-	containerdAddr string,
-	requestTimeout time.Duration,
-	dnsServers []string,
-	networkPool string,
-	maxContainers int,
-	restrictedNetworks []string,
-	initBin string,
-) (ifrit.Runner, error) {
-	const (
-		graceTime = 0
-		namespace = "concourse"
-	)
-
-	backendOpts := []runtime.GardenBackendOpt{}
-	networkOpts := []runtime.CNINetworkOpt{}
-
-	if len(dnsServers) > 0 {
-		networkOpts = append(networkOpts, runtime.WithNameServers(dnsServers))
-	}
-
-	if len(restrictedNetworks) > 0 {
-		networkOpts = append(networkOpts, runtime.WithRestrictedNetworks(restrictedNetworks))
-	}
-
-	if networkPool != "" {
-		networkOpts = append(networkOpts, runtime.WithCNINetworkConfig(
-			runtime.CNINetworkConfig{
-				BridgeName:  "concourse0",
-				NetworkName: "concourse",
-				Subnet:      networkPool,
-			}))
-	}
-
-	cniNetwork, err := runtime.NewCNINetwork(networkOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("new cni network: %w", err)
-	}
-
-	backendOpts = append(backendOpts,
-		runtime.WithNetwork(cniNetwork),
-		runtime.WithRequestTimeout(requestTimeout),
-		runtime.WithMaxContainers(maxContainers),
-		runtime.WithInitBinPath(initBin),
-	)
-
-	gardenBackend, err := runtime.NewGardenBackend(
-		libcontainerd.New(containerdAddr, namespace, requestTimeout),
-		backendOpts...,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("containerd containerd init: %w", err)
-	}
-
-	server := server.New("tcp", bindAddr,
-		graceTime,
-		&gardenBackend,
-		logger,
-	)
-
-	return gardenServerRunner{logger, server}, nil
-}
-
 // writeDefaultContainerdConfig writes a default containerd configuration file
 // to a destination.
-//
 func writeDefaultContainerdConfig(dest string) error {
 	// disable plugins we don't use:
 	//
@@ -111,6 +43,69 @@ func writeDefaultContainerdConfig(dest string) error {
 	return nil
 }
 
+// containerdGardenServerRunner launches a Garden server configured to interact
+// with containerd via the containerdAddr socket.
+func (cmd *WorkerCommand) containerdGardenServerRunner(
+	logger lager.Logger,
+	containerdAddr string,
+	dnsServers []string,
+) (ifrit.Runner, error) {
+	const (
+		graceTime = 0
+		namespace = "concourse"
+	)
+
+	backendOpts := []runtime.GardenBackendOpt{}
+	networkOpts := []runtime.CNINetworkOpt{}
+
+	if len(dnsServers) > 0 {
+		networkOpts = append(networkOpts, runtime.WithNameServers(dnsServers))
+	}
+
+	if len(cmd.Containerd.RestrictedNetworks) > 0 {
+		networkOpts = append(networkOpts, runtime.WithRestrictedNetworks(cmd.Containerd.RestrictedNetworks))
+	}
+
+	if cmd.Containerd.NetworkPool != "" {
+		networkOpts = append(networkOpts, runtime.WithCNINetworkConfig(
+			runtime.CNINetworkConfig{
+				BridgeName:  "concourse0",
+				NetworkName: "concourse",
+				Subnet:      cmd.Containerd.NetworkPool,
+			}))
+	}
+
+	cniNetwork, err := runtime.NewCNINetwork(networkOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("new cni network: %w", err)
+	}
+
+	backendOpts = append(backendOpts,
+		runtime.WithNetwork(cniNetwork),
+		runtime.WithRequestTimeout(cmd.Containerd.RequestTimeout),
+		runtime.WithMaxContainers(cmd.Containerd.MaxContainers),
+		runtime.WithInitBinPath(cmd.Containerd.InitBin),
+	)
+
+	gardenBackend, err := runtime.NewGardenBackend(
+		libcontainerd.New(containerdAddr, namespace, cmd.Containerd.RequestTimeout),
+		backendOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("containerd containerd init: %w", err)
+	}
+
+	server := server.New("tcp", cmd.bindAddr(),
+		graceTime,
+		&gardenBackend,
+		logger,
+	)
+
+	return gardenServerRunner{logger, server}, nil
+}
+
+// containerdRunner spawns a containerd and a Garden server process for use as the container
+// runtime of Concourse.
 func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, error) {
 	const sock = "/run/containerd/containerd.sock"
 
@@ -175,16 +170,10 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 		})
 	}
 
-	gardenServerRunner, err := containerdGardenServerRunner(
+	gardenServerRunner, err := cmd.containerdGardenServerRunner(
 		logger,
-		cmd.bindAddr(),
 		sock,
-		cmd.Containerd.RequestTimeout,
 		dnsServers,
-		cmd.Containerd.NetworkPool,
-		cmd.Containerd.MaxContainers,
-		cmd.Containerd.RestrictedNetworks,
-		cmd.Containerd.InitBin,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("containerd garden server runner: %w", err)

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -37,6 +37,7 @@ type GuardianRuntime struct {
 type ContainerdRuntime struct {
 	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Containerd daemon."`
 	Bin            string        `long:"bin"        description:"Path to a containerd executable (non-absolute names get resolved from $PATH)."`
+	InitBin        string        `long:"init-bin" default:"/usr/local/concourse/bin/init" description:"Path to a dumb init executable (non-absolute names get resolved from $PATH)."`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
 
 	//TODO can DNSConfig be simplifed to just a bool rather than struct with a bool?


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

closes #5984 

## Changes proposed by this PR:
Add a flag to containerd options and string that all the way down to where we're creating Garden containers.

## Notes to reviewer:

## Release Note

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] ~Added tests (Unit and/or Integration)~
- [ ] ~Updated [Documentation]~
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
