### PR TITLE
Removes unnecessary indexes from build events tables

### DIFF
--- a/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.down.sql
+++ b/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.down.sql
@@ -3,7 +3,6 @@ BEGIN;
   UPDATE build_events SET build_id_old = build_id WHERE build_id_old IS NULL;
 
   -- drop the indexes for the bigint column
-  DROP INDEX build_events_build_id_idx;
   DROP INDEX build_events_build_id_event_id;
 
   -- drop the bigint column
@@ -11,6 +10,6 @@ BEGIN;
 
   -- rename everything back
   ALTER TABLE build_events RENAME COLUMN build_id_old TO build_id;
-  ALTER INDEX build_events_build_id_old_idx RENAME TO build_events_build_id_idx;
   ALTER INDEX build_events_build_id_old_event_id  RENAME TO build_events_build_id_event_id;
+  CREATE INDEX build_events_build_id_idx ON build_events (build_id);
 COMMIT;

--- a/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.up.sql
+++ b/atc/db/migration/migrations/1603405319_prepare_build_events_for_bigint_migration.up.sql
@@ -1,13 +1,12 @@
 BEGIN;
   -- rename old column and indexes
   ALTER TABLE build_events RENAME COLUMN build_id TO build_id_old;
-  ALTER INDEX build_events_build_id_idx RENAME TO build_events_build_id_old_idx;
+  DROP INDEX build_events_build_id_idx;
   ALTER INDEX build_events_build_id_event_id RENAME TO build_events_build_id_old_event_id;
 
   -- add new bigint column which will be populated gradually at runtime
   ALTER TABLE build_events ADD COLUMN build_id bigint;
 
   -- create a replacement index along with what will become the new primary key
-  CREATE INDEX build_events_build_id_idx ON build_events (build_id);
   CREATE UNIQUE INDEX build_events_build_id_event_id ON build_events (build_id, event_id);
 COMMIT;

--- a/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.down.sql
+++ b/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.down.sql
@@ -23,7 +23,6 @@ BEGIN;
     SELECT id, name FROM teams
   LOOP
     RAISE NOTICE 'creating new indexes for team % (%)', team.id, team.name;
-    EXECUTE format('DROP INDEX team_build_events_%s_build_id', team.id);
     EXECUTE format('DROP INDEX team_build_events_%s_build_id_event_id', team.id);
   END LOOP;
   END
@@ -37,11 +36,10 @@ BEGIN;
     SELECT id, name FROM pipelines
   LOOP
     RAISE NOTICE 'dropping new indexes for pipeline % (%)', pipeline.id, pipeline.name;
-    EXECUTE format('DROP INDEX pipeline_build_events_%s_build_id', pipeline.id);
     EXECUTE format('DROP INDEX pipeline_build_events_%s_build_id_event_id', pipeline.id);
 
     RAISE NOTICE 'renaming old indexes for pipeline % (%)', pipeline.id, pipeline.name;
-    EXECUTE format('ALTER INDEX pipeline_build_events_%s_build_id_old RENAME TO pipeline_build_events_%s_build_id', pipeline.id, pipeline.id);
+    EXECUTE format('CREATE INDEX pipeline_build_events_%s_build_id ON pipeline_build_events_%s (build_id_old)', pipeline.id, pipeline.id);
     EXECUTE format('ALTER INDEX pipeline_build_events_%s_build_id_old_event_id RENAME TO pipeline_build_events_%s_build_id_event_id', pipeline.id, pipeline.id);
   END LOOP;
   END

--- a/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.up.sql
+++ b/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.up.sql
@@ -8,11 +8,10 @@ BEGIN;
     SELECT id, name FROM pipelines
   LOOP
     RAISE NOTICE 'renaming old indexes for pipeline % (%)', pipeline.id, pipeline.name;
-    EXECUTE format('ALTER INDEX pipeline_build_events_%s_build_id RENAME TO pipeline_build_events_%s_build_id_old', pipeline.id, pipeline.id);
+    EXECUTE format('DROP INDEX pipeline_build_events_%s_build_id', pipeline.id);
     EXECUTE format('ALTER INDEX pipeline_build_events_%s_build_id_event_id RENAME TO pipeline_build_events_%s_build_id_old_event_id', pipeline.id, pipeline.id);
 
     RAISE NOTICE 'creating new indexes for pipeline % (%)', pipeline.id, pipeline.name;
