### PR TITLE
Clear build events from previous resource/resource type check

### DIFF
--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -588,6 +588,17 @@ var _ = Describe("Resource", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeFalse())
 				})
+
+				It("deletes the previous build's events", func() {
+					var exists bool
+					err := dbConn.QueryRow(`SELECT EXISTS (
+						SELECT 1
+						FROM build_events
+						WHERE build_id = $1
+					)`, prevBuild.ID()).Scan(&exists)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(exists).To(BeFalse())
+				})
 			})
 		})
 	})

--- a/atc/db/resource_type_test.go
+++ b/atc/db/resource_type_test.go
@@ -614,6 +614,17 @@ var _ = Describe("ResourceType", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(found).To(BeFalse())
 				})
+
+				It("deletes the previous build's events", func() {
+					var exists bool
+					err := dbConn.QueryRow(`SELECT EXISTS (
+						SELECT 1
+						FROM build_events
+						WHERE build_id = $1
+					)`, prevBuild.ID()).Scan(&exists)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(exists).To(BeFalse())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

With #6022, we delete the previous build for a resource/resource type
check when we create a new one. However, since there's no foreign key
contraint on build_events.build_id, the build events never actually get
deleted.

We actually don't want a cascading delete on build_events, though, since
deleting pipelines would become super slow (currently, we're able to
just truncate/drop the pipeline_build_events table, but if deletes
cascaded, we'd end up performing a ton of row deletions, which is much
slower in postgres). So instead, let's just delete the build events when
we delete the corresponding build.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
