### PR TITLE
Ignore archived pipelines for instance group count in top bar

### DIFF
--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -5,6 +5,7 @@ module SideBar.SideBar exposing
     , hamburgerMenu
     , handleCallback
     , handleDelivery
+    , isPipelineVisible
     , lookupPipeline
     , tooltip
     , update

--- a/web/elm/src/Views/TopBar.elm
+++ b/web/elm/src/Views/TopBar.elm
@@ -18,7 +18,7 @@ import Html.Attributes
 import Message.Message exposing (DomID(..), Message(..))
 import RemoteData
 import Routes
-import SideBar.SideBar exposing (byPipelineId, lookupPipeline)
+import SideBar.SideBar exposing (byPipelineId, isPipelineVisible, lookupPipeline)
 import Url
 import Views.InstanceGroupBadge as InstanceGroupBadge
 import Views.Styles as Styles
@@ -121,6 +121,7 @@ pipelineBreadcrumbs session pipeline =
             session.pipelines
                 |> RemoteData.withDefault []
                 |> List.filter (\p -> p.name == pipeline.name && p.teamName == pipeline.teamName)
+                |> List.filter (isPipelineVisible session)
 
         inInstanceGroup =
             Concourse.isInstanceGroup pipelineGroup

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -129,6 +129,14 @@ pipelineInstance =
         |> Data.withInstanceVars instanceVars
 
 
+archivedPipelineInstance : Concourse.Pipeline
+archivedPipelineInstance =
+    Data.pipeline "team" 1
+        |> Data.withName "pipeline"
+        |> Data.withInstanceVars (Dict.fromList [ ( "foo", JsonString "bar" ) ])
+        |> Data.withArchived True
+
+
 all : Test
 all =
     describe "TopBar"
@@ -359,7 +367,11 @@ all =
             (Common.initRoute (Routes.Pipeline { id = Concourse.toPipelineId pipelineInstance, groups = [] })
                 |> Application.handleCallback
                     (Callback.AllPipelinesFetched <|
-                        Ok [ pipelineInstance, Data.pipeline "team" 2 |> Data.withName "pipeline" ]
+                        Ok
+                            [ pipelineInstance
+                            , archivedPipelineInstance
+                            , Data.pipeline "team" 2 |> Data.withName "pipeline"
+                            ]
                     )
                 |> Tuple.first
                 |> queryView


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

The instance group badge in the top bar (visible when you're viewing the pipeline/job/resource page for an instanced pipeline) displays a count that's inconsistent with the sidebar/dashboard because we weren't filtering out (non-favourited) archived pipelines

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
