### PR TITLE
Optimize fly tests

### DIFF
--- a/fly/integration/login_test.go
+++ b/fly/integration/login_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/onsi/gomega/ghttp"
 
 	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/fly/version"
 )
 
 var _ = Describe("login Command", func() {
@@ -619,38 +618,6 @@ var _ = Describe("login Command", func() {
 						Expect(sess.ExitCode()).To(Equal(0))
 					})
 				})
-			})
-		})
-
-		Context("when fly and atc differ in major versions", func() {
-			var flyVersion string
-
-			BeforeEach(func() {
-				major, minor, patch, err := version.GetSemver(atcVersion)
-				Expect(err).NotTo(HaveOccurred())
-
-				flyVersion = fmt.Sprintf("%d.%d.%d", major+1, minor, patch)
-				flyPath, err := gexec.Build(
-					"github.com/concourse/concourse/fly",
-					"-ldflags", fmt.Sprintf("-X github.com/concourse/concourse.Version=%s", flyVersion),
-				)
-				Expect(err).NotTo(HaveOccurred())
-				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "user", "-p", "pass")
-
-				loginATCServer.AppendHandlers(
-					infoHandler(),
-					tokenHandler(),
-					userInfoHandler(),
-				)
-			})
-
-			It("warns user and does not fail", func() {
-				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(sess).Should(gexec.Exit(0))
-				Expect(sess.Err).To(gbytes.Say(`fly version \(%s\) is out of sync with the target \(%s\). to sync up, run the following:\n\n    `, flyVersion, atcVersion))
-				Expect(sess.Err).To(gbytes.Say(`fly.* -t some-target sync\n`))
 			})
 		})
 

--- a/fly/integration/suite_test.go
+++ b/fly/integration/suite_test.go
@@ -31,7 +31,7 @@ var atcServer *ghttp.Server
 
 const targetName = "testserver"
 const teamName = "main"
-const atcVersion = "4.0.0"
+const atcVersion = "6.3.1"
 const workerVersion = "4.5.6"
 
 var teams = []atc.Team{

--- a/fly/integration/sync_test.go
+++ b/fly/integration/sync_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Syncing", func() {
 
 			<-sess.Exited
 			Expect(sess.ExitCode()).To(Equal(0))
-			Expect(sess.Out).To(gbytes.Say(`version 4.0.0 already matches; skipping`))
+			Expect(sess.Out).To(gbytes.Say(`version 6.3.1 already matches; skipping`))
 
 			expectBinaryToMatch(flyPath, expectedBinary)
 		})


### PR DESCRIPTION
## What does this PR accomplish?
No Impact

closes #6291.

## Changes proposed by this PR:
- fly: remove redundant login test
    The goal of the Versions Checks suite is to validate the behaviour for
    version discrepency between fly and the atc. Previously, this was being
    tested by keeping the atc mock servers's version constant, and changing the
    version of fly in each test. Since fly isn't mocked out it has to be
    rebuilt each time which even a single repetition of the build process
    considerably (5x by our count) slowing down the whole suite. This slow
    down can cause jobs on CI to timeout.

    The test coverage can be achieved by keeping the fly version constant
    and changing the atc mock server's version each time. This means fly
    will only have to be built once speeding up the suite significantly.

- fly: optimize version checks test suite
    This logic is already tested by the Version Checks suite. There is a
    minor difference where the test there implicitly tests the login by
    running a different command. And because of that command expects not
    only a warning message but a failure. This is a minor difference and is
    not worh the slowdown in testing and time outs on CI that this test
    comes with.
## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
