### PR TITLE
Backport #6336 to 6.7.x

### DIFF
--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -2,11 +2,10 @@ package setpipelinehelpers
 
 import (
 	"fmt"
+	"github.com/vito/go-interact/interact"
 	"net/url"
 	"os"
 	"sigs.k8s.io/yaml"
-
-	"github.com/vito/go-interact/interact"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/configvalidate"
@@ -25,6 +24,7 @@ type ATCConfig struct {
 	SkipInteraction  bool
 	CheckCredentials bool
 	CommandWarnings  []concourse.ConfigWarning
+	GivenTeamName    string
 }
 
 func (atcConfig ATCConfig) ApplyConfigInteraction() bool {
@@ -108,7 +108,11 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 }
 
 func (atcConfig ATCConfig) UnpausePipelineCommand() string {
-	return fmt.Sprintf("%s -t %s unpause-pipeline -p %s", os.Args[0], atcConfig.TargetName, atcConfig.PipelineName)
+	cmd := fmt.Sprintf("%s -t %s unpause-pipeline -p %s", os.Args[0], atcConfig.TargetName, atcConfig.PipelineName)
+	if atcConfig.GivenTeamName != "" {
+		cmd = fmt.Sprintf("%s --team %s", cmd, atcConfig.GivenTeamName)
+	}
+	return cmd
 }
 
 func (atcConfig ATCConfig) showPipelineUpdateResult(created bool, updated bool, paused bool) {

--- a/fly/commands/internal/setpipelinehelpers/atc_config_test.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config_test.go
@@ -37,4 +37,16 @@ var _ = Describe("UnpausePipelineCommand", func() {
 		expected := fmt.Sprintf("%s -t my-target unpause-pipeline -p my-pipeline", os.Args[0])
 		Expect(atcConfig.UnpausePipelineCommand()).To(Equal(expected))
 	})
+
+	Context("when given a different team name", func() {
+		It("adds --team option", func() {
+			atcConfig := ATCConfig{
+				TargetName: "my-target",
+				PipelineName: "my-pipeline",
+				GivenTeamName: "other-team",
+			}
+			expected := fmt.Sprintf(`%s -t my-target unpause-pipeline -p my-pipeline --team other-team`, os.Args[0])
+			Expect(atcConfig.UnpausePipelineCommand()).To(Equal(expected))
+		})
+	})
 })

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -80,6 +80,7 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 		SkipInteraction:  command.SkipInteractive || command.Config.FromStdin(),
 		CheckCredentials: command.CheckCredentials,
 		CommandWarnings:  warnings,
+		GivenTeamName:    command.Team,
 	}
 
 	yamlTemplateWithParams := templatehelpers.NewYamlTemplateWithParams(configPath, templateVariablesFiles, command.Var, command.YAMLVar)


### PR DESCRIPTION
Bug Fix

## Changes proposed by this PR:

Just backport of #6336.

## Notes to reviewer:

NA

## Release Note

Fixed a bug of `fly set-pipeline` where `--team` option was missing in the prompted unpause pipeline command.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
