### PR TITLE
Backport #6116 to 6.7.x: Prevent set_pipeline runtime error

### DIFF
--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -208,10 +208,14 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState) error {
 		logger.Debug("no-diff")
 
 		fmt.Fprintf(stdout, "no diff found.\n")
-		err := pipeline.SetParentIDs(step.metadata.JobID, step.metadata.BuildID)
-		if err != nil {
-			return err
+
+		if found {
+			err := pipeline.SetParentIDs(step.metadata.JobID, step.metadata.BuildID)
+			if err != nil {
+				return err
+			}
 		}
+
 		step.delegate.SetPipelineChanged(logger, false)
 		step.succeeded = true
 		step.delegate.Finished(logger, true)


### PR DESCRIPTION
## What does this PR accomplish?

Back port #6116 to 6.7.x and hopefully include in release 6.7.2.

We hit ATC crash today due to this bug. As we are waiting for 6.7.2, back port the fix to 6.7.x.

## Changes proposed by this PR:


## Notes to reviewer:


## Release Note

`set_pipeline` of a YML pipeline configuration file with no `jobs`: or `resources`: no longer causes a `runtime error: invalid memory address or nil pointer dereference`.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
