### PR TITLE
Remove legacy logic for dealing with resource versions that have a check order of zero

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1590,7 +1590,6 @@ func (b *build) Resources() ([]BuildInput, []BuildOutput, error) {
 		))`).
 		From("resource_config_versions versions, build_resource_config_version_inputs inputs, builds, resources").
 		Where(sq.Eq{"builds.id": b.id}).
-		Where(sq.NotEq{"versions.check_order": 0}).
 		Where(sq.Expr("inputs.build_id = builds.id")).
 		Where(sq.Expr("inputs.version_md5 = versions.version_md5")).
 		Where(sq.Expr("resources.resource_config_scope_id = versions.resource_config_scope_id")).
@@ -1641,7 +1640,6 @@ func (b *build) Resources() ([]BuildInput, []BuildOutput, error) {
 	rows, err = psql.Select("outputs.name", "versions.version").
 		From("resource_config_versions versions, build_resource_config_version_outputs outputs, builds, resources").
 		Where(sq.Eq{"builds.id": b.id}).
-		Where(sq.NotEq{"versions.check_order": 0}).
 		Where(sq.Expr("outputs.build_id = builds.id")).
 		Where(sq.Expr("outputs.version_md5 = versions.version_md5")).
 		Where(sq.Expr("outputs.resource_id = resources.id")).

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -1211,7 +1211,7 @@ var _ = Describe("Build", func() {
 			atc.EnableGlobalResources = false
 		})
 
-		It("should set the resource's config scope", func(){
+		It("should set the resource's config scope", func() {
 			resource, found, err := scenario.Pipeline.Resource("some-resource")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(found).To(BeTrue())

--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -518,17 +518,7 @@ func (builder Builder) WithVersionMetadata(resourceName string, version atc.Vers
 			return fmt.Errorf("resource '%s' not configured in pipeline", resourceName)
 		}
 
-		rc, found, err := builder.ResourceConfigFactory.FindResourceConfigByID(resource.ResourceConfigID())
-		if err != nil {
-			return err
-		}
-
-		if !found {
-			return fmt.Errorf("resource config not found for resource '%s'", resourceName)
-		}
-
-		// save metadata for v1
-		_, err = resource.SaveUncheckedVersion(version, metadata, rc)
+		_, err = resource.UpdateMetadata(version, metadata)
 		if err != nil {
 			return err
 		}

--- a/atc/db/migration/migrations/1606489231_remove_versions_with_check_order_of_0.down.sql
+++ b/atc/db/migration/migrations/1606489231_remove_versions_with_check_order_of_0.down.sql
@@ -1,0 +1,1 @@
+/* Nothing to do because up migration is deleting rows. */

--- a/atc/db/migration/migrations/1606489231_remove_versions_with_check_order_of_0.up.sql
+++ b/atc/db/migration/migrations/1606489231_remove_versions_with_check_order_of_0.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+  DELETE FROM resource_config_versions WHERE check_order = 0;
+
+COMMIT;

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -782,9 +782,6 @@ func (p *pipeline) LoadDebugVersionsDB() (*atc.DebugVersionsDB, error) {
 		Join("resources r ON r.id = o.resource_id").
 		Where(sq.Expr("r.resource_config_scope_id = v.resource_config_scope_id")).
 		Where(sq.Expr("(r.id, v.version_md5) NOT IN (SELECT resource_id, version_md5 from resource_disabled_versions)")).
-		Where(sq.NotEq{
-			"v.check_order": 0,
-		}).
 		Where(sq.Eq{
 			"b.status":      BuildStatusSucceeded,
 			"r.pipeline_id": p.id,
@@ -817,9 +814,6 @@ func (p *pipeline) LoadDebugVersionsDB() (*atc.DebugVersionsDB, error) {
 		Join("resources r ON r.id = i.resource_id").
 		Where(sq.Expr("r.resource_config_scope_id = v.resource_config_scope_id")).
 		Where(sq.Expr("(r.id, v.version_md5) NOT IN (SELECT resource_id, version_md5 from resource_disabled_versions)")).
-		Where(sq.NotEq{
-			"v.check_order": 0,
-		}).
 		Where(sq.Eq{
 			"r.pipeline_id": p.id,
 			"r.active":      true,
@@ -859,9 +853,6 @@ func (p *pipeline) LoadDebugVersionsDB() (*atc.DebugVersionsDB, error) {
 		From("resource_config_versions v").
 		Join("resources r ON r.resource_config_scope_id = v.resource_config_scope_id").
 		LeftJoin("resource_disabled_versions d ON d.resource_id = r.id AND d.version_md5 = v.version_md5").
-		Where(sq.NotEq{
-			"v.check_order": 0,
-		}).
 		Where(sq.Eq{
 			"r.pipeline_id": p.id,
 			"r.active":      true,

--- a/atc/db/resource_config_version.go
+++ b/atc/db/resource_config_version.go
@@ -73,10 +73,7 @@ var resourceConfigVersionQuery = psql.Select(`
 	v.check_order,
 	v.span_context
 `).
-	From("resource_config_versions v").
-	Where(sq.NotEq{
-		"v.check_order": 0,
-	})
+	From("resource_config_versions v")
 
 func (r *resourceConfigVersion) ID() int                                { return r.id }
 func (r *resourceConfigVersion) Version() Version                       { return r.version }

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -993,32 +993,6 @@ var _ = Describe("Resource", func() {
 				})
 			})
 		})
-
-		Context("when resource has a version with check order of 0", func() {
-			BeforeEach(func() {
-				scenario = dbtest.Setup(
-					builder.WithPipeline(atc.Config{
-						Resources: atc.ResourceConfigs{
-							{
-								Name:   "some-resource",
-								Type:   "some-base-resource-type",
-								Source: atc.Source{"some": "repository"},
-							},
-						},
-					}),
-					builder.WithResourceVersions("some-resource"),
-					builder.WithVersionMetadata("some-resource", atc.Version{"version": "not-returned"}, nil), // save unchecked version
-				)
-			})
-
-			It("does not return the version", func() {
-				historyPage, pagination, found, err := scenario.Resource("some-resource").Versions(db.Page{Limit: 2}, nil)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(found).To(BeTrue())
-				Expect(historyPage).To(BeNil())
-				Expect(pagination).To(Equal(db.Pagination{Newer: nil, Older: nil}))
-			})
-		})
 	})
 
 	Describe("PinVersion/UnpinVersion", func() {

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -160,7 +160,7 @@ var resourceTypesQuery = psql.Select(
 	LeftJoin(`LATERAL (
 		SELECT rcv.*
 		FROM resource_config_versions rcv
-		WHERE rcv.resource_config_scope_id = ro.id AND rcv.check_order != 0
+		WHERE rcv.resource_config_scope_id = ro.id
 		ORDER BY rcv.check_order DESC
 		LIMIT 1
 	) AS rcv ON true`).


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

Previously, Concourse would save a resource version with a check order of 0 using the method `SaveUncheckedVersion` for get steps that would try to save metadata on a version that can possibly not exist (because it got deleted within the time that the version was checked and the get step finished running). This has been changed to saving the metadata using `UpdateMetadata` on a resource which will not update the metadata if the version does not exist.

Even though we no longer use the SaveUncheckedVersion method (meaning we no longer save versions with check order of 0), the logic for dealing with versions with check order of 0 was never deleted. Within this commit, I added a migration
that deletes all rows within the database that has a check order of zero. This won't affect anything in the users perspective because versions with check order of 0 are invalid versions that won't even show up in the web ui. 

I also removed all queries that have a condition on check order of 0 because this case should no longer exist anymore. This will help speed up certain queries, for example we have seen the `build.Resources()` query take 1300 ms to run because the query planner chose to do a sequential scan on the `resource_config_versions` table to filter out versions that do not have a check order of 0, rather than just using an index scan. This is the query that I can referring to:

```
EXPLAIN ANALYZE SELECT inputs.name, resources.id, versions.version, 
COALESCE(inputs.first_occurrence, NOT EXISTS ( 
	SELECT 1
	FROM build_resource_config_version_inputs i, builds b
	WHERE versions.version_md5 = i.version_md5 
	AND resources.resource_config_scope_id = versions.resource_config_scope_id 
	AND resources.id = i.resource_id 
	AND b.job_id = builds.job_id 
	AND i.build_id = b.id 
	AND i.build_id < builds.id 
)) 
FROM resource_config_versions versions, build_resource_config_version_inputs inputs, builds, resources 
WHERE builds.id = 9144848 
AND versions.check_order <> 0 
AND inputs.build_id = builds.id 
AND inputs.version_md5 = versions.version_md5 
AND resources.resource_config_scope_id = versions.resource_config_scope_id 
AND resources.id = inputs.resource_id 
AND NOT EXISTS ( 
	SELECT 1 FROM build_resource_config_version_outputs outputs 
	WHERE outputs.version_md5 = versions.version_md5 
	AND versions.resource_config_scope_id = resources.resource_config_scope_id 
	AND outputs.resource_id = resources.id 
	AND outputs.build_id = inputs.build_id 
);
```

And this is the `EXPLAIN ANALYZE` of that query that is doing a seq scan for the `check_order <> 0` condition.

```
Nested Loop Anti Join  (cost=116607.18..202947.72 rows=22 width=59) (actual time=1355.987..1355.987 rows=0 loops=1)
  Join Filter: ((versions.resource_config_scope_id = resources.resource_config_scope_id) AND (outputs.build_id = inputs.build_id) AND (outputs.version_md5 = versions.version_md5))
  ->  Nested Loop  (cost=116606.76..202499.19 rows=22 width=120) (actual time=1355.987..1355.987 rows=0 loops=1)
        ->  Index Scan using builds_pkey on builds  (cost=0.56..8.57 rows=1 width=12) (actual time=0.014..0.019 rows=1 loops=1)
              Index Cond: (id = 2720635)
        ->  Hash Join  (cost=116606.20..202490.39 rows=22 width=108) (actual time=1355.965..1355.965 rows=0 loops=1)
              Hash Cond: ((versions.resource_config_scope_id = resources.resource_config_scope_id) AND (inputs.resource_id = resources.id))
              ->  Hash Join  (cost=115090.98..200725.75 rows=33227 width=104) (actual time=1352.373..1352.373 rows=0 loops=1)
                    Hash Cond: (inputs.version_md5 = versions.version_md5)
                    ->  Bitmap Heap Scan on build_resource_config_version_inputs inputs  (cost=1515.29..58829.04 rows=32869 width=53) (actual time=0.018..0.508 rows=2 loops=1)
                          Recheck Cond: (build_id = 2720635)
                          Heap Blocks: exact=1
                          ->  Bitmap Index Scan on build_resource_config_version_inputs_uniq  (cost=0.00..1507.07 rows=32869 width=0) (actual time=0.014..0.014 rows=2 loops=1)
                                Index Cond: (build_id = 2720635)
                    ->  Hash  (cost=70113.88..70113.88 rows=1660625 width=84) (actual time=1208.246..1208.246 rows=1658294 loops=1)
                          Buckets: 32768  Batches: 64  Memory Usage: 3219kB
                          ->  Seq Scan on resource_config_versions versions  (cost=0.00..70113.88 rows=1660625 width=84) (actual time=0.011..600.936 rows=1658294 loops=1)
                                Filter: (check_order <> 0)
              ->  Hash  (cost=1490.49..1490.49 rows=1649 width=8) (actual time=3.583..3.583 rows=1348 loops=1)
                    Buckets: 2048  Batches: 1  Memory Usage: 69kB
                    ->  Seq Scan on resources  (cost=0.00..1490.49 rows=1649 width=8) (actual time=0.005..3.284 rows=1649 loops=1)
  ->  Index Only Scan using build_resource_config_version_outputs_uniq on build_resource_config_version_outputs outputs  (cost=0.41..3.08 rows=1 width=45) (never executed)
        Index Cond: ((build_id = 2720635) AND (resource_id = resources.id))
        Heap Fetches: 0
  SubPlan 1
    ->  Result  (cost=1.12..17.17 rows=1 width=0) (never executed)
          One-Time Filter: (resources.resource_config_scope_id = versions.resource_config_scope_id)
          ->  Nested Loop  (cost=1.12..17.17 rows=1 width=0) (never executed)
                ->  Index Scan using build_inputs_resource_versions_idx on build_resource_config_version_inputs i  (cost=0.56..8.58 rows=1 width=8) (never executed)
                      Index Cond: ((resources.id = resource_id) AND (versions.version_md5 = version_md5))
                      Filter: (build_id < builds.id)
                ->  Index Only Scan using builds_ordered_by_job_id_idx on builds b  (cost=0.56..8.58 rows=1 width=8) (never executed)
                      Index Cond: ((job_id = builds.job_id) AND (id = i.build_id))
                      Heap Fetches: 0
