### PR TITLE
atc(feat): master - skip checking put-only resources

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1216,15 +1216,15 @@ func (b *build) SaveOutput(
 	versionJSON := string(versionBytes)
 
 	if newVersion {
-		err = theResource.(*resource).setResourceConfigScopeInTransaction(tx, resourceConfigScope)
-		if err != nil {
-			return err
-		}
-
 		err = incrementCheckOrder(tx, resourceConfigScope.ID(), versionJSON)
 		if err != nil {
 			return err
 		}
+	}
+
+	err = theResource.(*resource).setResourceConfigScopeInTransaction(tx, resourceConfigScope)
+	if err != nil {
+		return err
 	}
 
 	_, err = psql.Insert("build_resource_config_version_outputs").

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1244,6 +1244,16 @@ func (b *build) SaveOutput(
 		return err
 	}
 
+	// resource.SetResourceConfigScope has to be called after the transaction,
+	// because if resourceConfigScope is newly created by findOrCreateResourceConfigScope,
+	// before it's committed, SetResourceConfigScope will violate foreign key constraint.
+	if newVersion {
+		err = resource.SetResourceConfigScope(resourceConfigScope)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -1393,6 +1393,10 @@ var _ = Describe("Build", func() {
 					Name:    "some-resource",
 					Version: atc.Version{"ver": "2"},
 				},
+				{
+					Name:    "some-other-resource",
+					Version: atc.Version{"ver": "not-checked"},
+				},
 			}))
 		})
 

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -1211,6 +1211,13 @@ var _ = Describe("Build", func() {
 			atc.EnableGlobalResources = false
 		})
 
+		It("should set the resource's config scope", func(){
+			resource, found, err := scenario.Pipeline.Resource("some-resource")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(resource.ResourceConfigScopeID()).ToNot(BeZero())
+		})
+
 		Context("when the version does not exist", func() {
 			It("can save a build's output", func() {
 				rcv := scenario.ResourceVersion("some-resource", outputVersion)

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -142,6 +142,7 @@ func (c *checkFactory) Resources() ([]Resource, error) {
 	var resources []Resource
 
 	rows, err := resourcesQuery.
+		Join("(select DISTINCT(resource_id) FROM job_inputs) ji ON ji.resource_id = r.id").
 		Where(sq.Eq{"p.paused": false}).
 		RunWith(c.conn).
 		Query()

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -249,12 +249,71 @@ var _ = Describe("CheckFactory", func() {
 			resources []db.Resource
 		)
 
+		BeforeEach(func() {
+			defaultPipelineConfig = atc.Config{
+				Jobs: atc.JobConfigs{
+					{
+						Name: "some-job",
+						PlanSequence: []atc.Step{
+							{
+								Config: &atc.GetStep{
+									Name: "some-resource",
+								},
+							},
+							{
+								Config: &atc.PutStep{
+									Name: "some-put-only-resource",
+								},
+							},
+						},
+					},
+				},
+				Resources: atc.ResourceConfigs{
+					{
+						Name: "some-resource",
+						Type: "some-base-resource-type",
+						Source: atc.Source{
+							"some": "source",
+						},
+					},
+					{
+						Name: "some-put-only-resource",
+						Type: "some-base-resource-type",
+						Source: atc.Source{
+							"some": "source",
+						},
+					},
+				},
+				ResourceTypes: atc.ResourceTypes{
+					{
+						Name: "some-type",
+						Type: "some-base-resource-type",
+						Source: atc.Source{
+							"some-type": "source",
+						},
+					},
+				},
+			}
+
+			defaultPipelineRef = atc.PipelineRef{Name: "default-pipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
+			defaultPipeline, _, err = defaultTeam.SavePipeline(defaultPipelineRef, defaultPipelineConfig, db.ConfigVersion(1), false)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, found, err := defaultPipeline.Resource("some-resource")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			_, found, err = defaultPipeline.Resource("some-resource-put-only")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+		})
+
 		JustBeforeEach(func() {
 			resources, err = checkFactory.Resources()
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("include resources in return", func() {
+		It("include only resources-in-use in return", func() {
 			Expect(resources).To(HaveLen(1))
 			Expect(resources[0].Name()).To(Equal("some-resource"))
 		})

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -299,12 +299,8 @@ var _ = Describe("CheckFactory", func() {
 			defaultPipeline, _, err = defaultTeam.SavePipeline(defaultPipelineRef, defaultPipelineConfig, db.ConfigVersion(1), false)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, found, err := defaultPipeline.Resource("some-resource")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(found).To(BeTrue())
-
-			_, found, err = defaultPipeline.Resource("some-resource-put-only")
-			Expect(err).NotTo(HaveOccurred())
+			_, found, err := defaultPipeline.Resource("some-put-only-resource")
+			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())
 		})
 

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -208,6 +208,20 @@ func (r *resource) SetResourceConfigScope(scope ResourceConfigScope) error {
 
 	defer Rollback(tx)
 
+	err = r.setResourceConfigScopeInTransaction(tx, scope)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *resource) setResourceConfigScopeInTransaction(tx Tx, scope ResourceConfigScope) error {
 	results, err := psql.Update("resources").
 		Set("resource_config_id", scope.ResourceConfig().ID()).
 		Set("resource_config_scope_id", scope.ID()).
@@ -234,11 +248,6 @@ func (r *resource) SetResourceConfigScope(scope ResourceConfigScope) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
## What does this PR accomplish?

This is a re-submit of #5149 that was released in 6.0.0 and reverted in 6.6.0 because of two side effects:

1. Put-only resource's custom resource type is not auto checked.
2. Put-only resources don't show version history on the UI.

This PR is going to re-enable #5149 and solves the side effects.

## Changes proposed by this PR:

* Pick up #5149
* As @vito suggested, I modified `db.build.SaveOutput()` to call `resource.SetResourceConfigScope()`. So that put-only resource get its `resource_config_scope_id` field populated.

## Notes to reviewer:

Based on my tests, problem 1 has been resolved by recent @vito 's refactor. Now every `put` embeds a `check` and a `get` for image fetching, so `put` will always fetch up-to-date image. I have tested: 1) update image without bumping image tag; 2) update image with bumping image tag, in both cases, `put` fetched correct images.

I made a code change in this PR to solve problem 2. Now put-only resource's version history can be showed up:

![put-only-resource-show-version-list](https://user-images.githubusercontent.com/18585861/99348554-d49a6c80-28d4-11eb-95a5-48d1248f6dbd.png)


I haven't added any tests yet. Just want @vito or someone to take a look first from the design perspective.

## Release Note

An optimization which should lower the resource checking load on some instances: instead of checking all resources, only resources which are actually used as inputs will be checked. This feature was released in 6.0.0 and reverted in 6.6.0 because of its side effects. Now after resolving those side effects, it's back.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
