### PR TITLE
Remove --force in k8s-topgun test

### DIFF
--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -277,7 +277,6 @@ func helmDeploy(releaseName, namespace, chartDir string, args ...string) *gexec.
 	helmArgs := []string{
 		"upgrade",
 		"--install",
-		"--force",
 		"--namespace", namespace,
 		"--create-namespace",
 	}


### PR DESCRIPTION
Fix a CI error https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-topgun/builds/406#L600541ac:1319

where web scalling test trying to set web replica from 1 to 0 when `clusterIP` is not specified (with value ""). The cause of the failure can be found here https://github.com/helm/helm/issues/6378#issuecomment-557746499

So in our testing, or in real world use case, we should not use --force with helm upgrade when clusterIP is not set. Actually we might not need to use --force at all. The fact that --force was used IMO was inherited from helm 2. With helm 3 that doing 3-way diff it is smart enough to do an upgrade without enforcing a replacement strategic.
