### PR TITLE
set_pipeline prints 'no changes to apply'

### DIFF
--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -207,7 +207,7 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState, delegate S
 	if !diffExists {
 		logger.Debug("no-diff")
 
-		fmt.Fprintf(stdout, "no diff found.\n")
+		fmt.Fprintf(stdout, "no changes to apply.\n")
 
 		if found {
 			err := pipeline.SetParentIDs(step.metadata.JobID, step.metadata.BuildID)

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -316,8 +316,8 @@ jobs:
 						fakePipeline.SetParentIDsReturns(nil)
 					})
 
-					It("should log no-diff", func() {
-						Expect(stdout).To(gbytes.Say("no diff found."))
+					It("should log 'no changes to apply'", func() {
+						Expect(stdout).To(gbytes.Say("no changes to apply."))
 					})
 
 					It("should send a set pipeline changed event", func() {


### PR DESCRIPTION
## What does this PR accomplish?

closes #6162. `set_pipeline` of a pipeline YML config with no diff now reports "no changes to apply," which is consistent to `fly set-pipeline`'s behavior in the same scenario.

## Changes proposed by this PR:

`set_pipeline` of a pipeline YML config with no diff now reports "no changes to apply," which is consistent to `fly set-pipeline`'s behavior in the same scenario.

## Notes to reviewer:

While there may be a good way to DRY up the occurrence of the "no changes to apply" string -- which now occurs across two locations in source code -- this is the most simple, minimal change to make the messaging consistent.

## Release Note

`set_pipeline` now prints "no changes to apply" and thereby behaves similarly to `fly set-pipeline` when a pipeline config contains no changes.

## Contributor Checklist

- [X] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [X] [Signed] all commits
- [X] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
