### PR TITLE
Introduce dbtest package for higher-level test setup

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1243,7 +1243,7 @@ func (b *build) AdoptInputsAndPipes() ([]BuildInput, bool, error) {
 
 	defer tx.Rollback()
 
-	var found bool
+	var determined bool
 	err = psql.Select("inputs_determined").
 		From("jobs").
 		Where(sq.Eq{
@@ -1251,12 +1251,12 @@ func (b *build) AdoptInputsAndPipes() ([]BuildInput, bool, error) {
 		}).
 		RunWith(tx).
 		QueryRow().
-		Scan(&found)
+		Scan(&determined)
 	if err != nil {
 		return nil, false, err
 	}
 
-	if !found {
+	if !determined {
 		return nil, false, nil
 	}
 

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -31,11 +31,6 @@ type Checkable interface {
 
 	HasWebhook() bool
 
-	SetResourceConfig(
-		atc.Source,
-		atc.VersionedResourceTypes,
-	) (ResourceConfigScope, error)
-
 	CheckPlan(atc.Version, time.Duration, ResourceTypes, atc.Source) atc.CheckPlan
 	CreateBuild(context.Context, bool) (Build, bool, error)
 }

--- a/atc/db/db_suite_test.go
+++ b/atc/db/db_suite_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/concourse/concourse/atc/creds/credsfakes"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/metric"
 	"github.com/concourse/concourse/atc/postgresrunner"
@@ -50,6 +51,8 @@ var (
 	userFactory                         db.UserFactory
 	dbWall                              db.Wall
 	fakeClock                           dbfakes.FakeClock
+
+	builder dbtest.Builder
 
 	defaultWorkerResourceType atc.WorkerResourceType
 	uniqueWorkerResourceType  atc.WorkerResourceType
@@ -131,6 +134,8 @@ var _ = BeforeEach(func() {
 	workerTaskCacheFactory = db.NewWorkerTaskCacheFactory(dbConn)
 	userFactory = db.NewUserFactory(dbConn)
 	dbWall = db.NewWall(dbConn, &fakeClock)
+
+	builder = dbtest.NewBuilder(dbConn, lockFactory)
 
 	var err error
 	defaultTeam, err = teamFactory.CreateTeam(atc.Team{Name: "default-team"})

--- a/atc/db/dbfakes/fake_checkable.go
+++ b/atc/db/dbfakes/fake_checkable.go
@@ -165,20 +165,6 @@ type FakeCheckable struct {
 	resourceConfigScopeIDReturnsOnCall map[int]struct {
 		result1 int
 	}
-	SetResourceConfigStub        func(atc.Source, atc.VersionedResourceTypes) (db.ResourceConfigScope, error)
-	setResourceConfigMutex       sync.RWMutex
-	setResourceConfigArgsForCall []struct {
-		arg1 atc.Source
-		arg2 atc.VersionedResourceTypes
-	}
-	setResourceConfigReturns struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}
-	setResourceConfigReturnsOnCall map[int]struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}
 	SourceStub        func() atc.Source
 	sourceMutex       sync.RWMutex
 	sourceArgsForCall []struct {
@@ -993,70 +979,6 @@ func (fake *FakeCheckable) ResourceConfigScopeIDReturnsOnCall(i int, result1 int
 	}{result1}
 }
 
-func (fake *FakeCheckable) SetResourceConfig(arg1 atc.Source, arg2 atc.VersionedResourceTypes) (db.ResourceConfigScope, error) {
-	fake.setResourceConfigMutex.Lock()
-	ret, specificReturn := fake.setResourceConfigReturnsOnCall[len(fake.setResourceConfigArgsForCall)]
-	fake.setResourceConfigArgsForCall = append(fake.setResourceConfigArgsForCall, struct {
-		arg1 atc.Source
-		arg2 atc.VersionedResourceTypes
-	}{arg1, arg2})
-	fake.recordInvocation("SetResourceConfig", []interface{}{arg1, arg2})
-	fake.setResourceConfigMutex.Unlock()
-	if fake.SetResourceConfigStub != nil {
-		return fake.SetResourceConfigStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.setResourceConfigReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeCheckable) SetResourceConfigCallCount() int {
-	fake.setResourceConfigMutex.RLock()
-	defer fake.setResourceConfigMutex.RUnlock()
-	return len(fake.setResourceConfigArgsForCall)
-}
-
-func (fake *FakeCheckable) SetResourceConfigCalls(stub func(atc.Source, atc.VersionedResourceTypes) (db.ResourceConfigScope, error)) {
-	fake.setResourceConfigMutex.Lock()
-	defer fake.setResourceConfigMutex.Unlock()
-	fake.SetResourceConfigStub = stub
-}
-
-func (fake *FakeCheckable) SetResourceConfigArgsForCall(i int) (atc.Source, atc.VersionedResourceTypes) {
-	fake.setResourceConfigMutex.RLock()
-	defer fake.setResourceConfigMutex.RUnlock()
-	argsForCall := fake.setResourceConfigArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeCheckable) SetResourceConfigReturns(result1 db.ResourceConfigScope, result2 error) {
-	fake.setResourceConfigMutex.Lock()
-	defer fake.setResourceConfigMutex.Unlock()
-	fake.SetResourceConfigStub = nil
-	fake.setResourceConfigReturns = struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCheckable) SetResourceConfigReturnsOnCall(i int, result1 db.ResourceConfigScope, result2 error) {
-	fake.setResourceConfigMutex.Lock()
-	defer fake.setResourceConfigMutex.Unlock()
-	fake.SetResourceConfigStub = nil
-	if fake.setResourceConfigReturnsOnCall == nil {
-		fake.setResourceConfigReturnsOnCall = make(map[int]struct {
-			result1 db.ResourceConfigScope
-			result2 error
-		})
-	}
-	fake.setResourceConfigReturnsOnCall[i] = struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeCheckable) Source() atc.Source {
 	fake.sourceMutex.Lock()
 	ret, specificReturn := fake.sourceReturnsOnCall[len(fake.sourceArgsForCall)]
@@ -1348,8 +1270,6 @@ func (fake *FakeCheckable) Invocations() map[string][][]interface{} {
 	defer fake.pipelineRefMutex.RUnlock()
 	fake.resourceConfigScopeIDMutex.RLock()
 	defer fake.resourceConfigScopeIDMutex.RUnlock()
-	fake.setResourceConfigMutex.RLock()
-	defer fake.setResourceConfigMutex.RUnlock()
 	fake.sourceMutex.RLock()
 	defer fake.sourceMutex.RUnlock()
 	fake.tagsMutex.RLock()

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -133,6 +133,21 @@ type FakeResource struct {
 	enableVersionReturnsOnCall map[int]struct {
 		result1 error
 	}
+	FindVersionStub        func(atc.Version) (db.ResourceConfigVersion, bool, error)
+	findVersionMutex       sync.RWMutex
+	findVersionArgsForCall []struct {
+		arg1 atc.Version
+	}
+	findVersionReturns struct {
+		result1 db.ResourceConfigVersion
+		result2 bool
+		result3 error
+	}
+	findVersionReturnsOnCall map[int]struct {
+		result1 db.ResourceConfigVersion
+		result2 bool
+		result3 error
+	}
 	HasWebhookStub        func() bool
 	hasWebhookMutex       sync.RWMutex
 	hasWebhookArgsForCall []struct {
@@ -321,21 +336,6 @@ type FakeResource struct {
 	}
 	resourceConfigScopeIDReturnsOnCall map[int]struct {
 		result1 int
-	}
-	ResourceConfigVersionIDStub        func(atc.Version) (int, bool, error)
-	resourceConfigVersionIDMutex       sync.RWMutex
-	resourceConfigVersionIDArgsForCall []struct {
-		arg1 atc.Version
-	}
-	resourceConfigVersionIDReturns struct {
-		result1 int
-		result2 bool
-		result3 error
-	}
-	resourceConfigVersionIDReturnsOnCall map[int]struct {
-		result1 int
-		result2 bool
-		result3 error
 	}
 	SaveUncheckedVersionStub        func(atc.Version, db.ResourceConfigMetadataFields, db.ResourceConfig) (bool, error)
 	saveUncheckedVersionMutex       sync.RWMutex
@@ -1106,6 +1106,72 @@ func (fake *FakeResource) EnableVersionReturnsOnCall(i int, result1 error) {
 	fake.enableVersionReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeResource) FindVersion(arg1 atc.Version) (db.ResourceConfigVersion, bool, error) {
+	fake.findVersionMutex.Lock()
+	ret, specificReturn := fake.findVersionReturnsOnCall[len(fake.findVersionArgsForCall)]
+	fake.findVersionArgsForCall = append(fake.findVersionArgsForCall, struct {
+		arg1 atc.Version
+	}{arg1})
+	fake.recordInvocation("FindVersion", []interface{}{arg1})
+	fake.findVersionMutex.Unlock()
+	if fake.FindVersionStub != nil {
+		return fake.FindVersionStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.findVersionReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeResource) FindVersionCallCount() int {
+	fake.findVersionMutex.RLock()
+	defer fake.findVersionMutex.RUnlock()
+	return len(fake.findVersionArgsForCall)
+}
+
+func (fake *FakeResource) FindVersionCalls(stub func(atc.Version) (db.ResourceConfigVersion, bool, error)) {
+	fake.findVersionMutex.Lock()
+	defer fake.findVersionMutex.Unlock()
+	fake.FindVersionStub = stub
+}
+
+func (fake *FakeResource) FindVersionArgsForCall(i int) atc.Version {
+	fake.findVersionMutex.RLock()
+	defer fake.findVersionMutex.RUnlock()
+	argsForCall := fake.findVersionArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeResource) FindVersionReturns(result1 db.ResourceConfigVersion, result2 bool, result3 error) {
+	fake.findVersionMutex.Lock()
+	defer fake.findVersionMutex.Unlock()
+	fake.FindVersionStub = nil
+	fake.findVersionReturns = struct {
+		result1 db.ResourceConfigVersion
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeResource) FindVersionReturnsOnCall(i int, result1 db.ResourceConfigVersion, result2 bool, result3 error) {
+	fake.findVersionMutex.Lock()
+	defer fake.findVersionMutex.Unlock()
+	fake.FindVersionStub = nil
+	if fake.findVersionReturnsOnCall == nil {
+		fake.findVersionReturnsOnCall = make(map[int]struct {
+			result1 db.ResourceConfigVersion
+			result2 bool
+			result3 error
+		})
+	}
+	fake.findVersionReturnsOnCall[i] = struct {
+		result1 db.ResourceConfigVersion
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeResource) HasWebhook() bool {
@@ -2064,72 +2130,6 @@ func (fake *FakeResource) ResourceConfigScopeIDReturnsOnCall(i int, result1 int)
 	}{result1}
 }
 
-func (fake *FakeResource) ResourceConfigVersionID(arg1 atc.Version) (int, bool, error) {
-	fake.resourceConfigVersionIDMutex.Lock()
-	ret, specificReturn := fake.resourceConfigVersionIDReturnsOnCall[len(fake.resourceConfigVersionIDArgsForCall)]
-	fake.resourceConfigVersionIDArgsForCall = append(fake.resourceConfigVersionIDArgsForCall, struct {
-		arg1 atc.Version
-	}{arg1})
-	fake.recordInvocation("ResourceConfigVersionID", []interface{}{arg1})
-	fake.resourceConfigVersionIDMutex.Unlock()
-	if fake.ResourceConfigVersionIDStub != nil {
-		return fake.ResourceConfigVersionIDStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	fakeReturns := fake.resourceConfigVersionIDReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakeResource) ResourceConfigVersionIDCallCount() int {
-	fake.resourceConfigVersionIDMutex.RLock()
-	defer fake.resourceConfigVersionIDMutex.RUnlock()
-	return len(fake.resourceConfigVersionIDArgsForCall)
-}
-
-func (fake *FakeResource) ResourceConfigVersionIDCalls(stub func(atc.Version) (int, bool, error)) {
-	fake.resourceConfigVersionIDMutex.Lock()
-	defer fake.resourceConfigVersionIDMutex.Unlock()
-	fake.ResourceConfigVersionIDStub = stub
-}
-
-func (fake *FakeResource) ResourceConfigVersionIDArgsForCall(i int) atc.Version {
-	fake.resourceConfigVersionIDMutex.RLock()
-	defer fake.resourceConfigVersionIDMutex.RUnlock()
-	argsForCall := fake.resourceConfigVersionIDArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeResource) ResourceConfigVersionIDReturns(result1 int, result2 bool, result3 error) {
-	fake.resourceConfigVersionIDMutex.Lock()
-	defer fake.resourceConfigVersionIDMutex.Unlock()
-	fake.ResourceConfigVersionIDStub = nil
-	fake.resourceConfigVersionIDReturns = struct {
-		result1 int
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakeResource) ResourceConfigVersionIDReturnsOnCall(i int, result1 int, result2 bool, result3 error) {
-	fake.resourceConfigVersionIDMutex.Lock()
-	defer fake.resourceConfigVersionIDMutex.Unlock()
-	fake.ResourceConfigVersionIDStub = nil
-	if fake.resourceConfigVersionIDReturnsOnCall == nil {
-		fake.resourceConfigVersionIDReturnsOnCall = make(map[int]struct {
-			result1 int
-			result2 bool
-			result3 error
-		})
-	}
-	fake.resourceConfigVersionIDReturnsOnCall[i] = struct {
-		result1 int
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
 func (fake *FakeResource) SaveUncheckedVersion(arg1 atc.Version, arg2 db.ResourceConfigMetadataFields, arg3 db.ResourceConfig) (bool, error) {
 	fake.saveUncheckedVersionMutex.Lock()
 	ret, specificReturn := fake.saveUncheckedVersionReturnsOnCall[len(fake.saveUncheckedVersionArgsForCall)]
@@ -2902,6 +2902,8 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.disableVersionMutex.RUnlock()
 	fake.enableVersionMutex.RLock()
 	defer fake.enableVersionMutex.RUnlock()
+	fake.findVersionMutex.RLock()
+	defer fake.findVersionMutex.RUnlock()
 	fake.hasWebhookMutex.RLock()
 	defer fake.hasWebhookMutex.RUnlock()
 	fake.iDMutex.RLock()
@@ -2938,8 +2940,6 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.resourceConfigIDMutex.RUnlock()
 	fake.resourceConfigScopeIDMutex.RLock()
 	defer fake.resourceConfigScopeIDMutex.RUnlock()
-	fake.resourceConfigVersionIDMutex.RLock()
-	defer fake.resourceConfigVersionIDMutex.RUnlock()
 	fake.saveUncheckedVersionMutex.RLock()
 	defer fake.saveUncheckedVersionMutex.RUnlock()
 	fake.setPinCommentMutex.RLock()

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -363,20 +363,6 @@ type FakeResource struct {
 	setPinCommentReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetResourceConfigStub        func(atc.Source, atc.VersionedResourceTypes) (db.ResourceConfigScope, error)
-	setResourceConfigMutex       sync.RWMutex
-	setResourceConfigArgsForCall []struct {
-		arg1 atc.Source
-		arg2 atc.VersionedResourceTypes
-	}
-	setResourceConfigReturns struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}
-	setResourceConfigReturnsOnCall map[int]struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}
 	SetResourceConfigScopeStub        func(db.ResourceConfigScope) error
 	setResourceConfigScopeMutex       sync.RWMutex
 	setResourceConfigScopeArgsForCall []struct {
@@ -2255,70 +2241,6 @@ func (fake *FakeResource) SetPinCommentReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeResource) SetResourceConfig(arg1 atc.Source, arg2 atc.VersionedResourceTypes) (db.ResourceConfigScope, error) {
-	fake.setResourceConfigMutex.Lock()
-	ret, specificReturn := fake.setResourceConfigReturnsOnCall[len(fake.setResourceConfigArgsForCall)]
-	fake.setResourceConfigArgsForCall = append(fake.setResourceConfigArgsForCall, struct {
-		arg1 atc.Source
-		arg2 atc.VersionedResourceTypes
-	}{arg1, arg2})
-	fake.recordInvocation("SetResourceConfig", []interface{}{arg1, arg2})
-	fake.setResourceConfigMutex.Unlock()
-	if fake.SetResourceConfigStub != nil {
-		return fake.SetResourceConfigStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.setResourceConfigReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeResource) SetResourceConfigCallCount() int {
-	fake.setResourceConfigMutex.RLock()
-	defer fake.setResourceConfigMutex.RUnlock()
-	return len(fake.setResourceConfigArgsForCall)
-}
-
-func (fake *FakeResource) SetResourceConfigCalls(stub func(atc.Source, atc.VersionedResourceTypes) (db.ResourceConfigScope, error)) {
-	fake.setResourceConfigMutex.Lock()
-	defer fake.setResourceConfigMutex.Unlock()
-	fake.SetResourceConfigStub = stub
-}
-
-func (fake *FakeResource) SetResourceConfigArgsForCall(i int) (atc.Source, atc.VersionedResourceTypes) {
-	fake.setResourceConfigMutex.RLock()
-	defer fake.setResourceConfigMutex.RUnlock()
-	argsForCall := fake.setResourceConfigArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeResource) SetResourceConfigReturns(result1 db.ResourceConfigScope, result2 error) {
-	fake.setResourceConfigMutex.Lock()
-	defer fake.setResourceConfigMutex.Unlock()
-	fake.SetResourceConfigStub = nil
-	fake.setResourceConfigReturns = struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeResource) SetResourceConfigReturnsOnCall(i int, result1 db.ResourceConfigScope, result2 error) {
-	fake.setResourceConfigMutex.Lock()
-	defer fake.setResourceConfigMutex.Unlock()
-	fake.SetResourceConfigStub = nil
-	if fake.setResourceConfigReturnsOnCall == nil {
-		fake.setResourceConfigReturnsOnCall = make(map[int]struct {
-			result1 db.ResourceConfigScope
-			result2 error
-		})
-	}
-	fake.setResourceConfigReturnsOnCall[i] = struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeResource) SetResourceConfigScope(arg1 db.ResourceConfigScope) error {
 	fake.setResourceConfigScopeMutex.Lock()
 	ret, specificReturn := fake.setResourceConfigScopeReturnsOnCall[len(fake.setResourceConfigScopeArgsForCall)]
@@ -2944,8 +2866,6 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.saveUncheckedVersionMutex.RUnlock()
 	fake.setPinCommentMutex.RLock()
 	defer fake.setPinCommentMutex.RUnlock()
-	fake.setResourceConfigMutex.RLock()
-	defer fake.setResourceConfigMutex.RUnlock()
 	fake.setResourceConfigScopeMutex.RLock()
 	defer fake.setResourceConfigScopeMutex.RUnlock()
 	fake.sourceMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_config_version.go
+++ b/atc/db/dbfakes/fake_resource_config_version.go
@@ -51,16 +51,6 @@ type FakeResourceConfigVersion struct {
 		result1 bool
 		result2 error
 	}
-	ResourceConfigScopeStub        func() db.ResourceConfigScope
-	resourceConfigScopeMutex       sync.RWMutex
-	resourceConfigScopeArgsForCall []struct {
-	}
-	resourceConfigScopeReturns struct {
-		result1 db.ResourceConfigScope
-	}
-	resourceConfigScopeReturnsOnCall map[int]struct {
-		result1 db.ResourceConfigScope
-	}
 	SpanContextStub        func() propagation.HTTPSupplier
 	spanContextMutex       sync.RWMutex
 	spanContextArgsForCall []struct {
@@ -296,58 +286,6 @@ func (fake *FakeResourceConfigVersion) ReloadReturnsOnCall(i int, result1 bool, 
 	}{result1, result2}
 }
 
-func (fake *FakeResourceConfigVersion) ResourceConfigScope() db.ResourceConfigScope {
-	fake.resourceConfigScopeMutex.Lock()
-	ret, specificReturn := fake.resourceConfigScopeReturnsOnCall[len(fake.resourceConfigScopeArgsForCall)]
-	fake.resourceConfigScopeArgsForCall = append(fake.resourceConfigScopeArgsForCall, struct {
-	}{})
-	fake.recordInvocation("ResourceConfigScope", []interface{}{})
-	fake.resourceConfigScopeMutex.Unlock()
-	if fake.ResourceConfigScopeStub != nil {
-		return fake.ResourceConfigScopeStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.resourceConfigScopeReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeResourceConfigVersion) ResourceConfigScopeCallCount() int {
-	fake.resourceConfigScopeMutex.RLock()
-	defer fake.resourceConfigScopeMutex.RUnlock()
-	return len(fake.resourceConfigScopeArgsForCall)
-}
-
-func (fake *FakeResourceConfigVersion) ResourceConfigScopeCalls(stub func() db.ResourceConfigScope) {
-	fake.resourceConfigScopeMutex.Lock()
-	defer fake.resourceConfigScopeMutex.Unlock()
-	fake.ResourceConfigScopeStub = stub
-}
-
-func (fake *FakeResourceConfigVersion) ResourceConfigScopeReturns(result1 db.ResourceConfigScope) {
-	fake.resourceConfigScopeMutex.Lock()
-	defer fake.resourceConfigScopeMutex.Unlock()
-	fake.ResourceConfigScopeStub = nil
-	fake.resourceConfigScopeReturns = struct {
-		result1 db.ResourceConfigScope
-	}{result1}
-}
-
-func (fake *FakeResourceConfigVersion) ResourceConfigScopeReturnsOnCall(i int, result1 db.ResourceConfigScope) {
-	fake.resourceConfigScopeMutex.Lock()
-	defer fake.resourceConfigScopeMutex.Unlock()
-	fake.ResourceConfigScopeStub = nil
-	if fake.resourceConfigScopeReturnsOnCall == nil {
-		fake.resourceConfigScopeReturnsOnCall = make(map[int]struct {
-			result1 db.ResourceConfigScope
-		})
-	}
-	fake.resourceConfigScopeReturnsOnCall[i] = struct {
-		result1 db.ResourceConfigScope
-	}{result1}
-}
-
 func (fake *FakeResourceConfigVersion) SpanContext() propagation.HTTPSupplier {
 	fake.spanContextMutex.Lock()
 	ret, specificReturn := fake.spanContextReturnsOnCall[len(fake.spanContextArgsForCall)]
@@ -463,8 +401,6 @@ func (fake *FakeResourceConfigVersion) Invocations() map[string][][]interface{} 
 	defer fake.metadataMutex.RUnlock()
 	fake.reloadMutex.RLock()
 	defer fake.reloadMutex.RUnlock()
-	fake.resourceConfigScopeMutex.RLock()
-	defer fake.resourceConfigScopeMutex.RUnlock()
 	fake.spanContextMutex.RLock()
 	defer fake.spanContextMutex.RUnlock()
 	fake.versionMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_type.go
+++ b/atc/db/dbfakes/fake_resource_type.go
@@ -227,20 +227,6 @@ type FakeResourceType struct {
 	resourceConfigScopeIDReturnsOnCall map[int]struct {
 		result1 int
 	}
-	SetResourceConfigStub        func(atc.Source, atc.VersionedResourceTypes) (db.ResourceConfigScope, error)
-	setResourceConfigMutex       sync.RWMutex
-	setResourceConfigArgsForCall []struct {
-		arg1 atc.Source
-		arg2 atc.VersionedResourceTypes
-	}
-	setResourceConfigReturns struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}
-	setResourceConfigReturnsOnCall map[int]struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}
 	SetResourceConfigScopeStub        func(db.ResourceConfigScope) error
 	setResourceConfigScopeMutex       sync.RWMutex
 	setResourceConfigScopeArgsForCall []struct {
@@ -1391,70 +1377,6 @@ func (fake *FakeResourceType) ResourceConfigScopeIDReturnsOnCall(i int, result1 
 	}{result1}
 }
 
-func (fake *FakeResourceType) SetResourceConfig(arg1 atc.Source, arg2 atc.VersionedResourceTypes) (db.ResourceConfigScope, error) {
-	fake.setResourceConfigMutex.Lock()
-	ret, specificReturn := fake.setResourceConfigReturnsOnCall[len(fake.setResourceConfigArgsForCall)]
-	fake.setResourceConfigArgsForCall = append(fake.setResourceConfigArgsForCall, struct {
-		arg1 atc.Source
-		arg2 atc.VersionedResourceTypes
-	}{arg1, arg2})
-	fake.recordInvocation("SetResourceConfig", []interface{}{arg1, arg2})
-	fake.setResourceConfigMutex.Unlock()
-	if fake.SetResourceConfigStub != nil {
-		return fake.SetResourceConfigStub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.setResourceConfigReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeResourceType) SetResourceConfigCallCount() int {
-	fake.setResourceConfigMutex.RLock()
-	defer fake.setResourceConfigMutex.RUnlock()
-	return len(fake.setResourceConfigArgsForCall)
-}
-
-func (fake *FakeResourceType) SetResourceConfigCalls(stub func(atc.Source, atc.VersionedResourceTypes) (db.ResourceConfigScope, error)) {
-	fake.setResourceConfigMutex.Lock()
-	defer fake.setResourceConfigMutex.Unlock()
-	fake.SetResourceConfigStub = stub
-}
-
-func (fake *FakeResourceType) SetResourceConfigArgsForCall(i int) (atc.Source, atc.VersionedResourceTypes) {
-	fake.setResourceConfigMutex.RLock()
-	defer fake.setResourceConfigMutex.RUnlock()
-	argsForCall := fake.setResourceConfigArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeResourceType) SetResourceConfigReturns(result1 db.ResourceConfigScope, result2 error) {
-	fake.setResourceConfigMutex.Lock()
-	defer fake.setResourceConfigMutex.Unlock()
-	fake.SetResourceConfigStub = nil
-	fake.setResourceConfigReturns = struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeResourceType) SetResourceConfigReturnsOnCall(i int, result1 db.ResourceConfigScope, result2 error) {
-	fake.setResourceConfigMutex.Lock()
-	defer fake.setResourceConfigMutex.Unlock()
-	fake.SetResourceConfigStub = nil
-	if fake.setResourceConfigReturnsOnCall == nil {
-		fake.setResourceConfigReturnsOnCall = make(map[int]struct {
-			result1 db.ResourceConfigScope
-			result2 error
-		})
-	}
-	fake.setResourceConfigReturnsOnCall[i] = struct {
-		result1 db.ResourceConfigScope
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeResourceType) SetResourceConfigScope(arg1 db.ResourceConfigScope) error {
 	fake.setResourceConfigScopeMutex.Lock()
 	ret, specificReturn := fake.setResourceConfigScopeReturnsOnCall[len(fake.setResourceConfigScopeArgsForCall)]
@@ -1870,8 +1792,6 @@ func (fake *FakeResourceType) Invocations() map[string][][]interface{} {
 	defer fake.reloadMutex.RUnlock()
 	fake.resourceConfigScopeIDMutex.RLock()
 	defer fake.resourceConfigScopeIDMutex.RUnlock()
-	fake.setResourceConfigMutex.RLock()
-	defer fake.setResourceConfigMutex.RUnlock()
 	fake.setResourceConfigScopeMutex.RLock()
 	defer fake.setResourceConfigScopeMutex.RUnlock()
 	fake.sourceMutex.RLock()

--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -180,6 +180,11 @@ func (builder Builder) WithResourceVersions(resourceName string, versions ...atc
 			return fmt.Errorf("save versions: %w", err)
 		}
 
+		_, err = scope.UpdateLastCheckEndTime()
+		if err != nil {
+			return fmt.Errorf("update last check end time: %w", err)
+		}
+
 		err = resource.SetResourceConfigScope(scope)
 		if err != nil {
 			return fmt.Errorf("set resource scope: %w", err)

--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -85,7 +85,12 @@ func (builder Builder) WithPipeline(config atc.Config) SetupFunc {
 			}
 		}
 
-		p, _, err := scenario.Team.SavePipeline(atc.PipelineRef{Name: "some-pipeline"}, config, 0, false)
+		var from db.ConfigVersion
+		if scenario.Pipeline != nil {
+			from = scenario.Pipeline.ConfigVersion()
+		}
+
+		p, _, err := scenario.Team.SavePipeline(atc.PipelineRef{Name: "some-pipeline"}, config, from, false)
 		if err != nil {
 			return err
 		}
@@ -175,7 +180,7 @@ func (builder Builder) WithResourceVersions(resourceName string, versions ...atc
 			return fmt.Errorf("save versions: %w", err)
 		}
 
-		resource.SetResourceConfigScope(scope)
+		err = resource.SetResourceConfigScope(scope)
 		if err != nil {
 			return fmt.Errorf("set resource scope: %w", err)
 		}

--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -1,0 +1,285 @@
+package dbtest
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/lock"
+	uuid "github.com/nu7hatch/gouuid"
+)
+
+const GlobalBaseResourceType = "global-base-type"
+const UniqueBaseResourceType = "unique-base-type"
+
+type JobInputs map[string]atc.Version
+type JobOutputs map[string]atc.Version
+
+type Builder struct {
+	TeamFactory           db.TeamFactory
+	WorkerFactory         db.WorkerFactory
+	ResourceConfigFactory db.ResourceConfigFactory
+}
+
+func NewBuilder(conn db.Conn, lockFactory lock.LockFactory) Builder {
+	return Builder{
+		TeamFactory:           db.NewTeamFactory(conn, lockFactory),
+		WorkerFactory:         db.NewWorkerFactory(conn),
+		ResourceConfigFactory: db.NewResourceConfigFactory(conn, lockFactory),
+	}
+}
+
+func (builder Builder) WithTeam(teamName string) SetupFunc {
+	return func(scenario *Scenario) error {
+		t, err := builder.TeamFactory.CreateTeam(atc.Team{Name: teamName})
+		if err != nil {
+			return err
+		}
+
+		scenario.Team = t
+		return nil
+	}
+}
+
+func (builder Builder) WithWorker(worker atc.Worker) SetupFunc {
+	return func(scenario *Scenario) error {
+		w, err := builder.WorkerFactory.SaveWorker(worker, 0)
+		if err != nil {
+			return err
+		}
+
+		scenario.Workers = append(scenario.Workers, w)
+		return nil
+	}
+}
+
+func (builder Builder) WithPipeline(config atc.Config) SetupFunc {
+	return func(scenario *Scenario) error {
+		if scenario.Team == nil {
+			err := builder.WithTeam(unique("team"))(scenario)
+			if err != nil {
+				return fmt.Errorf("bootstrap team: %w", err)
+			}
+		}
+
+		p, _, err := scenario.Team.SavePipeline(atc.PipelineRef{Name: "some-pipeline"}, config, 0, false)
+		if err != nil {
+			return err
+		}
+
+		// XXX: set up workers with base resource types?
+
+		scenario.Pipeline = p
+		return nil
+	}
+}
+
+func (builder Builder) WithResourceVersions(resourceName string, versions ...atc.Version) SetupFunc {
+	return func(scenario *Scenario) error {
+		if scenario.Pipeline == nil {
+			err := builder.WithPipeline(atc.Config{
+				Resources: atc.ResourceConfigs{
+					{
+						Name:   resourceName,
+						Type:   GlobalBaseResourceType,
+						Source: atc.Source{"some": "source"},
+					},
+				},
+			})(scenario)
+			if err != nil {
+				return fmt.Errorf("bootstrap pipeline: %w", err)
+			}
+		}
+
+		// bootstrap workers to ensure base resource type exists
+		if len(scenario.Workers) == 0 {
+			err := builder.WithWorker(atc.Worker{
+				Name: unique("worker"),
+
+				GardenAddr:      unique("garden-addr"),
+				BaggageclaimURL: unique("baggageclaim-url"),
+
+				ResourceTypes: []atc.WorkerResourceType{
+					{
+						Type:    GlobalBaseResourceType,
+						Image:   "/path/to/global/image",
+						Version: "some-global-type-version",
+					},
+					{
+						Type:                 UniqueBaseResourceType,
+						Image:                "/path/to/unique/image",
+						Version:              "some-unique-type-version",
+						UniqueVersionHistory: true,
+					},
+				},
+			})(scenario)
+			if err != nil {
+				return fmt.Errorf("bootstrap workers: %w", err)
+			}
+		}
+
+		resource, found, err := scenario.Pipeline.Resource(resourceName)
+		if err != nil {
+			return err
+		}
+
+		if !found {
+			return fmt.Errorf("resource '%s' not configured in pipeline", resourceName)
+		}
+
+		resourceTypes, err := scenario.Pipeline.ResourceTypes()
+		if err != nil {
+			return fmt.Errorf("get pipeline resource types: %w", err)
+		}
+
+		resourceConfig, err := builder.ResourceConfigFactory.FindOrCreateResourceConfig(
+			resource.Type(),
+			resource.Source(),
+			resourceTypes.Deserialize(),
+		)
+		if err != nil {
+			return fmt.Errorf("find or create resource config: %w", err)
+		}
+
+		scope, err := resourceConfig.FindOrCreateScope(resource)
+		if err != nil {
+			return fmt.Errorf("find or create scope: %w", err)
+		}
+
+		err = scope.SaveVersions(db.SpanContext{}, versions)
+		if err != nil {
+			return fmt.Errorf("save versions: %w", err)
+		}
+
+		resource.SetResourceConfigScope(scope)
+		if err != nil {
+			return fmt.Errorf("set resource scope: %w", err)
+		}
+
+		return nil
+	}
+}
+
+func (builder Builder) WithJobBuild(assign *db.Build, jobName string, inputs JobInputs, outputs JobOutputs) SetupFunc {
+	return func(scenario *Scenario) error {
+		if scenario.Pipeline == nil {
+			return fmt.Errorf("no pipeline set in scenario")
+		}
+
+		job, found, err := scenario.Pipeline.Job(jobName)
+		if err != nil {
+			return err
+		}
+
+		if !found {
+			return fmt.Errorf("job '%s' not configured in pipeline", jobName)
+		}
+
+		resourceTypes, err := scenario.Pipeline.ResourceTypes()
+		if err != nil {
+			return fmt.Errorf("get pipeline resource types: %w", err)
+		}
+
+		jobInputs, err := job.AlgorithmInputs()
+		if err != nil {
+			return fmt.Errorf("get job inputs: %w", err)
+		}
+
+		jobOutputs, err := job.Outputs()
+		if err != nil {
+			return fmt.Errorf("get job outputs: %w", err)
+		}
+
+		mapping := db.InputMapping{}
+		for _, input := range jobInputs {
+			version, found := inputs[input.Name]
+			if !found {
+				return fmt.Errorf("no version specified for input '%s'", input.Name)
+			}
+
+			mapping[input.Name] = db.InputResult{
+				Input: &db.AlgorithmInput{
+					AlgorithmVersion: db.AlgorithmVersion{
+						Version:    db.ResourceVersion(md5Version(version)),
+						ResourceID: input.ResourceID,
+					},
+				},
+			}
+		}
+
+		err = job.SaveNextInputMapping(mapping, true)
+		if err != nil {
+			return fmt.Errorf("save job input mapping: %w", err)
+		}
+
+		build, err := job.CreateBuild()
+		if err != nil {
+			return fmt.Errorf("create job build: %w", err)
+		}
+
+		*assign = build
+
+		_, inputsReady, err := build.AdoptInputsAndPipes()
+		if err != nil {
+			return fmt.Errorf("adopt inputs and pipes: %w", err)
+		}
+
+		if !inputsReady {
+			return fmt.Errorf("inputs not available?")
+		}
+
+		for _, output := range jobOutputs {
+			version, found := outputs[output.Name]
+			if !found {
+				return fmt.Errorf("no version specified for output '%s'", output.Name)
+			}
+
+			resource, found, err := scenario.Pipeline.Resource(output.Resource)
+			if err != nil {
+				return fmt.Errorf("get output resource: %w", err)
+			}
+
+			if !found {
+				return fmt.Errorf("output '%s' refers to unknown resource '%s'", output.Name, output.Resource)
+			}
+
+			err = build.SaveOutput(
+				resource.Type(),
+				resource.Source(),
+				resourceTypes.Deserialize(),
+				version,
+				nil, // metadata
+				output.Name,
+				output.Resource,
+			)
+			if err != nil {
+				return fmt.Errorf("save build output: %w", err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func unique(kind string) string {
+	id, err := uuid.NewV4()
+	if err != nil {
+		panic(err)
+	}
+
+	return kind + "-" + id.String()
+}
+
+func md5Version(version atc.Version) string {
+	versionJSON, err := json.Marshal(version)
+	if err != nil {
+		panic(err)
+	}
+
+	hasher := md5.New()
+	hasher.Write([]byte(versionJSON))
+	return hex.EncodeToString(hasher.Sum(nil))
+}

--- a/atc/db/dbtest/scenario.go
+++ b/atc/db/dbtest/scenario.go
@@ -11,6 +11,8 @@ type Scenario struct {
 	Team     db.Team
 	Pipeline db.Pipeline
 	Workers  []db.Worker
+
+	SpanContext db.SpanContext
 }
 
 type SetupFunc func(*Scenario) error

--- a/atc/db/dbtest/scenario.go
+++ b/atc/db/dbtest/scenario.go
@@ -14,14 +14,17 @@ type Scenario struct {
 
 type SetupFunc func(*Scenario) error
 
-func Setup(setup ...SetupFunc) Scenario {
-	scenario := Scenario{}
+func Setup(setup ...SetupFunc) *Scenario {
+	scenario := &Scenario{}
+	scenario.Run(setup...)
+	return scenario
+}
+
+func (scenario *Scenario) Run(setup ...SetupFunc) {
 	for _, f := range setup {
-		err := f(&scenario)
+		err := f(scenario)
 		Expect(err).ToNot(HaveOccurred())
 	}
-
-	return scenario
 }
 
 func (scenario Scenario) Job(name string) db.Job {

--- a/atc/db/dbtest/scenario.go
+++ b/atc/db/dbtest/scenario.go
@@ -1,6 +1,7 @@
 package dbtest
 
 import (
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	. "github.com/onsi/gomega"
 )
@@ -45,4 +46,18 @@ func (scenario Scenario) Resource(name string) db.Resource {
 	Expect(found).To(BeTrue(), "resource '%s' not found", name)
 
 	return resource
+}
+
+func (scenario Scenario) ResourceVersion(name string, version atc.Version) db.ResourceConfigVersion {
+	Expect(scenario.Pipeline).ToNot(BeNil(), "pipeline not set in scenario")
+
+	resource, found, err := scenario.Pipeline.Resource(name)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue(), "resource '%s' not found", name)
+
+	rcv, found, err := resource.FindVersion(version)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue(), "resource version '%v' of '%s' not found", version, name)
+
+	return rcv
 }

--- a/atc/db/dbtest/scenario.go
+++ b/atc/db/dbtest/scenario.go
@@ -1,0 +1,45 @@
+package dbtest
+
+import (
+	"github.com/concourse/concourse/atc/db"
+	. "github.com/onsi/gomega"
+)
+
+// Scenario represents the state of the world for testing.
+type Scenario struct {
+	Team     db.Team
+	Pipeline db.Pipeline
+	Workers  []db.Worker
+}
+
+type SetupFunc func(*Scenario) error
+
+func Setup(setup ...SetupFunc) Scenario {
+	scenario := Scenario{}
+	for _, f := range setup {
+		err := f(&scenario)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	return scenario
+}
+
+func (scenario Scenario) Job(name string) db.Job {
+	Expect(scenario.Pipeline).ToNot(BeNil(), "pipeline not set in scenario")
+
+	job, found, err := scenario.Pipeline.Job(name)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue(), "job '%s' not found", name)
+
+	return job
+}
+
+func (scenario Scenario) Resource(name string) db.Resource {
+	Expect(scenario.Pipeline).ToNot(BeNil(), "pipeline not set in scenario")
+
+	resource, found, err := scenario.Pipeline.Resource(name)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue(), "resource '%s' not found", name)
+
+	return resource
+}

--- a/atc/db/dbtest/scenario.go
+++ b/atc/db/dbtest/scenario.go
@@ -48,6 +48,16 @@ func (scenario Scenario) Resource(name string) db.Resource {
 	return resource
 }
 
+func (scenario Scenario) ResourceType(name string) db.ResourceType {
+	Expect(scenario.Pipeline).ToNot(BeNil(), "pipeline not set in scenario")
+
+	resourceType, found, err := scenario.Pipeline.ResourceType(name)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue(), "resource type '%s' not found", name)
+
+	return resourceType
+}
+
 func (scenario Scenario) ResourceVersion(name string, version atc.Version) db.ResourceConfigVersion {
 	Expect(scenario.Pipeline).ToNot(BeNil(), "pipeline not set in scenario")
 

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -2345,11 +2345,11 @@ var _ = Describe("Job", func() {
 					})
 					Expect(err).NotTo(HaveOccurred())
 
-					versionID, found, err := pinnedResource.ResourceConfigVersionID(atc.Version{"api": "pinned"})
+					version, found, err := pinnedResource.FindVersion(atc.Version{"api": "pinned"})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 
-					pinned, err := pinnedResource.PinVersion(versionID)
+					pinned, err := pinnedResource.PinVersion(version.ID())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(pinned).To(BeTrue())
 				})
@@ -2476,11 +2476,11 @@ var _ = Describe("Job", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				versionID, found, err := pinnedResource.ResourceConfigVersionID(atc.Version{"some": "version"})
+				version, found, err := pinnedResource.FindVersion(atc.Version{"some": "version"})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 
-				pinned, err := pinnedResource.PinVersion(versionID)
+				pinned, err := pinnedResource.PinVersion(version.ID())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pinned).To(BeTrue())
 			})

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/tracing"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -1280,97 +1281,69 @@ var _ = Describe("Job", func() {
 
 	Describe("GetNextBuildInputs", func() {
 		var (
-			versions            []atc.ResourceVersion
-			job                 db.Job
-			resourceConfigScope db.ResourceConfigScope
-			resource            db.Resource
-			spanContext         db.SpanContext
+			versions    []atc.ResourceVersion
+			spanContext db.SpanContext
+			scenario    *dbtest.Scenario
 		)
 
 		BeforeEach(func() {
-			setupTx, err := dbConn.Begin()
-			Expect(err).ToNot(HaveOccurred())
+			spanContext = db.SpanContext{"fake": "version"}
 
-			brt := db.BaseResourceType{
-				Name: "some-type",
-			}
-
-			_, err = brt.FindOrCreate(setupTx, false)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(setupTx.Commit()).To(Succeed())
-
-			var created bool
-			pipeline, created, err = team.SavePipeline(atc.PipelineRef{Name: "build-inputs-pipeline"}, atc.Config{
-				Jobs: atc.JobConfigs{
-					{
-						Name: "some-job",
-						PlanSequence: []atc.Step{
-							{
-								Config: &atc.GetStep{
-									Name:     "some-input",
-									Resource: "some-resource",
-									Passed:   []string{"job-1", "job-2"},
-									Trigger:  true,
+			scenario = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Jobs: atc.JobConfigs{
+						{
+							Name: "some-job",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:     "some-input",
+										Resource: "some-resource",
+										Passed:   []string{"job-1", "job-2"},
+										Trigger:  true,
+									},
 								},
-							},
-							{
-								Config: &atc.GetStep{
-									Name:     "some-input-2",
-									Resource: "some-resource",
-									Passed:   []string{"job-1"},
-									Trigger:  true,
+								{
+									Config: &atc.GetStep{
+										Name:     "some-input-2",
+										Resource: "some-resource",
+										Passed:   []string{"job-1"},
+										Trigger:  true,
+									},
 								},
-							},
-							{
-								Config: &atc.GetStep{
-									Name:     "some-input-3",
-									Resource: "some-resource",
-									Trigger:  true,
+								{
+									Config: &atc.GetStep{
+										Name:     "some-input-3",
+										Resource: "some-resource",
+										Trigger:  true,
+									},
 								},
 							},
 						},
+						{
+							Name: "job-1",
+						},
+						{
+							Name: "job-2",
+						},
 					},
-					{
-						Name: "job-1",
+					Resources: atc.ResourceConfigs{
+						{
+							Name: "some-resource",
+							Type: "some-base-resource-type",
+						},
 					},
-					{
-						Name: "job-2",
-					},
-				},
-				Resources: atc.ResourceConfigs{
-					{
-						Name: "some-resource",
-						Type: "some-type",
-					},
-				},
-			}, db.ConfigVersion(0), false)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(created).To(BeTrue())
-
-			var found bool
-			job, found, err = pipeline.Job("some-job")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			resource, found, err = pipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			spanContext = db.SpanContext{"fake": "version"}
-			err = resourceConfigScope.SaveVersions(
-				spanContext,
-				[]atc.Version{
-					{"version": "v1"},
-					{"version": "v2"},
-					{"version": "v3"},
-				},
+				}),
+				builder.WithSpanContext(spanContext),
+				builder.WithResourceVersions(
+					"some-resource",
+					atc.Version{"version": "v1"},
+					atc.Version{"version": "v2"},
+					atc.Version{"version": "v3"},
+				),
 			)
-			Expect(err).NotTo(HaveOccurred())
 
-			reversions, _, found, err := resource.Versions(db.Page{Limit: 3}, nil)
+			reversions, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 3}, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 
@@ -1385,7 +1358,7 @@ var _ = Describe("Job", func() {
 					},
 				}
 
-				err := job.SaveNextInputMapping(inputVersions, false)
+				err := scenario.Job("some-job").SaveNextInputMapping(inputVersions, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				buildInputs := []db.BuildInput{
@@ -1395,7 +1368,7 @@ var _ = Describe("Job", func() {
 					},
 				}
 
-				actualBuildInputs, err := job.GetNextBuildInputs()
+				actualBuildInputs, err := scenario.Job("some-job").GetNextBuildInputs()
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(actualBuildInputs).To(ConsistOf(buildInputs))
@@ -1407,7 +1380,7 @@ var _ = Describe("Job", func() {
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
 								Version:    db.ResourceVersion(convertToMD5(versions[0].Version)),
-								ResourceID: resource.ID(),
+								ResourceID: scenario.Resource("some-resource").ID(),
 							},
 							FirstOccurrence: false,
 						},
@@ -1417,7 +1390,7 @@ var _ = Describe("Job", func() {
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
 								Version:    db.ResourceVersion(convertToMD5(versions[1].Version)),
-								ResourceID: resource.ID(),
+								ResourceID: scenario.Resource("some-resource").ID(),
 							},
 							FirstOccurrence: false,
 						},
@@ -1427,7 +1400,7 @@ var _ = Describe("Job", func() {
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
 								Version:    db.ResourceVersion(convertToMD5(versions[2].Version)),
-								ResourceID: resource.ID(),
+								ResourceID: scenario.Resource("some-resource").ID(),
 							},
 							FirstOccurrence: false,
 						},
@@ -1435,34 +1408,34 @@ var _ = Describe("Job", func() {
 					},
 				}
 
-				err := job.SaveNextInputMapping(inputVersions, true)
+				err := scenario.Job("some-job").SaveNextInputMapping(inputVersions, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				buildInputs := []db.BuildInput{
 					{
 						Name:            "some-input-1",
-						ResourceID:      resource.ID(),
+						ResourceID:      scenario.Resource("some-resource").ID(),
 						Version:         atc.Version{"version": "v1"},
 						FirstOccurrence: false,
 						Context:         spanContext,
 					},
 					{
 						Name:            "some-input-2",
-						ResourceID:      resource.ID(),
+						ResourceID:      scenario.Resource("some-resource").ID(),
 						Version:         atc.Version{"version": "v2"},
 						FirstOccurrence: false,
 						Context:         spanContext,
 					},
 					{
 						Name:            "some-input-3",
-						ResourceID:      resource.ID(),
+						ResourceID:      scenario.Resource("some-resource").ID(),
 						Version:         atc.Version{"version": "v3"},
 						FirstOccurrence: false,
 						Context:         spanContext,
 					},
 				}
 
-				actualBuildInputs, err := job.GetNextBuildInputs()
+				actualBuildInputs, err := scenario.Job("some-job").GetNextBuildInputs()
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(actualBuildInputs).To(ConsistOf(buildInputs))
@@ -1472,88 +1445,72 @@ var _ = Describe("Job", func() {
 
 	Describe("GetFullNextBuildInputs", func() {
 		var (
-			pipeline2           db.Pipeline
-			versions            []atc.ResourceVersion
-			job                 db.Job
-			job2                db.Job
-			resourceConfigScope db.ResourceConfigScope
-			resource            db.Resource
-			resource2           db.Resource
+			versions          []atc.ResourceVersion
+			scenarioPipeline1 *dbtest.Scenario
+			scenarioPipeline2 *dbtest.Scenario
 		)
 
 		BeforeEach(func() {
-			setupTx, err := dbConn.Begin()
-			Expect(err).ToNot(HaveOccurred())
+			scenarioPipeline1 = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Jobs: atc.JobConfigs{
+						{
+							Name: "some-job",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:     "some-input",
+										Resource: "some-resource",
+									},
+								},
+							},
+						},
+					},
+					Resources: atc.ResourceConfigs{
+						{
+							Name: "some-resource",
+							Type: "some-base-resource-type",
+						},
+					},
+				}),
+				builder.WithResourceVersions(
+					"some-resource",
+					atc.Version{"version": "v1"},
+					atc.Version{"version": "v2"},
+					atc.Version{"version": "v3"},
+				),
+				builder.WithVersionMetadata("some-resource", atc.Version{"version": "v1"}, db.ResourceConfigMetadataFields{
+					db.ResourceConfigMetadataField{
+						Name:  "name1",
+						Value: "value1",
+					},
+				}),
+			)
 
-			brt := db.BaseResourceType{
-				Name: "some-type",
-			}
-
-			_, err = brt.FindOrCreate(setupTx, false)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(setupTx.Commit()).To(Succeed())
-
-			var found bool
-			job, found, err = pipeline.Job("some-job")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			resource, found, err = pipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = resourceConfigScope.SaveVersions(nil, []atc.Version{
-				{"version": "v1"},
-				{"version": "v2"},
-				{"version": "v3"},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			// save metadata for v1
-			_, err = resource.SaveUncheckedVersion(atc.Version{"version": "v1"}, db.ResourceConfigMetadataFields{
-				db.ResourceConfigMetadataField{
-					Name:  "name1",
-					Value: "value1",
-				},
-			}, resourceConfigScope.ResourceConfig())
-			Expect(err).NotTo(HaveOccurred())
-
-			reversions, _, found, err := resource.Versions(db.Page{Limit: 3}, nil)
+			reversions, _, found, err := scenarioPipeline1.Resource("some-resource").Versions(db.Page{Limit: 3}, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 
 			versions = []atc.ResourceVersion{reversions[2], reversions[1], reversions[0]}
 
-			config := atc.Config{
-				Jobs: atc.JobConfigs{
-					{
-						Name: "some-job",
+			scenarioPipeline2 = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Jobs: atc.JobConfigs{
+						{
+							Name: "some-job",
+						},
+						{
+							Name: "some-other-job",
+						},
 					},
-					{
-						Name: "some-other-job",
+					Resources: atc.ResourceConfigs{
+						{
+							Name: "some-resource",
+							Type: "some-type",
+						},
 					},
-				},
-				Resources: atc.ResourceConfigs{
-					{
-						Name: "some-resource",
-						Type: "some-type",
-					},
-				},
-			}
-
-			pipeline2, _, err = team.SavePipeline(atc.PipelineRef{Name: "some-pipeline-2"}, config, 1, false)
-			Expect(err).ToNot(HaveOccurred())
-
-			resource2, found, err = pipeline2.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			job2, found, err = pipeline2.Job("some-job")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+				}),
+			)
 		})
 
 		It("gets next build inputs for the given job name", func() {
@@ -1562,7 +1519,7 @@ var _ = Describe("Job", func() {
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
 							Version:    db.ResourceVersion(convertToMD5(versions[0].Version)),
-							ResourceID: resource.ID(),
+							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: false,
 					},
@@ -1572,14 +1529,14 @@ var _ = Describe("Job", func() {
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
 							Version:    db.ResourceVersion(convertToMD5(versions[1].Version)),
-							ResourceID: resource.ID(),
+							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
 				},
 			}
-			err := job.SaveNextInputMapping(inputVersions, true)
+			err := scenarioPipeline1.Job("some-job").SaveNextInputMapping(inputVersions, true)
 			Expect(err).NotTo(HaveOccurred())
 
 			pipeline2InputVersions := db.InputMapping{
@@ -1587,32 +1544,32 @@ var _ = Describe("Job", func() {
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
 							Version:    db.ResourceVersion(convertToMD5(versions[2].Version)),
-							ResourceID: resource2.ID(),
+							ResourceID: scenarioPipeline2.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: false,
 					},
 					PassedBuildIDs: []int{},
 				},
 			}
-			err = job2.SaveNextInputMapping(pipeline2InputVersions, true)
+			err = scenarioPipeline2.Job("some-job").SaveNextInputMapping(pipeline2InputVersions, true)
 			Expect(err).NotTo(HaveOccurred())
 
 			buildInputs := []db.BuildInput{
 				{
 					Name:            "some-input-1",
-					ResourceID:      resource.ID(),
+					ResourceID:      scenarioPipeline1.Resource("some-resource").ID(),
 					Version:         atc.Version{"version": "v1"},
 					FirstOccurrence: false,
 				},
 				{
 					Name:            "some-input-2",
-					ResourceID:      resource.ID(),
+					ResourceID:      scenarioPipeline1.Resource("some-resource").ID(),
 					Version:         atc.Version{"version": "v2"},
 					FirstOccurrence: true,
 				},
 			}
 
-			actualBuildInputs, found, err := job.GetFullNextBuildInputs()
+			actualBuildInputs, found, err := scenarioPipeline1.Job("some-job").GetFullNextBuildInputs()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 
@@ -1624,7 +1581,7 @@ var _ = Describe("Job", func() {
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
 							Version:    db.ResourceVersion(convertToMD5(versions[2].Version)),
-							ResourceID: resource.ID(),
+							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: false,
 					},
@@ -1634,42 +1591,42 @@ var _ = Describe("Job", func() {
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
 							Version:    db.ResourceVersion(convertToMD5(versions[2].Version)),
-							ResourceID: resource.ID(),
+							ResourceID: scenarioPipeline1.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
 					},
 					PassedBuildIDs: []int{},
 				},
 			}
-			err = job.SaveNextInputMapping(inputVersions2, true)
+			err = scenarioPipeline1.Job("some-job").SaveNextInputMapping(inputVersions2, true)
 			Expect(err).NotTo(HaveOccurred())
 
 			buildInputs2 := []db.BuildInput{
 				{
 					Name:            "some-input-2",
-					ResourceID:      resource.ID(),
+					ResourceID:      scenarioPipeline1.Resource("some-resource").ID(),
 					Version:         atc.Version{"version": "v3"},
 					FirstOccurrence: false,
 				},
 				{
 					Name:            "some-input-3",
-					ResourceID:      resource.ID(),
+					ResourceID:      scenarioPipeline1.Resource("some-resource").ID(),
 					Version:         atc.Version{"version": "v3"},
 					FirstOccurrence: true,
 				},
 			}
 
-			actualBuildInputs2, found, err := job.GetFullNextBuildInputs()
+			actualBuildInputs2, found, err := scenarioPipeline1.Job("some-job").GetFullNextBuildInputs()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 
 			Expect(actualBuildInputs2).To(ConsistOf(buildInputs2))
 
 			By("updating next build inputs to an empty set when the mapping is nil")
-			err = job.SaveNextInputMapping(nil, true)
+			err = scenarioPipeline1.Job("some-job").SaveNextInputMapping(nil, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			actualBuildInputs3, found, err := job.GetFullNextBuildInputs()
+			actualBuildInputs3, found, err := scenarioPipeline1.Job("some-job").GetFullNextBuildInputs()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 			Expect(actualBuildInputs3).To(BeEmpty())
@@ -1677,15 +1634,15 @@ var _ = Describe("Job", func() {
 
 		It("distinguishes between a job with no inputs and a job with missing inputs", func() {
 			By("initially returning not found")
-			_, found, err := job.GetFullNextBuildInputs()
+			_, found, err := scenarioPipeline1.Job("some-job").GetFullNextBuildInputs()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeFalse())
 
 			By("returning found when an empty input mapping is saved")
-			err = job.SaveNextInputMapping(db.InputMapping{}, true)
+			err = scenarioPipeline1.Job("some-job").SaveNextInputMapping(db.InputMapping{}, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, found, err = job.GetFullNextBuildInputs()
+			_, found, err = scenarioPipeline1.Job("some-job").GetFullNextBuildInputs()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 		})
@@ -1696,10 +1653,10 @@ var _ = Describe("Job", func() {
 					ResolveError: "disaster",
 				},
 			}
-			err := job.SaveNextInputMapping(inputVersions, false)
+			err := scenarioPipeline1.Job("some-job").SaveNextInputMapping(inputVersions, false)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, found, err := job.GetFullNextBuildInputs()
+			_, found, err := scenarioPipeline1.Job("some-job").GetFullNextBuildInputs()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeFalse())
 		})
@@ -2188,81 +2145,63 @@ var _ = Describe("Job", func() {
 	})
 
 	Describe("AlgorithmInputs", func() {
-		var inputsJob db.Job
-		var inputsPipeline db.Pipeline
+		var scenario *dbtest.Scenario
 		var inputs db.InputConfigs
 
 		JustBeforeEach(func() {
 			var err error
-			inputs, err = inputsJob.AlgorithmInputs()
+			inputs, err = scenario.Job("some-job").AlgorithmInputs()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Context("when there is an input configured for the job", func() {
 			BeforeEach(func() {
-				var err error
-				inputsPipeline, _, err = team.SavePipeline(atc.PipelineRef{Name: "inputs-pipeline"}, atc.Config{
-					Jobs: atc.JobConfigs{
-						{
-							Name: "some-job",
-							PlanSequence: []atc.Step{
-								{
-									Config: &atc.GetStep{
-										Name:     "some-input",
-										Resource: "some-resource",
-										Params: atc.Params{
-											"some-param": "some-value",
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+								PlanSequence: []atc.Step{
+									{
+										Config: &atc.GetStep{
+											Name:     "some-input",
+											Resource: "some-resource",
+											Params: atc.Params{
+												"some-param": "some-value",
+											},
+											Passed:  []string{"job-1", "job-2"},
+											Trigger: true,
+											Version: &atc.VersionConfig{Every: true},
 										},
-										Passed:  []string{"job-1", "job-2"},
-										Trigger: true,
-										Version: &atc.VersionConfig{Every: true},
 									},
 								},
 							},
+							{
+								Name: "job-1",
+							},
+							{
+								Name: "job-2",
+							},
 						},
-						{
-							Name: "job-1",
+						Resources: atc.ResourceConfigs{
+							{
+								Name: "some-resource",
+								Type: "some-type",
+							},
 						},
-						{
-							Name: "job-2",
-						},
-					},
-					Resources: atc.ResourceConfigs{
-						{
-							Name: "some-resource",
-							Type: "some-type",
-						},
-					},
-				}, db.ConfigVersion(0), false)
-				Expect(err).ToNot(HaveOccurred())
-
-				var found bool
-				inputsJob, found, err = inputsPipeline.Job("some-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
+					}),
+				)
 			})
 
 			It("returns the input for the job", func() {
-				job1, found, err := inputsPipeline.Job("job-1")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				job2, found, err := inputsPipeline.Job("job-2")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				someResource, found, err := inputsPipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
 				Expect(inputs).To(Equal(db.InputConfigs{
 					{
 						Name:       "some-input",
-						JobID:      inputsJob.ID(),
-						ResourceID: someResource.ID(),
+						JobID:      scenario.Job("some-job").ID(),
+						ResourceID: scenario.Resource("some-resource").ID(),
 						Passed: db.JobSet{
-							job1.ID(): true,
-							job2.ID(): true,
+							scenario.Job("job-1").ID(): true,
+							scenario.Job("job-2").ID(): true,
 						},
 						UseEveryVersion: true,
 						Trigger:         true,
@@ -2273,48 +2212,39 @@ var _ = Describe("Job", func() {
 
 		Context("when the input is pinned through the get step", func() {
 			BeforeEach(func() {
-				var err error
-				inputsPipeline, _, err = team.SavePipeline(atc.PipelineRef{Name: "inputs-pipeline"}, atc.Config{
-					Jobs: atc.JobConfigs{
-						{
-							Name: "some-job",
-							PlanSequence: []atc.Step{
-								{
-									Config: &atc.GetStep{
-										Name:     "some-pinned-input",
-										Resource: "some-resource",
-										Version:  &atc.VersionConfig{Pinned: atc.Version{"input": "pinned"}},
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+								PlanSequence: []atc.Step{
+									{
+										Config: &atc.GetStep{
+											Name:     "some-pinned-input",
+											Resource: "some-resource",
+											Version:  &atc.VersionConfig{Pinned: atc.Version{"input": "pinned"}},
+										},
 									},
 								},
 							},
 						},
-					},
-					Resources: atc.ResourceConfigs{
-						{
-							Name:   "some-resource",
-							Type:   "some-type",
-							Source: atc.Source{"some": "source"},
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "source"},
+							},
 						},
-					},
-				}, db.ConfigVersion(0), false)
-				Expect(err).ToNot(HaveOccurred())
-
-				var found bool
-				inputsJob, found, err = inputsPipeline.Job("some-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
+					}),
+				)
 			})
 
 			It("pins the inputs to that version", func() {
-				someResource, found, err := inputsPipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
 				Expect(inputs).To(Equal(db.InputConfigs{
 					{
 						Name:          "some-pinned-input",
-						JobID:         inputsJob.ID(),
-						ResourceID:    someResource.ID(),
+						JobID:         scenario.Job("some-job").ID(),
+						ResourceID:    scenario.Resource("some-resource").ID(),
 						PinnedVersion: atc.Version{"input": "pinned"},
 					},
 				}))
@@ -2322,48 +2252,17 @@ var _ = Describe("Job", func() {
 
 			Context("when the input is also pinned through the api", func() {
 				BeforeEach(func() {
-					pinnedResource, found, err := inputsPipeline.Resource("some-resource")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					setupTx, err := dbConn.Begin()
-					Expect(err).ToNot(HaveOccurred())
-
-					brt := db.BaseResourceType{
-						Name: "some-type",
-					}
-
-					_, err = brt.FindOrCreate(setupTx, false)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(setupTx.Commit()).To(Succeed())
-
-					resourceConfigScope, err := pinnedResource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
-					Expect(err).ToNot(HaveOccurred())
-
-					err = resourceConfigScope.SaveVersions(nil, []atc.Version{
-						{"api": "pinned"},
-					})
-					Expect(err).NotTo(HaveOccurred())
-
-					version, found, err := pinnedResource.FindVersion(atc.Version{"api": "pinned"})
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					pinned, err := pinnedResource.PinVersion(version.ID())
-					Expect(err).NotTo(HaveOccurred())
-					Expect(pinned).To(BeTrue())
+					scenario.Run(
+						builder.WithPinnedVersion("some-resource", atc.Version{"api": "pinned"}),
+					)
 				})
 
 				It("resolves the pinned version to the version pinned through the get step", func() {
-					someResource, found, err := inputsPipeline.Resource("some-resource")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-
 					Expect(inputs).To(Equal(db.InputConfigs{
 						{
 							Name:          "some-pinned-input",
-							JobID:         inputsJob.ID(),
-							ResourceID:    someResource.ID(),
+							JobID:         scenario.Job("some-job").ID(),
+							ResourceID:    scenario.Resource("some-resource").ID(),
 							PinnedVersion: atc.Version{"input": "pinned"},
 						},
 					}))
@@ -2373,48 +2272,39 @@ var _ = Describe("Job", func() {
 
 		Context("when the input is pinned through the resource config", func() {
 			BeforeEach(func() {
-				var err error
-				inputsPipeline, _, err = team.SavePipeline(atc.PipelineRef{Name: "inputs-pipeline"}, atc.Config{
-					Jobs: atc.JobConfigs{
-						{
-							Name: "some-job",
-							PlanSequence: []atc.Step{
-								{
-									Config: &atc.GetStep{
-										Name:     "some-pinned-input",
-										Resource: "some-resource",
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+								PlanSequence: []atc.Step{
+									{
+										Config: &atc.GetStep{
+											Name:     "some-pinned-input",
+											Resource: "some-resource",
+										},
 									},
 								},
 							},
 						},
-					},
-					Resources: atc.ResourceConfigs{
-						{
-							Name:    "some-resource",
-							Type:    "some-type",
-							Source:  atc.Source{"some": "source"},
-							Version: atc.Version{"some": "version"},
+						Resources: atc.ResourceConfigs{
+							{
+								Name:    "some-resource",
+								Type:    "some-type",
+								Source:  atc.Source{"some": "source"},
+								Version: atc.Version{"some": "version"},
+							},
 						},
-					},
-				}, db.ConfigVersion(0), false)
-				Expect(err).ToNot(HaveOccurred())
-
-				var found bool
-				inputsJob, found, err = inputsPipeline.Job("some-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
+					}),
+				)
 			})
 
 			It("pins the inputs to that version", func() {
-				someResource, found, err := inputsPipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
 				Expect(inputs).To(Equal(db.InputConfigs{
 					{
 						Name:          "some-pinned-input",
-						JobID:         inputsJob.ID(),
-						ResourceID:    someResource.ID(),
+						JobID:         scenario.Job("some-job").ID(),
+						ResourceID:    scenario.Resource("some-resource").ID(),
 						PinnedVersion: atc.Version{"some": "version"},
 					},
 				}))
@@ -2423,78 +2313,39 @@ var _ = Describe("Job", func() {
 
 		Context("when the input is pinned through the api", func() {
 			BeforeEach(func() {
-				var err error
-				inputsPipeline, _, err = team.SavePipeline(atc.PipelineRef{Name: "inputs-pipeline"}, atc.Config{
-					Jobs: atc.JobConfigs{
-						{
-							Name: "some-job",
-							PlanSequence: []atc.Step{
-								{
-									Config: &atc.GetStep{
-										Name:     "some-pinned-input",
-										Resource: "some-resource",
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+								PlanSequence: []atc.Step{
+									{
+										Config: &atc.GetStep{
+											Name:     "some-pinned-input",
+											Resource: "some-resource",
+										},
 									},
 								},
 							},
 						},
-					},
-					Resources: atc.ResourceConfigs{
-						{
-							Name:   "some-resource",
-							Type:   "some-type",
-							Source: atc.Source{"some": "source"},
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "source"},
+							},
 						},
-					},
-				}, db.ConfigVersion(0), false)
-				Expect(err).ToNot(HaveOccurred())
-
-				var found bool
-				inputsJob, found, err = inputsPipeline.Job("some-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				pinnedResource, found, err := inputsPipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				setupTx, err := dbConn.Begin()
-				Expect(err).ToNot(HaveOccurred())
-
-				brt := db.BaseResourceType{
-					Name: "some-type",
-				}
-
-				_, err = brt.FindOrCreate(setupTx, false)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(setupTx.Commit()).To(Succeed())
-
-				resourceConfigScope, err := pinnedResource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
-				Expect(err).ToNot(HaveOccurred())
-
-				err = resourceConfigScope.SaveVersions(nil, []atc.Version{
-					{"some": "version"},
-				})
-				Expect(err).NotTo(HaveOccurred())
-
-				version, found, err := pinnedResource.FindVersion(atc.Version{"some": "version"})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				pinned, err := pinnedResource.PinVersion(version.ID())
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pinned).To(BeTrue())
+					}),
+					builder.WithPinnedVersion("some-resource", atc.Version{"some": "version"}),
+				)
 			})
 
 			It("pins the inputs to that version", func() {
-				someResource, found, err := inputsPipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
 				Expect(inputs).To(Equal(db.InputConfigs{
 					{
 						Name:          "some-pinned-input",
-						JobID:         inputsJob.ID(),
-						ResourceID:    someResource.ID(),
+						JobID:         scenario.Job("some-job").ID(),
+						ResourceID:    scenario.Resource("some-resource").ID(),
 						PinnedVersion: atc.Version{"some": "version"},
 					},
 				}))
@@ -2503,92 +2354,79 @@ var _ = Describe("Job", func() {
 
 		Context("when there are multiple inputs", func() {
 			BeforeEach(func() {
-				var err error
-				inputsPipeline, _, err = team.SavePipeline(atc.PipelineRef{Name: "inputs-pipeline"}, atc.Config{
-					Jobs: atc.JobConfigs{
-						{
-							Name: "some-job",
-							PlanSequence: []atc.Step{
-								{
-									Config: &atc.GetStep{
-										Name:     "some-input",
-										Resource: "some-resource",
-										Trigger:  true,
-										Version:  &atc.VersionConfig{Every: true},
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+								PlanSequence: []atc.Step{
+									{
+										Config: &atc.GetStep{
+											Name:     "some-input",
+											Resource: "some-resource",
+											Trigger:  true,
+											Version:  &atc.VersionConfig{Every: true},
+										},
+									},
+									{
+										Config: &atc.GetStep{
+											Name: "some-resource",
+										},
+									},
+									{
+										Config: &atc.GetStep{
+											Name:    "some-other-resource",
+											Trigger: true,
+											Version: &atc.VersionConfig{Latest: true},
+										},
 									},
 								},
-								{
-									Config: &atc.GetStep{
-										Name: "some-resource",
-									},
-								},
-								{
-									Config: &atc.GetStep{
-										Name:    "some-other-resource",
-										Trigger: true,
-										Version: &atc.VersionConfig{Latest: true},
+							},
+							{
+								Name: "some-other-job",
+								PlanSequence: []atc.Step{
+									{
+										Config: &atc.GetStep{
+											Name:     "other-job-resource",
+											Resource: "some-resource",
+										},
 									},
 								},
 							},
 						},
-						{
-							Name: "some-other-job",
-							PlanSequence: []atc.Step{
-								{
-									Config: &atc.GetStep{
-										Name:     "other-job-resource",
-										Resource: "some-resource",
-									},
-								},
+						Resources: atc.ResourceConfigs{
+							{
+								Name: "some-resource",
+								Type: "some-type",
+							},
+							{
+								Name: "some-other-resource",
+								Type: "some-type",
 							},
 						},
-					},
-					Resources: atc.ResourceConfigs{
-						{
-							Name: "some-resource",
-							Type: "some-type",
-						},
-						{
-							Name: "some-other-resource",
-							Type: "some-type",
-						},
-					},
-				}, db.ConfigVersion(0), false)
-				Expect(err).ToNot(HaveOccurred())
-
-				var found bool
-				inputsJob, found, err = inputsPipeline.Job("some-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
+					}),
+				)
 			})
 
 			It("returns all the inputs correctly", func() {
-				someResource, found, err := inputsPipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				someOtherResource, found, err := inputsPipeline.Resource("some-other-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
 				Expect(inputs).To(HaveLen(3))
 				Expect(inputs).To(ConsistOf(
 					db.InputConfig{
 						Name:            "some-input",
-						JobID:           inputsJob.ID(),
-						ResourceID:      someResource.ID(),
+						JobID:           scenario.Job("some-job").ID(),
+						ResourceID:      scenario.Resource("some-resource").ID(),
 						UseEveryVersion: true,
 						Trigger:         true,
 					},
 					db.InputConfig{
 						Name:       "some-resource",
-						JobID:      inputsJob.ID(),
-						ResourceID: someResource.ID(),
+						JobID:      scenario.Job("some-job").ID(),
+						ResourceID: scenario.Resource("some-resource").ID(),
 					},
 					db.InputConfig{
 						Name:       "some-other-resource",
-						JobID:      inputsJob.ID(),
-						ResourceID: someOtherResource.ID(),
+						JobID:      scenario.Job("some-job").ID(),
+						ResourceID: scenario.Resource("some-other-resource").ID(),
 						Trigger:    true,
 					}))
 			})
@@ -2596,60 +2434,51 @@ var _ = Describe("Job", func() {
 
 		Context("when the job has puts and tasks", func() {
 			BeforeEach(func() {
-				var err error
-				inputsPipeline, _, err = team.SavePipeline(atc.PipelineRef{Name: "inputs-pipeline"}, atc.Config{
-					Jobs: atc.JobConfigs{
-						{
-							Name: "some-job",
-							PlanSequence: []atc.Step{
-								{
-									Config: &atc.PutStep{
-										Name: "some-resource",
-									},
-								},
-								{
-									Config: &atc.TaskStep{
-										Name:       "some-task",
-										Privileged: true,
-										ConfigPath: "some/config/path.yml",
-										Config: &atc.TaskConfig{
-											RootfsURI: "some-image",
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+								PlanSequence: []atc.Step{
+									{
+										Config: &atc.PutStep{
+											Name: "some-resource",
 										},
 									},
-								},
-								{
-									Config: &atc.GetStep{
-										Name: "some-resource",
+									{
+										Config: &atc.TaskStep{
+											Name:       "some-task",
+											Privileged: true,
+											ConfigPath: "some/config/path.yml",
+											Config: &atc.TaskConfig{
+												RootfsURI: "some-image",
+											},
+										},
+									},
+									{
+										Config: &atc.GetStep{
+											Name: "some-resource",
+										},
 									},
 								},
 							},
 						},
-					},
-					Resources: atc.ResourceConfigs{
-						{
-							Name: "some-resource",
-							Type: "some-type",
+						Resources: atc.ResourceConfigs{
+							{
+								Name: "some-resource",
+								Type: "some-type",
+							},
 						},
-					},
-				}, db.ConfigVersion(0), false)
-				Expect(err).ToNot(HaveOccurred())
-
-				var found bool
-				inputsJob, found, err = inputsPipeline.Job("some-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
+					}),
+				)
 			})
 
 			It("only returns the gets (inputs to the job)", func() {
-				someResource, found, err := inputsPipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
 				Expect(inputs).To(Equal(db.InputConfigs{
 					{
 						Name:       "some-resource",
-						JobID:      inputsJob.ID(),
-						ResourceID: someResource.ID(),
+						JobID:      scenario.Job("some-job").ID(),
+						ResourceID: scenario.Resource("some-resource").ID(),
 					},
 				}))
 			})

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/clock"
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/creds/credsfakes"
+	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/vars"
 
 	"github.com/concourse/concourse/atc"
@@ -431,19 +432,13 @@ var _ = Describe("Pipeline", func() {
 		reallyOtherResourceName := "some-really-other-resource"
 
 		var (
-			dbPipeline      db.Pipeline
-			otherDBPipeline db.Pipeline
+			scenarioPipeline1 *dbtest.Scenario
+			scenarioPipeline2 *dbtest.Scenario
 
-			resource            db.Resource
-			resourceConfigScope db.ResourceConfigScope
-
-			otherResource db.Resource
-
-			reallyOtherResource            db.Resource
-			reallyOtherResourceConfigScope db.ResourceConfigScope
-
-			otherPipelineResource            db.Resource
-			otherPipelineResourceConfigScope db.ResourceConfigScope
+			resource              db.Resource
+			otherResource         db.Resource
+			reallyOtherResource   db.Resource
+			otherPipelineResource db.Resource
 		)
 
 		BeforeEach(func() {
@@ -562,6 +557,12 @@ var _ = Describe("Pipeline", func() {
 				},
 			}
 
+			scenarioPipeline1 = dbtest.Setup(
+				builder.WithPipeline(pipelineConfig),
+				builder.WithResourceVersions("some-resource"),
+				builder.WithResourceVersions("some-really-other-resource"),
+			)
+
 			otherPipelineConfig := atc.Config{
 				Groups: atc.GroupConfigs{
 					{
@@ -607,81 +608,27 @@ var _ = Describe("Pipeline", func() {
 				},
 			}
 
-			var err error
-			dbPipeline, _, err = team.SavePipeline(atc.PipelineRef{Name: "pipeline-name"}, pipelineConfig, 0, false)
-			Expect(err).ToNot(HaveOccurred())
+			scenarioPipeline2 = dbtest.Setup(
+				builder.WithPipeline(otherPipelineConfig),
+				builder.WithResourceVersions("some-other-resource"),
+			)
 
-			otherDBPipeline, _, err = team.SavePipeline(atc.PipelineRef{Name: "other-pipeline-name"}, otherPipelineConfig, 0, false)
-			Expect(err).ToNot(HaveOccurred())
-
-			resource, _, err = dbPipeline.Resource(resourceName)
-			Expect(err).ToNot(HaveOccurred())
-
-			otherResource, _, err = dbPipeline.Resource(otherResourceName)
-			Expect(err).ToNot(HaveOccurred())
-
-			reallyOtherResource, _, err = dbPipeline.Resource(reallyOtherResourceName)
-			Expect(err).ToNot(HaveOccurred())
-
-			otherPipelineResource, _, err = otherDBPipeline.Resource(otherResourceName)
-			Expect(err).ToNot(HaveOccurred())
-
-			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"source-config": "some-value"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			reallyOtherResourceConfigScope, err = reallyOtherResource.SetResourceConfig(atc.Source{"source-config": "some-really-other-value"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			otherPipelineResourceConfigScope, err = otherPipelineResource.SetResourceConfig(atc.Source{"other-source-config": "some-other-value"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
+			resource = scenarioPipeline1.Resource(resourceName)
+			otherResource = scenarioPipeline1.Resource(otherResourceName)
+			reallyOtherResource = scenarioPipeline1.Resource(reallyOtherResourceName)
+			otherPipelineResource = scenarioPipeline2.Resource(otherResourceName)
 		})
 
 		It("returns correct resource", func() {
 			Expect(resource.Name()).To(Equal("some-resource"))
-			Expect(resource.PipelineName()).To(Equal("pipeline-name"))
+			Expect(resource.PipelineName()).To(Equal("some-pipeline"))
 			Expect(resource.Type()).To(Equal("some-type"))
 			Expect(resource.Source()).To(Equal(atc.Source{"source-config": "some-value"}))
 		})
 
 		Context("DebugLoadVersionsDB", func() {
 			It("it can load all information about the current state of the db", func() {
-				job, found, err := dbPipeline.Job("some-job")
-				Expect(found).To(BeTrue())
-				Expect(err).ToNot(HaveOccurred())
-
-				otherJob, found, err := dbPipeline.Job("some-other-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				aJob, found, err := dbPipeline.Job("a-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				sharedJob, found, err := dbPipeline.Job("shared-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				randomJob, found, err := dbPipeline.Job("random-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				otherSerialGroupJob, found, err := dbPipeline.Job("other-serial-group-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				differentSerialGroupJob, found, err := dbPipeline.Job("different-serial-group-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				job1, found, err := dbPipeline.Job("job-1")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				job2, found, err := dbPipeline.Job("job-2")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				versions, err := dbPipeline.LoadDebugVersionsDB()
+				versions, err := scenarioPipeline1.Pipeline.LoadDebugVersionsDB()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(versions.ResourceVersions).To(BeEmpty())
 				Expect(versions.BuildOutputs).To(BeEmpty())
@@ -689,7 +636,7 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      resource.ID(),
 						Name:    resource.Name(),
-						ScopeID: intptr(resourceConfigScope.ID()),
+						ScopeID: intptr(resource.ResourceConfigScopeID()),
 					},
 					{
 						ID:      otherResource.ID(),
@@ -699,46 +646,47 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      reallyOtherResource.ID(),
 						Name:    reallyOtherResource.Name(),
-						ScopeID: intptr(reallyOtherResourceConfigScope.ID()),
+						ScopeID: intptr(reallyOtherResource.ResourceConfigScopeID()),
 					},
 				}))
-				Expect(versions.Jobs).To(ConsistOf([]atc.DebugJob{
-					{Name: "some-job", ID: job.ID()},
-					{Name: "some-other-job", ID: otherJob.ID()},
-					{Name: "a-job", ID: aJob.ID()},
-					{Name: "shared-job", ID: sharedJob.ID()},
-					{Name: "random-job", ID: randomJob.ID()},
-					{Name: "other-serial-group-job", ID: otherSerialGroupJob.ID()},
-					{Name: "different-serial-group-job", ID: differentSerialGroupJob.ID()},
-					{Name: "job-1", ID: job1.ID()},
-					{Name: "job-2", ID: job2.ID()},
-				}))
 
-				By("initially having no latest versioned resource")
-				_, found, err = resourceConfigScope.LatestVersion()
+				jobs := []atc.DebugJob{
+					{Name: "some-job", ID: scenarioPipeline1.Job("some-job").ID()},
+					{Name: "some-other-job", ID: scenarioPipeline1.Job("some-other-job").ID()},
+					{Name: "a-job", ID: scenarioPipeline1.Job("a-job").ID()},
+					{Name: "shared-job", ID: scenarioPipeline1.Job("shared-job").ID()},
+					{Name: "random-job", ID: scenarioPipeline1.Job("random-job").ID()},
+					{Name: "other-serial-group-job", ID: scenarioPipeline1.Job("other-serial-group-job").ID()},
+					{Name: "different-serial-group-job", ID: scenarioPipeline1.Job("different-serial-group-job").ID()},
+					{Name: "job-1", ID: scenarioPipeline1.Job("job-1").ID()},
+					{Name: "job-2", ID: scenarioPipeline1.Job("job-2").ID()},
+				}
+
+				Expect(versions.Jobs).To(ConsistOf(jobs))
+
+				By("initially having no versions")
+				resourceVersions, _, _, err := resource.Versions(db.Page{Limit: 10}, nil)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeFalse())
+				Expect(resourceVersions).To(HaveLen(0))
 
 				By("including saved versioned resources of the current pipeline")
-				err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "1"}})
-				Expect(err).ToNot(HaveOccurred())
+				scenarioPipeline1.Run(builder.WithResourceVersions(resourceName, atc.Version{"version": "1"}))
 
-				savedVR1, found, err := resourceConfigScope.LatestVersion()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "2"}})
-				Expect(err).ToNot(HaveOccurred())
-
-				savedVR2, found, err := resourceConfigScope.LatestVersion()
+				savedVR1, found, err := resource.FindVersion(atc.Version{"version": "1"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 
-				versions, err = dbPipeline.LoadDebugVersionsDB()
+				scenarioPipeline1.Run(builder.WithResourceVersions(resourceName, atc.Version{"version": "2"}))
+
+				savedVR2, found, err := resource.FindVersion(atc.Version{"version": "2"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				versions, err = scenarioPipeline1.Pipeline.LoadDebugVersionsDB()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(versions.ResourceVersions).To(ConsistOf([]atc.DebugResourceVersion{
-					{VersionID: savedVR1.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR1.CheckOrder()},
-					{VersionID: savedVR2.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR2.CheckOrder()},
+					{VersionID: savedVR1.ID(), ResourceID: resource.ID(), ScopeID: resource.ResourceConfigScopeID(), CheckOrder: savedVR1.CheckOrder()},
+					{VersionID: savedVR2.ID(), ResourceID: resource.ID(), ScopeID: resource.ResourceConfigScopeID(), CheckOrder: savedVR2.CheckOrder()},
 				}))
 
 				Expect(versions.BuildOutputs).To(BeEmpty())
@@ -746,7 +694,7 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      resource.ID(),
 						Name:    resource.Name(),
-						ScopeID: intptr(resourceConfigScope.ID()),
+						ScopeID: intptr(resource.ResourceConfigScopeID()),
 					},
 					{
 						ID:      otherResource.ID(),
@@ -756,34 +704,33 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      reallyOtherResource.ID(),
 						Name:    reallyOtherResource.Name(),
-						ScopeID: intptr(reallyOtherResourceConfigScope.ID()),
+						ScopeID: intptr(reallyOtherResource.ResourceConfigScopeID()),
 					},
 				}))
-				Expect(versions.Jobs).To(ConsistOf([]atc.DebugJob{
-					{Name: "some-job", ID: job.ID()},
-					{Name: "some-other-job", ID: otherJob.ID()},
-					{Name: "a-job", ID: aJob.ID()},
-					{Name: "shared-job", ID: sharedJob.ID()},
-					{Name: "random-job", ID: randomJob.ID()},
-					{Name: "other-serial-group-job", ID: otherSerialGroupJob.ID()},
-					{Name: "different-serial-group-job", ID: differentSerialGroupJob.ID()},
-					{Name: "job-1", ID: job1.ID()},
-					{Name: "job-2", ID: job2.ID()},
-				}))
+				Expect(versions.Jobs).To(ConsistOf(jobs))
 
 				By("not including saved versioned resources of other pipelines")
-				err = otherPipelineResourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "1"}})
-				Expect(err).ToNot(HaveOccurred())
+				scenarioPipeline2.Run(builder.WithResourceVersions(otherResourceName, atc.Version{"version": "1"}))
 
-				_, found, err = otherPipelineResourceConfigScope.LatestVersion()
+				_, found, err = otherPipelineResource.FindVersion(atc.Version{"version": "1"})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 
-				versions, err = dbPipeline.LoadDebugVersionsDB()
+				versions, err = scenarioPipeline1.Pipeline.LoadDebugVersionsDB()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(versions.ResourceVersions).To(ConsistOf([]atc.DebugResourceVersion{
-					{VersionID: savedVR1.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR1.CheckOrder()},
-					{VersionID: savedVR2.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR2.CheckOrder()},
+					{
+						VersionID:  savedVR1.ID(),
+						ResourceID: resource.ID(),
+						ScopeID:    resource.ResourceConfigScopeID(),
+						CheckOrder: savedVR1.CheckOrder(),
+					},
+					{
+						VersionID:  savedVR2.ID(),
+						ResourceID: resource.ID(),
+						ScopeID:    resource.ResourceConfigScopeID(),
+						CheckOrder: savedVR2.CheckOrder(),
+					},
 				}))
 
 				Expect(versions.BuildOutputs).To(BeEmpty())
@@ -791,7 +738,7 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      resource.ID(),
 						Name:    resource.Name(),
-						ScopeID: intptr(resourceConfigScope.ID()),
+						ScopeID: intptr(resource.ResourceConfigScopeID()),
 					},
 					{
 						ID:      otherResource.ID(),
@@ -801,23 +748,13 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      reallyOtherResource.ID(),
 						Name:    reallyOtherResource.Name(),
-						ScopeID: intptr(reallyOtherResourceConfigScope.ID()),
+						ScopeID: intptr(reallyOtherResource.ResourceConfigScopeID()),
 					},
 				}))
-				Expect(versions.Jobs).To(ConsistOf([]atc.DebugJob{
-					{Name: "some-job", ID: job.ID()},
-					{Name: "some-other-job", ID: otherJob.ID()},
-					{Name: "a-job", ID: aJob.ID()},
-					{Name: "shared-job", ID: sharedJob.ID()},
-					{Name: "random-job", ID: randomJob.ID()},
-					{Name: "other-serial-group-job", ID: otherSerialGroupJob.ID()},
-					{Name: "different-serial-group-job", ID: differentSerialGroupJob.ID()},
-					{Name: "job-1", ID: job1.ID()},
-					{Name: "job-2", ID: job2.ID()},
-				}))
+				Expect(versions.Jobs).To(ConsistOf(jobs))
 
 				By("including outputs of successful builds")
-				build1DB, err := aJob.CreateBuild()
+				build1DB, err := scenarioPipeline1.Job("a-job").CreateBuild()
 				Expect(err).ToNot(HaveOccurred())
 
 				err = build1DB.SaveOutput("some-type", atc.Source{"source-config": "some-value"}, atc.VersionedResourceTypes{}, atc.Version{"version": "1"}, nil, "some-output-name", "some-resource")
@@ -826,21 +763,21 @@ var _ = Describe("Pipeline", func() {
 				err = build1DB.Finish(db.BuildStatusSucceeded)
 				Expect(err).ToNot(HaveOccurred())
 
-				versions, err = dbPipeline.LoadDebugVersionsDB()
+				versions, err = scenarioPipeline1.Pipeline.LoadDebugVersionsDB()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(versions.ResourceVersions).To(ConsistOf([]atc.DebugResourceVersion{
-					{VersionID: savedVR1.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR1.CheckOrder()},
-					{VersionID: savedVR2.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR2.CheckOrder()},
+					{VersionID: savedVR1.ID(), ResourceID: resource.ID(), ScopeID: resource.ResourceConfigScopeID(), CheckOrder: savedVR1.CheckOrder()},
+					{VersionID: savedVR2.ID(), ResourceID: resource.ID(), ScopeID: resource.ResourceConfigScopeID(), CheckOrder: savedVR2.CheckOrder()},
 				}))
 
 				explicitOutput := atc.DebugBuildOutput{
 					DebugResourceVersion: atc.DebugResourceVersion{
 						VersionID:  savedVR1.ID(),
 						ResourceID: resource.ID(),
-						ScopeID:    resourceConfigScope.ID(),
+						ScopeID:    resource.ResourceConfigScopeID(),
 						CheckOrder: savedVR1.CheckOrder(),
 					},
-					JobID:   aJob.ID(),
+					JobID:   scenarioPipeline1.Job("a-job").ID(),
 					BuildID: build1DB.ID(),
 				}
 
@@ -852,7 +789,7 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      resource.ID(),
 						Name:    resource.Name(),
-						ScopeID: intptr(resourceConfigScope.ID()),
+						ScopeID: intptr(resource.ResourceConfigScopeID()),
 					},
 					{
 						ID:      otherResource.ID(),
@@ -862,23 +799,13 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      reallyOtherResource.ID(),
 						Name:    reallyOtherResource.Name(),
-						ScopeID: intptr(reallyOtherResourceConfigScope.ID()),
+						ScopeID: intptr(reallyOtherResource.ResourceConfigScopeID()),
 					},
 				}))
-				Expect(versions.Jobs).To(ConsistOf([]atc.DebugJob{
-					{Name: "some-job", ID: job.ID()},
-					{Name: "some-other-job", ID: otherJob.ID()},
-					{Name: "a-job", ID: aJob.ID()},
-					{Name: "shared-job", ID: sharedJob.ID()},
-					{Name: "random-job", ID: randomJob.ID()},
-					{Name: "other-serial-group-job", ID: otherSerialGroupJob.ID()},
-					{Name: "different-serial-group-job", ID: differentSerialGroupJob.ID()},
-					{Name: "job-1", ID: job1.ID()},
-					{Name: "job-2", ID: job2.ID()},
-				}))
+				Expect(versions.Jobs).To(ConsistOf(jobs))
 
 				By("not including outputs of failed builds")
-				build2DB, err := aJob.CreateBuild()
+				build2DB, err := scenarioPipeline1.Job("a-job").CreateBuild()
 				Expect(err).ToNot(HaveOccurred())
 
 				err = build2DB.SaveOutput("some-type", atc.Source{"source-config": "some-value"}, atc.VersionedResourceTypes{}, atc.Version{"version": "1"}, nil, "some-output-name", "some-resource")
@@ -887,11 +814,11 @@ var _ = Describe("Pipeline", func() {
 				err = build2DB.Finish(db.BuildStatusFailed)
 				Expect(err).ToNot(HaveOccurred())
 
-				versions, err = dbPipeline.LoadDebugVersionsDB()
+				versions, err = scenarioPipeline1.Pipeline.LoadDebugVersionsDB()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(versions.ResourceVersions).To(ConsistOf([]atc.DebugResourceVersion{
-					{VersionID: savedVR1.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR1.CheckOrder()},
-					{VersionID: savedVR2.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR2.CheckOrder()},
+					{VersionID: savedVR1.ID(), ResourceID: resource.ID(), ScopeID: resource.ResourceConfigScopeID(), CheckOrder: savedVR1.CheckOrder()},
+					{VersionID: savedVR2.ID(), ResourceID: resource.ID(), ScopeID: resource.ResourceConfigScopeID(), CheckOrder: savedVR2.CheckOrder()},
 				}))
 
 				Expect(versions.BuildOutputs).To(ConsistOf([]atc.DebugBuildOutput{
@@ -899,10 +826,10 @@ var _ = Describe("Pipeline", func() {
 						DebugResourceVersion: atc.DebugResourceVersion{
 							VersionID:  savedVR1.ID(),
 							ResourceID: resource.ID(),
-							ScopeID:    resourceConfigScope.ID(),
+							ScopeID:    resource.ResourceConfigScopeID(),
 							CheckOrder: savedVR1.CheckOrder(),
 						},
-						JobID:   aJob.ID(),
+						JobID:   scenarioPipeline1.Job("a-job").ID(),
 						BuildID: build1DB.ID(),
 					},
 				}))
@@ -911,7 +838,7 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      resource.ID(),
 						Name:    resource.Name(),
-						ScopeID: intptr(resourceConfigScope.ID()),
+						ScopeID: intptr(resource.ResourceConfigScopeID()),
 					},
 					{
 						ID:      otherResource.ID(),
@@ -921,27 +848,13 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      reallyOtherResource.ID(),
 						Name:    reallyOtherResource.Name(),
-						ScopeID: intptr(reallyOtherResourceConfigScope.ID()),
+						ScopeID: intptr(reallyOtherResource.ResourceConfigScopeID()),
 					},
 				}))
-				Expect(versions.Jobs).To(ConsistOf([]atc.DebugJob{
-					{Name: "some-job", ID: job.ID()},
-					{Name: "some-other-job", ID: otherJob.ID()},
-					{Name: "a-job", ID: aJob.ID()},
-					{Name: "shared-job", ID: sharedJob.ID()},
-					{Name: "random-job", ID: randomJob.ID()},
-					{Name: "other-serial-group-job", ID: otherSerialGroupJob.ID()},
-					{Name: "different-serial-group-job", ID: differentSerialGroupJob.ID()},
-					{Name: "job-1", ID: job1.ID()},
-					{Name: "job-2", ID: job2.ID()},
-				}))
+				Expect(versions.Jobs).To(ConsistOf(jobs))
 
 				By("not including outputs of builds in other pipelines")
-				anotherJob, found, err := otherDBPipeline.Job("a-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				otherPipelineBuild, err := anotherJob.CreateBuild()
+				otherPipelineBuild, err := scenarioPipeline1.Job("a-job").CreateBuild()
 				Expect(err).ToNot(HaveOccurred())
 
 				err = otherPipelineBuild.SaveOutput("some-type", atc.Source{"other-source-config": "some-other-value"}, atc.VersionedResourceTypes{}, atc.Version{"version": "1"}, nil, "some-output-name", "some-other-resource")
@@ -950,11 +863,11 @@ var _ = Describe("Pipeline", func() {
 				err = otherPipelineBuild.Finish(db.BuildStatusSucceeded)
 				Expect(err).ToNot(HaveOccurred())
 
-				versions, err = dbPipeline.LoadDebugVersionsDB()
+				versions, err = scenarioPipeline1.Pipeline.LoadDebugVersionsDB()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(versions.ResourceVersions).To(ConsistOf([]atc.DebugResourceVersion{
-					{VersionID: savedVR1.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR1.CheckOrder()},
-					{VersionID: savedVR2.ID(), ResourceID: resource.ID(), ScopeID: resourceConfigScope.ID(), CheckOrder: savedVR2.CheckOrder()},
+					{VersionID: savedVR1.ID(), ResourceID: resource.ID(), ScopeID: resource.ResourceConfigScopeID(), CheckOrder: savedVR1.CheckOrder()},
+					{VersionID: savedVR2.ID(), ResourceID: resource.ID(), ScopeID: resource.ResourceConfigScopeID(), CheckOrder: savedVR2.CheckOrder()},
 				}))
 
 				Expect(versions.BuildOutputs).To(ConsistOf([]atc.DebugBuildOutput{
@@ -962,10 +875,10 @@ var _ = Describe("Pipeline", func() {
 						DebugResourceVersion: atc.DebugResourceVersion{
 							VersionID:  savedVR1.ID(),
 							ResourceID: resource.ID(),
-							ScopeID:    resourceConfigScope.ID(),
+							ScopeID:    resource.ResourceConfigScopeID(),
 							CheckOrder: savedVR1.CheckOrder(),
 						},
-						JobID:   aJob.ID(),
+						JobID:   scenarioPipeline1.Job("a-job").ID(),
 						BuildID: build1DB.ID(),
 					},
 				}))
@@ -974,7 +887,7 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      resource.ID(),
 						Name:    resource.Name(),
-						ScopeID: intptr(resourceConfigScope.ID()),
+						ScopeID: intptr(resource.ResourceConfigScopeID()),
 					},
 					{
 						ID:      otherResource.ID(),
@@ -984,27 +897,12 @@ var _ = Describe("Pipeline", func() {
 					{
 						ID:      reallyOtherResource.ID(),
 						Name:    reallyOtherResource.Name(),
-						ScopeID: intptr(reallyOtherResourceConfigScope.ID()),
+						ScopeID: intptr(reallyOtherResource.ResourceConfigScopeID()),
 					},
 				}))
-				Expect(versions.Jobs).To(ConsistOf([]atc.DebugJob{
-					{Name: "some-job", ID: job.ID()},
-					{Name: "some-other-job", ID: otherJob.ID()},
-					{Name: "a-job", ID: aJob.ID()},
-					{Name: "shared-job", ID: sharedJob.ID()},
-					{Name: "random-job", ID: randomJob.ID()},
-					{Name: "other-serial-group-job", ID: otherSerialGroupJob.ID()},
-					{Name: "different-serial-group-job", ID: differentSerialGroupJob.ID()},
-					{Name: "job-1", ID: job1.ID()},
-					{Name: "job-2", ID: job2.ID()},
-				}))
+				Expect(versions.Jobs).To(ConsistOf(jobs))
 
-				By("including build inputs")
-				aJob, found, err = dbPipeline.Job("a-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				err = aJob.SaveNextInputMapping(db.InputMapping{
+				err = scenarioPipeline1.Job("a-job").SaveNextInputMapping(db.InputMapping{
 					"some-input-name": db.InputResult{
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
@@ -1017,7 +915,7 @@ var _ = Describe("Pipeline", func() {
 					}}, true)
 				Expect(err).ToNot(HaveOccurred())
 
-				build1DB, err = aJob.CreateBuild()
+				build1DB, err = scenarioPipeline1.Job("a-job").CreateBuild()
 				Expect(err).ToNot(HaveOccurred())
 
 				_, found, err = build1DB.AdoptInputsAndPipes()
@@ -1027,7 +925,7 @@ var _ = Describe("Pipeline", func() {
 				err = build1DB.Finish(db.BuildStatusSucceeded)
 				Expect(err).ToNot(HaveOccurred())
 
-				versions, err = dbPipeline.LoadDebugVersionsDB()
+				versions, err = scenarioPipeline1.Pipeline.LoadDebugVersionsDB()
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(versions.BuildInputs).To(ConsistOf([]atc.DebugBuildInput{
@@ -1035,10 +933,10 @@ var _ = Describe("Pipeline", func() {
 						DebugResourceVersion: atc.DebugResourceVersion{
 							VersionID:  savedVR1.ID(),
 							ResourceID: resource.ID(),
-							ScopeID:    resourceConfigScope.ID(),
+							ScopeID:    resource.ResourceConfigScopeID(),
 							CheckOrder: savedVR1.CheckOrder(),
 						},
-						JobID:     aJob.ID(),
+						JobID:     scenarioPipeline1.Job("a-job").ID(),
 						BuildID:   build1DB.ID(),
 						InputName: "some-input-name",
 					},
@@ -1049,10 +947,10 @@ var _ = Describe("Pipeline", func() {
 					DebugResourceVersion: atc.DebugResourceVersion{
 						VersionID:  savedVR1.ID(),
 						ResourceID: resource.ID(),
-						ScopeID:    resourceConfigScope.ID(),
+						ScopeID:    resource.ResourceConfigScopeID(),
 						CheckOrder: savedVR1.CheckOrder(),
 					},
-					JobID:   aJob.ID(),
+					JobID:   scenarioPipeline1.Job("a-job").ID(),
 					BuildID: build1DB.ID(),
 				}
 
@@ -1062,10 +960,10 @@ var _ = Describe("Pipeline", func() {
 				}))
 
 				By("including build rerun mappings for builds")
-				build2DB, err = aJob.RerunBuild(build1DB)
+				build2DB, err = scenarioPipeline1.Job("a-job").RerunBuild(build1DB)
 				Expect(err).ToNot(HaveOccurred())
 
-				versions, err = dbPipeline.LoadDebugVersionsDB()
+				versions, err = scenarioPipeline1.Pipeline.LoadDebugVersionsDB()
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(versions.BuildReruns).To(ConsistOf([]atc.DebugBuildRerun{
@@ -1079,23 +977,21 @@ var _ = Describe("Pipeline", func() {
 		})
 
 		It("can load up the latest versioned resource, enabled or not", func() {
-			By("initially having no latest versioned resource")
-			_, found, err := resourceConfigScope.LatestVersion()
+			By("initially having no versions")
+			resourceVersions, _, found, err := resource.Versions(db.Page{Limit: 10}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeFalse())
+			Expect(resourceVersions).To(HaveLen(0))
 
 			By("including saved versioned resources of the current pipeline")
-			err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "1"}})
-			Expect(err).ToNot(HaveOccurred())
+			scenarioPipeline1.Run(builder.WithResourceVersions(resourceName, atc.Version{"version": "1"}))
 
-			savedVR1, found, err := resourceConfigScope.LatestVersion()
+			savedVR1, found, err := resource.FindVersion(atc.Version{"version": "1"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "2"}})
-			Expect(err).ToNot(HaveOccurred())
+			scenarioPipeline1.Run(builder.WithResourceVersions(resourceName, atc.Version{"version": "2"}))
 
-			savedVR2, found, err := resourceConfigScope.LatestVersion()
+			savedVR2, found, err := resource.FindVersion(atc.Version{"version": "2"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
@@ -1103,23 +999,21 @@ var _ = Describe("Pipeline", func() {
 			Expect(savedVR2.Version()).To(Equal(db.Version{"version": "2"}))
 
 			By("not including saved versioned resources of other pipelines")
-			_, _, err = otherDBPipeline.Resource("some-other-resource")
-			Expect(err).ToNot(HaveOccurred())
+			scenarioPipeline2.Run(builder.WithResourceVersions(otherResourceName, atc.Version{"version": "3"}, atc.Version{"version": "4"}, atc.Version{"version": "5"}))
 
-			err = otherPipelineResourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "1"}, {"version": "2"}, {"version": "3"}})
-			Expect(err).ToNot(HaveOccurred())
-
-			otherPipelineSavedVR, found, err := otherPipelineResourceConfigScope.LatestVersion()
+			_, found, err = scenarioPipeline2.Resource(otherResourceName).FindVersion(atc.Version{"version": "3"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			Expect(otherPipelineSavedVR.Version()).To(Equal(db.Version{"version": "3"}))
+			_, found, err = scenarioPipeline2.Resource(otherResourceName).FindVersion(atc.Version{"version": "1"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeFalse())
 
 			By("including disabled versions")
 			err = resource.DisableVersion(savedVR2.ID())
 			Expect(err).ToNot(HaveOccurred())
 
-			latestVR, found, err := resourceConfigScope.LatestVersion()
+			latestVR, found, err := resource.FindVersion(atc.Version{"version": "2"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
@@ -1127,51 +1021,54 @@ var _ = Describe("Pipeline", func() {
 		})
 
 		It("initially has no pending build for a job", func() {
-			job, found, err := dbPipeline.Job("some-job")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			pendingBuilds, err := job.GetPendingBuilds()
+			pendingBuilds, err := scenarioPipeline1.Job("some-job").GetPendingBuilds()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pendingBuilds).To(HaveLen(0))
 		})
 	})
 
 	Describe("Destroy", func() {
-		var resourceConfigScope db.ResourceConfigScope
+		var scenario *dbtest.Scenario
 
 		It("removes the pipeline and all of its data", func() {
 			By("populating resources table")
-			resource, found, err := pipeline.Resource("some-resource")
-			Expect(found).To(BeTrue())
-			Expect(err).ToNot(HaveOccurred())
-
-			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			By("populating resource versions")
-			err = resourceConfigScope.SaveVersions(nil, []atc.Version{
-				{
-					"key": "value",
-				},
-			})
-			Expect(err).ToNot(HaveOccurred())
+			scenario = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Resources: atc.ResourceConfigs{
+						{
+							Name:   "some-resource",
+							Type:   "some-type",
+							Source: atc.Source{"some": "source"},
+						},
+					},
+					Jobs: atc.JobConfigs{
+						{
+							Name: "some-job",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:     "some-input",
+										Resource: "some-resource",
+									},
+								},
+							},
+						},
+					},
+				}),
+				builder.WithResourceVersions("some-resource", atc.Version{"key": "value"}),
+			)
 
 			By("populating builds")
-			job, found, err := pipeline.Job("job-name")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			build, err := job.CreateBuild()
+			build, err := scenario.Job("some-job").CreateBuild()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("populating build inputs")
-			err = job.SaveNextInputMapping(db.InputMapping{
+			err = scenario.Job("some-job").SaveNextInputMapping(db.InputMapping{
 				"build-input": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
 							Version:    db.ResourceVersion(convertToMD5(atc.Version{"key": "value"})),
-							ResourceID: resource.ID(),
+							ResourceID: scenario.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
 					},
@@ -1179,7 +1076,7 @@ var _ = Describe("Pipeline", func() {
 				}}, true)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, found, err = build.AdoptInputsAndPipes()
+			_, found, err := build.AdoptInputsAndPipes()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
@@ -1191,10 +1088,10 @@ var _ = Describe("Pipeline", func() {
 			err = build.SaveEvent(event.StartTask{})
 			Expect(err).ToNot(HaveOccurred())
 
-			err = pipeline.Destroy()
+			err = scenario.Pipeline.Destroy()
 			Expect(err).ToNot(HaveOccurred())
 
-			found, err = pipeline.Reload()
+			found, err = scenario.Pipeline.Reload()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeFalse())
 
@@ -1202,7 +1099,7 @@ var _ = Describe("Pipeline", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeFalse())
 
-			pipeline, found, err = team.Pipeline(atc.PipelineRef{Name: pipeline.Name()})
+			_, found, err = scenario.Team.Pipeline(atc.PipelineRef{Name: pipeline.Name()})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeFalse())
 		})
@@ -1490,51 +1387,62 @@ var _ = Describe("Pipeline", func() {
 		var (
 			resourceConfigVersion int
 			expectedBuilds        []int
-			resource              db.Resource
 			dbSecondBuild         db.Build
-			resourceConfigScope   db.ResourceConfigScope
+			scenario              *dbtest.Scenario
 		)
 
 		BeforeEach(func() {
-			job, found, err := pipeline.Job("job-name")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			scenario = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Jobs: atc.JobConfigs{
+						{
+							Name: "job-name",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:     "some-input",
+										Resource: "some-resource",
+									},
+								},
+							},
+						},
+						{
+							Name:   "some-other-job",
+							Serial: true,
+						},
+					},
+					Resources: atc.ResourceConfigs{
+						{
+							Name:   "some-resource",
+							Type:   "some-type",
+							Source: atc.Source{"some": "source"},
+						},
+					},
+				}),
+				builder.WithResourceVersions("some-resource", atc.Version{"version": "v1"}),
+			)
 
-			build, err := job.CreateBuild()
-
+			build, err := scenario.Job("job-name").CreateBuild()
 			Expect(err).ToNot(HaveOccurred())
 			expectedBuilds = append(expectedBuilds, build.ID())
 
-			secondBuild, err := job.CreateBuild()
+			secondBuild, err := scenario.Job("job-name").CreateBuild()
 			Expect(err).ToNot(HaveOccurred())
 			expectedBuilds = append(expectedBuilds, secondBuild.ID())
 
-			someOtherJob, found, err := pipeline.Job("some-other-job")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			_, err = someOtherJob.CreateBuild()
+			_, err = scenario.Job("some-other-job").CreateBuild()
 			Expect(err).ToNot(HaveOccurred())
 
 			dbBuild, found, err := buildFactory.Build(build.ID())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			resource, _, err = pipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-
-			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"version": "v1"}})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = job.SaveNextInputMapping(db.InputMapping{
+			err = scenario.Job("job-name").SaveNextInputMapping(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
 							Version:    db.ResourceVersion(convertToMD5(atc.Version{"version": "v1"})),
-							ResourceID: resource.ID(),
+							ResourceID: scenario.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
 					},
@@ -1550,19 +1458,19 @@ var _ = Describe("Pipeline", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			err = resourceConfigScope.SaveVersions(nil, []atc.Version{
-				{"version": "v2"},
-				{"version": "v3"},
-				{"version": "v4"},
-			})
-			Expect(err).ToNot(HaveOccurred())
+			scenario.Run(builder.WithResourceVersions(
+				"some-resource",
+				atc.Version{"version": "v2"},
+				atc.Version{"version": "v3"},
+				atc.Version{"version": "v4"},
+			))
 
-			err = job.SaveNextInputMapping(db.InputMapping{
+			err = scenario.Job("job-name").SaveNextInputMapping(db.InputMapping{
 				"some-input": db.InputResult{
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
 							Version:    db.ResourceVersion(convertToMD5(atc.Version{"version": "v1"})),
-							ResourceID: resource.ID(),
+							ResourceID: scenario.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
 					},
@@ -1572,7 +1480,7 @@ var _ = Describe("Pipeline", func() {
 					Input: &db.AlgorithmInput{
 						AlgorithmVersion: db.AlgorithmVersion{
 							Version:    db.ResourceVersion(convertToMD5(atc.Version{"version": "v3"})),
-							ResourceID: resource.ID(),
+							ResourceID: scenario.Resource("some-resource").ID(),
 						},
 						FirstOccurrence: true,
 					},
@@ -1585,15 +1493,13 @@ var _ = Describe("Pipeline", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			rcv1, found, err := resourceConfigScope.FindVersion(atc.Version{"version": "v1"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			rcv1 := scenario.ResourceVersion("some-resource", atc.Version{"version": "v1"})
 
 			resourceConfigVersion = rcv1.ID()
 		})
 
 		It("returns the two builds for which the provided version id was an input", func() {
-			builds, err := pipeline.GetBuildsWithVersionAsInput(resource.ID(), resourceConfigVersion)
+			builds, err := pipeline.GetBuildsWithVersionAsInput(scenario.Resource("some-resource").ID(), resourceConfigVersion)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(builds).To(HaveLen(len(expectedBuilds)))
 
@@ -1606,28 +1512,24 @@ var _ = Describe("Pipeline", func() {
 		})
 
 		It("returns the one build that uses the version as an input", func() {
-			rcv3, found, err := resourceConfigScope.FindVersion(atc.Version{"version": "v3"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			rcv3 := scenario.ResourceVersion("some-resource", atc.Version{"version": "v3"})
 
-			builds, err := pipeline.GetBuildsWithVersionAsInput(resource.ID(), rcv3.ID())
+			builds, err := pipeline.GetBuildsWithVersionAsInput(scenario.Resource("some-resource").ID(), rcv3.ID())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(builds).To(HaveLen(1))
 			Expect(builds[0].ID()).To(Equal(dbSecondBuild.ID()))
 		})
 
 		It("returns an empty slice of builds when the provided version id exists but is not used", func() {
-			rcv4, found, err := resourceConfigScope.FindVersion(atc.Version{"version": "v4"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			rcv4 := scenario.ResourceVersion("some-resource", atc.Version{"version": "v4"})
 
-			builds, err := pipeline.GetBuildsWithVersionAsInput(resource.ID(), rcv4.ID())
+			builds, err := pipeline.GetBuildsWithVersionAsInput(scenario.Resource("some-resource").ID(), rcv4.ID())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(builds).To(Equal([]db.Build{}))
 		})
 
 		It("returns an empty slice of builds when the provided version id doesn't exist", func() {
-			builds, err := pipeline.GetBuildsWithVersionAsInput(resource.ID(), resourceConfigVersion+100)
+			builds, err := pipeline.GetBuildsWithVersionAsInput(scenario.Resource("some-resource").ID(), resourceConfigVersion+100)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(builds).To(Equal([]db.Build{}))
 		})
@@ -1643,46 +1545,55 @@ var _ = Describe("Pipeline", func() {
 		var (
 			resourceConfigVersion int
 			expectedBuilds        []db.Build
-			resourceConfigScope   db.ResourceConfigScope
-			resource              db.Resource
 			secondBuild           db.Build
+			scenario              *dbtest.Scenario
 		)
 
 		BeforeEach(func() {
-			job, found, err := pipeline.Job("job-name")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			scenario = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Jobs: atc.JobConfigs{
+						{
+							Name: "job-name",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:     "some-input",
+										Resource: "some-resource",
+									},
+								},
+							},
+						},
+						{
+							Name:   "some-other-job",
+							Serial: true,
+						},
+					},
+					Resources: atc.ResourceConfigs{
+						{
+							Name:   "some-resource",
+							Type:   "some-type",
+							Source: atc.Source{"some": "source"},
+						},
+					},
+				}),
+				builder.WithResourceVersions("some-resource", atc.Version{"version": "v3"}, atc.Version{"version": "v4"}),
+			)
 
-			build, err := job.CreateBuild()
+			build, err := scenario.Job("job-name").CreateBuild()
 			Expect(err).ToNot(HaveOccurred())
 			expectedBuilds = append(expectedBuilds, build)
 
-			secondBuild, err = job.CreateBuild()
+			secondBuild, err = scenario.Job("job-name").CreateBuild()
 			Expect(err).ToNot(HaveOccurred())
 			expectedBuilds = append(expectedBuilds, secondBuild)
 
-			someOtherJob, found, err := pipeline.Job("some-other-job")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			_, err = someOtherJob.CreateBuild()
+			_, err = scenario.Job("some-other-job").CreateBuild()
 			Expect(err).ToNot(HaveOccurred())
 
 			dbBuild, found, err := buildFactory.Build(build.ID())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
-
-			resource, _, err = pipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-
-			resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = resourceConfigScope.SaveVersions(nil, []atc.Version{
-				{"version": "v3"},
-				{"version": "v4"},
-			})
-			Expect(err).ToNot(HaveOccurred())
 
 			err = dbBuild.SaveOutput("some-type", atc.Source{"some": "source"}, atc.VersionedResourceTypes{}, atc.Version{"version": "v1"}, []db.ResourceConfigMetadataField{
 				{
@@ -1707,36 +1618,30 @@ var _ = Describe("Pipeline", func() {
 			err = dbSecondBuild.SaveOutput("some-type", atc.Source{"some": "source"}, atc.VersionedResourceTypes{}, atc.Version{"version": "v3"}, nil, "some-output-name", "some-resource")
 			Expect(err).ToNot(HaveOccurred())
 
-			rcv1, found, err := resourceConfigScope.FindVersion(atc.Version{"version": "v1"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			rcv1 := scenario.ResourceVersion("some-resource", atc.Version{"version": "v1"})
 
 			resourceConfigVersion = rcv1.ID()
 		})
 
 		It("returns the two builds for which the provided version id was an output", func() {
-			builds, err := pipeline.GetBuildsWithVersionAsOutput(resource.ID(), resourceConfigVersion)
+			builds, err := pipeline.GetBuildsWithVersionAsOutput(scenario.Resource("some-resource").ID(), resourceConfigVersion)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(builds).To(ConsistOf(expectedBuilds))
 		})
 
 		It("returns the one build that uses the version as an input", func() {
-			rcv3, found, err := resourceConfigScope.FindVersion(atc.Version{"version": "v3"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			rcv3 := scenario.ResourceVersion("some-resource", atc.Version{"version": "v3"})
 
-			builds, err := pipeline.GetBuildsWithVersionAsOutput(resource.ID(), rcv3.ID())
+			builds, err := pipeline.GetBuildsWithVersionAsOutput(scenario.Resource("some-resource").ID(), rcv3.ID())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(builds).To(HaveLen(1))
 			Expect(builds[0].ID()).To(Equal(secondBuild.ID()))
 		})
 
 		It("returns an empty slice of builds when the provided version id exists but is not used", func() {
-			rcv4, found, err := resourceConfigScope.FindVersion(atc.Version{"version": "v4"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			rcv4 := scenario.ResourceVersion("some-resource", atc.Version{"version": "v4"})
 
-			builds, err := pipeline.GetBuildsWithVersionAsOutput(resource.ID(), rcv4.ID())
+			builds, err := pipeline.GetBuildsWithVersionAsOutput(scenario.Resource("some-resource").ID(), rcv4.ID())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(builds).To(Equal([]db.Build{}))
 		})
@@ -1748,7 +1653,7 @@ var _ = Describe("Pipeline", func() {
 		})
 
 		It("returns an empty slice of builds when the provided version id doesn't exist", func() {
-			builds, err := pipeline.GetBuildsWithVersionAsOutput(resource.ID(), resourceConfigVersion+100)
+			builds, err := pipeline.GetBuildsWithVersionAsOutput(scenario.Resource("some-resource").ID(), resourceConfigVersion+100)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(builds).To(Equal([]db.Build{}))
 		})
@@ -1861,55 +1766,41 @@ var _ = Describe("Pipeline", func() {
 
 	Describe("Resources", func() {
 		var resourceTypes db.ResourceTypes
+		var scenario *dbtest.Scenario
 
 		BeforeEach(func() {
-			var err error
-			resourceType, _, err := pipeline.ResourceType("some-resource-type")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resourceType.Version()).To(BeNil())
-
-			otherResourceType, _, err := pipeline.ResourceType("some-other-resource-type")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resourceType.Version()).To(BeNil())
-
-			setupTx, err := dbConn.Begin()
-			Expect(err).ToNot(HaveOccurred())
-
-			brt := db.BaseResourceType{
-				Name: "base-type",
-			}
-
-			_, err = brt.FindOrCreate(setupTx, false)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(setupTx.Commit()).To(Succeed())
-
-			resourceTypeScope, err := resourceType.SetResourceConfig(atc.Source{"some": "type-source"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = resourceTypeScope.SaveVersions(nil, []atc.Version{
-				{"version": "1"},
-				{"version": "2"},
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			otherResourceTypeScope, err := otherResourceType.SetResourceConfig(atc.Source{"some": "other-type-source"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = otherResourceTypeScope.SaveVersions(nil, []atc.Version{
-				{"version": "3"},
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = otherResourceTypeScope.SaveVersions(nil, []atc.Version{
-				{"version": "3"},
-				{"version": "5"},
-			})
-			Expect(err).ToNot(HaveOccurred())
+			scenario = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					ResourceTypes: atc.ResourceTypes{
+						{
+							Name:   "some-other-resource-type",
+							Type:   "global-base-type",
+							Source: atc.Source{"some": "other-type-soure"},
+						},
+						{
+							Name:   "some-resource-type",
+							Type:   "global-base-type",
+							Source: atc.Source{"some": "type-soure"},
+						},
+					},
+				}),
+				builder.WithResourceTypeVersions("some-resource-type",
+					atc.Version{"version": "1"},
+					atc.Version{"version": "2"},
+				),
+				builder.WithResourceTypeVersions("some-other-resource-type",
+					atc.Version{"version": "3"},
+				),
+				builder.WithResourceTypeVersions("some-other-resource-type",
+					atc.Version{"version": "3"},
+					atc.Version{"version": "5"},
+				),
+			)
 		})
 
 		JustBeforeEach(func() {
 			var err error
-			resourceTypes, err = pipeline.ResourceTypes()
+			resourceTypes, err = scenario.Pipeline.ResourceTypes()
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -1922,36 +1813,28 @@ var _ = Describe("Pipeline", func() {
 
 	Describe("ResourceVersion", func() {
 		var (
-			resourceVersion, rv   atc.ResourceVersion
+			rv                    atc.ResourceVersion
 			resourceConfigVersion db.ResourceConfigVersion
-			resource              db.Resource
+			scenario              *dbtest.Scenario
 		)
 
 		BeforeEach(func() {
-			var found bool
-			var err error
-			resource, found, err = pipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			scenario = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Resources: atc.ResourceConfigs{
+						{
+							Name:   "some-resource",
+							Type:   "some-type",
+							Source: atc.Source{"some": "source"},
+						},
+					},
+				}),
+				builder.WithResourceVersions("some-resource",
+					atc.Version{"version": "1"},
+				),
+			)
 
-			resourceConfig, err := resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			version := atc.Version{"version": "1"}
-			err = resourceConfig.SaveVersions(nil, []atc.Version{
-				version,
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			resourceConfigVersion, found, err = resourceConfig.FindVersion(version)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			resourceVersion = atc.ResourceVersion{
-				Version: version,
-				ID:      resourceConfigVersion.ID(),
-				Enabled: true,
-			}
+			resourceConfigVersion = scenario.ResourceVersion("some-resource", atc.Version{"version": "1"})
 		})
 
 		JustBeforeEach(func() {
@@ -1965,20 +1848,26 @@ var _ = Describe("Pipeline", func() {
 
 		Context("when a resource is enabled", func() {
 			It("should return the version with enabled set to true", func() {
-				Expect(rv).To(Equal(resourceVersion))
+				Expect(rv).To(Equal(atc.ResourceVersion{
+					Version: atc.Version{"version": "1"},
+					ID:      resourceConfigVersion.ID(),
+					Enabled: true,
+				}))
 			})
 		})
 
 		Context("when a resource is not enabled", func() {
 			BeforeEach(func() {
-				err := resource.DisableVersion(resourceConfigVersion.ID())
+				err := scenario.Resource("some-resource").DisableVersion(resourceConfigVersion.ID())
 				Expect(err).ToNot(HaveOccurred())
-
-				resourceVersion.Enabled = false
 			})
 
 			It("should return the version with enabled set to false", func() {
-				Expect(rv).To(Equal(resourceVersion))
+				Expect(rv).To(Equal(atc.ResourceVersion{
+					Version: atc.Version{"version": "1"},
+					ID:      resourceConfigVersion.ID(),
+					Enabled: false,
+				}))
 			})
 		})
 	})

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -54,7 +54,7 @@ type Resource interface {
 	BuildSummary() *atc.BuildSummary
 
 	Versions(page Page, versionFilter atc.Version) ([]atc.ResourceVersion, Pagination, bool, error)
-	FindVersion(filter atc.Version) (ResourceConfigVersion, bool, error)
+	FindVersion(filter atc.Version) (ResourceConfigVersion, bool, error) // Only used in tests!!
 	SaveUncheckedVersion(atc.Version, ResourceConfigMetadataFields, ResourceConfig) (bool, error)
 	UpdateMetadata(atc.Version, ResourceConfigMetadataFields) (bool, error)
 
@@ -468,6 +468,7 @@ func (r *resource) UpdateMetadata(version atc.Version, metadata ResourceConfigMe
 	return true, nil
 }
 
+// XXX: Deprecated, only used in tests
 func (r *resource) FindVersion(v atc.Version) (ResourceConfigVersion, bool, error) {
 	if r.resourceConfigScopeID == 0 {
 		return nil, false, nil

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -64,12 +64,6 @@ type Resource interface {
 	PinVersion(rcvID int) (bool, error)
 	UnpinVersion() error
 
-	// XXX(check-refactor): we should be able to remove this, but unfortunately a
-	// ton of db tests rely on it. i've started a refactor to clean up the db
-	// package, but it's definitely going to take some time - there's a lot of
-	// debt there.
-	SetResourceConfig(atc.Source, atc.VersionedResourceTypes) (ResourceConfigScope, error)
-
 	SetResourceConfigScope(ResourceConfigScope) error
 
 	CheckPlan(atc.Version, time.Duration, ResourceTypes, atc.Source) atc.CheckPlan
@@ -248,75 +242,6 @@ func (r *resource) SetResourceConfigScope(scope ResourceConfigScope) error {
 	}
 
 	return nil
-}
-
-func (r *resource) SetResourceConfig(source atc.Source, resourceTypes atc.VersionedResourceTypes) (ResourceConfigScope, error) {
-	resourceConfigDescriptor, err := constructResourceConfigDescriptor(r.type_, source, resourceTypes)
-	if err != nil {
-		return nil, err
-	}
-
-	tx, err := r.conn.Begin()
-	if err != nil {
-		return nil, err
-	}
-
-	defer Rollback(tx)
-
-	resourceConfig, err := resourceConfigDescriptor.findOrCreate(tx, r.lockFactory, r.conn)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = psql.Update("resources").
-		Set("resource_config_id", resourceConfig.ID()).
-		Where(sq.Eq{"id": r.id}).
-		Where(sq.Or{
-			sq.Eq{"resource_config_id": nil},
-			sq.NotEq{"resource_config_id": resourceConfig.ID()},
-		}).
-		RunWith(tx).
-		Exec()
-	if err != nil {
-		return nil, err
-	}
-
-	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, r.conn, r.lockFactory, resourceConfig, r)
-	if err != nil {
-		return nil, err
-	}
-
-	results, err := psql.Update("resources").
-		Set("resource_config_scope_id", resourceConfigScope.ID()).
-		Where(sq.Eq{"id": r.id}).
-		Where(sq.Or{
-			sq.Eq{"resource_config_scope_id": nil},
-			sq.NotEq{"resource_config_scope_id": resourceConfigScope.ID()},
-		}).
-		RunWith(tx).
-		Exec()
-	if err != nil {
-		return nil, err
-	}
-
-	rowsAffected, err := results.RowsAffected()
-	if err != nil {
-		return nil, err
-	}
-
-	if rowsAffected > 0 {
-		err = requestScheduleForJobsUsingResource(tx, r.id)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		return nil, err
-	}
-
-	return resourceConfigScope, nil
 }
 
 func (r *resource) CheckPlan(from atc.Version, interval time.Duration, resourceTypes ResourceTypes, sourceDefaults atc.Source) atc.CheckPlan {

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -202,6 +202,10 @@ func (r *resource) Reload() (bool, error) {
 	return true, nil
 }
 
+func (r *resource) SetResourceConfig(atc.Source, atc.VersionedResourceTypes) (ResourceConfigScope, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (r *resource) SetResourceConfigScope(scope ResourceConfigScope) error {
 	tx, err := r.conn.Begin()
 	if err != nil {

--- a/atc/db/resource_cache_lifecycle_test.go
+++ b/atc/db/resource_cache_lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbtest"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -338,13 +339,26 @@ var _ = Describe("ResourceCacheLifecycle", func() {
 
 		Context("when the cache is for a resource version used as an input for the next build of a job", func() {
 			It("does not remove the cache", func() {
-				err := defaultPipeline.Unpause()
+				scenario := dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name: "some-resource",
+								Type: "some-base-resource-type",
+								Source: atc.Source{
+									"some": "source",
+								},
+							},
+						},
+					}),
+					builder.WithResourceVersions("some-resource", atc.Version{"some": "version"}),
+				)
+
+				rc, found, err := resourceConfigFactory.FindResourceConfigByID(scenario.Resource("some-resource").ResourceConfigID())
+				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 
-				resourceConfigScope, err := defaultResource.SetResourceConfig(
-					atc.Source{"some": "source"},
-					atc.VersionedResourceTypes{},
-				)
+				resourceConfigScope, err := rc.FindOrCreateScope(scenario.Resource("some-resource"))
 				Expect(err).ToNot(HaveOccurred())
 
 				containerOwner := db.NewResourceConfigCheckSessionContainerOwner(
@@ -358,9 +372,6 @@ var _ = Describe("ResourceCacheLifecycle", func() {
 
 				_ = createResourceCacheWithUser(db.ForContainer(container.ID()))
 
-				err = resourceConfigScope.SaveVersions(nil, []atc.Version{{"some": "version"}})
-				Expect(err).ToNot(HaveOccurred())
-
 				resourceConfigVersion, found, err := resourceConfigScope.FindVersion(atc.Version{"some": "version"})
 				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
@@ -370,7 +381,7 @@ var _ = Describe("ResourceCacheLifecycle", func() {
 						Input: &db.AlgorithmInput{
 							AlgorithmVersion: db.AlgorithmVersion{
 								Version:    db.ResourceVersion(convertToMD5(atc.Version(resourceConfigVersion.Version()))),
-								ResourceID: defaultResource.ID(),
+								ResourceID: scenario.Resource("some-resource").ID(),
 							},
 						},
 						PassedBuildIDs: []int{},

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -127,8 +127,7 @@ func saveVersions(conn Conn, rcsID int, versions []atc.Version, spanContext Span
 
 func (r *resourceConfigScope) FindVersion(v atc.Version) (ResourceConfigVersion, bool, error) {
 	rcv := &resourceConfigVersion{
-		resourceConfigScope: r,
-		conn:                r.conn,
+		conn: r.conn,
 	}
 
 	versionByte, err := json.Marshal(v)
@@ -157,8 +156,7 @@ func (r *resourceConfigScope) FindVersion(v atc.Version) (ResourceConfigVersion,
 
 func (r *resourceConfigScope) LatestVersion() (ResourceConfigVersion, bool, error) {
 	rcv := &resourceConfigVersion{
-		conn:                r.conn,
-		resourceConfigScope: r,
+		conn: r.conn,
 	}
 
 	row := resourceConfigVersionQuery.

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -310,7 +310,6 @@ var _ = Describe("Resource Config Scope", func() {
 			})
 
 			It("gets the version of resource", func() {
-				Expect(latestCV.ResourceConfigScope().ID()).To(Equal(resourceScope.ID()))
 				Expect(latestCV.Version()).To(Equal(db.Version{"ref": "v1"}))
 				Expect(latestCV.CheckOrder()).To(Equal(1))
 			})

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -5,74 +5,64 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/atc/db/lock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Resource Config Scope", func() {
+	var scenario *dbtest.Scenario
 	var resourceScope db.ResourceConfigScope
-	var resource db.Resource
-	var pipeline db.Pipeline
 
 	BeforeEach(func() {
-		setupTx, err := dbConn.Begin()
+		scenario = dbtest.Setup(
+			builder.WithPipeline(atc.Config{
+				Resources: atc.ResourceConfigs{
+					{
+						Name: "some-resource",
+						Type: "some-base-resource-type",
+						Source: atc.Source{
+							"some": "source",
+						},
+					},
+				},
+				Jobs: atc.JobConfigs{
+					{
+						Name: "some-job",
+						PlanSequence: []atc.Step{
+							{
+								Config: &atc.GetStep{
+									Name: "some-resource",
+								},
+							},
+						},
+					},
+					{
+						Name: "downstream-job",
+						PlanSequence: []atc.Step{
+							{
+								Config: &atc.GetStep{
+									Name:   "some-resource",
+									Passed: []string{"some-job"},
+								},
+							},
+						},
+					},
+					{
+						Name: "some-other-job",
+					},
+				},
+			}),
+			builder.WithResourceVersions("some-resource"),
+		)
+
+		rc, found, err := resourceConfigFactory.FindResourceConfigByID(scenario.Resource("some-resource").ResourceConfigID())
 		Expect(err).ToNot(HaveOccurred())
-
-		brt := db.BaseResourceType{
-			Name: "some-type",
-		}
-
-		_, err = brt.FindOrCreate(setupTx, false)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(setupTx.Commit()).To(Succeed())
-
-		pipeline, _, err = defaultTeam.SavePipeline(atc.PipelineRef{Name: "scope-pipeline"}, atc.Config{
-			Resources: atc.ResourceConfigs{
-				{
-					Name: "some-resource",
-					Type: "some-type",
-					Source: atc.Source{
-						"some": "source",
-					},
-				},
-			},
-			Jobs: atc.JobConfigs{
-				{
-					Name: "some-job",
-					PlanSequence: []atc.Step{
-						{
-							Config: &atc.GetStep{
-								Name: "some-resource",
-							},
-						},
-					},
-				},
-				{
-					Name: "downstream-job",
-					PlanSequence: []atc.Step{
-						{
-							Config: &atc.GetStep{
-								Name:   "some-resource",
-								Passed: []string{"some-job"},
-							},
-						},
-					},
-				},
-				{
-					Name: "some-other-job",
-				},
-			},
-		}, db.ConfigVersion(0), false)
-		Expect(err).NotTo(HaveOccurred())
-
-		var found bool
-		resource, found, err = pipeline.Resource("some-resource")
-		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
 
-		resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
-		Expect(err).NotTo(HaveOccurred())
+		resourceScope, err = rc.FindOrCreateScope(scenario.Resource("some-resource"))
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Describe("SaveVersions", func() {
@@ -152,11 +142,7 @@ var _ = Describe("Resource Config Scope", func() {
 					err := resourceScope.SaveVersions(nil, originalVersionSlice)
 					Expect(err).ToNot(HaveOccurred())
 
-					job, found, err := pipeline.Job("some-job")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					requestedSchedule := job.ScheduleRequestedTime()
+					requestedSchedule := scenario.Job("some-job").ScheduleRequestedTime()
 
 					newVersions := []atc.Version{
 						{"ref": "v0"},
@@ -165,22 +151,14 @@ var _ = Describe("Resource Config Scope", func() {
 					err = resourceScope.SaveVersions(nil, newVersions)
 					Expect(err).ToNot(HaveOccurred())
 
-					found, err = job.Reload()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					Expect(job.ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule))
+					Expect(scenario.Job("some-job").ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule))
 				})
 
 				It("does not request schedule on the jobs that use the resource but through passed constraints", func() {
 					err := resourceScope.SaveVersions(nil, originalVersionSlice)
 					Expect(err).ToNot(HaveOccurred())
 
-					job, found, err := pipeline.Job("downstream-job")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					requestedSchedule := job.ScheduleRequestedTime()
+					requestedSchedule := scenario.Job("downstream-job").ScheduleRequestedTime()
 
 					newVersions := []atc.Version{
 						{"ref": "v0"},
@@ -189,22 +167,14 @@ var _ = Describe("Resource Config Scope", func() {
 					err = resourceScope.SaveVersions(nil, newVersions)
 					Expect(err).ToNot(HaveOccurred())
 
-					found, err = job.Reload()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					Expect(job.ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
+					Expect(scenario.Job("downstream-job").ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
 				})
 
 				It("does not request schedule on the jobs that do not use the resource", func() {
 					err := resourceScope.SaveVersions(nil, originalVersionSlice)
 					Expect(err).ToNot(HaveOccurred())
 
-					job, found, err := pipeline.Job("some-other-job")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					requestedSchedule := job.ScheduleRequestedTime()
+					requestedSchedule := scenario.Job("some-other-job").ScheduleRequestedTime()
 
 					newVersions := []atc.Version{
 						{"ref": "v0"},
@@ -213,11 +183,7 @@ var _ = Describe("Resource Config Scope", func() {
 					err = resourceScope.SaveVersions(nil, newVersions)
 					Expect(err).ToNot(HaveOccurred())
 
-					found, err = job.Reload()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					Expect(job.ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
+					Expect(scenario.Job("some-other-job").ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
 				})
 			})
 		})
@@ -257,16 +223,14 @@ var _ = Describe("Resource Config Scope", func() {
 
 				Expect(savedRCV.Version()).To(Equal(db.Version{"version": "1"}))
 
-				err = resource.DisableVersion(savedRCV.ID())
-				Expect(err).ToNot(HaveOccurred())
+				scenario.Run(builder.WithDisabledVersion("some-resource", atc.Version(savedRCV.Version())))
 
 				latestVR, found, err := resourceScope.LatestVersion()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(latestVR.Version()).To(Equal(db.Version{"version": "1"}))
 
-				err = resource.EnableVersion(savedRCV.ID())
-				Expect(err).ToNot(HaveOccurred())
+				scenario.Run(builder.WithEnabledVersion("some-resource", atc.Version(savedRCV.Version())))
 
 				latestVR, found, err = resourceScope.LatestVersion()
 				Expect(err).ToNot(HaveOccurred())
@@ -333,105 +297,30 @@ var _ = Describe("Resource Config Scope", func() {
 	})
 
 	Describe("UpdateLastCheckStartTime", func() {
-		var (
-			someResource        db.Resource
-			resourceConfigScope db.ResourceConfigScope
-		)
-
-		BeforeEach(func() {
-			var err error
-			var found bool
-
-			someResource, found, err = defaultPipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			pipelineResourceTypes, err := defaultPipeline.ResourceTypes()
-			Expect(err).ToNot(HaveOccurred())
-
-			resourceConfigScope, err = someResource.SetResourceConfig(
-				someResource.Source(),
-				pipelineResourceTypes.Deserialize(),
-			)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
 		It("updates last check start time", func() {
-			lastTime := someResource.LastCheckEndTime()
+			lastTime := scenario.Resource("some-resource").LastCheckEndTime()
 
-			updated, err := resourceConfigScope.UpdateLastCheckStartTime()
+			updated, err := resourceScope.UpdateLastCheckStartTime()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated).To(BeTrue())
 
-			found, err := someResource.Reload()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-			Expect(someResource.LastCheckStartTime()).To(BeTemporally(">", lastTime))
+			Expect(scenario.Resource("some-resource").LastCheckStartTime()).To(BeTemporally(">", lastTime))
 		})
 	})
 
 	Describe("UpdateLastCheckEndTime", func() {
-		var (
-			someResource        db.Resource
-			resourceConfigScope db.ResourceConfigScope
-		)
-
-		BeforeEach(func() {
-			var err error
-			var found bool
-
-			someResource, found, err = defaultPipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			pipelineResourceTypes, err := defaultPipeline.ResourceTypes()
-			Expect(err).ToNot(HaveOccurred())
-
-			resourceConfigScope, err = someResource.SetResourceConfig(
-				someResource.Source(),
-				pipelineResourceTypes.Deserialize(),
-			)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
 		It("updates last check end time", func() {
-			lastTime := someResource.LastCheckEndTime()
+			lastTime := scenario.Resource("some-resource").LastCheckEndTime()
 
-			updated, err := resourceConfigScope.UpdateLastCheckEndTime()
+			updated, err := resourceScope.UpdateLastCheckEndTime()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated).To(BeTrue())
 
-			found, err := someResource.Reload()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-			Expect(someResource.LastCheckEndTime()).To(BeTemporally(">", lastTime))
+			Expect(scenario.Resource("some-resource").LastCheckEndTime()).To(BeTemporally(">", lastTime))
 		})
 	})
 
 	Describe("AcquireResourceCheckingLock", func() {
-		var (
-			someResource        db.Resource
-			resourceConfigScope db.ResourceConfigScope
-		)
-
-		BeforeEach(func() {
-			var err error
-			var found bool
-
-			someResource, found, err = defaultPipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			pipelineResourceTypes, err := defaultPipeline.ResourceTypes()
-			Expect(err).ToNot(HaveOccurred())
-
-			resourceConfigScope, err = someResource.SetResourceConfig(
-				someResource.Source(),
-				pipelineResourceTypes.Deserialize(),
-			)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
 		Context("when there has been a check recently", func() {
 			var lock lock.Lock
 			var err error
@@ -439,7 +328,7 @@ var _ = Describe("Resource Config Scope", func() {
 			BeforeEach(func() {
 				var err error
 				var acquired bool
-				lock, acquired, err = resourceConfigScope.AcquireResourceCheckingLock(logger)
+				lock, acquired, err = resourceScope.AcquireResourceCheckingLock(logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(acquired).To(BeTrue())
 			})
@@ -449,7 +338,7 @@ var _ = Describe("Resource Config Scope", func() {
 			})
 
 			It("does not get the lock", func() {
-				_, acquired, err := resourceConfigScope.AcquireResourceCheckingLock(logger)
+				_, acquired, err := resourceScope.AcquireResourceCheckingLock(logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(acquired).To(BeFalse())
 			})
@@ -461,7 +350,7 @@ var _ = Describe("Resource Config Scope", func() {
 				})
 
 				It("gets the lock", func() {
-					lock, acquired, err := resourceConfigScope.AcquireResourceCheckingLock(logger)
+					lock, acquired, err := resourceScope.AcquireResourceCheckingLock(logger)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(acquired).To(BeTrue())
 
@@ -473,12 +362,12 @@ var _ = Describe("Resource Config Scope", func() {
 
 		Context("when there has not been a check recently", func() {
 			It("gets and keeps the lock and stops others from periodically getting it", func() {
-				lock, acquired, err := resourceConfigScope.AcquireResourceCheckingLock(logger)
+				lock, acquired, err := resourceScope.AcquireResourceCheckingLock(logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(acquired).To(BeTrue())
 
 				Consistently(func() bool {
-					_, acquired, err = resourceConfigScope.AcquireResourceCheckingLock(logger)
+					_, acquired, err = resourceScope.AcquireResourceCheckingLock(logger)
 					Expect(err).ToNot(HaveOccurred())
 
 					return acquired
@@ -489,7 +378,7 @@ var _ = Describe("Resource Config Scope", func() {
 
 				time.Sleep(time.Second)
 
-				lock, acquired, err = resourceConfigScope.AcquireResourceCheckingLock(logger)
+				lock, acquired, err = resourceScope.AcquireResourceCheckingLock(logger)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(acquired).To(BeTrue())
 

--- a/atc/db/resource_config_version.go
+++ b/atc/db/resource_config_version.go
@@ -16,7 +16,6 @@ type ResourceConfigVersion interface {
 	Version() Version
 	Metadata() ResourceConfigMetadataFields
 	CheckOrder() int
-	ResourceConfigScope() ResourceConfigScope
 	SpanContext() propagation.HTTPSupplier
 
 	Reload() (bool, error)
@@ -64,8 +63,6 @@ type resourceConfigVersion struct {
 	checkOrder  int
 	spanContext SpanContext
 
-	resourceConfigScope ResourceConfigScope
-
 	conn Conn
 }
 
@@ -85,9 +82,6 @@ func (r *resourceConfigVersion) ID() int                                { return
 func (r *resourceConfigVersion) Version() Version                       { return r.version }
 func (r *resourceConfigVersion) Metadata() ResourceConfigMetadataFields { return r.metadata }
 func (r *resourceConfigVersion) CheckOrder() int                        { return r.checkOrder }
-func (r *resourceConfigVersion) ResourceConfigScope() ResourceConfigScope {
-	return r.resourceConfigScope
-}
 func (r *resourceConfigVersion) SpanContext() propagation.HTTPSupplier {
 	return r.spanContext
 }

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -934,11 +934,11 @@ var _ = Describe("Resource", func() {
 		})
 	})
 
-	Describe("ResourceConfigVersion", func() {
+	Describe("FindVersion", func() {
 		var (
 			resource                   db.Resource
 			version                    atc.Version
-			rcvID                      int
+			rcv                        db.ResourceConfigVersion
 			resourceConfigVersionFound bool
 			foundErr                   error
 		)
@@ -953,7 +953,7 @@ var _ = Describe("Resource", func() {
 		})
 
 		JustBeforeEach(func() {
-			rcvID, resourceConfigVersionFound, foundErr = resource.ResourceConfigVersionID(version)
+			rcv, resourceConfigVersionFound, foundErr = resource.FindVersion(version)
 		})
 
 		Context("when the version exists", func() {
@@ -993,7 +993,7 @@ var _ = Describe("Resource", func() {
 
 				It("returns resource config version and true", func() {
 					Expect(resourceConfigVersionFound).To(BeTrue())
-					Expect(rcvID).To(Equal(resourceConfigVersion.ID()))
+					Expect(rcv.ID()).To(Equal(resourceConfigVersion.ID()))
 					Expect(foundErr).ToNot(HaveOccurred())
 				})
 			})
@@ -1005,7 +1005,7 @@ var _ = Describe("Resource", func() {
 
 				It("returns resource config version and true", func() {
 					Expect(resourceConfigVersionFound).To(BeTrue())
-					Expect(rcvID).To(Equal(resourceConfigVersion.ID()))
+					Expect(rcv.ID()).To(Equal(resourceConfigVersion.ID()))
 					Expect(foundErr).ToNot(HaveOccurred())
 				})
 			})
@@ -1021,7 +1021,7 @@ var _ = Describe("Resource", func() {
 
 				It("returns resource config version with highest order and true", func() {
 					Expect(resourceConfigVersionFound).To(BeTrue())
-					Expect(rcvID).To(Equal(resourceConfigVersion.ID()))
+					Expect(rcv.ID()).To(Equal(resourceConfigVersion.ID()))
 					Expect(foundErr).ToNot(HaveOccurred())
 				})
 			})
@@ -1037,7 +1037,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("does not find the resource config version", func() {
-					Expect(rcvID).To(Equal(0))
+					Expect(rcv).To(BeNil())
 					Expect(resourceConfigVersionFound).To(BeFalse())
 					Expect(foundErr).ToNot(HaveOccurred())
 				})

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/tracing"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -123,63 +124,50 @@ var _ = Describe("Resource", func() {
 
 	Describe("(Pipeline).Resource", func() {
 		var (
-			err      error
-			found    bool
-			resource db.Resource
+			scenario *dbtest.Scenario
 		)
 
 		Context("when the resource exists", func() {
 			BeforeEach(func() {
-				resource, found, err = pipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "repository"},
+							},
+						},
+					}),
+				)
 			})
 
 			It("returns the resource", func() {
-				Expect(found).To(BeTrue())
-				Expect(resource.Name()).To(Equal("some-resource"))
-				Expect(resource.Type()).To(Equal("registry-image"))
-				Expect(resource.Source()).To(Equal(atc.Source{"some": "repository"}))
-			})
-
-			Context("when the resource config id is set on the resource for the first time", func() {
-				var resourceScope db.ResourceConfigScope
-
-				BeforeEach(func() {
-					setupTx, err := dbConn.Begin()
-					Expect(err).ToNot(HaveOccurred())
-
-					brt := db.BaseResourceType{
-						Name: "registry-image",
-					}
-
-					_, err = brt.FindOrCreate(setupTx, false)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(setupTx.Commit()).To(Succeed())
-
-					resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-					Expect(err).NotTo(HaveOccurred())
-
-					found, err = resource.Reload()
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("returns the resource configd", func() {
-					Expect(found).To(BeTrue())
-					Expect(resource.ResourceConfigID()).To(Equal(resourceScope.ResourceConfig().ID()))
-				})
-			})
-
-			Context("when the resource config id is not set on the resource", func() {
-				It("returns no resource config id", func() {
-					Expect(found).To(BeTrue())
-					Expect(resource.ResourceConfigID()).To(Equal(0))
-				})
+				Expect(scenario.Resource("some-resource").Name()).To(Equal("some-resource"))
+				Expect(scenario.Resource("some-resource").Type()).To(Equal("some-base-resource-type"))
+				Expect(scenario.Resource("some-resource").Source()).To(Equal(atc.Source{"some": "repository"}))
 			})
 		})
 
 		Context("when the resource does not exist", func() {
-			JustBeforeEach(func() {
-				resource, found, err = pipeline.Resource("bonkers")
+			var resource db.Resource
+			var found bool
+			var err error
+
+			BeforeEach(func() {
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "repository"},
+							},
+						},
+					}),
+				)
+
+				resource, found, err = scenario.Pipeline.Resource("bonkers")
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -191,67 +179,54 @@ var _ = Describe("Resource", func() {
 	})
 
 	Describe("Enable/Disable Version", func() {
-		var resource db.Resource
-		var rcv db.ResourceConfigVersion
-		var err error
-		var found bool
+		var scenario *dbtest.Scenario
 
 		BeforeEach(func() {
-			resource, found, err = pipeline.Resource("some-other-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			setupTx, err := dbConn.Begin()
-			Expect(err).ToNot(HaveOccurred())
-
-			brt := db.BaseResourceType{
-				Name: "git",
-			}
-
-			_, err = brt.FindOrCreate(setupTx, false)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(setupTx.Commit()).To(Succeed())
-
-			resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = resourceScope.SaveVersions(nil, []atc.Version{
-				{"disabled": "version"},
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			rcv, found, err = resourceScope.FindVersion(atc.Version{"disabled": "version"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			scenario = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Jobs: atc.JobConfigs{
+						{
+							Name: "job-using-resource",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name: "some-other-resource",
+									},
+								},
+							},
+						},
+						{
+							Name: "not-using-resource",
+						},
+					},
+					Resources: atc.ResourceConfigs{
+						{
+							Name:   "some-other-resource",
+							Type:   "some-base-resource-type",
+							Source: atc.Source{"some": "other-repository"},
+						},
+					},
+				}),
+				builder.WithResourceVersions("some-other-resource", atc.Version{"disabled": "version"}),
+			)
 		})
 
 		Context("when disabling a version that exists", func() {
 			var disableErr error
 			var requestedSchedule1 time.Time
 			var requestedSchedule2 time.Time
-			var jobUsingResource db.Job
-			var jobNotUsingResource db.Job
 
 			BeforeEach(func() {
-				jobUsingResource, found, err = pipeline.Job("job-using-resource")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(found).To(BeTrue())
+				requestedSchedule1 = scenario.Job("job-using-resource").ScheduleRequestedTime()
+				requestedSchedule2 = scenario.Job("not-using-resource").ScheduleRequestedTime()
 
-				requestedSchedule1 = jobUsingResource.ScheduleRequestedTime()
-
-				jobNotUsingResource, found, err = pipeline.Job("not-using-resource")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				requestedSchedule2 = jobNotUsingResource.ScheduleRequestedTime()
-
-				disableErr = resource.DisableVersion(rcv.ID())
+				scenario.Run(builder.WithDisabledVersion("some-other-resource", atc.Version{"disabled": "version"}))
 			})
 
 			It("successfully disables the version", func() {
 				Expect(disableErr).ToNot(HaveOccurred())
 
-				versions, _, found, err := resource.Versions(db.Page{Limit: 3}, nil)
+				versions, _, found, err := scenario.Resource("some-other-resource").Versions(db.Page{Limit: 3}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(versions).To(HaveLen(1))
@@ -260,31 +235,28 @@ var _ = Describe("Resource", func() {
 			})
 
 			It("requests schedule on the jobs using that resource", func() {
-				found, err := jobUsingResource.Reload()
+				found, err := scenario.Job("job-using-resource").Reload()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 
-				Expect(jobUsingResource.ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule1))
+				Expect(scenario.Job("job-using-resource").ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule1))
 			})
 
 			It("does not request schedule on jobs that do not use the resource", func() {
-				found, err := jobNotUsingResource.Reload()
+				found, err := scenario.Job("not-using-resource").Reload()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(found).To(BeTrue())
 
-				Expect(jobNotUsingResource.ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule2))
+				Expect(scenario.Job("not-using-resource").ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule2))
 			})
 
 			Context("when enabling that version", func() {
-				var enableErr error
 				BeforeEach(func() {
-					enableErr = resource.EnableVersion(rcv.ID())
+					scenario.Run(builder.WithEnabledVersion("some-other-resource", atc.Version{"disabled": "version"}))
 				})
 
 				It("successfully enables the version", func() {
-					Expect(enableErr).ToNot(HaveOccurred())
-
-					versions, _, found, err := resource.Versions(db.Page{Limit: 3}, nil)
+					versions, _, found, err := scenario.Resource("some-other-resource").Versions(db.Page{Limit: 3}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(versions).To(HaveLen(1))
@@ -293,19 +265,19 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("request schedule on the jobs using that resource", func() {
-					found, err := jobUsingResource.Reload()
+					found, err := scenario.Job("job-using-resource").Reload()
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 
-					Expect(jobUsingResource.ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule1))
+					Expect(scenario.Job("job-using-resource").ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule1))
 				})
 
 				It("does not request schedule on jobs that do not use the resource", func() {
-					found, err := jobNotUsingResource.Reload()
+					found, err := scenario.Job("not-using-resource").Reload()
 					Expect(err).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 
-					Expect(jobNotUsingResource.ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule2))
+					Expect(scenario.Job("not-using-resource").ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule2))
 				})
 			})
 		})
@@ -313,7 +285,7 @@ var _ = Describe("Resource", func() {
 		Context("when disabling version that does not exist", func() {
 			var disableErr error
 			BeforeEach(func() {
-				resource, found, err := pipeline.Resource("some-resource")
+				resource, found, err := scenario.Pipeline.Resource("some-other-resource")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 
@@ -328,7 +300,11 @@ var _ = Describe("Resource", func() {
 		Context("when enabling a version that is already enabled", func() {
 			var enableError error
 			BeforeEach(func() {
-				enableError = resource.EnableVersion(rcv.ID())
+				resource, found, err := scenario.Pipeline.Resource("some-other-resource")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				enableError = resource.EnableVersion(scenario.ResourceVersion("some-other-resource", atc.Version{"disabled": "version"}).ID())
 			})
 
 			It("returns a non one row affected error", func() {
@@ -623,455 +599,9 @@ var _ = Describe("Resource", func() {
 		})
 	})
 
-	Describe("SetResourceConfig", func() {
-		var pipeline db.Pipeline
-		var config atc.Config
-
-		BeforeEach(func() {
-			var created bool
-			var err error
-			config = atc.Config{
-				ResourceTypes: atc.ResourceTypes{
-					{
-						Name:   "some-resourceType",
-						Type:   "base",
-						Source: atc.Source{"some": "repository"},
-					},
-				},
-				Resources: atc.ResourceConfigs{
-					{
-						Name:   "some-resource",
-						Type:   "some-type",
-						Source: atc.Source{"some": "repository"},
-					},
-					{
-						Name:   "some-other-resource",
-						Type:   "some-type",
-						Source: atc.Source{"some": "repository"},
-					},
-					{
-						Name:   "pipeline-resource",
-						Type:   "some-resourceType",
-						Source: atc.Source{"some": "repository"},
-					},
-					{
-						Name:   "other-pipeline-resource",
-						Type:   "some-resourceType",
-						Source: atc.Source{"some": "repository"},
-					},
-				},
-				Jobs: atc.JobConfigs{
-					{
-						Name: "job-using-resource",
-						PlanSequence: []atc.Step{
-							{
-								Config: &atc.GetStep{
-									Name: "some-resource",
-								},
-							},
-						},
-					},
-					{
-						Name: "not-using-resource",
-					},
-				},
-			}
-
-			pipeline, created, err = defaultTeam.SavePipeline(
-				atc.PipelineRef{Name: "pipeline-with-same-resources"},
-				config,
-				0,
-				false,
-			)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(created).To(BeTrue())
-		})
-
-		Context("when the enable global resources flag is set to true", func() {
-			BeforeEach(func() {
-				atc.EnableGlobalResources = true
-			})
-
-			Context("when the resource uses a base resource type with shared version history", func() {
-				var (
-					resourceScope1 db.ResourceConfigScope
-					resourceScope2 db.ResourceConfigScope
-					resource1      db.Resource
-					resource2      db.Resource
-				)
-
-				BeforeEach(func() {
-					var found bool
-					var err error
-					resource1, found, err = pipeline.Resource("some-resource")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					setupTx, err := dbConn.Begin()
-					Expect(err).ToNot(HaveOccurred())
-
-					brt := db.BaseResourceType{
-						Name: "some-type",
-					}
-
-					_, err = brt.FindOrCreate(setupTx, false)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(setupTx.Commit()).To(Succeed())
-
-					resourceScope1, err = resource1.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-					Expect(err).NotTo(HaveOccurred())
-
-					found, err = resource1.Reload()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-				})
-
-				It("has the resource config id and resource config scope id set on the resource", func() {
-					Expect(resourceScope1.Resource()).To(BeNil())
-					Expect(resource1.ResourceConfigID()).To(Equal(resourceScope1.ResourceConfig().ID()))
-					Expect(resource1.ResourceConfigScopeID()).To(Equal(resourceScope1.ID()))
-				})
-
-				Context("when another resource uses the same resource config", func() {
-					BeforeEach(func() {
-						var found bool
-						var err error
-						resource2, found, err = pipeline.Resource("some-other-resource")
-						Expect(err).ToNot(HaveOccurred())
-						Expect(found).To(BeTrue())
-
-						resourceScope2, err = resource2.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-						Expect(err).NotTo(HaveOccurred())
-
-						found, err = resource2.Reload()
-						Expect(err).NotTo(HaveOccurred())
-						Expect(found).To(BeTrue())
-					})
-
-					It("has the same resource config id and resource config scope id as the first resource", func() {
-						Expect(resource2.ResourceConfigID()).To(Equal(resourceScope2.ResourceConfig().ID()))
-						Expect(resource2.ResourceConfigScopeID()).To(Equal(resourceScope2.ID()))
-						Expect(resource1.ResourceConfigID()).To(Equal(resource2.ResourceConfigID()))
-						Expect(resource1.ResourceConfigScopeID()).To(Equal(resource2.ResourceConfigScopeID()))
-					})
-				})
-			})
-
-			Context("when the resource uses a base resource type that has unique version history", func() {
-				var (
-					resourceScope1 db.ResourceConfigScope
-					resourceScope2 db.ResourceConfigScope
-					resource1      db.Resource
-					resource2      db.Resource
-				)
-
-				BeforeEach(func() {
-					var found bool
-					var err error
-					resource1, found, err = pipeline.Resource("some-resource")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					setupTx, err := dbConn.Begin()
-					Expect(err).ToNot(HaveOccurred())
-
-					brt := db.BaseResourceType{
-						Name: "some-type",
-					}
-
-					_, err = brt.FindOrCreate(setupTx, true)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(setupTx.Commit()).To(Succeed())
-
-					resourceScope1, err = resource1.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-					Expect(err).NotTo(HaveOccurred())
-
-					found, err = resource1.Reload()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-				})
-
-				It("has the resource config id and resource config scope id set on the resource", func() {
-					Expect(resource1.ResourceConfigID()).To(Equal(resourceScope1.ResourceConfig().ID()))
-					Expect(resource1.ResourceConfigScopeID()).To(Equal(resourceScope1.ID()))
-				})
-
-				Context("when another resource uses the same resource config", func() {
-					BeforeEach(func() {
-						var found bool
-						var err error
-						resource2, found, err = pipeline.Resource("some-other-resource")
-						Expect(err).ToNot(HaveOccurred())
-						Expect(found).To(BeTrue())
-
-						resourceScope2, err = resource2.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-						Expect(err).NotTo(HaveOccurred())
-
-						found, err = resource2.Reload()
-						Expect(err).NotTo(HaveOccurred())
-						Expect(found).To(BeTrue())
-					})
-
-					It("has a different resource config scope id than the first resource", func() {
-						Expect(resource2.ResourceConfigID()).To(Equal(resourceScope2.ResourceConfig().ID()))
-						Expect(resource2.ResourceConfigScopeID()).To(Equal(resourceScope2.ID()))
-						Expect(resource1.ResourceConfigID()).To(Equal(resource2.ResourceConfigID()))
-						Expect(resource1.ResourceConfigScopeID()).ToNot(Equal(resource2.ResourceConfigScopeID()))
-					})
-				})
-			})
-		})
-
-		Context("when the enable global resources flag is set to false, all resources will have a unique history", func() {
-			BeforeEach(func() {
-				atc.EnableGlobalResources = false
-			})
-
-			Context("when the resource uses a base resource type with shared version history", func() {
-				var (
-					resource1 db.Resource
-					resource2 db.Resource
-				)
-
-				BeforeEach(func() {
-					var found bool
-					var err error
-					resource1, found, err = pipeline.Resource("some-resource")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					resource2, found, err = pipeline.Resource("some-other-resource")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					setupTx, err := dbConn.Begin()
-					Expect(err).ToNot(HaveOccurred())
-
-					brt := db.BaseResourceType{
-						Name: "some-type",
-					}
-
-					_, err = brt.FindOrCreate(setupTx, false)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(setupTx.Commit()).To(Succeed())
-
-					_, err = resource1.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-					Expect(err).NotTo(HaveOccurred())
-
-					_, err = resource2.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-					Expect(err).NotTo(HaveOccurred())
-
-					found, err = resource1.Reload()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					found, err = resource2.Reload()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-				})
-
-				It("has unique version histories", func() {
-					Expect(resource1.ResourceConfigScopeID()).ToNot(Equal(resource2.ResourceConfigScopeID()))
-				})
-			})
-		})
-
-		Context("when requesting schedule for setting resource config", func() {
-			var resource1 db.Resource
-
-			BeforeEach(func() {
-				var err error
-				var found bool
-				resource1, found, err = pipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				setupTx, err := dbConn.Begin()
-				Expect(err).ToNot(HaveOccurred())
-
-				brt := db.BaseResourceType{
-					Name: "some-type",
-				}
-
-				_, err = brt.FindOrCreate(setupTx, false)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(setupTx.Commit()).To(Succeed())
-			})
-
-			It("requests schedule on the jobs that use the resource", func() {
-				job, found, err := pipeline.Job("job-using-resource")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				requestedSchedule := job.ScheduleRequestedTime()
-
-				_, err = resource1.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-				Expect(err).NotTo(HaveOccurred())
-
-				found, err = job.Reload()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				Expect(job.ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule))
-			})
-
-			It("does not request schedule on the jobs that do not use the resource", func() {
-				job, found, err := pipeline.Job("not-using-resource")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				requestedSchedule := job.ScheduleRequestedTime()
-
-				_, err = resource1.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-				Expect(err).NotTo(HaveOccurred())
-
-				found, err = job.Reload()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				Expect(job.ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
-			})
-		})
-	})
-
-	Describe("FindVersion", func() {
-		var (
-			resource                   db.Resource
-			version                    atc.Version
-			rcv                        db.ResourceConfigVersion
-			resourceConfigVersionFound bool
-			foundErr                   error
-		)
-
-		BeforeEach(func() {
-			var err error
-			var found bool
-			version = atc.Version{"version": "12345"}
-			resource, found, err = pipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-		})
-
-		JustBeforeEach(func() {
-			rcv, resourceConfigVersionFound, foundErr = resource.FindVersion(version)
-		})
-
-		Context("when the version exists", func() {
-			var (
-				resourceConfigVersion db.ResourceConfigVersion
-				resourceScope         db.ResourceConfigScope
-			)
-
-			saveVersion := func(version atc.Version) {
-				setupTx, err := dbConn.Begin()
-				Expect(err).ToNot(HaveOccurred())
-
-				brt := db.BaseResourceType{
-					Name: "registry-image",
-				}
-
-				_, err = brt.FindOrCreate(setupTx, false)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(setupTx.Commit()).To(Succeed())
-
-				resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-				Expect(err).ToNot(HaveOccurred())
-
-				err = resourceScope.SaveVersions(nil, []atc.Version{version})
-				Expect(err).ToNot(HaveOccurred())
-
-				var found bool
-				resourceConfigVersion, found, err = resourceScope.FindVersion(version)
-				Expect(found).To(BeTrue())
-				Expect(err).ToNot(HaveOccurred())
-			}
-
-			Context("when the version is exact matched", func() {
-				BeforeEach(func() {
-					saveVersion(atc.Version{"version": "12345"})
-				})
-
-				It("returns resource config version and true", func() {
-					Expect(resourceConfigVersionFound).To(BeTrue())
-					Expect(rcv.ID()).To(Equal(resourceConfigVersion.ID()))
-					Expect(foundErr).ToNot(HaveOccurred())
-				})
-			})
-
-			Context("when the version is partially matched", func() {
-				BeforeEach(func() {
-					saveVersion(atc.Version{"version": "12345", "tag": "1.0.0"})
-				})
-
-				It("returns resource config version and true", func() {
-					Expect(resourceConfigVersionFound).To(BeTrue())
-					Expect(rcv.ID()).To(Equal(resourceConfigVersion.ID()))
-					Expect(foundErr).ToNot(HaveOccurred())
-				})
-			})
-
-			Context("when there are multiple versions partially matched", func() {
-				BeforeEach(func() {
-					version1 := atc.Version{"version": "12345", "tag": "1.0.0"}
-					saveVersion(version1)
-
-					version2 := atc.Version{"version": "12345", "tag": "2.0.0"}
-					saveVersion(version2)
-				})
-
-				It("returns resource config version with highest order and true", func() {
-					Expect(resourceConfigVersionFound).To(BeTrue())
-					Expect(rcv.ID()).To(Equal(resourceConfigVersion.ID()))
-					Expect(foundErr).ToNot(HaveOccurred())
-				})
-			})
-
-			Context("when the check order is 0", func() {
-				BeforeEach(func() {
-					saveVersion(atc.Version{"version": "12345"})
-
-					version = atc.Version{"version": "2"}
-					created, err := resource.SaveUncheckedVersion(version, nil, resourceScope.ResourceConfig())
-					Expect(err).ToNot(HaveOccurred())
-					Expect(created).To(BeTrue())
-				})
-
-				It("does not find the resource config version", func() {
-					Expect(rcv).To(BeNil())
-					Expect(resourceConfigVersionFound).To(BeFalse())
-					Expect(foundErr).ToNot(HaveOccurred())
-				})
-			})
-		})
-
-		Context("when the version is not found", func() {
-			BeforeEach(func() {
-				setupTx, err := dbConn.Begin()
-				Expect(err).ToNot(HaveOccurred())
-
-				brt := db.BaseResourceType{
-					Name: "registry-image",
-				}
-
-				_, err = brt.FindOrCreate(setupTx, false)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(setupTx.Commit()).To(Succeed())
-				_, err = resourceConfigFactory.FindOrCreateResourceConfig("registry-image", atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("returns false when resourceConfig is not found", func() {
-				Expect(foundErr).ToNot(HaveOccurred())
-				Expect(resourceConfigVersionFound).To(BeFalse())
-			})
-		})
-	})
-
 	Context("Versions", func() {
 		var (
-			originalVersionSlice []atc.Version
-			resource             db.Resource
-			resourceScope        db.ResourceConfigScope
+			scenario *dbtest.Scenario
 		)
 
 		Context("with version filters", func() {
@@ -1079,43 +609,31 @@ var _ = Describe("Resource", func() {
 			var resourceVersions []atc.ResourceVersion
 
 			BeforeEach(func() {
-				setupTx, err := dbConn.Begin()
-				Expect(err).ToNot(HaveOccurred())
-
-				brt := db.BaseResourceType{
-					Name: "git",
-				}
-
-				_, err = brt.FindOrCreate(setupTx, false)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(setupTx.Commit()).To(Succeed())
-
-				var found bool
-				resource, found, err = pipeline.Resource("some-other-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
-				Expect(err).ToNot(HaveOccurred())
-
-				originalVersionSlice = []atc.Version{
-					{"ref": "v0", "commit": "v0"},
-					{"ref": "v1", "commit": "v1"},
-					{"ref": "v2", "commit": "v2"},
-				}
-
-				err = resourceScope.SaveVersions(nil, originalVersionSlice)
-				Expect(err).ToNot(HaveOccurred())
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "repository"},
+							},
+						},
+					}),
+					builder.WithResourceVersions(
+						"some-resource",
+						atc.Version{"ref": "v0", "commit": "v0"},
+						atc.Version{"ref": "v1", "commit": "v1"},
+						atc.Version{"ref": "v2", "commit": "v2"},
+					),
+				)
 
 				resourceVersions = make([]atc.ResourceVersion, 0)
 
 				for i := 0; i < 3; i++ {
-					rcv, found, err := resourceScope.FindVersion(atc.Version{
+					rcv := scenario.ResourceVersion("some-resource", atc.Version{
 						"ref":    "v" + strconv.Itoa(i),
 						"commit": "v" + strconv.Itoa(i),
 					})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
 
 					var metadata []atc.MetadataField
 
@@ -1140,7 +658,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("return version that matches field filter", func() {
-					result, _, found, err := resource.Versions(db.Page{Limit: 10}, filter)
+					result, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 10}, filter)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(result)).To(Equal(1))
@@ -1154,7 +672,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("return no version", func() {
-					result, _, found, err := resource.Versions(db.Page{Limit: 10}, filter)
+					result, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 10}, filter)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(result)).To(Equal(0))
@@ -1167,7 +685,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("return version", func() {
-					result, _, found, err := resource.Versions(db.Page{Limit: 10}, filter)
+					result, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 10}, filter)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(result)).To(Equal(1))
@@ -1181,7 +699,7 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("return no version", func() {
-					result, _, found, err := resource.Versions(db.Page{Limit: 10}, filter)
+					result, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 10}, filter)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(result)).To(Equal(0))
@@ -1193,47 +711,35 @@ var _ = Describe("Resource", func() {
 			var resourceVersions []atc.ResourceVersion
 
 			BeforeEach(func() {
-				setupTx, err := dbConn.Begin()
-				Expect(err).ToNot(HaveOccurred())
-
-				brt := db.BaseResourceType{
-					Name: "git",
-				}
-
-				_, err = brt.FindOrCreate(setupTx, false)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(setupTx.Commit()).To(Succeed())
-
-				var found bool
-				resource, found, err = pipeline.Resource("some-other-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
-				Expect(err).ToNot(HaveOccurred())
-
-				originalVersionSlice = []atc.Version{
-					{"ref": "v0"},
-					{"ref": "v1"},
-					{"ref": "v2"},
-					{"ref": "v3"},
-					{"ref": "v4"},
-					{"ref": "v5"},
-					{"ref": "v6"},
-					{"ref": "v7"},
-					{"ref": "v8"},
-					{"ref": "v9"},
-				}
-
-				err = resourceScope.SaveVersions(nil, originalVersionSlice)
-				Expect(err).ToNot(HaveOccurred())
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "repository"},
+							},
+						},
+					}),
+					builder.WithResourceVersions(
+						"some-resource",
+						atc.Version{"ref": "v0"},
+						atc.Version{"ref": "v1"},
+						atc.Version{"ref": "v2"},
+						atc.Version{"ref": "v3"},
+						atc.Version{"ref": "v4"},
+						atc.Version{"ref": "v5"},
+						atc.Version{"ref": "v6"},
+						atc.Version{"ref": "v7"},
+						atc.Version{"ref": "v8"},
+						atc.Version{"ref": "v9"},
+					),
+				)
 
 				resourceVersions = make([]atc.ResourceVersion, 0)
 
 				for i := 0; i < 10; i++ {
-					rcv, found, err := resourceScope.FindVersion(atc.Version{"ref": "v" + strconv.Itoa(i)})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
+					rcv := scenario.ResourceVersion("some-resource", atc.Version{"ref": "v" + strconv.Itoa(i)})
 
 					var metadata []atc.MetadataField
 
@@ -1250,15 +756,11 @@ var _ = Describe("Resource", func() {
 
 					resourceVersions = append(resourceVersions, resourceVersion)
 				}
-
-				reloaded, err := resource.Reload()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(reloaded).To(BeTrue())
 			})
 
 			Context("with no from/to", func() {
 				It("returns the first page, with the given limit, and a next page", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 2}, nil)
+					historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -1271,7 +773,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with a to that places it in the middle of the versions", func() {
 				It("returns the versions, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{To: db.NewIntPtr(resourceVersions[6].ID), Limit: 2}, nil)
+					historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{To: db.NewIntPtr(resourceVersions[6].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -1284,7 +786,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with a to that places it to the oldest version", func() {
 				It("returns the versions, with no next page", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{To: db.NewIntPtr(resourceVersions[1].ID), Limit: 2}, nil)
+					historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{To: db.NewIntPtr(resourceVersions[1].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -1297,7 +799,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with a from that places it in the middle of the versions", func() {
 				It("returns the versions, with previous/next pages", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{From: db.NewIntPtr(resourceVersions[6].ID), Limit: 2}, nil)
+					historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{From: db.NewIntPtr(resourceVersions[6].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -1310,7 +812,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with a from that places it at the beginning of the most recent versions", func() {
 				It("returns the versions, with no previous page", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{From: db.NewIntPtr(resourceVersions[8].ID), Limit: 2}, nil)
+					historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{From: db.NewIntPtr(resourceVersions[8].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(2))
@@ -1325,13 +827,11 @@ var _ = Describe("Resource", func() {
 				BeforeEach(func() {
 					metadata := []db.ResourceConfigMetadataField{{Name: "name1", Value: "value1"}}
 
-					// save metadata
-					_, err := resource.SaveUncheckedVersion(atc.Version(resourceVersions[9].Version), metadata, resourceScope.ResourceConfig())
-					Expect(err).ToNot(HaveOccurred())
+					scenario.Run(builder.WithVersionMetadata("some-resource", atc.Version(resourceVersions[9].Version), metadata))
 				})
 
 				It("returns the metadata in the version history", func() {
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, nil)
+					historyPage, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 1}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
@@ -1340,13 +840,9 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("maintains existing metadata after same version is saved with no metadata", func() {
-					resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
-					Expect(err).ToNot(HaveOccurred())
+					scenario.Run(builder.WithResourceVersions("some-resource", atc.Version(resourceVersions[9].Version)))
 
-					err = resourceScope.SaveVersions(nil, []atc.Version{resourceVersions[9].Version})
-					Expect(err).ToNot(HaveOccurred())
-
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, atc.Version{})
+					historyPage, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 1}, atc.Version{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
@@ -1356,9 +852,9 @@ var _ = Describe("Resource", func() {
 
 				It("updates metadata after same version is saved with different metadata", func() {
 					newMetadata := []db.ResourceConfigMetadataField{{Name: "name-new", Value: "value-new"}}
-					_, err := resource.SaveUncheckedVersion(atc.Version(resourceVersions[9].Version), newMetadata, resourceScope.ResourceConfig())
+					scenario.Run(builder.WithVersionMetadata("some-resource", atc.Version(resourceVersions[9].Version), newMetadata))
 
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, atc.Version{})
+					historyPage, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 1}, atc.Version{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
@@ -1369,14 +865,13 @@ var _ = Describe("Resource", func() {
 
 			Context("when a version is disabled", func() {
 				BeforeEach(func() {
-					err := resource.DisableVersion(resourceVersions[9].ID)
-					Expect(err).ToNot(HaveOccurred())
+					scenario.Run(builder.WithDisabledVersion("some-resource", resourceVersions[9].Version))
 
 					resourceVersions[9].Enabled = false
 				})
 
 				It("returns a disabled version", func() {
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, nil)
+					historyPage, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 1}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(ConsistOf([]atc.ResourceVersion{resourceVersions[9]}))
@@ -1389,13 +884,11 @@ var _ = Describe("Resource", func() {
 				BeforeEach(func() {
 					metadata = []db.ResourceConfigMetadataField{{Name: "name1", Value: "value1"}}
 
-					updated, err := resource.UpdateMetadata(resourceVersions[9].Version, metadata)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(updated).To(BeTrue())
+					scenario.Run(builder.WithVersionMetadata("some-resource", atc.Version(resourceVersions[9].Version), metadata))
 				})
 
 				It("returns a version with metadata updated", func() {
-					historyPage, _, found, err := resource.Versions(db.Page{Limit: 1}, nil)
+					historyPage, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 1}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(len(historyPage)).To(Equal(1))
@@ -1409,47 +902,32 @@ var _ = Describe("Resource", func() {
 			var resourceVersions []atc.ResourceVersion
 
 			BeforeEach(func() {
-				setupTx, err := dbConn.Begin()
-				Expect(err).ToNot(HaveOccurred())
-
-				brt := db.BaseResourceType{
-					Name: "git",
-				}
-
-				_, err = brt.FindOrCreate(setupTx, false)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(setupTx.Commit()).To(Succeed())
-
-				var found bool
-				resource, found, err = pipeline.Resource("some-other-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
-				Expect(err).ToNot(HaveOccurred())
-
-				originalVersionSlice := []atc.Version{
-					{"ref": "v1"}, // id: 1, check_order: 1
-					{"ref": "v3"}, // id: 2, check_order: 2
-					{"ref": "v4"}, // id: 3, check_order: 3
-				}
-
-				err = resourceScope.SaveVersions(nil, originalVersionSlice)
-				Expect(err).ToNot(HaveOccurred())
-
-				secondVersionSlice := []atc.Version{
-					{"ref": "v2"}, // id: 4, check_order: 4
-					{"ref": "v3"}, // id: 2, check_order: 5
-					{"ref": "v4"}, // id: 3, check_order: 6
-				}
-
-				err = resourceScope.SaveVersions(nil, secondVersionSlice)
-				Expect(err).ToNot(HaveOccurred())
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "repository"},
+							},
+						},
+					}),
+					builder.WithResourceVersions(
+						"some-resource",
+						atc.Version{"ref": "v1"}, // id: 1, check_order: 1
+						atc.Version{"ref": "v3"}, // id: 2, check_order: 2
+						atc.Version{"ref": "v4"}, // id: 3, check_order: 3
+					),
+					builder.WithResourceVersions(
+						"some-resource",
+						atc.Version{"ref": "v2"}, // id: 4, check_order: 4
+						atc.Version{"ref": "v3"}, // id: 2, check_order: 5
+						atc.Version{"ref": "v4"}, // id: 3, check_order: 6
+					),
+				)
 
 				for i := 1; i < 5; i++ {
-					rcv, found, err := resourceScope.FindVersion(atc.Version{"ref": "v" + strconv.Itoa(i)})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
+					rcv := scenario.ResourceVersion("some-resource", atc.Version{"ref": "v" + strconv.Itoa(i)})
 
 					var metadata []atc.MetadataField
 
@@ -1472,7 +950,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with no from/to", func() {
 				It("returns versions ordered by check order", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 4}, nil)
+					historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 4}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(4))
@@ -1487,7 +965,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with from", func() {
 				It("returns the versions, with previous/next pages including from", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{From: db.NewIntPtr(resourceVersions[1].ID), Limit: 2}, nil)
+					historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{From: db.NewIntPtr(resourceVersions[1].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
@@ -1500,7 +978,7 @@ var _ = Describe("Resource", func() {
 
 			Context("with to", func() {
 				It("returns the builds, with previous/next pages including to", func() {
-					historyPage, pagination, found, err := resource.Versions(db.Page{To: db.NewIntPtr(resourceVersions[2].ID), Limit: 2}, nil)
+					historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{To: db.NewIntPtr(resourceVersions[2].ID), Limit: 2}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(historyPage).To(HaveLen(2))
@@ -1513,35 +991,24 @@ var _ = Describe("Resource", func() {
 		})
 
 		Context("when resource has a version with check order of 0", func() {
-			var resource db.Resource
-
 			BeforeEach(func() {
-				setupTx, err := dbConn.Begin()
-				Expect(err).ToNot(HaveOccurred())
-
-				brt := db.BaseResourceType{
-					Name: "git",
-				}
-
-				_, err = brt.FindOrCreate(setupTx, false)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(setupTx.Commit()).To(Succeed())
-
-				var found bool
-				resource, found, err = pipeline.Resource("some-other-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
-				Expect(err).ToNot(HaveOccurred())
-
-				created, err := resource.SaveUncheckedVersion(atc.Version{"version": "not-returned"}, nil, resourceScope.ResourceConfig())
-				Expect(err).ToNot(HaveOccurred())
-				Expect(created).To(BeTrue())
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-resource-type",
+								Source: atc.Source{"some": "repository"},
+							},
+						},
+					}),
+					builder.WithResourceVersions("some-resource"),
+					builder.WithVersionMetadata("some-resource", atc.Version{"version": "not-returned"}, nil), // save unchecked version
+				)
 			})
 
 			It("does not return the version", func() {
-				historyPage, pagination, found, err := resource.Versions(db.Page{Limit: 2}, nil)
+				historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 2}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
 				Expect(historyPage).To(BeNil())
@@ -1552,254 +1019,187 @@ var _ = Describe("Resource", func() {
 
 	Describe("PinVersion/UnpinVersion", func() {
 		var (
-			resource      db.Resource
-			resourceScope db.ResourceConfigScope
-			resID         int
+			scenario *dbtest.Scenario
 		)
 
 		BeforeEach(func() {
-			var found bool
-			var err error
-			resource, found, err = pipeline.Resource("some-other-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			setupTx, err := dbConn.Begin()
-			Expect(err).ToNot(HaveOccurred())
-
-			brt := db.BaseResourceType{
-				Name: "git",
-			}
-
-			_, err = brt.FindOrCreate(setupTx, false)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(setupTx.Commit()).To(Succeed())
-
-			resourceScope, err = resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = resourceScope.SaveVersions(nil, []atc.Version{
-				{"version": "v1"},
-				{"version": "v2"},
-				{"version": "v3"},
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			resConf, found, err := resourceScope.FindVersion(atc.Version{"version": "v1"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-			resID = resConf.ID()
+			scenario = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Resources: atc.ResourceConfigs{
+						{
+							Name:   "some-resource",
+							Type:   "some-base-resource-type",
+							Source: atc.Source{"some": "repository"},
+						},
+					},
+					Jobs: atc.JobConfigs{
+						{
+							Name: "job-using-resource",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name: "some-resource",
+									},
+								},
+							},
+						},
+						{
+							Name: "not-using-resource",
+						},
+					},
+				}),
+				builder.WithResourceVersions(
+					"some-resource",
+					atc.Version{"version": "v1"},
+					atc.Version{"version": "v2"},
+					atc.Version{"version": "v3"},
+				),
+			)
 		})
 
 		Context("when we use an invalid version id (does not exist)", func() {
 			var (
 				pinnedVersion atc.Version
 			)
+
 			BeforeEach(func() {
-				found, err := resource.PinVersion(resID)
+				found, err := scenario.Resource("some-resource").PinVersion(scenario.ResourceVersion("some-resource", atc.Version{"version": "v1"}).ID())
 				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 
-				found, err = resource.Reload()
-				Expect(found).To(BeTrue())
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(resource.CurrentPinnedVersion()).To(Equal(resource.APIPinnedVersion()))
-				pinnedVersion = resource.APIPinnedVersion()
+				Expect(scenario.Resource("some-resource").CurrentPinnedVersion()).To(Equal(scenario.Resource("some-resource").APIPinnedVersion()))
+				pinnedVersion = scenario.Resource("some-resource").APIPinnedVersion()
 			})
 
 			It("returns not found and does not update anything", func() {
-				found, err := resource.PinVersion(-1)
+				found, err := scenario.Resource("some-resource").PinVersion(-1)
 				Expect(found).To(BeFalse())
 				Expect(err).To(HaveOccurred())
 
-				Expect(resource.APIPinnedVersion()).To(Equal(pinnedVersion))
+				Expect(scenario.Resource("some-resource").APIPinnedVersion()).To(Equal(pinnedVersion))
 			})
 		})
 
 		Context("when requesting schedule for version pinning", func() {
 			It("requests schedule on all jobs using the resource", func() {
-				job, found, err := pipeline.Job("job-using-resource")
+				requestedSchedule := scenario.Job("job-using-resource").ScheduleRequestedTime()
+
+				found, err := scenario.Resource("some-resource").PinVersion(scenario.ResourceVersion("some-resource", atc.Version{"version": "v1"}).ID())
 				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 
-				requestedSchedule := job.ScheduleRequestedTime()
-
-				found, err = resource.PinVersion(resID)
-				Expect(found).To(BeTrue())
-				Expect(err).ToNot(HaveOccurred())
-
-				found, err = job.Reload()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				Expect(job.ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule))
+				Expect(scenario.Job("job-using-resource").ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule))
 			})
 
 			It("does not request schedule on jobs that do not use the resource", func() {
-				job, found, err := pipeline.Job("not-using-resource")
+				requestedSchedule := scenario.Job("not-using-resource").ScheduleRequestedTime()
+
+				found, err := scenario.Resource("some-resource").PinVersion(scenario.ResourceVersion("some-resource", atc.Version{"version": "v1"}).ID())
 				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 
-				requestedSchedule := job.ScheduleRequestedTime()
-
-				found, err = resource.PinVersion(resID)
-				Expect(found).To(BeTrue())
-				Expect(err).ToNot(HaveOccurred())
-
-				found, err = job.Reload()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				Expect(job.ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
+				Expect(scenario.Job("not-using-resource").ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
 			})
 		})
 
 		Context("when we pin a resource to a version", func() {
 			BeforeEach(func() {
-				found, err := resource.PinVersion(resID)
-				Expect(found).To(BeTrue())
-				Expect(err).ToNot(HaveOccurred())
-
-				found, err = resource.Reload()
+				found, err := scenario.Resource("some-resource").PinVersion(scenario.ResourceVersion("some-resource", atc.Version{"version": "v1"}).ID())
 				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 			})
 
 			Context("when the resource is not pinned", func() {
 				It("sets the api pinned version", func() {
-					Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
-					Expect(resource.CurrentPinnedVersion()).To(Equal(resource.APIPinnedVersion()))
+					Expect(scenario.Resource("some-resource").APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
+					Expect(scenario.Resource("some-resource").CurrentPinnedVersion()).To(Equal(scenario.Resource("some-resource").APIPinnedVersion()))
 				})
 			})
 
 			Context("when the resource is pinned by another version already", func() {
 				BeforeEach(func() {
-					resConf, found, err := resourceScope.FindVersion(atc.Version{"version": "v3"})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-					resID = resConf.ID()
-
-					found, err = resource.PinVersion(resID)
-					Expect(found).To(BeTrue())
-					Expect(err).ToNot(HaveOccurred())
-
-					found, err = resource.Reload()
+					found, err := scenario.Resource("some-resource").PinVersion(scenario.ResourceVersion("some-resource", atc.Version{"version": "v3"}).ID())
 					Expect(found).To(BeTrue())
 					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("switch the pin to given version", func() {
-					Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v3"}))
-					Expect(resource.CurrentPinnedVersion()).To(Equal(resource.APIPinnedVersion()))
+					Expect(scenario.Resource("some-resource").APIPinnedVersion()).To(Equal(atc.Version{"version": "v3"}))
+					Expect(scenario.Resource("some-resource").CurrentPinnedVersion()).To(Equal(scenario.Resource("some-resource").APIPinnedVersion()))
 				})
 			})
 
 			Context("when we set the pin comment on a resource", func() {
 				BeforeEach(func() {
-					err := resource.SetPinComment("foo")
-					Expect(err).ToNot(HaveOccurred())
-					reload, err := resource.Reload()
-					Expect(reload).To(BeTrue())
+					err := scenario.Resource("some-resource").SetPinComment("foo")
 					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("should set the pin comment", func() {
-					Expect(resource.PinComment()).To(Equal("foo"))
+					Expect(scenario.Resource("some-resource").PinComment()).To(Equal("foo"))
 				})
 			})
 
 			Context("when requesting schedule for version unpinning", func() {
 				It("requests schedule on all jobs using the resource", func() {
-					job, found, err := pipeline.Job("job-using-resource")
-					Expect(found).To(BeTrue())
+					requestedSchedule := scenario.Job("job-using-resource").ScheduleRequestedTime()
+
+					err := scenario.Resource("some-resource").UnpinVersion()
 					Expect(err).ToNot(HaveOccurred())
 
-					requestedSchedule := job.ScheduleRequestedTime()
-
-					err = resource.UnpinVersion()
-					Expect(err).ToNot(HaveOccurred())
-
-					found, err = job.Reload()
-					Expect(found).To(BeTrue())
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(job.ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule))
+					Expect(scenario.Job("job-using-resource").ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule))
 				})
 
 				It("does not request schedule on jobs that do not use the resource", func() {
-					job, found, err := pipeline.Job("not-using-resource")
-					Expect(found).To(BeTrue())
+					requestedSchedule := scenario.Job("not-using-resource").ScheduleRequestedTime()
+
+					err := scenario.Resource("some-resource").UnpinVersion()
 					Expect(err).ToNot(HaveOccurred())
 
-					requestedSchedule := job.ScheduleRequestedTime()
-
-					err = resource.UnpinVersion()
-					Expect(err).ToNot(HaveOccurred())
-
-					Expect(job.ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
+					Expect(scenario.Job("not-using-resource").ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
 				})
 			})
 
 			Context("when we unpin a resource to a version", func() {
 				BeforeEach(func() {
-					err := resource.UnpinVersion()
-					Expect(err).ToNot(HaveOccurred())
-
-					found, err := resource.Reload()
-					Expect(found).To(BeTrue())
+					err := scenario.Resource("some-resource").UnpinVersion()
 					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("sets the api pinned version to nil", func() {
-					Expect(resource.APIPinnedVersion()).To(BeNil())
-					Expect(resource.CurrentPinnedVersion()).To(BeNil())
+					Expect(scenario.Resource("some-resource").APIPinnedVersion()).To(BeNil())
+					Expect(scenario.Resource("some-resource").CurrentPinnedVersion()).To(BeNil())
 				})
 
 				It("unsets the pin comment", func() {
-					Expect(resource.PinComment()).To(BeEmpty())
+					Expect(scenario.Resource("some-resource").PinComment()).To(BeEmpty())
 				})
 			})
 		})
 
 		Context("when we pin a resource that is already pinned to a version (through the config)", func() {
-			var resConf db.ResourceConfigVersion
-
 			BeforeEach(func() {
-				var found bool
-				var err error
-				resource, found, err = pipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				setupTx, err := dbConn.Begin()
-				Expect(err).ToNot(HaveOccurred())
-
-				brt := db.BaseResourceType{
-					Name: "registry-image",
-				}
-
-				_, err = brt.FindOrCreate(setupTx, false)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(setupTx.Commit()).To(Succeed())
-
-				resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "repository"}, atc.VersionedResourceTypes{})
-				Expect(err).ToNot(HaveOccurred())
-
-				err = resourceScope.SaveVersions(nil, []atc.Version{
-					{"version": "v1"},
-					{"version": "v2"},
-					{"version": "v3"},
-				})
-				Expect(err).ToNot(HaveOccurred())
-
-				resConf, found, err = resourceScope.FindVersion(atc.Version{"version": "v1"})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
+				scenario.Run(
+					builder.WithPipeline(atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:    "some-resource",
+								Type:    "some-base-resource-type",
+								Source:  atc.Source{"some": "repository"},
+								Version: atc.Version{"pinned": "version"},
+							},
+						},
+					}),
+					builder.WithResourceVersions(
+						"some-resource",
+						atc.Version{"version": "v1"},
+						atc.Version{"version": "v2"},
+						atc.Version{"version": "v3"},
+					))
 			})
 
 			It("should fail to update the pinned version", func() {
-				found, err := resource.PinVersion(resConf.ID())
+				found, err := scenario.Resource("some-resource").PinVersion(scenario.ResourceVersion("some-resource", atc.Version{"version": "v1"}).ID())
 				Expect(found).To(BeFalse())
 				Expect(err).To(Equal(db.ErrPinnedThroughConfig))
 			})

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -233,6 +233,10 @@ func (t *resourceType) Reload() (bool, error) {
 	return true, nil
 }
 
+func (r *resourceType) SetResourceConfig(atc.Source, atc.VersionedResourceTypes) (ResourceConfigScope, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (r *resourceType) SetResourceConfigScope(scope ResourceConfigScope) error {
 	_, err := psql.Update("resource_types").
 		Set("resource_config_id", scope.ResourceConfig().ID()).

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -487,14 +487,6 @@ var _ = Describe("Team", func() {
 			var resourceContainer db.Container
 
 			BeforeEach(func() {
-				atcWorker := atc.Worker{
-					ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
-					Name:            "default-team-worker",
-					GardenAddr:      "3.4.5.6:7777",
-					BaggageclaimURL: "7.8.9.10:7878",
-					Team:            "some-test-team",
-				}
-
 				scenario = dbtest.Setup(
 					builder.WithTeam("some-test-team"),
 					builder.WithPipeline(atc.Config{
@@ -522,7 +514,13 @@ var _ = Describe("Team", func() {
 							},
 						},
 					}),
-					builder.WithTeamWorker(atcWorker),
+					builder.WithWorker(atc.Worker{
+						Name:            "default-team-worker",
+						Team:            "some-test-team",
+						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+						GardenAddr:      "3.4.5.6:7777",
+						BaggageclaimURL: "7.8.9.10:7878",
+					}),
 					builder.WithResourceVersions("some-resource"),
 				)
 
@@ -563,14 +561,6 @@ var _ = Describe("Team", func() {
 				)
 
 				BeforeEach(func() {
-					atcWorker := atc.Worker{
-						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
-						Name:            "other-team-worker",
-						GardenAddr:      "4.5.6.7:7777",
-						BaggageclaimURL: "8.9.10.11:7878",
-						Team:            "other-team",
-					}
-
 					otherScenario = dbtest.Setup(
 						builder.WithTeam("other-team"),
 						builder.WithPipeline(atc.Config{
@@ -598,7 +588,13 @@ var _ = Describe("Team", func() {
 								},
 							},
 						}),
-						builder.WithTeamWorker(atcWorker),
+						builder.WithWorker(atc.Worker{
+							Name:            "other-team-worker",
+							Team:            "other-team",
+							ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+							GardenAddr:      "4.5.6.7:7777",
+							BaggageclaimURL: "8.9.10.11:7878",
+						}),
 						builder.WithResourceVersions("some-resource"),
 					)
 

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/creds/credsfakes"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/atc/event"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -397,8 +398,8 @@ var _ = Describe("Team", func() {
 		var (
 			fakeSecretManager      *credsfakes.FakeSecrets
 			resourceContainer      db.CreatingContainer
-			resourceConfigScope    db.ResourceConfigScope
 			firstContainerCreating db.CreatingContainer
+			scenario               *dbtest.Scenario
 		)
 
 		Context("when there is a task container and a check container", func() {
@@ -406,109 +407,8 @@ var _ = Describe("Team", func() {
 				fakeSecretManager = new(credsfakes.FakeSecrets)
 				fakeSecretManager.GetReturns("", nil, false, nil)
 
-				job, found, err := defaultPipeline.Job("some-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				build, err := job.CreateBuild()
-				Expect(err).ToNot(HaveOccurred())
-
-				firstContainerCreating, err = defaultWorker.CreateContainer(db.NewBuildStepContainerOwner(build.ID(), atc.PlanID("some-job"), defaultTeam.ID()), db.ContainerMetadata{Type: "task", StepName: "some-task"})
-				Expect(err).ToNot(HaveOccurred())
-
-				expiries := db.ContainerOwnerExpiries{
-					Min: 5 * time.Minute,
-					Max: 1 * time.Hour,
-				}
-
-				pipelineResourceTypes, err := defaultPipeline.ResourceTypes()
-				Expect(err).ToNot(HaveOccurred())
-
-				resourceConfigScope, err = defaultResource.SetResourceConfig(defaultResource.Source(), pipelineResourceTypes.Deserialize())
-				Expect(err).ToNot(HaveOccurred())
-
-				resourceContainer, err = defaultWorker.CreateContainer(
-					db.NewResourceConfigCheckSessionContainerOwner(
-						resourceConfigScope.ResourceConfig().ID(),
-						resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
-						expiries,
-					),
-					db.ContainerMetadata{},
-				)
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("finds all the containers", func() {
-				containers, err := defaultTeam.Containers()
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(containers).To(HaveLen(2))
-				Expect(containers).To(ConsistOf(firstContainerCreating, resourceContainer))
-			})
-
-			It("does not find containers for other teams", func() {
-				containers, err := otherTeam.Containers()
-				Expect(err).ToNot(HaveOccurred())
-				Expect(containers).To(BeEmpty())
-			})
-
-		})
-
-		Context("when there is a check container on a team worker", func() {
-			var resourceContainer db.Container
-
-			BeforeEach(func() {
-				atcWorker := atc.Worker{
-					ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
-					Name:            "default-team-worker",
-					GardenAddr:      "3.4.5.6:7777",
-					BaggageclaimURL: "7.8.9.10:7878",
-					Team:            defaultTeam.Name(),
-				}
-
-				worker, err := defaultTeam.SaveWorker(atcWorker, 0)
-				Expect(err).ToNot(HaveOccurred())
-
-				expiries := db.ContainerOwnerExpiries{
-					Min: 5 * time.Minute,
-					Max: 1 * time.Hour,
-				}
-
-				resourceConfigScope, err = defaultResource.SetResourceConfig(defaultResource.Source(), atc.VersionedResourceTypes{})
-				Expect(err).ToNot(HaveOccurred())
-
-				resourceContainer, err = worker.CreateContainer(
-					db.NewResourceConfigCheckSessionContainerOwner(
-						resourceConfigScope.ResourceConfig().ID(),
-						resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
-						expiries,
-					),
-					db.ContainerMetadata{
-						Type: "check",
-					},
-				)
-			})
-
-			It("finds the container", func() {
-				containers, err := defaultTeam.Containers()
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(containers).To(HaveLen(1))
-				Expect(containers).To(ConsistOf(resourceContainer))
-			})
-
-			Context("when there is another check container with the same resource config on a different team worker", func() {
-				var (
-					resource2Container db.Container
-					otherTeam          db.Team
-					err                error
-				)
-
-				BeforeEach(func() {
-					otherTeam, err = teamFactory.CreateTeam(atc.Team{Name: "other-team"})
-					Expect(err).NotTo(HaveOccurred())
-
-					otherPipeline, _, err := otherTeam.SavePipeline(atc.PipelineRef{Name: "other-pipeline"}, atc.Config{
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
 						Jobs: atc.JobConfigs{
 							{
 								Name: "some-job",
@@ -532,46 +432,200 @@ var _ = Describe("Team", func() {
 								},
 							},
 						},
-					}, db.ConfigVersion(0), false)
-					Expect(err).NotTo(HaveOccurred())
+					}),
+					builder.WithWorker(atc.Worker{
+						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+						Name:            "some-default-worker",
+						GardenAddr:      "3.4.5.6:7777",
+						BaggageclaimURL: "7.8.9.10:7878",
+					}),
+					builder.WithResourceVersions("some-resource"),
+				)
 
-					otherResource, found, err := otherPipeline.Resource("some-resource")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
+				build, err := scenario.Job("some-job").CreateBuild()
+				Expect(err).ToNot(HaveOccurred())
 
+				firstContainerCreating, err = scenario.Workers[0].CreateContainer(db.NewBuildStepContainerOwner(build.ID(), atc.PlanID("some-job"), scenario.Team.ID()), db.ContainerMetadata{Type: "task", StepName: "some-task"})
+				Expect(err).ToNot(HaveOccurred())
+
+				expiries := db.ContainerOwnerExpiries{
+					Min: 5 * time.Minute,
+					Max: 1 * time.Hour,
+				}
+
+				rc, found, err := resourceConfigFactory.FindResourceConfigByID(scenario.Resource("some-resource").ResourceConfigID())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				resourceContainer, err = scenario.Workers[0].CreateContainer(
+					db.NewResourceConfigCheckSessionContainerOwner(
+						rc.ID(),
+						rc.OriginBaseResourceType().ID,
+						expiries,
+					),
+					db.ContainerMetadata{},
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("finds all the containers", func() {
+				containers, err := scenario.Team.Containers()
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(containers).To(HaveLen(2))
+				Expect(containers).To(ConsistOf(firstContainerCreating, resourceContainer))
+			})
+
+			It("does not find containers for other teams", func() {
+				containers, err := otherTeam.Containers()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(containers).To(BeEmpty())
+			})
+		})
+
+		Context("when there is a check container on a team worker", func() {
+			var resourceContainer db.Container
+
+			BeforeEach(func() {
+				atcWorker := atc.Worker{
+					ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+					Name:            "default-team-worker",
+					GardenAddr:      "3.4.5.6:7777",
+					BaggageclaimURL: "7.8.9.10:7878",
+					Team:            "some-test-team",
+				}
+
+				scenario = dbtest.Setup(
+					builder.WithTeam("some-test-team"),
+					builder.WithPipeline(atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+							},
+						},
+						Resources: atc.ResourceConfigs{
+							{
+								Name: "some-resource",
+								Type: "some-base-resource-type",
+								Source: atc.Source{
+									"some": "source",
+								},
+							},
+						},
+						ResourceTypes: atc.ResourceTypes{
+							{
+								Name: "some-type",
+								Type: "some-base-resource-type",
+								Source: atc.Source{
+									"some-type": "source",
+								},
+							},
+						},
+					}),
+					builder.WithTeamWorker(atcWorker),
+					builder.WithResourceVersions("some-resource"),
+				)
+
+				expiries := db.ContainerOwnerExpiries{
+					Min: 5 * time.Minute,
+					Max: 1 * time.Hour,
+				}
+
+				rc, found, err := resourceConfigFactory.FindResourceConfigByID(scenario.Resource("some-resource").ResourceConfigID())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				resourceContainer, err = scenario.Workers[0].CreateContainer(
+					db.NewResourceConfigCheckSessionContainerOwner(
+						rc.ID(),
+						rc.OriginBaseResourceType().ID,
+						expiries,
+					),
+					db.ContainerMetadata{
+						Type: "check",
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("finds the container", func() {
+				containers, err := scenario.Team.Containers()
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(containers).To(HaveLen(1))
+				Expect(containers).To(ConsistOf(resourceContainer))
+			})
+
+			Context("when there is another check container with the same resource config on a different team worker", func() {
+				var (
+					resource2Container db.Container
+					otherScenario      *dbtest.Scenario
+				)
+
+				BeforeEach(func() {
 					atcWorker := atc.Worker{
 						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
 						Name:            "other-team-worker",
 						GardenAddr:      "4.5.6.7:7777",
 						BaggageclaimURL: "8.9.10.11:7878",
-						Team:            otherTeam.Name(),
+						Team:            "other-team",
 					}
 
-					worker, err := otherTeam.SaveWorker(atcWorker, 0)
-					Expect(err).ToNot(HaveOccurred())
+					otherScenario = dbtest.Setup(
+						builder.WithTeam("other-team"),
+						builder.WithPipeline(atc.Config{
+							Jobs: atc.JobConfigs{
+								{
+									Name: "some-job",
+								},
+							},
+							Resources: atc.ResourceConfigs{
+								{
+									Name: "some-resource",
+									Type: "some-base-resource-type",
+									Source: atc.Source{
+										"some": "source",
+									},
+								},
+							},
+							ResourceTypes: atc.ResourceTypes{
+								{
+									Name: "some-type",
+									Type: "some-base-resource-type",
+									Source: atc.Source{
+										"some-type": "source",
+									},
+								},
+							},
+						}),
+						builder.WithTeamWorker(atcWorker),
+						builder.WithResourceVersions("some-resource"),
+					)
 
 					expiries := db.ContainerOwnerExpiries{
 						Min: 5 * time.Minute,
 						Max: 1 * time.Hour,
 					}
 
-					resourceConfigScope, err = otherResource.SetResourceConfig(otherResource.Source(), atc.VersionedResourceTypes{})
+					rc, found, err := resourceConfigFactory.FindResourceConfigByID(otherScenario.Resource("some-resource").ResourceConfigID())
 					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
 
-					resource2Container, err = worker.CreateContainer(
+					resource2Container, err = otherScenario.Workers[0].CreateContainer(
 						db.NewResourceConfigCheckSessionContainerOwner(
-							resourceConfigScope.ResourceConfig().ID(),
-							resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
+							rc.ID(),
+							rc.OriginBaseResourceType().ID,
 							expiries,
 						),
 						db.ContainerMetadata{
 							Type: "check",
 						},
 					)
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("returns the container only from the team", func() {
-					containers, err := otherTeam.Containers()
+					containers, err := otherScenario.Team.Containers()
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(containers).To(HaveLen(1))
@@ -590,13 +644,14 @@ var _ = Describe("Team", func() {
 						Max: 1 * time.Hour,
 					}
 
-					resourceConfigScope, err := defaultResource.SetResourceConfig(defaultResource.Source(), atc.VersionedResourceTypes{})
+					rc, found, err := resourceConfigFactory.FindResourceConfigByID(scenario.Resource("some-resource").ResourceConfigID())
 					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue())
 
-					globalResourceContainer, err = defaultWorker.CreateContainer(
+					globalResourceContainer, err = scenario.Workers[0].CreateContainer(
 						db.NewResourceConfigCheckSessionContainerOwner(
-							resourceConfigScope.ResourceConfig().ID(),
-							resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
+							rc.ID(),
+							rc.OriginBaseResourceType().ID,
 							expiries,
 						),
 						db.ContainerMetadata{
@@ -607,7 +662,7 @@ var _ = Describe("Team", func() {
 				})
 
 				It("returns the container only from the team worker and global worker", func() {
-					containers, err := defaultTeam.Containers()
+					containers, err := scenario.Team.Containers()
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(containers).To(HaveLen(2))
@@ -625,13 +680,34 @@ var _ = Describe("Team", func() {
 					Max: 1 * time.Hour,
 				}
 
-				resourceConfigScope, err := defaultResourceType.SetResourceConfig(defaultResourceType.Source(), atc.VersionedResourceTypes{})
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						ResourceTypes: atc.ResourceTypes{
+							{
+								Name: "some-type",
+								Type: "some-base-resource-type",
+								Source: atc.Source{
+									"some-type": "source",
+								},
+							},
+						},
+					}),
+					builder.WithWorker(atc.Worker{
+						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+						Name:            "some-default-worker",
+						GardenAddr:      "3.4.5.6:7777",
+						BaggageclaimURL: "7.8.9.10:7878",
+					}),
+					builder.WithResourceTypeVersions("some-type"),
+				)
+
+				rc, err := resourceConfigFactory.FindOrCreateResourceConfig(scenario.ResourceType("some-type").Type(), scenario.ResourceType("some-type").Source(), nil)
 				Expect(err).ToNot(HaveOccurred())
 
-				resourceContainer, err = defaultWorker.CreateContainer(
+				resourceContainer, err = scenario.Workers[0].CreateContainer(
 					db.NewResourceConfigCheckSessionContainerOwner(
-						resourceConfigScope.ResourceConfig().ID(),
-						resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
+						rc.ID(),
+						rc.OriginBaseResourceType().ID,
 						expiries,
 					),
 					db.ContainerMetadata{
@@ -642,7 +718,7 @@ var _ = Describe("Team", func() {
 			})
 
 			It("finds the container", func() {
-				containers, err := defaultTeam.Containers()
+				containers, err := scenario.Team.Containers()
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(containers).To(HaveLen(1))
@@ -1823,58 +1899,29 @@ var _ = Describe("Team", func() {
 		})
 
 		It("clears out api pinned version when resaving a pinned version on the pipeline config", func() {
-			pipeline, _, err := team.SavePipeline(pipelineRef, config, 0, false)
-			Expect(err).ToNot(HaveOccurred())
+			scenario := dbtest.Setup(
+				builder.WithPipeline(config),
+				builder.WithBaseResourceType(dbConn, "some-type"),
+				builder.WithResourceVersions(
+					"some-resource",
+					atc.Version{"version": "v1"},
+					atc.Version{"version": "v2"},
+				),
+				builder.WithPinnedVersion("some-resource", atc.Version{"version": "v1"}),
+			)
 
-			resource, found, err := pipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			setupTx, err := dbConn.Begin()
-			Expect(err).ToNot(HaveOccurred())
-
-			brt := db.BaseResourceType{
-				Name: "some-type",
-			}
-
-			_, err = brt.FindOrCreate(setupTx, false)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(setupTx.Commit()).To(Succeed())
-
-			rc, err := resource.SetResourceConfig(atc.Source{"source-config": "some-value"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = rc.SaveVersions(nil, []atc.Version{
-				{"version": "v1"},
-				{"version": "v2"},
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			rcv, found, err := rc.FindVersion(atc.Version{"version": "v1"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			found, err = resource.PinVersion(rcv.ID())
-			Expect(found).To(BeTrue())
-			Expect(err).ToNot(HaveOccurred())
-
-			reloaded, err := resource.Reload()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(reloaded).To(BeTrue())
-			Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
+			Expect(scenario.Resource("some-resource").APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 
 			config.Resources[0].Version = atc.Version{
 				"version": "v2",
 			}
 
-			savedPipeline, _, err := team.SavePipeline(pipelineRef, config, pipeline.ConfigVersion(), false)
-			Expect(err).ToNot(HaveOccurred())
+			scenario.Run(
+				builder.WithPipeline(config),
+			)
 
-			resource, found, err = savedPipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-			Expect(resource.ConfigPinnedVersion()).To(Equal(atc.Version{"version": "v2"}))
-			Expect(resource.APIPinnedVersion()).To(BeNil())
+			Expect(scenario.Resource("some-resource").ConfigPinnedVersion()).To(Equal(atc.Version{"version": "v2"}))
+			Expect(scenario.Resource("some-resource").APIPinnedVersion()).To(BeNil())
 		})
 
 		It("clears out config pinned version when it is removed", func() {
@@ -1904,53 +1951,24 @@ var _ = Describe("Team", func() {
 		})
 
 		It("does not clear the api pinned version when resaving pipeline config", func() {
-			pipeline, _, err := team.SavePipeline(pipelineRef, config, 0, false)
-			Expect(err).ToNot(HaveOccurred())
+			scenario := dbtest.Setup(
+				builder.WithPipeline(config),
+				builder.WithBaseResourceType(dbConn, "some-type"),
+				builder.WithResourceVersions(
+					"some-resource",
+					atc.Version{"version": "v1"},
+					atc.Version{"version": "v2"},
+				),
+				builder.WithPinnedVersion("some-resource", atc.Version{"version": "v1"}),
+			)
 
-			resource, found, err := pipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
+			Expect(scenario.Resource("some-resource").APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 
-			setupTx, err := dbConn.Begin()
-			Expect(err).ToNot(HaveOccurred())
+			scenario.Run(
+				builder.WithPipeline(config),
+			)
 
-			brt := db.BaseResourceType{
-				Name: "some-type",
-			}
-
-			_, err = brt.FindOrCreate(setupTx, false)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(setupTx.Commit()).To(Succeed())
-
-			rc, err := resource.SetResourceConfig(atc.Source{"source-config": "some-value"}, atc.VersionedResourceTypes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = rc.SaveVersions(nil, []atc.Version{
-				{"version": "v1"},
-				{"version": "v2"},
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			rcv, found, err := rc.FindVersion(atc.Version{"version": "v1"})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			found, err = resource.PinVersion(rcv.ID())
-			Expect(found).To(BeTrue())
-			Expect(err).ToNot(HaveOccurred())
-
-			reloaded, err := resource.Reload()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(reloaded).To(BeTrue())
-			Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
-
-			savedPipeline, _, err := team.SavePipeline(pipelineRef, config, pipeline.ConfigVersion(), false)
-			Expect(err).ToNot(HaveOccurred())
-
-			resource, found, err = savedPipeline.Resource("some-resource")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(found).To(BeTrue())
-			Expect(resource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
+			Expect(scenario.Resource("some-resource").APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 		})
 
 		It("marks resource as inactive if it is no longer in config", func() {
@@ -2333,56 +2351,27 @@ var _ = Describe("Team", func() {
 			})
 
 			Context("when new resource exists but is disabled", func() {
-				var pipeline db.Pipeline
+				var scenario *dbtest.Scenario
 				var resource db.Resource
-				var rcv db.ResourceConfigVersion
-				var err error
-				var found bool
 
 				BeforeEach(func() {
-					pipeline, _, err = team.SavePipeline(pipelineRef, config, 0, false)
-					Expect(err).ToNot(HaveOccurred())
+					scenario = dbtest.Setup(
+						builder.WithPipeline(config),
+						builder.WithBaseResourceType(dbConn, "some-type"),
+						builder.WithDisabledVersion("some-resource", atc.Version{"disabled": "version"}),
+					)
 
-					resource, found, err = pipeline.Resource("some-resource")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					setupTx, err := dbConn.Begin()
-					Expect(err).ToNot(HaveOccurred())
-
-					brt := db.BaseResourceType{
-						Name: "some-type",
-					}
-
-					_, err = brt.FindOrCreate(setupTx, false)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(setupTx.Commit()).To(Succeed())
-
-					resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
-					Expect(err).NotTo(HaveOccurred())
-
-					err = resourceScope.SaveVersions(nil, []atc.Version{
-						{"disabled": "version"},
-					})
-					Expect(err).ToNot(HaveOccurred())
-
-					rcv, found, err = resourceScope.FindVersion(atc.Version{"disabled": "version"})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					err = resource.DisableVersion(rcv.ID())
-					Expect(err).ToNot(HaveOccurred())
-
-					versions, _, found, err := resource.Versions(db.Page{Limit: 3}, nil)
+					versions, _, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 3}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeTrue())
 					Expect(versions).To(HaveLen(1))
 					Expect(versions[0].Version).To(Equal(atc.Version{"disabled": "version"}))
 					Expect(versions[0].Enabled).To(BeFalse())
+
+					resource = scenario.Resource("some-resource")
 				})
 
 				It("should not change the disabled version", func() {
-
 					config.Resources[0].Name = "disabled-resource"
 					config.Resources[0].OldName = "some-resource"
 					config.Jobs[0].PlanSequence = []atc.Step{
@@ -2399,10 +2388,11 @@ var _ = Describe("Team", func() {
 						},
 					}
 
-					pipeline, _, err = team.SavePipeline(pipelineRef, config, pipeline.ConfigVersion(), false)
-					Expect(err).ToNot(HaveOccurred())
+					scenario.Run(
+						builder.WithPipeline(config),
+					)
 
-					updatedResource, _, _ := pipeline.Resource("disabled-resource")
+					updatedResource := scenario.Resource("disabled-resource")
 					Expect(updatedResource.ID()).To(Equal(resource.ID()))
 
 					versions, _, found, err := updatedResource.Versions(db.Page{Limit: 3}, nil)
@@ -2415,47 +2405,23 @@ var _ = Describe("Team", func() {
 			})
 
 			Context("when new resource exists but the version is pinned", func() {
-				var pipeline db.Pipeline
+				var scenario *dbtest.Scenario
 				var resource db.Resource
-				var pinnedVersion atc.Version
-				var err error
 
 				BeforeEach(func() {
-					pipeline, _, err = team.SavePipeline(pipelineRef, config, 0, false)
-					Expect(err).ToNot(HaveOccurred())
+					scenario = dbtest.Setup(
+						builder.WithPipeline(config),
+						builder.WithBaseResourceType(dbConn, "some-type"),
+						builder.WithResourceVersions(
+							"some-resource",
+							atc.Version{"version": "v1"},
+							atc.Version{"version": "v2"},
+							atc.Version{"version": "v3"},
+						),
+						builder.WithPinnedVersion("some-resource", atc.Version{"version": "v1"}),
+					)
 
-					resource, _, _ = pipeline.Resource("some-resource")
-
-					setupTx, err := dbConn.Begin()
-					Expect(err).ToNot(HaveOccurred())
-
-					brt := db.BaseResourceType{
-						Name: "some-type",
-					}
-
-					_, err = brt.FindOrCreate(setupTx, false)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(setupTx.Commit()).To(Succeed())
-
-					resourceScope, err := resource.SetResourceConfig(atc.Source{"some": "other-repository"}, atc.VersionedResourceTypes{})
-					Expect(err).ToNot(HaveOccurred())
-
-					err = resourceScope.SaveVersions(nil, []atc.Version{
-						{"version": "v1"},
-						{"version": "v2"},
-						{"version": "v3"},
-					})
-					Expect(err).ToNot(HaveOccurred())
-
-					pinnedVersion = atc.Version{"version": "v1"}
-					resConf, found, err := resourceScope.FindVersion(pinnedVersion)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(found).To(BeTrue())
-					resID := resConf.ID()
-
-					found, err = resource.PinVersion(resID)
-					Expect(found).To(BeTrue())
-					Expect(err).ToNot(HaveOccurred())
+					resource = scenario.Resource("some-resource")
 				})
 
 				It("should not change the pinned version", func() {
@@ -2475,12 +2441,13 @@ var _ = Describe("Team", func() {
 						},
 					}
 
-					updatedPipeline, _, err := team.SavePipeline(pipelineRef, config, pipeline.ConfigVersion(), false)
-					Expect(err).ToNot(HaveOccurred())
+					scenario.Run(
+						builder.WithPipeline(config),
+					)
 
-					updatedResource, _, _ := updatedPipeline.Resource("pinned-resource")
+					updatedResource := scenario.Resource("pinned-resource")
 					Expect(updatedResource.ID()).To(Equal(resource.ID()))
-					Expect(updatedResource.APIPinnedVersion()).To(Equal(pinnedVersion))
+					Expect(updatedResource.APIPinnedVersion()).To(Equal(atc.Version{"version": "v1"}))
 				})
 			})
 		})
@@ -3459,22 +3426,48 @@ var _ = Describe("Team", func() {
 	Describe("IsContainerWithinTeam", func() {
 		Context("when the container is a check container", func() {
 			var resourceContainer db.Container
+			var scenario *dbtest.Scenario
+
 			expiries := db.ContainerOwnerExpiries{
 				Min: 5 * time.Minute,
 				Max: 1 * time.Hour,
 			}
 
 			BeforeEach(func() {
-				resourceConfigScope, err := defaultResource.SetResourceConfig(
-					defaultResource.Source(),
-					atc.VersionedResourceTypes{},
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+							},
+						},
+						Resources: atc.ResourceConfigs{
+							{
+								Name: "some-resource",
+								Type: "some-base-resource-type",
+								Source: atc.Source{
+									"some": "source",
+								},
+							},
+						},
+					}),
+					builder.WithWorker(atc.Worker{
+						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+						Name:            "some-default-worker",
+						GardenAddr:      "3.4.5.6:7777",
+						BaggageclaimURL: "7.8.9.10:7878",
+					}),
+					builder.WithResourceVersions("some-resource"),
 				)
-				Expect(err).ToNot(HaveOccurred())
 
-				resourceContainer, err = defaultWorker.CreateContainer(
+				rc, found, err := resourceConfigFactory.FindResourceConfigByID(scenario.Resource("some-resource").ResourceConfigID())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+
+				resourceContainer, err = scenario.Workers[0].CreateContainer(
 					db.NewResourceConfigCheckSessionContainerOwner(
-						resourceConfigScope.ResourceConfig().ID(),
-						resourceConfigScope.ResourceConfig().OriginBaseResourceType().ID,
+						rc.ID(),
+						rc.OriginBaseResourceType().ID,
 						expiries,
 					),
 					db.ContainerMetadata{},
@@ -3487,7 +3480,7 @@ var _ = Describe("Team", func() {
 
 				BeforeEach(func() {
 					var err error
-					ok, err = defaultTeam.IsContainerWithinTeam(resourceContainer.Handle(), true)
+					ok, err = scenario.Team.IsContainerWithinTeam(resourceContainer.Handle(), true)
 					Expect(err).ToNot(HaveOccurred())
 				})
 
@@ -3513,16 +3506,24 @@ var _ = Describe("Team", func() {
 
 		Context("when the container is owned by a team", func() {
 			var createdContainer db.Container
+			var scenario *dbtest.Scenario
 
 			BeforeEach(func() {
-				job, found, err := defaultPipeline.Job("some-job")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+							},
+						},
+					}),
+					builder.WithBaseWorker(),
+				)
 
-				build, err := job.CreateBuild()
+				build, err := scenario.Job("some-job").CreateBuild()
 				Expect(err).ToNot(HaveOccurred())
 
-				creatingContainer, err := defaultWorker.CreateContainer(db.NewBuildStepContainerOwner(build.ID(), atc.PlanID("some-job"), defaultTeam.ID()), db.ContainerMetadata{Type: "task", StepName: "some-task"})
+				creatingContainer, err := scenario.Workers[0].CreateContainer(db.NewBuildStepContainerOwner(build.ID(), atc.PlanID("some-job"), scenario.Team.ID()), db.ContainerMetadata{Type: "task", StepName: "some-task"})
 				Expect(err).ToNot(HaveOccurred())
 
 				createdContainer, err = creatingContainer.Created()
@@ -3534,7 +3535,7 @@ var _ = Describe("Team", func() {
 
 				BeforeEach(func() {
 					var err error
-					ok, err = defaultTeam.IsContainerWithinTeam(createdContainer.Handle(), false)
+					ok, err = scenario.Team.IsContainerWithinTeam(createdContainer.Handle(), false)
 					Expect(err).ToNot(HaveOccurred())
 				})
 

--- a/atc/db/versions_db_test.go
+++ b/atc/db/versions_db_test.go
@@ -732,7 +732,7 @@ var _ = Describe("VersionsDB", func() {
 
 	Describe("FindVersionOfResource", func() {
 		var (
-			scenario     dbtest.Scenario
+			scenario     *dbtest.Scenario
 			queryVersion atc.Version
 
 			resourceVersion db.ResourceVersion
@@ -758,10 +758,7 @@ var _ = Describe("VersionsDB", func() {
 				dbVersion = atc.Version{"tag": "v1", "commit": "v2"}
 
 				scenario = dbtest.Setup(
-					builder.WithResourceVersions(
-						"some-resource",
-						dbVersion,
-					),
+					builder.WithResourceVersions("some-resource", dbVersion),
 				)
 
 				queryVersion = atc.Version{"tag": "v1"}

--- a/atc/db/worker_factory_test.go
+++ b/atc/db/worker_factory_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbfakes"
+	"github.com/concourse/concourse/atc/db/dbtest"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -558,101 +559,87 @@ var _ = Describe("WorkerFactory", func() {
 		Context("when there are check containers", func() {
 			Context("when there are multiple of the same containers on the global, team and tagged worker", func() {
 				var (
-					owner        db.ContainerOwner
-					taggedWorker db.Worker
-					teamWorker   db.Worker
+					scenario *dbtest.Scenario
 				)
 
 				BeforeEach(func() {
-					ownerExpiries := db.ContainerOwnerExpiries{
-						Min: 5 * time.Minute,
-						Max: 5 * time.Minute,
-					}
-
-					var err error
-					otherPipeline, _, err := defaultTeam.SavePipeline(atc.PipelineRef{Name: "other-pipeline"}, atc.Config{
-						Resources: atc.ResourceConfigs{
-							{
-								Name: "some-resource",
-								Type: "some-base-resource-type",
-								Source: atc.Source{
-									"some": "source",
+					scenario = dbtest.Setup(
+						builder.WithPipeline(atc.Config{
+							Resources: atc.ResourceConfigs{
+								{
+									Name: "some-resource",
+									Type: "some-base-resource-type",
+									Source: atc.Source{
+										"some": "source",
+									},
 								},
 							},
-						},
-					}, db.ConfigVersion(0), false)
-					Expect(err).NotTo(HaveOccurred())
-
-					taggedWorkerSpec := atc.Worker{
-						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
-						GardenAddr:      "some-tagged-garden-addr",
-						BaggageclaimURL: "some-tagged-bc-url",
-						Name:            "some-tagged-name",
-						Tags:            []string{"some-tag"},
-					}
-
-					taggedWorker, err = workerFactory.SaveWorker(taggedWorkerSpec, 5*time.Minute)
-					Expect(err).NotTo(HaveOccurred())
-
-					teamWorkerSpec := atc.Worker{
-						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
-						GardenAddr:      "some-team-garden-addr",
-						BaggageclaimURL: "some-team-bc-url",
-						Name:            "some-team-name",
-						Team:            "default-team",
-					}
-
-					teamWorker, err = defaultTeam.SaveWorker(teamWorkerSpec, 5*time.Minute)
-					Expect(err).NotTo(HaveOccurred())
-
-					otherWorkerSpec := atc.Worker{
-						ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
-						GardenAddr:      "some-other-garden-addr",
-						BaggageclaimURL: "some-other-bc-url",
-						Name:            "some-other-name",
-					}
-
-					_, err = workerFactory.SaveWorker(otherWorkerSpec, 5*time.Minute)
-					Expect(err).NotTo(HaveOccurred())
-
-					containerMetadata = db.ContainerMetadata{
-						Type: "check",
-					}
-
-					otherResource, found, err := otherPipeline.Resource("some-resource")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(found).To(BeTrue())
-
-					rcs, err := otherResource.SetResourceConfig(atc.Source{"some": "source"}, atc.VersionedResourceTypes{})
-					Expect(err).NotTo(HaveOccurred())
-
-					owner = db.NewResourceConfigCheckSessionContainerOwner(
-						rcs.ResourceConfig().ID(),
-						rcs.ResourceConfig().OriginBaseResourceType().ID,
-						ownerExpiries,
+						}),
+						builder.WithWorker(atc.Worker{
+							ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+							GardenAddr:      "some-tagged-garden-addr",
+							BaggageclaimURL: "some-tagged-bc-url",
+							Name:            "some-tagged-name",
+							Tags:            []string{"some-tag"},
+						}),
+						builder.WithWorker(atc.Worker{
+							ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+							GardenAddr:      "some-team-garden-addr",
+							BaggageclaimURL: "some-team-bc-url",
+							Name:            "some-team-name",
+							Team:            "default-team",
+						}),
+						builder.WithWorker(atc.Worker{
+							ResourceTypes:   []atc.WorkerResourceType{defaultWorkerResourceType},
+							GardenAddr:      "some-other-garden-addr",
+							BaggageclaimURL: "some-other-bc-url",
+							Name:            "some-other-name",
+						}),
+						builder.WithResourceVersions(
+							"some-resource",
+						),
+						builder.WithCheckContainer(
+							"some-resource",
+							"some-other-name",
+						),
+						builder.WithCheckContainer(
+							"some-resource",
+							"some-tagged-name",
+						),
+						builder.WithCheckContainer(
+							"some-resource",
+							"some-team-name",
+						),
 					)
-
-					_, err = defaultWorker.CreateContainer(owner, containerMetadata)
-					Expect(err).ToNot(HaveOccurred())
-
-					_, err = taggedWorker.CreateContainer(owner, containerMetadata)
-					Expect(err).ToNot(HaveOccurred())
-
-					_, err = teamWorker.CreateContainer(owner, containerMetadata)
-					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("should find all the workers that have the same container", func() {
+					resource, found, err := scenario.Pipeline.Resource("some-resource")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue(), "resource '%s' not found", "some-resource")
+
+					rc, found, err := resourceConfigFactory.FindResourceConfigByID(resource.ResourceConfigID())
+					Expect(err).ToNot(HaveOccurred())
+					Expect(found).To(BeTrue(), "resource config '%s' not found", rc.ID())
+
+					owner := db.NewResourceConfigCheckSessionContainerOwner(
+						rc.ID(),
+						rc.OriginBaseResourceType().ID,
+						db.ContainerOwnerExpiries{
+							Min: 5 * time.Minute,
+							Max: 5 * time.Minute,
+						},
+					)
+
 					workers, err := workerFactory.FindWorkersForContainerByOwner(owner)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(workers).To(HaveLen(3))
 
 					var workerNames []string
 					for _, w := range workers {
 						workerNames = append(workerNames, w.Name())
 					}
 
-					Expect(workerNames).To(ConsistOf([]string{defaultWorker.Name(), taggedWorker.Name(), teamWorker.Name()}))
+					Expect(workerNames).To(ConsistOf([]string{"some-other-name", "some-tagged-name", "some-team-name"}))
 				})
 			})
 		})

--- a/atc/gc/gc_suite_test.go
+++ b/atc/gc/gc_suite_test.go
@@ -12,6 +12,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/postgresrunner"
 	. "github.com/onsi/ginkgo"
@@ -54,8 +55,11 @@ var (
 
 	usedResource     db.Resource
 	usedResourceType db.ResourceType
-	logger           *lagertest.TestLogger
-	fakeLogFunc      = func(logger lager.Logger, id lock.LockID) {}
+
+	builder dbtest.Builder
+
+	logger      *lagertest.TestLogger
+	fakeLogFunc = func(logger lager.Logger, id lock.LockID) {}
 )
 
 var _ = BeforeSuite(func() {
@@ -74,6 +78,8 @@ var _ = BeforeEach(func() {
 	dbConn = postgresRunner.OpenConn()
 
 	lockFactory = lock.NewLockFactory(postgresRunner.OpenSingleton(), fakeLogFunc, fakeLogFunc)
+
+	builder = dbtest.NewBuilder(dbConn, lockFactory)
 
 	teamFactory = db.NewTeamFactory(dbConn, lockFactory)
 	buildFactory = db.NewBuildFactory(dbConn, lockFactory, 0, time.Hour)

--- a/atc/gc/resource_cache_collector_test.go
+++ b/atc/gc/resource_cache_collector_test.go
@@ -7,6 +7,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/atc/gc"
 
 	. "github.com/onsi/ginkgo"
@@ -32,12 +33,33 @@ var _ = Describe("ResourceCacheCollector", func() {
 			var oneOffCache db.UsedResourceCache
 			var jobCache db.UsedResourceCache
 
-			var resource db.Resource
+			var scenario *dbtest.Scenario
 
 			BeforeEach(func() {
 				resourceCacheUseCollector = gc.NewResourceCacheUseCollector(resourceCacheLifecycle)
 
-				oneOffBuild, err = defaultTeam.CreateOneOffBuild()
+				scenario = dbtest.Setup(
+					builder.WithPipeline(atc.Config{
+						Resources: atc.ResourceConfigs{
+							{
+								Name:   "some-resource",
+								Type:   "some-base-type",
+								Source: atc.Source{"some": "source"},
+							},
+						},
+						Jobs: atc.JobConfigs{
+							{
+								Name: "some-job",
+							},
+							{
+								Name: "some-other-job",
+							},
+						},
+					}),
+					builder.WithResourceVersions("some-resource"),
+				)
+
+				oneOffBuild, err = scenario.Team.CreateOneOffBuild()
 				Expect(err).ToNot(HaveOccurred())
 
 				oneOffCache, err = resourceCacheFactory.FindOrCreateResourceCache(
@@ -52,7 +74,7 @@ var _ = Describe("ResourceCacheCollector", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				jobBuild, err = defaultJob.CreateBuild()
+				jobBuild, err = scenario.Job("some-job").CreateBuild()
 				Expect(err).ToNot(HaveOccurred())
 
 				jobCache, err = resourceCacheFactory.FindOrCreateResourceCache(
@@ -66,18 +88,6 @@ var _ = Describe("ResourceCacheCollector", func() {
 					atc.VersionedResourceTypes{},
 				)
 				Expect(err).NotTo(HaveOccurred())
-
-				var found bool
-				resource, found, err = defaultPipeline.Resource("some-resource")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-
-				_, err = resource.SetResourceConfig(
-					atc.Source{
-						"some": "source",
-					},
-					atc.VersionedResourceTypes{})
-				Expect(err).ToNot(HaveOccurred())
 			})
 
 			resourceCacheExists := func(resourceCache db.UsedResourceCache) bool {
@@ -123,12 +133,12 @@ var _ = Describe("ResourceCacheCollector", func() {
 							RunWith(dbConn).QueryRow().Scan(&versionMD5)
 						Expect(err).NotTo(HaveOccurred())
 
-						Expect(defaultJob.SaveNextInputMapping(db.InputMapping{
+						Expect(scenario.Job("some-job").SaveNextInputMapping(db.InputMapping{
 							"whatever": db.InputResult{
 								Input: &db.AlgorithmInput{
 									AlgorithmVersion: db.AlgorithmVersion{
 										Version:    db.ResourceVersion(versionMD5),
-										ResourceID: resource.ID(),
+										ResourceID: scenario.Resource("some-resource").ID(),
 									},
 								},
 							},
@@ -137,7 +147,7 @@ var _ = Describe("ResourceCacheCollector", func() {
 
 					Context("when pipeline is paused", func() {
 						BeforeEach(func() {
-							err := defaultPipeline.Pause()
+							err := scenario.Pipeline.Pause()
 							Expect(err).NotTo(HaveOccurred())
 						})
 
@@ -168,7 +178,7 @@ var _ = Describe("ResourceCacheCollector", func() {
 						var secondJobCache db.UsedResourceCache
 
 						BeforeEach(func() {
-							secondJobBuild, err = defaultJob.CreateBuild()
+							secondJobBuild, err = scenario.Job("some-job").CreateBuild()
 							Expect(err).ToNot(HaveOccurred())
 
 							secondJobCache, err = resourceCacheFactory.FindOrCreateResourceCache(
@@ -214,11 +224,7 @@ var _ = Describe("ResourceCacheCollector", func() {
 						var secondJobCache db.UsedResourceCache
 
 						BeforeEach(func() {
-							secondJob, found, err := defaultPipeline.Job("some-other-job")
-							Expect(err).NotTo(HaveOccurred())
-							Expect(found).To(BeTrue())
-
-							secondJobBuild, err = secondJob.CreateBuild()
+							secondJobBuild, err = scenario.Job("some-other-job").CreateBuild()
 							Expect(err).ToNot(HaveOccurred())
 
 							secondJobCache, err = resourceCacheFactory.FindOrCreateResourceCache(

--- a/atc/gc/resource_config_collector_test.go
+++ b/atc/gc/resource_config_collector_test.go
@@ -8,6 +8,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/atc/gc"
 
 	. "github.com/onsi/ginkgo"
@@ -137,11 +138,18 @@ var _ = Describe("ResourceConfigCollector", func() {
 
 			Context("when config is referenced in resources", func() {
 				BeforeEach(func() {
-					_, err := usedResource.SetResourceConfig(
-						atc.Source{"some": "source"},
-						atc.VersionedResourceTypes{},
+					dbtest.Setup(
+						builder.WithPipeline(atc.Config{
+							Resources: atc.ResourceConfigs{
+								{
+									Name:   "some-resource",
+									Type:   "some-base-type",
+									Source: atc.Source{"some": "source"},
+								},
+							},
+						}),
+						builder.WithResourceVersions("some-resource"),
 					)
-					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("preserve the config", func() {
@@ -187,11 +195,18 @@ var _ = Describe("ResourceConfigCollector", func() {
 
 			Context("when config is referenced in resource types", func() {
 				BeforeEach(func() {
-					_, err := usedResourceType.SetResourceConfig(
-						atc.Source{"some": "source-type"},
-						atc.VersionedResourceTypes{},
+					dbtest.Setup(
+						builder.WithPipeline(atc.Config{
+							ResourceTypes: atc.ResourceTypes{
+								{
+									Name:   "some-resource-type",
+									Type:   "some-base-type",
+									Source: atc.Source{"some": "source-type"},
+								},
+							},
+						}),
+						builder.WithResourceTypeVersions("some-resource-type"),
 					)
-					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("preserve the config", func() {


### PR DESCRIPTION
## What does this PR accomplish?

This PR introduces an `atc/db/dbtest` package for setting up test scenarios using higher-level (i.e. more stable) constructs. The aim of this pattern is to reduce the amount of churn whenever we make changes to how we model the internals, and also to reduce the amount of global test suite setup we've got going in under `atc/db`, primarily in `db_suite_test.go`.

## Changes proposed by this PR:

* Introduce `dbtest.Builder` which provides higher-level methods (e.g. `WithPipeline`, `WithResourceVersions`) for constructing a `dbtest.Scenario`.
* Convert all tests which used to use `(db.Resource).SetResourceConfig` to use `dbtest` instead.
* Removes `(db.Resource).SetResourceConfig`, as it's no longer used in production code, and with this PR, no longer used in tests.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
