### PR TITLE
Respect tags when fetching images, send public plans in fetching events

### DIFF
--- a/atc/engine/builder/build_step_delegate.go
+++ b/atc/engine/builder/build_step_delegate.go
@@ -241,6 +241,8 @@ func (delegate *buildStepDelegate) FetchImage(
 				Source: image.Source,
 
 				VersionedResourceTypes: types,
+
+				Tags: image.Tags,
 			},
 		}
 
@@ -281,6 +283,8 @@ func (delegate *buildStepDelegate) FetchImage(
 			Params:  image.Params,
 
 			VersionedResourceTypes: types,
+
+			Tags: image.Tags,
 		},
 	}
 

--- a/atc/engine/builder/build_step_delegate.go
+++ b/atc/engine/builder/build_step_delegate.go
@@ -249,7 +249,7 @@ func (delegate *buildStepDelegate) FetchImage(
 			Origin: event.Origin{
 				ID: event.OriginID(delegate.planID),
 			},
-			Plan: checkPlan,
+			PublicPlan: checkPlan.Public(),
 		})
 		if err != nil {
 			return worker.ImageSpec{}, fmt.Errorf("save image check event: %w", err)
@@ -289,7 +289,7 @@ func (delegate *buildStepDelegate) FetchImage(
 		Origin: event.Origin{
 			ID: event.OriginID(delegate.planID),
 		},
-		Plan: getPlan,
+		PublicPlan: getPlan.Public(),
 	})
 	if err != nil {
 		return worker.ImageSpec{}, fmt.Errorf("save image get event: %w", err)

--- a/atc/engine/builder/build_step_delegate_test.go
+++ b/atc/engine/builder/build_step_delegate_test.go
@@ -369,7 +369,7 @@ var _ = Describe("BuildStepDelegate", func() {
 					Origin: event.Origin{
 						ID: event.OriginID(planID),
 					},
-					Plan: expectedCheckPlan,
+					PublicPlan: expectedCheckPlan.Public(),
 				}))
 
 				e = fakeBuild.SaveEventArgsForCall(1)
@@ -378,7 +378,7 @@ var _ = Describe("BuildStepDelegate", func() {
 					Origin: event.Origin{
 						ID: event.OriginID(planID),
 					},
-					Plan: expectedGetPlan,
+					PublicPlan: expectedGetPlan.Public(),
 				}))
 			})
 		})
@@ -406,7 +406,7 @@ var _ = Describe("BuildStepDelegate", func() {
 					Origin: event.Origin{
 						ID: event.OriginID(planID),
 					},
-					Plan: expectedGetPlan,
+					PublicPlan: expectedGetPlan.Public(),
 				}))
 			})
 		})

