### PR TITLE
act(bug): 6.7.x: only inc `checks-enqueued` when a check is created.

### DIFF
--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -153,9 +153,9 @@ func (s *scanner) check(ctx context.Context, checkable db.Checkable, resourceTyp
 
 	if !created {
 		s.logger.Debug("check-already-exists")
+	} else {
+		metric.Metrics.ChecksEnqueued.Inc()
 	}
-
-	metric.Metrics.ChecksEnqueued.Inc()
 
 	return nil
 }


### PR DESCRIPTION
## What does this PR accomplish?

This is a small bug fix. The metrics checks-enqueued should only be increased when a check is created.

## Changes proposed by this PR:

Only inc `checks-enqueued` if created is true.

## Notes to reviewer:

#6272 for same bug fix on master branch has been merged. This is PR is back-porting the fix to 6.7.2, as 6.7.2 is a version we are waiting for.

## Release Note

Fixed a bug of the metrics checks-enqueued where its value might be higher than checks have been created.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
