### PR TITLE
make CNI plugins directory configurable

### DIFF
--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -174,12 +174,15 @@ func NewCNINetwork(opts ...CNINetworkOpt) (*cniNetwork, error) {
 	var err error
 
 	n := &cniNetwork{
-		binariesDir: binariesDir,
 		config:      defaultCNINetworkConfig,
 	}
 
 	for _, opt := range opts {
 		opt(n)
+	}
+
+	if n.binariesDir == "" {
+		n.binariesDir = binariesDir
 	}
 
 	if n.store == nil {

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -56,7 +56,7 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 	)
 
 	backendOpts := []runtime.GardenBackendOpt{}
-	networkOpts := []runtime.CNINetworkOpt{}
+	networkOpts := []runtime.CNINetworkOpt{runtime.WithCNIBinariesDir(cmd.Containerd.CNIPluginsDir)}
 
 	if len(dnsServers) > 0 {
 		networkOpts = append(networkOpts, runtime.WithNameServers(dnsServers))

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -39,7 +39,8 @@ type GuardianRuntime struct {
 type ContainerdRuntime struct {
 	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Containerd daemon."`
 	Bin            string        `long:"bin"        description:"Path to a containerd executable (non-absolute names get resolved from $PATH)."`
-	InitBin        string        `long:"init-bin" default:"/usr/local/concourse/bin/init" description:"Path to a dumb init executable (non-absolute names get resolved from $PATH)."`
+	InitBin        string        `long:"init-bin"   default:"/usr/local/concourse/bin/init" description:"Path to an init executable (non-absolute names get resolved from $PATH)."`
+	CNIPluginsDir  string        `long:"cni-plugins-dir" default:"/usr/local/concourse/bin" description:"Path to CNI network plugins."`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
 
 	//TODO can DNSConfig be simplifed to just a bool rather than struct with a bool?


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Feature**

containerd is currently failing on BOSH as the path for CNI network plugins is different there. Error from the worker logs:

```
$ tail -1 /var/vcap/sys/log/worker/worker.stdout.log
{"timestamp":"2020-10-05T20:00:40.964319903Z","level":"error","source":"worker","message":"worker.garden.garden-server.create.failed","data":{"error":"starting task: network add: cni net setup: failed to find plugin \"bridge\" in path [/usr/local/concourse/bin]","request":{"Handle":"734ee021-98da-4081-40fa-1b9fdd464cc8","GraceTime":0,"RootFSPath":"raw:///var/vcap/data/worker/work/volumes/live/be9b09ac-28c9-438f-650a-c7d232d84f39/volume","BindMounts":[{"src_path":"/var/vcap/data/worker/work/volumes/live/727c3689-1a2a-4925-5509-066904a30281/volume","dst_path":"/etc/ssl/certs"},{"src_path":"/var/vcap/data/worker/work/volumes/live/89ad10cc-f6a6-45d3-4a50-9b0e8f3ce822/volume","dst_path":"/scratch","mode":1}],"Network":"","Privileged":false,"Limits":{"bandwidth_limits":{},"cpu_limits":{},"disk_limits":{},"memory_limits":{},"pid_limits":{}}},"session":"1.2.2508"}}
```

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

Makes the path to CNI network plugin binaries configurable allowing for the BOSH release to specify the correct path.

Related BOSH Release PR: https://github.com/concourse/concourse-bosh-release/pull/125
Related Charts PR: https://github.com/concourse/concourse-chart/pull/156

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
