### PR TITLE
Use base resource type defaults in `get`/`put` steps

### DIFF
--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -39,17 +39,27 @@ var resources = db.SchedulerResources{
 		Type:   "some-resource-type",
 		Source: atc.Source{"some": "source"},
 	},
+	db.SchedulerResource{
+		Name:   "some-base-resource",
+		Type:   "some-base-resource-type",
+		Source: atc.Source{"some": "source"},
+	},
 }
 
 var resourceTypes = atc.VersionedResourceTypes{
 	{
 		ResourceType: atc.ResourceType{
-			Name:   "some-resource-type",
-			Type:   "some-base-resource-type",
-			Source: atc.Source{"some": "type-source"},
+			Name:     "some-resource-type",
+			Type:     "some-base-resource-type",
+			Source:   atc.Source{"some": "type-source"},
+			Defaults: atc.Source{"default-key": "default-value"},
 		},
 		Version: atc.Version{"some": "type-version"},
 	},
+}
+
+var baseResourceTypeDefaults = map[string]atc.Source{
+	"some-base-resource-type": {"default-key": "default-value"},
 }
 
 var factoryTests = []PlannerTest{
@@ -74,7 +84,7 @@ var factoryTests = []PlannerTest{
 				"name": "some-name",
 				"type": "some-resource-type",
 				"resource": "some-resource",
-				"source": {"some":"source"},
+				"source": {"some":"source","default-key":"default-value"},
 				"params": {"some":"params"},
 				"version": {"some":"version"},
 				"tags": ["tag-1", "tag-2"],
@@ -83,6 +93,44 @@ var factoryTests = []PlannerTest{
 						"name": "some-resource-type",
 						"type": "some-base-resource-type",
 						"source": {"some": "type-source"},
+						"defaults": {"default-key":"default-value"},
+						"version": {"some": "type-version"}
+					}
+				]
+			}
+		}`,
+	},
+	{
+		Title: "get step with base resource type",
+		Config: &atc.GetStep{
+			Name:     "some-name",
+			Resource: "some-base-resource",
+			Params:   atc.Params{"some": "params"},
+			Version:  &atc.VersionConfig{Pinned: atc.Version{"doesnt": "matter"}},
+			Tags:     atc.Tags{"tag-1", "tag-2"},
+		},
+		Inputs: []db.BuildInput{
+			{
+				Name:    "some-name",
+				Version: atc.Version{"some": "version"},
+			},
+		},
+		PlanJSON: `{
+			"id": "(unique)",
+			"get": {
+				"name": "some-name",
+				"type": "some-base-resource-type",
+				"resource": "some-base-resource",
+				"source": {"some":"source","default-key":"default-value"},
+				"params": {"some":"params"},
+				"version": {"some":"version"},
+				"tags": ["tag-1", "tag-2"],
+				"resource_types": [
+					{
+						"name": "some-resource-type",
+						"type": "some-base-resource-type",
+						"source": {"some": "type-source"},
+						"defaults": {"default-key":"default-value"},
 						"version": {"some": "type-version"}
 					}
 				]
@@ -134,7 +182,7 @@ var factoryTests = []PlannerTest{
 						"type": "some-resource-type",
 						"resource": "some-resource",
 						"inputs": "all",
-						"source": {"some":"source"},
+						"source": {"some":"source","default-key":"default-value"},
 						"params": {"some":"params"},
 						"tags": ["tag-1", "tag-2"],
 						"resource_types": [
@@ -142,6 +190,7 @@ var factoryTests = []PlannerTest{
 								"name": "some-resource-type",
 								"type": "some-base-resource-type",
 								"source": {"some": "type-source"},
+								"defaults": {"default-key":"default-value"},
 								"version": {"some": "type-version"}
 							}
 						]
@@ -153,7 +202,7 @@ var factoryTests = []PlannerTest{
 						"name": "some-name",
 						"type": "some-resource-type",
 						"resource": "some-resource",
-						"source": {"some":"source"},
+						"source": {"some":"source","default-key":"default-value"},
 						"params": {"some":"get-params"},
 						"tags": ["tag-1", "tag-2"],
 						"version_from": "1",
@@ -162,6 +211,7 @@ var factoryTests = []PlannerTest{
 								"name": "some-resource-type",
 								"type": "some-base-resource-type",
 								"source": {"some": "type-source"},
+								"defaults": {"default-key":"default-value"},
 								"version": {"some": "type-version"}
 							}
 						]
@@ -210,6 +260,7 @@ var factoryTests = []PlannerTest{
 						"name": "some-resource-type",
 						"type": "some-base-resource-type",
 						"source": {"some": "type-source"},
+						"defaults": {"default-key":"default-value"},
 						"version": {"some": "type-version"}
 					}
 				]
@@ -773,9 +824,11 @@ func (test PlannerTest) Run(s *PlannerSuite) {
 }
 
 func (s *PlannerSuite) TestFactory() {
+	atc.LoadBaseResourceTypeDefaults(baseResourceTypeDefaults)
 	for _, test := range factoryTests {
 		s.Run(test.Title, func() {
 			test.Run(s)
 		})
 	}
+	atc.LoadBaseResourceTypeDefaults(map[string]atc.Source{})
 }

--- a/atc/db/job_factory.go
+++ b/atc/db/job_factory.go
@@ -55,6 +55,11 @@ func (r *SchedulerResource) ApplySourceDefaults(resourceTypes atc.VersionedResou
 	parentType, found := resourceTypes.Lookup(r.Type)
 	if found {
 		r.Source = parentType.Defaults.Merge(r.Source)
+	} else {
+		defaults, found := atc.FindBaseResourceTypeDefaults(r.Type)
+		if found {
+			r.Source = defaults.Merge(r.Source)
+		}
 	}
 }
 

--- a/atc/db/job_factory_test.go
+++ b/atc/db/job_factory_test.go
@@ -1099,7 +1099,7 @@ var _ = Context("SchedulerResource", func() {
 			resource.ApplySourceDefaults(resourceTypes)
 		})
 
-		It("should applied defaults", func() {
+		It("should apply defaults", func() {
 			Expect(resource).To(Equal(db.SchedulerResource{
 				Name: "some-name",
 				Type: "some-type",
@@ -1108,6 +1108,30 @@ var _ = Context("SchedulerResource", func() {
 					"default-key": "default-value",
 				},
 			}))
+		})
+
+		Context("when the parent resource is not found", func() {
+			BeforeEach(func() {
+				resourceTypes = atc.VersionedResourceTypes{}
+				atc.LoadBaseResourceTypeDefaults(map[string]atc.Source{
+					"some-type": {"default-key": "default-value"},
+				})
+			})
+
+			AfterEach(func() {
+				atc.LoadBaseResourceTypeDefaults(map[string]atc.Source{})
+			})
+
+			It("should apply defaults using the base resource type", func() {
+				Expect(resource).To(Equal(db.SchedulerResource{
+					Name: "some-name",
+					Type: "some-type",
+					Source: atc.Source{
+						"some-key":    "some-value",
+						"default-key": "default-value",
+					},
+				}))
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

Follow up to #6079.

We noticed that the defaults we set for `get` and `put` steps backed by base
resource types weren't being applied since we only check the pipeline's
resource types to apply defaults. Note that we properly check the base
resource type for task image fetching.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* If parent resource type is not found in pipeline's resource types, check in base resource types when applying default
  * We do the same thing when we `Deserialize` the pipeline's resource types - https://github.com/concourse/concourse/blob/e1c0dbd1b1eee14e3ac1526ca5f44e4d416e06ce/atc/db/resource_type.go#L86-L100. If the resource isn't backed by a pipeline-local resource type though (e.g. uses `registry-image` directly), this doesn't apply
  * We also do the same thing on the `task` step's `image_resource`: https://github.com/concourse/concourse/blob/e1c0dbd1b1eee14e3ac1526ca5f44e4d416e06ce/atc/task.go#L50-L64
* This also adds some test coverage for `atc/builds/planner.go`, which had no coverage for applying defaults

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

e.g. `pipeline.yml`

```yaml
resources:
- name: thing
  type: registry-image
  source:
    repository: busybox

jobs:
- name: job
  plan:
  - get: thing
  - task: echo
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: {repository: busybox}
      run:
        path: sh
        args:
        - -c
        - echo "blah"
```

e.g. `defaults.yml` (in `docker-compose.yml`, add `CONCOURSE_BASE_RESOURCE_TYPE_DEFAULTS: /src/defaults.yml`)

```yaml
registry-image:
  debug: true
```

We should see the debug output for both the `get` step and the `task` image fetching - however, on `master`, we only see it for the latter.

## Release Note
<!--
If needed, you can leave a detailed description here which will be used to
generate the release note for the next version of Concourse. The title of the
PR will also be pulled into the release note.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
