### PR TITLE
Add index and mini refactor to the check lifecycle query

### DIFF
--- a/atc/db/migration/migrations/1612565824_add_index_on_build_ids_to_resources.down.sql
+++ b/atc/db/migration/migrations/1612565824_add_index_on_build_ids_to_resources.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  DROP INDEX resources_build_id_idx;
+COMMIT;

--- a/atc/db/migration/migrations/1612565824_add_index_on_build_ids_to_resources.up.sql
+++ b/atc/db/migration/migrations/1612565824_add_index_on_build_ids_to_resources.up.sql
@@ -1,0 +1,3 @@
+BEGIN;
+  CREATE INDEX resources_build_id_idx ON resources (build_id);
+COMMIT;


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

This PR adds an index to help speed up the deletion of the check builds and also adds a small refactor to the check lifecycle query. It should help speed up the query a little by using the `build_id` column on the resources table to figure out whether or not a check build needs to be gced or not.

The index will help speed up the `constraint resources_build_id_fkey on builds` from the checks gc query, here is the `EXPLAIN ANALYZE` of the query without the added index https://explain.depesz.com/s/Gl3M

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
