### PR TITLE
Add docker-compose overrides for SAML, LDAP, OAuth, and OIDC

### DIFF
--- a/hack/dc
+++ b/hack/dc
@@ -5,9 +5,10 @@ set -e -u
 cd $(dirname $0)/..
 
 args=(-f docker-compose.yml)
+core=(vault prometheus jaeger)
 
-for f in hack/overrides/*.yml; do
-  args+=(-f $f)
+for f in "${core[@]}"; do
+  args+=(-f "hack/overrides/$f.yml")
 done
 
 docker-compose ${args[@]} "$@"

--- a/hack/ldap/config.ldif
+++ b/hack/ldap/config.ldif
@@ -1,0 +1,44 @@
+# Already included in default config of Docker image osixia/openldap:1.4.0.
+#
+# dn: dc=example,dc=org
+# objectClass: dcObject
+# objectClass: organization
+# o: Example Company
+# dc: example
+
+dn: ou=People,dc=example,dc=org
+objectClass: organizationalUnit
+ou: People
+
+dn: cn=jane,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: smith
+cn: john
+mail: user1@example.com
+userpassword: user1pass
+
+dn: cn=john,ou=People,dc=example,dc=org
+objectClass: person
+objectClass: inetOrgPerson
+sn: doe
+cn: jane
+mail: user2@example.com
+userpassword: user2pass
+
+# Group definitions.
+
+dn: ou=Groups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: Groups
+
+dn: cn=admins,ou=Groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: admins
+member: cn=john,ou=People,dc=example,dc=org
+member: cn=jane,ou=People,dc=example,dc=org
+
+dn: cn=group1,ou=Groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: group1
+member: cn=john,ou=People,dc=example,dc=org

--- a/hack/oidc/config.json
+++ b/hack/oidc/config.json
@@ -1,0 +1,18 @@
+{
+  "idp_name": "http://oidc:9000",
+  "port": 9000,
+  "client_config": [
+    {
+      "client_id": "foo",
+      "client_secret": "bar",
+      "redirect_uris": [
+        "http://localhost:8080/sky/issuer/callback"
+      ]
+    }
+  ],
+  "claim_mapping": {
+    "openid": [ "sub" ],
+    "email": [ "email", "email_verified" ],
+    "profile": [ "id", "username", "preferred_username", "groups" ]
+  }
+}

--- a/hack/oidc/users.json
+++ b/hack/oidc/users.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "1",
+    "email": "user1@example.com",
+    "email_verified": true,
+    "username": "user1",
+    "preferred_username": "John",
+    "password": "user1pass",
+    "groups": ["group1"]
+  },
+  {
+    "id": "2",
+    "email": "user2@example.com",
+    "email_verified": true,
+    "username": "user2",
+    "preferred_username": "John",
+    "password": "user2pass",
+    "groups": []
+  }
+]

--- a/hack/overrides/ldap.yml
+++ b/hack/overrides/ldap.yml
@@ -1,0 +1,47 @@
+# ldap.yml - a docker-compose override that adds a LDAP auth to the stack
+#
+# This is basically ripped from dex's example directory
+#
+# There are 2 users and 2 groups
+# user1@example.com:user1pass;group1;admins
+# user2@example.com:user2pass;admins
+#
+# ref: https://github.com/dexidp/dex/blob/33e13c2aad9bb8a91abea6a2870dc178e3bd00de/examples/ldap/
+# ref: https://docs.docker.com/compose/extends/
+#
+version: '3'
+
+services:
+  web:
+    environment:
+      CONCOURSE_MAIN_TEAM_LDAP_USER: john
+      # CONCOURSE_MAIN_TEAM_LDAP_GROUP: group1
+
+      CONCOURSE_LDAP_HOST: ldap:389
+      CONCOURSE_LDAP_BIND_DN: cn=admin,dc=example,dc=org
+      CONCOURSE_LDAP_BIND_PW: admin
+      CONCOURSE_LDAP_INSECURE_NO_SSL: "true"
+
+      CONCOURSE_LDAP_USER_SEARCH_BASE_DN: ou=People,dc=example,dc=org
+      CONCOURSE_LDAP_USER_SEARCH_FILTER: "(objectClass=person)"
+      CONCOURSE_LDAP_USER_SEARCH_USERNAME: mail
+      CONCOURSE_LDAP_USER_SEARCH_ID_ATTR: DN
+      CONCOURSE_LDAP_USER_SEARCH_EMAIL_ATTR: mail
+      CONCOURSE_LDAP_USER_SEARCH_NAME_ATTR: cn
+
+      CONCOURSE_LDAP_GROUP_SEARCH_BASE_DN: ou=Groups,dc=example,dc=org
+      CONCOURSE_LDAP_GROUP_SEARCH_FILTER: "(objectClass=groupOfNames)"
+      CONCOURSE_LDAP_GROUP_SEARCH_USER_ATTR: DN
+      CONCOURSE_LDAP_GROUP_SEARCH_GROUP_ATTR: member
+      CONCOURSE_LDAP_GROUP_SEARCH_NAME_ATTR: cn
+
+  ldap:
+    image: osixia/openldap:1.4.0
+    # Copying is required because the entrypoint modifies the *.ldif files.
+    # For verbose output, use:  command: ["--copy-service", "--loglevel", "debug"]
+    command: ["--copy-service"]
+    # https://github.com/osixia/docker-openldap#seed-ldap-database-with-ldif
+    # Option 1: Add custom seed file -> mount to         /container/service/slapd/assets/config/bootstrap/ldif/custom/
+    # Option 2: Overwrite default seed file -> mount to  /container/service/slapd/assets/config/bootstrap/ldif/
+    volumes:
+    - ./hack/ldap/:/container/service/slapd/assets/config/bootstrap/ldif/custom/

--- a/hack/overrides/oauth.yml
+++ b/hack/overrides/oauth.yml
@@ -1,8 +1,6 @@
-# oauth.yml - a docker-compose override that adds a oidc IDP to the stack
+# oauth.yml - a docker-compose override that adds a OAuth auth to the stack
 #
-# Once running, head to `localhost:8000/simplesaml/` to get access to the IDP
-#
-# There are 2 users and an admin account:
+# There are 2 users and 1 group:
 # user1@example.com:user1pass;group1
 # user2@example.com:user2pass
 #
@@ -14,7 +12,7 @@ version: '3'
 services:
   web:
     environment:
-      # CONCOURSE_MAIN_TEAM_OAUTH_USER: user1
+      CONCOURSE_MAIN_TEAM_OAUTH_USER: user1
       # CONCOURSE_MAIN_TEAM_OAUTH_GROUP: group1
 
       CONCOURSE_OAUTH_CLIENT_ID: foo

--- a/hack/overrides/oauth.yml
+++ b/hack/overrides/oauth.yml
@@ -1,0 +1,40 @@
+# oauth.yml - a docker-compose override that adds a oidc IDP to the stack
+#
+# Once running, head to `localhost:8000/simplesaml/` to get access to the IDP
+#
+# There are 2 users and an admin account:
+# user1@example.com:user1pass;group1
+# user2@example.com:user2pass
+#
+# ref: https://hub.docker.com/r/kristophjunge/test-saml-idp/
+# ref: https://docs.docker.com/compose/extends/
+#
+version: '3'
+
+services:
+  web:
+    environment:
+      # CONCOURSE_MAIN_TEAM_OAUTH_USER: user1
+      # CONCOURSE_MAIN_TEAM_OAUTH_GROUP: group1
+
+      CONCOURSE_OAUTH_CLIENT_ID: foo
+      CONCOURSE_OAUTH_CLIENT_SECRET: bar
+      CONCOURSE_OAUTH_AUTH_URL: http://localhost:9000/auth
+      CONCOURSE_OAUTH_TOKEN_URL: http://oauth:9000/token
+      CONCOURSE_OAUTH_USERINFO_URL: http://oauth:9000/me
+
+      CONCOURSE_OAUTH_SCOPE: openid,email,profile
+      CONCOURSE_OAUTH_USER_ID_KEY: id
+      CONCOURSE_OAUTH_USER_NAME_KEY: username
+
+  oauth:
+    image: qlik/simple-oidc-provider
+    ports:
+    - 9000:9000
+    environment:
+      REDIRECTS: http://localhost:8080/sky/issuer/callback
+      CONFIG_FILE: /oidc/config.json
+      USERS_FILE: /oidc/users.json
+    volumes:
+    - ./hack/oidc:/oidc
+

--- a/hack/overrides/oidc.yml
+++ b/hack/overrides/oidc.yml
@@ -1,4 +1,4 @@
-# oidc.yml - a docker-compose override that adds a oidc IDP to the stack
+# oidc.yml - a docker-compose override that adds a OIDC auth to the stack
 #
 # There are 2 users and 1 group:
 # user1@example.com:user1pass;group1

--- a/hack/overrides/oidc.yml
+++ b/hack/overrides/oidc.yml
@@ -1,5 +1,9 @@
 # oidc.yml - a docker-compose override that adds a OIDC auth to the stack
 #
+# Note: due to docker networking, when logging into Concourse, it'll redirect
+# you to `http://oidc:9000/auth?client_id=...`. Just change the hostname to be
+# `http://localhost:9000/auth?client_id=...` and it'll work just fine.
+#
 # There are 2 users and 1 group:
 # user1@example.com:user1pass;group1
 # user2@example.com:user2pass

--- a/hack/overrides/oidc.yml
+++ b/hack/overrides/oidc.yml
@@ -1,0 +1,33 @@
+# oidc.yml - a docker-compose override that adds a oidc IDP to the stack
+#
+# There are 2 users and 1 group:
+# user1@example.com:user1pass;group1
+# user2@example.com:user2pass
+#
+# ref: https://hub.docker.com/r/qlik/simple-oidc-provider/
+# ref: https://docs.docker.com/compose/extends/
+#
+version: '3'
+
+services:
+  web:
+    environment:
+      # CONCOURSE_MAIN_TEAM_OIDC_USER: user1
+      CONCOURSE_MAIN_TEAM_OIDC_USER: John
+      # CONCOURSE_MAIN_TEAM_OIDC_GROUP: group1
+
+      CONCOURSE_OIDC_ISSUER: http://oidc:9000
+      CONCOURSE_OIDC_CLIENT_ID: foo
+      CONCOURSE_OIDC_CLIENT_SECRET: bar
+
+  oidc:
+    image: qlik/simple-oidc-provider
+    ports:
+    - 9000:9000
+    environment:
+      REDIRECTS: http://localhost:8080/sky/issuer/callback
+      CONFIG_FILE: /oidc/config.json
+      USERS_FILE: /oidc/users.json
+    volumes:
+    - ./hack/oidc:/oidc
+

--- a/hack/overrides/saml.yml
+++ b/hack/overrides/saml.yml
@@ -1,4 +1,4 @@
-# saml.yml - a docker-compose override that adds a saml IDP to the stack
+# saml.yml - a docker-compose override that adds a SAML auth to the stack
 #
 # Once running, head to `localhost:8000/simplesaml/` to get access to the IDP
 #

--- a/hack/overrides/saml.yml
+++ b/hack/overrides/saml.yml
@@ -1,0 +1,36 @@
+# saml.yml - a docker-compose override that adds a saml IDP to the stack
+#
+# Once running, head to `localhost:8000/simplesaml/` to get access to the IDP
+#
+# There are 2 users and an admin account:
+# user1:user1pass
+# user2:user2pass
+# admin:secret
+#
+# ref: https://hub.docker.com/r/kristophjunge/test-saml-idp/
+# ref: https://docs.docker.com/compose/extends/
+#
+version: '3'
+
+services:
+  web:
+    environment:
+      # CONCOURSE_MAIN_TEAM_SAML_USER: user1@example.com
+      CONCOURSE_MAIN_TEAM_SAML_GROUP: group2
+
+      CONCOURSE_SAML_SSO_URL: http://localhost:8000/simplesaml/saml2/idp/SSOService.php
+      CONCOURSE_SAML_ENTITY_ISSUER: concourse
+      CONCOURSE_SAML_USERNAME_ATTR: email
+      CONCOURSE_SAML_GROUPS_ATTR: eduPersonAffiliation
+      CONCOURSE_SAML_SKIP_SSL_VALIDATION: "true"
+      # still need to specify file even if we skip tls
+      CONCOURSE_SAML_CA_CERT: /bin/sh
+
+  saml:
+    image: kristophjunge/test-saml-idp
+    ports:
+    - 8000:8080
+    environment:
+      SIMPLESAMLPHP_SP_ENTITY_ID: concourse
+      SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: http://localhost:8080/sky/issuer/callback
+


### PR DESCRIPTION
The SAML one might be a bit weird to work with, but the others should be straight forward and mimics what we can expect from a real life scenario.