### PR TITLE
Preserve whitespace within build output

### DIFF
--- a/web/assets/css/build.less
+++ b/web/assets/css/build.less
@@ -47,7 +47,7 @@
 }
 
 .timestamped-logs {
-  white-space: pre-line;
+  white-space: break-spaces;
 }
 
 .timestamped-line {


### PR DESCRIPTION
## What does this PR accomplish?

The fix made for horizontal scrolling on build outputs #6083 caused whitespaces to be collapsed. Changing the property to `break-spaces` will keep the original fix of preventing horizontal scrolling but also preserving whitespaces. This will result in trailing whitespace being wrapped rather than trimmed. Maybe we can possibly trim it instead?

Bug Fix

closes #6149 .

## Changes proposed by this PR:
Change the property to `break-spaces`.

## Notes to reviewer:
How to reproduce:
1. Run `docker-compose up --build -d` and `yarn build` without this fix
1. Set a following pipeline that will output text formatted as a table:
```
---
jobs:
- name: hello
  plan:
    - task:
      config:
        platform: linux
        image_resource:
          type: registry-image
          source: {repository: ubuntu}
        run:
          path: sh
          args:
            - -c
            - |
              apt-get update -y
              apt-get install bsdmainutils -y
              mount | column -t
```
1. Run the pipeline and you should see that the whitespace in the table output is collapsed.
1. Add the fix back and run `yarn build`
1. If you take a look at the same build output, the whitespace should be preserved.

**NOTE**: `break-spaces` is not supported by older versions of web browsers. This might be something to keep a note of. The following link should show all the versions that support/do not support that property. https://caniuse.com/?search=white-space%3A%20break-spaces

**Possible future changes:** maybe we can trim trailing whitespace rather than wrapping it as it does right now.

## Release Note

- In v6.6.0, whitespace was collapsed in order to fix a bug with horizontal scrolling in the build output. This change will preserve all whitespace while also keeping the horizontal scrolling fix.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
