### PR TITLE
Allow filtering by exact match on the dashboard by quoting search terms

### DIFF
--- a/web/elm/src/Dashboard/Filter.elm
+++ b/web/elm/src/Dashboard/Filter.elm
@@ -151,10 +151,14 @@ parseFilters =
 
 filter : Parser Filter
 filter =
-    oneOf
-        [ succeed (Filter True) |. spaces |. symbol "-" |= groupFilter |. spaces
-        , succeed (Filter False) |. spaces |= groupFilter |. spaces
-        ]
+    succeed Filter
+        |. spaces
+        |= oneOf
+            [ symbol "-" |> map (always True)
+            , succeed False
+            ]
+        |= groupFilter
+        |. spaces
 
 
 type GroupFilter

--- a/web/elm/src/Dashboard/SearchBar.elm
+++ b/web/elm/src/Dashboard/SearchBar.elm
@@ -374,7 +374,12 @@ dropdownOptions { query, teams, pipelines } =
                 )
                 |> Set.toList
                 |> List.take 10
-                |> List.map (\teamName -> "team: " ++ teamName)
+                |> List.map (\teamName -> "team: " ++ quoted teamName)
 
         _ ->
             []
+
+
+quoted : String -> String
+quoted s =
+    "\"" ++ s ++ "\""

--- a/web/elm/tests/DashboardSearchTests.elm
+++ b/web/elm/tests/DashboardSearchTests.elm
@@ -239,6 +239,23 @@ hasData =
                 >> queryView
                 >> Query.findAll [ class "dashboard-team-group" ]
                 >> Query.count (Expect.equal 3)
+        , it "ignores leading spaces in the query" <|
+            Application.handleCallback
+                (Callback.AllTeamsFetched <|
+                    Ok
+                        [ Concourse.Team 1 "main"
+                        , Concourse.Team 2 "team2"
+                        ]
+                )
+                >> Tuple.first
+                >> Application.update
+                    (Msgs.Update <|
+                        Message.Message.FilterMsg " team: main"
+                    )
+                >> Tuple.first
+                >> queryView
+                >> Query.findAll [ class "dashboard-team-group" ]
+                >> Query.count (Expect.equal 1)
         , it "centers 'no results' message when typing a string with no hits" <|
             Application.handleCallback
                 (Callback.AllTeamsFetched <|

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -1010,7 +1010,7 @@ all =
                 }
                 |> Tuple.first
             )
-            [ it "when there are teams the dropdown displays them" <|
+            [ it "when there are teams the dropdown displays them quoted" <|
                 Application.handleCallback
                     (Callback.AllTeamsFetched <|
                         Ok
@@ -1031,8 +1031,8 @@ all =
                     >> Query.children []
                     >> Expect.all
                         [ Query.count (Expect.equal 2)
-                        , Query.first >> Query.has [ tag "li", text "team1" ]
-                        , Query.index 1 >> Query.has [ tag "li", text "team2" ]
+                        , Query.first >> Query.has [ tag "li", text "\"team1\"" ]
+                        , Query.index 1 >> Query.has [ tag "li", text "\"team2\"" ]
                         ]
             , it "when there are many teams, the dropdown only displays the first 10" <|
                 Application.handleCallback


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes #3010 .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Wherever a string term is accepted in the dashboard search bar (team name, pipeline name), allow quoting the term to force an exact match
  * e.g. `team: team` will match `team`, `team1`, `other-team`, `tremendous-and-magnificent`, as it uses fuzzy matching
  * `team: "team"` will only match `team`
* When a term has partial quotes (e.g. `"team`), it checks the prefix of strings
  * e.g. `team: "team` will match `team`, `team1`
  * When you're typing out the filter, and have the opening quote, it doesn't make sense to do an exact match, since everything will disappear until you finish what you're typing
* Teams that appear in the search dropdown are quoted, since if you're selecting a team from the dropdown, you probably want an exact match

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
