### PR TITLE
atc/worker: fix limit-active-tasks

### DIFF
--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -621,7 +621,9 @@ func (client *client) chooseTaskWorker(
 			workerSpec,
 			strategy,
 		); err != nil {
-			return nil, err
+			if _, ok := err.(NoWorkerFitContainerPlacementStrategyError); !ok {
+				return nil, err
+			}
 		}
 
 		if !strategy.ModifiesActiveTasks() {

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -621,7 +621,10 @@ func (client *client) chooseTaskWorker(
 			workerSpec,
 			strategy,
 		); err != nil {
-			if _, ok := err.(NoWorkerFitContainerPlacementStrategyError); !ok {
+			if chosenWorker == nil && !strategy.ModifiesActiveTasks() {
+				// only the limit-active-tasks placement strategy waits for a
+				// worker to become available. All others should error out for
+				// now
 				return nil, err
 			}
 		}


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #6356

Limit active tasks is supposed to wait for a worker to become available.
This broke in #6339. This commit fixes it when limit-active-tasks is one
of the placement strategies.

Also added a test to ensure the waiting for worker path is executed.

I tried to modify the code so all strategies would wait for workers but
I think this kind of waiting needs to happen in the worker.pool which
would break the metrics for limit-active-tasks which happens in
worker.client.chooseTaskWorker().

## Notes to reviewer:
Follow the reproducible steps in #6356 for acceptance.

Release notes are not needed. This is fixing a bug in an unreleased feature (#6339).

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [ ] ~Added release note (Optional)~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
