### PR TITLE
Add generic HTTP credential manager

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -86,6 +86,7 @@ import (
 	_ "github.com/concourse/concourse/atc/creds/conjur"
 	_ "github.com/concourse/concourse/atc/creds/credhub"
 	_ "github.com/concourse/concourse/atc/creds/dummy"
+	_ "github.com/concourse/concourse/atc/creds/http"
 	_ "github.com/concourse/concourse/atc/creds/kubernetes"
 	_ "github.com/concourse/concourse/atc/creds/secretsmanager"
 	_ "github.com/concourse/concourse/atc/creds/ssm"

--- a/atc/creds/http/http.go
+++ b/atc/creds/http/http.go
@@ -16,6 +16,9 @@ import (
 
 type HTTPSecretManager struct {
 	URL string
+
+	BasicAuthUsername string
+	BasicAuthPassword string
 }
 
 // NewSecretLookupPaths defines how variables will be searched in the underlying secret manager
@@ -43,7 +46,16 @@ func (h HTTPSecretManager) Get(secretPath string) (interface{}, *time.Time, bool
 	}
 	url += secretPath
 
-	resp, err := http.DefaultClient.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	if h.BasicAuthUsername != "" || h.BasicAuthPassword != "" {
+		req.SetBasicAuth(h.BasicAuthUsername, h.BasicAuthPassword)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/atc/creds/http/http.go
+++ b/atc/creds/http/http.go
@@ -1,0 +1,84 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/concourse/concourse/atc/creds"
+
+	"sigs.k8s.io/yaml"
+)
+
+type HTTPSecretManager struct {
+	URL string
+}
+
+// NewSecretLookupPaths defines how variables will be searched in the underlying secret manager
+func (h HTTPSecretManager) NewSecretLookupPaths(teamName string, pipelineName string, allowRootPath bool) []creds.SecretLookupPath {
+	lookupPaths := []creds.SecretLookupPath{}
+
+	if len(pipelineName) > 0 {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(teamName, pipelineName)+"/"))
+	}
+
+	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(teamName)+"/"))
+
+	if allowRootPath {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix("/"))
+	}
+
+	return lookupPaths
+}
+
+// Get retrieves the value and expiration of an individual secret
+func (h HTTPSecretManager) Get(secretPath string) (interface{}, *time.Time, bool, error) {
+	url := h.URL
+	if !strings.HasPrefix(secretPath, "/") {
+		url += "/"
+	}
+	url += secretPath
+
+	resp, err := http.DefaultClient.Get(url)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil, false, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, false, fmt.Errorf(
+			"Expected either 200 or 404, received %d", resp.StatusCode,
+		)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
+
+	if contentType == "application/x-yaml" || contentType == "text/yaml" {
+		var secret interface{}
+		if err := yaml.Unmarshal(body, &secret); err != nil {
+			return nil, nil, false, err
+		}
+		return secret, nil, true, nil
+	} else if contentType == "application/json" {
+		var secret interface{}
+		if err := json.Unmarshal(body, &secret); err != nil {
+			return nil, nil, false, err
+		}
+		return secret, nil, true, nil
+	}
+
+	return string(body), nil, true, nil
+}

--- a/atc/creds/http/http_factory.go
+++ b/atc/creds/http/http_factory.go
@@ -1,0 +1,25 @@
+package http
+
+import (
+	"code.cloudfoundry.org/lager"
+
+	"github.com/concourse/concourse/atc/creds"
+)
+
+type httpFactory struct {
+	log lager.Logger
+	url string
+}
+
+func NewHTTPFactory(log lager.Logger, url string) *httpFactory {
+	return &httpFactory{
+		log: log,
+		url: url,
+	}
+}
+
+func (factory *httpFactory) NewSecrets() creds.Secrets {
+	return &HTTPSecretManager{
+		URL: factory.url,
+	}
+}

