### PR TITLE
Abort a rerun build if requried version no long available

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1503,6 +1503,11 @@ func (b *build) AdoptRerunInputsAndPipes() ([]BuildInput, bool, error) {
 					}).
 					RunWith(b.conn).
 					Exec()
+
+				err = b.MarkAsAborted()
+				if err != nil {
+					return nil, false, err
+				}
 			}
 
 			return nil, false, err

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -2198,6 +2198,13 @@ var _ = Describe("Build", func() {
 				It("fails to adopt", func() {
 					Expect(adoptFound).To(BeFalse())
 				})
+
+				It("aborts the build", func() {
+					reloaded, err := retriggerBuild.Reload()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(reloaded).To(BeTrue())
+					Expect(retriggerBuild.IsAborted()).To(BeTrue())
+				})
 			})
 		})
 


### PR DESCRIPTION
## What does this PR accomplish?

closes #6215 .

## Changes proposed by this PR:
when concourse can not find a version of an input for a rerun build, it will mark the build to be aborted to prevent the build pending forverer.

## Notes to reviewer:
Originally the issue wants the build to be failed instead of aborted. But a `failed` state indicates a build is started and ended where input satisfaction is met already. This is not the case so I think `aborted` is more intuitive.

## Release Note
A rerun build will be aborted automatically if required version of any input is not available.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Added release note (Optional)

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed

