### PR TITLE
Fix unit test after go 1.16

### DIFF
--- a/fly/rc/target_test.go
+++ b/fly/rc/target_test.go
@@ -201,11 +201,11 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 				ok = expectedCaCertPool.AppendCertsFromPEM([]byte(rootCA))
 				Expect(ok).To(BeTrue())
 
-				Expect((*base).TLSClientConfig).To(Equal(&tls.Config{
-					InsecureSkipVerify: false,
-					RootCAs:            expectedCaCertPool,
-					Certificates:       []tls.Certificate{},
-				}))
+				config := (*base).TLSClientConfig
+				Expect(config.InsecureSkipVerify).To(Equal(false))
+				// x509.CertPool lazyily loads certs, which breaks direct equality comparisions
+				Expect(config.RootCAs.Subjects()).To(Equal(expectedCaCertPool.Subjects()))
+				Expect(config.Certificates).To(HaveLen(0))
 			})
 		})
 


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix | Feature | Documentation

Go 1.16 CertPool [loads certs lazily now](https://github.com/golang/go/commit/e8379ab5964a920e59dbcc5bc4eaa1bbf5a88e90), which messes up the ordering of the certs and causes `reflect.DeepEquals` to not resolve it properly

## Changes proposed by this PR:

Assert equivalence on the fields of the `TLSClientConfig` directly instead of the struct as a whole

## Notes to reviewer:

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [ ] ~Added release note (Optional)~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
