### PR TITLE
fly: add --team flag to order-pipelines

### DIFF
--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -17,7 +17,7 @@ var ErrMissingPipelineName = errors.New("Need to specify atleast one pipeline na
 type OrderPipelinesCommand struct {
 	Alphabetical bool                       `short:"a"  long:"alphabetical" description:"Order all pipelines alphabetically"`
 	Pipelines    []flaghelpers.PipelineFlag `short:"p" long:"pipeline" description:"Name of pipeline to order"`
-	Team         string                     `long:"team" description:"Name of the team to which the pipeline, if different from the target default"`
+	Team         string                     `long:"team" description:"Name of the team to which the pipelines belong, if different from the target default"`
 }
 
 func (command *OrderPipelinesCommand) Validate() (atc.OrderPipelinesRequest, error) {

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -126,6 +126,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
 			Entry("get-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
+			Entry("order-pipelines command returns an error",
+				exec.Command(flyPath, "-t", targetName, "order-pipelines", "-p", "pipeline", "--team", "doesnotexist")),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",


### PR DESCRIPTION
fly: add --team flag to order-pipelines


Allow for users to order pipelines for different teams
without switching targets

#5215

Signed-off-by: witjem <witjem@pm.me>


[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Feature 

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
