### PR TITLE
Acquire lock on `builds` table in `build_id` migrations

### DIFF
--- a/atc/db/migration/migrations/1603401316_alter_build_integers_to_bigints.down.sql
+++ b/atc/db/migration/migrations/1603401316_alter_build_integers_to_bigints.down.sql
@@ -1,4 +1,9 @@
 BEGIN;
+  -- Need to lock builds as migrating foreign key contraints seems to acquire an
+  -- AccessExclusiveLock on the downstream table. Locks are released at the end
+  -- of the transaction
+  LOCK TABLE builds IN ACCESS EXCLUSIVE MODE;
+
   ALTER TABLE jobs
       ALTER COLUMN next_build_id TYPE integer,
       ALTER COLUMN latest_completed_build_id TYPE integer,

--- a/atc/db/migration/migrations/1603401316_alter_build_integers_to_bigints.up.sql
+++ b/atc/db/migration/migrations/1603401316_alter_build_integers_to_bigints.up.sql
@@ -1,4 +1,9 @@
 BEGIN;
+  -- Need to lock builds as migrating foreign key contraints seems to acquire an
+  -- AccessExclusiveLock on the downstream table. Locks are released at the end
+  -- of the transaction
+  LOCK TABLE builds IN ACCESS EXCLUSIVE MODE;
+
   ALTER TABLE jobs
       ALTER COLUMN next_build_id TYPE bigint,
       ALTER COLUMN latest_completed_build_id TYPE bigint,


### PR DESCRIPTION
We were seeing deadlocks when trying to perform this migration due to
concurrent queries acquiring AccessShareLocks on builds, and interacting
with the tables which we `ALTER TABLE` on.

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>

<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes # .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
