### PR TITLE
feat(atc): add a new metrics "volumes streamd"

### DIFF
--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -66,6 +66,8 @@ type Monitor struct {
 
 	ConcurrentRequests         map[string]*Gauge
 	ConcurrentRequestsLimitHit map[string]*Counter
+
+	VolumesStreamed Counter
 }
 
 var Metrics = NewMonitor()

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -61,7 +61,7 @@ func (config *NewRelicConfig) IsConfigured() bool {
 
 func (config *NewRelicConfig) NewEmitter() (metric.Emitter, error) {
 	client := &http.Client{
-		Transport: &http.Transport{ Proxy: http.ProxyFromEnvironment },
+		Transport: &http.Transport{Proxy: http.ProxyFromEnvironment},
 		Timeout:   time.Minute,
 	}
 
@@ -101,7 +101,8 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		"database queries",
 		"database connections",
 		"worker unknown containers",
-		"worker unknown volumes":
+		"worker unknown volumes",
+		"volumes streamed":
 		emitter.NewRelicBatch = append(emitter.NewRelicBatch, emitter.transformToNewRelicEvent(event, ""))
 
 	// These are periodic metrics that are consolidated and only emitted once

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -52,6 +52,8 @@ type PrometheusEmitter struct {
 	checksStarted   prometheus.Counter
 	checksEnqueued  prometheus.Counter
 
+	volumesStreamed prometheus.Counter
+
 	workerContainers        *prometheus.GaugeVec
 	workerUnknownContainers *prometheus.GaugeVec
 	workerVolumes           *prometheus.GaugeVec
@@ -391,6 +393,16 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 	)
 	prometheus.MustRegister(checksEnqueued)
 
+	volumesStreamed := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "concourse",
+			Subsystem: "volumes",
+			Name:      "volumes_streams",
+			Help:      "Total number of volumes streamed from one worker to the other",
+		},
+	)
+	prometheus.MustRegister(volumesStreamed)
+
 	listener, err := net.Listen("tcp", config.bind())
 	if err != nil {
 		return nil, err
@@ -443,6 +455,8 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 		workerTasks:             workerTasks,
 		workerUnknownContainers: workerUnknownContainers,
 		workerUnknownVolumes:    workerUnknownVolumes,
+
+		volumesStreamed: volumesStreamed,
 	}
 	go emitter.periodicMetricGC()
 
@@ -518,6 +532,8 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 		emitter.checksEnqueued.Add(event.Value)
 	case "checks queue size":
 		emitter.checksQueueSize.Set(event.Value)
+	case "volumes streamed":
+		emitter.volumesStreamed.Add(event.Value)
 	default:
 		// unless we have a specific metric, we do nothing
 	}

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -397,7 +397,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 		prometheus.CounterOpts{
 			Namespace: "concourse",
 			Subsystem: "volumes",
-			Name:      "volumes_streams",
+			Name:      "volumes_streamed",
 			Help:      "Total number of volumes streamed from one worker to the other",
 		},
 	)

--- a/atc/metric/periodic.go
+++ b/atc/metric/periodic.go
@@ -76,6 +76,14 @@ func tick(logger lager.Logger, m *Monitor) {
 	)
 
 	m.emit(
+		logger.Session("volumes-streamed"),
+		Event{
+			Name:  "volumes streamed",
+			Value: m.VolumesStreamed.Delta(),
+		},
+	)
+
+	m.emit(
 		logger.Session("containers-created"),
 		Event{
 			Name:  "containers created",

--- a/atc/worker/artifact_source.go
+++ b/atc/worker/artifact_source.go
@@ -7,6 +7,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/compression"
+	"github.com/concourse/concourse/atc/metric"
 	"github.com/concourse/concourse/atc/runtime"
 	"github.com/concourse/concourse/tracing"
 	"github.com/hashicorp/go-multierror"
@@ -77,6 +78,11 @@ func (source *artifactSource) StreamTo(
 	defer out.Close()
 
 	err = destination.StreamIn(ctx, ".", source.compression.Encoding(), out)
+
+	// Inc counter if no error occurred.
+	if err == nil {
+		metric.Metrics.VolumesStreamed.Inc()
+	}
 
 	return err
 }


### PR DESCRIPTION
## What does this PR accomplish?

This PR adds a new metrics "volume stream", which will help measure volume streaming.

## Changes proposed by this PR:

Just add a counter metrics.

## Notes to reviewer:

I have tested the new metrics locally:

![volume-streamed](https://user-images.githubusercontent.com/18585861/96696262-2545a500-13bd-11eb-99c8-f9313de59208.png)


## Release Note

Added a new metrics "volume streamed".

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
