### PR TITLE
feat: P2P Volume Streaming

### DIFF
--- a/atc/worker/artifact_destination.go
+++ b/atc/worker/artifact_destination.go
@@ -16,4 +16,6 @@ type ArtifactDestination interface {
 	// StreamIn is called with a destination directory and the tar stream to
 	// expand into the destination directory.
 	StreamIn(context.Context, string, baggageclaim.Encoding, io.Reader) error
+
+	GetStreamInP2pUrl(ctx context.Context, path string) (string, error)
 }

--- a/atc/worker/artifact_source_test.go
+++ b/atc/worker/artifact_source_test.go
@@ -2,11 +2,13 @@ package worker_test
 
 import (
 	"archive/tar"
+	"code.cloudfoundry.org/clock/fakeclock"
 	"compress/gzip"
 	"context"
 	"errors"
 	"io"
 	"io/ioutil"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/baggageclaim"
@@ -28,6 +30,10 @@ var _ = Describe("StreamableArtifactSource", func() {
 		fakeDestination *workerfakes.FakeArtifactDestination
 		fakeVolume      *workerfakes.FakeVolume
 		fakeArtifact    *runtimefakes.FakeArtifact
+		fakeClock       *fakeclock.FakeClock
+
+		enabledP2pStreaming bool
+		p2pStreamingTimeout time.Duration
 
 		artifactSource worker.StreamableArtifactSource
 		comp           compression.Compression
@@ -41,65 +47,151 @@ var _ = Describe("StreamableArtifactSource", func() {
 		fakeVolume = new(workerfakes.FakeVolume)
 		fakeDestination = new(workerfakes.FakeArtifactDestination)
 		comp = compression.NewGzipCompression()
+		fakeClock = fakeclock.NewFakeClock(time.Now())
 
-		artifactSource = worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, comp)
+		enabledP2pStreaming = false
+		p2pStreamingTimeout = 15 * time.Minute
+
 		testLogger = lager.NewLogger("test")
 		disaster = errors.New("disaster")
 	})
 
-	Context("StreamTo", func() {
-		var (
-			streamToErr error
-			outStream   *gbytes.Buffer
-		)
+	JustBeforeEach(func() {
+		artifactSource = worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, comp, enabledP2pStreaming, p2pStreamingTimeout, fakeClock)
+	})
 
-		BeforeEach(func() {
-			outStream = gbytes.NewBuffer()
-			fakeVolume.StreamOutReturns(outStream, nil)
-		})
+	Context("StreamTo", func() {
+		var streamToErr error
 
 		JustBeforeEach(func() {
 			streamToErr = artifactSource.StreamTo(context.TODO(), fakeDestination)
 		})
 
-		Context("when ArtifactSource can successfully stream to ArtifactDestination", func() {
+		Context("via atc", func() {
+			var outStream *gbytes.Buffer
 
-			It("calls StreamOut and StreamIn with the correct params", func() {
-				Expect(fakeVolume.StreamOutCallCount()).To(Equal(1))
-
-				_, actualPath, encoding := fakeVolume.StreamOutArgsForCall(0)
-				Expect(actualPath).To(Equal("."))
-				Expect(encoding).To(Equal(baggageclaim.GzipEncoding))
-
-				_, actualPath, encoding, actualStreamedOutBits := fakeDestination.StreamInArgsForCall(0)
-				Expect(actualPath).To(Equal("."))
-				Expect(actualStreamedOutBits).To(Equal(outStream))
-				Expect(encoding).To(Equal(baggageclaim.GzipEncoding))
+			BeforeEach(func() {
+				outStream = gbytes.NewBuffer()
+				fakeVolume.StreamOutReturns(outStream, nil)
 			})
 
-			It("does not return an err", func() {
-				Expect(streamToErr).ToNot(HaveOccurred())
+			Context("when ArtifactSource can successfully stream to ArtifactDestination", func() {
+
+				It("calls StreamOut and StreamIn with the correct params", func() {
+					Expect(fakeVolume.StreamOutCallCount()).To(Equal(1))
+
+					_, actualPath, encoding := fakeVolume.StreamOutArgsForCall(0)
+					Expect(actualPath).To(Equal("."))
+					Expect(encoding).To(Equal(baggageclaim.GzipEncoding))
+
+					_, actualPath, encoding, actualStreamedOutBits := fakeDestination.StreamInArgsForCall(0)
+					Expect(actualPath).To(Equal("."))
+					Expect(actualStreamedOutBits).To(Equal(outStream))
+					Expect(encoding).To(Equal(baggageclaim.GzipEncoding))
+				})
+
+				It("does not return an err", func() {
+					Expect(streamToErr).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("when streaming out of source fails ", func() {
+				BeforeEach(func() {
+					fakeVolume.StreamOutReturns(nil, disaster)
+				})
+				It("returns the err", func() {
+					Expect(streamToErr).To(Equal(disaster))
+				})
+			})
+
+			Context("when streaming in to destination fails ", func() {
+				BeforeEach(func() {
+					fakeDestination.StreamInReturns(disaster)
+				})
+				It("returns the err", func() {
+					Expect(streamToErr).To(Equal(disaster))
+				})
+				It("closes the streamOut io.reader", func() {
+					Expect(outStream.Closed()).To(BeTrue())
+				})
 			})
 		})
 
-		Context("when streaming out of source fails ", func() {
+		Context("p2p", func() {
 			BeforeEach(func() {
-				fakeVolume.StreamOutReturns(nil, disaster)
+				enabledP2pStreaming = true
 			})
-			It("returns the err", func() {
-				Expect(streamToErr).To(Equal(disaster))
-			})
-		})
 
-		Context("when streaming in to destination fails ", func() {
-			BeforeEach(func() {
-				fakeDestination.StreamInReturns(disaster)
+			Context("GetStreamInP2pUrl fails", func() {
+				BeforeEach(func() {
+					fakeDestination.GetStreamInP2pUrlReturns("", disaster)
+				})
+
+				It("does return an err", func() {
+					Expect(streamToErr).To(HaveOccurred())
+					Expect(streamToErr).To(Equal(disaster))
+				})
+
+				It("should not call StreamP2pOut", func() {
+					Expect(fakeDestination.GetStreamInP2pUrlCallCount()).To(Equal(1))
+
+					_, actualPath := fakeDestination.GetStreamInP2pUrlArgsForCall(0)
+					Expect(actualPath).To(Equal("."))
+
+					Expect(fakeVolume.StreamP2pOutCallCount()).To(Equal(0))
+				})
 			})
-			It("returns the err", func() {
-				Expect(streamToErr).To(Equal(disaster))
-			})
-			It("closes the streamOut io.reader", func() {
-				Expect(outStream.Closed()).To(BeTrue())
+
+			Context("GetStreamInP2pUrl succeeds", func() {
+				BeforeEach(func() {
+					fakeDestination.GetStreamInP2pUrlReturns("some-url", nil)
+				})
+
+				It("calls GetStreamInP2pUrl and StreamP2pOut with the correct params", func() {
+					Expect(fakeDestination.GetStreamInP2pUrlCallCount()).To(Equal(1))
+
+					_, actualPath := fakeDestination.GetStreamInP2pUrlArgsForCall(0)
+					Expect(actualPath).To(Equal("."))
+
+					Expect(fakeVolume.StreamP2pOutCallCount()).To(Equal(1))
+
+					_, actualPath, actualStreamUrl, actualEncoding := fakeVolume.StreamP2pOutArgsForCall(0)
+					Expect(actualPath).To(Equal("."))
+					Expect(actualStreamUrl).To(Equal("some-url"))
+					Expect(actualEncoding).To(Equal(baggageclaim.GzipEncoding))
+				})
+
+				Context("StreamP2pOut fails", func() {
+					BeforeEach(func() {
+						fakeVolume.StreamP2pOutReturns(disaster)
+					})
+
+					It("does return an err", func() {
+						Expect(streamToErr).To(HaveOccurred())
+						Expect(streamToErr).To(Equal(disaster))
+					})
+				})
+
+				Context("StreamP2pOut times out", func() {
+					BeforeEach(func() {
+						fakeVolume.StreamP2pOutStub = func(ctx context.Context, s string, s2 string, encoding baggageclaim.Encoding) error {
+							fakeClock.Increment(time.Minute * 20)
+							time.Sleep(1 * time.Second)
+							return nil
+						}
+					})
+
+					It("does return an err", func() {
+						Expect(streamToErr).To(HaveOccurred())
+						Expect(streamToErr).To(Equal(errors.New("p2p stream to some-url timeout")))
+					})
+				})
+
+				Context("StreamP2pOut succeeds", func() {
+					It("does not return an err", func() {
+						Expect(streamToErr).ToNot(HaveOccurred())
+					})
+				})
 			})
 		})
 	})

--- a/atc/worker/choose_task_worker_test.go
+++ b/atc/worker/choose_task_worker_test.go
@@ -80,7 +80,9 @@ var _ = Describe("RunTaskStep", func() {
 				fakeProvider,
 				fakeCompression,
 				workerInterval,
-				workerStatusInterval)
+				workerStatusInterval,
+				false,
+				15*time.Minute)
 		})
 
 		Context("worker is available", func() {

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -291,6 +291,8 @@ func (client *client) RunTaskStep(
 		return TaskResult{}, err
 	}
 
+	eventDelegate.SelectedWorker(logger, chosenWorker.Name())
+
 	if strategy.ModifiesActiveTasks() {
 		defer decreaseActiveTasks(logger.Session("decrease-active-tasks"), chosenWorker)
 	}
@@ -306,8 +308,6 @@ func (client *client) RunTaskStep(
 	if err != nil {
 		return TaskResult{}, err
 	}
-
-	eventDelegate.SelectedWorker(logger, chosenWorker.Name())
 
 	// container already exited
 	exitStatusProp, _ := container.Properties()
@@ -700,7 +700,7 @@ func (client *client) wireInputsAndCaches(logger lager.Logger, spec *ContainerSp
 				return fmt.Errorf("volume not found for artifact id %v type %T", artifact.ID(), artifact)
 			}
 
-			source := NewStreamableArtifactSource(artifact, artifactVolume, client.compression, client.enabledP2pStreaming, client.p2pStreamingTimeout, nil)
+			source := NewStreamableArtifactSource(artifact, artifactVolume, client.compression, client.enabledP2pStreaming, client.p2pStreamingTimeout)
 			inputs = append(inputs, inputSource{source, path})
 		}
 	}
@@ -720,7 +720,7 @@ func (client *client) wireImageVolume(logger lager.Logger, spec *ImageSpec) erro
 		return fmt.Errorf("volume not found for artifact id %v type %T", imageArtifact.ID(), imageArtifact)
 	}
 
-	spec.ImageArtifactSource = NewStreamableArtifactSource(imageArtifact, artifactVolume, client.compression, client.enabledP2pStreaming, client.p2pStreamingTimeout, nil)
+	spec.ImageArtifactSource = NewStreamableArtifactSource(imageArtifact, artifactVolume, client.compression, client.enabledP2pStreaming, client.p2pStreamingTimeout)
 
 	return nil
 }

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -99,6 +99,8 @@ func NewClient(pool Pool,
 	compression compression.Compression,
 	workerPollingInterval time.Duration,
 	workerStatusPublishInterval time.Duration,
+	enabledP2pStreaming bool,
+	p2pStreamingTimeout time.Duration,
 ) *client {
 	return &client{
 		pool:                        pool,
@@ -106,6 +108,8 @@ func NewClient(pool Pool,
 		compression:                 compression,
 		workerPollingInterval:       workerPollingInterval,
 		workerStatusPublishInterval: workerStatusPublishInterval,
+		enabledP2pStreaming:         enabledP2pStreaming,
+		p2pStreamingTimeout:         p2pStreamingTimeout,
 	}
 }
 
@@ -115,6 +119,8 @@ type client struct {
 	compression                 compression.Compression
 	workerPollingInterval       time.Duration
 	workerStatusPublishInterval time.Duration
+	enabledP2pStreaming         bool
+	p2pStreamingTimeout         time.Duration
 }
 
 type TaskResult struct {
@@ -694,7 +700,7 @@ func (client *client) wireInputsAndCaches(logger lager.Logger, spec *ContainerSp
 				return fmt.Errorf("volume not found for artifact id %v type %T", artifact.ID(), artifact)
 			}
 
-			source := NewStreamableArtifactSource(artifact, artifactVolume, client.compression)
+			source := NewStreamableArtifactSource(artifact, artifactVolume, client.compression, client.enabledP2pStreaming, client.p2pStreamingTimeout, nil)
 			inputs = append(inputs, inputSource{source, path})
 		}
 	}
@@ -714,7 +720,7 @@ func (client *client) wireImageVolume(logger lager.Logger, spec *ImageSpec) erro
 		return fmt.Errorf("volume not found for artifact id %v type %T", imageArtifact.ID(), imageArtifact)
 	}
 
-	spec.ImageArtifactSource = NewStreamableArtifactSource(imageArtifact, artifactVolume, client.compression)
+	spec.ImageArtifactSource = NewStreamableArtifactSource(imageArtifact, artifactVolume, client.compression, client.enabledP2pStreaming, client.p2pStreamingTimeout, nil)
 
 	return nil
 }

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -322,7 +322,7 @@ var _ = Describe("Client", func() {
 				It("locates the volume and assigns it as an ImageArtifactSource", func() {
 					_, _, _, _, containerSpec := fakeWorker.FindOrCreateContainerArgsForCall(0)
 					imageSpec := containerSpec.ImageSpec
-					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute, nil)))
+					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute)))
 				})
 			})
 
@@ -551,7 +551,7 @@ var _ = Describe("Client", func() {
 					Expect(fakeChosenWorker.FetchCallCount()).To(Equal(1))
 					_, _, _, _, actualContainerSpec, _, _, _, _, _ := fakeChosenWorker.FetchArgsForCall(0)
 					imageSpec := actualContainerSpec.ImageSpec
-					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute, nil)))
+					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute)))
 				})
 			})
 		})
