### PR TITLE
Disable resource checking for individual resources

### DIFF
--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -638,7 +638,7 @@ jobs:
 											Name:         "some-resource",
 											Type:         "some-type",
 											Source:       nil,
-											CheckEvery:   "10s",
+											CheckEvery:   &atc.CheckEvery{Interval: 10 * time.Second},
 											CheckTimeout: "1m",
 										},
 									},
@@ -887,7 +887,7 @@ jobs:
 										Name:       "some-resource",
 										Type:       "some-type",
 										Source:     nil,
-										CheckEvery: "10s",
+										CheckEvery: &atc.CheckEvery{Interval: 10 * time.Second},
 									},
 								},
 									Jobs: atc.JobConfigs{

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -798,7 +798,7 @@ var _ = Describe("Resources API", func() {
 				resourceType2.TypeReturns("type-2")
 				resourceType2.SourceReturns(map[string]interface{}{"source-key-2": "source-value-2"})
 				resourceType2.PrivilegedReturns(true)
-				resourceType2.CheckEveryReturns("10ms")
+				resourceType2.CheckEveryReturns(&atc.CheckEvery{Interval: 10 * time.Millisecond})
 				resourceType2.TagsReturns([]string{"tag1", "tag2"})
 				resourceType2.ParamsReturns(map[string]interface{}{"param-key-2": "param-value-2"})
 				resourceType2.VersionReturns(map[string]string{

--- a/atc/config.go
+++ b/atc/config.go
@@ -2,8 +2,11 @@ package atc
 
 import (
 	"crypto/tls"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 	"sigs.k8s.io/yaml"
@@ -173,32 +176,75 @@ func (c VarSourceConfigs) OrderByDependency() (VarSourceConfigs, error) {
 }
 
 type ResourceConfig struct {
-	Name         string  `json:"name"`
-	OldName      string  `json:"old_name,omitempty"`
-	Public       bool    `json:"public,omitempty"`
-	WebhookToken string  `json:"webhook_token,omitempty"`
-	Type         string  `json:"type"`
-	Source       Source  `json:"source"`
-	CheckEvery   string  `json:"check_every,omitempty"`
-	CheckTimeout string  `json:"check_timeout,omitempty"`
-	Tags         Tags    `json:"tags,omitempty"`
-	Version      Version `json:"version,omitempty"`
-	Icon         string  `json:"icon,omitempty"`
+	Name         string     `json:"name"`
+	OldName      string     `json:"old_name,omitempty"`
+	Public       bool       `json:"public,omitempty"`
+	WebhookToken string     `json:"webhook_token,omitempty"`
+	Type         string     `json:"type"`
+	Source       Source     `json:"source"`
+	CheckEvery   CheckEvery `json:"check_every,omitempty"`
+	CheckTimeout string     `json:"check_timeout,omitempty"`
+	Tags         Tags       `json:"tags,omitempty"`
+	Version      Version    `json:"version,omitempty"`
+	Icon         string     `json:"icon,omitempty"`
 }
 
 type ResourceType struct {
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	Source     Source `json:"source"`
-	Defaults   Source `json:"defaults,omitempty"`
-	Privileged bool   `json:"privileged,omitempty"`
-	CheckEvery string `json:"check_every,omitempty"`
-	Tags       Tags   `json:"tags,omitempty"`
-	Params     Params `json:"params,omitempty"`
+	Name       string     `json:"name"`
+	Type       string     `json:"type"`
+	Source     Source     `json:"source"`
+	Defaults   Source     `json:"defaults,omitempty"`
+	Privileged bool       `json:"privileged,omitempty"`
+	CheckEvery CheckEvery `json:"check_every,omitempty"`
+	Tags       Tags       `json:"tags,omitempty"`
+	Params     Params     `json:"params,omitempty"`
 }
 
 type DisplayConfig struct {
 	BackgroundImage string `json:"background_image,omitempty"`
+}
+
+type CheckEvery struct {
+	Never    bool
+	Interval time.Duration
+}
+
+func (c *CheckEvery) UnmarshalJSON(checkEvery []byte) error {
+	var data interface{}
+
+	err := json.Unmarshal(checkEvery, &data)
+	if err != nil {
+		return err
+	}
+
+	actual, ok := data.(string)
+	if !ok {
+		return errors.New("non-string value provided")
+	}
+
+	if actual != "" {
+		if actual == "never" {
+			c.Never = true
+			return nil
+		}
+		c.Interval, err = time.ParseDuration(actual)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *CheckEvery) MarshalJSON() ([]byte, error) {
+	if c.Never {
+		return json.Marshal("never")
+	}
+
+	if c.Interval != 0 {
+		return json.Marshal(c.Interval.String())
+	}
+
+	return json.Marshal("")
 }
 
 type ResourceTypes []ResourceType

--- a/atc/config.go
+++ b/atc/config.go
@@ -176,28 +176,28 @@ func (c VarSourceConfigs) OrderByDependency() (VarSourceConfigs, error) {
 }
 
 type ResourceConfig struct {
-	Name         string     `json:"name"`
-	OldName      string     `json:"old_name,omitempty"`
-	Public       bool       `json:"public,omitempty"`
-	WebhookToken string     `json:"webhook_token,omitempty"`
-	Type         string     `json:"type"`
-	Source       Source     `json:"source"`
-	CheckEvery   CheckEvery `json:"check_every,omitempty"`
-	CheckTimeout string     `json:"check_timeout,omitempty"`
-	Tags         Tags       `json:"tags,omitempty"`
-	Version      Version    `json:"version,omitempty"`
-	Icon         string     `json:"icon,omitempty"`
+	Name         string      `json:"name"`
+	OldName      string      `json:"old_name,omitempty"`
+	Public       bool        `json:"public,omitempty"`
+	WebhookToken string      `json:"webhook_token,omitempty"`
+	Type         string      `json:"type"`
+	Source       Source      `json:"source"`
+	CheckEvery   *CheckEvery `json:"check_every,omitempty"`
+	CheckTimeout string      `json:"check_timeout,omitempty"`
+	Tags         Tags        `json:"tags,omitempty"`
+	Version      Version     `json:"version,omitempty"`
+	Icon         string      `json:"icon,omitempty"`
 }
 
 type ResourceType struct {
-	Name       string     `json:"name"`
-	Type       string     `json:"type"`
-	Source     Source     `json:"source"`
-	Defaults   Source     `json:"defaults,omitempty"`
-	Privileged bool       `json:"privileged,omitempty"`
-	CheckEvery CheckEvery `json:"check_every,omitempty"`
-	Tags       Tags       `json:"tags,omitempty"`
-	Params     Params     `json:"params,omitempty"`
+	Name       string      `json:"name"`
+	Type       string      `json:"type"`
+	Source     Source      `json:"source"`
+	Defaults   Source      `json:"defaults,omitempty"`
+	Privileged bool        `json:"privileged,omitempty"`
+	CheckEvery *CheckEvery `json:"check_every,omitempty"`
+	Tags       Tags        `json:"tags,omitempty"`
+	Params     Params      `json:"params,omitempty"`
 }
 
 type DisplayConfig struct {

--- a/atc/config_test.go
+++ b/atc/config_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Config", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					expected := ResourceConfig{
-						CheckEvery: CheckEvery{Never: true},
+						CheckEvery: &CheckEvery{Never: true},
 					}
 
 					Expect(resourceConfig).To(Equal(expected))
@@ -170,7 +170,7 @@ var _ = Describe("Config", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					expected := ResourceConfig{
-						CheckEvery: CheckEvery{Interval: 10 * time.Second},
+						CheckEvery: &CheckEvery{Interval: 10 * time.Second},
 					}
 
 					Expect(resourceConfig).To(Equal(expected))

--- a/atc/config_test.go
+++ b/atc/config_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Config", func() {
 					var resourceConfig ResourceConfig
 					bs := []byte(`{ "check_every": "some-string" }`)
 					err := json.Unmarshal(bs, &resourceConfig)
-					Expect(err).To(MatchError("time: invalid duration \"some-string\""))
+					Expect(err).To(MatchError(`time: invalid duration "some-string"`))
 				})
 			})
 

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -24,7 +24,7 @@ type Checkable interface {
 	Type() string
 	Source() atc.Source
 	Tags() atc.Tags
-	CheckEvery() string
+	CheckEvery() *atc.CheckEvery
 	CheckTimeout() string
 	LastCheckEndTime() time.Time
 	CurrentPinnedVersion() atc.Version
@@ -108,12 +108,9 @@ func (c *checkFactory) TryCreateCheck(ctx context.Context, checkable Checkable, 
 	if checkable.HasWebhook() {
 		interval = c.defaultWithWebhookCheckInterval
 	}
-	if every := checkable.CheckEvery(); every != "" {
-		if every != "never" {
-			interval, err = time.ParseDuration(every)
-			if err != nil {
-				return nil, false, fmt.Errorf("check interval: %s", err)
-			}
+	if checkable.CheckEvery() != nil {
+		if !checkable.CheckEvery().Never {
+			interval = checkable.CheckEvery().Interval
 		}
 	}
 

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -108,10 +108,8 @@ func (c *checkFactory) TryCreateCheck(ctx context.Context, checkable Checkable, 
 	if checkable.HasWebhook() {
 		interval = c.defaultWithWebhookCheckInterval
 	}
-	if checkable.CheckEvery() != nil {
-		if !checkable.CheckEvery().Never {
-			interval = checkable.CheckEvery().Interval
-		}
+	if checkable.CheckEvery() != nil && !checkable.CheckEvery().Never {
+		interval = checkable.CheckEvery().Interval
 	}
 
 	if !manuallyTriggered && time.Now().Before(checkable.LastCheckEndTime().Add(interval)) {

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -109,9 +109,11 @@ func (c *checkFactory) TryCreateCheck(ctx context.Context, checkable Checkable, 
 		interval = c.defaultWithWebhookCheckInterval
 	}
 	if every := checkable.CheckEvery(); every != "" {
-		interval, err = time.ParseDuration(every)
-		if err != nil {
-			return nil, false, fmt.Errorf("check interval: %s", err)
+		if every != "never" {
+			interval, err = time.ParseDuration(every)
+			if err != nil {
+				return nil, false, fmt.Errorf("check interval: %s", err)
+			}
 		}
 	}
 

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -153,7 +153,7 @@ var _ = Describe("CheckFactory", func() {
 
 		Context("when an interval is specified", func() {
 			BeforeEach(func() {
-				fakeResource.CheckEveryReturns("42s")
+				fakeResource.CheckEveryReturns(&atc.CheckEvery{Interval: 42 * time.Second})
 			})
 
 			It("sets it in the check plan", func() {
@@ -168,21 +168,11 @@ var _ = Describe("CheckFactory", func() {
 
 		Context("when CheckEvery is never", func() {
 			BeforeEach(func() {
-				fakeResource.CheckEveryReturns("never")
+				fakeResource.CheckEveryReturns(&atc.CheckEvery{Never: true})
 			})
 
 			It("does not try parsing the interval", func() {
 				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-
-		Context("when the interval is not parseable", func() {
-			BeforeEach(func() {
-				fakeResource.CheckEveryReturns("not-a-duration")
-			})
-
-			It("errors", func() {
-				Expect(err).To(HaveOccurred())
 			})
 		})
 

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -166,6 +166,16 @@ var _ = Describe("CheckFactory", func() {
 			})
 		})
 
+		Context("when CheckEvery is never", func() {
+			BeforeEach(func() {
+				fakeResource.CheckEveryReturns("never")
+			})
+
+			It("does not try parsing the interval", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
 		Context("when the interval is not parseable", func() {
 			BeforeEach(func() {
 				fakeResource.CheckEveryReturns("not-a-duration")

--- a/atc/db/dbfakes/fake_checkable.go
+++ b/atc/db/dbfakes/fake_checkable.go
@@ -11,15 +11,15 @@ import (
 )
 
 type FakeCheckable struct {
-	CheckEveryStub        func() string
+	CheckEveryStub        func() *atc.CheckEvery
 	checkEveryMutex       sync.RWMutex
 	checkEveryArgsForCall []struct {
 	}
 	checkEveryReturns struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}
 	checkEveryReturnsOnCall map[int]struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}
 	CheckPlanStub        func(atc.Version, time.Duration, db.ResourceTypes, atc.Source) atc.CheckPlan
 	checkPlanMutex       sync.RWMutex
@@ -220,7 +220,7 @@ type FakeCheckable struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCheckable) CheckEvery() string {
+func (fake *FakeCheckable) CheckEvery() *atc.CheckEvery {
 	fake.checkEveryMutex.Lock()
 	ret, specificReturn := fake.checkEveryReturnsOnCall[len(fake.checkEveryArgsForCall)]
 	fake.checkEveryArgsForCall = append(fake.checkEveryArgsForCall, struct {
@@ -243,32 +243,32 @@ func (fake *FakeCheckable) CheckEveryCallCount() int {
 	return len(fake.checkEveryArgsForCall)
 }
 
-func (fake *FakeCheckable) CheckEveryCalls(stub func() string) {
+func (fake *FakeCheckable) CheckEveryCalls(stub func() *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = stub
 }
 
-func (fake *FakeCheckable) CheckEveryReturns(result1 string) {
+func (fake *FakeCheckable) CheckEveryReturns(result1 *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = nil
 	fake.checkEveryReturns = struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}{result1}
 }
 
-func (fake *FakeCheckable) CheckEveryReturnsOnCall(i int, result1 string) {
+func (fake *FakeCheckable) CheckEveryReturnsOnCall(i int, result1 *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = nil
 	if fake.checkEveryReturnsOnCall == nil {
 		fake.checkEveryReturnsOnCall = make(map[int]struct {
-			result1 string
+			result1 *atc.CheckEvery
 		})
 	}
 	fake.checkEveryReturnsOnCall[i] = struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}{result1}
 }
 

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -31,15 +31,15 @@ type FakeResource struct {
 	buildSummaryReturnsOnCall map[int]struct {
 		result1 *atc.BuildSummary
 	}
-	CheckEveryStub        func() string
+	CheckEveryStub        func() *atc.CheckEvery
 	checkEveryMutex       sync.RWMutex
 	checkEveryArgsForCall []struct {
 	}
 	checkEveryReturns struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}
 	checkEveryReturnsOnCall map[int]struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}
 	CheckPlanStub        func(atc.Version, time.Duration, db.ResourceTypes, atc.Source) atc.CheckPlan
 	checkPlanMutex       sync.RWMutex
@@ -338,21 +338,6 @@ type FakeResource struct {
 	resourceConfigScopeIDReturnsOnCall map[int]struct {
 		result1 int
 	}
-	SaveUncheckedVersionStub        func(atc.Version, db.ResourceConfigMetadataFields, db.ResourceConfig) (bool, error)
-	saveUncheckedVersionMutex       sync.RWMutex
-	saveUncheckedVersionArgsForCall []struct {
-		arg1 atc.Version
-		arg2 db.ResourceConfigMetadataFields
-		arg3 db.ResourceConfig
-	}
-	saveUncheckedVersionReturns struct {
-		result1 bool
-		result2 error
-	}
-	saveUncheckedVersionReturnsOnCall map[int]struct {
-		result1 bool
-		result2 error
-	}
 	SetPinCommentStub        func(string) error
 	setPinCommentMutex       sync.RWMutex
 	setPinCommentArgsForCall []struct {
@@ -585,7 +570,7 @@ func (fake *FakeResource) BuildSummaryReturnsOnCall(i int, result1 *atc.BuildSum
 	}{result1}
 }
 
-func (fake *FakeResource) CheckEvery() string {
+func (fake *FakeResource) CheckEvery() *atc.CheckEvery {
 	fake.checkEveryMutex.Lock()
 	ret, specificReturn := fake.checkEveryReturnsOnCall[len(fake.checkEveryArgsForCall)]
 	fake.checkEveryArgsForCall = append(fake.checkEveryArgsForCall, struct {
@@ -608,32 +593,32 @@ func (fake *FakeResource) CheckEveryCallCount() int {
 	return len(fake.checkEveryArgsForCall)
 }
 
-func (fake *FakeResource) CheckEveryCalls(stub func() string) {
+func (fake *FakeResource) CheckEveryCalls(stub func() *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = stub
 }
 
-func (fake *FakeResource) CheckEveryReturns(result1 string) {
+func (fake *FakeResource) CheckEveryReturns(result1 *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = nil
 	fake.checkEveryReturns = struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}{result1}
 }
 
-func (fake *FakeResource) CheckEveryReturnsOnCall(i int, result1 string) {
+func (fake *FakeResource) CheckEveryReturnsOnCall(i int, result1 *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = nil
 	if fake.checkEveryReturnsOnCall == nil {
 		fake.checkEveryReturnsOnCall = make(map[int]struct {
-			result1 string
+			result1 *atc.CheckEvery
 		})
 	}
 	fake.checkEveryReturnsOnCall[i] = struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}{result1}
 }
 
@@ -2118,71 +2103,6 @@ func (fake *FakeResource) ResourceConfigScopeIDReturnsOnCall(i int, result1 int)
 	}{result1}
 }
 
-func (fake *FakeResource) SaveUncheckedVersion(arg1 atc.Version, arg2 db.ResourceConfigMetadataFields, arg3 db.ResourceConfig) (bool, error) {
-	fake.saveUncheckedVersionMutex.Lock()
-	ret, specificReturn := fake.saveUncheckedVersionReturnsOnCall[len(fake.saveUncheckedVersionArgsForCall)]
-	fake.saveUncheckedVersionArgsForCall = append(fake.saveUncheckedVersionArgsForCall, struct {
-		arg1 atc.Version
-		arg2 db.ResourceConfigMetadataFields
-		arg3 db.ResourceConfig
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("SaveUncheckedVersion", []interface{}{arg1, arg2, arg3})
-	fake.saveUncheckedVersionMutex.Unlock()
-	if fake.SaveUncheckedVersionStub != nil {
-		return fake.SaveUncheckedVersionStub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.saveUncheckedVersionReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeResource) SaveUncheckedVersionCallCount() int {
-	fake.saveUncheckedVersionMutex.RLock()
-	defer fake.saveUncheckedVersionMutex.RUnlock()
-	return len(fake.saveUncheckedVersionArgsForCall)
-}
-
-func (fake *FakeResource) SaveUncheckedVersionCalls(stub func(atc.Version, db.ResourceConfigMetadataFields, db.ResourceConfig) (bool, error)) {
-	fake.saveUncheckedVersionMutex.Lock()
-	defer fake.saveUncheckedVersionMutex.Unlock()
-	fake.SaveUncheckedVersionStub = stub
-}
-
-func (fake *FakeResource) SaveUncheckedVersionArgsForCall(i int) (atc.Version, db.ResourceConfigMetadataFields, db.ResourceConfig) {
-	fake.saveUncheckedVersionMutex.RLock()
-	defer fake.saveUncheckedVersionMutex.RUnlock()
-	argsForCall := fake.saveUncheckedVersionArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *FakeResource) SaveUncheckedVersionReturns(result1 bool, result2 error) {
-	fake.saveUncheckedVersionMutex.Lock()
-	defer fake.saveUncheckedVersionMutex.Unlock()
-	fake.SaveUncheckedVersionStub = nil
-	fake.saveUncheckedVersionReturns = struct {
-		result1 bool
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeResource) SaveUncheckedVersionReturnsOnCall(i int, result1 bool, result2 error) {
-	fake.saveUncheckedVersionMutex.Lock()
-	defer fake.saveUncheckedVersionMutex.Unlock()
-	fake.SaveUncheckedVersionStub = nil
-	if fake.saveUncheckedVersionReturnsOnCall == nil {
-		fake.saveUncheckedVersionReturnsOnCall = make(map[int]struct {
-			result1 bool
-			result2 error
-		})
-	}
-	fake.saveUncheckedVersionReturnsOnCall[i] = struct {
-		result1 bool
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeResource) SetPinComment(arg1 string) error {
 	fake.setPinCommentMutex.Lock()
 	ret, specificReturn := fake.setPinCommentReturnsOnCall[len(fake.setPinCommentArgsForCall)]
@@ -2864,8 +2784,6 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.resourceConfigIDMutex.RUnlock()
 	fake.resourceConfigScopeIDMutex.RLock()
 	defer fake.resourceConfigScopeIDMutex.RUnlock()
-	fake.saveUncheckedVersionMutex.RLock()
-	defer fake.saveUncheckedVersionMutex.RUnlock()
 	fake.setPinCommentMutex.RLock()
 	defer fake.setPinCommentMutex.RUnlock()
 	fake.setResourceConfigScopeMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_type.go
+++ b/atc/db/dbfakes/fake_resource_type.go
@@ -11,15 +11,15 @@ import (
 )
 
 type FakeResourceType struct {
-	CheckEveryStub        func() string
+	CheckEveryStub        func() *atc.CheckEvery
 	checkEveryMutex       sync.RWMutex
 	checkEveryArgsForCall []struct {
 	}
 	checkEveryReturns struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}
 	checkEveryReturnsOnCall map[int]struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}
 	CheckPlanStub        func(atc.Version, time.Duration, db.ResourceTypes, atc.Source) atc.CheckPlan
 	checkPlanMutex       sync.RWMutex
@@ -303,7 +303,7 @@ type FakeResourceType struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeResourceType) CheckEvery() string {
+func (fake *FakeResourceType) CheckEvery() *atc.CheckEvery {
 	fake.checkEveryMutex.Lock()
 	ret, specificReturn := fake.checkEveryReturnsOnCall[len(fake.checkEveryArgsForCall)]
 	fake.checkEveryArgsForCall = append(fake.checkEveryArgsForCall, struct {
@@ -326,32 +326,32 @@ func (fake *FakeResourceType) CheckEveryCallCount() int {
 	return len(fake.checkEveryArgsForCall)
 }
 
-func (fake *FakeResourceType) CheckEveryCalls(stub func() string) {
+func (fake *FakeResourceType) CheckEveryCalls(stub func() *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = stub
 }
 
-func (fake *FakeResourceType) CheckEveryReturns(result1 string) {
+func (fake *FakeResourceType) CheckEveryReturns(result1 *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = nil
 	fake.checkEveryReturns = struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}{result1}
 }
 
-func (fake *FakeResourceType) CheckEveryReturnsOnCall(i int, result1 string) {
+func (fake *FakeResourceType) CheckEveryReturnsOnCall(i int, result1 *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = nil
 	if fake.checkEveryReturnsOnCall == nil {
 		fake.checkEveryReturnsOnCall = make(map[int]struct {
-			result1 string
+			result1 *atc.CheckEvery
 		})
 	}
 	fake.checkEveryReturnsOnCall[i] = struct {
-		result1 string
+		result1 *atc.CheckEvery
 	}{result1}
 }
 

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -32,7 +32,7 @@ type Resource interface {
 	TeamName() string
 	Type() string
 	Source() atc.Source
-	CheckEvery() string
+	CheckEvery() *atc.CheckEvery
 	CheckTimeout() string
 	LastCheckStartTime() time.Time
 	LastCheckEndTime() time.Time
@@ -163,7 +163,7 @@ func (r *resource) TeamID() int                      { return r.teamID }
 func (r *resource) TeamName() string                 { return r.teamName }
 func (r *resource) Type() string                     { return r.type_ }
 func (r *resource) Source() atc.Source               { return r.config.Source }
-func (r *resource) CheckEvery() string               { return r.config.CheckEvery }
+func (r *resource) CheckEvery() *atc.CheckEvery      { return r.config.CheckEvery }
 func (r *resource) CheckTimeout() string             { return r.config.CheckTimeout }
 func (r *resource) LastCheckStartTime() time.Time    { return r.lastCheckStartTime }
 func (r *resource) LastCheckEndTime() time.Time      { return r.lastCheckEndTime }

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Resource", func() {
 						Name:         "some-resource-custom-check",
 						Type:         "git",
 						Source:       atc.Source{"some": "some-repository"},
-						CheckEvery:   "10ms",
+						CheckEvery:   &atc.CheckEvery{Interval: 10 * time.Millisecond},
 						CheckTimeout: "1m",
 					},
 				},
@@ -114,7 +114,7 @@ var _ = Describe("Resource", func() {
 				case "some-resource-custom-check":
 					Expect(r.Type()).To(Equal("git"))
 					Expect(r.Source()).To(Equal(atc.Source{"some": "some-repository"}))
-					Expect(r.CheckEvery()).To(Equal("10ms"))
+					Expect(r.CheckEvery().Interval.String()).To(Equal("10ms"))
 					Expect(r.CheckTimeout()).To(Equal("1m"))
 					Expect(r.HasWebhook()).To(BeFalse())
 				}

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -37,7 +37,7 @@ type ResourceType interface {
 	Defaults() atc.Source
 	Params() atc.Params
 	Tags() atc.Tags
-	CheckEvery() string
+	CheckEvery() *atc.CheckEvery
 	CheckTimeout() string
 	LastCheckStartTime() time.Time
 	LastCheckEndTime() time.Time
@@ -181,7 +181,7 @@ type resourceType struct {
 	params                atc.Params
 	tags                  atc.Tags
 	version               atc.Version
-	checkEvery            string
+	checkEvery            *atc.CheckEvery
 	lastCheckStartTime    time.Time
 	lastCheckEndTime      time.Time
 }
@@ -192,7 +192,7 @@ func (t *resourceType) TeamName() string              { return t.teamName }
 func (t *resourceType) Name() string                  { return t.name }
 func (t *resourceType) Type() string                  { return t.type_ }
 func (t *resourceType) Privileged() bool              { return t.privileged }
-func (t *resourceType) CheckEvery() string            { return t.checkEvery }
+func (t *resourceType) CheckEvery() *atc.CheckEvery   { return t.checkEvery }
 func (t *resourceType) CheckTimeout() string          { return "" }
 func (r *resourceType) LastCheckStartTime() time.Time { return r.lastCheckStartTime }
 func (r *resourceType) LastCheckEndTime() time.Time   { return r.lastCheckEndTime }

--- a/atc/db/resource_type_test.go
+++ b/atc/db/resource_type_test.go
@@ -49,7 +49,7 @@ var _ = Describe("ResourceType", func() {
 						Name:       "some-type-with-custom-check",
 						Type:       "registry-image",
 						Source:     atc.Source{"some": "repository"},
-						CheckEvery: "10ms",
+						CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
 					},
 				},
 			},
@@ -103,7 +103,7 @@ var _ = Describe("ResourceType", func() {
 					Expect(t.Source()).To(Equal(atc.Source{"some": "repository"}))
 					Expect(t.Defaults()).To(BeNil())
 					Expect(t.Version()).To(BeNil())
-					Expect(t.CheckEvery()).To(Equal("10ms"))
+					Expect(t.CheckEvery().Interval.String()).To(Equal("10ms"))
 				}
 			}
 
@@ -163,7 +163,7 @@ var _ = Describe("ResourceType", func() {
 								Name:       "some-name",
 								Type:       "some-custom-type",
 								Source:     atc.Source{"some": "repository"},
-								CheckEvery: "10ms",
+								CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
 							},
 						},
 					},
@@ -202,7 +202,7 @@ var _ = Describe("ResourceType", func() {
 								Name:       "some-custom-type",
 								Type:       "some-different-foo-type",
 								Source:     atc.Source{"some": "repository"},
-								CheckEvery: "10ms",
+								CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
 							},
 						},
 					},
@@ -245,19 +245,19 @@ var _ = Describe("ResourceType", func() {
 								Name:       "some-type-with-custom-check",
 								Type:       "registry-image",
 								Source:     atc.Source{"some": "repository"},
-								CheckEvery: "10ms",
+								CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
 							},
 							{
 								Name:       "some-custom-type",
 								Type:       "some-other-foo-type",
 								Source:     atc.Source{"some": "repository"},
-								CheckEvery: "10ms",
+								CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
 							},
 							{
 								Name:       "some-other-foo-type",
 								Type:       "some-other-type",
 								Source:     atc.Source{"some": "repository"},
-								CheckEvery: "10ms",
+								CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
 							},
 						},
 					},
@@ -332,7 +332,7 @@ var _ = Describe("ResourceType", func() {
 							Name:       "some-type-with-custom-check",
 							Type:       "registry-image",
 							Source:     atc.Source{"some": "repository"},
-							CheckEvery: "10ms",
+							CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
 						},
 					}))
 				})
@@ -384,7 +384,7 @@ var _ = Describe("ResourceType", func() {
 							Name:       "some-type-with-custom-check",
 							Type:       "registry-image",
 							Source:     atc.Source{"some": "repository"},
-							CheckEvery: "10ms",
+							CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
 						},
 					}))
 				})

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -58,9 +58,13 @@ func (s *scanner) Run(ctx context.Context) error {
 			}()
 			defer waitGroup.Done()
 
-			if resource.CheckEvery() != "never" {
-				s.check(spanCtx, resource, resourceTypes, resourceTypesChecked)
+			if checkEvery := resource.CheckEvery(); checkEvery != nil {
+				if checkEvery.Never {
+					return
+				}
 			}
+
+			s.check(spanCtx, resource, resourceTypes, resourceTypesChecked)
 		}(resource, resourceTypes)
 	}
 

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -58,7 +58,9 @@ func (s *scanner) Run(ctx context.Context) error {
 			}()
 			defer waitGroup.Done()
 
-			s.check(spanCtx, resource, resourceTypes, resourceTypesChecked)
+			if resource.CheckEvery() != "never" {
+				s.check(spanCtx, resource, resourceTypes, resourceTypesChecked)
+			}
 		}(resource, resourceTypes)
 	}
 

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -58,10 +58,8 @@ func (s *scanner) Run(ctx context.Context) error {
 			}()
 			defer waitGroup.Done()
 
-			if checkEvery := resource.CheckEvery(); checkEvery != nil {
-				if checkEvery.Never {
-					return
-				}
+			if resource.CheckEvery() != nil && resource.CheckEvery().Never {
+				return
 			}
 
 			s.check(spanCtx, resource, resourceTypes, resourceTypesChecked)

--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Scanner", func() {
 
 			Context("when CheckEvery is never", func() {
 				BeforeEach(func() {
-					fakeResource.CheckEveryReturns("never")
+					fakeResource.CheckEveryReturns(&atc.CheckEvery{Never: true})
 				})
 
 				It("does not check", func() {

--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -69,6 +69,16 @@ var _ = Describe("Scanner", func() {
 				})
 			})
 
+			Context("when CheckEvery is never", func() {
+				BeforeEach(func() {
+					fakeResource.CheckEveryReturns("never")
+				})
+
+				It("does not check", func() {
+					Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(0))
+				})
+			})
+
 			Context("when fetching resources types succeeds", func() {
 				var fakeResourceType *dbfakes.FakeResourceType
 


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

## Changes proposed by this PR:
This PR allows a user to disable automatic checking of a resource by setting `check_every: never` in a resource's definition. We've seen this request come up when people only want checking to happen via a webhook. The workaround has always been setting `check_every` to some large value like `99h`. 

## Notes to reviewer:
Lidar runs every ~10s. I tested using this pipeline:
```yaml
---
resources:
  - name: every-30s
    type: time
    check_every: never
    icon: clock-outline
    source:
      interval: 1s

jobs:
  - name: job
    public: true
    plan:
      - get: every-30s
        trigger: true
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: registry-image
            source: { repository: busybox }
          run:
            path: echo
            args: ["Hello, world!"]
```

## Release Note
* Automatic resource checking for individual resources can be disabled by setting `check_every: never` in a resource's definition

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
