### PR TITLE
Ignore paused jobs when determining pipeline status

### DIFF
--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -173,21 +173,24 @@ pipelineStatus jobs pipeline =
             isRunning =
                 List.any (\job -> job.nextBuild /= Nothing) jobs
 
+            unpausedJobs =
+                jobs |> List.filter (\job -> not job.paused)
+
             mostImportantJobStatus =
-                jobs
+                unpausedJobs
                     |> List.map jobStatus
                     |> List.sortWith Concourse.BuildStatus.ordering
                     |> List.head
 
             firstNonSuccess =
-                jobs
+                unpausedJobs
                     |> List.filter (jobStatus >> (/=) BuildStatusSucceeded)
                     |> List.filterMap transition
                     |> List.sortBy Time.posixToMillis
                     |> List.head
 
             lastTransition =
-                jobs
+                unpausedJobs
                     |> List.filterMap transition
                     |> List.sortBy Time.posixToMillis
                     |> List.reverse

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -68,6 +68,20 @@ hdPipelineView :
     }
     -> Html Message
 hdPipelineView { pipeline, pipelineRunningKeyframes, resourceError, existingJobs } =
+    let
+        bannerStyle =
+            if pipeline.stale then
+                Styles.pipelineCardBannerStaleHd
+
+            else if pipeline.archived then
+                Styles.pipelineCardBannerArchivedHd
+
+            else
+                Styles.pipelineCardBannerHd
+                    { status = pipelineStatus existingJobs pipeline
+                    , pipelineRunningKeyframes = pipelineRunningKeyframes
+                    }
+    in
     Html.a
         ([ class "card"
          , attribute "data-pipeline-name" pipeline.name
@@ -79,18 +93,7 @@ hdPipelineView { pipeline, pipelineRunningKeyframes, resourceError, existingJobs
         )
     <|
         [ Html.div
-            (if pipeline.stale then
-                Styles.pipelineCardBannerStaleHd
-
-             else if pipeline.archived then
-                Styles.pipelineCardBannerArchivedHd
-
-             else
-                Styles.pipelineCardBannerHd
-                    { status = pipelineStatus existingJobs pipeline
-                    , pipelineRunningKeyframes = pipelineRunningKeyframes
-                    }
-            )
+            (class "banner" :: bannerStyle)
             []
         , Html.div
             (class "dashboardhd-pipeline-name" :: Styles.pipelineCardBodyHd)

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -347,8 +347,8 @@ all =
                         [ class "card"
                         , containing [ text "pipeline" ]
                         ]
-                        >> Query.children []
-                        >> Query.first
+                        >> Query.find
+                            [ class "banner" ]
 
                 isSolid : String -> Query.Single ApplicationMsgs.TopLevelMessage -> Expectation
                 isSolid color =


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation


## Changes proposed by this PR:
It was annoying to see a pipeline with only green and blue jobs but still marked red. Logically the status of a paused job should be "paused" and not the status of the last build.

## Notes to reviewer:

## Release Note
- The UI will no longer consider paused jobs when figuring out the overall status of a pipeline

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
