### PR TITLE
Enhanced some logs to add worker name.

### DIFF
--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -227,7 +227,7 @@ func (client *client) RunCheckStep(
 		containerSpec,
 	)
 	if err != nil {
-		return CheckResult{}, fmt.Errorf("find or create container: %w", err)
+		return CheckResult{}, err
 	}
 
 	eventDelegate.Starting(logger)

--- a/atc/worker/worker.go
+++ b/atc/worker/worker.go
@@ -212,6 +212,20 @@ func (worker *gardenWorker) FindOrCreateContainer(
 	metadata db.ContainerMetadata,
 	containerSpec ContainerSpec,
 ) (Container, error) {
+	c, err := worker.findOrCreateContainer(ctx, logger, owner, metadata, containerSpec)
+	if err != nil {
+		return c, fmt.Errorf("find or create container on worker %s: %w", worker.Name(), err)
+	}
+	return c, err
+}
+
+func (worker *gardenWorker) findOrCreateContainer(
+	ctx context.Context,
+	logger lager.Logger,
+	owner db.ContainerOwner,
+	metadata db.ContainerMetadata,
+	containerSpec ContainerSpec,
+) (Container, error) {
 
 	var (
 		gardenContainer   gclient.Container

--- a/atc/worker/worker_test.go
+++ b/atc/worker/worker_test.go
@@ -1326,7 +1326,7 @@ var _ = Describe("Worker", func() {
 					})
 
 					It("returns an error", func() {
-						Expect(findOrCreateErr).To(Equal(disasterErr))
+						Expect(findOrCreateErr).To(Equal(fmt.Errorf("find or create container on worker some-worker: %w", disasterErr)))
 					})
 
 					It("does not mark container as created", func() {
@@ -1344,7 +1344,7 @@ var _ = Describe("Worker", func() {
 					})
 
 					It("returns an error", func() {
-						Expect(findOrCreateErr).To(Equal(disasterErr))
+						Expect(findOrCreateErr).To(Equal(fmt.Errorf("find or create container on worker some-worker: %w", disasterErr)))
 					})
 
 					It("does not mark container as created", func() {
@@ -1384,7 +1384,7 @@ var _ = Describe("Worker", func() {
 				})
 
 				It("returns an error", func() {
-					Expect(findOrCreateErr).To(Equal(containerNotFoundErr))
+					Expect(findOrCreateErr).To(Equal(fmt.Errorf("find or create container on worker some-worker: %w", containerNotFoundErr)))
 				})
 			})
 		})
@@ -1408,7 +1408,7 @@ var _ = Describe("Worker", func() {
 
 					It("fails w/ ResourceConfigCheckSessionExpiredError", func() {
 						Expect(findOrCreateErr).To(HaveOccurred())
-						Expect(findOrCreateErr).To(Equal(ResourceConfigCheckSessionExpiredError))
+						Expect(findOrCreateErr).To(Equal(fmt.Errorf("find or create container on worker some-worker: %w", ResourceConfigCheckSessionExpiredError)))
 					})
 				})
 
@@ -1419,7 +1419,7 @@ var _ = Describe("Worker", func() {
 
 					It("fails with the same err", func() {
 						Expect(findOrCreateErr).To(HaveOccurred())
-						Expect(findOrCreateErr).To(Equal(errors.New("err")))
+						Expect(findOrCreateErr).To(Equal(fmt.Errorf("find or create container on worker some-worker: %w", errors.New("err"))))
 					})
 				})
 			})


### PR DESCRIPTION
## What does this PR accomplish?

Today we encounter many errors saying like:

```
{"timestamp":"2020-10-21T07:57:34.458990024Z","level":"info","source":"atc","message":"atc.checker.errored","data":{"check":1288594293,"cluster":"Runway CI","error":"run check step: find or create container: runc state: runc: fork/exec /var/gdn/assets/linux/bin/runc: resource temporarily unavailable: ","session":"19"}}
```
To debug the error, we had to find on which worker it failed to create container. But Concourse doesn't provide any clue, nothing about worker in either logs and db.

## Changes proposed by this PR:

Add worker name to the log message.

## Notes to reviewer:

This is a tiny change but will help a lot on debugging container creation failure issues.

## Release Note

Add worker name to logs of container creation error.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [x] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
