### PR TITLE
Add a flag to migrate to the latest db version

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -258,15 +258,19 @@ type RunCommand struct {
 }
 
 type Migration struct {
-	Postgres           flag.PostgresConfig `group:"PostgreSQL Configuration" namespace:"postgres"`
-	EncryptionKey      flag.Cipher         `long:"encryption-key"     description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
-	OldEncryptionKey   flag.Cipher         `long:"old-encryption-key" description:"Encryption key previously used for encrypting sensitive information. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
-	CurrentDBVersion   bool                `long:"current-db-version" description:"Print the current database version and exit"`
-	SupportedDBVersion bool                `long:"supported-db-version" description:"Print the max supported database version and exit"`
-	MigrateDBToVersion int                 `long:"migrate-db-to-version" description:"Migrate to the specified database version and exit"`
+	Postgres               flag.PostgresConfig `group:"PostgreSQL Configuration" namespace:"postgres"`
+	EncryptionKey          flag.Cipher         `long:"encryption-key"     description:"A 16 or 32 length key used to encrypt sensitive information before storing it in the database."`
+	OldEncryptionKey       flag.Cipher         `long:"old-encryption-key" description:"Encryption key previously used for encrypting sensitive information. If provided without a new key, data is decrypted. If provided with a new key, data is re-encrypted."`
+	CurrentDBVersion       bool                `long:"current-db-version" description:"Print the current database version and exit"`
+	SupportedDBVersion     bool                `long:"supported-db-version" description:"Print the max supported database version and exit"`
+	MigrateDBToVersion     int                 `long:"migrate-db-to-version" description:"Migrate to the specified database version and exit"`
+	MigrateToLatestVersion bool                `long:"migrate-to-latest-version" description:"Migrate to the latest migration version and exit"`
 }
 
 func (m *Migration) Execute(args []string) error {
+	if m.MigrateToLatestVersion {
+		return m.migrateToLatestVersion()
+	}
 	if m.CurrentDBVersion {
 		return m.currentDBVersion()
 	}
@@ -279,7 +283,7 @@ func (m *Migration) Execute(args []string) error {
 	if m.OldEncryptionKey.AEAD != nil {
 		return m.rotateEncryptionKey()
 	}
-	return errors.New("must specify one of `--current-db-version`, `--supported-db-version`, `--migrate-db-to-version`, or `--old-encryption-key`")
+	return errors.New("must specify one of `--current-db-version`, `--supported-db-version`, `--migrate-db-to-version`, `--old-encryption-key`, or `--migrate-to-latest-version`")
 
 }
 
@@ -369,6 +373,23 @@ func (cmd *Migration) rotateEncryptionKey() error {
 	)
 
 	version, err := helper.CurrentVersion()
+	if err != nil {
+		return err
+	}
+
+	return helper.MigrateToVersion(version)
+}
+
+func (cmd *Migration) migrateToLatestVersion() error {
+	helper := migration.NewOpenHelper(
+		defaultDriverName,
+		cmd.Postgres.ConnectionString(),
+		nil,
+		nil,
+		nil,
+	)
+
+	version, err := helper.SupportedVersion()
 	if err != nil {
 		return err
 	}
@@ -1552,7 +1573,7 @@ func (cmd *RunCommand) constructDBConn(
 ) (db.Conn, error) {
 	dbConn, err := db.Open(logger.Session("db"), driverName, cmd.Postgres.ConnectionString(), cmd.newKey(), cmd.oldKey(), connectionName, lockFactory)
 	if err != nil {
-		return nil, fmt.Errorf("failed to migrate database: %s", err)
+		return nil, fmt.Errorf("failed to connect to database: %s", err)
 	}
 
 	// Instrument with Metrics

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -283,7 +283,7 @@ func (m *Migration) Execute(args []string) error {
 	if m.OldEncryptionKey.AEAD != nil {
 		return m.rotateEncryptionKey()
 	}
-	return errors.New("must specify one of `--current-db-version`, `--supported-db-version`, `--migrate-db-to-version`, `--old-encryption-key`, or `--migrate-to-latest-version`")
+	return errors.New("must specify one of `--migrate-to-latest-version`, `--current-db-version`, `--supported-db-version`, `--migrate-db-to-version`, or `--old-encryption-key`")
 
 }
 


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

Related to concourse/concourse-cart#194

## Changes proposed by this PR:
This PR adds a `--migrate-to-latest-version` flag to the `migrate`
command. It will migrate the db to the latest version.

## Notes to reviewer:
While doing concourse/concourse-chart#194 we found that the migrate
commnd does not automatically migrate to the latest db version. You can
do some shell scripting to accomplish that task using migrate and its
flags. We didn't want to write a script to do this in the chart though
and this seemed like a useful thing to add to the migrate command.

## Release Note
* add a `--migrate-to-latest-version` flag to the `migrate` command. This flag has concourse perform database migrations to the latest database version.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

