### PR TITLE
Remove any existing guardian assets

### DIFF
--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -54,6 +54,10 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 		return nil, err
 	}
 
+	// guardian does not overwrite existing assets. Therefore it can end up using
+	// old versions of assets that it's packed with
+	os.RemoveAll("/var/gdn/assets")
+
 	members := grouper.Members{}
 
 	gdnConfigFlag := []string{}


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #6236
closes https://github.com/concourse/concourse-bosh-release/issues/128

Signed-off-by: Taylor Silva <tsilva@pivotal.io>
Co-authored-by: Bohan Chen <bochen@pivotal.io>

## Changes proposed by this PR:
Always try and remove the guardian assets dir [(`/var/gdn/assets`)](https://github.com/cloudfoundry/guardian/blob/3837782d5e8fb8b7374e2b9109860690db15a5da/guardiancmd/command.go#L120)


## Release Note
* The worker will now clear out any existing Guardian assets on start-up (`/var/gdn/assets`)
* This fixes in-place upgrade scenarios where guardian was using old versions of runc

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] ~Added tests (Unit and/or Integration)~
- [ ] ~Updated [Documentation]~
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
