### PR TITLE
Fix quoting for var subkeys

### DIFF
--- a/vars/template.go
+++ b/vars/template.go
@@ -137,6 +137,7 @@ func (i interpolator) extractVarNames(value string) []string {
 
 func parseVarName(name string) VariableReference {
 	var pathPieces []string
+	var fields []string
 
 	varRef := VariableReference{Name: name}
 
@@ -151,8 +152,13 @@ func parseVarName(name string) VariableReference {
 	}
 
 	varRef.Path = strings.ReplaceAll(pathPieces[0], "\"", "")
+
 	if len(pathPieces) >= 2 {
-		varRef.Fields = pathPieces[1:]
+		for _, piece := range pathPieces[1:] {
+			fields = append(fields, strings.ReplaceAll(piece, "\"", ""))
+		}
+
+		varRef.Fields = fields
 	}
 
 	return varRef

--- a/vars/template_test.go
+++ b/vars/template_test.go
@@ -219,6 +219,19 @@ dup-key: ((key3))
 		Expect(string(result)).To(Equal(string([]byte("bar: fuzz\n"))))
 	})
 
+	It("can interpolate keys with dot in subkey into a byte slice", func() {
+		template := NewTemplate([]byte("bar: ((secret-name.\"secret.field\"))"))
+		vars := StaticVariables{
+			"secret-name": map[string]interface{}{
+				"secret.field": "topsekrit",
+			},
+		}
+
+		result, err := template.Evaluate(vars, EvaluateOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(result)).To(Equal(string([]byte("bar: topsekrit\n"))))
+	})
+
 	It("can interpolate a secret key in the middle of a string", func() {
 		template := NewTemplate([]byte("url: https://((ip))"))
 		vars := StaticVariables{


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix

closes #6107 .

## Changes proposed by this PR:
When the variable name is parsed into the path and fields in `vars/template.go`, we remove the escaped quotes from the path but not from the fields.

This breaks lookups for variable nested fields that contain characters such as `.`. 

The documentation already states that we can quote parts of the variable interpolation syntax when they contain special characters such as `.` or `:` so I didn't need to make any changes there.


## Notes to reviewer:
The PR can be tested as described in the linked issue #6107.

## Release Note
Fix interpolation of quoted variable fields containing special characters.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
