### PR TITLE
Fix regression preventing the use of nested fields with `fly set-pipeline --var`

### DIFF
--- a/atc/creds/retryable_secrets_test.go
+++ b/atc/creds/retryable_secrets_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Re-retrieval of secrets on retryable errors", func() {
 	It("should retry receiving a parameter in case of retryable error", func() {
 		flakySecretManager := makeFlakySecretManager(3)
 		retryableSecretManager := creds.NewRetryableSecrets(flakySecretManager, creds.SecretRetryConfig{Attempts: 5, Interval: time.Millisecond})
-		varDef := vars.VariableDefinition{Ref: vars.VariableReference{Name: "somevar"}}
+		varDef := vars.VariableDefinition{Ref: vars.VariableReference{Path: "somevar"}}
 		value, found, err := creds.NewVariables(retryableSecretManager, "team", "pipeline", false).Get(varDef)
 		Expect(value).To(BeEquivalentTo("received value"))
 		Expect(found).To(BeTrue())
@@ -39,7 +39,7 @@ var _ = Describe("Re-retrieval of secrets on retryable errors", func() {
 	It("should not receive a parameter if the number of retryable errors exceeded the number of allowed attempts", func() {
 		flakySecretManager := makeFlakySecretManager(10)
 		retryableSecretManager := creds.NewRetryableSecrets(flakySecretManager, creds.SecretRetryConfig{Attempts: 5, Interval: time.Millisecond})
-		varDef := vars.VariableDefinition{Ref: vars.VariableReference{Name: "somevar"}}
+		varDef := vars.VariableDefinition{Ref: vars.VariableReference{Path: "somevar"}}
 		value, found, err := creds.NewVariables(retryableSecretManager, "team", "pipeline", false).Get(varDef)
 		Expect(value).To(BeNil())
 		Expect(found).To(BeFalse())

--- a/atc/creds/secret_var_lookup_rules.go
+++ b/atc/creds/secret_var_lookup_rules.go
@@ -28,7 +28,6 @@ func NewSecretLookupWithPrefix(prefix string) SecretLookupPath {
 
 func (sl SecretLookupWithPrefix) VariableToSecretPath(ref vars.VariableReference) (vars.VariableReference, error) {
 	return vars.VariableReference{
-		Name:   sl.Prefix + ref.Name,
 		Path:   sl.Prefix + ref.Path,
 		Fields: ref.Fields,
 	}, nil

--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -33,8 +33,8 @@ type ExecuteCommand struct {
 	Outputs        []flaghelpers.OutputPairFlag       `short:"o" long:"output"      value-name:"NAME=PATH"    description:"An output to fetch from the task (can be specified multiple times)"`
 	Image          string                             `long:"image" description:"Image resource for the one-off build"`
 	Tags           []string                           `          long:"tag"         value-name:"TAG"          description:"A tag for a specific environment (can be specified multiple times)"`
-	Var            []flaghelpers.VariablePairFlag     `short:"v"  long:"var"       value-name:"[NAME=STRING]"  description:"Specify a string value to set for a variable in the pipeline"`
-	YAMLVar        []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"  value-name:"[NAME=YAML]"    description:"Specify a YAML value to set for a variable in the pipeline"`
+	Var            []flaghelpers.VariablePairFlag     `short:"v"  long:"var"       value-name:"[NAME=STRING]"  unquote:"false"  description:"Specify a string value to set for a variable in the pipeline"`
+	YAMLVar        []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"  value-name:"[NAME=YAML]"    unquote:"false"  description:"Specify a YAML value to set for a variable in the pipeline"`
 	VarsFrom       []atc.PathFlag                     `short:"l"  long:"load-vars-from"  description:"Variable flag that can be used for filling in template values in configuration from a YAML file"`
 }
 

--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -28,7 +28,7 @@ type ExecuteCommand struct {
 	Privileged     bool                               `short:"p" long:"privileged"                            description:"Run the task with full privileges"`
 	IncludeIgnored bool                               `          long:"include-ignored"                       description:"Including .gitignored paths. Disregards .gitignore entries and uploads everything"`
 	Inputs         []flaghelpers.InputPairFlag        `short:"i" long:"input"       value-name:"NAME=PATH"    description:"An input to provide to the task (can be specified multiple times)"`
-	InputMappings  []flaghelpers.VariablePairFlag     `short:"m" long:"input-mapping"       value-name:"[NAME=STRING]"    description:"Map a resource to a different name as task input"`
+	InputMappings  []flaghelpers.InputMappingPairFlag `short:"m" long:"input-mapping"       value-name:"[NAME=STRING]"    description:"Map a resource to a different name as task input"`
 	InputsFrom     flaghelpers.JobFlag                `short:"j" long:"inputs-from" value-name:"PIPELINE/JOB" description:"A job to base the inputs on"`
 	Outputs        []flaghelpers.OutputPairFlag       `short:"o" long:"output"      value-name:"NAME=PATH"    description:"An output to fetch from the task (can be specified multiple times)"`
 	Image          string                             `long:"image" description:"Image resource for the one-off build"`

--- a/fly/commands/internal/executehelpers/inputs.go
+++ b/fly/commands/internal/executehelpers/inputs.go
@@ -26,7 +26,7 @@ func DetermineInputs(
 	team concourse.Team,
 	taskInputs []atc.TaskInputConfig,
 	localInputMappings []flaghelpers.InputPairFlag,
-	userInputMappings []flaghelpers.VariablePairFlag,
+	userInputMappings []flaghelpers.InputMappingPairFlag,
 	jobInputImage string,
 	inputsFrom flaghelpers.JobFlag,
 	includeIgnored bool,
@@ -111,7 +111,7 @@ func DetermineInputs(
 	return inputs, inputMappings, imageResourceFromJob, resourceTypes, nil
 }
 
-func ConvertInputMappings(variables []flaghelpers.VariablePairFlag) map[string]string {
+func ConvertInputMappings(variables []flaghelpers.InputMappingPairFlag) map[string]string {
 	inputMappings := map[string]string{}
 	for _, flag := range variables {
 		inputMappings[flag.Name] = flag.Value

--- a/fly/commands/internal/flaghelpers/input_mapping_pair_flag.go
+++ b/fly/commands/internal/flaghelpers/input_mapping_pair_flag.go
@@ -1,0 +1,29 @@
+package flaghelpers
+
+import (
+	"fmt"
+	"strings"
+)
+
+type InputMappingPairFlag struct {
+	Name  string
+	Value string
+}
+
+func (pair *InputMappingPairFlag) UnmarshalFlag(value string) error {
+	var ok bool
+	pair.Name, pair.Value, ok = parseKeyValuePair(value)
+	if !ok {
+		return fmt.Errorf("invalid input mapping '%s' (must be name=value)", value)
+	}
+
+	return nil
+}
+
+func parseKeyValuePair(value string) (string, string, bool) {
+	vs := strings.SplitN(value, "=", 2)
+	if len(vs) != 2 {
+		return "", "", false
+	}
+	return vs[0], vs[1], true
+}

--- a/fly/commands/internal/flaghelpers/input_pair_flag.go
+++ b/fly/commands/internal/flaghelpers/input_pair_flag.go
@@ -12,25 +12,25 @@ type InputPairFlag struct {
 }
 
 func (pair *InputPairFlag) UnmarshalFlag(value string) error {
-	vs := strings.SplitN(value, "=", 2)
-	if len(vs) != 2 {
+	name, path, ok := parseKeyValuePair(value)
+	if !ok {
 		return fmt.Errorf("invalid input pair '%s' (must be name=path)", value)
 	}
 
-	matches, err := filepath.Glob(vs[1])
+	matches, err := filepath.Glob(path)
 	if err != nil {
-		return fmt.Errorf("failed to expand path '%s': %s", vs[1], err)
+		return fmt.Errorf("failed to expand path '%s': %s", path, err)
 	}
 
 	if len(matches) == 0 {
-		return fmt.Errorf("path '%s' does not exist", vs[1])
+		return fmt.Errorf("path '%s' does not exist", path)
 	}
 
 	if len(matches) > 1 {
-		return fmt.Errorf("path '%s' resolves to multiple entries: %s", vs[1], strings.Join(matches, ", "))
+		return fmt.Errorf("path '%s' resolves to multiple entries: %s", path, strings.Join(matches, ", "))
 	}
 
-	pair.Name = vs[0]
+	pair.Name = name
 	pair.Path = matches[0]
 
 	return nil

--- a/fly/commands/internal/flaghelpers/output_pair_flag.go
+++ b/fly/commands/internal/flaghelpers/output_pair_flag.go
@@ -2,7 +2,6 @@ package flaghelpers
 
 import (
 	"fmt"
-	"strings"
 )
 
 type OutputPairFlag struct {
@@ -11,13 +10,11 @@ type OutputPairFlag struct {
 }
 
 func (pair *OutputPairFlag) UnmarshalFlag(value string) error {
-	vs := strings.SplitN(value, "=", 2)
-	if len(vs) != 2 {
+	var ok bool
+	pair.Name, pair.Path, ok = parseKeyValuePair(value)
+	if !ok {
 		return fmt.Errorf("invalid output pair '%s' (must be name=path)", value)
 	}
-
-	pair.Name = vs[0]
-	pair.Path = vs[1]
 
 	return nil
 }

--- a/fly/commands/internal/flaghelpers/variable_pair_flag.go
+++ b/fly/commands/internal/flaghelpers/variable_pair_flag.go
@@ -2,7 +2,6 @@ package flaghelpers
 
 import (
 	"fmt"
-	"strings"
 )
 
 type VariablePairFlag struct {
@@ -11,13 +10,11 @@ type VariablePairFlag struct {
 }
 
 func (pair *VariablePairFlag) UnmarshalFlag(value string) error {
-	vs := strings.SplitN(value, "=", 2)
-	if len(vs) != 2 {
-		return fmt.Errorf("invalid input pair '%s' (must be name=value)", value)
+	var ok bool
+	pair.Name, pair.Value, ok = parseKeyValuePair(value)
+	if !ok {
+		return fmt.Errorf("invalid variable pair '%s' (must be name=value)", value)
 	}
-
-	pair.Name = vs[0]
-	pair.Value = vs[1]
 
 	return nil
 }

--- a/fly/commands/internal/flaghelpers/variable_pair_flag.go
+++ b/fly/commands/internal/flaghelpers/variable_pair_flag.go
@@ -2,19 +2,24 @@ package flaghelpers
 
 import (
 	"fmt"
+
+	"github.com/concourse/concourse/vars"
 )
 
-type VariablePairFlag struct {
-	Name  string
-	Value string
-}
+type VariablePairFlag vars.KVPair
 
 func (pair *VariablePairFlag) UnmarshalFlag(value string) error {
-	var ok bool
-	pair.Name, pair.Value, ok = parseKeyValuePair(value)
+	k, v, ok := parseKeyValuePair(value)
 	if !ok {
 		return fmt.Errorf("invalid variable pair '%s' (must be name=value)", value)
 	}
+
+	var err error
+	pair.Ref, err = vars.ParseReference(k)
+	if err != nil {
+		return err
+	}
+	pair.Value = v
 
 	return nil
 }

--- a/fly/commands/internal/flaghelpers/yaml_variable_pair_flag.go
+++ b/fly/commands/internal/flaghelpers/yaml_variable_pair_flag.go
@@ -2,7 +2,6 @@ package flaghelpers
 
 import (
 	"fmt"
-	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -13,14 +12,14 @@ type YAMLVariablePairFlag struct {
 }
 
 func (pair *YAMLVariablePairFlag) UnmarshalFlag(value string) error {
-	vs := strings.SplitN(value, "=", 2)
-	if len(vs) != 2 {
-		return fmt.Errorf("invalid input pair '%s' (must be name=value)", value)
+	k, v, ok := parseKeyValuePair(value)
+	if !ok {
+		return fmt.Errorf("invalid variable pair '%s' (must be name=value)", value)
 	}
 
-	pair.Name = vs[0]
+	pair.Name = k
 
-	err := yaml.Unmarshal([]byte(vs[1]), &pair.Value)
+	err := yaml.Unmarshal([]byte(v), &pair.Value)
 	if err != nil {
 		return err
 	}

--- a/fly/commands/internal/flaghelpers/yaml_variable_pair_flag_test.go
+++ b/fly/commands/internal/flaghelpers/yaml_variable_pair_flag_test.go
@@ -1,0 +1,65 @@
+package flaghelpers_test
+
+import (
+	"encoding/json"
+
+	"github.com/concourse/concourse/vars"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
+)
+
+var _ = Describe("YAMLVariablePair", func() {
+	Describe("UnmarshalFlag", func() {
+		var variable *flaghelpers.YAMLVariablePairFlag
+
+		BeforeEach(func() {
+			variable = &flaghelpers.YAMLVariablePairFlag{}
+		})
+
+		for _, tt := range []struct {
+			desc string
+			flag string
+			ref  vars.VariableReference
+			val  interface{}
+			err  string
+		}{
+			{
+				desc: "basic",
+				flag: "key=value",
+				ref:  vars.VariableReference{Path: "key", Fields: []string{}},
+				val:  "value",
+			},
+			{
+				desc: "unmarshals arbitrary yaml",
+				flag: `key={hello:world: [a, b, c]}`,
+				ref:  vars.VariableReference{Path: `key`, Fields: []string{}},
+				val:  map[string]interface{}{"hello:world": []interface{}{"a", "b", "c"}},
+			},
+			{
+				desc: "unmarshals numbers as json.Number",
+				flag: `key={int: 1, float: 1.23}`,
+				ref:  vars.VariableReference{Path: `key`, Fields: []string{}},
+				val:  map[string]interface{}{"int": json.Number("1"), "float": json.Number("1.23")},
+			},
+			{
+				desc: "errors if yaml is malformed",
+				flag: `key={a: b`,
+				err:  `error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}'`,
+			},
+		} {
+			tt := tt
+			It(tt.desc, func() {
+				err := variable.UnmarshalFlag(tt.flag)
+				if tt.err == "" {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(variable.Ref).To(Equal(tt.ref))
+					Expect(variable.Value).To(Equal(tt.val))
+				} else {
+					Expect(err).To(MatchError(tt.err))
+				}
+			})
+		}
+	})
+})

--- a/fly/commands/internal/templatehelpers/yaml_template.go
+++ b/fly/commands/internal/templatehelpers/yaml_template.go
@@ -50,14 +50,15 @@ func (yamlTemplate YamlTemplateWithParams) Evaluate(
 	var params []vars.Variables
 
 	// first, we take explicitly specified variables on the command line
-	flagVars := vars.StaticVariables{}
+	var flagVarPairs vars.KVPairs
 	for _, f := range yamlTemplate.templateVariables {
-		flagVars[f.Name] = f.Value
+		flagVarPairs = append(flagVarPairs, vars.KVPair(f))
 	}
 	for _, f := range yamlTemplate.yamlTemplateVariables {
-		flagVars[f.Name] = f.Value
+		flagVarPairs = append(flagVarPairs, vars.KVPair(f))
 	}
-	params = append(params, flagVars)
+
+	params = append(params, flagVarPairs.Expand())
 
 	// second, we take all files. with values in the files specified later on command line taking precedence over the
 	// same values in the files specified earlier on command line

--- a/fly/commands/internal/templatehelpers/yaml_template_test.go
+++ b/fly/commands/internal/templatehelpers/yaml_template_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/commands/internal/templatehelpers"
+	"github.com/concourse/concourse/vars"
 
 	"github.com/concourse/concourse/atc"
 
@@ -43,12 +44,12 @@ var _ = Describe("YAML Template With Params", func() {
 		})
 
 		It("resolves all variables successfully", func() {
-			vars := []flaghelpers.VariablePairFlag{
-				{Name: "param1", Value: "value1"},
-				{Name: "param2", Value: "value2"},
-				{Name: "param3", Value: "value3"},
+			variables := []flaghelpers.VariablePairFlag{
+				{Ref: vars.VariableReference{Path: "param1"}, Value: "value1"},
+				{Ref: vars.VariableReference{Path: "param2"}, Value: "value2"},
+				{Ref: vars.VariableReference{Path: "param3"}, Value: "value3"},
 			}
-			sampleYaml := templatehelpers.NewYamlTemplateWithParams(atc.PathFlag(filepath.Join(tmpdir, "sample.yml")), nil, vars, nil)
+			sampleYaml := templatehelpers.NewYamlTemplateWithParams(atc.PathFlag(filepath.Join(tmpdir, "sample.yml")), nil, variables, nil)
 			result, err := sampleYaml.Evaluate(false, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(result)).To(Equal(`section:
@@ -60,11 +61,11 @@ var _ = Describe("YAML Template With Params", func() {
 		})
 
 		It("leave param uninterpolated if it's not provided", func() {
-			vars := []flaghelpers.VariablePairFlag{
-				{Name: "param1", Value: "value1"},
-				{Name: "param2", Value: "value2"},
+			variables := []flaghelpers.VariablePairFlag{
+				{Ref: vars.VariableReference{Path: "param1"}, Value: "value1"},
+				{Ref: vars.VariableReference{Path: "param2"}, Value: "value2"},
 			}
-			sampleYaml := templatehelpers.NewYamlTemplateWithParams(atc.PathFlag(filepath.Join(tmpdir, "sample.yml")), nil, vars, nil)
+			sampleYaml := templatehelpers.NewYamlTemplateWithParams(atc.PathFlag(filepath.Join(tmpdir, "sample.yml")), nil, variables, nil)
 			result, err := sampleYaml.Evaluate(false, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(result)).To(Equal(`section:

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -19,8 +19,8 @@ type SetPipelineCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline"  required:"true"  description:"Pipeline to configure"`
 	Config   atc.PathFlag             `short:"c"  long:"config"    required:"true"  description:"Pipeline configuration file, \"-\" stands for stdin"`
 
-	Var     []flaghelpers.VariablePairFlag     `short:"v"  long:"var"       value-name:"[NAME=STRING]"  description:"Specify a string value to set for a variable in the pipeline"`
-	YAMLVar []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"  value-name:"[NAME=YAML]"    description:"Specify a YAML value to set for a variable in the pipeline"`
+	Var     []flaghelpers.VariablePairFlag     `short:"v"  long:"var"           unquote:"false"  value-name:"[NAME=STRING]"  description:"Specify a string value to set for a variable in the pipeline"`
+	YAMLVar []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"      unquote:"false"  value-name:"[NAME=YAML]"    description:"Specify a YAML value to set for a variable in the pipeline"`
 
 	VarsFrom []atc.PathFlag `short:"l"  long:"load-vars-from"  description:"Variable flag that can be used for filling in template values in configuration from a YAML file"`
 

--- a/fly/commands/validate_pipeline.go
+++ b/fly/commands/validate_pipeline.go
@@ -22,8 +22,8 @@ type ValidatePipelineCommand struct {
 	Output           bool         `short:"o" long:"output"                  description:"Output templated pipeline to stdout"`
 	EnableAcrossStep bool         `long:"enable-across-step"                description:"Enable the experimental across step to be used in jobs. The API is subject to change."`
 
-	Var     []flaghelpers.VariablePairFlag     `short:"v"  long:"var"       value-name:"[NAME=STRING]"  description:"Specify a string value to set for a variable in the pipeline"`
-	YAMLVar []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"  value-name:"[NAME=YAML]"    description:"Specify a YAML value to set for a variable in the pipeline"`
+	Var     []flaghelpers.VariablePairFlag     `short:"v"  long:"var"       unquote:"false"  value-name:"[NAME=STRING]"  description:"Specify a string value to set for a variable in the pipeline"`
+	YAMLVar []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"  unquote:"false"  value-name:"[NAME=YAML]"    description:"Specify a YAML value to set for a variable in the pipeline"`
 
 	VarsFrom []atc.PathFlag `short:"l"  long:"load-vars-from"  description:"Variable flag that can be used for filling in template values in configuration from a YAML file"`
 }

--- a/fly/integration/fixtures/nested-vars-pipeline.yml
+++ b/fly/integration/fixtures/nested-vars-pipeline.yml
@@ -1,0 +1,13 @@
+---
+resources:
+  - name: some-resource
+    type: some-type
+    source:
+      a: ((source.a))
+      b: ((source.b))
+      other: (("source.a"))
+
+jobs:
+  - name: some-job
+    plan:
+      - get: some-resource

--- a/fly/integration/fixtures/vars-pipeline-params-types.yml
+++ b/fly/integration/fixtures/vars-pipeline-params-types.yml
@@ -5,3 +5,4 @@ large-string-param: |
   -----END SOME KEY-----
 bool-param: true
 array-param: ["val-1", "val-2"]
+number-param: 1.23

--- a/fly/integration/fixtures/vars-pipeline.yml
+++ b/fly/integration/fixtures/vars-pipeline.yml
@@ -7,6 +7,7 @@ resources:
     config-a: ((param-a))
     config-b: ((param-b))
     bool: ((bool-param))
+    number: ((number-param))
   tags: ((array-param))
 
 jobs:

--- a/vars/named_vars.go
+++ b/vars/named_vars.go
@@ -15,7 +15,7 @@ func (m NamedVariables) Get(varDef VariableDefinition) (interface{}, bool, error
 		return vars.Get(varDef)
 	}
 
-	return nil, false, MissingSourceError{Name: varDef.Ref.Name, Source: varDef.Ref.Source}
+	return nil, false, MissingSourceError{Name: varDef.Ref.String(), Source: varDef.Ref.Source}
 }
 
 func (m NamedVariables) List() ([]VariableDefinition, error) {

--- a/vars/named_vars_test.go
+++ b/vars/named_vars_test.go
@@ -23,7 +23,7 @@ var _ = Describe("NamedVariables", func() {
 			vars2 := StaticVariables{"key2": "val"}
 			vars := NamedVariables{"s1": vars1, "s2": vars2}
 
-			val, found, err := vars.Get(VariableDefinition{Ref: VariableReference{Name: "s3:foo", Source: "s3"}})
+			val, found, err := vars.Get(VariableDefinition{Ref: VariableReference{Source: "s3", Path: "foo"}})
 			Expect(val).To(BeNil())
 			Expect(found).To(BeFalse())
 			Expect(err).To(HaveOccurred())
@@ -51,7 +51,7 @@ var _ = Describe("NamedVariables", func() {
 			vars2 := StaticVariables{"key2": "val"}
 			vars := NamedVariables{"s1": vars1, "s2": vars2}
 
-			val, found, err := vars.Get(VariableDefinition{Ref: VariableReference{Name: "key1"}})
+			val, found, err := vars.Get(VariableDefinition{Ref: VariableReference{Path: "key1"}})
 			Expect(val).To(BeNil())
 			Expect(found).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
@@ -62,7 +62,7 @@ var _ = Describe("NamedVariables", func() {
 			vars2 := &FakeVariables{GetErr: errors.New("fake-err")}
 			vars := NamedVariables{"s1": vars1, "s2": vars2}
 
-			val, found, err := vars.Get(VariableDefinition{Ref: VariableReference{Source: "s2", Name: "key3"}})
+			val, found, err := vars.Get(VariableDefinition{Ref: VariableReference{Source: "s2", Path: "key3"}})
 			Expect(val).To(BeNil())
 			Expect(found).To(BeFalse())
 			Expect(err).To(Equal(errors.New("fake-err")))

--- a/vars/reference_test.go
+++ b/vars/reference_test.go
@@ -1,0 +1,131 @@
+package vars_test
+
+import (
+	"github.com/concourse/concourse/vars"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("VariableReference", func() {
+	Describe("String", func() {
+		for _, tt := range []struct {
+			desc   string
+			ref    vars.VariableReference
+			result string
+		}{
+			{
+				desc:   "path",
+				ref:    vars.VariableReference{Path: "hello"},
+				result: "hello",
+			},
+			{
+				desc:   "path with fields",
+				ref:    vars.VariableReference{Path: "hello", Fields: []string{"a", "b"}},
+				result: "hello.a.b",
+			},
+			{
+				desc:   "segments contain special chars",
+				ref:    vars.VariableReference{Path: "hello.world", Fields: []string{"a.b", "foo:bar"}},
+				result: `"hello.world"."a.b"."foo:bar"`,
+			},
+			{
+				desc:   "segments contain special chars",
+				ref:    vars.VariableReference{Path: "hello.world", Fields: []string{"a", "foo:bar"}},
+				result: `"hello.world".a."foo:bar"`,
+			},
+			{
+				desc:   "var source",
+				ref:    vars.VariableReference{Source: "source", Path: "hello"},
+				result: "source:hello",
+			},
+		} {
+			tt := tt
+
+			It(tt.desc, func() {
+				Expect(tt.ref.String()).To(Equal(tt.result))
+			})
+		}
+	})
+
+	Describe("ParseReference", func() {
+		for _, tt := range []struct {
+			desc string
+			raw  string
+			ref  vars.VariableReference
+			err  string
+		}{
+			{
+				desc: "path",
+				raw:  "hello",
+				ref:  vars.VariableReference{Path: "hello", Fields: []string{}},
+			},
+			{
+				desc: "path with fields",
+				raw:  "hello.a.b",
+				ref:  vars.VariableReference{Path: "hello", Fields: []string{"a", "b"}},
+			},
+			{
+				desc: "segments contain special chars",
+				raw:  `"hello.world"."a.b"."foo:bar"`,
+				ref:  vars.VariableReference{Path: "hello.world", Fields: []string{"a.b", "foo:bar"}},
+			},
+			{
+				desc: "segments contain special chars",
+				raw:  `"hello.world".a."foo:bar"`,
+				ref:  vars.VariableReference{Path: "hello.world", Fields: []string{"a", "foo:bar"}},
+			},
+			{
+				desc: "var source",
+				raw:  "source:hello",
+				ref:  vars.VariableReference{Source: "source", Path: "hello", Fields: []string{}},
+			},
+			{
+				desc: "path with colon and no var source",
+				raw:  `"my:path"."field.1"."field.2"`,
+				ref:  vars.VariableReference{Path: "my:path", Fields: []string{"field.1", "field.2"}},
+			},
+			{
+				desc: "quoted var source",
+				raw:  `"some-source":path`,
+				err:  `invalid var '"some-source":path': source must not be quoted`,
+			},
+			{
+				desc: "empty path segment",
+				raw:  `vault:.field`,
+				err:  `invalid var 'vault:.field': empty field`,
+			},
+			{
+				desc: "empty quoted path segment",
+				raw:  `vault:"".field`,
+				err:  `invalid var 'vault:"".field': empty field`,
+			},
+			{
+				desc: "no path segments",
+				raw:  `vault:`,
+				err:  `invalid var 'vault:': empty field`,
+			},
+			{
+				desc: "trims spaces in path segments",
+				raw:  `hello .world `,
+				ref:  vars.VariableReference{Path: "hello", Fields: []string{"world"}},
+			},
+			{
+				desc: "does not trim spaces in quoted segments",
+				raw:  `" hello "."world "`,
+				ref:  vars.VariableReference{Path: " hello ", Fields: []string{"world "}},
+			},
+		} {
+			tt := tt
+
+			It(tt.desc, func() {
+				ref, err := vars.ParseReference(tt.raw)
+				if tt.err == "" {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ref).To(Equal(tt.ref))
+				} else {
+					Expect(err).To(MatchError(tt.err))
+				}
+			})
+		}
+	})
+})

--- a/vars/static_vars.go
+++ b/vars/static_vars.go
@@ -18,3 +18,78 @@ func (v StaticVariables) List() ([]VariableDefinition, error) {
 
 	return defs, nil
 }
+
+func (v StaticVariables) Flatten() KVPairs {
+	var flat KVPairs
+	for k, vv := range v {
+		flat = append(flat, flatten(k, nil, vv)...)
+	}
+	return flat
+}
+
+func flatten(path string, fields []string, value interface{}) KVPairs {
+	var flat KVPairs
+
+	switch node := value.(type) {
+	case map[string]interface{}:
+		for k, v := range node {
+			flat = append(flat, flatten(path, append(fields, k), v)...)
+		}
+	case map[interface{}]interface{}:
+		for k, v := range node {
+			if str, ok := k.(string); ok {
+				flat = append(flat, flatten(path, append(fields, str), v)...)
+			}
+		}
+	default:
+		flat = KVPairs{{
+			Ref: VariableReference{
+				Path:   path,
+				Fields: fields,
+			},
+			Value: value,
+		}}
+	}
+
+	return flat
+}
+
+type KVPair struct {
+	Ref   VariableReference
+	Value interface{}
+}
+
+type KVPairs []KVPair
+
+func (f KVPairs) Expand() StaticVariables {
+	out := map[string]interface{}{}
+	for _, pair := range f {
+		upsert(out, pair.Ref.Path, pair.Ref.Fields, pair.Value)
+	}
+	return out
+}
+
+func upsert(out map[string]interface{}, path string, fields []string, value interface{}) {
+	node, ok := out[path]
+	if !ok {
+		out[path] = constructValue(fields, value)
+		return
+	}
+	nodeMap, ok := node.(map[string]interface{})
+	if !ok {
+		out[path] = constructValue(fields, value)
+		return
+	}
+	if len(fields) == 0 {
+		out[path] = value
+		return
+	}
+	upsert(nodeMap, fields[0], fields[1:], value)
+}
+
+func constructValue(fields []string, value interface{}) interface{} {
+	if len(fields) == 0 {
+		return value
+	}
+	return constructValue(fields[:len(fields)-1], map[string]interface{}{fields[len(fields)-1]: value})
+}

--- a/vars/template.go
+++ b/vars/template.go
@@ -1,6 +1,7 @@
 package vars
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -106,7 +107,7 @@ func (i interpolator) Interpolate(node interface{}, tracker varsTracker) (interf
 				}
 
 				switch foundVal.(type) {
-				case string, int, int16, int32, int64, uint, uint16, uint32, uint64:
+				case string, int, int16, int32, int64, uint, uint16, uint32, uint64, json.Number:
 					foundValStr := fmt.Sprintf("%v", foundVal)
 					typedNode = strings.Replace(typedNode, fmt.Sprintf("((%s))", name), foundValStr, -1)
 				default:

--- a/vars/template_test.go
+++ b/vars/template_test.go
@@ -204,7 +204,7 @@ dup-key: ((key3))
 		Expect(result).To(Equal([]byte("dash: underscore\n")))
 	})
 
-	It("can interpolate keys with dot and colon into a byte slice", func() {
+	It("can interpolate quoted keys with dot and colon into a byte slice", func() {
 		template := NewTemplate([]byte("bar: ((foo:\"with.dot:colon\".buzz))"))
 		vars := NamedVariables{
 			"foo": StaticVariables{
@@ -216,7 +216,31 @@ dup-key: ((key3))
 
 		result, err := template.Evaluate(vars, EvaluateOpts{})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(result)).To(Equal(string([]byte("bar: fuzz\n"))))
+		Expect(string(result)).To(Equal("bar: fuzz\n"))
+	})
+
+	It("can interpolate quoted keys with colon and no var source", func() {
+		template := NewTemplate([]byte("bar: ((\"with:colon\"))"))
+		vars := StaticVariables{
+			"with:colon": "foo",
+		}
+
+		result, err := template.Evaluate(vars, EvaluateOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(result)).To(Equal("bar: foo\n"))
+	})
+
+	It("can interpolate quoted keys with dot in subkey into a byte slice", func() {
+		template := NewTemplate([]byte("bar: ((secret-name.\"secret.field\"))"))
+		vars := StaticVariables{
+			"secret-name": map[string]interface{}{
+				"secret.field": "topsekrit",
+			},
+		}
+
+		result, err := template.Evaluate(vars, EvaluateOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(result)).To(Equal(string([]byte("bar: topsekrit\n"))))
 	})
 
 	It("can interpolate a secret key in the middle of a string", func() {

--- a/vars/variables.go
+++ b/vars/variables.go
@@ -1,5 +1,10 @@
 package vars
 
+import (
+	"fmt"
+	"strings"
+)
+
 //go:generate counterfeiter . Variables
 
 type Variables interface {
@@ -8,7 +13,6 @@ type Variables interface {
 }
 
 type VariableReference struct {
-	Name   string
 	Source string
 	Path   string
 	Fields []string
@@ -18,4 +22,89 @@ type VariableDefinition struct {
 	Ref     VariableReference
 	Type    string
 	Options interface{}
+}
+
+func ParseReference(name string) (VariableReference, error) {
+	var ref VariableReference
+
+	input := name
+	if i, ok := findUnquoted(input, ':'); ok {
+		ref.Source = input[:i]
+		if strings.ContainsAny(ref.Source, `"`) {
+			return VariableReference{}, fmt.Errorf("invalid var '%s': source must not be quoted", name)
+		}
+		input = input[i+1:]
+	}
+	var fields []string
+	hasNextSegment := true
+	for hasNextSegment {
+		var field string
+		field, input, hasNextSegment = readPathSegment(input)
+		if field == "" {
+			return VariableReference{}, fmt.Errorf("invalid var '%s': empty field", name)
+		}
+		fields = append(fields, field)
+	}
+
+	if len(fields) == 0 {
+		// Should be impossible (since we'd error that the var is empty), but better safe than sorry
+		return VariableReference{}, fmt.Errorf("invalid var '%s': no fields", name)
+	}
+
+	ref.Path = fields[0]
+	ref.Fields = fields[1:]
+
+	return ref, nil
+}
+
+func findUnquoted(s string, r rune) (int, bool) {
+	quoted := false
+	for i, c := range s {
+		switch c {
+		case r:
+			if !quoted {
+				return i, true
+			}
+		case '"':
+			quoted = !quoted
+		}
+	}
+	return 0, false
+}
+
+func readPathSegment(raw string) (string, string, bool) {
+	var field string
+	var rest string
+	i, hasNextSegment := findUnquoted(raw, '.')
+	if hasNextSegment {
+		field = raw[:i]
+		rest = raw[i+1:]
+	} else {
+		field = raw
+	}
+	field = strings.TrimSpace(field)
+	field = strings.ReplaceAll(field, `"`, "")
+	return field, rest, hasNextSegment
+}
+
+func (r VariableReference) String() string {
+	var s strings.Builder
+	if r.Source != "" {
+		s.WriteString(r.Source + ":")
+	}
+	s.WriteString(refSegmentString(r.Path))
+	fields := r.Fields
+	for len(fields) > 0 {
+		s.WriteRune('.')
+		s.WriteString(refSegmentString(fields[0]))
+		fields = fields[1:]
+	}
+	return s.String()
+}
+
+func refSegmentString(seg string) string {
+	if strings.ContainsAny(seg, ".:") {
+		return fmt.Sprintf("%q", seg)
+	}
+	return seg
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #6279 .
cherry-picks #6170 to release/6.7.x (the non-instance vars stuff)

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

This was a bit of a doozy to cherry-pick since it built off of a couple refactors that I didn't include - hopefully I didn't break anything

## Release Note

* A regression was introduced in 6.5.0 that prevented the use of nested fields when setting a pipeline variable via `fly set-pipeline --var`
  * For instance, pre 6.5.0, `fly set-pipeline --var foo.bar=123 --var foo.baz=456` would create the variable `foo` with value `{bar: 123, baz: 456}` (that can be referenced in the pipeline config as `((foo.bar))`, `((foo.baz))`)
  * In 6.5.x/6.6.x, the same command would create variables `"foo.bar" = 123` and `"foo.baz" = 456` (that would have to be referenced in the pipeline config as `(("foo.bar"))` and `(("foo.baz"))`, respectively)
  * If you want to set a variable with a `.` in it, you can now quote the flag: e.g. `fly set-pipeline --var '"foo.bar"=123'` (note that this requires quoting the entire flag in `'...'` to avoid shell expansion)

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
