### PR TITLE
back-porting baggageclaim test change

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -7,6 +7,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/storage/v1"
+	k8sErrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,14 +48,20 @@ var _ = Describe("baggageclaim drivers", func() {
 			It("successfully recreates the worker", func() {
 				By("deploying concourse with ONLY one worker and having the worker pod use the gcloud disk and format it with btrfs")
 
+				scName := "btrfs"
+				createBtrfsStorageClass(scName)
+
 				setReleaseNameAndNamespace("real-btrfs-disk")
+				pvcName := "disk-" + namespace
 
 				deployWithDriverAndSelectors("btrfs", UBUNTU,
 					"--set=persistence.enabled=false",
 					"--set=worker.additionalVolumes[0].name=concourse-work-dir",
-					"--set=worker.additionalVolumes[0].gcePersistentDisk.pdName=disk-topgun-k8s-btrfs-test",
-					"--set=worker.additionalVolumes[0].gcePersistentDisk.fsType=btrfs",
+					"--set=worker.additionalVolumes[0].persistentVolumeClaim.claimName="+pvcName,
 				)
+
+				// We create the PVC after deploying because we need the namespace to be created first by helm
+				createPVC(pvcName, scName)
 
 				atc := waitAndLogin(namespace, releaseName+"-web")
 				defer atc.Close()
@@ -120,4 +129,30 @@ func deployWithDriverAndSelectors(driver string, selectorFlags ...string) {
 	}
 
 	deployConcourseChart(releaseName, append(helmDeployTestFlags, selectorFlags...)...)
+}
+
+func createBtrfsStorageClass(name string) {
+	_, err := kubeClient.StorageV1().StorageClasses().Create(&v1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: "btrfs"},
+		Provisioner: "kubernetes.io/gce-pd",
+		Parameters: map[string]string{
+			"type":   "pd-standard",
+			"fstype": name,
+		},
+	})
+	if err != nil && !k8sErrs.IsAlreadyExists(err) {
+		Fail("failed to create btrfs storage class: " + err.Error())
+	}
+}
+func createPVC(name string, scName string) {
+	_, err := kubeClient.CoreV1().PersistentVolumeClaims(namespace).
+		Create(&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &scName,
+				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi")}},
+			}})
+	Expect(err).To(BeNil(), "failed to create persistent volume claim "+name)
 }


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation


## Changes proposed by this PR:
Back-porting the baggageclaim fix from #6185 

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
