### PR TITLE
fly(fix): set-pipeline promoted unpause-pipeline command should have --team option.

### DIFF
--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -28,6 +28,7 @@ type ATCConfig struct {
 	SkipInteraction  bool
 	CheckCredentials bool
 	CommandWarnings  []concourse.ConfigWarning
+	GivenTeamName    string
 }
 
 func (atcConfig ATCConfig) ApplyConfigInteraction() bool {
@@ -126,7 +127,12 @@ func (atcConfig ATCConfig) UnpausePipelineCommand() string {
 	if strings.Contains(pipelineFlag, `"`) {
 		pipelineFlag = strconv.Quote(pipelineFlag)
 	}
-	return fmt.Sprintf("%s -t %s unpause-pipeline -p %s", os.Args[0], atcConfig.TargetName, pipelineFlag)
+
+	cmd := fmt.Sprintf("%s -t %s unpause-pipeline -p %s", os.Args[0], atcConfig.TargetName, pipelineFlag)
+	if atcConfig.GivenTeamName != "" {
+		cmd = fmt.Sprintf("%s --team %s", cmd, atcConfig.GivenTeamName)
+	}
+	return cmd
 }
 
 func (atcConfig ATCConfig) showPipelineUpdateResult(created bool, updated bool, paused bool) {

--- a/fly/commands/internal/setpipelinehelpers/atc_config_test.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config_test.go
@@ -42,6 +42,20 @@ var _ = Describe("UnpausePipelineCommand", func() {
 		Expect(atcConfig.UnpausePipelineCommand()).To(Equal(expected))
 	})
 
+	Context("when given a different team name", func() {
+		It("adds --team option", func() {
+			atcConfig := ATCConfig{
+				TargetName: "my-target",
+				PipelineRef: atc.PipelineRef{
+					Name: "my-pipeline",
+				},
+				GivenTeamName: "other-team",
+			}
+			expected := fmt.Sprintf(`%s -t my-target unpause-pipeline -p my-pipeline --team other-team`, os.Args[0])
+			Expect(atcConfig.UnpausePipelineCommand()).To(Equal(expected))
+		})
+	})
+
 	Context("when the instance vars require quoting", func() {
 		It("quotes the pipeline flag", func() {
 			atcConfig := ATCConfig{

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -102,6 +102,7 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 		SkipInteraction:  command.SkipInteractive || command.Config.FromStdin(),
 		CheckCredentials: command.CheckCredentials,
 		CommandWarnings:  warnings,
+		GivenTeamName:    command.Team,
 	}
 
 	yamlTemplateWithParams := templatehelpers.NewYamlTemplateWithParams(configPath, templateVariablesFiles, command.Var, command.YAMLVar, instanceVars)


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix

closes #6333.

## Changes proposed by this PR:

If `--team` option is specified to `fly set-pipeline`, then add `--team` to prompted `fly unpause-pipeline` command.

```
$ concourse.fork/fly/fly -t dev sp -c test-timer.yml -p test-timer --team main
<... omit pipeline content ...>
pipeline name: test-timer

apply configuration? [yN]: y
pipeline created!
you can view your pipeline here: http://localhost:8080/teams/main/pipelines/test-timer

the pipeline is currently paused. to unpause, either:
  - run the unpause-pipeline command:
    concourse.fork/fly/fly -t dev unpause-pipeline -p test-timer --team main
  - click play next to the pipeline in the web ui
```

## Notes to reviewer:

NA

## Release Note

Fixed a bug of `fly set-pipeline` where `--team` option was missing in the prompted unpause pipeline command.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
