### PR TITLE
Fix race condition with check build creation + starting

### DIFF
--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Build", func() {
 			BeforeEach(func() {
 				var err error
 				var created bool
-				build, created, err = defaultResource.CreateBuild(context.TODO(), false)
+				build, created, err = defaultResource.CreateBuild(context.TODO(), false, atc.Plan{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(created).To(BeTrue())
 			})
@@ -137,7 +137,7 @@ var _ = Describe("Build", func() {
 			BeforeEach(func() {
 				var err error
 				var created bool
-				build, created, err = defaultResourceType.CreateBuild(context.TODO(), false)
+				build, created, err = defaultResourceType.CreateBuild(context.TODO(), false, atc.Plan{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(created).To(BeTrue())
 			})
@@ -192,7 +192,7 @@ var _ = Describe("Build", func() {
 			BeforeEach(func() {
 				var err error
 				var created bool
-				build, created, err = defaultResource.CreateBuild(context.TODO(), false)
+				build, created, err = defaultResource.CreateBuild(context.TODO(), false, atc.Plan{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(created).To(BeTrue())
 			})
@@ -206,7 +206,7 @@ var _ = Describe("Build", func() {
 			BeforeEach(func() {
 				var err error
 				var created bool
-				build, created, err = defaultResourceType.CreateBuild(context.TODO(), false)
+				build, created, err = defaultResourceType.CreateBuild(context.TODO(), false, atc.Plan{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(created).To(BeTrue())
 			})
@@ -264,7 +264,7 @@ var _ = Describe("Build", func() {
 			BeforeEach(func() {
 				var err error
 				var created bool
-				build, created, err = defaultResource.CreateBuild(context.TODO(), false)
+				build, created, err = defaultResource.CreateBuild(context.TODO(), false, atc.Plan{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(created).To(BeTrue())
 			})
@@ -284,7 +284,7 @@ var _ = Describe("Build", func() {
 			BeforeEach(func() {
 				var err error
 				var created bool
-				build, created, err = defaultResourceType.CreateBuild(context.TODO(), false)
+				build, created, err = defaultResourceType.CreateBuild(context.TODO(), false, atc.Plan{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(created).To(BeTrue())
 			})

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -32,7 +32,7 @@ type Checkable interface {
 	HasWebhook() bool
 
 	CheckPlan(atc.Version, time.Duration, ResourceTypes, atc.Source) atc.CheckPlan
-	CreateBuild(context.Context, bool) (Build, bool, error)
+	CreateBuild(context.Context, bool, atc.Plan) (Build, bool, error)
 }
 
 //go:generate counterfeiter . CheckFactory
@@ -124,7 +124,7 @@ func (c *checkFactory) TryCreateCheck(ctx context.Context, checkable Checkable, 
 
 	plan := c.planFactory.NewPlan(checkPlan)
 
-	build, created, err := checkable.CreateBuild(ctx, manuallyTriggered)
+	build, created, err := checkable.CreateBuild(ctx, manuallyTriggered, plan)
 	if err != nil {
 		return nil, false, fmt.Errorf("create build: %w", err)
 	}
@@ -133,17 +133,7 @@ func (c *checkFactory) TryCreateCheck(ctx context.Context, checkable Checkable, 
 		return nil, false, nil
 	}
 
-	_, err = build.Start(plan)
-	if err != nil {
-		return nil, false, fmt.Errorf("start build: %w", err)
-	}
-
 	logger.Info("created-build", build.LagerData())
-
-	_, err = build.Reload()
-	if err != nil {
-		return nil, false, fmt.Errorf("reload build: %w", err)
-	}
 
 	return build, true, nil
 }

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -83,23 +83,11 @@ var _ = Describe("CheckFactory", func() {
 			})
 
 			It("starts the build with the check plan", func() {
-				Expect(fakeBuild.StartCallCount()).To(Equal(1))
-				plan := fakeBuild.StartArgsForCall(0)
+				Expect(fakeResource.CreateBuildCallCount()).To(Equal(1))
+				_, manuallyTriggered, plan := fakeResource.CreateBuildArgsForCall(0)
+				Expect(manuallyTriggered).To(BeFalse())
 				Expect(plan.ID).ToNot(BeEmpty())
 				Expect(plan.Check).To(Equal(&checkPlan))
-			})
-
-			Context("after starting", func() {
-				BeforeEach(func() {
-					fakeBuild.ReloadStub = func() (bool, error) {
-						fakeBuild.StatusReturns(db.BuildStatusStarted)
-						return true, nil
-					}
-				})
-
-				It("reloads the build so that it returns a started build", func() {
-					Expect(build.Status()).To(Equal(db.BuildStatusStarted))
-				})
 			})
 
 			Context("when the interval has not elapsed", func() {
@@ -245,23 +233,11 @@ var _ = Describe("CheckFactory", func() {
 					})
 
 					It("starts the build with the check plan", func() {
-						Expect(fakeBuild.StartCallCount()).To(Equal(1))
-						plan := fakeBuild.StartArgsForCall(0)
+						Expect(fakeResource.CreateBuildCallCount()).To(Equal(1))
+						_, manuallyTriggered, plan := fakeResource.CreateBuildArgsForCall(0)
+						Expect(manuallyTriggered).To(BeFalse())
 						Expect(plan.ID).ToNot(BeEmpty())
 						Expect(plan.Check).To(Equal(&checkPlan))
-					})
-
-					Context("after starting", func() {
-						BeforeEach(func() {
-							fakeBuild.ReloadStub = func() (bool, error) {
-								fakeBuild.StatusReturns(db.BuildStatusStarted)
-								return true, nil
-							}
-						})
-
-						It("reloads the build so that it returns a started build", func() {
-							Expect(build.Status()).To(Equal(db.BuildStatusStarted))
-						})
 					})
 				})
 			})

--- a/atc/db/dbfakes/fake_checkable.go
+++ b/atc/db/dbfakes/fake_checkable.go
@@ -45,11 +45,12 @@ type FakeCheckable struct {
 	checkTimeoutReturnsOnCall map[int]struct {
 		result1 string
 	}
-	CreateBuildStub        func(context.Context, bool) (db.Build, bool, error)
+	CreateBuildStub        func(context.Context, bool, atc.Plan) (db.Build, bool, error)
 	createBuildMutex       sync.RWMutex
 	createBuildArgsForCall []struct {
 		arg1 context.Context
 		arg2 bool
+		arg3 atc.Plan
 	}
 	createBuildReturns struct {
 		result1 db.Build
@@ -386,17 +387,18 @@ func (fake *FakeCheckable) CheckTimeoutReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeCheckable) CreateBuild(arg1 context.Context, arg2 bool) (db.Build, bool, error) {
+func (fake *FakeCheckable) CreateBuild(arg1 context.Context, arg2 bool, arg3 atc.Plan) (db.Build, bool, error) {
 	fake.createBuildMutex.Lock()
 	ret, specificReturn := fake.createBuildReturnsOnCall[len(fake.createBuildArgsForCall)]
 	fake.createBuildArgsForCall = append(fake.createBuildArgsForCall, struct {
 		arg1 context.Context
 		arg2 bool
-	}{arg1, arg2})
-	fake.recordInvocation("CreateBuild", []interface{}{arg1, arg2})
+		arg3 atc.Plan
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("CreateBuild", []interface{}{arg1, arg2, arg3})
 	fake.createBuildMutex.Unlock()
 	if fake.CreateBuildStub != nil {
-		return fake.CreateBuildStub(arg1, arg2)
+		return fake.CreateBuildStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -411,17 +413,17 @@ func (fake *FakeCheckable) CreateBuildCallCount() int {
 	return len(fake.createBuildArgsForCall)
 }
 
-func (fake *FakeCheckable) CreateBuildCalls(stub func(context.Context, bool) (db.Build, bool, error)) {
+func (fake *FakeCheckable) CreateBuildCalls(stub func(context.Context, bool, atc.Plan) (db.Build, bool, error)) {
 	fake.createBuildMutex.Lock()
 	defer fake.createBuildMutex.Unlock()
 	fake.CreateBuildStub = stub
 }
 
-func (fake *FakeCheckable) CreateBuildArgsForCall(i int) (context.Context, bool) {
+func (fake *FakeCheckable) CreateBuildArgsForCall(i int) (context.Context, bool, atc.Plan) {
 	fake.createBuildMutex.RLock()
 	defer fake.createBuildMutex.RUnlock()
 	argsForCall := fake.createBuildArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeCheckable) CreateBuildReturns(result1 db.Build, result2 bool, result3 error) {

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -85,11 +85,12 @@ type FakeResource struct {
 	configPinnedVersionReturnsOnCall map[int]struct {
 		result1 atc.Version
 	}
-	CreateBuildStub        func(context.Context, bool) (db.Build, bool, error)
+	CreateBuildStub        func(context.Context, bool, atc.Plan) (db.Build, bool, error)
 	createBuildMutex       sync.RWMutex
 	createBuildArgsForCall []struct {
 		arg1 context.Context
 		arg2 bool
+		arg3 atc.Plan
 	}
 	createBuildReturns struct {
 		result1 db.Build
@@ -855,17 +856,18 @@ func (fake *FakeResource) ConfigPinnedVersionReturnsOnCall(i int, result1 atc.Ve
 	}{result1}
 }
 
-func (fake *FakeResource) CreateBuild(arg1 context.Context, arg2 bool) (db.Build, bool, error) {
+func (fake *FakeResource) CreateBuild(arg1 context.Context, arg2 bool, arg3 atc.Plan) (db.Build, bool, error) {
 	fake.createBuildMutex.Lock()
 	ret, specificReturn := fake.createBuildReturnsOnCall[len(fake.createBuildArgsForCall)]
 	fake.createBuildArgsForCall = append(fake.createBuildArgsForCall, struct {
 		arg1 context.Context
 		arg2 bool
-	}{arg1, arg2})
-	fake.recordInvocation("CreateBuild", []interface{}{arg1, arg2})
+		arg3 atc.Plan
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("CreateBuild", []interface{}{arg1, arg2, arg3})
 	fake.createBuildMutex.Unlock()
 	if fake.CreateBuildStub != nil {
-		return fake.CreateBuildStub(arg1, arg2)
+		return fake.CreateBuildStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -880,17 +882,17 @@ func (fake *FakeResource) CreateBuildCallCount() int {
 	return len(fake.createBuildArgsForCall)
 }
 
-func (fake *FakeResource) CreateBuildCalls(stub func(context.Context, bool) (db.Build, bool, error)) {
+func (fake *FakeResource) CreateBuildCalls(stub func(context.Context, bool, atc.Plan) (db.Build, bool, error)) {
 	fake.createBuildMutex.Lock()
 	defer fake.createBuildMutex.Unlock()
 	fake.CreateBuildStub = stub
 }
 
-func (fake *FakeResource) CreateBuildArgsForCall(i int) (context.Context, bool) {
+func (fake *FakeResource) CreateBuildArgsForCall(i int) (context.Context, bool, atc.Plan) {
 	fake.createBuildMutex.RLock()
 	defer fake.createBuildMutex.RUnlock()
 	argsForCall := fake.createBuildArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeResource) CreateBuildReturns(result1 db.Build, result2 bool, result3 error) {

--- a/atc/db/dbfakes/fake_resource_type.go
+++ b/atc/db/dbfakes/fake_resource_type.go
@@ -45,11 +45,12 @@ type FakeResourceType struct {
 	checkTimeoutReturnsOnCall map[int]struct {
 		result1 string
 	}
-	CreateBuildStub        func(context.Context, bool) (db.Build, bool, error)
+	CreateBuildStub        func(context.Context, bool, atc.Plan) (db.Build, bool, error)
 	createBuildMutex       sync.RWMutex
 	createBuildArgsForCall []struct {
 		arg1 context.Context
 		arg2 bool
+		arg3 atc.Plan
 	}
 	createBuildReturns struct {
 		result1 db.Build
@@ -469,17 +470,18 @@ func (fake *FakeResourceType) CheckTimeoutReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) CreateBuild(arg1 context.Context, arg2 bool) (db.Build, bool, error) {
+func (fake *FakeResourceType) CreateBuild(arg1 context.Context, arg2 bool, arg3 atc.Plan) (db.Build, bool, error) {
 	fake.createBuildMutex.Lock()
 	ret, specificReturn := fake.createBuildReturnsOnCall[len(fake.createBuildArgsForCall)]
 	fake.createBuildArgsForCall = append(fake.createBuildArgsForCall, struct {
 		arg1 context.Context
 		arg2 bool
-	}{arg1, arg2})
-	fake.recordInvocation("CreateBuild", []interface{}{arg1, arg2})
+		arg3 atc.Plan
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("CreateBuild", []interface{}{arg1, arg2, arg3})
 	fake.createBuildMutex.Unlock()
 	if fake.CreateBuildStub != nil {
-		return fake.CreateBuildStub(arg1, arg2)
+		return fake.CreateBuildStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -494,17 +496,17 @@ func (fake *FakeResourceType) CreateBuildCallCount() int {
 	return len(fake.createBuildArgsForCall)
 }
 
-func (fake *FakeResourceType) CreateBuildCalls(stub func(context.Context, bool) (db.Build, bool, error)) {
+func (fake *FakeResourceType) CreateBuildCalls(stub func(context.Context, bool, atc.Plan) (db.Build, bool, error)) {
 	fake.createBuildMutex.Lock()
 	defer fake.createBuildMutex.Unlock()
 	fake.CreateBuildStub = stub
 }
 
-func (fake *FakeResourceType) CreateBuildArgsForCall(i int) (context.Context, bool) {
+func (fake *FakeResourceType) CreateBuildArgsForCall(i int) (context.Context, bool, atc.Plan) {
 	fake.createBuildMutex.RLock()
 	defer fake.createBuildMutex.RUnlock()
 	argsForCall := fake.createBuildArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeResourceType) CreateBuildReturns(result1 db.Build, result2 bool, result3 error) {

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -49,7 +49,7 @@ type ResourceType interface {
 	SetResourceConfigScope(ResourceConfigScope) error
 
 	CheckPlan(atc.Version, time.Duration, ResourceTypes, atc.Source) atc.CheckPlan
-	CreateBuild(context.Context, bool) (Build, bool, error)
+	CreateBuild(context.Context, bool, atc.Plan) (Build, bool, error)
 
 	Version() atc.Version
 
@@ -263,7 +263,7 @@ func (r *resourceType) CheckPlan(from atc.Version, interval time.Duration, resou
 	}
 }
 
-func (r *resourceType) CreateBuild(ctx context.Context, manuallyTriggered bool) (Build, bool, error) {
+func (r *resourceType) CreateBuild(ctx context.Context, manuallyTriggered bool, plan atc.Plan) (Build, bool, error) {
 	spanContextJSON, err := json.Marshal(NewSpanContext(ctx))
 	if err != nil {
 		return nil, false, err
@@ -326,7 +326,22 @@ func (r *resourceType) CreateBuild(ctx context.Context, manuallyTriggered bool) 
 		return nil, false, err
 	}
 
+	_, err = build.start(tx, plan)
+	if err != nil {
+		return nil, false, err
+	}
+
 	err = tx.Commit()
+	if err != nil {
+		return nil, false, err
+	}
+
+	err = r.conn.Bus().Notify(atc.ComponentBuildTracker)
+	if err != nil {
+		return nil, false, err
+	}
+
+	_, err = build.Reload()
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
## What does this PR accomplish?

follow-up for #6022

previously the check factory would create a build and then start it in a
separate database call. if the web node was shut down in between, the
pending build would be left there, but nothing would ever start it, and
checking would just stop until someone comes in and creates a new build.

now the build will be created and started in a single transaction.

a better refactor IMO would be to introduce a `builds.Starter` and use
it to simplify the job build starting and serial groups logic. but i
ain't got time for that!

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
