### PR TITLE
switch back to upstream go-flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/imdario/mergo v0.3.6
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/influxdata/influxdb1-client v0.0.0-20190118215656-f8cdb5d5f175
-	github.com/jessevdk/go-flags v1.4.0
+	github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/klauspost/compress v1.9.7
 	github.com/kr/pty v1.1.8
@@ -127,5 +127,3 @@ require (
 go 1.13
 
 replace github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
-
-replace github.com/jessevdk/go-flags => github.com/vito/go-flags v1.4.1-0.20200428200343-c7161c3bd74d

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,9 @@ github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20190118215656-f8cdb5d5f175 h1:NR6eyx+1eski3gN8uqdtjnfpmq0T3lO6HhrPheCPFFc=
 github.com/influxdata/influxdb1-client v0.0.0-20190118215656-f8cdb5d5f175/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7 h1:Ug59miTxVKVg5Oi2S5uHlKOIV5jBx4Hb2u0jIxxDaSs=
+github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/joefitzgerald/rainbow-reporter v0.1.0 h1:AuMG652zjdzI0YCCnXAqATtRBpGXMcAnrajcaTrSeuo=
@@ -680,8 +683,6 @@ github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOV
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vbauerster/mpb/v4 v4.6.1-0.20190319154207-3a6acfe12ac6 h1:nrfAgxqk5DJ20IK1tt0dXbT+heIiNeTmtvj+twRxCbo=
 github.com/vbauerster/mpb/v4 v4.6.1-0.20190319154207-3a6acfe12ac6/go.mod h1:bTEFEKvSeMyGvZVflCs/jDs0Jlc5RJJVSN72r0QxBJI=
-github.com/vito/go-flags v1.4.1-0.20200428200343-c7161c3bd74d h1:PjnCfyHrDAJTvOJr4q4lnxWfV3rrF3K5b5kfg1SjmW0=
-github.com/vito/go-flags v1.4.1-0.20200428200343-c7161c3bd74d/go.mod h1:07OkXRRK4EbEtvYreaZfRIqssDcoccQKxBVOBg1zgV0=
 github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec h1:Klu98tQ9Z1t23gvC7p7sCmvxkZxLhBHLNyrUPsWsYFg=
 github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec/go.mod h1:wPlfmglZmRWMYv/qJy3P+fK/UnoQB5ISk4txfNd9tDo=
 github.com/vito/go-sse v0.0.0-20160212001227-fd69d275caac h1:W7dFvBGUW6cNTGkOzxnb/zIPTrJiM/biDuycvlo3/ek=


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->

just addressing a bit of tech debt -- since our PR got merged, we might as well switch back to the mainline dependency.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->
You can see there's been no official release of go-flags since v1.4.0. I picked https://github.com/jessevdk/go-flags/commit/c17162fe8fd7 because it seems like @jessevdk merged a batch of PRs on July 11 2020, and that was the latest commit after that batch. I've looked over the other PRs that got merged and I pretty much trust that they won't cause us any issues, but you can look yourself:
* https://github.com/jessevdk/go-flags/pull/293 -- ini parser which we don't use?
* https://github.com/jessevdk/go-flags/pull/296 -- ini and man page features we don't use
* https://github.com/jessevdk/go-flags/pull/300 -- handy new API for adding commands to a group
* https://github.com/jessevdk/go-flags/pull/308 -- terminal-width thing that mostly seems to affect esoteric OSes
* https://github.com/jessevdk/go-flags/pull/312 -- affects autocomplete for `hidden:"true"` commands -- seems pretty sensible and we don't have many such commands anyway
* https://github.com/jessevdk/go-flags/issues/315 -- "refactoring" that allows for slightly cleaner error-handling

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] ~Added tests (Unit and/or Integration)~ should be a refactor
- [x] ~Updated [Documentation]~
- [x] ~Added release note (Optional)~ this is a very internal thing that concourse users probably don't care about

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [x] ~Documentation reviewed~
- [x] ~Release notes reviewed~
- [ ] PR acceptance performed
- [x] ~New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).~
