### PR TITLE
Don't enforce timeouts during image fetching

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -59,6 +59,7 @@ func (visitor *planVisitor) VisitTask(step *atc.TaskStep) error {
 		InputMapping:      step.InputMapping,
 		OutputMapping:     step.OutputMapping,
 		ImageArtifactName: step.ImageArtifactName,
+		Timeout:           step.Timeout,
 
 		VersionedResourceTypes: visitor.resourceTypes,
 	})
@@ -100,6 +101,7 @@ func (visitor *planVisitor) VisitGet(step *atc.GetStep) error {
 		Params:   step.Params,
 		Version:  &version,
 		Tags:     step.Tags,
+		Timeout:  step.Timeout,
 
 		VersionedResourceTypes: visitor.resourceTypes,
 	})
@@ -123,13 +125,16 @@ func (visitor *planVisitor) VisitPut(step *atc.PutStep) error {
 	resource.ApplySourceDefaults(visitor.resourceTypes)
 
 	atcPutPlan := atc.PutPlan{
-		Type:     resource.Type,
 		Name:     logicalName,
 		Resource: resourceName,
+		Type:     resource.Type,
 		Source:   resource.Source,
 		Params:   step.Params,
-		Tags:     step.Tags,
-		Inputs:   step.Inputs,
+
+		Inputs: step.Inputs,
+
+		Tags:    step.Tags,
+		Timeout: step.Timeout,
 
 		VersionedResourceTypes: visitor.resourceTypes,
 	}
@@ -137,14 +142,15 @@ func (visitor *planVisitor) VisitPut(step *atc.PutStep) error {
 	putPlan := visitor.planFactory.NewPlan(atcPutPlan)
 
 	dependentGetPlan := visitor.planFactory.NewPlan(atc.GetPlan{
-		Type:        resource.Type,
 		Name:        logicalName,
 		Resource:    resourceName,
+		Type:        resource.Type,
+		Source:      resource.Source,
+		Params:      step.GetParams,
 		VersionFrom: &putPlan.ID,
 
-		Params: step.GetParams,
-		Tags:   step.Tags,
-		Source: resource.Source,
+		Tags:    step.Tags,
+		Timeout: step.Timeout,
 
 		VersionedResourceTypes: visitor.resourceTypes,
 	})

--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -71,6 +71,7 @@ var factoryTests = []PlannerTest{
 			Params:   atc.Params{"some": "params"},
 			Version:  &atc.VersionConfig{Pinned: atc.Version{"doesnt": "matter"}},
 			Tags:     atc.Tags{"tag-1", "tag-2"},
+			Timeout:  "1h",
 		},
 		Inputs: []db.BuildInput{
 			{
@@ -88,6 +89,7 @@ var factoryTests = []PlannerTest{
 				"params": {"some":"params"},
 				"version": {"some":"version"},
 				"tags": ["tag-1", "tag-2"],
+				"timeout": "1h",
 				"resource_types": [
 					{
 						"name": "some-resource-type",
@@ -162,6 +164,7 @@ var factoryTests = []PlannerTest{
 			Tags:      atc.Tags{"tag-1", "tag-2"},
 			Inputs:    &atc.InputsConfig{All: true},
 			GetParams: atc.Params{"some": "get-params"},
+			Timeout:   "1h",
 		},
 		Inputs: []db.BuildInput{
 			{
@@ -185,6 +188,7 @@ var factoryTests = []PlannerTest{
 						"source": {"some":"source","default-key":"default-value"},
 						"params": {"some":"params"},
 						"tags": ["tag-1", "tag-2"],
+						"timeout": "1h",
 						"resource_types": [
 							{
 								"name": "some-resource-type",
@@ -206,6 +210,7 @@ var factoryTests = []PlannerTest{
 						"params": {"some":"get-params"},
 						"tags": ["tag-1", "tag-2"],
 						"version_from": "1",
+						"timeout": "1h",
 						"resource_types": [
 							{
 								"name": "some-resource-type",
@@ -237,6 +242,7 @@ var factoryTests = []PlannerTest{
 			InputMapping:      map[string]string{"generic": "specific"},
 			OutputMapping:     map[string]string{"specific": "generic"},
 			ImageArtifactName: "some-image",
+			Timeout:           "1h",
 		},
 
 		PlanJSON: `{
@@ -255,6 +261,7 @@ var factoryTests = []PlannerTest{
 				"input_mapping": {"generic": "specific"},
 				"output_mapping": {"specific": "generic"},
 				"image": "some-image",
+				"timeout": "1h",
 				"resource_types": [
 					{
 						"name": "some-resource-type",

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -298,17 +298,12 @@ func (step *CheckStep) runCheck(
 		StderrWriter: delegate.Stderr(),
 	}
 
-	processCtx := ctx
-	if step.plan.Timeout != "" {
-		timeout, err := time.ParseDuration(step.plan.Timeout)
-		if err != nil {
-			return worker.CheckResult{}, fmt.Errorf("parse timeout: %w", err)
-		}
-
-		var cancel func()
-		processCtx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
+	processCtx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout)
+	if err != nil {
+		return worker.CheckResult{}, err
 	}
+
+	defer cancel()
 
 	return step.workerClient.RunCheckStep(
 		processCtx,

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -232,6 +233,11 @@ func (step *GetStep) run(ctx context.Context, state RunState, delegate GetDelega
 		resourceToGet,
 	)
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			delegate.Errored(logger, TimeoutLogMessage)
+			return false, nil
+		}
+
 		return false, err
 	}
 

--- a/atc/exec/log_error_step_test.go
+++ b/atc/exec/log_error_step_test.go
@@ -3,6 +3,7 @@ package exec_test
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	. "github.com/concourse/concourse/atc/exec"
 	"github.com/concourse/concourse/atc/exec/build"
@@ -91,12 +92,14 @@ var _ = Describe("LogErrorStep", func() {
 		})
 
 		Context("when aborted", func() {
+			var canceled = fmt.Errorf("wrapped: %w", context.Canceled)
+
 			BeforeEach(func() {
-				fakeStep.RunReturns(false, context.Canceled)
+				fakeStep.RunReturns(false, canceled)
 			})
 
 			It("propagates the error", func() {
-				Expect(runErr).To(Equal(context.Canceled))
+				Expect(runErr).To(Equal(canceled))
 			})
 
 			It("logs 'interrupted'", func() {
@@ -107,12 +110,14 @@ var _ = Describe("LogErrorStep", func() {
 		})
 
 		Context("when timed out", func() {
+			var timedOut = fmt.Errorf("wrapped: %w", context.DeadlineExceeded)
+
 			BeforeEach(func() {
-				fakeStep.RunReturns(false, context.DeadlineExceeded)
+				fakeStep.RunReturns(false, timedOut)
 			})
 
 			It("propagates the error", func() {
-				Expect(runErr).To(Equal(context.DeadlineExceeded))
+				Expect(runErr).To(Equal(timedOut))
 			})
 
 			It("logs 'timeout exceeded'", func() {

--- a/atc/exec/maybe_timeout.go
+++ b/atc/exec/maybe_timeout.go
@@ -1,0 +1,21 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func MaybeTimeout(ctx context.Context, timeoutStr string) (context.Context, func(), error) {
+	if timeoutStr == "" {
+		return ctx, func() {}, nil
+	}
+
+	timeout, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse timeout: %w", err)
+	}
+
+	processCtx, cancel := context.WithTimeout(ctx, timeout)
+	return processCtx, cancel, nil
+}

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -231,7 +232,11 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 		resourceToPut,
 	)
 	if err != nil {
-		logger.Error("failed-to-put-resource", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			delegate.Errored(logger, TimeoutLogMessage)
+			return false, nil
+		}
+
 		return false, err
 	}
 

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -274,6 +275,11 @@ func (step *TaskStep) run(ctx context.Context, state RunState, delegate TaskDele
 	}
 
 	if runErr != nil {
+		if errors.Is(runErr, context.DeadlineExceeded) {
+			delegate.Errored(logger, TimeoutLogMessage)
+			return false, nil
+		}
+
 		return false, runErr
 	}
 

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -434,6 +434,8 @@ var _ = Describe("TaskStep", func() {
 			var (
 				fakeVolume1 *workerfakes.FakeVolume
 				fakeVolume2 *workerfakes.FakeVolume
+
+				taskResult worker.TaskResult
 			)
 
 			BeforeEach(func() {
@@ -451,7 +453,7 @@ var _ = Describe("TaskStep", func() {
 
 				fakeVolume1 = new(workerfakes.FakeVolume)
 				fakeVolume2 = new(workerfakes.FakeVolume)
-				taskResult := worker.TaskResult{
+				taskResult = worker.TaskResult{
 					ExitStatus: 0,
 					VolumeMounts: []worker.VolumeMount{
 						{
@@ -474,14 +476,8 @@ var _ = Describe("TaskStep", func() {
 				Expect(containerSpec.ArtifactByPath["some-artifact-root/some-path-2"]).ToNot(BeNil())
 			})
 
-			Context("when task belongs to a job", func() {
-				BeforeEach(func() {
-					stepMetadata.JobID = 12
-				})
-
+			itRegistersCaches := func() {
 				It("registers cache volumes as task caches", func() {
-					Expect(stepErr).ToNot(HaveOccurred())
-
 					Expect(fakeVolume1.InitializeTaskCacheCallCount()).To(Equal(1))
 					_, jID, stepName, cachePath, p := fakeVolume1.InitializeTaskCacheArgsForCall(0)
 					Expect(jID).To(Equal(stepMetadata.JobID))
@@ -495,6 +491,39 @@ var _ = Describe("TaskStep", func() {
 					Expect(stepName).To(Equal("some-task"))
 					Expect(cachePath).To(Equal("some-path-2"))
 					Expect(p).To(Equal(bool(taskPlan.Privileged)))
+				})
+			}
+
+			Context("when task belongs to a job", func() {
+				BeforeEach(func() {
+					stepMetadata.JobID = 12
+				})
+
+				Context("when the task succeeds", func() {
+					BeforeEach(func() {
+						taskResult.ExitStatus = 0
+						fakeClient.RunTaskStepReturns(taskResult, nil)
+					})
+
+					itRegistersCaches()
+				})
+
+				Context("when the task exits nonzero", func() {
+					BeforeEach(func() {
+						taskResult.ExitStatus = 1
+						fakeClient.RunTaskStepReturns(taskResult, nil)
+					})
+
+					itRegistersCaches()
+				})
+
+				Context("when the task errors", func() {
+					BeforeEach(func() {
+						taskResult.ExitStatus = 1
+						fakeClient.RunTaskStepReturns(taskResult, errors.New("bam"))
+					})
+
+					itRegistersCaches()
 				})
 			})
 
@@ -1074,34 +1103,17 @@ var _ = Describe("TaskStep", func() {
 					runTaskStepError = nil
 					fakeClient.RunTaskStepReturns(taskResult, runTaskStepError)
 				})
+
 				outputsAreRegistered()
 			})
 
-			Context("when RunTaskStep returns a context Canceled error", func() {
-				BeforeEach(func() {
-					runTaskStepError = context.Canceled
-					fakeClient.RunTaskStepReturns(taskResult, runTaskStepError)
-				})
-				outputsAreRegistered()
-			})
-			Context("when RunTaskStep returns a context DeadlineExceeded error", func() {
-				BeforeEach(func() {
-					runTaskStepError = context.DeadlineExceeded
-					fakeClient.RunTaskStepReturns(taskResult, runTaskStepError)
-				})
-				outputsAreRegistered()
-			})
-
-			Context("when RunTaskStep returns a unexpected error", func() {
+			Context("when RunTaskStep errors", func() {
 				BeforeEach(func() {
 					runTaskStepError = errors.New("some unexpected error")
 					fakeClient.RunTaskStepReturns(taskResult, runTaskStepError)
 				})
-				It("re-registers the outputs as artifacts", func() {
-					artifactMap := repo.AsMap()
-					Expect(artifactMap).To(BeEmpty())
-				})
 
+				outputsAreRegistered()
 			})
 		})
 

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -203,6 +203,10 @@ type GetPlan struct {
 
 	// Worker tags to influence placement of the container.
 	Tags Tags `json:"tags,omitempty"`
+
+	// A timeout to enforce on the resource `get` process. Note that fetching the
+	// resource's image does not count towards the timeout.
+	Timeout string `json:"timeout,omitempty"`
 }
 
 type PutPlan struct {
@@ -225,6 +229,10 @@ type PutPlan struct {
 
 	// Worker tags to influence placement of the container.
 	Tags Tags `json:"tags,omitempty"`
+
+	// A timeout to enforce on the resource `put` process. Note that fetching the
+	// resource's image does not count towards the timeout.
+	Timeout string `json:"timeout,omitempty"`
 }
 
 type CheckPlan struct {
@@ -249,7 +257,8 @@ type CheckPlan struct {
 	// will be skipped.
 	Interval string `json:"interval,omitempty"`
 
-	// A timeout to enforce on the check operation.
+	// A timeout to enforce on the resource `check` process. Note that fetching
+	// the resource's image does not count towards the timeout.
 	Timeout string `json:"timeout,omitempty"`
 
 	// Worker tags to influence placement of the container.
@@ -287,6 +296,10 @@ type TaskPlan struct {
 	// build plan.
 	InputMapping  map[string]string `json:"input_mapping,omitempty"`
 	OutputMapping map[string]string `json:"output_mapping,omitempty"`
+
+	// A timeout to enforce on the task's process. Note that etching the task's
+	// image does not count towards the timeout.
+	Timeout string `json:"timeout,omitempty"`
 
 	// Resource types to have available for use when fetching the task's image.
 	//

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -251,10 +251,6 @@ var StepPrecedence = []StepDetector{
 		New: func() StepConfig { return &RetryStep{} },
 	},
 	{
-		Key: "timeout",
-		New: func() StepConfig { return &TimeoutStep{} },
-	},
-	{
 		Key: "task",
 		New: func() StepConfig { return &TaskStep{} },
 	},
@@ -265,6 +261,10 @@ var StepPrecedence = []StepDetector{
 	{
 		Key: "get",
 		New: func() StepConfig { return &GetStep{} },
+	},
+	{
+		Key: "timeout",
+		New: func() StepConfig { return &TimeoutStep{} },
 	},
 	{
 		Key: "set_pipeline",
@@ -300,6 +300,7 @@ type GetStep struct {
 	Passed   []string       `json:"passed,omitempty"`
 	Trigger  bool           `json:"trigger,omitempty"`
 	Tags     Tags           `json:"tags,omitempty"`
+	Timeout  string         `json:"timeout,omitempty"`
 }
 
 func (step *GetStep) ResourceName() string {
@@ -321,6 +322,7 @@ type PutStep struct {
 	Inputs    *InputsConfig `json:"inputs,omitempty"`
 	Tags      Tags          `json:"tags,omitempty"`
 	GetParams Params        `json:"get_params,omitempty"`
+	Timeout   string        `json:"timeout,omitempty"`
 }
 
 func (step *PutStep) ResourceName() string {
@@ -346,6 +348,7 @@ type TaskStep struct {
 	InputMapping      map[string]string `json:"input_mapping,omitempty"`
 	OutputMapping     map[string]string `json:"output_mapping,omitempty"`
 	ImageArtifactName string            `json:"image,omitempty"`
+	Timeout           string            `json:"timeout,omitempty"`
 }
 
 func (step *TaskStep) Visit(v StepVisitor) error {

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -34,6 +34,7 @@ var factoryTests = []StepTest{
 			params: {some: params}
 			version: {some: version}
 			tags: [tag-1, tag-2]
+			timeout: 1h
 		`,
 		StepConfig: &atc.GetStep{
 			Name:     "some-name",
@@ -41,6 +42,7 @@ var factoryTests = []StepTest{
 			Params:   atc.Params{"some": "params"},
 			Version:  &atc.VersionConfig{Pinned: atc.Version{"some": "version"}},
 			Tags:     []string{"tag-1", "tag-2"},
+			Timeout:  "1h",
 		},
 	},
 	{
@@ -53,6 +55,7 @@ var factoryTests = []StepTest{
 			tags: [tag-1, tag-2]
 			inputs: all
 			get_params: {some: get-params}
+			timeout: 1h
 		`,
 		StepConfig: &atc.PutStep{
 			Name:      "some-name",
@@ -61,6 +64,7 @@ var factoryTests = []StepTest{
 			Tags:      []string{"tag-1", "tag-2"},
 			Inputs:    &atc.InputsConfig{All: true},
 			GetParams: atc.Params{"some": "get-params"},
+			Timeout:   "1h",
 		},
 	},
 	{
@@ -79,6 +83,7 @@ var factoryTests = []StepTest{
 			input_mapping: {generic: specific}
 			output_mapping: {specific: generic}
 			image: some-image
+			timeout: 1h
 		`,
 
 		StepConfig: &atc.TaskStep{
@@ -95,6 +100,7 @@ var factoryTests = []StepTest{
 			InputMapping:      map[string]string{"generic": "specific"},
 			OutputMapping:     map[string]string{"specific": "generic"},
 			ImageArtifactName: "some-image",
+			Timeout:           "1h",
 		},
 	},
 	{

--- a/atc/worker/client_test.go
+++ b/atc/worker/client_test.go
@@ -224,7 +224,6 @@ var _ = Describe("Client", func() {
 	})
 
 	Describe("RunCheckStep", func() {
-
 		var (
 			containerSpec     worker.ContainerSpec
 			workerSpec        worker.WorkerSpec
@@ -274,7 +273,6 @@ var _ = Describe("Client", func() {
 				fakeProcessSpec,
 				fakeEventDelegate,
 				fakeResource,
-				1*time.Nanosecond,
 			)
 		})
 
@@ -349,13 +347,6 @@ var _ = Describe("Client", func() {
 					Expect(fakeEventDelegate.SelectedWorkerCallCount()).To(Equal(1))
 					_, name := fakeEventDelegate.SelectedWorkerArgsForCall(0)
 					Expect(name).To(Equal("some-worker"))
-				})
-
-				It("runs check w/ timeout", func() {
-					ctx, _, _ := fakeResource.CheckArgsForCall(0)
-					_, hasDeadline := ctx.Deadline()
-
-					Expect(hasDeadline).To(BeTrue())
 				})
 
 				It("uses the right executable path in the proc spec", func() {

--- a/atc/worker/workerfakes/fake_client.go
+++ b/atc/worker/workerfakes/fake_client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"sync"
-	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/db"
@@ -66,7 +65,7 @@ type FakeClient struct {
 		result2 bool
 		result3 error
 	}
-	RunCheckStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource, time.Duration) (worker.CheckResult, error)
+	RunCheckStepStub        func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource) (worker.CheckResult, error)
 	runCheckStepMutex       sync.RWMutex
 	runCheckStepArgsForCall []struct {
 		arg1  context.Context
@@ -79,7 +78,6 @@ type FakeClient struct {
 		arg8  runtime.ProcessSpec
 		arg9  runtime.StartingEventDelegate
 		arg10 resource.Resource
-		arg11 time.Duration
 	}
 	runCheckStepReturns struct {
 		result1 worker.CheckResult
@@ -378,7 +376,7 @@ func (fake *FakeClient) FindVolumeReturnsOnCall(i int, result1 worker.Volume, re
 	}{result1, result2, result3}
 }
 
-func (fake *FakeClient) RunCheckStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 runtime.ProcessSpec, arg9 runtime.StartingEventDelegate, arg10 resource.Resource, arg11 time.Duration) (worker.CheckResult, error) {
+func (fake *FakeClient) RunCheckStep(arg1 context.Context, arg2 lager.Logger, arg3 db.ContainerOwner, arg4 worker.ContainerSpec, arg5 worker.WorkerSpec, arg6 worker.ContainerPlacementStrategy, arg7 db.ContainerMetadata, arg8 runtime.ProcessSpec, arg9 runtime.StartingEventDelegate, arg10 resource.Resource) (worker.CheckResult, error) {
 	fake.runCheckStepMutex.Lock()
 	ret, specificReturn := fake.runCheckStepReturnsOnCall[len(fake.runCheckStepArgsForCall)]
 	fake.runCheckStepArgsForCall = append(fake.runCheckStepArgsForCall, struct {
@@ -392,12 +390,11 @@ func (fake *FakeClient) RunCheckStep(arg1 context.Context, arg2 lager.Logger, ar
 		arg8  runtime.ProcessSpec
 		arg9  runtime.StartingEventDelegate
 		arg10 resource.Resource
-		arg11 time.Duration
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11})
-	fake.recordInvocation("RunCheckStep", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11})
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10})
+	fake.recordInvocation("RunCheckStep", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10})
 	fake.runCheckStepMutex.Unlock()
 	if fake.RunCheckStepStub != nil {
-		return fake.RunCheckStepStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
+		return fake.RunCheckStepStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -412,17 +409,17 @@ func (fake *FakeClient) RunCheckStepCallCount() int {
 	return len(fake.runCheckStepArgsForCall)
 }
 
-func (fake *FakeClient) RunCheckStepCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource, time.Duration) (worker.CheckResult, error)) {
+func (fake *FakeClient) RunCheckStepCalls(stub func(context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource) (worker.CheckResult, error)) {
 	fake.runCheckStepMutex.Lock()
 	defer fake.runCheckStepMutex.Unlock()
 	fake.RunCheckStepStub = stub
 }
 
-func (fake *FakeClient) RunCheckStepArgsForCall(i int) (context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource, time.Duration) {
+func (fake *FakeClient) RunCheckStepArgsForCall(i int) (context.Context, lager.Logger, db.ContainerOwner, worker.ContainerSpec, worker.WorkerSpec, worker.ContainerPlacementStrategy, db.ContainerMetadata, runtime.ProcessSpec, runtime.StartingEventDelegate, resource.Resource) {
 	fake.runCheckStepMutex.RLock()
 	defer fake.runCheckStepMutex.RUnlock()
 	argsForCall := fake.runCheckStepArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8, argsForCall.arg9, argsForCall.arg10, argsForCall.arg11
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8, argsForCall.arg9, argsForCall.arg10
 }
 
 func (fake *FakeClient) RunCheckStepReturns(result1 worker.CheckResult, result2 error) {

--- a/testflight/resource_check_timeout_test.go
+++ b/testflight/resource_check_timeout_test.go
@@ -31,9 +31,9 @@ var _ = Describe("A resource check which times out", func() {
 		It("prints an error and cancels the check", func() {
 			check := spawnFly("check-resource", "-r", inPipeline("my-resource"))
 			<-check.Exited
-			Expect(check).To(gexec.Exit(2))
-			Expect(check).To(gbytes.Say("timed out"))
-			Expect(check).To(gbytes.Say("errored"))
+			Expect(check).To(gexec.Exit(1))
+			Expect(check).To(gbytes.Say("timeout exceeded"))
+			Expect(check).To(gbytes.Say("failed"))
 		})
 	})
 


### PR DESCRIPTION
## What does this PR accomplish?

Feature

* Adds a `timeout:` field to the `task`, `get`, and `put` steps which gets parsed before the more general `timeout:` step modifier. This allows the `task`/`get`/`put` steps to enforce the timeout more narrowly - around the running of the actual process, so that it doesn't include the time spent fetching images.
* Bumps `retryhttp` to v1.1.0 to fix an issue I noticed during testing: if the timeout is reached while making a request to Baggageclaim, `retryhttp` considered the `context.DeadlineExceeded` error to be retryable, so rather than timing out it'd go into a retry loop.
* Tweaks the `check` step timeout to be consistent with `task`/`get`/`put`, i.e. enforced at the step level rather than being passed to the `worker.Client`.

## Notes to reviewer:

I'm not 100% sure if this is a good idea. It feels more technically correct, because it's awkward to have to factor in time spent fetching images when determining an appropriate timeout, given that they'll be cached half the time. But it does make it harder to enforce timeouts on image fetching. You could work around it by explicitly using the `timeout:` step modifier, I guess.

## Contributor Checklist

<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
