### PR TITLE
Check step only acquires lock for periodic pipeline resource checks

### DIFF
--- a/atc/builds/tracker_test.go
+++ b/atc/builds/tracker_test.go
@@ -2,6 +2,7 @@ package builds_test
 
 import (
 	"context"
+	"io/ioutil"
 	"testing"
 	"time"
 
@@ -11,9 +12,14 @@ import (
 	"github.com/concourse/concourse/atc/db/dbfakes"
 	"github.com/concourse/concourse/atc/engine"
 	"github.com/concourse/concourse/atc/engine/enginefakes"
+	"github.com/concourse/concourse/atc/util"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+func init() {
+	util.PanicSink = ioutil.Discard
+}
 
 type TrackerSuite struct {
 	suite.Suite

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -137,6 +137,12 @@ type Lock interface {
 	Release() error
 }
 
+// NoopLock is a fake lock for use when a lock is conditionally acquired.
+type NoopLock struct{}
+
+// Release does nothing. Successfully.
+func (NoopLock) Release() error { return nil }
+
 //go:generate counterfeiter . LockDB
 
 type LockDB interface {

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -93,19 +93,21 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 		}
 	}
 
-	var lock lock.Lock
-	for {
-		var acquired bool
-		lock, acquired, err = scope.AcquireResourceCheckingLock(logger)
-		if err != nil {
-			return nil, false, fmt.Errorf("acquire lock: %w", err)
-		}
+	var lock lock.Lock = lock.NoopLock{}
+	if d.plan.Resource != "" {
+		for {
+			var acquired bool
+			lock, acquired, err = scope.AcquireResourceCheckingLock(logger)
+			if err != nil {
+				return nil, false, fmt.Errorf("acquire lock: %w", err)
+			}
 
-		if acquired {
-			break
-		}
+			if acquired {
+				break
+			}
 
-		d.clock.Sleep(time.Second)
+			d.clock.Sleep(time.Second)
+		}
 	}
 
 	end, err := scope.LastCheckEndTime()

--- a/atc/engine/engine_suite_test.go
+++ b/atc/engine/engine_suite_test.go
@@ -3,11 +3,16 @@ package engine_test
 import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/exec"
+	"github.com/concourse/concourse/atc/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"testing"
 )
+
+func init() {
+	util.PanicSink = GinkgoWriter
+}
 
 func TestEngine(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/atc/exec/aggregate.go
+++ b/atc/exec/aggregate.go
@@ -2,10 +2,8 @@ package exec
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"runtime/debug"
 
+	"github.com/concourse/concourse/atc/util"
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -27,10 +25,8 @@ func (step AggregateStep) Run(ctx context.Context, state RunState) (bool, error)
 		s := s
 		go func() {
 			defer func() {
-				if r := recover(); r != nil {
-					err := fmt.Errorf("panic in aggregate step: %v", r)
-
-					fmt.Fprintf(os.Stderr, "%s\n %s\n", err.Error(), string(debug.Stack()))
+				err := util.DumpPanic(recover(), "aggregate step")
+				if err != nil {
 					errs <- err
 				}
 			}()

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -310,7 +310,7 @@ func (step *CheckStep) runCheck(
 }
 
 func (step *CheckStep) containerOwner(resourceConfig db.ResourceConfig) db.ContainerOwner {
-	if step.plan.Resource == "" && step.plan.ResourceType == "" {
+	if step.plan.Resource == "" {
 		return db.NewBuildStepContainerOwner(
 			step.metadata.BuildID,
 			step.planID,

--- a/atc/exec/exec_suite_test.go
+++ b/atc/exec/exec_suite_test.go
@@ -11,7 +11,12 @@ import (
 	"github.com/concourse/concourse/atc/exec"
 	"github.com/concourse/concourse/atc/policy"
 	"github.com/concourse/concourse/atc/policy/policyfakes"
+	"github.com/concourse/concourse/atc/util"
 )
+
+func init() {
+	util.PanicSink = GinkgoWriter
+}
 
 func TestExec(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/atc/lidar/lidar_suite_test.go
+++ b/atc/lidar/lidar_suite_test.go
@@ -1,11 +1,16 @@
 package lidar_test
 
 import (
+	"github.com/concourse/concourse/atc/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"testing"
 )
+
+func init() {
+	util.PanicSink = GinkgoWriter
+}
 
 func TestLidar(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -2,16 +2,13 @@ package lidar
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"runtime/debug"
 	"strconv"
 	"sync"
 
-	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/metric"
+	"github.com/concourse/concourse/atc/util"
 	"github.com/concourse/concourse/tracing"
 )
 
@@ -53,17 +50,9 @@ func (s *scanner) Run(ctx context.Context) error {
 		waitGroup.Add(1)
 
 		go func(resource db.Resource, resourceTypes db.ResourceTypes) {
-			loggerData := lager.Data{
-				"resource_id":   strconv.Itoa(resource.ID()),
-				"resource_name": resource.Name(),
-				"pipeline_name": resource.PipelineName(),
-				"team_name":     resource.TeamName(),
-			}
 			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("panic in scanner run %s: %v", loggerData, r)
-
-					fmt.Fprintf(os.Stderr, "%s\n %s\n", err.Error(), string(debug.Stack()))
+				err := util.DumpPanic(recover(), "scanning resource %d", resource.ID())
+				if err != nil {
 					logger.Error("panic-in-scanner-run", err)
 				}
 			}()

--- a/atc/scheduler/scheduler_suite_test.go
+++ b/atc/scheduler/scheduler_suite_test.go
@@ -1,11 +1,16 @@
 package scheduler_test
 
 import (
+	"github.com/concourse/concourse/atc/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"testing"
 )
+
+func init() {
+	util.PanicSink = GinkgoWriter
+}
 
 func TestScheduler(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/atc/util/panic_dump.go
+++ b/atc/util/panic_dump.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
+)
+
+var PanicSink io.Writer = os.Stderr
+
+func DumpPanic(recovered interface{}, msg string, args ...interface{}) error {
+	if recovered == nil {
+		return nil
+	}
+
+	err := fmt.Errorf("panic in %s: %v", fmt.Sprintf(msg, args...), recovered)
+
+	fmt.Fprintf(PanicSink, "%s\n %s\n", err.Error(), string(debug.Stack()))
+	return err
+}


### PR DESCRIPTION
## What does this PR accomplish?

fixes #6217

## Changes proposed by this PR:

* Cleans up all the panics from test output.
* Don't re-use resource type check containers, since they really shouldn't need caching semantics (they're almost always `registry-image`).
* Only acquires the resource config scope lock when checking a resource.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
