### PR TITLE
Start non-privileged containers in their own cgroup namespace

### DIFF
--- a/worker/runtime/spec/namespaces.go
+++ b/worker/runtime/spec/namespaces.go
@@ -13,6 +13,7 @@ var (
 
 	UnprivilegedContainerNamespaces = append(PrivilegedContainerNamespaces,
 		specs.LinuxNamespace{Type: specs.UserNamespace},
+		specs.LinuxNamespace{Type: specs.CgroupNamespace},
 	)
 )
 

--- a/worker/runtime/spec/namespaces.go
+++ b/worker/runtime/spec/namespaces.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"errors"
 	"os"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -37,5 +38,8 @@ func OciNamespaces(privileged bool) []specs.LinuxNamespace {
 
 func cgroupNamespacesSupported() bool {
 	_, err := os.Stat("/proc/self/ns/cgroup")
-	return !os.IsNotExist(err)
+	if err != nil {
+		return !errors.Is(err, os.ErrNotExist)
+	}
+	return true
 }

--- a/worker/runtime/spec/namespaces.go
+++ b/worker/runtime/spec/namespaces.go
@@ -21,7 +21,10 @@ var (
 )
 
 func init() {
-	cgroupNamespacesEnabled()
+	if cgroupNamespacesSupported() {
+		UnprivilegedContainerNamespaces = append(UnprivilegedContainerNamespaces,
+			specs.LinuxNamespace{Type: specs.CgroupNamespace})
+	}
 }
 
 func OciNamespaces(privileged bool) []specs.LinuxNamespace {
@@ -32,11 +35,7 @@ func OciNamespaces(privileged bool) []specs.LinuxNamespace {
 	return PrivilegedContainerNamespaces
 }
 
-func cgroupNamespacesEnabled() {
-	if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
-		return
-	}
-
-	UnprivilegedContainerNamespaces = append(UnprivilegedContainerNamespaces,
-		specs.LinuxNamespace{Type: specs.CgroupNamespace})
+func cgroupNamespacesSupported() bool {
+	_, err := os.Stat("/proc/self/ns/cgroup")
+	return !os.IsNotExist(err)
 }

--- a/worker/runtime/spec/namespaces.go
+++ b/worker/runtime/spec/namespaces.go
@@ -1,6 +1,10 @@
 package spec
 
-import "github.com/opencontainers/runtime-spec/specs-go"
+import (
+	"os"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
 
 var (
 	PrivilegedContainerNamespaces = []specs.LinuxNamespace{
@@ -13,9 +17,12 @@ var (
 
 	UnprivilegedContainerNamespaces = append(PrivilegedContainerNamespaces,
 		specs.LinuxNamespace{Type: specs.UserNamespace},
-		specs.LinuxNamespace{Type: specs.CgroupNamespace},
 	)
 )
+
+func init() {
+	cgroupNamespacesEnabled()
+}
 
 func OciNamespaces(privileged bool) []specs.LinuxNamespace {
 	if !privileged {
@@ -23,4 +30,13 @@ func OciNamespaces(privileged bool) []specs.LinuxNamespace {
 	}
 
 	return PrivilegedContainerNamespaces
+}
+
+func cgroupNamespacesEnabled() {
+	if _, err := os.Stat("/proc/self/ns/cgroup"); os.IsNotExist(err) {
+		return
+	}
+
+	UnprivilegedContainerNamespaces = append(UnprivilegedContainerNamespaces,
+		specs.LinuxNamespace{Type: specs.CgroupNamespace})
 }


### PR DESCRIPTION
## What does this PR accomplish?
Feature

closes #6474 .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

[cgroup namespaces]() give a process its own set of cgroup root directories. This allows for better isolation from the host or parent/ancestor processes.

Support for this feature was [introduced](https://phoronix.com/scan.php?page=news_item&px=CGroup-Namespaces-Linux-4.6) in Linux Kernel 4.6. The minimum Kernel version we support with containerd is 4.4 on Ubuntu 16.04. Fortunately, Ubuntu's own distribution of Kernel 4.4 (used on 16.04 Xenial) had the feature [backported](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1546775) via a patch.

This can be confirmed by running a VM with the latest Ubuntu 16.04 image (e.g. `generic/ubuntu1604` in Vagrant). `cgroup` is listed under namespaces.

```diff
vagrant@ubuntu1604:~$ uname -a
Linux ubuntu1604.localdomain 4.4.0-201-generic #233-Ubuntu SMP Thu Jan 14 06:10:28 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
vagrant@ubuntu1604:~$ ls -l /proc/self/ns
total 0
+ lrwxrwxrwx 1 vagrant vagrant 0 Feb  2 16:26 cgroup -> cgroup:[4026531835]
lrwxrwxrwx 1 vagrant vagrant 0 Feb  2 16:26 ipc -> ipc:[4026531839]
lrwxrwxrwx 1 vagrant vagrant 0 Feb  2 16:26 mnt -> mnt:[4026531840]
lrwxrwxrwx 1 vagrant vagrant 0 Feb  2 16:26 net -> net:[4026531957]
lrwxrwxrwx 1 vagrant vagrant 0 Feb  2 16:26 pid -> pid:[4026531836]
lrwxrwxrwx 1 vagrant vagrant 0 Feb  2 16:26 user -> user:[4026531837]
lrwxrwxrwx 1 vagrant vagrant 0 Feb  2 16:26 uts -> uts:[4026531838]
```

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

We validated the change by checking that a Concourse container has a different cgroup namespace ID from the host i.e. worker. 

Namespaces for the worker the container is on:
```
$ docker exec -it concourse_worker_1 /bin/bash
root@bc53e72d5076:/src# ls -l /proc/self/ns
total 0
lrwxrwxrwx 1 root root 0 Feb  2 17:08 cgroup -> cgroup:[4026531835]
lrwxrwxrwx 1 root root 0 Feb  2 17:08 ipc -> ipc:[4026532822]
lrwxrwxrwx 1 root root 0 Feb  2 17:08 mnt -> mnt:[4026532820]
lrwxrwxrwx 1 root root 0 Feb  2 17:08 net -> net:[4026532825]
lrwxrwxrwx 1 root root 0 Feb  2 17:08 pid -> pid:[4026532823]
lrwxrwxrwx 1 root root 0 Feb  2 17:08 pid_for_children -> pid:[4026532823]
lrwxrwxrwx 1 root root 0 Feb  2 17:08 user -> user:[4026531837]
lrwxrwxrwx 1 root root 0 Feb  2 17:08 uts -> uts:[4026532821]
```

Namespaces inside the container:
```
# ls -l /proc/self/ns
total 0
lrwxrwxrwx    1 root     root             0 Feb  2 17:08 cgroup -> cgroup:[4026533154]
lrwxrwxrwx    1 root     root             0 Feb  2 17:08 ipc -> ipc:[4026533075]
lrwxrwxrwx    1 root     root             0 Feb  2 17:08 mnt -> mnt:[4026533073]
lrwxrwxrwx    1 root     root             0 Feb  2 17:08 net -> net:[4026533078]
lrwxrwxrwx    1 root     root             0 Feb  2 17:08 pid -> pid:[4026533076]
lrwxrwxrwx    1 root     root             0 Feb  2 17:08 pid_for_children -> pid:[4026533076]
lrwxrwxrwx    1 root     root             0 Feb  2 17:08 user -> user:[4026533072]
lrwxrwxrwx    1 root     root             0 Feb  2 17:08 uts -> uts:[4026533074]
```

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* Start non-privileged containers in their own cgroup namespace

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
