### PR TITLE
Add more tooltips for action buttons

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -279,7 +279,7 @@ viewBuildHeader session model build =
                         ]
                             ++ (if buttonDisabled && buttonHovered then
                                     [ Html.div
-                                        (Build.Styles.buttonTooltip 240)
+                                        []
                                         [ Html.text <|
                                             "manual triggering disabled "
                                                 ++ "in job config"

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -661,12 +661,30 @@ view session model =
         ]
 
 
-tooltip : Model -> { a | hovered : HoverState.HoverState } -> Maybe Tooltip.Tooltip
+tooltip : Model -> Session -> Maybe Tooltip.Tooltip
 tooltip model session =
-    model.output
-        |> toMaybe
-        |> Maybe.andThen .steps
-        |> Maybe.andThen (\steps -> StepTree.tooltip steps session)
+    tryAll
+        [ model.output
+            |> toMaybe
+            |> Maybe.andThen .steps
+            |> Maybe.andThen (\steps -> StepTree.tooltip steps session)
+        , Header.tooltip model session
+        ]
+
+
+tryAll : List (Maybe a) -> Maybe a
+tryAll maybes =
+    List.foldl
+        (\prev cur ->
+            case prev of
+                Nothing ->
+                    cur
+
+                _ ->
+                    prev
+        )
+        Nothing
+        maybes
 
 
 breadcrumbs : Session -> Model -> Html Message

--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -3,6 +3,7 @@ module Build.Header.Header exposing
     , handleCallback
     , handleDelivery
     , header
+    , tooltip
     , update
     , view
     )
@@ -36,6 +37,7 @@ import Routes
 import SideBar.SideBar exposing (byPipelineId, lookupPipeline)
 import StrictEvents exposing (DeltaMode(..))
 import Time
+import Tooltip
 
 
 historyId : String
@@ -81,7 +83,6 @@ header session model =
                             else
                                 Views.Light
                         , backgroundColor = Concourse.BuildStatus.BuildStatusFailed
-                        , tooltip = False
                         }
 
                  else if model.job /= Nothing then
@@ -101,7 +102,6 @@ header session model =
                             else
                                 Views.Light
                         , backgroundColor = model.status
-                        , tooltip = isHovered
                         }
 
                  else
@@ -125,7 +125,6 @@ header session model =
                             else
                                 Views.Light
                         , backgroundColor = model.status
-                        , tooltip = isHovered && model.disableManualTrigger
                         }
 
                  else
@@ -135,6 +134,43 @@ header session model =
     , backgroundColor = model.status
     , tabs = tabs model
     }
+
+
+tooltip : Model r -> Session -> Maybe Tooltip.Tooltip
+tooltip model session =
+    case session.hovered of
+        HoverState.Tooltip TriggerBuildButton _ ->
+            Just
+                { body =
+                    Html.text <|
+                        if model.disableManualTrigger then
+                            "manual triggering disabled in job config"
+
+                        else
+                            "trigger a new build"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        HoverState.Tooltip RerunBuildButton _ ->
+            Just
+                { body = Html.text "re-run with the same inputs"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        HoverState.Tooltip AbortBuildButton _ ->
+            Just
+                { body = Html.text "abort the current build"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        _ ->
+            Nothing
 
 
 tabs : Model r -> List Views.BuildTab

--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -169,6 +169,14 @@ tooltip model session =
                 , containerAttrs = Nothing
                 }
 
+        HoverState.Tooltip JobName _ ->
+            Just
+                { body = Html.text "view job builds"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
         _ ->
             Nothing
 

--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -318,13 +318,16 @@ viewButton { type_, backgroundColor, backgroundShade, isClickable } =
 viewTitle : String -> Maybe Concourse.JobIdentifier -> Html Message
 viewTitle name jobID =
     case jobID of
-        Just id ->
+        Just jid ->
             Html.a
                 [ href <|
                     Routes.toString <|
-                        Routes.Job { id = id, page = Nothing }
+                        Routes.Job { id = jid, page = Nothing }
+                , onMouseEnter <| Hover <| Just Message.JobName
+                , onMouseLeave <| Hover Nothing
+                , id <| toHtmlID Message.JobName
                 ]
-                [ Html.span [ class "build-name" ] [ Html.text id.jobName ]
+                [ Html.span [ class "build-name" ] [ Html.text jid.jobName ]
                 , Html.span [ style "letter-spacing" "-1px" ] [ Html.text (" #" ++ name) ]
                 ]
 

--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -27,6 +27,7 @@ import Html.Attributes
         )
 import Html.Events exposing (onBlur, onFocus, onMouseEnter, onMouseLeave)
 import Html.Lazy
+import Message.Effects exposing (toHtmlID)
 import Message.Message as Message exposing (Message(..))
 import Routes
 import StrictEvents exposing (onLeftClick, onWheel)
@@ -89,7 +90,6 @@ type alias ButtonView =
     , isClickable : Bool
     , backgroundShade : BackgroundShade
     , backgroundColor : BuildStatus
-    , tooltip : Bool
     }
 
 
@@ -239,7 +239,7 @@ viewBuildTab backgroundColor tab =
 
 
 viewButton : ButtonView -> Html Message
-viewButton { type_, tooltip, backgroundColor, backgroundShade, isClickable } =
+viewButton { type_, backgroundColor, backgroundShade, isClickable } =
     let
         image =
             case type_ of
@@ -304,6 +304,7 @@ viewButton { type_, tooltip, backgroundColor, backgroundShade, isClickable } =
          , onMouseLeave <| Hover Nothing
          , onFocus <| Hover <| Just domID
          , onBlur <| Hover Nothing
+         , id <| toHtmlID domID
          ]
             ++ styles
         )
@@ -312,47 +313,7 @@ viewButton { type_, tooltip, backgroundColor, backgroundShade, isClickable } =
             , image = image
             }
             []
-        , tooltipArrow tooltip type_
-        , viewTooltip tooltip type_
         ]
-
-
-tooltipArrow : Bool -> ButtonType -> Html Message
-tooltipArrow tooltip type_ =
-    case ( tooltip, type_ ) of
-        ( True, Trigger ) ->
-            Html.div
-                Styles.buttonTooltipArrow
-                []
-
-        ( True, Rerun ) ->
-            Html.div
-                Styles.buttonTooltipArrow
-                []
-
-        _ ->
-            Html.text ""
-
-
-viewTooltip : Bool -> ButtonType -> Html Message
-viewTooltip tooltip type_ =
-    case ( tooltip, type_ ) of
-        ( True, Trigger ) ->
-            Html.div
-                (Styles.buttonTooltip 240)
-                [ Html.text <|
-                    "manual triggering disabled in job config"
-                ]
-
-        ( True, Rerun ) ->
-            Html.div
-                (Styles.buttonTooltip 165)
-                [ Html.text <|
-                    "re-run with the same inputs"
-                ]
-
-        _ ->
-            Html.text ""
 
 
 viewTitle : String -> Maybe Concourse.JobIdentifier -> Html Message

--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -298,7 +298,6 @@ viewButton { type_, backgroundColor, backgroundShade, isClickable } =
         ([ attribute "role" "button"
          , attribute "tabindex" "0"
          , attribute "aria-label" accessibilityLabel
-         , attribute "title" accessibilityLabel
          , onLeftClick <| Click domID
          , onMouseEnter <| Hover <| Just domID
          , onMouseLeave <| Hover Nothing

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -1252,7 +1252,7 @@ tooltip model { hovered } =
                     { direction = Tooltip.Top
                     , alignment = Tooltip.Start
                     }
-                , arrow = Just { size = 5, color = Colors.tooltipBackground }
+                , arrow = Just 5
                 }
 
         HoverState.Tooltip (StepInitialization _) _ ->
@@ -1265,7 +1265,7 @@ tooltip model { hovered } =
                     { direction = Tooltip.Top
                     , alignment = Tooltip.End
                     }
-                , arrow = Just { size = 5, color = Colors.tooltipBackground }
+                , arrow = Just 5
                 }
 
         HoverState.Tooltip (StepState id) _ ->
@@ -1307,5 +1307,5 @@ stepDurationTooltip { state, initialize, start, finish } =
         { direction = Tooltip.Top
         , alignment = Tooltip.End
         }
-    , arrow = Just { size = 5, color = Colors.tooltipBackground }
+    , arrow = Just 5
     }

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -1253,6 +1253,7 @@ tooltip model { hovered } =
                     , alignment = Tooltip.Start
                     }
                 , arrow = Just 5
+                , containerAttrs = Nothing
                 }
 
         HoverState.Tooltip (StepInitialization _) _ ->
@@ -1266,6 +1267,7 @@ tooltip model { hovered } =
                     , alignment = Tooltip.End
                     }
                 , arrow = Just 5
+                , containerAttrs = Nothing
                 }
 
         HoverState.Tooltip (StepState id) _ ->
@@ -1308,4 +1310,5 @@ stepDurationTooltip { state, initialize, start, finish } =
         , alignment = Tooltip.End
         }
     , arrow = Just 5
+    , containerAttrs = Nothing
     }

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -2,8 +2,6 @@ module Build.Styles exposing
     ( MetadataCellType(..)
     , abortButton
     , body
-    , buttonTooltip
-    , buttonTooltipArrow
     , changedStepTooltip
     , durationTooltip
     , errorLog
@@ -143,39 +141,6 @@ button =
     , style "border-color" Colors.background
     , style "border-style" "solid"
     ]
-
-
-buttonTooltipArrow : List (Html.Attribute msg)
-buttonTooltipArrow =
-    [ style "width" "0"
-    , style "height" "0"
-    , style "left" "50%"
-    , style "bottom" "0"
-    , style "margin-left" "-5px"
-    , style "border-bottom" <| "5px solid " ++ Colors.frame
-    , style "border-left" "5px solid transparent"
-    , style "border-right" "5px solid transparent"
-    , style "position" "absolute"
-    ]
-
-
-buttonTooltip : Int -> List (Html.Attribute msg)
-buttonTooltip width =
-    [ style "position" "absolute"
-    , style "right" "0"
-    , style "top" "100%"
-    , style "width" <| String.fromInt width ++ "px"
-    , style "color" Colors.text
-    , style "background-color" Colors.frame
-    , style "padding" "10px"
-    , style "text-align" "right"
-    , style "pointer-events" "none"
-    , style "z-index" "1"
-
-    -- ^ need a value greater than 0 (inherited from .fixed-header) since this
-    -- element is earlier in the document than the build tabs
-    ]
-        ++ Views.Styles.defaultFont
 
 
 stepHeader : StepState -> List (Html.Attribute msg)

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -236,9 +236,7 @@ stepStatusIcon =
 
 changedStepTooltip : List (Html.Attribute msg)
 changedStepTooltip =
-    [ style "background-color" Colors.tooltipBackground
-    , style "color" Colors.tooltipText
-    , style "padding" "5px"
+    [ style "padding" "5px"
     , style "z-index" "100"
     , style "width" "fit-content"
     , style "pointer-events" "none"
@@ -248,9 +246,7 @@ changedStepTooltip =
 
 durationTooltip : List (Html.Attribute msg)
 durationTooltip =
-    [ style "background-color" Colors.tooltipBackground
-    , style "color" Colors.tooltipText
-    , style "padding" "5px"
+    [ style "padding" "5px"
     , style "z-index" "100"
     , style "width" "fit-content"
     , style "pointer-events" "none"

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -236,22 +236,12 @@ stepStatusIcon =
 
 changedStepTooltip : List (Html.Attribute msg)
 changedStepTooltip =
-    [ style "padding" "5px"
-    , style "z-index" "100"
-    , style "width" "fit-content"
-    , style "pointer-events" "none"
-    ]
-        ++ Application.Styles.disableInteraction
+    style "pointer-events" "none" :: Application.Styles.disableInteraction
 
 
 durationTooltip : List (Html.Attribute msg)
 durationTooltip =
-    [ style "padding" "5px"
-    , style "z-index" "100"
-    , style "width" "fit-content"
-    , style "pointer-events" "none"
-    ]
-        ++ Application.Styles.disableInteraction
+    style "pointer-events" "none" :: Application.Styles.disableInteraction
 
 
 errorLog : List (Html.Attribute msg)

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -54,6 +54,8 @@ import Html.Events
     exposing
         ( onMouseEnter
         , onMouseLeave
+        , onMouseOut
+        , onMouseOver
         )
 import Http
 import List.Extra
@@ -1114,6 +1116,8 @@ dashboardView session model =
             (class (.pageBodyClass Message.Effects.stickyHeaderConfig)
                 :: id (toHtmlID Dashboard)
                 :: onScroll Scrolled
+                :: onMouseOver (Hover <| Just Dashboard)
+                :: onMouseOut (Hover Nothing)
                 :: Styles.content model.highDensity
             )
             (case model.pipelines of

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -872,10 +872,10 @@ tooltip session =
                                 else
                                     "expose pipeline"
                         , attachPosition =
-                            { direction = Tooltip.Top
+                            { direction = Tooltip.Bottom
                             , alignment = Tooltip.End
                             }
-                        , arrow = Nothing
+                        , arrow = Just 5
                         , containerAttrs = Nothing
                         }
                     )
@@ -894,10 +894,10 @@ tooltip session =
                         else
                             "favorite pipeline"
                 , attachPosition =
-                    { direction = Tooltip.Top
+                    { direction = Tooltip.Bottom
                     , alignment = Tooltip.End
                     }
-                , arrow = Nothing
+                , arrow = Just 5
                 , containerAttrs = Nothing
                 }
 
@@ -914,10 +914,10 @@ tooltip session =
                                 else
                                     "pause pipeline"
                         , attachPosition =
-                            { direction = Tooltip.Top
+                            { direction = Tooltip.Bottom
                             , alignment = Tooltip.End
                             }
-                        , arrow = Nothing
+                        , arrow = Just 5
                         , containerAttrs = Nothing
                         }
                     )

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -855,10 +855,7 @@ tooltip session =
     case session.hovered of
         HoverState.Tooltip (Message.PipelineStatusIcon _ _) _ ->
             Just
-                { body =
-                    Html.div
-                        Styles.jobsDisabledTooltip
-                        [ Html.text "automatic job monitoring disabled" ]
+                { body = Html.text "automatic job monitoring disabled"
                 , attachPosition = { direction = Tooltip.Top, alignment = Tooltip.Start }
                 , arrow = Nothing
                 }
@@ -869,15 +866,12 @@ tooltip session =
                 |> Maybe.map
                     (\p ->
                         { body =
-                            Html.div
-                                Styles.visibilityTooltip
-                                [ Html.text <|
-                                    if p.public then
-                                        "hide pipeline"
+                            Html.text <|
+                                if p.public then
+                                    "hide pipeline"
 
-                                    else
-                                        "expose pipeline"
-                                ]
+                                else
+                                    "expose pipeline"
                         , attachPosition =
                             { direction = Tooltip.Top
                             , alignment = Tooltip.End
@@ -893,7 +887,7 @@ tooltip session =
                         Styles.jobPreviewTooltip
                         [ Html.text jobName ]
                 , attachPosition = { direction = Tooltip.Right 0, alignment = Tooltip.Middle 30 }
-                , arrow = Just { size = 15, color = "#000" }
+                , arrow = Just 15
                 }
 
         HoverState.Tooltip (Message.PipelinePreview _ id) _ ->
@@ -909,7 +903,7 @@ tooltip session =
                             { direction = Tooltip.Right 0
                             , alignment = Tooltip.Middle 30
                             }
-                        , arrow = Just { size = 15, color = "#000" }
+                        , arrow = Just 15
                         }
                     )
 
@@ -926,7 +920,7 @@ tooltip session =
                             { direction = Tooltip.Right 0
                             , alignment = Tooltip.Middle 30
                             }
-                        , arrow = Just { size = 15, color = "#000" }
+                        , arrow = Just 15
                         }
                     )
 
@@ -943,7 +937,7 @@ tooltip session =
                             { direction = Tooltip.Right 0
                             , alignment = Tooltip.Middle 30
                             }
-                        , arrow = Just { size = 15, color = "#000" }
+                        , arrow = Just 15
                         }
                     )
 
