### PR TITLE
metrics: make tasks_wait_duration histogram record up to 1h

### DIFF
--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -187,7 +187,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 		Subsystem: "tasks",
 		Name:      "wait_duration",
 		Help:      "Elapsed time waiting for execution",
-		Buckets:   []float64{1, 15, 30, 60, 120, 180, 240, 300, 600, 1200},
+		Buckets:   []float64{30, 60, 120, 300, 600, 1200, 1800, 2400, 3000, 3600},
 	}, []string{"teamId", "workerTags", "platform"})
 	prometheus.MustRegister(tasksWaitingDuration)
 


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix

closes #6505

## Changes proposed by this PR:

Prometheus histogram `tasks_wait_duration` had a too thin partitioning that recorded only up to 20m. This means that everything >20m was clumped together, making it impossible to plot meaningful quantiles.

Detailed explanation, with plots, can be found in the associated ticket #6505

## Notes to reviewer:

Better way is to have a look at the associated ticket #6505.

## Release Note

Metrics: `tasks_wait_duration` histogram will now record up to 1h (closes: #6505)

## Contributor Checklist

<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [X] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [X] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
