### PR TITLE
start containerd with low oom_score

### DIFF
--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"bytes"
 	"fmt"
+	"github.com/concourse/concourse/worker/workercmd"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -38,10 +39,15 @@ func (s *IntegrationSuite) containerdSocket() string {
 }
 
 func (s *IntegrationSuite) startContainerd() {
+	configPath := filepath.Join(s.tmpDir, "containerd.toml")
+	err := workercmd.WriteDefaultContainerdConfig(configPath)
+	s.NoError(err)
+
 	command := exec.Command("containerd",
 		"--address="+s.containerdSocket(),
 		"--root="+filepath.Join(s.tmpDir, "root"),
 		"--state="+filepath.Join(s.tmpDir, "state"),
+		"--config="+configPath,
 	)
 
 	command.Stdout = &s.stdout
@@ -50,7 +56,7 @@ func (s *IntegrationSuite) startContainerd() {
 		Pdeathsig: syscall.SIGKILL,
 	}
 
-	err := command.Start()
+	err = command.Start()
 	s.NoError(err)
 
 	s.containerdProcess = command

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -20,9 +20,9 @@ import (
 	"github.com/tedsuo/ifrit/grouper"
 )
 
-// writeDefaultContainerdConfig writes a default containerd configuration file
+// WriteDefaultContainerdConfig writes a default containerd configuration file
 // to a destination.
-func writeDefaultContainerdConfig(dest string) error {
+func WriteDefaultContainerdConfig(dest string) error {
 	// disable plugins we don't use:
 	//
 	// - CRI: we're not supposed to be targetted by a kubelet, so there's no
@@ -33,8 +33,10 @@ func writeDefaultContainerdConfig(dest string) error {
 	//                   on a single snapshotter implementation we can better
 	//                   reason about potential problems down the road.
 	//
-	const config = `disabled_plugins = ["cri", "aufs", "btrfs", "zfs"]`
-
+	const config = `
+oom_score = -999
+disabled_plugins = ["cri", "aufs", "btrfs", "zfs"]
+`
 	err := ioutil.WriteFile(dest, []byte(config), 0755)
 	if err != nil {
 		return fmt.Errorf("write file %s: %w", dest, err)
@@ -123,7 +125,7 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 	if cmd.Containerd.Config.Path() != "" {
 		config = cmd.Containerd.Config.Path()
 	} else {
-		err := writeDefaultContainerdConfig(config)
+		err := WriteDefaultContainerdConfig(config)
 		if err != nil {
 			return nil, fmt.Errorf("write default containerd config: %w", err)
 		}


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix

part of #6246

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
It is [recommended](https://github.com/containerd/containerd/blob/master/docs/ops.md) that containerd be started with an `oom_score` of -999. We want it to be at the level of other system daemons. This is so that containerd never runs into an out of memory state before the containers it's managing are cleaned up. At the same time it should not be unkillable.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->
To test change the following in the worker section `docker-compose.yml`:
- Change `CONCOURSE_GARDEN_DNS_PROXY_ENABLE` to `CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE`
- Set `CONCOURSE_RUNTIME: "containerd"`
```
docker-compose up --build

#get onto the worker
docker exec -it concourse_worker_1 bash

ps auxww
#pick the PID of containerd daemon from the list
cat /proc/[CONTAINERD_PID]/oom_adj_score
```

The result should be `-999`. 
## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* It is [recommended](https://github.com/containerd/containerd/blob/master/docs/ops.md) that containerd be started with an `oom_score` of -999. We want it to be at the level of other system daemons. This is so that containerd never runs into an out of memory state before the containers it's managing are cleaned up. At the same time it should not be unkillable.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
