### PR TITLE
Fix pipeline cards being rendered off-screen when sidebar was open

### DIFF
--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -338,7 +338,8 @@ handleCallback callback ( model, effects ) =
                 , pipelinesError = Nothing
               }
             , effects
-                ++ (if List.isEmpty allPipelinesInEntireCluster then
+                ++ GetViewportOf Dashboard
+                :: (if List.isEmpty allPipelinesInEntireCluster then
                         [ ModifyUrl "/" ]
 
                     else

--- a/web/elm/tests/PipelineGridTests.elm
+++ b/web/elm/tests/PipelineGridTests.elm
@@ -125,6 +125,13 @@ all =
                         )
                     |> Tuple.second
                     |> Common.contains (GetViewportOf Dashboard)
+        , test "fetches the viewport of the scrollable area when pipelines are fetched" <|
+            \_ ->
+                loadDashboardWithSize 600 600
+                    |> Application.handleCallback
+                        (Callback.AllPipelinesFetched (Ok []))
+                    |> Tuple.second
+                    |> Common.contains (GetViewportOf Dashboard)
         , test "renders pipeline cards in a single column grid when the viewport is narrow" <|
             \_ ->
                 loadDashboardWithSize 300 600


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

This has been an intermittent bug that I've noticed since #5118 - if the
sidebar is open and you refresh the page, occasionally the pipeline
cards will be rendered as if the sidebar was not opened (meaning that
the lazy rendering computation thinks it has more room to work with, and
a column may be rendered partially off-screen)

<img width="1280" alt="Screen Shot 2020-09-30 at 8 53 41 PM" src="https://user-images.githubusercontent.com/26583442/94754976-e776d300-0360-11eb-9898-37a06cbbec59.png">


## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Request dashboard size when pipelines are fetched. We recompute the dashboard position when we fetch sidebar state from session storage, but the sidebar will not open until the pipelines have been fetched.
  * We could probably get away with re-requesting the dashboard size after the first `AllPipelinesFetched` response, but doing it every time doesn't really hurt

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

This is a particularly prevalent bug when the network speed is slow, so your best bet to repro this is to use the "Slow 3G" network emulation in Chrome/Firefox.

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

* Fixes occasional bug where pipelines would be rendered off-screen after a refresh on the dashboard

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
