### PR TITLE
Optimize postgres runner for db tests

### DIFF
--- a/atc/db/db_suite_test.go
+++ b/atc/db/db_suite_test.go
@@ -1,7 +1,6 @@
 package db_test
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/metric"
 	"github.com/concourse/concourse/atc/postgresrunner"
-	"github.com/tedsuo/ifrit"
 )
 
 func TestDB(t *testing.T) {
@@ -29,7 +27,6 @@ func TestDB(t *testing.T) {
 
 var (
 	postgresRunner postgresrunner.Runner
-	dbProcess      ifrit.Process
 
 	dbConn                              db.Conn
 	fakeSecrets                         *credsfakes.FakeSecrets
@@ -95,15 +92,7 @@ var (
 	psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 )
 
-var _ = BeforeSuite(func() {
-	postgresRunner = postgresrunner.Runner{
-		Port: 5433 + GinkgoParallelNode(),
-	}
-
-	dbProcess = ifrit.Invoke(postgresRunner)
-
-	postgresRunner.InitializeTestDBTemplate()
-})
+var _ = postgresrunner.GinkgoRunner(&postgresRunner)
 
 var _ = BeforeEach(func() {
 	postgresRunner.CreateTestDBFromTemplate()
@@ -243,9 +232,4 @@ var _ = AfterEach(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	postgresRunner.DropTestDB()
-})
-
-var _ = AfterSuite(func() {
-	dbProcess.Signal(os.Interrupt)
-	<-dbProcess.Wait()
 })

--- a/atc/db/db_suite_test.go
+++ b/atc/db/db_suite_test.go
@@ -106,7 +106,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	postgresRunner.RestoreDBFromTemplate()
+	postgresRunner.CreateTestDBFromTemplate()
 
 	dbConn = postgresRunner.OpenConn()
 
@@ -241,6 +241,8 @@ func destroy(d interface{ Destroy() error }) {
 var _ = AfterEach(func() {
 	err := dbConn.Close()
 	Expect(err).NotTo(HaveOccurred())
+
+	postgresRunner.DropTestDB()
 })
 
 var _ = AfterSuite(func() {

--- a/atc/db/db_suite_test.go
+++ b/atc/db/db_suite_test.go
@@ -102,11 +102,11 @@ var _ = BeforeSuite(func() {
 
 	dbProcess = ifrit.Invoke(postgresRunner)
 
-	postgresRunner.CreateTestDB()
+	postgresRunner.InitializeTestDBTemplate()
 })
 
 var _ = BeforeEach(func() {
-	postgresRunner.Truncate()
+	postgresRunner.RestoreDBFromTemplate()
 
 	dbConn = postgresRunner.OpenConn()
 

--- a/atc/db/lock/lock_suite_test.go
+++ b/atc/db/lock/lock_suite_test.go
@@ -1,13 +1,9 @@
 package lock_test
 
 import (
-	"os"
-	"time"
-
 	"github.com/concourse/concourse/atc/postgresrunner"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/tedsuo/ifrit"
 
 	"testing"
 )
@@ -18,19 +14,5 @@ func TestLock(t *testing.T) {
 }
 
 var postgresRunner postgresrunner.Runner
-var dbProcess ifrit.Process
 
-var _ = BeforeSuite(func() {
-	postgresRunner = postgresrunner.Runner{
-		Port: 5433 + GinkgoParallelNode(),
-	}
-
-	dbProcess = ifrit.Invoke(postgresRunner)
-
-	postgresRunner.InitializeTestDBTemplate()
-})
-
-var _ = AfterSuite(func() {
-	dbProcess.Signal(os.Interrupt)
-	Eventually(dbProcess.Wait(), 10*time.Second).Should(Receive())
-})
+var _ = postgresrunner.GinkgoRunner(&postgresRunner)

--- a/atc/db/lock/lock_suite_test.go
+++ b/atc/db/lock/lock_suite_test.go
@@ -27,7 +27,7 @@ var _ = BeforeSuite(func() {
 
 	dbProcess = ifrit.Invoke(postgresRunner)
 
-	postgresRunner.CreateTestDB()
+	postgresRunner.InitializeTestDBTemplate()
 })
 
 var _ = AfterSuite(func() {

--- a/atc/db/lock/lock_test.go
+++ b/atc/db/lock/lock_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Locks", func() {
 	)
 
 	BeforeEach(func() {
-		postgresRunner.Truncate()
+		postgresRunner.CreateTestDBFromTemplate()
 
 		listener = pq.NewListener(postgresRunner.DataSourceName(), time.Second, time.Minute, nil)
 		Eventually(listener.Ping, 5*time.Second).ShouldNot(HaveOccurred())
@@ -61,6 +61,8 @@ var _ = Describe("Locks", func() {
 		if dbLock != nil {
 			_ = dbLock.Release()
 		}
+
+		postgresRunner.DropTestDB()
 	})
 
 	Describe("locks in general", func() {

--- a/atc/db/migration/migration_suite_test.go
+++ b/atc/db/migration/migration_suite_test.go
@@ -1,14 +1,10 @@
 package migration_test
 
 import (
-	"os"
-	"time"
-
 	"github.com/concourse/concourse/atc/postgresrunner"
 	"github.com/gobuffalo/packr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/tedsuo/ifrit"
 
 	"testing"
 )
@@ -19,14 +15,8 @@ func TestMigration(t *testing.T) {
 }
 
 var postgresRunner postgresrunner.Runner
-var dbProcess ifrit.Process
 
-var _ = BeforeSuite(func() {
-	postgresRunner = postgresrunner.Runner{
-		Port: 5433 + GinkgoParallelNode(),
-	}
-	dbProcess = ifrit.Invoke(postgresRunner)
-})
+var _ = postgresrunner.GinkgoRunner(&postgresRunner)
 
 var _ = BeforeEach(func() {
 	postgresRunner.CreateEmptyTestDB()
@@ -34,11 +24,6 @@ var _ = BeforeEach(func() {
 
 var _ = AfterEach(func() {
 	postgresRunner.DropTestDB()
-})
-
-var _ = AfterSuite(func() {
-	dbProcess.Signal(os.Interrupt)
-	Eventually(dbProcess.Wait(), 10*time.Second).Should(Receive())
 })
 
 var asset = packr.NewBox("./migrations").MustBytes

--- a/atc/db/migration/migration_suite_test.go
+++ b/atc/db/migration/migration_suite_test.go
@@ -29,7 +29,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	postgresRunner.CreateTestDB()
+	postgresRunner.CreateEmptyTestDB()
 })
 
 var _ = AfterEach(func() {

--- a/atc/gc/gc_suite_test.go
+++ b/atc/gc/gc_suite_test.go
@@ -69,11 +69,11 @@ var _ = BeforeSuite(func() {
 
 	dbProcess = ifrit.Invoke(postgresRunner)
 
-	postgresRunner.CreateTestDB()
+	postgresRunner.InitializeTestDBTemplate()
 })
 
 var _ = BeforeEach(func() {
-	postgresRunner.Truncate()
+	postgresRunner.CreateTestDBFromTemplate()
 
 	dbConn = postgresRunner.OpenConn()
 
@@ -153,6 +153,7 @@ var _ = BeforeEach(func() {
 
 var _ = AfterEach(func() {
 	Expect(dbConn.Close()).To(Succeed())
+	postgresRunner.DropTestDB()
 })
 
 var _ = AfterSuite(func() {

--- a/atc/gc/gc_suite_test.go
+++ b/atc/gc/gc_suite_test.go
@@ -2,7 +2,6 @@ package gc_test
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"code.cloudfoundry.org/lager"
@@ -17,7 +16,6 @@ import (
 	"github.com/concourse/concourse/atc/postgresrunner"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/tedsuo/ifrit"
 
 	"testing"
 )
@@ -35,7 +33,6 @@ var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 var (
 	postgresRunner postgresrunner.Runner
-	dbProcess      ifrit.Process
 
 	dbConn                 db.Conn
 	err                    error
@@ -62,15 +59,7 @@ var (
 	fakeLogFunc = func(logger lager.Logger, id lock.LockID) {}
 )
 
-var _ = BeforeSuite(func() {
-	postgresRunner = postgresrunner.Runner{
-		Port: 5433 + GinkgoParallelNode(),
-	}
-
-	dbProcess = ifrit.Invoke(postgresRunner)
-
-	postgresRunner.InitializeTestDBTemplate()
-})
+var _ = postgresrunner.GinkgoRunner(&postgresRunner)
 
 var _ = BeforeEach(func() {
 	postgresRunner.CreateTestDBFromTemplate()
@@ -154,9 +143,4 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() {
 	Expect(dbConn.Close()).To(Succeed())
 	postgresRunner.DropTestDB()
-})
-
-var _ = AfterSuite(func() {
-	dbProcess.Signal(os.Interrupt)
-	Eventually(dbProcess.Wait(), 10*time.Second).Should(Receive())
 })

--- a/atc/integration/integration_suite_test.go
+++ b/atc/integration/integration_suite_test.go
@@ -26,20 +26,11 @@ import (
 var (
 	cmd            *atccmd.RunCommand
 	postgresRunner postgresrunner.Runner
-	dbProcess      ifrit.Process
 	atcProcess     ifrit.Process
 	atcURL         string
 )
 
-var _ = BeforeSuite(func() {
-	postgresRunner = postgresrunner.Runner{
-		Port: 5433 + GinkgoParallelNode(),
-	}
-
-	dbProcess = ifrit.Invoke(postgresRunner)
-
-	postgresRunner.InitializeTestDBTemplate()
-})
+var _ = postgresrunner.GinkgoRunner(&postgresRunner)
 
 var _ = BeforeEach(func() {
 	cmd = &atccmd.RunCommand{}
@@ -104,11 +95,6 @@ var _ = AfterEach(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	postgresRunner.DropTestDB()
-})
-
-var _ = AfterSuite(func() {
-	dbProcess.Signal(os.Interrupt)
-	<-dbProcess.Wait()
 })
 
 func TestIntegration(t *testing.T) {

--- a/atc/integration/team_migration_test.go
+++ b/atc/integration/team_migration_test.go
@@ -25,10 +25,6 @@ var _ = XDescribe("ATC 3.13 Team Migration Test", func() {
 		password string
 	)
 
-	BeforeSuite(func() {
-		rand.Seed(time.Now().UnixNano())
-	})
-
 	BeforeEach(func() {
 		username = randomString()
 		password = randomString()

--- a/atc/postgresrunner/ginkgo.go
+++ b/atc/postgresrunner/ginkgo.go
@@ -1,0 +1,40 @@
+package postgresrunner
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tedsuo/ifrit"
+)
+
+type none struct{}
+
+func GinkgoRunner(runner *Runner) none {
+	var dbProcess ifrit.Process
+
+	BeforeSuite(func() {
+		InitializeRunnerForGinkgo(runner, &dbProcess)
+	})
+
+	AfterSuite(func() {
+		dbProcess.Signal(os.Interrupt)
+		Eventually(dbProcess.Wait(), 10*time.Second).Should(Receive())
+	})
+
+	return none{}
+}
+
+func InitializeRunnerForGinkgo(runner *Runner, dbProcess *ifrit.Process) {
+	*runner = Runner{
+		Port: 5433 + GinkgoParallelNode(),
+	}
+	*dbProcess = ifrit.Invoke(*runner)
+	runner.InitializeTestDBTemplate()
+}
+
+func FinalizeRunnerForGinkgo(runner *Runner, dbProcess *ifrit.Process) {
+	(*dbProcess).Signal(os.Interrupt)
+	Eventually((*dbProcess).Wait(), 10*time.Second).Should(Receive())
+}

--- a/atc/postgresrunner/postgresrunner.go
+++ b/atc/postgresrunner/postgresrunner.go
@@ -105,6 +105,7 @@ full_page_writes = off
 func appendToFile(path string, content string) {
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0755)
 	Expect(err).ToNot(HaveOccurred())
+	defer f.Close()
 
 	_, err = f.WriteString(content)
 	Expect(err).ToNot(HaveOccurred())

--- a/atc/scheduler/algorithm/suite_test.go
+++ b/atc/scheduler/algorithm/suite_test.go
@@ -54,11 +54,11 @@ var _ = BeforeSuite(func() {
 
 	dbProcess = ifrit.Invoke(postgresRunner)
 
-	postgresRunner.CreateTestDB()
+	postgresRunner.InitializeTestDBTemplate()
 })
 
 var _ = BeforeEach(func() {
-	postgresRunner.Truncate()
+	postgresRunner.CreateTestDBFromTemplate()
 
 	dbConn = postgresRunner.OpenConn()
 
@@ -69,6 +69,8 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() {
 	err := dbConn.Close()
 	Expect(err).NotTo(HaveOccurred())
+
+	postgresRunner.DropTestDB()
 })
 
 var _ = AfterSuite(func() {

--- a/atc/scheduler/algorithm/suite_test.go
+++ b/atc/scheduler/algorithm/suite_test.go
@@ -48,13 +48,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	postgresRunner = postgresrunner.Runner{
-		Port: 5433 + GinkgoParallelNode(),
-	}
-
-	dbProcess = ifrit.Invoke(postgresRunner)
-
-	postgresRunner.InitializeTestDBTemplate()
+	postgresrunner.InitializeRunnerForGinkgo(&postgresRunner, &dbProcess)
 })
 
 var _ = BeforeEach(func() {
@@ -74,8 +68,7 @@ var _ = AfterEach(func() {
 })
 
 var _ = AfterSuite(func() {
-	dbProcess.Signal(os.Interrupt)
-	<-dbProcess.Wait()
+	postgresrunner.FinalizeRunnerForGinkgo(&postgresRunner, &dbProcess)
 
 	if exporter != nil {
 		exporter.Flush()

--- a/cmd/concourse/concourse_test.go
+++ b/cmd/concourse/concourse_test.go
@@ -38,10 +38,8 @@ var _ = Describe("Web Command", func() {
 
 	BeforeEach(func() {
 		hostKeyFile, hostPubKeyFile, _, _ = generateSSHKeypair()
-		postgresRunner = postgresrunner.Runner{
-			Port: 5433 + GinkgoParallelNode(),
-		}
-		dbProcess = ifrit.Invoke(postgresRunner)
+		postgresrunner.InitializeRunnerForGinkgo(&postgresRunner, &dbProcess)
+
 		postgresRunner.CreateEmptyTestDB()
 
 		concourseCommand = exec.Command(
@@ -82,9 +80,7 @@ var _ = Describe("Web Command", func() {
 		<-concourseProcess.Wait()
 		postgresRunner.DropTestDB()
 
-		dbProcess.Signal(os.Interrupt)
-		err := <-dbProcess.Wait()
-		Expect(err).NotTo(HaveOccurred())
+		postgresrunner.FinalizeRunnerForGinkgo(&postgresRunner, &dbProcess)
 		os.Remove(hostKeyFile)
 		os.Remove(hostPubKeyFile)
 		os.Remove(filepath.Dir(hostPubKeyFile))

--- a/cmd/concourse/concourse_test.go
+++ b/cmd/concourse/concourse_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Web Command", func() {
 			Port: 5433 + GinkgoParallelNode(),
 		}
 		dbProcess = ifrit.Invoke(postgresRunner)
-		postgresRunner.CreateTestDB()
+		postgresRunner.CreateEmptyTestDB()
 
 		concourseCommand = exec.Command(
 			concoursePath,

--- a/skymarshal/dexserver/dexserver_suite_test.go
+++ b/skymarshal/dexserver/dexserver_suite_test.go
@@ -1,12 +1,9 @@
 package dexserver_test
 
 import (
-	"os"
-
 	"github.com/concourse/concourse/atc/postgresrunner"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/tedsuo/ifrit"
 
 	"testing"
 )
@@ -17,15 +14,8 @@ func TestDexServer(t *testing.T) {
 }
 
 var postgresRunner postgresrunner.Runner
-var dbProcess ifrit.Process
 
-var _ = BeforeSuite(func() {
-	postgresRunner = postgresrunner.Runner{
-		Port: 5433 + GinkgoParallelNode(),
-	}
-	dbProcess = ifrit.Invoke(postgresRunner)
-	postgresRunner.InitializeTestDBTemplate()
-})
+var _ = postgresrunner.GinkgoRunner(&postgresRunner)
 
 var _ = BeforeEach(func() {
 	postgresRunner.CreateTestDBFromTemplate()
@@ -33,9 +23,4 @@ var _ = BeforeEach(func() {
 
 var _ = AfterEach(func() {
 	postgresRunner.DropTestDB()
-})
-
-var _ = AfterSuite(func() {
-	dbProcess.Signal(os.Interrupt)
-	<-dbProcess.Wait()
 })

--- a/skymarshal/dexserver/dexserver_suite_test.go
+++ b/skymarshal/dexserver/dexserver_suite_test.go
@@ -24,10 +24,11 @@ var _ = BeforeSuite(func() {
 		Port: 5433 + GinkgoParallelNode(),
 	}
 	dbProcess = ifrit.Invoke(postgresRunner)
+	postgresRunner.InitializeTestDBTemplate()
 })
 
 var _ = BeforeEach(func() {
-	postgresRunner.CreateTestDB()
+	postgresRunner.CreateTestDBFromTemplate()
 })
 
 var _ = AfterEach(func() {


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->

Make tests that require running a local Postgres server faster (~2x faster on my machine)

```
# Before changes
ginkgo -p ./atc/db  560.68s user 1597.73s system 754% cpu 4:46.20 total

# After changes
ginkgo -p ./atc/db  172.06s user 645.53s system 777% cpu 1:45.15 total
```

On CI, it seems to be a *bit* faster, but not as drastic - the DB suite went from ~3 minutes to ~2 minutes

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Create a `TEMPLATE DATABASE` once after migrations were run and replace the `testdb` after each test with a copy of the template
  * `postgresRunner.Truncate` avoids needing to re-run migrations, but surprisingly to me, turned out to be pretty slow - it's a (relatively) constant time operation (regardless of the size of the tables), but for such small tables, it seems to be faster to just `DROP` the whole database and recreate it
  * Using a template also avoids needing to re-run migrations
* Add some minor optimizations based on the fact that durability is not a requirement (see https://www.postgresql.org/docs/13/non-durability.html)

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
