### PR TITLE
worker/runtime: remove no-op device rule

### DIFF
--- a/worker/runtime/spec/devices.go
+++ b/worker/runtime/spec/devices.go
@@ -3,29 +3,19 @@ package spec
 import "github.com/opencontainers/runtime-spec/specs-go"
 
 var (
+	// runc adds a list of devices by default.
+	// The rule below gets appended to that list.
+	// The rules along with some context can be found here:
+	// https://github.com/opencontainers/runc/blob/94ae7afa36cc3b8f551e0bc67cf83e5efdf2555f/libcontainer/specconv/spec_linux.go#L50-L192
+	// Currently these rules are highly permissive. We may want to re-visit them, but presently we don't know if they can
+	// be overriden.
+	// Linux docs about how cgroup device rules work:
+	// https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/cgroup-v1/devices.rst
 	AnyContainerDevices = []specs.LinuxDeviceCgroup{
-		// runc allows these
-		{Access: "m", Type: "c", Major: deviceWildcard(), Minor: deviceWildcard(), Allow: true},
-		{Access: "m", Type: "b", Major: deviceWildcard(), Minor: deviceWildcard(), Allow: true},
-
-		{Access: "rwm", Type: "c", Major: intRef(1), Minor: intRef(3), Allow: true},          // /dev/null
-		{Access: "rwm", Type: "c", Major: intRef(1), Minor: intRef(8), Allow: true},          // /dev/random
-		{Access: "rwm", Type: "c", Major: intRef(1), Minor: intRef(7), Allow: true},          // /dev/full
-		{Access: "rwm", Type: "c", Major: intRef(5), Minor: intRef(0), Allow: true},          // /dev/tty
-		{Access: "rwm", Type: "c", Major: intRef(1), Minor: intRef(5), Allow: true},          // /dev/zero
-		{Access: "rwm", Type: "c", Major: intRef(1), Minor: intRef(9), Allow: true},          // /dev/urandom
-		{Access: "rwm", Type: "c", Major: intRef(136), Minor: deviceWildcard(), Allow: true}, // /dev/pts/*
-		{Access: "rwm", Type: "c", Major: intRef(5), Minor: intRef(2), Allow: true},          // /dev/ptmx
-		{Access: "rwm", Type: "c", Major: intRef(10), Minor: intRef(200), Allow: true},       // /dev/net/tun
-
-		// we allow this
-		{Access: "rwm", Type: "c", Major: intRef(10), Minor: intRef(229), Allow: true}, // /dev/fuse
-	}
-
-	PrivilegedOnlyDevices = []specs.LinuxDeviceCgroup{
-		{Allow: false, Access: "rwm"},
+		// This allows use of the FUSE filesystem. We are following Guardian in this case, and aren't sure of the
+		// exact use cases.
+		{Access: "rwm", Type: "c", Major: intRef(10), Minor: intRef(229), Allow: true}, 	// /dev/fuse
 	}
 )
 
 func intRef(i int64) *int64  { return &i }
-func deviceWildcard() *int64 { return intRef(-1) }

--- a/worker/runtime/spec/spec.go
+++ b/worker/runtime/spec/spec.go
@@ -208,11 +208,6 @@ func defaultGardenOciSpec(initBinPath string, privileged bool, maxUid, maxGid ui
 		capabilities = OciCapabilities(privileged)
 	)
 
-	devices := AnyContainerDevices
-	if privileged {
-		devices = append(PrivilegedOnlyDevices, devices...)
-	}
-
 	spec := &specs.Spec{
 		Process: &specs.Process{
 			Args:         []string{"/tmp/gdn-init"},
@@ -222,7 +217,7 @@ func defaultGardenOciSpec(initBinPath string, privileged bool, maxUid, maxGid ui
 		Linux: &specs.Linux{
 			Namespaces: namespaces,
 			Resources: &specs.LinuxResources{
-				Devices: devices,
+				Devices: AnyContainerDevices,
 			},
 			UIDMappings: OciIDMappings(privileged, maxUid),
 			GIDMappings: OciIDMappings(privileged, maxGid),

--- a/worker/runtime/spec/spec_test.go
+++ b/worker/runtime/spec/spec_test.go
@@ -401,16 +401,6 @@ func (s *SpecSuite) TestContainerSpec() {
 			},
 		},
 		{
-			desc: "default devices privileged",
-			gdn: garden.ContainerSpec{
-				Handle: "handle", RootFSPath: "raw:///rootfs",
-				Privileged: true,
-			},
-			check: func(oci *specs.Spec) {
-				s.Equal(append(spec.PrivilegedOnlyDevices, spec.AnyContainerDevices...), oci.Linux.Resources.Devices)
-			},
-		},
-		{
 			desc: "env + default path",
 			gdn: garden.ContainerSpec{
 				Handle: "handle", RootFSPath: "raw:///rootfs",


### PR DESCRIPTION
## What does this PR accomplish?
Misc

Related to #6475

CC @taylorsilva 

## Changes proposed by this PR:
~~We did a bunch of testing to verify that this rule is truly a no-op. We
even wrote a garbage rule:~~

```
{Allow: false, Access: "akdsjasdjasd"},
```

~~and the container was created successfully. With or without that rule
the list of devices in
/sys/fs/cgroup/devices/[container-id]/devices.list was the same as the
unprivileged containers under
/sys/fs/cgroup/devices/garden/[container-id]/devices.list~~

~~We later learned that this default list of devices is very permissive
and "arguably insecure" in the words of a runc dev.~~

~~In future it might make sense to further restrict unprivileged
containers, specifically removing the first two rules which allow mknod
for all block and char devices, which basically gives you read-write for
any device...~~


It appears that runc adds all of these device rules by default with the exception of `/dev/fuse`.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

