### PR TITLE
WIP: mark streamed volume as cache

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -772,7 +772,7 @@ func (cmd *RunCommand) constructAPIMembers(
 	)
 
 	pool := worker.NewPool(workerProvider)
-	workerClient := worker.NewClient(pool, workerProvider, compressionLib, workerAvailabilityPollingInterval, workerStatusPublishInterval, cmd.FeatureFlags.EnableP2PVolumeStreaming, cmd.P2pVolumeStreamingTimeout)
+	workerClient := worker.NewClient(pool, workerProvider, compressionLib, workerAvailabilityPollingInterval, workerStatusPublishInterval, cmd.FeatureFlags.EnableP2PVolumeStreaming, cmd.P2pVolumeStreamingTimeout, dbResourceCacheFactory)
 
 	credsManagers := cmd.CredentialManagers
 	dbPipelineFactory := db.NewPipelineFactory(dbConn, lockFactory)
@@ -1031,6 +1031,7 @@ func (cmd *RunCommand) backendComponents(
 		workerStatusPublishInterval,
 		cmd.FeatureFlags.EnableP2PVolumeStreaming,
 		cmd.P2pVolumeStreamingTimeout,
+		dbResourceCacheFactory,
 	)
 
 	defaultLimits, err := cmd.parseDefaultLimits()

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -75,6 +75,7 @@ type Team interface {
 	FindCreatedContainerByHandle(string) (CreatedContainer, bool, error)
 	FindWorkerForContainer(handle string) (Worker, bool, error)
 	FindWorkerForVolume(handle string) (Worker, bool, error)
+	FindWorkersForResourceCache(rcId int) ([]Worker, error)
 
 	UpdateProviderAuth(auth atc.TeamAuth) error
 }
