### PR TITLE
Add team groups to Dex response for Bitbucket connector

### DIFF
--- a/skymarshal/skycmd/bitbucketcloud_flags.go
+++ b/skymarshal/skycmd/bitbucketcloud_flags.go
@@ -45,9 +45,10 @@ func (flag *BitbucketCloudFlags) Serialize(redirectURI string) ([]byte, error) {
 	}
 
 	return json.Marshal(bitbucketcloud.Config{
-		ClientID:     flag.ClientID,
-		ClientSecret: flag.ClientSecret,
-		RedirectURI:  redirectURI,
+		ClientID:          flag.ClientID,
+		ClientSecret:      flag.ClientSecret,
+		RedirectURI:       redirectURI,
+		IncludeTeamGroups: true,
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>

<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #6419 .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Due to changes in upstream dex, we need to set `IncludeTeamGroups` to `true`

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

I'm not exactly sure how this worked before, ~and don't have a bitbucket cloud account to test this with, so 🤷~ but have tested this with a bitbucket cloud account and it seems to work fine. Here's how I tested it:

1. Created a new workspace in Bitbucket cloud (e.g. `testconcourse`)
2. Created a test group in the workspace and added my user account to it (e.g. `testgroup`)
3. Configured an OAuth app with redirect URI http://localhost:8080/sky/issuer/callback within the workspace, granting access to `Account > {Email, Read}` + `Workspace membership > Read`
4. Configured Concourse to use that app's client ID and secret
```diff
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       CONCOURSE_MAIN_TEAM_LOCAL_USER: test
       CONCOURSE_CLUSTER_NAME: dev
       CONCOURSE_ENABLE_ACROSS_STEP: "true"
+      CONCOURSE_BITBUCKET_CLOUD_CLIENT_ID: clientid
+      CONCOURSE_BITBUCKET_CLOUD_CLIENT_SECRET: clientsecret

   worker:
     build: .
```
5. `fly -t dev set-team -n other-team --bitbucket-cloud-team=testconcourse/testgroup`

Without this PR, my access token has groups `[testconcourse]` - with this PR, it has groups `[testconcourse, testconcourse/testgroup, testconcourse/developers, testconcourse/administrators]`

## Release Note

* Fixes Bitbucket Cloud auth, which was previously attempting to use a [deprecated (and recently removed) API endpoint](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/)

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
