### PR TITLE
atc(feat): add new container placement strategies: limit-max-containers and limit-max-volumes.

### DIFF
--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -12,8 +12,10 @@ import (
 )
 
 type ContainerPlacementStrategyOptions struct {
-	ContainerPlacementStrategy []string `long:"container-placement-strategy" default:"volume-locality" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" description:"Method by which a worker is selected during container placement. If multiple methods are specified, they will be applied in order. Random strategy should only be used alone."`
-	MaxActiveTasksPerWorker    int      `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
+	ContainerPlacementStrategy   []string `long:"container-placement-strategy" default:"volume-locality" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" choice:"limit-active-containers" choice:"limit-active-volumes" description:"Method by which a worker is selected during container placement. If multiple methods are specified, they will be applied in order. Random strategy should only be used alone."`
+	MaxActiveTasksPerWorker      int      `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
+	MaxActiveContainersPerWorker int      `long:"max-active-containers-per-worker" default:"0" description:"Maximum allowed number of active containers per worker. Has effect only when used with limit-active-containers placement strategy. 0 means no limit."`
+	MaxActiveVolumesPerWorker    int      `long:"max-active-volumes-per-worker" default:"0" description:"Maximum allowed number of active volumes per worker. Has effect only when used with limit-active-volumes placement strategy. 0 means no limit."`
 }
 
 type ContainerPlacementStrategy interface {
@@ -46,6 +48,16 @@ func NewContainerPlacementStrategy(opts ContainerPlacementStrategyOptions) (*con
 				return nil, errors.New("max-active-tasks-per-worker must be greater or equal than 0")
 			}
 			cps.nodes = append(cps.nodes, newLimitActiveTasksPlacementStrategy(opts.MaxActiveTasksPerWorker))
+		case "limit-active-containers":
+			if opts.MaxActiveContainersPerWorker < 0 {
+				return nil, errors.New("max-active-containers-per-worker must be greater or equal than 0")
+			}
+			cps.nodes = append(cps.nodes, newLimitActiveContainersPlacementStrategy(opts.MaxActiveContainersPerWorker))
+		case "limit-active-volumes":
+			if opts.MaxActiveVolumesPerWorker < 0 {
+				return nil, errors.New("max-active-volumes-per-worker must be greater or equal than 0")
+			}
+			cps.nodes = append(cps.nodes, newLimitActiveVolumesPlacementStrategy(opts.MaxActiveVolumesPerWorker))
 		case "volume-locality":
 			cps.nodes = append(cps.nodes, newVolumeLocalityPlacementStrategyNode())
 		default:
@@ -168,7 +180,7 @@ func (strategy *LimitActiveTasksPlacementStrategyNode) Choose(logger lager.Logge
 	for _, w := range workers {
 		activeTasks, err := w.ActiveTasks()
 		if err != nil {
-			logger.Error("Cannot retrive active tasks on worker. Skipping.", err)
+			logger.Error("Cannot retrieve active tasks on worker. Skipping.", err)
 			continue
 		}
 
@@ -189,4 +201,56 @@ func (strategy *LimitActiveTasksPlacementStrategyNode) Choose(logger lager.Logge
 
 func (strategy *LimitActiveTasksPlacementStrategyNode) ModifiesActiveTasks() bool {
 	return true
+}
+
+type LimitActiveContainersPlacementStrategyNode struct {
+	maxContainers int
+}
+
+func newLimitActiveContainersPlacementStrategy(maxContainers int) ContainerPlacementStrategyChainNode {
+	return &LimitActiveContainersPlacementStrategyNode{
+		maxContainers: maxContainers,
+	}
+}
+
+func (strategy *LimitActiveContainersPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
+	candidates := []Worker{}
+
+	for _, w := range workers {
+		if w.ActiveContainers() <= strategy.maxContainers {
+			candidates = append(candidates, w)
+		}
+	}
+
+	return candidates, nil
+}
+
+func (strategy *LimitActiveContainersPlacementStrategyNode) ModifiesActiveTasks() bool {
+	return false
+}
+
+type LimitActiveVolumesPlacementStrategyNode struct {
+	maxVolumes int
+}
+
+func newLimitActiveVolumesPlacementStrategy(maxVolumes int) ContainerPlacementStrategyChainNode {
+	return &LimitActiveVolumesPlacementStrategyNode{
+		maxVolumes: maxVolumes,
+	}
+}
+
+func (strategy *LimitActiveVolumesPlacementStrategyNode) Choose(logger lager.Logger, workers []Worker, spec ContainerSpec) ([]Worker, error) {
+	candidates := []Worker{}
+
+	for _, w := range workers {
+		if w.ActiveVolumes() <= strategy.maxVolumes {
+			candidates = append(candidates, w)
+		}
+	}
+
+	return candidates, nil
+}
+
+func (strategy *LimitActiveVolumesPlacementStrategyNode) ModifiesActiveTasks() bool {
+	return false
 }

--- a/atc/worker/worker.go
+++ b/atc/worker/worker.go
@@ -80,6 +80,9 @@ type Worker interface {
 	ActiveTasks() (int, error)
 	IncreaseActiveTasks() error
 	DecreaseActiveTasks() error
+
+	ActiveContainers() int
+	ActiveVolumes() int
 }
 
 type gardenWorker struct {
@@ -786,4 +789,12 @@ func (worker *gardenWorker) IncreaseActiveTasks() error {
 }
 func (worker *gardenWorker) DecreaseActiveTasks() error {
 	return worker.dbWorker.DecreaseActiveTasks()
+}
+
+func (worker *gardenWorker) ActiveContainers() int {
+	return worker.dbWorker.ActiveContainers()
+}
+
+func (worker *gardenWorker) ActiveVolumes() int {
+	return worker.dbWorker.ActiveVolumes()
 }

--- a/atc/worker/workerfakes/fake_worker.go
+++ b/atc/worker/workerfakes/fake_worker.go
@@ -17,6 +17,16 @@ import (
 )
 
 type FakeWorker struct {
+	ActiveContainersStub        func() int
+	activeContainersMutex       sync.RWMutex
+	activeContainersArgsForCall []struct {
+	}
+	activeContainersReturns struct {
+		result1 int
+	}
+	activeContainersReturnsOnCall map[int]struct {
+		result1 int
+	}
 	ActiveTasksStub        func() (int, error)
 	activeTasksMutex       sync.RWMutex
 	activeTasksArgsForCall []struct {
@@ -28,6 +38,16 @@ type FakeWorker struct {
 	activeTasksReturnsOnCall map[int]struct {
 		result1 int
 		result2 error
+	}
+	ActiveVolumesStub        func() int
+	activeVolumesMutex       sync.RWMutex
+	activeVolumesArgsForCall []struct {
+	}
+	activeVolumesReturns struct {
+		result1 int
+	}
+	activeVolumesReturnsOnCall map[int]struct {
+		result1 int
 	}
 	BuildContainersStub        func() int
 	buildContainersMutex       sync.RWMutex
@@ -322,6 +342,58 @@ type FakeWorker struct {
 	invocationsMutex sync.RWMutex
 }
 
+func (fake *FakeWorker) ActiveContainers() int {
+	fake.activeContainersMutex.Lock()
+	ret, specificReturn := fake.activeContainersReturnsOnCall[len(fake.activeContainersArgsForCall)]
+	fake.activeContainersArgsForCall = append(fake.activeContainersArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ActiveContainers", []interface{}{})
+	fake.activeContainersMutex.Unlock()
+	if fake.ActiveContainersStub != nil {
+		return fake.ActiveContainersStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.activeContainersReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeWorker) ActiveContainersCallCount() int {
+	fake.activeContainersMutex.RLock()
+	defer fake.activeContainersMutex.RUnlock()
+	return len(fake.activeContainersArgsForCall)
+}
+
+func (fake *FakeWorker) ActiveContainersCalls(stub func() int) {
+	fake.activeContainersMutex.Lock()
+	defer fake.activeContainersMutex.Unlock()
+	fake.ActiveContainersStub = stub
+}
+
+func (fake *FakeWorker) ActiveContainersReturns(result1 int) {
+	fake.activeContainersMutex.Lock()
+	defer fake.activeContainersMutex.Unlock()
+	fake.ActiveContainersStub = nil
+	fake.activeContainersReturns = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeWorker) ActiveContainersReturnsOnCall(i int, result1 int) {
+	fake.activeContainersMutex.Lock()
+	defer fake.activeContainersMutex.Unlock()
+	fake.ActiveContainersStub = nil
+	if fake.activeContainersReturnsOnCall == nil {
+		fake.activeContainersReturnsOnCall = make(map[int]struct {
+			result1 int
+		})
+	}
+	fake.activeContainersReturnsOnCall[i] = struct {
+		result1 int
+	}{result1}
+}
+
 func (fake *FakeWorker) ActiveTasks() (int, error) {
 	fake.activeTasksMutex.Lock()
 	ret, specificReturn := fake.activeTasksReturnsOnCall[len(fake.activeTasksArgsForCall)]
@@ -375,6 +447,58 @@ func (fake *FakeWorker) ActiveTasksReturnsOnCall(i int, result1 int, result2 err
 		result1 int
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeWorker) ActiveVolumes() int {
+	fake.activeVolumesMutex.Lock()
+	ret, specificReturn := fake.activeVolumesReturnsOnCall[len(fake.activeVolumesArgsForCall)]
+	fake.activeVolumesArgsForCall = append(fake.activeVolumesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ActiveVolumes", []interface{}{})
+	fake.activeVolumesMutex.Unlock()
+	if fake.ActiveVolumesStub != nil {
+		return fake.ActiveVolumesStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.activeVolumesReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeWorker) ActiveVolumesCallCount() int {
+	fake.activeVolumesMutex.RLock()
+	defer fake.activeVolumesMutex.RUnlock()
+	return len(fake.activeVolumesArgsForCall)
+}
+
+func (fake *FakeWorker) ActiveVolumesCalls(stub func() int) {
+	fake.activeVolumesMutex.Lock()
+	defer fake.activeVolumesMutex.Unlock()
+	fake.ActiveVolumesStub = stub
+}
+
+func (fake *FakeWorker) ActiveVolumesReturns(result1 int) {
+	fake.activeVolumesMutex.Lock()
+	defer fake.activeVolumesMutex.Unlock()
+	fake.ActiveVolumesStub = nil
+	fake.activeVolumesReturns = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeWorker) ActiveVolumesReturnsOnCall(i int, result1 int) {
+	fake.activeVolumesMutex.Lock()
+	defer fake.activeVolumesMutex.Unlock()
+	fake.ActiveVolumesStub = nil
+	if fake.activeVolumesReturnsOnCall == nil {
+		fake.activeVolumesReturnsOnCall = make(map[int]struct {
+			result1 int
+		})
+	}
+	fake.activeVolumesReturnsOnCall[i] = struct {
+		result1 int
+	}{result1}
 }
 
 func (fake *FakeWorker) BuildContainers() int {
@@ -1686,8 +1810,12 @@ func (fake *FakeWorker) UptimeReturnsOnCall(i int, result1 time.Duration) {
 func (fake *FakeWorker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.activeContainersMutex.RLock()
+	defer fake.activeContainersMutex.RUnlock()
 	fake.activeTasksMutex.RLock()
 	defer fake.activeTasksMutex.RUnlock()
+	fake.activeVolumesMutex.RLock()
+	defer fake.activeVolumesMutex.RUnlock()
 	fake.buildContainersMutex.RLock()
 	defer fake.buildContainersMutex.RUnlock()
 	fake.certsVolumeMutex.RLock()


### PR DESCRIPTION
## What does this PR accomplish?

To minimum volume streaming, we are using the container placement strategy "volume-locality". But sometime, this strategy makes busy worker busier, the following "worker containers" chart is from our prod cluster:

![worker-containers-spike](https://user-images.githubusercontent.com/18585861/100978711-c0fe2f80-357d-11eb-8385-37bdc48bb220.png)

From the chart, we can see a spike. At that time, what we saw is, many build failed with error, "insufficient workers", spiked workers stalled, etc. In the meantime, there were a lot of other workers not busy, but they didn't share workload with those spiked workers.

Though garden support max containers restriction, the control is on worker, it's too late. Ideally, ATC should avoid to dispatch too many containers to a worker to make the worker overloaded.

With #6208, we will be able to chain multiple strategies. This PR is adding two new strategies `limit-max-containers` and `limit-max-volumes` that can filter out overloaded workers. So we may configure container placement strategy as `[limit-max-containers, limit-max-volumes, volume-locality, fewest-build-containers]`, which should be better balance workloads among workers.

## Notes to reviewer:

Calling for an initial review now. Tests have not been added yet.

## Release Note

Added two new container placement strategy: `limit-max-containers` and `limit-max-volumes`. That helps avoid workers to be overloaded. A strategy chain can be `[limit-max-containers, limit-max-volumes, volume-locality, fewest-build-containers]`, that may help better balance workloads among workers.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