@@ -954,7 +948,7 @@ tooltip session =
                         Styles.cardTooltip
                         [ Html.text groupName ]
                 , attachPosition = { direction = Tooltip.Right 0, alignment = Tooltip.Middle 30 }
-                , arrow = Just { size = 15, color = "#000" }
+                , arrow = Just 15
                 }
 
         HoverState.Tooltip (Message.InstanceGroupCardNameHD _ groupName) _ ->
@@ -964,7 +958,7 @@ tooltip session =
                         Styles.cardTooltip
                         [ Html.text groupName ]
                 , attachPosition = { direction = Tooltip.Right 0, alignment = Tooltip.Middle 30 }
-                , arrow = Just { size = 15, color = "#000" }
+                , arrow = Just 15
                 }
 
         HoverState.Tooltip (Message.PipelineCardInstanceVar _ _ key value) _ ->
@@ -974,7 +968,7 @@ tooltip session =
                         Styles.cardTooltip
                         [ Html.text <| key ++ ": " ++ value ]
                 , attachPosition = { direction = Tooltip.Right 0, alignment = Tooltip.Middle 30 }
-                , arrow = Just { size = 15, color = "#000" }
+                , arrow = Just 15
                 }
 
         _ ->

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -350,12 +350,12 @@ footerView session pipeline section now hovered existingJobs =
                     status == PipelineStatus.PipelineStatusPaused
                 , pipeline = pipelineId
                 , isToggleHovered =
-                    HoverState.isHovered (PipelineCardPauseToggle section pipelineId) hovered
+                    HoverState.isHovered (PipelineCardPauseToggle section pipeline.id) hovered
                 , isToggleLoading = pipeline.isToggleLoading
                 , tooltipPosition = Views.Styles.Above
                 , margin = "0"
                 , userState = session.userState
-                , domID = PipelineCardPauseToggle section pipelineId
+                , domID = PipelineCardPauseToggle section pipeline.id
                 }
 
         visibilityButton =
@@ -381,7 +381,7 @@ footerView session pipeline section now hovered existingJobs =
                 , isSideBar = False
                 , domID = PipelineCardFavoritedIcon section pipeline.id
                 }
-                [ id <| Effects.toHtmlID <| PipelineCardFavoritedIcon section pipeline.id ]
+                []
     in
     Html.div
         (class "card-footer" :: Styles.pipelineCardFooter)

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -26,7 +26,6 @@ module Dashboard.Styles exposing
     , jobPreview
     , jobPreviewLink
     , jobPreviewTooltip
-    , jobsDisabledTooltip
     , legend
     , legendItem
     , legendSeparator
@@ -69,7 +68,6 @@ module Dashboard.Styles exposing
     , topBarContent
     , topCliIcon
     , visibilityToggle
-    , visibilityTooltip
     , welcomeCard
     , welcomeCardBody
     , welcomeCardTitle
@@ -937,31 +935,9 @@ visibilityToggle { public, isClickable, isHovered } =
     ]
 
 
-visibilityTooltip : List (Html.Attribute msg)
-visibilityTooltip =
-    [ style "background-color" Colors.tooltipBackground
-    , style "color" Colors.tooltipText
-    , style "white-space" "nowrap"
-    , style "padding" "2.5px"
-    ]
-
-
-jobsDisabledTooltip : List (Html.Attribute msg)
-jobsDisabledTooltip =
-    [ style "background-color" Colors.tooltipBackground
-    , style "color" Colors.tooltipText
-    , style "padding" "2.5px"
-    ]
-
-
 cardTooltip : List (Html.Attribute msg)
 cardTooltip =
-    [ style "position" "absolute"
-    , style "left" "100%"
-    , style "padding" "6px 12px 6px 6px"
-    , style "background-color" "#000"
-    , style "font-size" "13px"
-    , style "white-space" "nowrap"
+    [ style "padding" "6px 12px 6px 6px"
     ]
 
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -85,6 +85,7 @@ import Dashboard.Grid.Constants as GridConstants
 import Html
 import Html.Attributes exposing (style)
 import ScreenSize exposing (ScreenSize(..))
+import Tooltip
 import Views.Styles
 
 
@@ -938,7 +939,12 @@ visibilityToggle { public, isClickable, isHovered } =
 cardTooltip : List (Html.Attribute msg)
 cardTooltip =
     [ style "padding" "6px 12px 6px 6px"
+    , style "height" "30px"
+    , style "box-sizing" "border-box"
+    , style "display" "flex"
+    , style "align-items" "center"
     ]
+        ++ Tooltip.colors
 
 
 jobPreviewTooltip : List (Html.Attribute msg)

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -50,7 +50,7 @@ import Job.Styles as Styles
 import List.Extra
 import Login.Login as Login
 import Message.Callback exposing (Callback(..))
-import Message.Effects exposing (Effect(..))
+import Message.Effects exposing (Effect(..), toHtmlID)
 import Message.Message exposing (DomID(..), Message(..))
 import Message.Subscription exposing (Delivery(..), Interval(..), Subscription(..))
 import Message.TopLevelMessage exposing (TopLevelMessage(..))
@@ -448,9 +448,39 @@ view session model =
         ]
 
 
