### PR TITLE
Allow underscore in identifiers

### DIFF
--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -74,7 +74,7 @@ var _ = Describe("ValidateConfig", func() {
 						},
 						{
 							Config: &atc.LoadVarStep{
-								Name: "some-var",
+								Name: "some_var",
 								File: "some-input/some-file.json",
 							},
 						},
@@ -139,7 +139,7 @@ var _ = Describe("ValidateConfig", func() {
 		Context("when a resource has an invalid identifier", func() {
 			BeforeEach(func() {
 				config.Resources = append(config.Resources, atc.ResourceConfig{
-					Name: "some_resource",
+					Name: "_some-resource",
 					Type: "some-type",
 					Source: atc.Source{
 						"source-config": "some-value",
@@ -149,7 +149,7 @@ var _ = Describe("ValidateConfig", func() {
 
 			It("returns a warning", func() {
 				Expect(warnings).To(HaveLen(1))
-				Expect(warnings[0].Message).To(ContainSubstring("'some_resource' is not a valid identifier"))
+				Expect(warnings[0].Message).To(ContainSubstring("'_some-resource' is not a valid identifier"))
 			})
 		})
 

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -11,9 +11,9 @@ type ConfigWarning struct {
 	Message string `json:"message"`
 }
 
-var validIdentifiers = regexp.MustCompile(`^[\p{Ll}\p{Lt}\p{Lm}\p{Lo}][\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-.]*$`)
+var validIdentifiers = regexp.MustCompile(`^[\p{Ll}\p{Lt}\p{Lm}\p{Lo}][\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-_.]*$`)
 var startsWithLetter = regexp.MustCompile(`^[^\p{Ll}\p{Lt}\p{Lm}\p{Lo}]`)
-var invalidCharacter = regexp.MustCompile(`([^\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-.])`)
+var invalidCharacter = regexp.MustCompile(`([^\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-_.])`)
 
 func ValidateIdentifier(identifier string, context ...string) *ConfigWarning {
 	if identifier != "" && !validIdentifiers.MatchString(identifier) {

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -27,6 +27,11 @@ var _ = Describe("ValidateIdentifier", func() {
 			warning:     false,
 		},
 		{
+			description: "contains an underscore",
+			identifier:  "some_thing",
+			warning:     false,
+		},
+		{
 			description: "starts with a number",
 			identifier:  "1something",
 			message:     "must start with a lowercase letter",
@@ -51,9 +56,9 @@ var _ = Describe("ValidateIdentifier", func() {
 			warning:     true,
 		},
 		{
-			description: "contains an underscore",
-			identifier:  "some_thing",
-			message:     "illegal character '_'",
+			description: "contains a space",
+			identifier:  "some thing",
+			message:     "illegal character ' '",
 			warning:     true,
 		},
 		{


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes #6070 .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