@@ -823,7 +823,7 @@ var _ = Describe("Client", func() {
 			It("locates the volume and assigns it as an ImageArtifactSource", func() {
 				_, _, _, _, containerSpec := fakeWorker.FindOrCreateContainerArgsForCall(0)
 				imageSpec := containerSpec.ImageSpec
-				Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute, nil)))
+				Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute)))
 			})
 		})
 
@@ -1508,7 +1508,7 @@ var _ = Describe("Client", func() {
 				It("locates the volume and assigns it as an ImageArtifactSource", func() {
 					_, _, _, _, containerSpec := fakeChosenWorker.FindOrCreateContainerArgsForCall(0)
 					imageSpec := containerSpec.ImageSpec
-					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute, nil)))
+					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute)))
 				})
 			})
 		})

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Client", func() {
 		workerPolling := 1 * time.Second
 		workerStatus := 2 * time.Second
 
-		client = worker.NewClient(fakePool, fakeProvider, fakeCompression, workerPolling, workerStatus)
+		client = worker.NewClient(fakePool, fakeProvider, fakeCompression, workerPolling, workerStatus, false, 15*time.Minute)
 	})
 
 	Describe("FindContainer", func() {
@@ -322,7 +322,7 @@ var _ = Describe("Client", func() {
 				It("locates the volume and assigns it as an ImageArtifactSource", func() {
 					_, _, _, _, containerSpec := fakeWorker.FindOrCreateContainerArgsForCall(0)
 					imageSpec := containerSpec.ImageSpec
-					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression)))
+					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute, nil)))
 				})
 			})
 
