### PR TITLE
Deterministic ordering of `?vars` params for instanced pipelines API

### DIFF
--- a/atc/pipeline.go
+++ b/atc/pipeline.go
@@ -122,6 +122,12 @@ func InstanceVarsFromQueryParams(q url.Values) (InstanceVars, error) {
 	if len(kvPairs) == 0 {
 		return nil, nil
 	}
+	// Need to sort kv-pairs so that you can specify ?vars={...} along with
+	// patches (...&vars.foo=123) and not have the patches occasionally
+	// truncated (due to non-deterministic map iteration)
+	sort.Slice(kvPairs, func(i, j int) bool {
+		return kvPairs[i].Ref.String() < kvPairs[j].Ref.String()
+	})
 	instanceVars, _ := kvPairs.Expand()["vars"].(map[string]interface{})
 	return InstanceVars(instanceVars), nil
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation
(unreleased)

when parsing the key-value pairs for pipeline instances from API
requests.

this is unlikely to matter, since internally, we only use the query
params in two ways:

* ?vars={...full JSON...}
* ?vars.foo=123&vars.bar.baz="def" (i.e. every var in non-overlapping)

initially I figured we could just use the order that the query params
were specified in, but since `url.Values` is a `map`, iteration order is
non-deterministic. while we *could* use `url.RawQuery` and parse it
ourselves to maintain the order, this didn't seem worthwhile

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Sort key-value pairs so that result is deterministic

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
