### PR TITLE
`fly intercept` falls back to `sh` when `bash` is missing (containerd runtime)

### DIFF
--- a/testflight/intercept_shell_test.go
+++ b/testflight/intercept_shell_test.go
@@ -1,0 +1,58 @@
+package testflight_test
+
+import (
+	"io"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("fly intercept default shell", func() {
+	BeforeEach(func() {
+		setAndUnpausePipeline("fixtures/wait-for-intercept.yml")
+	})
+
+	const testBash = `[ -n "$BASH_VERSION" ] && echo "yes bash" || echo "no bash"` + "\n"
+
+	Context("when the container has bash", func() {
+		It("defaults to bash", func() {
+			By("triggering the build")
+			wait := spawnFly("trigger-job", "-w", "-j", inPipeline("wait"))
+			Eventually(wait).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
+
+			By("intercepting the container")
+			pr, pw := io.Pipe()
+			session := spawnFlyOpts(withStdin(pr))("intercept", "-j", inPipeline("wait"), "-s", "wait-for-intercept")
+
+			By("checking shell is bash")
+			pw.Write([]byte(testBash))
+			Eventually(session, 10*time.Second).Should(gbytes.Say("yes bash"))
+
+			session.Kill()
+		})
+	})
+
+	Context("when the container does not have bash", func() {
+		It("falls back to sh", func() {
+			By("triggering the build")
+			wait := spawnFly("trigger-job", "-w", "-j", inPipeline("wait"))
+			Eventually(wait).Should(gbytes.Say("waiting for /tmp/stop-waiting"))
+
+			By("removing bash")
+			fly("intercept", "-j", pipelineName+"/wait", "-s", "wait-for-intercept", "--", "rm", "-f", "/bin/bash")
+
+			By("intercepting the container")
+			pr, pw := io.Pipe()
+			session := spawnFlyOpts(withStdin(pr))("intercept", "-j", inPipeline("wait"), "-s", "wait-for-intercept")
+			Eventually(session.Err).Should(gbytes.Say(`Couldn't find "bash".*retrying with "sh"`))
+
+			By("checking shell is not bash")
+			pw.Write([]byte(testBash))
+			Eventually(session, 10*time.Second).Should(gbytes.Say("no bash"))
+
+			session.Kill()
+		})
+	})
+})

--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -104,9 +104,6 @@ func (c *Container) Run(
 
 	proc, err := task.Exec(ctx, id, &procSpec, cio.NewCreator(cioOpts...))
 	if err != nil {
-		if isNoSuchExecutable(err) {
-			return nil, garden.ExecutableNotFoundError{Message: err.Error()}
-		}
 		return nil, fmt.Errorf("task exec: %w", err)
 	}
 
@@ -117,6 +114,9 @@ func (c *Container) Run(
 
 	err = proc.Start(ctx)
 	if err != nil {
+		if isNoSuchExecutable(err) {
+			return nil, garden.ExecutableNotFoundError{Message: err.Error()}
+		}
 		return nil, fmt.Errorf("proc start: %w", err)
 	}
 

--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"time"
 
 	"code.cloudfoundry.org/garden"
@@ -103,6 +104,9 @@ func (c *Container) Run(
 
 	proc, err := task.Exec(ctx, id, &procSpec, cio.NewCreator(cioOpts...))
 	if err != nil {
+		if isNoSuchExecutable(err) {
+			return nil, garden.ExecutableNotFoundError{Message: err.Error()}
+		}
 		return nil, fmt.Errorf("task exec: %w", err)
 	}
 
@@ -359,7 +363,6 @@ func (c *Container) setupContainerdProcSpec(gdnProcSpec garden.ProcessSpec, cont
 		}
 	}
 
-
 	if gdnProcSpec.User != "" {
 		var ok bool
 		var err error
@@ -391,4 +394,11 @@ func containerdCIO(gdnProcIO garden.ProcessIO, tty bool) []cio.Opt {
 	}
 
 	return cioOpts
+}
+
+func isNoSuchExecutable(err error) bool {
+	noSuchFile := regexp.MustCompile(`starting container process caused: exec: .*: stat .*: no such file or directory`)
+	executableNotFound := regexp.MustCompile(`starting container process caused: exec: .*: executable file not found in \$PATH`)
+
+	return noSuchFile.MatchString(err.Error()) || executableNotFound.MatchString(err.Error())
 }

--- a/worker/runtime/container_test.go
+++ b/worker/runtime/container_test.go
@@ -116,22 +116,6 @@ func (s *ContainerSuite) TestRunTaskExecError() {
 	s.True(errors.Is(err, expectedErr))
 }
 
-func (s *ContainerSuite) TestRunTaskExecErrorExecutableNotFound() {
-	s.containerdContainer.SpecReturns(&specs.Spec{
-		Process: &specs.Process{},
-		Root:    &specs.Root{},
-	}, nil)
-
-	s.containerdContainer.TaskReturns(s.containerdTask, nil)
-
-	exeNotFoundErr := errors.New("OCI runtime exec failed: exec failed: container_linux.go:345: starting container process caused: exec: potato: executable file not found in $PATH")
-
-	s.containerdTask.ExecReturns(nil, exeNotFoundErr)
-
-	_, err := s.container.Run(garden.ProcessSpec{}, garden.ProcessIO{})
-	s.True(errors.Is(err, garden.ExecutableNotFoundError{Message: exeNotFoundErr.Error()}))
-}
-
 func (s *ContainerSuite) TestRunProcWaitError() {
 	s.containerdContainer.SpecReturns(&specs.Spec{
 		Process: &specs.Process{},
@@ -162,6 +146,22 @@ func (s *ContainerSuite) TestRunProcStartError() {
 
 	_, err := s.container.Run(garden.ProcessSpec{}, garden.ProcessIO{})
 	s.True(errors.Is(err, expectedErr))
+}
+
+func (s *ContainerSuite) TestRunProcStartErrorExecutableNotFound() {
+	s.containerdContainer.SpecReturns(&specs.Spec{
+		Process: &specs.Process{},
+		Root:    &specs.Root{},
+	}, nil)
+
+	s.containerdContainer.TaskReturns(s.containerdTask, nil)
+	s.containerdTask.ExecReturns(s.containerdProcess, nil)
+
+	exeNotFoundErr := errors.New("OCI runtime exec failed: exec failed: container_linux.go:345: starting container process caused: exec: potato: executable file not found in $PATH")
+	s.containerdProcess.StartReturns(exeNotFoundErr)
+
+	_, err := s.container.Run(garden.ProcessSpec{}, garden.ProcessIO{})
+	s.True(errors.Is(err, garden.ExecutableNotFoundError{Message: exeNotFoundErr.Error()}))
 }
 
 func (s *ContainerSuite) TestRunProcCloseIOError() {

--- a/worker/runtime/container_test.go
+++ b/worker/runtime/container_test.go
@@ -116,6 +116,22 @@ func (s *ContainerSuite) TestRunTaskExecError() {
 	s.True(errors.Is(err, expectedErr))
 }
 
+func (s *ContainerSuite) TestRunTaskExecErrorExecutableNotFound() {
+	s.containerdContainer.SpecReturns(&specs.Spec{
+		Process: &specs.Process{},
+		Root:    &specs.Root{},
+	}, nil)
+
+	s.containerdContainer.TaskReturns(s.containerdTask, nil)
+
+	exeNotFoundErr := errors.New("OCI runtime exec failed: exec failed: container_linux.go:345: starting container process caused: exec: potato: executable file not found in $PATH")
+
+	s.containerdTask.ExecReturns(nil, exeNotFoundErr)
+
+	_, err := s.container.Run(garden.ProcessSpec{}, garden.ProcessIO{})
+	s.True(errors.Is(err, garden.ExecutableNotFoundError{Message: exeNotFoundErr.Error()}))
+}
+
 func (s *ContainerSuite) TestRunProcWaitError() {
 	s.containerdContainer.SpecReturns(&specs.Spec{
 		Process: &specs.Process{},


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

#6098 changed the behaviour of `fly intercept` to fallback to `sh` as the default command if the container doesn't have `bash`. However, this requires cooperation with the runtime to return a specific garden error, which containerd did not follow.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Return a `garden.ExecutableNotFoundError` when the executable is not found (logic copied from [Guardian](https://github.com/cloudfoundry/guardian/blob/3da697a62154c6d1f797aede3a0fb23f2297e6cd/rundmc/runcontainerd/runcontainerd.go#L201-L221))
* Add testflight coverage

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