-tooltip : Model -> a -> Maybe Tooltip.Tooltip
-tooltip _ _ =
-    Nothing
+tooltip : Model -> Session -> Maybe Tooltip.Tooltip
+tooltip model session =
+    case ( model.job |> RemoteData.toMaybe, session.hovered ) of
+        ( Just job, HoverState.Tooltip TriggerBuildButton _ ) ->
+            Just
+                { body =
+                    Html.text <|
+                        if job.disableManualTrigger then
+                            "manual triggering disabled in job config"
+
+                        else
+                            "trigger a new build"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        ( Just job, HoverState.Tooltip ToggleJobButton _ ) ->
+            Just
+                { body =
+                    Html.text <|
+                        if job.paused then
+                            "unpause job"
+
+                        else
+                            "pause job"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        _ ->
+            Nothing
 
 
 viewMainJobsSection : Session -> Model -> Html Message
@@ -495,7 +525,7 @@ viewMainJobsSection session model =
 
                               else
                                 Html.button
-                                    ([ id "pause-toggle"
+                                    ([ id <| toHtmlID ToggleJobButton
                                      , onMouseEnter <| Hover <| Just ToggleJobButton
                                      , onMouseLeave <| Hover Nothing
                                      , onClick <| Click ToggleJobButton
@@ -527,7 +557,8 @@ viewMainJobsSection session model =
 
                           else
                             Html.button
-                                ([ class "trigger-build"
+                                ([ id <| toHtmlID TriggerBuildButton
+                                 , class "trigger-build"
                                  , onLeftClick <| Click TriggerBuildButton
                                  , attribute "aria-label" "Trigger Build"
                                  , attribute "title" "Trigger Build"
@@ -548,18 +579,6 @@ viewMainJobsSection session model =
                                             && not job.disableManualTrigger
                                     )
                                 ]
-                                    ++ (if job.disableManualTrigger && triggerHovered then
-                                            [ Html.div
-                                                Styles.triggerTooltip
-                                                [ Html.text <|
-                                                    "manual triggering disabled "
-                                                        ++ "in job config"
-                                                ]
-                                            ]
-
-                                        else
-                                            []
-                                       )
                         ]
                     , Html.div
                         [ id "pagination-header"

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -479,6 +479,33 @@ tooltip model session =
                 , containerAttrs = Nothing
                 }
 
+        ( _, HoverState.Tooltip (JobBuildLink buildName) _ ) ->
+            Just
+                { body =
+                    Html.text <|
+                        "view build #"
+                            ++ buildName
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
+                , arrow = Nothing
+                , containerAttrs = Nothing
+                }
+
+        ( _, HoverState.Tooltip NextPageButton _ ) ->
+            Just
+                { body = Html.text "view next page"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        ( _, HoverState.Tooltip PreviousPageButton _ ) ->
+            Just
+                { body = Html.text "view previous page"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
         _ ->
             Nothing
 
@@ -665,6 +692,7 @@ viewPaginationBar session model =
                                 ([ StrictEvents.onLeftClick <| GoToRoute jobRoute
                                  , href <| Routes.toString <| jobRoute
                                  , attribute "aria-label" "Previous Page"
+                                 , id <| toHtmlID PreviousPageButton
                                  ]
                                     ++ chevronLeft
                                         { enabled = True
@@ -704,6 +732,7 @@ viewPaginationBar session model =
                                 ([ StrictEvents.onLeftClick <| GoToRoute jobRoute
                                  , href <| Routes.toString jobRoute
                                  , attribute "aria-label" "Next Page"
+                                 , id <| toHtmlID NextPageButton
                                  ]
                                     ++ chevronRight
                                         { enabled = True
@@ -762,6 +791,10 @@ viewBuildWithResources session model bwr =
 
 viewBuildHeader : Concourse.Build -> Html Message
 viewBuildHeader b =
+    let
+        domID =
+            JobBuildLink b.name
+    in
     Html.a
         [ class <| Concourse.BuildStatus.show b.status
         , StrictEvents.onLeftClick <|
@@ -770,9 +803,11 @@ viewBuildHeader b =
         , href <|
             Routes.toString <|
                 Routes.buildRoute b.id b.name b.job
+        , onMouseEnter <| Hover <| Just domID
+        , onMouseLeave <| Hover Nothing
+        , id <| toHtmlID domID
         ]
-        [ Html.text ("#" ++ b.name)
-        ]
+        [ Html.text ("#" ++ b.name) ]
 
 
 viewBuildResources : BuildWithResources -> List (Html Message)

--- a/web/elm/src/Job/Styles.elm
+++ b/web/elm/src/Job/Styles.elm
@@ -10,7 +10,6 @@ import Colors
 import Concourse.BuildStatus exposing (BuildStatus)
 import Html
 import Html.Attributes exposing (style)
-import Views.Styles
 
 
 triggerButton : Bool -> Bool -> BuildStatus -> List (Html.Attribute msg)

--- a/web/elm/src/Job/Styles.elm
+++ b/web/elm/src/Job/Styles.elm
@@ -4,7 +4,6 @@ module Job.Styles exposing
     , icon
     , noBuildsMessage
     , triggerButton
-    , triggerTooltip
     )
 
 import Colors
@@ -47,20 +46,6 @@ icon hovered =
         else
             "0.5"
     ]
-
-
-triggerTooltip : List (Html.Attribute msg)
-triggerTooltip =
-    [ style "position" "absolute"
-    , style "right" "100%"
-    , style "top" "15px"
-    , style "width" "300px"
-    , style "color" Colors.buildTooltipText
-    , style "padding" "10px"
-    , style "text-align" "right"
-    , style "pointer-events" "none"
-    ]
-        ++ Views.Styles.defaultFont
 
 
 buildResourceHeader : List (Html.Attribute msg)

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -804,6 +804,18 @@ toHtmlID domId =
         PinBar ->
             "pin-bar"
 
+        JobName ->
+            "job-name"
+
+        JobBuildLink name ->
+            "job-build-" ++ Base64.encode name
+
+        NextPageButton ->
+            "next-page"
+
+        PreviousPageButton ->
+            "previous-page"
+
         _ ->
             ""
 

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -786,6 +786,24 @@ toHtmlID domId =
         ToggleJobButton ->
             "toggle-job-button"
 
+        CheckButton _ ->
+            "check-button"
+
+        PinIcon ->
+            "pin-icon"
+
+        EditButton ->
+            "edit-button"
+
+        PinButton id ->
+            "pin-button_" ++ String.fromInt id.versionID
+
+        VersionToggle id ->
+            "version-toggle_" ++ String.fromInt id.versionID
+
+        PinBar ->
+            "pin-bar"
+
         _ ->
             ""
 

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -688,6 +688,18 @@ toHtmlID domId =
                 ++ encodePipelineId p
                 ++ "_visibility"
 
+        PipelineCardFavoritedIcon section p ->
+            pipelinesSectionName section
+                ++ "_"
+                ++ encodePipelineId p
+                ++ "_favorite"
+
+        PipelineCardPauseToggle section p ->
+            pipelinesSectionName section
+                ++ "_"
+                ++ encodePipelineId p
+                ++ "_toggle_pause"
+
         PipelineCardName section p ->
             pipelinesSectionName section
                 ++ "_"

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -774,6 +774,15 @@ toHtmlID domId =
         TopBarPinIcon ->
             "top-bar-pin-icon"
 
+        AbortBuildButton ->
+            "abort-build-button"
+
+        RerunBuildButton ->
+            "rerun-build-button"
+
+        TriggerBuildButton ->
+            "trigger-build-button"
+
         _ ->
             ""
 

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -756,6 +756,12 @@ toHtmlID domId =
         TopBarFavoritedIcon _ ->
             "top-bar-favorited-icon"
 
+        TopBarPauseToggle _ ->
+            "top-bar-pause-toggle"
+
+        TopBarPinIcon ->
+            "top-bar-pin-icon"
+
         _ ->
             ""
 

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -783,6 +783,9 @@ toHtmlID domId =
         TriggerBuildButton ->
             "trigger-build-button"
 
+        ToggleJobButton ->
+            "toggle-job-button"
+
         _ ->
             ""
 

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -67,6 +67,7 @@ type DomID
     | PipelineCardInstanceVar PipelinesSection Concourse.DatabaseID String String
     | PipelineStatusIcon PipelinesSection Concourse.DatabaseID
     | PipelineCardPauseToggle PipelinesSection Concourse.PipelineIdentifier
+    | TopBarPinIcon
     | TopBarFavoritedIcon Concourse.DatabaseID
     | TopBarPauseToggle Concourse.PipelineIdentifier
     | VisibilityButton PipelinesSection Concourse.DatabaseID

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -48,6 +48,8 @@ type DomID
     | TriggerBuildButton
     | AbortBuildButton
     | RerunBuildButton
+    | JobName
+    | JobBuildLink Concourse.BuildName
     | PreviousPageButton
     | NextPageButton
     | CheckButton Bool

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -66,12 +66,12 @@ type DomID
     | InstanceGroupCardNameHD Concourse.TeamName String
     | PipelineCardInstanceVar PipelinesSection Concourse.DatabaseID String String
     | PipelineStatusIcon PipelinesSection Concourse.DatabaseID
-    | PipelineCardPauseToggle PipelinesSection Concourse.PipelineIdentifier
+    | PipelineCardFavoritedIcon PipelinesSection Concourse.DatabaseID
+    | PipelineCardPauseToggle PipelinesSection Concourse.DatabaseID
     | TopBarPinIcon
     | TopBarFavoritedIcon Concourse.DatabaseID
     | TopBarPauseToggle Concourse.PipelineIdentifier
     | VisibilityButton PipelinesSection Concourse.DatabaseID
-    | PipelineCardFavoritedIcon PipelinesSection Concourse.DatabaseID
     | FooterCliIcon Cli.Cli
     | WelcomeCardCliIcon Cli.Cli
     | CopyTokenButton

--- a/web/elm/src/Pinned.elm
+++ b/web/elm/src/Pinned.elm
@@ -30,7 +30,7 @@ type VersionPinState
     = Enabled
     | PinnedDynamically
     | NotThePinnedVersion
-    | PinnedStatically Bool
+    | PinnedStatically
     | Disabled
     | InTransition
 
@@ -113,7 +113,7 @@ pinState version id resourcePinState =
     case resourcePinState of
         PinnedStaticallyTo v ->
             if v == version then
-                PinnedStatically False
+                PinnedStatically
 
             else
                 Disabled

--- a/web/elm/src/Pipeline/PinMenu/PinMenu.elm
+++ b/web/elm/src/Pipeline/PinMenu/PinMenu.elm
@@ -115,6 +115,7 @@ tooltip model session =
                                 "view pinned resources"
                     , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
                     , arrow = Nothing
+                    , containerAttrs = Nothing
                     }
 
         _ ->
@@ -251,8 +252,7 @@ getPinnedResources fetchedResources =
 viewView : View -> Html Message
 viewView view =
     Html.div
-        (([ ( id <| toHtmlID TopBarPinIcon, True )
-          , ( onMouseEnter <| Hover <| Just TopBarPinIcon, True )
+        (([ ( onMouseEnter <| Hover <| Just TopBarPinIcon, True )
           , ( onMouseLeave <| Hover Nothing, True )
           , ( onClick <| Click TopBarPinIcon, view.clickable )
           ]
@@ -262,7 +262,7 @@ viewView view =
             ++ Styles.pinIconBackground view
         )
         (Html.div
-            (Styles.pinIcon view)
+            (id (toHtmlID TopBarPinIcon) :: Styles.pinIcon view)
             []
             :: ([ Maybe.map viewBadge view.badge
                 , Maybe.map viewDropdown view.dropdown

--- a/web/elm/src/Pipeline/PinMenu/PinMenu.elm
+++ b/web/elm/src/Pipeline/PinMenu/PinMenu.elm
@@ -2,10 +2,12 @@ module Pipeline.PinMenu.PinMenu exposing
     ( TableRow
     , View
     , pinMenu
+    , tooltip
     , update
     , viewPinMenu
     )
 
+import Application.Models exposing (Session)
 import Colors
 import Concourse
 import Dict
@@ -14,11 +16,13 @@ import HoverState
 import Html exposing (Html)
 import Html.Attributes exposing (id, style)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
+import Message.Effects exposing (toHtmlID)
 import Message.Message exposing (DomID(..), Message(..))
 import Pipeline.PinMenu.Styles as Styles
 import Pipeline.PinMenu.Views as Views
 import Routes
 import SideBar.Styles as SS
+import Tooltip
 import Views.Styles
 
 
@@ -31,8 +35,7 @@ type alias Model b =
 
 
 type alias View =
-    { hoverable : Bool
-    , clickable : Bool
+    { clickable : Bool
     , background : Views.Background
     , opacity : SS.Opacity
     , badge : Maybe Badge
@@ -81,13 +84,44 @@ type alias TableRow =
 update : Message -> ET (Model b)
 update message ( model, effects ) =
     case message of
-        Click PinIcon ->
+        Click TopBarPinIcon ->
             ( { model | pinMenuExpanded = not model.pinMenuExpanded }
             , effects
             )
 
         _ ->
             ( model, effects )
+
+
+tooltip : Model b -> Session -> Maybe Tooltip.Tooltip
+tooltip model session =
+    case session.hovered of
+        HoverState.Tooltip TopBarPinIcon _ ->
+            let
+                pinnedResources =
+                    getPinnedResources model.fetchedResources
+            in
+            if model.pinMenuExpanded then
+                Nothing
+
+            else
+                Just
+                    { body =
+                        Html.div
+                            Tooltip.defaultStyle
+                            [ Html.text <|
+                                if List.isEmpty pinnedResources then
+                                    "no pinned resources"
+
+                                else
+                                    "view pinned resources"
+                            ]
+                    , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
+                    , arrow = Nothing
+                    }
+
+        _ ->
+            Nothing
 
 
 pinMenu :
@@ -109,12 +143,11 @@ pinMenu { hovered } model =
             pinCount > 0
 
         isHovered =
-            hovered == HoverState.Hovered PinIcon
+            hovered == HoverState.Hovered TopBarPinIcon
     in
-    { hoverable = hasPinnedResources
-    , clickable = hasPinnedResources
+    { clickable = hasPinnedResources
     , opacity =
-        if isHovered || model.pinMenuExpanded then
+        if hasPinnedResources && (isHovered || model.pinMenuExpanded) then
             SS.Bright
 
         else if hasPinnedResources then
@@ -221,10 +254,10 @@ getPinnedResources fetchedResources =
 viewView : View -> Html Message
 viewView view =
     Html.div
-        (([ ( id "pin-icon", True )
-          , ( onMouseEnter <| Hover <| Just PinIcon, view.hoverable )
-          , ( onMouseLeave <| Hover Nothing, view.hoverable )
-          , ( onClick <| Click PinIcon, view.clickable )
+        (([ ( id <| toHtmlID TopBarPinIcon, True )
+          , ( onMouseEnter <| Hover <| Just TopBarPinIcon, True )
+          , ( onMouseLeave <| Hover Nothing, True )
+          , ( onClick <| Click TopBarPinIcon, view.clickable )
           ]
             |> List.filter Tuple.second
             |> List.map Tuple.first

--- a/web/elm/src/Pipeline/PinMenu/PinMenu.elm
+++ b/web/elm/src/Pipeline/PinMenu/PinMenu.elm
@@ -113,8 +113,8 @@ tooltip model session =
 
                             else
                                 "view pinned resources"
-                    , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
-                    , arrow = Nothing
+                    , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                    , arrow = Just 5
                     , containerAttrs = Nothing
                     }
 

--- a/web/elm/src/Pipeline/PinMenu/PinMenu.elm
+++ b/web/elm/src/Pipeline/PinMenu/PinMenu.elm
@@ -107,15 +107,12 @@ tooltip model session =
             else
                 Just
                     { body =
-                        Html.div
-                            Tooltip.defaultStyle
-                            [ Html.text <|
-                                if List.isEmpty pinnedResources then
-                                    "no pinned resources"
+                        Html.text <|
+                            if List.isEmpty pinnedResources then
+                                "no pinned resources"
 
-                                else
-                                    "view pinned resources"
-                            ]
+                            else
+                                "view pinned resources"
                     , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
                     , arrow = Nothing
                     }

--- a/web/elm/src/Pipeline/PinMenu/Styles.elm
+++ b/web/elm/src/Pipeline/PinMenu/Styles.elm
@@ -27,7 +27,6 @@ pinIconBackground :
 pinIconBackground { background, clickable } =
     [ style "position" "relative"
     , style "border-left" <| "1px solid " ++ Colors.background
-    , style "border-bottom" <| "1px solid " ++ Colors.frame
     , style "width" "54px"
     , style "height" "54px"
     , style "display" "flex"
@@ -54,8 +53,8 @@ pinIcon { opacity } =
     [ style "background-image" <|
         Assets.backgroundImage <|
             Just Assets.PinIconWhite
-    , style "width" "18px"
-    , style "height" "18px"
+    , style "width" "20px"
+    , style "height" "20px"
     , style "background-repeat" "no-repeat"
     , style "background-position" "50% 50%"
     , style "background-size" "contain"

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -446,15 +446,12 @@ tooltip model session =
             in
             Just
                 { body =
-                    Html.div
-                        Tooltip.defaultStyle
-                        [ Html.text <|
-                            if isFavorited then
-                                "unfavorite pipeline"
+                    Html.text <|
+                        if isFavorited then
+                            "unfavorite pipeline"
 
-                            else
-                                "favorite pipeline"
-                        ]
+                        else
+                            "favorite pipeline"
                 , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
                 , arrow = Nothing
                 }
@@ -462,15 +459,12 @@ tooltip model session =
         HoverState.Tooltip (TopBarPauseToggle _) _ ->
             Just
                 { body =
-                    Html.div
-                        Tooltip.defaultStyle
-                        [ Html.text <|
-                            if isPaused model.pipeline then
-                                "unpause pipeline"
+                    Html.text <|
+                        if isPaused model.pipeline then
+                            "unpause pipeline"
 
-                            else
-                                "pause pipeline"
-                        ]
+                        else
+                            "pause pipeline"
                 , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
                 , arrow = Nothing
                 }

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -35,7 +35,7 @@ import Http
 import Keyboard
 import Login.Login as Login
 import Message.Callback exposing (Callback(..))
-import Message.Effects exposing (Effect(..), toHtmlID)
+import Message.Effects exposing (Effect(..))
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Message.Subscription
     exposing

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -450,8 +450,8 @@ tooltip model session =
 
                         else
                             "favorite pipeline"
-                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
-                , arrow = Nothing
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
                 , containerAttrs = Nothing
                 }
 
@@ -464,8 +464,8 @@ tooltip model session =
 
                         else
                             "pause pipeline"
-                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
-                , arrow = Nothing
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
                 , containerAttrs = Nothing
                 }
 

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -392,9 +392,7 @@ view session model =
                 , TopBar.breadcrumbs session route
                 , PinMenu.viewPinMenu session model
                 , Html.div
-                    (id (toHtmlID <| TopBarFavoritedIcon <| getPipelineId model.pipeline)
-                        :: Styles.favoritedIcon
-                    )
+                    Styles.favoritedIcon
                     [ FavoritedIcon.view
                         { isHovered = HoverState.isHovered (TopBarFavoritedIcon <| getPipelineId model.pipeline) session.hovered
                         , isFavorited =
@@ -409,7 +407,7 @@ view session model =
 
                   else
                     Html.div
-                        (id (toHtmlID <| TopBarPauseToggle model.pipelineLocator) :: Styles.pauseToggle)
+                        Styles.pauseToggle
                         [ PauseToggle.view
                             { pipeline = model.pipelineLocator
                             , isPaused = isPaused model.pipeline
@@ -454,6 +452,7 @@ tooltip model session =
                             "favorite pipeline"
                 , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
                 , arrow = Nothing
+                , containerAttrs = Nothing
                 }
 
         HoverState.Tooltip (TopBarPauseToggle _) _ ->
@@ -467,6 +466,7 @@ tooltip model session =
                             "pause pipeline"
                 , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
                 , arrow = Nothing
+                , containerAttrs = Nothing
                 }
 
         _ ->

--- a/web/elm/src/Resource/Models.elm
+++ b/web/elm/src/Resource/Models.elm
@@ -71,5 +71,4 @@ type alias Version =
     , expanded : Bool
     , inputTo : List Concourse.Build
     , outputOf : List Concourse.Build
-    , showTooltip : Bool
     }

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -1078,6 +1078,22 @@ tooltip model session =
                 _ ->
                     Nothing
 
+        HoverState.Tooltip NextPageButton _ ->
+            Just
+                { body = Html.text "view next page"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        HoverState.Tooltip PreviousPageButton _ ->
+            Just
+                { body = Html.text "view previous page"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
         _ ->
             model.output
                 |> Maybe.andThen .steps
@@ -1230,6 +1246,7 @@ paginationMenu { hovered } model =
                                     , page = Just page
                                     }
                          , attribute "aria-label" "Previous Page"
+                         , id <| toHtmlID PreviousPageButton
                          ]
                             ++ chevronLeft
                                 { enabled = True
@@ -1267,6 +1284,7 @@ paginationMenu { hovered } model =
                                     , page = Just page
                                     }
                          , attribute "aria-label" "Next Page"
+                         , id <| toHtmlID NextPageButton
                          ]
                             ++ chevronRight
                                 { enabled = True

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -1649,10 +1649,7 @@ isPipelineArchived session id =
 
 
 viewVersionedResources :
-    { a
-        | hovered : HoverState.HoverState
-        , pipelines : WebData (List Concourse.Pipeline)
-    }
+    { a | pipelines : WebData (List Concourse.Pipeline) }
     ->
         { b
             | versions : Paginated Models.Version
@@ -1667,26 +1664,16 @@ viewVersionedResources session model =
     in
     model
         |> versions
-        |> List.map
-            (\v ->
-                viewVersionedResource
-                    { version = v
-                    , pinnedVersion = model.pinnedVersion
-                    , hovered = session.hovered
-                    , archived = archived
-                    }
-            )
+        |> List.map (\v -> viewVersionedResource { version = v, archived = archived })
         |> Html.ul [ class "list list-collapsable list-enableDisable resource-versions" ]
 
 
 viewVersionedResource :
     { version : VersionPresenter
-    , pinnedVersion : Models.PinnedVersion
-    , hovered : HoverState.HoverState
     , archived : Bool
     }
     -> Html Message
-viewVersionedResource { version, hovered, archived } =
+viewVersionedResource { version, archived } =
     Html.li
         (case ( version.pinState, version.enabled ) of
             ( Disabled, _ ) ->
@@ -1717,7 +1704,6 @@ viewVersionedResource { version, hovered, archived } =
                 , viewPinButton
                     { versionID = version.id
                     , pinState = version.pinState
-                    , hovered = hovered
                     }
                 ]
              )
@@ -1820,10 +1806,9 @@ viewEnabledCheckbox ({ enabled, id } as params) =
 viewPinButton :
     { versionID : Models.VersionId
     , pinState : VersionPinState
-    , hovered : HoverState.HoverState
     }
     -> Html Message
-viewPinButton { versionID, pinState, hovered } =
+viewPinButton { versionID, pinState } =
     let
         eventHandlers =
             [ onMouseOver <| Hover <| Just <| PinButton versionID

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -396,7 +396,6 @@ handleCallback callback session ( model, effects ) =
                                             , expanded = False
                                             , inputTo = []
                                             , outputOf = []
-                                            , showTooltip = False
                                             }
                                 )
                     }
@@ -927,13 +926,7 @@ versions model =
                 , expanded = v.expanded
                 , inputTo = v.inputTo
                 , outputOf = v.outputOf
-                , pinState =
-                    case Pinned.pinState v.version v.id model.pinnedVersion of
-                        PinnedStatically _ ->
-                            PinnedStatically v.showTooltip
-
-                        x ->
-                            x
+                , pinState = Pinned.pinState v.version v.id model.pinnedVersion
                 }
             )
 
@@ -980,11 +973,115 @@ view session model =
         ]
 
 
-tooltip : Model -> { a | hovered : HoverState.HoverState } -> Maybe Tooltip.Tooltip
+tooltip : Model -> Session -> Maybe Tooltip.Tooltip
 tooltip model session =
-    model.output
-        |> Maybe.andThen .steps
-        |> Maybe.andThen (\steps -> StepTree.tooltip steps session)
+    case session.hovered of
+        HoverState.Tooltip (CheckButton _) _ ->
+            Just
+                { body = Html.text "trigger manual check"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        HoverState.Tooltip PinIcon _ ->
+            Just
+                { body = Html.text "unpin version"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        HoverState.Tooltip EditButton _ ->
+            Just
+                { body = Html.text "edit pin comment"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.End }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        HoverState.Tooltip (PinButton id) _ ->
+            let
+                version =
+                    model.versions.content |> List.Extra.find (\v -> v.id == id)
+
+                isPinnedDynamically =
+                    case ( version, model.pinnedVersion ) of
+                        ( Just cur, PinnedDynamicallyTo _ v ) ->
+                            cur.version == v
+
+                        _ ->
+                            False
+
+                isStatic =
+                    case model.pinnedVersion of
+                        PinnedStaticallyTo _ ->
+                            True
+
+                        _ ->
+                            False
+            in
+            Just
+                { body =
+                    Html.text <|
+                        if isStatic then
+                            "version is pinned in the pipeline config"
+
+                        else if isPinnedDynamically then
+                            "unpin version"
+
+                        else
+                            "pin version"
+                , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
+        HoverState.Tooltip (VersionToggle id) _ ->
+            let
+                enabled =
+                    model
+                        |> versions
+                        |> List.Extra.find (\v -> v.id == id)
+                        |> Maybe.map .enabled
+            in
+            (case enabled of
+                Just Models.Enabled ->
+                    Just "disable version"
+
+                Just Models.Disabled ->
+                    Just "enable version"
+
+                _ ->
+                    Nothing
+            )
+                |> Maybe.map
+                    (\text ->
+                        { body =
+                            Html.text text
+                        , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
+                        , arrow = Just 5
+                        , containerAttrs = Nothing
+                        }
+                    )
+
+        HoverState.Tooltip PinBar _ ->
+            case model.pinnedVersion of
+                PinnedStaticallyTo _ ->
+                    Just
+                        { body = Html.text "version is pinned in the pipeline config"
+                        , attachPosition = { direction = Tooltip.Bottom, alignment = Tooltip.Start }
+                        , arrow = Nothing
+                        , containerAttrs = Nothing
+                        }
+
+                _ ->
+                    Nothing
+
+        _ ->
+            model.output
+                |> Maybe.andThen .steps
+                |> Maybe.andThen (\steps -> StepTree.tooltip steps session)
 
 
 header : Session -> Model -> Html Message
@@ -1296,7 +1393,8 @@ checkButton ({ hovered, userState, checkStatus } as params) =
             (isClickable && isHovered) || isCurrentlyChecking
     in
     Html.div
-        ([ onMouseEnter <| Hover <| Just <| CheckButton isMember
+        ([ id <| toHtmlID <| CheckButton isMember
+         , onMouseEnter <| Hover <| Just <| CheckButton isMember
          , onMouseLeave <| Hover Nothing
          ]
             ++ Resource.Styles.checkButton isClickable
@@ -1387,7 +1485,7 @@ editButton session =
         { sizePx = 16
         , image = Assets.PencilIcon
         }
-        ([ id "edit-button"
+        ([ id <| toHtmlID EditButton
          , onMouseEnter <| Hover <| Just EditButton
          , onMouseLeave <| Hover Nothing
          , onClick <| Click EditButton
@@ -1498,7 +1596,7 @@ pinBar session { pinnedVersion, resourceIdentifier } =
     in
     Html.div
         (attrList
-            [ ( id "pin-bar", True )
+            [ ( id <| toHtmlID PinBar, True )
             , ( onMouseEnter <| Hover <| Just PinBar, isPinnedStatically )
             , ( onMouseLeave <| Hover Nothing, isPinnedStatically )
             ]
@@ -1514,14 +1612,16 @@ pinBar session { pinnedVersion, resourceIdentifier } =
                     Assets.PinIconGrey
             }
             (attrList
-                [ ( id "pin-icon", True )
+                [ ( id <| toHtmlID PinIcon, True )
                 , ( onClick <| Click PinIcon
                   , isPinnedDynamically && not archived
                   )
                 , ( onMouseEnter <| Hover <| Just PinIcon
                   , isPinnedDynamically && not archived
                   )
-                , ( onMouseLeave <| Hover Nothing, True )
+                , ( onMouseLeave <| Hover Nothing
+                  , isPinnedDynamically && not archived
+                  )
                 ]
                 ++ Resource.Styles.pinIcon
                     { clickable = isPinnedDynamically && not archived
@@ -1534,15 +1634,6 @@ pinBar session { pinnedVersion, resourceIdentifier } =
 
                     _ ->
                         []
-               )
-            ++ (if HoverState.isHovered PinBar session.hovered then
-                    [ Html.div
-                        (id "pin-bar-tooltip" :: Resource.Styles.pinBarTooltip)
-                        [ Html.text "pinned in pipeline config" ]
-                    ]
-
-                else
-                    []
                )
         )
 
@@ -1689,21 +1780,26 @@ viewEnabledCheckbox :
     -> Html Message
 viewEnabledCheckbox ({ enabled, id } as params) =
     let
-        clickHandler =
-            case enabled of
-                Models.Enabled ->
-                    [ onClick <| Click <| VersionToggle id ]
+        eventHandlers =
+            [ onMouseOver <| Hover <| Just <| VersionToggle id
+            , onMouseOut <| Hover Nothing
+            ]
+                ++ (case enabled of
+                        Models.Enabled ->
+                            [ onClick <| Click <| VersionToggle id ]
 
-                Models.Changing ->
-                    []
+                        Models.Changing ->
+                            []
 
-                Models.Disabled ->
-                    [ onClick <| Click <| VersionToggle id ]
+                        Models.Disabled ->
+                            [ onClick <| Click <| VersionToggle id ]
+                   )
     in
     Html.div
-        (Html.Attributes.attribute "aria-label" "Toggle Resource Version Enabled"
+        (Html.Attributes.id (toHtmlID <| VersionToggle id)
+            :: Html.Attributes.attribute "aria-label" "Toggle Resource Version Enabled"
             :: Resource.Styles.enabledCheckbox params
-            ++ clickHandler
+            ++ eventHandlers
         )
         (case enabled of
             Models.Enabled ->
@@ -1730,43 +1826,38 @@ viewPinButton :
 viewPinButton { versionID, pinState, hovered } =
     let
         eventHandlers =
-            case pinState of
-                Enabled ->
-                    [ onClick <| Click <| PinButton versionID ]
+            [ onMouseOver <| Hover <| Just <| PinButton versionID
+            , onMouseOut <| Hover Nothing
+            ]
+                ++ (case pinState of
+                        Enabled ->
+                            [ onClick <| Click <| PinButton versionID ]
 
-                PinnedDynamically ->
-                    [ onClick <| Click <| PinButton versionID ]
+                        PinnedDynamically ->
+                            [ onClick <| Click <| PinButton versionID ]
 
-                NotThePinnedVersion ->
-                    [ onClick <| Click <| PinButton versionID ]
+                        NotThePinnedVersion ->
+                            [ onClick <| Click <| PinButton versionID ]
 
-                PinnedStatically _ ->
-                    [ onMouseOver <| Hover <| Just <| PinButton versionID
-                    , onMouseOut <| Hover Nothing
-                    ]
+                        PinnedStatically ->
+                            [ onMouseOver <| Hover <| Just <| PinButton versionID
+                            , onMouseOut <| Hover Nothing
+                            ]
 
-                Disabled ->
-                    []
+                        Disabled ->
+                            []
 
-                InTransition ->
-                    []
+                        InTransition ->
+                            []
+                   )
     in
     Html.div
-        (Html.Attributes.attribute "aria-label" "Pin Resource Version"
+        (id (toHtmlID <| PinButton versionID)
+            :: Html.Attributes.attribute "aria-label" "Pin Resource Version"
             :: Resource.Styles.pinButton pinState
             ++ eventHandlers
         )
         (case pinState of
-            PinnedStatically _ ->
-                if HoverState.isHovered (PinButton versionID) hovered then
-                    [ Html.div
-                        Resource.Styles.pinButtonTooltip
-                        [ Html.text "enable via pipeline config" ]
-                    ]
-
-                else
-                    []
-
             InTransition ->
                 [ Spinner.spinner
                     { sizePx = 12.5

--- a/web/elm/src/Resource/Styles.elm
+++ b/web/elm/src/Resource/Styles.elm
@@ -20,10 +20,8 @@ module Resource.Styles exposing
     , headerResourceName
     , pagination
     , pinBar
-    , pinBarTooltip
     , pinBarViewVersion
     , pinButton
-    , pinButtonTooltip
     , pinIcon
     , pinTools
     , versionHeader
@@ -91,18 +89,6 @@ pinIcon { clickable, hover } =
     , style "background-origin" "content-box"
     , style "min-width" "14px"
     , style "min-height" "14px"
-    ]
-
-
-pinBarTooltip : List (Html.Attribute msg)
-pinBarTooltip =
-    [ style "position" "absolute"
-    , style "top" "-10px"
-    , style "left" "30px"
-    , style "background-color" Colors.tooltipBackground
-    , style "color" Colors.tooltipText
-    , style "padding" "5px"
-    , style "z-index" "2"
     ]
 
 
@@ -181,7 +167,7 @@ pinButton pinState =
             Pinned.NotThePinnedVersion ->
                 "pointer"
 
-            Pinned.PinnedStatically _ ->
+            Pinned.PinnedStatically ->
                 "default"
 
             Pinned.Disabled ->
@@ -197,18 +183,6 @@ pinButton pinState =
 
                 _ ->
                     Just Assets.PinIconWhite
-    ]
-
-
-pinButtonTooltip : List (Html.Attribute msg)
-pinButtonTooltip =
-    [ style "position" "absolute"
-    , style "bottom" "25px"
-    , style "background-color" Colors.tooltipBackground
-    , style "color" Colors.tooltipText
-    , style "z-index" "2"
-    , style "padding" "5px"
-    , style "width" "170px"
     ]
 
 
@@ -232,7 +206,7 @@ pinBarViewVersion =
 borderColor : Pinned.VersionPinState -> String
 borderColor pinnedState =
     case pinnedState of
-        Pinned.PinnedStatically _ ->
+        Pinned.PinnedStatically ->
             Colors.pinned
 
         Pinned.PinnedDynamically ->

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -240,18 +240,19 @@ tooltip { hovered } =
     case hovered of
         HoverState.Tooltip (SideBarTeam _ teamName) _ ->
             Just
-                { body = Html.div Styles.tooltipBody [ Html.text teamName ]
+                { body = Html.text teamName
                 , attachPosition =
                     { direction =
                         Tooltip.Right (Styles.tooltipArrowSize - Styles.tooltipOffset)
                     , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize
                     }
                 , arrow = Just Styles.tooltipArrowSize
+                , containerAttrs = Just Styles.tooltipBody
                 }
 
         HoverState.Tooltip (SideBarPipeline _ pipelineID) _ ->
             Just
-                { body = Html.div Styles.tooltipBody [ Html.text pipelineID.pipelineName ]
+                { body = Html.text pipelineID.pipelineName
                 , attachPosition =
                     { direction =
                         Tooltip.Right <|
@@ -262,16 +263,18 @@ tooltip { hovered } =
                     , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize
                     }
                 , arrow = Just Styles.tooltipArrowSize
+                , containerAttrs = Just Styles.tooltipBody
                 }
 
         HoverState.Tooltip (SideBarInstanceGroup _ _ name) _ ->
             Just
-                { body = Html.div Styles.tooltipBody [ Html.text name ]
+                { body = Html.text name
                 , attachPosition =
                     { direction = Tooltip.Right <| Styles.tooltipArrowSize - Styles.tooltipOffset
                     , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize
                     }
                 , arrow = Just Styles.tooltipArrowSize
+                , containerAttrs = Just Styles.tooltipBody
                 }
 
         _ ->

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -13,7 +13,6 @@ module SideBar.SideBar exposing
     )
 
 import Assets
-import Colors
 import Concourse
 import EffectTransformer exposing (ET)
 import HoverState
@@ -247,7 +246,7 @@ tooltip { hovered } =
                         Tooltip.Right (Styles.tooltipArrowSize - Styles.tooltipOffset)
                     , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize
                     }
-                , arrow = Just { size = Styles.tooltipArrowSize, color = Colors.tooltipBackground }
+                , arrow = Just Styles.tooltipArrowSize
                 }
 
         HoverState.Tooltip (SideBarPipeline _ pipelineID) _ ->
@@ -262,7 +261,7 @@ tooltip { hovered } =
                                 - Styles.tooltipOffset
                     , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize
                     }
-                , arrow = Just { size = Styles.tooltipArrowSize, color = Colors.tooltipBackground }
+                , arrow = Just Styles.tooltipArrowSize
                 }
 
         HoverState.Tooltip (SideBarInstanceGroup _ _ name) _ ->
@@ -272,7 +271,7 @@ tooltip { hovered } =
                     { direction = Tooltip.Right <| Styles.tooltipArrowSize - Styles.tooltipOffset
                     , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize
                     }
-                , arrow = Just { size = Styles.tooltipArrowSize, color = Colors.tooltipBackground }
+                , arrow = Just Styles.tooltipArrowSize
                 }
 
         _ ->

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -24,7 +24,6 @@ module SideBar.Styles exposing
     , teamHeader
     , teamIcon
     , teamName
-    , tooltip
     , tooltipArrowSize
     , tooltipBody
     , tooltipOffset
@@ -35,6 +34,7 @@ import ColorValues
 import Colors
 import Html
 import Html.Attributes as Attr exposing (style)
+import Tooltip
 import Views.Icon as Icon
 import Views.Styles
 
@@ -380,22 +380,13 @@ pipelineFavorite fav =
     ]
 
 
-tooltip : Float -> Float -> List (Html.Attribute msg)
-tooltip top left =
-    [ style "position" "fixed"
-    , style "left" <| String.fromFloat left ++ "px"
-    , style "top" <| String.fromFloat top ++ "px"
-    , style "margin-top" "-15px"
-    , style "z-index" "1"
-    , style "display" "flex"
-    ]
-
-
 tooltipBody : List (Html.Attribute msg)
 tooltipBody =
-    [ style "padding-right" "10px"
+    [ style "padding-right" "12px"
+    , style "padding-left" "6px"
     , style "font-size" "12px"
     , style "display" "flex"
     , style "align-items" "center"
     , style "height" "30px"
     ]
+        ++ Tooltip.colors

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -393,9 +393,7 @@ tooltip top left =
 
 tooltipBody : List (Html.Attribute msg)
 tooltipBody =
-    [ style "background-color" Colors.tooltipBackground
-    , style "color" Colors.tooltipText
-    , style "padding-right" "10px"
+    [ style "padding-right" "10px"
     , style "font-size" "12px"
     , style "display" "flex"
     , style "align-items" "center"

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -3,6 +3,7 @@ module Tooltip exposing
     , Direction(..)
     , Model
     , Tooltip
+    , colors
     , handleCallback
     , handleDelivery
     , hoverAttrs
@@ -36,6 +37,7 @@ type alias Model m =
 type alias Tooltip =
     { body : Html Message
     , arrow : Maybe Float
+    , containerAttrs : Maybe (List (Html.Attribute Message))
     , attachPosition : AttachPosition
     }
 
@@ -146,9 +148,9 @@ position { direction, alignment } { element, viewport } =
                     [ style "left" <| String.fromFloat (target.x + (target.width - width) / 2) ++ "px" ]
 
                 ( Bottom, End ) ->
-                    [ style "right" <| String.fromFloat (target.x + target.width) ++ "px" ]
+                    [ style "right" <| String.fromFloat (viewport.width - target.x - target.width) ++ "px" ]
     in
-    [ style "position" "fixed", style "z-index" "999" ] ++ vertical ++ horizontal
+    [ style "position" "fixed", style "z-index" "10000" ] ++ vertical ++ horizontal
 
 
 handleCallback : Callback -> ET (Model m)
@@ -222,13 +224,17 @@ arrowView { direction } target size =
 
 
 view : Model m -> Tooltip -> Html Message
-view { hovered } { body, attachPosition, arrow } =
+view { hovered } { body, attachPosition, arrow, containerAttrs } =
     case ( hovered, arrow ) of
         ( HoverState.Tooltip _ target, a ) ->
+            let
+                attrs =
+                    Maybe.withDefault defaultTooltipStyle containerAttrs
+            in
             Html.div
                 (id "tooltips" :: style "pointer-events" "none" :: position attachPosition target)
                 [ Maybe.map (arrowView attachPosition target) a |> Maybe.withDefault (Html.text "")
-                , Html.div tooltipStyle [ body ]
+                , Html.div attrs [ body ]
                 ]
 
         _ ->
@@ -255,9 +261,13 @@ handleDelivery session delivery ( model, effects ) =
             ( model, effects )
 
 
-tooltipStyle : List (Html.Attribute msg)
-tooltipStyle =
+colors : List (Html.Attribute msg)
+colors =
     [ style "background-color" Colors.tooltipBackground
     , style "color" Colors.tooltipText
-    , style "padding" "2.5px"
     ]
+
+
+defaultTooltipStyle : List (Html.Attribute msg)
+defaultTooltipStyle =
+    style "padding" "2.5px" :: colors

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -3,7 +3,6 @@ module Tooltip exposing
     , Direction(..)
     , Model
     , Tooltip
-    , defaultStyle
     , handleCallback
     , handleDelivery
     , hoverAttrs
@@ -27,13 +26,6 @@ type alias Model m =
     { m | hovered : HoverState.HoverState }
 
 
-type alias Tooltip =
-    { body : Html Message
-    , arrow : Maybe Arrow
-    , attachPosition : AttachPosition
-    }
-
-
 
 -- Many tooltips, especially in crowded parts of the UI, have an extra
 -- triangular piece sticking out that points to the tooltip's target. Online
@@ -41,9 +33,10 @@ type alias Tooltip =
 -- predominating.
 
 
-type alias Arrow =
-    { size : Float
-    , color : String
+type alias Tooltip =
+    { body : Html Message
+    , arrow : Maybe Float
+    , attachPosition : AttachPosition
     }
 
 
@@ -192,8 +185,12 @@ handleCallback callback ( model, effects ) =
             ( model, effects )
 
 
-arrowView : AttachPosition -> Browser.Dom.Element -> Arrow -> Html Message
-arrowView { direction } target { size, color } =
+arrowView : AttachPosition -> Browser.Dom.Element -> Float -> Html Message
+arrowView { direction } target size =
+    let
+        color =
+            Colors.tooltipBackground
+    in
     Html.div
         ((case direction of
             Top ->
@@ -231,7 +228,7 @@ view { hovered } { body, attachPosition, arrow } =
             Html.div
                 (id "tooltips" :: style "pointer-events" "none" :: position attachPosition target)
                 [ Maybe.map (arrowView attachPosition target) a |> Maybe.withDefault (Html.text "")
-                , body
+                , Html.div tooltipStyle [ body ]
                 ]
 
         _ ->
@@ -258,8 +255,8 @@ handleDelivery session delivery ( model, effects ) =
             ( model, effects )
 
 
-defaultStyle : List (Html.Attribute msg)
-defaultStyle =
+tooltipStyle : List (Html.Attribute msg)
+tooltipStyle =
     [ style "background-color" Colors.tooltipBackground
     , style "color" Colors.tooltipText
     , style "padding" "2.5px"

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -3,6 +3,7 @@ module Tooltip exposing
     , Direction(..)
     , Model
     , Tooltip
+    , defaultStyle
     , handleCallback
     , handleDelivery
     , hoverAttrs
@@ -10,6 +11,7 @@ module Tooltip exposing
     )
 
 import Browser.Dom
+import Colors
 import EffectTransformer exposing (ET)
 import HoverState exposing (TooltipPosition(..))
 import Html exposing (Html)
@@ -59,6 +61,7 @@ type alias AttachPosition =
 type Direction
     = Top
     | Right Float
+    | Bottom
 
 
 type Alignment
@@ -126,6 +129,9 @@ position { direction, alignment } { element, viewport } =
                 ( Right _, End ) ->
                     [ style "bottom" <| String.fromFloat (viewport.height - target.y - target.height) ++ "px" ]
 
+                ( Bottom, _ ) ->
+                    [ style "top" <| String.fromFloat (target.y + target.height) ++ "px" ]
+
         horizontal =
             case ( direction, alignment ) of
                 ( Top, Start ) ->
@@ -139,8 +145,17 @@ position { direction, alignment } { element, viewport } =
 
                 ( Right offset, _ ) ->
                     [ style "left" <| String.fromFloat (target.x + target.width + offset) ++ "px" ]
+
+                ( Bottom, Start ) ->
+                    [ style "left" <| String.fromFloat target.x ++ "px" ]
+
+                ( Bottom, Middle width ) ->
+                    [ style "left" <| String.fromFloat (target.x + (target.width - width) / 2) ++ "px" ]
+
+                ( Bottom, End ) ->
+                    [ style "right" <| String.fromFloat (target.x + target.width) ++ "px" ]
     in
-    [ style "position" "fixed", style "z-index" "100" ] ++ vertical ++ horizontal
+    [ style "position" "fixed", style "z-index" "999" ] ++ vertical ++ horizontal
 
 
 handleCallback : Callback -> ET (Model m)
@@ -194,6 +209,13 @@ arrowView { direction } target { size, color } =
                 , style "border-bottom" <| String.fromFloat size ++ "px solid transparent"
                 , style "margin-left" <| "-" ++ String.fromFloat size ++ "px"
                 ]
+
+            Bottom ->
+                [ style "border-bottom" <| String.fromFloat size ++ "px solid " ++ color
+                , style "border-left" <| String.fromFloat size ++ "px solid transparent"
+                , style "border-right" <| String.fromFloat size ++ "px solid transparent"
+                , style "margin-top" <| "-" ++ String.fromFloat size ++ "px"
+                ]
          )
             ++ position
                 { direction = direction, alignment = Middle (2 * size) }
@@ -234,3 +256,11 @@ handleDelivery session delivery ( model, effects ) =
 
         _ ->
             ( model, effects )
+
+
+defaultStyle : List (Html.Attribute msg)
+defaultStyle =
+    [ style "background-color" Colors.tooltipBackground
+    , style "color" Colors.tooltipText
+    , style "padding" "2.5px"
+    ]

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -125,7 +125,8 @@ position { direction, alignment } { element, viewport } =
                     [ style "bottom" <| String.fromFloat (viewport.height - target.y - target.height) ++ "px" ]
 
                 ( Bottom, _ ) ->
-                    [ style "top" <| String.fromFloat (target.y + target.height) ++ "px" ]
+                    -- Bottom needs a little padding to be further from the pointer cursor
+                    [ style "top" <| String.fromFloat (target.y + target.height + 8) ++ "px" ]
 
         horizontal =
             case ( direction, alignment ) of
@@ -270,4 +271,4 @@ colors =
 
 defaultTooltipStyle : List (Html.Attribute msg)
 defaultTooltipStyle =
-    style "padding" "2.5px" :: colors
+    style "padding" "5px" :: colors

--- a/web/elm/src/Views/FavoritedIcon.elm
+++ b/web/elm/src/Views/FavoritedIcon.elm
@@ -2,8 +2,9 @@ module Views.FavoritedIcon exposing (view)
 
 import Assets
 import Html exposing (Html)
-import Html.Attributes exposing (style)
+import Html.Attributes exposing (id, style)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
+import Message.Effects exposing (toHtmlID)
 import Message.Message exposing (DomID(..), Message(..))
 import Views.Icon as Icon
 
@@ -29,6 +30,7 @@ view params attrs =
          , onClick <| Click <| params.domID
          , onMouseEnter <| Hover <| Just <| params.domID
          , onMouseLeave <| Hover Nothing
+         , id <| toHtmlID params.domID
          ]
             ++ attrs
         )

--- a/web/elm/src/Views/Icon.elm
+++ b/web/elm/src/Views/Icon.elm
@@ -1,4 +1,4 @@
-module Views.Icon exposing (icon, iconWithTooltip)
+module Views.Icon exposing (icon)
 
 import Assets
 import Html exposing (Html)
@@ -10,15 +10,6 @@ icon :
     -> List (Html.Attribute msg)
     -> Html msg
 icon { sizePx, image } attrs =
-    iconWithTooltip { sizePx = sizePx, image = image } attrs []
-
-
-iconWithTooltip :
-    { sizePx : Int, image : Assets.Asset }
-    -> List (Html.Attribute msg)
-    -> List (Html msg)
-    -> Html msg
-iconWithTooltip { sizePx, image } attrs tooltipContent =
     Html.div
         ([ style "background-image" <|
             Assets.backgroundImage <|
@@ -30,4 +21,4 @@ iconWithTooltip { sizePx, image } attrs tooltipContent =
          ]
             ++ attrs
         )
-        tooltipContent
+        []

--- a/web/elm/src/Views/PauseToggle.elm
+++ b/web/elm/src/Views/PauseToggle.elm
@@ -3,8 +3,9 @@ module Views.PauseToggle exposing (view)
 import Assets
 import Concourse
 import Html exposing (Html)
-import Html.Attributes exposing (class)
+import Html.Attributes exposing (class, id)
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
+import Message.Effects exposing (toHtmlID)
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import UserState exposing (UserState(..))
 import Views.Icon as Icon
@@ -42,6 +43,7 @@ view params =
                 ++ [ onMouseEnter <| Hover <| Just <| params.domID
                    , onMouseLeave <| Hover Nothing
                    , class "pause-toggle"
+                   , id <| toHtmlID params.domID
                    ]
                 ++ (if isClickable then
                         [ onClick <| Click <| params.domID ]

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -152,29 +152,7 @@ all =
                             )
             ]
         , describe "buttons"
-            [ describe "trigger"
-                [ test "has tooltip on hover when manual triggering is disabled" <|
-                    \_ ->
-                        Header.header
-                            { session
-                                | hovered =
-                                    HoverState.Hovered
-                                        Message.TriggerBuildButton
-                            }
-                            { model | disableManualTrigger = False }
-                            |> .rightWidgets
-                            |> Common.notContains
-                                (Views.Button <|
-                                    Just
-                                        { type_ = Views.Trigger
-                                        , isClickable = False
-                                        , backgroundShade = Views.Dark
-                                        , backgroundColor = model.status
-                                        , tooltip = True
-                                        }
-                                )
-                ]
-            , describe "re-run"
+            [ describe "re-run"
                 [ test "does not appear on non-running one-off build" <|
                     \_ ->
                         Header.header session
@@ -187,7 +165,6 @@ all =
                                         , isClickable = True
                                         , backgroundShade = Views.Light
                                         , backgroundColor = BuildStatusSucceeded
-                                        , tooltip = False
                                         }
                                 )
                 , test "appears on non-running job build" <|
@@ -202,27 +179,6 @@ all =
                                         , isClickable = True
                                         , backgroundShade = Views.Light
                                         , backgroundColor = BuildStatusSucceeded
-                                        , tooltip = False
-                                        }
-                                )
-                , test "is hoverable with tooltip" <|
-                    \_ ->
-                        { model | status = BuildStatusSucceeded, job = Just jobId }
-                            |> Header.header
-                                { session
-                                    | hovered =
-                                        HoverState.Hovered
-                                            Message.RerunBuildButton
-                                }
-                            |> .rightWidgets
-                            |> Common.contains
-                                (Views.Button <|
-                                    Just
-                                        { type_ = Views.Rerun
-                                        , isClickable = True
-                                        , backgroundShade = Views.Dark
-                                        , backgroundColor = BuildStatusSucceeded
-                                        , tooltip = True
                                         }
                                 )
                 , test "clicking sends RerunJobBuild API call" <|

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -2246,6 +2246,10 @@ all =
                         >> Tuple.first
                         >> expectTooltip RerunBuildButton "re-run with the same inputs"
                 ]
+            , test "job name has a tooltip" <|
+                givenBuildFetched
+                    >> Tuple.first
+                    >> expectTooltip JobName "view job builds"
             , describe "when history and details fetched with manual triggering disabled" <|
                 let
                     givenHistoryAndDetailsFetched =

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -2184,38 +2184,18 @@ all =
                             [ attribute <|
                                 Attr.attribute "aria-label" "Trigger Build"
                             ]
-                        >> Query.has
-                            [ style "padding" "10px"
-                            , style "background-color" brightGreen
-                            , style "outline" "none"
-                            , style "margin" "0"
-                            , style "border-width" "0 0 0 1px"
-                            , style "border-color" darkGreen
-                            , style "border-style" "solid"
-                            ]
+                        >> Query.has [ style "background-color" brightGreen ]
                 , test "hovered trigger build button is styled as a box of the secondary color of the build status" <|
                     givenHistoryAndDetailsFetched
                         >> Tuple.first
-                        >> Application.update
-                            (Msgs.Update <|
-                                Message.Message.Hover <|
-                                    Just Message.Message.TriggerBuildButton
-                            )
+                        >> hoverOver Message.Message.TriggerBuildButton
                         >> Tuple.first
                         >> Common.queryView
                         >> Query.find
                             [ attribute <|
                                 Attr.attribute "aria-label" "Trigger Build"
                             ]
-                        >> Query.has
-                            [ style "padding" "10px"
-                            , style "background-color" darkGreen
-                            , style "outline" "none"
-                            , style "margin" "0"
-                            , style "border-width" "0 0 0 1px"
-                            , style "border-color" darkGreen
-                            , style "border-style" "solid"
-                            ]
+                        >> Query.has [ style "background-color" darkGreen ]
                 , test "trigger build button has pointer cursor" <|
                     givenHistoryAndDetailsFetched
                         >> Tuple.first
@@ -2241,6 +2221,31 @@ all =
                                 , image = Assets.AddCircleIcon |> Assets.CircleOutlineIcon
                                 }
                             )
+                , test "hovering trigger build button displays a tooltip" <|
+                    givenHistoryAndDetailsFetched
+                        >> Tuple.first
+                        >> hoverOver Message.Message.TriggerBuildButton
+                        >> Tuple.first
+                        >> Common.queryView
+                        >> Query.find [ id "tooltips" ]
+                        >> Query.has [ text "trigger a new build" ]
+                , test "rerun build button in the header" <|
+                    givenHistoryAndDetailsFetched
+                        >> Tuple.first
+                        >> Common.queryView
+                        >> Query.find [ id "build-header" ]
+                        >> Query.has
+                            [ attribute <|
+                                Attr.attribute "aria-label" "Rerun Build"
+                            ]
+                , test "hovering rerun build button displays a tooltip" <|
+                    givenHistoryAndDetailsFetched
+                        >> Tuple.first
+                        >> hoverOver Message.Message.RerunBuildButton
+                        >> Tuple.first
+                        >> Common.queryView
+                        >> Query.find [ id "tooltips" ]
+                        >> Query.has [ text "re-run with the same inputs" ]
                 ]
             , describe "when history and details fetched with manual triggering disabled" <|
                 let
@@ -2279,22 +2284,23 @@ all =
                                 }
                         }
                     , hoveredSelector =
-                        { description = "grey plus icon with tooltip"
+                        { description = "grey plus icon"
                         , selector =
-                            [ style "position" "relative"
-                            , containing
-                                [ containing
-                                    [ text "manual triggering disabled in job config" ]
-                                ]
-                            , containing <|
-                                iconSelector
-                                    { size = "40px"
-                                    , image = Assets.AddCircleIcon |> Assets.CircleOutlineIcon
-                                    }
-                            ]
+                            iconSelector
+                                { size = "40px"
+                                , image = Assets.AddCircleIcon |> Assets.CircleOutlineIcon
+                                }
                         }
                     , hoverable = Message.Message.TriggerBuildButton
                     }
+                , test "hovering displays a tooltip" <|
+                    givenHistoryAndDetailsFetched
+                        >> Tuple.first
+                        >> hoverOver Message.Message.TriggerBuildButton
+                        >> Tuple.first
+                        >> Common.queryView
+                        >> Query.find [ id "tooltips" ]
+                        >> Query.has [ text "manual triggering disabled in job config" ]
                 ]
             ]
         , describe "given build started and history and details fetched" <|
@@ -2335,38 +2341,26 @@ all =
                         [ attribute <|
                             Attr.attribute "aria-label" "Abort Build"
                         ]
-                    >> Query.has
-                        [ style "padding" "10px"
-                        , style "background-color" brightRed
-                        , style "outline" "none"
-                        , style "margin" "0"
-                        , style "border-width" "0 0 0 1px"
-                        , style "border-color" darkRed
-                        , style "border-style" "solid"
-                        ]
+                    >> Query.has [ style "background-color" brightRed ]
             , test "hovered abort build button is styled as a dark red box" <|
                 givenBuildStarted
                     >> Tuple.first
-                    >> Application.update
-                        (Msgs.Update <|
-                            Message.Message.Hover <|
-                                Just Message.Message.AbortBuildButton
-                        )
+                    >> hoverOver Message.Message.AbortBuildButton
                     >> Tuple.first
                     >> Common.queryView
                     >> Query.find
                         [ attribute <|
                             Attr.attribute "aria-label" "Abort Build"
                         ]
-                    >> Query.has
-                        [ style "padding" "10px"
-                        , style "background-color" darkRed
-                        , style "outline" "none"
-                        , style "margin" "0"
-                        , style "border-width" "0 0 0 1px"
-                        , style "border-color" darkRed
-                        , style "border-style" "solid"
-                        ]
+                    >> Query.has [ style "background-color" darkRed ]
+            , test "shows tooltip when hovered" <|
+                givenBuildStarted
+                    >> Tuple.first
+                    >> hoverOver Message.Message.AbortBuildButton
+                    >> Tuple.first
+                    >> Common.queryView
+                    >> Query.find [ id "tooltips" ]
+                    >> Query.has [ text "abort the current build" ]
             , test "abort build button has pointer cursor" <|
                 givenBuildStarted
                     >> Tuple.first

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -8,7 +8,7 @@ import Build.Models as Models
 import Build.StepTree.Models as STModels
 import Char
 import Colors
-import Common exposing (defineHoverBehaviour, isColorWithStripes)
+import Common exposing (defineHoverBehaviour, hoverOver, isColorWithStripes)
 import Concourse exposing (BuildPrepStatus(..))
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.Pagination exposing (Direction(..))
@@ -3884,51 +3884,3 @@ receiveEvent :
     -> ( Application.Model, List Effects.Effect )
 receiveEvent envelope =
     Application.update (Msgs.DeliveryReceived <| EventsReceived <| Ok [ envelope ])
-
-
-hoverOver domID =
-    Application.update
-        (Msgs.Update (Message.Message.Hover (Just domID)))
-        >> Tuple.first
-        >> Application.handleDelivery
-            (ClockTicked OneSecond <|
-                Time.millisToPosix 1
-            )
-        >> Tuple.first
-        >> Application.handleCallback
-            (Callback.GotViewport domID <|
-                Ok
-                    { scene =
-                        { width = 1
-                        , height = 0
-                        }
-                    , viewport =
-                        { width = 1
-                        , height = 0
-                        , x = 0
-                        , y = 0
-                        }
-                    }
-            )
-        >> Tuple.first
-        >> Application.handleCallback
-            (Callback.GotElement <|
-                Ok
-                    { scene =
-                        { width = 0
-                        , height = 0
-                        }
-                    , viewport =
-                        { width = 0
-                        , height = 0
-                        , x = 0
-                        , y = 0
-                        }
-                    , element =
-                        { x = 0
-                        , y = 0
-                        , width = 1
-                        , height = 1
-                        }
-                    }
-            )

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -8,7 +8,14 @@ import Build.Models as Models
 import Build.StepTree.Models as STModels
 import Char
 import Colors
-import Common exposing (defineHoverBehaviour, hoverOver, isColorWithStripes)
+import Common
+    exposing
+        ( defineHoverBehaviour
+        , expectTooltip
+        , expectTooltipWith
+        , hoverOver
+        , isColorWithStripes
+        )
 import Concourse exposing (BuildPrepStatus(..))
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.Pagination exposing (Direction(..))
@@ -22,7 +29,7 @@ import Json.Encode as Encode
 import Keyboard
 import Message.Callback as Callback
 import Message.Effects as Effects
-import Message.Message
+import Message.Message exposing (DomID(..))
 import Message.ScrollDirection as ScrollDirection
 import Message.Subscription as Subscription exposing (Delivery(..), Interval(..))
 import Message.TopLevelMessage as Msgs
@@ -2224,11 +2231,7 @@ all =
                 , test "hovering trigger build button displays a tooltip" <|
                     givenHistoryAndDetailsFetched
                         >> Tuple.first
-                        >> hoverOver Message.Message.TriggerBuildButton
-                        >> Tuple.first
-                        >> Common.queryView
-                        >> Query.find [ id "tooltips" ]
-                        >> Query.has [ text "trigger a new build" ]
+                        >> expectTooltip TriggerBuildButton "trigger a new build"
                 , test "rerun build button in the header" <|
                     givenHistoryAndDetailsFetched
                         >> Tuple.first
@@ -2241,11 +2244,7 @@ all =
                 , test "hovering rerun build button displays a tooltip" <|
                     givenHistoryAndDetailsFetched
                         >> Tuple.first
-                        >> hoverOver Message.Message.RerunBuildButton
-                        >> Tuple.first
-                        >> Common.queryView
-                        >> Query.find [ id "tooltips" ]
-                        >> Query.has [ text "re-run with the same inputs" ]
+                        >> expectTooltip RerunBuildButton "re-run with the same inputs"
                 ]
             , describe "when history and details fetched with manual triggering disabled" <|
                 let
@@ -2296,11 +2295,7 @@ all =
                 , test "hovering displays a tooltip" <|
                     givenHistoryAndDetailsFetched
                         >> Tuple.first
-                        >> hoverOver Message.Message.TriggerBuildButton
-                        >> Tuple.first
-                        >> Common.queryView
-                        >> Query.find [ id "tooltips" ]
-                        >> Query.has [ text "manual triggering disabled in job config" ]
+                        >> expectTooltip TriggerBuildButton "manual triggering disabled in job config"
                 ]
             ]
         , describe "given build started and history and details fetched" <|
@@ -2356,11 +2351,7 @@ all =
             , test "shows tooltip when hovered" <|
                 givenBuildStarted
                     >> Tuple.first
-                    >> hoverOver Message.Message.AbortBuildButton
-                    >> Tuple.first
-                    >> Common.queryView
-                    >> Query.find [ id "tooltips" ]
-                    >> Query.has [ text "abort the current build" ]
+                    >> expectTooltip AbortBuildButton "abort the current build"
             , test "abort build button has pointer cursor" <|
                 givenBuildStarted
                     >> Tuple.first
@@ -3212,15 +3203,8 @@ all =
                                     ]
                             )
                         >> Tuple.first
-                        >> hoverOver (Message.Message.StepState "plan")
-                        >> Tuple.first
-                        >> Common.queryView
-                        >> Query.find [ id "tooltips" ]
-                        >> Query.children []
-                        >> Query.index -1
-                        >> Query.findAll [ tag "tr" ]
-                        >> Query.index 0
-                        >> Query.has [ text "initialization", text "10s" ]
+                        >> expectTooltipWith (StepState "plan")
+                            (Query.has [ text "initialization", text "10s" ])
                 , test "finished task lists step duration in tooltip" <|
                     fetchPlanWithTaskStep
                         >> Application.handleDelivery
@@ -3248,15 +3232,8 @@ all =
                                     ]
                             )
                         >> Tuple.first
-                        >> hoverOver (Message.Message.StepState "plan")
-                        >> Tuple.first
-                        >> Common.queryView
-                        >> Query.find [ id "tooltips" ]
-                        >> Query.children []
-                        >> Query.index -1
-                        >> Query.findAll [ tag "tr" ]
-                        >> Query.index 1
-                        >> Query.has [ text "step", text "20s" ]
+                        >> expectTooltipWith (StepState "plan")
+                            (Query.has [ text "step", text "20s" ])
                 , test "running step has loading spinner at the right" <|
                     fetchPlanWithTaskStep
                         >> Application.handleDelivery
@@ -3297,11 +3274,7 @@ all =
                                     ]
                             )
                         >> Tuple.first
-                        >> hoverOver (Message.Message.StepState "plan")
-                        >> Tuple.first
-                        >> Common.queryView
-                        >> Query.find [ id "tooltips" ]
-                        >> Query.has [ text "running" ]
+                        >> expectTooltip (StepState "plan") "running"
                 , test "pending step has dashed circle at the right" <|
                     fetchPlanWithTaskStep
                         >> Common.queryView
@@ -3317,11 +3290,7 @@ all =
                             )
                 , test "pending step shows pending in tooltip" <|
                     fetchPlanWithTaskStep
-                        >> hoverOver (Message.Message.StepState "plan")
-                        >> Tuple.first
-                        >> Common.queryView
-                        >> Query.find [ id "tooltips" ]
-                        >> Query.has [ text "pending" ]
+                        >> expectTooltip (StepState "plan") "pending"
                 , test "interrupted step has no-entry circle at the right" <|
                     fetchPlanWithTaskStep
                         >> Application.handleDelivery
@@ -3377,11 +3346,7 @@ all =
                                     ]
                             )
                         >> Tuple.first
-                        >> hoverOver (Message.Message.StepState "plan")
-                        >> Tuple.first
-                        >> Common.queryView
-                        >> Query.find [ id "tooltips" ]
-                        >> Query.has [ text "interrupted" ]
+                        >> expectTooltip (StepState "plan") "interrupted"
                 , test "cancelled step has dashed circle with dot at the right" <|
                     fetchPlanWithTaskStep
                         >> Application.handleDelivery
@@ -3421,11 +3386,7 @@ all =
                                     ]
                             )
                         >> Tuple.first
-                        >> hoverOver (Message.Message.StepState "plan")
-                        >> Tuple.first
-                        >> Common.queryView
-                        >> Query.find [ id "tooltips" ]
-                        >> Query.has [ text "cancelled" ]
+                        >> expectTooltip (StepState "plan") "cancelled"
                 , test "failing step has an X at the far right" <|
                     fetchPlanWithGetStep
                         >> Application.handleDelivery

--- a/web/elm/tests/Common.elm
+++ b/web/elm/tests/Common.elm
@@ -5,6 +5,7 @@ module Common exposing
     , given
     , givenDataUnauthenticated
     , gotPipelines
+    , hoverOver
     , iOpenTheBuildPage
     , init
     , initQuery
@@ -26,6 +27,7 @@ import Application.Application as Application
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Data
+import EffectTransformer exposing (ET)
 import Expect exposing (Expectation)
 import Html
 import Html.Attributes as Attr
@@ -33,6 +35,7 @@ import List.Extra
 import Message.Callback as Callback
 import Message.Effects exposing (Effect)
 import Message.Message exposing (DomID(..), Message(..))
+import Message.Subscription exposing (Delivery(..))
 import Message.TopLevelMessage exposing (TopLevelMessage(..))
 import Routes
 import Test exposing (Test, describe, test)
@@ -341,7 +344,45 @@ gotPipelines data =
         >> Tuple.first
 
 
-
--- 6 places where Application.init is used with a query
--- 6 places where Application.init is used with a fragment
--- 1 place where Application.init is used with an instance name
+hoverOver : Message.Message.DomID -> Application.Model -> ( Application.Model, List Effect )
+hoverOver domID =
+    Application.update
+        (Update (Message.Message.Hover (Just domID)))
+        >> Tuple.first
+        >> Application.handleCallback
+            (Callback.GotViewport domID <|
+                Ok
+                    { scene =
+                        { width = 1
+                        , height = 0
+                        }
+                    , viewport =
+                        { width = 1
+                        , height = 0
+                        , x = 0
+                        , y = 0
+                        }
+                    }
+            )
+        >> Tuple.first
+        >> Application.handleCallback
+            (Callback.GotElement <|
+                Ok
+                    { scene =
+                        { width = 0
+                        , height = 0
+                        }
+                    , viewport =
+                        { width = 0
+                        , height = 0
+                        , x = 0
+                        , y = 0
+                        }
+                    , element =
+                        { x = 0
+                        , y = 0
+                        , width = 1
+                        , height = 1
+                        }
+                    }
+            )

--- a/web/elm/tests/Common.elm
+++ b/web/elm/tests/Common.elm
@@ -2,6 +2,8 @@ module Common exposing
     ( and
     , contains
     , defineHoverBehaviour
+    , expectNoTooltip
+    , expectTooltip
     , given
     , givenDataUnauthenticated
     , gotPipelines
@@ -41,7 +43,7 @@ import Routes
 import Test exposing (Test, describe, test)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (Selector, attribute, style)
+import Test.Html.Selector exposing (Selector, attribute, id, style, text)
 import Url
 
 
@@ -386,3 +388,20 @@ hoverOver domID =
                         }
                     }
             )
+
+
+expectTooltip : DomID -> String -> Application.Model -> Expect.Expectation
+expectTooltip domID tooltip =
+    hoverOver domID
+        >> Tuple.first
+        >> queryView
+        >> Query.find [ id "tooltips" ]
+        >> Query.has [ text tooltip ]
+
+
+expectNoTooltip : DomID -> Application.Model -> Expect.Expectation
+expectNoTooltip domID =
+    hoverOver domID
+        >> Tuple.first
+        >> queryView
+        >> Query.hasNot [ id "tooltips" ]

--- a/web/elm/tests/Common.elm
+++ b/web/elm/tests/Common.elm
@@ -4,6 +4,7 @@ module Common exposing
     , defineHoverBehaviour
     , expectNoTooltip
     , expectTooltip
+    , expectTooltipWith
     , given
     , givenDataUnauthenticated
     , gotPipelines
@@ -397,6 +398,15 @@ expectTooltip domID tooltip =
         >> queryView
         >> Query.find [ id "tooltips" ]
         >> Query.has [ text tooltip ]
+
+
+expectTooltipWith : DomID -> (Query.Single TopLevelMessage -> Expect.Expectation) -> Application.Model -> Expect.Expectation
+expectTooltipWith domID expectation =
+    hoverOver domID
+        >> Tuple.first
+        >> queryView
+        >> Query.find [ id "tooltips" ]
+        >> expectation
 
 
 expectNoTooltip : DomID -> Application.Model -> Expect.Expectation

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -445,6 +445,17 @@ all =
                     |> Common.queryView
                     |> Query.find [ id "top-bar-app" ]
                     |> Query.has [ style "height" "54px" ]
+        , test "hovering over dashboard clears tooltip" <|
+            \_ ->
+                Common.init "/"
+                    |> givenDataAndUser
+                        (apiData [ ( "team", [] ) ])
+                        (userWithRoles [])
+                    |> Tuple.first
+                    |> Common.queryView
+                    |> Query.find [ id "dashboard" ]
+                    |> Event.simulate Event.mouseOver
+                    |> Event.expect (ApplicationMsgs.Update <| Msgs.Hover <| Just Msgs.Dashboard)
         , describe "loading section" <|
             [ test "has a loading section when awaiting API data" <|
                 \_ ->

--- a/web/elm/tests/DashboardTooltipTests.elm
+++ b/web/elm/tests/DashboardTooltipTests.elm
@@ -11,6 +11,7 @@ import HoverState exposing (HoverState(..))
 import Html
 import Message.Message exposing (DomID(..), PipelinesSection(..))
 import RemoteData exposing (RemoteData(..))
+import Set
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (text)
@@ -47,6 +48,63 @@ all =
                     |> Maybe.withDefault (Html.text "")
                     |> Query.fromHtml
                     |> Query.has [ text "expose" ]
+        , test "says 'favorite' when an unfavorited pipeline is hovered" <|
+            \_ ->
+                Dashboard.tooltip
+                    { session
+                        | hovered =
+                            Tooltip
+                                (PipelineCardFavoritedIcon AllPipelinesSection 1)
+                                Data.elementPosition
+                        , pipelines = Success [ Data.pipeline "team" 1 ]
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "favorite" ]
+        , test "says 'unfavorite' when a favorited pipeline is hovered" <|
+            \_ ->
+                Dashboard.tooltip
+                    { session
+                        | hovered =
+                            Tooltip
+                                (PipelineCardFavoritedIcon AllPipelinesSection 1)
+                                Data.elementPosition
+                        , pipelines = Success [ Data.pipeline "team" 1 ]
+                        , favoritedPipelines = Set.singleton 1
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "unfavorite" ]
+        , test "says 'pause' when an unpaused pipeline is hovered" <|
+            \_ ->
+                Dashboard.tooltip
+                    { session
+                        | hovered =
+                            Tooltip
+                                (PipelineCardPauseToggle AllPipelinesSection 1)
+                                Data.elementPosition
+                        , pipelines = Success [ Data.pipeline "team" 1 |> Data.withPaused False ]
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "pause" ]
+        , test "says 'unpause' when a paused pipeline is hovered" <|
+            \_ ->
+                Dashboard.tooltip
+                    { session
+                        | hovered =
+                            Tooltip
+                                (PipelineCardPauseToggle AllPipelinesSection 1)
+                                Data.elementPosition
+                        , pipelines = Success [ Data.pipeline "team" 1 |> Data.withPaused True ]
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "unpause" ]
         , test "says 'disabled' when a pipeline with jobs disabled is hovered" <|
             \_ ->
                 Dashboard.tooltip

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -2,7 +2,7 @@ module JobTests exposing (all)
 
 import Application.Application as Application
 import Assets
-import Common exposing (defineHoverBehaviour, queryView)
+import Common exposing (defineHoverBehaviour, hoverOver, queryView)
 import Concourse exposing (Build, JsonValue(..))
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.Pagination exposing (Direction(..), Paginated)
@@ -120,11 +120,11 @@ all =
                 init { disabled = False, paused = False }
                     >> queryView
                     >> Query.find [ class "build-header" ]
-                    >> Query.has [ id "pause-toggle" ]
+                    >> Query.has [ id toggleJobID ]
             , test "play/pause has background of the header color, faded" <|
                 init { disabled = False, paused = False }
                     >> queryView
-                    >> Query.find [ id "pause-toggle" ]
+                    >> Query.find [ id toggleJobID ]
                     >> Query.has
                         [ style "padding" "10px"
                         , style "border" "none"
@@ -140,7 +140,7 @@ all =
                         )
                     >> Tuple.first
                     >> queryView
-                    >> Query.find [ id "pause-toggle" ]
+                    >> Query.find [ id toggleJobID ]
                     >> Query.has
                         [ style "padding" "10px"
                         , style "border" "none"
@@ -152,7 +152,7 @@ all =
                 , setup =
                     init { disabled = False, paused = False } ()
                 , query =
-                    queryView >> Query.find [ id "pause-toggle" ]
+                    queryView >> Query.find [ id toggleJobID ]
                 , unhoveredSelector =
                     { description = "grey pause icon"
                     , selector =
@@ -178,7 +178,7 @@ all =
                 , setup =
                     init { disabled = False, paused = True } ()
                 , query =
-                    queryView >> Query.find [ id "pause-toggle" ]
+                    queryView >> Query.find [ id toggleJobID ]
                 , unhoveredSelector =
                     { description = "grey play icon"
                     , selector =
@@ -296,32 +296,44 @@ all =
                                 }
                     }
                 , hoveredSelector =
-                    { description = "grey plus icon with tooltip"
+                    { description = "grey plus icon"
                     , selector =
-                        [ style "position" "relative"
-                        , containing
-                            [ containing
-                                [ text "manual triggering disabled in job config" ]
-                            , style "position" "absolute"
-                            , style "right" "100%"
-                            , style "top" "15px"
-                            , style "width" "300px"
-                            , style "color" "#ecf0f1"
-                            , style "font-size" "12px"
-                            , style "font-family" Views.Styles.fontFamilyDefault
-                            , style "padding" "10px"
-                            , style "text-align" "right"
-                            ]
-                        , containing <|
-                            [ style "opacity" "0.5" ]
-                                ++ iconSelector
-                                    { size = "40px"
-                                    , image = Assets.AddCircleIcon |> Assets.CircleOutlineIcon
-                                    }
-                        ]
+                        style "opacity" "0.5"
+                            :: iconSelector
+                                { size = "40px"
+                                , image = Assets.AddCircleIcon |> Assets.CircleOutlineIcon
+                                }
                     }
                 , hoverable = Message.Message.TriggerBuildButton
                 }
+            , test "hovering trigger build button has tooltip" <|
+                init { disabled = False, paused = False }
+                    >> hoverOver TriggerBuildButton
+                    >> Tuple.first
+                    >> Common.queryView
+                    >> Query.find [ id "tooltips" ]
+                    >> Query.has [ text "trigger a new build" ]
+            , test "hovering disabled trigger build button has tooltip" <|
+                init { disabled = True, paused = False }
+                    >> hoverOver TriggerBuildButton
+                    >> Tuple.first
+                    >> Common.queryView
+                    >> Query.find [ id "tooltips" ]
+                    >> Query.has [ text "manual triggering disabled in job config" ]
+            , test "hovering pause toggle button has tooltip" <|
+                init { disabled = False, paused = False }
+                    >> hoverOver ToggleJobButton
+                    >> Tuple.first
+                    >> Common.queryView
+                    >> Query.find [ id "tooltips" ]
+                    >> Query.has [ text "pause job" ]
+            , test "hovering paused pause toggle button has tooltip" <|
+                init { disabled = False, paused = True }
+                    >> hoverOver ToggleJobButton
+                    >> Tuple.first
+                    >> Common.queryView
+                    >> Query.find [ id "tooltips" ]
+                    >> Query.has [ text "unpause job" ]
             , describe "archived pipelines" <|
                 let
                     fetchArchivedPipeline =
@@ -346,7 +358,7 @@ all =
                     initWithArchivedPipeline
                         >> queryView
                         >> Query.find [ class "build-header" ]
-                        >> Query.hasNot [ id "pause-toggle" ]
+                        >> Query.hasNot [ id toggleJobID ]
                 , test "header still includes job name" <|
                     initWithArchivedPipeline
                         >> queryView
@@ -968,3 +980,7 @@ loadingIndicatorSelector =
     , style "width" "14px"
     , style "margin" "7px"
     ]
+
+
+toggleJobID =
+    Effects.toHtmlID ToggleJobButton

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -318,6 +318,15 @@ all =
             , test "hovering paused pause toggle button has tooltip" <|
                 init { disabled = False, paused = True }
                     >> expectTooltip ToggleJobButton "unpause job"
+            , test "hovering build link has tooltip" <|
+                init { disabled = False, paused = True }
+                    >> expectTooltip (JobBuildLink "1.1") "view build #1.1"
+            , test "hovering next page button has tooltip" <|
+                init { disabled = False, paused = True }
+                    >> expectTooltip NextPageButton "view next page"
+            , test "hovering previous page button has tooltip" <|
+                init { disabled = False, paused = True }
+                    >> expectTooltip PreviousPageButton "view previous page"
             , describe "archived pipelines" <|
                 let
                     fetchArchivedPipeline =

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -2,7 +2,7 @@ module JobTests exposing (all)
 
 import Application.Application as Application
 import Assets
-import Common exposing (defineHoverBehaviour, hoverOver, queryView)
+import Common exposing (defineHoverBehaviour, expectTooltip, hoverOver, queryView)
 import Concourse exposing (Build, JsonValue(..))
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.Pagination exposing (Direction(..), Paginated)
@@ -308,32 +308,16 @@ all =
                 }
             , test "hovering trigger build button has tooltip" <|
                 init { disabled = False, paused = False }
-                    >> hoverOver TriggerBuildButton
-                    >> Tuple.first
-                    >> Common.queryView
-                    >> Query.find [ id "tooltips" ]
-                    >> Query.has [ text "trigger a new build" ]
+                    >> expectTooltip TriggerBuildButton "trigger a new build"
             , test "hovering disabled trigger build button has tooltip" <|
                 init { disabled = True, paused = False }
-                    >> hoverOver TriggerBuildButton
-                    >> Tuple.first
-                    >> Common.queryView
-                    >> Query.find [ id "tooltips" ]
-                    >> Query.has [ text "manual triggering disabled in job config" ]
+                    >> expectTooltip TriggerBuildButton "manual triggering disabled in job config"
             , test "hovering pause toggle button has tooltip" <|
                 init { disabled = False, paused = False }
-                    >> hoverOver ToggleJobButton
-                    >> Tuple.first
-                    >> Common.queryView
-                    >> Query.find [ id "tooltips" ]
-                    >> Query.has [ text "pause job" ]
+                    >> expectTooltip ToggleJobButton "pause job"
             , test "hovering paused pause toggle button has tooltip" <|
                 init { disabled = False, paused = True }
-                    >> hoverOver ToggleJobButton
-                    >> Tuple.first
-                    >> Common.queryView
-                    >> Query.find [ id "tooltips" ]
-                    >> Query.has [ text "unpause job" ]
+                    >> expectTooltip ToggleJobButton "unpause job"
             , describe "archived pipelines" <|
                 let
                     fetchArchivedPipeline =

--- a/web/elm/tests/PauseToggleTests.elm
+++ b/web/elm/tests/PauseToggleTests.elm
@@ -40,7 +40,7 @@ all =
                         , margin = ""
                         , userState = userState
                         , tooltipPosition = Styles.Above
-                        , domID = PipelineCardPauseToggle AllPipelinesSection pipeline
+                        , domID = PipelineCardPauseToggle AllPipelinesSection 1
                         }
                         |> Query.fromHtml
                         |> Query.has [ style "opacity" "0.2" ]
@@ -54,7 +54,7 @@ all =
                         , margin = ""
                         , userState = userState
                         , tooltipPosition = Styles.Above
-                        , domID = PipelineCardPauseToggle AllPipelinesSection pipeline
+                        , domID = PipelineCardPauseToggle AllPipelinesSection 1
                         }
                         |> Query.fromHtml
                         |> Query.has
@@ -82,7 +82,7 @@ all =
                         , margin = ""
                         , userState = userState
                         , tooltipPosition = Styles.Below
-                        , domID = PipelineCardPauseToggle AllPipelinesSection pipeline
+                        , domID = PipelineCardPauseToggle AllPipelinesSection 1
                         }
                         |> Query.fromHtml
                         |> Query.has

--- a/web/elm/tests/PinMenu/PinMenuTests.elm
+++ b/web/elm/tests/PinMenu/PinMenuTests.elm
@@ -64,13 +64,7 @@ all =
                             Just [ Data.resource (Just "v1") |> Data.withName "test" ]
                     }
             in
-            [ test "is hoverable" <|
-                \_ ->
-                    model
-                        |> PinMenu.pinMenu { hovered = HoverState.NoHover }
-                        |> .hoverable
-                        |> Expect.equal True
-            , test "is clickable" <|
+            [ test "is clickable" <|
                 \_ ->
                     model
                         |> PinMenu.pinMenu { hovered = HoverState.NoHover }
@@ -107,13 +101,13 @@ all =
             , test "has bright icon when hovered" <|
                 \_ ->
                     model
-                        |> PinMenu.pinMenu { hovered = HoverState.Hovered PinIcon }
+                        |> PinMenu.pinMenu { hovered = HoverState.Hovered TopBarPinIcon }
                         |> .opacity
                         |> Expect.equal SS.Bright
             , test "clicking brightens background" <|
                 \_ ->
                     ( model, [] )
-                        |> PinMenu.update (Click PinIcon)
+                        |> PinMenu.update (Click TopBarPinIcon)
                         |> Tuple.first
                         |> PinMenu.pinMenu { hovered = HoverState.NoHover }
                         |> .background
@@ -121,7 +115,7 @@ all =
             , test "clicking brightens icon" <|
                 \_ ->
                     ( model, [] )
-                        |> PinMenu.update (Click PinIcon)
+                        |> PinMenu.update (Click TopBarPinIcon)
                         |> Tuple.first
                         |> PinMenu.pinMenu { hovered = HoverState.NoHover }
                         |> .opacity
@@ -129,7 +123,7 @@ all =
             , test "clicking reveals dropdown" <|
                 \_ ->
                     ( model, [] )
-                        |> PinMenu.update (Click PinIcon)
+                        |> PinMenu.update (Click TopBarPinIcon)
                         |> Tuple.first
                         |> PinMenu.pinMenu { hovered = HoverState.NoHover }
                         |> .dropdown
@@ -167,7 +161,7 @@ all =
             , test "clicking again dismisses dropdown" <|
                 \_ ->
                     ( { model | pinMenuExpanded = True }, [] )
-                        |> PinMenu.update (Click PinIcon)
+                        |> PinMenu.update (Click TopBarPinIcon)
                         |> Tuple.first
                         |> PinMenu.pinMenu { hovered = HoverState.NoHover }
                         |> .dropdown

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -2305,7 +2305,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+                                            [ Data.pipeline "team" 1 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                         , query =
@@ -2326,7 +2326,7 @@ all =
                                        , style "opacity" "0.5"
                                        ]
                             }
-                        , hoverable = Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
+                        , hoverable = Msgs.PipelineCardPauseToggle AllPipelinesSection 1
                         , hoveredSelector =
                             { description = "a bright 20px square pause button with pointer cursor"
                             , selector =
@@ -2350,11 +2350,11 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+                                            [ Data.pipeline "team" 1 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Application.handleDelivery
-                                    (Message.Subscription.FavoritedPipelinesReceived <| Ok <| Set.singleton 0)
+                                    (Message.Subscription.FavoritedPipelinesReceived <| Ok <| Set.singleton 1)
                                 |> Tuple.first
                         , query =
                             Common.queryView
@@ -2376,7 +2376,7 @@ all =
                                        ]
                             }
                         , hoverable =
-                            Msgs.PipelineCardPauseToggle FavoritesSection Data.pipelineId
+                            Msgs.PipelineCardPauseToggle FavoritesSection 1
                         , hoveredSelector =
                             { description = "a bright 20px square pause button with pointer cursor"
                             , selector =
@@ -2400,7 +2400,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ Data.pipeline "team" 0
+                                            [ Data.pipeline "team" 1
                                                 |> Data.withName "pipeline"
                                                 |> Data.withPaused True
                                             ]
@@ -2424,7 +2424,7 @@ all =
                                        , style "opacity" "0.5"
                                        ]
                             }
-                        , hoverable = Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
+                        , hoverable = Msgs.PipelineCardPauseToggle AllPipelinesSection 1
                         , hoveredSelector =
                             { description = "an opaque 20px square play button with pointer cursor"
                             , selector =
@@ -2447,7 +2447,7 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+                                            [ Data.pipeline "team" 1 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -2457,7 +2457,7 @@ all =
                                 |> Event.expect
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection 1
                                     )
                     , test "pause button turns into spinner on click" <|
                         \_ ->
@@ -2473,13 +2473,13 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+                                            [ Data.pipeline "team" 1 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection 1
                                     )
                                 |> Tuple.first
                                 |> Common.queryView
@@ -2495,13 +2495,13 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+                                            [ Data.pipeline "team" 1 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection 1
                                     )
                                 |> Tuple.second
                                 |> Expect.equal [ Effects.SendTogglePipelineRequest Data.pipelineId False ]
@@ -2515,13 +2515,13 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+                                            [ Data.pipeline "team" 1 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection 1
                                     )
                                 |> Tuple.first
                                 |> Application.handleCallback
@@ -2537,13 +2537,13 @@ all =
                                 |> Application.handleCallback
                                     (Callback.AllPipelinesFetched <|
                                         Ok
-                                            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+                                            [ Data.pipeline "team" 1 |> Data.withName "pipeline" ]
                                     )
                                 |> Tuple.first
                                 |> Application.update
                                     (ApplicationMsgs.Update <|
                                         Msgs.Click <|
-                                            Msgs.PipelineCardPauseToggle AllPipelinesSection Data.pipelineId
+                                            Msgs.PipelineCardPauseToggle AllPipelinesSection 1
                                     )
                                 |> Tuple.first
                                 |> Application.handleCallback

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -334,22 +334,6 @@ all =
                         , style "opacity" "30%"
                         , style "filter" "grayscale(1)"
                         ]
-        , describe "sidebar tooltips"
-            [ test "hovering over instance group gets its viewport" <|
-                let
-                    domID =
-                        SideBarInstanceGroup AllPipelinesSection "main" "group"
-                in
-                \_ ->
-                    Common.init "/teams/team/pipelines/pipeline"
-                        |> Application.update
-                            (Msgs.Update <|
-                                Hover <|
-                                    Just domID
-                            )
-                        |> Tuple.second
-                        |> Common.contains (Effects.GetViewportOf domID)
-            ]
         , describe "update" <|
             let
                 defaultModel : Pipeline.Model
@@ -501,7 +485,7 @@ all =
                 [ it "shows a pin icon on top bar" <|
                     Common.queryView
                         >> Query.find [ id "top-bar-app" ]
-                        >> Query.has [ id "pin-icon" ]
+                        >> Query.has [ id "top-bar-pin-icon" ]
                 , it "shows a star icon on top bar" <|
                     Common.queryView
                         >> Query.find [ id "top-bar-app" ]

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -678,11 +678,7 @@ all =
                 [ defineHoverBehaviour
                     { name = "star icon"
                     , setup = Common.init "teams/t/pipelines/p"
-                    , query =
-                        queryView
-                            >> Query.find [ id "top-bar-favorited-icon" ]
-                            >> Query.children []
-                            >> Query.first
+                    , query = queryView >> Query.find [ id "top-bar-favorited-icon" ]
                     , unhoveredSelector =
                         { description = "faded star icon"
                         , selector =
@@ -713,8 +709,6 @@ all =
                             |> Tuple.first
                             |> queryView
                             |> Query.find [ id "top-bar-favorited-icon" ]
-                            |> Query.children []
-                            |> Query.first
                             |> Event.simulate Event.click
                             |> Event.expect favMsg
                 , test "click has FavoritedPipeline effect" <|

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -3359,6 +3359,16 @@ all =
                     init
                         |> givenResourcePinnedStatically
                         |> expectTooltip PinBar "version is pinned in the pipeline config"
+            , test "next page button" <|
+                \_ ->
+                    init
+                        |> givenVersionsWithPagination
+                        |> expectTooltip NextPageButton "view next page"
+            , test "previous page button" <|
+                \_ ->
+                    init
+                        |> givenVersionsWithPagination
+                        |> expectTooltip PreviousPageButton "view previous page"
             ]
         ]
 

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -5,7 +5,7 @@ import Application.Models exposing (Session)
 import Assets
 import Build.StepTree.Models as STModels
 import ColorValues
-import Common exposing (defineHoverBehaviour, queryView)
+import Common exposing (defineHoverBehaviour, expectNoTooltip, expectTooltip, queryView)
 import Concourse exposing (JsonValue(..))
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.Pagination exposing (Direction(..), Page, Pagination)
@@ -115,11 +115,6 @@ purpleHex =
 lightGreyHex : String
 lightGreyHex =
     "#3d3c3c"
-
-
-tooltipGreyHex : String
-tooltipGreyHex =
-    "#9b9b9b"
 
 
 darkGreyHex : String
@@ -860,7 +855,7 @@ all =
                             |> Query.find (versionSelector version)
                             |> findLast [ tag "div", containing [ text version ] ]
                             |> Query.has purpleOutlineSelector
-                , test "mousing over pin bar sends TogglePinBarTooltip message" <|
+                , test "mousing over pin bar sends Hover message" <|
                     \_ ->
                         init
                             |> givenResourcePinnedStatically
@@ -869,60 +864,6 @@ all =
                             |> Event.simulate Event.mouseEnter
                             |> Event.expect
                                 (Msgs.Update <| Message.Message.Hover <| Just Message.Message.PinBar)
-                , test "TogglePinBarTooltip causes tooltip to appear" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> hoverOverPinBar
-                            |> queryView
-                            |> Query.has pinBarTooltipSelector
-                , test "pin bar tooltip has text 'pinned in pipeline config'" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> hoverOverPinBar
-                            |> queryView
-                            |> Query.find pinBarTooltipSelector
-                            |> Query.has [ text "pinned in pipeline config" ]
-                , test "pin bar tooltip is positioned above and near the left of the pin bar" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> hoverOverPinBar
-                            |> queryView
-                            |> Query.find pinBarTooltipSelector
-                            |> Query.has
-                                [ style "position" "absolute"
-                                , style "top" "-10px"
-                                , style "left" "30px"
-                                ]
-                , test "pin bar tooltip is light grey" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> hoverOverPinBar
-                            |> queryView
-                            |> Query.find pinBarTooltipSelector
-                            |> Query.has
-                                [ style "background-color" ColorValues.grey20 ]
-                , test "pin bar tooltip has a bit of padding around text" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> hoverOverPinBar
-                            |> queryView
-                            |> Query.find pinBarTooltipSelector
-                            |> Query.has
-                                [ style "padding" "5px" ]
-                , test "pin bar tooltip appears above other elements in the DOM" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> hoverOverPinBar
-                            |> queryView
-                            |> Query.find pinBarTooltipSelector
-                            |> Query.has
-                                [ style "z-index" "2" ]
                 , test "mousing out of pin bar sends Hover Nothing message" <|
                     \_ ->
                         init
@@ -933,15 +874,6 @@ all =
                             |> Event.simulate Event.mouseLeave
                             |> Event.expect
                                 (Msgs.Update <| Message.Message.Hover Nothing)
-                , test "when mousing off pin bar, tooltip disappears" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> hoverOverPinBar
-                            |> update (Message.Message.Hover Nothing)
-                            |> Tuple.first
-                            |> queryView
-                            |> Query.hasNot pinBarTooltipSelector
                 ]
             , describe "per-version pin buttons"
                 [ test "unpinned versions are lower opacity" <|
@@ -967,36 +899,6 @@ all =
                                         Just <|
                                             Message.Message.PinButton versionID
                                 )
-                , test "mousing over an unpinned version's pin button doesn't send any msg" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> givenVersionsWithoutPagination
-                            |> queryView
-                            |> Query.find (versionSelector otherVersion)
-                            |> Query.find pinButtonSelector
-                            |> Event.simulate Event.mouseOver
-                            |> Event.toResult
-                            |> Expect.err
-                , test "shows tooltip on the pinned version's pin button on ToggleVersionTooltip" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> givenVersionsWithoutPagination
-                            |> hoverOverPinButton
-                            |> queryView
-                            |> Query.find (versionSelector version)
-                            |> Query.has versionTooltipSelector
-                , test "keeps tooltip on the pinned version's pin button on autorefresh" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> givenVersionsWithoutPagination
-                            |> hoverOverPinButton
-                            |> givenVersionsWithoutPagination
-                            |> queryView
-                            |> Query.find (versionSelector version)
-                            |> Query.has versionTooltipSelector
                 , test "mousing off the pinned version's pin button sends Hover Nothing" <|
                     \_ ->
                         init
@@ -1009,29 +911,6 @@ all =
                             |> Event.simulate Event.mouseOut
                             |> Event.expect
                                 (Msgs.Update <| Message.Message.Hover Nothing)
-                , test "mousing off an unpinned version's pin button doesn't send any msg" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> givenVersionsWithoutPagination
-                            |> hoverOverPinButton
-                            |> queryView
-                            |> Query.find (versionSelector otherVersion)
-                            |> Query.find pinButtonSelector
-                            |> Event.simulate Event.mouseOut
-                            |> Event.toResult
-                            |> Expect.err
-                , test "hides tooltip on the pinned version's pin button on ToggleVersionTooltip" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedStatically
-                            |> givenVersionsWithoutPagination
-                            |> hoverOverPinButton
-                            |> update (Message.Message.Hover Nothing)
-                            |> Tuple.first
-                            |> queryView
-                            |> Query.find (versionSelector version)
-                            |> Query.hasNot versionTooltipSelector
                 , test "clicking on pin button on pinned version doesn't send any msg" <|
                     \_ ->
                         init
@@ -1080,13 +959,7 @@ all =
                             |> queryView
                             |> Query.find [ id "pin-bar" ]
                 in
-                [ test "when mousing over pin bar, tooltip does not appear" <|
-                    \_ ->
-                        pinBar
-                            |> Event.simulate Event.mouseEnter
-                            |> Event.toResult
-                            |> Expect.err
-                , test "aligns its children on top left" <|
+                [ test "aligns its children on top left" <|
                     \_ ->
                         pinBar
                             |> Query.has [ style "align-items" "flex-start" ]
@@ -1512,15 +1385,6 @@ all =
                                     Assets.backgroundImage <|
                                         Just Assets.PinIconWhite
                                 ]
-                , test "does not show tooltip on the pin button on ToggleVersionTooltip" <|
-                    \_ ->
-                        init
-                            |> givenResourcePinnedDynamically
-                            |> givenVersionsWithoutPagination
-                            |> hoverOverPinButton
-                            |> queryView
-                            |> Query.find (versionSelector version)
-                            |> Query.hasNot versionTooltipSelector
                 , test "unpinned versions are lower opacity" <|
                     \_ ->
                         init
@@ -2319,16 +2183,6 @@ all =
                                     , style "background-position" "50% 50%"
                                     ]
                             )
-                , test "pin buttons are positioned to anchor their tooltips" <|
-                    allVersions
-                        >> Query.each
-                            (Query.children []
-                                >> Query.first
-                                >> Query.children []
-                                >> Query.index 1
-                                >> Query.has
-                                    [ style "position" "relative" ]
-                            )
                 , test "version headers lay out horizontally, centering" <|
                     allVersions
                         >> Query.each
@@ -2380,15 +2234,6 @@ all =
                         |> Event.simulate Event.mouseEnter
                         |> Event.toResult
                         |> Expect.err
-            , test "does not show tooltip on the pin icon on ToggleVersionTooltip" <|
-                \_ ->
-                    init
-                        |> givenResourceIsNotPinned
-                        |> givenVersionsWithoutPagination
-                        |> hoverOverPinButton
-                        |> queryView
-                        |> Query.find (versionSelector version)
-                        |> Query.hasNot versionTooltipSelector
             , test "all pin buttons have pointer cursor" <|
                 \_ ->
                     init
@@ -3452,6 +3297,69 @@ all =
                                 (Effects.GetViewportOf <| Message.Message.StepState "plan")
                 ]
             ]
+        , describe "tooltips" <|
+            [ test "manual check button" <|
+                \_ ->
+                    init
+                        |> givenResourceIsNotPinned
+                        |> expectTooltip (CheckButton False) "trigger manual check"
+            , test "pin icon" <|
+                \_ ->
+                    init
+                        |> givenResourcePinnedDynamically
+                        |> expectTooltip PinIcon "unpin version"
+            , test "edit button" <|
+                \_ ->
+                    init
+                        |> givenResourcePinnedDynamically
+                        |> expectTooltip EditButton "edit pin comment"
+            , test "version pin button, no pin" <|
+                \_ ->
+                    init
+                        |> givenResourceIsNotPinned
+                        |> givenVersionsWithoutPagination
+                        |> expectTooltip (PinButton versionID) "pin version"
+            , test "version pin button, other version pinned" <|
+                \_ ->
+                    init
+                        |> givenResourcePinnedDynamically
+                        |> givenVersionsWithoutPagination
+                        |> expectTooltip (PinButton otherVersionID) "pin version"
+            , test "version pin button, current version pinned" <|
+                \_ ->
+                    init
+                        |> givenResourcePinnedDynamically
+                        |> givenVersionsWithoutPagination
+                        |> expectTooltip (PinButton versionID) "unpin version"
+            , test "version pin button, static pin" <|
+                \_ ->
+                    init
+                        |> givenResourcePinnedStatically
+                        |> givenVersionsWithoutPagination
+                        |> expectTooltip (PinButton otherVersionID) "version is pinned in the pipeline config"
+            , test "enable version toggle button, enabled" <|
+                \_ ->
+                    init
+                        |> givenResourcePinnedDynamically
+                        |> givenVersionsWithoutPagination
+                        |> expectTooltip (VersionToggle otherVersionID) "disable version"
+            , test "enable version toggle button, disabled" <|
+                \_ ->
+                    init
+                        |> givenResourcePinnedDynamically
+                        |> givenVersionsWithoutPagination
+                        |> expectTooltip (VersionToggle disabledVersionID) "enable version"
+            , test "pin bar, dynamic pin" <|
+                \_ ->
+                    init
+                        |> givenResourcePinnedDynamically
+                        |> expectNoTooltip PinBar
+            , test "pin bar, static pin" <|
+                \_ ->
+                    init
+                        |> givenResourcePinnedStatically
+                        |> expectTooltip PinBar "version is pinned in the pipeline config"
+            ]
         ]
 
 
@@ -3824,23 +3732,6 @@ purpleOutlineSelector =
 findLast : List Selector -> Query.Single msg -> Query.Single msg
 findLast selectors =
     Query.findAll selectors >> Query.index -1
-
-
-pinBarTooltipSelector : List Selector
-pinBarTooltipSelector =
-    [ id "pin-bar-tooltip" ]
-
-
-versionTooltipSelector : List Selector
-versionTooltipSelector =
-    [ style "position" "absolute"
-    , style "bottom" "25px"
-    , style "background-color" ColorValues.grey20
-    , style "z-index" "2"
-    , style "padding" "5px"
-    , style "width" "170px"
-    , containing [ text "enable via pipeline config" ]
-    ]
 
 
 pinButtonHasTransitionState : Query.Single msg -> Expectation

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -290,17 +290,11 @@ all =
                         >> Query.hasNot [ id "logout-button" ]
                 , it "renders pause pipeline button" <|
                     Query.find [ id "top-bar-pause-toggle" ]
-                        >> Query.children []
-                        >> Query.first
                         >> Query.has
                             [ style "background-image" <|
                                 Assets.backgroundImage <|
                                     Just Assets.PauseIcon
                             ]
-                , it "draws lighter grey line to the left of pause pipeline button" <|
-                    Query.find [ id "top-bar-pause-toggle" ]
-                        >> Query.has
-                            [ style "border-left" <| "1px solid " ++ borderGrey ]
                 ]
             , it "clicking a pinned resource navigates to the pinned resource page" <|
                 Application.update
@@ -891,11 +885,7 @@ all =
             [ defineHoverBehaviour
                 { name = "play pipeline icon when authorized"
                 , setup = givenPipelinePaused |> givenUserAuthorized
-                , query =
-                    queryView
-                        >> Query.find [ id "top-bar-pause-toggle" ]
-                        >> Query.children []
-                        >> Query.first
+                , query = queryView >> Query.find [ id "top-bar-pause-toggle" ]
                 , unhoveredSelector =
                     { description = "faded play button with light border"
                     , selector =
@@ -926,11 +916,7 @@ all =
             , defineHoverBehaviour
                 { name = "play pipeline icon when unauthenticated"
                 , setup = givenPipelinePaused
-                , query =
-                    queryView
-                        >> Query.find [ id "top-bar-pause-toggle" ]
-                        >> Query.children []
-                        >> Query.first
+                , query = queryView >> Query.find [ id "top-bar-pause-toggle" ]
                 , unhoveredSelector =
                     { description = "faded play button with light border"
                     , selector =
@@ -961,11 +947,7 @@ all =
             , defineHoverBehaviour
                 { name = "play pipeline icon when unauthorized"
                 , setup = givenPipelinePaused |> givenUserUnauthorized
-                , query =
-                    queryView
-                        >> Query.find [ id "top-bar-pause-toggle" ]
-                        >> Query.children []
-                        >> Query.first
+                , query = queryView >> Query.find [ id "top-bar-pause-toggle" ]
                 , unhoveredSelector =
                     { description = "faded play button with light border"
                     , selector =
@@ -1006,8 +988,6 @@ all =
                     givenPipelinePaused
                         |> queryView
                         |> Query.find [ id "top-bar-pause-toggle" ]
-                        |> Query.children []
-                        |> Query.first
                         |> Event.simulate Event.click
                         |> Event.expect toggleMsg
             , test "play button unclickable for non-members" <|
@@ -1016,8 +996,6 @@ all =
                         |> givenUserUnauthorized
                         |> queryView
                         |> Query.find [ id "top-bar-pause-toggle" ]
-                        |> Query.children []
-                        |> Query.first
                         |> Event.simulate Event.click
                         |> Event.toResult
                         |> Expect.err
@@ -1037,9 +1015,6 @@ all =
                         |> Application.update toggleMsg
                         |> Tuple.first
                         |> queryView
-                        |> Query.find [ id "top-bar-pause-toggle" ]
-                        |> Query.children []
-                        |> Query.first
                         |> Query.has
                             [ style "animation"
                                 "container-rotate 1568ms linear infinite"
@@ -1068,8 +1043,6 @@ all =
                         |> Tuple.first
                         |> queryView
                         |> Query.find [ id "top-bar-pause-toggle" ]
-                        |> Query.children []
-                        |> Query.first
                         |> Query.has
                             (iconSelector
                                 { size = "20px"

--- a/web/wats/test/build.js
+++ b/web/wats/test/build.js
@@ -31,8 +31,8 @@ test('shows abort hooks', async t => {
   await t.context.web.waitForText("say-bye-from-job");
   // await t.context.web.waitForText("looping");
 
-  await t.context.web.page.waitFor('button[title="Abort Build"]');
-  await t.context.web.page.click('button[title="Abort Build"]');
+  await t.context.web.page.waitFor('button[aria-label="Abort Build"]');
+  await t.context.web.page.click('button[aria-label="Abort Build"]');
 
   await t.context.web.waitForBackgroundColor('.build-header', palette.brown, {
     timeout: 60000,


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes #5972 .

Adds tooltips to the pipeline page as per the issue, as well as the Dashboard, Build page, Job page, and Resource page. Also makes tooltip colours consistent throughout the app.

Note: it does not address the uniform padding issue on the pipeline page - there were browser inconsistencies which made it difficult/impossible to make things look good across all browsers.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Use the new(ish) `tooltip` function for defining all tooltips (that I could find), rather than each page rendering their own tooltips
* Made it easier to render consistently styled tooltips by applying default styles in the `Tooltip` module (and consequently use the new tooltip style for all the tooltips)
* New tooltips
  * Dashboard
    * Pipeline card favourite icon
    * Pipeline card pause toggle
  * Pipeline page
    * Top bar pause toggle
    * Top bar favourite icon
    * Top bar pin menu icon
  * Build page
    * Trigger build button
    * Rerun build button
    * Abort build button
  * Job page
    * Trigger build button
    * Pause toggle button
  * Resource page
    * Trigger manual check button
    * Pin version button
    * Enable version button
    * Unpin button (in pin bar)
    * Edit comment button
    * Pin bar (for statically pinned)

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* Many buttons in the UI now have a tooltip on hover to indicate what they do

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
