### PR TITLE
fly: add --team option to get-pipeline command

### DIFF
--- a/fly/commands/get_pipeline.go
+++ b/fly/commands/get_pipeline.go
@@ -13,12 +13,14 @@ import (
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
+	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/mattn/go-isatty"
 )
 
 type GetPipelineCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Get configuration of this pipeline"`
 	JSON     bool                     `short:"j" long:"json"                     description:"Print config as json instead of yaml"`
+	Team     string                   `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *GetPipelineCommand) Validate() error {
@@ -42,7 +44,18 @@ func (command *GetPipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	config, _, found, err := target.Team().PipelineConfig(command.Pipeline.Ref())
+	var team concourse.Team
+
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team)
+		if err != nil {
+			return err
+		}
+	} else {
+		team = target.Team()
+	}
+
+	config, _, found, err := team.PipelineConfig(command.Pipeline.Ref())
 	if err != nil {
 		return err
 	}

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -124,6 +124,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", "doesnotexist")),
 			Entry("destroy-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
+			Entry("get-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -160,6 +162,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", "other-team")),
 			Entry("destroy-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", "other-team")),
+			Entry("get-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", "other-team")),
 		)
 	})
 })


### PR DESCRIPTION
Allows fly cli to get pipeline for different teams
without having to switch targets

concourse/concourse#5215

Signed-off-by: techgaun <coolsamar207@gmail.com>

<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Feature

references #5215 .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
- Allows fly cli to get pipeline for different teams
without having to switch targets by adding `--team` fly CLI switch

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
