### PR TITLE
fly: add --team option to get-pipeline command, backport #6144 to 6.7.x

### DIFF
--- a/fly/commands/get_pipeline.go
+++ b/fly/commands/get_pipeline.go
@@ -13,12 +13,14 @@ import (
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/fly/ui"
+	"github.com/concourse/concourse/go-concourse/concourse"
 	"github.com/mattn/go-isatty"
 )
 
 type GetPipelineCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Get configuration of this pipeline"`
 	JSON     bool                     `short:"j" long:"json"                     description:"Print config as json instead of yaml"`
+	Team     string                   `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *GetPipelineCommand) Validate() error {
@@ -45,7 +47,18 @@ func (command *GetPipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	config, _, found, err := target.Team().PipelineConfig(pipelineName)
+	var team concourse.Team
+
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team)
+		if err != nil {
+			return err
+		}
+	} else {
+		team = target.Team()
+	}
+
+	config, _, found, err := team.PipelineConfig(pipelineName)
 	if err != nil {
 		return err
 	}

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -124,6 +124,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", "doesnotexist")),
 			Entry("destroy-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
+			Entry("get-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", "doesnotexist")),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -160,6 +162,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "pipeline", "-c", "fixtures/testConfig.yml", "--team", "other-team")),
 			Entry("destroy-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", "other-team")),
+			Entry("get-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", "other-team")),
 		)
 	})
 })

--- a/fly/integration/get_pipeline_test.go
+++ b/fly/integration/get_pipeline_test.go
@@ -207,15 +207,12 @@ var _ = Describe("Fly CLI", func() {
 				Context("when specifying a pipeline name", func() {
 					var (
 						path        string
-						queryParams string
 					)
 
 					BeforeEach(func() {
 						var err error
 						path, err = atc.Routes.CreatePathForRoute(atc.GetConfig, rata.Params{"pipeline_name": "some-pipeline", "team_name": team})
 						Expect(err).NotTo(HaveOccurred())
-
-						queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
 					})
 
 					Context("when specifying pipeline vars", func() {
@@ -224,14 +221,14 @@ var _ = Describe("Fly CLI", func() {
 							BeforeEach(func() {
 								atcServer.AppendHandlers(
 									ghttp.CombineHandlers(
-										ghttp.VerifyRequest("GET", path, queryParams),
+										ghttp.VerifyRequest("GET", path),
 										ghttp.RespondWithJSONEncoded(200, atc.ConfigResponse{Config: config}, http.Header{atc.ConfigVersionHeader: {"42"}}),
 									),
 								)
 							})
 
 							It("prints the config as yaml to stdout", func() {
-								flyCmd := exec.Command(flyPath, "-t", targetName, "get-pipeline", "--pipeline", "some-pipeline/branch:master", "--team", team)
+								flyCmd := exec.Command(flyPath, "-t", targetName, "get-pipeline", "--pipeline", "some-pipeline", "--team", team)
 
 								sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 								Expect(err).NotTo(HaveOccurred())

--- a/fly/integration/get_pipeline_test.go
+++ b/fly/integration/get_pipeline_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os/exec"
 
@@ -186,6 +187,132 @@ var _ = Describe("Fly CLI", func() {
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(printedConfig).To(Equal(config))
+						})
+					})
+				})
+			})
+
+			Context("with a custom team", func() {
+				team := "diff-team"
+				BeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", team)),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+								Name: team,
+							}),
+						),
+					)
+				})
+				Context("when specifying a pipeline name", func() {
+					var (
+						path        string
+						queryParams string
+					)
+
+					BeforeEach(func() {
+						var err error
+						path, err = atc.Routes.CreatePathForRoute(atc.GetConfig, rata.Params{"pipeline_name": "some-pipeline", "team_name": team})
+						Expect(err).NotTo(HaveOccurred())
+
+						queryParams = "instance_vars=%7B%22branch%22%3A%22master%22%7D"
+					})
+
+					Context("when specifying pipeline vars", func() {
+
+						Context("and pipeline exists", func() {
+							BeforeEach(func() {
+								atcServer.AppendHandlers(
+									ghttp.CombineHandlers(
+										ghttp.VerifyRequest("GET", path, queryParams),
+										ghttp.RespondWithJSONEncoded(200, atc.ConfigResponse{Config: config}, http.Header{atc.ConfigVersionHeader: {"42"}}),
+									),
+								)
+							})
+
+							It("prints the config as yaml to stdout", func() {
+								flyCmd := exec.Command(flyPath, "-t", targetName, "get-pipeline", "--pipeline", "some-pipeline/branch:master", "--team", team)
+
+								sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+								Expect(err).NotTo(HaveOccurred())
+
+								<-sess.Exited
+								Expect(sess.ExitCode()).To(Equal(0))
+
+								var printedConfig atc.Config
+								err = yaml.Unmarshal(sess.Out.Contents(), &printedConfig)
+								Expect(err).NotTo(HaveOccurred())
+
+								Expect(printedConfig).To(Equal(config))
+							})
+						})
+					})
+
+					Context("and pipeline is not found", func() {
+						JustBeforeEach(func() {
+							atcServer.AppendHandlers(
+								ghttp.CombineHandlers(
+									ghttp.VerifyRequest("GET", path),
+									ghttp.RespondWithJSONEncoded(http.StatusNotFound, ""),
+								),
+							)
+						})
+
+						It("should print pipeline not found error", func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "get-pipeline", "--pipeline", "some-pipeline", "-j", "--team", team)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(1))
+
+							Expect(sess.Err).To(gbytes.Say("error: pipeline not found"))
+						})
+					})
+
+					Context("when atc returns valid config", func() {
+						BeforeEach(func() {
+							atcServer.AppendHandlers(
+								ghttp.CombineHandlers(
+									ghttp.VerifyRequest("GET", path),
+									ghttp.RespondWithJSONEncoded(200, atc.ConfigResponse{Config: config}, http.Header{atc.ConfigVersionHeader: {"42"}}),
+								),
+							)
+						})
+
+						It("prints the config as yaml to stdout", func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "get-pipeline", "--pipeline", "some-pipeline", "--team", team)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(0))
+
+							var printedConfig atc.Config
+							err = yaml.Unmarshal(sess.Out.Contents(), &printedConfig)
+							Expect(err).NotTo(HaveOccurred())
+
+							Expect(printedConfig).To(Equal(config))
+						})
+
+						Context("when -j is given", func() {
+							It("prints the config as json to stdout", func() {
+								flyCmd := exec.Command(flyPath, "-t", targetName, "get-pipeline", "--pipeline", "some-pipeline", "-j", "--team", team)
+
+								sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+								Expect(err).NotTo(HaveOccurred())
+
+								<-sess.Exited
+								Expect(sess.ExitCode()).To(Equal(0))
+
+								var printedConfig atc.Config
+								err = json.Unmarshal(sess.Out.Contents(), &printedConfig)
+								Expect(err).NotTo(HaveOccurred())
+
+								Expect(printedConfig).To(Equal(config))
+							})
 						})
 					})
 				})


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix | **Feature** | Documentation

Back port #6177 to 6.7.x. Allows fly cli to get pipeline for different teams without having to switch targets.

6.7 has supported `--team` option with `fly set-pipeine`, which is very useful for us cluster maintainers. Unfortunately `fly get-pipeline` doesn't support `--team` on 6.7 though #6144 has supported that on master. This PR backports #6144 to 6.7.x. As there are a few merged bug fixes on branch 6.7.x, I guess there would be a 6.7.4.

## Changes proposed by this PR:


## Notes to reviewer:


## Release Note

Allows fly cli to get pipeline for different teams without having to switch targets by adding `--team` option to `fly get-pipeline`.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
