### PR TITLE
Ensure task, set_pipeline, load_var steps have names

### DIFF
--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -407,7 +407,7 @@ var _ = Describe("Config API", func() {
 						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"errors": [
-										"identifier cannot be an empty string"
+										"pipeline: identifier cannot be an empty string"
 								]
 							}`))
 					})

--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -353,25 +353,25 @@ var _ = Describe("Config API", func() {
 			})
 
 			Context("when an identifier is invalid", func() {
+				Context("and is a string", func() {
+					BeforeEach(func() {
+						var err error
+						request, err = requestGenerator.CreateRequest(atc.SaveConfig, rata.Params{
+							"team_name":     "_team",
+							"pipeline_name": "_pipeline",
+						}, nil)
+						Expect(err).NotTo(HaveOccurred())
 
-				BeforeEach(func() {
-					var err error
-					request, err = requestGenerator.CreateRequest(atc.SaveConfig, rata.Params{
-						"team_name":     "_team",
-						"pipeline_name": "_pipeline",
-					}, nil)
-					Expect(err).NotTo(HaveOccurred())
+						request.Header.Set("Content-Type", "application/json")
 
-					request.Header.Set("Content-Type", "application/json")
+						payload, err := json.Marshal(pipelineConfig)
+						Expect(err).NotTo(HaveOccurred())
 
-					payload, err := json.Marshal(pipelineConfig)
-					Expect(err).NotTo(HaveOccurred())
+						request.Body = gbytes.BufferWithBytes(payload)
+					})
 
-					request.Body = gbytes.BufferWithBytes(payload)
-				})
-
-				It("returns warnings in the response body", func() {
-					Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+					It("returns warnings in the response body", func() {
+						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"warnings": [
 									{
@@ -384,7 +384,35 @@ var _ = Describe("Config API", func() {
 									}
 								]
 							}`))
+					})
 				})
+				Context("and is an empty string", func() {
+					BeforeEach(func() {
+						var err error
+						request, err = requestGenerator.CreateRequest(atc.SaveConfig, rata.Params{
+							"team_name":     "",
+							"pipeline_name": "",
+						}, nil)
+						Expect(err).NotTo(HaveOccurred())
+
+						request.Header.Set("Content-Type", "application/json")
+
+						payload, err := json.Marshal(pipelineConfig)
+						Expect(err).NotTo(HaveOccurred())
+
+						request.Body = gbytes.BufferWithBytes(payload)
+					})
+
+					It("returns warnings in the response body", func() {
+						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							{
+								"errors": [
+										"identifier cannot be an empty string"
+								]
+							}`))
+					})
+				})
+
 			})
 
 			Context("when a config version is specified", func() {

--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -71,7 +71,7 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	pipelineName := rata.Param(r, "pipeline_name")
 	warning, err := atc.ValidateIdentifier(pipelineName, "pipeline")
 	if err != nil {
-		session.Info("ignoring-invalid-config", lager.Data{"error": err.Error()})
+		session.Info("ignoring-pipeline-name", lager.Data{"error": err.Error()})
 		s.handleBadRequest(w, err.Error())
 		return
 	}
@@ -82,7 +82,7 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	teamName := rata.Param(r, "team_name")
 	warning, err = atc.ValidateIdentifier(teamName, "team")
 	if err != nil {
-		session.Info("ignoring-invalid-config", lager.Data{"error": err.Error()})
+		session.Info("ignoring-team-name", lager.Data{"error": err.Error()})
 		s.handleBadRequest(w, err.Error())
 		return
 	}

--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -69,19 +69,28 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pipelineName := rata.Param(r, "pipeline_name")
-	warning := atc.ValidateIdentifier(pipelineName, "pipeline")
+	warning, err := atc.ValidateIdentifier(pipelineName, "pipeline")
+	if err != nil {
+		session.Info("ignoring-invalid-config", lager.Data{"error": err.Error()})
+		s.handleBadRequest(w, err.Error())
+		return
+	}
 	if warning != nil {
 		warnings = append(warnings, *warning)
 	}
 
 	teamName := rata.Param(r, "team_name")
-	warning = atc.ValidateIdentifier(teamName, "team")
+	warning, err = atc.ValidateIdentifier(teamName, "team")
+	if err != nil {
+		session.Info("ignoring-invalid-config", lager.Data{"error": err.Error()})
+		s.handleBadRequest(w, err.Error())
+		return
+	}
 	if warning != nil {
 		warnings = append(warnings, *warning)
 	}
 
 	pipelineRef := atc.PipelineRef{Name: pipelineName}
-	var err error
 	pipelineRef.InstanceVars, err = atc.InstanceVarsFromQueryParams(r.URL.Query())
 	if atc.EnablePipelineInstances {
 		if err != nil {

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1614,12 +1614,13 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				Context("when the new name is an invalid identifier", func() {
-					BeforeEach(func() {
-						requestBody = `{"name":"_some-new-name"}`
-					})
+					Context("and is a string", func() {
+						BeforeEach(func() {
+							requestBody = `{"name":"_some-new-name"}`
+						})
 
-					It("returns a warning in the response body", func() {
-						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+						It("returns a warning in the response body", func() {
+							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"warnings": [
 									{
@@ -1628,6 +1629,21 @@ var _ = Describe("Pipelines API", func() {
 									}
 								]
 							}`))
+						})
+					})
+					Context("and is an empty string", func() {
+						BeforeEach(func() {
+							requestBody = `{"name":""}`
+						})
+
+						It("returns a warning in the response body", func() {
+							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							{
+								"errors": [
+										"identifier cannot be an empty string"
+								]
+							}`))
+						})
 					})
 				})
 			})

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1640,7 +1640,7 @@ var _ = Describe("Pipelines API", func() {
 							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"errors": [
-										"identifier cannot be an empty string"
+										"pipeline: identifier cannot be an empty string"
 								]
 							}`))
 						})

