### PR TITLE
Migrate build_id references to bigint, batch event migration

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -38,6 +38,7 @@ import (
 	"github.com/concourse/concourse/atc/db/encryption"
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/db/migration"
+	"github.com/concourse/concourse/atc/db/migration/batch"
 	"github.com/concourse/concourse/atc/engine"
 	"github.com/concourse/concourse/atc/engine/builder"
 	"github.com/concourse/concourse/atc/gc"
@@ -141,6 +142,9 @@ type RunCommand struct {
 
 	EncryptionKey    flag.Cipher `long:"encryption-key"     description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
 	OldEncryptionKey flag.Cipher `long:"old-encryption-key" description:"Encryption key previously used for encrypting sensitive information. If provided without a new key, data is encrypted. If provided with a new key, data is re-encrypted."`
+
+	BuildEventsBigintMigrationBatchSize int           `long:"build-events-bigint-batch-size" default:"100000" description:"Number of events to migrate in each batch."`
+	BuildEventsBigintMigrationInterval  time.Duration `long:"build-events-bigint-interval" default:"10s" description:"Interval on which to migrate each batch."`
 
 	DebugBindIP   flag.IP `long:"debug-bind-ip"   default:"127.0.0.1" description:"IP address on which to listen for the pprof debugger endpoints."`
 	DebugBindPort uint16  `long:"debug-bind-port" default:"8079"      description:"Port on which to listen for the pprof debugger endpoints."`
@@ -1098,6 +1102,18 @@ func (cmd *RunCommand) backendComponents(
 				Interval: cmd.BuildTrackerInterval,
 			},
 			Runnable: builds.NewTracker(dbBuildFactory, engine),
+		},
+		{
+			Component: atc.Component{
+				Name:     atc.ComponentBatchMigrator,
+				Interval: cmd.BuildEventsBigintMigrationInterval,
+			},
+			Runnable: batch.Runner{
+				Migrator: batch.BuildEventsBigintMigrator{
+					DB:        dbConn,
+					BatchSize: cmd.BuildEventsBigintMigrationBatchSize,
+				},
+			},
 		},
 		{
 			Component: atc.Component{

--- a/atc/component.go
+++ b/atc/component.go
@@ -7,6 +7,7 @@ const (
 	ComponentBuildTracker               = "tracker"
 	ComponentLidarScanner               = "scanner"
 	ComponentBuildReaper                = "reaper"
+	ComponentBatchMigrator              = "batch_migrator"
 	ComponentSyslogDrainer              = "drainer"
 	ComponentCollectorAccessTokens      = "collector_access_tokens"
 	ComponentCollectorArtifacts         = "collector_artifacts"

--- a/atc/db/migration/batch/build_events_bigint.go
+++ b/atc/db/migration/batch/build_events_bigint.go
@@ -1,0 +1,141 @@
+package batch
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagerctx"
+	sq "github.com/Masterminds/squirrel"
+	"github.com/lib/pq"
+	_ "github.com/lib/pq"
+
+	"github.com/concourse/concourse/atc/db"
+)
+
+var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
+
+type BuildEventsBigintMigrator struct {
+	DB        db.Conn
+	BatchSize int
+}
+
+func (migrator BuildEventsBigintMigrator) Migrate(ctx context.Context) (bool, error) {
+	logger := lagerctx.FromContext(ctx).Session("migrate")
+
+	logger.Debug("start")
+	defer logger.Debug("done")
+
+	var highBuild, highEvent int
+	err := psql.Select("build_id_old", "event_id").
+		From("build_events").
+		Where(sq.Eq{"build_id": nil}).
+		OrderBy("build_id_old DESC", "event_id DESC").
+		Limit(1).
+		RunWith(migrator.DB).
+		QueryRowContext(ctx).
+		Scan(&highBuild, &highEvent)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			logger.Debug("nothing-to-migrate")
+			return true, nil
+		}
+
+		var pqErr *pq.Error
+		// NB: unfortunately this approach will result in a postgresql server-side
+		// error log, but there's no guarantee that we have permissions to inspect
+		// the schema, so i don't know of another option :/
+		if errors.As(err, &pqErr) && pqErr.Code.Name() == "undefined_column" {
+			logger.Debug("already-migrated")
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	var lowBuild, lowEvent int
+	err = psql.Select("build_id_old", "event_id").
+		From("build_events").
+		Where(sq.Eq{"build_id": nil}).
+		Where(sq.Expr("(build_id_old, event_id) <= (?, ?)", highBuild, highEvent)).
+		OrderBy("build_id_old DESC", "event_id DESC").
+		Offset(uint64(migrator.BatchSize)).
+		Limit(1).
+		RunWith(migrator.DB).
+		QueryRowContext(ctx).
+		Scan(&lowBuild, &lowEvent)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			logger.Info("last-batch")
+		} else {
+			return false, err
+		}
+	}
+
+	logger.Info("migrating", lager.Data{
+		"from": []int{highBuild, highEvent},
+		"to":   []int{lowBuild, lowEvent},
+	})
+
+	result, err := psql.Update("build_events").
+		Set("build_id", sq.Expr("build_id_old")).
+		Where(sq.Eq{"build_id": nil}).
+		Where(sq.Expr("(build_id_old, event_id) <= (?, ?)", highBuild, highEvent)).
+		Where(sq.Expr("(build_id_old, event_id) > (?, ?)", lowBuild, lowEvent)).
+		RunWith(migrator.DB).
+		ExecContext(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+
+	logger.Debug("rows-affected", lager.Data{
+		"rows": rows,
+	})
+
+	return false, nil
+}
+
+func (migrator BuildEventsBigintMigrator) Cleanup(ctx context.Context) error {
+	logger := lagerctx.FromContext(ctx).Session("cleanup")
+
+	logger.Debug("start")
+	defer logger.Debug("done")
+
+	tx, err := migrator.DB.Begin()
+	if err != nil {
+		return err
+	}
+
+	defer tx.Rollback()
+
+	_, err = tx.ExecContext(ctx, `
+    ALTER TABLE build_events
+		ADD CONSTRAINT build_events_build_id_event_id_pkey PRIMARY KEY USING INDEX build_events_build_id_event_id
+	`)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, `DROP INDEX build_events_build_id_old_event_id`)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, `DROP INDEX build_events_build_id_old_idx`)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, `ALTER TABLE build_events DROP COLUMN build_id_old`)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}

--- a/atc/db/migration/batch/build_events_bigint_test.go
+++ b/atc/db/migration/batch/build_events_bigint_test.go
@@ -1,0 +1,308 @@
+package batch_test
+
+import (
+	"context"
+	"crypto/sha1"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagerctx"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/migration"
+	"github.com/concourse/concourse/atc/db/migration/batch"
+	"github.com/lib/pq"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type BuildEventsBigintSuite struct {
+	suite.Suite
+	*require.Assertions
+
+	PostgresHost string
+
+	dbName string
+	conn   db.Conn
+
+	ctx context.Context
+}
+
+func TestBuildEventsBigint(t *testing.T) {
+	pgHost := os.Getenv("BATCH_POSTGRES_HOST")
+	if pgHost == "" {
+		t.Skip("$BATCH_POSTGRES_HOST not configured")
+		return
+	}
+
+	suite.Run(t, &BuildEventsBigintSuite{
+		Assertions: require.New(t),
+
+		PostgresHost: pgHost,
+	})
+}
+
+func (s *BuildEventsBigintSuite) SetupTest() {
+	logger := lager.NewLogger("test")
+
+	if testing.Verbose() {
+		logger.RegisterSink(lager.NewPrettySink(os.Stderr, lager.ERROR))
+	}
+
+	s.ctx = lagerctx.NewContext(context.Background(), logger)
+	s.dbName = s.uniqueName()
+
+	setupConn := s.open(fmt.Sprintf("host=%s dbname=postgres", s.PostgresHost))
+
+	s.dropDb(setupConn)
+
+	_, err := setupConn.ExecContext(s.ctx, `CREATE DATABASE `+s.dbName)
+	s.NoError(err)
+
+	s.NoError(setupConn.Close())
+
+	dsn := fmt.Sprintf("host=%s dbname=%s", s.PostgresHost, s.dbName)
+	testConn := s.open(dsn)
+
+	err = migration.NewMigrator(testConn, nil).Migrate(nil, nil, 1603405319)
+	s.NoError(err)
+
+	s.conn = db.NewConn("test", testConn, dsn, nil, nil)
+}
+
+func (s *BuildEventsBigintSuite) TearDownTest() {
+	if s.conn != nil {
+		s.NoError(s.conn.Close())
+	}
+
+	teardownConn := s.open(fmt.Sprintf("host=%s dbname=postgres", s.PostgresHost))
+
+	s.dropDb(teardownConn)
+
+	s.NoError(teardownConn.Close())
+}
+
+func (s *BuildEventsBigintSuite) TestBasic() {
+	migrator := batch.BuildEventsBigintMigrator{
+		DB:        s.conn,
+		BatchSize: 100,
+	}
+
+	s.seedData(1, 100)
+
+	cleanup, err := migrator.Migrate(s.ctx)
+	s.NoError(err)
+	s.False(cleanup)
+
+	cleanup, err = migrator.Migrate(s.ctx)
+	s.NoError(err)
+	s.True(cleanup)
+
+	cleanup, err = migrator.Migrate(s.ctx)
+	s.NoError(err)
+	s.True(cleanup)
+
+	err = migrator.Cleanup(s.ctx)
+	s.NoError(err)
+
+	cleanup, err = migrator.Migrate(s.ctx)
+	s.NoError(err)
+	s.False(cleanup)
+
+	s.assertFinished()
+}
+
+func (s *BuildEventsBigintSuite) TestMigratesInBatches() {
+	migrator := batch.BuildEventsBigintMigrator{
+		DB:        s.conn,
+		BatchSize: 5000,
+	}
+
+	totalEvents := s.seedData(100, 500)
+
+	batchesDone := 0
+
+	for {
+		done, err := migrator.Migrate(s.ctx)
+		s.NoError(err)
+
+		if done {
+			break
+		}
+
+		batchesDone++
+		s.assertRemaining(totalEvents - (migrator.BatchSize * batchesDone))
+	}
+
+	err := migrator.Cleanup(s.ctx)
+	s.NoError(err)
+
+	s.assertFinished()
+}
+
+func (s *BuildEventsBigintSuite) TestNoBuildsSucceeds() {
+	migrator := batch.BuildEventsBigintMigrator{
+		DB:        s.conn,
+		BatchSize: 1,
+	}
+
+	migrated, err := migrator.Migrate(s.ctx)
+	s.NoError(err)
+	s.True(migrated)
+
+	err = migrator.Cleanup(s.ctx)
+	s.NoError(err)
+
+	s.assertFinished()
+}
+
+func (s *BuildEventsBigintSuite) TestPerformance() {
+	if os.Getenv("SLOW") == "" {
+		s.T().Skip("$SLOW not set; skipping slow test")
+	}
+
+	immediate := make(chan time.Time)
+	close(immediate)
+
+	for _, sample := range []struct {
+		BatchSize      int
+		Builds         int
+		EventsPerBuild int
+	}{
+		{
+			BatchSize:      10000,
+			Builds:         1000,
+			EventsPerBuild: 1000,
+		},
+		{
+			BatchSize:      100000,
+			Builds:         1000,
+			EventsPerBuild: 1000,
+		},
+		{
+			BatchSize:      500000,
+			Builds:         1000,
+			EventsPerBuild: 1000,
+		},
+		{
+			BatchSize:      1000000,
+			Builds:         1000,
+			EventsPerBuild: 1000,
+		},
+		{
+			BatchSize:      100000,
+			Builds:         10000,
+			EventsPerBuild: 1000,
+		},
+	} {
+		sample := sample
+
+		s.Run(fmt.Sprintf("%d events @ %d batch", sample.Builds*sample.EventsPerBuild, sample.BatchSize), func() {
+			migrator := batch.BuildEventsBigintMigrator{
+				DB:        s.conn,
+				BatchSize: sample.BatchSize,
+			}
+
+			s.seedData(sample.Builds, sample.EventsPerBuild)
+
+			start := time.Now()
+
+			last := start
+			for {
+				done, err := migrator.Migrate(s.ctx)
+				s.NoError(err)
+
+				if done {
+					break
+				}
+
+				debug("batch took", time.Since(last).String())
+
+				last = time.Now()
+			}
+
+			debug("total took", time.Since(start).String())
+
+			s.assertRemaining(0)
+		})
+	}
+}
+
+func (s *BuildEventsBigintSuite) seedData(builds, events int) int {
+	_, err := s.conn.ExecContext(s.ctx, `TRUNCATE TABLE build_events`)
+	s.NoError(err)
+
+	start := time.Now()
+	res, err := s.conn.ExecContext(s.ctx, `
+		INSERT INTO build_events (build_id_old, type, payload, event_id, version)
+		SELECT build.id, 'log', '{"origin":{"id":"some-plan-id","source":"stderr"},"payload":"hello","time":123}', event.id, '1.0'
+		FROM generate_series(1, $1) AS build (id), generate_series(1, $2) AS event (id)
+	`, builds, events)
+	s.NoError(err)
+
+	rows, err := res.RowsAffected()
+	s.NoError(err)
+
+	debug("seeding", int(rows), "rows took", time.Since(start).String())
+
+	return int(rows)
+}
+
+func (s *BuildEventsBigintSuite) assertRemaining(n int) {
+	var remaining int
+	s.NoError(s.conn.QueryRowContext(s.ctx, `SELECT COUNT(1) FROM build_events WHERE build_id IS NULL`).Scan(&remaining))
+	s.Equal(n, remaining)
+}
+
+func (s *BuildEventsBigintSuite) assertFinished() {
+	s.assertRemaining(0)
+
+	_, err := s.conn.ExecContext(s.ctx, `SELECT build_id_old FROM build_events LIMIT 1`)
+	s.Error(err)
+
+	var pqErr *pq.Error
+	s.True(errors.As(err, &pqErr))
+	s.Equal("undefined_column", pqErr.Code.Name())
+}
+
+func (s *BuildEventsBigintSuite) open(dsn string) *sql.DB {
+	conn, err := sql.Open("postgres", dsn)
+	s.NoError(err)
+
+	return conn
+}
+
+func (s *BuildEventsBigintSuite) uniqueName() string {
+	hash := sha1.New()
+
+	_, err := fmt.Fprint(hash, s.T().Name())
+	s.NoError(err)
+
+	return fmt.Sprintf("testdb_%x", hash.Sum(nil))
+}
+
+func (s *BuildEventsBigintSuite) dropDb(conn *sql.DB) {
+	_, err := conn.ExecContext(s.ctx, `
+		SELECT pid, pg_terminate_backend(pid)
+		FROM pg_stat_activity
+		WHERE datname = $1 AND pid <> pg_backend_pid()
+	`, s.dbName)
+	s.NoError(err)
+
+	_, err = conn.ExecContext(s.ctx, `DROP DATABASE IF EXISTS `+s.dbName)
+	s.NoError(err)
+}
+
+var logger = log.New(os.Stderr, "", log.Ltime|log.Lmicroseconds)
+
+func debug(args ...interface{}) {
+	if testing.Verbose() {
+		logger.Println(args...)
+	}
+}

--- a/atc/db/migration/batch/runner.go
+++ b/atc/db/migration/batch/runner.go
@@ -1,0 +1,31 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+)
+
+type Migrator interface {
+	Migrate(context.Context) (bool, error)
+	Cleanup(context.Context) error
+}
+
+type Runner struct {
+	Migrator Migrator
+}
+
+func (runner Runner) Run(ctx context.Context) error {
+	cleanup, err := runner.Migrator.Migrate(ctx)
+	if err != nil {
+		return fmt.Errorf("migrate: %w", err)
+	}
+
+	if cleanup {
+		err = runner.Migrator.Cleanup(ctx)
+		if err != nil {
+			return fmt.Errorf("cleanup: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/atc/db/migration/batch/runner.go
+++ b/atc/db/migration/batch/runner.go
@@ -15,17 +15,25 @@ type Runner struct {
 }
 
 func (runner Runner) Run(ctx context.Context) error {
-	cleanup, err := runner.Migrator.Migrate(ctx)
+	_, err := runner.Migrator.Migrate(ctx)
 	if err != nil {
 		return fmt.Errorf("migrate: %w", err)
 	}
 
-	if cleanup {
-		err = runner.Migrator.Cleanup(ctx)
-		if err != nil {
-			return fmt.Errorf("cleanup: %w", err)
-		}
-	}
+	// XXX(6203): we should enable this someday - but not this day.
+	//
+	// it's not safe to run Cleanup because it breaks the down migration.
+	//
+	// the complexity of this may be a sign that it would make more sense for
+	// incremental/batch migrations to be a feature of the migration library
+	// itself so it can know whether it's safe to perform the down migration.
+
+	// if cleanup {
+	// 	err = runner.Migrator.Cleanup(ctx)
+	// 	if err != nil {
+	// 		return fmt.Errorf("cleanup: %w", err)
+	// 	}
+	// }
 
 	return nil
 }

--- a/atc/db/migration/migrations/1603401316_alter_build_integers_to_bigints.down.sql
+++ b/atc/db/migration/migrations/1603401316_alter_build_integers_to_bigints.down.sql
@@ -1,0 +1,37 @@
+BEGIN;
+  ALTER TABLE jobs
+      ALTER COLUMN next_build_id TYPE integer,
+      ALTER COLUMN latest_completed_build_id TYPE integer,
+      ALTER COLUMN transition_build_id TYPE integer;
+
+  ALTER TABLE build_pipes
+      ALTER COLUMN from_build_id TYPE integer,
+      ALTER COLUMN to_build_id TYPE integer;
+
+  ALTER TABLE build_image_resource_caches
+      ALTER COLUMN build_id TYPE integer;
+
+  ALTER TABLE build_resource_config_version_inputs
+      ALTER COLUMN build_id TYPE integer;
+
+  ALTER TABLE build_resource_config_version_outputs
+      ALTER COLUMN build_id TYPE integer;
+
+  ALTER TABLE containers
+      ALTER COLUMN build_id TYPE integer;
+
+  ALTER TABLE next_build_pipes
+      ALTER COLUMN from_build_id TYPE integer;
+
+  ALTER TABLE pipelines
+      ALTER COLUMN parent_build_id TYPE integer;
+
+  ALTER TABLE resource_cache_uses
+      ALTER COLUMN build_id TYPE integer;
+
+  ALTER TABLE successful_build_outputs
+      ALTER COLUMN build_id TYPE integer;
+
+  ALTER TABLE worker_artifacts
+      ALTER COLUMN build_id TYPE integer;
+COMMIT;

--- a/atc/db/migration/migrations/1603401316_alter_build_integers_to_bigints.up.sql
+++ b/atc/db/migration/migrations/1603401316_alter_build_integers_to_bigints.up.sql
@@ -1,0 +1,37 @@
+BEGIN;
+  ALTER TABLE jobs
+      ALTER COLUMN next_build_id TYPE bigint,
+      ALTER COLUMN latest_completed_build_id TYPE bigint,
+      ALTER COLUMN transition_build_id TYPE bigint;
+
+  ALTER TABLE build_pipes
+      ALTER COLUMN from_build_id TYPE bigint,
+      ALTER COLUMN to_build_id TYPE bigint;
+
+  ALTER TABLE build_image_resource_caches
+      ALTER COLUMN build_id TYPE bigint;
+
+  ALTER TABLE build_resource_config_version_inputs
+      ALTER COLUMN build_id TYPE bigint;
+
+  ALTER TABLE build_resource_config_version_outputs
+      ALTER COLUMN build_id TYPE bigint;
+
+  ALTER TABLE containers
+      ALTER COLUMN build_id TYPE bigint;
+
+  ALTER TABLE next_build_pipes
+      ALTER COLUMN from_build_id TYPE bigint;
+
+  ALTER TABLE pipelines
+      ALTER COLUMN parent_build_id TYPE bigint;
+
+  ALTER TABLE resource_cache_uses
+      ALTER COLUMN build_id TYPE bigint;
+
+  ALTER TABLE successful_build_outputs
+      ALTER COLUMN build_id TYPE bigint;
+
+  ALTER TABLE worker_artifacts
+      ALTER COLUMN build_id TYPE bigint;
+COMMIT;

--- a/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.down.sql
+++ b/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.down.sql
@@ -1,4 +1,7 @@
 BEGIN;
+  -- restore id for any newly written events
+  UPDATE build_events SET build_id_old = build_id WHERE build_id_old IS NULL;
+
   -- drop the indexes for the bigint column
   DROP INDEX build_events_build_id_idx;
   DROP INDEX build_events_build_id_event_id;

--- a/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.down.sql
+++ b/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+  -- drop the indexes for the bigint column
+  DROP INDEX build_events_build_id_idx;
+  DROP INDEX build_events_build_id_event_id;
+
+  -- drop the bigint column
+  ALTER TABLE build_events DROP COLUMN build_id;
+
+  -- rename everything back
+  ALTER TABLE build_events RENAME COLUMN build_id_old TO build_id;
+  ALTER INDEX build_events_build_id_old_idx RENAME TO build_events_build_id_idx;
+  ALTER INDEX build_events_build_id_old_event_id  RENAME TO build_events_build_id_event_id;
+COMMIT;

--- a/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.up.sql
+++ b/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+  -- rename old column and indexes
+  ALTER TABLE build_events RENAME COLUMN build_id TO build_id_old;
+  ALTER INDEX build_events_build_id_idx RENAME TO build_events_build_id_old_idx;
+  ALTER INDEX build_events_build_id_event_id RENAME TO build_events_build_id_old_event_id;
+
+  -- add new bigint column which will be populated gradually at runtime
+  ALTER TABLE build_events ADD COLUMN build_id bigint;
+
+  -- create a replacement index along with what will become the new primary key
+  CREATE INDEX build_events_build_id_idx ON build_events (build_id);
+  CREATE UNIQUE INDEX build_events_build_id_event_id ON build_events (build_id, event_id);
+COMMIT;


### PR DESCRIPTION
## What does this PR accomplish?

fixes #6199

follow-up to #6022

This introduces a handful of migrations which convert `build_id` foreign key references to `bigint` in-place. For `build_events` that approach would grind everything to a halt because it can have millions of rows, so this PR adds a batch migration component which will migrate build events in batches of 100,000 (by default) every 10 seconds (by default). Flags are also added for both settings just in case operators feel that it's too aggressive or too slow depending on their situation.

The migration first renames `build_events.build_id` to `build_events.build_id_old`, and then adds a "new" `build_id bigint` column and updates the indexes. This rename dance ensures other `web` nodes which may be running mid-upgrade will write their events as `bigints`, so that the batch migrator doesn't have to play "catch-up." Build events are migrated from newest to oldest. Older builds will just not have any logs until the migrator gets to them. When all events are migrated, a final schema cleanup is performed and the primary key is updated.

## Release Note

* This migration can be quite slow if you have a ton of builds, meaning `web` nodes may take a while to start upon upgrading.
* Build events are migrated at runtime in batches of 100,000 every 10 seconds, newest to oldest. Until this migration completes, older build logs will not be present.
  * The batch size can be configured with `--build-events-bigint-batch-size` (integer).
  * The batch interval can be configured with `--build-events-bigint-interval` (duration).

## Contributor Checklist

- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
