### PR TITLE
fly: structure: avoid recompiling in tests

### DIFF
--- a/fly/commands/sync.go
+++ b/fly/commands/sync.go
@@ -9,7 +9,6 @@ import (
 	"github.com/vbauerster/mpb/v4"
 	"github.com/vbauerster/mpb/v4/decor"
 
-	"github.com/concourse/concourse"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/rc"
@@ -52,7 +51,7 @@ func (command *SyncCommand) Execute(args []string) error {
 		return err
 	}
 
-	if !command.Force && info.Version == concourse.Version {
+	if !command.Force && info.Version == rc.LocalVersion {
 		fmt.Printf("version %s already matches; skipping\n", info.Version)
 		return nil
 	}

--- a/fly/commands/version.go
+++ b/fly/commands/version.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/concourse/concourse"
+	"github.com/concourse/concourse/fly/rc"
 )
 
 func init() {
 	Fly.Version = func() {
-		fmt.Println(concourse.Version)
+		fmt.Println(rc.LocalVersion)
 		os.Exit(0)
 	}
 }

--- a/fly/integration/login_test.go
+++ b/fly/integration/login_test.go
@@ -630,12 +630,9 @@ var _ = Describe("login Command", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				flyVersion = fmt.Sprintf("%d.%d.%d", major+1, minor, patch)
-				flyPath, err := gexec.Build(
-					"github.com/concourse/concourse/fly",
-					"-ldflags", fmt.Sprintf("-X github.com/concourse/concourse.Version=%s", flyVersion),
-				)
-				Expect(err).NotTo(HaveOccurred())
+
 				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-u", "user", "-p", "pass")
+				flyCmd.Env = append(os.Environ(), "FAKE_FLY_VERSION="+flyVersion)
 
 				loginATCServer.AppendHandlers(
 					infoHandler(),

--- a/fly/integration/sync_test.go
+++ b/fly/integration/sync_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -21,12 +22,33 @@ import (
 
 var _ = Describe("Syncing", func() {
 	var (
-		flyVersion string
-		flyPath    string
+		flyVersion    string
+		copiedFlyDir  string
+		copiedFlyPath string
 	)
 
-	cliHandler := func() http.HandlerFunc {
-		return ghttp.CombineHandlers(
+	BeforeEach(func() {
+		copiedFlyDir, err := ioutil.TempDir("", "fly_sync")
+		Expect(err).ToNot(HaveOccurred())
+
+		copiedFly, err := os.Create(filepath.Join(copiedFlyDir, "fly"))
+		Expect(err).ToNot(HaveOccurred())
+
+		fly, err := os.Open(flyPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = io.Copy(copiedFly, fly)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(copiedFly.Close()).To(Succeed())
+
+		Expect(fly.Close()).To(Succeed())
+
+		copiedFlyPath = copiedFly.Name()
+
+		Expect(os.Chmod(copiedFlyPath, 0755)).To(Succeed())
+
+		atcServer.AppendHandlers(ghttp.CombineHandlers(
 			ghttp.VerifyRequest("GET", "/api/v1/cli"),
 			func(w http.ResponseWriter, r *http.Request) {
 				arch := r.URL.Query().Get("arch")
@@ -40,19 +62,26 @@ var _ = Describe("Syncing", func() {
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprint(w, "this will totally execute")
 			},
-		)
-	}
+		))
+	})
 
-	JustBeforeEach(func() {
-		var err error
-		flyPath, err = gexec.Build(
-			"github.com/concourse/concourse/fly",
-			"-ldflags", fmt.Sprintf("-X github.com/concourse/concourse.Version=%s", flyVersion),
-		)
+	AfterEach(func() {
+		Expect(os.RemoveAll(copiedFlyDir)).To(Succeed())
+	})
+
+	downloadAndReplaceExecutable := func(arg ...string) {
+		flyCmd := exec.Command(copiedFlyPath, arg...)
+		flyCmd.Env = append(os.Environ(), "FAKE_FLY_VERSION="+flyVersion)
+
+		sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 
-		atcServer.AppendHandlers(cliHandler())
-	})
+		<-sess.Exited
+		Expect(sess.ExitCode()).To(Equal(0))
+
+		expected := []byte("this will totally execute")
+		expectBinaryToMatch(copiedFlyPath, expected[:8])
+	}
 
 	Context("When versions mismatch between fly + atc", func() {
 		BeforeEach(func() {
@@ -63,11 +92,11 @@ var _ = Describe("Syncing", func() {
 		})
 
 		It("downloads and replaces the currently running executable with target", func() {
-			downloadAndReplaceExecutable(flyPath, "-t", targetName, "sync")
+			downloadAndReplaceExecutable("-t", targetName, "sync")
 		})
 
 		It("downloads and replaces the currently running executable with target URL", func() {
-			downloadAndReplaceExecutable(flyPath, "sync", "-c", atcServer.URL())
+			downloadAndReplaceExecutable("sync", "-c", atcServer.URL())
 		})
 
 		Context("When the user running sync doesn't have write permissions for the target directory", func() {
@@ -85,11 +114,12 @@ var _ = Describe("Syncing", func() {
 					return
 				}
 
-				os.Chmod(filepath.Dir(flyPath), 0500)
+				Expect(os.Chmod(filepath.Dir(copiedFlyPath), 0500)).To(Succeed())
 
-				expectedBinary := readBinary(flyPath)
+				expectedBinary := readBinary(copiedFlyPath)
 
-				flyCmd := exec.Command(flyPath, "sync", "-c", atcServer.URL())
+				flyCmd := exec.Command(copiedFlyPath, "sync", "-c", atcServer.URL())
+				flyCmd.Env = append(os.Environ(), "FAKE_FLY_VERSION="+flyVersion)
 
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
@@ -98,7 +128,7 @@ var _ = Describe("Syncing", func() {
 				Expect(sess.ExitCode()).To(Equal(1))
 				Expect(sess.Err).To(gbytes.Say("update failed.*permission denied"))
 
-				expectBinaryToMatch(flyPath, expectedBinary)
+				expectBinaryToMatch(copiedFlyPath, expectedBinary)
 			})
 		})
 	})
@@ -107,10 +137,12 @@ var _ = Describe("Syncing", func() {
 		BeforeEach(func() {
 			flyVersion = atcVersion
 		})
-		It("informs the user, and doesn't download/replace the executable", func() {
-			expectedBinary := readBinary(flyPath)
 
-			flyCmd := exec.Command(flyPath, "sync", "-c", atcServer.URL())
+		It("informs the user, and doesn't download/replace the executable", func() {
+			expectedBinary := readBinary(copiedFlyPath)
+
+			flyCmd := exec.Command(copiedFlyPath, "sync", "-c", atcServer.URL())
+			flyCmd.Env = append(os.Environ(), "FAKE_FLY_VERSION="+flyVersion)
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
@@ -119,23 +151,10 @@ var _ = Describe("Syncing", func() {
 			Expect(sess.ExitCode()).To(Equal(0))
 			Expect(sess.Out).To(gbytes.Say(`version 4.0.0 already matches; skipping`))
 
-			expectBinaryToMatch(flyPath, expectedBinary)
+			expectBinaryToMatch(copiedFlyPath, expectedBinary)
 		})
 	})
 })
-
-func downloadAndReplaceExecutable(flyPath string, arg ...string) {
-	flyCmd := exec.Command(flyPath, arg...)
-
-	sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-	Expect(err).NotTo(HaveOccurred())
-
-	<-sess.Exited
-	Expect(sess.ExitCode()).To(Equal(0))
-
-	expected := []byte("this will totally execute")
-	expectBinaryToMatch(flyPath, expected[:8])
-}
 
 func readBinary(path string) []byte {
 	expectedBinary, err := ioutil.ReadFile(flyPath)

--- a/fly/integration/version_test.go
+++ b/fly/integration/version_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 
 	"github.com/concourse/concourse"
@@ -32,14 +33,10 @@ var _ = Describe("Version Checks", func() {
 	})
 
 	JustBeforeEach(func() {
-		flyPath, err := gexec.Build(
-			"github.com/concourse/concourse/fly",
-			"-ldflags", fmt.Sprintf("-X github.com/concourse/concourse.Version=%s", flyVersion),
-		)
-		Expect(err).NotTo(HaveOccurred())
-
 		flyCmd := exec.Command(flyPath, "-t", targetName, "containers")
+		flyCmd.Env = append(os.Environ(), "FAKE_FLY_VERSION="+flyVersion)
 
+		var err error
 		flySession, err = gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/fly/rc/target.go
+++ b/fly/rc/target.go
@@ -20,6 +20,15 @@ import (
 	"golang.org/x/oauth2"
 )
 
+var LocalVersion = conc.Version
+
+func init() {
+	ver, found := os.LookupEnv("FAKE_FLY_VERSION")
+	if found {
+		LocalVersion = ver
+	}
+}
+
 type ErrVersionMismatch struct {
 	flyVersion string
 	atcVersion string
@@ -454,7 +463,7 @@ func (t *target) validate(allowVersionMismatch bool) error {
 		return err
 	}
 
-	if info.Version == conc.Version || version.IsDev(conc.Version) {
+	if info.Version == LocalVersion || version.IsDev(LocalVersion) {
 		return nil
 	}
 
@@ -463,18 +472,18 @@ func (t *target) validate(allowVersionMismatch bool) error {
 		return err
 	}
 
-	flyMajor, flyMinor, flyPatch, err := version.GetSemver(conc.Version)
+	flyMajor, flyMinor, flyPatch, err := version.GetSemver(LocalVersion)
 	if err != nil {
 		return err
 	}
 
 	if !allowVersionMismatch && (atcMajor != flyMajor || atcMinor != flyMinor) {
-		return NewErrVersionMismatch(conc.Version, info.Version, t.name)
+		return NewErrVersionMismatch(LocalVersion, info.Version, t.name)
 	}
 
 	if atcMajor != flyMajor || atcMinor != flyMinor || atcPatch != flyPatch {
 		fmt.Fprintln(ui.Stderr, ui.WarningColor("WARNING:\n"))
-		fmt.Fprintln(ui.Stderr, ui.WarningColor(NewErrVersionMismatch(conc.Version, info.Version, t.name).Error()))
+		fmt.Fprintln(ui.Stderr, ui.WarningColor(NewErrVersionMismatch(LocalVersion, info.Version, t.name).Error()))
 	}
 
 	return nil


### PR DESCRIPTION
## Changes proposed by this PR:

Rather than re-compiling `fly` with the version var overridden, allow faking out the client version via an env var. This speeds up the `fly` integration suite (11m48s -> 6m18s) and should reduce timeout flakiness in CI on the Windows/Darwin workers.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
