### PR TITLE
allow @ sign in var

### DIFF
--- a/vars/template.go
+++ b/vars/template.go
@@ -62,7 +62,7 @@ type interpolator struct{}
 
 var (
 	pathRegex                  = regexp.MustCompile(`("[^"]*"|[^\.]+)+`)
-	interpolationRegex         = regexp.MustCompile(`\(\((([-/\.\w\pL]+\:)?[-/\.:"\w\pL]+)\)\)`)
+	interpolationRegex         = regexp.MustCompile(`\(\((([-/\.\w\pL]+\:)?[-/\.:@"\w\pL]+)\)\)`)
 	interpolationAnchoredRegex = regexp.MustCompile("\\A" + interpolationRegex.String() + "\\z")
 )
 

--- a/vars/template_test.go
+++ b/vars/template_test.go
@@ -242,6 +242,17 @@ dup-key: ((key3))
 		Expect(result).To(Equal([]byte("uri: nats://nats:secret@10.0.0.0:4222\n")))
 	})
 
+	It("allows @ in a var name", func() {
+		template := NewTemplate([]byte("((\"foo/bar/me.com-test@me.com/password\"))"))
+		vars := StaticVariables{
+			"foo/bar/me.com-test@me.com/password": "secret",
+		}
+
+		result, err := template.Evaluate(vars, EvaluateOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal([]byte("secret\n")))
+	})
+
 	It("can interpolate multiple keys of type string and int in the middle of a string", func() {
 		template := NewTemplate([]byte("address: ((ip)):((port))"))
 		vars := StaticVariables{


### PR DESCRIPTION
What does this PR accomplish?

Fix a bug raised in https://github.com/concourse/concourse/pull/5898#issuecomment-704309084

## Changes proposed by this PR:
allow `@` sign in the var path match regex


## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
