### PR TITLE
audit: log user IP address

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -214,15 +214,16 @@ type RunCommand struct {
 	DefaultMemoryLimit *string `long:"default-task-memory-limit" description:"Default maximum memory per task, 0 means unlimited"`
 
 	Auditor struct {
-		EnableBuildAuditLog     bool `long:"enable-build-auditing" description:"Enable auditing for all api requests connected to builds."`
-		EnableContainerAuditLog bool `long:"enable-container-auditing" description:"Enable auditing for all api requests connected to containers."`
-		EnableJobAuditLog       bool `long:"enable-job-auditing" description:"Enable auditing for all api requests connected to jobs."`
-		EnablePipelineAuditLog  bool `long:"enable-pipeline-auditing" description:"Enable auditing for all api requests connected to pipelines."`
-		EnableResourceAuditLog  bool `long:"enable-resource-auditing" description:"Enable auditing for all api requests connected to resources."`
-		EnableSystemAuditLog    bool `long:"enable-system-auditing" description:"Enable auditing for all api requests connected to system transactions."`
-		EnableTeamAuditLog      bool `long:"enable-team-auditing" description:"Enable auditing for all api requests connected to teams."`
-		EnableWorkerAuditLog    bool `long:"enable-worker-auditing" description:"Enable auditing for all api requests connected to workers."`
-		EnableVolumeAuditLog    bool `long:"enable-volume-auditing" description:"Enable auditing for all api requests connected to volumes."`
+		EnableBuildAuditLog     bool   `long:"enable-build-auditing" description:"Enable auditing for all api requests connected to builds."`
+		EnableContainerAuditLog bool   `long:"enable-container-auditing" description:"Enable auditing for all api requests connected to containers."`
+		EnableJobAuditLog       bool   `long:"enable-job-auditing" description:"Enable auditing for all api requests connected to jobs."`
+		EnablePipelineAuditLog  bool   `long:"enable-pipeline-auditing" description:"Enable auditing for all api requests connected to pipelines."`
+		EnableResourceAuditLog  bool   `long:"enable-resource-auditing" description:"Enable auditing for all api requests connected to resources."`
+		EnableSystemAuditLog    bool   `long:"enable-system-auditing" description:"Enable auditing for all api requests connected to system transactions."`
+		EnableTeamAuditLog      bool   `long:"enable-team-auditing" description:"Enable auditing for all api requests connected to teams."`
+		EnableWorkerAuditLog    bool   `long:"enable-worker-auditing" description:"Enable auditing for all api requests connected to workers."`
+		EnableVolumeAuditLog    bool   `long:"enable-volume-auditing" description:"Enable auditing for all api requests connected to volumes."`
+		ClientIPHeader          string `long:"client-ip-header" description:"A header that a reverse proxy will set to the client's IP address. If not set then X-REAL-IP and X-FORWARD-FOR will be used in that order."`
 	}
 
 	Syslog struct {
@@ -1863,6 +1864,7 @@ func (cmd *RunCommand) constructAPIHandler(
 		cmd.Auditor.EnableWorkerAuditLog,
 		cmd.Auditor.EnableVolumeAuditLog,
 		logger,
+		cmd.Auditor.ClientIPHeader,
 	)
 
 	customRoles, err := cmd.parseCustomRoles()

--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -164,6 +164,6 @@ func (a *auditor) ValidateAction(action string) bool {
 func (a *auditor) Audit(action string, userName string, r *http.Request) {
 	err := r.ParseForm()
 	if err == nil && a.ValidateAction(action) {
-		a.logger.Info("audit", lager.Data{"action": action, "user": userName, "parameters": r.Form})
+		a.logger.Info("audit", lager.Data{"action": action, "user": userName, "ip": r.RemoteAddr, "parameters": r.Form})
 	}
 }

--- a/atc/auditor/auditor_test.go
+++ b/atc/auditor/auditor_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Audit", func() {
 			EnableWorkerAuditLog,
 			EnableVolumeAuditLog,
 			logger,
+			"CUSTOM-IP-HEADER",
 		)
 	})
 
@@ -115,6 +116,7 @@ var _ = Describe("Audit", func() {
 			Entry("logs the X-REAL-IP", "X-REAL-IP", "127.0.0.2", "127.0.0.2"),
 			Entry("logs the X-FORWARDED-FOR", "X-FORWARDED-FOR", "127.0.0.3", "127.0.0.3"),
 			Entry("logs only one IP from X-FORWARDED-FOR", "X-FORWARDED-FOR", "127.0.0.3,127.0.0.55,192.14.22.46", "127.0.0.3"),
+			Entry("logs the IP from the custom header", "CUSTOM-IP-HEADER", "127.0.0.12", "127.0.0.12"),
 		)
 	})
 


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

From concourse/concourse#6456

## Changes proposed by this PR:
Has the auditor also log a users IP address. Will log based on available headers (X-REAL-IP and X-FORWARDED-FOR) and fall back to `RemoteAddr` if no header is available.


## Release Note

* The audit logs now log a user's IP address

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

