### PR TITLE
Fix pipeline UI non-trigger input edges showing up as trigger

### DIFF
--- a/web/public/index.mjs
+++ b/web/public/index.mjs
@@ -46,7 +46,7 @@ function redrawFunction(svg, jobs, resources, newUrl) {
       .attr("class", function(edge) { return "edge " + edge.source.node.status })
 
     svgEdges.each(function(edge) {
-      if (edge.customData !== null && edge.customData.trigger === false) {
+      if (edge.customData !== null && edge.customData.trigger !== true) {
         d3.select(this).classed("trigger-false", true)
       }
     })


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix

## Changes proposed by this PR:

i set omitempty for the trigger field, which resulted in `=== false` not
being satisfied, since it became `undefined`. so let's just switch it to
`!== true`.

for anyone wondering why this isn't a simple bool check: the CSS sets
`stroke-dasharray` for non-trigger inputs, which could be set as the
default, but it's not super obvious what you'd set to remove the
dasharray when the .trigger class is present.

i guess you could set `.edge:not(.trigger)` to have a dasharray, but
don't really have an appetite to rock the boat in "legacy" CSS/SVG
logic.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
