### PR TITLE
topgun: use busybox for http proxy... for now

### DIFF
--- a/topgun/tasks/http-proxy.yml
+++ b/topgun/tasks/http-proxy.yml
@@ -2,8 +2,8 @@
 platform: linux
 
 image_resource:
-  type: mock
-  source: {mirror_self: true}
+  type: registry-image
+  source: {repository: busybox}
 
 run:
   path: sh


### PR DESCRIPTION
## What does this PR accomplish?

This test isn't happy with GNU `wget`, and I don't really have time to investigate why - it consistently failed with [this error](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/bosh-topgun-runtime/builds/403#L5f92985f:2555:2558):

    + wget -Y on example.com
    --2020-10-23 13:54:02--  http://example.com/
    Resolving proxy.example.com (proxy.example.com)... failed: Name or service not known.
    wget: unable to resolve host address 'proxy.example.com'

Not sure what would be so different between busybox `wget` and GNU `wget`.

In any case, going to just bring this back to busybox for now to unblock the pipeline. I suspect we'll *have* to fix this at some point, but we can deal with that after v6.7.0 is out.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
