### PR TITLE
containerd: Implement `Container.Info()` for exposing a container's IP address

### DIFF
--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -3,12 +3,14 @@ package runtime_test
 import (
 	"context"
 	"errors"
+	"net"
 	"strings"
 
 	"github.com/concourse/concourse/worker/runtime"
 	"github.com/concourse/concourse/worker/runtime/iptables/iptablesfakes"
 	"github.com/concourse/concourse/worker/runtime/libcontainerd/libcontainerdfakes"
 	"github.com/concourse/concourse/worker/runtime/runtimefakes"
+	"github.com/containerd/go-cni"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -18,9 +20,10 @@ type CNINetworkSuite struct {
 	suite.Suite
 	*require.Assertions
 
-	network runtime.Network
-	cni     *runtimefakes.FakeCNI
-	store   *runtimefakes.FakeFileStore
+	network  runtime.Network
+	cni      *runtimefakes.FakeCNI
+	store    *runtimefakes.FakeFileStore
+	iptables *iptablesfakes.FakeIptables
 }
 
 func (s *CNINetworkSuite) SetupTest() {
@@ -28,11 +31,12 @@ func (s *CNINetworkSuite) SetupTest() {
 
 	s.store = new(runtimefakes.FakeFileStore)
 	s.cni = new(runtimefakes.FakeCNI)
+	s.iptables = new(iptablesfakes.FakeIptables)
 
 	s.network, err = runtime.NewCNINetwork(
 		runtime.WithCNIFileStore(s.store),
 		runtime.WithCNIClient(s.cni),
-		runtime.WithIptables(new(iptablesfakes.FakeIptables)),
+		runtime.WithIptables(s.iptables),
 	)
 	s.NoError(err)
 }
@@ -45,6 +49,7 @@ func (s *CNINetworkSuite) TestNewCNINetworkWithInvalidConfigDoesntFail() {
 		runtime.WithCNINetworkConfig(runtime.CNINetworkConfig{
 			Subnet: "_____________",
 		}),
+		runtime.WithIptables(s.iptables),
 	)
 	s.NoError(err)
 }
@@ -106,6 +111,7 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithNameServers() {
 	network, err := runtime.NewCNINetwork(
 		runtime.WithCNIFileStore(s.store),
 		runtime.WithNameServers([]string{"6.6.7.7", "1.2.3.4"}),
+		runtime.WithIptables(s.iptables),
 	)
 	s.NoError(err)
 
@@ -119,6 +125,7 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithNameServers() {
 func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithoutNameServers() {
 	network, err := runtime.NewCNINetwork(
 		runtime.WithCNIFileStore(s.store),
+		runtime.WithIptables(s.iptables),
 	)
 	s.NoError(err)
 
@@ -135,37 +142,63 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithoutNameServers() {
 }
 
 func (s *CNINetworkSuite) TestSetupRestrictedNetworksCreatesEmptyAdminChain() {
-	fakeIpt := new(iptablesfakes.FakeIptables)
 	network, err := runtime.NewCNINetwork(
 		runtime.WithRestrictedNetworks([]string{"1.1.1.1", "8.8.8.8"}),
-		runtime.WithIptables(fakeIpt),
+		runtime.WithIptables(s.iptables),
 	)
 
 	err = network.SetupRestrictedNetworks()
 	s.NoError(err)
 
-	tablename, chainName := fakeIpt.CreateChainOrFlushIfExistsArgsForCall(0)
+	tablename, chainName := s.iptables.CreateChainOrFlushIfExistsArgsForCall(0)
 	s.Equal(tablename, "filter")
 	s.Equal(chainName, "CONCOURSE-OPERATOR")
 
-	tablename, chainName, rulespec := fakeIpt.AppendRuleArgsForCall(0)
+	tablename, chainName, rulespec := s.iptables.AppendRuleArgsForCall(0)
 	s.Equal(tablename, "filter")
 	s.Equal(chainName, "CONCOURSE-OPERATOR")
 	s.Equal(rulespec, []string{"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"})
 
-	tablename, chainName, rulespec = fakeIpt.AppendRuleArgsForCall(1)
+	tablename, chainName, rulespec = s.iptables.AppendRuleArgsForCall(1)
 	s.Equal(tablename, "filter")
 	s.Equal(chainName, "CONCOURSE-OPERATOR")
 	s.Equal(rulespec, []string{"-d", "1.1.1.1", "-j", "REJECT"})
 
-	tablename, chainName, rulespec = fakeIpt.AppendRuleArgsForCall(2)
+	tablename, chainName, rulespec = s.iptables.AppendRuleArgsForCall(2)
 	s.Equal(tablename, "filter")
 	s.Equal(chainName, "CONCOURSE-OPERATOR")
 	s.Equal(rulespec, []string{"-d", "8.8.8.8", "-j", "REJECT"})
 }
 
+func (s *CNINetworkSuite) TestAdd() {
+	containerIP := net.IPv4(1, 2, 3, 4)
+	hostIP := net.IPv4(5, 6, 7, 8)
+	task := new(libcontainerdfakes.FakeTask)
+
+	task.PidReturns(123)
+	task.IDReturns("id")
+	s.cni.SetupReturns(&cni.CNIResult{Interfaces: map[string]*cni.Config{
+		"eth0": {
+			IPConfigs: []*cni.IPConfig{{
+				IP:      containerIP,
+				Gateway: hostIP,
+			}},
+		},
+	}}, nil)
+
+	ips, err := s.network.Add(context.Background(), task)
+	s.NoError(err)
+	s.Equal(containerIP, ips.ContainerIP)
+	s.Equal(hostIP, ips.HostIP)
+
+	s.Equal(1, s.cni.SetupCallCount())
+	_, id, netns, _ := s.cni.SetupArgsForCall(0)
+	s.Equal("id", id)
+	s.Equal("/proc/123/ns/net", netns)
+}
+
 func (s *CNINetworkSuite) TestAddNilTask() {
-	err := s.network.Add(context.Background(), nil)
+	_, err := s.network.Add(context.Background(), nil)
 	s.EqualError(err, "nil task")
 }
 
@@ -173,22 +206,22 @@ func (s *CNINetworkSuite) TestAddSetupErrors() {
 	s.cni.SetupReturns(nil, errors.New("setup-err"))
 	task := new(libcontainerdfakes.FakeTask)
 
-	err := s.network.Add(context.Background(), task)
+	_, err := s.network.Add(context.Background(), task)
 	s.EqualError(errors.Unwrap(err), "setup-err")
 }
 
-func (s *CNINetworkSuite) TestAdd() {
-	task := new(libcontainerdfakes.FakeTask)
-	task.PidReturns(123)
-	task.IDReturns("id")
+func (s *CNINetworkSuite) TestAddMissingIP() {
+	for _, result := range []*cni.CNIResult{
+		{Interfaces: map[string]*cni.Config{}},
+		{Interfaces: map[string]*cni.Config{"eth0": {IPConfigs: []*cni.IPConfig{}}}},
+	} {
+		s.cni.SetupReturns(result, nil)
+		task := new(libcontainerdfakes.FakeTask)
 
-	err := s.network.Add(context.Background(), task)
-	s.NoError(err)
-
-	s.Equal(1, s.cni.SetupCallCount())
-	_, id, netns, _ := s.cni.SetupArgsForCall(0)
-	s.Equal("id", id)
-	s.Equal("/proc/123/ns/net", netns)
+		ips, err := s.network.Add(context.Background(), task)
+		s.NoError(err)
+		s.Nil(ips)
+	}
 }
 
 func (s *CNINetworkSuite) TestRemoveNilTask() {

--- a/worker/runtime/integration/sample/main.go
+++ b/worker/runtime/integration/sample/main.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	flagWaitForSignal = flag.String("wait-for-signal", "", "wait for a sigal (sigterm|sighup)")
-	flagHttpGet       = flag.String("http-get", "", "website to perform an HTTP GET request against")
-	flagWriteTenTimes = flag.String("write-many-times", "", "writes a string to stdout many times")
-	flagCatFile       = flag.String("cat", "", "writes contents of file to stdout")
+	flagWaitForSignal  = flag.String("wait-for-signal", "", "wait for a signal (sigterm|sighup)")
+	flagHttpGet        = flag.String("http-get", "", "website to perform an HTTP GET request against")
+	flagHttpServe      = flag.Int("http-serve", 0, "port on which to serve a simple HTTP server")
+	flagWriteManyTimes = flag.String("write-many-times", "", "writes a string to stdout many times")
+	flagCatFile        = flag.String("cat", "", "writes contents of file to stdout")
 
 	signals = map[string]os.Signal{
 		"sighup":  syscall.SIGHUP,
@@ -62,7 +63,16 @@ func httpGet(url string) {
 	fmt.Println(resp.Status)
 }
 
-func writeTenTimes(content string) {
+func httpServe(port int) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), handler); err != nil {
+		panic(err)
+	}
+}
+
+func writeManyTimes(content string) {
 	for i := 0; i < 20; i++ {
 		fmt.Println(content)
 		time.Sleep(300 * time.Millisecond)
@@ -85,8 +95,10 @@ func main() {
 		waitForSignal(*flagWaitForSignal)
 	case *flagHttpGet != "":
 		httpGet(*flagHttpGet)
-	case *flagWriteTenTimes != "":
-		writeTenTimes(*flagWriteTenTimes)
+	case *flagHttpServe != 0:
+		httpServe(*flagHttpServe)
+	case *flagWriteManyTimes != "":
+		writeManyTimes(*flagWriteManyTimes)
 	case *flagCatFile != "":
 		catFile(*flagCatFile)
 	default:

--- a/worker/runtime/network.go
+++ b/worker/runtime/network.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"net"
 
 	"github.com/containerd/containerd"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -13,18 +14,29 @@ type Network interface {
 	// SetupMounts prepares mounts that might be necessary for proper
 	// networking functionality.
 	//
-	SetupMounts(handle string) (mounts []specs.Mount, err error)
+	SetupMounts(handle string) ([]specs.Mount, error)
 
 	// SetupRestrictedNetworks sets up networking rules to prevent
 	// container access to specified network ranges
 	//
-	SetupRestrictedNetworks() (err error)
+	SetupRestrictedNetworks() error
 
-	// Add adds a task to the network.
+	// Add adds a task to the network and returns info about the
+	// assigned IP addresses of the virtual ethernet pair.
 	//
-	Add(ctx context.Context, task containerd.Task) (err error)
+	Add(ctx context.Context, task containerd.Task) (*IPInfo, error)
 
 	// Removes a task from the network.
 	//
-	Remove(ctx context.Context, task containerd.Task) (err error)
+	Remove(ctx context.Context, task containerd.Task) error
+}
+
+type IPInfo struct {
+	// ContainerIP is the IP address of the container side of the
+	// virtual ethernet pair.
+	ContainerIP net.IP
+
+	// HostIP is the IP address of the gateway which controls the
+	// host side of the virtual ethernet pair.
+	HostIP net.IP
 }

--- a/worker/runtime/runtimefakes/fake_network.go
+++ b/worker/runtime/runtimefakes/fake_network.go
@@ -11,17 +11,19 @@ import (
 )
 
 type FakeNetwork struct {
-	AddStub        func(context.Context, containerd.Task) error
+	AddStub        func(context.Context, containerd.Task) (*runtime.IPInfo, error)
 	addMutex       sync.RWMutex
 	addArgsForCall []struct {
 		arg1 context.Context
 		arg2 containerd.Task
 	}
 	addReturns struct {
-		result1 error
+		result1 *runtime.IPInfo
+		result2 error
 	}
 	addReturnsOnCall map[int]struct {
-		result1 error
+		result1 *runtime.IPInfo
+		result2 error
 	}
 	RemoveStub        func(context.Context, containerd.Task) error
 	removeMutex       sync.RWMutex
@@ -62,7 +64,7 @@ type FakeNetwork struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeNetwork) Add(arg1 context.Context, arg2 containerd.Task) error {
+func (fake *FakeNetwork) Add(arg1 context.Context, arg2 containerd.Task) (*runtime.IPInfo, error) {
 	fake.addMutex.Lock()
 	ret, specificReturn := fake.addReturnsOnCall[len(fake.addArgsForCall)]
 	fake.addArgsForCall = append(fake.addArgsForCall, struct {
@@ -75,10 +77,10 @@ func (fake *FakeNetwork) Add(arg1 context.Context, arg2 containerd.Task) error {
 		return fake.AddStub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
 	fakeReturns := fake.addReturns
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeNetwork) AddCallCount() int {
@@ -87,7 +89,7 @@ func (fake *FakeNetwork) AddCallCount() int {
 	return len(fake.addArgsForCall)
 }
 
-func (fake *FakeNetwork) AddCalls(stub func(context.Context, containerd.Task) error) {
+func (fake *FakeNetwork) AddCalls(stub func(context.Context, containerd.Task) (*runtime.IPInfo, error)) {
 	fake.addMutex.Lock()
 	defer fake.addMutex.Unlock()
 	fake.AddStub = stub
@@ -100,27 +102,30 @@ func (fake *FakeNetwork) AddArgsForCall(i int) (context.Context, containerd.Task
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeNetwork) AddReturns(result1 error) {
+func (fake *FakeNetwork) AddReturns(result1 *runtime.IPInfo, result2 error) {
 	fake.addMutex.Lock()
 	defer fake.addMutex.Unlock()
 	fake.AddStub = nil
 	fake.addReturns = struct {
-		result1 error
-	}{result1}
+		result1 *runtime.IPInfo
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeNetwork) AddReturnsOnCall(i int, result1 error) {
+func (fake *FakeNetwork) AddReturnsOnCall(i int, result1 *runtime.IPInfo, result2 error) {
 	fake.addMutex.Lock()
 	defer fake.addMutex.Unlock()
 	fake.AddStub = nil
 	if fake.addReturnsOnCall == nil {
 		fake.addReturnsOnCall = make(map[int]struct {
-			result1 error
+			result1 *runtime.IPInfo
+			result2 error
 		})
 	}
 	fake.addReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+		result1 *runtime.IPInfo
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeNetwork) Remove(arg1 context.Context, arg2 containerd.Task) error {


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

The motivation for this can be seen in the newly added integration test: finding a containers IP address so that containers on the same host can communicate via the bridge network. This will make concourse/rfcs#84 possible with a containerd runtime.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* When we create a new virtual ethernet pair for a container, take note of the assigned IP addresses of the container-side and host-side of the veth pair
  * The container-side can be reached by other containers on the same host via the bridge network
  * The host-side is the IP of the bridge network I believe - not sure what we can use this for, but it doesn't hurt to keep track of
* Note: we currently aren't hitting `Container.Info()` at all, but this change can make it easy to implement `services` as proposed in the RFC, since Guardian already has this behaviour

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
