### PR TITLE
Fix existing placement strategy tests and add new test case for chained strategies

### DIFF
--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -87,7 +87,6 @@ func NewRandomPlacementStrategy() ContainerPlacementStrategy {
 	return s
 }
 
-
 type VolumeLocalityPlacementStrategyNode struct {
 	rand *rand.Rand
 }

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -1,12 +1,19 @@
 package worker
 
 import (
+	"errors"
 	"math/rand"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/db"
 )
+
+type ContainerPlacementStrategyOptions struct {
+	ContainerPlacementStrategy string `long:"container-placement-strategy" default:"volume-locality" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" description:"Method by which a worker is selected during container placement. Multiple methods can be chained by +, e.g. volume-locality+fewest-build-containers"`
+	MaxActiveTasksPerWorker    int    `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
+}
 
 type ContainerPlacementStrategy interface {
 	//TODO: Don't pass around container metadata since it's not guaranteed to be deterministic.
@@ -15,17 +22,83 @@ type ContainerPlacementStrategy interface {
 	ModifiesActiveTasks() bool
 }
 
-type VolumeLocalityPlacementStrategy struct {
+type ContainerPlacementStrategyChainNode interface {
+	Choose(lager.Logger, []Worker, ContainerSpec) ([]Worker, error)
+	ModifiesActiveTasks() bool
+}
+
+type containerPlacementStrategy struct {
+	nodes []ContainerPlacementStrategyChainNode
+}
+
+func NewContainerPlacementStrategy(opts ContainerPlacementStrategyOptions) (*containerPlacementStrategy, error) {
+	cps := &containerPlacementStrategy{nodes: []ContainerPlacementStrategyChainNode{}}
+	strategies := strings.Split(opts.ContainerPlacementStrategy, "+")
+	for _, strategy := range strategies {
+		strategy := strings.TrimSpace(strategy)
+		switch strategy {
+		case "random":
+			cps.nodes = append(cps.nodes, newRandomPlacementStrategyNode())
+		case "fewest-build-containers":
+			cps.nodes = append(cps.nodes, newFewestBuildContainersPlacementStrategy())
+		case "limit-active-tasks":
+			if opts.MaxActiveTasksPerWorker < 0 {
+				return nil, errors.New("max-active-tasks-per-worker must be greater or equal than 0")
+			}
+			cps.nodes = append(cps.nodes, newLimitActiveTasksPlacementStrategy(opts.MaxActiveTasksPerWorker))
+		default:
+			cps.nodes = append(cps.nodes, newVolumeLocalityPlacementStrategyNode())
+		}
+	}
+	return cps, nil
+}
+
+func (strategy *containerPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
+	var err error
+	for _, node := range strategy.nodes {
+		workers, err = node.Choose(logger, workers, spec)
+		if err != nil {
+			return nil, err
+		}
+		if len(workers) == 0 {
+			return nil, nil
+		}
+	}
+	if len(workers) == 1 {
+		return workers[0], nil
+	}
+
+	// If there are still multiple candidate, choose a random one.
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return workers[r.Intn(len(workers))], nil
+}
+
+func (strategy *containerPlacementStrategy) ModifiesActiveTasks() bool {
+	for _, node := range strategy.nodes {
+		if node.ModifiesActiveTasks() {
+			return true
+		}
+	}
+	return false
+}
+
+func NewRandomPlacementStrategy() ContainerPlacementStrategy {
+	s, _ := NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "random"})
+	return s
+}
+
+
+type VolumeLocalityPlacementStrategyNode struct {
 	rand *rand.Rand
 }
 
-func NewVolumeLocalityPlacementStrategy() ContainerPlacementStrategy {
-	return &VolumeLocalityPlacementStrategy{
+func newVolumeLocalityPlacementStrategyNode() ContainerPlacementStrategyChainNode {
+	return &VolumeLocalityPlacementStrategyNode{
 		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
-func (strategy *VolumeLocalityPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
+func (strategy *VolumeLocalityPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
 	workersByCount := map[int][]Worker{}
 	var highestCount int
 	for _, w := range workers {
@@ -49,26 +122,24 @@ func (strategy *VolumeLocalityPlacementStrategy) Choose(logger lager.Logger, wor
 		}
 	}
 
-	highestLocalityWorkers := workersByCount[highestCount]
-
-	return highestLocalityWorkers[strategy.rand.Intn(len(highestLocalityWorkers))], nil
+	return workersByCount[highestCount], nil
 }
 
-func (strategy *VolumeLocalityPlacementStrategy) ModifiesActiveTasks() bool {
+func (strategy *VolumeLocalityPlacementStrategyNode) ModifiesActiveTasks() bool {
 	return false
 }
 
-type FewestBuildContainersPlacementStrategy struct {
+type FewestBuildContainersPlacementStrategyNode struct {
 	rand *rand.Rand
 }
 
-func NewFewestBuildContainersPlacementStrategy() ContainerPlacementStrategy {
-	return &FewestBuildContainersPlacementStrategy{
+func newFewestBuildContainersPlacementStrategy() ContainerPlacementStrategyChainNode {
+	return &FewestBuildContainersPlacementStrategyNode{
 		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
-func (strategy *FewestBuildContainersPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
+func (strategy *FewestBuildContainersPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
 	workersByWork := map[int][]Worker{}
 	var minWork int
 
@@ -80,27 +151,26 @@ func (strategy *FewestBuildContainersPlacementStrategy) Choose(logger lager.Logg
 		}
 	}
 
-	leastBusyWorkers := workersByWork[minWork]
-	return leastBusyWorkers[strategy.rand.Intn(len(leastBusyWorkers))], nil
+	return workersByWork[minWork], nil
 }
 
-func (strategy *FewestBuildContainersPlacementStrategy) ModifiesActiveTasks() bool {
+func (strategy *FewestBuildContainersPlacementStrategyNode) ModifiesActiveTasks() bool {
 	return false
 }
 
-type LimitActiveTasksPlacementStrategy struct {
+type LimitActiveTasksPlacementStrategyNode struct {
 	rand     *rand.Rand
 	maxTasks int
 }
 
-func NewLimitActiveTasksPlacementStrategy(maxTasks int) ContainerPlacementStrategy {
-	return &LimitActiveTasksPlacementStrategy{
+func newLimitActiveTasksPlacementStrategy(maxTasks int) ContainerPlacementStrategyChainNode {
+	return &LimitActiveTasksPlacementStrategyNode{
 		rand:     rand.New(rand.NewSource(time.Now().UnixNano())),
 		maxTasks: maxTasks,
 	}
 }
 
-func (strategy *LimitActiveTasksPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
+func (strategy *LimitActiveTasksPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
 	workersByWork := map[int][]Worker{}
 	minActiveTasks := -1
 
@@ -123,31 +193,27 @@ func (strategy *LimitActiveTasksPlacementStrategy) Choose(logger lager.Logger, w
 		}
 	}
 
-	leastBusyWorkers := workersByWork[minActiveTasks]
-	if len(leastBusyWorkers) < 1 {
-		return nil, nil
-	}
-	return leastBusyWorkers[strategy.rand.Intn(len(leastBusyWorkers))], nil
+	return workersByWork[minActiveTasks], nil
 }
 
-func (strategy *LimitActiveTasksPlacementStrategy) ModifiesActiveTasks() bool {
+func (strategy *LimitActiveTasksPlacementStrategyNode) ModifiesActiveTasks() bool {
 	return true
 }
 
-type RandomPlacementStrategy struct {
+type RandomPlacementStrategyNode struct {
 	rand *rand.Rand
 }
 
-func NewRandomPlacementStrategy() ContainerPlacementStrategy {
-	return &RandomPlacementStrategy{
+func newRandomPlacementStrategyNode() ContainerPlacementStrategyChainNode {
+	return &RandomPlacementStrategyNode{
 		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
-func (strategy *RandomPlacementStrategy) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) (Worker, error) {
-	return workers[strategy.rand.Intn(len(workers))], nil
+func (strategy *RandomPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
+	return []Worker{workers[strategy.rand.Intn(len(workers))]}, nil
 }
 
-func (strategy *RandomPlacementStrategy) ModifiesActiveTasks() bool {
+func (strategy *RandomPlacementStrategyNode) ModifiesActiveTasks() bool {
 	return false
 }

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -45,8 +45,11 @@ var _ = Describe("FewestBuildContainersPlacementStrategy", func() {
 			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "fewest-build-containers"})
 			Expect(newStrategyError).ToNot(HaveOccurred())
 			compatibleWorker1 = new(workerfakes.FakeWorker)
+			compatibleWorker1.NameReturns("compatibleWorker1")
 			compatibleWorker2 = new(workerfakes.FakeWorker)
+			compatibleWorker2.NameReturns("compatibleWorker2")
 			compatibleWorker3 = new(workerfakes.FakeWorker)
+			compatibleWorker3.NameReturns("compatibleWorker3")
 
 			spec = ContainerSpec{
 				ImageSpec: ImageSpec{ResourceType: "some-type"},
@@ -172,17 +175,22 @@ var _ = Describe("VolumeLocalityPlacementStrategy", func() {
 
 			compatibleWorkerOneCache1 = new(workerfakes.FakeWorker)
 			compatibleWorkerOneCache1.SatisfiesReturns(true)
+			compatibleWorkerOneCache1.NameReturns("compatibleWorkerOneCache1")
 
 			compatibleWorkerOneCache2 = new(workerfakes.FakeWorker)
+			compatibleWorkerOneCache2.NameReturns("compatibleWorkerOneCache2")
 			compatibleWorkerOneCache2.SatisfiesReturns(true)
 
 			compatibleWorkerTwoCaches = new(workerfakes.FakeWorker)
+			compatibleWorkerTwoCaches.NameReturns("compatibleWorkerTwoCaches")
 			compatibleWorkerTwoCaches.SatisfiesReturns(true)
 
 			compatibleWorkerNoCaches1 = new(workerfakes.FakeWorker)
+			compatibleWorkerNoCaches1.NameReturns("compatibleWorkerNoCaches1")
 			compatibleWorkerNoCaches1.SatisfiesReturns(true)
 
 			compatibleWorkerNoCaches2 = new(workerfakes.FakeWorker)
+			compatibleWorkerNoCaches2.NameReturns("compatibleWorkerNoCaches2")
 			compatibleWorkerNoCaches2.SatisfiesReturns(true)
 		})
 
@@ -322,8 +330,11 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 			Expect(newStrategyError).ToNot(HaveOccurred())
 
 			compatibleWorker1 = new(workerfakes.FakeWorker)
+			compatibleWorker1.NameReturns("compatibleWorker1")
 			compatibleWorker2 = new(workerfakes.FakeWorker)
+			compatibleWorker2.NameReturns("compatibleWorker2")
 			compatibleWorker3 = new(workerfakes.FakeWorker)
+			compatibleWorker3.NameReturns("compatibleWorker3")
 
 			spec = ContainerSpec{
 				ImageSpec: ImageSpec{ResourceType: "some-type"},
@@ -378,6 +389,7 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 				BeforeEach(func() {
 					workers = []Worker{compatibleWorker1, compatibleWorker2, compatibleWorker3}
 					compatibleWorker1.ActiveTasksReturns(1, nil)
+					compatibleWorker2.ActiveTasksReturns(2, nil)
 					compatibleWorker3.ActiveTasksReturns(1, nil)
 				})
 
@@ -450,7 +462,7 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 							)
 							Expect(chooseErr).ToNot(HaveOccurred())
 							return chosenWorker
-						}).Should(Or(Equal(compatibleWorker1), Equal(compatibleWorker3)))
+						}).Should(Not(BeNil()))
 					})
 				})
 			})

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -23,6 +23,8 @@ var (
 	chosenWorker Worker
 	chooseErr    error
 
+	newStrategyError error
+
 	compatibleWorkerOneCache1 *workerfakes.FakeWorker
 	compatibleWorkerOneCache2 *workerfakes.FakeWorker
 	compatibleWorkerTwoCaches *workerfakes.FakeWorker
@@ -40,7 +42,8 @@ var _ = Describe("FewestBuildContainersPlacementStrategy", func() {
 
 		BeforeEach(func() {
 			logger = lagertest.NewTestLogger("build-containers-equal-placement-test")
-			strategy = NewFewestBuildContainersPlacementStrategy()
+			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "fewest-build-containers"})
+			Expect(newStrategyError).ToNot(HaveOccurred())
 			compatibleWorker1 = new(workerfakes.FakeWorker)
 			compatibleWorker2 = new(workerfakes.FakeWorker)
 			compatibleWorker3 = new(workerfakes.FakeWorker)
@@ -129,7 +132,8 @@ var _ = Describe("VolumeLocalityPlacementStrategy", func() {
 
 		BeforeEach(func() {
 			logger = lagertest.NewTestLogger("volume-locality-placement-test")
-			strategy = NewVolumeLocalityPlacementStrategy()
+			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "volume-locality"})
+			Expect(newStrategyError).ToNot(HaveOccurred())
 
 			fakeInput1 := new(workerfakes.FakeInputSource)
 			fakeInput1AS := new(workerfakes.FakeArtifactSource)
@@ -264,7 +268,7 @@ var _ = Describe("VolumeLocalityPlacementStrategy", func() {
 	})
 })
 
-var _ = Describe("RandomPlacementStrategy", func() {
+var _ = Describe("RandomPlacementStrategyNode", func() {
 	Describe("Choose", func() {
 		JustBeforeEach(func() {
 			chosenWorker, chooseErr = strategy.Choose(
@@ -314,7 +318,9 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 
 		BeforeEach(func() {
 			logger = lagertest.NewTestLogger("active-tasks-equal-placement-test")
-			strategy = NewLimitActiveTasksPlacementStrategy(0)
+			strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 0})
+			Expect(newStrategyError).ToNot(HaveOccurred())
+
 			compatibleWorker1 = new(workerfakes.FakeWorker)
 			compatibleWorker2 = new(workerfakes.FakeWorker)
 			compatibleWorker3 = new(workerfakes.FakeWorker)
@@ -390,7 +396,8 @@ var _ = Describe("LimitActiveTasksPlacementStrategy", func() {
 		})
 		Context("when max-tasks-per-worker is set to 1", func() {
 			BeforeEach(func() {
-				strategy = NewLimitActiveTasksPlacementStrategy(1)
+				strategy, newStrategyError = NewContainerPlacementStrategy(ContainerPlacementStrategyOptions{ContainerPlacementStrategy: "limit-active-tasks", MaxActiveTasksPerWorker: 1})
+				Expect(newStrategyError).ToNot(HaveOccurred())
 			})
 			Context("when there are multiple workers", func() {
 				BeforeEach(func() {


### PR DESCRIPTION
## What does this PR accomplish?
- Fix tests that happened to pass due to incorrect assertions (expecting fakes inequality to hold true when it didn't)
- Add new test case for chained container placement strategies

## Changes proposed by this PR:
Modified atc/worker/placement_test.go

## Notes to reviewer:
- Each commit is standalone
- 🛑  This is blocked on @evanchaoli 's PR #6208

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
