### PR TITLE
fly: Add fish auto complete

### DIFF
--- a/fly/commands/completion.go
+++ b/fly/commands/completion.go
@@ -1,9 +1,12 @@
 package commands
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 type CompletionCommand struct {
-	Shell string `long:"shell" required:"true" choice:"bash" choice:"zsh"` // add more choices later
+	Shell string `long:"shell" required:"true" choice:"bash" choice:"zsh" choice:"fish"` // add more choices later
 }
 
 // credits:
@@ -18,6 +21,52 @@ const bashCompletionSnippet = `_fly_compl() {
 complete -F _fly_compl fly
 `
 
+func fishCompletionSnippetHelper(snippet string, prefix string, commandType reflect.Type) string {
+	for i := 0; i < commandType.NumField(); i++ {
+		var tags = commandType.Field(i).Tag
+		var template = "complete -c fly"
+
+		var command, alias = tags.Get("command"), tags.Get("alias")
+		var long, short = tags.Get("long"), tags.Get("short")
+		var description = tags.Get("description")
+
+		if command != "" {
+			template += fmt.Sprintf(" -n __fish_use_subcommand -a \"%s\"", command)
+		}
+
+		if prefix != "" {
+			template += fmt.Sprintf(" -n \"__fish_seen_subcommand_from %s\"", prefix)
+		}
+
+		if description != "" {
+			if alias != "" {
+				template += fmt.Sprintf(" -d \"%s (alias: %s)\"", description, alias)
+			} else {
+				template += fmt.Sprintf(" -d \"%s\"", description)
+			}
+		}
+
+		if long != "" {
+			template += fmt.Sprintf(" --l \"%s\"", long)
+		}
+
+		if short != "" {
+			template += fmt.Sprintf(" -s \"%s\"", short)
+		}
+
+		snippet += template + "\n"
+
+		// A subcommand is found, recursion begins.
+		if command != "" {
+			snippet = fishCompletionSnippetHelper(snippet, prefix+" "+command, commandType.Field(i).Type)
+		}
+	}
+
+	return snippet
+}
+
+var fishCompletionSnippet = fishCompletionSnippetHelper("", "", reflect.TypeOf(Fly))
+
 // initial implemenation just using bashcompinit
 const zshCompletionSnippet = `autoload -Uz compinit && compinit
 autoload -Uz bashcompinit && bashcompinit
@@ -30,6 +79,9 @@ func (command *CompletionCommand) Execute([]string) error {
 		return err
 	case "zsh":
 		_, err := fmt.Print(zshCompletionSnippet)
+		return err
+	case "fish":
+		_, err := fmt.Print(fishCompletionSnippet)
 		return err
 	default:
 		// this should be unreachable


### PR DESCRIPTION
## What does this PR accomplish?
Feature

## Changes proposed by this PR:

Add the autocomplete for fish.

## Notes to reviewer:
#4012 introduce the `fly completion` command. and I can add fish completion code to this subcommand.

The interface looks like
![image](https://user-images.githubusercontent.com/12945182/100689097-bd707a00-33be-11eb-8819-0cd5abc5631e.png)

and for subcommand:
![image](https://user-images.githubusercontent.com/12945182/100689136-d5e09480-33be-11eb-83e6-59b30d38aa38.png)

If someone wants to use or test this path, need to run this command first (in fish):
```fish
fly completion --shell fish | source
```
then type `<tab>` randomly while using fly.

## Release Note
* fly: add autocomplete for fish.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
