### PR TITLE
Prevent set_pipeline runtime error

### DIFF
--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -208,10 +208,14 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState, delegate S
 		logger.Debug("no-diff")
 
 		fmt.Fprintf(stdout, "no diff found.\n")
-		err := pipeline.SetParentIDs(step.metadata.JobID, step.metadata.BuildID)
-		if err != nil {
-			return err
+
+		if found {
+			err := pipeline.SetParentIDs(step.metadata.JobID, step.metadata.BuildID)
+			if err != nil {
+				return err
+			}
 		}
+
 		delegate.SetPipelineChanged(logger, false)
 		step.succeeded = true
 		delegate.Finished(logger, true)

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -31,18 +31,6 @@ jobs:
 - name:
 `
 
-	const badPipelineContentWithTaskSyntax = `
----
-platform: linux
-image_resource:
-  type: registry-image
-  source: {repository: busybox}
-run:
- path: echo
- args:
-   - hello
-`
-
 	const badPipelineContentWithEmptyContent = `
 ---
 `
@@ -261,30 +249,6 @@ jobs:
 			})
 		})
 
-		Context("when pipeline file exists but has task syntax", func() {
-			BeforeEach(func() {
-				fakeWorkerClient.StreamFileFromArtifactReturns(&fakeReadCloser{str: badPipelineContentWithTaskSyntax}, nil)
-			})
-
-			It("should not return error", func() {
-				Expect(stepErr).NotTo(HaveOccurred())
-			})
-
-			It("should log no-diff", func() {
-				Expect(stdout).To(gbytes.Say("no diff found."))
-			})
-
-			It("should send a set pipeline changed event", func() {
-				Expect(fakeDelegate.SetPipelineChangedCallCount()).To(Equal(1))
-				_, changed := fakeDelegate.SetPipelineChangedArgsForCall(0)
-				Expect(changed).To(BeFalse())
-			})
-
-			It("should not update the job and build id", func() {
-				Expect(fakePipeline.SetParentIDsCallCount()).To(Equal(0))
-			})
-		})
-
 		Context("when pipeline file exists but is empty", func() {
 			BeforeEach(func() {
 				fakeWorkerClient.StreamFileFromArtifactReturns(&fakeReadCloser{str: badPipelineContentWithEmptyContent}, nil)
@@ -343,6 +307,30 @@ jobs:
 
 				It("should stdout have message", func() {
 					Expect(stdout).To(gbytes.Say("done"))
+				})
+
+				Context("when no diff is found", func() {
+					BeforeEach(func() {
+						fakeWorkerClient.StreamFileFromArtifactReturns(&fakeReadCloser{str: badPipelineContentWithEmptyContent}, nil)
+					})
+
+					It("should not return error", func() {
+						Expect(stepErr).NotTo(HaveOccurred())
+					})
+
+					It("should log no-diff", func() {
+						Expect(stdout).To(gbytes.Say("no diff found."))
+					})
+
+					It("should send a set pipeline changed event", func() {
+						Expect(fakeDelegate.SetPipelineChangedCallCount()).To(Equal(1))
+						_, changed := fakeDelegate.SetPipelineChangedArgsForCall(0)
+						Expect(changed).To(BeFalse())
+					})
+
+					It("should not update the job and build id", func() {
+						Expect(fakePipeline.SetParentIDsCallCount()).To(Equal(0))
+					})
 				})
 			})
 

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -31,6 +31,22 @@ jobs:
 - name:
 `
 
+	const badPipelineContentWithTaskSyntax = `
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source: {repository: busybox}
+run:
+ path: echo
+ args:
+   - hello
+`
+
+	const badPipelineContentWithEmptyContent = `
+---
+`
+
 	const pipelineContent = `
 ---
 jobs:
@@ -242,6 +258,54 @@ jobs:
 				Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
 				_, succeeded := fakeDelegate.FinishedArgsForCall(0)
 				Expect(succeeded).To(BeFalse())
+			})
+		})
+
+		Context("when pipeline file exists but has task syntax", func() {
+			BeforeEach(func() {
+				fakeWorkerClient.StreamFileFromArtifactReturns(&fakeReadCloser{str: badPipelineContentWithTaskSyntax}, nil)
+			})
+
+			It("should not return error", func() {
+				Expect(stepErr).NotTo(HaveOccurred())
+			})
+
+			It("should log no-diff", func() {
+				Expect(stdout).To(gbytes.Say("no diff found."))
+			})
+
+			It("should send a set pipeline changed event", func() {
+				Expect(fakeDelegate.SetPipelineChangedCallCount()).To(Equal(1))
+				_, changed := fakeDelegate.SetPipelineChangedArgsForCall(0)
+				Expect(changed).To(BeFalse())
+			})
+
+			It("should not update the job and build id", func() {
+				Expect(fakePipeline.SetParentIDsCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when pipeline file exists but is empty", func() {
+			BeforeEach(func() {
+				fakeWorkerClient.StreamFileFromArtifactReturns(&fakeReadCloser{str: badPipelineContentWithEmptyContent}, nil)
+			})
+
+			It("should not return error", func() {
+				Expect(stepErr).NotTo(HaveOccurred())
+			})
+
+			It("should log no-diff", func() {
+				Expect(stdout).To(gbytes.Say("no diff found."))
+			})
+
+			It("should send a set pipeline changed event", func() {
+				Expect(fakeDelegate.SetPipelineChangedCallCount()).To(Equal(1))
+				_, changed := fakeDelegate.SetPipelineChangedArgsForCall(0)
+				Expect(changed).To(BeFalse())
+			})
+
+			It("should not update the job and build id", func() {
+				Expect(fakePipeline.SetParentIDsCallCount()).To(Equal(0))
 			})
 		})
 

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -33,3 +33,7 @@
 
   A new metric called `tasks_wait_duration_bucket` is also added to express as quantiles the average time spent by tasks awaiting execution. PR: #5981
   ![Example graph for the task wait time histograms.](https://user-images.githubusercontent.com/40891147/89990749-189d2600-dc83-11ea-8fde-ae579fdb0a0a.png)
+
+#### <sub><sup><a name="6111" href="#6111">:link:</a></sup></sub> bug
+
+* @mdb Running `set_pipeline` against a pipeline config YML file with no `jobs:` no longer causes runtime error. Issue: #6111 PR: #6116

--- a/release-notes/latest.md
+++ b/release-notes/latest.md
@@ -33,7 +33,3 @@
 
   A new metric called `tasks_wait_duration_bucket` is also added to express as quantiles the average time spent by tasks awaiting execution. PR: #5981
   ![Example graph for the task wait time histograms.](https://user-images.githubusercontent.com/40891147/89990749-189d2600-dc83-11ea-8fde-ae579fdb0a0a.png)
-
-#### <sub><sup><a name="6111" href="#6111">:link:</a></sup></sub> bug
-
-* @mdb Running `set_pipeline` against a pipeline config YML file with no `jobs:` no longer causes runtime error. Issue: #6111 PR: #6116


### PR DESCRIPTION
## What does this PR accomplish?

This PR seeks to address issue #6111 by preventing a `runtime error: invalid memory address or nil pointer dereference` when `set_pipeline` is run with a `file:` whose YML contains unexpected content.

## Changes proposed by this PR:

This PR attempts to prevent the runtime error in the most minimal way possible by _only_ attempting to invoke `pipeline.SetParentIDs(step.metadata.JobID, step.metadata.BuildID)` _if_ a pipeline is found by `team.Pipeline(pipelineRef)`, in effect avoiding a scenario where `pipeline` doesn't exist and where `pipeline.SetParentIDs()` causes a runtime error.

One could imagine other solutions, such as perhaps improved [configvalidate#Validate](https://github.com/concourse/concourse/blob/master/atc/configvalidate/validate.go#L25) functionality to protect against this. However, the solution implemented in this PR aspires to be a simple first pass at fixing the problem with a minimal code change.

## Notes to reviewer:

This fix can be verified by running `docker-compose up --build` against this code and `fly set-pipeline`-ing the following pipeline...

```yaml
resource_types:

- name: git-ubuntu
  type: registry-image
  source:
    repository: concourse/git-resource
    tag: ubuntu

resources:

- name: gist
  type: git-ubuntu
  source:
    uri: https://gist.github.com/ac6ae0980b268ae5ff2449fef3ab87c5.git

jobs:

- name: update-pipeline-with-task-yml
  plan:
  - get: gist
  - set_pipeline: bad-pipeline
    file: gist/task.yml

- name: update-pipeline-with-empty-yml
  plan:
  - get: gist
  - set_pipeline: bad-pipeline
    file: gist/empty.yml

- name: update-pipeline-with-valid-yml
  plan:
  - get: gist
  - set_pipeline: good-pipeline
    file: gist/valid-pipeline.yml
```

Running `update-pipeline-with-task-yml` and `update-pipeline-with-empty-yml` should not result in newly-set `bad-pipeline` pipelines. Running `update-pipeline-with-valid-yml` _should_ result in a newly-set `good-pipeline`.

## Release Note

`set_pipeline` of a YML pipeline configuration file with no `jobs:` or `resources:` no longer causes a `runtime error: invalid memory address or nil pointer dereference`.

## Contributor Checklist

- [X] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [X] [Signed] all commits
- [X] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
