### PR TITLE
Parse `--garden-max-containers` as a string

### DIFF
--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -7,16 +7,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/localip"
 	concourseCmd "github.com/concourse/concourse/cmd"
+	flags "github.com/jessevdk/go-flags"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/grouper"
-	flags "github.com/jessevdk/go-flags"
 )
 
 // Guardian binary flags - these are passed along as-is to the gdn binary as options.
@@ -32,7 +31,7 @@ type GdnBinaryFlags struct {
 		} `group:"Container Networking"`
 
 		Limits struct {
-			MaxContainers *int `long:"max-containers" description:"Maximum container capacity. 0 means no limit. (default:250)"`
+			MaxContainers string `long:"max-containers" description:"Maximum container capacity. 0 means no limit. (default:250)"`
 		} `group:"Limits"`
 	} `group:"server"`
 }
@@ -206,9 +205,9 @@ func getGdnFlagsFromConfig(configPath string) (GdnBinaryFlags, error) {
 func (cmd *WorkerCommand) getGdnFlagsFromStruct(configFlags GdnBinaryFlags) []string {
 	var cliFlags []string
 
-	if cmd.Guardian.BinaryFlags.Server.Limits.MaxContainers != nil {
-		cliFlags = append(cliFlags, "--max-containers", strconv.Itoa(*cmd.Guardian.BinaryFlags.Server.Limits.MaxContainers))
-	} else if configFlags.Server.Limits.MaxContainers == nil {
+	if cmd.Guardian.BinaryFlags.Server.Limits.MaxContainers != "" {
+		cliFlags = append(cliFlags, "--max-containers", cmd.Guardian.BinaryFlags.Server.Limits.MaxContainers)
+	} else if configFlags.Server.Limits.MaxContainers == "" {
 		cliFlags = append(cliFlags, "--max-containers", defaultGdnMaxContainers)
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

k8s topgun was failing because the value for `CONCOURSE_GARDEN_MAX_CONTAINERS` was quoted, while the flag was a
`*int`. Let's just unmarshal it as a string, pass it on to guardian as is, and allow guardian to do the validation.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

You can test this by setting `CONCOURSE_GARDEN_MAX_CONTAINERS: '"100"'` in `docker-compose.yml` - it will fail on master, but will work with this fix. Doing this worked before #6087 was merged

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
