### PR TITLE
Fallback hijack to sh when bash is missing

### DIFF
--- a/atc/api/containerserver/hijack.go
+++ b/atc/api/containerserver/hijack.go
@@ -229,6 +229,14 @@ func (s *Server) hijack(hLog lager.Logger, conn *websocket.Conn, request hijackR
 		Stderr: errW,
 	})
 	if err != nil {
+		if _, ok := err.(garden.ExecutableNotFoundError); ok {
+			hLog.Info("executable-not-found")
+
+			_ = conn.WriteJSON(atc.HijackOutput{
+				ExecutableNotFound: true,
+			})
+		}
+
 		_ = conn.WriteJSON(atc.HijackOutput{
 			Error: err.Error(),
 		})

--- a/atc/hijack_payload.go
+++ b/atc/hijack_payload.go
@@ -28,8 +28,9 @@ type HijackInput struct {
 }
 
 type HijackOutput struct {
-	Stdout     []byte `json:"stdout,omitempty"`
-	Stderr     []byte `json:"stderr,omitempty"`
-	Error      string `json:"error,omitempty"`
-	ExitStatus *int   `json:"exit_status,omitempty"`
+	Stdout             []byte `json:"stdout,omitempty"`
+	Stderr             []byte `json:"stderr,omitempty"`
+	Error              string `json:"error,omitempty"`
+	ExitStatus         *int   `json:"exit_status,omitempty"`
+	ExecutableNotFound bool   `json:"executable_not_found,omitempty"`
 }

--- a/atc/worker/transport/hijack_streamer.go
+++ b/atc/worker/transport/hijack_streamer.go
@@ -104,6 +104,12 @@ func (h *WorkerHijackStreamer) Hijack(ctx context.Context, handler string, body 
 		if err != nil {
 			return nil, nil, fmt.Errorf("Backend error: Exit status: %d, error reading response body: %s", httpResp.StatusCode, err)
 		}
+		var gerr garden.Error
+		if err := gerr.UnmarshalJSON(errRespBytes); err == nil {
+			if _, ok := gerr.Err.(garden.ExecutableNotFoundError); ok {
+				return nil, nil, gerr.Err
+			}
+		}
 
 		return nil, nil, fmt.Errorf("Backend error: Exit status: %d, message: %s", httpResp.StatusCode, errRespBytes)
 	}

--- a/fly/commands/internal/hijacker/hijacker_test.go
+++ b/fly/commands/internal/hijacker/hijacker_test.go
@@ -1,6 +1,7 @@
 package hijacker_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -82,16 +83,17 @@ var _ = Describe("Hijacker", func() {
 
 			reqGenerator := rata.NewRequestGenerator(server.URL(), atc.Routes)
 
-			stdin := gbytes.NewBuffer()
+			inputs := make(chan atc.HijackInput, 1)
 			stdout := gbytes.NewBuffer()
 			stderr := gbytes.NewBuffer()
+			ctx := context.Background()
 
 			h := hijacker.New(tlsConfig, reqGenerator, nil)
-			_, err := h.Hijack("some-team", "hello", atc.HijackProcessSpec{
+			_, _, err := h.Hijack(ctx, "some-team", "hello", atc.HijackProcessSpec{
 				Path: "/bin/echo",
 				Args: []string{"hello", "world"},
 			}, hijacker.ProcessIO{
-				In:  stdin,
+				In:  inputs,
 				Out: stdout,
 				Err: stderr,
 			})


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | Feature

Fixes  #5877

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
The intent of this PR was to allow `fly hijack` commands with no path specified, to assume the user just wants some shell, and if `bash` isn't available, try again with `sh`. This required some changes to atc to unmarshal a `garden.ExecutableNotFoundError` sent from the container, and turning that into a special message sent back to fly.

It feels a little inelegant to pass back another return variable (a `bool`) in a couple places where we already pass an exit status `int`, but I didn't have enough understanding of the exit status codes to feel comfortable just passing back `254`, and figured if golang supports it, another return var is better then some weird edge case where `254` is passed back and the user is unexpectedly re-hijacking with `sh`.

This is based on prior work and suggestions on https://github.com/concourse/concourse/pull/4755

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->
The default behaviour of the `fly hijack` command when a path is not specified was to use `"bash"`. This default behaviour has changed so that it first tries to use `"bash"`, but if the container returns an error indicating bash is not available, `fly` will retry the hijack using more limited but more common `"sh"`. If this fallback logic is not desired, the user can explicitly specify `bash` as the path argument to the `fly hijack` command. 

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the [BOSH](https://github.com/concourse/concourse-bosh-release) and [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for the [integration tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env) (for example, if they are Garden configs that are not displayed in the `--help` text).
 