### PR TITLE
atc(fix): fix an authorization bug, when a user has multiple roles in a team, then it may randomly hit "forbidden" error.

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -159,17 +159,17 @@ func (a *access) TeamNames() []string {
 }
 
 func (a *access) hasPermission(roles []string) bool {
-	has := false
+	allow := false
 	for _, role := range roles {
-		has = has || a.hasPermissionCheckingRole(role)
-		if has {
+		allow = allow || a.hasRequiredRole(role)
+		if allow {
 			return true
 		}
 	}
 	return false
 }
 
-func (a *access) hasPermissionCheckingRole(role string) bool {
+func (a *access) hasRequiredRole(role string) bool {
 	switch a.requiredRole {
 	case OwnerRole:
 		return role == OwnerRole

--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -159,21 +159,29 @@ func (a *access) TeamNames() []string {
 }
 
 func (a *access) hasPermission(roles []string) bool {
+	has := false
 	for _, role := range roles {
-		switch a.requiredRole {
-		case OwnerRole:
-			return role == OwnerRole
-		case MemberRole:
-			return role == OwnerRole || role == MemberRole
-		case OperatorRole:
-			return role == OwnerRole || role == MemberRole || role == OperatorRole
-		case ViewerRole:
-			return role == OwnerRole || role == MemberRole || role == OperatorRole || role == ViewerRole
-		default:
-			return false
+		has = has || a.hasPermissionCheckingRole(role)
+		if has {
+			return true
 		}
 	}
 	return false
+}
+
+func (a *access) hasPermissionCheckingRole(role string) bool {
+	switch a.requiredRole {
+	case OwnerRole:
+		return role == OwnerRole
+	case MemberRole:
+		return role == OwnerRole || role == MemberRole
+	case OperatorRole:
+		return role == OwnerRole || role == MemberRole || role == OperatorRole
+	case ViewerRole:
+		return role == OwnerRole || role == MemberRole || role == OperatorRole || role == ViewerRole
+	default:
+		return false
+	}
 }
 
 func (a *access) claims() map[string]interface{} {


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix 

closes #6367 .

## Changes proposed by this PR:

This is a small logic error in function `hasPermission()`, and fixed the bad logic.

## Release Note

Fix an authorization bug, when a user has multiple roles in a team, then it may randomly hit "forbidden" error.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
