### PR TITLE
Fix OIDC connector not fetching groups claim

### DIFF
--- a/skymarshal/skycmd/oidc_flags.go
+++ b/skymarshal/skycmd/oidc_flags.go
@@ -28,6 +28,7 @@ type OIDCFlags struct {
 	HostedDomains      []string    `long:"hosted-domains" description:"List of whitelisted domains when using Google, only users from a listed domain will be allowed to log in"`
 	CACerts            []flag.File `long:"ca-cert" description:"CA Certificate"`
 	InsecureSkipVerify bool        `long:"skip-ssl-validation" description:"Skip SSL validation"`
+	DisableGroups      bool        `long:"disable-groups" description:"Disable OIDC groups claims"`
 }
 
 func (flag *OIDCFlags) Name() string {
@@ -66,15 +67,16 @@ func (flag *OIDCFlags) Serialize(redirectURI string) ([]byte, error) {
 	}
 
 	config := oidc.Config{
-		Issuer:             flag.Issuer,
-		ClientID:           flag.ClientID,
-		ClientSecret:       flag.ClientSecret,
-		Scopes:             flag.Scopes,
-		UserNameKey:        flag.UserNameKey,
-		HostedDomains:      flag.HostedDomains,
-		RootCAs:            caCerts,
-		InsecureSkipVerify: flag.InsecureSkipVerify,
-		RedirectURI:        redirectURI,
+		Issuer:               flag.Issuer,
+		ClientID:             flag.ClientID,
+		ClientSecret:         flag.ClientSecret,
+		Scopes:               flag.Scopes,
+		UserNameKey:          flag.UserNameKey,
+		HostedDomains:        flag.HostedDomains,
+		RootCAs:              caCerts,
+		InsecureSkipVerify:   flag.InsecureSkipVerify,
+		RedirectURI:          redirectURI,
+		InsecureEnableGroups: !flag.DisableGroups,
 	}
 
 	config.ClaimMapping.GroupsKey = flag.GroupsKey


### PR DESCRIPTION
Add --oidc-disable-groups flag to OIDC connector configure.

## Release Note
Fixed a regression that introduced in 6.7.3 that OIDC connector by default not fetching groups claim. Now OIDC connector always fetches groups claim unless `--oidc-disable-groups` flag is set. Backport of https://github.com/concourse/concourse/pull/6436.