--- a/atc/creds/http/http_factory.go
+++ b/atc/creds/http/http_factory.go
@@ -9,17 +9,29 @@ import (
 type httpFactory struct {
 	log lager.Logger
 	url string
+
+	basicAuthUsername string
+	basicAuthPassword string
 }
 
-func NewHTTPFactory(log lager.Logger, url string) *httpFactory {
+func NewHTTPFactory(
+	log lager.Logger, url string,
+	basicAuthUsername, basicAuthPassword string,
+) *httpFactory {
 	return &httpFactory{
 		log: log,
 		url: url,
+
+		basicAuthUsername: basicAuthUsername,
+		basicAuthPassword: basicAuthPassword,
 	}
 }
 
 func (factory *httpFactory) NewSecrets() creds.Secrets {
 	return &HTTPSecretManager{
 		URL: factory.url,
+
+		BasicAuthUsername: factory.basicAuthUsername,
+		BasicAuthPassword: factory.basicAuthPassword,
 	}
 }

--- a/atc/creds/http/http_suite_test.go
+++ b/atc/creds/http/http_suite_test.go
@@ -1,0 +1,13 @@
+package http_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHTTP(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HTTP Suite")
+}

--- a/atc/creds/http/http_test.go
+++ b/atc/creds/http/http_test.go
@@ -178,5 +178,27 @@ var _ = Describe("HTTP", func() {
 				}))
 			})
 		})
+
+		Context("when using basic auth", func() {
+			BeforeEach(func() {
+				h.BasicAuthUsername = "un"
+				h.BasicAuthPassword = "pw"
+			})
+
+			It("should add the Authorization header", func() {
+				s.AppendHandlers(ghttp.CombineHandlers(
+					ghttp.VerifyBasicAuth("un", "pw"),
+					ghttp.RespondWith(200, "a basic auth protected secret"),
+				))
+
+				secret, found, err := variables.Get(
+					vars.Reference{Path: "foo"},
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(Equal(true))
+				Expect(secret).To(Equal("a basic auth protected secret"))
+			})
+		})
 	})
 })

--- a/atc/creds/http/http_test.go
+++ b/atc/creds/http/http_test.go
@@ -136,5 +136,47 @@ var _ = Describe("HTTP", func() {
 				Expect(paths).NotTo(ContainElement("/foo"))
 			})
 		})
+
+		Context("when returning a YAML secret", func() {
+			It("should deserialize", func() {
+				handler := func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Add("Content-Type", "text/yaml")
+					w.Write([]byte("---\n'this is a': 'yaml secret'"))
+				}
+
+				s.AppendHandlers(handler)
+
+				secret, found, err := variables.Get(
+					vars.Reference{Path: "foo"},
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(Equal(true))
+				Expect(secret).To(Equal(map[string]interface{}{
+					"this is a": "yaml secret",
+				}))
+			})
+		})
+
+		Context("when returning a JSON secret", func() {
+			It("should deserialize", func() {
+				handler := func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Add("Content-Type", "application/json")
+					w.Write([]byte(`{"this is a": "json secret"}`))
+				}
+
+				s.AppendHandlers(handler)
+
+				secret, found, err := variables.Get(
+					vars.Reference{Path: "foo"},
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(Equal(true))
+				Expect(secret).To(Equal(map[string]interface{}{
+					"this is a": "json secret",
+				}))
+			})
+		})
 	})
 })

