### PR TITLE
[release/6.7.x] use k8s/client-go v11.0 for topgun

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -1,7 +1,6 @@
 package k8s_test
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -111,7 +110,7 @@ func baggageclaimFails(driver string, selectorFlags ...string) {
 				var logs []byte
 				pods := getPods(namespace, metav1.ListOptions{LabelSelector: "app=" + namespace + "-worker"})
 				for _, p := range pods {
-					contents, _ := kubeClient.CoreV1().Pods(namespace).GetLogs(p.Name, &corev1.PodLogOptions{}).Do(context.TODO()).Raw()
+					contents, _ := kubeClient.CoreV1().Pods(namespace).GetLogs(p.Name, &corev1.PodLogOptions{}).Do().Raw()
 					logs = append(logs, contents...)
 				}
 
@@ -133,27 +132,27 @@ func deployWithDriverAndSelectors(driver string, selectorFlags ...string) {
 }
 
 func createBtrfsStorageClass(name string) {
-	_, err := kubeClient.StorageV1().StorageClasses().Create(context.TODO(), &v1.StorageClass{
+	_, err := kubeClient.StorageV1().StorageClasses().Create(&v1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "btrfs"},
 		Provisioner: "kubernetes.io/gce-pd",
 		Parameters: map[string]string{
 			"type":   "pd-standard",
 			"fstype": name,
 		},
-	}, metav1.CreateOptions{})
+	})
 	if err != nil && !k8sErrs.IsAlreadyExists(err) {
 		Fail("failed to create btrfs storage class: " + err.Error())
 	}
 }
 func createPVC(name string, scName string) {
 	_, err := kubeClient.CoreV1().PersistentVolumeClaims(namespace).
-		Create(context.TODO(), &corev1.PersistentVolumeClaim{
+		Create(&corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				StorageClassName: &scName,
 				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 					corev1.ResourceStorage: resource.MustParse("1Gi")}},
-			}}, metav1.CreateOptions{})
+			}})
 	Expect(err).To(BeNil(), "failed to create persistent volume claim "+name)
 }

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -3,7 +3,6 @@ package k8s_test
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -341,7 +340,7 @@ func helmDestroy(releaseName, namespace string) {
 }
 
 func getPods(namespace string, listOptions metav1.ListOptions) []corev1.Pod {
-	pods, err := kubeClient.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
+	pods, err := kubeClient.CoreV1().Pods(namespace).List(listOptions)
 	Expect(err).ToNot(HaveOccurred())
 
 	return pods.Items
@@ -429,7 +428,7 @@ func waitAndLogin(namespace, service string) Endpoint {
 func cleanupReleases() {
 	for releaseName, namespace := range deployedReleases {
 		helmDestroy(releaseName, namespace)
-		kubeClient.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
+		kubeClient.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{})
 	}
 
 	deployedReleases = make(map[string]string)


### PR DESCRIPTION
safer to rewrite topgun than to bump dependencies everywhere else