Planning time: 2.410 ms
Execution time: 1356.219 ms
```

Typically, it will do an index scan but sometimes when possibly the database is under load it will chose to do the seq scan due to the query planner determining a lower total cost for it (not sure why though). The `EXPLAIN ANALYZE` below shows the normal case of it using the index scan and being significantly faster.

```
Nested Loop Anti Join  (cost=5998.73..333669.69 rows=22 width=59) (actual time=17.216..17.216 rows=0 loops=1)
  Join Filter: ((versions.resource_config_scope_id = resources.resource_config_scope_id) AND (outputs.build_id = inputs.build_id) AND (outputs.version_md5 = versions.version_md5))
  ->  Nested Loop  (cost=5998.31..333221.16 rows=22 width=120) (actual time=17.216..17.216 rows=0 loops=1)
        ->  Index Scan using builds_pkey on builds  (cost=0.56..8.57 rows=1 width=12) (actual time=0.042..0.044 rows=1 loops=1)
              Index Cond: (id = 2720635)
        ->  Nested Loop  (cost=5997.76..333212.37 rows=22 width=108) (actual time=17.169..17.169 rows=0 loops=1)
              ->  Hash Join  (cost=5997.33..63773.91 rows=32876 width=57) (actual time=17.144..17.147 rows=2 loops=1)
                    Hash Cond: (inputs.resource_id = resources.id)
                    ->  Bitmap Heap Scan on build_resource_config_version_inputs inputs  (cost=1515.35..58839.88 rows=32876 width=53) (actual time=6.584..6.586 rows=2 loops=1)
                          Recheck Cond: (build_id = 2720635)
                          Heap Blocks: exact=1
                          ->  Bitmap Index Scan on build_resource_config_version_inputs_uniq  (cost=0.00..1507.13 rows=32876 width=0) (actual time=5.568..5.568 rows=2 loops=1)
                                Index Cond: (build_id = 2720635)
                    ->  Hash  (cost=4461.37..4461.37 rows=1649 width=8) (actual time=10.478..10.478 rows=1649 loops=1)
                          Buckets: 2048  Batches: 1  Memory Usage: 80kB
                          ->  Index Scan using resources_pkey on resources  (cost=0.28..4461.37 rows=1649 width=8) (actual time=0.007..10.107 rows=1649 loops=1)
              ->  Index Scan using resource_config_scope_id_and_version_md5_unique on resource_config_versions versions  (cost=0.43..8.19 rows=1 width=84) (actual time=0.007..0.007 rows=0 loops=2)
                    Index Cond: ((resource_config_scope_id = resources.resource_config_scope_id) AND (version_md5 = inputs.version_md5))
                    Filter: (check_order <> 0)
  ->  Index Only Scan using build_resource_config_version_outputs_uniq on build_resource_config_version_outputs outputs  (cost=0.41..3.08 rows=1 width=45) (never executed)
        Index Cond: ((build_id = 2720635) AND (resource_id = resources.id))
        Heap Fetches: 0
  SubPlan 1
    ->  Result  (cost=1.12..17.17 rows=1 width=0) (never executed)
          One-Time Filter: (resources.resource_config_scope_id = versions.resource_config_scope_id)
          ->  Nested Loop  (cost=1.12..17.17 rows=1 width=0) (never executed)
                ->  Index Scan using build_inputs_resource_versions_idx on build_resource_config_version_inputs i  (cost=0.56..8.58 rows=1 width=8) (never executed)
                      Index Cond: ((resources.id = resource_id) AND (versions.version_md5 = version_md5))
                      Filter: (build_id < builds.id)
                ->  Index Only Scan using builds_ordered_by_job_id_idx on builds b  (cost=0.56..8.58 rows=1 width=8) (never executed)
                      Index Cond: ((job_id = builds.job_id) AND (id = i.build_id))
                      Heap Fetches: 0