@@ -551,7 +551,7 @@ var _ = Describe("Client", func() {
 					Expect(fakeChosenWorker.FetchCallCount()).To(Equal(1))
 					_, _, _, _, actualContainerSpec, _, _, _, _, _ := fakeChosenWorker.FetchArgsForCall(0)
 					imageSpec := actualContainerSpec.ImageSpec
-					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression)))
+					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute, nil)))
 				})
 			})
 		})
@@ -823,7 +823,7 @@ var _ = Describe("Client", func() {
 			It("locates the volume and assigns it as an ImageArtifactSource", func() {
 				_, _, _, _, containerSpec := fakeWorker.FindOrCreateContainerArgsForCall(0)
 				imageSpec := containerSpec.ImageSpec
-				Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression)))
+				Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute, nil)))
 			})
 		})
 
@@ -1508,7 +1508,7 @@ var _ = Describe("Client", func() {
 				It("locates the volume and assigns it as an ImageArtifactSource", func() {
 					_, _, _, _, containerSpec := fakeChosenWorker.FindOrCreateContainerArgsForCall(0)
 					imageSpec := containerSpec.ImageSpec
-					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression)))
+					Expect(imageSpec.ImageArtifactSource).To(Equal(worker.NewStreamableArtifactSource(fakeArtifact, fakeVolume, fakeCompression, false, 15*time.Minute, nil)))
 				})
 			})
 		})

