### PR TITLE
Fix: ignore unknown keys in garden ini

### DIFF
--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -186,7 +186,7 @@ func flagify(env string) string {
 
 func getGdnFlagsFromConfig(configPath string) (GdnBinaryFlags, error) {
 	var configFlags GdnBinaryFlags
-	parser := flags.NewParser(&configFlags, flags.Default)
+	parser := flags.NewParser(&configFlags, flags.Default | flags.IgnoreUnknown)
 	parser.NamespaceDelimiter = "-"
 
 	iniParser := flags.NewIniParser(parser)


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

In the [`bin-smoke` job](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/bin-smoke/builds/289) the test was timing out. We figured out the worker wasn't coming up and found this error in the logs:

```
error: /etc/concourse/garden.ini:2: unknown option: dns-server
```

## Changes proposed by this PR:
We started parsing the garden ini as part of #6087. After that PR the
worker would fail to come up if the garden.ini contained any unknown
keys (unknown to Concourse).

This commit will unblock the pipeline. We should spend some time
thinking about this area of the codebase and figure out what the best
strategy moving forward should be.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
