### PR TITLE
hide "group:" dropdown suggestion in search

### DIFF
--- a/web/elm/src/Dashboard/Filter.elm
+++ b/web/elm/src/Dashboard/Filter.elm
@@ -47,6 +47,11 @@ type alias Filter =
     }
 
 
+filterTypes : List String
+filterTypes =
+    [ "status", "team", "group" ]
+
+
 type TeamFilter
     = Team StringFilter
     | Pipeline PipelineFilter
@@ -68,11 +73,6 @@ type StatusFilter
     = PipelineStatus PipelineStatus
     | PipelineRunning
     | IncompleteStatus String
-
-
-filterTypes : List String
-filterTypes =
-    [ "status", "team", "group" ]
 
 
 filterTeams : { r | favoritedPipelines : Set DatabaseID } -> Model -> Dict String (List Pipeline)
@@ -342,6 +342,11 @@ suggestions pipelines query =
             case curFilter of
                 Pipeline (Name (Fuzzy s)) ->
                     filterTypes
+                        -- As long as instanced pipelines are experimental,
+                        -- lets not suggest the "group:" filter. Note that it
+                        -- can still be applied, and group suggestions will
+                        -- appear when you explicitly type "group:"
+                        |> List.filter ((/=) "group")
                         |> List.filter (String.startsWith s)
                         |> List.map (\v -> v ++ ":")
 

--- a/web/elm/tests/DashboardSearchBarTests.elm
+++ b/web/elm/tests/DashboardSearchBarTests.elm
@@ -246,10 +246,9 @@ all =
                         >> findDropdown
                         >> Query.findAll [ tag "li" ]
                         >> Expect.all
-                            [ Query.count (Expect.equal 3)
+                            [ Query.count (Expect.equal 2)
                             , Query.index 0 >> Query.has [ text "status:" ]
                             , Query.index 1 >> Query.has [ text "team:" ]
-                            , Query.index 2 >> Query.has [ text "group:" ]
                             ]
                 , describe "navigating dropdown items" <|
                     let
@@ -435,9 +434,9 @@ all =
                             prefixedSuggestionsTest query "" expected
                     in
                     [ -- available filters
-                      simpleSuggestionsTest "" [ "status:", "team:", "group:" ]
-                    , simpleSuggestionsTest "-" [ "-status:", "-team:", "-group:" ]
-                    , simpleSuggestionsTest " " [ "status:", "team:", "group:" ]
+                      simpleSuggestionsTest "" [ "status:", "team:" ]
+                    , simpleSuggestionsTest "-" [ "-status:", "-team:" ]
+                    , simpleSuggestionsTest " " [ "status:", "team:" ]
 
                     -- status
                     , simpleSuggestionsTest "st" [ "status:" ]
@@ -470,8 +469,6 @@ all =
                     , suggestionsTest manyTeams "team:" (findSuggestions >> Query.count (Expect.equal 10))
 
                     -- group
-                    , simpleSuggestionsTest "g" [ "group:" ]
-                    , simpleSuggestionsTest "group" [ "group:" ]
                     , simpleSuggestionsTest "group:" [ "group:\"group\"", "group:\"other-group\"" ]
                     , simpleSuggestionsTest "group:oth" [ "group:\"other-group\"" ]
                     , simpleSuggestionsTest "group:\"group\"" []
@@ -480,7 +477,7 @@ all =
                     , simpleSuggestionsTest "foo" []
 
                     -- takes last filter
-                    , prefixedSuggestionsTest "team:other-team " "team:other-team " [ "status:", "team:", "group:" ]
+                    , prefixedSuggestionsTest "team:other-team " "team:other-team " [ "status:", "team:" ]
                     , prefixedSuggestionsTest "team:other-team s" "team:other-team " [ "status:" ]
                     , prefixedSuggestionsTest "team:other-team -status:a" "team:other-team " [ "-status:aborted" ]
 


### PR DESCRIPTION
since instanced pipelines are still experimental and we need to figure
out the UX for them, it's confusing to suggest the "group:" filter in
the search bar, especially because instanced pipelines are disabled by
default.

with this commit, we hide the "group:" filter from the dropdown so you
don't stumble upon it. note that if you want to apply a "group:" filter,
you still can, and it'll still give suggestions after you've typed
"group:"