Planning time: 24.914 ms
Execution time: 17.414 ms
```

Now if I want to get rid of the case that it will ever chose the slow plan that does a seq scan, I can just remove the `check_order <> 0` filter altogether and then it will never need to do the seq scan. The `EXPLAIN ANALYZE` below shows the result of no longer needing to do the check order filter, which makes it even faster.

```
Nested Loop Anti Join  (cost=2.24..112.58 rows=1 width=59) (actual time=0.086..0.086 rows=0 loops=1)
  Join Filter: ((versions.resource_config_scope_id = resources.resource_config_scope_id) AND (outputs.build_id = inputs.build_id) AND (outputs.version_md5 = versions.version_md5))
  ->  Nested Loop  (cost=1.82..89.64 rows=1 width=120) (actual time=0.086..0.086 rows=0 loops=1)
        ->  Nested Loop  (cost=1.26..81.05 rows=1 width=108) (actual time=0.085..0.085 rows=0 loops=1)
              ->  Index Scan using build_resource_config_version_inputs_uniq on build_resource_config_version_inputs inputs  (cost=0.56..14.00 rows=4 width=53) (actual time=0.058..0.060 rows=2 loops=1)
                    Index Cond: (build_id = 2720635)
              ->  Nested Loop  (cost=0.71..16.75 rows=1 width=92) (actual time=0.011..0.011 rows=0 loops=2)
                    ->  Index Scan using resources_pkey on resources  (cost=0.28..8.29 rows=1 width=8) (actual time=0.004..0.004 rows=1 loops=2)
                          Index Cond: (id = inputs.resource_id)
                    ->  Index Scan using resource_config_scope_id_and_version_md5_unique on resource_config_versions versions  (cost=0.43..8.45 rows=1 width=84) (actual time=0.006..0.006 rows=0 loops=2)
                          Index Cond: ((resource_config_scope_id = resources.resource_config_scope_id) AND (version_md5 = inputs.version_md5))
        ->  Index Scan using builds_pkey on builds  (cost=0.56..8.57 rows=1 width=12) (never executed)
              Index Cond: (id = 2720635)
  ->  Index Only Scan using build_resource_config_version_outputs_uniq on build_resource_config_version_outputs outputs  (cost=0.41..3.08 rows=1 width=45) (never executed)
        Index Cond: ((build_id = 2720635) AND (resource_id = resources.id))
        Heap Fetches: 0
  SubPlan 1
    ->  Result  (cost=1.12..17.17 rows=1 width=0) (never executed)
          One-Time Filter: (resources.resource_config_scope_id = versions.resource_config_scope_id)
          ->  Nested Loop  (cost=1.12..17.17 rows=1 width=0) (never executed)
                ->  Index Scan using build_inputs_resource_versions_idx on build_resource_config_version_inputs i  (cost=0.56..8.58 rows=1 width=8) (never executed)
                      Index Cond: ((resources.id = resource_id) AND (versions.version_md5 = version_md5))
                      Filter: (build_id < builds.id)
                ->  Index Only Scan using builds_ordered_by_job_id_idx on builds b  (cost=0.56..8.58 rows=1 width=8) (never executed)
                      Index Cond: ((job_id = builds.job_id) AND (id = i.build_id))
                      Heap Fetches: 0
Planning time: 2.974 ms
Execution time: 0.242 ms
```

## Release Note
* Includes a migration that will delete any versions with a check order of 0. This should not affect anything because versions with a check order of 0 are _invalid_ versions. 
* Should speed up some queries that had legacy logic with filtering on versions with a check order of 0.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
