### PR TITLE
Fix fly integration tests on windows

### DIFF
--- a/fly/integration/archive_pipeline_test.go
+++ b/fly/integration/archive_pipeline_test.go
@@ -329,7 +329,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
 
-				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-p, --pipeline'"))
+				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
 	})

--- a/fly/integration/checklist_test.go
+++ b/fly/integration/checklist_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
 
-				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-p, --pipeline'"))
+				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
 

--- a/fly/integration/destroy_pipeline_test.go
+++ b/fly/integration/destroy_pipeline_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
 
-				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-p, --pipeline'"))
+				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
 

--- a/fly/integration/expose_pipeline_test.go
+++ b/fly/integration/expose_pipeline_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
 
-				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-p, --pipeline'"))
+				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
 

--- a/fly/integration/get_pipeline_test.go
+++ b/fly/integration/get_pipeline_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Fly CLI", func() {
 					<-sess.Exited
 					Expect(sess.ExitCode()).To(Equal(1))
 
-					Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-p, --pipeline'"))
+					Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 				})
 			})
 

--- a/fly/integration/hide_pipeline_test.go
+++ b/fly/integration/hide_pipeline_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
 
-				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-p, --pipeline'"))
+				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
 

--- a/fly/integration/ordering_pipelines_test.go
+++ b/fly/integration/ordering_pipelines_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
 
-				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-p, --pipeline'"))
+				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
 

--- a/fly/integration/pause_pipeline_test.go
+++ b/fly/integration/pause_pipeline_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
 
-				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-p, --pipeline'"))
+				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
 

--- a/fly/integration/rename_pipeline_test.go
+++ b/fly/integration/rename_pipeline_test.go
@@ -74,7 +74,7 @@ var _ = Describe("RenamePipeline", func() {
 			<-sess.Exited
 			Expect(sess.ExitCode()).To(Equal(1))
 
-			Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-o, --old-name'"))
+			Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("o", "old-name")))
 		})
 	})
 

--- a/fly/integration/unpause_pipeline_test.go
+++ b/fly/integration/unpause_pipeline_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
 
-				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `-p, --pipeline'"))
+				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
 


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

36848225a496d5920dfa7ff7ba2680456f4ee2ec added some fly integration tests that asserted on error messages like

> invalid argument for flag `-p, --pipeline'

For windows, the flag format that is printed is `/p, /pipeline', causing these tests to fail on windows.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Use the `osFlag` helper in place of the hardcoded flags

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