--- a/atc/worker/image/image.go
+++ b/atc/worker/image/image.go
@@ -212,3 +212,7 @@ type artifactDestination struct {
 func (wad *artifactDestination) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, tarStream io.Reader) error {
 	return wad.destination.StreamIn(ctx, path, encoding, tarStream)
 }
+
+func (wad *artifactDestination) GetStreamInP2pUrl(ctx context.Context, path string) (string, error) {
+	return wad.destination.GetStreamInP2pUrl(ctx, path)
+}

--- a/atc/worker/volume.go
+++ b/atc/worker/volume.go
@@ -24,6 +24,9 @@ type Volume interface {
 	StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, tarStream io.Reader) error
 	StreamOut(ctx context.Context, path string, encoding baggageclaim.Encoding) (io.ReadCloser, error)
 
+	GetStreamInP2pUrl(ctx context.Context, path string) (string, error)
+	StreamP2pOut(ctx context.Context, path string, destUrl string, encoding baggageclaim.Encoding) error
+
 	COWStrategy() baggageclaim.COWStrategy
 
 	InitializeResourceCache(db.UsedResourceCache) error
@@ -100,6 +103,14 @@ func (v *volume) StreamIn(ctx context.Context, path string, encoding baggageclai
 
 func (v *volume) StreamOut(ctx context.Context, path string, encoding baggageclaim.Encoding) (io.ReadCloser, error) {
 	return v.bcVolume.StreamOut(ctx, path, encoding)
+}
+
+func (v *volume) GetStreamInP2pUrl(ctx context.Context, path string) (string, error) {
+	return v.bcVolume.GetStreamInP2pUrl(ctx, path)
+}
+
+func (v *volume) StreamP2pOut(ctx context.Context, path string, destUrl string, encoding baggageclaim.Encoding) error {
+	return v.bcVolume.StreamP2pOut(ctx, path, destUrl, encoding)
 }
 
 func (v *volume) Properties() (baggageclaim.VolumeProperties, error) {

--- a/atc/worker/workerfakes/fake_artifact_destination.go
+++ b/atc/worker/workerfakes/fake_artifact_destination.go
@@ -11,6 +11,20 @@ import (
 )
 
 type FakeArtifactDestination struct {
+	GetStreamInP2pUrlStub        func(context.Context, string) (string, error)
+	getStreamInP2pUrlMutex       sync.RWMutex
+	getStreamInP2pUrlArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	getStreamInP2pUrlReturns struct {
+		result1 string
+		result2 error
+	}
+	getStreamInP2pUrlReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	StreamInStub        func(context.Context, string, baggageclaim.Encoding, io.Reader) error
 	streamInMutex       sync.RWMutex
 	streamInArgsForCall []struct {
@@ -27,6 +41,70 @@ type FakeArtifactDestination struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeArtifactDestination) GetStreamInP2pUrl(arg1 context.Context, arg2 string) (string, error) {
+	fake.getStreamInP2pUrlMutex.Lock()
+	ret, specificReturn := fake.getStreamInP2pUrlReturnsOnCall[len(fake.getStreamInP2pUrlArgsForCall)]
+	fake.getStreamInP2pUrlArgsForCall = append(fake.getStreamInP2pUrlArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetStreamInP2pUrl", []interface{}{arg1, arg2})
+	fake.getStreamInP2pUrlMutex.Unlock()
+	if fake.GetStreamInP2pUrlStub != nil {
+		return fake.GetStreamInP2pUrlStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getStreamInP2pUrlReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeArtifactDestination) GetStreamInP2pUrlCallCount() int {
+	fake.getStreamInP2pUrlMutex.RLock()
+	defer fake.getStreamInP2pUrlMutex.RUnlock()
+	return len(fake.getStreamInP2pUrlArgsForCall)
+}
+
+func (fake *FakeArtifactDestination) GetStreamInP2pUrlCalls(stub func(context.Context, string) (string, error)) {
+	fake.getStreamInP2pUrlMutex.Lock()
+	defer fake.getStreamInP2pUrlMutex.Unlock()
+	fake.GetStreamInP2pUrlStub = stub
+}
+
+func (fake *FakeArtifactDestination) GetStreamInP2pUrlArgsForCall(i int) (context.Context, string) {
+	fake.getStreamInP2pUrlMutex.RLock()
+	defer fake.getStreamInP2pUrlMutex.RUnlock()
+	argsForCall := fake.getStreamInP2pUrlArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeArtifactDestination) GetStreamInP2pUrlReturns(result1 string, result2 error) {
+	fake.getStreamInP2pUrlMutex.Lock()
+	defer fake.getStreamInP2pUrlMutex.Unlock()
+	fake.GetStreamInP2pUrlStub = nil
+	fake.getStreamInP2pUrlReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeArtifactDestination) GetStreamInP2pUrlReturnsOnCall(i int, result1 string, result2 error) {
+	fake.getStreamInP2pUrlMutex.Lock()
+	defer fake.getStreamInP2pUrlMutex.Unlock()
+	fake.GetStreamInP2pUrlStub = nil
+	if fake.getStreamInP2pUrlReturnsOnCall == nil {
+		fake.getStreamInP2pUrlReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.getStreamInP2pUrlReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeArtifactDestination) StreamIn(arg1 context.Context, arg2 string, arg3 baggageclaim.Encoding, arg4 io.Reader) error {
@@ -95,6 +173,8 @@ func (fake *FakeArtifactDestination) StreamInReturnsOnCall(i int, result1 error)
 func (fake *FakeArtifactDestination) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.getStreamInP2pUrlMutex.RLock()
+	defer fake.getStreamInP2pUrlMutex.RUnlock()
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/worker/workerfakes/fake_volume.go
+++ b/atc/worker/workerfakes/fake_volume.go
@@ -57,6 +57,20 @@ type FakeVolume struct {
 	getResourceCacheIDReturnsOnCall map[int]struct {
 		result1 int
 	}
+	GetStreamInP2pUrlStub        func(context.Context, string) (string, error)
+	getStreamInP2pUrlMutex       sync.RWMutex
+	getStreamInP2pUrlArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	getStreamInP2pUrlReturns struct {
+		result1 string
+		result2 error
+	}
+	getStreamInP2pUrlReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	HandleStub        func() string
 	handleMutex       sync.RWMutex
 	handleArgsForCall []struct {
@@ -180,6 +194,20 @@ type FakeVolume struct {
 	streamOutReturnsOnCall map[int]struct {
 		result1 io.ReadCloser
 		result2 error
+	}
+	StreamP2pOutStub        func(context.Context, string, string, baggageclaim.Encoding) error
+	streamP2pOutMutex       sync.RWMutex
+	streamP2pOutArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 baggageclaim.Encoding
+	}
+	streamP2pOutReturns struct {
+		result1 error
+	}
+	streamP2pOutReturnsOnCall map[int]struct {
+		result1 error
 	}
 	WorkerNameStub        func() string
 	workerNameMutex       sync.RWMutex
@@ -413,6 +441,70 @@ func (fake *FakeVolume) GetResourceCacheIDReturnsOnCall(i int, result1 int) {
 	fake.getResourceCacheIDReturnsOnCall[i] = struct {
 		result1 int
 	}{result1}
+}
+
+func (fake *FakeVolume) GetStreamInP2pUrl(arg1 context.Context, arg2 string) (string, error) {
+	fake.getStreamInP2pUrlMutex.Lock()
+	ret, specificReturn := fake.getStreamInP2pUrlReturnsOnCall[len(fake.getStreamInP2pUrlArgsForCall)]
+	fake.getStreamInP2pUrlArgsForCall = append(fake.getStreamInP2pUrlArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetStreamInP2pUrl", []interface{}{arg1, arg2})
+	fake.getStreamInP2pUrlMutex.Unlock()
+	if fake.GetStreamInP2pUrlStub != nil {
+		return fake.GetStreamInP2pUrlStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getStreamInP2pUrlReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeVolume) GetStreamInP2pUrlCallCount() int {
+	fake.getStreamInP2pUrlMutex.RLock()
+	defer fake.getStreamInP2pUrlMutex.RUnlock()
+	return len(fake.getStreamInP2pUrlArgsForCall)
+}
+
+func (fake *FakeVolume) GetStreamInP2pUrlCalls(stub func(context.Context, string) (string, error)) {
+	fake.getStreamInP2pUrlMutex.Lock()
+	defer fake.getStreamInP2pUrlMutex.Unlock()
+	fake.GetStreamInP2pUrlStub = stub
+}
+
+func (fake *FakeVolume) GetStreamInP2pUrlArgsForCall(i int) (context.Context, string) {
+	fake.getStreamInP2pUrlMutex.RLock()
+	defer fake.getStreamInP2pUrlMutex.RUnlock()
+	argsForCall := fake.getStreamInP2pUrlArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeVolume) GetStreamInP2pUrlReturns(result1 string, result2 error) {
+	fake.getStreamInP2pUrlMutex.Lock()
+	defer fake.getStreamInP2pUrlMutex.Unlock()
+	fake.GetStreamInP2pUrlStub = nil
+	fake.getStreamInP2pUrlReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVolume) GetStreamInP2pUrlReturnsOnCall(i int, result1 string, result2 error) {
+	fake.getStreamInP2pUrlMutex.Lock()
+	defer fake.getStreamInP2pUrlMutex.Unlock()
+	fake.GetStreamInP2pUrlStub = nil
+	if fake.getStreamInP2pUrlReturnsOnCall == nil {
+		fake.getStreamInP2pUrlReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.getStreamInP2pUrlReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeVolume) Handle() string {
@@ -1011,6 +1103,69 @@ func (fake *FakeVolume) StreamOutReturnsOnCall(i int, result1 io.ReadCloser, res
 	}{result1, result2}
 }
 
+func (fake *FakeVolume) StreamP2pOut(arg1 context.Context, arg2 string, arg3 string, arg4 baggageclaim.Encoding) error {
+	fake.streamP2pOutMutex.Lock()
+	ret, specificReturn := fake.streamP2pOutReturnsOnCall[len(fake.streamP2pOutArgsForCall)]
+	fake.streamP2pOutArgsForCall = append(fake.streamP2pOutArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 baggageclaim.Encoding
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("StreamP2pOut", []interface{}{arg1, arg2, arg3, arg4})
+	fake.streamP2pOutMutex.Unlock()
+	if fake.StreamP2pOutStub != nil {
+		return fake.StreamP2pOutStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.streamP2pOutReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeVolume) StreamP2pOutCallCount() int {
+	fake.streamP2pOutMutex.RLock()
+	defer fake.streamP2pOutMutex.RUnlock()
+	return len(fake.streamP2pOutArgsForCall)
+}
+
+func (fake *FakeVolume) StreamP2pOutCalls(stub func(context.Context, string, string, baggageclaim.Encoding) error) {
+	fake.streamP2pOutMutex.Lock()
+	defer fake.streamP2pOutMutex.Unlock()
+	fake.StreamP2pOutStub = stub
+}
+
+func (fake *FakeVolume) StreamP2pOutArgsForCall(i int) (context.Context, string, string, baggageclaim.Encoding) {
+	fake.streamP2pOutMutex.RLock()
+	defer fake.streamP2pOutMutex.RUnlock()
+	argsForCall := fake.streamP2pOutArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeVolume) StreamP2pOutReturns(result1 error) {
+	fake.streamP2pOutMutex.Lock()
+	defer fake.streamP2pOutMutex.Unlock()
+	fake.StreamP2pOutStub = nil
+	fake.streamP2pOutReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeVolume) StreamP2pOutReturnsOnCall(i int, result1 error) {
+	fake.streamP2pOutMutex.Lock()
+	defer fake.streamP2pOutMutex.Unlock()
+	fake.StreamP2pOutStub = nil
+	if fake.streamP2pOutReturnsOnCall == nil {
+		fake.streamP2pOutReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.streamP2pOutReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeVolume) WorkerName() string {
 	fake.workerNameMutex.Lock()
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
@@ -1074,6 +1229,8 @@ func (fake *FakeVolume) Invocations() map[string][][]interface{} {
 	defer fake.destroyMutex.RUnlock()
 	fake.getResourceCacheIDMutex.RLock()
 	defer fake.getResourceCacheIDMutex.RUnlock()
+	fake.getStreamInP2pUrlMutex.RLock()
+	defer fake.getStreamInP2pUrlMutex.RUnlock()
 	fake.handleMutex.RLock()
 	defer fake.handleMutex.RUnlock()
 	fake.initializeArtifactMutex.RLock()
@@ -1094,6 +1251,8 @@ func (fake *FakeVolume) Invocations() map[string][][]interface{} {
 	defer fake.streamInMutex.RUnlock()
 	fake.streamOutMutex.RLock()
 	defer fake.streamOutMutex.RUnlock()
+	fake.streamP2pOutMutex.RLock()
+	defer fake.streamP2pOutMutex.RUnlock()
 	fake.workerNameMutex.RLock()
 	defer fake.workerNameMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/concourse/dex v0.2.1
 	github.com/concourse/flag v1.1.0
 	github.com/concourse/go-archive v1.0.1
-	github.com/concourse/retryhttp v1.0.2
+	github.com/concourse/retryhttp v1.1.0
 	github.com/containerd/cgroups v0.0.0-20191220161829-06e718085901 // indirect
 	github.com/containerd/containerd v1.3.4
 	github.com/containerd/continuity v0.0.0-20191214063359-1097c8bae83b // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
-	github.com/concourse/baggageclaim v1.8.0
+	github.com/concourse/baggageclaim v1.9.0
 	github.com/concourse/dex v0.2.1
 	github.com/concourse/flag v1.1.0
 	github.com/concourse/go-archive v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2/go.mod h
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/concourse/baggageclaim v1.8.0 h1:nOIXTm0oIVLEc/5JbLxYe6q62h5BYdILV3gExVJ9r3M=
-github.com/concourse/baggageclaim v1.8.0/go.mod h1:UdvVE2W8LgXcCz0ZdKBwUbpKZ0KN4Fx1OeY1xtZOUvY=
+github.com/concourse/baggageclaim v1.9.0 h1:GnpOGMJro1wqYisUn1mRnGbsethu1WUwagf2jMHXNiY=
+github.com/concourse/baggageclaim v1.9.0/go.mod h1:UdvVE2W8LgXcCz0ZdKBwUbpKZ0KN4Fx1OeY1xtZOUvY=
 github.com/concourse/dex v0.2.1 h1:p7aOohrGHG6+HDFlsenOJ4Du7wsJ3sAmyz0EsXX4WRk=
 github.com/concourse/dex v0.2.1/go.mod h1:PF+R+Z86u1A2eU3hqpx33Df2YgZvBwas8QflgMiliQo=
 github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0 h1:t/LhUZLVitR1Ow2YOnduCsavhwFUklBMoGVYUCqmCqk=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -228,6 +230,8 @@ github.com/concourse/go-archive v1.0.1/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv
 github.com/concourse/retryhttp v0.0.0-20170802173037-937335fd9545/go.mod h1:4+V9YCkKuoV7rg+/No+ZM9FsO3BK4tIJNUiYMI7nki0=
 github.com/concourse/retryhttp v1.0.2 h1:Qlag8vPBvXN79XyuM+XSf0/+jIYWnnivPwaa3ijbgdk=
 github.com/concourse/retryhttp v1.0.2/go.mod h1:t/8nUqzPriXrWczdqI7tHoEvFe+tJplQHS/fO3BzdlA=
+github.com/concourse/retryhttp v1.1.0 h1:tbsCtyU4Bioaw01Un3f10tgBBzVDWvWkOQyfl5ZCs8g=
+github.com/concourse/retryhttp v1.1.0/go.mod h1:QHhy6lQHGmqOKNv0UdoUPYzsTOy9wrf6nHfYsJpow0o=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20191220161829-06e718085901 h1:ttn8unuUj4LRsB92Gjs6ORv0uyyzvuo+Ax5llW1YtJo=
 github.com/containerd/cgroups v0.0.0-20191220161829-06e718085901/go.mod h1:FwbKQCduYoQfIgPclXEWCx5nXWYmnAV7+syVQrs+Z/w=

--- a/versions.go
+++ b/versions.go
@@ -11,4 +11,4 @@ var Version = "0.0.0-dev"
 //
 // New features that are otherwise backwards-compatible should result in a
 // minor version bump.
-var WorkerVersion = "2.2"
+var WorkerVersion = "2.3"


### PR DESCRIPTION
## What does this PR accomplish?

This PR implements P2P Volume Streaming (https://github.com/concourse/rfcs/pull/82). In deployments where workers can reach to each other, P2P Volume Streaming should:

* Speed up volume streaming between workers
* Reduce ATC's cpu/memory/network usages that spend on volume streaming

Corresponding baggeclaim part code change is https://github.com/concourse/baggageclaim/pull/39

I have done a PoC. In the PoC, I run the 20 pipelines with the following code:

```yaml
resources:
- name: timer
  type: time
  source:
    interval: 1m

jobs:
- name: test
  public: true
  plan:
  - get: timer
    trigger: true

  - task: t1
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: {repository: busybox}
      outputs:
      - name: out1
      run:
        path: sh
        args:
         - -exc
         - dd bs=1024 count=50000 </dev/urandom >out1/f1.bin

  - task: t2
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: {repository: busybox}
      inputs:
      - name: out1
      outputs:
      - name: out2
      run:
        path: sh
        args:
         - -exc
         - dd bs=1024 count=50000 </dev/urandom >out2/f2.bin
         - ls -l out1/

  - task: t3
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: {repository: busybox}
      inputs:
      - name: out2
      outputs:
      - name: out3
      run:
        path: sh
        args:
         - -exc
         - dd bs=1024 count=50000 </dev/urandom >out3/f3.bin
         - ls -l out2/

  - task: t4
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: {repository: busybox}
      inputs:
      - name: out3
      outputs:
      - name: out4
      run:
        path: sh
        args:
         - -exc
         - dd bs=1024 count=50000 </dev/urandom >out4/f4.bin
         - ls -l out3/

  - task: t5
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: {repository: busybox}
      inputs:
      - name: out4
      run:
        path: sh
        args:
         - -exc
         - ls -l out4/
```

All pipelines are triggered a 1-minute timer, and a pipeline contains 5 tasks, each task just generate a 50MB random binary file, and is used in next task.

My test cluster has 1 ATC node and 4 workers, using `random` container placement strategy, so that a lot of volume streaming would happen.

I ran the test without and with P2P mode each for ~40 minutes. The following metrics shows big performance improvement with P2P mode:

First, let's see build status. The two rounds of test should generate same number of builds. But we can see that, under P2P mode, the test generated more successful builds, which indicates that under P2P mode, build ran faster because of shorter volume streaming time.

<img width="375" alt="build-status" src="https://user-images.githubusercontent.com/18585861/97384597-f5415900-190a-11eb-97e9-eb96f3064444.png">

Also, let's see volumes streamed. Both tests caused roughly same number of volume streaming.

<img width="377" alt="volumes-streamed" src="https://user-images.githubusercontent.com/18585861/97385164-19ea0080-190c-11eb-82bf-d6dfef91ade8.png">

Then let's difference of ATC cpu/memory/network usages.

<img width="375" alt="web-cpu" src="https://user-images.githubusercontent.com/18585861/97385274-5ddd0580-190c-11eb-9011-70165633a1f6.png">

<img width="376" alt="web-memory-used" src="https://user-images.githubusercontent.com/18585861/97385296-65041380-190c-11eb-800b-c242a63a92c4.png">

<img width="376" alt="web-network" src="https://user-images.githubusercontent.com/18585861/97385315-6e8d7b80-190c-11eb-8a10-bc17e5b76e7e.png">

We can see that, ATC cpu/memory usages under P2P mode are just roughly 1/3 of non-P2P mode. And the usage curves under P2P mode are smoother and flat-ter, which indicates that ATC under P2P mode should be more stable.

As expected, as volume streaming bits not going through ATC, under P2P mode, ATC's network usage is only at KB level.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:

So far the code is still dirty, and tests have not been updated.

EDIT: I have cleaned up the code, so it's ready for review. Please ignore changes in `go.mod`, `docker-compose.yml` and `Dockerfile`. They ease my local tests, I'll revert them when review is done.

EDIT: I have cleaned up all of the code changes, and added test cases. Now this PR is ready for review.

NOTE: With this feature, worker version should be bumped, because two BC endpoints are added, workers must be redeployed, otherwise this feature won't work.

## Release Note

- Support P2P volume streaming directly between two workers instead of through the ATC.
  - This is an opt-in feature enabled with `--enable-p2p-volume-streaming` or env var `$CONCOURSE_ENABLE_P2P_VOLUME_STREAMING` on the web nodes. When this feature is enabled, `--baggageclaim-bind-ip` on workers should be set to `0.0.0.0` so that baggage claim can be accessed from another workers.
  - This should only be used for clusters where all workers can reach each other on the same local network.
  -  Adds `--baggageclaim-p2p-interface-name-pattern` and `--baggageclaim-p2p-interface-family` to the `worker` command.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
