### PR TITLE
Update last check end time on check failure/error

### DIFF
--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -177,6 +177,10 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 		if err != nil {
 			metric.Metrics.ChecksFinishedWithError.Inc()
 
+			if _, updateErr := scope.UpdateLastCheckEndTime(); updateErr != nil {
+				return false, fmt.Errorf("update check end time: %w", updateErr)
+			}
+
 			if pointErr := delegate.PointToCheckedConfig(scope); pointErr != nil {
 				return false, fmt.Errorf("update resource config scope: %w", pointErr)
 			}

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -675,6 +675,10 @@ var _ = Describe("CheckStep", func() {
 					Expect(scope).To(Equal(fakeResourceConfigScope))
 				})
 
+				It("updates the scope's last check end time", func() {
+					Expect(fakeResourceConfigScope.UpdateLastCheckEndTimeCallCount()).To(Equal(1))
+				})
+
 				// Finished is for script success/failure, whereas this is an error
 				It("does not emit a Finished event", func() {
 					Expect(fakeDelegate.FinishedCallCount()).To(Equal(0))
@@ -691,6 +695,10 @@ var _ = Describe("CheckStep", func() {
 						// don't return an error - the script output has already been
 						// printed, and emitting an errored event would double it up
 						Expect(stepErr).ToNot(HaveOccurred())
+					})
+
+					It("updates the scope's last check end time", func() {
+						Expect(fakeResourceConfigScope.UpdateLastCheckEndTimeCallCount()).To(Equal(1))
 					})
 
 					It("emits a failed Finished event", func() {


### PR DESCRIPTION
## Changes proposed by this PR:

follow-up for #6022

previously the check step would only update the last check end time when
the check succeeded. this meant that if the check failed or errored,
we'd actually check again immediately, which is a bit too aggressive.

this brings it back to the old behavior, which is to update the last
check end time on failure/error.

## Contributor Checklist

- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
