### PR TITLE
Fix mount issues on containerd

### DIFF
--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -28,7 +28,7 @@ var (
 			Destination: "/dev/shm",
 			Type:        "tmpfs",
 			Source:      "shm",
-			Options:     []string{"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"},
+			Options:     []string{"nosuid", "noexec", "nodev", "mode=1777"},
 		},
 		{
 			Destination: "/dev/mqueue",

--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -57,8 +57,8 @@ var (
 	}
 )
 
-func AnyContainerMounts(initBinPath string) []specs.Mount {
-	return append(
+func ContainerMounts(privileged bool, initBinPath string) []specs.Mount {
+	mounts := append(
 		[]specs.Mount{
 			{
 				Source:      initBinPath,
@@ -69,4 +69,23 @@ func AnyContainerMounts(initBinPath string) []specs.Mount {
 		},
 		DefaultContainerMounts...,
 	)
+	// Following the current behaviour for privileged containers in Docker
+	if privileged {
+		for i, ociMount := range mounts {
+			if ociMount.Destination == "/sys" || ociMount.Type == "cgroup" {
+				clearReadOnly(&mounts[i])
+			}
+		}
+	}
+	return mounts
+}
+
+func clearReadOnly(m *specs.Mount) {
+	var opt []string
+	for _, o := range m.Options {
+		if o != "ro" {
+			opt = append(opt, o)
+		}
+	}
+	m.Options = opt
 }

--- a/worker/runtime/spec/spec.go
+++ b/worker/runtime/spec/spec.go
@@ -227,7 +227,7 @@ func defaultGardenOciSpec(initBinPath string, privileged bool, maxUid, maxGid ui
 			UIDMappings: OciIDMappings(privileged, maxUid),
 			GIDMappings: OciIDMappings(privileged, maxGid),
 		},
-		Mounts: AnyContainerMounts(initBinPath),
+		Mounts: ContainerMounts(privileged, initBinPath),
 	}
 
 	if !privileged {

--- a/worker/runtime/spec/spec_test.go
+++ b/worker/runtime/spec/spec_test.go
@@ -21,7 +21,7 @@ type SpecSuite struct {
 }
 
 func uint64Ptr(i uint64) *uint64 { return &i }
-func int64Ptr(i int64) *int64 { return &i }
+func int64Ptr(i int64) *int64    { return &i }
 
 func (s *SpecSuite) TestContainerSpecValidations() {
 	for _, tc := range []struct {
@@ -293,7 +293,7 @@ func (s *SpecSuite) TestOciResourceLimits() {
 		{
 			desc: "PID limit",
 			limits: garden.Limits{
-				Pid: garden.PidLimits {
+				Pid: garden.PidLimits{
 					Max: 1000,
 				},
 			},
@@ -304,8 +304,8 @@ func (s *SpecSuite) TestOciResourceLimits() {
 			},
 		},
 		{
-			desc: "No limits specified",
-			limits: garden.Limits{},
+			desc:     "No limits specified",
+			limits:   garden.Limits{},
 			expected: nil,
 		},
 	} {
@@ -324,18 +324,18 @@ func (s *SpecSuite) TestOciCgroupsPath() {
 		expected   string
 	}{
 		{
-			desc: "not privileged",
-			basePath: "garden",
-			handle: "1234",
+			desc:       "not privileged",
+			basePath:   "garden",
+			handle:     "1234",
 			privileged: false,
-			expected: "garden/1234",
+			expected:   "garden/1234",
 		},
 		{
-			desc: "privileged",
-			basePath: "garden",
-			handle: "1234",
+			desc:       "privileged",
+			basePath:   "garden",
+			handle:     "1234",
 			privileged: true,
-			expected: "",
+			expected:   "",
 		},
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
@@ -402,7 +402,7 @@ func (s *SpecSuite) TestContainerSpec() {
 		},
 		{
 			desc: "default devices privileged",
-			gdn:  garden.ContainerSpec{
+			gdn: garden.ContainerSpec{
 				Handle: "handle", RootFSPath: "raw:///rootfs",
 				Privileged: true,
 			},


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix

part of #6246

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Set the appropriate permissions for mounts in privileged containers. 
* Use the Linux default size for `/dev/shm` (shared memory) mount.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

Bring up Concourse.
```
docker-compose -f docker-compose.yml -f ./hack/overrides/containerd.yml  up --build
``` 

Create the following pipeline: `build.yml`

```
---
resources:
# The repo with our Dockerfile
- name: concourse-examples
  type: git
  icon: github
  source:
    uri: https://github.com/concourse/examples.git
    branch: master

jobs:
- name: build
  plan:
  - get: concourse-examples
  - task: build-task-image
    privileged: true
    config:
      platform: linux
      image_resource:
        type: registry-image
        source:
          # Check out the README for oci-build-task at
          # https://github.com/vito/oci-build-task
          repository: vito/oci-build-task
      inputs:
      - name: concourse-examples
      outputs:
      - name: image
      params:
        CONTEXT: concourse-examples/Dockerfiles/simple
      run:
        path: build
```

Login and run the job.

```
fly -t dev login -u test -p test
fly -t dev sp -p docker-build -c build.yml
fly -t dev unpause-pipeline -p docker-build
fly -t dev trigger-job -w -j docker-build/build
```
## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* Set the appropriate permissions for mounts in privileged containers. 
* Use the Linux default size for `/dev/shm` (shared memory) mount.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