--- a/atc/engine/builder/build_step_delegate_test.go
+++ b/atc/engine/builder/build_step_delegate_test.go
@@ -122,6 +122,7 @@ var _ = Describe("BuildStepDelegate", func() {
 				Type:   "docker",
 				Source: atc.Source{"some": "((source-var))"},
 				Params: atc.Params{"some": "((params-var))"},
+				Tags:   atc.Tags{"some", "tags"},
 			}
 
 			types = atc.VersionedResourceTypes{
@@ -152,6 +153,7 @@ var _ = Describe("BuildStepDelegate", func() {
 					Type:                   "docker",
 					Source:                 atc.Source{"some": "((source-var))"},
 					VersionedResourceTypes: types,
+					Tags:                   atc.Tags{"some", "tags"},
 				},
 			}
 
@@ -164,6 +166,7 @@ var _ = Describe("BuildStepDelegate", func() {
 					Version:                &atc.Version{"some": "version"},
 					Params:                 atc.Params{"some": "((params-var))"},
 					VersionedResourceTypes: types,
+					Tags:                   atc.Tags{"some", "tags"},
 				},
 			}
 

--- a/atc/event/events.go
+++ b/atc/event/events.go
@@ -1,6 +1,8 @@
 package event
 
 import (
+	"encoding/json"
+
 	"github.com/concourse/concourse/atc"
 )
 
@@ -214,19 +216,19 @@ func (Finish) EventType() atc.EventType  { return EventTypeFinish }
 func (Finish) Version() atc.EventVersion { return "1.0" }
 
 type ImageCheck struct {
-	Time   int64    `json:"time"`
-	Origin Origin   `json:"origin"`
-	Plan   atc.Plan `json:"plan"`
+	Time       int64            `json:"time"`
+	Origin     Origin           `json:"origin"`
+	PublicPlan *json.RawMessage `json:"plan"`
 }
 
 func (ImageCheck) EventType() atc.EventType  { return EventTypeImageCheck }
-func (ImageCheck) Version() atc.EventVersion { return "1.0" }
+func (ImageCheck) Version() atc.EventVersion { return "1.1" }
 
 type ImageGet struct {
-	Time   int64    `json:"time"`
-	Origin Origin   `json:"origin"`
-	Plan   atc.Plan `json:"plan"`
+	Time       int64            `json:"time"`
+	Origin     Origin           `json:"origin"`
+	PublicPlan *json.RawMessage `json:"plan"`
 }
 
 func (ImageGet) EventType() atc.EventType  { return EventTypeImageGet }
-func (ImageGet) Version() atc.EventVersion { return "1.0" }
+func (ImageGet) Version() atc.EventVersion { return "1.1" }

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -250,6 +250,10 @@ func (step *CheckStep) runCheck(
 			Source:  resourceType.Source,
 			Params:  resourceType.Params,
 			Version: resourceType.Version,
+			Tags:    resourceType.Tags,
+		}
+		if len(image.Tags) == 0 {
+			image.Tags = step.plan.Tags
 		}
 
 		types := step.plan.VersionedResourceTypes.Without(step.plan.Type)

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -269,7 +269,6 @@ func (step *CheckStep) runCheck(
 		BindMounts: []worker.BindMountSource{
 			&worker.CertsVolumeMount{Logger: logger},
 		},
-		Tags:   step.plan.Tags,
 		TeamID: step.metadata.TeamID,
 		Env:    step.metadata.Env(),
 	}

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -307,10 +307,6 @@ var _ = Describe("CheckStep", func() {
 						}))
 					})
 
