### PR TITLE
Fix 'fly sync' Windows tests

### DIFF
--- a/fly/integration/execute_with_outputs_test.go
+++ b/fly/integration/execute_with_outputs_test.go
@@ -240,7 +240,7 @@ run:
 				Expect(err).NotTo(HaveOccurred())
 
 				// sync with after create
-				Eventually(streaming).Should(BeClosed())
+				<-streaming
 
 				close(events)
 
@@ -267,10 +267,9 @@ run:
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(sess.Err).Should(gbytes.Say("error: unknown output 'wrong-output'"))
-
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(1))
+				Expect(sess.Err).To(gbytes.Say("error: unknown output 'wrong-output'"))
 			})
 		})
 	})

--- a/fly/integration/sync_test.go
+++ b/fly/integration/sync_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Syncing", func() {
 		copiedFlyDir, err := ioutil.TempDir("", "fly_sync")
 		Expect(err).ToNot(HaveOccurred())
 
-		copiedFly, err := os.Create(filepath.Join(copiedFlyDir, "fly"))
+		copiedFly, err := os.Create(filepath.Join(copiedFlyDir, filepath.Base(flyPath)))
 		Expect(err).ToNot(HaveOccurred())
 
 		fly, err := os.Open(flyPath)
@@ -46,7 +46,10 @@ var _ = Describe("Syncing", func() {
 
 		copiedFlyPath = copiedFly.Name()
 
-		Expect(os.Chmod(copiedFlyPath, 0755)).To(Succeed())
+		fi, err := os.Stat(flyPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.Chmod(copiedFlyPath, fi.Mode())).To(Succeed())
 
 		atcServer.AppendHandlers(ghttp.CombineHandlers(
 			ghttp.VerifyRequest("GET", "/api/v1/cli"),


### PR DESCRIPTION
## Changes proposed by this PR:

Name the executable `fly.exe` instead of `fly` (by using the same original filename)

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
