### PR TITLE
Add team groups to Dex response for Bitbucket connector

### DIFF
--- a/skymarshal/skycmd/bitbucketcloud_flags.go
+++ b/skymarshal/skycmd/bitbucketcloud_flags.go
@@ -45,9 +45,10 @@ func (flag *BitbucketCloudFlags) Serialize(redirectURI string) ([]byte, error) {
 	}
 
 	return json.Marshal(bitbucketcloud.Config{
-		ClientID:     flag.ClientID,
-		ClientSecret: flag.ClientSecret,
-		RedirectURI:  redirectURI,
+		ClientID:          flag.ClientID,
+		ClientSecret:      flag.ClientSecret,
+		RedirectURI:       redirectURI,
+		IncludeTeamGroups: true,
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>

<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

Copy of #6442 for master

Note - it seems like there are two issues with the bitbucket connector:

1. the issue that's described in #6419 (it's only fetching workspaces, not subgroups in workspaces)
2. pre-7.0 (and 6.7.3), the version of dex we were using references an old API endpoint that has been removed

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* Fixes Bitbucket Cloud auth, which was previously attempting to use a [deprecated (and recently removed) API endpoint](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/)

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