--- a/atc/creds/http/http_test.go
+++ b/atc/creds/http/http_test.go
@@ -1,0 +1,140 @@
+package http_test
+
+import (
+	"net/http"
+
+	"github.com/concourse/concourse/atc/creds"
+	httpcreds "github.com/concourse/concourse/atc/creds/http"
+	"github.com/concourse/concourse/vars"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("HTTP", func() {
+
+	var (
+		h         *httpcreds.HTTPSecretManager
+		variables vars.Variables
+
+		s *ghttp.Server
+	)
+
+	BeforeEach(func() {
+		s = ghttp.NewServer()
+
+		h = &httpcreds.HTTPSecretManager{
+			URL: s.URL(),
+		}
+
+		variables = creds.NewVariables(h, "team", "pipeline", true)
+	})
+
+	AfterEach(func() {
+		s.Close()
+	})
+
+	Describe("Get()", func() {
+		It("should get secret from pipeline", func() {
+			paths := []string{}
+
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				paths = append(paths, r.URL.Path)
+
+				if r.URL.Path == "/team/pipeline/foo" {
+					w.Write([]byte("this secret value is a string"))
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}
+
+			s.AppendHandlers(handler)
+
+			secret, found, err := variables.Get(
+				vars.Reference{Path: "foo"},
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(Equal(true))
+			Expect(secret).To(Equal("this secret value is a string"))
+			Expect(paths).To(ContainElement("/team/pipeline/foo"))
+		})
+
+		It("should get secret from team", func() {
+			paths := []string{}
+
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				paths = append(paths, r.URL.Path)
+
+				if r.URL.Path == "/team/foo" {
+					w.Write([]byte("this secret value is a string"))
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}
+
+			s.AppendHandlers(handler, handler)
+
+			secret, found, err := variables.Get(
+				vars.Reference{Path: "foo"},
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(Equal(true))
+			Expect(secret).To(Equal("this secret value is a string"))
+			Expect(paths).To(ContainElement("/team/foo"))
+		})
+
+		It("should get secret from root", func() {
+			paths := []string{}
+
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				paths = append(paths, r.URL.Path)
+
+				if r.URL.Path == "/foo" {
+					w.Write([]byte("this secret value is a string"))
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}
+
+			s.AppendHandlers(handler, handler, handler)
+
+			secret, found, err := variables.Get(
+				vars.Reference{Path: "foo"},
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(Equal(true))
+			Expect(secret).To(Equal("this secret value is a string"))
+			Expect(paths).To(ContainElement("/foo"))
+		})
+
+		Context("when not allowing the root path", func() {
+			BeforeEach(func() {
+				variables = creds.NewVariables(h, "team", "pipeline", false)
+			})
+
+			It("should not request the root", func() {
+				paths := []string{}
+
+				handler := func(w http.ResponseWriter, r *http.Request) {
+					paths = append(paths, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+
+				s.AppendHandlers(handler, handler, handler)
+
+				secret, found, err := variables.Get(
+					vars.Reference{Path: "foo"},
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(Equal(false))
+				Expect(secret).To(BeNil())
+				Expect(paths).NotTo(ContainElement("/foo"))
+			})
+		})
+	})
+})

--- a/atc/creds/http/manager.go
+++ b/atc/creds/http/manager.go
@@ -82,4 +82,6 @@ func (manager HTTPManager) NewSecretsFactory(logger lager.Logger) (creds.Secrets
 
 func (manager HTTPManager) Close(logger lager.Logger) {
 	// TODO - to implement
+	// This is consistent with other secret managers
+	// Currently there does not seem to be anything left to clean up
 }

--- a/atc/creds/http/manager.go
+++ b/atc/creds/http/manager.go
@@ -1,0 +1,68 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/concourse/concourse/atc/creds"
+)
+
+type HTTPManager struct {
+	URL string `long:"url" description:"HTTP server address used to access secrets."`
+}
+
+func (manager *HTTPManager) Init(log lager.Logger) error {
+	return nil
+}
+
+func (manager HTTPManager) IsConfigured() bool {
+	return manager.URL != ""
+}
+
+func (manager HTTPManager) Validate() error {
+	parsedUrl, err := url.Parse(manager.URL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %s", err)
+	}
+
+	// "foo" will parse without error (as a Path, with an empty Host)
+	// so we'll do a few additional sanity checks that this is a valid URL
+	// copied from atc/credhub/manager.go
+	if parsedUrl.Host == "" || !(parsedUrl.Scheme == "http" || parsedUrl.Scheme == "https") {
+		return fmt.Errorf("invalid URL (must be http or https)")
+	}
+
+	return nil
+}
+
+func (manager HTTPManager) Health() (*creds.HealthResponse, error) {
+	path := "/health"
+
+	healthResponse := &creds.HealthResponse{
+		Method: path,
+	}
+
+	resp, err := http.Get(manager.URL + path)
+	if err != nil {
+		return healthResponse, err
+	}
+	defer resp.Body.Close()
+
+	healthResponse.Response = resp.StatusCode
+
+	if resp.StatusCode != http.StatusOK {
+		return healthResponse, fmt.Errorf("expected HTTP 200 received %d", resp.StatusCode)
+	}
+
+	return healthResponse, nil
+}
+
+func (manager HTTPManager) NewSecretsFactory(logger lager.Logger) (creds.SecretsFactory, error) {
+	return NewHTTPFactory(logger, manager.URL), nil
+}
+
+func (manager HTTPManager) Close(logger lager.Logger) {
+	// TODO - to implement
+}

--- a/atc/creds/http/manager_factory.go
+++ b/atc/creds/http/manager_factory.go
@@ -23,7 +23,7 @@ func (factory *httpManagerFactory) AddConfig(group *flags.Group) creds.Manager {
 		panic(err)
 	}
 
-	subGroup.Namespace = "http"
+	subGroup.Namespace = "http-credential-manager"
 
 	return manager
 }

--- a/atc/creds/http/manager_factory.go
+++ b/atc/creds/http/manager_factory.go
@@ -1,0 +1,33 @@
+package http
+
+import (
+	"github.com/concourse/concourse/atc/creds"
+	flags "github.com/jessevdk/go-flags"
+)
+
+type httpManagerFactory struct{}
+
+func init() {
+	creds.Register("http", NewHTTPManagerFactory())
+}
+
+func NewHTTPManagerFactory() creds.ManagerFactory {
+	return &httpManagerFactory{}
+}
+
+func (factory *httpManagerFactory) AddConfig(group *flags.Group) creds.Manager {
+	manager := &HTTPManager{}
+
+	subGroup, err := group.AddGroup("HTTP Credential Management", "", manager)
+	if err != nil {
+		panic(err)
+	}
+
+	subGroup.Namespace = "http"
+
+	return manager
+}
+
+func (factory *httpManagerFactory) NewInstance(interface{}) (creds.Manager, error) {
+	return &HTTPManager{}, nil
+}

--- a/atc/creds/http/manager_test.go
+++ b/atc/creds/http/manager_test.go
@@ -1,0 +1,76 @@
+package http_test
+
+import (
+	"net/http"
+
+	httpcreds "github.com/concourse/concourse/atc/creds/http"
+	flags "github.com/jessevdk/go-flags"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("HTTPManager", func() {
+	var (
+		manager httpcreds.HTTPManager
+
+		s *ghttp.Server
+	)
+
+	BeforeEach(func() {
+		s = ghttp.NewServer()
+	})
+
+	AfterEach(func() {
+		s.Close()
+	})
+
+	Describe("IsConfigured()", func() {
+		BeforeEach(func() {
+			_, err := flags.ParseArgs(&manager, []string{})
+			Expect(err).To(BeNil())
+		})
+
+		It("fails on empty HTTPManager", func() {
+			Expect(manager.IsConfigured()).To(BeFalse())
+		})
+
+		It("passes if URL is set", func() {
+			manager.URL = "hello://world"
+			Expect(manager.IsConfigured()).To(BeTrue())
+		})
+	})
+
+	Describe("Health()", func() {
+		BeforeEach(func() {
+			manager.URL = s.URL()
+		})
+
+		Context("when the server is healthy", func() {
+			BeforeEach(func() {
+				s.RouteToHandler("GET", "/health", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				})
+			})
+
+			It("does not error", func() {
+				_, err := manager.Health()
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when the server is not healthy", func() {
+			BeforeEach(func() {
+				s.RouteToHandler("GET", "/health", func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusNotFound)
+				})
+			})
+
+			It("errors", func() {
+				_, err := manager.Health()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/atc/creds/http/manager_test.go
+++ b/atc/creds/http/manager_test.go
@@ -72,5 +72,22 @@ var _ = Describe("HTTPManager", func() {
 				Expect(err).To(HaveOccurred())
 			})
 		})
+
+		Context("when using basic auth", func() {
+			BeforeEach(func() {
+				manager.BasicAuthUsername = "un"
+				manager.BasicAuthPassword = "pw"
+			})
+
+			It("should add the Authorization header", func() {
+				s.AppendHandlers(ghttp.CombineHandlers(
+					ghttp.VerifyBasicAuth("un", "pw"),
+					ghttp.RespondWith(200, "ok"),
+				))
+
+				_, err := manager.Health()
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
 	})
 })

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -214,12 +214,12 @@ func (emitter *NewRelicEmitter) emitBatch(logger lager.Logger, payload []NewReli
 	}
 
 	resp, err := emitter.Client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		logger.Error("failed-to-send-request",
 			errors.Wrap(metric.ErrFailedToEmit, err.Error()))
 		return
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)

--- a/atc/policy/opa/agent_suite_test.go
+++ b/atc/policy/opa/agent_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestVault(t *testing.T) {
+func TestOPA(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Policy Agent Suite")
 }


### PR DESCRIPTION
## What does this PR accomplish?

Feature

## Changes proposed by this PR:

Concourse currently supports the following external software systems for managing credentials:

* Vault
* Kubernetes
* CredHub
* AWS SSM
* AWS Secrets Manager
* Conjur

These are either SaaS offerings or fairly non-trivial distributed systems.

This pull request adds a new generic credential manager which uses HTTP, using the following API:

* `GET $url/health`
* `GET $url/$secret`
* `GET $url/$team/$secret`
* `GET $url/$team/$pipeline/$secret`

This minimal API is quite simple to implement, but gives a lot of control to the user deploying Concourse. Adding and persistenting credentials to the implementation of a manager is up to the implementer. One could use this feature as a shim to use etcd/consul/zookeeper

I intend to use this feature as experimentation for smaller/simpler Concourse deployments (and Concourse deployments which use HSMs). I would like to use a credential manager, but without the overhead of the more fully featured credential managers.

The credential manager can be configured with the following options:
- URL (the base URL to which HTTP requests are made)
- Basic auth username/password (optional)

## Notes to reviewer:

The following code block is a ruby application which functions as a primitive credential manager, which can be used for testing:

```ruby
require "sinatra"
require "yaml"

set :bind, "0.0.0.0"

SECRETS = {
  "main" => {
    "my-pipeline" => {

      "my-json-secret" => {
        type: :json,
        value: {
          "foo" => "bar",
        },
      },

      "my-yaml-secret" => {
        type: :yaml,
        value: {
          "foo" => "bar",
        },
      },

      "my-plain-secret" => {
        value: "foo bar baz",
      },
    },
  },
}.freeze

get "/health" do
  "OK"
end

get "/:team/:pipeline/:secret" do |team, pipeline, secret|
  secret = SECRETS.dig(team, pipeline, secret)

  halt(404, "secret not found") if secret.nil?

  status 200

  case secret[:type]
  when :json
    headers "Content-Type" => "application/json"
    body secret[:value].to_json
  when :yaml
    headers "Content-Type" => "text/yaml"
    body secret[:value].to_yaml
  else
    headers "Content-Type" => "text/plain"
    body secret[:value]
  end
end
```

If using `docker-compose` to test the you will have to use `172.18.0.1:4567` or similar if you are running this on your host. ie `CONCOURSE_HTTP_CREDENTIAL_MANAGER_URL: http://172.18.0.1:4567`

Using the pipeline:

```yaml
---
jobs:
  - name: print
    plan:
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          params:
            MY_PLAIN_SECRET: ((my-plain-secret))
            MY_JSON_SECRET_FOO: ((my-json-secret.foo))
            MY_YAML_SECRET_FOO: ((my-yaml-secret.foo))
          run:
            path: sh
            args:
              - -c
              - |
                echo "MY_PLAIN_SECRET: $MY_PLAIN_SECRET"
                echo
                echo "MY_JSON_SECRET.foo: $MY_JSON_SECRET_FOO"
                echo
                echo "MY_YAML_SECRET.foo: $MY_YAML_SECRET_FOO"
```

produces:

![screenshot of pipeline using http credential manager](https://user-images.githubusercontent.com/1482692/103245059-dab14d80-4956-11eb-87da-588463d9ace2.png)


## Release Note

* Add (experimental) generic HTTP credential manager

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
