### PR TITLE
fly: give more leeway for slow test

### DIFF
--- a/fly/integration/builds_test.go
+++ b/fly/integration/builds_test.go
@@ -228,7 +228,7 @@ var _ = Describe("Fly CLI", func() {
 			})
 
 			It("returns all the builds", func() {
-				runningBuildDuration := time.Duration(time.Now().Unix()-runningBuildStartTime.Unix()) * time.Second
+				runningBuildDuration := time.Since(runningBuildStartTime)
 
 				Eventually(session.Out).Should(PrintTable(ui.Table{
 					Headers: expectedHeaders,
@@ -242,7 +242,7 @@ var _ = Describe("Fly CLI", func() {
 							{
 								Contents: TableDurationWithDelta{
 									Duration: runningBuildDuration,
-									Delta:    2 * time.Second,
+									Delta:    20 * time.Second,
 									Suffix:   "+",
 								}.String(),
 							},


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

Couldn't easily reproduce the error locally, but I'm just going to extend the delta so we don't run into this. Seems odd that our windows/darwin workers are so slow on this test, though.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* <!-- Release note here. Delete section if not needed. -->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
