### PR TITLE
`fly pin-resource` requires a version if the resource is unpinned

### DIFF
--- a/fly/commands/pin_resource.go
+++ b/fly/commands/pin_resource.go
@@ -3,11 +3,13 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
+	"github.com/jessevdk/go-flags"
 )
 
 type PinResourceCommand struct {
@@ -30,6 +32,24 @@ func (command *PinResourceCommand) Execute([]string) error {
 	team := target.Team()
 
 	pipelineRef := command.Resource.PipelineRef
+
+	if command.Version == nil && command.Comment == "" {
+		shortDelim := "-"
+		longDelim := "--"
+		if runtime.GOOS == "windows" {
+			shortDelim = "/"
+			longDelim = "/"
+		}
+		return &flags.Error{
+			Type: flags.ErrRequired,
+			Message: fmt.Sprintf(
+				"the required flag `%sv, %sversion' was not specified",
+				shortDelim,
+				longDelim,
+			),
+		}
+	}
+
 	if command.Version != nil {
 		latestResourceVersion, err := GetLatestResourceVersion(team, command.Resource, *command.Version)
 		if err != nil {

--- a/fly/commands/pin_resource.go
+++ b/fly/commands/pin_resource.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"

--- a/fly/integration/pin_resource_test.go
+++ b/fly/integration/pin_resource_test.go
@@ -161,6 +161,17 @@ var _ = Describe("Fly CLI", func() {
 				})
 			})
 
+			Context("when no resource version is specified", func() {
+				It("asks the user to specify a version", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "pin-resource", "-r", pipelineResource)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(1))
+					Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("v", "version") + "' was not specified"))
+				})
+			})
+
 			Context("when pin comment is provided", func() {
 				BeforeEach(func() {
 					commentPath, err = atc.Routes.CreatePathForRoute(atc.SetPinCommentOnResource, rata.Params{


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #6094.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
add the `required` struct tag to the `Version` field, and an integration test -- just in case we ever change flag libraries.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->
Previously, you could run the command on an unpinned resource without passing a version -- it would run and succeed, but do nothing. Now the command will fail and print an error message.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] ~Updated [Documentation]~
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [x] ~Documentation reviewed~
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