-					It("with tags set", func() {
-						Expect(containerSpec.Tags).To(ConsistOf("some", "tags"))
-					})
-
 					It("with teamid set", func() {
 						Expect(containerSpec.TeamID).To(Equal(345))
 					})

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -142,6 +142,10 @@ func (step *GetStep) run(ctx context.Context, state RunState, delegate GetDelega
 			Source:  resourceType.Source,
 			Params:  resourceType.Params,
 			Version: resourceType.Version,
+			Tags:    resourceType.Tags,
+		}
+		if len(image.Tags) == 0 {
+			image.Tags = step.plan.Tags
 		}
 
 		types := step.plan.VersionedResourceTypes.Without(step.plan.Type)

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -112,7 +112,6 @@ var _ = Describe("GetStep", func() {
 			Type:    "some-base-type",
 			Source:  atc.Source{"some": "((source-var))"},
 			Params:  atc.Params{"some": "((params-var))"},
-			Tags:    []string{"some", "tags"},
 			Version: &atc.Version{"some": "version"},
 			VersionedResourceTypes: atc.VersionedResourceTypes{
 				{
@@ -254,10 +253,20 @@ var _ = Describe("GetStep", func() {
 		Expect(actualWorkerSpec).To(Equal(
 			worker.WorkerSpec{
 				ResourceType: "some-base-type",
-				Tags:         atc.Tags{"some", "tags"},
 				TeamID:       stepMetadata.TeamID,
 			},
 		))
+	})
+
+	Context("when the plan specifies tags", func() {
+		BeforeEach(func() {
+			getPlan.Tags = atc.Tags{"some", "tags"}
+		})
+
+		It("sets them in the WorkerSpec", func() {
+			_, _, _, _, actualWorkerSpec, _, _, _, _, _, _ := fakeClient.RunGetStepArgsForCall(0)
+			Expect(actualWorkerSpec.Tags).To(Equal([]string{"some", "tags"}))
+		})
 	})
 
 	Context("when using a custom resource type", func() {
@@ -303,11 +312,54 @@ var _ = Describe("GetStep", func() {
 			Expect(privileged).To(BeFalse())
 		})
 
+		Context("when the plan configures tags", func() {
+			BeforeEach(func() {
+				getPlan.Tags = atc.Tags{"plan", "tags"}
+			})
+
+			It("fetches using the tags", func() {
+				Expect(fakeDelegate.FetchImageCallCount()).To(Equal(1))
+				_, imageResource, _, _ := fakeDelegate.FetchImageArgsForCall(0)
+				Expect(imageResource.Tags).To(Equal(atc.Tags{"plan", "tags"}))
+			})
+		})
+
+		Context("when the resource type configures tags", func() {
+			BeforeEach(func() {
+				taggedType, found := getPlan.VersionedResourceTypes.Lookup("some-custom-type")
+				Expect(found).To(BeTrue())
+
+				taggedType.Tags = atc.Tags{"type", "tags"}
+
+				newTypes := getPlan.VersionedResourceTypes.Without("some-custom-type")
+				newTypes = append(newTypes, taggedType)
+
+				getPlan.VersionedResourceTypes = newTypes
+			})
+
+			It("fetches using the type tags", func() {
+				Expect(fakeDelegate.FetchImageCallCount()).To(Equal(1))
+				_, imageResource, _, _ := fakeDelegate.FetchImageArgsForCall(0)
+				Expect(imageResource.Tags).To(Equal(atc.Tags{"type", "tags"}))
+			})
+
+			Context("when the plan ALSO configures tags", func() {
+				BeforeEach(func() {
+					getPlan.Tags = atc.Tags{"plan", "tags"}
+				})
+
+				It("fetches using only the type tags", func() {
+					Expect(fakeDelegate.FetchImageCallCount()).To(Equal(1))
+					_, imageResource, _, _ := fakeDelegate.FetchImageArgsForCall(0)
+					Expect(imageResource.Tags).To(Equal(atc.Tags{"type", "tags"}))
+				})
+			})
+		})
+
 		It("calls RunGetStep with the correct WorkerSpec", func() {
 			_, _, _, _, actualWorkerSpec, _, _, _, _, _, _ := fakeClient.RunGetStepArgsForCall(0)
 			Expect(actualWorkerSpec).To(Equal(
 				worker.WorkerSpec{
-					Tags:   atc.Tags{"some", "tags"},
 					TeamID: stepMetadata.TeamID,
 				},
 			))

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -159,6 +159,10 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 			Source:  resourceType.Source,
 			Params:  resourceType.Params,
 			Version: resourceType.Version,
+			Tags:    resourceType.Tags,
+		}
+		if len(image.Tags) == 0 {
+			image.Tags = step.plan.Tags
 		}
 
 		types := step.plan.VersionedResourceTypes.Without(step.plan.Type)

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -175,7 +175,6 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 
 	containerSpec := worker.ContainerSpec{
 		ImageSpec: imageSpec,
-		Tags:      step.plan.Tags,
 		TeamID:    step.metadata.TeamID,
 
 		Dir: step.containerMetadata.WorkingDirectory,

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -318,7 +318,6 @@ var _ = Describe("PutStep", func() {
 		Expect(actualContainerSpec.ImageSpec).To(Equal(worker.ImageSpec{
 			ResourceType: "some-resource-type",
 		}))
-		Expect(actualContainerSpec.Tags).To(Equal([]string{"some", "tags"}))
 		Expect(actualContainerSpec.TeamID).To(Equal(123))
 		Expect(actualContainerSpec.Env).To(Equal(stepMetadata.Env()))
 		Expect(actualContainerSpec.Dir).To(Equal("/tmp/build/put"))

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -290,9 +290,14 @@ func (step *TaskStep) imageSpec(ctx context.Context, state RunState, delegate Ta
 
 		//an image_resource
 	} else if config.ImageResource != nil {
+		image := *config.ImageResource
+		if len(image.Tags) == 0 {
+			image.Tags = step.plan.Tags
+		}
+
 		return delegate.FetchImage(
 			ctx,
-			*config.ImageResource,
+			image,
 			step.plan.VersionedResourceTypes,
 			step.plan.Privileged,
 		)

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -367,8 +367,6 @@ func (step *TaskStep) containerSpec(state RunState, imageSpec worker.ImageSpec, 
 	}
 
 	containerSpec := worker.ContainerSpec{
-		Platform:  config.Platform,
-		Tags:      step.plan.Tags,
 		TeamID:    step.metadata.TeamID,
 		ImageSpec: imageSpec,
 		Limits:    limits,

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -214,11 +214,11 @@ var _ = Describe("TaskStep", func() {
 				taskPlan.Tags = atc.Tags{"plan", "tags"}
 			})
 
-			It("creates a containerSpec with the tags", func() {
+			It("creates a worker spec with the tags", func() {
 				Expect(fakeClient.RunTaskStepCallCount()).To(Equal(1))
 
-				_, _, _, containerSpec, _, _, _, _, _, _ := fakeClient.RunTaskStepArgsForCall(0)
-				Expect(containerSpec.Tags).To(Equal([]string{"plan", "tags"}))
+				_, _, _, _, workerSpec, _, _, _, _, _ := fakeClient.RunTaskStepArgsForCall(0)
+				Expect(workerSpec.Tags).To(Equal([]string{"plan", "tags"}))
 			})
 		})
 

--- a/atc/public_plan.go
+++ b/atc/public_plan.go
@@ -161,13 +161,13 @@ func (plan AcrossPlan) Public() *json.RawMessage {
 	}
 
 	return enc(struct {
-		Vars        []AcrossVar  `json:"vars"`
-		Steps       []scopedStep `json:"steps"`
-		FailFast    bool         `json:"fail_fast,omitempty"`
+		Vars     []AcrossVar  `json:"vars"`
+		Steps    []scopedStep `json:"steps"`
+		FailFast bool         `json:"fail_fast,omitempty"`
 	}{
-		Vars:        plan.Vars,
-		Steps:       steps,
-		FailFast:    plan.FailFast,
+		Vars:     plan.Vars,
+		Steps:    steps,
+		FailFast: plan.FailFast,
 	})
 }
 
@@ -193,9 +193,9 @@ func (plan EnsurePlan) Public() *json.RawMessage {
 
 func (plan GetPlan) Public() *json.RawMessage {
 	return enc(struct {
+		Name     string   `json:"name"`
 		Type     string   `json:"type"`
-		Name     string   `json:"name,omitempty"`
-		Resource string   `json:"resource"`
+		Resource string   `json:"resource,omitempty"`
 		Version  *Version `json:"version,omitempty"`
 	}{
 		Type:     plan.Type,
@@ -207,8 +207,8 @@ func (plan GetPlan) Public() *json.RawMessage {
 
 func (plan DependentGetPlan) Public() *json.RawMessage {
 	return enc(struct {
+		Name     string `json:"name"`
 		Type     string `json:"type"`
-		Name     string `json:"name,omitempty"`
 		Resource string `json:"resource"`
 	}{
 		Type:     plan.Type,
@@ -259,9 +259,9 @@ func (plan OnSuccessPlan) Public() *json.RawMessage {
 
 func (plan PutPlan) Public() *json.RawMessage {
 	return enc(struct {
+		Name     string `json:"name"`
 		Type     string `json:"type"`
-		Name     string `json:"name,omitempty"`
-		Resource string `json:"resource"`
+		Resource string `json:"resource,omitempty"`
 	}{
 		Type:     plan.Type,
 		Name:     plan.Name,
@@ -271,8 +271,8 @@ func (plan PutPlan) Public() *json.RawMessage {
 
 func (plan CheckPlan) Public() *json.RawMessage {
 	return enc(struct {
+		Name string `json:"name"`
 		Type string `json:"type"`
-		Name string `json:"name,omitempty"`
 	}{
 		Type: plan.Type,
 		Name: plan.Name,

--- a/atc/task.go
+++ b/atc/task.go
@@ -44,6 +44,7 @@ type ImageResource struct {
 	Source  Source  `json:"source"`
 	Version Version `json:"version,omitempty"`
 	Params  Params  `json:"params,omitempty"`
+	Tags    Tags    `json:"tags,omitempty"`
 }
 
 func (ir *ImageResource) ApplySourceDefaults(resourceTypes VersionedResourceTypes) {

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -591,7 +591,7 @@ func (client *client) chooseTaskWorker(
 
 	tasksWaitingLabels := metric.TasksWaitingLabels{
 		TeamId:     strconv.Itoa(workerSpec.TeamID),
-		WorkerTags: strings.Join(containerSpec.Tags, "_"),
+		WorkerTags: strings.Join(workerSpec.Tags, "_"),
 		Platform:   workerSpec.Platform,
 	}
 

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -227,6 +227,7 @@ var _ = Describe("Client", func() {
 
 		var (
 			containerSpec     worker.ContainerSpec
+			workerSpec        worker.WorkerSpec
 			result            worker.CheckResult
 			err, expectedErr  error
 			fakeResource      *resourcefakes.FakeResource
@@ -240,14 +241,16 @@ var _ = Describe("Client", func() {
 			stdout := new(gbytes.Buffer)
 			stderr := new(gbytes.Buffer)
 			containerSpec = worker.ContainerSpec{
-				Platform: "some-platform",
-				Tags:     []string{"step", "tags"},
-				TeamID:   123,
+				TeamID: 123,
 				ImageSpec: worker.ImageSpec{
 					ResourceType: "some-base-type",
 					Privileged:   false,
 				},
 				Dir: "some-artifact-root",
+			}
+			workerSpec = worker.WorkerSpec{
+				Platform: "some-platform",
+				Tags:     []string{"step", "tags"},
 			}
 			fakeProcessSpec = runtime.ProcessSpec{
 				Path:         "/opt/resource/out",
@@ -259,7 +262,6 @@ var _ = Describe("Client", func() {
 		JustBeforeEach(func() {
 			owner := new(dbfakes.FakeContainerOwner)
 			fakeStrategy := new(workerfakes.FakeContainerPlacementStrategy)
-			workerSpec := worker.WorkerSpec{}
 
 			result, err = client.RunCheckStep(
 				context.Background(),
@@ -435,9 +437,7 @@ var _ = Describe("Client", func() {
 			ctx, _ = context.WithCancel(context.Background())
 			owner = new(dbfakes.FakeContainerOwner)
 			containerSpec = worker.ContainerSpec{
-				Platform: "some-platform",
-				Tags:     []string{"step", "tags"},
-				TeamID:   123,
+				TeamID: 123,
 				ImageSpec: worker.ImageSpec{
 					ResourceType: "some-base-type",
 					Privileged:   false,
@@ -445,7 +445,10 @@ var _ = Describe("Client", func() {
 				Dir: "some-artifact-root",
 			}
 			fakeStrategy = new(workerfakes.FakeContainerPlacementStrategy)
-			workerSpec = worker.WorkerSpec{}
+			workerSpec = worker.WorkerSpec{
+				Platform: "some-platform",
+				Tags:     []string{"step", "tags"},
+			}
 			fakeChosenWorker = new(workerfakes.FakeWorker)
 			fakeEventDelegate = new(runtimefakes.FakeStartingEventDelegate)
 
@@ -625,11 +628,12 @@ var _ = Describe("Client", func() {
 				planId,
 				teamId,
 			)
-			fakeWorkerSpec = worker.WorkerSpec{}
-			fakeContainerSpec = worker.ContainerSpec{
+			fakeWorkerSpec = worker.WorkerSpec{
 				Platform: "some-platform",
 				Tags:     []string{"step", "tags"},
-				TeamID:   123,
+			}
+			fakeContainerSpec = worker.ContainerSpec{
+				TeamID: 123,
 				ImageSpec: worker.ImageSpec{
 					ImageArtifactSource: new(workerfakes.FakeStreamableArtifactSource),
 					Privileged:          false,
@@ -1402,9 +1406,7 @@ var _ = Describe("Client", func() {
 			ctx = context.Background()
 			owner = new(dbfakes.FakeContainerOwner)
 			containerSpec = worker.ContainerSpec{
-				Platform: "some-platform",
-				Tags:     []string{"step", "tags"},
-				TeamID:   123,
+				TeamID: 123,
 				ImageSpec: worker.ImageSpec{
 					ResourceType: "some-base-type",
 					Privileged:   false,
@@ -1412,7 +1414,10 @@ var _ = Describe("Client", func() {
 				Dir: "some-artifact-root",
 			}
 			fakeStrategy = new(workerfakes.FakeContainerPlacementStrategy)
-			workerSpec = worker.WorkerSpec{}
+			workerSpec = worker.WorkerSpec{
+				Platform: "some-platform",
+				Tags:     []string{"step", "tags"},
+			}
 			fakeChosenWorker = new(workerfakes.FakeWorker)
 			fakeEventDelegate = new(runtimefakes.FakeStartingEventDelegate)
 

--- a/atc/worker/container_spec.go
+++ b/atc/worker/container_spec.go
@@ -17,8 +17,6 @@ type WorkerSpec struct {
 }
 
 type ContainerSpec struct {
-	Platform  string
-	Tags      []string
 	TeamID    int
 	ImageSpec ImageSpec
 	Env       []string

--- a/atc/worker/fetch_source_test.go
+++ b/atc/worker/fetch_source_test.go
@@ -101,7 +101,6 @@ var _ = Describe("FetchSource", func() {
 			fakeResource,
 			worker.ContainerSpec{
 				TeamID: 42,
-				Tags:   []string{},
 				ImageSpec: worker.ImageSpec{
 					ResourceType: "fake-resource-type",
 				},
@@ -217,7 +216,6 @@ var _ = Describe("FetchSource", func() {
 				Expect(containerSpec).To(Equal(
 					worker.ContainerSpec{
 						TeamID: 42,
-						Tags:   []string{},
 						ImageSpec: worker.ImageSpec{
 							ResourceType: "fake-resource-type",
 						},

--- a/topgun/runtime/resource_certs_test.go
+++ b/topgun/runtime/resource_certs_test.go
@@ -45,13 +45,9 @@ var _ = Describe("Resource Certs", func() {
 		})
 
 		It("bind mounts the certs volume to resource get containers", func() {
-			trigger := Fly.Start("trigger-job", "-j", "resources/use-em")
+			trigger := Fly.Start("trigger-job", "-w", "-j", "resources/use-em")
 			<-trigger.Exited
-
-			Eventually(func() string {
-				builds := FlyTable("builds", "-j", "resources/use-em")
-				return builds[0]["status"]
-			}).Should(Equal("failed"))
+			Expect(trigger.ExitCode()).To(Equal(1))
 
 			hijackSession := Fly.Start("hijack", "-j", "resources/use-em", "-s", "certs", "--", "ls", "/etc/ssl/certs")
 			<-hijackSession.Exited
@@ -60,13 +56,9 @@ var _ = Describe("Resource Certs", func() {
 		})
 
 		It("bind mounts the certs volume to resource put containers", func() {
-			trigger := Fly.Start("trigger-job", "-j", "resources/use-em")
+			trigger := Fly.Start("trigger-job", "-w", "-j", "resources/use-em")
 			<-trigger.Exited
-
-			Eventually(func() string {
-				builds := FlyTable("builds", "-j", "resources/use-em")
-				return builds[0]["status"]
-			}).Should(Equal("failed"))
+			Expect(trigger.ExitCode()).To(Equal(1))
 
 			hijackSession := Fly.Start("hijack", "-j", "resources/use-em", "-s", "put-certs", "--", "ls", "/etc/ssl/certs")
 			Eventually(hijackSession).Should(gexec.Exit(0))
@@ -74,6 +66,5 @@ var _ = Describe("Resource Certs", func() {
 			certsContent := string(hijackSession.Out.Contents())
 			Expect(certsContent).ToNot(HaveLen(0))
 		})
-
 	})
 })


### PR DESCRIPTION
## What does this PR accomplish?

**Bug Fix**

This contains two fixes for topgun:

* Fixes a regression introduced by #6153 - when all workers are tagged, image fetching would fail because the tags configured on the step were not respected during image fetching, which resulted in looking only for untagged workers. Now the tags configured either on the resource type (`check`/`get`/`put`) or the step (`task`/`check`/`get`/`put`) will be respected.
  * In addition, `tags:` may now be specified on task's `image_resource`. This was added because the `atc.ImageResource` type is used for fetching all this, and it seems reasonable to allow it to be configured there anyhow. (This is technically a new feature I guess.)
* When sending `ImageCheck` and `ImageGet` events, send only the *public* build plan, not the full build plan. This caused topgun tests covering database encryption and secret management to fail, because secrets ended up being saved in the event stream.
  * Sending the public plan is consistent with `/api/v1/builds/<id>/plan`, which the web UI also uses.


## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
