### PR TITLE
Allow favoriting instance groups

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -683,6 +683,7 @@ sampleSession =
     , expandedTeamsInAllPipelines = Set.empty
     , collapsedTeamsInFavorites = Set.empty
     , favoritedPipelines = Set.empty
+    , favoritedInstanceGroups = Set.empty
     , hovered = HoverState.NoHover
     , sideBarState =
         { isOpen = False

--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -143,6 +143,7 @@ buildView session model =
                     |> Maybe.map
                         (\j ->
                             { pipelineName = j.pipelineName
+                            , pipelineInstanceVars = j.pipelineInstanceVars
                             , teamName = j.teamName
                             }
                         )

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -89,6 +89,7 @@ init flags url =
             , screenSize = ScreenSize.Desktop
             , timeZone = Time.utc
             , favoritedPipelines = Set.empty
+            , favoritedInstanceGroups = Set.empty
             , route = route
             }
 
@@ -116,6 +117,7 @@ init flags url =
       , GetScreenSize
       , LoadSideBarState
       , LoadFavoritedPipelines
+      , LoadFavoritedInstanceGroups
       , FetchClusterInfo
       ]
         ++ handleTokenEffect

--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -456,9 +456,7 @@ view model =
 subscriptions : Model -> List Subscription
 subscriptions model =
     [ OnNonHrefLinkClicked
-    , OnTokenReceived
-    , OnSideBarStateReceived
-    , OnFavoritedPipelinesReceived
+    , OnLocalStorageReceived
     , OnWindowResize
     ]
         ++ (if model.session.draggingSideBar then

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -652,6 +652,7 @@ view session model =
                     |> Maybe.map
                         (\j ->
                             { pipelineName = j.pipelineName
+                            , pipelineInstanceVars = j.pipelineInstanceVars
                             , teamName = j.teamName
                             }
                         )

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -72,7 +72,7 @@ module Concourse exposing
     , encodeResource
     , encodeTeam
     , flattenJson
-    , groupPipelines
+    , groupPipelinesWithinTeam
     , hyphenNotation
     , isInstanceGroup
     , mapBuildPlan
@@ -547,10 +547,10 @@ type PipelineGrouping pipeline
     | InstanceGroup pipeline (List pipeline)
 
 
-groupPipelines :
+groupPipelinesWithinTeam :
     List { p | name : String, instanceVars : InstanceVars }
     -> List (PipelineGrouping { p | name : String, instanceVars : InstanceVars })
-groupPipelines =
+groupPipelinesWithinTeam =
     List.Extra.gatherEqualsBy .name
         >> List.map
             (\( p, ps ) ->

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -76,6 +76,7 @@ module Concourse exposing
     , mapBuildPlan
     , pipelineId
     , retrieveCSRFToken
+    , toInstanceGroupId
     , toPipelineId
     )
 
@@ -1025,6 +1026,11 @@ type alias InstanceGroupIdentifier =
     { teamName : TeamName
     , name : PipelineName
     }
+
+
+toInstanceGroupId : { p | teamName : TeamName, name : PipelineName } -> InstanceGroupIdentifier
+toInstanceGroupId { teamName, name } =
+    { teamName = teamName, name = name }
 
 
 

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -51,6 +51,7 @@ module Concourse exposing
     , decodeBuildResources
     , decodeCause
     , decodeInfo
+    , decodeInstanceGroupId
     , decodeInstanceVars
     , decodeJob
     , decodeJsonValue
@@ -63,6 +64,7 @@ module Concourse exposing
     , decodeVersionedResource
     , emptyBuildResources
     , encodeBuild
+    , encodeInstanceGroupId
     , encodeInstanceVars
     , encodeJob
     , encodeJsonValue
@@ -1031,6 +1033,21 @@ type alias InstanceGroupIdentifier =
 toInstanceGroupId : { p | teamName : TeamName, name : PipelineName } -> InstanceGroupIdentifier
 toInstanceGroupId { teamName, name } =
     { teamName = teamName, name = name }
+
+
+encodeInstanceGroupId : InstanceGroupIdentifier -> Json.Encode.Value
+encodeInstanceGroupId { teamName, name } =
+    Json.Encode.object
+        [ ( "team_name", Json.Encode.string teamName )
+        , ( "name", Json.Encode.string name )
+        ]
+
+
+decodeInstanceGroupId : Json.Decode.Decoder InstanceGroupIdentifier
+decodeInstanceGroupId =
+    Json.Decode.succeed InstanceGroupIdentifier
+        |> andMap (Json.Decode.field "team_name" Json.Decode.string)
+        |> andMap (Json.Decode.field "name" Json.Decode.string)
 
 
 

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -74,6 +74,7 @@ module Concourse exposing
     , flattenJson
     , groupPipelinesWithinTeam
     , hyphenNotation
+    , isInInstanceGroup
     , isInstanceGroup
     , mapBuildPlan
     , pipelineId
@@ -562,7 +563,7 @@ groupPipelinesWithinTeam =
             )
 
 
-isInstanceGroup : List { p | name : String, instanceVars : InstanceVars } -> Bool
+isInstanceGroup : List { p | instanceVars : InstanceVars } -> Bool
 isInstanceGroup pipelines =
     case pipelines of
         p :: ps ->
@@ -570,6 +571,21 @@ isInstanceGroup pipelines =
 
         _ ->
             False
+
+
+isInInstanceGroup :
+    List { a | id : DatabaseID, name : String, teamName : String, instanceVars : InstanceVars }
+    -> { b | id : DatabaseID, name : String, teamName : String, instanceVars : InstanceVars }
+    -> Bool
+isInInstanceGroup allPipelines p =
+    not (Dict.isEmpty p.instanceVars)
+        || List.any
+            (\p2 ->
+                (p.name == p2.name)
+                    && (p.teamName == p2.teamName)
+                    && (p.id /= p2.id)
+            )
+            allPipelines
 
 
 type alias AcrossPlan =

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -683,7 +683,7 @@ updateBody session msg ( model, effects ) =
 
         DragEnd ->
             case ( model.dragState, model.dropState ) of
-                ( Dragging teamName name, Dropping target ) ->
+                ( Dragging teamName identifier, Dropping target ) ->
                     let
                         teamCards =
                             model.pipelines
@@ -692,7 +692,7 @@ updateBody session msg ( model, effects ) =
                                 |> groupCardsWithinTeam
                                 |> (\cards ->
                                         cards
-                                            |> (case Drag.dragCardIndices name target cards of
+                                            |> (case Drag.dragCardIndices identifier target cards of
                                                     Just ( from, to ) ->
                                                         Drag.drag from to
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -884,7 +884,7 @@ tooltip session =
         HoverState.Tooltip (Message.PipelineCardFavoritedIcon _ id) _ ->
             let
                 isFavorited =
-                    Set.member id session.favoritedPipelines
+                    Favorites.isPipelineFavorited session { id = id }
             in
             Just
                 { body =

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1326,27 +1326,14 @@ cardsView session params teamCards =
                     favoritedCards =
                         teamCards
                             |> List.concatMap Tuple.second
-                            |> List.filterMap
+                            |> List.filter
                                 (\c ->
-                                    let
-                                        isFavorited =
-                                            Favorites.isPipelineFavorited session
-                                    in
                                     case c of
                                         PipelineCard p ->
-                                            if isFavorited p then
-                                                Just <| PipelineCard p
+                                            Favorites.isPipelineFavorited session p
 
-                                            else
-                                                Nothing
-
-                                        InstanceGroupCard p ps ->
-                                            case List.filter isFavorited (p :: ps) of
-                                                x :: xs ->
-                                                    Just <| InstanceGroupCard x xs
-
-                                                [] ->
-                                                    Nothing
+                                        InstanceGroupCard p _ ->
+                                            Favorites.isInstanceGroupFavorited session (Concourse.toInstanceGroupId p)
                                 )
 
                     allPipelinesHeader =

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -37,6 +37,7 @@ import Dashboard.Styles as Styles
 import Dashboard.Text as Text
 import Dict exposing (Dict)
 import EffectTransformer exposing (ET)
+import Favorites
 import FetchResult exposing (FetchResult(..), changedFrom)
 import HoverState
 import Html exposing (Html)
@@ -1331,8 +1332,8 @@ cardsView session params teamCards =
                             |> List.filterMap
                                 (\c ->
                                     let
-                                        isFavorited p =
-                                            Set.member p.id session.favoritedPipelines
+                                        isFavorited =
+                                            Favorites.isPipelineFavorited session
                                     in
                                     case c of
                                         PipelineCard p ->

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -713,6 +713,9 @@ updateBody session msg ( model, effects ) =
                                                         PipelineCard p ->
                                                             [ p ]
 
+                                                        InstancedPipelineCard p ->
+                                                            [ p ]
+
                                                         InstanceGroupCard p ps ->
                                                             p :: ps
                                                 )
@@ -1299,7 +1302,7 @@ instanceGroupCardsView session model =
                             |> List.map
                                 (\( p, ps ) ->
                                     ( team ++ " / " ++ p.name
-                                    , p :: ps |> List.map PipelineCard
+                                    , p :: ps |> List.map InstancedPipelineCard
                                     )
                                 )
                     )
@@ -1336,6 +1339,13 @@ cardsView session params teamCards =
                                             else
                                                 []
 
+                                        InstancedPipelineCard p ->
+                                            if Favorites.isPipelineFavorited session p then
+                                                [ c ]
+
+                                            else
+                                                []
+
                                         InstanceGroupCard p ps ->
                                             (if Favorites.isInstanceGroupFavorited session (Concourse.toInstanceGroupId p) then
                                                 [ c ]
@@ -1344,7 +1354,7 @@ cardsView session params teamCards =
                                                 []
                                             )
                                                 ++ (List.filter (Favorites.isPipelineFavorited session) (p :: ps)
-                                                        |> List.map PipelineCard
+                                                        |> List.map InstancedPipelineCard
                                                    )
                                 )
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -812,9 +812,6 @@ subscriptions =
     , OnKeyDown
     , OnKeyUp
     , OnWindowResize
-    , OnCachedJobsReceived
-    , OnCachedPipelinesReceived
-    , OnCachedTeamsReceived
     ]
 
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1021,6 +1021,21 @@ tooltip session =
                 , containerAttrs = Just Styles.cardTooltip
                 }
 
+        HoverState.Tooltip (Message.PipelineCardInstanceVars _ _ vars) _ ->
+            Just
+                { body =
+                    Html.text
+                        (vars
+                            |> Dict.toList
+                            |> List.concatMap (\( k, v ) -> Concourse.flattenJson k v)
+                            |> List.map (\( k, v ) -> k ++ ":" ++ v)
+                            |> String.join ", "
+                        )
+                , attachPosition = { direction = Tooltip.Right 0, alignment = Tooltip.Middle 30 }
+                , arrow = Just 15
+                , containerAttrs = Just Styles.cardTooltip
+                }
+
         _ ->
             Nothing
 

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -902,6 +902,27 @@ tooltip session =
                 , containerAttrs = Nothing
                 }
 
+        HoverState.Tooltip (Message.InstanceGroupCardFavoritedIcon _ id) _ ->
+            let
+                isFavorited =
+                    Favorites.isInstanceGroupFavorited session id
+            in
+            Just
+                { body =
+                    Html.text <|
+                        if isFavorited then
+                            "unfavorite instance group"
+
+                        else
+                            "favorite instance group"
+                , attachPosition =
+                    { direction = Tooltip.Bottom
+                    , alignment = Tooltip.End
+                    }
+                , arrow = Just 5
+                , containerAttrs = Nothing
+                }
+
         HoverState.Tooltip (Message.PipelineCardPauseToggle _ id) _ ->
             session
                 |> lookupPipeline (byDatabaseId id)

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -689,7 +689,7 @@ updateBody session msg ( model, effects ) =
                             model.pipelines
                                 |> Maybe.andThen (Dict.get teamName)
                                 |> Maybe.withDefault []
-                                |> groupCards
+                                |> groupCardsWithinTeam
                                 |> (\cards ->
                                         cards
                                             |> (case Drag.dragCardIndices name target cards of
@@ -1260,16 +1260,16 @@ regularCardsView session params =
                 |> List.map
                     (\( team, teamPipelines ) ->
                         ( team
-                        , groupCards teamPipelines
+                        , groupCardsWithinTeam teamPipelines
                         )
                     )
     in
     cardsView session params teamCards
 
 
-groupCards : List Pipeline -> List Card
-groupCards =
-    Concourse.groupPipelines
+groupCardsWithinTeam : List Pipeline -> List Card
+groupCardsWithinTeam =
+    Concourse.groupPipelinesWithinTeam
         >> List.map
             (\g ->
                 case g of

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1314,7 +1314,7 @@ cardsView session params teamCards =
             params.jobs
                 |> FetchResult.withDefault Dict.empty
 
-        inInstanceGroupView =
+        viewingInstanceGroups =
             Filter.isViewingInstanceGroups params.query
 
         ( headerView, offsetHeight ) =
@@ -1326,14 +1326,26 @@ cardsView session params teamCards =
                     favoritedCards =
                         teamCards
                             |> List.concatMap Tuple.second
-                            |> List.filter
+                            |> List.concatMap
                                 (\c ->
                                     case c of
                                         PipelineCard p ->
-                                            Favorites.isPipelineFavorited session p
+                                            if Favorites.isPipelineFavorited session p then
+                                                [ c ]
 
-                                        InstanceGroupCard p _ ->
-                                            Favorites.isInstanceGroupFavorited session (Concourse.toInstanceGroupId p)
+                                            else
+                                                []
+
+                                        InstanceGroupCard p ps ->
+                                            (if Favorites.isInstanceGroupFavorited session (Concourse.toInstanceGroupId p) then
+                                                [ c ]
+
+                                             else
+                                                []
+                                            )
+                                                ++ (List.filter (Favorites.isPipelineFavorited session) (p :: ps)
+                                                        |> List.map PipelineCard
+                                                   )
                                 )
 
                     allPipelinesHeader =
@@ -1356,7 +1368,7 @@ cardsView session params teamCards =
                                 , viewportWidth = params.viewportWidth
                                 , viewportHeight = params.viewportHeight
                                 , scrollTop = params.scrollTop - offset
-                                , isInstanceGroupView = inInstanceGroupView
+                                , viewingInstanceGroups = viewingInstanceGroups
                                 }
                                 favoritedCards
                     in
@@ -1373,7 +1385,7 @@ cardsView session params teamCards =
                         , jobs = jobs
                         , dashboardView = params.dashboardView
                         , query = params.query
-                        , inInstanceGroupView = inInstanceGroupView
+                        , viewingInstanceGroups = viewingInstanceGroups
                         }
                         layout.headers
                         layout.cards
@@ -1419,6 +1431,7 @@ cardsView session params teamCards =
                                             , viewportWidth = params.viewportWidth
                                             , viewportHeight = params.viewportHeight
                                             , scrollTop = params.scrollTop - startingOffset
+                                            , viewingInstanceGroups = viewingInstanceGroups
                                             }
                                             teamName
                                             cards
@@ -1436,7 +1449,7 @@ cardsView session params teamCards =
                                     , jobs = jobs
                                     , dashboardView = params.dashboardView
                                     , query = params.query
-                                    , inInstanceGroupView = inInstanceGroupView
+                                    , viewingInstanceGroups = viewingInstanceGroups
                                     }
                                     teamName
                                     layout.cards

--- a/web/elm/src/Dashboard/Drag.elm
+++ b/web/elm/src/Dashboard/Drag.elm
@@ -15,7 +15,7 @@ insertAt idx x xs =
             x :: xs
 
 
