### PR TITLE
Check that a pipeline contains at least one job

### DIFF
--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -728,7 +728,18 @@ resource_types:
 - name: some-type
   type: some-base-resource-type
   source:
-    FOO: ((BAR))`
+    FOO: ((BAR))
+
+resources:
+- name: some-resource
+  type: some-type
+  source:
+    foo: bar
+
+jobs:
+- name: some-job
+  plan:
+  - get: some-resource`
 
 									request.Header.Set("Content-Type", "application/x-yaml")
 									request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))
@@ -1123,7 +1134,6 @@ jobs:
 							})
 						})
 					})
-
 
 				})
 

--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -730,16 +730,11 @@ resource_types:
   source:
     FOO: ((BAR))
 
-resources:
-- name: some-resource
-  type: some-type
-  source:
-    foo: bar
-
 jobs:
 - name: some-job
   plan:
-  - get: some-resource`
+  - task: some-task
+    file: some/task/config.yaml`
 
 									request.Header.Set("Content-Type", "application/x-yaml")
 									request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -255,7 +255,7 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 	names := map[string]int{}
 
 	if len(c.Jobs) == 0 {
-		errorMessages = append(errorMessages, "no jobs found. pipeline must contain at least one job")
+		errorMessages = append(errorMessages, "jobs: pipeline must contain at least one job")
 		return warnings, compositeErr(errorMessages)
 	}
 

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -254,6 +254,11 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 
 	names := map[string]int{}
 
+	if len(c.Jobs) == 0 {
+		errorMessages = append(errorMessages, "no jobs found. pipeline must contain at least one job")
+		return warnings, compositeErr(errorMessages)
+	}
+
 	for i, job := range c.Jobs {
 		var identifier string
 		if job.Name == "" {

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -2113,4 +2113,17 @@ var _ = Describe("ValidateConfig", func() {
 			})
 		})
 	})
+
+	Describe("invalid pipeline", func() {
+		Context("contains zero jobs", func() {
+			BeforeEach(func() {
+				config = atc.Config{}
+			})
+			It("is an invalid pipeline", func() {
+				Expect(errorMessages).To(HaveLen(1))
+				Expect(errorMessages[0]).To(ContainSubstring("no jobs found. pipeline must contain at least one job"))
+			})
+
+		})
+	})
 })

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -2121,7 +2121,7 @@ var _ = Describe("ValidateConfig", func() {
 			})
 			It("is an invalid pipeline", func() {
 				Expect(errorMessages).To(HaveLen(1))
-				Expect(errorMessages[0]).To(ContainSubstring("no jobs found. pipeline must contain at least one job"))
+				Expect(errorMessages[0]).To(ContainSubstring("pipeline must contain at least one job"))
 			})
 
 		})

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -254,18 +254,12 @@ jobs:
 				fakeWorkerClient.StreamFileFromArtifactReturns(&fakeReadCloser{str: badPipelineContentWithEmptyContent}, nil)
 			})
 
-			It("should not return error", func() {
+			It("should return an error", func() {
 				Expect(stepErr).NotTo(HaveOccurred())
 			})
 
-			It("should log no-diff", func() {
-				Expect(stdout).To(gbytes.Say("no diff found."))
-			})
-
-			It("should send a set pipeline changed event", func() {
-				Expect(fakeDelegate.SetPipelineChangedCallCount()).To(Equal(1))
-				_, changed := fakeDelegate.SetPipelineChangedArgsForCall(0)
-				Expect(changed).To(BeFalse())
+			It("should log an error message", func() {
+				Expect(stderr).To(gbytes.Say("pipeline must contain at least one job"))
 			})
 
 			It("should not update the job and build id", func() {
@@ -307,30 +301,6 @@ jobs:
 
 				It("should stdout have message", func() {
 					Expect(stdout).To(gbytes.Say("done"))
-				})
-
-				Context("when no diff is found", func() {
-					BeforeEach(func() {
-						fakeWorkerClient.StreamFileFromArtifactReturns(&fakeReadCloser{str: badPipelineContentWithEmptyContent}, nil)
-					})
-
-					It("should not return error", func() {
-						Expect(stepErr).NotTo(HaveOccurred())
-					})
-
-					It("should log no-diff", func() {
-						Expect(stdout).To(gbytes.Say("no diff found."))
-					})
-
-					It("should send a set pipeline changed event", func() {
-						Expect(fakeDelegate.SetPipelineChangedCallCount()).To(Equal(1))
-						_, changed := fakeDelegate.SetPipelineChangedArgsForCall(0)
-						Expect(changed).To(BeFalse())
-					})
-
-					It("should not update the job and build id", func() {
-						Expect(fakePipeline.SetParentIDsCallCount()).To(Equal(0))
-					})
 				})
 			})
 


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | Feature | Documentation | **Enhancement**

## Changes proposed by this PR:
From concourse/concourse#6111 we found that it was possible for any yaml
to pass pipeline validation and that ended up having some side-affects that
brought down the ATC. This commit will now ensure that any yaml someone
tries to pass off as a pipeline needs to contain at least one job. A
pipeline without a job is not very useful.

More context in this comment:
https://github.com/concourse/concourse/pull/6116#issuecomment-708449186

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
When validating a pipeline using the `confgivalidate` package, validation should ensure that at least one job is present in the pipeline. If no job is found than an error is returned.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
