### PR TITLE
feat(atc): support chained container placement strategies.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -159,8 +159,8 @@ type RunCommand struct {
 	ResourceWithWebhookCheckingInterval time.Duration `long:"resource-with-webhook-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources that has webhook defined."`
 	MaxChecksPerSecond                  int           `long:"max-checks-per-second" description:"Maximum number of checks that can be started per second. If not specified, this will be calculated as (# of resources)/(resource checking interval). -1 value will remove this maximum limit of checks per second."`
 
-	ContainerPlacementStrategy        string        `long:"container-placement-strategy" default:"volume-locality" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" description:"Method by which a worker is selected during container placement."`
-	MaxActiveTasksPerWorker           int           `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
+	ContainerPlacementStrategyOptions worker.ContainerPlacementStrategyOptions `group:"Container Placement Strategy"`
+
 	BaggageclaimResponseHeaderTimeout time.Duration `long:"baggageclaim-response-header-timeout" default:"1m" description:"How long to wait for Baggageclaim to send the response header."`
 	StreamingArtifactsCompression     string        `long:"streaming-artifacts-compression" default:"gzip" choice:"gzip" choice:"zstd" description:"Compression algorithm for internal streaming."`
 
@@ -1592,25 +1592,7 @@ func (cmd *RunCommand) constructLockConn(driverName string) (*sql.DB, error) {
 }
 
 func (cmd *RunCommand) chooseBuildContainerStrategy() (worker.ContainerPlacementStrategy, error) {
-	var strategy worker.ContainerPlacementStrategy
-	if cmd.ContainerPlacementStrategy != "limit-active-tasks" && cmd.MaxActiveTasksPerWorker != 0 {
-		return nil, errors.New("max-active-tasks-per-worker has only effect with limit-active-tasks strategy")
-	}
-	if cmd.MaxActiveTasksPerWorker < 0 {
-		return nil, errors.New("max-active-tasks-per-worker must be greater or equal than 0")
-	}
-	switch cmd.ContainerPlacementStrategy {
-	case "random":
-		strategy = worker.NewRandomPlacementStrategy()
-	case "fewest-build-containers":
-		strategy = worker.NewFewestBuildContainersPlacementStrategy()
-	case "limit-active-tasks":
-		strategy = worker.NewLimitActiveTasksPlacementStrategy(cmd.MaxActiveTasksPerWorker)
-	default:
-		strategy = worker.NewVolumeLocalityPlacementStrategy()
-	}
-
-	return strategy, nil
+	return worker.NewContainerPlacementStrategy(cmd.ContainerPlacementStrategyOptions)
 }
 
 func (cmd *RunCommand) configureAuthForDefaultTeam(teamFactory db.TeamFactory) error {

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -89,14 +89,10 @@ func NewRandomPlacementStrategy() ContainerPlacementStrategy {
 	return s
 }
 
-type VolumeLocalityPlacementStrategyNode struct {
-	rand *rand.Rand
-}
+type VolumeLocalityPlacementStrategyNode struct{}
 
 func newVolumeLocalityPlacementStrategyNode() ContainerPlacementStrategyChainNode {
-	return &VolumeLocalityPlacementStrategyNode{
-		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
-	}
+	return &VolumeLocalityPlacementStrategyNode{}
 }
 
 func (strategy *VolumeLocalityPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
@@ -130,14 +126,10 @@ func (strategy *VolumeLocalityPlacementStrategyNode) ModifiesActiveTasks() bool 
 	return false
 }
 
-type FewestBuildContainersPlacementStrategyNode struct {
-	rand *rand.Rand
-}
+type FewestBuildContainersPlacementStrategyNode struct{}
 
 func newFewestBuildContainersPlacementStrategy() ContainerPlacementStrategyChainNode {
-	return &FewestBuildContainersPlacementStrategyNode{
-		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
-	}
+	return &FewestBuildContainersPlacementStrategyNode{}
 }
 
 func (strategy *FewestBuildContainersPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
@@ -160,13 +152,11 @@ func (strategy *FewestBuildContainersPlacementStrategyNode) ModifiesActiveTasks(
 }
 
 type LimitActiveTasksPlacementStrategyNode struct {
-	rand     *rand.Rand
 	maxTasks int
 }
 
 func newLimitActiveTasksPlacementStrategy(maxTasks int) ContainerPlacementStrategyChainNode {
 	return &LimitActiveTasksPlacementStrategyNode{
-		rand:     rand.New(rand.NewSource(time.Now().UnixNano())),
 		maxTasks: maxTasks,
 	}
 }

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -12,8 +12,8 @@ import (
 )
 
 type ContainerPlacementStrategyOptions struct {
-	ContainerPlacementStrategy string `long:"container-placement-strategy" default:"volume-locality" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" description:"Method by which a worker is selected during container placement. Multiple methods can be chained by +, e.g. volume-locality+fewest-build-containers"`
-	MaxActiveTasksPerWorker    int    `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
+	ContainerPlacementStrategy []string `long:"container-placement-strategy" default:"volume-locality" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" description:"Method by which a worker is selected during container placement. If multiple methods are specified, they will be applied in order."`
+	MaxActiveTasksPerWorker    int      `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
 }
 
 type ContainerPlacementStrategy interface {
@@ -34,8 +34,7 @@ type containerPlacementStrategy struct {
 
 func NewContainerPlacementStrategy(opts ContainerPlacementStrategyOptions) (*containerPlacementStrategy, error) {
 	cps := &containerPlacementStrategy{nodes: []ContainerPlacementStrategyChainNode{}}
-	strategies := strings.Split(opts.ContainerPlacementStrategy, "+")
-	for _, strategy := range strategies {
+	for _, strategy := range opts.ContainerPlacementStrategy {
 		strategy := strings.TrimSpace(strategy)
 		switch strategy {
 		case "random":
@@ -86,7 +85,7 @@ func (strategy *containerPlacementStrategy) ModifiesActiveTasks() bool {
 }
 
 func NewRandomPlacementStrategy() ContainerPlacementStrategy {
-	s, _ := NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "random"})
+	s, _ := NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: []string{"random"}})
 	return s
 }
 

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -1,12 +1,19 @@
 package worker
 
 import (
+	"errors"
 	"math/rand"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/db"
 )
+
+type ContainerPlacementStrategyOptions struct {
+	ContainerPlacementStrategy string `long:"container-placement-strategy" default:"volume-locality" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" description:"Method by which a worker is selected during container placement. Multiple methods can be chained by +, e.g. volume-locality+fewest-build-containers"`
+	MaxActiveTasksPerWorker    int    `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
+}
 
 type ContainerPlacementStrategy interface {
 	//TODO: Don't pass around container metadata since it's not guaranteed to be deterministic.
@@ -15,17 +22,83 @@ type ContainerPlacementStrategy interface {
 	ModifiesActiveTasks() bool
 }
 
-type VolumeLocalityPlacementStrategy struct {
+type ContainerPlacementStrategyChainNode interface {
+	Choose(lager.Logger, []Worker, ContainerSpec) ([]Worker, error)
+	ModifiesActiveTasks() bool
+}
+
+type containerPlacementStrategy struct {
+	nodes []ContainerPlacementStrategyChainNode
+}
+
+func NewContainerPlacementStrategy(opts ContainerPlacementStrategyOptions) (*containerPlacementStrategy, error) {
+	cps := &containerPlacementStrategy{nodes: []ContainerPlacementStrategyChainNode{}}
+	strategies := strings.Split(opts.ContainerPlacementStrategy, "+")
+	for _, strategy := range strategies {
+		strategy := strings.TrimSpace(strategy)
+		switch strategy {
+		case "random":
+			cps.nodes = append(cps.nodes, newRandomPlacementStrategyNode())
+		case "fewest-build-containers":
+			cps.nodes = append(cps.nodes, newFewestBuildContainersPlacementStrategy())
+		case "limit-active-tasks":
+			if opts.MaxActiveTasksPerWorker < 0 {
+				return nil, errors.New("max-active-tasks-per-worker must be greater or equal than 0")
+			}
+			cps.nodes = append(cps.nodes, newLimitActiveTasksPlacementStrategy(opts.MaxActiveTasksPerWorker))
+		default:
+			cps.nodes = append(cps.nodes, newVolumeLocalityPlacementStrategyNode())
+		}
+	}
+	return cps, nil
+}
+
+func (strategy *containerPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
+	var err error
+	for _, node := range strategy.nodes {
+		workers, err = node.Choose(logger, workers, spec)
+		if err != nil {
+			return nil, err
+		}
+		if len(workers) == 0 {
+			return nil, nil
+		}
+	}
+	if len(workers) == 1 {
+		return workers[0], nil
+	}
+
+	// If there are still multiple candidate, choose a random one.
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return workers[r.Intn(len(workers))], nil
+}
+
+func (strategy *containerPlacementStrategy) ModifiesActiveTasks() bool {
+	for _, node := range strategy.nodes {
+		if node.ModifiesActiveTasks() {
+			return true
+		}
+	}
+	return false
+}
+
+func NewRandomPlacementStrategy() ContainerPlacementStrategy {
+	s, _ := NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "random"})
+	return s
+}
+
+
+type VolumeLocalityPlacementStrategyNode struct {
 	rand *rand.Rand
 }
 
-func NewVolumeLocalityPlacementStrategy() ContainerPlacementStrategy {
-	return &VolumeLocalityPlacementStrategy{
+func newVolumeLocalityPlacementStrategyNode() ContainerPlacementStrategyChainNode {
+	return &VolumeLocalityPlacementStrategyNode{
 		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
-func (strategy *VolumeLocalityPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
+func (strategy *VolumeLocalityPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
 	workersByCount := map[int][]Worker{}
 	var highestCount int
 	for _, w := range workers {
@@ -49,26 +122,24 @@ func (strategy *VolumeLocalityPlacementStrategy) Choose(logger lager.Logger, wor
 		}
 	}
 
-	highestLocalityWorkers := workersByCount[highestCount]
-
-	return highestLocalityWorkers[strategy.rand.Intn(len(highestLocalityWorkers))], nil
+	return workersByCount[highestCount], nil
 }
 
-func (strategy *VolumeLocalityPlacementStrategy) ModifiesActiveTasks() bool {
+func (strategy *VolumeLocalityPlacementStrategyNode) ModifiesActiveTasks() bool {
 	return false
 }
 
-type FewestBuildContainersPlacementStrategy struct {
+type FewestBuildContainersPlacementStrategyNode struct {
 	rand *rand.Rand
 }
 
-func NewFewestBuildContainersPlacementStrategy() ContainerPlacementStrategy {
-	return &FewestBuildContainersPlacementStrategy{
+func newFewestBuildContainersPlacementStrategy() ContainerPlacementStrategyChainNode {
+	return &FewestBuildContainersPlacementStrategyNode{
 		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
-func (strategy *FewestBuildContainersPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
+func (strategy *FewestBuildContainersPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
 	workersByWork := map[int][]Worker{}
 	var minWork int
 
@@ -80,27 +151,26 @@ func (strategy *FewestBuildContainersPlacementStrategy) Choose(logger lager.Logg
 		}
 	}
 
-	leastBusyWorkers := workersByWork[minWork]
-	return leastBusyWorkers[strategy.rand.Intn(len(leastBusyWorkers))], nil
+	return workersByWork[minWork], nil
 }
 
-func (strategy *FewestBuildContainersPlacementStrategy) ModifiesActiveTasks() bool {
+func (strategy *FewestBuildContainersPlacementStrategyNode) ModifiesActiveTasks() bool {
 	return false
 }
 
-type LimitActiveTasksPlacementStrategy struct {
+type LimitActiveTasksPlacementStrategyNode struct {
 	rand     *rand.Rand
 	maxTasks int
 }
 
-func NewLimitActiveTasksPlacementStrategy(maxTasks int) ContainerPlacementStrategy {
-	return &LimitActiveTasksPlacementStrategy{
+func newLimitActiveTasksPlacementStrategy(maxTasks int) ContainerPlacementStrategyChainNode {
+	return &LimitActiveTasksPlacementStrategyNode{
 		rand:     rand.New(rand.NewSource(time.Now().UnixNano())),
 		maxTasks: maxTasks,
 	}
 }
 
-func (strategy *LimitActiveTasksPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
+func (strategy *LimitActiveTasksPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
 	workersByWork := map[int][]Worker{}
 	minActiveTasks := -1
 
@@ -123,31 +193,27 @@ func (strategy *LimitActiveTasksPlacementStrategy) Choose(logger lager.Logger, w
 		}
 	}
 
-	leastBusyWorkers := workersByWork[minActiveTasks]
-	if len(leastBusyWorkers) < 1 {
-		return nil, nil
-	}
-	return leastBusyWorkers[strategy.rand.Intn(len(leastBusyWorkers))], nil
+	return workersByWork[minActiveTasks], nil
 }
 
-func (strategy *LimitActiveTasksPlacementStrategy) ModifiesActiveTasks() bool {
+func (strategy *LimitActiveTasksPlacementStrategyNode) ModifiesActiveTasks() bool {
 	return true
 }
 
-type RandomPlacementStrategy struct {
+type RandomPlacementStrategyNode struct {
 	rand *rand.Rand
 }
 
-func NewRandomPlacementStrategy() ContainerPlacementStrategy {
-	return &RandomPlacementStrategy{
+func newRandomPlacementStrategyNode() ContainerPlacementStrategyChainNode {
+	return &RandomPlacementStrategyNode{
 		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
-func (strategy *RandomPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
-	return workers[strategy.rand.Intn(len(workers))], nil
+func (strategy *RandomPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
+	return []Worker{workers[strategy.rand.Intn(len(workers))]}, nil
 }
 
-func (strategy *RandomPlacementStrategy) ModifiesActiveTasks() bool {
+func (strategy *RandomPlacementStrategyNode) ModifiesActiveTasks() bool {
 	return false
 }

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"strings"
 	"time"
@@ -46,8 +47,10 @@ func NewContainerPlacementStrategy(opts ContainerPlacementStrategyOptions) (*con
 				return nil, errors.New("max-active-tasks-per-worker must be greater or equal than 0")
 			}
 			cps.nodes = append(cps.nodes, newLimitActiveTasksPlacementStrategy(opts.MaxActiveTasksPerWorker))
-		default:
+		case "volume-locality":
 			cps.nodes = append(cps.nodes, newVolumeLocalityPlacementStrategyNode())
+		default:
+			return nil, fmt.Errorf("invalid container placement strategy %s", strategy)
 		}
 	}
 	return cps, nil
@@ -86,7 +89,6 @@ func NewRandomPlacementStrategy() ContainerPlacementStrategy {
 	s, _ := NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "random"})
 	return s
 }
-
 
 type VolumeLocalityPlacementStrategyNode struct {
 	rand *rand.Rand

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -44,7 +44,7 @@ var _ = Describe("FewestBuildContainersPlacementStrategy", func() {
 
 		BeforeEach(func() {
 			logger = lagertest.NewTestLogger("build-containers-equal-placement-test")
-			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "fewest-build-containers"})
+			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: []string{"fewest-build-containers"}})
 			Expect(newStrategyError).ToNot(HaveOccurred())
 			compatibleWorker1 = new(workerfakes.FakeWorker)
 			compatibleWorker1.NameReturns("compatibleWorker1")
@@ -137,7 +137,7 @@ var _ = Describe("VolumeLocalityPlacementStrategy", func() {
 
 		BeforeEach(func() {
 			logger = lagertest.NewTestLogger("volume-locality-placement-test")
-			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "volume-locality"})
+			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: []string{"volume-locality"}})
 			Expect(newStrategyError).ToNot(HaveOccurred())
 
 			fakeInput1 := new(workerfakes.FakeInputSource)
@@ -329,7 +329,7 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 		Context("when MaxActiveTasksPerWorker less than 0", func() {
 			BeforeEach(func() {
 				logger = lagertest.NewTestLogger("active-tasks-equal-placement-test")
-				strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: -1})
+				strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: []string{"limit-active-tasks"}, MaxActiveTasksPerWorker: -1})
 			})
 			It("should fail", func() {
 				Expect(newStrategyError).To(HaveOccurred())
@@ -341,7 +341,7 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 		Context("when MaxActiveTasksPerWorker less than 0", func() {
 			BeforeEach(func() {
 				logger = lagertest.NewTestLogger("active-tasks-equal-placement-test")
-				strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 0})
+				strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: []string{"limit-active-tasks"}, MaxActiveTasksPerWorker: 0})
 				Expect(newStrategyError).ToNot(HaveOccurred())
 
 				compatibleWorker1 = new(workerfakes.FakeWorker)
@@ -423,7 +423,7 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 			})
 			Context("when max-tasks-per-worker is set to 1", func() {
 				BeforeEach(func() {
-					strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 1})
+					strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: []string{"limit-active-tasks"}, MaxActiveTasksPerWorker: 1})
 					Expect(newStrategyError).ToNot(HaveOccurred())
 				})
 				Context("when there are multiple workers", func() {
@@ -496,7 +496,7 @@ var _ = Describe("ChainedPlacementStrategy #Choose", func() {
 		logger = lagertest.NewTestLogger("build-containers-equal-placement-test")
 		strategy, newStrategyError = NewContainerPlacementStrategy(
 			ContainerPlacementStrategyOptions{
-				ContainerPlacementStrategy: "fewest-build-containers+volume-locality",
+				ContainerPlacementStrategy: []string{"fewest-build-containers", "volume-locality"},
 			})
 		Expect(newStrategyError).ToNot(HaveOccurred())
 		someWorker1 = new(workerfakes.FakeWorker)

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -23,6 +23,8 @@ var (
 	chosenWorker Worker
 	chooseErr    error
 
+	newStrategyError error
+
 	compatibleWorkerOneCache1 *workerfakes.FakeWorker
 	compatibleWorkerOneCache2 *workerfakes.FakeWorker
 	compatibleWorkerTwoCaches *workerfakes.FakeWorker
@@ -40,7 +42,8 @@ var _ = Describe("FewestBuildContainersPlacementStrategy", func() {
 
 		BeforeEach(func() {
 			logger = lagertest.NewTestLogger("build-containers-equal-placement-test")
-			strategy = NewFewestBuildContainersPlacementStrategy()
+			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "fewest-build-containers"})
+			Expect(newStrategyError).ToNot(HaveOccurred())
 			compatibleWorker1 = new(workerfakes.FakeWorker)
 			compatibleWorker2 = new(workerfakes.FakeWorker)
 			compatibleWorker3 = new(workerfakes.FakeWorker)
@@ -129,7 +132,8 @@ var _ = Describe("VolumeLocalityPlacementStrategy", func() {
 
 		BeforeEach(func() {
 			logger = lagertest.NewTestLogger("volume-locality-placement-test")
-			strategy = NewVolumeLocalityPlacementStrategy()
+			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "volume-locality"})
+			Expect(newStrategyError).ToNot(HaveOccurred())
 
 			fakeInput1 := new(workerfakes.FakeInputSource)
 			fakeInput1AS := new(workerfakes.FakeArtifactSource)
@@ -264,7 +268,7 @@ var _ = Describe("VolumeLocalityPlacementStrategy", func() {
 	})
 })
 
-var _ = Describe("RandomPlacementStrategy", func() {
+var _ = Describe("RandomPlacementStrategyNode", func() {
 	Describe("Choose", func() {
 		JustBeforeEach(func() {
 			chosenWorker, chooseErr = strategy.Choose(
@@ -314,7 +318,9 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 
 		BeforeEach(func() {
 			logger = lagertest.NewTestLogger("active-tasks-equal-placement-test")
-			strategy = NewLimitActiveTasksPlacementStrategy(0)
+			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 0})
+			Expect(newStrategyError).ToNot(HaveOccurred())
+
 			compatibleWorker1 = new(workerfakes.FakeWorker)
 			compatibleWorker2 = new(workerfakes.FakeWorker)
 			compatibleWorker3 = new(workerfakes.FakeWorker)
@@ -390,7 +396,8 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 		})
 		Context("when max-tasks-per-worker is set to 1", func() {
 			BeforeEach(func() {
-				strategy = NewLimitActiveTasksPlacementStrategy(1)
+				strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 1})
+				Expect(newStrategyError).ToNot(HaveOccurred())
 			})
 			Context("when there are multiple workers", func() {
 				BeforeEach(func() {

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -278,7 +278,7 @@ var _ = Describe("VolumeLocalityPlacementStrategy", func() {
 	})
 })
 
-var _ = Describe("RandomPlacementStrategyNode", func() {
+var _ = Describe("No strategy should equal to random strategy", func() {
 	Describe("Choose", func() {
 		JustBeforeEach(func() {
 			chosenWorker, chooseErr = strategy.Choose(

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -1,6 +1,8 @@
 package worker_test
 
 import (
+	"errors"
+
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	"github.com/concourse/concourse/atc/db"
@@ -45,8 +47,11 @@ var _ = Describe("FewestBuildContainersPlacementStrategy", func() {
 			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "fewest-build-containers"})
 			Expect(newStrategyError).ToNot(HaveOccurred())
 			compatibleWorker1 = new(workerfakes.FakeWorker)
+			compatibleWorker1.NameReturns("compatibleWorker1")
 			compatibleWorker2 = new(workerfakes.FakeWorker)
+			compatibleWorker2.NameReturns("compatibleWorker2")
 			compatibleWorker3 = new(workerfakes.FakeWorker)
+			compatibleWorker3.NameReturns("compatibleWorker3")
 
 			spec = ContainerSpec{
 				ImageSpec: ImageSpec{ResourceType: "some-type"},
@@ -172,18 +177,23 @@ var _ = Describe("VolumeLocalityPlacementStrategy", func() {
 
 			compatibleWorkerOneCache1 = new(workerfakes.FakeWorker)
 			compatibleWorkerOneCache1.SatisfiesReturns(true)
+			compatibleWorkerOneCache1.NameReturns("compatibleWorkerOneCache1")
 
 			compatibleWorkerOneCache2 = new(workerfakes.FakeWorker)
 			compatibleWorkerOneCache2.SatisfiesReturns(true)
+			compatibleWorkerOneCache2.NameReturns("compatibleWorkerOneCache2")
 
 			compatibleWorkerTwoCaches = new(workerfakes.FakeWorker)
 			compatibleWorkerTwoCaches.SatisfiesReturns(true)
+			compatibleWorkerTwoCaches.NameReturns("compatibleWorkerTwoCaches")
 
 			compatibleWorkerNoCaches1 = new(workerfakes.FakeWorker)
 			compatibleWorkerNoCaches1.SatisfiesReturns(true)
+			compatibleWorkerNoCaches1.NameReturns("compatibleWorkerNoCaches1")
 
 			compatibleWorkerNoCaches2 = new(workerfakes.FakeWorker)
 			compatibleWorkerNoCaches2.SatisfiesReturns(true)
+			compatibleWorkerNoCaches2.NameReturns("compatibleWorkerNoCaches2")
 		})
 
 		Context("with one having the most local caches", func() {
@@ -316,72 +326,69 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 		var compatibleWorker2 *workerfakes.FakeWorker
 		var compatibleWorker3 *workerfakes.FakeWorker
 
-		BeforeEach(func() {
-			logger = lagertest.NewTestLogger("active-tasks-equal-placement-test")
-			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 0})
-			Expect(newStrategyError).ToNot(HaveOccurred())
-
-			compatibleWorker1 = new(workerfakes.FakeWorker)
-			compatibleWorker2 = new(workerfakes.FakeWorker)
-			compatibleWorker3 = new(workerfakes.FakeWorker)
-
-			spec = ContainerSpec{
-				ImageSpec: ImageSpec{ResourceType: "some-type"},
-
-				Type: "task",
-
-				TeamID: 4567,
-
-				Inputs: []InputSource{},
-			}
-		})
-
-		Context("when there is only one worker with any amount of running tasks", func() {
+		Context("when MaxActiveTasksPerWorker less than 0", func() {
 			BeforeEach(func() {
-				workers = []Worker{compatibleWorker1}
-				compatibleWorker1.ActiveTasksReturns(42, nil)
+				logger = lagertest.NewTestLogger("active-tasks-equal-placement-test")
+				strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: -1})
 			})
-
-			It("picks that worker", func() {
-				chosenWorker, chooseErr = strategy.Choose(
-					logger,
-					workers,
-					spec,
-				)
-				Expect(chooseErr).ToNot(HaveOccurred())
-				Expect(chosenWorker).To(Equal(compatibleWorker1))
+			It("should fail", func() {
+				Expect(newStrategyError).To(HaveOccurred())
+				Expect(newStrategyError).To(Equal(errors.New("max-active-tasks-per-worker must be greater or equal than 0")))
+				Expect(strategy).To(BeNil())
 			})
 		})
 
-		Context("when there are multiple workers", func() {
+		Context("when MaxActiveTasksPerWorker less than 0", func() {
 			BeforeEach(func() {
-				workers = []Worker{compatibleWorker1, compatibleWorker2, compatibleWorker3}
+				logger = lagertest.NewTestLogger("active-tasks-equal-placement-test")
+				strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 0})
+				Expect(newStrategyError).ToNot(HaveOccurred())
 
-				compatibleWorker1.ActiveTasksReturns(2, nil)
-				compatibleWorker2.ActiveTasksReturns(1, nil)
-				compatibleWorker3.ActiveTasksReturns(2, nil)
+				compatibleWorker1 = new(workerfakes.FakeWorker)
+				compatibleWorker1.NameReturns("compatibleWorker1")
+				compatibleWorker2 = new(workerfakes.FakeWorker)
+				compatibleWorker2.NameReturns("compatibleWorker2")
+				compatibleWorker3 = new(workerfakes.FakeWorker)
+				compatibleWorker3.NameReturns("compatibleWorker3")
+
+				spec = ContainerSpec{
+					ImageSpec: ImageSpec{ResourceType: "some-type"},
+
+					Type: "task",
+
+					TeamID: 4567,
+
+					Inputs: []InputSource{},
+				}
 			})
 
-			It("a task picks the one with least amount of active tasks", func() {
-				Consistently(func() Worker {
+			Context("when there is only one worker with any amount of running tasks", func() {
+				BeforeEach(func() {
+					workers = []Worker{compatibleWorker1}
+					compatibleWorker1.ActiveTasksReturns(42, nil)
+				})
+
+				It("picks that worker", func() {
 					chosenWorker, chooseErr = strategy.Choose(
 						logger,
 						workers,
 						spec,
 					)
 					Expect(chooseErr).ToNot(HaveOccurred())
-					return chosenWorker
-				}).Should(Equal(compatibleWorker2))
+					Expect(chosenWorker).To(Equal(compatibleWorker1))
+				})
 			})
 
-			Context("when all the workers have the same number of active tasks", func() {
+			Context("when there are multiple workers", func() {
 				BeforeEach(func() {
 					workers = []Worker{compatibleWorker1, compatibleWorker2, compatibleWorker3}
-					compatibleWorker1.ActiveTasksReturns(1, nil)
-					compatibleWorker3.ActiveTasksReturns(1, nil)
+
+					compatibleWorker1.ActiveTasksReturns(2, nil)
+					compatibleWorker2.ActiveTasksReturns(1, nil)
+					compatibleWorker3.ActiveTasksReturns(2, nil)
 				})
 
-				It("a task picks any of them", func() {
+				It("a task picks the one with least amount of active tasks", func() {
 					Consistently(func() Worker {
 						chosenWorker, chooseErr = strategy.Choose(
 							logger,
@@ -390,58 +397,18 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 						)
 						Expect(chooseErr).ToNot(HaveOccurred())
 						return chosenWorker
-					}).Should(Or(Equal(compatibleWorker1), Equal(compatibleWorker3)))
-				})
-			})
-		})
-		Context("when max-tasks-per-worker is set to 1", func() {
-			BeforeEach(func() {
-				strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 1})
-				Expect(newStrategyError).ToNot(HaveOccurred())
-			})
-			Context("when there are multiple workers", func() {
-				BeforeEach(func() {
-					workers = []Worker{compatibleWorker1, compatibleWorker2, compatibleWorker3}
-
-					compatibleWorker1.ActiveTasksReturns(1, nil)
-					compatibleWorker2.ActiveTasksReturns(0, nil)
-					compatibleWorker3.ActiveTasksReturns(1, nil)
+					}).Should(Equal(compatibleWorker2))
 				})
 
-				It("picks the worker with no active tasks", func() {
-					chosenWorker, chooseErr = strategy.Choose(
-						logger,
-						workers,
-						spec,
-					)
-					Expect(chooseErr).ToNot(HaveOccurred())
-					Expect(chosenWorker).To(Equal(compatibleWorker2))
-				})
-			})
-
-			Context("when all workers have active tasks", func() {
-				BeforeEach(func() {
-					workers = []Worker{compatibleWorker1, compatibleWorker2, compatibleWorker3}
-
-					compatibleWorker1.ActiveTasksReturns(1, nil)
-					compatibleWorker2.ActiveTasksReturns(1, nil)
-					compatibleWorker3.ActiveTasksReturns(1, nil)
-				})
-
-				It("picks no worker", func() {
-					chosenWorker, chooseErr = strategy.Choose(
-						logger,
-						workers,
-						spec,
-					)
-					Expect(chooseErr).ToNot(HaveOccurred())
-					Expect(chosenWorker).To(BeNil())
-				})
-				Context("when the container is not of type 'task'", func() {
+				Context("when all the workers have the same number of active tasks", func() {
 					BeforeEach(func() {
-						spec.Type = ""
+						workers = []Worker{compatibleWorker1, compatibleWorker2, compatibleWorker3}
+						compatibleWorker1.ActiveTasksReturns(1, nil)
+						compatibleWorker2.ActiveTasksReturns(1, nil)
+						compatibleWorker3.ActiveTasksReturns(1, nil)
 					})
-					It("picks any worker", func() {
+
+					It("a task picks any of them", func() {
 						Consistently(func() Worker {
 							chosenWorker, chooseErr = strategy.Choose(
 								logger,
@@ -450,10 +417,167 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 							)
 							Expect(chooseErr).ToNot(HaveOccurred())
 							return chosenWorker
-						}).Should(Or(Equal(compatibleWorker1), Equal(compatibleWorker3)))
+						}).Should(Or(Equal(compatibleWorker1), Equal(compatibleWorker2), Equal(compatibleWorker3)))
+					})
+				})
+			})
+			Context("when max-tasks-per-worker is set to 1", func() {
+				BeforeEach(func() {
+					strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 1})
+					Expect(newStrategyError).ToNot(HaveOccurred())
+				})
+				Context("when there are multiple workers", func() {
+					BeforeEach(func() {
+						workers = []Worker{compatibleWorker1, compatibleWorker2, compatibleWorker3}
+
+						compatibleWorker1.ActiveTasksReturns(1, nil)
+						compatibleWorker2.ActiveTasksReturns(0, nil)
+						compatibleWorker3.ActiveTasksReturns(1, nil)
+					})
+
+					It("picks the worker with no active tasks", func() {
+						chosenWorker, chooseErr = strategy.Choose(
+							logger,
+							workers,
+							spec,
+						)
+						Expect(chooseErr).ToNot(HaveOccurred())
+						Expect(chosenWorker).To(Equal(compatibleWorker2))
+					})
+				})
+
+				Context("when all workers have active tasks", func() {
+					BeforeEach(func() {
+						workers = []Worker{compatibleWorker1, compatibleWorker2, compatibleWorker3}
+
+						compatibleWorker1.ActiveTasksReturns(1, nil)
+						compatibleWorker2.ActiveTasksReturns(1, nil)
+						compatibleWorker3.ActiveTasksReturns(1, nil)
+					})
+
+					It("picks no worker", func() {
+						chosenWorker, chooseErr = strategy.Choose(
+							logger,
+							workers,
+							spec,
+						)
+						Expect(chooseErr).ToNot(HaveOccurred())
+						Expect(chosenWorker).To(BeNil())
+					})
+					Context("when the container is not of type 'task'", func() {
+						BeforeEach(func() {
+							spec.Type = ""
+						})
+						It("picks any worker", func() {
+							Consistently(func() Worker {
+								chosenWorker, chooseErr = strategy.Choose(
+									logger,
+									workers,
+									spec,
+								)
+								Expect(chooseErr).ToNot(HaveOccurred())
+								return chosenWorker
+							}).Should(Or(Equal(compatibleWorker1), Equal(compatibleWorker2), Equal(compatibleWorker3)))
+						})
 					})
 				})
 			})
 		})
+	})
+})
+
+var _ = Describe("ChainedPlacementStrategy #Choose", func() {
+
+	var someWorker1 *workerfakes.FakeWorker
+	var someWorker2 *workerfakes.FakeWorker
+	var someWorker3 *workerfakes.FakeWorker
+
+	BeforeEach(func() {
+		logger = lagertest.NewTestLogger("build-containers-equal-placement-test")
+		strategy, newStrategyError = NewContainerPlacementStrategy(
+			ContainerPlacementStrategyOptions{
+				ContainerPlacementStrategy: "fewest-build-containers+volume-locality",
+			})
+		Expect(newStrategyError).ToNot(HaveOccurred())
+		someWorker1 = new(workerfakes.FakeWorker)
+		someWorker1.NameReturns("worker1")
+		someWorker2 = new(workerfakes.FakeWorker)
+		someWorker2.NameReturns("worker2")
+		someWorker3 = new(workerfakes.FakeWorker)
+		someWorker3.NameReturns("worker3")
+
+		spec = ContainerSpec{
+			ImageSpec: ImageSpec{ResourceType: "some-type"},
+
+			TeamID: 4567,
+
+			Inputs: []InputSource{},
+		}
+	})
+
+	Context("when there are multiple workers", func() {
+		BeforeEach(func() {
+			workers = []Worker{someWorker1, someWorker2, someWorker3}
+
+			someWorker1.BuildContainersReturns(30)
+			someWorker2.BuildContainersReturns(20)
+			someWorker3.BuildContainersReturns(10)
+		})
+
+		It("picks the one with least amount of containers", func() {
+			Consistently(func() Worker {
+				chosenWorker, chooseErr = strategy.Choose(
+					logger,
+					workers,
+					spec,
+				)
+				Expect(chooseErr).ToNot(HaveOccurred())
+				return chosenWorker
+			}).Should(Equal(someWorker3))
+		})
+
+		Context("when there is more than one worker with the same number of build containers", func() {
+			BeforeEach(func() {
+				workers = []Worker{someWorker1, someWorker2, someWorker3}
+				someWorker1.BuildContainersReturns(10)
+				someWorker2.BuildContainersReturns(20)
+				someWorker3.BuildContainersReturns(10)
+
+				fakeInput1 := new(workerfakes.FakeInputSource)
+				fakeInput1AS := new(workerfakes.FakeArtifactSource)
+				fakeInput1AS.ExistsOnStub = func(logger lager.Logger, worker Worker) (Volume, bool, error) {
+					switch worker {
+					case someWorker3:
+						return new(workerfakes.FakeVolume), true, nil
+					default:
+						return nil, false, nil
+					}
+				}
+				fakeInput1.SourceReturns(fakeInput1AS)
+
+				spec = ContainerSpec{
+					ImageSpec: ImageSpec{ResourceType: "some-type"},
+
+					TeamID: 4567,
+
+					Inputs: []InputSource{
+						fakeInput1,
+					},
+				}
+			})
+			It("picks the one with the most volumes", func() {
+				Consistently(func() Worker {
+					cWorker, cErr := strategy.Choose(
+						logger,
+						workers,
+						spec,
+					)
+					Expect(cErr).ToNot(HaveOccurred())
+					return cWorker
+				}).Should(Equal(someWorker3))
+
+			})
+		})
+
 	})
 })


### PR DESCRIPTION
## What does this PR accomplish?

Currently if a container placement strategy results multiple candidate workers, then it will randomly pick up one from the candidates.

Say, if `volume-locality` strategy results 2 candidate workers, why choose the one that has less containers or tasks?

With PR implements a strategy chain, so that if one strategy results multiple candidate workers, then next strategy can be applied.

## Changes proposed by this PR:

Organizes multiple strategies as a chain.

## Notes to reviewer:

Please review from the design perspective first. If you are ok with the design, I'll add more tests for chained strategies. This enhancement should not break any existing strategy.

## Release Note

* Enhanced container placement strategy to support chained strategies, for example `CONCOURSE_CONTAINER_PLACEMENT_STRATEGY=volume-locality,fewest-build-containers`

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