--- a/atc/api/pipelineserver/rename.go
+++ b/atc/api/pipelineserver/rename.go
@@ -30,7 +30,11 @@ func (s *Server) RenamePipeline(team db.Team) http.Handler {
 		}
 
 		var warnings []atc.ConfigWarning
-		warning := atc.ValidateIdentifier(rename.NewName, "pipeline")
+		var errs []string
+		warning, err := atc.ValidateIdentifier(rename.NewName, "pipeline")
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
 		}
@@ -49,7 +53,7 @@ func (s *Server) RenamePipeline(team db.Team) http.Handler {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		err = json.NewEncoder(w).Encode(atc.SaveConfigResponse{Warnings: warnings})
+		err = json.NewEncoder(w).Encode(atc.SaveConfigResponse{Warnings: warnings, Errors: errs})
 		if err != nil {
 			logger.Error("failed-to-encode-response", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -564,22 +564,37 @@ var _ = Describe("Teams API", func() {
 					Expect(response.StatusCode).To(Equal(http.StatusOK))
 				})
 
-				Context("when a warning occurs", func() {
+				Context("when the new name is an invalid identifier", func() {
+					Context("and is a string", func() {
+						BeforeEach(func() {
+							requestBody = `{"name":"_some-new-name"}`
+						})
 
-					BeforeEach(func() {
-						requestBody = `{"name":"_some-new-name"}`
-					})
-
-					It("returns a warning in the response body", func() {
-						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+						It("returns a warning in the response body", func() {
+							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"warnings": [
-								{
-									"type": "invalid_identifier",
-									"message": "team: '_some-new-name' is not a valid identifier: must start with a lowercase letter"
-								}
+									{
+										"type": "invalid_identifier",
+										"message": "team: '_some-new-name' is not a valid identifier: must start with a lowercase letter"
+									}
 								]
 							}`))
+						})
+					})
+					Context("and is an empty string", func() {
+						BeforeEach(func() {
+							requestBody = `{"name":""}`
+						})
+
+						It("returns a warning in the response body", func() {
+							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							{
+								"errors": [
+										"identifier cannot be an empty string"
+								]
+							}`))
+						})
 					})
 				})
 			})

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -591,7 +591,7 @@ var _ = Describe("Teams API", func() {
 							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"errors": [
-										"identifier cannot be an empty string"
+										"team: identifier cannot be an empty string"
 								]
 							}`))
 						})

--- a/atc/api/teamserver/rename.go
+++ b/atc/api/teamserver/rename.go
@@ -29,7 +29,11 @@ func (s *Server) RenameTeam(team db.Team) http.Handler {
 		}
 
 		var warnings []atc.ConfigWarning
-		warning := atc.ValidateIdentifier(rename.NewName, "team")
+		var errs []string
+		warning, err := atc.ValidateIdentifier(rename.NewName, "team")
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
 		}
@@ -42,7 +46,7 @@ func (s *Server) RenameTeam(team db.Team) http.Handler {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		err = json.NewEncoder(w).Encode(atc.SaveConfigResponse{Warnings: warnings})
+		err = json.NewEncoder(w).Encode(atc.SaveConfigResponse{Warnings: warnings, Errors: errs})
 		if err != nil {
 			s.logger.Error("failed-to-encode-response", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/teamserver/set.go
+++ b/atc/api/teamserver/set.go
@@ -64,7 +64,10 @@ func (s *Server) SetTeam(w http.ResponseWriter, r *http.Request) {
 	} else if acc.IsAdmin() {
 		hLog.Debug("creating team")
 
-		warning := atc.ValidateIdentifier(atcTeam.Name, "team")
+		warning, err := atc.ValidateIdentifier(atcTeam.Name, "team")
+		if err != nil {
+			response.Errors = append(response.Errors, err.Error())
+		}
 		if warning != nil {
 			response.Warnings = append(response.Warnings, *warning)
 		}

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -85,7 +85,11 @@ func validateGroups(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("groups.%s", group.Name)
 		}
 
-		warning := ValidateIdentifier(group.Name, identifier)
+		warning, err := ValidateIdentifier(group.Name, identifier)
+		if err != nil {
+			errorMessages = append(errorMessages,
+				fmt.Sprintf("%s: %s", identifier, err.Error()))
+		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
 		}
@@ -158,7 +162,11 @@ func validateResources(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("resources.%s", resource.Name)
 		}
 
-		warning := ValidateIdentifier(resource.Name, identifier)
+		warning, err := ValidateIdentifier(resource.Name, identifier)
+		if err != nil {
+			errorMessages = append(errorMessages,
+				fmt.Sprintf("%s: %s", identifier, err.Error()))
+		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
 		}
@@ -200,7 +208,11 @@ func validateResourceTypes(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("resource_types.%s", resourceType.Name)
 		}
 
-		warning := ValidateIdentifier(resourceType.Name, identifier)
+		warning, err := ValidateIdentifier(resourceType.Name, identifier)
+		if err != nil {
+			errorMessages = append(errorMessages,
+				fmt.Sprintf("%s: %s", identifier, err.Error()))
+		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
 		}
@@ -278,7 +290,11 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("jobs.%s", job.Name)
 		}
 
-		warning := ValidateIdentifier(job.Name, identifier)
+		warning, err := ValidateIdentifier(job.Name, identifier)
+		if err != nil {
+			errorMessages = append(errorMessages,
+				fmt.Sprintf("%s: %s", identifier, err.Error()))
+		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
 		}
@@ -371,7 +387,11 @@ func validateVarSources(c Config) ([]ConfigWarning, error) {
 			identifier = fmt.Sprintf("var_sources.%s", cm.Name)
 		}
 
-		warning := ValidateIdentifier(cm.Name, identifier)
+		warning, err := ValidateIdentifier(cm.Name, identifier)
+		if err != nil {
+			errorMessages = append(errorMessages,
+				fmt.Sprintf("%s: %s", identifier, err.Error()))
+		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
 		}

--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -87,8 +87,7 @@ func validateGroups(c Config) ([]ConfigWarning, error) {
 
 		warning, err := ValidateIdentifier(group.Name, identifier)
 		if err != nil {
-			errorMessages = append(errorMessages,
-				fmt.Sprintf("%s: %s", identifier, err.Error()))
+			errorMessages = append(errorMessages, err.Error())
 		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
@@ -164,8 +163,7 @@ func validateResources(c Config) ([]ConfigWarning, error) {
 
 		warning, err := ValidateIdentifier(resource.Name, identifier)
 		if err != nil {
-			errorMessages = append(errorMessages,
-				fmt.Sprintf("%s: %s", identifier, err.Error()))
+			errorMessages = append(errorMessages, err.Error())
 		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
@@ -210,8 +208,7 @@ func validateResourceTypes(c Config) ([]ConfigWarning, error) {
 
 		warning, err := ValidateIdentifier(resourceType.Name, identifier)
 		if err != nil {
-			errorMessages = append(errorMessages,
-				fmt.Sprintf("%s: %s", identifier, err.Error()))
+			errorMessages = append(errorMessages, err.Error())
 		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
@@ -292,8 +289,7 @@ func validateJobs(c Config) ([]ConfigWarning, error) {
 
 		warning, err := ValidateIdentifier(job.Name, identifier)
 		if err != nil {
-			errorMessages = append(errorMessages,
-				fmt.Sprintf("%s: %s", identifier, err.Error()))
+			errorMessages = append(errorMessages, err.Error())
 		}
 		if warning != nil {
 			warnings = append(warnings, *warning)
@@ -389,8 +385,7 @@ func validateVarSources(c Config) ([]ConfigWarning, error) {
 
 		warning, err := ValidateIdentifier(cm.Name, identifier)
 		if err != nil {
-			errorMessages = append(errorMessages,
-				fmt.Sprintf("%s: %s", identifier, err.Error()))
+			errorMessages = append(errorMessages, err.Error())
 		}
 		if warning != nil {
 			warnings = append(warnings, *warning)

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -951,7 +951,7 @@ var _ = Describe("ValidateConfig", func() {
 					Expect(errorMessages).To(HaveLen(1))
 					Expect(errorMessages[0]).To(ContainSubstring("invalid jobs:"))
 					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].task(): must specify either `file:` or `config:`"))
-					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].task(): identifier required"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].task(): identifier cannot be an empty string"))
 				})
 			})
 
@@ -1653,7 +1653,7 @@ var _ = Describe("ValidateConfig", func() {
 				It("does return an error", func() {
 					Expect(errorMessages).To(HaveLen(1))
 					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].set_pipeline(): no file specified"))
-					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].set_pipeline(): pipeline name required"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].set_pipeline(): identifier cannot be an empty string"))
 				})
 			})
 
@@ -1752,7 +1752,7 @@ var _ = Describe("ValidateConfig", func() {
 				})
 			})
 
-			Context("when a load_var has name or file defined", func() {
+			Context("when a load_var has no name or file defined", func() {
 				BeforeEach(func() {
 					job.PlanSequence = append(job.PlanSequence, atc.Step{
 						Config: &atc.LoadVarStep{},
@@ -1764,7 +1764,7 @@ var _ = Describe("ValidateConfig", func() {
 				It("returns an error", func() {
 					Expect(errorMessages).To(HaveLen(1))
 					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].load_var(): no file specified"))
-					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].load_var(): identifier required"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].load_var(): identifier cannot be an empty string"))
 				})
 			})
 

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -938,12 +938,10 @@ var _ = Describe("ValidateConfig", func() {
 		})
 
 		Describe("plans", func() {
-			Context("when a task plan has neither a config or a path set", func() {
+			Context("when a task plan has neither a config, path, or name set set", func() {
 				BeforeEach(func() {
 					job.PlanSequence = append(job.PlanSequence, atc.Step{
-						Config: &atc.TaskStep{
-							Name: "lol",
-						},
+						Config: &atc.TaskStep{},
 					})
 
 					config.Jobs = append(config.Jobs, job)
@@ -952,7 +950,8 @@ var _ = Describe("ValidateConfig", func() {
 				It("returns an error", func() {
 					Expect(errorMessages).To(HaveLen(1))
 					Expect(errorMessages[0]).To(ContainSubstring("invalid jobs:"))
-					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].task(lol): must specify either `file:` or `config:`"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].task(): must specify either `file:` or `config:`"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].task(): identifier required"))
 				})
 			})
 
@@ -1642,12 +1641,10 @@ var _ = Describe("ValidateConfig", func() {
 				})
 			})
 
-			Context("when a set_pipeline step has no file configured", func() {
+			Context("when a set_pipeline step has no name or file configured", func() {
 				BeforeEach(func() {
 					job.PlanSequence = append(job.PlanSequence, atc.Step{
-						Config: &atc.SetPipelineStep{
-							Name: "other-pipeline",
-						},
+						Config: &atc.SetPipelineStep{},
 					})
 
 					config.Jobs = append(config.Jobs, job)
@@ -1655,7 +1652,8 @@ var _ = Describe("ValidateConfig", func() {
 
 				It("does return an error", func() {
 					Expect(errorMessages).To(HaveLen(1))
-					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].set_pipeline(other-pipeline): no file specified"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].set_pipeline(): no file specified"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].set_pipeline(): pipeline name required"))
 				})
 			})
 
@@ -1754,12 +1752,10 @@ var _ = Describe("ValidateConfig", func() {
 				})
 			})
 
-			Context("when a load_var has not defined 'File'", func() {
+			Context("when a load_var has name or file defined", func() {
 				BeforeEach(func() {
 					job.PlanSequence = append(job.PlanSequence, atc.Step{
-						Config: &atc.LoadVarStep{
-							Name: "a-var",
-						},
+						Config: &atc.LoadVarStep{},
 					})
 
 					config.Jobs = append(config.Jobs, job)
@@ -1767,7 +1763,8 @@ var _ = Describe("ValidateConfig", func() {
 
 				It("returns an error", func() {
 					Expect(errorMessages).To(HaveLen(1))
-					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].load_var(a-var): no file specified"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].load_var(): no file specified"))
+					Expect(errorMessages[0]).To(ContainSubstring("jobs.some-other-job.plan.do[0].load_var(): identifier required"))
 				})
 			})
 

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -1,7 +1,6 @@
 package atc
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -17,12 +16,11 @@ var startsWithLetter = regexp.MustCompile(`^[^\p{Ll}\p{Lt}\p{Lm}\p{Lo}]`)
 var invalidCharacter = regexp.MustCompile(`([^\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-_.])`)
 
 func ValidateIdentifier(identifier string, context ...string) (*ConfigWarning, error) {
-	var err error
 	if identifier == "" {
-		return nil, errors.New("identifier cannot be an empty string")
+		return nil, fmt.Errorf("%s: identifier cannot be an empty string", strings.Join(context, ""))
 	}
 
-	if identifier != "" && !validIdentifiers.MatchString(identifier) {
+	if !validIdentifiers.MatchString(identifier) {
 		var reason string
 		if startsWithLetter.MatchString(identifier) {
 			reason = "must start with a lowercase letter"
@@ -32,7 +30,7 @@ func ValidateIdentifier(identifier string, context ...string) (*ConfigWarning, e
 		return &ConfigWarning{
 			Type:    "invalid_identifier",
 			Message: fmt.Sprintf("%s: %s", strings.Join(context, ""), fmt.Sprintf("'%s' is not a valid identifier: %s", identifier, reason)),
-		}, err
+		}, nil
 	}
-	return nil, err
+	return nil, nil
 }

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -1,6 +1,7 @@
 package atc
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -15,7 +16,12 @@ var validIdentifiers = regexp.MustCompile(`^[\p{Ll}\p{Lt}\p{Lm}\p{Lo}][\p{Ll}\p{
 var startsWithLetter = regexp.MustCompile(`^[^\p{Ll}\p{Lt}\p{Lm}\p{Lo}]`)
 var invalidCharacter = regexp.MustCompile(`([^\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-_.])`)
 
-func ValidateIdentifier(identifier string, context ...string) *ConfigWarning {
+func ValidateIdentifier(identifier string, context ...string) (*ConfigWarning, error) {
+	var err error
+	if identifier == "" {
+		return nil, errors.New("identifier cannot be an empty string")
+	}
+
 	if identifier != "" && !validIdentifiers.MatchString(identifier) {
 		var reason string
 		if startsWithLetter.MatchString(identifier) {
@@ -26,7 +32,7 @@ func ValidateIdentifier(identifier string, context ...string) *ConfigWarning {
 		return &ConfigWarning{
 			Type:    "invalid_identifier",
 			Message: fmt.Sprintf("%s: %s", strings.Join(context, ""), fmt.Sprintf("'%s' is not a valid identifier: %s", identifier, reason)),
-		}
+		}, err
 	}
-	return nil
+	return nil, err
 }

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -11,8 +11,9 @@ var _ = Describe("ValidateIdentifier", func() {
 	type testCase struct {
 		description string
 		identifier  string
-		message     string
+		warningMsg  string
 		warning     bool
+		errorMsg    string
 	}
 
 	for _, test := range []testCase{
@@ -34,38 +35,43 @@ var _ = Describe("ValidateIdentifier", func() {
 		{
 			description: "starts with a number",
 			identifier:  "1something",
-			message:     "must start with a lowercase letter",
+			warningMsg:  "must start with a lowercase letter",
 			warning:     true,
 		},
 		{
 			description: "starts with hyphen",
 			identifier:  "-something",
-			message:     "must start with a lowercase letter",
+			warningMsg:  "must start with a lowercase letter",
 			warning:     true,
 		},
 		{
 			description: "starts with period",
 			identifier:  ".something",
-			message:     "must start with a lowercase letter",
+			warningMsg:  "must start with a lowercase letter",
 			warning:     true,
 		},
 		{
 			description: "starts with an uppercase letter",
 			identifier:  "Something",
-			message:     "must start with a lowercase letter",
+			warningMsg:  "must start with a lowercase letter",
 			warning:     true,
 		},
 		{
 			description: "contains a space",
 			identifier:  "some thing",
-			message:     "illegal character ' '",
+			warningMsg:  "illegal character ' '",
 			warning:     true,
 		},
 		{
 			description: "contains an uppercase letter",
 			identifier:  "someThing",
-			message:     "illegal character 'T'",
+			warningMsg:  "illegal character 'T'",
 			warning:     true,
+		},
+		{
+			description: "is an empty string",
+			identifier:  "",
+			errorMsg:    "identifier cannot be an empty string",
 		},
 	} {
 		test := test
@@ -78,12 +84,15 @@ var _ = Describe("ValidateIdentifier", func() {
 				it = "runs without warning"
 			}
 			It(it, func() {
-				warning := atc.ValidateIdentifier(test.identifier)
+				warning, err := atc.ValidateIdentifier(test.identifier)
 				if test.warning {
 					Expect(warning).NotTo(BeNil())
-					Expect(warning.Message).To(ContainSubstring(test.message))
+					Expect(warning.Message).To(ContainSubstring(test.warningMsg))
 				} else {
 					Expect(warning).To(BeNil())
+					if test.errorMsg != "" {
+						Expect(err).To(MatchError(test.errorMsg))
+					}
 				}
 			})
 		})
@@ -92,7 +101,7 @@ var _ = Describe("ValidateIdentifier", func() {
 	Describe("ValidateIdentifier with context", func() {
 		Context("when an identifier is invalid", func() {
 			It("returns an error with context", func() {
-				warning := atc.ValidateIdentifier("_something", "pipeline")
+				warning, _ := atc.ValidateIdentifier("_something", "pipeline")
 				Expect(warning).NotTo(BeNil())
 				Expect(warning.Message).To(ContainSubstring("'_something' is not a valid identifier"))
 			})

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -71,7 +71,7 @@ var _ = Describe("ValidateIdentifier", func() {
 		{
 			description: "is an empty string",
 			identifier:  "",
-			errorMsg:    "identifier cannot be an empty string",
+			errorMsg:    ": identifier cannot be an empty string",
 		},
 	} {
 		test := test

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -64,11 +64,10 @@ func (validator *StepValidator) VisitTask(plan *TaskStep) error {
 	validator.pushContext(fmt.Sprintf(".task(%s)", plan.Name))
 	defer validator.popContext()
 
-	if plan.Name == "" {
-		validator.recordError("identifier required")
+	warning, err := ValidateIdentifier(plan.Name, validator.context...)
+	if err != nil {
+		validator.recordError(err.Error())
 	}
-
-	warning := ValidateIdentifier(plan.Name, validator.context...)
 	if warning != nil {
 		validator.recordWarning(*warning)
 	}
@@ -111,7 +110,10 @@ func (validator *StepValidator) VisitGet(step *GetStep) error {
 	validator.pushContext(fmt.Sprintf(".get(%s)", step.Name))
 	defer validator.popContext()
 
-	warning := ValidateIdentifier(step.Name, validator.context...)
+	warning, err := ValidateIdentifier(step.Name, validator.context...)
+	if err != nil {
+		validator.recordError(err.Error())
+	}
 	if warning != nil {
 		validator.recordWarning(*warning)
 	}
@@ -169,7 +171,10 @@ func (validator *StepValidator) VisitPut(step *PutStep) error {
 	validator.pushContext(".put(%s)", step.Name)
 	defer validator.popContext()
 
-	warning := ValidateIdentifier(step.Name, validator.context...)
+	warning, err := ValidateIdentifier(step.Name, validator.context...)
+	if err != nil {
+		validator.recordError(err.Error())
+	}
 	if warning != nil {
 		validator.recordWarning(*warning)
 	}
@@ -188,11 +193,10 @@ func (validator *StepValidator) VisitSetPipeline(step *SetPipelineStep) error {
 	validator.pushContext(".set_pipeline(%s)", step.Name)
 	defer validator.popContext()
 
-	if step.Name == "" {
-		validator.recordError("pipeline name required")
+	warning, err := ValidateIdentifier(step.Name, validator.context...)
+	if err != nil {
+		validator.recordError(err.Error())
 	}
-
-	warning := ValidateIdentifier(step.Name, validator.context...)
 	if warning != nil {
 		validator.recordWarning(*warning)
 	}
@@ -208,11 +212,10 @@ func (validator *StepValidator) VisitLoadVar(step *LoadVarStep) error {
 	validator.pushContext(".load_var(%s)", step.Name)
 	defer validator.popContext()
 
-	if step.Name == "" {
-		validator.recordError("identifier required")
+	warning, err := ValidateIdentifier(step.Name, validator.context...)
+	if err != nil {
+		validator.recordError(err.Error())
 	}
-
-	warning := ValidateIdentifier(step.Name, validator.context...)
 	if warning != nil {
 		validator.recordWarning(*warning)
 	}

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -64,6 +64,10 @@ func (validator *StepValidator) VisitTask(plan *TaskStep) error {
 	validator.pushContext(fmt.Sprintf(".task(%s)", plan.Name))
 	defer validator.popContext()
 
+	if plan.Name == "" {
+		validator.recordError("identifier required")
+	}
+
 	warning := ValidateIdentifier(plan.Name, validator.context...)
 	if warning != nil {
 		validator.recordWarning(*warning)
@@ -184,6 +188,10 @@ func (validator *StepValidator) VisitSetPipeline(step *SetPipelineStep) error {
 	validator.pushContext(".set_pipeline(%s)", step.Name)
 	defer validator.popContext()
 
+	if step.Name == "" {
+		validator.recordError("pipeline name required")
+	}
+
 	warning := ValidateIdentifier(step.Name, validator.context...)
 	if warning != nil {
 		validator.recordWarning(*warning)
@@ -199,6 +207,10 @@ func (validator *StepValidator) VisitSetPipeline(step *SetPipelineStep) error {
 func (validator *StepValidator) VisitLoadVar(step *LoadVarStep) error {
 	validator.pushContext(".load_var(%s)", step.Name)
 	defer validator.popContext()
+
+	if step.Name == "" {
+		validator.recordError("identifier required")
+	}
 
 	warning := ValidateIdentifier(step.Name, validator.context...)
 	if warning != nil {

--- a/fly/commands/internal/flaghelpers/pipeline_flag.go
+++ b/fly/commands/internal/flaghelpers/pipeline_flag.go
@@ -26,7 +26,11 @@ func (flag *PipelineFlag) Validate() ([]concourse.ConfigWarning, error) {
 			return nil, errors.New("pipeline name cannot contain '/'")
 		}
 
-		if warning := atc.ValidateIdentifier(flag.Name, "pipeline"); warning != nil {
+		warning, err := atc.ValidateIdentifier(flag.Name, "pipeline")
+		if err != nil {
+			return nil, errors.New("pipeline name cannot contain '/'")
+		}
+		if warning != nil {
 			warnings = append(warnings, concourse.ConfigWarning{
 				Type:    warning.Type,
 				Message: warning.Message,

--- a/fly/commands/internal/flaghelpers/pipeline_flag.go
+++ b/fly/commands/internal/flaghelpers/pipeline_flag.go
@@ -28,7 +28,7 @@ func (flag *PipelineFlag) Validate() ([]concourse.ConfigWarning, error) {
 
 		warning, err := atc.ValidateIdentifier(flag.Name, "pipeline")
 		if err != nil {
-			return nil, errors.New("pipeline name cannot contain '/'")
+			return nil, err
 		}
 		if warning != nil {
 			warnings = append(warnings, concourse.ConfigWarning{

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -40,7 +40,8 @@ func (command *SetPipelineCommand) Validate() ([]concourse.ConfigWarning, error)
 		err = errors.New("pipeline name cannot contain '/'")
 	}
 	if command.Team != "" {
-		if warning := atc.ValidateIdentifier(command.Team, "team"); warning != nil {
+		var warning *atc.ConfigWarning
+		if warning, err = atc.ValidateIdentifier(command.Team, "team"); warning != nil {
 			warnings = append(warnings, concourse.ConfigWarning{
 				Type:    warning.Type,
 				Message: warning.Message,

--- a/fly/commands/set_team.go
+++ b/fly/commands/set_team.go
@@ -33,7 +33,11 @@ type SetTeamCommand struct {
 
 func (command *SetTeamCommand) Validate() ([]concourse.ConfigWarning, error) {
 	var warnings []concourse.ConfigWarning
-	if warning := atc.ValidateIdentifier(command.Team.Name(), "team"); warning != nil {
+	warning, err := atc.ValidateIdentifier(command.Team.Name(), "team")
+	if err != nil {
+		return nil, err
+	}
+	if warning != nil {
 		warnings = append(warnings, concourse.ConfigWarning{
 			Type:    warning.Type,
 			Message: warning.Message,


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

fixes #6405

## Changes proposed by this PR:
These steps should always have names provided. Our docs note that names
are required but our validation doesn't return an error for empty
strings on these steps.

Put and Get steps are safe from this because the validator checks that
their resources exist.

## Release Note

* Return an error when no identifier is provided for task, set_pipeline, and load_var steps

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

