### PR TITLE
fly: add --team option to expose-pipeline command

### DIFF
--- a/fly/commands/expose_pipeline.go
+++ b/fly/commands/expose_pipeline.go
@@ -6,10 +6,12 @@ import (
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 type ExposePipelineCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Pipeline to expose"`
+	Team     string                   `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *ExposePipelineCommand) Validate() error {
@@ -33,8 +35,19 @@ func (command *ExposePipelineCommand) Execute(args []string) error {
 		return err
 	}
 
+	var team concourse.Team
+
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team)
+		if err != nil {
+			return err
+		}
+	} else {
+		team = target.Team()
+	}
+
 	pipelineRef := command.Pipeline.Ref()
-	found, err := target.Team().ExposePipeline(pipelineRef)
+	found, err := team.ExposePipeline(pipelineRef)
 	if err != nil {
 		return err
 	}

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"net/http"
 	"os/exec"
 
@@ -90,11 +91,13 @@ var _ = Describe("Fly CLI", func() {
 	})
 
 	Context("when --team is set", func() {
+		nonExistentTeam := "doesnotexist"
+		otherTeam := "other-team"
 		DescribeTable("and the team does not exist",
 			func(flyCmd *exec.Cmd) {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/teams/doesnotexist"),
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", nonExistentTeam)),
 						ghttp.RespondWith(http.StatusNotFound, nil),
 					),
 				)
@@ -105,36 +108,38 @@ var _ = Describe("Fly CLI", func() {
 				Eventually(sess.Err.Contents).Should(ContainSubstring(`error: team 'doesnotexist' does not exist`))
 			},
 			Entry("trigger-job command returns an error",
-				exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", nonExistentTeam)),
+			Entry("expose-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "expose-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("hide-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "hide-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "hide-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("hijack command returns an error",
-				exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", nonExistentTeam)),
 			Entry("jobs command returns an error",
-				exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("pause-job command returns an error",
-				exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", nonExistentTeam)),
 			Entry("pause-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "pause-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "pause-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("unpause-job command returns an error",
-				exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", nonExistentTeam)),
 			Entry("unpause-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "unpause-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "unpause-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("set-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", nonExistentTeam)),
 			Entry("destroy-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("get-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("order-pipelines command returns an error",
-				exec.Command(flyPath, "-t", targetName, "order-pipelines", "-p", "pipeline", "--team", "doesnotexist")),
+				exec.Command(flyPath, "-t", targetName, "order-pipelines", "-p", "pipeline", "--team", nonExistentTeam)),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
 			func(flyCmd *exec.Cmd) {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", otherTeam)),
 						ghttp.RespondWith(http.StatusForbidden, nil),
 					),
 				)
@@ -145,27 +150,29 @@ var _ = Describe("Fly CLI", func() {
 				Eventually(sess.Err.Contents).Should(ContainSubstring(`error: you do not have a role on team 'other-team'`))
 			},
 			Entry("trigger-job command returns an error",
-				exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", otherTeam)),
+			Entry("expose-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "expose-pipeline", "-p", "pipeline", "--team", otherTeam)),
 			Entry("hide-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "hide-pipeline", "-p", "pipeline", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "hide-pipeline", "-p", "pipeline", "--team", otherTeam)),
 			Entry("hijack command returns an error",
-				exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "hijack", "--handle", "container-id", "--team", otherTeam)),
 			Entry("jobs command returns an error",
-				exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "jobs", "-p", "pipeline", "--team", otherTeam)),
 			Entry("pause-job command returns an error",
-				exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "pause-job", "-j", "pipeline/job", "--team", otherTeam)),
 			Entry("pause-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "pause-pipeline", "-p", "pipeline", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "pause-pipeline", "-p", "pipeline", "--team", otherTeam)),
 			Entry("unpause-job command returns an error",
-				exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", "pipeline/job", "--team", otherTeam)),
 			Entry("unpause-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "unpause-pipeline", "-p", "pipeline", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "unpause-pipeline", "-p", "pipeline", "--team", otherTeam)),
 			Entry("set-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", otherTeam)),
 			Entry("destroy-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", otherTeam)),
 			Entry("get-pipeline command returns an error",
-				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", "other-team")),
+				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", otherTeam)),
 		)
 	})
 })


### PR DESCRIPTION
Allows fly cli to expose pipeline for different
team without having to switch targets

concourse/concourse#5215

Signed-off-by: techgaun <coolsamar207@gmail.com>

## What does this PR accomplish?

Feature

references #5215 .

## Changes proposed by this PR:

Allows fly cli to expose pipeline for different
team without having to switch targets

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
