### PR TITLE
Use dot notation in instanced pipelines API

### DIFF
--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -267,7 +267,7 @@ var _ = Describe("cc.xml", func() {
 
 				Context("when an instanced pipeline is found", func() {
 					var fakePipeline *dbfakes.FakePipeline
-					instanceVars := atc.InstanceVars{"hello": "world"}
+					instanceVars := atc.InstanceVars{"branch": "feature/foo"}
 					BeforeEach(func() {
 						fakePipeline = new(dbfakes.FakePipeline)
 						fakePipeline.InstanceVarsReturns(instanceVars)
@@ -297,7 +297,7 @@ var _ = Describe("cc.xml", func() {
 
 						Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else/hello:world/some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job?var.hello=%22world%22"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else/branch:&#34;feature/foo&#34;/some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job?var.branch=%22feature%2Ffoo%22"/>
 </Projects>
 `))
 					})

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -297,7 +297,7 @@ var _ = Describe("cc.xml", func() {
 
 						Expect(body).To(MatchXML(`
 <Projects>
-  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else/branch:&#34;feature/foo&#34;/some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job?var.branch=%22feature%2Ffoo%22"/>
+  <Project activity="Sleeping" lastBuildLabel="42" lastBuildStatus="Success" lastBuildTime="2018-11-04T21:26:38Z" name="something-else/branch:&#34;feature/foo&#34;/some-job" webUrl="https://example.com/teams/a-team/pipelines/something-else/jobs/some-job?vars.branch=%22feature%2Ffoo%22"/>
 </Projects>
 `))
 					})

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -110,17 +110,17 @@ func (s *Server) buildProject(j atc.JobSummary) Project {
 		LastBuildStatus: lastBuildStatus,
 		LastBuildTime:   time.Unix(j.FinishedBuild.EndTime, 0).UTC().Format(time.RFC3339),
 		Name:            fmt.Sprintf("%s/%s", pipelineRef.String(), j.Name),
-		WebUrl:          s.createWebUrl(j.TeamName, j.Name, pipelineRef),
+		WebUrl:          s.createWebUrl(j.TeamName, pipelineRef, j.Name),
 	}
 }
 
-func (s *Server) createWebUrl(teamName, jobName string, pipelineRef atc.PipelineRef) string {
+func (s *Server) createWebUrl(teamName string, pipelineRef atc.PipelineRef, jobName string) string {
 	externalURL, err := url.Parse(s.externalURL)
 	if err != nil {
 		fmt.Println("Could not parse externalURL")
 	}
 
-	queryParams := pipelineRef.QueryParams().Encode()
+	queryParams := pipelineRef.WebQueryParams().Encode()
 	if queryParams != "" {
 		queryParams = "?" + queryParams
 	}

--- a/atc/api/ccserver/get.go
+++ b/atc/api/ccserver/get.go
@@ -120,7 +120,7 @@ func (s *Server) createWebUrl(teamName string, pipelineRef atc.PipelineRef, jobN
 		fmt.Println("Could not parse externalURL")
 	}
 
-	queryParams := pipelineRef.WebQueryParams().Encode()
+	queryParams := pipelineRef.QueryParams().Encode()
 	if queryParams != "" {
 		queryParams = "?" + queryParams
 	}

--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Config API", func() {
 						Context("when instance vars are malformed", func() {
 							BeforeEach(func() {
 								query := request.URL.Query()
-								query.Add("instance_vars", "{")
+								query.Add("vars.branch", "{")
 								request.URL.RawQuery = query.Encode()
 							})
 
@@ -193,7 +193,7 @@ var _ = Describe("Config API", func() {
 								Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 										{
 											"errors": [
-												"instance_vars is malformed: unexpected end of JSON input"
+												"instance vars are malformed: unexpected end of JSON input"
 											]
 										}`))
 							})
@@ -206,7 +206,7 @@ var _ = Describe("Config API", func() {
 						Context("when instance vars is valid", func() {
 							BeforeEach(func() {
 								query := request.URL.Query()
-								query.Add("instance_vars", "{\"branch\":\"feature\"}")
+								query.Add("vars.branch", `"feature"`)
 								request.URL.RawQuery = query.Encode()
 
 								fakePipeline.InstanceVarsReturns(atc.InstanceVars{"branch": "feature"})
@@ -1050,7 +1050,7 @@ jobs:
 							Context("when instance vars are malformed", func() {
 								BeforeEach(func() {
 									query := request.URL.Query()
-									query.Add("instance_vars", "{")
+									query.Add("vars.foo", "{")
 									request.URL.RawQuery = query.Encode()
 								})
 
@@ -1069,7 +1069,7 @@ jobs:
 									Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 										{
 											"errors": [
-												"instance_vars is malformed: unexpected end of JSON input"
+												"instance vars are malformed: unexpected end of JSON input"
 											]
 										}`))
 								})
@@ -1082,7 +1082,7 @@ jobs:
 							Context("when instance vars is valid", func() {
 								BeforeEach(func() {
 									query := request.URL.Query()
-									query.Add("instance_vars", "{\"branch\":\"feature\"}")
+									query.Add("vars", "{\"branch\":\"feature\"}")
 									request.URL.RawQuery = query.Encode()
 								})
 

--- a/atc/api/configserver/get.go
+++ b/atc/api/configserver/get.go
@@ -16,13 +16,12 @@ func (s *Server) GetConfig(w http.ResponseWriter, r *http.Request) {
 	teamName := rata.Param(r, "team_name")
 	pipelineName := rata.Param(r, "pipeline_name")
 	pipelineRef := atc.PipelineRef{Name: pipelineName}
-	if instanceVars := r.URL.Query().Get("instance_vars"); instanceVars != "" {
-		err := json.Unmarshal([]byte(instanceVars), &pipelineRef.InstanceVars)
-		if err != nil {
-			logger.Error("malformed-instance-vars", err)
-			s.handleBadRequest(w, fmt.Sprintf("instance_vars is malformed: %s", err))
-			return
-		}
+	var err error
+	pipelineRef.InstanceVars, err = atc.InstanceVarsFromQueryParams(r.URL.Query())
+	if err != nil {
+		logger.Error("malformed-instance-vars", err)
+		s.handleBadRequest(w, fmt.Sprintf("instance vars are malformed: %v", err))
+		return
 	}
 
 	team, found, err := s.teamFactory.FindTeam(teamName)

--- a/atc/api/containers_test.go
+++ b/atc/api/containers_test.go
@@ -232,6 +232,24 @@ var _ = Describe("Containers API", func() {
 				})
 			})
 
+			Describe("querying with pipeline instance vars", func() {
+				BeforeEach(func() {
+					req.URL.RawQuery = url.Values{
+						"vars": []string{`{"branch":"master"}`},
+					}.Encode()
+				})
+
+				It("queries with it in the metadata", func() {
+					_, err := client.Do(req)
+					Expect(err).NotTo(HaveOccurred())
+
+					meta := dbTeam.FindContainersByMetadataArgsForCall(0)
+					Expect(meta).To(Equal(db.ContainerMetadata{
+						PipelineInstanceVars: `{"branch":"master"}`,
+					}))
+				})
+			})
+
 			Describe("querying with job id", func() {
 				BeforeEach(func() {
 					req.URL.RawQuery = url.Values{

--- a/atc/api/containers_test.go
+++ b/atc/api/containers_test.go
@@ -355,7 +355,7 @@ var _ = Describe("Containers API", func() {
 						"type":          []string{"check"},
 						"resource_name": []string{"some-resource"},
 						"pipeline_name": []string{"some-pipeline"},
-						"instance_vars": []string{string(rawInstanceVars)},
+						"vars":          []string{string(rawInstanceVars)},
 					}.Encode()
 				})
 

--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -1425,8 +1425,8 @@ var _ = Describe("Jobs API", func() {
 							It("returns Link headers per rfc5988", func() {
 								link := fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/builds?`, externalURL)
 								Expect(response.Header["Link"]).To(ConsistOf([]string{
-									link + `from=4&limit=2&instance_vars=%7B%22branch%22%3A%22master%22%7D>; rel="previous"`,
-									link + `to=2&limit=2&instance_vars=%7B%22branch%22%3A%22master%22%7D>; rel="next"`,
+									link + `from=4&limit=2&vars.branch=%22master%22>; rel="previous"`,
+									link + `to=2&limit=2&vars.branch=%22master%22>; rel="next"`,
 								}))
 							})
 						})

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1838,8 +1838,8 @@ var _ = Describe("Pipelines API", func() {
 						It("returns Link headers per rfc5988", func() {
 							link := fmt.Sprintf(`<%s/api/v1/teams/some-team/pipelines/some-pipeline/builds?`, externalURL)
 							Expect(response.Header["Link"]).To(ConsistOf([]string{
-								link + `to=2&limit=2&instance_vars=%7B%22branch%22%3A%22master%22%7D>; rel="next"`,
-								link + `from=4&limit=2&instance_vars=%7B%22branch%22%3A%22master%22%7D>; rel="previous"`,
+								link + `to=2&limit=2&vars.branch=%22master%22>; rel="next"`,
+								link + `from=4&limit=2&vars.branch=%22master%22>; rel="previous"`,
 							}))
 						})
 					})

--- a/atc/api/pipelineserver/reject_archived_handler_factory.go
+++ b/atc/api/pipelineserver/reject_archived_handler_factory.go
@@ -1,7 +1,6 @@
 package pipelineserver
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/concourse/concourse/atc"
@@ -34,12 +33,11 @@ func (ra RejectArchivedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	teamName := r.FormValue(":team_name")
 	pipelineName := r.FormValue(":pipeline_name")
 	pipelineRef := atc.PipelineRef{Name: pipelineName}
-	if instanceVars := r.URL.Query().Get("instance_vars"); instanceVars != "" {
-		err := json.Unmarshal([]byte(instanceVars), &pipelineRef.InstanceVars)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
+	var err error
+	pipelineRef.InstanceVars, err = atc.InstanceVarsFromQueryParams(r.URL.Query())
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
 	}
 
 	team, found, err := ra.teamFactory.FindTeam(teamName)

--- a/atc/api/pipelineserver/scoped_handler_factory.go
+++ b/atc/api/pipelineserver/scoped_handler_factory.go
@@ -1,7 +1,6 @@
 package pipelineserver
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/concourse/concourse/atc"
@@ -26,12 +25,11 @@ func (pdbh *ScopedHandlerFactory) HandlerFor(pipelineScopedHandler func(db.Pipel
 		teamName := r.FormValue(":team_name")
 		pipelineName := r.FormValue(":pipeline_name")
 		pipelineRef := atc.PipelineRef{Name: pipelineName}
-		if instanceVars := r.URL.Query().Get("instance_vars"); instanceVars != "" {
-			err := json.Unmarshal([]byte(instanceVars), &pipelineRef.InstanceVars)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
+		var err error
+		pipelineRef.InstanceVars, err = atc.InstanceVarsFromQueryParams(r.URL.Query())
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 
 		pipeline, ok := r.Context().Value(auth.PipelineContextKey).(db.Pipeline)

--- a/atc/api/versions_test.go
+++ b/atc/api/versions_test.go
@@ -420,8 +420,8 @@ var _ = Describe("Versions API", func() {
 							It("returns Link headers per rfc5988", func() {
 								link := fmt.Sprintf(`<%s/api/v1/teams/a-team/pipelines/some-pipeline/resources/some-resource/versions?`, externalURL)
 								Expect(response.Header["Link"]).To(ConsistOf([]string{
-									link + `to=2&limit=2&instance_vars=%7B%22branch%22%3A%22master%22%7D>; rel="next"`,
-									link + `from=4&limit=2&instance_vars=%7B%22branch%22%3A%22master%22%7D>; rel="previous"`,
+									link + `to=2&limit=2&vars.branch=%22master%22>; rel="next"`,
+									link + `from=4&limit=2&vars.branch=%22master%22>; rel="previous"`,
 								}))
 							})
 						})

--- a/atc/pipeline.go
+++ b/atc/pipeline.go
@@ -42,7 +42,7 @@ func (iv InstanceVars) String() string {
 	for _, kvPair := range iv.sortedKVPairs() {
 		rawVal, _ := json.Marshal(kvPair.Value)
 		val := string(rawVal)
-		if !requiresQuoting(kvPair.Value) {
+		if !instanceVarValueRequiresQuoting(kvPair.Value) {
 			val = unquoteString(val)
 		}
 		parts = append(parts, fmt.Sprintf("%s:%s", kvPair.Ref, val))
@@ -58,7 +58,7 @@ func (iv InstanceVars) sortedKVPairs() vars.KVPairs {
 	return kvPairs
 }
 
-func requiresQuoting(v interface{}) bool {
+func instanceVarValueRequiresQuoting(v interface{}) bool {
 	str, ok := v.(string)
 	if !ok {
 		return false
@@ -71,7 +71,7 @@ func requiresQuoting(v interface{}) bool {
 	if !isStringAfterUnmarshal {
 		return true
 	}
-	return strings.ContainsAny(str, ",: ")
+	return strings.ContainsAny(str, ",: /")
 }
 
 func unquoteString(s string) string {

--- a/atc/pipeline_test.go
+++ b/atc/pipeline_test.go
@@ -48,8 +48,9 @@ var _ = Describe("PipelineRef", func() {
 					"colon": "a:b",
 					"comma": "a,b",
 					"space": "a b",
+					"slash": "a/b",
 				}},
-				out: `some-pipeline/colon:"a:b",comma:"a,b",space:"a b"`,
+				out: `some-pipeline/colon:"a:b",comma:"a,b",slash:"a/b",space:"a b"`,
 			},
 			{
 				desc: "quotes string values that match special YAML values",

--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -403,7 +403,7 @@ func (locator stepContainerLocator) locate(fingerprint *containerFingerprint) (m
 	if fingerprint.jobName != "" {
 		reqValues["pipeline_name"] = fingerprint.pipelineName
 		if fingerprint.pipelineInstanceVars != "" {
-			reqValues["instance_vars"] = fingerprint.pipelineInstanceVars
+			reqValues["vars"] = fingerprint.pipelineInstanceVars
 		}
 		reqValues["job_name"] = fingerprint.jobName
 		if fingerprint.buildNameOrID != "" {
@@ -435,7 +435,7 @@ func (locator checkContainerLocator) locate(fingerprint *containerFingerprint) (
 		reqValues["pipeline_name"] = fingerprint.pipelineName
 	}
 	if fingerprint.pipelineInstanceVars != "" {
-		reqValues["instance_vars"] = fingerprint.pipelineInstanceVars
+		reqValues["vars"] = fingerprint.pipelineInstanceVars
 	}
 
 	return reqValues, nil

--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -287,7 +287,10 @@ func (command *HijackCommand) getContainerFingerprintFromUrl(target rc.Target, u
 		checkName:     urlMap["resources"],
 	}
 
-	instanceVars := atc.InstanceVarsFromWebQueryParams(u.Query())
+	instanceVars, err := atc.InstanceVarsFromQueryParams(u.Query())
+	if err != nil {
+		return nil, err
+	}
 	if len(instanceVars) > 0 {
 		instanceVarsPayload, err := json.Marshal(instanceVars)
 		if err != nil {

--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -281,11 +281,19 @@ func (command *HijackCommand) getContainerFingerprintFromUrl(target rc.Target, u
 	}
 
 	fingerprint := &containerFingerprint{
-		pipelineName:         urlMap["pipelines"],
-		pipelineInstanceVars: u.Query().Get("instance_vars"),
-		jobName:              urlMap["jobs"],
-		buildNameOrID:        urlMap["builds"],
-		checkName:            urlMap["resources"],
+		pipelineName:  urlMap["pipelines"],
+		jobName:       urlMap["jobs"],
+		buildNameOrID: urlMap["builds"],
+		checkName:     urlMap["resources"],
+	}
+
+	instanceVars := atc.InstanceVarsFromWebQueryParams(u.Query())
+	if len(instanceVars) > 0 {
+		instanceVarsPayload, err := json.Marshal(instanceVars)
+		if err != nil {
+			return nil, err
+		}
+		fingerprint.pipelineInstanceVars = string(instanceVarsPayload)
 	}
 
 	return fingerprint, nil
@@ -302,20 +310,14 @@ func (command *HijackCommand) getContainerFingerprint(target rc.Target, team con
 		}
 	}
 
-	pipelineName := command.Check.PipelineRef.Name
+	pipelineRef := command.Check.PipelineRef
 	if command.Job.PipelineRef.Name != "" {
-		pipelineName = command.Job.PipelineRef.Name
+		pipelineRef = command.Job.PipelineRef
 	}
 
 	var pipelineInstanceVars string
-	var instanceVars atc.InstanceVars
-	if command.Check.PipelineRef.InstanceVars != nil {
-		instanceVars = command.Check.PipelineRef.InstanceVars
-	} else {
-		instanceVars = command.Job.PipelineRef.InstanceVars
-	}
-	if instanceVars != nil {
-		instanceVarsJSON, _ := json.Marshal(instanceVars)
+	if pipelineRef.InstanceVars != nil {
+		instanceVarsJSON, _ := json.Marshal(pipelineRef.InstanceVars)
 		pipelineInstanceVars = string(instanceVarsJSON)
 	}
 
@@ -323,7 +325,7 @@ func (command *HijackCommand) getContainerFingerprint(target rc.Target, team con
 		fp  *string
 		cmd string
 	}{
-		{fp: &fingerprint.pipelineName, cmd: pipelineName},
+		{fp: &fingerprint.pipelineName, cmd: pipelineRef.Name},
 		{fp: &fingerprint.pipelineInstanceVars, cmd: pipelineInstanceVars},
 		{fp: &fingerprint.buildNameOrID, cmd: command.Build},
 		{fp: &fingerprint.stepName, cmd: command.StepName},

--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -125,7 +125,7 @@ func (atcConfig ATCConfig) showPipelineUpdateResult(pipeline atc.Pipeline, creat
 			fmt.Println("Could not parse targetURL")
 		}
 
-		queryParams := atcConfig.PipelineRef.WebQueryParams().Encode()
+		queryParams := atcConfig.PipelineRef.QueryParams().Encode()
 		if queryParams != "" {
 			queryParams = "?" + queryParams
 		}

--- a/fly/commands/pipelines.go
+++ b/fly/commands/pipelines.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/concourse/concourse/atc"
@@ -83,6 +84,7 @@ func (command *PipelinesCommand) Execute([]string) error {
 		}
 
 		row := ui.TableRow{}
+		row = append(row, ui.TableCell{Contents: strconv.Itoa(p.ID)})
 		row = append(row, ui.TableCell{Contents: p.Ref().String()})
 		if command.All {
 			row = append(row, ui.TableCell{Contents: p.TeamName})
@@ -103,9 +105,9 @@ func (command *PipelinesCommand) Execute([]string) error {
 func (command *PipelinesCommand) buildHeader() []string {
 	var headers []string
 	if command.All {
-		headers = []string{"name", "team", "paused", "public"}
+		headers = []string{"id", "name", "team", "paused", "public"}
 	} else {
-		headers = []string{"name", "paused", "public"}
+		headers = []string{"id", "name", "paused", "public"}
 	}
 
 	if command.IncludeArchived {

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -83,7 +83,7 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 	ansi.DisableColors(command.DisableAnsiColor)
 
 	var instanceVars atc.InstanceVars
-	if command.InstanceVars != nil {
+	if len(command.InstanceVars) != 0 {
 		var kvPairs vars.KVPairs
 		for _, iv := range command.InstanceVars {
 			kvPairs = append(kvPairs, vars.KVPair(iv))

--- a/fly/commands/watch.go
+++ b/fly/commands/watch.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -50,13 +49,9 @@ func getBuildIDFromURL(target rc.Target, urlParam string) (int, error) {
 	}
 
 	if urlMap["pipelines"] != "" && urlMap["jobs"] != "" {
-		pipelineRef := atc.PipelineRef{Name: urlMap["pipelines"]}
-		if instanceVars := u.Query().Get("instance_vars"); instanceVars != "" {
-			err := json.Unmarshal([]byte(instanceVars), &pipelineRef.InstanceVars)
-			if err != nil {
-				err = fmt.Errorf("Failed to parse query params in (%s, %s)", urlParam, target.URL())
-				return 0, err
-			}
+		pipelineRef := atc.PipelineRef{
+			Name:         urlMap["pipelines"],
+			InstanceVars: atc.InstanceVarsFromWebQueryParams(u.Query()),
 		}
 		build, err := GetBuild(client, target.Team(), urlMap["jobs"], urlMap["builds"], pipelineRef)
 

--- a/fly/commands/watch.go
+++ b/fly/commands/watch.go
@@ -49,9 +49,10 @@ func getBuildIDFromURL(target rc.Target, urlParam string) (int, error) {
 	}
 
 	if urlMap["pipelines"] != "" && urlMap["jobs"] != "" {
-		pipelineRef := atc.PipelineRef{
-			Name:         urlMap["pipelines"],
-			InstanceVars: atc.InstanceVarsFromWebQueryParams(u.Query()),
+		pipelineRef := atc.PipelineRef{Name: urlMap["pipelines"]}
+		pipelineRef.InstanceVars, err = atc.InstanceVarsFromQueryParams(u.Query())
+		if err != nil {
+			return 0, err
 		}
 		build, err := GetBuild(client, target.Team(), urlMap["jobs"], urlMap["builds"], pipelineRef)
 

--- a/fly/integration/abort_build_test.go
+++ b/fly/integration/abort_build_test.go
@@ -104,7 +104,7 @@ var _ = Describe("AbortBuild", func() {
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "instance_vars=%7B%22branch%22%3A%22master%22%7D"),
+						ghttp.VerifyRequest("GET", expectedURL, "vars.branch=%22master%22"),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuild),
 					),
 

--- a/fly/integration/archive_pipeline_test.go
+++ b/fly/integration/archive_pipeline_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Fly CLI", func() {
 				path, err = atc.Routes.CreatePathForRoute(atc.ArchivePipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
 				Expect(err).NotTo(HaveOccurred())
 
-				queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+				queryParams = "vars.branch=%22master%22"
 			})
 
 			Context("when the pipeline exists", func() {

--- a/fly/integration/builds_test.go
+++ b/fly/integration/builds_test.go
@@ -882,7 +882,7 @@ var _ = Describe("Fly CLI", func() {
 				cmdArgs = append(cmdArgs, "some-pipeline/branch:master")
 
 				expectedURL = "/api/v1/teams/main/pipelines/some-pipeline/builds"
-				queryParams = []string{"instance_vars=%7B%22branch%22%3A%22master%22%7D", "limit=50"}
+				queryParams = []string{"vars.branch=%22master%22", "limit=50"}
 				returnedStatusCode = http.StatusOK
 				returnedBuilds = []atc.Build{
 					{
@@ -942,7 +942,7 @@ var _ = Describe("Fly CLI", func() {
 					cmdArgs = append(cmdArgs, "-c")
 					cmdArgs = append(cmdArgs, "98")
 
-					queryParams = []string{"instance_vars=%7B%22branch%22%3A%22master%22%7D", "limit=98"}
+					queryParams = []string{"vars.branch=%22master%22", "limit=98"}
 					returnedStatusCode = http.StatusOK
 					returnedBuilds = []atc.Build{
 						{
@@ -986,7 +986,7 @@ var _ = Describe("Fly CLI", func() {
 					cmdArgs = append(cmdArgs, "--since", since.Format(timeLayout))
 					cmdArgs = append(cmdArgs, "--until", until.Format(timeLayout))
 
-					queryParams = []string{"instance_vars=%7B%22branch%22%3A%22master%22%7D", "limit=50", fmt.Sprintf("from=%d", since.Unix()), fmt.Sprintf("to=%d", until.Unix()), "timestamps=true"}
+					queryParams = []string{"vars.branch=%22master%22", "limit=50", fmt.Sprintf("from=%d", since.Unix()), fmt.Sprintf("to=%d", until.Unix()), "timestamps=true"}
 				})
 
 				It("returns the builds correctly", func() {

--- a/fly/integration/check_resource_test.go
+++ b/fly/integration/check_resource_test.go
@@ -44,7 +44,7 @@ var _ = Describe("CheckResource", func() {
 		}}
 
 		expectedURL = "/api/v1/teams/main/pipelines/mypipeline/resources/myresource/check"
-		expectedQueryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		expectedQueryParams = "vars.branch=%22master%22"
 	})
 
 	Context("when ATC request succeeds", func() {

--- a/fly/integration/check_resource_type_test.go
+++ b/fly/integration/check_resource_type_test.go
@@ -42,7 +42,7 @@ var _ = Describe("CheckResourceType", func() {
 		}}
 
 		expectedURL = "/api/v1/teams/main/pipelines/mypipeline/resource-types/myresource/check"
-		expectedQueryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		expectedQueryParams = "vars.branch=%22master%22"
 	})
 
 	Context("when version is specified", func() {

--- a/fly/integration/checklist_test.go
+++ b/fly/integration/checklist_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Fly CLI", func() {
 			JustBeforeEach(func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines/some-pipeline/config", "instance_vars=%7B%22branch%22%3A%22master%22%7D"),
+						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines/some-pipeline/config", "vars.branch=%22master%22"),
 						ghttp.RespondWithJSONEncoded(200, atc.ConfigResponse{Config: config}, http.Header{atc.ConfigVersionHeader: {"42"}}),
 					),
 				)

--- a/fly/integration/clear_task_cache_test.go
+++ b/fly/integration/clear_task_cache_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Fly CLI", func() {
 
 			BeforeEach(func() {
 				args = append(args, "-j", "some-pipeline/branch:master/some-job", "-s", "some-step-name")
-				expectedQueryParams = []string{"instance_vars=%7B%22branch%22%3A%22master%22%7D"}
+				expectedQueryParams = []string{"vars.branch=%22master%22"}
 			})
 
 			yes := func() {

--- a/fly/integration/destroy_pipeline_test.go
+++ b/fly/integration/destroy_pipeline_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Fly CLI", func() {
 				fmt.Fprintf(stdin, "n\n")
 			}
 
-			queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			queryParams := "vars.branch=%22master%22"
 
 			It("warns that it's about to do bad things", func() {
 				Eventually(sess).Should(gbytes.Say("!!! this will remove all data for pipeline `some-pipeline/branch:master`"))

--- a/fly/integration/disable_resource_version_test.go
+++ b/fly/integration/disable_resource_version_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Fly CLI", func() {
 
 		Context("when the resource is specified", func() {
 			BeforeEach(func() {
-				expectedQueryParams = append(expectedQueryParams, "instance_vars=%7B%22branch%22%3A%22master%22%7D")
+				expectedQueryParams = append(expectedQueryParams, "vars.branch=%22master%22")
 			})
 
 			Context("when the resource version json string is specified", func() {
@@ -86,7 +86,7 @@ var _ = Describe("Fly CLI", func() {
 							ghttp.RespondWithJSONEncoded(expectedGetStatus, []atc.ResourceVersion{expectedVersion}),
 						),
 						ghttp.CombineHandlers(
-							ghttp.VerifyRequest("PUT", disablePath, "instance_vars=%7B%22branch%22%3A%22master%22%7D"),
+							ghttp.VerifyRequest("PUT", disablePath, "vars.branch=%22master%22"),
 							ghttp.RespondWith(expectedPutStatus, nil),
 						),
 					)

--- a/fly/integration/enable_resource_version_test.go
+++ b/fly/integration/enable_resource_version_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Fly CLI", func() {
 
 		Context("when the resource is specified", func() {
 			BeforeEach(func() {
-				expectedQueryParams = append(expectedQueryParams, "instance_vars=%7B%22branch%22%3A%22master%22%7D")
+				expectedQueryParams = append(expectedQueryParams, "vars.branch=%22master%22")
 			})
 
 			Context("when the resource version json string is specified", func() {
@@ -86,7 +86,7 @@ var _ = Describe("Fly CLI", func() {
 							ghttp.RespondWithJSONEncoded(expectedGetStatus, []atc.ResourceVersion{expectedVersion}),
 						),
 						ghttp.CombineHandlers(
-							ghttp.VerifyRequest("PUT", enablePath, "instance_vars=%7B%22branch%22%3A%22master%22%7D"),
+							ghttp.VerifyRequest("PUT", enablePath, "vars.branch=%22master%22"),
 							ghttp.RespondWith(expectedPutStatus, nil),
 						),
 					)

--- a/fly/integration/execute_test.go
+++ b/fly/integration/execute_test.go
@@ -277,7 +277,7 @@ run:
 				taskPlan,
 			})
 
-			expectedQueryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQueryParams := "vars.branch=%22master%22"
 			atcServer.RouteToHandler("POST", "/api/v1/teams/main/pipelines/some-pipeline/builds",
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/api/v1/teams/main/pipelines/some-pipeline/builds", expectedQueryParams),

--- a/fly/integration/expose_pipeline_test.go
+++ b/fly/integration/expose_pipeline_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Fly CLI", func() {
 				path, err = atc.Routes.CreatePathForRoute(atc.ExposePipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
 				Expect(err).NotTo(HaveOccurred())
 
-				queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+				queryParams = "vars.branch=%22master%22"
 			})
 
 			Context("when the pipeline exists", func() {
@@ -138,7 +138,7 @@ var _ = Describe("Fly CLI", func() {
 					path, err = atc.Routes.CreatePathForRoute(atc.ExposePipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": team})
 					Expect(err).NotTo(HaveOccurred())
 
-					queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+					queryParams = "vars.branch=%22master%22"
 				})
 
 				Context("when the pipeline exists", func() {

--- a/fly/integration/get_pipeline_test.go
+++ b/fly/integration/get_pipeline_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Fly CLI", func() {
 					path, err = atc.Routes.CreatePathForRoute(atc.GetConfig, rata.Params{"pipeline_name": "some-pipeline", "team_name": "main"})
 					Expect(err).NotTo(HaveOccurred())
 
-					queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+					queryParams = "vars.branch=%22master%22"
 				})
 
 				Context("when specifying pipeline vars", func() {
@@ -251,7 +251,7 @@ var _ = Describe("Fly CLI", func() {
 						path, err = atc.Routes.CreatePathForRoute(atc.GetConfig, rata.Params{"pipeline_name": "some-pipeline", "team_name": team})
 						Expect(err).NotTo(HaveOccurred())
 
-						queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+						queryParams = "vars.branch=%22master%22"
 					})
 
 					Context("when specifying pipeline vars", func() {

--- a/fly/integration/hide_pipeline_test.go
+++ b/fly/integration/hide_pipeline_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Fly CLI", func() {
 				path, err = atc.Routes.CreatePathForRoute(atc.HidePipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": teamName})
 				Expect(err).NotTo(HaveOccurred())
 
-				queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+				queryParams = "vars.branch=%22master%22"
 			})
 
 			Context("when the pipeline exists", func() {

--- a/fly/integration/hijack_test.go
+++ b/fly/integration/hijack_test.go
@@ -670,7 +670,7 @@ var _ = Describe("Hijacking", func() {
 						})
 
 						It("hijacks the given check container by URL", func() {
-							hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/a-pipeline/resources/some-resource-name"+"?instance_vars=%7B%22branch%22%3A%22master%22%7D")
+							hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/a-pipeline/resources/some-resource-name"+"?var.branch=%22master%22")
 						})
 					})
 				})
@@ -761,15 +761,15 @@ var _ = Describe("Hijacking", func() {
 
 					Context("when pipeline instance is specified", func() {
 						BeforeEach(func() {
-							containerArguments = append(containerArguments, "instance_vars=%7B%22branch%22%3A%22master%22%7D")
+							containerArguments = append(containerArguments, "instance_vars=%7B%22branch%22%3A%22master%22%2C%22other.field%22%3A123%7D")
 						})
 
 						It("hijacks the job's next build with '<pipeline>/<instance_vars>/<job>'", func() {
-							hijack("--job", "some-pipeline/branch:master/some-job", "--step", "some-step")
+							hijack("--job", `some-pipeline/branch:master,"other.field":123/some-job`, "--step", "some-step")
 						})
 
 						It("hijacks the job's next build when URL is specified", func() {
-							hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job"+"?instance_vars=%7B%22branch%22%3A%22master%22%7D", "--step", "some-step")
+							hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job"+`?var.branch="master"&var."other.field"=123&ignore=true`, "--step", "some-step")
 						})
 					})
 

--- a/fly/integration/hijack_test.go
+++ b/fly/integration/hijack_test.go
@@ -662,7 +662,7 @@ var _ = Describe("Hijacking", func() {
 
 					Context("and with pipeline instance is specified", func() {
 						BeforeEach(func() {
-							containerArguments = append(containerArguments, "instance_vars=%7B%22branch%22%3A%22master%22%7D")
+							containerArguments = append(containerArguments, "vars=%7B%22branch%22%3A%22master%22%7D")
 						})
 
 						It("can accept the check resources name and a pipeline", func() {
@@ -670,7 +670,7 @@ var _ = Describe("Hijacking", func() {
 						})
 
 						It("hijacks the given check container by URL", func() {
-							hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/a-pipeline/resources/some-resource-name"+"?var.branch=%22master%22")
+							hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/a-pipeline/resources/some-resource-name"+"?vars.branch=%22master%22")
 						})
 					})
 				})
@@ -761,7 +761,7 @@ var _ = Describe("Hijacking", func() {
 
 					Context("when pipeline instance is specified", func() {
 						BeforeEach(func() {
-							containerArguments = append(containerArguments, "instance_vars=%7B%22branch%22%3A%22master%22%2C%22other.field%22%3A123%7D")
+							containerArguments = append(containerArguments, "vars=%7B%22branch%22%3A%22master%22%2C%22other.field%22%3A123%7D")
 						})
 
 						It("hijacks the job's next build with '<pipeline>/<instance_vars>/<job>'", func() {
@@ -769,7 +769,7 @@ var _ = Describe("Hijacking", func() {
 						})
 
 						It("hijacks the job's next build when URL is specified", func() {
-							hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job"+`?var.branch="master"&var."other.field"=123&ignore=true`, "--step", "some-step")
+							hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job"+`?vars.branch="master"&vars."other.field"=123&ignore=true`, "--step", "some-step")
 						})
 					})
 

--- a/fly/integration/jobs_test.go
+++ b/fly/integration/jobs_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Fly CLI", func() {
 				flyCmd = exec.Command(flyPath, "-t", targetName, "jobs", "--pipeline", "pipeline/branch:master")
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", expectedURL, "instance_vars=%7B%22branch%22%3A%22master%22%7D"),
+						ghttp.VerifyRequest("GET", expectedURL, "vars.branch=%22master%22"),
 						ghttp.RespondWithJSONEncoded(200, sampleJobs),
 					),
 				)

--- a/fly/integration/ordering_pipelines_test.go
+++ b/fly/integration/ordering_pipelines_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Fly CLI", func() {
 							Expect(sess.ExitCode()).To(Equal(0))
 							Eventually(sess).Should(gbytes.Say(`ordered pipelines`))
 							Eventually(sess).Should(gbytes.Say(`  - awesome-pipeline/branch:master`))
-							Eventually(sess).Should(gbytes.Say(`  - awesome-pipeline/branch:feature/bar`))
+							Eventually(sess).Should(gbytes.Say(`  - awesome-pipeline/branch:"feature/bar"`))
 
 						}).To(Change(func() int {
 							return len(atcServer.ReceivedRequests())

--- a/fly/integration/pause_job_test.go
+++ b/fly/integration/pause_job_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Fly CLI", func() {
 			pipelineRef = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 			fullJobName = fmt.Sprintf("%s/%s", pipelineRef.String(), jobName)
 			apiPath = fmt.Sprintf("/api/v1/teams/main/pipelines/%s/jobs/%s/pause", pipelineName, jobName)
-			queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			queryParams = "vars.branch=%22master%22"
 		})
 
 		Context("when user is on the same team as the given pipeline/job's team", func() {

--- a/fly/integration/pause_pipeline_test.go
+++ b/fly/integration/pause_pipeline_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Fly CLI", func() {
 				path, err = atc.Routes.CreatePathForRoute(atc.PausePipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": teamName})
 				Expect(err).NotTo(HaveOccurred())
 
-				queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+				queryParams = "vars.branch=%22master%22"
 			})
 
 			Context("when the pipeline exists", func() {

--- a/fly/integration/pin_resource_test.go
+++ b/fly/integration/pin_resource_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Fly CLI", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			expectedQueryParams = []string{
-				"instance_vars=%7B%22branch%22%3A%22master%22%7D",
+				"vars.branch=%22master%22",
 				"filter=some:value",
 			}
 		})
@@ -83,7 +83,6 @@ var _ = Describe("Fly CLI", func() {
 			Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("v", "version") + "' was not specified"))
 		})
 
-
 		Context("when a version is specified", func() {
 			JustBeforeEach(func() {
 				atcServer.AppendHandlers(
@@ -92,7 +91,7 @@ var _ = Describe("Fly CLI", func() {
 						ghttp.RespondWithJSONEncoded(listVersionsStatus, []atc.ResourceVersion{versionToPin}),
 					),
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("PUT", pinVersionPath, "instance_vars=%7B%22branch%22%3A%22master%22%7D"),
+						ghttp.VerifyRequest("PUT", pinVersionPath, "vars.branch=%22master%22"),
 						ghttp.RespondWith(pinVersionStatus, nil),
 					),
 				)
@@ -165,7 +164,7 @@ var _ = Describe("Fly CLI", func() {
 						ghttp.RespondWithJSONEncoded(listVersionsStatus, []atc.ResourceVersion{versionToPin}),
 					),
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("PUT", pinVersionPath, "instance_vars=%7B%22branch%22%3A%22master%22%7D"),
+						ghttp.VerifyRequest("PUT", pinVersionPath, "vars.branch=%22master%22"),
 						ghttp.RespondWith(pinVersionStatus, nil),
 					),
 					ghttp.CombineHandlers(

--- a/fly/integration/pipelines_test.go
+++ b/fly/integration/pipelines_test.go
@@ -35,10 +35,10 @@ var _ = Describe("Fly CLI", func() {
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
 							ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
-								{Name: "pipeline-1-longer", Paused: false, Public: false, LastUpdated: 1},
-								{Name: "pipeline-2", Paused: true, Public: false, LastUpdated: 1},
-								{Name: "pipeline-3", Paused: false, Public: true, LastUpdated: 1},
-								{Name: "archived-pipeline", Paused: false, Archived: true, Public: true, LastUpdated: 1},
+								{ID: 1, Name: "pipeline-1-longer", Paused: false, Public: false, LastUpdated: 1},
+								{ID: 2, Name: "pipeline-2", Paused: true, Public: false, LastUpdated: 1},
+								{ID: 3, Name: "pipeline-3", Paused: false, Public: true, LastUpdated: 1},
+								{ID: 4, Name: "archived-pipeline", Paused: false, Archived: true, Public: true, LastUpdated: 1},
 							}),
 						),
 					)
@@ -56,7 +56,7 @@ var _ = Describe("Fly CLI", func() {
 						Eventually(sess).Should(gexec.Exit(0))
 						Expect(sess.Out.Contents()).To(MatchJSON(`[
                 {
-                  "id": 0,
+                  "id": 1,
                   "name": "pipeline-1-longer",
                   "paused": false,
                   "public": false,
@@ -65,7 +65,7 @@ var _ = Describe("Fly CLI", func() {
                   "last_updated": 1
                 },
                 {
-                  "id": 0,
+                  "id": 2,
                   "name": "pipeline-2",
                   "paused": true,
                   "public": false,
@@ -74,7 +74,7 @@ var _ = Describe("Fly CLI", func() {
                   "last_updated": 1
                 },
                 {
-                  "id": 0,
+                  "id": 3,
                   "name": "pipeline-3",
                   "paused": false,
                   "public": true,
@@ -93,15 +93,16 @@ var _ = Describe("Fly CLI", func() {
 
 					Expect(sess.Out).To(PrintTableWithHeaders(ui.Table{
 						Headers: ui.TableRow{
+							{Contents: "id", Color: color.New(color.Bold)},
 							{Contents: "name", Color: color.New(color.Bold)},
 							{Contents: "paused", Color: color.New(color.Bold)},
 							{Contents: "public", Color: color.New(color.Bold)},
 							{Contents: "last updated", Color: color.New(color.Bold)},
 						},
 						Data: []ui.TableRow{
-							{{Contents: "pipeline-1-longer"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
-							{{Contents: "pipeline-2"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
-							{{Contents: "pipeline-3"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "1"}, {Contents: "pipeline-1-longer"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "2"}, {Contents: "pipeline-2"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "3"}, {Contents: "pipeline-3"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
 						},
 					}))
 				})
@@ -122,13 +123,13 @@ var _ = Describe("Fly CLI", func() {
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/pipelines"),
 							ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
-								{Name: "pipeline-1-longer", Paused: false, Public: false, TeamName: "main", LastUpdated: 1},
-								{Name: "pipeline-2", Paused: true, Public: false, TeamName: "main", LastUpdated: 1},
-								{Name: "pipeline-3", Paused: false, Public: true, TeamName: "main", LastUpdated: 1},
-								{Name: "archived-pipeline", Paused: false, Archived: true, Public: true, TeamName: "main", LastUpdated: 1},
-								{Name: "foreign-pipeline-1", Paused: false, Public: true, TeamName: "other", LastUpdated: 1},
-								{Name: "foreign-pipeline-2", Paused: false, Public: true, TeamName: "other", LastUpdated: 1},
-								{Name: "foreign-archived-pipeline", Paused: false, Archived: true, Public: true, TeamName: "other", LastUpdated: 1},
+								{ID: 1, Name: "pipeline-1-longer", Paused: false, Public: false, TeamName: "main", LastUpdated: 1},
+								{ID: 2, Name: "pipeline-2", Paused: true, Public: false, TeamName: "main", LastUpdated: 1},
+								{ID: 3, Name: "pipeline-3", Paused: false, Public: true, TeamName: "main", LastUpdated: 1},
+								{ID: 4, Name: "archived-pipeline", Paused: false, Archived: true, Public: true, TeamName: "main", LastUpdated: 1},
+								{ID: 5, Name: "foreign-pipeline-1", Paused: false, Public: true, TeamName: "other", LastUpdated: 1},
+								{ID: 6, Name: "foreign-pipeline-2", Paused: false, Public: true, TeamName: "other", LastUpdated: 1},
+								{ID: 7, Name: "foreign-archived-pipeline", Paused: false, Archived: true, Public: true, TeamName: "other", LastUpdated: 1},
 							}),
 						),
 					)
@@ -146,7 +147,7 @@ var _ = Describe("Fly CLI", func() {
 						Eventually(sess).Should(gexec.Exit(0))
 						Expect(sess.Out.Contents()).To(MatchJSON(`[
                 {
-                  "id": 0,
+                  "id": 1,
                   "name": "pipeline-1-longer",
                   "paused": false,
                   "public": false,
@@ -155,7 +156,7 @@ var _ = Describe("Fly CLI", func() {
                   "last_updated": 1
                 },
                 {
-                  "id": 0,
+                  "id": 2,
                   "name": "pipeline-2",
                   "paused": true,
                   "public": false,
@@ -164,7 +165,7 @@ var _ = Describe("Fly CLI", func() {
                   "last_updated": 1
                 },
                 {
-                  "id": 0,
+                  "id": 3,
                   "name": "pipeline-3",
                   "paused": false,
                   "public": true,
@@ -173,7 +174,7 @@ var _ = Describe("Fly CLI", func() {
                   "last_updated": 1
                 },
                 {
-                  "id": 0,
+                  "id": 5,
                   "name": "foreign-pipeline-1",
                   "paused": false,
                   "public": true,
@@ -182,7 +183,7 @@ var _ = Describe("Fly CLI", func() {
                   "last_updated": 1
                 },
                 {
-                  "id": 0,
+                  "id": 6,
                   "name": "foreign-pipeline-2",
                   "paused": false,
                   "public": true,
@@ -201,6 +202,7 @@ var _ = Describe("Fly CLI", func() {
 
 					Expect(sess.Out).To(PrintTableWithHeaders(ui.Table{
 						Headers: ui.TableRow{
+							{Contents: "id", Color: color.New(color.Bold)},
 							{Contents: "name", Color: color.New(color.Bold)},
 							{Contents: "team", Color: color.New(color.Bold)},
 							{Contents: "paused", Color: color.New(color.Bold)},
@@ -208,11 +210,11 @@ var _ = Describe("Fly CLI", func() {
 							{Contents: "last updated", Color: color.New(color.Bold)},
 						},
 						Data: []ui.TableRow{
-							{{Contents: "pipeline-1-longer"}, {Contents: "main"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
-							{{Contents: "pipeline-2"}, {Contents: "main"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
-							{{Contents: "pipeline-3"}, {Contents: "main"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
-							{{Contents: "foreign-pipeline-1"}, {Contents: "other"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
-							{{Contents: "foreign-pipeline-2"}, {Contents: "other"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "1"}, {Contents: "pipeline-1-longer"}, {Contents: "main"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "2"}, {Contents: "pipeline-2"}, {Contents: "main"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "3"}, {Contents: "pipeline-3"}, {Contents: "main"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "5"}, {Contents: "foreign-pipeline-1"}, {Contents: "other"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "6"}, {Contents: "foreign-pipeline-2"}, {Contents: "other"}, {Contents: "no"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: time.Unix(1, 0).String()}},
 						},
 					}))
 				})
@@ -236,8 +238,8 @@ var _ = Describe("Fly CLI", func() {
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
 							ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
-								{Name: "pipeline-1-longer", Paused: false, Public: false, TeamName: "main", LastUpdated: 1},
-								{Name: "archived-pipeline", Paused: true, Archived: true, Public: true, TeamName: "main", LastUpdated: 1},
+								{ID: 1, Name: "pipeline-1-longer", Paused: false, Public: false, TeamName: "main", LastUpdated: 1},
+								{ID: 2, Name: "archived-pipeline", Paused: true, Archived: true, Public: true, TeamName: "main", LastUpdated: 1},
 							}),
 						),
 					)
@@ -248,6 +250,7 @@ var _ = Describe("Fly CLI", func() {
 
 					Expect(sess.Out).To(PrintTableWithHeaders(ui.Table{
 						Headers: ui.TableRow{
+							{Contents: "id", Color: color.New(color.Bold)},
 							{Contents: "name", Color: color.New(color.Bold)},
 							{Contents: "paused", Color: color.New(color.Bold)},
 							{Contents: "public", Color: color.New(color.Bold)},
@@ -255,8 +258,8 @@ var _ = Describe("Fly CLI", func() {
 							{Contents: "last updated", Color: color.New(color.Bold)},
 						},
 						Data: []ui.TableRow{
-							{{Contents: "pipeline-1-longer"}, {Contents: "no"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
-							{{Contents: "archived-pipeline"}, {Contents: "yes"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "yes"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "1"}, {Contents: "pipeline-1-longer"}, {Contents: "no"}, {Contents: "no"}, {Contents: "no"}, {Contents: time.Unix(1, 0).String()}},
+							{{Contents: "2"}, {Contents: "archived-pipeline"}, {Contents: "yes"}, {Contents: "yes", Color: color.New(color.FgCyan)}, {Contents: "yes"}, {Contents: time.Unix(1, 0).String()}},
 						},
 					}))
 				})

--- a/fly/integration/pipelines_test.go
+++ b/fly/integration/pipelines_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(sess).Should(gexec.Exit(0))
-					Eventually(sess.Out).Should(gbytes.Say("instanced-pipeline/branch:feature/foo"))
+					Eventually(sess.Out).Should(gbytes.Say(`instanced-pipeline/branch:"feature/foo"`))
 					Eventually(sess.Out).Should(gbytes.Say("instanced-pipeline/branch:master"))
 					Eventually(sess.Out).ShouldNot(gbytes.Say("some-pipeline-1"))
 					Eventually(sess.Out).ShouldNot(gbytes.Say("some-pipeline-2"))

--- a/fly/integration/rename_pipeline_test.go
+++ b/fly/integration/rename_pipeline_test.go
@@ -94,7 +94,7 @@ var _ = Describe("RenamePipeline", func() {
 	Context("when all the inputs are provided", func() {
 
 		BeforeEach(func() {
-			expectedQueryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQueryParams = "vars.branch=%22master%22"
 		})
 
 		It("successfully renames the pipeline to the provided name", func() {

--- a/fly/integration/resource_versions_test.go
+++ b/fly/integration/resource_versions_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Fly CLI", func() {
 	Describe("resource-versions", func() {
 		var (
 			flyCmd      *exec.Cmd
-			queryParams = []string{"instance_vars=%7B%22branch%22%3A%22master%22%7D", "limit=50"}
+			queryParams = []string{"vars.branch=%22master%22", "limit=50"}
 		)
 
 		BeforeEach(func() {

--- a/fly/integration/resources_test.go
+++ b/fly/integration/resources_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Fly CLI", func() {
 				pipelineRef := atc.PipelineRef{Name: "pipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines/pipeline/resources", "instance_vars=%7B%22branch%22%3A%22master%22%7D"),
+						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines/pipeline/resources", "vars.branch=%22master%22"),
 						ghttp.RespondWithJSONEncoded(200, []atc.Resource{
 							{
 								Name:                 "resource-1",

--- a/fly/integration/trigger_job_test.go
+++ b/fly/integration/trigger_job_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Fly CLI", func() {
 			otherRandomPath, err = atc.Routes.CreatePathForRoute(atc.CreateJobBuild, rata.Params{"pipeline_name": "awesome-pipeline", "job_name": "awesome-job", "team_name": "random-team"})
 			Expect(err).NotTo(HaveOccurred())
 
-			queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			queryParams = "vars.branch=%22master%22"
 		})
 
 		Context("when the pipeline and job name are specified", func() {

--- a/fly/integration/unpause_job_test.go
+++ b/fly/integration/unpause_job_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Fly CLI", func() {
 			pipelineRef = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 			fullJobName = fmt.Sprintf("%s/%s", pipelineRef.String(), jobName)
 			apiPath = fmt.Sprintf("/api/v1/teams/main/pipelines/%s/jobs/%s/unpause", pipelineName, jobName)
-			queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			queryParams = "vars.branch=%22master%22"
 
 			flyCmd = exec.Command(flyPath, "-t", targetName, "unpause-job", "-j", fullJobName)
 		})

--- a/fly/integration/unpause_pipeline_test.go
+++ b/fly/integration/unpause_pipeline_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Fly CLI", func() {
 				otherPath, err = atc.Routes.CreatePathForRoute(atc.UnpausePipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "other-team"})
 				Expect(err).NotTo(HaveOccurred())
 
-				queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+				queryParams = "vars.branch=%22master%22"
 			})
 
 			Context("when the pipeline exists", func() {

--- a/fly/integration/unpin_resource_test.go
+++ b/fly/integration/unpin_resource_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Fly CLI", func() {
 			resourceName        = "resource"
 			pipelineRef         = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 			pipelineResource    = fmt.Sprintf("%s/%s", pipelineRef.String(), resourceName)
-			expectedQueryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQueryParams = "vars.branch=%22master%22"
 		)
 
 		BeforeEach(func() {

--- a/fly/integration/watch_test.go
+++ b/fly/integration/watch_test.go
@@ -140,11 +140,11 @@ var _ = Describe("Watching", func() {
 
 		BeforeEach(func() {
 			expectedURL = "/api/v1/teams/main/pipelines/some-pipeline/jobs/some-job"
-			expectedQueryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQueryParams = "vars.branch=%22master%22"
 			expectedStatusCode = http.StatusOK
 			expectedResponse = atc.Job{}
 
-			webQueryParams = "var.branch=%22master%22"
+			webQueryParams = "vars.branch=%22master%22"
 		})
 
 		JustBeforeEach(func() {

--- a/fly/integration/watch_test.go
+++ b/fly/integration/watch_test.go
@@ -134,6 +134,8 @@ var _ = Describe("Watching", func() {
 			expectedQueryParams string
 			expectedStatusCode  int
 			expectedResponse    interface{}
+
+			webQueryParams string
 		)
 
 		BeforeEach(func() {
@@ -141,6 +143,8 @@ var _ = Describe("Watching", func() {
 			expectedQueryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
 			expectedStatusCode = http.StatusOK
 			expectedResponse = atc.Job{}
+
+			webQueryParams = "var.branch=%22master%22"
 		})
 
 		JustBeforeEach(func() {
@@ -191,7 +195,7 @@ var _ = Describe("Watching", func() {
 			})
 
 			It("watches the job's next build URL", func() {
-				watch("--url", atcServer.URL()+"/teams/main/pipelines/some-pipeline/jobs/some-job?"+expectedQueryParams)
+				watch("--url", atcServer.URL()+"/teams/main/pipelines/some-pipeline/jobs/some-job?"+webQueryParams)
 			})
 		})
 
@@ -213,7 +217,7 @@ var _ = Describe("Watching", func() {
 			})
 
 			It("watches the job's finished build URL", func() {
-				watch("--url", atcServer.URL()+"/teams/main/pipelines/some-pipeline/jobs/some-job?"+expectedQueryParams)
+				watch("--url", atcServer.URL()+"/teams/main/pipelines/some-pipeline/jobs/some-job?"+webQueryParams)
 			})
 		})
 
@@ -233,7 +237,7 @@ var _ = Describe("Watching", func() {
 			})
 
 			It("watches the given build URL", func() {
-				watch("--url", atcServer.URL()+"/teams/main/pipelines/some-pipeline/jobs/some-job/builds/3?"+expectedQueryParams)
+				watch("--url", atcServer.URL()+"/teams/main/pipelines/some-pipeline/jobs/some-job/builds/3?"+webQueryParams)
 			})
 		})
 	})

--- a/go-concourse/concourse/build_inputs_test.go
+++ b/go-concourse/concourse/build_inputs_test.go
@@ -13,7 +13,7 @@ import (
 var _ = Describe("ATC Handler Build Inputs", func() {
 	Describe("BuildInputsForJob", func() {
 		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/inputs"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		Context("when pipeline/job exists", func() {
@@ -67,7 +67,7 @@ var _ = Describe("ATC Handler Build Inputs", func() {
 
 	Describe("BuildsWithVersionAsInput", func() {
 		expectedURL := "/api/v1/teams/some-team/pipelines/some-pipeline/resources/myresource/versions/2/input_to"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "some-pipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		var expectedBuilds []atc.Build

--- a/go-concourse/concourse/build_outputs_of_test.go
+++ b/go-concourse/concourse/build_outputs_of_test.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("ATC Handler Build Outputs", func() {
 	Describe("BuildsWithVersionAsOutput", func() {
 		expectedURL := "/api/v1/teams/some-team/pipelines/some-pipeline/resources/myresource/versions/2/output_of"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "some-pipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		var expectedBuilds []atc.Build

--- a/go-concourse/concourse/builds_test.go
+++ b/go-concourse/concourse/builds_test.go
@@ -70,7 +70,7 @@ var _ = Describe("ATC Handler Builds", func() {
 			expectedBuild atc.Build
 		)
 		BeforeEach(func() {
-			queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			queryParams = "vars.branch=%22master%22"
 			pipelineRef = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 			jobName = "myjob"
 
@@ -108,7 +108,7 @@ var _ = Describe("ATC Handler Builds", func() {
 		)
 
 		BeforeEach(func() {
-			queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			queryParams = "vars.branch=%22master%22"
 			pipelineRef = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 			jobName = "myjob"
 			buildName = "mybuild"
@@ -147,7 +147,7 @@ var _ = Describe("ATC Handler Builds", func() {
 
 		BeforeEach(func() {
 			expectedURL = "/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/builds/mybuild"
-			queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			queryParams = "vars.branch=%22master%22"
 			pipelineRef = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 		})
 

--- a/go-concourse/concourse/check_resource_test.go
+++ b/go-concourse/concourse/check_resource_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("CheckResource", func() {
 	var (
 		expectedURL   = "/api/v1/teams/some-team/pipelines/mypipeline/resources/myresource/check"
-		expectedQuery = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		expectedQuery = "vars.branch=%22master%22"
 		pipelineRef   = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 	)
 

--- a/go-concourse/concourse/check_resource_type_test.go
+++ b/go-concourse/concourse/check_resource_type_test.go
@@ -14,7 +14,7 @@ import (
 var _ = Describe("CheckResourceType", func() {
 	var (
 		expectedURL   = "/api/v1/teams/some-team/pipelines/mypipeline/resource-types/myresource/check"
-		expectedQuery = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		expectedQuery = "vars.branch=%22master%22"
 		pipelineRef   = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 	)
 

--- a/go-concourse/concourse/configs_test.go
+++ b/go-concourse/concourse/configs_test.go
@@ -107,7 +107,7 @@ var _ = Describe("ATC Handler Configs", func() {
 						Name:         "mypipeline",
 						InstanceVars: atc.InstanceVars{"branch": "master"},
 					}
-					expectedQueryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+					expectedQueryParams = "vars.branch=%22master%22"
 				})
 
 				It("returns the given config and version for that pipeline instance", func() {
@@ -256,14 +256,14 @@ var _ = Describe("ATC Handler Configs", func() {
 					}
 				})
 
-				It("submits with instance_vars query param set", func() {
+				It("submits with vars.xxx query params set", func() {
 					Expect(atcServer.ReceivedRequests()).To(HaveLen(0))
 
 					_, _, _, err := team.CreateOrUpdatePipelineConfig(pipelineRef, expectedVersion, expectedConfig, checkCredentials)
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(atcServer.ReceivedRequests()).To(HaveLen(1))
-					Expect(atcServer.ReceivedRequests()[0].URL.RawQuery).To(Equal("instance_vars=%7B%22branch%22%3A%22feature%22%7D"))
+					Expect(atcServer.ReceivedRequests()[0].URL.RawQuery).To(Equal("vars.branch=%22feature%22"))
 				})
 			})
 
@@ -329,14 +329,14 @@ var _ = Describe("ATC Handler Configs", func() {
 					}
 				})
 
-				It("submits with instance_vars query param set", func() {
+				It("submits with vars.xxx query params set", func() {
 					Expect(atcServer.ReceivedRequests()).To(HaveLen(0))
 
 					_, _, _, err := team.CreateOrUpdatePipelineConfig(pipelineRef, expectedVersion, expectedConfig, checkCredentials)
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(atcServer.ReceivedRequests()).To(HaveLen(1))
-					Expect(atcServer.ReceivedRequests()[0].URL.RawQuery).To(Equal("instance_vars=%7B%22branch%22%3A%22feature%22%7D"))
+					Expect(atcServer.ReceivedRequests()[0].URL.RawQuery).To(Equal("vars.branch=%22feature%22"))
 				})
 			})
 

--- a/go-concourse/concourse/jobs_test.go
+++ b/go-concourse/concourse/jobs_test.go
@@ -18,7 +18,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 		var (
 			expectedJobs  []atc.Job
 			expectedURL   = "/api/v1/teams/some-team/pipelines/mypipeline/jobs"
-			expectedQuery = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery = "vars.branch=%22master%22"
 			pipelineRef   = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -85,7 +85,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 		var (
 			expectedJob atc.Job
 			expectedURL = "/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob"
-			queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			queryParams = "vars.branch=%22master%22"
 			pipelineRef = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -171,7 +171,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 		)
 
 		BeforeEach(func() {
-			expectedQuery = []string{"instance_vars=%7B%22branch%22%3A%22master%22%7D"}
+			expectedQuery = []string{"vars.branch=%22master%22"}
 		})
 
 		JustBeforeEach(func() {
@@ -352,7 +352,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 			pipelineName   = "banana"
 			jobName        = "disjob"
 			expectedURL    = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/jobs/%s/pause", pipelineName, jobName)
-			expectedQuery  = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery  = "vars.branch=%22master%22"
 			pipelineRef    = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -420,7 +420,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 			pipelineName   = "banana"
 			jobName        = "disjob"
 			expectedURL    = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/jobs/%s/unpause", pipelineName, jobName)
-			expectedQuery  = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery  = "vars.branch=%22master%22"
 			pipelineRef    = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -488,7 +488,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 			pipelineName   = "banana"
 			jobName        = "disjob"
 			expectedURL    = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/jobs/%s/schedule", pipelineName, jobName)
-			expectedQuery  = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery  = "vars.branch=%22master%22"
 			pipelineRef    = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -560,7 +560,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 
 		BeforeEach(func() {
 			requestMethod = "DELETE"
-			expectedQuery = []string{"instance_vars=%7B%22branch%22%3A%22master%22%7D"}
+			expectedQuery = []string{"vars.branch=%22master%22"}
 		})
 
 		Context("when job step exists", func() {

--- a/go-concourse/concourse/pipelines_test.go
+++ b/go-concourse/concourse/pipelines_test.go
@@ -16,7 +16,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 	Describe("PausePipeline", func() {
 
 		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline/pause"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		Context("when the pipeline exists", func() {
@@ -56,7 +56,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 	Describe("ArchivePipeline", func() {
 
 		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline/archive"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		Context("when the pipeline exists", func() {
@@ -97,7 +97,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 	Describe("UnpausePipeline", func() {
 
 		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline/unpause"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		Context("when the pipeline exists", func() {
@@ -137,7 +137,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 	Describe("ExposePipeline", func() {
 
 		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline/expose"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		Context("when the pipeline exists", func() {
@@ -177,7 +177,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 	Describe("HidePipeline", func() {
 
 		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline/hide"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		Context("when the pipeline exists", func() {
@@ -278,7 +278,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 	Describe("Pipeline", func() {
 		var expectedPipeline atc.Pipeline
 		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		BeforeEach(func() {
@@ -425,7 +425,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 	Describe("DeletePipeline", func() {
 		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		Context("when the pipeline exists", func() {
@@ -478,7 +478,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 		BeforeEach(func() {
 			expectedURL = "/api/v1/teams/some-team/pipelines/mypipeline/rename"
-			expectedQueryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQueryParams = "vars.branch=%22master%22"
 			expectedRequestBody = `{"name":"newpipelinename"}`
 			expectedResponse = atc.SaveConfigResponse{
 				Errors:   nil,
@@ -560,7 +560,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 	Describe("CreatePipelineBuild", func() {
 		expectedURL := "/api/v1/teams/some-team/pipelines/mypipeline/builds"
-		queryParams := "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+		queryParams := "vars.branch=%22master%22"
 		pipelineRef := atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 
 		var (
@@ -627,7 +627,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 			}
 
 			expectedURL = fmt.Sprint("/api/v1/teams/some-team/pipelines/mypipeline/builds")
-			expectedQuery = []string{"instance_vars=%7B%22branch%22%3A%22master%22%7D"}
+			expectedQuery = []string{"vars.branch=%22master%22"}
 			pipelineRef = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 		})
 

--- a/go-concourse/concourse/resource_test.go
+++ b/go-concourse/concourse/resource_test.go
@@ -15,7 +15,7 @@ var _ = Describe("ATC Handler Resource", func() {
 			expectedResources []atc.Resource
 
 			expectedURL   = "/api/v1/teams/some-team/pipelines/some-pipeline/resources"
-			expectedQuery = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery = "vars.branch=%22master%22"
 			pipelineRef   = atc.PipelineRef{Name: "some-pipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -54,7 +54,7 @@ var _ = Describe("ATC Handler Resource", func() {
 			clientErr        error
 
 			expectedURL   = "/api/v1/teams/some-team/pipelines/some-pipeline/resources/myresource"
-			expectedQuery = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery = "vars.branch=%22master%22"
 			pipelineRef   = atc.PipelineRef{Name: "some-pipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 

--- a/go-concourse/concourse/resourceversions_test.go
+++ b/go-concourse/concourse/resourceversions_test.go
@@ -35,7 +35,7 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 		BeforeEach(func() {
 			page = concourse.Page{}
 			filter = atc.Version{}
-			expectedQuery = []string{"instance_vars=%7B%22branch%22%3A%22master%22%7D"}
+			expectedQuery = []string{"vars.branch=%22master%22"}
 
 			expectedVersions = []atc.ResourceVersion{
 				{
@@ -218,7 +218,7 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			resourceName      = "myresource"
 			resourceVersionID = 42
 			expectedURL       = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/resources/%s/versions/%s/disable", pipelineName, resourceName, strconv.Itoa(resourceVersionID))
-			expectedQuery     = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery     = "vars.branch=%22master%22"
 			pipelineRef       = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -287,7 +287,7 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			resourceName      = "myresource"
 			resourceVersionID = 42
 			expectedURL       = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/resources/%s/versions/%s/enable", pipelineName, resourceName, strconv.Itoa(resourceVersionID))
-			expectedQuery     = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery     = "vars.branch=%22master%22"
 			pipelineRef       = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -357,7 +357,7 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			resourceName      = "myresource"
 			resourceVersionID = 42
 			expectedURL       = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/resources/%s/versions/%s/pin", pipelineName, resourceName, strconv.Itoa(resourceVersionID))
-			expectedQuery     = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery     = "vars.branch=%22master%22"
 			pipelineRef       = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -426,7 +426,7 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			pipelineName   = "banana"
 			resourceName   = "myresource"
 			expectedURL    = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/resources/%s/unpin", pipelineName, resourceName)
-			expectedQuery  = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery  = "vars.branch=%22master%22"
 			pipelineRef    = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 
@@ -495,7 +495,7 @@ var _ = Describe("ATC Handler Resource Versions", func() {
 			pipelineName       = "banana"
 			resourceName       = "myresource"
 			expectedURL        = fmt.Sprintf("/api/v1/teams/some-team/pipelines/%s/resources/%s/pin_comment", pipelineName, resourceName)
-			expectedQuery      = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+			expectedQuery      = "vars.branch=%22master%22"
 			pipelineRef        = atc.PipelineRef{Name: pipelineName, InstanceVars: atc.InstanceVars{"branch": "master"}}
 		)
 

--- a/vars/static_vars.go
+++ b/vars/static_vars.go
@@ -100,9 +100,9 @@ type KVPair struct {
 
 type KVPairs []KVPair
 
-func (f KVPairs) Expand() StaticVariables {
-	out := map[string]interface{}{}
-	for _, pair := range f {
+func (p KVPairs) Expand() StaticVariables {
+	out := make(map[string]interface{}, len(p))
+	for _, pair := range p {
 		upsert(out, pair.Ref.Path, pair.Ref.Fields, pair.Value)
 	}
 	return out


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

With #6105, the query parameters for instanced pipelines in the UI changed from `?instance_vars=...ugly URL encoded JSON` to `vars.var1.field1="value"&vars.var2=123&...`. For consistency with the UI, let's also change the query parameters used in the API.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* `fly pipelines` includes pipeline ID column
* Instanced pipelines are now accessed using the API endpoints `/teams/:team_name/pipelines/:pipeline_name/...?vars.foo.bar=123&vars."baz.qux"="abc"` (corresponds with instance vars `{"foo": {"bar": 123}, "baz.qux": "abc"}`)
  * Previously, this would be `?instance_vars={"foo": {"bar": 123}, "baz.qux": "abc"}`
  * Note that `?vars={"foo":{"bar":123},"baz.qux":"abc"}` is also supported
* Quote `/` contained within an instance var value when converting to string form
  * e.g. `-j release/branch:"feature/foo"/shipit`
  * It still correctly parses if you provide `-j release/branch:feature/foo/shipit`, but that's confusing - when we generate these flags, we should quote it

TODO:

* [ ] ~Fix syslog drainer tag format~
  * The format isn't officially documented anywhere, but we want to be cautious about changing it so as not to break syslog consumers
  * We want to change it because it provides no information about pipeline instance vars
  * Nevermind, going to leave this for a future PR

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
