### PR TITLE
[WIP] Add "limit-total-allocated-memory"

### DIFF
--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -93,7 +93,7 @@ func NewHandler(
 	pipelineServer := pipelineserver.NewServer(logger, dbTeamFactory, dbPipelineFactory, externalURL)
 	configServer := configserver.NewServer(logger, dbTeamFactory, secretManager)
 	ccServer := ccserver.NewServer(logger, dbTeamFactory, externalURL)
-	workerServer := workerserver.NewServer(logger, workerTeamFactory, dbWorkerFactory)
+	workerServer := workerserver.NewServer(logger, workerTeamFactory, dbWorkerFactory, containerRepository)
 	logLevelServer := loglevelserver.NewServer(logger, sink)
 	cliServer := cliserver.NewServer(logger, absCLIDownloadsDir)
 	containerServer := containerserver.NewServer(logger, workerClient, secretManager, varSourcePool, interceptTimeoutFactory, interceptUpdateInterval, containerRepository, destroyer, clock)

--- a/atc/api/present/worker.go
+++ b/atc/api/present/worker.go
@@ -5,7 +5,7 @@ import (
 	"github.com/concourse/concourse/atc/db"
 )
 
-func Worker(workerInfo db.Worker) atc.Worker {
+func Worker(workerInfo db.Worker, activeContainers int) atc.Worker {
 	gardenAddr := ""
 	if workerInfo.GardenAddr() != nil {
 		gardenAddr = *workerInfo.GardenAddr()
@@ -29,7 +29,7 @@ func Worker(workerInfo db.Worker) atc.Worker {
 		HTTPProxyURL:     workerInfo.HTTPProxyURL(),
 		HTTPSProxyURL:    workerInfo.HTTPSProxyURL(),
 		NoProxy:          workerInfo.NoProxy(),
-		ActiveContainers: workerInfo.ActiveContainers(),
+		ActiveContainers: activeContainers,
 		ActiveVolumes:    workerInfo.ActiveVolumes(),
 		ActiveTasks:      activeTasks,
 		ResourceTypes:    workerInfo.ResourceTypes(),

--- a/atc/api/workers_test.go
+++ b/atc/api/workers_test.go
@@ -787,7 +787,6 @@ var _ = Describe("Workers API", func() {
 			fakeWorker = new(dbfakes.FakeWorker)
 			workerName = "some-name"
 			fakeWorker.NameReturns(workerName)
-			fakeWorker.ActiveContainersReturns(2)
 			fakeWorker.ActiveVolumesReturns(10)
 			fakeWorker.ActiveTasksReturns(42, nil)
 			fakeWorker.PlatformReturns("penguin")
@@ -795,6 +794,7 @@ var _ = Describe("Workers API", func() {
 			fakeWorker.StateReturns(db.WorkerStateRunning)
 			fakeWorker.TeamNameReturns("some-team")
 			fakeWorker.EphemeralReturns(true)
+			fakeContainerRepository.GetActiveContainerCountReturns(2)
 
 			ttlStr = "30s"
 			ttl, err = time.ParseDuration(ttlStr)

--- a/atc/api/workerserver/heartbeat.go
+++ b/atc/api/workerserver/heartbeat.go
@@ -84,7 +84,7 @@ func (s *Server) HeartbeatWorker(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	err = json.NewEncoder(w).Encode(present.Worker(savedWorker))
+	err = json.NewEncoder(w).Encode(present.Worker(savedWorker, registration.ActiveContainers))
 	if err != nil {
 		logger.Error("failed-to-encode-worker", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/workerserver/list.go
+++ b/atc/api/workerserver/list.go
@@ -34,7 +34,8 @@ func (s *Server) ListWorkers(w http.ResponseWriter, r *http.Request) {
 
 	atcWorkers := make([]atc.Worker, len(workers))
 	for i, savedWorker := range workers {
-		atcWorkers[i] = present.Worker(savedWorker)
+		activeContainers := s.containerRepository.GetActiveContainerCount(savedWorker.Name())
+		atcWorkers[i] = present.Worker(savedWorker, activeContainers)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/atc/api/workerserver/server.go
+++ b/atc/api/workerserver/server.go
@@ -8,19 +8,21 @@ import (
 type Server struct {
 	logger lager.Logger
 
-	teamFactory     db.TeamFactory
-	dbWorkerFactory db.WorkerFactory
+	teamFactory         db.TeamFactory
+	dbWorkerFactory     db.WorkerFactory
+	containerRepository db.ContainerRepository
 }
 
 func NewServer(
 	logger lager.Logger,
 	teamFactory db.TeamFactory,
 	dbWorkerFactory db.WorkerFactory,
-
+	containerRepository db.ContainerRepository,
 ) *Server {
 	return &Server{
-		logger:          logger,
-		teamFactory:     teamFactory,
-		dbWorkerFactory: dbWorkerFactory,
+		logger:              logger,
+		teamFactory:         teamFactory,
+		dbWorkerFactory:     dbWorkerFactory,
+		containerRepository: containerRepository,
 	}
 }

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -745,6 +745,7 @@ func (cmd *RunCommand) constructAPIMembers(
 	dbTaskCacheFactory := db.NewTaskCacheFactory(dbConn)
 	dbVolumeRepository := db.NewVolumeRepository(dbConn)
 	dbWorkerFactory := db.NewWorkerFactory(workerConn)
+	dbContainerRepository := db.NewContainerRepository(dbConn)
 	workerVersion, err := workerVersion()
 	if err != nil {
 		return nil, err
@@ -767,6 +768,7 @@ func (cmd *RunCommand) constructAPIMembers(
 		dbVolumeRepository,
 		teamFactory,
 		dbWorkerFactory,
+		dbContainerRepository,
 		workerVersion,
 		cmd.BaggageclaimResponseHeaderTimeout,
 		cmd.GardenRequestTimeout,
@@ -779,7 +781,6 @@ func (cmd *RunCommand) constructAPIMembers(
 	dbPipelineFactory := db.NewPipelineFactory(dbConn, lockFactory)
 	dbJobFactory := db.NewJobFactory(dbConn, lockFactory)
 	dbResourceFactory := db.NewResourceFactory(dbConn, lockFactory)
-	dbContainerRepository := db.NewContainerRepository(dbConn)
 	gcContainerDestroyer := gc.NewDestroyer(logger, dbContainerRepository, dbVolumeRepository)
 	dbBuildFactory := db.NewBuildFactory(dbConn, lockFactory, cmd.GC.OneOffBuildGracePeriod, cmd.GC.FailedGracePeriod)
 	dbCheckFactory := db.NewCheckFactory(dbConn, lockFactory, secretManager, cmd.varSourcePool, db.CheckDurations{
@@ -995,6 +996,7 @@ func (cmd *RunCommand) backendComponents(
 	dbWorkerTaskCacheFactory := db.NewWorkerTaskCacheFactory(dbConn)
 	dbVolumeRepository := db.NewVolumeRepository(dbConn)
 	dbWorkerFactory := db.NewWorkerFactory(dbConn)
+	dbContainerRepository := db.NewContainerRepository(dbConn)
 	workerVersion, err := workerVersion()
 	if err != nil {
 		return nil, err
@@ -1019,6 +1021,7 @@ func (cmd *RunCommand) backendComponents(
 		dbVolumeRepository,
 		teamFactory,
 		dbWorkerFactory,
+		dbContainerRepository,
 		workerVersion,
 		cmd.BaggageclaimResponseHeaderTimeout,
 		cmd.GardenRequestTimeout,

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1042,7 +1042,7 @@ func (cmd *RunCommand) backendComponents(
 		return nil, err
 	}
 
-	buildContainerStrategy, err := cmd.chooseBuildContainerStrategy()
+	buildContainerStrategy, err := cmd.chooseBuildContainerStrategy(dbContainerRepository)
 	if err != nil {
 		return nil, err
 	}
@@ -1591,8 +1591,8 @@ func (cmd *RunCommand) constructLockConn(driverName string) (*sql.DB, error) {
 	return dbConn, nil
 }
 
-func (cmd *RunCommand) chooseBuildContainerStrategy() (worker.ContainerPlacementStrategy, error) {
-	return worker.NewContainerPlacementStrategy(cmd.ContainerPlacementStrategyOptions)
+func (cmd *RunCommand) chooseBuildContainerStrategy(dbContainerRepository db.ContainerRepository) (worker.ContainerPlacementStrategy, error) {
+	return worker.NewContainerPlacementStrategy(cmd.ContainerPlacementStrategyOptions, dbContainerRepository)
 }
 
 func (cmd *RunCommand) configureAuthForDefaultTeam(teamFactory db.TeamFactory) error {

--- a/atc/db/container_metadata.go
+++ b/atc/db/container_metadata.go
@@ -1,6 +1,10 @@
 package db
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/concourse/concourse/atc"
+)
 
 type ContainerMetadata struct {
 	Type ContainerType
@@ -19,6 +23,7 @@ type ContainerMetadata struct {
 	PipelineInstanceVars string
 	JobName              string
 	BuildName            string
+	ContainerLimits      atc.ContainerLimits
 }
 
 type ContainerType string
@@ -96,6 +101,14 @@ func (metadata ContainerMetadata) SQLMap() map[string]interface{} {
 		m["meta_build_name"] = metadata.BuildName
 	}
 
+	if metadata.ContainerLimits.CPU != nil {
+		m["meta_cpu_limit"] = metadata.ContainerLimits.CPU
+	}
+
+	if metadata.ContainerLimits.Memory != nil {
+		m["meta_memory_limit"] = metadata.ContainerLimits.Memory
+	}
+
 	return m
 }
 
@@ -112,6 +125,8 @@ var containerMetadataColumns = []string{
 	"meta_pipeline_instance_vars",
 	"meta_job_name",
 	"meta_build_name",
+	"meta_cpu_limit",
+	"meta_memory_limit",
 }
 
 func (metadata *ContainerMetadata) ScanTargets() []interface{} {
@@ -128,5 +143,7 @@ func (metadata *ContainerMetadata) ScanTargets() []interface{} {
 		&metadata.PipelineInstanceVars,
 		&metadata.JobName,
 		&metadata.BuildName,
+		&metadata.ContainerLimits.CPU,
+		&metadata.ContainerLimits.Memory,
 	}
 }

--- a/atc/db/dbfakes/fake_container_repository.go
+++ b/atc/db/dbfakes/fake_container_repository.go
@@ -75,18 +75,18 @@ type FakeContainerRepository struct {
 	getActiveContainerCountReturnsOnCall map[int]struct {
 		result1 int
 	}
-	GetActiveContainersStub        func(string) ([]db.Container, error)
-	getActiveContainersMutex       sync.RWMutex
-	getActiveContainersArgsForCall []struct {
+	GetActiveContainerResourcesStub        func(string) (int, int)
+	getActiveContainerResourcesMutex       sync.RWMutex
+	getActiveContainerResourcesArgsForCall []struct {
 		arg1 string
 	}
-	getActiveContainersReturns struct {
-		result1 []db.Container
-		result2 error
+	getActiveContainerResourcesReturns struct {
+		result1 int
+		result2 int
 	}
-	getActiveContainersReturnsOnCall map[int]struct {
-		result1 []db.Container
-		result2 error
+	getActiveContainerResourcesReturnsOnCall map[int]struct {
+		result1 int
+		result2 int
 	}
 	RemoveDestroyingContainersStub        func(string, []string) (int, error)
 	removeDestroyingContainersMutex       sync.RWMutex
@@ -439,66 +439,66 @@ func (fake *FakeContainerRepository) GetActiveContainerCountReturnsOnCall(i int,
 	}{result1}
 }
 
-func (fake *FakeContainerRepository) GetActiveContainers(arg1 string) ([]db.Container, error) {
-	fake.getActiveContainersMutex.Lock()
-	ret, specificReturn := fake.getActiveContainersReturnsOnCall[len(fake.getActiveContainersArgsForCall)]
-	fake.getActiveContainersArgsForCall = append(fake.getActiveContainersArgsForCall, struct {
+func (fake *FakeContainerRepository) GetActiveContainerResources(arg1 string) (int, int) {
+	fake.getActiveContainerResourcesMutex.Lock()
+	ret, specificReturn := fake.getActiveContainerResourcesReturnsOnCall[len(fake.getActiveContainerResourcesArgsForCall)]
+	fake.getActiveContainerResourcesArgsForCall = append(fake.getActiveContainerResourcesArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	fake.recordInvocation("GetActiveContainers", []interface{}{arg1})
-	fake.getActiveContainersMutex.Unlock()
-	if fake.GetActiveContainersStub != nil {
-		return fake.GetActiveContainersStub(arg1)
+	fake.recordInvocation("GetActiveContainerResources", []interface{}{arg1})
+	fake.getActiveContainerResourcesMutex.Unlock()
+	if fake.GetActiveContainerResourcesStub != nil {
+		return fake.GetActiveContainerResourcesStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getActiveContainersReturns
+	fakeReturns := fake.getActiveContainerResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeContainerRepository) GetActiveContainersCallCount() int {
-	fake.getActiveContainersMutex.RLock()
-	defer fake.getActiveContainersMutex.RUnlock()
-	return len(fake.getActiveContainersArgsForCall)
+func (fake *FakeContainerRepository) GetActiveContainerResourcesCallCount() int {
+	fake.getActiveContainerResourcesMutex.RLock()
+	defer fake.getActiveContainerResourcesMutex.RUnlock()
+	return len(fake.getActiveContainerResourcesArgsForCall)
 }
 
-func (fake *FakeContainerRepository) GetActiveContainersCalls(stub func(string) ([]db.Container, error)) {
-	fake.getActiveContainersMutex.Lock()
-	defer fake.getActiveContainersMutex.Unlock()
-	fake.GetActiveContainersStub = stub
+func (fake *FakeContainerRepository) GetActiveContainerResourcesCalls(stub func(string) (int, int)) {
+	fake.getActiveContainerResourcesMutex.Lock()
+	defer fake.getActiveContainerResourcesMutex.Unlock()
+	fake.GetActiveContainerResourcesStub = stub
 }
 
-func (fake *FakeContainerRepository) GetActiveContainersArgsForCall(i int) string {
-	fake.getActiveContainersMutex.RLock()
-	defer fake.getActiveContainersMutex.RUnlock()
-	argsForCall := fake.getActiveContainersArgsForCall[i]
+func (fake *FakeContainerRepository) GetActiveContainerResourcesArgsForCall(i int) string {
+	fake.getActiveContainerResourcesMutex.RLock()
+	defer fake.getActiveContainerResourcesMutex.RUnlock()
+	argsForCall := fake.getActiveContainerResourcesArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeContainerRepository) GetActiveContainersReturns(result1 []db.Container, result2 error) {
-	fake.getActiveContainersMutex.Lock()
-	defer fake.getActiveContainersMutex.Unlock()
-	fake.GetActiveContainersStub = nil
-	fake.getActiveContainersReturns = struct {
-		result1 []db.Container
-		result2 error
+func (fake *FakeContainerRepository) GetActiveContainerResourcesReturns(result1 int, result2 int) {
+	fake.getActiveContainerResourcesMutex.Lock()
+	defer fake.getActiveContainerResourcesMutex.Unlock()
+	fake.GetActiveContainerResourcesStub = nil
+	fake.getActiveContainerResourcesReturns = struct {
+		result1 int
+		result2 int
 	}{result1, result2}
 }
 
-func (fake *FakeContainerRepository) GetActiveContainersReturnsOnCall(i int, result1 []db.Container, result2 error) {
-	fake.getActiveContainersMutex.Lock()
-	defer fake.getActiveContainersMutex.Unlock()
-	fake.GetActiveContainersStub = nil
-	if fake.getActiveContainersReturnsOnCall == nil {
-		fake.getActiveContainersReturnsOnCall = make(map[int]struct {
-			result1 []db.Container
-			result2 error
+func (fake *FakeContainerRepository) GetActiveContainerResourcesReturnsOnCall(i int, result1 int, result2 int) {
+	fake.getActiveContainerResourcesMutex.Lock()
+	defer fake.getActiveContainerResourcesMutex.Unlock()
+	fake.GetActiveContainerResourcesStub = nil
+	if fake.getActiveContainerResourcesReturnsOnCall == nil {
+		fake.getActiveContainerResourcesReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 int
 		})
 	}
-	fake.getActiveContainersReturnsOnCall[i] = struct {
-		result1 []db.Container
-		result2 error
+	fake.getActiveContainerResourcesReturnsOnCall[i] = struct {
+		result1 int
+		result2 int
 	}{result1, result2}
 }
 
@@ -713,8 +713,8 @@ func (fake *FakeContainerRepository) Invocations() map[string][][]interface{} {
 	defer fake.findOrphanedContainersMutex.RUnlock()
 	fake.getActiveContainerCountMutex.RLock()
 	defer fake.getActiveContainerCountMutex.RUnlock()
-	fake.getActiveContainersMutex.RLock()
-	defer fake.getActiveContainersMutex.RUnlock()
+	fake.getActiveContainerResourcesMutex.RLock()
+	defer fake.getActiveContainerResourcesMutex.RUnlock()
 	fake.removeDestroyingContainersMutex.RLock()
 	defer fake.removeDestroyingContainersMutex.RUnlock()
 	fake.removeMissingContainersMutex.RLock()

--- a/atc/db/dbfakes/fake_container_repository.go
+++ b/atc/db/dbfakes/fake_container_repository.go
@@ -64,6 +64,30 @@ type FakeContainerRepository struct {
 		result3 []db.DestroyingContainer
 		result4 error
 	}
+	GetActiveContainerCountStub        func(string) int
+	getActiveContainerCountMutex       sync.RWMutex
+	getActiveContainerCountArgsForCall []struct {
+		arg1 string
+	}
+	getActiveContainerCountReturns struct {
+		result1 int
+	}
+	getActiveContainerCountReturnsOnCall map[int]struct {
+		result1 int
+	}
+	GetActiveContainersStub        func(string) ([]db.Container, error)
+	getActiveContainersMutex       sync.RWMutex
+	getActiveContainersArgsForCall []struct {
+		arg1 string
+	}
+	getActiveContainersReturns struct {
+		result1 []db.Container
+		result2 error
+	}
+	getActiveContainersReturnsOnCall map[int]struct {
+		result1 []db.Container
+		result2 error
+	}
 	RemoveDestroyingContainersStub        func(string, []string) (int, error)
 	removeDestroyingContainersMutex       sync.RWMutex
 	removeDestroyingContainersArgsForCall []struct {
@@ -355,6 +379,129 @@ func (fake *FakeContainerRepository) FindOrphanedContainersReturnsOnCall(i int, 
 	}{result1, result2, result3, result4}
 }
 
+func (fake *FakeContainerRepository) GetActiveContainerCount(arg1 string) int {
+	fake.getActiveContainerCountMutex.Lock()
+	ret, specificReturn := fake.getActiveContainerCountReturnsOnCall[len(fake.getActiveContainerCountArgsForCall)]
+	fake.getActiveContainerCountArgsForCall = append(fake.getActiveContainerCountArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetActiveContainerCount", []interface{}{arg1})
+	fake.getActiveContainerCountMutex.Unlock()
+	if fake.GetActiveContainerCountStub != nil {
+		return fake.GetActiveContainerCountStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.getActiveContainerCountReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeContainerRepository) GetActiveContainerCountCallCount() int {
+	fake.getActiveContainerCountMutex.RLock()
+	defer fake.getActiveContainerCountMutex.RUnlock()
+	return len(fake.getActiveContainerCountArgsForCall)
+}
+
+func (fake *FakeContainerRepository) GetActiveContainerCountCalls(stub func(string) int) {
+	fake.getActiveContainerCountMutex.Lock()
+	defer fake.getActiveContainerCountMutex.Unlock()
+	fake.GetActiveContainerCountStub = stub
+}
+
+func (fake *FakeContainerRepository) GetActiveContainerCountArgsForCall(i int) string {
+	fake.getActiveContainerCountMutex.RLock()
+	defer fake.getActiveContainerCountMutex.RUnlock()
+	argsForCall := fake.getActiveContainerCountArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeContainerRepository) GetActiveContainerCountReturns(result1 int) {
+	fake.getActiveContainerCountMutex.Lock()
+	defer fake.getActiveContainerCountMutex.Unlock()
+	fake.GetActiveContainerCountStub = nil
+	fake.getActiveContainerCountReturns = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeContainerRepository) GetActiveContainerCountReturnsOnCall(i int, result1 int) {
+	fake.getActiveContainerCountMutex.Lock()
+	defer fake.getActiveContainerCountMutex.Unlock()
+	fake.GetActiveContainerCountStub = nil
+	if fake.getActiveContainerCountReturnsOnCall == nil {
+		fake.getActiveContainerCountReturnsOnCall = make(map[int]struct {
+			result1 int
+		})
+	}
+	fake.getActiveContainerCountReturnsOnCall[i] = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeContainerRepository) GetActiveContainers(arg1 string) ([]db.Container, error) {
+	fake.getActiveContainersMutex.Lock()
+	ret, specificReturn := fake.getActiveContainersReturnsOnCall[len(fake.getActiveContainersArgsForCall)]
+	fake.getActiveContainersArgsForCall = append(fake.getActiveContainersArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetActiveContainers", []interface{}{arg1})
+	fake.getActiveContainersMutex.Unlock()
+	if fake.GetActiveContainersStub != nil {
+		return fake.GetActiveContainersStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getActiveContainersReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeContainerRepository) GetActiveContainersCallCount() int {
+	fake.getActiveContainersMutex.RLock()
+	defer fake.getActiveContainersMutex.RUnlock()
+	return len(fake.getActiveContainersArgsForCall)
+}
+
+func (fake *FakeContainerRepository) GetActiveContainersCalls(stub func(string) ([]db.Container, error)) {
+	fake.getActiveContainersMutex.Lock()
+	defer fake.getActiveContainersMutex.Unlock()
+	fake.GetActiveContainersStub = stub
+}
+
+func (fake *FakeContainerRepository) GetActiveContainersArgsForCall(i int) string {
+	fake.getActiveContainersMutex.RLock()
+	defer fake.getActiveContainersMutex.RUnlock()
+	argsForCall := fake.getActiveContainersArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeContainerRepository) GetActiveContainersReturns(result1 []db.Container, result2 error) {
+	fake.getActiveContainersMutex.Lock()
+	defer fake.getActiveContainersMutex.Unlock()
+	fake.GetActiveContainersStub = nil
+	fake.getActiveContainersReturns = struct {
+		result1 []db.Container
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeContainerRepository) GetActiveContainersReturnsOnCall(i int, result1 []db.Container, result2 error) {
+	fake.getActiveContainersMutex.Lock()
+	defer fake.getActiveContainersMutex.Unlock()
+	fake.GetActiveContainersStub = nil
+	if fake.getActiveContainersReturnsOnCall == nil {
+		fake.getActiveContainersReturnsOnCall = make(map[int]struct {
+			result1 []db.Container
+			result2 error
+		})
+	}
+	fake.getActiveContainersReturnsOnCall[i] = struct {
+		result1 []db.Container
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeContainerRepository) RemoveDestroyingContainers(arg1 string, arg2 []string) (int, error) {
 	var arg2Copy []string
 	if arg2 != nil {
@@ -564,6 +711,10 @@ func (fake *FakeContainerRepository) Invocations() map[string][][]interface{} {
 	defer fake.findDestroyingContainersMutex.RUnlock()
 	fake.findOrphanedContainersMutex.RLock()
 	defer fake.findOrphanedContainersMutex.RUnlock()
+	fake.getActiveContainerCountMutex.RLock()
+	defer fake.getActiveContainerCountMutex.RUnlock()
+	fake.getActiveContainersMutex.RLock()
+	defer fake.getActiveContainersMutex.RUnlock()
 	fake.removeDestroyingContainersMutex.RLock()
 	defer fake.removeDestroyingContainersMutex.RUnlock()
 	fake.removeMissingContainersMutex.RLock()

--- a/atc/db/dbfakes/fake_worker.go
+++ b/atc/db/dbfakes/fake_worker.go
@@ -10,16 +10,6 @@ import (
 )
 
 type FakeWorker struct {
-	ActiveContainersStub        func() int
-	activeContainersMutex       sync.RWMutex
-	activeContainersArgsForCall []struct {
-	}
-	activeContainersReturns struct {
-		result1 int
-	}
-	activeContainersReturnsOnCall map[int]struct {
-		result1 int
-	}
 	ActiveTasksStub        func() (int, error)
 	activeTasksMutex       sync.RWMutex
 	activeTasksArgsForCall []struct {
@@ -329,58 +319,6 @@ type FakeWorker struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeWorker) ActiveContainers() int {
-	fake.activeContainersMutex.Lock()
-	ret, specificReturn := fake.activeContainersReturnsOnCall[len(fake.activeContainersArgsForCall)]
-	fake.activeContainersArgsForCall = append(fake.activeContainersArgsForCall, struct {
-	}{})
-	fake.recordInvocation("ActiveContainers", []interface{}{})
-	fake.activeContainersMutex.Unlock()
-	if fake.ActiveContainersStub != nil {
-		return fake.ActiveContainersStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.activeContainersReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeWorker) ActiveContainersCallCount() int {
-	fake.activeContainersMutex.RLock()
-	defer fake.activeContainersMutex.RUnlock()
-	return len(fake.activeContainersArgsForCall)
-}
-
-func (fake *FakeWorker) ActiveContainersCalls(stub func() int) {
-	fake.activeContainersMutex.Lock()
-	defer fake.activeContainersMutex.Unlock()
-	fake.ActiveContainersStub = stub
-}
-
-func (fake *FakeWorker) ActiveContainersReturns(result1 int) {
-	fake.activeContainersMutex.Lock()
-	defer fake.activeContainersMutex.Unlock()
-	fake.ActiveContainersStub = nil
-	fake.activeContainersReturns = struct {
-		result1 int
-	}{result1}
-}
-
-func (fake *FakeWorker) ActiveContainersReturnsOnCall(i int, result1 int) {
-	fake.activeContainersMutex.Lock()
-	defer fake.activeContainersMutex.Unlock()
-	fake.ActiveContainersStub = nil
-	if fake.activeContainersReturnsOnCall == nil {
-		fake.activeContainersReturnsOnCall = make(map[int]struct {
-			result1 int
-		})
-	}
-	fake.activeContainersReturnsOnCall[i] = struct {
-		result1 int
-	}{result1}
 }
 
 func (fake *FakeWorker) ActiveTasks() (int, error) {
@@ -1932,8 +1870,6 @@ func (fake *FakeWorker) VersionReturnsOnCall(i int, result1 *string) {
 func (fake *FakeWorker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.activeContainersMutex.RLock()
-	defer fake.activeContainersMutex.RUnlock()
 	fake.activeTasksMutex.RLock()
 	defer fake.activeTasksMutex.RUnlock()
 	fake.activeVolumesMutex.RLock()

--- a/atc/db/migration/migrations/1610709815_remove_active_containers_field.down.sql
+++ b/atc/db/migration/migrations/1610709815_remove_active_containers_field.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE workers ADD COLUMN active_containers integer DEFAULT 0;
+COMMIT;

--- a/atc/db/migration/migrations/1610709815_remove_active_containers_field.up.sql
+++ b/atc/db/migration/migrations/1610709815_remove_active_containers_field.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  ALTER TABLE workers DROP COLUMN active_containers;
+COMMIT;

--- a/atc/db/migration/migrations/1610727991_add_resource_limits_to_containers.down.sql
+++ b/atc/db/migration/migrations/1610727991_add_resource_limits_to_containers.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+  ALTER TABLE containers DROP COLUMN meta_cpu_limit;
+  ALTER TABLE containers DROP COLUMN meta_memory_limit;
+COMMIT;

--- a/atc/db/migration/migrations/1610727991_add_resource_limits_to_containers.up.sql
+++ b/atc/db/migration/migrations/1610727991_add_resource_limits_to_containers.up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+  ALTER TABLE containers ADD COLUMN meta_cpu_limit integer;
+  ALTER TABLE containers ADD COLUMN meta_memory_limit integer;
+COMMIT;

--- a/atc/db/worker.go
+++ b/atc/db/worker.go
@@ -59,7 +59,6 @@ type Worker interface {
 	HTTPProxyURL() string
 	HTTPSProxyURL() string
 	NoProxy() string
-	ActiveContainers() int
 	ActiveVolumes() int
 	ResourceTypes() []atc.WorkerResourceType
 	Platform() string
@@ -88,26 +87,25 @@ type Worker interface {
 type worker struct {
 	conn Conn
 
-	name             string
-	version          *string
-	state            WorkerState
-	gardenAddr       *string
-	baggageclaimURL  *string
-	httpProxyURL     string
-	httpsProxyURL    string
-	noProxy          string
-	activeContainers int
-	activeVolumes    int
-	activeTasks      int
-	resourceTypes    []atc.WorkerResourceType
-	platform         string
-	tags             []string
-	teamID           int
-	teamName         string
-	startTime        time.Time
-	expiresAt        time.Time
-	certsPath        *string
-	ephemeral        bool
+	name            string
+	version         *string
+	state           WorkerState
+	gardenAddr      *string
+	baggageclaimURL *string
+	httpProxyURL    string
+	httpsProxyURL   string
+	noProxy         string
+	activeVolumes   int
+	activeTasks     int
+	resourceTypes   []atc.WorkerResourceType
+	platform        string
+	tags            []string
+	teamID          int
+	teamName        string
+	startTime       time.Time
+	expiresAt       time.Time
+	certsPath       *string
+	ephemeral       bool
 }
 
 func (worker *worker) Name() string             { return worker.name }
@@ -120,7 +118,6 @@ func (worker *worker) BaggageclaimURL() *string { return worker.baggageclaimURL 
 func (worker *worker) HTTPProxyURL() string                    { return worker.httpProxyURL }
 func (worker *worker) HTTPSProxyURL() string                   { return worker.httpsProxyURL }
 func (worker *worker) NoProxy() string                         { return worker.noProxy }
-func (worker *worker) ActiveContainers() int                   { return worker.activeContainers }
 func (worker *worker) ActiveVolumes() int                      { return worker.activeVolumes }
 func (worker *worker) ResourceTypes() []atc.WorkerResourceType { return worker.resourceTypes }
 func (worker *worker) Platform() string                        { return worker.platform }

--- a/atc/db/worker_factory.go
+++ b/atc/db/worker_factory.go
@@ -45,7 +45,6 @@ var workersQuery = psql.Select(`
 		w.http_proxy_url,
 		w.https_proxy_url,
 		w.no_proxy,
-		w.active_containers,
 		w.active_volumes,
 		w.resource_types,
 		w.platform,
@@ -152,7 +151,6 @@ func scanWorker(worker *worker, row scannable) error {
 		&httpProxyURL,
 		&httpsProxyURL,
 		&noProxy,
-		&worker.activeContainers,
 		&worker.activeVolumes,
 		&resourceTypes,
 		&platform,
@@ -254,7 +252,6 @@ func (f *workerFactory) HeartbeatWorker(atcWorker atc.Worker, ttl time.Duration)
 
 	_, err = psql.Update("workers").
 		Set("expires", sq.Expr(expires)).
-		Set("active_containers", atcWorker.ActiveContainers).
 		Set("active_volumes", atcWorker.ActiveVolumes).
 		Set("state", sq.Expr("("+cSQL+")")).
 		Where(sq.Eq{"name": atcWorker.Name}).
@@ -396,7 +393,6 @@ func saveWorker(tx Tx, atcWorker atc.Worker, teamID *int, ttl time.Duration, con
 
 	values := []interface{}{
 		atcWorker.GardenAddr,
-		atcWorker.ActiveContainers,
 		atcWorker.ActiveVolumes,
 		resourceTypes,
 		tags,
@@ -427,7 +423,6 @@ func saveWorker(tx Tx, atcWorker atc.Worker, teamID *int, ttl time.Duration, con
 			"expires",
 			"start_time",
 			"addr",
-			"active_containers",
 			"active_volumes",
 			"resource_types",
 			"tags",
@@ -452,7 +447,6 @@ func saveWorker(tx Tx, atcWorker atc.Worker, teamID *int, ttl time.Duration, con
 				expires = `+expires+`,
 				start_time = `+startTime+`,
 				addr = ?,
-				active_containers = ?,
 				active_volumes = ?,
 				resource_types = ?,
 				tags = ?,
@@ -491,25 +485,24 @@ func saveWorker(tx Tx, atcWorker atc.Worker, teamID *int, ttl time.Duration, con
 	}
 
 	savedWorker := &worker{
-		name:             atcWorker.Name,
-		version:          workerVersion,
-		state:            workerState,
-		gardenAddr:       &atcWorker.GardenAddr,
-		baggageclaimURL:  &atcWorker.BaggageclaimURL,
-		certsPath:        atcWorker.CertsPath,
-		httpProxyURL:     atcWorker.HTTPProxyURL,
-		httpsProxyURL:    atcWorker.HTTPSProxyURL,
-		noProxy:          atcWorker.NoProxy,
-		activeContainers: atcWorker.ActiveContainers,
-		activeVolumes:    atcWorker.ActiveVolumes,
-		resourceTypes:    atcWorker.ResourceTypes,
-		platform:         atcWorker.Platform,
-		tags:             atcWorker.Tags,
-		teamName:         atcWorker.Team,
-		teamID:           workerTeamID,
-		startTime:        time.Unix(atcWorker.StartTime, 0),
-		ephemeral:        atcWorker.Ephemeral,
-		conn:             conn,
+		name:            atcWorker.Name,
+		version:         workerVersion,
+		state:           workerState,
+		gardenAddr:      &atcWorker.GardenAddr,
+		baggageclaimURL: &atcWorker.BaggageclaimURL,
+		certsPath:       atcWorker.CertsPath,
+		httpProxyURL:    atcWorker.HTTPProxyURL,
+		httpsProxyURL:   atcWorker.HTTPSProxyURL,
+		noProxy:         atcWorker.NoProxy,
+		activeVolumes:   atcWorker.ActiveVolumes,
+		resourceTypes:   atcWorker.ResourceTypes,
+		platform:        atcWorker.Platform,
+		tags:            atcWorker.Tags,
+		teamName:        atcWorker.Team,
+		teamID:          workerTeamID,
+		startTime:       time.Unix(atcWorker.StartTime, 0),
+		ephemeral:       atcWorker.Ephemeral,
+		conn:            conn,
 	}
 
 	workerBaseResourceTypeIDs := []int{}

--- a/atc/db/worker_factory_test.go
+++ b/atc/db/worker_factory_test.go
@@ -226,7 +226,6 @@ var _ = Describe("WorkerFactory", func() {
 				Expect(foundWorker.HTTPSProxyURL()).To(Equal("some-https-proxy-url"))
 				Expect(foundWorker.NoProxy()).To(Equal("some-no-proxy"))
 				Expect(foundWorker.Ephemeral()).To(Equal(true))
-				Expect(foundWorker.ActiveContainers()).To(Equal(140))
 				Expect(foundWorker.ActiveVolumes()).To(Equal(550))
 				Expect(foundWorker.ResourceTypes()).To(Equal([]atc.WorkerResourceType{
 					{
@@ -391,19 +390,16 @@ var _ = Describe("WorkerFactory", func() {
 
 	Describe("HeartbeatWorker", func() {
 		var (
-			ttl              time.Duration
-			epsilon          time.Duration
-			activeContainers int
-			activeVolumes    int
+			ttl           time.Duration
+			epsilon       time.Duration
+			activeVolumes int
 		)
 
 		BeforeEach(func() {
 			ttl = 5 * time.Minute
 			epsilon = 30 * time.Second
-			activeContainers = 0
 			activeVolumes = 0
 
-			atcWorker.ActiveContainers = activeContainers
 			atcWorker.ActiveVolumes = activeVolumes
 		})
 
@@ -413,8 +409,7 @@ var _ = Describe("WorkerFactory", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("updates the expires field, and the number of active containers and volumes", func() {
-				atcWorker.ActiveContainers = 1
+			It("updates the expires field, and the number of active volumes", func() {
 				atcWorker.ActiveVolumes = 3
 
 				now := time.Now()
@@ -430,7 +425,6 @@ var _ = Describe("WorkerFactory", func() {
 
 				Expect(foundWorker.Name()).To(Equal(atcWorker.Name))
 				Expect(foundWorker.ExpiresAt()).To(BeTemporally("~", later, epsilon))
-				Expect(foundWorker.ActiveContainers()).To(And(Not(Equal(activeContainers)), Equal(1)))
 				Expect(foundWorker.ActiveVolumes()).To(And(Not(Equal(activeVolumes)), Equal(3)))
 				Expect(*foundWorker.GardenAddr()).To(Equal("some-garden-addr"))
 				Expect(*foundWorker.BaggageclaimURL()).To(Equal("some-bc-url"))

--- a/atc/exec/retry_error_step_test.go
+++ b/atc/exec/retry_error_step_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/concourse/concourse/atc/exec"
 	"github.com/concourse/concourse/atc/exec/build"
 	"github.com/concourse/concourse/atc/exec/execfakes"
+	"github.com/concourse/concourse/atc/worker"
 	"github.com/concourse/concourse/atc/worker/transport"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -98,12 +99,12 @@ var _ = Describe("RetryErrorStep", func() {
 				Expect(message).To(Equal(fmt.Sprintf("%s, will retry ...", cause.Error())))
 			})
 
-			Context("when build aborted", func(){
-				BeforeEach(func(){
+			Context("when build aborted", func() {
+				BeforeEach(func() {
 					cancel()
 				})
 
-				It("should not retry", func(){
+				It("should not retry", func() {
 					Expect(runErr).To(Equal(cause))
 				})
 			})
@@ -122,6 +123,17 @@ var _ = Describe("RetryErrorStep", func() {
 
 		Context("when net.Error error happened", func() {
 			cause := &net.OpError{Op: "read", Net: "test", Source: nil, Addr: nil, Err: errors.New("test")}
+			BeforeEach(func() {
+				fakeStep.RunReturns(false, cause)
+			})
+
+			It("should return retriable", func() {
+				Expect(runErr).To(Equal(Retriable{cause}))
+			})
+		})
+
+		Context("when worker.NoWorkerFitContainerPlacementStrategyError error happened", func() {
+			cause := &worker.NoWorkerFitContainerPlacementStrategyError{Strategy: "test-strategy"}
 			BeforeEach(func() {
 				fakeStep.RunReturns(false, cause)
 			})

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -216,6 +216,7 @@ func (step *TaskStep) run(ctx context.Context, state RunState, delegate TaskDele
 	if config.Limits.Memory == nil {
 		config.Limits.Memory = step.defaultLimits.Memory
 	}
+	step.containerMetadata.ContainerLimits = *config.Limits
 
 	delegate.Initializing(logger)
 

--- a/atc/worker/container_test.go
+++ b/atc/worker/container_test.go
@@ -45,6 +45,7 @@ var _ = Describe("RunScript", func() {
 		fakeFetcher              *workerfakes.FakeFetcher
 		fakeDBTeamFactory        *dbfakes.FakeTeamFactory
 		fakeDBWorker             *dbfakes.FakeWorker
+		fakeContainerRepository  *dbfakes.FakeContainerRepository
 		fakeCreatedContainer     *dbfakes.FakeCreatedContainer
 		fakeResourceCacheFactory *dbfakes.FakeResourceCacheFactory
 
@@ -74,6 +75,7 @@ var _ = Describe("RunScript", func() {
 		fakeFetcher = new(workerfakes.FakeFetcher)
 		fakeDBTeamFactory = new(dbfakes.FakeTeamFactory)
 		fakeDBWorker = new(dbfakes.FakeWorker)
+		fakeContainerRepository = new(dbfakes.FakeContainerRepository)
 		fakeResourceCacheFactory = new(dbfakes.FakeResourceCacheFactory)
 
 		fakeOwner = new(dbfakes.FakeContainerOwner)
@@ -101,6 +103,7 @@ var _ = Describe("RunScript", func() {
 			fakeFetcher,
 			fakeDBTeamFactory,
 			fakeDBWorker,
+			fakeContainerRepository,
 			fakeResourceCacheFactory,
 			0,
 		)

--- a/atc/worker/db_worker_provider.go
+++ b/atc/worker/db_worker_provider.go
@@ -28,6 +28,7 @@ type dbWorkerProvider struct {
 	dbVolumeRepository                db.VolumeRepository
 	dbTeamFactory                     db.TeamFactory
 	dbWorkerFactory                   db.WorkerFactory
+	dbContainerRepository             db.ContainerRepository
 	workerVersion                     version.Version
 	baggageclaimResponseHeaderTimeout time.Duration
 	gardenRequestTimeout              time.Duration
@@ -46,6 +47,7 @@ func NewDBWorkerProvider(
 	dbVolumeRepository db.VolumeRepository,
 	dbTeamFactory db.TeamFactory,
 	workerFactory db.WorkerFactory,
+	containerRepository db.ContainerRepository,
 	workerVersion version.Version,
 	baggageclaimResponseHeaderTimeout, gardenRequestTimeout time.Duration,
 ) WorkerProvider {
@@ -62,6 +64,7 @@ func NewDBWorkerProvider(
 		dbVolumeRepository:                dbVolumeRepository,
 		dbTeamFactory:                     dbTeamFactory,
 		dbWorkerFactory:                   workerFactory,
+		dbContainerRepository:             containerRepository,
 		workerVersion:                     workerVersion,
 		baggageclaimResponseHeaderTimeout: baggageclaimResponseHeaderTimeout,
 		gardenRequestTimeout:              gardenRequestTimeout,
@@ -212,6 +215,7 @@ func (provider *dbWorkerProvider) NewGardenWorker(logger lager.Logger, savedWork
 		provider.resourceFetcher,
 		provider.dbTeamFactory,
 		savedWorker,
+		provider.dbContainerRepository,
 		provider.dbResourceCacheFactory,
 		buildContainersCount,
 	)

--- a/atc/worker/db_worker_provider_test.go
+++ b/atc/worker/db_worker_provider_test.go
@@ -47,6 +47,7 @@ var _ = Describe("DBProvider", func() {
 		fakeImageFactory                    *workerfakes.FakeImageFactory
 		fakeDBVolumeRepository              *dbfakes.FakeVolumeRepository
 		fakeDBWorkerFactory                 *dbfakes.FakeWorkerFactory
+		fakeContainerRepository             *dbfakes.FakeContainerRepository
 		fakeDBTeamFactory                   *dbfakes.FakeTeamFactory
 		fakeDBWorkerBaseResourceTypeFactory *dbfakes.FakeWorkerBaseResourceTypeFactory
 		fakeDBWorkerTaskCacheFactory        *dbfakes.FakeWorkerTaskCacheFactory
@@ -117,7 +118,6 @@ var _ = Describe("DBProvider", func() {
 		fakeWorker1.GardenAddrReturns(&gardenAddr)
 		fakeWorker1.BaggageclaimURLReturns(&baggageclaimURL)
 		fakeWorker1.StateReturns(db.WorkerStateRunning)
-		fakeWorker1.ActiveContainersReturns(2)
 		fakeWorker1.ResourceTypesReturns([]atc.WorkerResourceType{
 			{Type: "some-resource-a", Image: "some-image-a"}})
 
@@ -130,7 +130,6 @@ var _ = Describe("DBProvider", func() {
 		fakeWorker2.GardenAddrReturns(&gardenAddr)
 		fakeWorker2.BaggageclaimURLReturns(&baggageclaimURL)
 		fakeWorker2.StateReturns(db.WorkerStateRunning)
-		fakeWorker2.ActiveContainersReturns(2)
 		fakeWorker2.ResourceTypesReturns([]atc.WorkerResourceType{
 			{Type: "some-resource-b", Image: "some-image-b"}})
 
@@ -161,6 +160,7 @@ var _ = Describe("DBProvider", func() {
 		fakeLockFactory.AcquireReturns(fakeLock, true, nil)
 
 		fakeDBWorkerFactory = new(dbfakes.FakeWorkerFactory)
+		fakeContainerRepository = new(dbfakes.FakeContainerRepository)
 
 		wantWorkerVersion, err = version.NewVersionFromString("1.1.0")
 		Expect(err).ToNot(HaveOccurred())
@@ -178,6 +178,7 @@ var _ = Describe("DBProvider", func() {
 			fakeDBVolumeRepository,
 			fakeDBTeamFactory,
 			fakeDBWorkerFactory,
+			fakeContainerRepository,
 			wantWorkerVersion,
 			baggageclaimResponseHeaderTimeout,
 			gardenRequestTimeout,
@@ -233,7 +234,6 @@ var _ = Describe("DBProvider", func() {
 					landingWorker.GardenAddrReturns(&gardenAddr)
 					landingWorker.BaggageclaimURLReturns(&baggageclaimURL)
 					landingWorker.StateReturns(db.WorkerStateLanding)
-					landingWorker.ActiveContainersReturns(5)
 					landingWorker.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 
@@ -242,7 +242,6 @@ var _ = Describe("DBProvider", func() {
 					stalledWorker.GardenAddrReturns(&gardenAddr)
 					stalledWorker.BaggageclaimURLReturns(&baggageclaimURL)
 					stalledWorker.StateReturns(db.WorkerStateStalled)
-					stalledWorker.ActiveContainersReturns(0)
 					stalledWorker.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 
@@ -267,7 +266,6 @@ var _ = Describe("DBProvider", func() {
 					worker1.GardenAddrReturns(&gardenAddr)
 					worker1.BaggageclaimURLReturns(&baggageclaimURL)
 					worker1.StateReturns(db.WorkerStateRunning)
-					worker1.ActiveContainersReturns(5)
 					worker1.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 					version1 := "1.1.0"
@@ -278,7 +276,6 @@ var _ = Describe("DBProvider", func() {
 					worker2.GardenAddrReturns(&gardenAddr)
 					worker2.BaggageclaimURLReturns(&baggageclaimURL)
 					worker2.StateReturns(db.WorkerStateRunning)
-					worker2.ActiveContainersReturns(0)
 					worker2.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 					version2 := "2.0.0"
@@ -289,7 +286,6 @@ var _ = Describe("DBProvider", func() {
 					worker3.GardenAddrReturns(&gardenAddr)
 					worker3.BaggageclaimURLReturns(&baggageclaimURL)
 					worker3.StateReturns(db.WorkerStateRunning)
-					worker3.ActiveContainersReturns(0)
 					worker3.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 					version3 := "0.0.0"
@@ -317,7 +313,6 @@ var _ = Describe("DBProvider", func() {
 					worker1.GardenAddrReturns(&gardenAddr)
 					worker1.BaggageclaimURLReturns(&baggageclaimURL)
 					worker1.StateReturns(db.WorkerStateRunning)
-					worker1.ActiveContainersReturns(5)
 					worker1.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 					version1 := "1.1.0"
@@ -328,7 +323,6 @@ var _ = Describe("DBProvider", func() {
 					worker2.GardenAddrReturns(&gardenAddr)
 					worker2.BaggageclaimURLReturns(&baggageclaimURL)
 					worker2.StateReturns(db.WorkerStateRunning)
-					worker2.ActiveContainersReturns(0)
 					worker2.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 					version2 := "1.2.0"
@@ -339,7 +333,6 @@ var _ = Describe("DBProvider", func() {
 					worker3.GardenAddrReturns(&gardenAddr)
 					worker3.BaggageclaimURLReturns(&baggageclaimURL)
 					worker3.StateReturns(db.WorkerStateRunning)
-					worker3.ActiveContainersReturns(0)
 					worker3.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 					version3 := "1.0.0"
@@ -368,7 +361,6 @@ var _ = Describe("DBProvider", func() {
 					worker1.GardenAddrReturns(&gardenAddr)
 					worker1.BaggageclaimURLReturns(&baggageclaimURL)
 					worker1.StateReturns(db.WorkerStateRunning)
-					worker1.ActiveContainersReturns(5)
 					worker1.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 
@@ -391,7 +383,6 @@ var _ = Describe("DBProvider", func() {
 					worker1.GardenAddrReturns(&gardenAddr)
 					worker1.BaggageclaimURLReturns(&baggageclaimURL)
 					worker1.StateReturns(db.WorkerStateRunning)
-					worker1.ActiveContainersReturns(5)
 					worker1.ResourceTypesReturns([]atc.WorkerResourceType{
 						{Type: "some-resource-b", Image: "some-image-b"}})
 					version1 := "1.1..0.2-bogus=version"

--- a/atc/worker/worker.go
+++ b/atc/worker/worker.go
@@ -91,9 +91,10 @@ type gardenWorker struct {
 	imageFactory         ImageFactory
 	resourceCacheFactory db.ResourceCacheFactory
 	Fetcher
-	dbWorker        db.Worker
-	buildContainers int
-	helper          workerHelper
+	dbWorker              db.Worker
+	dbContainerRepository db.ContainerRepository
+	buildContainers       int
+	helper                workerHelper
 }
 
 // NewGardenWorker constructs a Worker using the gardenWorker runtime implementation and allows container and volume
@@ -107,6 +108,7 @@ func NewGardenWorker(
 	fetcher Fetcher,
 	dbTeamFactory db.TeamFactory,
 	dbWorker db.Worker,
+	dbContainerRepository db.ContainerRepository,
 	resourceCacheFactory db.ResourceCacheFactory,
 	numBuildContainers int,
 	// TODO: numBuildContainers is only needed for placement strategy but this
@@ -122,14 +124,15 @@ func NewGardenWorker(
 	}
 
 	return &gardenWorker{
-		gardenClient:         gardenClient,
-		volumeClient:         volumeClient,
-		imageFactory:         imageFactory,
-		Fetcher:              fetcher,
-		dbWorker:             dbWorker,
-		resourceCacheFactory: resourceCacheFactory,
-		buildContainers:      numBuildContainers,
-		helper:               workerHelper,
+		gardenClient:          gardenClient,
+		volumeClient:          volumeClient,
+		imageFactory:          imageFactory,
+		Fetcher:               fetcher,
+		dbWorker:              dbWorker,
+		dbContainerRepository: dbContainerRepository,
+		resourceCacheFactory:  resourceCacheFactory,
+		buildContainers:       numBuildContainers,
+		helper:                workerHelper,
 	}
 }
 
@@ -792,7 +795,7 @@ func (worker *gardenWorker) DecreaseActiveTasks() error {
 }
 
 func (worker *gardenWorker) ActiveContainers() int {
-	return worker.dbWorker.ActiveContainers()
+	return worker.dbContainerRepository.GetActiveContainerCount(worker.dbWorker.Name())
 }
 
 func (worker *gardenWorker) ActiveVolumes() int {

--- a/atc/worker/worker_test.go
+++ b/atc/worker/worker_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Worker", func() {
 		workerName               string
 		gardenWorker             Worker
 		workerVersion            string
+		fakeContainerRepository  *dbfakes.FakeContainerRepository
 		fakeGardenClient         *gclientfakes.FakeClient
 		fakeImageFactory         *workerfakes.FakeImageFactory
 		fakeImage                *workerfakes.FakeImage
@@ -92,6 +93,7 @@ var _ = Describe("Worker", func() {
 		workerVersion = "1.2.3"
 		fakeDBWorker = new(dbfakes.FakeWorker)
 
+		fakeContainerRepository = new(dbfakes.FakeContainerRepository)
 		fakeGardenClient = new(gclientfakes.FakeClient)
 		fakeImageFactory = new(workerfakes.FakeImageFactory)
 		fakeImage = new(workerfakes.FakeImage)
@@ -203,7 +205,7 @@ var _ = Describe("Worker", func() {
 	})
 
 	JustBeforeEach(func() {
-		fakeDBWorker.ActiveContainersReturns(activeContainers)
+		fakeContainerRepository.GetActiveContainerCountReturns(activeContainers)
 		fakeDBWorker.ResourceTypesReturns(resourceTypes)
 		fakeDBWorker.PlatformReturns(platform)
 		fakeDBWorker.TagsReturns(tags)
@@ -223,6 +225,7 @@ var _ = Describe("Worker", func() {
 			fakeFetcher,
 			fakeDBTeamFactory,
 			fakeDBWorker,
+			fakeContainerRepository,
 			fakeResourceCacheFactory,
 			0,
 		)


### PR DESCRIPTION

## What does this PR accomplish?

Bug Fix | _Feature_ | Documentation


## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
* Refactored how the number of active containers is tracked/retrieved to use `containers` table as source of truth
* Add the configured container limits to the `containers` table
* Use the configured limits together with per-worker max resources flags to create new strategy that attempts to limit tasks landing on workers based on their resource usage (rather than just the number of tasks)
* Make "no workers" a retriable error so that large tasks do not immediately fail and instead wait for a worker with enough space

## Notes to reviewer:
There are quite a few changes to unpack that kind of go together here but could potentially be split if that would make things easier. I write pretty long commit messages but there are also some thoughts on bits that weren't necessarily the most obvious route below:

* Rather than tracking the number of active containers via the worker heartbeats, use the containers table and find all "creating" or "created" tasks. This then means `fly workers` reflects the state of the world that the ATC would use for any decision making as well as fixing a longstanding issue where the `fly workers` containers column showed a wildly different number to the `fly containers` output.
* By storing the containers configured limits in the `containers` table, we need to check that table in every strategy `Choose` call which could be slow. I decided (currently) to put this logic in the `ContainerRepository` code to keep the stuff that interacts with the `containers` table together but this may create an `O(n)` operation in the strategy code where `n = number of workers`. The alternative to this I think is to hydrate the "ActiveContainers" property of a worker object directly using a join in the main DB query so the worker object would contain the currently used resources directly without having to make another DB call per-worker.
* By making the error retriable we kind of lumped it in with the `enable-rerun-when-worker-disappears` flag which isn't quite right. I would like to go over this whole behaviour at some point and maybe have a command line option for "errors to retry" and have those come from some kind of known list of errors but for now it is _kind of related_ to disappearing workers (if you don't think about it too much!) so I've left it like that.

## Release Note
* A new placement strategy "limit-total-resources" can be used together with container limits so that large tasks will wait for available resources to become free before running


## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