-    EXECUTE format('CREATE INDEX pipeline_build_events_%s_build_id ON pipeline_build_events_%s (build_id)', pipeline.id, pipeline.id);
     EXECUTE format('CREATE UNIQUE INDEX pipeline_build_events_%s_build_id_event_id ON pipeline_build_events_%s (build_id, event_id)', pipeline.id, pipeline.id);
   END LOOP;
   END;
@@ -27,7 +26,6 @@ BEGIN;
     SELECT id, name FROM teams
   LOOP
     RAISE NOTICE 'creating new indexes for team % (%)', team.id, team.name;
-    EXECUTE format('CREATE INDEX team_build_events_%s_build_id ON team_build_events_%s (build_id)', team.id, team.id);
     EXECUTE format('CREATE UNIQUE INDEX team_build_events_%s_build_id_event_id ON team_build_events_%s (build_id, event_id)', team.id, team.id);
   END LOOP;
   END;
@@ -39,9 +37,7 @@ BEGIN;
   CREATE OR REPLACE FUNCTION on_pipeline_insert() RETURNS TRIGGER AS $$
   BEGIN
     EXECUTE format('CREATE TABLE IF NOT EXISTS pipeline_build_events_%s () INHERITS (build_events)', NEW.id);
-    EXECUTE format('CREATE INDEX pipeline_build_events_%s_build_id ON pipeline_build_events_%s (build_id)', NEW.id, NEW.id);
     EXECUTE format('CREATE UNIQUE INDEX pipeline_build_events_%s_build_id_event_id ON pipeline_build_events_%s (build_id, event_id)', NEW.id, NEW.id);
-    EXECUTE format('CREATE INDEX pipeline_build_events_%s_build_id_old ON pipeline_build_events_%s (build_id_old)', NEW.id, NEW.id);
     EXECUTE format('CREATE UNIQUE INDEX pipeline_build_events_%s_build_id_old_event_id ON pipeline_build_events_%s (build_id_old, event_id)', NEW.id, NEW.id);
     RETURN NULL;
   END;
@@ -53,7 +49,6 @@ BEGIN;
   CREATE OR REPLACE FUNCTION on_team_insert() RETURNS TRIGGER AS $$
   BEGIN
     EXECUTE format('CREATE TABLE IF NOT EXISTS team_build_events_%s () INHERITS (build_events)', NEW.id);
-    EXECUTE format('CREATE INDEX team_build_events_%s_build_id ON team_build_events_%s (build_id)', NEW.id, NEW.id);
     EXECUTE format('CREATE UNIQUE INDEX team_build_events_%s_build_id_event_id ON team_build_events_%s (build_id, event_id)', NEW.id, NEW.id);
     RETURN NULL;
   END;

--- a/atc/db/migration/migrations/1612457776_add_check_build_events_partition.down.sql
+++ b/atc/db/migration/migrations/1612457776_add_check_build_events_partition.down.sql
@@ -1,5 +1,4 @@
 BEGIN;
-  DROP INDEX check_build_events_build_id;
   DROP INDEX check_build_events_build_id_event_id;
   DROP TABLE check_build_events;
 COMMIT;

--- a/atc/db/migration/migrations/1612457776_add_check_build_events_partition.up.sql
+++ b/atc/db/migration/migrations/1612457776_add_check_build_events_partition.up.sql
@@ -1,5 +1,4 @@
 BEGIN;
   CREATE TABLE check_build_events () INHERITS (build_events);
-  CREATE INDEX check_build_events_build_id ON check_build_events (build_id);
   CREATE UNIQUE INDEX check_build_events_build_id_event_id ON check_build_events (build_id, event_id);
 COMMIT;


### PR DESCRIPTION
## What does this PR accomplish?

This PR removes a few indexes that should be unnecessary. Any queries that query on the `build_id` column can actually use the unique multi column index on `build_id` and `event_id`. Since the build events tables are updated really frequently, limiting the number of indexes that are applied to the table will help with the speed of inserts or updates.

These changes to existing migrations should be okay because it is not released yet with v7.0 but we did upgrade `ci` and `hush-house` with the migrations without this change so we will need to remove the indexes from those environments manually.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
