### PR TITLE
Add an example for the release note section in the pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,9 +38,13 @@ Mainly, pointers to review the PR, and how they can test it.
 
 ## Release Note
 <!--
-If needed, you can leave a detailed description here which will be used to
-generate the release note for the next version of Concourse. The title of the
-PR will also be pulled into the release note.
+If needed, you can leave a list of detailed descriptions here which will be
+used to generate the release note for the next version of Concourse. The title
+of the PR will also be pulled into the release note.
+
+Example:
+* Reticulating splines is the new process Concourse uses to create the network
+  of lines between jobs.
 -->
 
 ## Contributor Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,10 @@ of the PR will also be pulled into the release note.
 Example:
 * Reticulating splines is the new process Concourse uses to create the network
   of lines between jobs.
+* Combines many short lines and curves into a network of splines.
 -->
+
+* <!-- Release note here. Delete section if not needed. -->
 
 ## Contributor Checklist
 <!--


### PR DESCRIPTION
## What does this PR accomplish?
The format of the release note section in a pr description should be in a list. It looks best like that in the generated release note :D

## Changes proposed by this PR:
I added an example that shows the format of the release note section should be in a list.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
