### PR TITLE
Determine `across` step's `max_in_flight` at runtime

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -215,17 +215,10 @@ func (visitor *planVisitor) VisitInParallel(step *atc.InParallelStep) error {
 func (visitor *planVisitor) VisitAcross(step *atc.AcrossStep) error {
 	vars := make([]atc.AcrossVar, len(step.Vars))
 	for i, v := range step.Vars {
-		maxInFlight := 1
-		if v.MaxInFlight != nil {
-			maxInFlight = v.MaxInFlight.Limit
-			if v.MaxInFlight.All {
-				maxInFlight = len(v.Values)
-			}
-		}
 		vars[i] = atc.AcrossVar{
 			Var:         v.Var,
 			Values:      v.Values,
-			MaxInFlight: maxInFlight,
+			MaxInFlight: v.MaxInFlight,
 		}
 	}
 

--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -426,8 +426,9 @@ var factoryTests = []PlannerTest{
 					MaxInFlight: &atc.MaxInFlightConfig{All: true},
 				},
 				{
-					Var:    "var2",
-					Values: []interface{}{"b1", "b2"},
+					Var:         "var2",
+					Values:      []interface{}{"b1", "b2"},
+					MaxInFlight: &atc.MaxInFlightConfig{Limit: 1},
 				},
 			},
 		},
@@ -439,7 +440,7 @@ var factoryTests = []PlannerTest{
 					{
 						"name": "var1",
 						"values": ["a1", "a2"],
-						"max_in_flight": 2
+						"max_in_flight": "all"
 					},
 					{
 						"name": "var2",

--- a/atc/exec/across_step.go
+++ b/atc/exec/across_step.go
@@ -95,7 +95,7 @@ func (step AcrossStep) acrossStepExecutor(state RunState, varIndex int, steps []
 	return parallelExecutor{
 		stepName: "across",
 
-		maxInFlight: step.vars[varIndex].MaxInFlight.EffectiveLimit(numValues),
+		maxInFlight: step.vars[varIndex].MaxInFlight,
 		failFast:    step.failFast,
 		count:       numValues,
 
@@ -113,7 +113,7 @@ func (step AcrossStep) acrossStepLeafExecutor(state RunState, steps []ScopedStep
 	return parallelExecutor{
 		stepName: "across",
 
-		maxInFlight: lastVar.MaxInFlight.EffectiveLimit(len(steps)),
+		maxInFlight: lastVar.MaxInFlight,
 		failFast:    step.failFast,
 		count:       len(steps),
 

--- a/atc/exec/across_step.go
+++ b/atc/exec/across_step.go
@@ -95,7 +95,7 @@ func (step AcrossStep) acrossStepExecutor(state RunState, varIndex int, steps []
 	return parallelExecutor{
 		stepName: "across",
 
-		maxInFlight: step.vars[varIndex].MaxInFlight,
+		maxInFlight: step.vars[varIndex].MaxInFlight.EffectiveLimit(numValues),
 		failFast:    step.failFast,
 		count:       numValues,
 
@@ -113,7 +113,7 @@ func (step AcrossStep) acrossStepLeafExecutor(state RunState, steps []ScopedStep
 	return parallelExecutor{
 		stepName: "across",
 
-		maxInFlight: lastVar.MaxInFlight,
+		maxInFlight: lastVar.MaxInFlight.EffectiveLimit(len(steps)),
 		failFast:    step.failFast,
 		count:       len(steps),
 

--- a/atc/exec/across_step_test.go
+++ b/atc/exec/across_step_test.go
@@ -104,17 +104,16 @@ var _ = Describe("AcrossStep", func() {
 			{
 				Var:         "var1",
 				Values:      []interface{}{"a1", "a2"},
-				MaxInFlight: 2,
+				MaxInFlight: &atc.MaxInFlightConfig{All: true},
 			},
 			{
-				Var:         "var2",
-				Values:      []interface{}{"b1", "b2"},
-				MaxInFlight: 1,
+				Var:    "var2",
+				Values: []interface{}{"b1", "b2"},
 			},
 			{
 				Var:         "var3",
 				Values:      []interface{}{"c1", "c2"},
-				MaxInFlight: 2,
+				MaxInFlight: &atc.MaxInFlightConfig{Limit: 2},
 			},
 		}
 		started = make(chan vals, 8)

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -170,9 +170,9 @@ type AcrossPlan struct {
 }
 
 type AcrossVar struct {
-	Var         string        `json:"name"`
-	Values      []interface{} `json:"values"`
-	MaxInFlight int           `json:"max_in_flight"`
+	Var         string             `json:"name"`
+	Values      []interface{}      `json:"values"`
+	MaxInFlight *MaxInFlightConfig `json:"max_in_flight,omitempty"`
 }
 
 type VarScopedPlan struct {

--- a/atc/public_plan_test.go
+++ b/atc/public_plan_test.go
@@ -368,12 +368,12 @@ var _ = Describe("Plan", func() {
 								{
 									Var:         "v1",
 									Values:      []interface{}{"a"},
-									MaxInFlight: 1,
+									MaxInFlight: &atc.MaxInFlightConfig{Limit: 1},
 								},
 								{
 									Var:         "v2",
 									Values:      []interface{}{"b"},
-									MaxInFlight: 2,
+									MaxInFlight: &atc.MaxInFlightConfig{All: true},
 								},
 							},
 							Steps: []atc.VarScopedPlan{
@@ -673,7 +673,7 @@ var _ = Describe("Plan", func() {
 	      {
 	        "name": "v2",
 	        "values": ["b"],
-	        "max_in_flight": 2
+	        "max_in_flight": "all"
 	      }
 	    ],
 	    "steps": [

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -644,6 +644,16 @@ func (c *MaxInFlightConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.Limit)
 }
 
+func (c *MaxInFlightConfig) EffectiveLimit(numSteps int) int {
+	if c == nil {
+		return 1
+	}
+	if c.All {
+		return numSteps
+	}
+	return c.Limit
+}
+
 // A VersionConfig represents the choice to include every version of a
 // resource, the latest version of a resource, or a pinned (specific) one.
 type VersionConfig struct {


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Refactor**

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* When `max_in_flight: all` is specified on an `across` step, determine the effective max in flight at runtime rather than at plan time
  * This will make it possible to implement the dynamic across step, where the number of var values is not known until runtime

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

Despite changing the type of `atc.AcrossVar.MaxInFlight`, this won't break unmarshaling existing `across` plans. All valid integers can also be unmarshaled as a valid `atc.MaxInFlightConfig` - now, the value `"all"` is also supported

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
