### PR TITLE
Emit start/finish metrics from check step

### DIFF
--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -61,7 +61,6 @@ type Monitor struct {
 
 	ChecksFinishedWithError   Counter
 	ChecksFinishedWithSuccess Counter
-	ChecksQueueSize           Gauge
 	ChecksStarted             Counter
 	ChecksEnqueued            Counter
 

--- a/atc/metric/periodic.go
+++ b/atc/metric/periodic.go
@@ -220,14 +220,6 @@ func tick(logger lager.Logger, m *Monitor) {
 		},
 	)
 
-	m.emit(
-		logger.Session("checks-queue-size"),
-		Event{
-			Name:  "checks queue size",
-			Value: m.ChecksQueueSize.Max(),
-		},
-	)
-
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix

## Changes proposed by this PR:

This PR is a followup for #6022 that re-introduces the check start/finish
metrics, previously emitted by the LIDAR checker, now emitted by the check
step.

## Notes to reviewer:

n/a

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] ~~Added tests (Unit and/or Integration)~~
- [ ] ~~Updated [Documentation]~~
- [ ] ~~Added release note (Optional)~~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