-dragCardIndices : Int -> DropTarget -> List Card -> Maybe ( Int, Int )
+dragCardIndices : String -> DropTarget -> List Card -> Maybe ( Int, Int )
 dragCardIndices cardId target cards =
     let
         cardIndex id =
@@ -26,8 +26,8 @@ dragCardIndices cardId target cards =
 
         toIndex =
             (case target of
-                Before name ->
-                    cardIndex name
+                Before id ->
+                    cardIndex id
 
                 End ->
                     List.length cards |> Just

--- a/web/elm/src/Dashboard/Filter.elm
+++ b/web/elm/src/Dashboard/Filter.elm
@@ -133,7 +133,7 @@ runFilter jobs existingJobs f =
         InstanceGroup sf ->
             Dict.map
                 (\_ ->
-                    Concourse.groupPipelines
+                    Concourse.groupPipelinesWithinTeam
                         >> List.filterMap
                             (\g ->
                                 case g of

--- a/web/elm/src/Dashboard/Filter.elm
+++ b/web/elm/src/Dashboard/Filter.elm
@@ -1,5 +1,6 @@
 module Dashboard.Filter exposing (Suggestion, filterTeams, isViewingInstanceGroups, suggestions)
 
+import Application.Models exposing (Session)
 import Concourse exposing (DatabaseID, flattenJson)
 import Concourse.PipelineStatus
     exposing
@@ -12,6 +13,7 @@ import Dashboard.Group.Models exposing (Card(..), Pipeline)
 import Dashboard.Models exposing (Model)
 import Dashboard.Pipeline as Pipeline
 import Dict exposing (Dict)
+import Favorites
 import FetchResult
 import List.Extra
 import Parser
@@ -75,8 +77,8 @@ type StatusFilter
     | IncompleteStatus String
 
 
-filterTeams : { r | favoritedPipelines : Set DatabaseID } -> Model -> Dict String (List Pipeline)
-filterTeams { favoritedPipelines } { pipelineJobs, jobs, query, teams, pipelines, dashboardView } =
+filterTeams : Session -> Model -> Dict String (List Pipeline)
+filterTeams session { pipelineJobs, jobs, query, teams, pipelines, dashboardView } =
     let
         teamsToFilter =
             teams
@@ -86,7 +88,7 @@ filterTeams { favoritedPipelines } { pipelineJobs, jobs, query, teams, pipelines
                 |> Dict.union (pipelines |> Maybe.withDefault Dict.empty)
                 |> Dict.map
                     (\_ p ->
-                        List.filter (prefilter dashboardView favoritedPipelines) p
+                        List.filter (prefilter session dashboardView) p
                     )
     in
     parseFilters query
@@ -94,11 +96,11 @@ filterTeams { favoritedPipelines } { pipelineJobs, jobs, query, teams, pipelines
         |> List.foldr (runFilter (FetchResult.withDefault Dict.empty jobs) pipelineJobs) teamsToFilter
 
 
-prefilter : Routes.DashboardView -> Set DatabaseID -> Pipeline -> Bool
-prefilter view favoritedPipelines p =
+prefilter : Session -> Routes.DashboardView -> Pipeline -> Bool
+prefilter session view p =
     case view of
         Routes.ViewNonArchivedPipelines ->
-            not p.archived || Set.member p.id favoritedPipelines
+            not p.archived || Favorites.isPipelineFavorited session p
 
         _ ->
             True

--- a/web/elm/src/Dashboard/Filter.elm
+++ b/web/elm/src/Dashboard/Filter.elm
@@ -1,7 +1,7 @@
 module Dashboard.Filter exposing (Suggestion, filterTeams, isViewingInstanceGroups, suggestions)
 
 import Application.Models exposing (Session)
-import Concourse exposing (DatabaseID, flattenJson)
+import Concourse exposing (flattenJson)
 import Concourse.PipelineStatus
     exposing
         ( PipelineStatus(..)
@@ -39,7 +39,6 @@ import Parser
         , symbol
         )
 import Routes
-import Set exposing (Set)
 import Simple.Fuzzy
 
 

--- a/web/elm/src/Dashboard/Grid.elm
+++ b/web/elm/src/Dashboard/Grid.elm
@@ -289,8 +289,8 @@ cardSizes :
 cardSizes pipelineLayers =
     List.map
         (\card ->
-            case card of
-                PipelineCard pipeline ->
+            let
+                pipelineCardSize pipeline =
                     Dict.get pipeline.id pipelineLayers
                         |> Maybe.withDefault []
                         |> (\layers ->
@@ -302,6 +302,13 @@ cardSizes pipelineLayers =
                                         |> Maybe.withDefault 0
                                     )
                            )
+            in
+            case card of
+                PipelineCard pipeline ->
+                    pipelineCardSize pipeline
+
+                InstancedPipelineCard pipeline ->
+                    pipelineCardSize pipeline
 
                 InstanceGroupCard _ _ ->
                     ( 1, 1 )
@@ -423,29 +430,32 @@ computeCards config params cards =
 numHeaderRows : Bool -> Models.Card -> Int
 numHeaderRows viewingInstanceGroups card =
     case card of
-        Models.PipelineCard pipeline ->
-            if Dict.isEmpty pipeline.instanceVars then
-                1
+        Models.PipelineCard _ ->
+            1
 
-            else
-                let
-                    groupNameHeader =
-                        if viewingInstanceGroups then
-                            -- Don't display instance group name inside the
-                            -- card when viewing instance groups since it's in
-                            -- the outer header
-                            0
+        Models.InstancedPipelineCard pipeline ->
+            let
+                groupNameHeader =
+                    if viewingInstanceGroups then
+                        -- Don't display instance group name inside the
+                        -- card when viewing instance groups since it's in
+                        -- the outer header
+                        0
 
-                        else
-                            1
+                    else
+                        1
 
-                    instanceVarHeaders =
+                instanceVarHeaders =
+                    if Dict.isEmpty pipeline.instanceVars then
+                        1
+
+                    else
                         pipeline.instanceVars
                             |> Dict.toList
                             |> List.concatMap (\( k, v ) -> flattenJson k v)
                             |> List.length
-                in
-                groupNameHeader + instanceVarHeaders
+            in
+            groupNameHeader + instanceVarHeaders
 
         Models.InstanceGroupCard _ _ ->
             1

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -11,7 +11,7 @@ import Application.Models exposing (Session)
 import Concourse
 import Dashboard.Grid as Grid
 import Dashboard.Grid.Constants as GridConstants
-import Dashboard.Group.Models exposing (Card(..), Pipeline)
+import Dashboard.Group.Models exposing (Card(..), Pipeline, cardIdentifier)
 import Dashboard.Group.Tag as Tag
 import Dashboard.InstanceGroup as InstanceGroup
 import Dashboard.Models exposing (DragState(..), DropState(..))
@@ -406,14 +406,14 @@ pipelineCardView session params section { bounds, headerHeight, pipeline, inInst
                             "event.dataTransfer.setData('text/plain', '');"
                         , draggable "true"
                         , on "dragstart"
-                            (Json.Decode.succeed (DragStart pipeline.teamName pipeline.id))
+                            (Json.Decode.succeed (DragStart pipeline.teamName <| cardIdentifier <| PipelineCard pipeline))
                         , on "dragend" (Json.Decode.succeed DragEnd)
                         ]
 
                     else
                         []
                    )
-                ++ (if params.dragState == Dragging pipeline.teamName pipeline.id then
+                ++ (if params.dragState == Dragging pipeline.teamName (cardIdentifier <| PipelineCard pipeline) then
                         [ style "width" "0"
                         , style "margin" "0 12.5px"
                         , style "overflow" "hidden"
@@ -507,14 +507,14 @@ instanceGroupCardView session params section { bounds, headerHeight } p ps =
                             "event.dataTransfer.setData('text/plain', '');"
                         , draggable "true"
                         , on "dragstart"
-                            (Json.Decode.succeed (DragStart p.teamName p.id))
+                            (Json.Decode.succeed (DragStart p.teamName <| cardIdentifier <| InstanceGroupCard p ps))
                         , on "dragend" (Json.Decode.succeed DragEnd)
                         ]
 
                     else
                         []
                    )
-                ++ (if params.dragState == Dragging p.teamName p.id then
+                ++ (if params.dragState == Dragging p.teamName (cardIdentifier <| InstanceGroupCard p ps) then
                         [ style "width" "0"
                         , style "margin" "0 12.5px"
                         , style "overflow" "hidden"

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -59,7 +59,7 @@ view :
         , jobs : Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job
         , dashboardView : Routes.DashboardView
         , query : String
-        , inInstanceGroupView : Bool
+        , viewingInstanceGroups : Bool
         }
     -> Concourse.TeamName
     -> List Grid.Card
@@ -153,7 +153,7 @@ viewFavoritePipelines :
         , jobs : Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job
         , dashboardView : Routes.DashboardView
         , query : String
-        , inInstanceGroupView : Bool
+        , viewingInstanceGroups : Bool
         }
     -> List Grid.Header
     -> List Grid.Card
@@ -315,7 +315,7 @@ pipelineCardView :
             , pipelineLayers : Dict Concourse.DatabaseID (List (List Concourse.JobName))
             , pipelineJobs : Dict Concourse.DatabaseID (List Concourse.JobName)
             , jobs : Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job
-            , inInstanceGroupView : Bool
+            , viewingInstanceGroups : Bool
         }
     -> PipelinesSection
     ->
@@ -359,7 +359,7 @@ pipelineCardView session params section { bounds, headerHeight, pipeline } teamN
              , style "height" "100%"
              , attribute "data-pipeline-name" pipeline.name
              ]
-                ++ (if section == AllPipelinesSection && not pipeline.stale && not params.inInstanceGroupView then
+                ++ (if section == AllPipelinesSection && not pipeline.stale && not params.viewingInstanceGroups then
                         [ attribute
                             "ondragstart"
                             "event.dataTransfer.setData('text/plain', '');"
@@ -408,7 +408,7 @@ pipelineCardView session params section { bounds, headerHeight, pipeline } teamN
                 , headerHeight = headerHeight
                 , hovered = session.hovered
                 , section = section
-                , inInstanceGroupView = params.inInstanceGroupView
+                , viewingInstanceGroups = params.viewingInstanceGroups
                 }
             ]
         ]

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -82,6 +82,19 @@ view session params teamName cards =
                                         { bounds = bounds
                                         , headerHeight = headerHeight
                                         , pipeline = pipeline
+                                        , inInstanceGroup = False
+                                        }
+                                        teamName
+                                        |> (\html -> ( String.fromInt pipeline.id, html ))
+
+                                InstancedPipelineCard pipeline ->
+                                    pipelineCardView session
+                                        params
+                                        AllPipelinesSection
+                                        { bounds = bounds
+                                        , headerHeight = headerHeight
+                                        , pipeline = pipeline
+                                        , inInstanceGroup = True
                                         }
                                         teamName
                                         |> (\html -> ( String.fromInt pipeline.id, html ))
@@ -172,6 +185,19 @@ viewFavoritePipelines session params headers cards =
                                     { bounds = bounds
                                     , pipeline = pipeline
                                     , headerHeight = headerHeight
+                                    , inInstanceGroup = False
+                                    }
+                                    pipeline.teamName
+                                    |> (\html -> ( String.fromInt pipeline.id, html ))
+
+                            InstancedPipelineCard pipeline ->
+                                pipelineCardView session
+                                    params
+                                    FavoritesSection
+                                    { bounds = bounds
+                                    , pipeline = pipeline
+                                    , headerHeight = headerHeight
+                                    , inInstanceGroup = True
                                     }
                                     pipeline.teamName
                                     |> (\html -> ( String.fromInt pipeline.id, html ))
@@ -263,6 +289,20 @@ hdView { pipelinesWithResourceErrors, pipelineJobs, jobs, dashboardView, query }
                                                 |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
                                         }
 
+                                InstancedPipelineCard p ->
+                                    Pipeline.hdPipelineView
+                                        session
+                                        { pipeline = p
+                                        , resourceError =
+                                            pipelinesWithResourceErrors
+                                                |> Set.member p.id
+                                        , existingJobs =
+                                            pipelineJobs
+                                                |> Dict.get p.id
+                                                |> Maybe.withDefault []
+                                                |> List.filterMap (\j -> Dict.get ( p.id, j ) jobs)
+                                        }
+
                                 InstanceGroupCard p ps ->
                                     InstanceGroup.hdCardView
                                         { pipeline = p
@@ -322,10 +362,11 @@ pipelineCardView :
         { bounds : Grid.Bounds
         , pipeline : Pipeline
         , headerHeight : Float
+        , inInstanceGroup : Bool
         }
     -> String
     -> Html Message
-pipelineCardView session params section { bounds, headerHeight, pipeline } teamName =
+pipelineCardView session params section { bounds, headerHeight, pipeline, inInstanceGroup } teamName =
     Html.div
         ([ class "card-wrapper"
          , style "position" "absolute"
@@ -409,6 +450,7 @@ pipelineCardView session params section { bounds, headerHeight, pipeline } teamN
                 , hovered = session.hovered
                 , section = section
                 , viewingInstanceGroups = params.viewingInstanceGroups
+                , inInstanceGroup = inInstanceGroup
                 }
             ]
         ]

--- a/web/elm/src/Dashboard/Group.elm
+++ b/web/elm/src/Dashboard/Group.elm
@@ -489,6 +489,7 @@ instanceGroupCardView session params section { bounds, headerHeight } p ps =
                    )
             )
             [ InstanceGroup.cardView
+                session
                 { pipeline = p
                 , pipelines = ps
                 , resourceError =
@@ -499,8 +500,6 @@ instanceGroupCardView session params section { bounds, headerHeight } p ps =
                         (p :: ps)
                 , pipelineJobs = params.pipelineJobs
                 , jobs = params.jobs
-                , hovered = session.hovered
-                , pipelineRunningKeyframes = session.pipelineRunningKeyframes
                 , section = section
                 , headerHeight = headerHeight
                 , dashboardView = params.dashboardView

--- a/web/elm/src/Dashboard/Group/Models.elm
+++ b/web/elm/src/Dashboard/Group/Models.elm
@@ -15,17 +15,17 @@ type Card
     | InstanceGroupCard Pipeline (List Pipeline)
 
 
-cardIdentifier : Card -> Int
+cardIdentifier : Card -> String
 cardIdentifier c =
     case c of
         PipelineCard p ->
-            p.id
+            String.fromInt p.id
 
         InstancedPipelineCard p ->
-            p.id
+            String.fromInt p.id
 
         InstanceGroupCard p _ ->
-            p.id
+            p.teamName ++ "/" ++ p.name
 
 
 cardName : Card -> String

--- a/web/elm/src/Dashboard/Group/Models.elm
+++ b/web/elm/src/Dashboard/Group/Models.elm
@@ -11,6 +11,7 @@ import Concourse
 
 type Card
     = PipelineCard Pipeline
+    | InstancedPipelineCard Pipeline
     | InstanceGroupCard Pipeline (List Pipeline)
 
 
@@ -18,6 +19,9 @@ cardIdentifier : Card -> Int
 cardIdentifier c =
     case c of
         PipelineCard p ->
+            p.id
+
+        InstancedPipelineCard p ->
             p.id
 
         InstanceGroupCard p _ ->
@@ -30,6 +34,9 @@ cardName c =
         PipelineCard p ->
             p.name
 
+        InstancedPipelineCard p ->
+            p.name
+
         InstanceGroupCard p _ ->
             p.name
 
@@ -38,6 +45,9 @@ cardTeamName : Card -> String
 cardTeamName c =
     case c of
         PipelineCard p ->
+            p.teamName
+
+        InstancedPipelineCard p ->
             p.teamName
 
         InstanceGroupCard p _ ->

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -9,6 +9,7 @@ import Dashboard.Group.Models exposing (Pipeline)
 import Dashboard.Pipeline exposing (pipelineStatus)
 import Dashboard.Styles as Styles
 import Dict exposing (Dict)
+import Favorites
 import HoverState
 import Html exposing (Html)
 import Html.Attributes
@@ -258,7 +259,7 @@ footerView session pipeline section =
 
         favoritedIcon =
             Views.FavoritedIcon.view
-                { isFavorited = Set.member pipeline.id session.favoritedPipelines
+                { isFavorited = Favorites.isPipelineFavorited session pipeline
                 , isHovered = HoverState.isHovered domID session.hovered
                 , isSideBar = False
                 , domID = domID

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -173,7 +173,7 @@ bodyView :
 bodyView session section pipelines pipelineJobs jobs =
     let
         cols =
-            floor <| sqrt <| toFloat <| List.length pipelines
+            ceiling <| sqrt <| toFloat <| List.length pipelines
 
         padRow row =
             let

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -254,12 +254,15 @@ footerView :
     -> Html Message
 footerView session pipeline section =
     let
+        groupID =
+            Concourse.toInstanceGroupId pipeline
+
         domID =
-            InstanceGroupCardFavoritedIcon section (Concourse.toInstanceGroupId pipeline)
+            InstanceGroupCardFavoritedIcon section groupID
 
         favoritedIcon =
             Views.FavoritedIcon.view
-                { isFavorited = Favorites.isPipelineFavorited session pipeline
+                { isFavorited = Favorites.isInstanceGroupFavorited session groupID
                 , isHovered = HoverState.isHovered domID session.hovered
                 , isSideBar = False
                 , domID = domID

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -149,13 +149,13 @@ headerView section dashboardView query pipeline pipelines resourceError headerHe
         ]
         [ Html.div
             (class "card-header" :: Styles.instanceGroupCardHeader headerHeight)
-            [ InstanceGroupBadge.view ColorValues.grey20 <| List.length (pipeline :: pipelines)
-            , Html.div
+            [ Html.div
                 (class "dashboard-group-name"
                     :: Styles.instanceGroupName
                     ++ Tooltip.hoverAttrs (InstanceGroupCardName section pipeline.teamName pipeline.name)
                 )
-                [ Html.text pipeline.name
+                [ InstanceGroupBadge.view ColorValues.grey20 <| List.length (pipeline :: pipelines)
+                , Html.text pipeline.name
                 ]
             , Html.div
                 [ classList [ ( "dashboard-resource-error", resourceError ) ] ]

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -1,5 +1,6 @@
 module Dashboard.InstanceGroup exposing (cardView, hdCardView)
 
+import Application.Models exposing (Session)
 import ColorValues
 import Concourse
 import Concourse.BuildStatus exposing (BuildStatus(..))
@@ -17,12 +18,15 @@ import Html.Attributes
         , classList
         , draggable
         , href
+        , id
         , style
         )
 import List.Extra
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes
+import Set
 import Tooltip
+import Views.FavoritedIcon
 import Views.InstanceGroupBadge as InstanceGroupBadge
 
 
@@ -94,20 +98,20 @@ hdCardView { pipeline, pipelines, resourceError, dashboardView, query } =
 
 
 cardView :
-    { pipeline : Pipeline
-    , pipelines : List Pipeline
-    , hovered : HoverState.HoverState
-    , pipelineRunningKeyframes : String
-    , resourceError : Bool
-    , pipelineJobs : Dict Concourse.DatabaseID (List Concourse.JobName)
-    , jobs : Dict ( Concourse.DatabaseID, String ) Concourse.Job
-    , section : PipelinesSection
-    , dashboardView : Routes.DashboardView
-    , query : String
-    , headerHeight : Float
-    }
+    Session
+    ->
+        { pipeline : Pipeline
+        , pipelines : List Pipeline
+        , resourceError : Bool
+        , pipelineJobs : Dict Concourse.DatabaseID (List Concourse.JobName)
+        , jobs : Dict ( Concourse.DatabaseID, String ) Concourse.Job
+        , section : PipelinesSection
+        , dashboardView : Routes.DashboardView
+        , query : String
+        , headerHeight : Float
+        }
     -> Html Message
-cardView { pipeline, pipelines, hovered, pipelineRunningKeyframes, resourceError, pipelineJobs, jobs, section, dashboardView, query, headerHeight } =
+cardView session { pipeline, pipelines, resourceError, pipelineJobs, jobs, section, dashboardView, query, headerHeight } =
     Html.div
         (Styles.instanceGroupCard
             ++ (if section == AllPipelinesSection && not pipeline.stale then
@@ -125,7 +129,8 @@ cardView { pipeline, pipelines, hovered, pipelineRunningKeyframes, resourceError
         )
         [ Html.div (class "banner" :: Styles.instanceGroupCardBanner) []
         , headerView section dashboardView query pipeline pipelines resourceError headerHeight
-        , bodyView pipelineRunningKeyframes section hovered (pipeline :: pipelines) pipelineJobs jobs
+        , bodyView session section (pipeline :: pipelines) pipelineJobs jobs
+        , footerView session pipeline section
         ]
 
 
@@ -159,14 +164,13 @@ headerView section dashboardView query pipeline pipelines resourceError headerHe
 
 
 bodyView :
-    String
+    Session
     -> PipelinesSection
-    -> HoverState.HoverState
     -> List Pipeline
     -> Dict Concourse.DatabaseID (List Concourse.JobName)
     -> Dict ( Concourse.DatabaseID, Concourse.JobName ) Concourse.Job
     -> Html Message
-bodyView pipelineRunningKeyframes section hovered pipelines pipelineJobs jobs =
+bodyView session section pipelines pipelineJobs jobs =
     let
         cols =
             floor <| sqrt <| toFloat <| List.length pipelines
@@ -197,10 +201,10 @@ bodyView pipelineRunningKeyframes section hovered pipelines pipelineJobs jobs =
             in
             Html.div
                 (Styles.instanceGroupCardPipelineBox
-                    pipelineRunningKeyframes
+                    session.pipelineRunningKeyframes
                     (HoverState.isHovered
                         (PipelinePreview section p.id)
-                        hovered
+                        session.hovered
                     )
                     (pipelineStatus curPipelineJobs p)
                     ++ Tooltip.hoverAttrs (PipelinePreview section p.id)
@@ -240,3 +244,25 @@ bodyView pipelineRunningKeyframes section hovered pipelines pipelineJobs jobs =
                         (viewRow paddedRow)
                 )
         )
+
+
+footerView :
+    Session
+    -> Pipeline
+    -> PipelinesSection
+    -> Html Message
+footerView session pipeline section =
+    let
+        domID =
+            InstanceGroupCardFavoritedIcon section (Concourse.toInstanceGroupId pipeline)
+
+        favoritedIcon =
+            Views.FavoritedIcon.view
+                { isFavorited = Set.member pipeline.id session.favoritedPipelines
+                , isHovered = HoverState.isHovered domID session.hovered
+                , isSideBar = False
+                , domID = domID
+                }
+                []
+    in
+    Html.div (class "card-footer" :: Styles.instanceGroupCardFooter) [ favoritedIcon ]

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -19,13 +19,11 @@ import Html.Attributes
         , classList
         , draggable
         , href
-        , id
         , style
         )
 import List.Extra
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes
-import Set
 import Tooltip
 import Views.FavoritedIcon
 import Views.InstanceGroupBadge as InstanceGroupBadge

--- a/web/elm/src/Dashboard/Models.elm
+++ b/web/elm/src/Dashboard/Models.elm
@@ -54,7 +54,7 @@ type FetchError
 
 type DragState
     = NotDragging
-    | Dragging Concourse.TeamName Int
+    | Dragging Concourse.TeamName String
 
 
 type DropState

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -16,6 +16,7 @@ import Dashboard.Group.Models exposing (Pipeline)
 import Dashboard.Styles as Styles
 import Dict
 import Duration
+import Favorites
 import HoverState
 import Html exposing (Html)
 import Html.Attributes
@@ -32,7 +33,6 @@ import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes
-import Set
 import Time
 import Tooltip
 import UserState
@@ -376,7 +376,7 @@ footerView session pipeline section now hovered existingJobs =
 
         favoritedIcon =
             Views.FavoritedIcon.view
-                { isFavorited = Set.member pipeline.id session.favoritedPipelines
+                { isFavorited = Favorites.isPipelineFavorited session pipeline
                 , isHovered = HoverState.isHovered (PipelineCardFavoritedIcon section pipeline.id) hovered
                 , isSideBar = False
                 , domID = PipelineCardFavoritedIcon section pipeline.id

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -32,7 +32,6 @@ import Html.Attributes
 import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
-import RemoteData
 import Routes
 import Time
 import Tooltip

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -127,9 +127,10 @@ pipelineView :
         , section : PipelinesSection
         , headerHeight : Float
         , viewingInstanceGroups : Bool
+        , inInstanceGroup : Bool
         }
     -> Html Message
-pipelineView session { now, pipeline, hovered, resourceError, existingJobs, layers, section, headerHeight, viewingInstanceGroups } =
+pipelineView session { now, pipeline, hovered, resourceError, existingJobs, layers, section, headerHeight, viewingInstanceGroups, inInstanceGroup } =
     let
         bannerStyle =
             if pipeline.stale then
@@ -143,11 +144,6 @@ pipelineView session { now, pipeline, hovered, resourceError, existingJobs, laye
                     { status = pipelineStatus existingJobs pipeline
                     , pipelineRunningKeyframes = session.pipelineRunningKeyframes
                     }
-
-        inInstanceGroup =
-            Concourse.isInInstanceGroup
-                (RemoteData.withDefault [] session.pipelines)
-                pipeline
     in
     Html.div
         (Styles.pipelineCard

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -11,6 +11,7 @@ module Dashboard.Styles exposing
     , infoBar
     , infoCliIcon
     , infoItem
+    , inlineInstanceVar
     , instanceGroupCard
     , instanceGroupCardBadge
     , instanceGroupCardBanner
@@ -239,6 +240,11 @@ pipelineName =
 instanceVar : List (Html.Attribute msg)
 instanceVar =
     pipelineName ++ [ style "letter-spacing" "0.05em" ]
+
+
+inlineInstanceVar : List (Html.Attribute msg)
+inlineInstanceVar =
+    [ style "padding-right" "8px" ]
 
 
 noInstanceVars : List (Html.Attribute msg)

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -17,6 +17,7 @@ module Dashboard.Styles exposing
     , instanceGroupCardBannerHd
     , instanceGroupCardBody
     , instanceGroupCardBodyHd
+    , instanceGroupCardFooter
     , instanceGroupCardHd
     , instanceGroupCardHeader
     , instanceGroupCardNameHd
@@ -297,7 +298,7 @@ instanceGroupCardBody : List (Html.Attribute msg)
 instanceGroupCardBody =
     [ style "background-color" Colors.card
     , style "padding" "20px 36px"
-    , style "margin" "2px 0 0 0"
+    , style "margin" "2px 0"
     , style "flex-grow" "1"
     , style "display" "flex"
     , style "flex-direction" "column"
@@ -518,6 +519,15 @@ pipelineCardFooter =
     [ style "padding" "13.5px"
     , style "display" "flex"
     , style "justify-content" "space-between"
+    , style "background-color" Colors.card
+    ]
+
+
+instanceGroupCardFooter : List (Html.Attribute msg)
+instanceGroupCardFooter =
+    [ style "padding" "13.5px"
+    , style "display" "flex"
+    , style "justify-content" "flex-end"
     , style "background-color" Colors.card
     ]
 

--- a/web/elm/src/Dashboard/Styles.elm
+++ b/web/elm/src/Dashboard/Styles.elm
@@ -209,8 +209,8 @@ noPipelineCardHeader =
     ]
 
 
-cardHeaderCommon : Float -> List (Html.Attribute msg)
-cardHeaderCommon height =
+pipelineCardHeader : Float -> List (Html.Attribute msg)
+pipelineCardHeader height =
     [ style "background-color" Colors.card
     , style "color" Colors.dashboardPipelineHeaderText
     , style "font-size" "1.5em"
@@ -221,17 +221,9 @@ cardHeaderCommon height =
     ]
 
 
-pipelineCardHeader : Float -> List (Html.Attribute msg)
-pipelineCardHeader height =
-    cardHeaderCommon height
-
-
 instanceGroupCardHeader : Float -> List (Html.Attribute msg)
-instanceGroupCardHeader height =
-    cardHeaderCommon height
-        ++ [ style "display" "flex"
-           , style "align-items" "center"
-           ]
+instanceGroupCardHeader =
+    pipelineCardHeader
 
 
 pipelineName : List (Html.Attribute msg)
@@ -257,6 +249,9 @@ noInstanceVars =
 instanceGroupName : List (Html.Attribute msg)
 instanceGroupName =
     pipelineName
+        ++ [ style "display" "flex"
+           , style "align-items" "center"
+           ]
 
 
 emptyCardBody : List (Html.Attribute msg)

--- a/web/elm/src/Favorites.elm
+++ b/web/elm/src/Favorites.elm
@@ -2,7 +2,6 @@ module Favorites exposing (Model, handleDelivery, isFavorited, isInstanceGroupFa
 
 import Concourse exposing (PipelineGrouping(..))
 import EffectTransformer exposing (ET)
-import Json.Encode
 import Message.Callback exposing (Callback(..))
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..))

--- a/web/elm/src/Favorites.elm
+++ b/web/elm/src/Favorites.elm
@@ -1,6 +1,6 @@
-module Favorites exposing (Model, handleDelivery, isInstanceGroupFavorited, isPipelineFavorited, update)
+module Favorites exposing (Model, handleDelivery, isFavorited, isInstanceGroupFavorited, isPipelineFavorited, update)
 
-import Concourse
+import Concourse exposing (PipelineGrouping(..))
 import EffectTransformer exposing (ET)
 import Json.Encode
 import Message.Callback exposing (Callback(..))
@@ -46,7 +46,7 @@ update message ( model, effects ) =
             )
     in
     case message of
-        Click (SideBarFavoritedIcon pipelineID) ->
+        Click (SideBarPipelineFavoritedIcon pipelineID) ->
             toggleFavoritePipeline pipelineID
 
         Click (PipelineCardFavoritedIcon _ pipelineID) ->
@@ -55,8 +55,11 @@ update message ( model, effects ) =
         Click (TopBarFavoritedIcon pipelineID) ->
             toggleFavoritePipeline pipelineID
 
-        Click (InstanceGroupCardFavoritedIcon _ pipelineID) ->
-            toggleFavoriteInstanceGroup pipelineID
+        Click (SideBarInstanceGroupFavoritedIcon groupID) ->
+            toggleFavoriteInstanceGroup groupID
+
+        Click (InstanceGroupCardFavoritedIcon _ groupID) ->
+            toggleFavoriteInstanceGroup groupID
 
         _ ->
             ( model, effects )
@@ -73,6 +76,25 @@ handleDelivery delivery ( model, effects ) =
 
         _ ->
             ( model, effects )
+
+
+isFavorited :
+    Model m
+    ->
+        PipelineGrouping
+            { r
+                | name : Concourse.PipelineName
+                , teamName : Concourse.TeamName
+                , id : Concourse.DatabaseID
+            }
+    -> Bool
+isFavorited model group =
+    case group of
+        RegularPipeline p ->
+            isPipelineFavorited model p
+
+        InstanceGroup p _ ->
+            isInstanceGroupFavorited model (Concourse.toInstanceGroupId p)
 
 
 isPipelineFavorited :

--- a/web/elm/src/Favorites.elm
+++ b/web/elm/src/Favorites.elm
@@ -1,0 +1,63 @@
+module Favorites exposing (Model, handleDelivery, isPipelineFavorited, update)
+
+import Concourse
+import EffectTransformer exposing (ET)
+import Message.Callback exposing (Callback(..))
+import Message.Effects as Effects
+import Message.Message exposing (DomID(..), Message(..))
+import Message.Subscription exposing (Delivery(..))
+import Set exposing (Set)
+
+
+type alias Model m =
+    { m
+        | favoritedPipelines : Set Concourse.DatabaseID
+    }
+
+
+update : Message -> ET (Model m)
+update message ( model, effects ) =
+    let
+        toggle element set =
+            if Set.member element set then
+                Set.remove element set
+
+            else
+                Set.insert element set
+
+        toggleFavorite pipelineID =
+            let
+                favoritedPipelines =
+                    toggle pipelineID model.favoritedPipelines
+            in
+            ( { model | favoritedPipelines = favoritedPipelines }
+            , [ Effects.SaveFavoritedPipelines <| favoritedPipelines ]
+            )
+    in
+    case message of
+        Click (SideBarFavoritedIcon pipelineID) ->
+            toggleFavorite pipelineID
+
+        Click (PipelineCardFavoritedIcon _ pipelineID) ->
+            toggleFavorite pipelineID
+
+        Click (TopBarFavoritedIcon pipelineID) ->
+            toggleFavorite pipelineID
+
+        _ ->
+            ( model, effects )
+
+
+handleDelivery : Delivery -> ET (Model m)
+handleDelivery delivery ( model, effects ) =
+    case delivery of
+        FavoritedPipelinesReceived (Ok pipelines) ->
+            ( { model | favoritedPipelines = pipelines }, effects )
+
+        _ ->
+            ( model, effects )
+
+
+isPipelineFavorited : Model m -> { r | id : Concourse.DatabaseID } -> Bool
+isPipelineFavorited { favoritedPipelines } { id } =
+    Set.member id favoritedPipelines

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -440,6 +440,7 @@ view session model =
             [ SideBar.view session
                 (Just
                     { pipelineName = model.jobIdentifier.pipelineName
+                    , pipelineInstanceVars = model.jobIdentifier.pipelineInstanceVars
                     , teamName = model.jobIdentifier.teamName
                     }
                 )

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -683,6 +683,11 @@ toHtmlID domId =
         SideBarPipeline section id ->
             pipelinesSectionName section ++ "_" ++ String.fromInt id
 
+        SideBarInstancedPipeline section id ->
+            -- This can be the same as SideBarPipeline because they are
+            -- mutually exclusive
+            pipelinesSectionName section ++ "_" ++ String.fromInt id
+
         SideBarInstanceGroup section teamName groupName ->
             pipelinesSectionName section
                 ++ "_"

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -680,8 +680,8 @@ toHtmlID domId =
         SideBarTeam section t ->
             pipelinesSectionName section ++ "_" ++ Base64.encode t
 
-        SideBarPipeline section p ->
-            pipelinesSectionName section ++ "_" ++ Base64.encode p.teamName ++ "_" ++ Base64.encode p.pipelineName
+        SideBarPipeline section id ->
+            pipelinesSectionName section ++ "_" ++ String.fromInt id
 
         SideBarInstanceGroup section teamName groupName ->
             pipelinesSectionName section

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -760,6 +760,12 @@ toHtmlID domId =
                 ++ "_var_"
                 ++ Base64.encode varName
 
+        PipelineCardInstanceVars section p _ ->
+            pipelinesSectionName section
+                ++ "_"
+                ++ encodePipelineId p
+                ++ "_vars"
+
         PipelinePreview section p ->
             "pipeline_preview_"
                 ++ pipelinesSectionName section

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -35,10 +35,8 @@ import Message.Storage
         , favoritedPipelinesKey
         , jobsKey
         , loadFromLocalStorage
-        , loadFromSessionStorage
         , pipelinesKey
         , saveToLocalStorage
-        , saveToSessionStorage
         , sideBarStateKey
         , teamsKey
         , tokenKey
@@ -594,10 +592,10 @@ runEffect effect key csrfToken =
             loadFromLocalStorage tokenKey
 
         SaveSideBarState state ->
-            saveToSessionStorage ( sideBarStateKey, encodeSideBarState state )
+            saveToLocalStorage ( sideBarStateKey, encodeSideBarState state )
 
         LoadSideBarState ->
-            loadFromSessionStorage sideBarStateKey
+            loadFromLocalStorage sideBarStateKey
 
         SaveCachedJobs jobs ->
             saveToLocalStorage ( jobsKey, jobs |> Json.Encode.list encodeJob )

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -32,6 +32,7 @@ import Message.ScrollDirection exposing (ScrollDirection(..))
 import Message.Storage
     exposing
         ( deleteFromLocalStorage
+        , favoritedInstanceGroupsKey
         , favoritedPipelinesKey
         , jobsKey
         , loadFromLocalStorage
@@ -190,6 +191,8 @@ type Effect
     | SyncStickyBuildLogHeaders
     | SaveFavoritedPipelines (Set DatabaseID)
     | LoadFavoritedPipelines
+    | SaveFavoritedInstanceGroups (Set ( Concourse.TeamName, Concourse.PipelineName ))
+    | LoadFavoritedInstanceGroups
 
 
 type alias VersionId =
@@ -623,6 +626,19 @@ runEffect effect key csrfToken =
 
         LoadFavoritedPipelines ->
             loadFromLocalStorage favoritedPipelinesKey
+
+        SaveFavoritedInstanceGroups igs ->
+            saveToLocalStorage
+                ( favoritedInstanceGroupsKey
+                , igs
+                    |> Json.Encode.set
+                        (\( teamName, name ) ->
+                            Concourse.encodeInstanceGroupId { teamName = teamName, name = name }
+                        )
+                )
+
+        LoadFavoritedInstanceGroups ->
+            loadFromLocalStorage favoritedInstanceGroupsKey
 
         SaveCachedTeams teams ->
             saveToLocalStorage ( teamsKey, teams |> Json.Encode.list encodeTeam )

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -713,6 +713,14 @@ toHtmlID domId =
                 ++ encodePipelineId p
                 ++ "_favorite"
 
+        InstanceGroupCardFavoritedIcon section { teamName, name } ->
+            pipelinesSectionName section
+                ++ "_"
+                ++ Base64.encode teamName
+                ++ "_"
+                ++ Base64.encode name
+                ++ "_favorite"
+
         PipelineCardPauseToggle section p ->
             pipelinesSectionName section
                 ++ "_"

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -99,7 +99,7 @@ type DomID
     | SideBarIcon
     | SideBarResizeHandle
     | SideBarTeam PipelinesSection String
-    | SideBarPipeline PipelinesSection Concourse.PipelineIdentifier
+    | SideBarPipeline PipelinesSection Concourse.DatabaseID
     | SideBarInstanceGroup PipelinesSection Concourse.TeamName String
     | SideBarPipelineFavoritedIcon Concourse.DatabaseID
     | SideBarInstanceGroupFavoritedIcon Concourse.InstanceGroupIdentifier

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -67,6 +67,7 @@ type DomID
     | PipelineCardNameHD Concourse.DatabaseID
     | InstanceGroupCardNameHD Concourse.TeamName String
     | PipelineCardInstanceVar PipelinesSection Concourse.DatabaseID String String
+    | PipelineCardInstanceVars PipelinesSection Concourse.DatabaseID Concourse.InstanceVars
     | PipelineStatusIcon PipelinesSection Concourse.DatabaseID
     | PipelineCardFavoritedIcon PipelinesSection Concourse.DatabaseID
     | InstanceGroupCardFavoritedIcon PipelinesSection Concourse.InstanceGroupIdentifier

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -24,7 +24,7 @@ type Message
     | ToggleGroup Concourse.PipelineGroup
     | SetGroups (List String)
       -- Dashboard
-    | DragStart String Int
+    | DragStart String String
     | DragOver DropTarget
     | DragEnd
       -- Resource
@@ -128,5 +128,5 @@ type alias VersionId =
 
 
 type DropTarget
-    = Before Int
+    = Before String
     | End

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -69,6 +69,7 @@ type DomID
     | PipelineCardInstanceVar PipelinesSection Concourse.DatabaseID String String
     | PipelineStatusIcon PipelinesSection Concourse.DatabaseID
     | PipelineCardFavoritedIcon PipelinesSection Concourse.DatabaseID
+    | InstanceGroupCardFavoritedIcon PipelinesSection Concourse.InstanceGroupIdentifier
     | PipelineCardPauseToggle PipelinesSection Concourse.DatabaseID
     | TopBarPinIcon
     | TopBarFavoritedIcon Concourse.DatabaseID

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -100,6 +100,7 @@ type DomID
     | SideBarResizeHandle
     | SideBarTeam PipelinesSection String
     | SideBarPipeline PipelinesSection Concourse.DatabaseID
+    | SideBarInstancedPipeline PipelinesSection Concourse.DatabaseID
     | SideBarInstanceGroup PipelinesSection Concourse.TeamName String
     | SideBarPipelineFavoritedIcon Concourse.DatabaseID
     | SideBarInstanceGroupFavoritedIcon Concourse.InstanceGroupIdentifier

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -101,7 +101,8 @@ type DomID
     | SideBarTeam PipelinesSection String
     | SideBarPipeline PipelinesSection Concourse.PipelineIdentifier
     | SideBarInstanceGroup PipelinesSection Concourse.TeamName String
-    | SideBarFavoritedIcon Concourse.DatabaseID
+    | SideBarPipelineFavoritedIcon Concourse.DatabaseID
+    | SideBarInstanceGroupFavoritedIcon Concourse.InstanceGroupIdentifier
     | Dashboard
     | DashboardGroup String
 

--- a/web/elm/src/Message/Storage.elm
+++ b/web/elm/src/Message/Storage.elm
@@ -2,6 +2,7 @@ port module Message.Storage exposing
     ( Key
     , Value
     , deleteFromLocalStorage
+    , favoritedInstanceGroupsKey
     , favoritedPipelinesKey
     , jobsKey
     , loadFromLocalStorage
@@ -64,3 +65,8 @@ teamsKey =
 favoritedPipelinesKey : Key
 favoritedPipelinesKey =
     "favorited_pipelines"
+
+
+favoritedInstanceGroupsKey : Key
+favoritedInstanceGroupsKey =
+    "favorited_instance_groups"

--- a/web/elm/src/Message/Storage.elm
+++ b/web/elm/src/Message/Storage.elm
@@ -5,12 +5,9 @@ port module Message.Storage exposing
     , favoritedPipelinesKey
     , jobsKey
     , loadFromLocalStorage
-    , loadFromSessionStorage
     , pipelinesKey
     , receivedFromLocalStorage
-    , receivedFromSessionStorage
     , saveToLocalStorage
-    , saveToSessionStorage
     , sideBarStateKey
     , teamsKey
     , tokenKey
@@ -30,22 +27,13 @@ type alias Value =
 port saveToLocalStorage : ( Key, Json.Encode.Value ) -> Cmd msg
 
 
-port saveToSessionStorage : ( Key, Json.Encode.Value ) -> Cmd msg
-
-
 port deleteFromLocalStorage : Key -> Cmd msg
 
 
 port loadFromLocalStorage : Key -> Cmd msg
 
 
-port loadFromSessionStorage : Key -> Cmd msg
-
-
 port receivedFromLocalStorage : (( Key, Value ) -> msg) -> Sub msg
-
-
-port receivedFromSessionStorage : (( Key, Value ) -> msg) -> Sub msg
 
 
 sideBarStateKey : Key

--- a/web/elm/src/Message/Subscription.elm
+++ b/web/elm/src/Message/Subscription.elm
@@ -29,7 +29,6 @@ import Message.Storage as Storage
         , jobsKey
         , pipelinesKey
         , receivedFromLocalStorage
-        , receivedFromSessionStorage
         , sideBarStateKey
         , teamsKey
         , tokenKey
@@ -182,7 +181,7 @@ runSubscription s =
                     TokenReceived
 
         OnSideBarStateReceived ->
-            receivedFromSessionStorage <|
+            receivedFromLocalStorage <|
                 decodeStorageResponse sideBarStateKey
                     decodeSideBarState
                     SideBarStateReceived

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -18,6 +18,7 @@ import Colors
 import Concourse
 import Concourse.Cli as Cli
 import EffectTransformer exposing (ET)
+import Favorites
 import HoverState
 import Html exposing (Html)
 import Html.Attributes
@@ -48,7 +49,6 @@ import Pipeline.PinMenu.PinMenu as PinMenu
 import Pipeline.Styles as Styles
 import RemoteData exposing (WebData)
 import Routes
-import Set
 import SideBar.SideBar as SideBar
 import StrictEvents exposing (onLeftClickOrShiftLeftClick)
 import Svg
@@ -396,7 +396,9 @@ view session model =
                     [ FavoritedIcon.view
                         { isHovered = HoverState.isHovered (TopBarFavoritedIcon <| getPipelineId model.pipeline) session.hovered
                         , isFavorited =
-                            Set.member (getPipelineId model.pipeline) session.favoritedPipelines
+                            model.pipeline
+                                |> RemoteData.map (Favorites.isPipelineFavorited session)
+                                |> RemoteData.withDefault False
                         , isSideBar = False
                         , domID = TopBarFavoritedIcon <| getPipelineId model.pipeline
                         }

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -442,7 +442,8 @@ tooltip model session =
         HoverState.Tooltip (TopBarFavoritedIcon _) _ ->
             let
                 isFavorited =
-                    Set.member (getPipelineId model.pipeline) session.favoritedPipelines
+                    RemoteData.map (Favorites.isPipelineFavorited session) model.pipeline
+                        |> RemoteData.withDefault False
             in
             Just
                 { body =

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -954,6 +954,7 @@ view session model =
             [ SideBar.view session
                 (Just
                     { pipelineName = model.resourceIdentifier.pipelineName
+                    , pipelineInstanceVars = model.resourceIdentifier.pipelineInstanceVars
                     , teamName = model.resourceIdentifier.teamName
                     }
                 )

--- a/web/elm/src/SideBar/InstanceGroup.elm
+++ b/web/elm/src/SideBar/InstanceGroup.elm
@@ -2,9 +2,11 @@ module SideBar.InstanceGroup exposing (instanceGroup)
 
 import Concourse
 import Dashboard.FilterBuilder exposing (instanceGroupFilter)
+import Favorites
 import HoverState
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes
+import Set exposing (Set)
 import SideBar.Styles as Styles
 import SideBar.Views as Views
 
@@ -20,6 +22,7 @@ instanceGroup :
     { a
         | hovered : HoverState.HoverState
         , currentPipeline : Maybe (PipelineScoped b)
+        , favoritedInstanceGroups : Set ( Concourse.TeamName, Concourse.PipelineName )
         , isFavoritesSection : Bool
     }
     -> Concourse.Pipeline
@@ -52,6 +55,12 @@ instanceGroup params p ps =
 
         isHovered =
             HoverState.isHovered domID params.hovered
+
+        id =
+            Concourse.toInstanceGroupId p
+
+        isFavorited =
+            Favorites.isInstanceGroupFavorited params id
 
         color =
             if isHovered then
@@ -93,4 +102,9 @@ instanceGroup params p ps =
         { count = List.length (p :: ps)
         , color = color
         }
+    , starIcon =
+        { filled = isFavorited
+        , isBright = isHovered || isCurrent
+        }
+    , id = id
     }

--- a/web/elm/src/SideBar/Pipeline.elm
+++ b/web/elm/src/SideBar/Pipeline.elm
@@ -2,6 +2,7 @@ module SideBar.Pipeline exposing (pipeline)
 
 import Assets
 import Concourse
+import Favorites
 import HoverState
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Routes
@@ -53,7 +54,7 @@ pipeline params p =
             HoverState.isHovered domID params.hovered
 
         isFavorited =
-            Set.member p.id params.favoritedPipelines
+            Favorites.isPipelineFavorited params p
     in
     { icon =
         if p.archived then

--- a/web/elm/src/SideBar/Pipeline.elm
+++ b/web/elm/src/SideBar/Pipeline.elm
@@ -45,13 +45,15 @@ pipeline isInstancedPipeline params p =
         pipelineId =
             Concourse.toPipelineId p
 
-        domID =
-            (if isInstancedPipeline then
+        domIDFn =
+            if isInstancedPipeline then
                 SideBarInstancedPipeline
 
-             else
+            else
                 SideBarPipeline
-            )
+
+        domID =
+            domIDFn
                 (if params.isFavoritesSection then
                     FavoritesSection
 

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -300,7 +300,7 @@ tooltip model =
             lookupPipeline (byDatabaseId id) model
                 |> Maybe.map
                     (\p ->
-                        { body = Html.div Styles.tooltipBody [ Html.text <| Pipeline.instancedPipelineText p ]
+                        { body = Html.text <| Pipeline.instancedPipelineText p
                         , attachPosition =
                             { direction = Tooltip.Right beyondStarOffset
                             , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -253,12 +253,6 @@ view model currentPipeline =
 tooltip : Model m -> Maybe Tooltip.Tooltip
 tooltip model =
     let
-        hovered =
-            model.hovered
-
-        sideBarState =
-            model.sideBarState
-
         isSideBarClickable =
             hasVisiblePipelines model
 
@@ -326,7 +320,7 @@ tooltip model =
                     if not isSideBarClickable then
                         "no visible pipelines"
 
-                    else if sideBarState.isOpen then
+                    else if model.sideBarState.isOpen then
                         "hide sidebar"
 
                     else

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -286,12 +286,13 @@ tooltip model =
             lookupPipeline (byDatabaseId id) model
                 |> Maybe.map
                     (\p ->
-                        { body = Html.div Styles.tooltipBody [ Html.text <| Pipeline.regularPipelineText p ]
+                        { body = Html.text <| Pipeline.regularPipelineText p
                         , attachPosition =
                             { direction = Tooltip.Right beyondStarOffset
                             , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize
                             }
-                        , arrow = Just { size = Styles.tooltipArrowSize, color = Colors.tooltipBackground }
+                        , arrow = Just Styles.tooltipArrowSize
+                        , containerAttrs = Just Styles.tooltipBody
                         }
                     )
 

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -13,7 +13,8 @@ module SideBar.SideBar exposing
     )
 
 import Assets
-import Concourse
+import Colors
+import Concourse exposing (PipelineGrouping(..))
 import EffectTransformer exposing (ET)
 import Favorites
 import HoverState
@@ -35,6 +36,7 @@ import RemoteData exposing (RemoteData(..), WebData)
 import Routes
 import ScreenSize exposing (ScreenSize(..))
 import Set exposing (Set)
+import SideBar.Pipeline as Pipeline
 import SideBar.State exposing (SideBarState)
 import SideBar.Styles as Styles
 import SideBar.Team as Team
@@ -63,6 +65,7 @@ type alias PipelineScoped a =
     { a
         | teamName : String
         , pipelineName : String
+        , pipelineInstanceVars : Concourse.InstanceVars
     }
 
 
@@ -260,7 +263,7 @@ tooltip model =
         isSideBarClickable =
             hasVisiblePipelines model
     in
-    case hovered of
+    case model.hovered of
         HoverState.Tooltip (SideBarTeam _ teamName) _ ->
             Just
                 { body = Html.text teamName
@@ -273,21 +276,24 @@ tooltip model =
                 , containerAttrs = Just Styles.tooltipBody
                 }
 
-        HoverState.Tooltip (SideBarPipeline _ pipelineID) _ ->
-            Just
-                { body = Html.text pipelineID.pipelineName
-                , attachPosition =
-                    { direction =
-                        Tooltip.Right <|
-                            Styles.tooltipArrowSize
-                                + (Styles.starPadding * 2)
-                                + Styles.starWidth
-                                - Styles.tooltipOffset
-                    , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize
-                    }
-                , arrow = Just Styles.tooltipArrowSize
-                , containerAttrs = Just Styles.tooltipBody
-                }
+        HoverState.Tooltip (SideBarPipeline _ id) _ ->
+            lookupPipeline (byDatabaseId id) model
+                |> Maybe.map
+                    (\p ->
+                        { body = Html.div Styles.tooltipBody [ Html.text <| Pipeline.text p ]
+                        , attachPosition =
+                            { direction =
+                                Tooltip.Right <|
+                                    Styles.tooltipArrowSize
+                                        + (Styles.starPadding * 2)
+                                        + Styles.starWidth
+                                        - Styles.tooltipOffset
+                            , alignment = Tooltip.Middle <| 2 * Styles.tooltipArrowSize
+                            }
+                        , arrow = Just Styles.tooltipArrowSize
+                        , containerAttrs = Just Styles.tooltipBody
+                        }
+                    )
 
         HoverState.Tooltip (SideBarInstanceGroup _ _ name) _ ->
             Just
@@ -372,6 +378,30 @@ allPipelinesSection model currentPipeline =
 favoritedPipelinesSection : Model m -> Maybe (PipelineScoped a) -> List (Html Message)
 favoritedPipelinesSection model currentPipeline =
     let
+        extractTeamFavorites pipelines =
+            Concourse.groupPipelinesWithinTeam pipelines
+                |> List.concatMap
+                    (\g ->
+                        case g of
+                            RegularPipeline p ->
+                                if Favorites.isPipelineFavorited model p then
+                                    [ g ]
+
+                                else
+                                    []
+
+                            InstanceGroup p ps ->
+                                (if Favorites.isInstanceGroupFavorited model (Concourse.toInstanceGroupId p) then
+                                    [ g ]
+
+                                 else
+                                    []
+                                )
+                                    ++ (List.filter (Favorites.isPipelineFavorited model) (p :: ps)
+                                            |> List.map RegularPipeline
+                                       )
+                    )
+
         favoritedPipelinesByTeam =
             model.pipelines
                 |> RemoteData.withDefault []
@@ -379,8 +409,7 @@ favoritedPipelinesSection model currentPipeline =
                 |> List.map
                     (\( p, ps ) ->
                         ( p.teamName
-                        , Concourse.groupPipelinesWithinTeam (p :: ps)
-                            |> List.filter (Favorites.isFavorited model)
+                        , extractTeamFavorites (p :: ps)
                         )
                     )
                 |> List.filter (Tuple.second >> List.isEmpty >> not)

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -13,7 +13,6 @@ module SideBar.SideBar exposing
     )
 
 import Assets
-import Colors
 import Concourse
 import EffectTransformer exposing (ET)
 import Favorites

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -350,9 +350,7 @@ allPipelinesSection : Model m -> Maybe (PipelineScoped a) -> List (Html Message)
 allPipelinesSection model currentPipeline =
     let
         pipelinesByTeam =
-            model.pipelines
-                |> RemoteData.withDefault []
-                |> List.filter (isPipelineVisible model)
+            visiblePipelines model
                 |> List.Extra.gatherEqualsBy .teamName
                 |> List.map
                     (\( p, ps ) ->
@@ -426,8 +424,7 @@ favoritedPipelinesSection model currentPipeline =
                     )
 
         favoritedPipelinesByTeam =
-            model.pipelines
-                |> RemoteData.withDefault []
+            visiblePipelines model
                 |> List.Extra.gatherEqualsBy .teamName
                 |> List.map
                     (\( p, ps ) ->
@@ -517,11 +514,16 @@ sideBarIcon model =
             ]
 
 
-hasVisiblePipelines : Model m -> Bool
-hasVisiblePipelines model =
+visiblePipelines : Model m -> List Concourse.Pipeline
+visiblePipelines model =
     model.pipelines
-        |> RemoteData.map (List.any (isPipelineVisible model))
-        |> RemoteData.withDefault False
+        |> RemoteData.withDefault []
+        |> List.filter (isPipelineVisible model)
+
+
+hasVisiblePipelines : Model m -> Bool
+hasVisiblePipelines =
+    visiblePipelines >> List.isEmpty >> not
 
 
 isPipelineVisible : { a | favoritedPipelines : Set Concourse.DatabaseID } -> Concourse.Pipeline -> Bool

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -5,12 +5,12 @@ module SideBar.Styles exposing
     , SidebarElementColor(..)
     , collapseIcon
     , column
+    , favoriteIcon
     , iconGroup
     , instanceGroup
     , instanceGroupBadge
     , opacityAttr
     , pipeline
-    , pipelineFavorite
     , pipelineIcon
     , pipelineName
     , sectionHeader
@@ -343,8 +343,8 @@ instanceGroupBadge { count, color } =
         [ Html.text text ]
 
 
-pipelineFavorite : { filled : Bool, isBright : Bool } -> List (Html.Attribute msg)
-pipelineFavorite fav =
+favoriteIcon : { filled : Bool, isBright : Bool } -> List (Html.Attribute msg)
+favoriteIcon fav =
     [ style "background-image" <|
         Assets.backgroundImage <|
             Just <|

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -13,6 +13,7 @@ module SideBar.Styles exposing
     , pipeline
     , pipelineIcon
     , pipelineName
+    , pipelineTextIcon
     , sectionHeader
     , sideBar
     , sideBarHandle
@@ -313,6 +314,19 @@ pipelineIcon asset =
     , style "background-position" "center"
     , style "margin-left" "28px"
     , style "flex-shrink" "0"
+    ]
+
+
+pipelineTextIcon : List (Html.Attribute msg)
+pipelineTextIcon =
+    [ style "height" "18px"
+    , style "width" "18px"
+    , style "margin-left" "28px"
+    , style "flex-shrink" "0"
+    , style "display" "flex"
+    , style "justify-content" "center"
+    , style "align-items" "center"
+    , style "font-size" "16px"
     ]
 
 

--- a/web/elm/src/SideBar/Team.elm
+++ b/web/elm/src/SideBar/Team.elm
@@ -15,6 +15,7 @@ type alias PipelineScoped a =
     { a
         | teamName : String
         , pipelineName : String
+        , pipelineInstanceVars : Concourse.InstanceVars
     }
 
 

--- a/web/elm/src/SideBar/Team.elm
+++ b/web/elm/src/SideBar/Team.elm
@@ -1,4 +1,4 @@
-module SideBar.Team exposing (team)
+module SideBar.Team exposing (PipelineType(..), team)
 
 import Assets
 import Concourse exposing (PipelineGrouping(..))
@@ -19,10 +19,16 @@ type alias PipelineScoped a =
     }
 
 
+type PipelineType
+    = RegularPipeline Concourse.Pipeline
+    | InstancedPipeline Concourse.Pipeline
+    | InstanceGroup Concourse.Pipeline (List Concourse.Pipeline)
+
+
 team :
     { a
         | hovered : HoverState.HoverState
-        , pipelines : List (PipelineGrouping Concourse.Pipeline)
+        , pipelines : List PipelineType
         , currentPipeline : Maybe (PipelineScoped b)
         , favoritedPipelines : Set Int
         , favoritedInstanceGroups : Set ( Concourse.TeamName, Concourse.PipelineName )
@@ -80,10 +86,13 @@ team params t =
             |> List.map
                 (\g ->
                     case g of
-                        Concourse.RegularPipeline p ->
-                            Pipeline.pipeline params p |> Views.PipelineListItem
+                        RegularPipeline p ->
+                            Pipeline.regularPipeline params p |> Views.PipelineListItem
 
-                        Concourse.InstanceGroup p ps ->
+                        InstancedPipeline p ->
+                            Pipeline.instancedPipeline params p |> Views.PipelineListItem
+
+                        InstanceGroup p ps ->
                             InstanceGroup.instanceGroup params p ps |> Views.InstanceGroupListItem
                 )
     , background =

--- a/web/elm/src/SideBar/Team.elm
+++ b/web/elm/src/SideBar/Team.elm
@@ -1,7 +1,7 @@
 module SideBar.Team exposing (team)
 
 import Assets
-import Concourse
+import Concourse exposing (PipelineGrouping(..))
 import HoverState
 import Message.Message exposing (DomID(..), Message(..), PipelinesSection(..))
 import Set exposing (Set)
@@ -21,9 +21,10 @@ type alias PipelineScoped a =
 team :
     { a
         | hovered : HoverState.HoverState
-        , pipelines : List Concourse.Pipeline
+        , pipelines : List (PipelineGrouping Concourse.Pipeline)
         , currentPipeline : Maybe (PipelineScoped b)
         , favoritedPipelines : Set Int
+        , favoritedInstanceGroups : Set ( Concourse.TeamName, Concourse.PipelineName )
         , isFavoritesSection : Bool
     }
     -> { name : String, isExpanded : Bool }
@@ -75,7 +76,6 @@ team params t =
     , isExpanded = t.isExpanded
     , listItems =
         params.pipelines
-            |> Concourse.groupPipelines
             |> List.map
                 (\g ->
                     case g of

--- a/web/elm/src/SideBar/Views.elm
+++ b/web/elm/src/SideBar/Views.elm
@@ -99,6 +99,11 @@ type alias InstanceGroup =
         { count : Int
         , color : Styles.SidebarElementColor
         }
+    , starIcon :
+        { filled : Bool
+        , isBright : Bool
+        }
+    , id : Concourse.InstanceGroupIdentifier
     }
 
 
@@ -120,8 +125,8 @@ viewPipeline p =
             )
             [ Html.text p.name.text ]
         , Html.div
-            (Styles.pipelineFavorite p.starIcon
-                ++ [ onLeftClickStopPropagation <| Click <| SideBarFavoritedIcon p.databaseID ]
+            (Styles.favoriteIcon p.starIcon
+                ++ [ onLeftClickStopPropagation <| Click <| SideBarPipelineFavoritedIcon p.databaseID ]
             )
             []
         ]
@@ -142,6 +147,11 @@ viewInstanceGroup ig =
                 :: Styles.pipelineName ig.name
             )
             [ Html.text ig.name.text ]
+        , Html.div
+            (Styles.favoriteIcon ig.starIcon
+                ++ [ onLeftClickStopPropagation <| Click <| SideBarInstanceGroupFavoritedIcon ig.id ]
+            )
+            []
         ]
 
 

--- a/web/elm/src/SideBar/Views.elm
+++ b/web/elm/src/SideBar/Views.elm
@@ -1,5 +1,6 @@
 module SideBar.Views exposing
-    ( InstanceGroup
+    ( Icon(..)
+    , InstanceGroup
     , Pipeline
     , Team
     , TeamListItem(..)
@@ -67,8 +68,13 @@ type TeamListItem
     | InstanceGroupListItem InstanceGroup
 
 
+type Icon
+    = AssetIcon Assets.Asset
+    | TextIcon String
+
+
 type alias Pipeline =
-    { icon : Assets.Asset
+    { icon : Icon
     , name :
         { color : Styles.SidebarElementColor
         , text : String
@@ -116,9 +122,16 @@ viewPipeline p =
                , onMouseLeave <| Hover Nothing
                ]
         )
-        [ Html.div
-            (Styles.pipelineIcon p.icon)
-            []
+        [ case p.icon of
+            AssetIcon asset ->
+                Html.div
+                    (Styles.pipelineIcon asset)
+                    []
+
+            TextIcon s ->
+                Html.div
+                    Styles.pipelineTextIcon
+                    [ Html.text s ]
         , Html.div
             (id (toHtmlID p.domID)
                 :: Styles.pipelineName p.name

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -104,6 +104,9 @@ policy domID =
         PipelineCardInstanceVar _ _ _ _ ->
             OnlyShowWhenOverflowing
 
+        PipelineCardInstanceVars _ _ _ ->
+            OnlyShowWhenOverflowing
+
         _ ->
             AlwaysShow
 

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -80,6 +80,9 @@ policy domID =
         SideBarPipeline _ _ ->
             OnlyShowWhenOverflowing
 
+        SideBarInstancedPipeline _ _ ->
+            OnlyShowWhenOverflowing
+
         SideBarTeam _ _ ->
             OnlyShowWhenOverflowing
 

--- a/web/elm/tests/ApplicationTests.elm
+++ b/web/elm/tests/ApplicationTests.elm
@@ -19,19 +19,16 @@ import Url
 all : Test
 all =
     describe "top-level application"
-        [ test "should subscribe to clicks from the not-automatically-linked boxes in the pipeline, and the token return" <|
+        [ test "should subscribe to clicks from the not-automatically-linked boxes in the pipeline" <|
             \_ ->
                 Common.init "/teams/t/pipelines/p/"
                     |> Application.subscriptions
-                    |> Expect.all
-                        [ Common.contains Subscription.OnNonHrefLinkClicked
-                        , Common.contains Subscription.OnTokenReceived
-                        ]
-        , test "subscribes to the favorited pipelines response" <|
+                    |> Common.contains Subscription.OnNonHrefLinkClicked
+        , test "subscribes to local storage" <|
             \_ ->
                 Common.init "/teams/t/pipelines/p/"
                     |> Application.subscriptions
-                    |> Common.contains Subscription.OnFavoritedPipelinesReceived
+                    |> Common.contains Subscription.OnLocalStorageReceived
         , test "loads favorited pipelines on init" <|
             \_ ->
                 Application.init

--- a/web/elm/tests/ApplicationTests.elm
+++ b/web/elm/tests/ApplicationTests.elm
@@ -29,7 +29,7 @@ all =
                 Common.init "/teams/t/pipelines/p/"
                     |> Application.subscriptions
                     |> Common.contains Subscription.OnLocalStorageReceived
-        , test "loads favorited pipelines on init" <|
+        , test "loads favorited pipelines/instance groups on init" <|
             \_ ->
                 Application.init
                     { turbulenceImgSrc = ""
@@ -46,7 +46,10 @@ all =
                     , fragment = Nothing
                     }
                     |> Tuple.second
-                    |> Common.contains Effects.LoadFavoritedPipelines
+                    |> Expect.all
+                        [ Common.contains Effects.LoadFavoritedPipelines
+                        , Common.contains Effects.LoadFavoritedInstanceGroups
+                        ]
         , test "clicking a not-automatically-linked box in the pipeline redirects" <|
             \_ ->
                 Common.init "/teams/t/pipelines/p/"

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -399,6 +399,7 @@ session =
     , pipelineRunningKeyframes = ""
     , timeZone = Time.utc
     , favoritedPipelines = Set.empty
+    , favoritedInstanceGroups = Set.empty
     , route = Routes.Build { id = Data.jobBuildId, highlight = Routes.HighlightNothing }
     }
 

--- a/web/elm/tests/DashboardCacheTests.elm
+++ b/web/elm/tests/DashboardCacheTests.elm
@@ -73,21 +73,6 @@ all =
                     }
                     |> Tuple.second
                     |> Common.contains LoadCachedTeams
-        , test "subscribes to receive cached jobs" <|
-            \_ ->
-                whenOnDashboard { highDensity = False }
-                    |> Application.subscriptions
-                    |> Common.contains Subscription.OnCachedJobsReceived
-        , test "subscribes to receive cached pipelines" <|
-            \_ ->
-                whenOnDashboard { highDensity = False }
-                    |> Application.subscriptions
-                    |> Common.contains Subscription.OnCachedPipelinesReceived
-        , test "subscribes to receive cached teams" <|
-            \_ ->
-                whenOnDashboard { highDensity = False }
-                    |> Application.subscriptions
-                    |> Common.contains Subscription.OnCachedTeamsReceived
         , test "renders pipelines when receive cached pipelines delivery" <|
             \_ ->
                 whenOnDashboard { highDensity = False }

--- a/web/elm/tests/DashboardCacheTests.elm
+++ b/web/elm/tests/DashboardCacheTests.elm
@@ -240,7 +240,7 @@ all =
                         )
                     |> Tuple.first
                     |> Application.update
-                        (TopLevelMessage.Update <| Message.DragStart "team" 1)
+                        (TopLevelMessage.Update <| Message.DragStart "team" "1")
                     |> Tuple.first
                     |> Application.update
                         (TopLevelMessage.Update <| Message.DragOver End)

--- a/web/elm/tests/DashboardInstanceGroupTests.elm
+++ b/web/elm/tests/DashboardInstanceGroupTests.elm
@@ -257,7 +257,17 @@ all =
                 findInstanceVars =
                     Query.findAll [ class "instance-var" ]
             in
-            [ test "displays instance vars in header" <|
+            [ test "does not display group name in header" <|
+                \_ ->
+                    whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
+                        |> gotPipelines
+                            [ pipelineInstanceWithVars 1
+                                [ ( "a", JsonString "b" ) ]
+                            ]
+                        |> Common.queryView
+                        |> findHeader
+                        |> Query.hasNot [ text "group" ]
+            , test "displays instance vars in header" <|
                 \_ ->
                     whenOnDashboardViewingInstanceGroup { dashboardView = ViewNonArchivedPipelines }
                         |> gotPipelines

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -2000,7 +2000,7 @@ all =
                         (Callback.AllJobsFetched <| Ok [])
                     |> Tuple.first
                     |> Application.update
-                        (ApplicationMsgs.Update <| Msgs.DragStart "team" 1)
+                        (ApplicationMsgs.Update <| Msgs.DragStart "team" "1")
                     |> Tuple.first
                     |> Application.handleDelivery
                         (ClockTicked FiveSeconds <|

--- a/web/elm/tests/DashboardTooltipTests.elm
+++ b/web/elm/tests/DashboardTooltipTests.elm
@@ -262,6 +262,24 @@ all =
                     |> Maybe.withDefault (Html.text "")
                     |> Query.fromHtml
                     |> Query.has [ text "foo.bar: some-value" ]
+        , test "displays instance var key: value when hovering over pipeline card instance vars in favorites" <|
+            \_ ->
+                Dashboard.tooltip
+                    { session
+                        | hovered =
+                            Tooltip
+                                (PipelineCardInstanceVars AllPipelinesSection 1 <|
+                                    Dict.fromList
+                                        [ ( "foo", JsonString "bar" )
+                                        , ( "baz", JsonObject [ ( "qux", JsonNumber 123 ) ] )
+                                        ]
+                                )
+                                Data.elementPosition
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "baz.qux:123, foo:bar" ]
         ]
 
 

--- a/web/elm/tests/DashboardTooltipTests.elm
+++ b/web/elm/tests/DashboardTooltipTests.elm
@@ -56,7 +56,6 @@ all =
                             Tooltip
                                 (PipelineCardFavoritedIcon AllPipelinesSection 1)
                                 Data.elementPosition
-                        , pipelines = Success [ Data.pipeline "team" 1 ]
                     }
                     |> Maybe.map .body
                     |> Maybe.withDefault (Html.text "")
@@ -70,8 +69,36 @@ all =
                             Tooltip
                                 (PipelineCardFavoritedIcon AllPipelinesSection 1)
                                 Data.elementPosition
-                        , pipelines = Success [ Data.pipeline "team" 1 ]
                         , favoritedPipelines = Set.singleton 1
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "unfavorite" ]
+        , test "says 'favorite' when an unfavorited instance group is hovered" <|
+            \_ ->
+                Dashboard.tooltip
+                    { session
+                        | hovered =
+                            Tooltip
+                                (InstanceGroupCardFavoritedIcon AllPipelinesSection { teamName = "team", name = "group" })
+                                Data.elementPosition
+                        , pipelines = Success [ Data.pipeline "team" 1 ]
+                    }
+                    |> Maybe.map .body
+                    |> Maybe.withDefault (Html.text "")
+                    |> Query.fromHtml
+                    |> Query.has [ text "favorite" ]
+        , test "says 'unfavorite' when a favorited instance group is hovered" <|
+            \_ ->
+                Dashboard.tooltip
+                    { session
+                        | hovered =
+                            Tooltip
+                                (InstanceGroupCardFavoritedIcon AllPipelinesSection { teamName = "team", name = "group" })
+                                Data.elementPosition
+                        , pipelines = Success [ Data.pipeline "team" 1 ]
+                        , favoritedInstanceGroups = Set.singleton ( "team", "group" )
                     }
                     |> Maybe.map .body
                     |> Maybe.withDefault (Html.text "")

--- a/web/elm/tests/InstanceGroupCardTests.elm
+++ b/web/elm/tests/InstanceGroupCardTests.elm
@@ -509,6 +509,64 @@ all =
                                 ]
                 ]
             ]
+        , describe "footer" <|
+            let
+                instance =
+                    pipelineInstance BuildStatusSucceeded False 1
+
+                groupId =
+                    Concourse.toInstanceGroupId (Tuple.first instance)
+
+                setup =
+                    whenOnDashboard { highDensity = False }
+                        |> gotPipelines
+                            [ pipelineInstance BuildStatusSucceeded False 1 ]
+
+                footer =
+                    Common.queryView
+                        >> Query.find [ class "card-footer" ]
+                        >> Query.children []
+                        >> Query.first
+
+                unfilledFavoritedIcon =
+                    iconSelector
+                        { size = "20px"
+                        , image = Assets.FavoritedToggleIcon { isFavorited = False, isHovered = False, isSideBar = False }
+                        }
+
+                unfilledBrightFavoritedIcon =
+                    iconSelector
+                        { size = "20px"
+                        , image = Assets.FavoritedToggleIcon { isFavorited = False, isHovered = True, isSideBar = False }
+                        }
+            in
+            [ test "renders a footer with a favorite icon" <|
+                \_ ->
+                    setup
+                        |> Common.queryView
+                        |> findCard
+                        |> Query.find [ class "card-footer" ]
+                        |> Query.has unfilledFavoritedIcon
+            , defineHoverBehaviour
+                { name = "favorited icon toggle"
+                , setup = setup
+                , query = footer
+                , unhoveredSelector =
+                    { description = "faded star icon"
+                    , selector =
+                        unfilledFavoritedIcon
+                            ++ [ style "cursor" "pointer" ]
+                    }
+                , hoverable =
+                    Msgs.InstanceGroupCardFavoritedIcon AllPipelinesSection groupId
+                , hoveredSelector =
+                    { description = "bright star icon"
+                    , selector =
+                        unfilledBrightFavoritedIcon
+                            ++ [ style "cursor" "pointer" ]
+                    }
+                }
+            ]
         , describe "when pipeline instances are favorited" <|
             [ test "only the favorited instances are shown in the favorites section" <|
                 \_ ->

--- a/web/elm/tests/InstanceGroupCardTests.elm
+++ b/web/elm/tests/InstanceGroupCardTests.elm
@@ -533,11 +533,19 @@ all =
                         |> gotPipelines
                             [ pipelineInstance BuildStatusSucceeded False 1 ]
 
-                isFavorited =
+                groupIsFavorited =
                     Application.handleDelivery
                         (FavoritedInstanceGroupsReceived <|
                             Ok <|
                                 Set.singleton ( groupId.teamName, groupId.name )
+                        )
+                        >> Tuple.first
+
+                instanceIsFavorited =
+                    Application.handleDelivery
+                        (FavoritedPipelinesReceived <|
+                            Ok <|
+                                Set.singleton 1
                         )
                         >> Tuple.first
 
@@ -614,7 +622,7 @@ all =
             , test "favorited instance groups are loaded from storage" <|
                 \_ ->
                     setup
-                        |> isFavorited
+                        |> groupIsFavorited
                         |> Common.queryView
                         |> findTeamSection
                         |> findCard
@@ -622,9 +630,18 @@ all =
             , test "favorited instance groups are rendered in favorite section" <|
                 \_ ->
                     setup
-                        |> isFavorited
+                        |> groupIsFavorited
                         |> Common.queryView
                         |> findFavoritesSection
                         |> hasCard
+            , test "both favorited instance groups and favorited instances in the group are rendered in favorite section" <|
+                \_ ->
+                    setup
+                        |> groupIsFavorited
+                        |> instanceIsFavorited
+                        |> Common.queryView
+                        |> findFavoritesSection
+                        |> Query.findAll cardSelector
+                        |> Query.count (Expect.equal 2)
             ]
         ]

--- a/web/elm/tests/InstanceGroupCardTests.elm
+++ b/web/elm/tests/InstanceGroupCardTests.elm
@@ -539,6 +539,12 @@ all =
                         { size = "20px"
                         , image = Assets.FavoritedToggleIcon { isFavorited = False, isHovered = True, isSideBar = False }
                         }
+
+                filledFavoritedIcon =
+                    iconSelector
+                        { size = "20px"
+                        , image = Assets.FavoritedToggleIcon { isFavorited = True, isHovered = False, isSideBar = False }
+                        }
             in
             [ test "renders a footer with a favorite icon" <|
                 \_ ->
@@ -566,6 +572,37 @@ all =
                             ++ [ style "cursor" "pointer" ]
                     }
                 }
+            , test "clicking the favorite icon favorites the group" <|
+                \_ ->
+                    setup
+                        |> Application.update
+                            (ApplicationMsgs.Update <|
+                                Msgs.Click <|
+                                    InstanceGroupCardFavoritedIcon AllPipelinesSection groupId
+                            )
+                        |> Expect.all
+                            [ Tuple.second
+                                >> Common.contains
+                                    (Effects.SaveFavoritedInstanceGroups <|
+                                        Set.singleton ( groupId.teamName, groupId.name )
+                                    )
+                            , Tuple.first
+                                >> Common.queryView
+                                >> findCard
+                                >> Query.has filledFavoritedIcon
+                            ]
+            , test "favorited instance groups are loaded from storage" <|
+                \_ ->
+                    setup
+                        |> Application.handleDelivery
+                            (FavoritedInstanceGroupsReceived <|
+                                Ok <|
+                                    Set.singleton ( groupId.teamName, groupId.name )
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> findCard
+                        |> Query.has filledFavoritedIcon
             ]
         , describe "when pipeline instances are favorited" <|
             [ test "only the favorited instances are shown in the favorites section" <|

--- a/web/elm/tests/InstanceGroupCardTests.elm
+++ b/web/elm/tests/InstanceGroupCardTests.elm
@@ -285,8 +285,8 @@ all =
             , test "pads the last row if there's not enough boxes" <|
                 \_ ->
                     let
-                        thirdRow =
-                            Query.index 2 >> Query.children []
+                        secondRow =
+                            Query.index 1 >> Query.children []
 
                         lastCol =
                             Query.index -1
@@ -302,7 +302,7 @@ all =
                         |> Common.queryView
                         |> findBody
                         |> rows
-                        |> thirdRow
+                        |> secondRow
                         |> lastCol
                         |> Expect.all
                             [ Query.has [ style "flex-grow" "1" ]

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -404,7 +404,11 @@ all =
                         ]
                         >> findCardHeader
                         >> Expect.all
-                            [ Query.has [ text "group" ]
+                            [ Query.has
+                                [ style "height" "80px"
+                                , style "box-sizing" "border-box"
+                                ]
+                            , Query.has [ text "group" ]
                             , Query.has [ text "no instance vars" ]
                             ]
                 ]

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -2595,7 +2595,7 @@ all =
                                         |> Tuple.first
                                 , query = favoritedToggle
                                 , unhoveredSelector =
-                                    { description = "faded 20px square"
+                                    { description = "faded star icon"
                                     , selector =
                                         unfilledFavoritedIcon
                                             ++ [ style "cursor" "pointer" ]
@@ -2603,7 +2603,7 @@ all =
                                 , hoverable =
                                     Msgs.PipelineCardFavoritedIcon AllPipelinesSection pipelineId
                                 , hoveredSelector =
-                                    { description = "bright 20px square"
+                                    { description = "bright star icon"
                                     , selector =
                                         unfilledBrightFavoritedIcon
                                             ++ [ style "cursor" "pointer" ]

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -8,11 +8,13 @@ import Common
     exposing
         ( defineHoverBehaviour
         , givenDataUnauthenticated
+        , gotPipelines
         , isColorWithStripes
         )
-import Concourse
+import Concourse exposing (JsonValue(..))
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.PipelineStatus exposing (PipelineStatus(..), StatusDetails(..))
+import DashboardInstanceGroupTests exposing (pipelineInstanceWithVars)
 import DashboardTests
     exposing
         ( afterSeconds
@@ -40,6 +42,7 @@ import DashboardTests
         , white
         )
 import Data
+import Dict
 import Expect exposing (Expectation)
 import Html.Attributes as Attr
 import Message.Callback as Callback
@@ -70,6 +73,9 @@ all =
                 -> Query.Single ApplicationMsgs.TopLevelMessage
             findBody =
                 Query.find [ class "card-body" ]
+
+            findFavoritesSection =
+                Query.find [ id "dashboard-favorite-pipelines" ]
 
             pipelineWithStatus :
                 BuildStatus
@@ -357,6 +363,51 @@ all =
                             Effects.toHtmlID <|
                                 Msgs.PipelineCardName Msgs.AllPipelinesSection 1
                         ]
+            , describe "favorited pipeline instances" <|
+                let
+                    setup pipelines _ =
+                        whenOnDashboard { highDensity = False }
+                            |> givenDataUnauthenticated
+                                (apiData [ ( "team", [] ) ])
+                            |> Tuple.first
+                            |> gotPipelines pipelines
+                            |> Application.handleDelivery
+                                (FavoritedPipelinesReceived <|
+                                    Ok (Set.singleton 1)
+                                )
+                            |> Tuple.first
+
+                    findCardHeader =
+                        Common.queryView
+                            >> findFavoritesSection
+                            >> Query.find
+                                [ class "card"
+                                , containing [ text "group" ]
+                                ]
+                            >> Query.find [ class "card-header" ]
+                in
+                [ test "header displays instance vars and group name" <|
+                    setup [ pipelineInstanceWithVars 1 [ ( "foo", JsonString "bar" ) ] ]
+                        >> findCardHeader
+                        >> Expect.all
+                            [ Query.has
+                                [ style "height" "80px"
+                                , style "box-sizing" "border-box"
+                                ]
+                            , Query.has [ text "group" ]
+                            , Query.has [ containing [ text "foo" ], containing [ text "bar" ] ]
+                            ]
+                , test "an instance with no instance vars displays \"no instance vars\"" <|
+                    setup
+                        [ pipelineInstanceWithVars 1 []
+                        , pipelineInstanceWithVars 2 [ ( "foo", JsonString "bar" ) ]
+                        ]
+                        >> findCardHeader
+                        >> Expect.all
+                            [ Query.has [ text "group" ]
+                            , Query.has [ text "no instance vars" ]
+                            ]
+                ]
             ]
         , describe "colored banner" <|
             let

--- a/web/elm/tests/PipelineCardTests.elm
+++ b/web/elm/tests/PipelineCardTests.elm
@@ -411,6 +411,27 @@ all =
                             , Query.has [ text "group" ]
                             , Query.has [ text "no instance vars" ]
                             ]
+                , test "all instance vars appear on the same row" <|
+                    setup
+                        [ pipelineInstanceWithVars 1
+                            [ ( "a", JsonString "1" )
+                            , ( "b", JsonString "2" )
+                            ]
+                        ]
+                        >> findCardHeader
+                        >> Expect.all
+                            [ Query.has
+                                [ style "height" "80px"
+                                , style "box-sizing" "border-box"
+                                ]
+                            , Query.has [ text "group" ]
+                            , Query.has
+                                [ containing [ text "a" ]
+                                , containing [ text "1" ]
+                                , containing [ text "b" ]
+                                , containing [ text "2" ]
+                                ]
+                            ]
                 ]
             ]
         , describe "colored banner" <|

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -3879,6 +3879,7 @@ session =
         }
     , draggingSideBar = False
     , favoritedPipelines = Set.empty
+    , favoritedInstanceGroups = Set.empty
     , screenSize = ScreenSize.Desktop
     , timeZone = Time.utc
     , route = Routes.Resource { id = Data.resourceId, page = Nothing }

--- a/web/elm/tests/SideBar/InstanceGroupTests.elm
+++ b/web/elm/tests/SideBar/InstanceGroupTests.elm
@@ -22,6 +22,7 @@ import Test.Html.Selector exposing (style)
 defaultState =
     { active = False
     , hovered = False
+    , favorited = False
     , isFavoritesSection = False
     }
 
@@ -45,6 +46,25 @@ all =
                                 , color = Styles.White
                                 }
                 ]
+            , describe "when not favorited"
+                [ test "displays a bright unfilled star icon when hovered" <|
+                    \_ ->
+                        viewInstanceGroup { defaultState | active = True, hovered = True }
+                            |> .starIcon
+                            |> Expect.equal { filled = False, isBright = True }
+                ]
+            , describe "when favorited"
+                [ test "displays a bright filled star icon" <|
+                    \_ ->
+                        viewInstanceGroup
+                            { defaultState
+                                | active = True
+                                , hovered = True
+                                , favorited = True
+                            }
+                            |> .starIcon
+                            |> Expect.equal { filled = True, isBright = True }
+                ]
             ]
         , describe "when unhovered"
             [ test "background is dark" <|
@@ -58,6 +78,25 @@ all =
                         |> .badge
                         |> .color
                         |> Expect.equal Styles.LightGrey
+            , describe "when unfavorited"
+                [ test "displays a dim unfilled star icon" <|
+                    \_ ->
+                        viewInstanceGroup { defaultState | active = True, hovered = False }
+                            |> .starIcon
+                            |> Expect.equal { filled = False, isBright = True }
+                ]
+            , describe "when favorited"
+                [ test "displays a bright filled star icon" <|
+                    \_ ->
+                        viewInstanceGroup
+                            { defaultState
+                                | active = True
+                                , hovered = True
+                                , favorited = True
+                            }
+                            |> .starIcon
+                            |> Expect.equal { filled = True, isBright = True }
+                ]
             ]
         , test "font weight is bold" <|
             \_ ->
@@ -125,10 +164,11 @@ all =
 viewInstanceGroup :
     { active : Bool
     , hovered : Bool
+    , favorited : Bool
     , isFavoritesSection : Bool
     }
     -> Views.InstanceGroup
-viewInstanceGroup { active, hovered, isFavoritesSection } =
+viewInstanceGroup { active, hovered, favorited, isFavoritesSection } =
     let
         hoveredDomId =
             if hovered then
@@ -143,10 +183,18 @@ viewInstanceGroup { active, hovered, isFavoritesSection } =
 
             else
                 Nothing
+
+        favoritedInstanceGroups =
+            if favorited then
+                Set.singleton ( "team", "group" )
+
+            else
+                Set.empty
     in
     InstanceGroup.instanceGroup
         { hovered = hoveredDomId
         , currentPipeline = activePipeline
+        , favoritedInstanceGroups = favoritedInstanceGroups
         , isFavoritesSection = isFavoritesSection
         }
         (pipeline 1)

--- a/web/elm/tests/SideBar/PipelineTests.elm
+++ b/web/elm/tests/SideBar/PipelineTests.elm
@@ -168,7 +168,7 @@ all =
                         |> viewPipeline { defaultState | isFavoritesSection = False }
                         |> .domID
                         |> Expect.equal
-                            (SideBarPipeline AllPipelinesSection Data.pipelineId)
+                            (SideBarPipeline AllPipelinesSection pipeline.id)
             ]
         , describe "when in favorites section"
             [ test "domID is for Favorites section" <|
@@ -177,7 +177,7 @@ all =
                         |> viewPipeline { defaultState | isFavoritesSection = True }
                         |> .domID
                         |> Expect.equal
-                            (SideBarPipeline FavoritesSection Data.pipelineId)
+                            (SideBarPipeline FavoritesSection pipeline.id)
             ]
         ]
 
@@ -194,7 +194,7 @@ viewPipeline { active, hovered, favorited, isFavoritesSection } p =
     let
         hoveredDomId =
             if hovered then
-                HoverState.Hovered (SideBarPipeline AllPipelinesSection Data.pipelineId)
+                HoverState.Hovered (SideBarPipeline AllPipelinesSection p.id)
 
             else
                 HoverState.NoHover

--- a/web/elm/tests/SideBar/TeamTests.elm
+++ b/web/elm/tests/SideBar/TeamTests.elm
@@ -318,7 +318,7 @@ team { active, expanded, hovered, hasFavorited, isFavoritesSection } =
                 HoverState.NoHover
 
         pipelines =
-            [ Data.pipeline "team" 0 |> Data.withName "pipeline" |> Concourse.RegularPipeline ]
+            [ Data.pipeline "team" 0 |> Data.withName "pipeline" |> Team.RegularPipeline ]
 
         pipelineIdentifier =
             { teamName = "team", pipelineName = "pipeline", pipelineInstanceVars = Dict.empty }

--- a/web/elm/tests/SideBar/TeamTests.elm
+++ b/web/elm/tests/SideBar/TeamTests.elm
@@ -3,6 +3,7 @@ module SideBar.TeamTests exposing (all)
 import Common
 import Concourse
 import Data
+import Dict
 import Expect
 import HoverState exposing (TooltipPosition(..))
 import Html exposing (Html)
@@ -320,7 +321,7 @@ team { active, expanded, hovered, hasFavorited, isFavoritesSection } =
             [ Data.pipeline "team" 0 |> Data.withName "pipeline" |> Concourse.RegularPipeline ]
 
         pipelineIdentifier =
-            { teamName = "team", pipelineName = "pipeline" }
+            { teamName = "team", pipelineName = "pipeline", pipelineInstanceVars = Dict.empty }
 
         activePipeline =
             if active then

--- a/web/elm/tests/SideBar/TeamTests.elm
+++ b/web/elm/tests/SideBar/TeamTests.elm
@@ -1,6 +1,7 @@
 module SideBar.TeamTests exposing (all)
 
 import Common
+import Concourse
 import Data
 import Expect
 import HoverState exposing (TooltipPosition(..))
@@ -316,7 +317,7 @@ team { active, expanded, hovered, hasFavorited, isFavoritesSection } =
                 HoverState.NoHover
 
         pipelines =
-            [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
+            [ Data.pipeline "team" 0 |> Data.withName "pipeline" |> Concourse.RegularPipeline ]
 
         pipelineIdentifier =
             { teamName = "team", pipelineName = "pipeline" }
@@ -340,6 +341,7 @@ team { active, expanded, hovered, hasFavorited, isFavoritesSection } =
         , pipelines = pipelines
         , currentPipeline = activePipeline
         , favoritedPipelines = favoritedPipelines
+        , favoritedInstanceGroups = Set.empty
         , isFavoritesSection = isFavoritesSection
         }
         { name = "team"

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -604,7 +604,7 @@ hasSideBar iAmLookingAtThePage =
                 , selector =
                     [ style "color" ColorValues.grey30 ]
                 }
-            , hoverable = Message.SideBarPipeline AllPipelinesSection Data.pipelineId
+            , hoverable = Message.SideBarPipeline AllPipelinesSection 0
             , hoveredSelector =
                 { description = "dark background and light text"
                 , selector =
@@ -734,6 +734,20 @@ hasSideBar iAmLookingAtThePage =
                     >> when iAmLookingAtTheFirstInstanceGroupStar
                     >> then_ iSeeFilledStarIcon
             ]
+        , describe "favorited pipeline instances" <|
+            [ test "favorited instances appear in the favorites section" <|
+                given iHaveAnOpenSideBar_
+                    >> given myBrowserFetchedAnInstanceGroup
+                    >> given myBrowserFetchedFavoritedPipelineInstances
+                    >> when iAmLookingAtTheTeamInTheFavoritesSection
+                    >> then_ iSeeThePipelineInstance
+            , test "instance list item links to the correct pipeline" <|
+                given iHaveAnOpenSideBar_
+                    >> given myBrowserFetchedAnInstanceGroup
+                    >> given myBrowserFetchedFavoritedPipelineInstances
+                    >> when iAmLookingAtTheTeamInTheFavoritesSection
+                    >> then_ iSeeALinkToThePipelineInstance
+            ]
         , test "subscribes to 5-second tick" <|
             given iAmLookingAtThePage
                 >> then_ myBrowserNotifiesEveryFiveSeconds
@@ -822,7 +836,7 @@ hasCurrentPipelineInSideBar iAmLookingAtThePage =
             >> given iClickedTheSideBarIcon
             >> when iAmLookingAtTheOtherPipeline
             >> then_ iSeeTheTextIsBright
-    , test "pipeline with same name on other team has invisible border" <|
+    , test "pipeline with same name on other team is not highlighted" <|
         given iAmLookingAtThePage
             >> given iAmOnANonPhoneScreen
             >> given myBrowserFetchedPipelinesFromMultipleTeams
@@ -897,6 +911,16 @@ all =
         , describe "resource page current pipeline" <|
             hasCurrentPipelineInSideBar (when iOpenTheResourcePage)
         , describe "on notfound page" <| hasSideBar (when iOpenTheNotFoundPage)
+        , test "other instances within the instance group are not highlighted" <|
+            given iAmViewingThePipelinePageForAnInstance
+                >> given iAmOnANonPhoneScreen
+                >> given myBrowserFetchedPipelines
+                >> given iClickedTheHamburgerIcon
+                >> given myBrowserFetchedAnInstanceGroup
+                >> given myBrowserFetchedFavoritedPipelineInstances
+                >> when iAmLookingAtTheFavoritesSection
+                >> when iAmLookingAtTheOtherInstance
+                >> then_ iSeeAnInvisibleBackground
         ]
 
 
@@ -1294,15 +1318,7 @@ iSeeItHasAValidTeamId =
 
 
 iSeeItHasAValidPipelineId =
-    Query.has
-        [ id <|
-            (pipelinesSectionName AllPipelinesSection
-                ++ "_"
-                ++ Base64.encode "team"
-                ++ "_"
-                ++ Base64.encode "pipeline"
-            )
-        ]
+    Query.has [ id <| (pipelinesSectionName AllPipelinesSection ++ "_0") ]
 
 
 iSeeItHasAValidInstanceGroupId =
@@ -1515,6 +1531,21 @@ iSeeItIsALinkToTheFirstInstanceGroup =
         ]
 
 
+iSeeALinkToThePipelineInstance =
+    Query.has
+        [ tag "a"
+        , Common.routeHref <|
+            Routes.Pipeline
+                { id =
+                    { teamName = "team"
+                    , pipelineName = "group"
+                    , pipelineInstanceVars = Dict.fromList [ ( "version", JsonString "1" ) ]
+                    }
+                , groups = []
+                }
+        ]
+
+
 iToggledToHighDensity =
     Tuple.first
         >> Application.update
@@ -1719,6 +1750,20 @@ iAmViewingThePipelinePage =
     iOpenedThePipelinePage >> Tuple.first
 
 
+iAmViewingThePipelinePageForAnInstance _ =
+    ( Common.initRoute <|
+        Routes.Pipeline
+            { id =
+                { teamName = "team"
+                , pipelineName = "group"
+                , pipelineInstanceVars = Dict.fromList [ ( "version", JsonString "v1" ) ]
+                }
+            , groups = []
+            }
+    , []
+    )
+
+
 iShrankTheViewport =
     Tuple.first >> Application.handleDelivery (Subscription.WindowResized 300 300)
 
@@ -1844,6 +1889,14 @@ myBrowserFetchedFavoritedPipelines =
             )
 
 
+myBrowserFetchedFavoritedPipelineInstances =
+    Tuple.first
+        >> Application.handleDelivery
+            (Subscription.FavoritedPipelinesReceived <|
+                Ok (Set.fromList [ 1, 2 ])
+            )
+
+
 myBrowserFetchedFavoritedInstanceGroups =
     Tuple.first
         >> Application.handleDelivery
@@ -1922,7 +1975,7 @@ iHoveredThePipelineLink =
             (TopLevelMessage.Update <|
                 Message.Hover <|
                     Just <|
-                        Message.SideBarPipeline AllPipelinesSection Data.pipelineId
+                        Message.SideBarPipeline AllPipelinesSection 0
             )
 
 
@@ -1937,6 +1990,10 @@ iSeeTheTeamNameAbove =
 
 iSeeThePipelineNameBelow =
     Query.children [] >> Query.index 1 >> Query.has [ text "pipeline" ]
+
+
+iSeeThePipelineInstance =
+    Query.has [ text "group/version:1" ]
 
 
 iSeeNoPipelineNames =
@@ -2082,6 +2139,10 @@ iAmLookingAtThePipelineWithTheSameName =
     iAmLookingAtThePipelineList
         >> Query.children [ containing [ text "yet-another-pipeline" ] ]
         >> Query.first
+
+
+iAmLookingAtTheOtherInstance =
+    Query.find [ tag "a", containing [ text "group/version:2" ] ]
 
 
 myBrowserNotifiesEveryFiveSeconds =

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -747,6 +747,12 @@ hasSideBar iAmLookingAtThePage =
                     >> given myBrowserFetchedFavoritedPipelineInstances
                     >> when iAmLookingAtTheTeamInTheFavoritesSection
                     >> then_ iSeeALinkToThePipelineInstance
+            , test "displays instance group if any instances are favorited" <|
+                given iHaveAnOpenSideBar_
+                    >> given myBrowserFetchedAnInstanceGroup
+                    >> given myBrowserFetchedFavoritedPipelineInstances
+                    >> when iAmLookingAtTheTeamInTheFavoritesSection
+                    >> then_ iSeeTheInstanceGroup
             ]
         , test "subscribes to 5-second tick" <|
             given iAmLookingAtThePage
@@ -1992,8 +1998,11 @@ iSeeThePipelineNameBelow =
     Query.children [] >> Query.index 1 >> Query.has [ text "pipeline" ]
 
 
+iSeeTheInstanceGroup =
+    iSeeItIsALinkToTheFirstInstanceGroup
+
 iSeeThePipelineInstance =
-    Query.has [ text "group/version:1" ]
+    Query.has [ text "version:1" ]
 
 
 iSeeNoPipelineNames =
@@ -2142,7 +2151,7 @@ iAmLookingAtThePipelineWithTheSameName =
 
 
 iAmLookingAtTheOtherInstance =
-    Query.find [ tag "a", containing [ text "group/version:2" ] ]
+    Query.find [ tag "a", containing [ text "version:2" ] ]
 
 
 myBrowserNotifiesEveryFiveSeconds =

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -55,9 +55,6 @@ pageLoadIsSideBarCompatible iAmLookingAtThePage =
     , test "fetches screen size on page load" <|
         when iAmLookingAtThePage
             >> then_ myBrowserFetchesScreenSize
-    , test "listens for sidebar state on page load" <|
-        when iAmLookingAtThePage
-            >> then_ myBrowserListensForSideBarStates
     , test "fetches sidebar state on page load" <|
         when iAmLookingAtThePage
             >> then_ myBrowserFetchesSideBarState
@@ -2165,12 +2162,6 @@ iSeeItStretches =
 
 iSeeThreeChildrenDivs =
     Query.children [ tag "div" ] >> Query.count (Expect.equal 3)
-
-
-myBrowserListensForSideBarStates =
-    Tuple.first
-        >> Application.subscriptions
-        >> Common.contains Subscription.OnSideBarStateReceived
 
 
 myBrowserReadSideBarState =

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -733,6 +733,12 @@ hasSideBar iAmLookingAtThePage =
                     >> given myBrowserFetchedFavoritedInstanceGroups
                     >> when iAmLookingAtTheFirstInstanceGroupStar
                     >> then_ iSeeFilledStarIcon
+            , test "favorited instance groups are displayed in favorites section" <|
+                given iHaveAnOpenSideBarWithAnInstanceGroup
+                    >> given iClickedThePipelineGroup
+                    >> given myBrowserFetchedFavoritedInstanceGroups
+                    >> when iAmLookingAtTheFavoritesSection
+                    >> then_ iSeeABadge
             ]
         , describe "favorited pipeline instances" <|
             [ test "favorited instances appear in the favorites section" <|
@@ -1853,6 +1859,10 @@ myBrowserFetchedAnInstanceGroup =
                     , Data.pipeline "team" 3
                         |> Data.withName "group"
                         |> Data.withInstanceVars Dict.empty
+                    , Data.pipeline "team" 4
+                        |> Data.withName "group"
+                        |> Data.withInstanceVars (Dict.fromList [ ( "version", JsonString "4" ) ])
+                        |> Data.withArchived True
                     ]
             )
 
@@ -2000,6 +2010,7 @@ iSeeThePipelineNameBelow =
 
 iSeeTheInstanceGroup =
     iSeeItIsALinkToTheFirstInstanceGroup
+
 
 iSeeThePipelineInstance =
     Query.has [ text "version:1" ]

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -485,14 +485,14 @@ hasSideBar iAmLookingAtThePage =
             given iHaveAnOpenSideBar_
                 >> given iClickedThePipelineGroup
                 >> when iAmLookingAtTheFirstPipelineStar
-                >> then_ (itIsClickable <| Message.SideBarFavoritedIcon 0)
+                >> then_ (itIsClickable <| Message.SideBarPipelineFavoritedIcon 0)
         , test "pipeline gets favorited when star icon is clicked" <|
             given iHaveAnOpenSideBar_
                 >> given iClickedThePipelineGroup
                 >> given iClickedTheFirstPipelineStar
                 >> when iAmLookingAtTheFirstPipelineStar
                 >> then_ iSeeFilledStarIcon
-        , test "clicked on favorited pipeline has unfilled star icon" <|
+        , test "clicked on favorited pipeline unfavorites it" <|
             given iHaveAnOpenSideBar_
                 >> given iClickedThePipelineGroup
                 >> given iClickedTheFirstPipelineStar
@@ -705,6 +705,34 @@ hasSideBar iAmLookingAtThePage =
                         ]
                     }
                 }
+            , test "star icon is clickable" <|
+                given iHaveAnOpenSideBarWithAnInstanceGroup
+                    >> given iClickedThePipelineGroup
+                    >> when iAmLookingAtTheFirstInstanceGroupStar
+                    >> then_
+                        (itIsClickable <|
+                            Message.SideBarInstanceGroupFavoritedIcon
+                                { teamName = "team", name = "group" }
+                        )
+            , test "instance group gets favorited when star icon is clicked" <|
+                given iHaveAnOpenSideBarWithAnInstanceGroup
+                    >> given iClickedThePipelineGroup
+                    >> given iClickedTheFirstInstanceGroupStar
+                    >> when iAmLookingAtTheFirstInstanceGroupStar
+                    >> then_ iSeeFilledStarIcon
+            , test "clicked on favorited instance group unfavorites it" <|
+                given iHaveAnOpenSideBarWithAnInstanceGroup
+                    >> given iClickedThePipelineGroup
+                    >> given iClickedTheFirstInstanceGroupStar
+                    >> given iClickedTheFirstInstanceGroupStar
+                    >> when iAmLookingAtTheFirstInstanceGroupStar
+                    >> then_ iSeeUnfilledStarIcon
+            , test "favorited instance groups are loaded from local storage" <|
+                given iHaveAnOpenSideBarWithAnInstanceGroup
+                    >> given iClickedThePipelineGroup
+                    >> given myBrowserFetchedFavoritedInstanceGroups
+                    >> when iAmLookingAtTheFirstInstanceGroupStar
+                    >> then_ iSeeFilledStarIcon
             ]
         , test "subscribes to 5-second tick" <|
             given iAmLookingAtThePage
@@ -1345,18 +1373,17 @@ iClickedTheFirstPipelineStar =
         >> Application.update
             (TopLevelMessage.Update <|
                 Message.Click <|
-                    Message.SideBarFavoritedIcon 0
+                    Message.SideBarPipelineFavoritedIcon 0
             )
 
 
-iClickedFavoritedPipelineStar =
-    iClickedTheFirstPipelineStar
-
-
-iAmLookingAtThePreviousPipelineStar =
-    iAmLookingAtTheFirstPipeline
-        >> Query.findAll [ attribute <| Attr.attribute "aria-label" "Favorite Icon" ]
-        >> Query.index 0
+iClickedTheFirstInstanceGroupStar =
+    Tuple.first
+        >> Application.update
+            (TopLevelMessage.Update <|
+                Message.Click <|
+                    Message.SideBarInstanceGroupFavoritedIcon { teamName = "team", name = "group" }
+            )
 
 
 iSeeAMinusIcon =
@@ -1570,7 +1597,13 @@ iAmLookingAtTheFirstInstanceGroupBadge =
 iAmLookingAtTheFirstPipelineStar =
     iAmLookingAtTheFirstPipeline
         >> Query.findAll [ attribute <| Attr.attribute "aria-label" "Favorite Icon" ]
-        >> Query.index 0
+        >> Query.first
+
+
+iAmLookingAtTheFirstInstanceGroupStar =
+    iAmLookingAtTheFirstInstanceGroup
+        >> Query.findAll [ attribute <| Attr.attribute "aria-label" "Favorite Icon" ]
+        >> Query.first
 
 
 iAmLookingAtTheAllPipelinesSection =
@@ -1808,6 +1841,14 @@ myBrowserFetchedFavoritedPipelines =
         >> Application.handleDelivery
             (Subscription.FavoritedPipelinesReceived <|
                 Ok (Set.singleton 0)
+            )
+
+
+myBrowserFetchedFavoritedInstanceGroups =
+    Tuple.first
+        >> Application.handleDelivery
+            (Subscription.FavoritedInstanceGroupsReceived <|
+                Ok (Set.singleton ( "team", "group" ))
             )
 
 

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -927,7 +927,7 @@ all =
             given iAmViewingThePipelinePageForAnInstance
                 >> given iAmOnANonPhoneScreen
                 >> given myBrowserFetchedPipelines
-                >> given iClickedTheHamburgerIcon
+                >> given iClickedTheSideBarIcon
                 >> given myBrowserFetchedAnInstanceGroup
                 >> given myBrowserFetchedFavoritedPipelineInstances
                 >> when iAmLookingAtTheFavoritesSection

--- a/web/elm/tests/TooltipTests.elm
+++ b/web/elm/tests/TooltipTests.elm
@@ -81,7 +81,7 @@ nonOverflowingViewport =
 
 domID : DomID
 domID =
-    SideBarPipeline AllPipelinesSection Data.pipelineId
+    SideBarPipeline AllPipelinesSection 1
 
 
 overflowingViewport : Browser.Dom.Viewport

--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -103,8 +103,9 @@ app.ports.deleteFromLocalStorage.subscribe(function(key) {
 
 const csrfTokenKey = "csrf_token";
 const favoritedPipelinesKey = "favorited_pipelines";
+const favoritedInstanceGroupsKey = "favorited_instance_groups";
 window.addEventListener('storage', function(event) {
-  if (event.key === csrfTokenKey || event.key === favoritedPipelinesKey) {
+  if (event.key === csrfTokenKey || event.key === favoritedPipelinesKey || event.key === favoritedInstanceGroupsKey) {
     const value = localStorage.getItem(event.key);
     setTimeout(function() {
       app.ports.receivedFromLocalStorage.send([event.key, value]);

--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -86,18 +86,6 @@ app.ports.saveToLocalStorage.subscribe(function(params) {
   }
 });
 
-app.ports.saveToSessionStorage.subscribe(function(params) {
-  if (!params || params.length !== 2) {
-    return;
-  }
-  const [key, value] = params;
-  try {
-    sessionStorage.setItem(key, JSON.stringify(value));
-  } catch(err) {
-    console.error(err);
-  }
-});
-
 app.ports.loadFromLocalStorage.subscribe(function(key) {
   const value = localStorage.getItem(key);
   if (value === null) {
@@ -105,16 +93,6 @@ app.ports.loadFromLocalStorage.subscribe(function(key) {
   }
   setTimeout(function() {
     app.ports.receivedFromLocalStorage.send([key, value]);
-  }, 0);
-});
-
-app.ports.loadFromSessionStorage.subscribe(function(key) {
-  const value = sessionStorage.getItem(key);
-  if (value === null) {
-    return;
-  }
-  setTimeout(function() {
-    app.ports.receivedFromSessionStorage.send([key, value]);
   }, 0);
 });
 


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

<img width="1000" alt="Screen Shot 2021-01-23 at 9 41 49 PM" src="https://user-images.githubusercontent.com/26583442/105619802-114a7e80-5dc4-11eb-8f66-614d696fa9d0.png">

Previously, only individual instances could be favourited. When instances were favourited, the instance group card would be displayed in the favourites section, but with the set of instances filtered down to only those that were favourited.

I figured you'd typically only care about a few instances, and the old approach made it easy to find those instances at a glance - but there are definitely valid cases for wanting to see all instances at once, and this PR makes that possible (without needing to favourite each individual instance).

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Store favourited instance groups in `localStorage`
* Store sidebar state in `localStorage` (rather than `sessionStorage`)
  * Wasn't strictly necessary, but allowed simplifying the code, and if you use the sidebar, you'll probably want it to stay open when you open a new tab
* Display `PipelineCard` for each favourited instance, even when not viewing instance groups via the `group:...` filter
  * The `PipelineCards` contain both the group name + instance vars
  * In contrast, when viewing instance groups, the `PipelineCards` only contain the instance vars, because the headers outside of the cards contain the instance group name
* Display pipeline list items in the sidebar for favourited instances using the same `fly` notation
  * i.e. `group-name/var1:val1,var2:val2`

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
