### PR TITLE
Only set Guardian flag default when flag not provided by user

### DIFF
--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -107,8 +107,9 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 
 	gdnArgs := append(gdnConfigFlag, append([]string{"server"}, gdnServerFlags...)...)
 
+	var configFlags GdnBinaryFlags
 	if cmd.Guardian.Config != "" {
-		configFlags, err := getGdnFlagsFromConfig(cmd.Guardian.Config.Path())
+		configFlags, err = getGdnFlagsFromConfig(cmd.Guardian.Config.Path())
 		if err != nil {
 			return nil, err
 		}

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -3,9 +3,7 @@
 package workercmd
 
 import (
-	"bufio"
 	"fmt"
-	"github.com/concourse/flag"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +16,7 @@ import (
 	concourseCmd "github.com/concourse/concourse/cmd"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/grouper"
+	flags "github.com/jessevdk/go-flags"
 )
 
 // Guardian binary flags - these are passed along as-is to the gdn binary as options.
@@ -27,15 +26,21 @@ import (
 // This is needed in order to avoid unintentional overrides of user values set in the optional config file.
 // See getGdnFlagsFromStruct for details.
 type GdnBinaryFlags struct {
-	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Garden backend. e.g. 'foo-bar=a,b' for '--foo-bar a --foo-bar b'."`
-	MaxContainers  *int          `long:"max-containers" description:"Maximum container capacity. 0 means no limit. (default:250)"`
-	NetworkPool    string        `long:"network-pool" description:"Network range to use for dynamically allocated container subnets. (default:10.80.0.0/16)"`
+	Server struct {
+		Network struct {
+			Pool string `long:"network-pool" description:"Network range to use for dynamically allocated container subnets. (default:10.80.0.0/16)"`
+		} `group:"Container Networking"`
+
+		Limits struct {
+			MaxContainers *int `long:"max-containers" description:"Maximum container capacity. 0 means no limit. (default:250)"`
+		} `group:"Limits"`
+	} `group:"server"`
 }
 
 // Defaults for GdnBinaryFlags
 const (
 	defaultGdnMaxContainers = "250"
-	defaultGdnNetworkPool = "10.80.0.0/16"
+	defaultGdnNetworkPool   = "10.80.0.0/16"
 )
 
 // This prepares the Guardian runtime using the gdn binary.
@@ -54,8 +59,8 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 
 	gdnConfigFlag := []string{}
 
-	if cmd.Guardian.BinaryFlags.Config.Path() != "" {
-		gdnConfigFlag = append(gdnConfigFlag, "--config", cmd.Guardian.BinaryFlags.Config.Path())
+	if cmd.Guardian.Config.Path() != "" {
+		gdnConfigFlag = append(gdnConfigFlag, "--config", cmd.Guardian.Config.Path())
 	}
 
 	gdnServerFlags := []string{
@@ -102,13 +107,14 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 
 	gdnArgs := append(gdnConfigFlag, append([]string{"server"}, gdnServerFlags...)...)
 
-
-	flagsInConfig, err := getGdnFlagsFromConfig(cmd.Guardian.BinaryFlags.Config.Path())
-	if err != nil {
-		return nil, err
+	if cmd.Guardian.Config != "" {
+		configFlags, err := getGdnFlagsFromConfig(cmd.Guardian.Config.Path())
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	gdnArgs = append(gdnArgs, cmd.getGdnFlagsFromStruct(flagsInConfig)...)
+	gdnArgs = append(gdnArgs, cmd.getGdnFlagsFromStruct(configFlags)...)
 
 	bin := "gdn"
 	if cmd.Guardian.Bin != "" {
@@ -178,30 +184,15 @@ func flagify(env string) string {
 	return strings.Replace(strings.ToLower(env), "_", "-", -1)
 }
 
-func getGdnFlagsFromConfig(configPath string) ([]string, error){
-	var configFlags []string
+func getGdnFlagsFromConfig(configPath string) (GdnBinaryFlags, error) {
+	var configFlags GdnBinaryFlags
+	parser := flags.NewParser(&configFlags, flags.Default)
+	parser.NamespaceDelimiter = "-"
 
-	if configPath != "" {
-		file, err := os.Open(configPath)
-		if err != nil {
-			return []string{}, err
-		}
-		defer file.Close()
-		bs := bufio.NewScanner(file)
-		for bs.Scan() {
-			line := bs.Text()
-
-			if len(line) == 0 || line[0] == '#' || line[0] == ';' {
-				continue
-			}
-
-			parts := strings.Split(line, "=")
-			if len(parts) != 2 {
-				continue
-			}
-
-			configFlags = append(configFlags, "--" + strings.TrimSpace(parts[0]))
-		}
+	iniParser := flags.NewIniParser(parser)
+	err := iniParser.ParseFile(configPath)
+	if err != nil {
+		return GdnBinaryFlags{}, err
 	}
 
 	return configFlags, nil
@@ -211,30 +202,20 @@ func getGdnFlagsFromConfig(configPath string) ([]string, error){
 // 1. Sets GdnBinaryFlag when it has been set by user either via env or CLI option
 // 2. Does nothing if flag is present in config.ini
 // 3. Sets default value
-func (cmd *WorkerCommand) getGdnFlagsFromStruct(flagsInConfig []string) []string {
+func (cmd *WorkerCommand) getGdnFlagsFromStruct(configFlags GdnBinaryFlags) []string {
 	var cliFlags []string
 
-	if cmd.Guardian.BinaryFlags.MaxContainers != nil {
-		cliFlags = append(cliFlags, "--max-containers", strconv.Itoa(*cmd.Guardian.BinaryFlags.MaxContainers))
-
-	} else if !isFlagInList("--max-containers", flagsInConfig) {
+	if cmd.Guardian.BinaryFlags.Server.Limits.MaxContainers != nil {
+		cliFlags = append(cliFlags, "--max-containers", strconv.Itoa(*cmd.Guardian.BinaryFlags.Server.Limits.MaxContainers))
+	} else if configFlags.Server.Limits.MaxContainers == nil {
 		cliFlags = append(cliFlags, "--max-containers", defaultGdnMaxContainers)
 	}
 
-	if cmd.Guardian.BinaryFlags.NetworkPool != "" {
-		cliFlags = append(cliFlags, "--network-pool", cmd.Guardian.BinaryFlags.NetworkPool)
-	} else if !isFlagInList("--network-pool", flagsInConfig) {
+	if cmd.Guardian.BinaryFlags.Server.Network.Pool != "" {
+		cliFlags = append(cliFlags, "--network-pool", cmd.Guardian.BinaryFlags.Server.Network.Pool)
+	} else if configFlags.Server.Network.Pool == "" {
 		cliFlags = append(cliFlags, "--network-pool", defaultGdnNetworkPool)
 	}
 
 	return cliFlags
-}
-
-func isFlagInList(flag string, flagList []string) bool {
-	for _, fl := range flagList {
-		if fl == flag {
-			return true
-		}
-	}
-	return false
 }

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -29,13 +29,10 @@ type RuntimeConfiguration struct {
 
 type GuardianRuntime struct {
 	Bin            string        `long:"bin"        description:"Path to a garden server executable (non-absolute names get resolved from $PATH)."`
-	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Garden backend. Guardian flags as env vars, e.g. 'CONCOURSE_GARDEN_FOO_BAR=a,b' for '--foo-bar a --foo-bar b'."`
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 
-	//Guardian specific flags - these are passed along as-is to the gdn binary as options. The defaults have been defined to suite Concourse.
-	MaxContainers  int           `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`
-	NetworkPool    string        `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
+	BinaryFlags GdnBinaryFlags
 }
 
 type ContainerdRuntime struct {

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -32,6 +32,7 @@ type GuardianRuntime struct {
 	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 
+  Config         flag.File     `long:"config"     description:"Path to a config file to use for the Garden backend. e.g. 'foo-bar=a,b' for '--foo-bar a --foo-bar b'."`
 	BinaryFlags GdnBinaryFlags
 }
 


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix

CI currently breaking on this [test](https://github.com/concourse/concourse/blob/64a12a7023f7a68993730c3add624e38773eb9fd/topgun/k8s/garden_config_test.go#L61-L62). `config.ini` values get overridden by default values for Guardian.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

Move `gdn` binary specific flags to own struct called, `GdnBinaryFlags`.

Using go-flags to set Concourse specific defaults for gdn binary flags overrides any value the user may pass via the config.ini file for Guardian. These are now set manually when the values are not present in the config and the defaults are still stated in the command description.

Following conditions are met in the order given
1. Sets GdnBinaryFlag when it has been set by user either via env or CLI option
2. Does nothing if flag is present in config.ini
3. Sets default value

There might be a simpler way to do this in the future using the go-flags IniParser that Guardian uses to parse the config.ini.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->
To test the 3 scenarios:
1. `docker-compose up`
2. `docker exec -it concourse_worker_1 bash`
3. `ps auxww`
4. Check if the gdn process is running with the correct flags


**Scenario 1:** No config, no flags i.e. vanilla docker-compose
Result: max-containers set to 250 and network-pool set to `10.80.0.0/16`

**Scenario 2:** Config file provided but no flags
Example config file (at `/tmp/config.ini` on local):
```
[server]
max-containers=300
network-pool=10.80.0.0/16
```

Add a volume to `worker` section in `docker-compose.yml`
 
```
worker:
    ....
   volumes:
         - /tmp/config.ini:/concourse-config/config.ini
    environment:
         CONCOURSE_GARDEN_CONFIG: "/concourse-config/config.ini"
```

Result: max-containers and network-pool not set

**Scenario 3:** Config file provided AND flags provided (alternatively can also take out config file)
Same as before and add following to worker.environment section of `docker-compose.yml`
```
CONCOURSE_GARDEN_MAX_CONTAINERS: 500
CONCOURSE_GARDEN_NETWORK_POOL: 10.80.0.0/10
```

Result:  max-containers set to 500 and network-pool set to `10.80.0.0/10`

## Release Note
Only pass garden the configured defaults within Concourse for the guardian flags `max-containers` and `network-pool` if it is not set through the garden config file, environment variables or flags.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
