### PR TITLE
Fix build finished metric for prometheus

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -315,13 +315,14 @@ func (b *build) LagerData() lager.Data {
 	return data
 }
 
-// TracingAttrs returns attributes which are to be emitted in spans and
-// metrics pertaining to the build.
+// TracingAttrs returns attributes which are to be emitted in spans and metrics
+// pertaining to the build. Metrics emitters may depend on specific attribute
+// names being set.
 func (b *build) TracingAttrs() tracing.Attrs {
 	data := tracing.Attrs{
-		"build_id": strconv.Itoa(b.id),
-		"build":    b.name,
-		"team":     b.teamName,
+		"build_id":  strconv.Itoa(b.id),
+		"build":     b.name,
+		"team_name": b.teamName,
 	}
 
 	if b.pipelineID != 0 {

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -235,9 +235,9 @@ var _ = Describe("Build", func() {
 
 			It("includes build and team info", func() {
 				Expect(attrs).To(Equal(tracing.Attrs{
-					"build_id": strconv.Itoa(build.ID()),
-					"build":    build.Name(),
-					"team":     team.Name(),
+					"build_id":  strconv.Itoa(build.ID()),
+					"build":     build.Name(),
+					"team_name": team.Name(),
 				}))
 			})
 		})
@@ -251,11 +251,11 @@ var _ = Describe("Build", func() {
 
 			It("includes build, team, pipeline, and job info", func() {
 				Expect(attrs).To(Equal(tracing.Attrs{
-					"build_id": strconv.Itoa(build.ID()),
-					"build":    build.Name(),
-					"team":     build.TeamName(),
-					"pipeline": build.PipelineName(),
-					"job":      defaultJob.Name(),
+					"build_id":  strconv.Itoa(build.ID()),
+					"build":     build.Name(),
+					"team_name": build.TeamName(),
+					"pipeline":  build.PipelineName(),
+					"job":       defaultJob.Name(),
 				}))
 			})
 		})
@@ -271,11 +271,11 @@ var _ = Describe("Build", func() {
 
 			It("includes build, team, and pipeline", func() {
 				Expect(attrs).To(Equal(tracing.Attrs{
-					"build_id": strconv.Itoa(build.ID()),
-					"build":    build.Name(),
-					"team":     build.TeamName(),
-					"pipeline": build.PipelineName(),
-					"resource": defaultResource.Name(),
+					"build_id":  strconv.Itoa(build.ID()),
+					"build":     build.Name(),
+					"team_name": build.TeamName(),
+					"pipeline":  build.PipelineName(),
+					"resource":  defaultResource.Name(),
 				}))
 			})
 		})
@@ -293,7 +293,7 @@ var _ = Describe("Build", func() {
 				Expect(attrs).To(Equal(tracing.Attrs{
 					"build_id":      strconv.Itoa(build.ID()),
 					"build":         build.Name(),
-					"team":          build.TeamName(),
+					"team_name":     build.TeamName(),
 					"pipeline":      build.PipelineName(),
 					"resource_type": defaultResourceType.Name(),
 				}))


### PR DESCRIPTION
## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #6343 .

the prometheus emitter relied on a specific attribute name being set
("team_name"), but we had renamed it to "team" which broke the metric.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Rename `team` attribute to `team_name`

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

* this was broken in checks-as-builds, so doesn't affect any released version
* this changes the attribute name for traces as well - since it's experimental we figured it wouldn't be too big a problem 🤷 

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
