### PR TITLE
cleanup k8s topgun releases if failure outside of `It` block

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("baggageclaim drivers", func() {
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 	onPks(func() {

--- a/topgun/k8s/container_limits_test.go
+++ b/topgun/k8s/container_limits_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Container Limits", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 })

--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -17,7 +17,7 @@ var _ = Describe("DNS Resolution", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 		atc.Close()
 	})
 

--- a/topgun/k8s/ephemeral_worker_test.go
+++ b/topgun/k8s/ephemeral_worker_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Ephemeral workers", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 		atc.Close()
 	})
 

--- a/topgun/k8s/external_postgres_test.go
+++ b/topgun/k8s/external_postgres_test.go
@@ -41,7 +41,7 @@ var _ = Describe("External PostgreSQL", func() {
 
 	AfterEach(func() {
 		helmDestroy(pgReleaseName, namespace)
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 	It("can have pipelines set", func() {

--- a/topgun/k8s/external_worker_test.go
+++ b/topgun/k8s/external_worker_test.go
@@ -72,8 +72,7 @@ var _ = Describe("external workers through separate deployments", func() {
 
 	AfterEach(func() {
 		atc.Close()
-		cleanup(releaseName+"-web", namespace+"-web")
-		cleanup(releaseName+"-worker", namespace+"-worker")
+		cleanupReleases()
 	})
 
 	Context("main team worker, webs only allow team workers", func() {

--- a/topgun/k8s/garden_config_test.go
+++ b/topgun/k8s/garden_config_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Garden Config", func() {
 
 	AfterEach(func() {
 		garden.Close()
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 	Context("passing a config map location to the worker to be used by gdn", func() {

--- a/topgun/k8s/https_web_tls_termination_test.go
+++ b/topgun/k8s/https_web_tls_termination_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 
 		AfterEach(func() {
 			atc.Close()
-			cleanup(releaseName, namespace)
+			cleanupReleases()
 		})
 
 		Context("with tls termination at web", func() {

--- a/topgun/k8s/kubernetes_creds_mgmt_test.go
+++ b/topgun/k8s/kubernetes_creds_mgmt_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Kubernetes credential management", func() {
 
 	AfterEach(func() {
 		atc.Close()
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 	JustBeforeEach(func() {

--- a/topgun/k8s/mainteam_role_test.go
+++ b/topgun/k8s/mainteam_role_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Main team role config", func() {
 
 	AfterEach(func() {
 		atc.Close()
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 	Context("Adding team role config yaml to web", func() {

--- a/topgun/k8s/prometheus_test.go
+++ b/topgun/k8s/prometheus_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Prometheus integration", func() {
 
 	AfterEach(func() {
 		helmDestroy(prometheusReleaseName, namespace)
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 	It("Is able to retrieve concourse metrics", func() {

--- a/topgun/k8s/tsa_node_port_test.go
+++ b/topgun/k8s/tsa_node_port_test.go
@@ -19,7 +19,7 @@ var _ = Describe("TSA Service Node Port", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 })

--- a/topgun/k8s/web_scaling_test.go
+++ b/topgun/k8s/web_scaling_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Scaling web instances", func() {
 	})
 
 	AfterEach(func() {
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 	It("succeeds", func() {

--- a/topgun/k8s/worker_lifecycle_test.go
+++ b/topgun/k8s/worker_lifecycle_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Worker lifecycle", func() {
 
 	AfterEach(func() {
 		atc.Close()
-		cleanup(releaseName, namespace)
+		cleanupReleases()
 	})
 
 	Context("terminating the worker", func() {


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | Feature | Documentation

closes #6121

## Changes proposed by this PR:
- keep track of which releases were successfully deployed by helm
- delete all know deployed releases on test suite exit

## Notes to reviewer:

## Release Note

## Contributor Checklist

- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
