### PR TITLE
atc: abort a rerun build if input version gone

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1351,6 +1351,11 @@ func (b *build) AdoptRerunInputsAndPipes() ([]BuildInput, bool, error) {
 					}).
 					RunWith(b.conn).
 					Exec()
+
+				err = b.MarkAsAborted()
+				if err != nil {
+					return nil, false, err
+				}
 			}
 
 			return nil, false, err

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -2473,6 +2473,29 @@ var _ = Describe("Build", func() {
 				Expect(reloaded).To(BeTrue())
 				Expect(retriggerBuild.InputsReady()).To(BeTrue())
 			})
+
+			Context("when the version becomes unavailable", func() {
+				BeforeEach(func() {
+					resourceConfigScope, err = resource.SetResourceConfig(atc.Source{"some": "new-source"}, atc.VersionedResourceTypes{})
+					Expect(err).ToNot(HaveOccurred())
+
+					err = resourceConfigScope.SaveVersions(nil, []atc.Version{
+						{"some": "new-version"},
+					})
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("fails to adopt", func() {
+					Expect(adoptFound).To(BeFalse())
+				})
+
+				It("aborts the build", func() {
+					reloaded, err := retriggerBuild.Reload()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(reloaded).To(BeTrue())
+					Expect(retriggerBuild.IsAborted()).To(BeTrue())
+				})
+			})
 		})
 
 		Context("when the build to retrigger off of does not have inputs or pipes", func() {


### PR DESCRIPTION
cherry-picking the commit https://github.com/concourse/concourse/pull/6242/commits/ec9b0f637020e4eaa004baf8bf20cb5e737b5bc1 from master to 6.7.x

Needed to update the test setup to the old way.