### PR TITLE
Proposing fix for OIDC groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "repository": "https://github.com/concourse/concourse",
   "license": "Apache-2.0",
   "dependencies": {
-    "element-ui": "^2.15.0",
-    "request": "^2.86.0",
-    "vue-resource": "^1.5.1"
+    "request": "^2.86.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "repository": "https://github.com/concourse/concourse",
   "license": "Apache-2.0",
   "dependencies": {
-    "request": "^2.86.0"
+    "element-ui": "^2.15.0",
+    "request": "^2.86.0",
+    "vue-resource": "^1.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/skymarshal/skycmd/oidc_flags.go
+++ b/skymarshal/skycmd/oidc_flags.go
@@ -28,7 +28,7 @@ type OIDCFlags struct {
 	HostedDomains      []string    `long:"hosted-domains" description:"List of whitelisted domains when using Google, only users from a listed domain will be allowed to log in"`
 	CACerts            []flag.File `long:"ca-cert" description:"CA Certificate"`
 	InsecureSkipVerify bool        `long:"skip-ssl-validation" description:"Skip SSL validation"`
-  InsecureEnableGroups bool      `long:"enable-groups" description:"Enable OIDC groups"`
+  DisableGroups bool      `long:"disable-groups" description:"Enable OIDC groups"`
 }
 
 func (flag *OIDCFlags) Name() string {
@@ -76,7 +76,7 @@ func (flag *OIDCFlags) Serialize(redirectURI string) ([]byte, error) {
 		RootCAs:            caCerts,
 		InsecureSkipVerify: flag.InsecureSkipVerify,
 		RedirectURI:        redirectURI,
-    InsecureEnableGroups: flag.InsecureEnableGroups,
+    InsecureEnableGroups: ! flag.DisableGroups,
 	}
 
 	config.ClaimMapping.GroupsKey = flag.GroupsKey

--- a/skymarshal/skycmd/oidc_flags.go
+++ b/skymarshal/skycmd/oidc_flags.go
@@ -28,7 +28,7 @@ type OIDCFlags struct {
 	HostedDomains      []string    `long:"hosted-domains" description:"List of whitelisted domains when using Google, only users from a listed domain will be allowed to log in"`
 	CACerts            []flag.File `long:"ca-cert" description:"CA Certificate"`
 	InsecureSkipVerify bool        `long:"skip-ssl-validation" description:"Skip SSL validation"`
-  DisableGroups bool      `long:"disable-groups" description:"Enable OIDC groups"`
+  DisableGroups bool      `long:"disable-groups" description:"Disable OIDC groups claims"`
 }
 
 func (flag *OIDCFlags) Name() string {

--- a/skymarshal/skycmd/oidc_flags.go
+++ b/skymarshal/skycmd/oidc_flags.go
@@ -28,6 +28,7 @@ type OIDCFlags struct {
 	HostedDomains      []string    `long:"hosted-domains" description:"List of whitelisted domains when using Google, only users from a listed domain will be allowed to log in"`
 	CACerts            []flag.File `long:"ca-cert" description:"CA Certificate"`
 	InsecureSkipVerify bool        `long:"skip-ssl-validation" description:"Skip SSL validation"`
+  InsecureEnableGroups bool      `long:"enable-groups" description:"Enable OIDC groups"`
 }
 
 func (flag *OIDCFlags) Name() string {
@@ -75,6 +76,7 @@ func (flag *OIDCFlags) Serialize(redirectURI string) ([]byte, error) {
 		RootCAs:            caCerts,
 		InsecureSkipVerify: flag.InsecureSkipVerify,
 		RedirectURI:        redirectURI,
+    InsecureEnableGroups: flag.InsecureEnableGroups,
 	}
 
 	config.ClaimMapping.GroupsKey = flag.GroupsKey


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?

Bug Fix 

closes #6435

## Changes proposed by this PR:

## Notes to reviewer:
Since Dex has the option InsecureEnableGroups set to false by default and concourse did not overwrite this, the OIDC connector ignores the groups coming from the upstream provider. This seems to be pretty bad for concourse, since its current RBAC model heavily relies on groups and many users (including myself) use those to manage access.
Adding an --oidc-enable-groups flag allows to override this behavior (if necessary) and thus to use groups again.


## Release Note
Added an --oidc-disable-groups flag that by default fetches groups claims from an upstream OIDC provider.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [ ] Tests reviewed
- [x] Documentation reviewed
- [x] Release notes reviewed
- [x] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