@@ -160,6 +161,18 @@ func (t *team) FindWorkerForContainer(handle string) (Worker, bool, error) {
 func (t *team) FindWorkerForVolume(handle string) (Worker, bool, error) {
 	return getWorker(t.conn, workersQuery.Join("volumes v ON v.worker_name = w.name").Where(sq.And{
 		sq.Eq{"v.handle": handle},
+	}))
+}
+
+func (t *team) FindWorkersForResourceCache(rcId int) ([]Worker, error) {
+	return getWorkers(
+		t.conn, workersQuery.
+			Join("volumes v ON v.worker_name = w.name").
+			Join("worker_resource_caches wrc ON v.worker_resource_cache_id = wrc.id").
+			Join("resource_caches rc ON rc.id = wrc.resource_cache_id").
+			Where(sq.And{
+				sq.Eq{"rc.id": rcId},
+				sq.Eq{"w.state": "running"},
 	}))
 }
 

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -1,13 +1,11 @@
 package exec
 
 import (
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagerctx"
 	"context"
 	"errors"
 	"fmt"
-	"io"
-
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagerctx"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
@@ -17,6 +15,7 @@ import (
 	"github.com/concourse/concourse/atc/worker"
 	"github.com/concourse/concourse/tracing"
 	"go.opentelemetry.io/otel/api/trace"
+	"io"
 )
 
 type ErrPipelineNotFound struct {
@@ -244,7 +243,7 @@ func (step *GetStep) run(ctx context.Context, state RunState, delegate GetDelega
 			getResult.GetArtifact,
 		)
 
-		if step.plan.Resource != "" {
+		if step.plan.Resource != "" && !getResult.FromCache {
 			delegate.UpdateVersion(logger, step.plan, getResult.VersionResult)
 		}
 

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -1,12 +1,10 @@
 package exec
 
 import (
-	"context"
-	"errors"
-	"io"
-
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
+	"context"
+	"errors"
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/db"
@@ -15,6 +13,7 @@ import (
 	"github.com/concourse/concourse/atc/worker"
 	"github.com/concourse/concourse/tracing"
 	"go.opentelemetry.io/otel/api/trace"
+	"io"
 )
 
 //go:generate counterfeiter . PutDelegateFactory

--- a/atc/worker/artifact_destination.go
+++ b/atc/worker/artifact_destination.go
@@ -18,4 +18,6 @@ type ArtifactDestination interface {
 	StreamIn(context.Context, string, baggageclaim.Encoding, io.Reader) error
 
 	GetStreamInP2pUrl(ctx context.Context, path string) (string, error)
+
+	Volume() Volume
 }

--- a/atc/worker/db_worker_provider.go
+++ b/atc/worker/db_worker_provider.go
@@ -171,6 +171,31 @@ func (provider *dbWorkerProvider) FindWorkerForVolume(
 	return worker, true, err
 }
 
+func (provider *dbWorkerProvider) FindWorkersForResourceCache(
+	logger lager.Logger,
+	teamID int,
+	rcId int,
+) ([]Worker, error) {
+	logger = logger.Session("worker-for-volume")
+	team := provider.dbTeamFactory.GetByID(teamID)
+
+	dbWorkers, err := team.FindWorkersForResourceCache(rcId)
+	if err != nil {
+		return nil, err
+	}
+
+	workers := []Worker{}
+	for _, dbWorker := range dbWorkers {
+		worker := provider.NewGardenWorker(logger, dbWorker, 0)
+		if !worker.IsVersionCompatible(logger, provider.workerVersion) {
+			continue
+		}
+		workers = append(workers, worker)
+	}
+
+	return workers, nil
+}
+
 func (provider *dbWorkerProvider) NewGardenWorker(logger lager.Logger, savedWorker db.Worker, buildContainersCount int) Worker {
 	gcf := gclient.NewGardenClientFactory(
 		provider.dbWorkerFactory,
@@ -216,3 +241,4 @@ func (provider *dbWorkerProvider) NewGardenWorker(logger lager.Logger, savedWork
 		buildContainersCount,
 	)
 }
+

--- a/atc/worker/fetch_source.go
+++ b/atc/worker/fetch_source.go
@@ -5,6 +5,8 @@ package worker
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
@@ -88,7 +90,7 @@ func (s *fetchSource) Find() (GetResult, Volume, bool, error) {
 
 	volume, found, err := s.worker.FindVolumeForResourceCache(s.logger, s.cache)
 	if err != nil {
-		sLog.Error("failed-to-find-initialized-on", err)
+		sLog.Error("EVAN-failed-to-find-initialized-on", err)
 		return result, nil, false, err
 	}
 
@@ -130,6 +132,8 @@ func (s *fetchSource) Find() (GetResult, Volume, bool, error) {
 // yet before creating it under the lock
 func (s *fetchSource) Create(ctx context.Context) (GetResult, Volume, error) {
 	sLog := s.logger.Session("create")
+
+	fmt.Fprintf(os.Stderr, "EVAN:fetchSource.Create, cache_id=%d\n", s.cache.ID())
 
 	findResult, volume, found, err := s.Find()
 	if err != nil {

--- a/atc/worker/image/image.go
+++ b/atc/worker/image/image.go
@@ -216,3 +216,7 @@ func (wad *artifactDestination) StreamIn(ctx context.Context, path string, encod
 func (wad *artifactDestination) GetStreamInP2pUrl(ctx context.Context, path string) (string, error) {
 	return wad.destination.GetStreamInP2pUrl(ctx, path)
 }
+
+func (wad *artifactDestination) Volume() worker.Volume {
+	return wad.destination
+}

--- a/atc/worker/image/image_factory.go
+++ b/atc/worker/image/image_factory.go
@@ -2,6 +2,8 @@ package image
 
 import (
 	"errors"
+	"fmt"
+	"os"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/worker"
@@ -23,6 +25,7 @@ func (f *imageFactory) GetImage(
 	teamID int,
 ) (worker.Image, error) {
 	if imageSpec.ImageArtifactSource != nil {
+		fmt.Fprintf(os.Stderr, "EVAN:imageFactory.GetImage go to imageProvidedByPreviousStep, imageSpec=%+v\n", imageSpec)
 		artifactVolume, existsOnWorker, err := imageSpec.ImageArtifactSource.ExistsOn(logger, worker)
 		if err != nil {
 			logger.Error("failed-to-check-if-volume-exists-on-worker", err)
@@ -30,6 +33,7 @@ func (f *imageFactory) GetImage(
 		}
 
 		if existsOnWorker {
+			fmt.Fprintf(os.Stderr, "EVAN:imageFactory.GetImage go to imageProvidedByPreviousStep, on same worker %s\n", artifactVolume.WorkerName())
 			return &imageProvidedByPreviousStepOnSameWorker{
 				artifactVolume: artifactVolume,
 				imageSpec:      imageSpec,
@@ -38,6 +42,7 @@ func (f *imageFactory) GetImage(
 			}, nil
 		}
 
+		fmt.Fprintf(os.Stderr, "EVAN:imageFactory.GetImage go to imageProvidedByPreviousStep, on different worker\n")
 		return &imageProvidedByPreviousStepOnDifferentWorker{
 			imageSpec:    imageSpec,
 			teamID:       teamID,
@@ -46,6 +51,7 @@ func (f *imageFactory) GetImage(
 	}
 
 	if imageSpec.ResourceType != "" {
+		fmt.Fprintf(os.Stderr, "EVAN:imageFactory.GetImage go to imageFromBaseResourceType, worker=%s resourceTypeName=%s\n", worker.Name(), imageSpec.ResourceType)
 		return &imageFromBaseResourceType{
 			worker:           worker,
 			resourceTypeName: imageSpec.ResourceType,

--- a/atc/worker/pool.go
+++ b/atc/worker/pool.go
@@ -34,6 +34,12 @@ type WorkerProvider interface {
 		owner db.ContainerOwner,
 	) ([]Worker, error)
 
+	FindWorkersForResourceCache(
+		logger lager.Logger,
+		teamID int,
+		rcId int,
+		) ([]Worker, error)
+
 	NewGardenWorker(
 		logger lager.Logger,
 		savedWorker db.Worker,
@@ -61,6 +67,12 @@ type Pool interface {
 		lager.Logger,
 		WorkerSpec,
 	) (Worker, error)
+
+	FindWorkersForResourceCache(
+		lager.Logger,
+		int,
+		int,
+		) ([]Worker, error)
 
 	ContainerInWorker(
 		lager.Logger,
@@ -205,4 +217,8 @@ func (pool *pool) FindOrChooseWorker(
 	}
 
 	return workers[rand.Intn(len(workers))], nil
+}
+
+func (pool *pool) FindWorkersForResourceCache(logger lager.Logger, teamId int, rcId int) ([]Worker, error) {
+	return pool.provider.FindWorkersForResourceCache(logger, teamId, rcId)
 }

--- a/atc/worker/volume.go
+++ b/atc/worker/volume.go
@@ -38,6 +38,8 @@ type Volume interface {
 
 	WorkerName() string
 	Destroy() error
+
+	Volume() Volume
 }
 
 type VolumeMount struct {
@@ -178,4 +180,8 @@ func (v *volume) InitializeTaskCache(
 
 func (v *volume) CreateChildForContainer(creatingContainer db.CreatingContainer, mountPath string) (db.CreatingVolume, error) {
 	return v.dbVolume.CreateChildForContainer(creatingContainer, mountPath)
+}
+
+func (v *volume) Volume() Volume {
+	return v
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
     - 8080:8080
     environment:
-      CONCOURSE_LOG_LEVEL: debug
+      CONCOURSE_LOG_LEVEL: info
       CONCOURSE_POSTGRES_HOST: db
       CONCOURSE_POSTGRES_USER: dev
       CONCOURSE_POSTGRES_PASSWORD: dev
@@ -32,6 +32,8 @@ services:
       CONCOURSE_CLUSTER_NAME: dev
       CONCOURSE_ENABLE_PIPELINE_INSTANCES: "true"
       CONCOURSE_ENABLE_ACROSS_STEP: "true"
+      CONCOURSE_ENABLE_P2P_VOLUME_STREAMING: "true"
+      CONCOURSE_CONTAINER_PLACEMENT_STRATEGY: "random"
 
   worker:
     build: .
@@ -42,6 +44,50 @@ services:
     ports:
     - 7777:7777
     - 7788:7788
+    stop_signal: SIGUSR2
+    environment:
+      CONCOURSE_LOG_LEVEL: debug
+      CONCOURSE_TSA_HOST: web:2222
+
+      # avoid using loopbacks
+      CONCOURSE_BAGGAGECLAIM_DRIVER: overlay
+
+      # so we can reach Garden/Baggageclaim for debugging
+      CONCOURSE_BIND_IP: 0.0.0.0
+      CONCOURSE_BAGGAGECLAIM_BIND_IP: 0.0.0.0
+      CONCOURSE_GARDEN_DNS_PROXY_ENABLE: "true"
+
+  worker2:
+    build: .
+    image: concourse/concourse:local
+    command: worker
+    privileged: true
+    depends_on: [web]
+    ports:
+    - 8777:7777
+    - 8788:7788
+    stop_signal: SIGUSR2
+    environment:
+      CONCOURSE_LOG_LEVEL: debug
+      CONCOURSE_TSA_HOST: web:2222
+
+      # avoid using loopbacks
+      CONCOURSE_BAGGAGECLAIM_DRIVER: overlay
+
+      # so we can reach Garden/Baggageclaim for debugging
+      CONCOURSE_BIND_IP: 0.0.0.0
+      CONCOURSE_BAGGAGECLAIM_BIND_IP: 0.0.0.0
+      CONCOURSE_GARDEN_DNS_PROXY_ENABLE: "true"
+
+  worker3:
+    build: .
+    image: concourse/concourse:local
+    command: worker
+    privileged: true
+    depends_on: [web]
+    ports:
+    - 9777:7777
+    - 9788:7788
     stop_signal: SIGUSR2
     environment:
       CONCOURSE_LOG_LEVEL: debug


### PR DESCRIPTION
## What does this PR accomplish?

Feature

fixes: #6218 

This is a performance enhancement PR:

1. Mark streamed volume as cache. This though generally benefit performance, it particular optimize @vito's new refactor of using `check` and `get` steps for image fetching.
2. Enhance `get` step to stream fetched volume from local/remote workers, thus avoid duplicate interacts with outside sources of `get`.

## Changes proposed by this PR:


## Notes to reviewer:

So far the code is dirty, you may hold on reviewing it.

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* <!-- Release note here. Delete section if not needed. -->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
