### PR TITLE
Use proper types for jobs and resources on pipeline page

### DIFF
--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -358,6 +358,19 @@ var _ = Describe("Resources API", func() {
 					]`))
 				})
 
+				Context("when the pipeline has no resources", func() {
+					BeforeEach(func() {
+						fakePipeline.ResourcesReturns(nil, nil)
+					})
+
+					It("returns an empty list", func() {
+						body, err := ioutil.ReadAll(response.Body)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(body).To(MatchJSON(`[]`))
+					})
+				})
+
 				Context("when getting the resource config fails", func() {
 					Context("when the resources are not found", func() {
 						BeforeEach(func() {

--- a/atc/api/resourceserver/list.go
+++ b/atc/api/resourceserver/list.go
@@ -20,7 +20,7 @@ func (s *Server) ListResources(pipeline db.Pipeline) http.Handler {
 			return
 		}
 
-		var presentedResources []atc.Resource
+		presentedResources := []atc.Resource{}
 		for _, resource := range resources {
 			presentedResources = append(
 				presentedResources,

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -60,6 +60,7 @@ module Concourse exposing
     , encodeBuild
     , encodeJob
     , encodePipeline
+    , encodeResource
     , encodeTeam
     , mapBuildPlan
     , retrieveCSRFToken
@@ -747,7 +748,6 @@ encodeJob job =
         , ( "finished_build", job.finishedBuild |> encodeMaybeBuild )
         , ( "transition_build", job.finishedBuild |> encodeMaybeBuild )
         , ( "paused", job.paused |> Json.Encode.bool )
-        , ( "disable_manual_trigger", job.paused |> Json.Encode.bool )
         , ( "disable_manual_trigger", job.disableManualTrigger |> Json.Encode.bool )
         , ( "inputs", job.inputs |> Json.Encode.list encodeJobInput )
         , ( "outputs", job.outputs |> Json.Encode.list encodeJobOutput )
@@ -936,6 +936,23 @@ decodeResource =
         |> andMap (Json.Decode.maybe (Json.Decode.field "build" decodeBuild))
 
 
+encodeResource : Resource -> Json.Encode.Value
+encodeResource r =
+    Json.Encode.object
+        ([ ( "team_name", r.teamName |> Json.Encode.string ) |> Just
+         , ( "pipeline_name", r.pipelineName |> Json.Encode.string ) |> Just
+         , ( "name", r.name |> Json.Encode.string ) |> Just
+         , optionalField "icon" Json.Encode.string r.icon
+         , optionalField "last_checked" (secondsFromDate >> Json.Encode.int) r.lastChecked
+         , optionalField "pinned_version" encodeVersion r.pinnedVersion
+         , ( "pinned_in_config", r.pinnedInConfig |> Json.Encode.bool ) |> Just
+         , optionalField "pin_comment" Json.Encode.string r.pinComment
+         , ( "build", r.build |> encodeMaybeBuild ) |> Just
+         ]
+            |> List.filterMap identity
+        )
+
+
 decodeVersionedResource : Json.Decode.Decoder VersionedResource
 decodeVersionedResource =
     Json.Decode.succeed VersionedResource
@@ -956,6 +973,11 @@ type alias Version =
 decodeVersion : Json.Decode.Decoder Version
 decodeVersion =
     Json.Decode.dict Json.Decode.string
+
+
+encodeVersion : Version -> Json.Encode.Value
+encodeVersion =
+    Json.Encode.dict identity Json.Encode.string
 
 
 

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -4,7 +4,6 @@ import Browser.Dom
 import Concourse
 import Concourse.Pagination exposing (Page, Paginated)
 import Http
-import Json.Encode
 import Message.Message
     exposing
         ( DomID
@@ -26,13 +25,13 @@ type Callback
     | BuildTriggered (Fetched Concourse.Build)
     | JobBuildsFetched (Fetched ( Page, Paginated Concourse.Build ))
     | JobFetched (Fetched Concourse.Job)
-    | JobsFetched (Fetched Json.Encode.Value)
+    | JobsFetched (Fetched (List Concourse.Job))
     | PipelineFetched (Fetched Concourse.Pipeline)
     | PipelinesFetched (Fetched (List Concourse.Pipeline))
     | PipelineToggled Concourse.PipelineIdentifier (Fetched ())
     | PipelinesOrdered String (Fetched ())
     | UserFetched (Fetched Concourse.User)
-    | ResourcesFetched (Fetched Json.Encode.Value)
+    | ResourcesFetched (Fetched (List Concourse.Resource))
     | BuildResourcesFetched (Fetched ( Int, Concourse.BuildResources ))
     | ResourceFetched (Fetched Concourse.Resource)
     | VersionedResourcesFetched (Fetched ( Page, Paginated Concourse.VersionedResource ))

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -154,7 +154,7 @@ type Effect
     | PauseJob Concourse.JobIdentifier
     | UnpauseJob Concourse.JobIdentifier
     | ResetPipelineFocus
-    | RenderPipeline Json.Encode.Value Json.Encode.Value
+    | RenderPipeline (List Concourse.Job) (List Concourse.Resource)
     | RedirectToLogin
     | LoadExternal String
     | NavigateTo String
@@ -218,7 +218,7 @@ runEffect effect key csrfToken =
         FetchJobs id ->
             Api.get
                 (Endpoints.PipelineJobsList |> Endpoints.Pipeline id)
-                |> Api.expectJson Json.Decode.value
+                |> Api.expectJson (Json.Decode.list Concourse.decodeJob)
                 |> Api.request
                 |> Task.attempt JobsFetched
 
@@ -255,7 +255,7 @@ runEffect effect key csrfToken =
         FetchResources id ->
             Api.get
                 (Endpoints.PipelineResourcesList |> Endpoints.Pipeline id)
-                |> Api.expectJson Json.Decode.value
+                |> Api.expectJson (Json.Decode.list Concourse.decodeResource)
                 |> Api.request
                 |> Task.attempt ResourcesFetched
 
@@ -383,7 +383,10 @@ runEffect effect key csrfToken =
             resetPipelineFocus ()
 
         RenderPipeline jobs resources ->
-            renderPipeline ( jobs, resources )
+            renderPipeline
+                ( Json.Encode.list Concourse.encodeJob jobs
+                , Json.Encode.list Concourse.encodeResource resources
+                )
 
         DoPinVersion id ->
             Api.put

--- a/web/elm/src/Pipeline/PinMenu/PinMenu.elm
+++ b/web/elm/src/Pipeline/PinMenu/PinMenu.elm
@@ -14,8 +14,6 @@ import HoverState
 import Html exposing (Html)
 import Html.Attributes exposing (id, style)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
-import Json.Decode
-import Json.Encode
 import Message.Message exposing (DomID(..), Message(..))
 import Pipeline.PinMenu.Styles as Styles
 import Pipeline.PinMenu.Views as Views
@@ -26,7 +24,7 @@ import Views.Styles
 
 type alias Model b =
     { b
-        | fetchedResources : Maybe Json.Encode.Value
+        | fetchedResources : Maybe (List Concourse.Resource)
         , pipelineLocator : Concourse.PipelineIdentifier
         , pinMenuExpanded : Bool
     }
@@ -205,16 +203,18 @@ viewPinMenu session m =
         |> viewView
 
 
-getPinnedResources : Maybe Json.Encode.Value -> List ( String, Concourse.Version )
+getPinnedResources : Maybe (List Concourse.Resource) -> List ( String, Concourse.Version )
 getPinnedResources fetchedResources =
     case fetchedResources of
         Nothing ->
             []
 
-        Just res ->
-            Json.Decode.decodeValue (Json.Decode.list Concourse.decodeResource) res
-                |> Result.withDefault []
-                |> List.filterMap (\r -> Maybe.map (\v -> ( r.name, v )) r.pinnedVersion)
+        Just resources ->
+            resources
+                |> List.filterMap
+                    (\r ->
+                        Maybe.map (\v -> ( r.name, v )) r.pinnedVersion
+                    )
 
 
 viewView : View -> Html Message

--- a/web/elm/tests/PinMenu/PinMenuTests.elm
+++ b/web/elm/tests/PinMenu/PinMenuTests.elm
@@ -61,22 +61,7 @@ all =
                 model =
                     { init
                         | fetchedResources =
-                            Just <|
-                                JE.list identity
-                                    [ JE.object
-                                        [ ( "team_name", JE.string "team" )
-                                        , ( "pipeline_name", JE.string "pipeline" )
-                                        , ( "name", JE.string "test" )
-                                        , ( "type", JE.string "type" )
-                                        , ( "pinned_version"
-                                          , JE.object
-                                                [ ( "version"
-                                                  , JE.string "v1"
-                                                  )
-                                                ]
-                                          )
-                                        ]
-                                    ]
+                            Just [ Data.resource "v1" |> Data.withName "test" ]
                     }
             in
             [ test "is hoverable" <|

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -782,15 +782,8 @@ givenPinnedResource : Application.Model -> Application.Model
 givenPinnedResource =
     Application.handleCallback
         (Callback.ResourcesFetched <|
-            Ok <|
-                Json.Encode.list identity
-                    [ Json.Encode.object
-                        [ ( "team_name", Json.Encode.string "team" )
-                        , ( "pipeline_name", Json.Encode.string "pipeline" )
-                        , ( "name", Json.Encode.string "resource" )
-                        , ( "pinned_version", Json.Encode.object [ ( "version", Json.Encode.string "v1" ) ] )
-                        ]
-                    ]
+            Ok
+                [ Data.resource "v1" ]
         )
         >> Tuple.first
 
@@ -799,21 +792,10 @@ givenMultiplePinnedResources : Application.Model -> Application.Model
 givenMultiplePinnedResources =
     Application.handleCallback
         (Callback.ResourcesFetched <|
-            Ok <|
-                Json.Encode.list identity
-                    [ Json.Encode.object
-                        [ ( "team_name", Json.Encode.string "team" )
-                        , ( "pipeline_name", Json.Encode.string "pipeline" )
-                        , ( "name", Json.Encode.string "resource" )
-                        , ( "pinned_version", Json.Encode.object [ ( "version", Json.Encode.string "v1" ) ] )
-                        ]
-                    , Json.Encode.object
-                        [ ( "team_name", Json.Encode.string "team" )
-                        , ( "pipeline_name", Json.Encode.string "pipeline" )
-                        , ( "name", Json.Encode.string "other-resource" )
-                        , ( "pinned_version", Json.Encode.object [ ( "version", Json.Encode.string "v2" ) ] )
-                        ]
-                    ]
+            Ok
+                [ Data.resource "v1"
+                , Data.resource "v2"
+                ]
         )
         >> Tuple.first
 

--- a/web/elm/tests/SerializationTests.elm
+++ b/web/elm/tests/SerializationTests.elm
@@ -22,6 +22,16 @@ all =
                     |> Concourse.encodeJob
                     |> Json.Decode.decodeValue Concourse.decodeJob
                     |> Expect.equal (Ok job)
+        , test "resource encoding/decoding are inverses" <|
+            \_ ->
+                let
+                    resource =
+                        Data.resource "version"
+                in
+                resource
+                    |> Concourse.encodeResource
+                    |> Json.Decode.decodeValue Concourse.decodeResource
+                    |> Expect.equal (Ok resource)
         , test "build encoding/decoding are inverses" <|
             \_ ->
                 let


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

I *think* this fixes a bug that I *think* was introduced by #6137 - but I haven't figured out how to reproduce it. Please read the first commit message, as it contains more context, but I was seeing an Elm runtime error on CI which prevented the pipeline page from being updated.

And even if it doesn't fix the bug, at least it's a decent refactor!

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Use proper types (`List Concourse.Job`, `List Concourse.Resource`) instead of the generic `Json.Encode.Value` on the pipeline page
* Resource server returns `[]` instead of `null` when a pipeline has no resources

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

The function that errored is as follows (see the first commit message for context):

```javascript
function K(r, n, e, t) {
        if (100 < e)
            return t.push(L(r, n)),
            !0;
        if (r === n)
            return !0;
        if ("object" != typeof r || null === r || null === n)
            return "function" == typeof r && k(5),
            !1;
        for (var u in r.$ < 0 && (r = et(r),
        n = et(n)),
        r)
            if (!K(r[u], n[u], e + 1, t))
                return !1;
        return !0
    }
```

Again, I believe this is the equality check function

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [x] Documentation reviewed
- [x] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
