### PR TITLE
update fake files generated by latest version of counterfeiter.

### DIFF
--- a/atc/api/accessor/accessorfakes/fake_access.go
+++ b/atc/api/accessor/accessorfakes/fake_access.go
@@ -109,15 +109,16 @@ func (fake *FakeAccess) Claims() accessor.Claims {
 	ret, specificReturn := fake.claimsReturnsOnCall[len(fake.claimsArgsForCall)]
 	fake.claimsArgsForCall = append(fake.claimsArgsForCall, struct {
 	}{})
+	stub := fake.ClaimsStub
+	fakeReturns := fake.claimsReturns
 	fake.recordInvocation("Claims", []interface{}{})
 	fake.claimsMutex.Unlock()
-	if fake.ClaimsStub != nil {
-		return fake.ClaimsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.claimsReturns
 	return fakeReturns.result1
 }
 
@@ -161,15 +162,16 @@ func (fake *FakeAccess) HasToken() bool {
 	ret, specificReturn := fake.hasTokenReturnsOnCall[len(fake.hasTokenArgsForCall)]
 	fake.hasTokenArgsForCall = append(fake.hasTokenArgsForCall, struct {
 	}{})
+	stub := fake.HasTokenStub
+	fakeReturns := fake.hasTokenReturns
 	fake.recordInvocation("HasToken", []interface{}{})
 	fake.hasTokenMutex.Unlock()
-	if fake.HasTokenStub != nil {
-		return fake.HasTokenStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasTokenReturns
 	return fakeReturns.result1
 }
 
@@ -213,15 +215,16 @@ func (fake *FakeAccess) IsAdmin() bool {
 	ret, specificReturn := fake.isAdminReturnsOnCall[len(fake.isAdminArgsForCall)]
 	fake.isAdminArgsForCall = append(fake.isAdminArgsForCall, struct {
 	}{})
+	stub := fake.IsAdminStub
+	fakeReturns := fake.isAdminReturns
 	fake.recordInvocation("IsAdmin", []interface{}{})
 	fake.isAdminMutex.Unlock()
-	if fake.IsAdminStub != nil {
-		return fake.IsAdminStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isAdminReturns
 	return fakeReturns.result1
 }
 
@@ -265,15 +268,16 @@ func (fake *FakeAccess) IsAuthenticated() bool {
 	ret, specificReturn := fake.isAuthenticatedReturnsOnCall[len(fake.isAuthenticatedArgsForCall)]
 	fake.isAuthenticatedArgsForCall = append(fake.isAuthenticatedArgsForCall, struct {
 	}{})
+	stub := fake.IsAuthenticatedStub
+	fakeReturns := fake.isAuthenticatedReturns
 	fake.recordInvocation("IsAuthenticated", []interface{}{})
 	fake.isAuthenticatedMutex.Unlock()
-	if fake.IsAuthenticatedStub != nil {
-		return fake.IsAuthenticatedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isAuthenticatedReturns
 	return fakeReturns.result1
 }
 
@@ -318,15 +322,16 @@ func (fake *FakeAccess) IsAuthorized(arg1 string) bool {
 	fake.isAuthorizedArgsForCall = append(fake.isAuthorizedArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.IsAuthorizedStub
+	fakeReturns := fake.isAuthorizedReturns
 	fake.recordInvocation("IsAuthorized", []interface{}{arg1})
 	fake.isAuthorizedMutex.Unlock()
-	if fake.IsAuthorizedStub != nil {
-		return fake.IsAuthorizedStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isAuthorizedReturns
 	return fakeReturns.result1
 }
 
@@ -377,15 +382,16 @@ func (fake *FakeAccess) IsSystem() bool {
 	ret, specificReturn := fake.isSystemReturnsOnCall[len(fake.isSystemArgsForCall)]
 	fake.isSystemArgsForCall = append(fake.isSystemArgsForCall, struct {
 	}{})
+	stub := fake.IsSystemStub
+	fakeReturns := fake.isSystemReturns
 	fake.recordInvocation("IsSystem", []interface{}{})
 	fake.isSystemMutex.Unlock()
-	if fake.IsSystemStub != nil {
-		return fake.IsSystemStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isSystemReturns
 	return fakeReturns.result1
 }
 
@@ -429,15 +435,16 @@ func (fake *FakeAccess) TeamNames() []string {
 	ret, specificReturn := fake.teamNamesReturnsOnCall[len(fake.teamNamesArgsForCall)]
 	fake.teamNamesArgsForCall = append(fake.teamNamesArgsForCall, struct {
 	}{})
+	stub := fake.TeamNamesStub
+	fakeReturns := fake.teamNamesReturns
 	fake.recordInvocation("TeamNames", []interface{}{})
 	fake.teamNamesMutex.Unlock()
-	if fake.TeamNamesStub != nil {
-		return fake.TeamNamesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamNamesReturns
 	return fakeReturns.result1
 }
 
@@ -481,15 +488,16 @@ func (fake *FakeAccess) TeamRoles() map[string][]string {
 	ret, specificReturn := fake.teamRolesReturnsOnCall[len(fake.teamRolesArgsForCall)]
 	fake.teamRolesArgsForCall = append(fake.teamRolesArgsForCall, struct {
 	}{})
+	stub := fake.TeamRolesStub
+	fakeReturns := fake.teamRolesReturns
 	fake.recordInvocation("TeamRoles", []interface{}{})
 	fake.teamRolesMutex.Unlock()
-	if fake.TeamRolesStub != nil {
-		return fake.TeamRolesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamRolesReturns
 	return fakeReturns.result1
 }
 
@@ -533,15 +541,16 @@ func (fake *FakeAccess) UserInfo() atc.UserInfo {
 	ret, specificReturn := fake.userInfoReturnsOnCall[len(fake.userInfoArgsForCall)]
 	fake.userInfoArgsForCall = append(fake.userInfoArgsForCall, struct {
 	}{})
+	stub := fake.UserInfoStub
+	fakeReturns := fake.userInfoReturns
 	fake.recordInvocation("UserInfo", []interface{}{})
 	fake.userInfoMutex.Unlock()
-	if fake.UserInfoStub != nil {
-		return fake.UserInfoStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.userInfoReturns
 	return fakeReturns.result1
 }
 

--- a/atc/api/accessor/accessorfakes/fake_access_factory.go
+++ b/atc/api/accessor/accessorfakes/fake_access_factory.go
@@ -34,15 +34,16 @@ func (fake *FakeAccessFactory) Create(arg1 *http.Request, arg2 string) (accessor
 		arg1 *http.Request
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1, arg2})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/api/accessor/accessorfakes/fake_access_token_fetcher.go
+++ b/atc/api/accessor/accessorfakes/fake_access_token_fetcher.go
@@ -34,15 +34,16 @@ func (fake *FakeAccessTokenFetcher) GetAccessToken(arg1 string) (db.AccessToken,
 	fake.getAccessTokenArgsForCall = append(fake.getAccessTokenArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetAccessTokenStub
+	fakeReturns := fake.getAccessTokenReturns
 	fake.recordInvocation("GetAccessToken", []interface{}{arg1})
 	fake.getAccessTokenMutex.Unlock()
-	if fake.GetAccessTokenStub != nil {
-		return fake.GetAccessTokenStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getAccessTokenReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/api/accessor/accessorfakes/fake_handler.go
+++ b/atc/api/accessor/accessorfakes/fake_handler.go
@@ -23,9 +23,10 @@ func (fake *FakeHandler) ServeHTTP(arg1 http.ResponseWriter, arg2 *http.Request)
 		arg1 http.ResponseWriter
 		arg2 *http.Request
 	}{arg1, arg2})
+	stub := fake.ServeHTTPStub
 	fake.recordInvocation("ServeHTTP", []interface{}{arg1, arg2})
 	fake.serveHTTPMutex.Unlock()
-	if fake.ServeHTTPStub != nil {
+	if stub != nil {
 		fake.ServeHTTPStub(arg1, arg2)
 	}
 }

--- a/atc/api/accessor/accessorfakes/fake_notifications.go
+++ b/atc/api/accessor/accessorfakes/fake_notifications.go
@@ -43,15 +43,16 @@ func (fake *FakeNotifications) Listen(arg1 string) (chan bool, error) {
 	fake.listenArgsForCall = append(fake.listenArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListenStub
+	fakeReturns := fake.listenReturns
 	fake.recordInvocation("Listen", []interface{}{arg1})
 	fake.listenMutex.Unlock()
-	if fake.ListenStub != nil {
-		return fake.ListenStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listenReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -107,15 +108,16 @@ func (fake *FakeNotifications) Unlisten(arg1 string, arg2 chan bool) error {
 		arg1 string
 		arg2 chan bool
 	}{arg1, arg2})
+	stub := fake.UnlistenStub
+	fakeReturns := fake.unlistenReturns
 	fake.recordInvocation("Unlisten", []interface{}{arg1, arg2})
 	fake.unlistenMutex.Unlock()
-	if fake.UnlistenStub != nil {
-		return fake.UnlistenStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unlistenReturns
 	return fakeReturns.result1
 }
 

--- a/atc/api/accessor/accessorfakes/fake_team_fetcher.go
+++ b/atc/api/accessor/accessorfakes/fake_team_fetcher.go
@@ -30,15 +30,16 @@ func (fake *FakeTeamFetcher) GetTeams() ([]db.Team, error) {
 	ret, specificReturn := fake.getTeamsReturnsOnCall[len(fake.getTeamsArgsForCall)]
 	fake.getTeamsArgsForCall = append(fake.getTeamsArgsForCall, struct {
 	}{})
+	stub := fake.GetTeamsStub
+	fakeReturns := fake.getTeamsReturns
 	fake.recordInvocation("GetTeams", []interface{}{})
 	fake.getTeamsMutex.Unlock()
-	if fake.GetTeamsStub != nil {
-		return fake.GetTeamsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getTeamsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/api/accessor/accessorfakes/fake_token_verifier.go
+++ b/atc/api/accessor/accessorfakes/fake_token_verifier.go
@@ -32,15 +32,16 @@ func (fake *FakeTokenVerifier) Verify(arg1 *http.Request) (map[string]interface{
 	fake.verifyArgsForCall = append(fake.verifyArgsForCall, struct {
 		arg1 *http.Request
 	}{arg1})
+	stub := fake.VerifyStub
+	fakeReturns := fake.verifyReturns
 	fake.recordInvocation("Verify", []interface{}{arg1})
 	fake.verifyMutex.Unlock()
-	if fake.VerifyStub != nil {
-		return fake.VerifyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.verifyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/api/auth/authfakes/fake_handler.go
+++ b/atc/api/auth/authfakes/fake_handler.go
@@ -23,9 +23,10 @@ func (fake *FakeHandler) ServeHTTP(arg1 http.ResponseWriter, arg2 *http.Request)
 		arg1 http.ResponseWriter
 		arg2 *http.Request
 	}{arg1, arg2})
+	stub := fake.ServeHTTPStub
 	fake.recordInvocation("ServeHTTP", []interface{}{arg1, arg2})
 	fake.serveHTTPMutex.Unlock()
-	if fake.ServeHTTPStub != nil {
+	if stub != nil {
 		fake.ServeHTTPStub(arg1, arg2)
 	}
 }

--- a/atc/api/auth/authfakes/fake_rejector.go
+++ b/atc/api/auth/authfakes/fake_rejector.go
@@ -31,9 +31,10 @@ func (fake *FakeRejector) Forbidden(arg1 http.ResponseWriter, arg2 *http.Request
 		arg1 http.ResponseWriter
 		arg2 *http.Request
 	}{arg1, arg2})
+	stub := fake.ForbiddenStub
 	fake.recordInvocation("Forbidden", []interface{}{arg1, arg2})
 	fake.forbiddenMutex.Unlock()
-	if fake.ForbiddenStub != nil {
+	if stub != nil {
 		fake.ForbiddenStub(arg1, arg2)
 	}
 }
@@ -63,9 +64,10 @@ func (fake *FakeRejector) Unauthorized(arg1 http.ResponseWriter, arg2 *http.Requ
 		arg1 http.ResponseWriter
 		arg2 *http.Request
 	}{arg1, arg2})
+	stub := fake.UnauthorizedStub
 	fake.recordInvocation("Unauthorized", []interface{}{arg1, arg2})
 	fake.unauthorizedMutex.Unlock()
-	if fake.UnauthorizedStub != nil {
+	if stub != nil {
 		fake.UnauthorizedStub(arg1, arg2)
 	}
 }

--- a/atc/api/containerserver/containerserverfakes/fake_intercept_timeout.go
+++ b/atc/api/containerserver/containerserverfakes/fake_intercept_timeout.go
@@ -42,15 +42,16 @@ func (fake *FakeInterceptTimeout) Channel() <-chan time.Time {
 	ret, specificReturn := fake.channelReturnsOnCall[len(fake.channelArgsForCall)]
 	fake.channelArgsForCall = append(fake.channelArgsForCall, struct {
 	}{})
+	stub := fake.ChannelStub
+	fakeReturns := fake.channelReturns
 	fake.recordInvocation("Channel", []interface{}{})
 	fake.channelMutex.Unlock()
-	if fake.ChannelStub != nil {
-		return fake.ChannelStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.channelReturns
 	return fakeReturns.result1
 }
 
@@ -94,15 +95,16 @@ func (fake *FakeInterceptTimeout) Error() error {
 	ret, specificReturn := fake.errorReturnsOnCall[len(fake.errorArgsForCall)]
 	fake.errorArgsForCall = append(fake.errorArgsForCall, struct {
 	}{})
+	stub := fake.ErrorStub
+	fakeReturns := fake.errorReturns
 	fake.recordInvocation("Error", []interface{}{})
 	fake.errorMutex.Unlock()
-	if fake.ErrorStub != nil {
-		return fake.ErrorStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.errorReturns
 	return fakeReturns.result1
 }
 
@@ -145,9 +147,10 @@ func (fake *FakeInterceptTimeout) Reset() {
 	fake.resetMutex.Lock()
 	fake.resetArgsForCall = append(fake.resetArgsForCall, struct {
 	}{})
+	stub := fake.ResetStub
 	fake.recordInvocation("Reset", []interface{}{})
 	fake.resetMutex.Unlock()
-	if fake.ResetStub != nil {
+	if stub != nil {
 		fake.ResetStub()
 	}
 }

--- a/atc/api/containerserver/containerserverfakes/fake_intercept_timeout_factory.go
+++ b/atc/api/containerserver/containerserverfakes/fake_intercept_timeout_factory.go
@@ -27,15 +27,16 @@ func (fake *FakeInterceptTimeoutFactory) NewInterceptTimeout() containerserver.I
 	ret, specificReturn := fake.newInterceptTimeoutReturnsOnCall[len(fake.newInterceptTimeoutArgsForCall)]
 	fake.newInterceptTimeoutArgsForCall = append(fake.newInterceptTimeoutArgsForCall, struct {
 	}{})
+	stub := fake.NewInterceptTimeoutStub
+	fakeReturns := fake.newInterceptTimeoutReturns
 	fake.recordInvocation("NewInterceptTimeout", []interface{}{})
 	fake.newInterceptTimeoutMutex.Unlock()
-	if fake.NewInterceptTimeoutStub != nil {
-		return fake.NewInterceptTimeoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newInterceptTimeoutReturns
 	return fakeReturns.result1
 }
 

--- a/atc/api/pipelineserver/pipelineserverfakes/fake_logger.go
+++ b/atc/api/pipelineserver/pipelineserverfakes/fake_logger.go
@@ -82,9 +82,10 @@ func (fake *FakeLogger) Debug(arg1 string, arg2 ...lager.Data) {
 		arg1 string
 		arg2 []lager.Data
 	}{arg1, arg2})
+	stub := fake.DebugStub
 	fake.recordInvocation("Debug", []interface{}{arg1, arg2})
 	fake.debugMutex.Unlock()
-	if fake.DebugStub != nil {
+	if stub != nil {
 		fake.DebugStub(arg1, arg2...)
 	}
 }
@@ -115,9 +116,10 @@ func (fake *FakeLogger) Error(arg1 string, arg2 error, arg3 ...lager.Data) {
 		arg2 error
 		arg3 []lager.Data
 	}{arg1, arg2, arg3})
+	stub := fake.ErrorStub
 	fake.recordInvocation("Error", []interface{}{arg1, arg2, arg3})
 	fake.errorMutex.Unlock()
-	if fake.ErrorStub != nil {
+	if stub != nil {
 		fake.ErrorStub(arg1, arg2, arg3...)
 	}
 }
@@ -148,9 +150,10 @@ func (fake *FakeLogger) Fatal(arg1 string, arg2 error, arg3 ...lager.Data) {
 		arg2 error
 		arg3 []lager.Data
 	}{arg1, arg2, arg3})
+	stub := fake.FatalStub
 	fake.recordInvocation("Fatal", []interface{}{arg1, arg2, arg3})
 	fake.fatalMutex.Unlock()
-	if fake.FatalStub != nil {
+	if stub != nil {
 		fake.FatalStub(arg1, arg2, arg3...)
 	}
 }
@@ -180,9 +183,10 @@ func (fake *FakeLogger) Info(arg1 string, arg2 ...lager.Data) {
 		arg1 string
 		arg2 []lager.Data
 	}{arg1, arg2})
+	stub := fake.InfoStub
 	fake.recordInvocation("Info", []interface{}{arg1, arg2})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
+	if stub != nil {
 		fake.InfoStub(arg1, arg2...)
 	}
 }
@@ -211,9 +215,10 @@ func (fake *FakeLogger) RegisterSink(arg1 lager.Sink) {
 	fake.registerSinkArgsForCall = append(fake.registerSinkArgsForCall, struct {
 		arg1 lager.Sink
 	}{arg1})
+	stub := fake.RegisterSinkStub
 	fake.recordInvocation("RegisterSink", []interface{}{arg1})
 	fake.registerSinkMutex.Unlock()
-	if fake.RegisterSinkStub != nil {
+	if stub != nil {
 		fake.RegisterSinkStub(arg1)
 	}
 }
@@ -244,15 +249,16 @@ func (fake *FakeLogger) Session(arg1 string, arg2 ...lager.Data) lager.Logger {
 		arg1 string
 		arg2 []lager.Data
 	}{arg1, arg2})
+	stub := fake.SessionStub
+	fakeReturns := fake.sessionReturns
 	fake.recordInvocation("Session", []interface{}{arg1, arg2})
 	fake.sessionMutex.Unlock()
-	if fake.SessionStub != nil {
-		return fake.SessionStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sessionReturns
 	return fakeReturns.result1
 }
 
@@ -303,15 +309,16 @@ func (fake *FakeLogger) SessionName() string {
 	ret, specificReturn := fake.sessionNameReturnsOnCall[len(fake.sessionNameArgsForCall)]
 	fake.sessionNameArgsForCall = append(fake.sessionNameArgsForCall, struct {
 	}{})
+	stub := fake.SessionNameStub
+	fakeReturns := fake.sessionNameReturns
 	fake.recordInvocation("SessionName", []interface{}{})
 	fake.sessionNameMutex.Unlock()
-	if fake.SessionNameStub != nil {
-		return fake.SessionNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sessionNameReturns
 	return fakeReturns.result1
 }
 
@@ -356,15 +363,16 @@ func (fake *FakeLogger) WithData(arg1 lager.Data) lager.Logger {
 	fake.withDataArgsForCall = append(fake.withDataArgsForCall, struct {
 		arg1 lager.Data
 	}{arg1})
+	stub := fake.WithDataStub
+	fakeReturns := fake.withDataReturns
 	fake.recordInvocation("WithData", []interface{}{arg1})
 	fake.withDataMutex.Unlock()
-	if fake.WithDataStub != nil {
-		return fake.WithDataStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.withDataReturns
 	return fakeReturns.result1
 }
 

--- a/atc/api/policychecker/policycheckerfakes/fake_policy_checker.go
+++ b/atc/api/policychecker/policycheckerfakes/fake_policy_checker.go
@@ -38,15 +38,16 @@ func (fake *FakePolicyChecker) Check(arg1 string, arg2 accessor.Access, arg3 *ht
 		arg2 accessor.Access
 		arg3 *http.Request
 	}{arg1, arg2, arg3})
+	stub := fake.CheckStub
+	fakeReturns := fake.checkReturns
 	fake.recordInvocation("Check", []interface{}{arg1, arg2, arg3})
 	fake.checkMutex.Unlock()
-	if fake.CheckStub != nil {
-		return fake.CheckStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checkReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/auditor/auditorfakes/fake_auditor.go
+++ b/atc/auditor/auditorfakes/fake_auditor.go
@@ -27,9 +27,10 @@ func (fake *FakeAuditor) Audit(arg1 string, arg2 string, arg3 *http.Request) {
 		arg2 string
 		arg3 *http.Request
 	}{arg1, arg2, arg3})
+	stub := fake.AuditStub
 	fake.recordInvocation("Audit", []interface{}{arg1, arg2, arg3})
 	fake.auditMutex.Unlock()
-	if fake.AuditStub != nil {
+	if stub != nil {
 		fake.AuditStub(arg1, arg2, arg3)
 	}
 }

--- a/atc/compression/compressionfakes/fake_compression.go
+++ b/atc/compression/compressionfakes/fake_compression.go
@@ -42,15 +42,16 @@ func (fake *FakeCompression) Encoding() baggageclaim.Encoding {
 	ret, specificReturn := fake.encodingReturnsOnCall[len(fake.encodingArgsForCall)]
 	fake.encodingArgsForCall = append(fake.encodingArgsForCall, struct {
 	}{})
+	stub := fake.EncodingStub
+	fakeReturns := fake.encodingReturns
 	fake.recordInvocation("Encoding", []interface{}{})
 	fake.encodingMutex.Unlock()
-	if fake.EncodingStub != nil {
-		return fake.EncodingStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.encodingReturns
 	return fakeReturns.result1
 }
 
@@ -95,15 +96,16 @@ func (fake *FakeCompression) NewReader(arg1 io.ReadCloser) (io.ReadCloser, error
 	fake.newReaderArgsForCall = append(fake.newReaderArgsForCall, struct {
 		arg1 io.ReadCloser
 	}{arg1})
+	stub := fake.NewReaderStub
+	fakeReturns := fake.newReaderReturns
 	fake.recordInvocation("NewReader", []interface{}{arg1})
 	fake.newReaderMutex.Unlock()
-	if fake.NewReaderStub != nil {
-		return fake.NewReaderStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newReaderReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/creds/credsfakes/fake_secrets.go
+++ b/atc/creds/credsfakes/fake_secrets.go
@@ -49,15 +49,16 @@ func (fake *FakeSecrets) Get(arg1 string) (interface{}, *time.Time, bool, error)
 	fake.getArgsForCall = append(fake.getArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetStub
+	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1})
 	fake.getMutex.Unlock()
-	if fake.GetStub != nil {
-		return fake.GetStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.getReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -120,15 +121,16 @@ func (fake *FakeSecrets) NewSecretLookupPaths(arg1 string, arg2 string, arg3 boo
 		arg2 string
 		arg3 bool
 	}{arg1, arg2, arg3})
+	stub := fake.NewSecretLookupPathsStub
+	fakeReturns := fake.newSecretLookupPathsReturns
 	fake.recordInvocation("NewSecretLookupPaths", []interface{}{arg1, arg2, arg3})
 	fake.newSecretLookupPathsMutex.Unlock()
-	if fake.NewSecretLookupPathsStub != nil {
-		return fake.NewSecretLookupPathsStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newSecretLookupPathsReturns
 	return fakeReturns.result1
 }
 

--- a/atc/creds/credsfakes/fake_secrets_factory.go
+++ b/atc/creds/credsfakes/fake_secrets_factory.go
@@ -27,15 +27,16 @@ func (fake *FakeSecretsFactory) NewSecrets() creds.Secrets {
 	ret, specificReturn := fake.newSecretsReturnsOnCall[len(fake.newSecretsArgsForCall)]
 	fake.newSecretsArgsForCall = append(fake.newSecretsArgsForCall, struct {
 	}{})
+	stub := fake.NewSecretsStub
+	fakeReturns := fake.newSecretsReturns
 	fake.recordInvocation("NewSecrets", []interface{}{})
 	fake.newSecretsMutex.Unlock()
-	if fake.NewSecretsStub != nil {
-		return fake.NewSecretsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newSecretsReturns
 	return fakeReturns.result1
 }
 

--- a/atc/creds/credsfakes/fake_var_source_pool.go
+++ b/atc/creds/credsfakes/fake_var_source_pool.go
@@ -46,9 +46,10 @@ func (fake *FakeVarSourcePool) Close() {
 	fake.closeMutex.Lock()
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
+	if stub != nil {
 		fake.CloseStub()
 	}
 }
@@ -73,15 +74,16 @@ func (fake *FakeVarSourcePool) FindOrCreate(arg1 lager.Logger, arg2 map[string]i
 		arg2 map[string]interface{}
 		arg3 creds.ManagerFactory
 	}{arg1, arg2, arg3})
+	stub := fake.FindOrCreateStub
+	fakeReturns := fake.findOrCreateReturns
 	fake.recordInvocation("FindOrCreate", []interface{}{arg1, arg2, arg3})
 	fake.findOrCreateMutex.Unlock()
-	if fake.FindOrCreateStub != nil {
-		return fake.FindOrCreateStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -135,15 +137,16 @@ func (fake *FakeVarSourcePool) Size() int {
 	ret, specificReturn := fake.sizeReturnsOnCall[len(fake.sizeArgsForCall)]
 	fake.sizeArgsForCall = append(fake.sizeArgsForCall, struct {
 	}{})
+	stub := fake.SizeStub
+	fakeReturns := fake.sizeReturns
 	fake.recordInvocation("Size", []interface{}{})
 	fake.sizeMutex.Unlock()
-	if fake.SizeStub != nil {
-		return fake.SizeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sizeReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_access_token_factory.go
+++ b/atc/db/dbfakes/fake_access_token_factory.go
@@ -46,15 +46,16 @@ func (fake *FakeAccessTokenFactory) CreateAccessToken(arg1 string, arg2 db.Claim
 		arg1 string
 		arg2 db.Claims
 	}{arg1, arg2})
+	stub := fake.CreateAccessTokenStub
+	fakeReturns := fake.createAccessTokenReturns
 	fake.recordInvocation("CreateAccessToken", []interface{}{arg1, arg2})
 	fake.createAccessTokenMutex.Unlock()
-	if fake.CreateAccessTokenStub != nil {
-		return fake.CreateAccessTokenStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createAccessTokenReturns
 	return fakeReturns.result1
 }
 
@@ -106,15 +107,16 @@ func (fake *FakeAccessTokenFactory) GetAccessToken(arg1 string) (db.AccessToken,
 	fake.getAccessTokenArgsForCall = append(fake.getAccessTokenArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetAccessTokenStub
+	fakeReturns := fake.getAccessTokenReturns
 	fake.recordInvocation("GetAccessToken", []interface{}{arg1})
 	fake.getAccessTokenMutex.Unlock()
-	if fake.GetAccessTokenStub != nil {
-		return fake.GetAccessTokenStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getAccessTokenReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/db/dbfakes/fake_access_token_lifecycle.go
+++ b/atc/db/dbfakes/fake_access_token_lifecycle.go
@@ -32,15 +32,16 @@ func (fake *FakeAccessTokenLifecycle) RemoveExpiredAccessTokens(arg1 time.Durati
 	fake.removeExpiredAccessTokensArgsForCall = append(fake.removeExpiredAccessTokensArgsForCall, struct {
 		arg1 time.Duration
 	}{arg1})
+	stub := fake.RemoveExpiredAccessTokensStub
+	fakeReturns := fake.removeExpiredAccessTokensReturns
 	fake.recordInvocation("RemoveExpiredAccessTokens", []interface{}{arg1})
 	fake.removeExpiredAccessTokensMutex.Unlock()
-	if fake.RemoveExpiredAccessTokensStub != nil {
-		return fake.RemoveExpiredAccessTokensStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.removeExpiredAccessTokensReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_build.go
+++ b/atc/db/dbfakes/fake_build.go
@@ -722,15 +722,16 @@ func (fake *FakeBuild) AbortNotifier() (db.Notifier, error) {
 	ret, specificReturn := fake.abortNotifierReturnsOnCall[len(fake.abortNotifierArgsForCall)]
 	fake.abortNotifierArgsForCall = append(fake.abortNotifierArgsForCall, struct {
 	}{})
+	stub := fake.AbortNotifierStub
+	fakeReturns := fake.abortNotifierReturns
 	fake.recordInvocation("AbortNotifier", []interface{}{})
 	fake.abortNotifierMutex.Unlock()
-	if fake.AbortNotifierStub != nil {
-		return fake.AbortNotifierStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.abortNotifierReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -779,15 +780,16 @@ func (fake *FakeBuild) AcquireTrackingLock(arg1 lager.Logger, arg2 time.Duration
 		arg1 lager.Logger
 		arg2 time.Duration
 	}{arg1, arg2})
+	stub := fake.AcquireTrackingLockStub
+	fakeReturns := fake.acquireTrackingLockReturns
 	fake.recordInvocation("AcquireTrackingLock", []interface{}{arg1, arg2})
 	fake.acquireTrackingLockMutex.Unlock()
-	if fake.AcquireTrackingLockStub != nil {
-		return fake.AcquireTrackingLockStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.acquireTrackingLockReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -844,15 +846,16 @@ func (fake *FakeBuild) AdoptInputsAndPipes() ([]db.BuildInput, bool, error) {
 	ret, specificReturn := fake.adoptInputsAndPipesReturnsOnCall[len(fake.adoptInputsAndPipesArgsForCall)]
 	fake.adoptInputsAndPipesArgsForCall = append(fake.adoptInputsAndPipesArgsForCall, struct {
 	}{})
+	stub := fake.AdoptInputsAndPipesStub
+	fakeReturns := fake.adoptInputsAndPipesReturns
 	fake.recordInvocation("AdoptInputsAndPipes", []interface{}{})
 	fake.adoptInputsAndPipesMutex.Unlock()
-	if fake.AdoptInputsAndPipesStub != nil {
-		return fake.AdoptInputsAndPipesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.adoptInputsAndPipesReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -902,15 +905,16 @@ func (fake *FakeBuild) AdoptRerunInputsAndPipes() ([]db.BuildInput, bool, error)
 	ret, specificReturn := fake.adoptRerunInputsAndPipesReturnsOnCall[len(fake.adoptRerunInputsAndPipesArgsForCall)]
 	fake.adoptRerunInputsAndPipesArgsForCall = append(fake.adoptRerunInputsAndPipesArgsForCall, struct {
 	}{})
+	stub := fake.AdoptRerunInputsAndPipesStub
+	fakeReturns := fake.adoptRerunInputsAndPipesReturns
 	fake.recordInvocation("AdoptRerunInputsAndPipes", []interface{}{})
 	fake.adoptRerunInputsAndPipesMutex.Unlock()
-	if fake.AdoptRerunInputsAndPipesStub != nil {
-		return fake.AdoptRerunInputsAndPipesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.adoptRerunInputsAndPipesReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -961,15 +965,16 @@ func (fake *FakeBuild) Artifact(arg1 int) (db.WorkerArtifact, error) {
 	fake.artifactArgsForCall = append(fake.artifactArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.ArtifactStub
+	fakeReturns := fake.artifactReturns
 	fake.recordInvocation("Artifact", []interface{}{arg1})
 	fake.artifactMutex.Unlock()
-	if fake.ArtifactStub != nil {
-		return fake.ArtifactStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.artifactReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1023,15 +1028,16 @@ func (fake *FakeBuild) Artifacts() ([]db.WorkerArtifact, error) {
 	ret, specificReturn := fake.artifactsReturnsOnCall[len(fake.artifactsArgsForCall)]
 	fake.artifactsArgsForCall = append(fake.artifactsArgsForCall, struct {
 	}{})
+	stub := fake.ArtifactsStub
+	fakeReturns := fake.artifactsReturns
 	fake.recordInvocation("Artifacts", []interface{}{})
 	fake.artifactsMutex.Unlock()
-	if fake.ArtifactsStub != nil {
-		return fake.ArtifactsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.artifactsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1078,15 +1084,16 @@ func (fake *FakeBuild) CreatedBy() *string {
 	ret, specificReturn := fake.createdByReturnsOnCall[len(fake.createdByArgsForCall)]
 	fake.createdByArgsForCall = append(fake.createdByArgsForCall, struct {
 	}{})
+	stub := fake.CreatedByStub
+	fakeReturns := fake.createdByReturns
 	fake.recordInvocation("CreatedBy", []interface{}{})
 	fake.createdByMutex.Unlock()
-	if fake.CreatedByStub != nil {
-		return fake.CreatedByStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createdByReturns
 	return fakeReturns.result1
 }
 
@@ -1130,15 +1137,16 @@ func (fake *FakeBuild) Delete() (bool, error) {
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 	}{})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1185,15 +1193,16 @@ func (fake *FakeBuild) EndTime() time.Time {
 	ret, specificReturn := fake.endTimeReturnsOnCall[len(fake.endTimeArgsForCall)]
 	fake.endTimeArgsForCall = append(fake.endTimeArgsForCall, struct {
 	}{})
+	stub := fake.EndTimeStub
+	fakeReturns := fake.endTimeReturns
 	fake.recordInvocation("EndTime", []interface{}{})
 	fake.endTimeMutex.Unlock()
-	if fake.EndTimeStub != nil {
-		return fake.EndTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.endTimeReturns
 	return fakeReturns.result1
 }
 
@@ -1238,15 +1247,16 @@ func (fake *FakeBuild) Events(arg1 uint) (db.EventSource, error) {
 	fake.eventsArgsForCall = append(fake.eventsArgsForCall, struct {
 		arg1 uint
 	}{arg1})
+	stub := fake.EventsStub
+	fakeReturns := fake.eventsReturns
 	fake.recordInvocation("Events", []interface{}{arg1})
 	fake.eventsMutex.Unlock()
-	if fake.EventsStub != nil {
-		return fake.EventsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.eventsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1301,15 +1311,16 @@ func (fake *FakeBuild) Finish(arg1 db.BuildStatus) error {
 	fake.finishArgsForCall = append(fake.finishArgsForCall, struct {
 		arg1 db.BuildStatus
 	}{arg1})
+	stub := fake.FinishStub
+	fakeReturns := fake.finishReturns
 	fake.recordInvocation("Finish", []interface{}{arg1})
 	fake.finishMutex.Unlock()
-	if fake.FinishStub != nil {
-		return fake.FinishStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.finishReturns
 	return fakeReturns.result1
 }
 
@@ -1360,15 +1371,16 @@ func (fake *FakeBuild) HasPlan() bool {
 	ret, specificReturn := fake.hasPlanReturnsOnCall[len(fake.hasPlanArgsForCall)]
 	fake.hasPlanArgsForCall = append(fake.hasPlanArgsForCall, struct {
 	}{})
+	stub := fake.HasPlanStub
+	fakeReturns := fake.hasPlanReturns
 	fake.recordInvocation("HasPlan", []interface{}{})
 	fake.hasPlanMutex.Unlock()
-	if fake.HasPlanStub != nil {
-		return fake.HasPlanStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasPlanReturns
 	return fakeReturns.result1
 }
 
@@ -1412,15 +1424,16 @@ func (fake *FakeBuild) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -1464,15 +1477,16 @@ func (fake *FakeBuild) InputsReady() bool {
 	ret, specificReturn := fake.inputsReadyReturnsOnCall[len(fake.inputsReadyArgsForCall)]
 	fake.inputsReadyArgsForCall = append(fake.inputsReadyArgsForCall, struct {
 	}{})
+	stub := fake.InputsReadyStub
+	fakeReturns := fake.inputsReadyReturns
 	fake.recordInvocation("InputsReady", []interface{}{})
 	fake.inputsReadyMutex.Unlock()
-	if fake.InputsReadyStub != nil {
-		return fake.InputsReadyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.inputsReadyReturns
 	return fakeReturns.result1
 }
 
@@ -1516,15 +1530,16 @@ func (fake *FakeBuild) Interceptible() (bool, error) {
 	ret, specificReturn := fake.interceptibleReturnsOnCall[len(fake.interceptibleArgsForCall)]
 	fake.interceptibleArgsForCall = append(fake.interceptibleArgsForCall, struct {
 	}{})
+	stub := fake.InterceptibleStub
+	fakeReturns := fake.interceptibleReturns
 	fake.recordInvocation("Interceptible", []interface{}{})
 	fake.interceptibleMutex.Unlock()
-	if fake.InterceptibleStub != nil {
-		return fake.InterceptibleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.interceptibleReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1571,15 +1586,16 @@ func (fake *FakeBuild) IsAborted() bool {
 	ret, specificReturn := fake.isAbortedReturnsOnCall[len(fake.isAbortedArgsForCall)]
 	fake.isAbortedArgsForCall = append(fake.isAbortedArgsForCall, struct {
 	}{})
+	stub := fake.IsAbortedStub
+	fakeReturns := fake.isAbortedReturns
 	fake.recordInvocation("IsAborted", []interface{}{})
 	fake.isAbortedMutex.Unlock()
-	if fake.IsAbortedStub != nil {
-		return fake.IsAbortedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isAbortedReturns
 	return fakeReturns.result1
 }
 
@@ -1623,15 +1639,16 @@ func (fake *FakeBuild) IsCompleted() bool {
 	ret, specificReturn := fake.isCompletedReturnsOnCall[len(fake.isCompletedArgsForCall)]
 	fake.isCompletedArgsForCall = append(fake.isCompletedArgsForCall, struct {
 	}{})
+	stub := fake.IsCompletedStub
+	fakeReturns := fake.isCompletedReturns
 	fake.recordInvocation("IsCompleted", []interface{}{})
 	fake.isCompletedMutex.Unlock()
-	if fake.IsCompletedStub != nil {
-		return fake.IsCompletedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isCompletedReturns
 	return fakeReturns.result1
 }
 
@@ -1675,15 +1692,16 @@ func (fake *FakeBuild) IsDrained() bool {
 	ret, specificReturn := fake.isDrainedReturnsOnCall[len(fake.isDrainedArgsForCall)]
 	fake.isDrainedArgsForCall = append(fake.isDrainedArgsForCall, struct {
 	}{})
+	stub := fake.IsDrainedStub
+	fakeReturns := fake.isDrainedReturns
 	fake.recordInvocation("IsDrained", []interface{}{})
 	fake.isDrainedMutex.Unlock()
-	if fake.IsDrainedStub != nil {
-		return fake.IsDrainedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isDrainedReturns
 	return fakeReturns.result1
 }
 
@@ -1727,15 +1745,16 @@ func (fake *FakeBuild) IsManuallyTriggered() bool {
 	ret, specificReturn := fake.isManuallyTriggeredReturnsOnCall[len(fake.isManuallyTriggeredArgsForCall)]
 	fake.isManuallyTriggeredArgsForCall = append(fake.isManuallyTriggeredArgsForCall, struct {
 	}{})
+	stub := fake.IsManuallyTriggeredStub
+	fakeReturns := fake.isManuallyTriggeredReturns
 	fake.recordInvocation("IsManuallyTriggered", []interface{}{})
 	fake.isManuallyTriggeredMutex.Unlock()
-	if fake.IsManuallyTriggeredStub != nil {
-		return fake.IsManuallyTriggeredStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isManuallyTriggeredReturns
 	return fakeReturns.result1
 }
 
@@ -1780,15 +1799,16 @@ func (fake *FakeBuild) IsNewerThanLastCheckOf(arg1 db.Resource) bool {
 	fake.isNewerThanLastCheckOfArgsForCall = append(fake.isNewerThanLastCheckOfArgsForCall, struct {
 		arg1 db.Resource
 	}{arg1})
+	stub := fake.IsNewerThanLastCheckOfStub
+	fakeReturns := fake.isNewerThanLastCheckOfReturns
 	fake.recordInvocation("IsNewerThanLastCheckOf", []interface{}{arg1})
 	fake.isNewerThanLastCheckOfMutex.Unlock()
-	if fake.IsNewerThanLastCheckOfStub != nil {
-		return fake.IsNewerThanLastCheckOfStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isNewerThanLastCheckOfReturns
 	return fakeReturns.result1
 }
 
@@ -1839,15 +1859,16 @@ func (fake *FakeBuild) IsRunning() bool {
 	ret, specificReturn := fake.isRunningReturnsOnCall[len(fake.isRunningArgsForCall)]
 	fake.isRunningArgsForCall = append(fake.isRunningArgsForCall, struct {
 	}{})
+	stub := fake.IsRunningStub
+	fakeReturns := fake.isRunningReturns
 	fake.recordInvocation("IsRunning", []interface{}{})
 	fake.isRunningMutex.Unlock()
-	if fake.IsRunningStub != nil {
-		return fake.IsRunningStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isRunningReturns
 	return fakeReturns.result1
 }
 
@@ -1891,15 +1912,16 @@ func (fake *FakeBuild) IsScheduled() bool {
 	ret, specificReturn := fake.isScheduledReturnsOnCall[len(fake.isScheduledArgsForCall)]
 	fake.isScheduledArgsForCall = append(fake.isScheduledArgsForCall, struct {
 	}{})
+	stub := fake.IsScheduledStub
+	fakeReturns := fake.isScheduledReturns
 	fake.recordInvocation("IsScheduled", []interface{}{})
 	fake.isScheduledMutex.Unlock()
-	if fake.IsScheduledStub != nil {
-		return fake.IsScheduledStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isScheduledReturns
 	return fakeReturns.result1
 }
 
@@ -1943,15 +1965,16 @@ func (fake *FakeBuild) JobID() int {
 	ret, specificReturn := fake.jobIDReturnsOnCall[len(fake.jobIDArgsForCall)]
 	fake.jobIDArgsForCall = append(fake.jobIDArgsForCall, struct {
 	}{})
+	stub := fake.JobIDStub
+	fakeReturns := fake.jobIDReturns
 	fake.recordInvocation("JobID", []interface{}{})
 	fake.jobIDMutex.Unlock()
-	if fake.JobIDStub != nil {
-		return fake.JobIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.jobIDReturns
 	return fakeReturns.result1
 }
 
@@ -1995,15 +2018,16 @@ func (fake *FakeBuild) JobName() string {
 	ret, specificReturn := fake.jobNameReturnsOnCall[len(fake.jobNameArgsForCall)]
 	fake.jobNameArgsForCall = append(fake.jobNameArgsForCall, struct {
 	}{})
+	stub := fake.JobNameStub
+	fakeReturns := fake.jobNameReturns
 	fake.recordInvocation("JobName", []interface{}{})
 	fake.jobNameMutex.Unlock()
-	if fake.JobNameStub != nil {
-		return fake.JobNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.jobNameReturns
 	return fakeReturns.result1
 }
 
@@ -2047,15 +2071,16 @@ func (fake *FakeBuild) LagerData() lager.Data {
 	ret, specificReturn := fake.lagerDataReturnsOnCall[len(fake.lagerDataArgsForCall)]
 	fake.lagerDataArgsForCall = append(fake.lagerDataArgsForCall, struct {
 	}{})
+	stub := fake.LagerDataStub
+	fakeReturns := fake.lagerDataReturns
 	fake.recordInvocation("LagerData", []interface{}{})
 	fake.lagerDataMutex.Unlock()
-	if fake.LagerDataStub != nil {
-		return fake.LagerDataStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lagerDataReturns
 	return fakeReturns.result1
 }
 
@@ -2099,15 +2124,16 @@ func (fake *FakeBuild) MarkAsAborted() error {
 	ret, specificReturn := fake.markAsAbortedReturnsOnCall[len(fake.markAsAbortedArgsForCall)]
 	fake.markAsAbortedArgsForCall = append(fake.markAsAbortedArgsForCall, struct {
 	}{})
+	stub := fake.MarkAsAbortedStub
+	fakeReturns := fake.markAsAbortedReturns
 	fake.recordInvocation("MarkAsAborted", []interface{}{})
 	fake.markAsAbortedMutex.Unlock()
-	if fake.MarkAsAbortedStub != nil {
-		return fake.MarkAsAbortedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.markAsAbortedReturns
 	return fakeReturns.result1
 }
 
@@ -2151,15 +2177,16 @@ func (fake *FakeBuild) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -2203,15 +2230,16 @@ func (fake *FakeBuild) Pipeline() (db.Pipeline, bool, error) {
 	ret, specificReturn := fake.pipelineReturnsOnCall[len(fake.pipelineArgsForCall)]
 	fake.pipelineArgsForCall = append(fake.pipelineArgsForCall, struct {
 	}{})
+	stub := fake.PipelineStub
+	fakeReturns := fake.pipelineReturns
 	fake.recordInvocation("Pipeline", []interface{}{})
 	fake.pipelineMutex.Unlock()
-	if fake.PipelineStub != nil {
-		return fake.PipelineStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.pipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2261,15 +2289,16 @@ func (fake *FakeBuild) PipelineID() int {
 	ret, specificReturn := fake.pipelineIDReturnsOnCall[len(fake.pipelineIDArgsForCall)]
 	fake.pipelineIDArgsForCall = append(fake.pipelineIDArgsForCall, struct {
 	}{})
+	stub := fake.PipelineIDStub
+	fakeReturns := fake.pipelineIDReturns
 	fake.recordInvocation("PipelineID", []interface{}{})
 	fake.pipelineIDMutex.Unlock()
-	if fake.PipelineIDStub != nil {
-		return fake.PipelineIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineIDReturns
 	return fakeReturns.result1
 }
 
@@ -2313,15 +2342,16 @@ func (fake *FakeBuild) PipelineInstanceVars() atc.InstanceVars {
 	ret, specificReturn := fake.pipelineInstanceVarsReturnsOnCall[len(fake.pipelineInstanceVarsArgsForCall)]
 	fake.pipelineInstanceVarsArgsForCall = append(fake.pipelineInstanceVarsArgsForCall, struct {
 	}{})
+	stub := fake.PipelineInstanceVarsStub
+	fakeReturns := fake.pipelineInstanceVarsReturns
 	fake.recordInvocation("PipelineInstanceVars", []interface{}{})
 	fake.pipelineInstanceVarsMutex.Unlock()
-	if fake.PipelineInstanceVarsStub != nil {
-		return fake.PipelineInstanceVarsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineInstanceVarsReturns
 	return fakeReturns.result1
 }
 
@@ -2365,15 +2395,16 @@ func (fake *FakeBuild) PipelineName() string {
 	ret, specificReturn := fake.pipelineNameReturnsOnCall[len(fake.pipelineNameArgsForCall)]
 	fake.pipelineNameArgsForCall = append(fake.pipelineNameArgsForCall, struct {
 	}{})
+	stub := fake.PipelineNameStub
+	fakeReturns := fake.pipelineNameReturns
 	fake.recordInvocation("PipelineName", []interface{}{})
 	fake.pipelineNameMutex.Unlock()
-	if fake.PipelineNameStub != nil {
-		return fake.PipelineNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineNameReturns
 	return fakeReturns.result1
 }
 
@@ -2417,15 +2448,16 @@ func (fake *FakeBuild) PipelineRef() atc.PipelineRef {
 	ret, specificReturn := fake.pipelineRefReturnsOnCall[len(fake.pipelineRefArgsForCall)]
 	fake.pipelineRefArgsForCall = append(fake.pipelineRefArgsForCall, struct {
 	}{})
+	stub := fake.PipelineRefStub
+	fakeReturns := fake.pipelineRefReturns
 	fake.recordInvocation("PipelineRef", []interface{}{})
 	fake.pipelineRefMutex.Unlock()
-	if fake.PipelineRefStub != nil {
-		return fake.PipelineRefStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineRefReturns
 	return fakeReturns.result1
 }
 
@@ -2469,15 +2501,16 @@ func (fake *FakeBuild) Preparation() (db.BuildPreparation, bool, error) {
 	ret, specificReturn := fake.preparationReturnsOnCall[len(fake.preparationArgsForCall)]
 	fake.preparationArgsForCall = append(fake.preparationArgsForCall, struct {
 	}{})
+	stub := fake.PreparationStub
+	fakeReturns := fake.preparationReturns
 	fake.recordInvocation("Preparation", []interface{}{})
 	fake.preparationMutex.Unlock()
-	if fake.PreparationStub != nil {
-		return fake.PreparationStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.preparationReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2527,15 +2560,16 @@ func (fake *FakeBuild) PrivatePlan() atc.Plan {
 	ret, specificReturn := fake.privatePlanReturnsOnCall[len(fake.privatePlanArgsForCall)]
 	fake.privatePlanArgsForCall = append(fake.privatePlanArgsForCall, struct {
 	}{})
+	stub := fake.PrivatePlanStub
+	fakeReturns := fake.privatePlanReturns
 	fake.recordInvocation("PrivatePlan", []interface{}{})
 	fake.privatePlanMutex.Unlock()
-	if fake.PrivatePlanStub != nil {
-		return fake.PrivatePlanStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.privatePlanReturns
 	return fakeReturns.result1
 }
 
@@ -2579,15 +2613,16 @@ func (fake *FakeBuild) PublicPlan() *json.RawMessage {
 	ret, specificReturn := fake.publicPlanReturnsOnCall[len(fake.publicPlanArgsForCall)]
 	fake.publicPlanArgsForCall = append(fake.publicPlanArgsForCall, struct {
 	}{})
+	stub := fake.PublicPlanStub
+	fakeReturns := fake.publicPlanReturns
 	fake.recordInvocation("PublicPlan", []interface{}{})
 	fake.publicPlanMutex.Unlock()
-	if fake.PublicPlanStub != nil {
-		return fake.PublicPlanStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.publicPlanReturns
 	return fakeReturns.result1
 }
 
@@ -2631,15 +2666,16 @@ func (fake *FakeBuild) ReapTime() time.Time {
 	ret, specificReturn := fake.reapTimeReturnsOnCall[len(fake.reapTimeArgsForCall)]
 	fake.reapTimeArgsForCall = append(fake.reapTimeArgsForCall, struct {
 	}{})
+	stub := fake.ReapTimeStub
+	fakeReturns := fake.reapTimeReturns
 	fake.recordInvocation("ReapTime", []interface{}{})
 	fake.reapTimeMutex.Unlock()
-	if fake.ReapTimeStub != nil {
-		return fake.ReapTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.reapTimeReturns
 	return fakeReturns.result1
 }
 
@@ -2683,15 +2719,16 @@ func (fake *FakeBuild) Reload() (bool, error) {
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
 	fake.reloadArgsForCall = append(fake.reloadArgsForCall, struct {
 	}{})
+	stub := fake.ReloadStub
+	fakeReturns := fake.reloadReturns
 	fake.recordInvocation("Reload", []interface{}{})
 	fake.reloadMutex.Unlock()
-	if fake.ReloadStub != nil {
-		return fake.ReloadStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.reloadReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2738,15 +2775,16 @@ func (fake *FakeBuild) RerunNumber() int {
 	ret, specificReturn := fake.rerunNumberReturnsOnCall[len(fake.rerunNumberArgsForCall)]
 	fake.rerunNumberArgsForCall = append(fake.rerunNumberArgsForCall, struct {
 	}{})
+	stub := fake.RerunNumberStub
+	fakeReturns := fake.rerunNumberReturns
 	fake.recordInvocation("RerunNumber", []interface{}{})
 	fake.rerunNumberMutex.Unlock()
-	if fake.RerunNumberStub != nil {
-		return fake.RerunNumberStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.rerunNumberReturns
 	return fakeReturns.result1
 }
 
@@ -2790,15 +2828,16 @@ func (fake *FakeBuild) RerunOf() int {
 	ret, specificReturn := fake.rerunOfReturnsOnCall[len(fake.rerunOfArgsForCall)]
 	fake.rerunOfArgsForCall = append(fake.rerunOfArgsForCall, struct {
 	}{})
+	stub := fake.RerunOfStub
+	fakeReturns := fake.rerunOfReturns
 	fake.recordInvocation("RerunOf", []interface{}{})
 	fake.rerunOfMutex.Unlock()
-	if fake.RerunOfStub != nil {
-		return fake.RerunOfStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.rerunOfReturns
 	return fakeReturns.result1
 }
 
@@ -2842,15 +2881,16 @@ func (fake *FakeBuild) RerunOfName() string {
 	ret, specificReturn := fake.rerunOfNameReturnsOnCall[len(fake.rerunOfNameArgsForCall)]
 	fake.rerunOfNameArgsForCall = append(fake.rerunOfNameArgsForCall, struct {
 	}{})
+	stub := fake.RerunOfNameStub
+	fakeReturns := fake.rerunOfNameReturns
 	fake.recordInvocation("RerunOfName", []interface{}{})
 	fake.rerunOfNameMutex.Unlock()
-	if fake.RerunOfNameStub != nil {
-		return fake.RerunOfNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.rerunOfNameReturns
 	return fakeReturns.result1
 }
 
@@ -2894,15 +2934,16 @@ func (fake *FakeBuild) ResourceID() int {
 	ret, specificReturn := fake.resourceIDReturnsOnCall[len(fake.resourceIDArgsForCall)]
 	fake.resourceIDArgsForCall = append(fake.resourceIDArgsForCall, struct {
 	}{})
+	stub := fake.ResourceIDStub
+	fakeReturns := fake.resourceIDReturns
 	fake.recordInvocation("ResourceID", []interface{}{})
 	fake.resourceIDMutex.Unlock()
-	if fake.ResourceIDStub != nil {
-		return fake.ResourceIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceIDReturns
 	return fakeReturns.result1
 }
 
@@ -2946,15 +2987,16 @@ func (fake *FakeBuild) ResourceName() string {
 	ret, specificReturn := fake.resourceNameReturnsOnCall[len(fake.resourceNameArgsForCall)]
 	fake.resourceNameArgsForCall = append(fake.resourceNameArgsForCall, struct {
 	}{})
+	stub := fake.ResourceNameStub
+	fakeReturns := fake.resourceNameReturns
 	fake.recordInvocation("ResourceName", []interface{}{})
 	fake.resourceNameMutex.Unlock()
-	if fake.ResourceNameStub != nil {
-		return fake.ResourceNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceNameReturns
 	return fakeReturns.result1
 }
 
@@ -2998,15 +3040,16 @@ func (fake *FakeBuild) ResourceTypeID() int {
 	ret, specificReturn := fake.resourceTypeIDReturnsOnCall[len(fake.resourceTypeIDArgsForCall)]
 	fake.resourceTypeIDArgsForCall = append(fake.resourceTypeIDArgsForCall, struct {
 	}{})
+	stub := fake.ResourceTypeIDStub
+	fakeReturns := fake.resourceTypeIDReturns
 	fake.recordInvocation("ResourceTypeID", []interface{}{})
 	fake.resourceTypeIDMutex.Unlock()
-	if fake.ResourceTypeIDStub != nil {
-		return fake.ResourceTypeIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceTypeIDReturns
 	return fakeReturns.result1
 }
 
@@ -3050,15 +3093,16 @@ func (fake *FakeBuild) ResourceTypeName() string {
 	ret, specificReturn := fake.resourceTypeNameReturnsOnCall[len(fake.resourceTypeNameArgsForCall)]
 	fake.resourceTypeNameArgsForCall = append(fake.resourceTypeNameArgsForCall, struct {
 	}{})
+	stub := fake.ResourceTypeNameStub
+	fakeReturns := fake.resourceTypeNameReturns
 	fake.recordInvocation("ResourceTypeName", []interface{}{})
 	fake.resourceTypeNameMutex.Unlock()
-	if fake.ResourceTypeNameStub != nil {
-		return fake.ResourceTypeNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceTypeNameReturns
 	return fakeReturns.result1
 }
 
@@ -3102,15 +3146,16 @@ func (fake *FakeBuild) Resources() ([]db.BuildInput, []db.BuildOutput, error) {
 	ret, specificReturn := fake.resourcesReturnsOnCall[len(fake.resourcesArgsForCall)]
 	fake.resourcesArgsForCall = append(fake.resourcesArgsForCall, struct {
 	}{})
+	stub := fake.ResourcesStub
+	fakeReturns := fake.resourcesReturns
 	fake.recordInvocation("Resources", []interface{}{})
 	fake.resourcesMutex.Unlock()
-	if fake.ResourcesStub != nil {
-		return fake.ResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.resourcesReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3160,15 +3205,16 @@ func (fake *FakeBuild) ResourcesChecked() (bool, error) {
 	ret, specificReturn := fake.resourcesCheckedReturnsOnCall[len(fake.resourcesCheckedArgsForCall)]
 	fake.resourcesCheckedArgsForCall = append(fake.resourcesCheckedArgsForCall, struct {
 	}{})
+	stub := fake.ResourcesCheckedStub
+	fakeReturns := fake.resourcesCheckedReturns
 	fake.recordInvocation("ResourcesChecked", []interface{}{})
 	fake.resourcesCheckedMutex.Unlock()
-	if fake.ResourcesCheckedStub != nil {
-		return fake.ResourcesCheckedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.resourcesCheckedReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3216,15 +3262,16 @@ func (fake *FakeBuild) SaveEvent(arg1 atc.Event) error {
 	fake.saveEventArgsForCall = append(fake.saveEventArgsForCall, struct {
 		arg1 atc.Event
 	}{arg1})
+	stub := fake.SaveEventStub
+	fakeReturns := fake.saveEventReturns
 	fake.recordInvocation("SaveEvent", []interface{}{arg1})
 	fake.saveEventMutex.Unlock()
-	if fake.SaveEventStub != nil {
-		return fake.SaveEventStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveEventReturns
 	return fakeReturns.result1
 }
 
@@ -3276,15 +3323,16 @@ func (fake *FakeBuild) SaveImageResourceVersion(arg1 db.UsedResourceCache) error
 	fake.saveImageResourceVersionArgsForCall = append(fake.saveImageResourceVersionArgsForCall, struct {
 		arg1 db.UsedResourceCache
 	}{arg1})
+	stub := fake.SaveImageResourceVersionStub
+	fakeReturns := fake.saveImageResourceVersionReturns
 	fake.recordInvocation("SaveImageResourceVersion", []interface{}{arg1})
 	fake.saveImageResourceVersionMutex.Unlock()
-	if fake.SaveImageResourceVersionStub != nil {
-		return fake.SaveImageResourceVersionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveImageResourceVersionReturns
 	return fakeReturns.result1
 }
 
@@ -3342,15 +3390,16 @@ func (fake *FakeBuild) SaveOutput(arg1 string, arg2 atc.Source, arg3 atc.Version
 		arg6 string
 		arg7 string
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	stub := fake.SaveOutputStub
+	fakeReturns := fake.saveOutputReturns
 	fake.recordInvocation("SaveOutput", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	fake.saveOutputMutex.Unlock()
-	if fake.SaveOutputStub != nil {
-		return fake.SaveOutputStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveOutputReturns
 	return fakeReturns.result1
 }
 
@@ -3406,15 +3455,16 @@ func (fake *FakeBuild) SavePipeline(arg1 atc.PipelineRef, arg2 int, arg3 atc.Con
 		arg4 db.ConfigVersion
 		arg5 bool
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.SavePipelineStub
+	fakeReturns := fake.savePipelineReturns
 	fake.recordInvocation("SavePipeline", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.savePipelineMutex.Unlock()
-	if fake.SavePipelineStub != nil {
-		return fake.SavePipelineStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.savePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3471,15 +3521,16 @@ func (fake *FakeBuild) Schema() string {
 	ret, specificReturn := fake.schemaReturnsOnCall[len(fake.schemaArgsForCall)]
 	fake.schemaArgsForCall = append(fake.schemaArgsForCall, struct {
 	}{})
+	stub := fake.SchemaStub
+	fakeReturns := fake.schemaReturns
 	fake.recordInvocation("Schema", []interface{}{})
 	fake.schemaMutex.Unlock()
-	if fake.SchemaStub != nil {
-		return fake.SchemaStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.schemaReturns
 	return fakeReturns.result1
 }
 
@@ -3524,15 +3575,16 @@ func (fake *FakeBuild) SetDrained(arg1 bool) error {
 	fake.setDrainedArgsForCall = append(fake.setDrainedArgsForCall, struct {
 		arg1 bool
 	}{arg1})
+	stub := fake.SetDrainedStub
+	fakeReturns := fake.setDrainedReturns
 	fake.recordInvocation("SetDrained", []interface{}{arg1})
 	fake.setDrainedMutex.Unlock()
-	if fake.SetDrainedStub != nil {
-		return fake.SetDrainedStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setDrainedReturns
 	return fakeReturns.result1
 }
 
@@ -3584,15 +3636,16 @@ func (fake *FakeBuild) SetInterceptible(arg1 bool) error {
 	fake.setInterceptibleArgsForCall = append(fake.setInterceptibleArgsForCall, struct {
 		arg1 bool
 	}{arg1})
+	stub := fake.SetInterceptibleStub
+	fakeReturns := fake.setInterceptibleReturns
 	fake.recordInvocation("SetInterceptible", []interface{}{arg1})
 	fake.setInterceptibleMutex.Unlock()
-	if fake.SetInterceptibleStub != nil {
-		return fake.SetInterceptibleStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setInterceptibleReturns
 	return fakeReturns.result1
 }
 
@@ -3643,15 +3696,16 @@ func (fake *FakeBuild) SpanContext() propagation.HTTPSupplier {
 	ret, specificReturn := fake.spanContextReturnsOnCall[len(fake.spanContextArgsForCall)]
 	fake.spanContextArgsForCall = append(fake.spanContextArgsForCall, struct {
 	}{})
+	stub := fake.SpanContextStub
+	fakeReturns := fake.spanContextReturns
 	fake.recordInvocation("SpanContext", []interface{}{})
 	fake.spanContextMutex.Unlock()
-	if fake.SpanContextStub != nil {
-		return fake.SpanContextStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.spanContextReturns
 	return fakeReturns.result1
 }
 
@@ -3696,15 +3750,16 @@ func (fake *FakeBuild) Start(arg1 atc.Plan) (bool, error) {
 	fake.startArgsForCall = append(fake.startArgsForCall, struct {
 		arg1 atc.Plan
 	}{arg1})
+	stub := fake.StartStub
+	fakeReturns := fake.startReturns
 	fake.recordInvocation("Start", []interface{}{arg1})
 	fake.startMutex.Unlock()
-	if fake.StartStub != nil {
-		return fake.StartStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.startReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3758,15 +3813,16 @@ func (fake *FakeBuild) StartTime() time.Time {
 	ret, specificReturn := fake.startTimeReturnsOnCall[len(fake.startTimeArgsForCall)]
 	fake.startTimeArgsForCall = append(fake.startTimeArgsForCall, struct {
 	}{})
+	stub := fake.StartTimeStub
+	fakeReturns := fake.startTimeReturns
 	fake.recordInvocation("StartTime", []interface{}{})
 	fake.startTimeMutex.Unlock()
-	if fake.StartTimeStub != nil {
-		return fake.StartTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.startTimeReturns
 	return fakeReturns.result1
 }
 
@@ -3810,15 +3866,16 @@ func (fake *FakeBuild) Status() db.BuildStatus {
 	ret, specificReturn := fake.statusReturnsOnCall[len(fake.statusArgsForCall)]
 	fake.statusArgsForCall = append(fake.statusArgsForCall, struct {
 	}{})
+	stub := fake.StatusStub
+	fakeReturns := fake.statusReturns
 	fake.recordInvocation("Status", []interface{}{})
 	fake.statusMutex.Unlock()
-	if fake.StatusStub != nil {
-		return fake.StatusStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.statusReturns
 	return fakeReturns.result1
 }
 
@@ -3863,15 +3920,16 @@ func (fake *FakeBuild) SyslogTag(arg1 event.OriginID) string {
 	fake.syslogTagArgsForCall = append(fake.syslogTagArgsForCall, struct {
 		arg1 event.OriginID
 	}{arg1})
+	stub := fake.SyslogTagStub
+	fakeReturns := fake.syslogTagReturns
 	fake.recordInvocation("SyslogTag", []interface{}{arg1})
 	fake.syslogTagMutex.Unlock()
-	if fake.SyslogTagStub != nil {
-		return fake.SyslogTagStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.syslogTagReturns
 	return fakeReturns.result1
 }
 
@@ -3922,15 +3980,16 @@ func (fake *FakeBuild) TeamID() int {
 	ret, specificReturn := fake.teamIDReturnsOnCall[len(fake.teamIDArgsForCall)]
 	fake.teamIDArgsForCall = append(fake.teamIDArgsForCall, struct {
 	}{})
+	stub := fake.TeamIDStub
+	fakeReturns := fake.teamIDReturns
 	fake.recordInvocation("TeamID", []interface{}{})
 	fake.teamIDMutex.Unlock()
-	if fake.TeamIDStub != nil {
-		return fake.TeamIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamIDReturns
 	return fakeReturns.result1
 }
 
@@ -3974,15 +4033,16 @@ func (fake *FakeBuild) TeamName() string {
 	ret, specificReturn := fake.teamNameReturnsOnCall[len(fake.teamNameArgsForCall)]
 	fake.teamNameArgsForCall = append(fake.teamNameArgsForCall, struct {
 	}{})
+	stub := fake.TeamNameStub
+	fakeReturns := fake.teamNameReturns
 	fake.recordInvocation("TeamName", []interface{}{})
 	fake.teamNameMutex.Unlock()
-	if fake.TeamNameStub != nil {
-		return fake.TeamNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamNameReturns
 	return fakeReturns.result1
 }
 
@@ -4026,15 +4086,16 @@ func (fake *FakeBuild) TracingAttrs() tracing.Attrs {
 	ret, specificReturn := fake.tracingAttrsReturnsOnCall[len(fake.tracingAttrsArgsForCall)]
 	fake.tracingAttrsArgsForCall = append(fake.tracingAttrsArgsForCall, struct {
 	}{})
+	stub := fake.TracingAttrsStub
+	fakeReturns := fake.tracingAttrsReturns
 	fake.recordInvocation("TracingAttrs", []interface{}{})
 	fake.tracingAttrsMutex.Unlock()
-	if fake.TracingAttrsStub != nil {
-		return fake.TracingAttrsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tracingAttrsReturns
 	return fakeReturns.result1
 }
 
@@ -4081,15 +4142,16 @@ func (fake *FakeBuild) Variables(arg1 lager.Logger, arg2 creds.Secrets, arg3 cre
 		arg2 creds.Secrets
 		arg3 creds.VarSourcePool
 	}{arg1, arg2, arg3})
+	stub := fake.VariablesStub
+	fakeReturns := fake.variablesReturns
 	fake.recordInvocation("Variables", []interface{}{arg1, arg2, arg3})
 	fake.variablesMutex.Unlock()
-	if fake.VariablesStub != nil {
-		return fake.VariablesStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.variablesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_build_factory.go
+++ b/atc/db/dbfakes/fake_build_factory.go
@@ -113,15 +113,16 @@ func (fake *FakeBuildFactory) AllBuilds(arg1 db.Page) ([]db.Build, db.Pagination
 	fake.allBuildsArgsForCall = append(fake.allBuildsArgsForCall, struct {
 		arg1 db.Page
 	}{arg1})
+	stub := fake.AllBuildsStub
+	fakeReturns := fake.allBuildsReturns
 	fake.recordInvocation("AllBuilds", []interface{}{arg1})
 	fake.allBuildsMutex.Unlock()
-	if fake.AllBuildsStub != nil {
-		return fake.AllBuildsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.allBuildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -179,15 +180,16 @@ func (fake *FakeBuildFactory) Build(arg1 int) (db.Build, bool, error) {
 	fake.buildArgsForCall = append(fake.buildArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.BuildStub
+	fakeReturns := fake.buildReturns
 	fake.recordInvocation("Build", []interface{}{arg1})
 	fake.buildMutex.Unlock()
-	if fake.BuildStub != nil {
-		return fake.BuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -244,15 +246,16 @@ func (fake *FakeBuildFactory) GetAllStartedBuilds() ([]db.Build, error) {
 	ret, specificReturn := fake.getAllStartedBuildsReturnsOnCall[len(fake.getAllStartedBuildsArgsForCall)]
 	fake.getAllStartedBuildsArgsForCall = append(fake.getAllStartedBuildsArgsForCall, struct {
 	}{})
+	stub := fake.GetAllStartedBuildsStub
+	fakeReturns := fake.getAllStartedBuildsReturns
 	fake.recordInvocation("GetAllStartedBuilds", []interface{}{})
 	fake.getAllStartedBuildsMutex.Unlock()
-	if fake.GetAllStartedBuildsStub != nil {
-		return fake.GetAllStartedBuildsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getAllStartedBuildsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -299,15 +302,16 @@ func (fake *FakeBuildFactory) GetDrainableBuilds() ([]db.Build, error) {
 	ret, specificReturn := fake.getDrainableBuildsReturnsOnCall[len(fake.getDrainableBuildsArgsForCall)]
 	fake.getDrainableBuildsArgsForCall = append(fake.getDrainableBuildsArgsForCall, struct {
 	}{})
+	stub := fake.GetDrainableBuildsStub
+	fakeReturns := fake.getDrainableBuildsReturns
 	fake.recordInvocation("GetDrainableBuilds", []interface{}{})
 	fake.getDrainableBuildsMutex.Unlock()
-	if fake.GetDrainableBuildsStub != nil {
-		return fake.GetDrainableBuildsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getDrainableBuildsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -354,15 +358,16 @@ func (fake *FakeBuildFactory) MarkNonInterceptibleBuilds() error {
 	ret, specificReturn := fake.markNonInterceptibleBuildsReturnsOnCall[len(fake.markNonInterceptibleBuildsArgsForCall)]
 	fake.markNonInterceptibleBuildsArgsForCall = append(fake.markNonInterceptibleBuildsArgsForCall, struct {
 	}{})
+	stub := fake.MarkNonInterceptibleBuildsStub
+	fakeReturns := fake.markNonInterceptibleBuildsReturns
 	fake.recordInvocation("MarkNonInterceptibleBuilds", []interface{}{})
 	fake.markNonInterceptibleBuildsMutex.Unlock()
-	if fake.MarkNonInterceptibleBuildsStub != nil {
-		return fake.MarkNonInterceptibleBuildsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.markNonInterceptibleBuildsReturns
 	return fakeReturns.result1
 }
 
@@ -407,15 +412,16 @@ func (fake *FakeBuildFactory) PublicBuilds(arg1 db.Page) ([]db.Build, db.Paginat
 	fake.publicBuildsArgsForCall = append(fake.publicBuildsArgsForCall, struct {
 		arg1 db.Page
 	}{arg1})
+	stub := fake.PublicBuildsStub
+	fakeReturns := fake.publicBuildsReturns
 	fake.recordInvocation("PublicBuilds", []interface{}{arg1})
 	fake.publicBuildsMutex.Unlock()
-	if fake.PublicBuildsStub != nil {
-		return fake.PublicBuildsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.publicBuildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -479,15 +485,16 @@ func (fake *FakeBuildFactory) VisibleBuilds(arg1 []string, arg2 db.Page) ([]db.B
 		arg1 []string
 		arg2 db.Page
 	}{arg1Copy, arg2})
+	stub := fake.VisibleBuildsStub
+	fakeReturns := fake.visibleBuildsReturns
 	fake.recordInvocation("VisibleBuilds", []interface{}{arg1Copy, arg2})
 	fake.visibleBuildsMutex.Unlock()
-	if fake.VisibleBuildsStub != nil {
-		return fake.VisibleBuildsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.visibleBuildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/db/dbfakes/fake_check_factory.go
+++ b/atc/db/dbfakes/fake_check_factory.go
@@ -62,15 +62,16 @@ func (fake *FakeCheckFactory) ResourceTypes() ([]db.ResourceType, error) {
 	ret, specificReturn := fake.resourceTypesReturnsOnCall[len(fake.resourceTypesArgsForCall)]
 	fake.resourceTypesArgsForCall = append(fake.resourceTypesArgsForCall, struct {
 	}{})
+	stub := fake.ResourceTypesStub
+	fakeReturns := fake.resourceTypesReturns
 	fake.recordInvocation("ResourceTypes", []interface{}{})
 	fake.resourceTypesMutex.Unlock()
-	if fake.ResourceTypesStub != nil {
-		return fake.ResourceTypesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.resourceTypesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -117,15 +118,16 @@ func (fake *FakeCheckFactory) Resources() ([]db.Resource, error) {
 	ret, specificReturn := fake.resourcesReturnsOnCall[len(fake.resourcesArgsForCall)]
 	fake.resourcesArgsForCall = append(fake.resourcesArgsForCall, struct {
 	}{})
+	stub := fake.ResourcesStub
+	fakeReturns := fake.resourcesReturns
 	fake.recordInvocation("Resources", []interface{}{})
 	fake.resourcesMutex.Unlock()
-	if fake.ResourcesStub != nil {
-		return fake.ResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.resourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -177,15 +179,16 @@ func (fake *FakeCheckFactory) TryCreateCheck(arg1 context.Context, arg2 db.Check
 		arg4 atc.Version
 		arg5 bool
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.TryCreateCheckStub
+	fakeReturns := fake.tryCreateCheckReturns
 	fake.recordInvocation("TryCreateCheck", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.tryCreateCheckMutex.Unlock()
-	if fake.TryCreateCheckStub != nil {
-		return fake.TryCreateCheckStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.tryCreateCheckReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/db/dbfakes/fake_check_lifecycle.go
+++ b/atc/db/dbfakes/fake_check_lifecycle.go
@@ -27,15 +27,16 @@ func (fake *FakeCheckLifecycle) DeleteCompletedChecks() error {
 	ret, specificReturn := fake.deleteCompletedChecksReturnsOnCall[len(fake.deleteCompletedChecksArgsForCall)]
 	fake.deleteCompletedChecksArgsForCall = append(fake.deleteCompletedChecksArgsForCall, struct {
 	}{})
+	stub := fake.DeleteCompletedChecksStub
+	fakeReturns := fake.deleteCompletedChecksReturns
 	fake.recordInvocation("DeleteCompletedChecks", []interface{}{})
 	fake.deleteCompletedChecksMutex.Unlock()
-	if fake.DeleteCompletedChecksStub != nil {
-		return fake.DeleteCompletedChecksStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteCompletedChecksReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_checkable.go
+++ b/atc/db/dbfakes/fake_checkable.go
@@ -225,15 +225,16 @@ func (fake *FakeCheckable) CheckEvery() *atc.CheckEvery {
 	ret, specificReturn := fake.checkEveryReturnsOnCall[len(fake.checkEveryArgsForCall)]
 	fake.checkEveryArgsForCall = append(fake.checkEveryArgsForCall, struct {
 	}{})
+	stub := fake.CheckEveryStub
+	fakeReturns := fake.checkEveryReturns
 	fake.recordInvocation("CheckEvery", []interface{}{})
 	fake.checkEveryMutex.Unlock()
-	if fake.CheckEveryStub != nil {
-		return fake.CheckEveryStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkEveryReturns
 	return fakeReturns.result1
 }
 
@@ -281,15 +282,16 @@ func (fake *FakeCheckable) CheckPlan(arg1 atc.Version, arg2 time.Duration, arg3 
 		arg3 db.ResourceTypes
 		arg4 atc.Source
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CheckPlanStub
+	fakeReturns := fake.checkPlanReturns
 	fake.recordInvocation("CheckPlan", []interface{}{arg1, arg2, arg3, arg4})
 	fake.checkPlanMutex.Unlock()
-	if fake.CheckPlanStub != nil {
-		return fake.CheckPlanStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkPlanReturns
 	return fakeReturns.result1
 }
 
@@ -340,15 +342,16 @@ func (fake *FakeCheckable) CheckTimeout() string {
 	ret, specificReturn := fake.checkTimeoutReturnsOnCall[len(fake.checkTimeoutArgsForCall)]
 	fake.checkTimeoutArgsForCall = append(fake.checkTimeoutArgsForCall, struct {
 	}{})
+	stub := fake.CheckTimeoutStub
+	fakeReturns := fake.checkTimeoutReturns
 	fake.recordInvocation("CheckTimeout", []interface{}{})
 	fake.checkTimeoutMutex.Unlock()
-	if fake.CheckTimeoutStub != nil {
-		return fake.CheckTimeoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -395,15 +398,16 @@ func (fake *FakeCheckable) CreateBuild(arg1 context.Context, arg2 bool, arg3 atc
 		arg2 bool
 		arg3 atc.Plan
 	}{arg1, arg2, arg3})
+	stub := fake.CreateBuildStub
+	fakeReturns := fake.createBuildReturns
 	fake.recordInvocation("CreateBuild", []interface{}{arg1, arg2, arg3})
 	fake.createBuildMutex.Unlock()
-	if fake.CreateBuildStub != nil {
-		return fake.CreateBuildStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.createBuildReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -460,15 +464,16 @@ func (fake *FakeCheckable) CurrentPinnedVersion() atc.Version {
 	ret, specificReturn := fake.currentPinnedVersionReturnsOnCall[len(fake.currentPinnedVersionArgsForCall)]
 	fake.currentPinnedVersionArgsForCall = append(fake.currentPinnedVersionArgsForCall, struct {
 	}{})
+	stub := fake.CurrentPinnedVersionStub
+	fakeReturns := fake.currentPinnedVersionReturns
 	fake.recordInvocation("CurrentPinnedVersion", []interface{}{})
 	fake.currentPinnedVersionMutex.Unlock()
-	if fake.CurrentPinnedVersionStub != nil {
-		return fake.CurrentPinnedVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.currentPinnedVersionReturns
 	return fakeReturns.result1
 }
 
@@ -512,15 +517,16 @@ func (fake *FakeCheckable) HasWebhook() bool {
 	ret, specificReturn := fake.hasWebhookReturnsOnCall[len(fake.hasWebhookArgsForCall)]
 	fake.hasWebhookArgsForCall = append(fake.hasWebhookArgsForCall, struct {
 	}{})
+	stub := fake.HasWebhookStub
+	fakeReturns := fake.hasWebhookReturns
 	fake.recordInvocation("HasWebhook", []interface{}{})
 	fake.hasWebhookMutex.Unlock()
-	if fake.HasWebhookStub != nil {
-		return fake.HasWebhookStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasWebhookReturns
 	return fakeReturns.result1
 }
 
@@ -564,15 +570,16 @@ func (fake *FakeCheckable) LastCheckEndTime() time.Time {
 	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
 	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
 	}{})
+	stub := fake.LastCheckEndTimeStub
+	fakeReturns := fake.lastCheckEndTimeReturns
 	fake.recordInvocation("LastCheckEndTime", []interface{}{})
 	fake.lastCheckEndTimeMutex.Unlock()
-	if fake.LastCheckEndTimeStub != nil {
-		return fake.LastCheckEndTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastCheckEndTimeReturns
 	return fakeReturns.result1
 }
 
@@ -616,15 +623,16 @@ func (fake *FakeCheckable) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -668,15 +676,16 @@ func (fake *FakeCheckable) Pipeline() (db.Pipeline, bool, error) {
 	ret, specificReturn := fake.pipelineReturnsOnCall[len(fake.pipelineArgsForCall)]
 	fake.pipelineArgsForCall = append(fake.pipelineArgsForCall, struct {
 	}{})
+	stub := fake.PipelineStub
+	fakeReturns := fake.pipelineReturns
 	fake.recordInvocation("Pipeline", []interface{}{})
 	fake.pipelineMutex.Unlock()
-	if fake.PipelineStub != nil {
-		return fake.PipelineStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.pipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -726,15 +735,16 @@ func (fake *FakeCheckable) PipelineID() int {
 	ret, specificReturn := fake.pipelineIDReturnsOnCall[len(fake.pipelineIDArgsForCall)]
 	fake.pipelineIDArgsForCall = append(fake.pipelineIDArgsForCall, struct {
 	}{})
+	stub := fake.PipelineIDStub
+	fakeReturns := fake.pipelineIDReturns
 	fake.recordInvocation("PipelineID", []interface{}{})
 	fake.pipelineIDMutex.Unlock()
-	if fake.PipelineIDStub != nil {
-		return fake.PipelineIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineIDReturns
 	return fakeReturns.result1
 }
 
@@ -778,15 +788,16 @@ func (fake *FakeCheckable) PipelineInstanceVars() atc.InstanceVars {
 	ret, specificReturn := fake.pipelineInstanceVarsReturnsOnCall[len(fake.pipelineInstanceVarsArgsForCall)]
 	fake.pipelineInstanceVarsArgsForCall = append(fake.pipelineInstanceVarsArgsForCall, struct {
 	}{})
+	stub := fake.PipelineInstanceVarsStub
+	fakeReturns := fake.pipelineInstanceVarsReturns
 	fake.recordInvocation("PipelineInstanceVars", []interface{}{})
 	fake.pipelineInstanceVarsMutex.Unlock()
-	if fake.PipelineInstanceVarsStub != nil {
-		return fake.PipelineInstanceVarsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineInstanceVarsReturns
 	return fakeReturns.result1
 }
 
@@ -830,15 +841,16 @@ func (fake *FakeCheckable) PipelineName() string {
 	ret, specificReturn := fake.pipelineNameReturnsOnCall[len(fake.pipelineNameArgsForCall)]
 	fake.pipelineNameArgsForCall = append(fake.pipelineNameArgsForCall, struct {
 	}{})
+	stub := fake.PipelineNameStub
+	fakeReturns := fake.pipelineNameReturns
 	fake.recordInvocation("PipelineName", []interface{}{})
 	fake.pipelineNameMutex.Unlock()
-	if fake.PipelineNameStub != nil {
-		return fake.PipelineNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineNameReturns
 	return fakeReturns.result1
 }
 
@@ -882,15 +894,16 @@ func (fake *FakeCheckable) PipelineRef() atc.PipelineRef {
 	ret, specificReturn := fake.pipelineRefReturnsOnCall[len(fake.pipelineRefArgsForCall)]
 	fake.pipelineRefArgsForCall = append(fake.pipelineRefArgsForCall, struct {
 	}{})
+	stub := fake.PipelineRefStub
+	fakeReturns := fake.pipelineRefReturns
 	fake.recordInvocation("PipelineRef", []interface{}{})
 	fake.pipelineRefMutex.Unlock()
-	if fake.PipelineRefStub != nil {
-		return fake.PipelineRefStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineRefReturns
 	return fakeReturns.result1
 }
 
@@ -934,15 +947,16 @@ func (fake *FakeCheckable) ResourceConfigScopeID() int {
 	ret, specificReturn := fake.resourceConfigScopeIDReturnsOnCall[len(fake.resourceConfigScopeIDArgsForCall)]
 	fake.resourceConfigScopeIDArgsForCall = append(fake.resourceConfigScopeIDArgsForCall, struct {
 	}{})
+	stub := fake.ResourceConfigScopeIDStub
+	fakeReturns := fake.resourceConfigScopeIDReturns
 	fake.recordInvocation("ResourceConfigScopeID", []interface{}{})
 	fake.resourceConfigScopeIDMutex.Unlock()
-	if fake.ResourceConfigScopeIDStub != nil {
-		return fake.ResourceConfigScopeIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceConfigScopeIDReturns
 	return fakeReturns.result1
 }
 
@@ -986,15 +1000,16 @@ func (fake *FakeCheckable) Source() atc.Source {
 	ret, specificReturn := fake.sourceReturnsOnCall[len(fake.sourceArgsForCall)]
 	fake.sourceArgsForCall = append(fake.sourceArgsForCall, struct {
 	}{})
+	stub := fake.SourceStub
+	fakeReturns := fake.sourceReturns
 	fake.recordInvocation("Source", []interface{}{})
 	fake.sourceMutex.Unlock()
-	if fake.SourceStub != nil {
-		return fake.SourceStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sourceReturns
 	return fakeReturns.result1
 }
 
@@ -1038,15 +1053,16 @@ func (fake *FakeCheckable) Tags() atc.Tags {
 	ret, specificReturn := fake.tagsReturnsOnCall[len(fake.tagsArgsForCall)]
 	fake.tagsArgsForCall = append(fake.tagsArgsForCall, struct {
 	}{})
+	stub := fake.TagsStub
+	fakeReturns := fake.tagsReturns
 	fake.recordInvocation("Tags", []interface{}{})
 	fake.tagsMutex.Unlock()
-	if fake.TagsStub != nil {
-		return fake.TagsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tagsReturns
 	return fakeReturns.result1
 }
 
@@ -1090,15 +1106,16 @@ func (fake *FakeCheckable) TeamID() int {
 	ret, specificReturn := fake.teamIDReturnsOnCall[len(fake.teamIDArgsForCall)]
 	fake.teamIDArgsForCall = append(fake.teamIDArgsForCall, struct {
 	}{})
+	stub := fake.TeamIDStub
+	fakeReturns := fake.teamIDReturns
 	fake.recordInvocation("TeamID", []interface{}{})
 	fake.teamIDMutex.Unlock()
-	if fake.TeamIDStub != nil {
-		return fake.TeamIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamIDReturns
 	return fakeReturns.result1
 }
 
@@ -1142,15 +1159,16 @@ func (fake *FakeCheckable) TeamName() string {
 	ret, specificReturn := fake.teamNameReturnsOnCall[len(fake.teamNameArgsForCall)]
 	fake.teamNameArgsForCall = append(fake.teamNameArgsForCall, struct {
 	}{})
+	stub := fake.TeamNameStub
+	fakeReturns := fake.teamNameReturns
 	fake.recordInvocation("TeamName", []interface{}{})
 	fake.teamNameMutex.Unlock()
-	if fake.TeamNameStub != nil {
-		return fake.TeamNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamNameReturns
 	return fakeReturns.result1
 }
 
@@ -1194,15 +1212,16 @@ func (fake *FakeCheckable) Type() string {
 	ret, specificReturn := fake.typeReturnsOnCall[len(fake.typeArgsForCall)]
 	fake.typeArgsForCall = append(fake.typeArgsForCall, struct {
 	}{})
+	stub := fake.TypeStub
+	fakeReturns := fake.typeReturns
 	fake.recordInvocation("Type", []interface{}{})
 	fake.typeMutex.Unlock()
-	if fake.TypeStub != nil {
-		return fake.TypeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.typeReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_clock.go
+++ b/atc/db/dbfakes/fake_clock.go
@@ -39,15 +39,16 @@ func (fake *FakeClock) Now() time.Time {
 	ret, specificReturn := fake.nowReturnsOnCall[len(fake.nowArgsForCall)]
 	fake.nowArgsForCall = append(fake.nowArgsForCall, struct {
 	}{})
+	stub := fake.NowStub
+	fakeReturns := fake.nowReturns
 	fake.recordInvocation("Now", []interface{}{})
 	fake.nowMutex.Unlock()
-	if fake.NowStub != nil {
-		return fake.NowStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nowReturns
 	return fakeReturns.result1
 }
 
@@ -92,15 +93,16 @@ func (fake *FakeClock) Until(arg1 time.Time) time.Duration {
 	fake.untilArgsForCall = append(fake.untilArgsForCall, struct {
 		arg1 time.Time
 	}{arg1})
+	stub := fake.UntilStub
+	fakeReturns := fake.untilReturns
 	fake.recordInvocation("Until", []interface{}{arg1})
 	fake.untilMutex.Unlock()
-	if fake.UntilStub != nil {
-		return fake.UntilStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.untilReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_component.go
+++ b/atc/db/dbfakes/fake_component.go
@@ -100,15 +100,16 @@ func (fake *FakeComponent) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -152,15 +153,16 @@ func (fake *FakeComponent) Interval() time.Duration {
 	ret, specificReturn := fake.intervalReturnsOnCall[len(fake.intervalArgsForCall)]
 	fake.intervalArgsForCall = append(fake.intervalArgsForCall, struct {
 	}{})
+	stub := fake.IntervalStub
+	fakeReturns := fake.intervalReturns
 	fake.recordInvocation("Interval", []interface{}{})
 	fake.intervalMutex.Unlock()
-	if fake.IntervalStub != nil {
-		return fake.IntervalStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.intervalReturns
 	return fakeReturns.result1
 }
 
@@ -204,15 +206,16 @@ func (fake *FakeComponent) IntervalElapsed() bool {
 	ret, specificReturn := fake.intervalElapsedReturnsOnCall[len(fake.intervalElapsedArgsForCall)]
 	fake.intervalElapsedArgsForCall = append(fake.intervalElapsedArgsForCall, struct {
 	}{})
+	stub := fake.IntervalElapsedStub
+	fakeReturns := fake.intervalElapsedReturns
 	fake.recordInvocation("IntervalElapsed", []interface{}{})
 	fake.intervalElapsedMutex.Unlock()
-	if fake.IntervalElapsedStub != nil {
-		return fake.IntervalElapsedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.intervalElapsedReturns
 	return fakeReturns.result1
 }
 
@@ -256,15 +259,16 @@ func (fake *FakeComponent) LastRan() time.Time {
 	ret, specificReturn := fake.lastRanReturnsOnCall[len(fake.lastRanArgsForCall)]
 	fake.lastRanArgsForCall = append(fake.lastRanArgsForCall, struct {
 	}{})
+	stub := fake.LastRanStub
+	fakeReturns := fake.lastRanReturns
 	fake.recordInvocation("LastRan", []interface{}{})
 	fake.lastRanMutex.Unlock()
-	if fake.LastRanStub != nil {
-		return fake.LastRanStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastRanReturns
 	return fakeReturns.result1
 }
 
@@ -308,15 +312,16 @@ func (fake *FakeComponent) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -360,15 +365,16 @@ func (fake *FakeComponent) Paused() bool {
 	ret, specificReturn := fake.pausedReturnsOnCall[len(fake.pausedArgsForCall)]
 	fake.pausedArgsForCall = append(fake.pausedArgsForCall, struct {
 	}{})
+	stub := fake.PausedStub
+	fakeReturns := fake.pausedReturns
 	fake.recordInvocation("Paused", []interface{}{})
 	fake.pausedMutex.Unlock()
-	if fake.PausedStub != nil {
-		return fake.PausedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pausedReturns
 	return fakeReturns.result1
 }
 
@@ -412,15 +418,16 @@ func (fake *FakeComponent) Reload() (bool, error) {
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
 	fake.reloadArgsForCall = append(fake.reloadArgsForCall, struct {
 	}{})
+	stub := fake.ReloadStub
+	fakeReturns := fake.reloadReturns
 	fake.recordInvocation("Reload", []interface{}{})
 	fake.reloadMutex.Unlock()
-	if fake.ReloadStub != nil {
-		return fake.ReloadStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.reloadReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -467,15 +474,16 @@ func (fake *FakeComponent) UpdateLastRan() error {
 	ret, specificReturn := fake.updateLastRanReturnsOnCall[len(fake.updateLastRanArgsForCall)]
 	fake.updateLastRanArgsForCall = append(fake.updateLastRanArgsForCall, struct {
 	}{})
+	stub := fake.UpdateLastRanStub
+	fakeReturns := fake.updateLastRanReturns
 	fake.recordInvocation("UpdateLastRan", []interface{}{})
 	fake.updateLastRanMutex.Unlock()
-	if fake.UpdateLastRanStub != nil {
-		return fake.UpdateLastRanStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateLastRanReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_component_factory.go
+++ b/atc/db/dbfakes/fake_component_factory.go
@@ -47,15 +47,16 @@ func (fake *FakeComponentFactory) CreateOrUpdate(arg1 atc.Component) (db.Compone
 	fake.createOrUpdateArgsForCall = append(fake.createOrUpdateArgsForCall, struct {
 		arg1 atc.Component
 	}{arg1})
+	stub := fake.CreateOrUpdateStub
+	fakeReturns := fake.createOrUpdateReturns
 	fake.recordInvocation("CreateOrUpdate", []interface{}{arg1})
 	fake.createOrUpdateMutex.Unlock()
-	if fake.CreateOrUpdateStub != nil {
-		return fake.CreateOrUpdateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createOrUpdateReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -110,15 +111,16 @@ func (fake *FakeComponentFactory) Find(arg1 string) (db.Component, bool, error) 
 	fake.findArgsForCall = append(fake.findArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindStub
+	fakeReturns := fake.findReturns
 	fake.recordInvocation("Find", []interface{}{arg1})
 	fake.findMutex.Unlock()
-	if fake.FindStub != nil {
-		return fake.FindStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/db/dbfakes/fake_conn.go
+++ b/atc/db/dbfakes/fake_conn.go
@@ -238,15 +238,16 @@ func (fake *FakeConn) Begin() (db.Tx, error) {
 	ret, specificReturn := fake.beginReturnsOnCall[len(fake.beginArgsForCall)]
 	fake.beginArgsForCall = append(fake.beginArgsForCall, struct {
 	}{})
+	stub := fake.BeginStub
+	fakeReturns := fake.beginReturns
 	fake.recordInvocation("Begin", []interface{}{})
 	fake.beginMutex.Unlock()
-	if fake.BeginStub != nil {
-		return fake.BeginStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.beginReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -295,15 +296,16 @@ func (fake *FakeConn) BeginTx(arg1 context.Context, arg2 *sql.TxOptions) (db.Tx,
 		arg1 context.Context
 		arg2 *sql.TxOptions
 	}{arg1, arg2})
+	stub := fake.BeginTxStub
+	fakeReturns := fake.beginTxReturns
 	fake.recordInvocation("BeginTx", []interface{}{arg1, arg2})
 	fake.beginTxMutex.Unlock()
-	if fake.BeginTxStub != nil {
-		return fake.BeginTxStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.beginTxReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -357,15 +359,16 @@ func (fake *FakeConn) Bus() db.NotificationsBus {
 	ret, specificReturn := fake.busReturnsOnCall[len(fake.busArgsForCall)]
 	fake.busArgsForCall = append(fake.busArgsForCall, struct {
 	}{})
+	stub := fake.BusStub
+	fakeReturns := fake.busReturns
 	fake.recordInvocation("Bus", []interface{}{})
 	fake.busMutex.Unlock()
-	if fake.BusStub != nil {
-		return fake.BusStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.busReturns
 	return fakeReturns.result1
 }
 
@@ -409,15 +412,16 @@ func (fake *FakeConn) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -461,15 +465,16 @@ func (fake *FakeConn) Driver() driver.Driver {
 	ret, specificReturn := fake.driverReturnsOnCall[len(fake.driverArgsForCall)]
 	fake.driverArgsForCall = append(fake.driverArgsForCall, struct {
 	}{})
+	stub := fake.DriverStub
+	fakeReturns := fake.driverReturns
 	fake.recordInvocation("Driver", []interface{}{})
 	fake.driverMutex.Unlock()
-	if fake.DriverStub != nil {
-		return fake.DriverStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.driverReturns
 	return fakeReturns.result1
 }
 
@@ -513,15 +518,16 @@ func (fake *FakeConn) EncryptionStrategy() encryption.Strategy {
 	ret, specificReturn := fake.encryptionStrategyReturnsOnCall[len(fake.encryptionStrategyArgsForCall)]
 	fake.encryptionStrategyArgsForCall = append(fake.encryptionStrategyArgsForCall, struct {
 	}{})
+	stub := fake.EncryptionStrategyStub
+	fakeReturns := fake.encryptionStrategyReturns
 	fake.recordInvocation("EncryptionStrategy", []interface{}{})
 	fake.encryptionStrategyMutex.Unlock()
-	if fake.EncryptionStrategyStub != nil {
-		return fake.EncryptionStrategyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.encryptionStrategyReturns
 	return fakeReturns.result1
 }
 
@@ -567,15 +573,16 @@ func (fake *FakeConn) Exec(arg1 string, arg2 ...interface{}) (sql.Result, error)
 		arg1 string
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.ExecStub
+	fakeReturns := fake.execReturns
 	fake.recordInvocation("Exec", []interface{}{arg1, arg2})
 	fake.execMutex.Unlock()
-	if fake.ExecStub != nil {
-		return fake.ExecStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.execReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -632,15 +639,16 @@ func (fake *FakeConn) ExecContext(arg1 context.Context, arg2 string, arg3 ...int
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.ExecContextStub
+	fakeReturns := fake.execContextReturns
 	fake.recordInvocation("ExecContext", []interface{}{arg1, arg2, arg3})
 	fake.execContextMutex.Unlock()
-	if fake.ExecContextStub != nil {
-		return fake.ExecContextStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.execContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -694,15 +702,16 @@ func (fake *FakeConn) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -746,15 +755,16 @@ func (fake *FakeConn) Ping() error {
 	ret, specificReturn := fake.pingReturnsOnCall[len(fake.pingArgsForCall)]
 	fake.pingArgsForCall = append(fake.pingArgsForCall, struct {
 	}{})
+	stub := fake.PingStub
+	fakeReturns := fake.pingReturns
 	fake.recordInvocation("Ping", []interface{}{})
 	fake.pingMutex.Unlock()
-	if fake.PingStub != nil {
-		return fake.PingStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pingReturns
 	return fakeReturns.result1
 }
 
@@ -799,15 +809,16 @@ func (fake *FakeConn) Prepare(arg1 string) (*sql.Stmt, error) {
 	fake.prepareArgsForCall = append(fake.prepareArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PrepareStub
+	fakeReturns := fake.prepareReturns
 	fake.recordInvocation("Prepare", []interface{}{arg1})
 	fake.prepareMutex.Unlock()
-	if fake.PrepareStub != nil {
-		return fake.PrepareStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.prepareReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -863,15 +874,16 @@ func (fake *FakeConn) PrepareContext(arg1 context.Context, arg2 string) (*sql.St
 		arg1 context.Context
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.PrepareContextStub
+	fakeReturns := fake.prepareContextReturns
 	fake.recordInvocation("PrepareContext", []interface{}{arg1, arg2})
 	fake.prepareContextMutex.Unlock()
-	if fake.PrepareContextStub != nil {
-		return fake.PrepareContextStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.prepareContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -927,15 +939,16 @@ func (fake *FakeConn) Query(arg1 string, arg2 ...interface{}) (*sql.Rows, error)
 		arg1 string
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.QueryStub
+	fakeReturns := fake.queryReturns
 	fake.recordInvocation("Query", []interface{}{arg1, arg2})
 	fake.queryMutex.Unlock()
-	if fake.QueryStub != nil {
-		return fake.QueryStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.queryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -992,15 +1005,16 @@ func (fake *FakeConn) QueryContext(arg1 context.Context, arg2 string, arg3 ...in
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.QueryContextStub
+	fakeReturns := fake.queryContextReturns
 	fake.recordInvocation("QueryContext", []interface{}{arg1, arg2, arg3})
 	fake.queryContextMutex.Unlock()
-	if fake.QueryContextStub != nil {
-		return fake.QueryContextStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.queryContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1056,15 +1070,16 @@ func (fake *FakeConn) QueryRow(arg1 string, arg2 ...interface{}) squirrel.RowSca
 		arg1 string
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.QueryRowStub
+	fakeReturns := fake.queryRowReturns
 	fake.recordInvocation("QueryRow", []interface{}{arg1, arg2})
 	fake.queryRowMutex.Unlock()
-	if fake.QueryRowStub != nil {
-		return fake.QueryRowStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.queryRowReturns
 	return fakeReturns.result1
 }
 
@@ -1118,15 +1133,16 @@ func (fake *FakeConn) QueryRowContext(arg1 context.Context, arg2 string, arg3 ..
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.QueryRowContextStub
+	fakeReturns := fake.queryRowContextReturns
 	fake.recordInvocation("QueryRowContext", []interface{}{arg1, arg2, arg3})
 	fake.queryRowContextMutex.Unlock()
-	if fake.QueryRowContextStub != nil {
-		return fake.QueryRowContextStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.queryRowContextReturns
 	return fakeReturns.result1
 }
 
@@ -1177,9 +1193,10 @@ func (fake *FakeConn) SetMaxIdleConns(arg1 int) {
 	fake.setMaxIdleConnsArgsForCall = append(fake.setMaxIdleConnsArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.SetMaxIdleConnsStub
 	fake.recordInvocation("SetMaxIdleConns", []interface{}{arg1})
 	fake.setMaxIdleConnsMutex.Unlock()
-	if fake.SetMaxIdleConnsStub != nil {
+	if stub != nil {
 		fake.SetMaxIdleConnsStub(arg1)
 	}
 }
@@ -1208,9 +1225,10 @@ func (fake *FakeConn) SetMaxOpenConns(arg1 int) {
 	fake.setMaxOpenConnsArgsForCall = append(fake.setMaxOpenConnsArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.SetMaxOpenConnsStub
 	fake.recordInvocation("SetMaxOpenConns", []interface{}{arg1})
 	fake.setMaxOpenConnsMutex.Unlock()
-	if fake.SetMaxOpenConnsStub != nil {
+	if stub != nil {
 		fake.SetMaxOpenConnsStub(arg1)
 	}
 }
@@ -1239,15 +1257,16 @@ func (fake *FakeConn) Stats() sql.DBStats {
 	ret, specificReturn := fake.statsReturnsOnCall[len(fake.statsArgsForCall)]
 	fake.statsArgsForCall = append(fake.statsArgsForCall, struct {
 	}{})
+	stub := fake.StatsStub
+	fakeReturns := fake.statsReturns
 	fake.recordInvocation("Stats", []interface{}{})
 	fake.statsMutex.Unlock()
-	if fake.StatsStub != nil {
-		return fake.StatsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.statsReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_container.go
+++ b/atc/db/dbfakes/fake_container.go
@@ -67,15 +67,16 @@ func (fake *FakeContainer) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -119,15 +120,16 @@ func (fake *FakeContainer) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -171,15 +173,16 @@ func (fake *FakeContainer) Metadata() db.ContainerMetadata {
 	ret, specificReturn := fake.metadataReturnsOnCall[len(fake.metadataArgsForCall)]
 	fake.metadataArgsForCall = append(fake.metadataArgsForCall, struct {
 	}{})
+	stub := fake.MetadataStub
+	fakeReturns := fake.metadataReturns
 	fake.recordInvocation("Metadata", []interface{}{})
 	fake.metadataMutex.Unlock()
-	if fake.MetadataStub != nil {
-		return fake.MetadataStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.metadataReturns
 	return fakeReturns.result1
 }
 
@@ -223,15 +226,16 @@ func (fake *FakeContainer) State() string {
 	ret, specificReturn := fake.stateReturnsOnCall[len(fake.stateArgsForCall)]
 	fake.stateArgsForCall = append(fake.stateArgsForCall, struct {
 	}{})
+	stub := fake.StateStub
+	fakeReturns := fake.stateReturns
 	fake.recordInvocation("State", []interface{}{})
 	fake.stateMutex.Unlock()
-	if fake.StateStub != nil {
-		return fake.StateStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stateReturns
 	return fakeReturns.result1
 }
 
@@ -275,15 +279,16 @@ func (fake *FakeContainer) WorkerName() string {
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
 	fake.workerNameArgsForCall = append(fake.workerNameArgsForCall, struct {
 	}{})
+	stub := fake.WorkerNameStub
+	fakeReturns := fake.workerNameReturns
 	fake.recordInvocation("WorkerName", []interface{}{})
 	fake.workerNameMutex.Unlock()
-	if fake.WorkerNameStub != nil {
-		return fake.WorkerNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerNameReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_container_owner.go
+++ b/atc/db/dbfakes/fake_container_owner.go
@@ -49,15 +49,16 @@ func (fake *FakeContainerOwner) Create(arg1 db.Tx, arg2 string) (map[string]inte
 		arg1 db.Tx
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1, arg2})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -112,15 +113,16 @@ func (fake *FakeContainerOwner) Find(arg1 db.Conn) (squirrel.Eq, bool, error) {
 	fake.findArgsForCall = append(fake.findArgsForCall, struct {
 		arg1 db.Conn
 	}{arg1})
+	stub := fake.FindStub
+	fakeReturns := fake.findReturns
 	fake.recordInvocation("Find", []interface{}{arg1})
 	fake.findMutex.Unlock()
-	if fake.FindStub != nil {
-		return fake.FindStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/db/dbfakes/fake_container_repository.go
+++ b/atc/db/dbfakes/fake_container_repository.go
@@ -112,15 +112,16 @@ func (fake *FakeContainerRepository) DestroyFailedContainers() (int, error) {
 	ret, specificReturn := fake.destroyFailedContainersReturnsOnCall[len(fake.destroyFailedContainersArgsForCall)]
 	fake.destroyFailedContainersArgsForCall = append(fake.destroyFailedContainersArgsForCall, struct {
 	}{})
+	stub := fake.DestroyFailedContainersStub
+	fakeReturns := fake.destroyFailedContainersReturns
 	fake.recordInvocation("DestroyFailedContainers", []interface{}{})
 	fake.destroyFailedContainersMutex.Unlock()
-	if fake.DestroyFailedContainersStub != nil {
-		return fake.DestroyFailedContainersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyFailedContainersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -174,15 +175,16 @@ func (fake *FakeContainerRepository) DestroyUnknownContainers(arg1 string, arg2 
 		arg1 string
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.DestroyUnknownContainersStub
+	fakeReturns := fake.destroyUnknownContainersReturns
 	fake.recordInvocation("DestroyUnknownContainers", []interface{}{arg1, arg2Copy})
 	fake.destroyUnknownContainersMutex.Unlock()
-	if fake.DestroyUnknownContainersStub != nil {
-		return fake.DestroyUnknownContainersStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyUnknownContainersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -237,15 +239,16 @@ func (fake *FakeContainerRepository) FindDestroyingContainers(arg1 string) ([]st
 	fake.findDestroyingContainersArgsForCall = append(fake.findDestroyingContainersArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindDestroyingContainersStub
+	fakeReturns := fake.findDestroyingContainersReturns
 	fake.recordInvocation("FindDestroyingContainers", []interface{}{arg1})
 	fake.findDestroyingContainersMutex.Unlock()
-	if fake.FindDestroyingContainersStub != nil {
-		return fake.FindDestroyingContainersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findDestroyingContainersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -299,15 +302,16 @@ func (fake *FakeContainerRepository) FindOrphanedContainers() ([]db.CreatingCont
 	ret, specificReturn := fake.findOrphanedContainersReturnsOnCall[len(fake.findOrphanedContainersArgsForCall)]
 	fake.findOrphanedContainersArgsForCall = append(fake.findOrphanedContainersArgsForCall, struct {
 	}{})
+	stub := fake.FindOrphanedContainersStub
+	fakeReturns := fake.findOrphanedContainersReturns
 	fake.recordInvocation("FindOrphanedContainers", []interface{}{})
 	fake.findOrphanedContainersMutex.Unlock()
-	if fake.FindOrphanedContainersStub != nil {
-		return fake.FindOrphanedContainersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.findOrphanedContainersReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -367,15 +371,16 @@ func (fake *FakeContainerRepository) RemoveDestroyingContainers(arg1 string, arg
 		arg1 string
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.RemoveDestroyingContainersStub
+	fakeReturns := fake.removeDestroyingContainersReturns
 	fake.recordInvocation("RemoveDestroyingContainers", []interface{}{arg1, arg2Copy})
 	fake.removeDestroyingContainersMutex.Unlock()
-	if fake.RemoveDestroyingContainersStub != nil {
-		return fake.RemoveDestroyingContainersStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.removeDestroyingContainersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -430,15 +435,16 @@ func (fake *FakeContainerRepository) RemoveMissingContainers(arg1 time.Duration)
 	fake.removeMissingContainersArgsForCall = append(fake.removeMissingContainersArgsForCall, struct {
 		arg1 time.Duration
 	}{arg1})
+	stub := fake.RemoveMissingContainersStub
+	fakeReturns := fake.removeMissingContainersReturns
 	fake.recordInvocation("RemoveMissingContainers", []interface{}{arg1})
 	fake.removeMissingContainersMutex.Unlock()
-	if fake.RemoveMissingContainersStub != nil {
-		return fake.RemoveMissingContainersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.removeMissingContainersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -499,15 +505,16 @@ func (fake *FakeContainerRepository) UpdateContainersMissingSince(arg1 string, a
 		arg1 string
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.UpdateContainersMissingSinceStub
+	fakeReturns := fake.updateContainersMissingSinceReturns
 	fake.recordInvocation("UpdateContainersMissingSince", []interface{}{arg1, arg2Copy})
 	fake.updateContainersMissingSinceMutex.Unlock()
-	if fake.UpdateContainersMissingSinceStub != nil {
-		return fake.UpdateContainersMissingSinceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateContainersMissingSinceReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_created_container.go
+++ b/atc/db/dbfakes/fake_created_container.go
@@ -100,15 +100,16 @@ func (fake *FakeCreatedContainer) Destroying() (db.DestroyingContainer, error) {
 	ret, specificReturn := fake.destroyingReturnsOnCall[len(fake.destroyingArgsForCall)]
 	fake.destroyingArgsForCall = append(fake.destroyingArgsForCall, struct {
 	}{})
+	stub := fake.DestroyingStub
+	fakeReturns := fake.destroyingReturns
 	fake.recordInvocation("Destroying", []interface{}{})
 	fake.destroyingMutex.Unlock()
-	if fake.DestroyingStub != nil {
-		return fake.DestroyingStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyingReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -155,15 +156,16 @@ func (fake *FakeCreatedContainer) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -207,15 +209,16 @@ func (fake *FakeCreatedContainer) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -259,15 +262,16 @@ func (fake *FakeCreatedContainer) LastHijack() time.Time {
 	ret, specificReturn := fake.lastHijackReturnsOnCall[len(fake.lastHijackArgsForCall)]
 	fake.lastHijackArgsForCall = append(fake.lastHijackArgsForCall, struct {
 	}{})
+	stub := fake.LastHijackStub
+	fakeReturns := fake.lastHijackReturns
 	fake.recordInvocation("LastHijack", []interface{}{})
 	fake.lastHijackMutex.Unlock()
-	if fake.LastHijackStub != nil {
-		return fake.LastHijackStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastHijackReturns
 	return fakeReturns.result1
 }
 
@@ -311,15 +315,16 @@ func (fake *FakeCreatedContainer) Metadata() db.ContainerMetadata {
 	ret, specificReturn := fake.metadataReturnsOnCall[len(fake.metadataArgsForCall)]
 	fake.metadataArgsForCall = append(fake.metadataArgsForCall, struct {
 	}{})
+	stub := fake.MetadataStub
+	fakeReturns := fake.metadataReturns
 	fake.recordInvocation("Metadata", []interface{}{})
 	fake.metadataMutex.Unlock()
-	if fake.MetadataStub != nil {
-		return fake.MetadataStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.metadataReturns
 	return fakeReturns.result1
 }
 
@@ -363,15 +368,16 @@ func (fake *FakeCreatedContainer) State() string {
 	ret, specificReturn := fake.stateReturnsOnCall[len(fake.stateArgsForCall)]
 	fake.stateArgsForCall = append(fake.stateArgsForCall, struct {
 	}{})
+	stub := fake.StateStub
+	fakeReturns := fake.stateReturns
 	fake.recordInvocation("State", []interface{}{})
 	fake.stateMutex.Unlock()
-	if fake.StateStub != nil {
-		return fake.StateStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stateReturns
 	return fakeReturns.result1
 }
 
@@ -415,15 +421,16 @@ func (fake *FakeCreatedContainer) UpdateLastHijack() error {
 	ret, specificReturn := fake.updateLastHijackReturnsOnCall[len(fake.updateLastHijackArgsForCall)]
 	fake.updateLastHijackArgsForCall = append(fake.updateLastHijackArgsForCall, struct {
 	}{})
+	stub := fake.UpdateLastHijackStub
+	fakeReturns := fake.updateLastHijackReturns
 	fake.recordInvocation("UpdateLastHijack", []interface{}{})
 	fake.updateLastHijackMutex.Unlock()
-	if fake.UpdateLastHijackStub != nil {
-		return fake.UpdateLastHijackStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateLastHijackReturns
 	return fakeReturns.result1
 }
 
@@ -467,15 +474,16 @@ func (fake *FakeCreatedContainer) WorkerName() string {
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
 	fake.workerNameArgsForCall = append(fake.workerNameArgsForCall, struct {
 	}{})
+	stub := fake.WorkerNameStub
+	fakeReturns := fake.workerNameReturns
 	fake.recordInvocation("WorkerName", []interface{}{})
 	fake.workerNameMutex.Unlock()
-	if fake.WorkerNameStub != nil {
-		return fake.WorkerNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerNameReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_created_volume.go
+++ b/atc/db/dbfakes/fake_created_volume.go
@@ -214,15 +214,16 @@ func (fake *FakeCreatedVolume) BaseResourceType() (*db.UsedWorkerBaseResourceTyp
 	ret, specificReturn := fake.baseResourceTypeReturnsOnCall[len(fake.baseResourceTypeArgsForCall)]
 	fake.baseResourceTypeArgsForCall = append(fake.baseResourceTypeArgsForCall, struct {
 	}{})
+	stub := fake.BaseResourceTypeStub
+	fakeReturns := fake.baseResourceTypeReturns
 	fake.recordInvocation("BaseResourceType", []interface{}{})
 	fake.baseResourceTypeMutex.Unlock()
-	if fake.BaseResourceTypeStub != nil {
-		return fake.BaseResourceTypeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.baseResourceTypeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -269,15 +270,16 @@ func (fake *FakeCreatedVolume) ContainerHandle() string {
 	ret, specificReturn := fake.containerHandleReturnsOnCall[len(fake.containerHandleArgsForCall)]
 	fake.containerHandleArgsForCall = append(fake.containerHandleArgsForCall, struct {
 	}{})
+	stub := fake.ContainerHandleStub
+	fakeReturns := fake.containerHandleReturns
 	fake.recordInvocation("ContainerHandle", []interface{}{})
 	fake.containerHandleMutex.Unlock()
-	if fake.ContainerHandleStub != nil {
-		return fake.ContainerHandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.containerHandleReturns
 	return fakeReturns.result1
 }
 
@@ -323,15 +325,16 @@ func (fake *FakeCreatedVolume) CreateChildForContainer(arg1 db.CreatingContainer
 		arg1 db.CreatingContainer
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.CreateChildForContainerStub
+	fakeReturns := fake.createChildForContainerReturns
 	fake.recordInvocation("CreateChildForContainer", []interface{}{arg1, arg2})
 	fake.createChildForContainerMutex.Unlock()
-	if fake.CreateChildForContainerStub != nil {
-		return fake.CreateChildForContainerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createChildForContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -385,15 +388,16 @@ func (fake *FakeCreatedVolume) Destroying() (db.DestroyingVolume, error) {
 	ret, specificReturn := fake.destroyingReturnsOnCall[len(fake.destroyingArgsForCall)]
 	fake.destroyingArgsForCall = append(fake.destroyingArgsForCall, struct {
 	}{})
+	stub := fake.DestroyingStub
+	fakeReturns := fake.destroyingReturns
 	fake.recordInvocation("Destroying", []interface{}{})
 	fake.destroyingMutex.Unlock()
-	if fake.DestroyingStub != nil {
-		return fake.DestroyingStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyingReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -440,15 +444,16 @@ func (fake *FakeCreatedVolume) GetResourceCacheID() int {
 	ret, specificReturn := fake.getResourceCacheIDReturnsOnCall[len(fake.getResourceCacheIDArgsForCall)]
 	fake.getResourceCacheIDArgsForCall = append(fake.getResourceCacheIDArgsForCall, struct {
 	}{})
+	stub := fake.GetResourceCacheIDStub
+	fakeReturns := fake.getResourceCacheIDReturns
 	fake.recordInvocation("GetResourceCacheID", []interface{}{})
 	fake.getResourceCacheIDMutex.Unlock()
-	if fake.GetResourceCacheIDStub != nil {
-		return fake.GetResourceCacheIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getResourceCacheIDReturns
 	return fakeReturns.result1
 }
 
@@ -492,15 +497,16 @@ func (fake *FakeCreatedVolume) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -546,15 +552,16 @@ func (fake *FakeCreatedVolume) InitializeArtifact(arg1 string, arg2 int) (db.Wor
 		arg1 string
 		arg2 int
 	}{arg1, arg2})
+	stub := fake.InitializeArtifactStub
+	fakeReturns := fake.initializeArtifactReturns
 	fake.recordInvocation("InitializeArtifact", []interface{}{arg1, arg2})
 	fake.initializeArtifactMutex.Unlock()
-	if fake.InitializeArtifactStub != nil {
-		return fake.InitializeArtifactStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.initializeArtifactReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -609,15 +616,16 @@ func (fake *FakeCreatedVolume) InitializeResourceCache(arg1 db.UsedResourceCache
 	fake.initializeResourceCacheArgsForCall = append(fake.initializeResourceCacheArgsForCall, struct {
 		arg1 db.UsedResourceCache
 	}{arg1})
+	stub := fake.InitializeResourceCacheStub
+	fakeReturns := fake.initializeResourceCacheReturns
 	fake.recordInvocation("InitializeResourceCache", []interface{}{arg1})
 	fake.initializeResourceCacheMutex.Unlock()
-	if fake.InitializeResourceCacheStub != nil {
-		return fake.InitializeResourceCacheStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.initializeResourceCacheReturns
 	return fakeReturns.result1
 }
 
@@ -671,15 +679,16 @@ func (fake *FakeCreatedVolume) InitializeTaskCache(arg1 int, arg2 string, arg3 s
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.InitializeTaskCacheStub
+	fakeReturns := fake.initializeTaskCacheReturns
 	fake.recordInvocation("InitializeTaskCache", []interface{}{arg1, arg2, arg3})
 	fake.initializeTaskCacheMutex.Unlock()
-	if fake.InitializeTaskCacheStub != nil {
-		return fake.InitializeTaskCacheStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.initializeTaskCacheReturns
 	return fakeReturns.result1
 }
 
@@ -730,15 +739,16 @@ func (fake *FakeCreatedVolume) ParentHandle() string {
 	ret, specificReturn := fake.parentHandleReturnsOnCall[len(fake.parentHandleArgsForCall)]
 	fake.parentHandleArgsForCall = append(fake.parentHandleArgsForCall, struct {
 	}{})
+	stub := fake.ParentHandleStub
+	fakeReturns := fake.parentHandleReturns
 	fake.recordInvocation("ParentHandle", []interface{}{})
 	fake.parentHandleMutex.Unlock()
-	if fake.ParentHandleStub != nil {
-		return fake.ParentHandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.parentHandleReturns
 	return fakeReturns.result1
 }
 
@@ -782,15 +792,16 @@ func (fake *FakeCreatedVolume) Path() string {
 	ret, specificReturn := fake.pathReturnsOnCall[len(fake.pathArgsForCall)]
 	fake.pathArgsForCall = append(fake.pathArgsForCall, struct {
 	}{})
+	stub := fake.PathStub
+	fakeReturns := fake.pathReturns
 	fake.recordInvocation("Path", []interface{}{})
 	fake.pathMutex.Unlock()
-	if fake.PathStub != nil {
-		return fake.PathStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pathReturns
 	return fakeReturns.result1
 }
 
@@ -834,15 +845,16 @@ func (fake *FakeCreatedVolume) ResourceType() (*db.VolumeResourceType, error) {
 	ret, specificReturn := fake.resourceTypeReturnsOnCall[len(fake.resourceTypeArgsForCall)]
 	fake.resourceTypeArgsForCall = append(fake.resourceTypeArgsForCall, struct {
 	}{})
+	stub := fake.ResourceTypeStub
+	fakeReturns := fake.resourceTypeReturns
 	fake.recordInvocation("ResourceType", []interface{}{})
 	fake.resourceTypeMutex.Unlock()
-	if fake.ResourceTypeStub != nil {
-		return fake.ResourceTypeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.resourceTypeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -889,15 +901,16 @@ func (fake *FakeCreatedVolume) TaskIdentifier() (int, atc.PipelineRef, string, s
 	ret, specificReturn := fake.taskIdentifierReturnsOnCall[len(fake.taskIdentifierArgsForCall)]
 	fake.taskIdentifierArgsForCall = append(fake.taskIdentifierArgsForCall, struct {
 	}{})
+	stub := fake.TaskIdentifierStub
+	fakeReturns := fake.taskIdentifierReturns
 	fake.recordInvocation("TaskIdentifier", []interface{}{})
 	fake.taskIdentifierMutex.Unlock()
-	if fake.TaskIdentifierStub != nil {
-		return fake.TaskIdentifierStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4, ret.result5
 	}
-	fakeReturns := fake.taskIdentifierReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4, fakeReturns.result5
 }
 
@@ -953,15 +966,16 @@ func (fake *FakeCreatedVolume) TeamID() int {
 	ret, specificReturn := fake.teamIDReturnsOnCall[len(fake.teamIDArgsForCall)]
 	fake.teamIDArgsForCall = append(fake.teamIDArgsForCall, struct {
 	}{})
+	stub := fake.TeamIDStub
+	fakeReturns := fake.teamIDReturns
 	fake.recordInvocation("TeamID", []interface{}{})
 	fake.teamIDMutex.Unlock()
-	if fake.TeamIDStub != nil {
-		return fake.TeamIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamIDReturns
 	return fakeReturns.result1
 }
 
@@ -1005,15 +1019,16 @@ func (fake *FakeCreatedVolume) Type() db.VolumeType {
 	ret, specificReturn := fake.typeReturnsOnCall[len(fake.typeArgsForCall)]
 	fake.typeArgsForCall = append(fake.typeArgsForCall, struct {
 	}{})
+	stub := fake.TypeStub
+	fakeReturns := fake.typeReturns
 	fake.recordInvocation("Type", []interface{}{})
 	fake.typeMutex.Unlock()
-	if fake.TypeStub != nil {
-		return fake.TypeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.typeReturns
 	return fakeReturns.result1
 }
 
@@ -1057,15 +1072,16 @@ func (fake *FakeCreatedVolume) WorkerArtifactID() int {
 	ret, specificReturn := fake.workerArtifactIDReturnsOnCall[len(fake.workerArtifactIDArgsForCall)]
 	fake.workerArtifactIDArgsForCall = append(fake.workerArtifactIDArgsForCall, struct {
 	}{})
+	stub := fake.WorkerArtifactIDStub
+	fakeReturns := fake.workerArtifactIDReturns
 	fake.recordInvocation("WorkerArtifactID", []interface{}{})
 	fake.workerArtifactIDMutex.Unlock()
-	if fake.WorkerArtifactIDStub != nil {
-		return fake.WorkerArtifactIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerArtifactIDReturns
 	return fakeReturns.result1
 }
 
@@ -1109,15 +1125,16 @@ func (fake *FakeCreatedVolume) WorkerName() string {
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
 	fake.workerNameArgsForCall = append(fake.workerNameArgsForCall, struct {
 	}{})
+	stub := fake.WorkerNameStub
+	fakeReturns := fake.workerNameReturns
 	fake.recordInvocation("WorkerName", []interface{}{})
 	fake.workerNameMutex.Unlock()
-	if fake.WorkerNameStub != nil {
-		return fake.WorkerNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerNameReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_creating_container.go
+++ b/atc/db/dbfakes/fake_creating_container.go
@@ -91,15 +91,16 @@ func (fake *FakeCreatingContainer) Created() (db.CreatedContainer, error) {
 	ret, specificReturn := fake.createdReturnsOnCall[len(fake.createdArgsForCall)]
 	fake.createdArgsForCall = append(fake.createdArgsForCall, struct {
 	}{})
+	stub := fake.CreatedStub
+	fakeReturns := fake.createdReturns
 	fake.recordInvocation("Created", []interface{}{})
 	fake.createdMutex.Unlock()
-	if fake.CreatedStub != nil {
-		return fake.CreatedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createdReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -146,15 +147,16 @@ func (fake *FakeCreatingContainer) Failed() (db.FailedContainer, error) {
 	ret, specificReturn := fake.failedReturnsOnCall[len(fake.failedArgsForCall)]
 	fake.failedArgsForCall = append(fake.failedArgsForCall, struct {
 	}{})
+	stub := fake.FailedStub
+	fakeReturns := fake.failedReturns
 	fake.recordInvocation("Failed", []interface{}{})
 	fake.failedMutex.Unlock()
-	if fake.FailedStub != nil {
-		return fake.FailedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.failedReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -201,15 +203,16 @@ func (fake *FakeCreatingContainer) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -253,15 +256,16 @@ func (fake *FakeCreatingContainer) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -305,15 +309,16 @@ func (fake *FakeCreatingContainer) Metadata() db.ContainerMetadata {
 	ret, specificReturn := fake.metadataReturnsOnCall[len(fake.metadataArgsForCall)]
 	fake.metadataArgsForCall = append(fake.metadataArgsForCall, struct {
 	}{})
+	stub := fake.MetadataStub
+	fakeReturns := fake.metadataReturns
 	fake.recordInvocation("Metadata", []interface{}{})
 	fake.metadataMutex.Unlock()
-	if fake.MetadataStub != nil {
-		return fake.MetadataStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.metadataReturns
 	return fakeReturns.result1
 }
 
@@ -357,15 +362,16 @@ func (fake *FakeCreatingContainer) State() string {
 	ret, specificReturn := fake.stateReturnsOnCall[len(fake.stateArgsForCall)]
 	fake.stateArgsForCall = append(fake.stateArgsForCall, struct {
 	}{})
+	stub := fake.StateStub
+	fakeReturns := fake.stateReturns
 	fake.recordInvocation("State", []interface{}{})
 	fake.stateMutex.Unlock()
-	if fake.StateStub != nil {
-		return fake.StateStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stateReturns
 	return fakeReturns.result1
 }
 
@@ -409,15 +415,16 @@ func (fake *FakeCreatingContainer) WorkerName() string {
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
 	fake.workerNameArgsForCall = append(fake.workerNameArgsForCall, struct {
 	}{})
+	stub := fake.WorkerNameStub
+	fakeReturns := fake.workerNameReturns
 	fake.recordInvocation("WorkerName", []interface{}{})
 	fake.workerNameMutex.Unlock()
-	if fake.WorkerNameStub != nil {
-		return fake.WorkerNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerNameReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_creating_volume.go
+++ b/atc/db/dbfakes/fake_creating_volume.go
@@ -61,15 +61,16 @@ func (fake *FakeCreatingVolume) Created() (db.CreatedVolume, error) {
 	ret, specificReturn := fake.createdReturnsOnCall[len(fake.createdArgsForCall)]
 	fake.createdArgsForCall = append(fake.createdArgsForCall, struct {
 	}{})
+	stub := fake.CreatedStub
+	fakeReturns := fake.createdReturns
 	fake.recordInvocation("Created", []interface{}{})
 	fake.createdMutex.Unlock()
-	if fake.CreatedStub != nil {
-		return fake.CreatedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createdReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -116,15 +117,16 @@ func (fake *FakeCreatingVolume) Failed() (db.FailedVolume, error) {
 	ret, specificReturn := fake.failedReturnsOnCall[len(fake.failedArgsForCall)]
 	fake.failedArgsForCall = append(fake.failedArgsForCall, struct {
 	}{})
+	stub := fake.FailedStub
+	fakeReturns := fake.failedReturns
 	fake.recordInvocation("Failed", []interface{}{})
 	fake.failedMutex.Unlock()
-	if fake.FailedStub != nil {
-		return fake.FailedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.failedReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -171,15 +173,16 @@ func (fake *FakeCreatingVolume) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -223,15 +226,16 @@ func (fake *FakeCreatingVolume) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_destroying_container.go
+++ b/atc/db/dbfakes/fake_destroying_container.go
@@ -79,15 +79,16 @@ func (fake *FakeDestroyingContainer) Destroy() (bool, error) {
 	ret, specificReturn := fake.destroyReturnsOnCall[len(fake.destroyArgsForCall)]
 	fake.destroyArgsForCall = append(fake.destroyArgsForCall, struct {
 	}{})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -134,15 +135,16 @@ func (fake *FakeDestroyingContainer) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -186,15 +188,16 @@ func (fake *FakeDestroyingContainer) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -238,15 +241,16 @@ func (fake *FakeDestroyingContainer) Metadata() db.ContainerMetadata {
 	ret, specificReturn := fake.metadataReturnsOnCall[len(fake.metadataArgsForCall)]
 	fake.metadataArgsForCall = append(fake.metadataArgsForCall, struct {
 	}{})
+	stub := fake.MetadataStub
+	fakeReturns := fake.metadataReturns
 	fake.recordInvocation("Metadata", []interface{}{})
 	fake.metadataMutex.Unlock()
-	if fake.MetadataStub != nil {
-		return fake.MetadataStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.metadataReturns
 	return fakeReturns.result1
 }
 
@@ -290,15 +294,16 @@ func (fake *FakeDestroyingContainer) State() string {
 	ret, specificReturn := fake.stateReturnsOnCall[len(fake.stateArgsForCall)]
 	fake.stateArgsForCall = append(fake.stateArgsForCall, struct {
 	}{})
+	stub := fake.StateStub
+	fakeReturns := fake.stateReturns
 	fake.recordInvocation("State", []interface{}{})
 	fake.stateMutex.Unlock()
-	if fake.StateStub != nil {
-		return fake.StateStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stateReturns
 	return fakeReturns.result1
 }
 
@@ -342,15 +347,16 @@ func (fake *FakeDestroyingContainer) WorkerName() string {
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
 	fake.workerNameArgsForCall = append(fake.workerNameArgsForCall, struct {
 	}{})
+	stub := fake.WorkerNameStub
+	fakeReturns := fake.workerNameReturns
 	fake.recordInvocation("WorkerName", []interface{}{})
 	fake.workerNameMutex.Unlock()
-	if fake.WorkerNameStub != nil {
-		return fake.WorkerNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerNameReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_destroying_volume.go
+++ b/atc/db/dbfakes/fake_destroying_volume.go
@@ -49,15 +49,16 @@ func (fake *FakeDestroyingVolume) Destroy() (bool, error) {
 	ret, specificReturn := fake.destroyReturnsOnCall[len(fake.destroyArgsForCall)]
 	fake.destroyArgsForCall = append(fake.destroyArgsForCall, struct {
 	}{})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -104,15 +105,16 @@ func (fake *FakeDestroyingVolume) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -156,15 +158,16 @@ func (fake *FakeDestroyingVolume) WorkerName() string {
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
 	fake.workerNameArgsForCall = append(fake.workerNameArgsForCall, struct {
 	}{})
+	stub := fake.WorkerNameStub
+	fakeReturns := fake.workerNameReturns
 	fake.recordInvocation("WorkerName", []interface{}{})
 	fake.workerNameMutex.Unlock()
-	if fake.WorkerNameStub != nil {
-		return fake.WorkerNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerNameReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_event_source.go
+++ b/atc/db/dbfakes/fake_event_source.go
@@ -40,15 +40,16 @@ func (fake *FakeEventSource) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -92,15 +93,16 @@ func (fake *FakeEventSource) Next() (event.Envelope, error) {
 	ret, specificReturn := fake.nextReturnsOnCall[len(fake.nextArgsForCall)]
 	fake.nextArgsForCall = append(fake.nextArgsForCall, struct {
 	}{})
+	stub := fake.NextStub
+	fakeReturns := fake.nextReturns
 	fake.recordInvocation("Next", []interface{}{})
 	fake.nextMutex.Unlock()
-	if fake.NextStub != nil {
-		return fake.NextStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.nextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_executor.go
+++ b/atc/db/dbfakes/fake_executor.go
@@ -34,15 +34,16 @@ func (fake *FakeExecutor) Exec(arg1 string, arg2 ...interface{}) (sql.Result, er
 		arg1 string
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.ExecStub
+	fakeReturns := fake.execReturns
 	fake.recordInvocation("Exec", []interface{}{arg1, arg2})
 	fake.execMutex.Unlock()
-	if fake.ExecStub != nil {
-		return fake.ExecStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.execReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_failed_container.go
+++ b/atc/db/dbfakes/fake_failed_container.go
@@ -79,15 +79,16 @@ func (fake *FakeFailedContainer) Destroy() (bool, error) {
 	ret, specificReturn := fake.destroyReturnsOnCall[len(fake.destroyArgsForCall)]
 	fake.destroyArgsForCall = append(fake.destroyArgsForCall, struct {
 	}{})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -134,15 +135,16 @@ func (fake *FakeFailedContainer) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -186,15 +188,16 @@ func (fake *FakeFailedContainer) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -238,15 +241,16 @@ func (fake *FakeFailedContainer) Metadata() db.ContainerMetadata {
 	ret, specificReturn := fake.metadataReturnsOnCall[len(fake.metadataArgsForCall)]
 	fake.metadataArgsForCall = append(fake.metadataArgsForCall, struct {
 	}{})
+	stub := fake.MetadataStub
+	fakeReturns := fake.metadataReturns
 	fake.recordInvocation("Metadata", []interface{}{})
 	fake.metadataMutex.Unlock()
-	if fake.MetadataStub != nil {
-		return fake.MetadataStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.metadataReturns
 	return fakeReturns.result1
 }
 
@@ -290,15 +294,16 @@ func (fake *FakeFailedContainer) State() string {
 	ret, specificReturn := fake.stateReturnsOnCall[len(fake.stateArgsForCall)]
 	fake.stateArgsForCall = append(fake.stateArgsForCall, struct {
 	}{})
+	stub := fake.StateStub
+	fakeReturns := fake.stateReturns
 	fake.recordInvocation("State", []interface{}{})
 	fake.stateMutex.Unlock()
-	if fake.StateStub != nil {
-		return fake.StateStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stateReturns
 	return fakeReturns.result1
 }
 
@@ -342,15 +347,16 @@ func (fake *FakeFailedContainer) WorkerName() string {
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
 	fake.workerNameArgsForCall = append(fake.workerNameArgsForCall, struct {
 	}{})
+	stub := fake.WorkerNameStub
+	fakeReturns := fake.workerNameReturns
 	fake.recordInvocation("WorkerName", []interface{}{})
 	fake.workerNameMutex.Unlock()
-	if fake.WorkerNameStub != nil {
-		return fake.WorkerNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerNameReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_job.go
+++ b/atc/db/dbfakes/fake_job.go
@@ -509,15 +509,16 @@ func (fake *FakeJob) AcquireSchedulingLock(arg1 lager.Logger) (lock.Lock, bool, 
 	fake.acquireSchedulingLockArgsForCall = append(fake.acquireSchedulingLockArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.AcquireSchedulingLockStub
+	fakeReturns := fake.acquireSchedulingLockReturns
 	fake.recordInvocation("AcquireSchedulingLock", []interface{}{arg1})
 	fake.acquireSchedulingLockMutex.Unlock()
-	if fake.AcquireSchedulingLockStub != nil {
-		return fake.AcquireSchedulingLockStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.acquireSchedulingLockReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -574,15 +575,16 @@ func (fake *FakeJob) AlgorithmInputs() (db.InputConfigs, error) {
 	ret, specificReturn := fake.algorithmInputsReturnsOnCall[len(fake.algorithmInputsArgsForCall)]
 	fake.algorithmInputsArgsForCall = append(fake.algorithmInputsArgsForCall, struct {
 	}{})
+	stub := fake.AlgorithmInputsStub
+	fakeReturns := fake.algorithmInputsReturns
 	fake.recordInvocation("AlgorithmInputs", []interface{}{})
 	fake.algorithmInputsMutex.Unlock()
-	if fake.AlgorithmInputsStub != nil {
-		return fake.AlgorithmInputsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.algorithmInputsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -630,15 +632,16 @@ func (fake *FakeJob) Build(arg1 string) (db.Build, bool, error) {
 	fake.buildArgsForCall = append(fake.buildArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.BuildStub
+	fakeReturns := fake.buildReturns
 	fake.recordInvocation("Build", []interface{}{arg1})
 	fake.buildMutex.Unlock()
-	if fake.BuildStub != nil {
-		return fake.BuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -696,15 +699,16 @@ func (fake *FakeJob) Builds(arg1 db.Page) ([]db.Build, db.Pagination, error) {
 	fake.buildsArgsForCall = append(fake.buildsArgsForCall, struct {
 		arg1 db.Page
 	}{arg1})
+	stub := fake.BuildsStub
+	fakeReturns := fake.buildsReturns
 	fake.recordInvocation("Builds", []interface{}{arg1})
 	fake.buildsMutex.Unlock()
-	if fake.BuildsStub != nil {
-		return fake.BuildsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -762,15 +766,16 @@ func (fake *FakeJob) BuildsWithTime(arg1 db.Page) ([]db.Build, db.Pagination, er
 	fake.buildsWithTimeArgsForCall = append(fake.buildsWithTimeArgsForCall, struct {
 		arg1 db.Page
 	}{arg1})
+	stub := fake.BuildsWithTimeStub
+	fakeReturns := fake.buildsWithTimeReturns
 	fake.recordInvocation("BuildsWithTime", []interface{}{arg1})
 	fake.buildsWithTimeMutex.Unlock()
-	if fake.BuildsWithTimeStub != nil {
-		return fake.BuildsWithTimeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsWithTimeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -829,15 +834,16 @@ func (fake *FakeJob) ClearTaskCache(arg1 string, arg2 string) (int64, error) {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ClearTaskCacheStub
+	fakeReturns := fake.clearTaskCacheReturns
 	fake.recordInvocation("ClearTaskCache", []interface{}{arg1, arg2})
 	fake.clearTaskCacheMutex.Unlock()
-	if fake.ClearTaskCacheStub != nil {
-		return fake.ClearTaskCacheStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.clearTaskCacheReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -891,15 +897,16 @@ func (fake *FakeJob) Config() (atc.JobConfig, error) {
 	ret, specificReturn := fake.configReturnsOnCall[len(fake.configArgsForCall)]
 	fake.configArgsForCall = append(fake.configArgsForCall, struct {
 	}{})
+	stub := fake.ConfigStub
+	fakeReturns := fake.configReturns
 	fake.recordInvocation("Config", []interface{}{})
 	fake.configMutex.Unlock()
-	if fake.ConfigStub != nil {
-		return fake.ConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.configReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -947,15 +954,16 @@ func (fake *FakeJob) CreateBuild(arg1 string) (db.Build, error) {
 	fake.createBuildArgsForCall = append(fake.createBuildArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CreateBuildStub
+	fakeReturns := fake.createBuildReturns
 	fake.recordInvocation("CreateBuild", []interface{}{arg1})
 	fake.createBuildMutex.Unlock()
-	if fake.CreateBuildStub != nil {
-		return fake.CreateBuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1009,15 +1017,16 @@ func (fake *FakeJob) DisableManualTrigger() bool {
 	ret, specificReturn := fake.disableManualTriggerReturnsOnCall[len(fake.disableManualTriggerArgsForCall)]
 	fake.disableManualTriggerArgsForCall = append(fake.disableManualTriggerArgsForCall, struct {
 	}{})
+	stub := fake.DisableManualTriggerStub
+	fakeReturns := fake.disableManualTriggerReturns
 	fake.recordInvocation("DisableManualTrigger", []interface{}{})
 	fake.disableManualTriggerMutex.Unlock()
-	if fake.DisableManualTriggerStub != nil {
-		return fake.DisableManualTriggerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.disableManualTriggerReturns
 	return fakeReturns.result1
 }
 
@@ -1062,15 +1071,16 @@ func (fake *FakeJob) EnsurePendingBuildExists(arg1 context.Context) error {
 	fake.ensurePendingBuildExistsArgsForCall = append(fake.ensurePendingBuildExistsArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.EnsurePendingBuildExistsStub
+	fakeReturns := fake.ensurePendingBuildExistsReturns
 	fake.recordInvocation("EnsurePendingBuildExists", []interface{}{arg1})
 	fake.ensurePendingBuildExistsMutex.Unlock()
-	if fake.EnsurePendingBuildExistsStub != nil {
-		return fake.EnsurePendingBuildExistsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.ensurePendingBuildExistsReturns
 	return fakeReturns.result1
 }
 
@@ -1121,15 +1131,16 @@ func (fake *FakeJob) FinishedAndNextBuild() (db.Build, db.Build, error) {
 	ret, specificReturn := fake.finishedAndNextBuildReturnsOnCall[len(fake.finishedAndNextBuildArgsForCall)]
 	fake.finishedAndNextBuildArgsForCall = append(fake.finishedAndNextBuildArgsForCall, struct {
 	}{})
+	stub := fake.FinishedAndNextBuildStub
+	fakeReturns := fake.finishedAndNextBuildReturns
 	fake.recordInvocation("FinishedAndNextBuild", []interface{}{})
 	fake.finishedAndNextBuildMutex.Unlock()
-	if fake.FinishedAndNextBuildStub != nil {
-		return fake.FinishedAndNextBuildStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.finishedAndNextBuildReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1179,15 +1190,16 @@ func (fake *FakeJob) FirstLoggedBuildID() int {
 	ret, specificReturn := fake.firstLoggedBuildIDReturnsOnCall[len(fake.firstLoggedBuildIDArgsForCall)]
 	fake.firstLoggedBuildIDArgsForCall = append(fake.firstLoggedBuildIDArgsForCall, struct {
 	}{})
+	stub := fake.FirstLoggedBuildIDStub
+	fakeReturns := fake.firstLoggedBuildIDReturns
 	fake.recordInvocation("FirstLoggedBuildID", []interface{}{})
 	fake.firstLoggedBuildIDMutex.Unlock()
-	if fake.FirstLoggedBuildIDStub != nil {
-		return fake.FirstLoggedBuildIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.firstLoggedBuildIDReturns
 	return fakeReturns.result1
 }
 
@@ -1231,15 +1243,16 @@ func (fake *FakeJob) GetFullNextBuildInputs() ([]db.BuildInput, bool, error) {
 	ret, specificReturn := fake.getFullNextBuildInputsReturnsOnCall[len(fake.getFullNextBuildInputsArgsForCall)]
 	fake.getFullNextBuildInputsArgsForCall = append(fake.getFullNextBuildInputsArgsForCall, struct {
 	}{})
+	stub := fake.GetFullNextBuildInputsStub
+	fakeReturns := fake.getFullNextBuildInputsReturns
 	fake.recordInvocation("GetFullNextBuildInputs", []interface{}{})
 	fake.getFullNextBuildInputsMutex.Unlock()
-	if fake.GetFullNextBuildInputsStub != nil {
-		return fake.GetFullNextBuildInputsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getFullNextBuildInputsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1289,15 +1302,16 @@ func (fake *FakeJob) GetNextBuildInputs() ([]db.BuildInput, error) {
 	ret, specificReturn := fake.getNextBuildInputsReturnsOnCall[len(fake.getNextBuildInputsArgsForCall)]
 	fake.getNextBuildInputsArgsForCall = append(fake.getNextBuildInputsArgsForCall, struct {
 	}{})
+	stub := fake.GetNextBuildInputsStub
+	fakeReturns := fake.getNextBuildInputsReturns
 	fake.recordInvocation("GetNextBuildInputs", []interface{}{})
 	fake.getNextBuildInputsMutex.Unlock()
-	if fake.GetNextBuildInputsStub != nil {
-		return fake.GetNextBuildInputsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getNextBuildInputsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1344,15 +1358,16 @@ func (fake *FakeJob) GetPendingBuilds() ([]db.Build, error) {
 	ret, specificReturn := fake.getPendingBuildsReturnsOnCall[len(fake.getPendingBuildsArgsForCall)]
 	fake.getPendingBuildsArgsForCall = append(fake.getPendingBuildsArgsForCall, struct {
 	}{})
+	stub := fake.GetPendingBuildsStub
+	fakeReturns := fake.getPendingBuildsReturns
 	fake.recordInvocation("GetPendingBuilds", []interface{}{})
 	fake.getPendingBuildsMutex.Unlock()
-	if fake.GetPendingBuildsStub != nil {
-		return fake.GetPendingBuildsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPendingBuildsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1399,15 +1414,16 @@ func (fake *FakeJob) HasNewInputs() bool {
 	ret, specificReturn := fake.hasNewInputsReturnsOnCall[len(fake.hasNewInputsArgsForCall)]
 	fake.hasNewInputsArgsForCall = append(fake.hasNewInputsArgsForCall, struct {
 	}{})
+	stub := fake.HasNewInputsStub
+	fakeReturns := fake.hasNewInputsReturns
 	fake.recordInvocation("HasNewInputs", []interface{}{})
 	fake.hasNewInputsMutex.Unlock()
-	if fake.HasNewInputsStub != nil {
-		return fake.HasNewInputsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasNewInputsReturns
 	return fakeReturns.result1
 }
 
@@ -1451,15 +1467,16 @@ func (fake *FakeJob) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -1503,15 +1520,16 @@ func (fake *FakeJob) Inputs() ([]atc.JobInput, error) {
 	ret, specificReturn := fake.inputsReturnsOnCall[len(fake.inputsArgsForCall)]
 	fake.inputsArgsForCall = append(fake.inputsArgsForCall, struct {
 	}{})
+	stub := fake.InputsStub
+	fakeReturns := fake.inputsReturns
 	fake.recordInvocation("Inputs", []interface{}{})
 	fake.inputsMutex.Unlock()
-	if fake.InputsStub != nil {
-		return fake.InputsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.inputsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1558,15 +1576,16 @@ func (fake *FakeJob) MaxInFlight() int {
 	ret, specificReturn := fake.maxInFlightReturnsOnCall[len(fake.maxInFlightArgsForCall)]
 	fake.maxInFlightArgsForCall = append(fake.maxInFlightArgsForCall, struct {
 	}{})
+	stub := fake.MaxInFlightStub
+	fakeReturns := fake.maxInFlightReturns
 	fake.recordInvocation("MaxInFlight", []interface{}{})
 	fake.maxInFlightMutex.Unlock()
-	if fake.MaxInFlightStub != nil {
-		return fake.MaxInFlightStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.maxInFlightReturns
 	return fakeReturns.result1
 }
 
@@ -1610,15 +1629,16 @@ func (fake *FakeJob) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -1662,15 +1682,16 @@ func (fake *FakeJob) Outputs() ([]atc.JobOutput, error) {
 	ret, specificReturn := fake.outputsReturnsOnCall[len(fake.outputsArgsForCall)]
 	fake.outputsArgsForCall = append(fake.outputsArgsForCall, struct {
 	}{})
+	stub := fake.OutputsStub
+	fakeReturns := fake.outputsReturns
 	fake.recordInvocation("Outputs", []interface{}{})
 	fake.outputsMutex.Unlock()
-	if fake.OutputsStub != nil {
-		return fake.OutputsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.outputsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1717,15 +1738,16 @@ func (fake *FakeJob) Pause() error {
 	ret, specificReturn := fake.pauseReturnsOnCall[len(fake.pauseArgsForCall)]
 	fake.pauseArgsForCall = append(fake.pauseArgsForCall, struct {
 	}{})
+	stub := fake.PauseStub
+	fakeReturns := fake.pauseReturns
 	fake.recordInvocation("Pause", []interface{}{})
 	fake.pauseMutex.Unlock()
-	if fake.PauseStub != nil {
-		return fake.PauseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pauseReturns
 	return fakeReturns.result1
 }
 
@@ -1769,15 +1791,16 @@ func (fake *FakeJob) Paused() bool {
 	ret, specificReturn := fake.pausedReturnsOnCall[len(fake.pausedArgsForCall)]
 	fake.pausedArgsForCall = append(fake.pausedArgsForCall, struct {
 	}{})
+	stub := fake.PausedStub
+	fakeReturns := fake.pausedReturns
 	fake.recordInvocation("Paused", []interface{}{})
 	fake.pausedMutex.Unlock()
-	if fake.PausedStub != nil {
-		return fake.PausedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pausedReturns
 	return fakeReturns.result1
 }
 
@@ -1821,15 +1844,16 @@ func (fake *FakeJob) Pipeline() (db.Pipeline, bool, error) {
 	ret, specificReturn := fake.pipelineReturnsOnCall[len(fake.pipelineArgsForCall)]
 	fake.pipelineArgsForCall = append(fake.pipelineArgsForCall, struct {
 	}{})
+	stub := fake.PipelineStub
+	fakeReturns := fake.pipelineReturns
 	fake.recordInvocation("Pipeline", []interface{}{})
 	fake.pipelineMutex.Unlock()
-	if fake.PipelineStub != nil {
-		return fake.PipelineStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.pipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1879,15 +1903,16 @@ func (fake *FakeJob) PipelineID() int {
 	ret, specificReturn := fake.pipelineIDReturnsOnCall[len(fake.pipelineIDArgsForCall)]
 	fake.pipelineIDArgsForCall = append(fake.pipelineIDArgsForCall, struct {
 	}{})
+	stub := fake.PipelineIDStub
+	fakeReturns := fake.pipelineIDReturns
 	fake.recordInvocation("PipelineID", []interface{}{})
 	fake.pipelineIDMutex.Unlock()
-	if fake.PipelineIDStub != nil {
-		return fake.PipelineIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineIDReturns
 	return fakeReturns.result1
 }
 
@@ -1931,15 +1956,16 @@ func (fake *FakeJob) PipelineInstanceVars() atc.InstanceVars {
 	ret, specificReturn := fake.pipelineInstanceVarsReturnsOnCall[len(fake.pipelineInstanceVarsArgsForCall)]
 	fake.pipelineInstanceVarsArgsForCall = append(fake.pipelineInstanceVarsArgsForCall, struct {
 	}{})
+	stub := fake.PipelineInstanceVarsStub
+	fakeReturns := fake.pipelineInstanceVarsReturns
 	fake.recordInvocation("PipelineInstanceVars", []interface{}{})
 	fake.pipelineInstanceVarsMutex.Unlock()
-	if fake.PipelineInstanceVarsStub != nil {
-		return fake.PipelineInstanceVarsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineInstanceVarsReturns
 	return fakeReturns.result1
 }
 
@@ -1983,15 +2009,16 @@ func (fake *FakeJob) PipelineName() string {
 	ret, specificReturn := fake.pipelineNameReturnsOnCall[len(fake.pipelineNameArgsForCall)]
 	fake.pipelineNameArgsForCall = append(fake.pipelineNameArgsForCall, struct {
 	}{})
+	stub := fake.PipelineNameStub
+	fakeReturns := fake.pipelineNameReturns
 	fake.recordInvocation("PipelineName", []interface{}{})
 	fake.pipelineNameMutex.Unlock()
-	if fake.PipelineNameStub != nil {
-		return fake.PipelineNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineNameReturns
 	return fakeReturns.result1
 }
 
@@ -2035,15 +2062,16 @@ func (fake *FakeJob) PipelineRef() atc.PipelineRef {
 	ret, specificReturn := fake.pipelineRefReturnsOnCall[len(fake.pipelineRefArgsForCall)]
 	fake.pipelineRefArgsForCall = append(fake.pipelineRefArgsForCall, struct {
 	}{})
+	stub := fake.PipelineRefStub
+	fakeReturns := fake.pipelineRefReturns
 	fake.recordInvocation("PipelineRef", []interface{}{})
 	fake.pipelineRefMutex.Unlock()
-	if fake.PipelineRefStub != nil {
-		return fake.PipelineRefStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineRefReturns
 	return fakeReturns.result1
 }
 
@@ -2087,15 +2115,16 @@ func (fake *FakeJob) Public() bool {
 	ret, specificReturn := fake.publicReturnsOnCall[len(fake.publicArgsForCall)]
 	fake.publicArgsForCall = append(fake.publicArgsForCall, struct {
 	}{})
+	stub := fake.PublicStub
+	fakeReturns := fake.publicReturns
 	fake.recordInvocation("Public", []interface{}{})
 	fake.publicMutex.Unlock()
-	if fake.PublicStub != nil {
-		return fake.PublicStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.publicReturns
 	return fakeReturns.result1
 }
 
@@ -2139,15 +2168,16 @@ func (fake *FakeJob) Reload() (bool, error) {
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
 	fake.reloadArgsForCall = append(fake.reloadArgsForCall, struct {
 	}{})
+	stub := fake.ReloadStub
+	fakeReturns := fake.reloadReturns
 	fake.recordInvocation("Reload", []interface{}{})
 	fake.reloadMutex.Unlock()
-	if fake.ReloadStub != nil {
-		return fake.ReloadStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.reloadReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2194,15 +2224,16 @@ func (fake *FakeJob) RequestSchedule() error {
 	ret, specificReturn := fake.requestScheduleReturnsOnCall[len(fake.requestScheduleArgsForCall)]
 	fake.requestScheduleArgsForCall = append(fake.requestScheduleArgsForCall, struct {
 	}{})
+	stub := fake.RequestScheduleStub
+	fakeReturns := fake.requestScheduleReturns
 	fake.recordInvocation("RequestSchedule", []interface{}{})
 	fake.requestScheduleMutex.Unlock()
-	if fake.RequestScheduleStub != nil {
-		return fake.RequestScheduleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.requestScheduleReturns
 	return fakeReturns.result1
 }
 
@@ -2248,15 +2279,16 @@ func (fake *FakeJob) RerunBuild(arg1 db.Build, arg2 string) (db.Build, error) {
 		arg1 db.Build
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RerunBuildStub
+	fakeReturns := fake.rerunBuildReturns
 	fake.recordInvocation("RerunBuild", []interface{}{arg1, arg2})
 	fake.rerunBuildMutex.Unlock()
-	if fake.RerunBuildStub != nil {
-		return fake.RerunBuildStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.rerunBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2312,15 +2344,16 @@ func (fake *FakeJob) SaveNextInputMapping(arg1 db.InputMapping, arg2 bool) error
 		arg1 db.InputMapping
 		arg2 bool
 	}{arg1, arg2})
+	stub := fake.SaveNextInputMappingStub
+	fakeReturns := fake.saveNextInputMappingReturns
 	fake.recordInvocation("SaveNextInputMapping", []interface{}{arg1, arg2})
 	fake.saveNextInputMappingMutex.Unlock()
-	if fake.SaveNextInputMappingStub != nil {
-		return fake.SaveNextInputMappingStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveNextInputMappingReturns
 	return fakeReturns.result1
 }
 
@@ -2372,15 +2405,16 @@ func (fake *FakeJob) ScheduleBuild(arg1 db.Build) (bool, error) {
 	fake.scheduleBuildArgsForCall = append(fake.scheduleBuildArgsForCall, struct {
 		arg1 db.Build
 	}{arg1})
+	stub := fake.ScheduleBuildStub
+	fakeReturns := fake.scheduleBuildReturns
 	fake.recordInvocation("ScheduleBuild", []interface{}{arg1})
 	fake.scheduleBuildMutex.Unlock()
-	if fake.ScheduleBuildStub != nil {
-		return fake.ScheduleBuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.scheduleBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2434,15 +2468,16 @@ func (fake *FakeJob) ScheduleRequestedTime() time.Time {
 	ret, specificReturn := fake.scheduleRequestedTimeReturnsOnCall[len(fake.scheduleRequestedTimeArgsForCall)]
 	fake.scheduleRequestedTimeArgsForCall = append(fake.scheduleRequestedTimeArgsForCall, struct {
 	}{})
+	stub := fake.ScheduleRequestedTimeStub
+	fakeReturns := fake.scheduleRequestedTimeReturns
 	fake.recordInvocation("ScheduleRequestedTime", []interface{}{})
 	fake.scheduleRequestedTimeMutex.Unlock()
-	if fake.ScheduleRequestedTimeStub != nil {
-		return fake.ScheduleRequestedTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.scheduleRequestedTimeReturns
 	return fakeReturns.result1
 }
 
@@ -2487,15 +2522,16 @@ func (fake *FakeJob) SetHasNewInputs(arg1 bool) error {
 	fake.setHasNewInputsArgsForCall = append(fake.setHasNewInputsArgsForCall, struct {
 		arg1 bool
 	}{arg1})
+	stub := fake.SetHasNewInputsStub
+	fakeReturns := fake.setHasNewInputsReturns
 	fake.recordInvocation("SetHasNewInputs", []interface{}{arg1})
 	fake.setHasNewInputsMutex.Unlock()
-	if fake.SetHasNewInputsStub != nil {
-		return fake.SetHasNewInputsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setHasNewInputsReturns
 	return fakeReturns.result1
 }
 
@@ -2546,15 +2582,16 @@ func (fake *FakeJob) Tags() []string {
 	ret, specificReturn := fake.tagsReturnsOnCall[len(fake.tagsArgsForCall)]
 	fake.tagsArgsForCall = append(fake.tagsArgsForCall, struct {
 	}{})
+	stub := fake.TagsStub
+	fakeReturns := fake.tagsReturns
 	fake.recordInvocation("Tags", []interface{}{})
 	fake.tagsMutex.Unlock()
-	if fake.TagsStub != nil {
-		return fake.TagsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tagsReturns
 	return fakeReturns.result1
 }
 
@@ -2598,15 +2635,16 @@ func (fake *FakeJob) TeamID() int {
 	ret, specificReturn := fake.teamIDReturnsOnCall[len(fake.teamIDArgsForCall)]
 	fake.teamIDArgsForCall = append(fake.teamIDArgsForCall, struct {
 	}{})
+	stub := fake.TeamIDStub
+	fakeReturns := fake.teamIDReturns
 	fake.recordInvocation("TeamID", []interface{}{})
 	fake.teamIDMutex.Unlock()
-	if fake.TeamIDStub != nil {
-		return fake.TeamIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamIDReturns
 	return fakeReturns.result1
 }
 
@@ -2650,15 +2688,16 @@ func (fake *FakeJob) TeamName() string {
 	ret, specificReturn := fake.teamNameReturnsOnCall[len(fake.teamNameArgsForCall)]
 	fake.teamNameArgsForCall = append(fake.teamNameArgsForCall, struct {
 	}{})
+	stub := fake.TeamNameStub
+	fakeReturns := fake.teamNameReturns
 	fake.recordInvocation("TeamName", []interface{}{})
 	fake.teamNameMutex.Unlock()
-	if fake.TeamNameStub != nil {
-		return fake.TeamNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamNameReturns
 	return fakeReturns.result1
 }
 
@@ -2702,15 +2741,16 @@ func (fake *FakeJob) Unpause() error {
 	ret, specificReturn := fake.unpauseReturnsOnCall[len(fake.unpauseArgsForCall)]
 	fake.unpauseArgsForCall = append(fake.unpauseArgsForCall, struct {
 	}{})
+	stub := fake.UnpauseStub
+	fakeReturns := fake.unpauseReturns
 	fake.recordInvocation("Unpause", []interface{}{})
 	fake.unpauseMutex.Unlock()
-	if fake.UnpauseStub != nil {
-		return fake.UnpauseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unpauseReturns
 	return fakeReturns.result1
 }
 
@@ -2755,15 +2795,16 @@ func (fake *FakeJob) UpdateFirstLoggedBuildID(arg1 int) error {
 	fake.updateFirstLoggedBuildIDArgsForCall = append(fake.updateFirstLoggedBuildIDArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.UpdateFirstLoggedBuildIDStub
+	fakeReturns := fake.updateFirstLoggedBuildIDReturns
 	fake.recordInvocation("UpdateFirstLoggedBuildID", []interface{}{arg1})
 	fake.updateFirstLoggedBuildIDMutex.Unlock()
-	if fake.UpdateFirstLoggedBuildIDStub != nil {
-		return fake.UpdateFirstLoggedBuildIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateFirstLoggedBuildIDReturns
 	return fakeReturns.result1
 }
 
@@ -2815,15 +2856,16 @@ func (fake *FakeJob) UpdateLastScheduled(arg1 time.Time) error {
 	fake.updateLastScheduledArgsForCall = append(fake.updateLastScheduledArgsForCall, struct {
 		arg1 time.Time
 	}{arg1})
+	stub := fake.UpdateLastScheduledStub
+	fakeReturns := fake.updateLastScheduledReturns
 	fake.recordInvocation("UpdateLastScheduled", []interface{}{arg1})
 	fake.updateLastScheduledMutex.Unlock()
-	if fake.UpdateLastScheduledStub != nil {
-		return fake.UpdateLastScheduledStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateLastScheduledReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_job_factory.go
+++ b/atc/db/dbfakes/fake_job_factory.go
@@ -55,15 +55,16 @@ func (fake *FakeJobFactory) AllActiveJobs() ([]atc.JobSummary, error) {
 	ret, specificReturn := fake.allActiveJobsReturnsOnCall[len(fake.allActiveJobsArgsForCall)]
 	fake.allActiveJobsArgsForCall = append(fake.allActiveJobsArgsForCall, struct {
 	}{})
+	stub := fake.AllActiveJobsStub
+	fakeReturns := fake.allActiveJobsReturns
 	fake.recordInvocation("AllActiveJobs", []interface{}{})
 	fake.allActiveJobsMutex.Unlock()
-	if fake.AllActiveJobsStub != nil {
-		return fake.AllActiveJobsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.allActiveJobsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -110,15 +111,16 @@ func (fake *FakeJobFactory) JobsToSchedule() (db.SchedulerJobs, error) {
 	ret, specificReturn := fake.jobsToScheduleReturnsOnCall[len(fake.jobsToScheduleArgsForCall)]
 	fake.jobsToScheduleArgsForCall = append(fake.jobsToScheduleArgsForCall, struct {
 	}{})
+	stub := fake.JobsToScheduleStub
+	fakeReturns := fake.jobsToScheduleReturns
 	fake.recordInvocation("JobsToSchedule", []interface{}{})
 	fake.jobsToScheduleMutex.Unlock()
-	if fake.JobsToScheduleStub != nil {
-		return fake.JobsToScheduleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.jobsToScheduleReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -171,15 +173,16 @@ func (fake *FakeJobFactory) VisibleJobs(arg1 []string) ([]atc.JobSummary, error)
 	fake.visibleJobsArgsForCall = append(fake.visibleJobsArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.VisibleJobsStub
+	fakeReturns := fake.visibleJobsReturns
 	fake.recordInvocation("VisibleJobs", []interface{}{arg1Copy})
 	fake.visibleJobsMutex.Unlock()
-	if fake.VisibleJobsStub != nil {
-		return fake.VisibleJobsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.visibleJobsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_listener.go
+++ b/atc/db/dbfakes/fake_listener.go
@@ -60,15 +60,16 @@ func (fake *FakeListener) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -113,15 +114,16 @@ func (fake *FakeListener) Listen(arg1 string) error {
 	fake.listenArgsForCall = append(fake.listenArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListenStub
+	fakeReturns := fake.listenReturns
 	fake.recordInvocation("Listen", []interface{}{arg1})
 	fake.listenMutex.Unlock()
-	if fake.ListenStub != nil {
-		return fake.ListenStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.listenReturns
 	return fakeReturns.result1
 }
 
@@ -172,15 +174,16 @@ func (fake *FakeListener) NotificationChannel() <-chan *pq.Notification {
 	ret, specificReturn := fake.notificationChannelReturnsOnCall[len(fake.notificationChannelArgsForCall)]
 	fake.notificationChannelArgsForCall = append(fake.notificationChannelArgsForCall, struct {
 	}{})
+	stub := fake.NotificationChannelStub
+	fakeReturns := fake.notificationChannelReturns
 	fake.recordInvocation("NotificationChannel", []interface{}{})
 	fake.notificationChannelMutex.Unlock()
-	if fake.NotificationChannelStub != nil {
-		return fake.NotificationChannelStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.notificationChannelReturns
 	return fakeReturns.result1
 }
 
@@ -225,15 +228,16 @@ func (fake *FakeListener) Unlisten(arg1 string) error {
 	fake.unlistenArgsForCall = append(fake.unlistenArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.UnlistenStub
+	fakeReturns := fake.unlistenReturns
 	fake.recordInvocation("Unlisten", []interface{}{arg1})
 	fake.unlistenMutex.Unlock()
-	if fake.UnlistenStub != nil {
-		return fake.UnlistenStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unlistenReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_notifier.go
+++ b/atc/db/dbfakes/fake_notifier.go
@@ -37,15 +37,16 @@ func (fake *FakeNotifier) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -89,15 +90,16 @@ func (fake *FakeNotifier) Notify() <-chan struct{} {
 	ret, specificReturn := fake.notifyReturnsOnCall[len(fake.notifyArgsForCall)]
 	fake.notifyArgsForCall = append(fake.notifyArgsForCall, struct {
 	}{})
+	stub := fake.NotifyStub
+	fakeReturns := fake.notifyReturns
 	fake.recordInvocation("Notify", []interface{}{})
 	fake.notifyMutex.Unlock()
-	if fake.NotifyStub != nil {
-		return fake.NotifyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.notifyReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_pipeline.go
+++ b/atc/db/dbfakes/fake_pipeline.go
@@ -552,15 +552,16 @@ func (fake *FakePipeline) Archive() error {
 	ret, specificReturn := fake.archiveReturnsOnCall[len(fake.archiveArgsForCall)]
 	fake.archiveArgsForCall = append(fake.archiveArgsForCall, struct {
 	}{})
+	stub := fake.ArchiveStub
+	fakeReturns := fake.archiveReturns
 	fake.recordInvocation("Archive", []interface{}{})
 	fake.archiveMutex.Unlock()
-	if fake.ArchiveStub != nil {
-		return fake.ArchiveStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.archiveReturns
 	return fakeReturns.result1
 }
 
@@ -604,15 +605,16 @@ func (fake *FakePipeline) Archived() bool {
 	ret, specificReturn := fake.archivedReturnsOnCall[len(fake.archivedArgsForCall)]
 	fake.archivedArgsForCall = append(fake.archivedArgsForCall, struct {
 	}{})
+	stub := fake.ArchivedStub
+	fakeReturns := fake.archivedReturns
 	fake.recordInvocation("Archived", []interface{}{})
 	fake.archivedMutex.Unlock()
-	if fake.ArchivedStub != nil {
-		return fake.ArchivedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.archivedReturns
 	return fakeReturns.result1
 }
 
@@ -657,15 +659,16 @@ func (fake *FakePipeline) Builds(arg1 db.Page) ([]db.Build, db.Pagination, error
 	fake.buildsArgsForCall = append(fake.buildsArgsForCall, struct {
 		arg1 db.Page
 	}{arg1})
+	stub := fake.BuildsStub
+	fakeReturns := fake.buildsReturns
 	fake.recordInvocation("Builds", []interface{}{arg1})
 	fake.buildsMutex.Unlock()
-	if fake.BuildsStub != nil {
-		return fake.BuildsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -723,15 +726,16 @@ func (fake *FakePipeline) BuildsWithTime(arg1 db.Page) ([]db.Build, db.Paginatio
 	fake.buildsWithTimeArgsForCall = append(fake.buildsWithTimeArgsForCall, struct {
 		arg1 db.Page
 	}{arg1})
+	stub := fake.BuildsWithTimeStub
+	fakeReturns := fake.buildsWithTimeReturns
 	fake.recordInvocation("BuildsWithTime", []interface{}{arg1})
 	fake.buildsWithTimeMutex.Unlock()
-	if fake.BuildsWithTimeStub != nil {
-		return fake.BuildsWithTimeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsWithTimeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -789,15 +793,16 @@ func (fake *FakePipeline) Causality(arg1 int) ([]db.Cause, error) {
 	fake.causalityArgsForCall = append(fake.causalityArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.CausalityStub
+	fakeReturns := fake.causalityReturns
 	fake.recordInvocation("Causality", []interface{}{arg1})
 	fake.causalityMutex.Unlock()
-	if fake.CausalityStub != nil {
-		return fake.CausalityStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.causalityReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -851,15 +856,16 @@ func (fake *FakePipeline) CheckPaused() (bool, error) {
 	ret, specificReturn := fake.checkPausedReturnsOnCall[len(fake.checkPausedArgsForCall)]
 	fake.checkPausedArgsForCall = append(fake.checkPausedArgsForCall, struct {
 	}{})
+	stub := fake.CheckPausedStub
+	fakeReturns := fake.checkPausedReturns
 	fake.recordInvocation("CheckPaused", []interface{}{})
 	fake.checkPausedMutex.Unlock()
-	if fake.CheckPausedStub != nil {
-		return fake.CheckPausedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checkPausedReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -906,15 +912,16 @@ func (fake *FakePipeline) Config() (atc.Config, error) {
 	ret, specificReturn := fake.configReturnsOnCall[len(fake.configArgsForCall)]
 	fake.configArgsForCall = append(fake.configArgsForCall, struct {
 	}{})
+	stub := fake.ConfigStub
+	fakeReturns := fake.configReturns
 	fake.recordInvocation("Config", []interface{}{})
 	fake.configMutex.Unlock()
-	if fake.ConfigStub != nil {
-		return fake.ConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.configReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -961,15 +968,16 @@ func (fake *FakePipeline) ConfigVersion() db.ConfigVersion {
 	ret, specificReturn := fake.configVersionReturnsOnCall[len(fake.configVersionArgsForCall)]
 	fake.configVersionArgsForCall = append(fake.configVersionArgsForCall, struct {
 	}{})
+	stub := fake.ConfigVersionStub
+	fakeReturns := fake.configVersionReturns
 	fake.recordInvocation("ConfigVersion", []interface{}{})
 	fake.configVersionMutex.Unlock()
-	if fake.ConfigVersionStub != nil {
-		return fake.ConfigVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.configVersionReturns
 	return fakeReturns.result1
 }
 
@@ -1013,15 +1021,16 @@ func (fake *FakePipeline) CreateOneOffBuild() (db.Build, error) {
 	ret, specificReturn := fake.createOneOffBuildReturnsOnCall[len(fake.createOneOffBuildArgsForCall)]
 	fake.createOneOffBuildArgsForCall = append(fake.createOneOffBuildArgsForCall, struct {
 	}{})
+	stub := fake.CreateOneOffBuildStub
+	fakeReturns := fake.createOneOffBuildReturns
 	fake.recordInvocation("CreateOneOffBuild", []interface{}{})
 	fake.createOneOffBuildMutex.Unlock()
-	if fake.CreateOneOffBuildStub != nil {
-		return fake.CreateOneOffBuildStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createOneOffBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1069,15 +1078,16 @@ func (fake *FakePipeline) CreateStartedBuild(arg1 atc.Plan) (db.Build, error) {
 	fake.createStartedBuildArgsForCall = append(fake.createStartedBuildArgsForCall, struct {
 		arg1 atc.Plan
 	}{arg1})
+	stub := fake.CreateStartedBuildStub
+	fakeReturns := fake.createStartedBuildReturns
 	fake.recordInvocation("CreateStartedBuild", []interface{}{arg1})
 	fake.createStartedBuildMutex.Unlock()
-	if fake.CreateStartedBuildStub != nil {
-		return fake.CreateStartedBuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createStartedBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1131,15 +1141,16 @@ func (fake *FakePipeline) Dashboard() ([]atc.JobSummary, error) {
 	ret, specificReturn := fake.dashboardReturnsOnCall[len(fake.dashboardArgsForCall)]
 	fake.dashboardArgsForCall = append(fake.dashboardArgsForCall, struct {
 	}{})
+	stub := fake.DashboardStub
+	fakeReturns := fake.dashboardReturns
 	fake.recordInvocation("Dashboard", []interface{}{})
 	fake.dashboardMutex.Unlock()
-	if fake.DashboardStub != nil {
-		return fake.DashboardStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.dashboardReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1192,15 +1203,16 @@ func (fake *FakePipeline) DeleteBuildEventsByBuildIDs(arg1 []int) error {
 	fake.deleteBuildEventsByBuildIDsArgsForCall = append(fake.deleteBuildEventsByBuildIDsArgsForCall, struct {
 		arg1 []int
 	}{arg1Copy})
+	stub := fake.DeleteBuildEventsByBuildIDsStub
+	fakeReturns := fake.deleteBuildEventsByBuildIDsReturns
 	fake.recordInvocation("DeleteBuildEventsByBuildIDs", []interface{}{arg1Copy})
 	fake.deleteBuildEventsByBuildIDsMutex.Unlock()
-	if fake.DeleteBuildEventsByBuildIDsStub != nil {
-		return fake.DeleteBuildEventsByBuildIDsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteBuildEventsByBuildIDsReturns
 	return fakeReturns.result1
 }
 
@@ -1251,15 +1263,16 @@ func (fake *FakePipeline) Destroy() error {
 	ret, specificReturn := fake.destroyReturnsOnCall[len(fake.destroyArgsForCall)]
 	fake.destroyArgsForCall = append(fake.destroyArgsForCall, struct {
 	}{})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1
 }
 
@@ -1303,15 +1316,16 @@ func (fake *FakePipeline) Display() *atc.DisplayConfig {
 	ret, specificReturn := fake.displayReturnsOnCall[len(fake.displayArgsForCall)]
 	fake.displayArgsForCall = append(fake.displayArgsForCall, struct {
 	}{})
+	stub := fake.DisplayStub
+	fakeReturns := fake.displayReturns
 	fake.recordInvocation("Display", []interface{}{})
 	fake.displayMutex.Unlock()
-	if fake.DisplayStub != nil {
-		return fake.DisplayStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.displayReturns
 	return fakeReturns.result1
 }
 
@@ -1355,15 +1369,16 @@ func (fake *FakePipeline) Expose() error {
 	ret, specificReturn := fake.exposeReturnsOnCall[len(fake.exposeArgsForCall)]
 	fake.exposeArgsForCall = append(fake.exposeArgsForCall, struct {
 	}{})
+	stub := fake.ExposeStub
+	fakeReturns := fake.exposeReturns
 	fake.recordInvocation("Expose", []interface{}{})
 	fake.exposeMutex.Unlock()
-	if fake.ExposeStub != nil {
-		return fake.ExposeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.exposeReturns
 	return fakeReturns.result1
 }
 
@@ -1409,15 +1424,16 @@ func (fake *FakePipeline) GetBuildsWithVersionAsInput(arg1 int, arg2 int) ([]db.
 		arg1 int
 		arg2 int
 	}{arg1, arg2})
+	stub := fake.GetBuildsWithVersionAsInputStub
+	fakeReturns := fake.getBuildsWithVersionAsInputReturns
 	fake.recordInvocation("GetBuildsWithVersionAsInput", []interface{}{arg1, arg2})
 	fake.getBuildsWithVersionAsInputMutex.Unlock()
-	if fake.GetBuildsWithVersionAsInputStub != nil {
-		return fake.GetBuildsWithVersionAsInputStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getBuildsWithVersionAsInputReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1473,15 +1489,16 @@ func (fake *FakePipeline) GetBuildsWithVersionAsOutput(arg1 int, arg2 int) ([]db
 		arg1 int
 		arg2 int
 	}{arg1, arg2})
+	stub := fake.GetBuildsWithVersionAsOutputStub
+	fakeReturns := fake.getBuildsWithVersionAsOutputReturns
 	fake.recordInvocation("GetBuildsWithVersionAsOutput", []interface{}{arg1, arg2})
 	fake.getBuildsWithVersionAsOutputMutex.Unlock()
-	if fake.GetBuildsWithVersionAsOutputStub != nil {
-		return fake.GetBuildsWithVersionAsOutputStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getBuildsWithVersionAsOutputReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1535,15 +1552,16 @@ func (fake *FakePipeline) Groups() atc.GroupConfigs {
 	ret, specificReturn := fake.groupsReturnsOnCall[len(fake.groupsArgsForCall)]
 	fake.groupsArgsForCall = append(fake.groupsArgsForCall, struct {
 	}{})
+	stub := fake.GroupsStub
+	fakeReturns := fake.groupsReturns
 	fake.recordInvocation("Groups", []interface{}{})
 	fake.groupsMutex.Unlock()
-	if fake.GroupsStub != nil {
-		return fake.GroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.groupsReturns
 	return fakeReturns.result1
 }
 
@@ -1587,15 +1605,16 @@ func (fake *FakePipeline) Hide() error {
 	ret, specificReturn := fake.hideReturnsOnCall[len(fake.hideArgsForCall)]
 	fake.hideArgsForCall = append(fake.hideArgsForCall, struct {
 	}{})
+	stub := fake.HideStub
+	fakeReturns := fake.hideReturns
 	fake.recordInvocation("Hide", []interface{}{})
 	fake.hideMutex.Unlock()
-	if fake.HideStub != nil {
-		return fake.HideStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hideReturns
 	return fakeReturns.result1
 }
 
@@ -1639,15 +1658,16 @@ func (fake *FakePipeline) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -1691,15 +1711,16 @@ func (fake *FakePipeline) InstanceVars() atc.InstanceVars {
 	ret, specificReturn := fake.instanceVarsReturnsOnCall[len(fake.instanceVarsArgsForCall)]
 	fake.instanceVarsArgsForCall = append(fake.instanceVarsArgsForCall, struct {
 	}{})
+	stub := fake.InstanceVarsStub
+	fakeReturns := fake.instanceVarsReturns
 	fake.recordInvocation("InstanceVars", []interface{}{})
 	fake.instanceVarsMutex.Unlock()
-	if fake.InstanceVarsStub != nil {
-		return fake.InstanceVarsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.instanceVarsReturns
 	return fakeReturns.result1
 }
 
@@ -1744,15 +1765,16 @@ func (fake *FakePipeline) Job(arg1 string) (db.Job, bool, error) {
 	fake.jobArgsForCall = append(fake.jobArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.JobStub
+	fakeReturns := fake.jobReturns
 	fake.recordInvocation("Job", []interface{}{arg1})
 	fake.jobMutex.Unlock()
-	if fake.JobStub != nil {
-		return fake.JobStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.jobReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1809,15 +1831,16 @@ func (fake *FakePipeline) Jobs() (db.Jobs, error) {
 	ret, specificReturn := fake.jobsReturnsOnCall[len(fake.jobsArgsForCall)]
 	fake.jobsArgsForCall = append(fake.jobsArgsForCall, struct {
 	}{})
+	stub := fake.JobsStub
+	fakeReturns := fake.jobsReturns
 	fake.recordInvocation("Jobs", []interface{}{})
 	fake.jobsMutex.Unlock()
-	if fake.JobsStub != nil {
-		return fake.JobsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.jobsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1864,15 +1887,16 @@ func (fake *FakePipeline) LastUpdated() time.Time {
 	ret, specificReturn := fake.lastUpdatedReturnsOnCall[len(fake.lastUpdatedArgsForCall)]
 	fake.lastUpdatedArgsForCall = append(fake.lastUpdatedArgsForCall, struct {
 	}{})
+	stub := fake.LastUpdatedStub
+	fakeReturns := fake.lastUpdatedReturns
 	fake.recordInvocation("LastUpdated", []interface{}{})
 	fake.lastUpdatedMutex.Unlock()
-	if fake.LastUpdatedStub != nil {
-		return fake.LastUpdatedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastUpdatedReturns
 	return fakeReturns.result1
 }
 
@@ -1916,15 +1940,16 @@ func (fake *FakePipeline) LoadDebugVersionsDB() (*atc.DebugVersionsDB, error) {
 	ret, specificReturn := fake.loadDebugVersionsDBReturnsOnCall[len(fake.loadDebugVersionsDBArgsForCall)]
 	fake.loadDebugVersionsDBArgsForCall = append(fake.loadDebugVersionsDBArgsForCall, struct {
 	}{})
+	stub := fake.LoadDebugVersionsDBStub
+	fakeReturns := fake.loadDebugVersionsDBReturns
 	fake.recordInvocation("LoadDebugVersionsDB", []interface{}{})
 	fake.loadDebugVersionsDBMutex.Unlock()
-	if fake.LoadDebugVersionsDBStub != nil {
-		return fake.LoadDebugVersionsDBStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.loadDebugVersionsDBReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1971,15 +1996,16 @@ func (fake *FakePipeline) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -2023,15 +2049,16 @@ func (fake *FakePipeline) ParentBuildID() int {
 	ret, specificReturn := fake.parentBuildIDReturnsOnCall[len(fake.parentBuildIDArgsForCall)]
 	fake.parentBuildIDArgsForCall = append(fake.parentBuildIDArgsForCall, struct {
 	}{})
+	stub := fake.ParentBuildIDStub
+	fakeReturns := fake.parentBuildIDReturns
 	fake.recordInvocation("ParentBuildID", []interface{}{})
 	fake.parentBuildIDMutex.Unlock()
-	if fake.ParentBuildIDStub != nil {
-		return fake.ParentBuildIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.parentBuildIDReturns
 	return fakeReturns.result1
 }
 
@@ -2075,15 +2102,16 @@ func (fake *FakePipeline) ParentJobID() int {
 	ret, specificReturn := fake.parentJobIDReturnsOnCall[len(fake.parentJobIDArgsForCall)]
 	fake.parentJobIDArgsForCall = append(fake.parentJobIDArgsForCall, struct {
 	}{})
+	stub := fake.ParentJobIDStub
+	fakeReturns := fake.parentJobIDReturns
 	fake.recordInvocation("ParentJobID", []interface{}{})
 	fake.parentJobIDMutex.Unlock()
-	if fake.ParentJobIDStub != nil {
-		return fake.ParentJobIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.parentJobIDReturns
 	return fakeReturns.result1
 }
 
@@ -2127,15 +2155,16 @@ func (fake *FakePipeline) Pause() error {
 	ret, specificReturn := fake.pauseReturnsOnCall[len(fake.pauseArgsForCall)]
 	fake.pauseArgsForCall = append(fake.pauseArgsForCall, struct {
 	}{})
+	stub := fake.PauseStub
+	fakeReturns := fake.pauseReturns
 	fake.recordInvocation("Pause", []interface{}{})
 	fake.pauseMutex.Unlock()
-	if fake.PauseStub != nil {
-		return fake.PauseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pauseReturns
 	return fakeReturns.result1
 }
 
@@ -2179,15 +2208,16 @@ func (fake *FakePipeline) Paused() bool {
 	ret, specificReturn := fake.pausedReturnsOnCall[len(fake.pausedArgsForCall)]
 	fake.pausedArgsForCall = append(fake.pausedArgsForCall, struct {
 	}{})
+	stub := fake.PausedStub
+	fakeReturns := fake.pausedReturns
 	fake.recordInvocation("Paused", []interface{}{})
 	fake.pausedMutex.Unlock()
-	if fake.PausedStub != nil {
-		return fake.PausedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pausedReturns
 	return fakeReturns.result1
 }
 
@@ -2231,15 +2261,16 @@ func (fake *FakePipeline) Public() bool {
 	ret, specificReturn := fake.publicReturnsOnCall[len(fake.publicArgsForCall)]
 	fake.publicArgsForCall = append(fake.publicArgsForCall, struct {
 	}{})
+	stub := fake.PublicStub
+	fakeReturns := fake.publicReturns
 	fake.recordInvocation("Public", []interface{}{})
 	fake.publicMutex.Unlock()
-	if fake.PublicStub != nil {
-		return fake.PublicStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.publicReturns
 	return fakeReturns.result1
 }
 
@@ -2283,15 +2314,16 @@ func (fake *FakePipeline) Reload() (bool, error) {
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
 	fake.reloadArgsForCall = append(fake.reloadArgsForCall, struct {
 	}{})
+	stub := fake.ReloadStub
+	fakeReturns := fake.reloadReturns
 	fake.recordInvocation("Reload", []interface{}{})
 	fake.reloadMutex.Unlock()
-	if fake.ReloadStub != nil {
-		return fake.ReloadStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.reloadReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2339,15 +2371,16 @@ func (fake *FakePipeline) Resource(arg1 string) (db.Resource, bool, error) {
 	fake.resourceArgsForCall = append(fake.resourceArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ResourceStub
+	fakeReturns := fake.resourceReturns
 	fake.recordInvocation("Resource", []interface{}{arg1})
 	fake.resourceMutex.Unlock()
-	if fake.ResourceStub != nil {
-		return fake.ResourceStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.resourceReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2405,15 +2438,16 @@ func (fake *FakePipeline) ResourceByID(arg1 int) (db.Resource, bool, error) {
 	fake.resourceByIDArgsForCall = append(fake.resourceByIDArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.ResourceByIDStub
+	fakeReturns := fake.resourceByIDReturns
 	fake.recordInvocation("ResourceByID", []interface{}{arg1})
 	fake.resourceByIDMutex.Unlock()
-	if fake.ResourceByIDStub != nil {
-		return fake.ResourceByIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.resourceByIDReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2471,15 +2505,16 @@ func (fake *FakePipeline) ResourceType(arg1 string) (db.ResourceType, bool, erro
 	fake.resourceTypeArgsForCall = append(fake.resourceTypeArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ResourceTypeStub
+	fakeReturns := fake.resourceTypeReturns
 	fake.recordInvocation("ResourceType", []interface{}{arg1})
 	fake.resourceTypeMutex.Unlock()
-	if fake.ResourceTypeStub != nil {
-		return fake.ResourceTypeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.resourceTypeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2537,15 +2572,16 @@ func (fake *FakePipeline) ResourceTypeByID(arg1 int) (db.ResourceType, bool, err
 	fake.resourceTypeByIDArgsForCall = append(fake.resourceTypeByIDArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.ResourceTypeByIDStub
+	fakeReturns := fake.resourceTypeByIDReturns
 	fake.recordInvocation("ResourceTypeByID", []interface{}{arg1})
 	fake.resourceTypeByIDMutex.Unlock()
-	if fake.ResourceTypeByIDStub != nil {
-		return fake.ResourceTypeByIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.resourceTypeByIDReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2602,15 +2638,16 @@ func (fake *FakePipeline) ResourceTypes() (db.ResourceTypes, error) {
 	ret, specificReturn := fake.resourceTypesReturnsOnCall[len(fake.resourceTypesArgsForCall)]
 	fake.resourceTypesArgsForCall = append(fake.resourceTypesArgsForCall, struct {
 	}{})
+	stub := fake.ResourceTypesStub
+	fakeReturns := fake.resourceTypesReturns
 	fake.recordInvocation("ResourceTypes", []interface{}{})
 	fake.resourceTypesMutex.Unlock()
-	if fake.ResourceTypesStub != nil {
-		return fake.ResourceTypesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.resourceTypesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2658,15 +2695,16 @@ func (fake *FakePipeline) ResourceVersion(arg1 int) (atc.ResourceVersion, bool, 
 	fake.resourceVersionArgsForCall = append(fake.resourceVersionArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.ResourceVersionStub
+	fakeReturns := fake.resourceVersionReturns
 	fake.recordInvocation("ResourceVersion", []interface{}{arg1})
 	fake.resourceVersionMutex.Unlock()
-	if fake.ResourceVersionStub != nil {
-		return fake.ResourceVersionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.resourceVersionReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2723,15 +2761,16 @@ func (fake *FakePipeline) Resources() (db.Resources, error) {
 	ret, specificReturn := fake.resourcesReturnsOnCall[len(fake.resourcesArgsForCall)]
 	fake.resourcesArgsForCall = append(fake.resourcesArgsForCall, struct {
 	}{})
+	stub := fake.ResourcesStub
+	fakeReturns := fake.resourcesReturns
 	fake.recordInvocation("Resources", []interface{}{})
 	fake.resourcesMutex.Unlock()
-	if fake.ResourcesStub != nil {
-		return fake.ResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.resourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2780,15 +2819,16 @@ func (fake *FakePipeline) SetParentIDs(arg1 int, arg2 int) error {
 		arg1 int
 		arg2 int
 	}{arg1, arg2})
+	stub := fake.SetParentIDsStub
+	fakeReturns := fake.setParentIDsReturns
 	fake.recordInvocation("SetParentIDs", []interface{}{arg1, arg2})
 	fake.setParentIDsMutex.Unlock()
-	if fake.SetParentIDsStub != nil {
-		return fake.SetParentIDsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setParentIDsReturns
 	return fakeReturns.result1
 }
 
@@ -2839,15 +2879,16 @@ func (fake *FakePipeline) TeamID() int {
 	ret, specificReturn := fake.teamIDReturnsOnCall[len(fake.teamIDArgsForCall)]
 	fake.teamIDArgsForCall = append(fake.teamIDArgsForCall, struct {
 	}{})
+	stub := fake.TeamIDStub
+	fakeReturns := fake.teamIDReturns
 	fake.recordInvocation("TeamID", []interface{}{})
 	fake.teamIDMutex.Unlock()
-	if fake.TeamIDStub != nil {
-		return fake.TeamIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamIDReturns
 	return fakeReturns.result1
 }
 
@@ -2891,15 +2932,16 @@ func (fake *FakePipeline) TeamName() string {
 	ret, specificReturn := fake.teamNameReturnsOnCall[len(fake.teamNameArgsForCall)]
 	fake.teamNameArgsForCall = append(fake.teamNameArgsForCall, struct {
 	}{})
+	stub := fake.TeamNameStub
+	fakeReturns := fake.teamNameReturns
 	fake.recordInvocation("TeamName", []interface{}{})
 	fake.teamNameMutex.Unlock()
-	if fake.TeamNameStub != nil {
-		return fake.TeamNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamNameReturns
 	return fakeReturns.result1
 }
 
@@ -2943,15 +2985,16 @@ func (fake *FakePipeline) Unpause() error {
 	ret, specificReturn := fake.unpauseReturnsOnCall[len(fake.unpauseArgsForCall)]
 	fake.unpauseArgsForCall = append(fake.unpauseArgsForCall, struct {
 	}{})
+	stub := fake.UnpauseStub
+	fakeReturns := fake.unpauseReturns
 	fake.recordInvocation("Unpause", []interface{}{})
 	fake.unpauseMutex.Unlock()
-	if fake.UnpauseStub != nil {
-		return fake.UnpauseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unpauseReturns
 	return fakeReturns.result1
 }
 
@@ -2995,15 +3038,16 @@ func (fake *FakePipeline) VarSources() atc.VarSourceConfigs {
 	ret, specificReturn := fake.varSourcesReturnsOnCall[len(fake.varSourcesArgsForCall)]
 	fake.varSourcesArgsForCall = append(fake.varSourcesArgsForCall, struct {
 	}{})
+	stub := fake.VarSourcesStub
+	fakeReturns := fake.varSourcesReturns
 	fake.recordInvocation("VarSources", []interface{}{})
 	fake.varSourcesMutex.Unlock()
-	if fake.VarSourcesStub != nil {
-		return fake.VarSourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.varSourcesReturns
 	return fakeReturns.result1
 }
 
@@ -3050,15 +3094,16 @@ func (fake *FakePipeline) Variables(arg1 lager.Logger, arg2 creds.Secrets, arg3 
 		arg2 creds.Secrets
 		arg3 creds.VarSourcePool
 	}{arg1, arg2, arg3})
+	stub := fake.VariablesStub
+	fakeReturns := fake.variablesReturns
 	fake.recordInvocation("Variables", []interface{}{arg1, arg2, arg3})
 	fake.variablesMutex.Unlock()
-	if fake.VariablesStub != nil {
-		return fake.VariablesStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.variablesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_pipeline_factory.go
+++ b/atc/db/dbfakes/fake_pipeline_factory.go
@@ -54,15 +54,16 @@ func (fake *FakePipelineFactory) AllPipelines() ([]db.Pipeline, error) {
 	ret, specificReturn := fake.allPipelinesReturnsOnCall[len(fake.allPipelinesArgsForCall)]
 	fake.allPipelinesArgsForCall = append(fake.allPipelinesArgsForCall, struct {
 	}{})
+	stub := fake.AllPipelinesStub
+	fakeReturns := fake.allPipelinesReturns
 	fake.recordInvocation("AllPipelines", []interface{}{})
 	fake.allPipelinesMutex.Unlock()
-	if fake.AllPipelinesStub != nil {
-		return fake.AllPipelinesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.allPipelinesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -109,15 +110,16 @@ func (fake *FakePipelineFactory) PipelinesToSchedule() ([]db.Pipeline, error) {
 	ret, specificReturn := fake.pipelinesToScheduleReturnsOnCall[len(fake.pipelinesToScheduleArgsForCall)]
 	fake.pipelinesToScheduleArgsForCall = append(fake.pipelinesToScheduleArgsForCall, struct {
 	}{})
+	stub := fake.PipelinesToScheduleStub
+	fakeReturns := fake.pipelinesToScheduleReturns
 	fake.recordInvocation("PipelinesToSchedule", []interface{}{})
 	fake.pipelinesToScheduleMutex.Unlock()
-	if fake.PipelinesToScheduleStub != nil {
-		return fake.PipelinesToScheduleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.pipelinesToScheduleReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -170,15 +172,16 @@ func (fake *FakePipelineFactory) VisiblePipelines(arg1 []string) ([]db.Pipeline,
 	fake.visiblePipelinesArgsForCall = append(fake.visiblePipelinesArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.VisiblePipelinesStub
+	fakeReturns := fake.visiblePipelinesReturns
 	fake.recordInvocation("VisiblePipelines", []interface{}{arg1Copy})
 	fake.visiblePipelinesMutex.Unlock()
-	if fake.VisiblePipelinesStub != nil {
-		return fake.VisiblePipelinesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.visiblePipelinesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_pipeline_lifecycle.go
+++ b/atc/db/dbfakes/fake_pipeline_lifecycle.go
@@ -37,15 +37,16 @@ func (fake *FakePipelineLifecycle) ArchiveAbandonedPipelines() error {
 	ret, specificReturn := fake.archiveAbandonedPipelinesReturnsOnCall[len(fake.archiveAbandonedPipelinesArgsForCall)]
 	fake.archiveAbandonedPipelinesArgsForCall = append(fake.archiveAbandonedPipelinesArgsForCall, struct {
 	}{})
+	stub := fake.ArchiveAbandonedPipelinesStub
+	fakeReturns := fake.archiveAbandonedPipelinesReturns
 	fake.recordInvocation("ArchiveAbandonedPipelines", []interface{}{})
 	fake.archiveAbandonedPipelinesMutex.Unlock()
-	if fake.ArchiveAbandonedPipelinesStub != nil {
-		return fake.ArchiveAbandonedPipelinesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.archiveAbandonedPipelinesReturns
 	return fakeReturns.result1
 }
 
@@ -89,15 +90,16 @@ func (fake *FakePipelineLifecycle) RemoveBuildEventsForDeletedPipelines() error 
 	ret, specificReturn := fake.removeBuildEventsForDeletedPipelinesReturnsOnCall[len(fake.removeBuildEventsForDeletedPipelinesArgsForCall)]
 	fake.removeBuildEventsForDeletedPipelinesArgsForCall = append(fake.removeBuildEventsForDeletedPipelinesArgsForCall, struct {
 	}{})
+	stub := fake.RemoveBuildEventsForDeletedPipelinesStub
+	fakeReturns := fake.removeBuildEventsForDeletedPipelinesReturns
 	fake.recordInvocation("RemoveBuildEventsForDeletedPipelines", []interface{}{})
 	fake.removeBuildEventsForDeletedPipelinesMutex.Unlock()
-	if fake.RemoveBuildEventsForDeletedPipelinesStub != nil {
-		return fake.RemoveBuildEventsForDeletedPipelinesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeBuildEventsForDeletedPipelinesReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -471,15 +471,16 @@ func (fake *FakeResource) APIPinnedVersion() atc.Version {
 	ret, specificReturn := fake.aPIPinnedVersionReturnsOnCall[len(fake.aPIPinnedVersionArgsForCall)]
 	fake.aPIPinnedVersionArgsForCall = append(fake.aPIPinnedVersionArgsForCall, struct {
 	}{})
+	stub := fake.APIPinnedVersionStub
+	fakeReturns := fake.aPIPinnedVersionReturns
 	fake.recordInvocation("APIPinnedVersion", []interface{}{})
 	fake.aPIPinnedVersionMutex.Unlock()
-	if fake.APIPinnedVersionStub != nil {
-		return fake.APIPinnedVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.aPIPinnedVersionReturns
 	return fakeReturns.result1
 }
 
@@ -523,15 +524,16 @@ func (fake *FakeResource) BuildSummary() *atc.BuildSummary {
 	ret, specificReturn := fake.buildSummaryReturnsOnCall[len(fake.buildSummaryArgsForCall)]
 	fake.buildSummaryArgsForCall = append(fake.buildSummaryArgsForCall, struct {
 	}{})
+	stub := fake.BuildSummaryStub
+	fakeReturns := fake.buildSummaryReturns
 	fake.recordInvocation("BuildSummary", []interface{}{})
 	fake.buildSummaryMutex.Unlock()
-	if fake.BuildSummaryStub != nil {
-		return fake.BuildSummaryStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.buildSummaryReturns
 	return fakeReturns.result1
 }
 
@@ -575,15 +577,16 @@ func (fake *FakeResource) CheckEvery() *atc.CheckEvery {
 	ret, specificReturn := fake.checkEveryReturnsOnCall[len(fake.checkEveryArgsForCall)]
 	fake.checkEveryArgsForCall = append(fake.checkEveryArgsForCall, struct {
 	}{})
+	stub := fake.CheckEveryStub
+	fakeReturns := fake.checkEveryReturns
 	fake.recordInvocation("CheckEvery", []interface{}{})
 	fake.checkEveryMutex.Unlock()
-	if fake.CheckEveryStub != nil {
-		return fake.CheckEveryStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkEveryReturns
 	return fakeReturns.result1
 }
 
@@ -631,15 +634,16 @@ func (fake *FakeResource) CheckPlan(arg1 atc.Version, arg2 time.Duration, arg3 d
 		arg3 db.ResourceTypes
 		arg4 atc.Source
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CheckPlanStub
+	fakeReturns := fake.checkPlanReturns
 	fake.recordInvocation("CheckPlan", []interface{}{arg1, arg2, arg3, arg4})
 	fake.checkPlanMutex.Unlock()
-	if fake.CheckPlanStub != nil {
-		return fake.CheckPlanStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkPlanReturns
 	return fakeReturns.result1
 }
 
@@ -690,15 +694,16 @@ func (fake *FakeResource) CheckTimeout() string {
 	ret, specificReturn := fake.checkTimeoutReturnsOnCall[len(fake.checkTimeoutArgsForCall)]
 	fake.checkTimeoutArgsForCall = append(fake.checkTimeoutArgsForCall, struct {
 	}{})
+	stub := fake.CheckTimeoutStub
+	fakeReturns := fake.checkTimeoutReturns
 	fake.recordInvocation("CheckTimeout", []interface{}{})
 	fake.checkTimeoutMutex.Unlock()
-	if fake.CheckTimeoutStub != nil {
-		return fake.CheckTimeoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -742,15 +747,16 @@ func (fake *FakeResource) Config() atc.ResourceConfig {
 	ret, specificReturn := fake.configReturnsOnCall[len(fake.configArgsForCall)]
 	fake.configArgsForCall = append(fake.configArgsForCall, struct {
 	}{})
+	stub := fake.ConfigStub
+	fakeReturns := fake.configReturns
 	fake.recordInvocation("Config", []interface{}{})
 	fake.configMutex.Unlock()
-	if fake.ConfigStub != nil {
-		return fake.ConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.configReturns
 	return fakeReturns.result1
 }
 
@@ -794,15 +800,16 @@ func (fake *FakeResource) ConfigPinnedVersion() atc.Version {
 	ret, specificReturn := fake.configPinnedVersionReturnsOnCall[len(fake.configPinnedVersionArgsForCall)]
 	fake.configPinnedVersionArgsForCall = append(fake.configPinnedVersionArgsForCall, struct {
 	}{})
+	stub := fake.ConfigPinnedVersionStub
+	fakeReturns := fake.configPinnedVersionReturns
 	fake.recordInvocation("ConfigPinnedVersion", []interface{}{})
 	fake.configPinnedVersionMutex.Unlock()
-	if fake.ConfigPinnedVersionStub != nil {
-		return fake.ConfigPinnedVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.configPinnedVersionReturns
 	return fakeReturns.result1
 }
 
@@ -849,15 +856,16 @@ func (fake *FakeResource) CreateBuild(arg1 context.Context, arg2 bool, arg3 atc.
 		arg2 bool
 		arg3 atc.Plan
 	}{arg1, arg2, arg3})
+	stub := fake.CreateBuildStub
+	fakeReturns := fake.createBuildReturns
 	fake.recordInvocation("CreateBuild", []interface{}{arg1, arg2, arg3})
 	fake.createBuildMutex.Unlock()
-	if fake.CreateBuildStub != nil {
-		return fake.CreateBuildStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.createBuildReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -914,15 +922,16 @@ func (fake *FakeResource) CurrentPinnedVersion() atc.Version {
 	ret, specificReturn := fake.currentPinnedVersionReturnsOnCall[len(fake.currentPinnedVersionArgsForCall)]
 	fake.currentPinnedVersionArgsForCall = append(fake.currentPinnedVersionArgsForCall, struct {
 	}{})
+	stub := fake.CurrentPinnedVersionStub
+	fakeReturns := fake.currentPinnedVersionReturns
 	fake.recordInvocation("CurrentPinnedVersion", []interface{}{})
 	fake.currentPinnedVersionMutex.Unlock()
-	if fake.CurrentPinnedVersionStub != nil {
-		return fake.CurrentPinnedVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.currentPinnedVersionReturns
 	return fakeReturns.result1
 }
 
@@ -967,15 +976,16 @@ func (fake *FakeResource) DisableVersion(arg1 int) error {
 	fake.disableVersionArgsForCall = append(fake.disableVersionArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.DisableVersionStub
+	fakeReturns := fake.disableVersionReturns
 	fake.recordInvocation("DisableVersion", []interface{}{arg1})
 	fake.disableVersionMutex.Unlock()
-	if fake.DisableVersionStub != nil {
-		return fake.DisableVersionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.disableVersionReturns
 	return fakeReturns.result1
 }
 
@@ -1027,15 +1037,16 @@ func (fake *FakeResource) EnableVersion(arg1 int) error {
 	fake.enableVersionArgsForCall = append(fake.enableVersionArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.EnableVersionStub
+	fakeReturns := fake.enableVersionReturns
 	fake.recordInvocation("EnableVersion", []interface{}{arg1})
 	fake.enableVersionMutex.Unlock()
-	if fake.EnableVersionStub != nil {
-		return fake.EnableVersionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.enableVersionReturns
 	return fakeReturns.result1
 }
 
@@ -1087,15 +1098,16 @@ func (fake *FakeResource) FindVersion(arg1 atc.Version) (db.ResourceConfigVersio
 	fake.findVersionArgsForCall = append(fake.findVersionArgsForCall, struct {
 		arg1 atc.Version
 	}{arg1})
+	stub := fake.FindVersionStub
+	fakeReturns := fake.findVersionReturns
 	fake.recordInvocation("FindVersion", []interface{}{arg1})
 	fake.findVersionMutex.Unlock()
-	if fake.FindVersionStub != nil {
-		return fake.FindVersionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findVersionReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1152,15 +1164,16 @@ func (fake *FakeResource) HasWebhook() bool {
 	ret, specificReturn := fake.hasWebhookReturnsOnCall[len(fake.hasWebhookArgsForCall)]
 	fake.hasWebhookArgsForCall = append(fake.hasWebhookArgsForCall, struct {
 	}{})
+	stub := fake.HasWebhookStub
+	fakeReturns := fake.hasWebhookReturns
 	fake.recordInvocation("HasWebhook", []interface{}{})
 	fake.hasWebhookMutex.Unlock()
-	if fake.HasWebhookStub != nil {
-		return fake.HasWebhookStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasWebhookReturns
 	return fakeReturns.result1
 }
 
@@ -1204,15 +1217,16 @@ func (fake *FakeResource) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -1256,15 +1270,16 @@ func (fake *FakeResource) Icon() string {
 	ret, specificReturn := fake.iconReturnsOnCall[len(fake.iconArgsForCall)]
 	fake.iconArgsForCall = append(fake.iconArgsForCall, struct {
 	}{})
+	stub := fake.IconStub
+	fakeReturns := fake.iconReturns
 	fake.recordInvocation("Icon", []interface{}{})
 	fake.iconMutex.Unlock()
-	if fake.IconStub != nil {
-		return fake.IconStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iconReturns
 	return fakeReturns.result1
 }
 
@@ -1308,15 +1323,16 @@ func (fake *FakeResource) LastCheckEndTime() time.Time {
 	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
 	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
 	}{})
+	stub := fake.LastCheckEndTimeStub
+	fakeReturns := fake.lastCheckEndTimeReturns
 	fake.recordInvocation("LastCheckEndTime", []interface{}{})
 	fake.lastCheckEndTimeMutex.Unlock()
-	if fake.LastCheckEndTimeStub != nil {
-		return fake.LastCheckEndTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastCheckEndTimeReturns
 	return fakeReturns.result1
 }
 
@@ -1360,15 +1376,16 @@ func (fake *FakeResource) LastCheckStartTime() time.Time {
 	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
 	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
 	}{})
+	stub := fake.LastCheckStartTimeStub
+	fakeReturns := fake.lastCheckStartTimeReturns
 	fake.recordInvocation("LastCheckStartTime", []interface{}{})
 	fake.lastCheckStartTimeMutex.Unlock()
-	if fake.LastCheckStartTimeStub != nil {
-		return fake.LastCheckStartTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastCheckStartTimeReturns
 	return fakeReturns.result1
 }
 
@@ -1412,15 +1429,16 @@ func (fake *FakeResource) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -1464,15 +1482,16 @@ func (fake *FakeResource) NotifyScan() error {
 	ret, specificReturn := fake.notifyScanReturnsOnCall[len(fake.notifyScanArgsForCall)]
 	fake.notifyScanArgsForCall = append(fake.notifyScanArgsForCall, struct {
 	}{})
+	stub := fake.NotifyScanStub
+	fakeReturns := fake.notifyScanReturns
 	fake.recordInvocation("NotifyScan", []interface{}{})
 	fake.notifyScanMutex.Unlock()
-	if fake.NotifyScanStub != nil {
-		return fake.NotifyScanStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.notifyScanReturns
 	return fakeReturns.result1
 }
 
@@ -1516,15 +1535,16 @@ func (fake *FakeResource) PinComment() string {
 	ret, specificReturn := fake.pinCommentReturnsOnCall[len(fake.pinCommentArgsForCall)]
 	fake.pinCommentArgsForCall = append(fake.pinCommentArgsForCall, struct {
 	}{})
+	stub := fake.PinCommentStub
+	fakeReturns := fake.pinCommentReturns
 	fake.recordInvocation("PinComment", []interface{}{})
 	fake.pinCommentMutex.Unlock()
-	if fake.PinCommentStub != nil {
-		return fake.PinCommentStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pinCommentReturns
 	return fakeReturns.result1
 }
 
@@ -1569,15 +1589,16 @@ func (fake *FakeResource) PinVersion(arg1 int) (bool, error) {
 	fake.pinVersionArgsForCall = append(fake.pinVersionArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.PinVersionStub
+	fakeReturns := fake.pinVersionReturns
 	fake.recordInvocation("PinVersion", []interface{}{arg1})
 	fake.pinVersionMutex.Unlock()
-	if fake.PinVersionStub != nil {
-		return fake.PinVersionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.pinVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1631,15 +1652,16 @@ func (fake *FakeResource) Pipeline() (db.Pipeline, bool, error) {
 	ret, specificReturn := fake.pipelineReturnsOnCall[len(fake.pipelineArgsForCall)]
 	fake.pipelineArgsForCall = append(fake.pipelineArgsForCall, struct {
 	}{})
+	stub := fake.PipelineStub
+	fakeReturns := fake.pipelineReturns
 	fake.recordInvocation("Pipeline", []interface{}{})
 	fake.pipelineMutex.Unlock()
-	if fake.PipelineStub != nil {
-		return fake.PipelineStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.pipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1689,15 +1711,16 @@ func (fake *FakeResource) PipelineID() int {
 	ret, specificReturn := fake.pipelineIDReturnsOnCall[len(fake.pipelineIDArgsForCall)]
 	fake.pipelineIDArgsForCall = append(fake.pipelineIDArgsForCall, struct {
 	}{})
+	stub := fake.PipelineIDStub
+	fakeReturns := fake.pipelineIDReturns
 	fake.recordInvocation("PipelineID", []interface{}{})
 	fake.pipelineIDMutex.Unlock()
-	if fake.PipelineIDStub != nil {
-		return fake.PipelineIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineIDReturns
 	return fakeReturns.result1
 }
 
@@ -1741,15 +1764,16 @@ func (fake *FakeResource) PipelineInstanceVars() atc.InstanceVars {
 	ret, specificReturn := fake.pipelineInstanceVarsReturnsOnCall[len(fake.pipelineInstanceVarsArgsForCall)]
 	fake.pipelineInstanceVarsArgsForCall = append(fake.pipelineInstanceVarsArgsForCall, struct {
 	}{})
+	stub := fake.PipelineInstanceVarsStub
+	fakeReturns := fake.pipelineInstanceVarsReturns
 	fake.recordInvocation("PipelineInstanceVars", []interface{}{})
 	fake.pipelineInstanceVarsMutex.Unlock()
-	if fake.PipelineInstanceVarsStub != nil {
-		return fake.PipelineInstanceVarsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineInstanceVarsReturns
 	return fakeReturns.result1
 }
 
@@ -1793,15 +1817,16 @@ func (fake *FakeResource) PipelineName() string {
 	ret, specificReturn := fake.pipelineNameReturnsOnCall[len(fake.pipelineNameArgsForCall)]
 	fake.pipelineNameArgsForCall = append(fake.pipelineNameArgsForCall, struct {
 	}{})
+	stub := fake.PipelineNameStub
+	fakeReturns := fake.pipelineNameReturns
 	fake.recordInvocation("PipelineName", []interface{}{})
 	fake.pipelineNameMutex.Unlock()
-	if fake.PipelineNameStub != nil {
-		return fake.PipelineNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineNameReturns
 	return fakeReturns.result1
 }
 
@@ -1845,15 +1870,16 @@ func (fake *FakeResource) PipelineRef() atc.PipelineRef {
 	ret, specificReturn := fake.pipelineRefReturnsOnCall[len(fake.pipelineRefArgsForCall)]
 	fake.pipelineRefArgsForCall = append(fake.pipelineRefArgsForCall, struct {
 	}{})
+	stub := fake.PipelineRefStub
+	fakeReturns := fake.pipelineRefReturns
 	fake.recordInvocation("PipelineRef", []interface{}{})
 	fake.pipelineRefMutex.Unlock()
-	if fake.PipelineRefStub != nil {
-		return fake.PipelineRefStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineRefReturns
 	return fakeReturns.result1
 }
 
@@ -1897,15 +1923,16 @@ func (fake *FakeResource) Public() bool {
 	ret, specificReturn := fake.publicReturnsOnCall[len(fake.publicArgsForCall)]
 	fake.publicArgsForCall = append(fake.publicArgsForCall, struct {
 	}{})
+	stub := fake.PublicStub
+	fakeReturns := fake.publicReturns
 	fake.recordInvocation("Public", []interface{}{})
 	fake.publicMutex.Unlock()
-	if fake.PublicStub != nil {
-		return fake.PublicStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.publicReturns
 	return fakeReturns.result1
 }
 
@@ -1949,15 +1976,16 @@ func (fake *FakeResource) Reload() (bool, error) {
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
 	fake.reloadArgsForCall = append(fake.reloadArgsForCall, struct {
 	}{})
+	stub := fake.ReloadStub
+	fakeReturns := fake.reloadReturns
 	fake.recordInvocation("Reload", []interface{}{})
 	fake.reloadMutex.Unlock()
-	if fake.ReloadStub != nil {
-		return fake.ReloadStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.reloadReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2004,15 +2032,16 @@ func (fake *FakeResource) ResourceConfigID() int {
 	ret, specificReturn := fake.resourceConfigIDReturnsOnCall[len(fake.resourceConfigIDArgsForCall)]
 	fake.resourceConfigIDArgsForCall = append(fake.resourceConfigIDArgsForCall, struct {
 	}{})
+	stub := fake.ResourceConfigIDStub
+	fakeReturns := fake.resourceConfigIDReturns
 	fake.recordInvocation("ResourceConfigID", []interface{}{})
 	fake.resourceConfigIDMutex.Unlock()
-	if fake.ResourceConfigIDStub != nil {
-		return fake.ResourceConfigIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceConfigIDReturns
 	return fakeReturns.result1
 }
 
@@ -2056,15 +2085,16 @@ func (fake *FakeResource) ResourceConfigScopeID() int {
 	ret, specificReturn := fake.resourceConfigScopeIDReturnsOnCall[len(fake.resourceConfigScopeIDArgsForCall)]
 	fake.resourceConfigScopeIDArgsForCall = append(fake.resourceConfigScopeIDArgsForCall, struct {
 	}{})
+	stub := fake.ResourceConfigScopeIDStub
+	fakeReturns := fake.resourceConfigScopeIDReturns
 	fake.recordInvocation("ResourceConfigScopeID", []interface{}{})
 	fake.resourceConfigScopeIDMutex.Unlock()
-	if fake.ResourceConfigScopeIDStub != nil {
-		return fake.ResourceConfigScopeIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceConfigScopeIDReturns
 	return fakeReturns.result1
 }
 
@@ -2109,15 +2139,16 @@ func (fake *FakeResource) SetPinComment(arg1 string) error {
 	fake.setPinCommentArgsForCall = append(fake.setPinCommentArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SetPinCommentStub
+	fakeReturns := fake.setPinCommentReturns
 	fake.recordInvocation("SetPinComment", []interface{}{arg1})
 	fake.setPinCommentMutex.Unlock()
-	if fake.SetPinCommentStub != nil {
-		return fake.SetPinCommentStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setPinCommentReturns
 	return fakeReturns.result1
 }
 
@@ -2169,15 +2200,16 @@ func (fake *FakeResource) SetResourceConfigScope(arg1 db.ResourceConfigScope) er
 	fake.setResourceConfigScopeArgsForCall = append(fake.setResourceConfigScopeArgsForCall, struct {
 		arg1 db.ResourceConfigScope
 	}{arg1})
+	stub := fake.SetResourceConfigScopeStub
+	fakeReturns := fake.setResourceConfigScopeReturns
 	fake.recordInvocation("SetResourceConfigScope", []interface{}{arg1})
 	fake.setResourceConfigScopeMutex.Unlock()
-	if fake.SetResourceConfigScopeStub != nil {
-		return fake.SetResourceConfigScopeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setResourceConfigScopeReturns
 	return fakeReturns.result1
 }
 
@@ -2228,15 +2260,16 @@ func (fake *FakeResource) Source() atc.Source {
 	ret, specificReturn := fake.sourceReturnsOnCall[len(fake.sourceArgsForCall)]
 	fake.sourceArgsForCall = append(fake.sourceArgsForCall, struct {
 	}{})
+	stub := fake.SourceStub
+	fakeReturns := fake.sourceReturns
 	fake.recordInvocation("Source", []interface{}{})
 	fake.sourceMutex.Unlock()
-	if fake.SourceStub != nil {
-		return fake.SourceStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sourceReturns
 	return fakeReturns.result1
 }
 
@@ -2280,15 +2313,16 @@ func (fake *FakeResource) Tags() atc.Tags {
 	ret, specificReturn := fake.tagsReturnsOnCall[len(fake.tagsArgsForCall)]
 	fake.tagsArgsForCall = append(fake.tagsArgsForCall, struct {
 	}{})
+	stub := fake.TagsStub
+	fakeReturns := fake.tagsReturns
 	fake.recordInvocation("Tags", []interface{}{})
 	fake.tagsMutex.Unlock()
-	if fake.TagsStub != nil {
-		return fake.TagsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tagsReturns
 	return fakeReturns.result1
 }
 
@@ -2332,15 +2366,16 @@ func (fake *FakeResource) TeamID() int {
 	ret, specificReturn := fake.teamIDReturnsOnCall[len(fake.teamIDArgsForCall)]
 	fake.teamIDArgsForCall = append(fake.teamIDArgsForCall, struct {
 	}{})
+	stub := fake.TeamIDStub
+	fakeReturns := fake.teamIDReturns
 	fake.recordInvocation("TeamID", []interface{}{})
 	fake.teamIDMutex.Unlock()
-	if fake.TeamIDStub != nil {
-		return fake.TeamIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamIDReturns
 	return fakeReturns.result1
 }
 
@@ -2384,15 +2419,16 @@ func (fake *FakeResource) TeamName() string {
 	ret, specificReturn := fake.teamNameReturnsOnCall[len(fake.teamNameArgsForCall)]
 	fake.teamNameArgsForCall = append(fake.teamNameArgsForCall, struct {
 	}{})
+	stub := fake.TeamNameStub
+	fakeReturns := fake.teamNameReturns
 	fake.recordInvocation("TeamName", []interface{}{})
 	fake.teamNameMutex.Unlock()
-	if fake.TeamNameStub != nil {
-		return fake.TeamNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamNameReturns
 	return fakeReturns.result1
 }
 
@@ -2436,15 +2472,16 @@ func (fake *FakeResource) Type() string {
 	ret, specificReturn := fake.typeReturnsOnCall[len(fake.typeArgsForCall)]
 	fake.typeArgsForCall = append(fake.typeArgsForCall, struct {
 	}{})
+	stub := fake.TypeStub
+	fakeReturns := fake.typeReturns
 	fake.recordInvocation("Type", []interface{}{})
 	fake.typeMutex.Unlock()
-	if fake.TypeStub != nil {
-		return fake.TypeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.typeReturns
 	return fakeReturns.result1
 }
 
@@ -2488,15 +2525,16 @@ func (fake *FakeResource) UnpinVersion() error {
 	ret, specificReturn := fake.unpinVersionReturnsOnCall[len(fake.unpinVersionArgsForCall)]
 	fake.unpinVersionArgsForCall = append(fake.unpinVersionArgsForCall, struct {
 	}{})
+	stub := fake.UnpinVersionStub
+	fakeReturns := fake.unpinVersionReturns
 	fake.recordInvocation("UnpinVersion", []interface{}{})
 	fake.unpinVersionMutex.Unlock()
-	if fake.UnpinVersionStub != nil {
-		return fake.UnpinVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.unpinVersionReturns
 	return fakeReturns.result1
 }
 
@@ -2542,15 +2580,16 @@ func (fake *FakeResource) UpdateMetadata(arg1 atc.Version, arg2 db.ResourceConfi
 		arg1 atc.Version
 		arg2 db.ResourceConfigMetadataFields
 	}{arg1, arg2})
+	stub := fake.UpdateMetadataStub
+	fakeReturns := fake.updateMetadataReturns
 	fake.recordInvocation("UpdateMetadata", []interface{}{arg1, arg2})
 	fake.updateMetadataMutex.Unlock()
-	if fake.UpdateMetadataStub != nil {
-		return fake.UpdateMetadataStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateMetadataReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2606,15 +2645,16 @@ func (fake *FakeResource) Versions(arg1 db.Page, arg2 atc.Version) ([]atc.Resour
 		arg1 db.Page
 		arg2 atc.Version
 	}{arg1, arg2})
+	stub := fake.VersionsStub
+	fakeReturns := fake.versionsReturns
 	fake.recordInvocation("Versions", []interface{}{arg1, arg2})
 	fake.versionsMutex.Unlock()
-	if fake.VersionsStub != nil {
-		return fake.VersionsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.versionsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -2674,15 +2714,16 @@ func (fake *FakeResource) WebhookToken() string {
 	ret, specificReturn := fake.webhookTokenReturnsOnCall[len(fake.webhookTokenArgsForCall)]
 	fake.webhookTokenArgsForCall = append(fake.webhookTokenArgsForCall, struct {
 	}{})
+	stub := fake.WebhookTokenStub
+	fakeReturns := fake.webhookTokenReturns
 	fake.recordInvocation("WebhookToken", []interface{}{})
 	fake.webhookTokenMutex.Unlock()
-	if fake.WebhookTokenStub != nil {
-		return fake.WebhookTokenStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.webhookTokenReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_resource_cache_factory.go
+++ b/atc/db/dbfakes/fake_resource_cache_factory.go
@@ -82,15 +82,16 @@ func (fake *FakeResourceCacheFactory) FindOrCreateResourceCache(arg1 db.Resource
 		arg5 atc.Params
 		arg6 atc.VersionedResourceTypes
 	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	stub := fake.FindOrCreateResourceCacheStub
+	fakeReturns := fake.findOrCreateResourceCacheReturns
 	fake.recordInvocation("FindOrCreateResourceCache", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.findOrCreateResourceCacheMutex.Unlock()
-	if fake.FindOrCreateResourceCacheStub != nil {
-		return fake.FindOrCreateResourceCacheStub(arg1, arg2, arg3, arg4, arg5, arg6)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateResourceCacheReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -145,15 +146,16 @@ func (fake *FakeResourceCacheFactory) FindResourceCacheByID(arg1 int) (db.UsedRe
 	fake.findResourceCacheByIDArgsForCall = append(fake.findResourceCacheByIDArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.FindResourceCacheByIDStub
+	fakeReturns := fake.findResourceCacheByIDReturns
 	fake.recordInvocation("FindResourceCacheByID", []interface{}{arg1})
 	fake.findResourceCacheByIDMutex.Unlock()
-	if fake.FindResourceCacheByIDStub != nil {
-		return fake.FindResourceCacheByIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findResourceCacheByIDReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -211,15 +213,16 @@ func (fake *FakeResourceCacheFactory) ResourceCacheMetadata(arg1 db.UsedResource
 	fake.resourceCacheMetadataArgsForCall = append(fake.resourceCacheMetadataArgsForCall, struct {
 		arg1 db.UsedResourceCache
 	}{arg1})
+	stub := fake.ResourceCacheMetadataStub
+	fakeReturns := fake.resourceCacheMetadataReturns
 	fake.recordInvocation("ResourceCacheMetadata", []interface{}{arg1})
 	fake.resourceCacheMetadataMutex.Unlock()
-	if fake.ResourceCacheMetadataStub != nil {
-		return fake.ResourceCacheMetadataStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.resourceCacheMetadataReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -280,15 +283,16 @@ func (fake *FakeResourceCacheFactory) UpdateResourceCacheMetadata(arg1 db.UsedRe
 		arg1 db.UsedResourceCache
 		arg2 []atc.MetadataField
 	}{arg1, arg2Copy})
+	stub := fake.UpdateResourceCacheMetadataStub
+	fakeReturns := fake.updateResourceCacheMetadataReturns
 	fake.recordInvocation("UpdateResourceCacheMetadata", []interface{}{arg1, arg2Copy})
 	fake.updateResourceCacheMetadataMutex.Unlock()
-	if fake.UpdateResourceCacheMetadataStub != nil {
-		return fake.UpdateResourceCacheMetadataStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateResourceCacheMetadataReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_resource_cache_lifecycle.go
+++ b/atc/db/dbfakes/fake_resource_cache_lifecycle.go
@@ -52,15 +52,16 @@ func (fake *FakeResourceCacheLifecycle) CleanBuildImageResourceCaches(arg1 lager
 	fake.cleanBuildImageResourceCachesArgsForCall = append(fake.cleanBuildImageResourceCachesArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.CleanBuildImageResourceCachesStub
+	fakeReturns := fake.cleanBuildImageResourceCachesReturns
 	fake.recordInvocation("CleanBuildImageResourceCaches", []interface{}{arg1})
 	fake.cleanBuildImageResourceCachesMutex.Unlock()
-	if fake.CleanBuildImageResourceCachesStub != nil {
-		return fake.CleanBuildImageResourceCachesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanBuildImageResourceCachesReturns
 	return fakeReturns.result1
 }
 
@@ -112,15 +113,16 @@ func (fake *FakeResourceCacheLifecycle) CleanUpInvalidCaches(arg1 lager.Logger) 
 	fake.cleanUpInvalidCachesArgsForCall = append(fake.cleanUpInvalidCachesArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.CleanUpInvalidCachesStub
+	fakeReturns := fake.cleanUpInvalidCachesReturns
 	fake.recordInvocation("CleanUpInvalidCaches", []interface{}{arg1})
 	fake.cleanUpInvalidCachesMutex.Unlock()
-	if fake.CleanUpInvalidCachesStub != nil {
-		return fake.CleanUpInvalidCachesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanUpInvalidCachesReturns
 	return fakeReturns.result1
 }
 
@@ -172,15 +174,16 @@ func (fake *FakeResourceCacheLifecycle) CleanUsesForFinishedBuilds(arg1 lager.Lo
 	fake.cleanUsesForFinishedBuildsArgsForCall = append(fake.cleanUsesForFinishedBuildsArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.CleanUsesForFinishedBuildsStub
+	fakeReturns := fake.cleanUsesForFinishedBuildsReturns
 	fake.recordInvocation("CleanUsesForFinishedBuilds", []interface{}{arg1})
 	fake.cleanUsesForFinishedBuildsMutex.Unlock()
-	if fake.CleanUsesForFinishedBuildsStub != nil {
-		return fake.CleanUsesForFinishedBuildsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanUsesForFinishedBuildsReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_resource_config.go
+++ b/atc/db/dbfakes/fake_resource_config.go
@@ -81,15 +81,16 @@ func (fake *FakeResourceConfig) CreatedByBaseResourceType() *db.UsedBaseResource
 	ret, specificReturn := fake.createdByBaseResourceTypeReturnsOnCall[len(fake.createdByBaseResourceTypeArgsForCall)]
 	fake.createdByBaseResourceTypeArgsForCall = append(fake.createdByBaseResourceTypeArgsForCall, struct {
 	}{})
+	stub := fake.CreatedByBaseResourceTypeStub
+	fakeReturns := fake.createdByBaseResourceTypeReturns
 	fake.recordInvocation("CreatedByBaseResourceType", []interface{}{})
 	fake.createdByBaseResourceTypeMutex.Unlock()
-	if fake.CreatedByBaseResourceTypeStub != nil {
-		return fake.CreatedByBaseResourceTypeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createdByBaseResourceTypeReturns
 	return fakeReturns.result1
 }
 
@@ -133,15 +134,16 @@ func (fake *FakeResourceConfig) CreatedByResourceCache() db.UsedResourceCache {
 	ret, specificReturn := fake.createdByResourceCacheReturnsOnCall[len(fake.createdByResourceCacheArgsForCall)]
 	fake.createdByResourceCacheArgsForCall = append(fake.createdByResourceCacheArgsForCall, struct {
 	}{})
+	stub := fake.CreatedByResourceCacheStub
+	fakeReturns := fake.createdByResourceCacheReturns
 	fake.recordInvocation("CreatedByResourceCache", []interface{}{})
 	fake.createdByResourceCacheMutex.Unlock()
-	if fake.CreatedByResourceCacheStub != nil {
-		return fake.CreatedByResourceCacheStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createdByResourceCacheReturns
 	return fakeReturns.result1
 }
 
@@ -186,15 +188,16 @@ func (fake *FakeResourceConfig) FindOrCreateScope(arg1 db.Resource) (db.Resource
 	fake.findOrCreateScopeArgsForCall = append(fake.findOrCreateScopeArgsForCall, struct {
 		arg1 db.Resource
 	}{arg1})
+	stub := fake.FindOrCreateScopeStub
+	fakeReturns := fake.findOrCreateScopeReturns
 	fake.recordInvocation("FindOrCreateScope", []interface{}{arg1})
 	fake.findOrCreateScopeMutex.Unlock()
-	if fake.FindOrCreateScopeStub != nil {
-		return fake.FindOrCreateScopeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateScopeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -248,15 +251,16 @@ func (fake *FakeResourceConfig) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -300,15 +304,16 @@ func (fake *FakeResourceConfig) LastReferenced() time.Time {
 	ret, specificReturn := fake.lastReferencedReturnsOnCall[len(fake.lastReferencedArgsForCall)]
 	fake.lastReferencedArgsForCall = append(fake.lastReferencedArgsForCall, struct {
 	}{})
+	stub := fake.LastReferencedStub
+	fakeReturns := fake.lastReferencedReturns
 	fake.recordInvocation("LastReferenced", []interface{}{})
 	fake.lastReferencedMutex.Unlock()
-	if fake.LastReferencedStub != nil {
-		return fake.LastReferencedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastReferencedReturns
 	return fakeReturns.result1
 }
 
@@ -352,15 +357,16 @@ func (fake *FakeResourceConfig) OriginBaseResourceType() *db.UsedBaseResourceTyp
 	ret, specificReturn := fake.originBaseResourceTypeReturnsOnCall[len(fake.originBaseResourceTypeArgsForCall)]
 	fake.originBaseResourceTypeArgsForCall = append(fake.originBaseResourceTypeArgsForCall, struct {
 	}{})
+	stub := fake.OriginBaseResourceTypeStub
+	fakeReturns := fake.originBaseResourceTypeReturns
 	fake.recordInvocation("OriginBaseResourceType", []interface{}{})
 	fake.originBaseResourceTypeMutex.Unlock()
-	if fake.OriginBaseResourceTypeStub != nil {
-		return fake.OriginBaseResourceTypeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.originBaseResourceTypeReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_resource_config_check_session_lifecycle.go
+++ b/atc/db/dbfakes/fake_resource_config_check_session_lifecycle.go
@@ -37,15 +37,16 @@ func (fake *FakeResourceConfigCheckSessionLifecycle) CleanExpiredResourceConfigC
 	ret, specificReturn := fake.cleanExpiredResourceConfigCheckSessionsReturnsOnCall[len(fake.cleanExpiredResourceConfigCheckSessionsArgsForCall)]
 	fake.cleanExpiredResourceConfigCheckSessionsArgsForCall = append(fake.cleanExpiredResourceConfigCheckSessionsArgsForCall, struct {
 	}{})
+	stub := fake.CleanExpiredResourceConfigCheckSessionsStub
+	fakeReturns := fake.cleanExpiredResourceConfigCheckSessionsReturns
 	fake.recordInvocation("CleanExpiredResourceConfigCheckSessions", []interface{}{})
 	fake.cleanExpiredResourceConfigCheckSessionsMutex.Unlock()
-	if fake.CleanExpiredResourceConfigCheckSessionsStub != nil {
-		return fake.CleanExpiredResourceConfigCheckSessionsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanExpiredResourceConfigCheckSessionsReturns
 	return fakeReturns.result1
 }
 
@@ -89,15 +90,16 @@ func (fake *FakeResourceConfigCheckSessionLifecycle) CleanInactiveResourceConfig
 	ret, specificReturn := fake.cleanInactiveResourceConfigCheckSessionsReturnsOnCall[len(fake.cleanInactiveResourceConfigCheckSessionsArgsForCall)]
 	fake.cleanInactiveResourceConfigCheckSessionsArgsForCall = append(fake.cleanInactiveResourceConfigCheckSessionsArgsForCall, struct {
 	}{})
+	stub := fake.CleanInactiveResourceConfigCheckSessionsStub
+	fakeReturns := fake.cleanInactiveResourceConfigCheckSessionsReturns
 	fake.recordInvocation("CleanInactiveResourceConfigCheckSessions", []interface{}{})
 	fake.cleanInactiveResourceConfigCheckSessionsMutex.Unlock()
-	if fake.CleanInactiveResourceConfigCheckSessionsStub != nil {
-		return fake.CleanInactiveResourceConfigCheckSessionsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanInactiveResourceConfigCheckSessionsReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_resource_config_factory.go
+++ b/atc/db/dbfakes/fake_resource_config_factory.go
@@ -61,15 +61,16 @@ func (fake *FakeResourceConfigFactory) CleanUnreferencedConfigs(arg1 time.Durati
 	fake.cleanUnreferencedConfigsArgsForCall = append(fake.cleanUnreferencedConfigsArgsForCall, struct {
 		arg1 time.Duration
 	}{arg1})
+	stub := fake.CleanUnreferencedConfigsStub
+	fakeReturns := fake.cleanUnreferencedConfigsReturns
 	fake.recordInvocation("CleanUnreferencedConfigs", []interface{}{arg1})
 	fake.cleanUnreferencedConfigsMutex.Unlock()
-	if fake.CleanUnreferencedConfigsStub != nil {
-		return fake.CleanUnreferencedConfigsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanUnreferencedConfigsReturns
 	return fakeReturns.result1
 }
 
@@ -123,15 +124,16 @@ func (fake *FakeResourceConfigFactory) FindOrCreateResourceConfig(arg1 string, a
 		arg2 atc.Source
 		arg3 atc.VersionedResourceTypes
 	}{arg1, arg2, arg3})
+	stub := fake.FindOrCreateResourceConfigStub
+	fakeReturns := fake.findOrCreateResourceConfigReturns
 	fake.recordInvocation("FindOrCreateResourceConfig", []interface{}{arg1, arg2, arg3})
 	fake.findOrCreateResourceConfigMutex.Unlock()
-	if fake.FindOrCreateResourceConfigStub != nil {
-		return fake.FindOrCreateResourceConfigStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateResourceConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -186,15 +188,16 @@ func (fake *FakeResourceConfigFactory) FindResourceConfigByID(arg1 int) (db.Reso
 	fake.findResourceConfigByIDArgsForCall = append(fake.findResourceConfigByIDArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.FindResourceConfigByIDStub
+	fakeReturns := fake.findResourceConfigByIDReturns
 	fake.recordInvocation("FindResourceConfigByID", []interface{}{arg1})
 	fake.findResourceConfigByIDMutex.Unlock()
-	if fake.FindResourceConfigByIDStub != nil {
-		return fake.FindResourceConfigByIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findResourceConfigByIDReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/db/dbfakes/fake_resource_config_scope.go
+++ b/atc/db/dbfakes/fake_resource_config_scope.go
@@ -144,15 +144,16 @@ func (fake *FakeResourceConfigScope) AcquireResourceCheckingLock(arg1 lager.Logg
 	fake.acquireResourceCheckingLockArgsForCall = append(fake.acquireResourceCheckingLockArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.AcquireResourceCheckingLockStub
+	fakeReturns := fake.acquireResourceCheckingLockReturns
 	fake.recordInvocation("AcquireResourceCheckingLock", []interface{}{arg1})
 	fake.acquireResourceCheckingLockMutex.Unlock()
-	if fake.AcquireResourceCheckingLockStub != nil {
-		return fake.AcquireResourceCheckingLockStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.acquireResourceCheckingLockReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -210,15 +211,16 @@ func (fake *FakeResourceConfigScope) FindVersion(arg1 atc.Version) (db.ResourceC
 	fake.findVersionArgsForCall = append(fake.findVersionArgsForCall, struct {
 		arg1 atc.Version
 	}{arg1})
+	stub := fake.FindVersionStub
+	fakeReturns := fake.findVersionReturns
 	fake.recordInvocation("FindVersion", []interface{}{arg1})
 	fake.findVersionMutex.Unlock()
-	if fake.FindVersionStub != nil {
-		return fake.FindVersionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findVersionReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -275,15 +277,16 @@ func (fake *FakeResourceConfigScope) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -327,15 +330,16 @@ func (fake *FakeResourceConfigScope) LastCheckEndTime() (time.Time, error) {
 	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
 	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
 	}{})
+	stub := fake.LastCheckEndTimeStub
+	fakeReturns := fake.lastCheckEndTimeReturns
 	fake.recordInvocation("LastCheckEndTime", []interface{}{})
 	fake.lastCheckEndTimeMutex.Unlock()
-	if fake.LastCheckEndTimeStub != nil {
-		return fake.LastCheckEndTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.lastCheckEndTimeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -382,15 +386,16 @@ func (fake *FakeResourceConfigScope) LatestVersion() (db.ResourceConfigVersion, 
 	ret, specificReturn := fake.latestVersionReturnsOnCall[len(fake.latestVersionArgsForCall)]
 	fake.latestVersionArgsForCall = append(fake.latestVersionArgsForCall, struct {
 	}{})
+	stub := fake.LatestVersionStub
+	fakeReturns := fake.latestVersionReturns
 	fake.recordInvocation("LatestVersion", []interface{}{})
 	fake.latestVersionMutex.Unlock()
-	if fake.LatestVersionStub != nil {
-		return fake.LatestVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.latestVersionReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -440,15 +445,16 @@ func (fake *FakeResourceConfigScope) Resource() db.Resource {
 	ret, specificReturn := fake.resourceReturnsOnCall[len(fake.resourceArgsForCall)]
 	fake.resourceArgsForCall = append(fake.resourceArgsForCall, struct {
 	}{})
+	stub := fake.ResourceStub
+	fakeReturns := fake.resourceReturns
 	fake.recordInvocation("Resource", []interface{}{})
 	fake.resourceMutex.Unlock()
-	if fake.ResourceStub != nil {
-		return fake.ResourceStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceReturns
 	return fakeReturns.result1
 }
 
@@ -492,15 +498,16 @@ func (fake *FakeResourceConfigScope) ResourceConfig() db.ResourceConfig {
 	ret, specificReturn := fake.resourceConfigReturnsOnCall[len(fake.resourceConfigArgsForCall)]
 	fake.resourceConfigArgsForCall = append(fake.resourceConfigArgsForCall, struct {
 	}{})
+	stub := fake.ResourceConfigStub
+	fakeReturns := fake.resourceConfigReturns
 	fake.recordInvocation("ResourceConfig", []interface{}{})
 	fake.resourceConfigMutex.Unlock()
-	if fake.ResourceConfigStub != nil {
-		return fake.ResourceConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceConfigReturns
 	return fakeReturns.result1
 }
 
@@ -551,15 +558,16 @@ func (fake *FakeResourceConfigScope) SaveVersions(arg1 db.SpanContext, arg2 []at
 		arg1 db.SpanContext
 		arg2 []atc.Version
 	}{arg1, arg2Copy})
+	stub := fake.SaveVersionsStub
+	fakeReturns := fake.saveVersionsReturns
 	fake.recordInvocation("SaveVersions", []interface{}{arg1, arg2Copy})
 	fake.saveVersionsMutex.Unlock()
-	if fake.SaveVersionsStub != nil {
-		return fake.SaveVersionsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveVersionsReturns
 	return fakeReturns.result1
 }
 
@@ -610,15 +618,16 @@ func (fake *FakeResourceConfigScope) UpdateLastCheckEndTime() (bool, error) {
 	ret, specificReturn := fake.updateLastCheckEndTimeReturnsOnCall[len(fake.updateLastCheckEndTimeArgsForCall)]
 	fake.updateLastCheckEndTimeArgsForCall = append(fake.updateLastCheckEndTimeArgsForCall, struct {
 	}{})
+	stub := fake.UpdateLastCheckEndTimeStub
+	fakeReturns := fake.updateLastCheckEndTimeReturns
 	fake.recordInvocation("UpdateLastCheckEndTime", []interface{}{})
 	fake.updateLastCheckEndTimeMutex.Unlock()
-	if fake.UpdateLastCheckEndTimeStub != nil {
-		return fake.UpdateLastCheckEndTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateLastCheckEndTimeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -665,15 +674,16 @@ func (fake *FakeResourceConfigScope) UpdateLastCheckStartTime() (bool, error) {
 	ret, specificReturn := fake.updateLastCheckStartTimeReturnsOnCall[len(fake.updateLastCheckStartTimeArgsForCall)]
 	fake.updateLastCheckStartTimeArgsForCall = append(fake.updateLastCheckStartTimeArgsForCall, struct {
 	}{})
+	stub := fake.UpdateLastCheckStartTimeStub
+	fakeReturns := fake.updateLastCheckStartTimeReturns
 	fake.recordInvocation("UpdateLastCheckStartTime", []interface{}{})
 	fake.updateLastCheckStartTimeMutex.Unlock()
-	if fake.UpdateLastCheckStartTimeStub != nil {
-		return fake.UpdateLastCheckStartTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateLastCheckStartTimeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_resource_config_version.go
+++ b/atc/db/dbfakes/fake_resource_config_version.go
@@ -80,15 +80,16 @@ func (fake *FakeResourceConfigVersion) CheckOrder() int {
 	ret, specificReturn := fake.checkOrderReturnsOnCall[len(fake.checkOrderArgsForCall)]
 	fake.checkOrderArgsForCall = append(fake.checkOrderArgsForCall, struct {
 	}{})
+	stub := fake.CheckOrderStub
+	fakeReturns := fake.checkOrderReturns
 	fake.recordInvocation("CheckOrder", []interface{}{})
 	fake.checkOrderMutex.Unlock()
-	if fake.CheckOrderStub != nil {
-		return fake.CheckOrderStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkOrderReturns
 	return fakeReturns.result1
 }
 
@@ -132,15 +133,16 @@ func (fake *FakeResourceConfigVersion) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -184,15 +186,16 @@ func (fake *FakeResourceConfigVersion) Metadata() db.ResourceConfigMetadataField
 	ret, specificReturn := fake.metadataReturnsOnCall[len(fake.metadataArgsForCall)]
 	fake.metadataArgsForCall = append(fake.metadataArgsForCall, struct {
 	}{})
+	stub := fake.MetadataStub
+	fakeReturns := fake.metadataReturns
 	fake.recordInvocation("Metadata", []interface{}{})
 	fake.metadataMutex.Unlock()
-	if fake.MetadataStub != nil {
-		return fake.MetadataStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.metadataReturns
 	return fakeReturns.result1
 }
 
@@ -236,15 +239,16 @@ func (fake *FakeResourceConfigVersion) Reload() (bool, error) {
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
 	fake.reloadArgsForCall = append(fake.reloadArgsForCall, struct {
 	}{})
+	stub := fake.ReloadStub
+	fakeReturns := fake.reloadReturns
 	fake.recordInvocation("Reload", []interface{}{})
 	fake.reloadMutex.Unlock()
-	if fake.ReloadStub != nil {
-		return fake.ReloadStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.reloadReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -291,15 +295,16 @@ func (fake *FakeResourceConfigVersion) SpanContext() propagation.HTTPSupplier {
 	ret, specificReturn := fake.spanContextReturnsOnCall[len(fake.spanContextArgsForCall)]
 	fake.spanContextArgsForCall = append(fake.spanContextArgsForCall, struct {
 	}{})
+	stub := fake.SpanContextStub
+	fakeReturns := fake.spanContextReturns
 	fake.recordInvocation("SpanContext", []interface{}{})
 	fake.spanContextMutex.Unlock()
-	if fake.SpanContextStub != nil {
-		return fake.SpanContextStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.spanContextReturns
 	return fakeReturns.result1
 }
 
@@ -343,15 +348,16 @@ func (fake *FakeResourceConfigVersion) Version() db.Version {
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
 	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
 	}{})
+	stub := fake.VersionStub
+	fakeReturns := fake.versionReturns
 	fake.recordInvocation("Version", []interface{}{})
 	fake.versionMutex.Unlock()
-	if fake.VersionStub != nil {
-		return fake.VersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.versionReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_resource_factory.go
+++ b/atc/db/dbfakes/fake_resource_factory.go
@@ -57,15 +57,16 @@ func (fake *FakeResourceFactory) AllResources() ([]db.Resource, error) {
 	ret, specificReturn := fake.allResourcesReturnsOnCall[len(fake.allResourcesArgsForCall)]
 	fake.allResourcesArgsForCall = append(fake.allResourcesArgsForCall, struct {
 	}{})
+	stub := fake.AllResourcesStub
+	fakeReturns := fake.allResourcesReturns
 	fake.recordInvocation("AllResources", []interface{}{})
 	fake.allResourcesMutex.Unlock()
-	if fake.AllResourcesStub != nil {
-		return fake.AllResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.allResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -113,15 +114,16 @@ func (fake *FakeResourceFactory) Resource(arg1 int) (db.Resource, bool, error) {
 	fake.resourceArgsForCall = append(fake.resourceArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.ResourceStub
+	fakeReturns := fake.resourceReturns
 	fake.recordInvocation("Resource", []interface{}{arg1})
 	fake.resourceMutex.Unlock()
-	if fake.ResourceStub != nil {
-		return fake.ResourceStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.resourceReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -184,15 +186,16 @@ func (fake *FakeResourceFactory) VisibleResources(arg1 []string) ([]db.Resource,
 	fake.visibleResourcesArgsForCall = append(fake.visibleResourcesArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.VisibleResourcesStub
+	fakeReturns := fake.visibleResourcesReturns
 	fake.recordInvocation("VisibleResources", []interface{}{arg1Copy})
 	fake.visibleResourcesMutex.Unlock()
-	if fake.VisibleResourcesStub != nil {
-		return fake.VisibleResourcesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.visibleResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_resource_type.go
+++ b/atc/db/dbfakes/fake_resource_type.go
@@ -308,15 +308,16 @@ func (fake *FakeResourceType) CheckEvery() *atc.CheckEvery {
 	ret, specificReturn := fake.checkEveryReturnsOnCall[len(fake.checkEveryArgsForCall)]
 	fake.checkEveryArgsForCall = append(fake.checkEveryArgsForCall, struct {
 	}{})
+	stub := fake.CheckEveryStub
+	fakeReturns := fake.checkEveryReturns
 	fake.recordInvocation("CheckEvery", []interface{}{})
 	fake.checkEveryMutex.Unlock()
-	if fake.CheckEveryStub != nil {
-		return fake.CheckEveryStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkEveryReturns
 	return fakeReturns.result1
 }
 
@@ -364,15 +365,16 @@ func (fake *FakeResourceType) CheckPlan(arg1 atc.Version, arg2 time.Duration, ar
 		arg3 db.ResourceTypes
 		arg4 atc.Source
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CheckPlanStub
+	fakeReturns := fake.checkPlanReturns
 	fake.recordInvocation("CheckPlan", []interface{}{arg1, arg2, arg3, arg4})
 	fake.checkPlanMutex.Unlock()
-	if fake.CheckPlanStub != nil {
-		return fake.CheckPlanStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkPlanReturns
 	return fakeReturns.result1
 }
 
@@ -423,15 +425,16 @@ func (fake *FakeResourceType) CheckTimeout() string {
 	ret, specificReturn := fake.checkTimeoutReturnsOnCall[len(fake.checkTimeoutArgsForCall)]
 	fake.checkTimeoutArgsForCall = append(fake.checkTimeoutArgsForCall, struct {
 	}{})
+	stub := fake.CheckTimeoutStub
+	fakeReturns := fake.checkTimeoutReturns
 	fake.recordInvocation("CheckTimeout", []interface{}{})
 	fake.checkTimeoutMutex.Unlock()
-	if fake.CheckTimeoutStub != nil {
-		return fake.CheckTimeoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -478,15 +481,16 @@ func (fake *FakeResourceType) CreateBuild(arg1 context.Context, arg2 bool, arg3 
 		arg2 bool
 		arg3 atc.Plan
 	}{arg1, arg2, arg3})
+	stub := fake.CreateBuildStub
+	fakeReturns := fake.createBuildReturns
 	fake.recordInvocation("CreateBuild", []interface{}{arg1, arg2, arg3})
 	fake.createBuildMutex.Unlock()
-	if fake.CreateBuildStub != nil {
-		return fake.CreateBuildStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.createBuildReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -543,15 +547,16 @@ func (fake *FakeResourceType) CurrentPinnedVersion() atc.Version {
 	ret, specificReturn := fake.currentPinnedVersionReturnsOnCall[len(fake.currentPinnedVersionArgsForCall)]
 	fake.currentPinnedVersionArgsForCall = append(fake.currentPinnedVersionArgsForCall, struct {
 	}{})
+	stub := fake.CurrentPinnedVersionStub
+	fakeReturns := fake.currentPinnedVersionReturns
 	fake.recordInvocation("CurrentPinnedVersion", []interface{}{})
 	fake.currentPinnedVersionMutex.Unlock()
-	if fake.CurrentPinnedVersionStub != nil {
-		return fake.CurrentPinnedVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.currentPinnedVersionReturns
 	return fakeReturns.result1
 }
 
@@ -595,15 +600,16 @@ func (fake *FakeResourceType) Defaults() atc.Source {
 	ret, specificReturn := fake.defaultsReturnsOnCall[len(fake.defaultsArgsForCall)]
 	fake.defaultsArgsForCall = append(fake.defaultsArgsForCall, struct {
 	}{})
+	stub := fake.DefaultsStub
+	fakeReturns := fake.defaultsReturns
 	fake.recordInvocation("Defaults", []interface{}{})
 	fake.defaultsMutex.Unlock()
-	if fake.DefaultsStub != nil {
-		return fake.DefaultsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.defaultsReturns
 	return fakeReturns.result1
 }
 
@@ -647,15 +653,16 @@ func (fake *FakeResourceType) HasWebhook() bool {
 	ret, specificReturn := fake.hasWebhookReturnsOnCall[len(fake.hasWebhookArgsForCall)]
 	fake.hasWebhookArgsForCall = append(fake.hasWebhookArgsForCall, struct {
 	}{})
+	stub := fake.HasWebhookStub
+	fakeReturns := fake.hasWebhookReturns
 	fake.recordInvocation("HasWebhook", []interface{}{})
 	fake.hasWebhookMutex.Unlock()
-	if fake.HasWebhookStub != nil {
-		return fake.HasWebhookStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasWebhookReturns
 	return fakeReturns.result1
 }
 
@@ -699,15 +706,16 @@ func (fake *FakeResourceType) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -751,15 +759,16 @@ func (fake *FakeResourceType) LastCheckEndTime() time.Time {
 	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
 	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
 	}{})
+	stub := fake.LastCheckEndTimeStub
+	fakeReturns := fake.lastCheckEndTimeReturns
 	fake.recordInvocation("LastCheckEndTime", []interface{}{})
 	fake.lastCheckEndTimeMutex.Unlock()
-	if fake.LastCheckEndTimeStub != nil {
-		return fake.LastCheckEndTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastCheckEndTimeReturns
 	return fakeReturns.result1
 }
 
@@ -803,15 +812,16 @@ func (fake *FakeResourceType) LastCheckStartTime() time.Time {
 	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
 	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
 	}{})
+	stub := fake.LastCheckStartTimeStub
+	fakeReturns := fake.lastCheckStartTimeReturns
 	fake.recordInvocation("LastCheckStartTime", []interface{}{})
 	fake.lastCheckStartTimeMutex.Unlock()
-	if fake.LastCheckStartTimeStub != nil {
-		return fake.LastCheckStartTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastCheckStartTimeReturns
 	return fakeReturns.result1
 }
 
@@ -855,15 +865,16 @@ func (fake *FakeResourceType) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -907,15 +918,16 @@ func (fake *FakeResourceType) Params() atc.Params {
 	ret, specificReturn := fake.paramsReturnsOnCall[len(fake.paramsArgsForCall)]
 	fake.paramsArgsForCall = append(fake.paramsArgsForCall, struct {
 	}{})
+	stub := fake.ParamsStub
+	fakeReturns := fake.paramsReturns
 	fake.recordInvocation("Params", []interface{}{})
 	fake.paramsMutex.Unlock()
-	if fake.ParamsStub != nil {
-		return fake.ParamsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.paramsReturns
 	return fakeReturns.result1
 }
 
@@ -959,15 +971,16 @@ func (fake *FakeResourceType) Pipeline() (db.Pipeline, bool, error) {
 	ret, specificReturn := fake.pipelineReturnsOnCall[len(fake.pipelineArgsForCall)]
 	fake.pipelineArgsForCall = append(fake.pipelineArgsForCall, struct {
 	}{})
+	stub := fake.PipelineStub
+	fakeReturns := fake.pipelineReturns
 	fake.recordInvocation("Pipeline", []interface{}{})
 	fake.pipelineMutex.Unlock()
-	if fake.PipelineStub != nil {
-		return fake.PipelineStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.pipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1017,15 +1030,16 @@ func (fake *FakeResourceType) PipelineID() int {
 	ret, specificReturn := fake.pipelineIDReturnsOnCall[len(fake.pipelineIDArgsForCall)]
 	fake.pipelineIDArgsForCall = append(fake.pipelineIDArgsForCall, struct {
 	}{})
+	stub := fake.PipelineIDStub
+	fakeReturns := fake.pipelineIDReturns
 	fake.recordInvocation("PipelineID", []interface{}{})
 	fake.pipelineIDMutex.Unlock()
-	if fake.PipelineIDStub != nil {
-		return fake.PipelineIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineIDReturns
 	return fakeReturns.result1
 }
 
@@ -1069,15 +1083,16 @@ func (fake *FakeResourceType) PipelineInstanceVars() atc.InstanceVars {
 	ret, specificReturn := fake.pipelineInstanceVarsReturnsOnCall[len(fake.pipelineInstanceVarsArgsForCall)]
 	fake.pipelineInstanceVarsArgsForCall = append(fake.pipelineInstanceVarsArgsForCall, struct {
 	}{})
+	stub := fake.PipelineInstanceVarsStub
+	fakeReturns := fake.pipelineInstanceVarsReturns
 	fake.recordInvocation("PipelineInstanceVars", []interface{}{})
 	fake.pipelineInstanceVarsMutex.Unlock()
-	if fake.PipelineInstanceVarsStub != nil {
-		return fake.PipelineInstanceVarsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineInstanceVarsReturns
 	return fakeReturns.result1
 }
 
@@ -1121,15 +1136,16 @@ func (fake *FakeResourceType) PipelineName() string {
 	ret, specificReturn := fake.pipelineNameReturnsOnCall[len(fake.pipelineNameArgsForCall)]
 	fake.pipelineNameArgsForCall = append(fake.pipelineNameArgsForCall, struct {
 	}{})
+	stub := fake.PipelineNameStub
+	fakeReturns := fake.pipelineNameReturns
 	fake.recordInvocation("PipelineName", []interface{}{})
 	fake.pipelineNameMutex.Unlock()
-	if fake.PipelineNameStub != nil {
-		return fake.PipelineNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineNameReturns
 	return fakeReturns.result1
 }
 
@@ -1173,15 +1189,16 @@ func (fake *FakeResourceType) PipelineRef() atc.PipelineRef {
 	ret, specificReturn := fake.pipelineRefReturnsOnCall[len(fake.pipelineRefArgsForCall)]
 	fake.pipelineRefArgsForCall = append(fake.pipelineRefArgsForCall, struct {
 	}{})
+	stub := fake.PipelineRefStub
+	fakeReturns := fake.pipelineRefReturns
 	fake.recordInvocation("PipelineRef", []interface{}{})
 	fake.pipelineRefMutex.Unlock()
-	if fake.PipelineRefStub != nil {
-		return fake.PipelineRefStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pipelineRefReturns
 	return fakeReturns.result1
 }
 
@@ -1225,15 +1242,16 @@ func (fake *FakeResourceType) Privileged() bool {
 	ret, specificReturn := fake.privilegedReturnsOnCall[len(fake.privilegedArgsForCall)]
 	fake.privilegedArgsForCall = append(fake.privilegedArgsForCall, struct {
 	}{})
+	stub := fake.PrivilegedStub
+	fakeReturns := fake.privilegedReturns
 	fake.recordInvocation("Privileged", []interface{}{})
 	fake.privilegedMutex.Unlock()
-	if fake.PrivilegedStub != nil {
-		return fake.PrivilegedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.privilegedReturns
 	return fakeReturns.result1
 }
 
@@ -1277,15 +1295,16 @@ func (fake *FakeResourceType) Reload() (bool, error) {
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
 	fake.reloadArgsForCall = append(fake.reloadArgsForCall, struct {
 	}{})
+	stub := fake.ReloadStub
+	fakeReturns := fake.reloadReturns
 	fake.recordInvocation("Reload", []interface{}{})
 	fake.reloadMutex.Unlock()
-	if fake.ReloadStub != nil {
-		return fake.ReloadStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.reloadReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1332,15 +1351,16 @@ func (fake *FakeResourceType) ResourceConfigScopeID() int {
 	ret, specificReturn := fake.resourceConfigScopeIDReturnsOnCall[len(fake.resourceConfigScopeIDArgsForCall)]
 	fake.resourceConfigScopeIDArgsForCall = append(fake.resourceConfigScopeIDArgsForCall, struct {
 	}{})
+	stub := fake.ResourceConfigScopeIDStub
+	fakeReturns := fake.resourceConfigScopeIDReturns
 	fake.recordInvocation("ResourceConfigScopeID", []interface{}{})
 	fake.resourceConfigScopeIDMutex.Unlock()
-	if fake.ResourceConfigScopeIDStub != nil {
-		return fake.ResourceConfigScopeIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceConfigScopeIDReturns
 	return fakeReturns.result1
 }
 
@@ -1385,15 +1405,16 @@ func (fake *FakeResourceType) SetResourceConfigScope(arg1 db.ResourceConfigScope
 	fake.setResourceConfigScopeArgsForCall = append(fake.setResourceConfigScopeArgsForCall, struct {
 		arg1 db.ResourceConfigScope
 	}{arg1})
+	stub := fake.SetResourceConfigScopeStub
+	fakeReturns := fake.setResourceConfigScopeReturns
 	fake.recordInvocation("SetResourceConfigScope", []interface{}{arg1})
 	fake.setResourceConfigScopeMutex.Unlock()
-	if fake.SetResourceConfigScopeStub != nil {
-		return fake.SetResourceConfigScopeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setResourceConfigScopeReturns
 	return fakeReturns.result1
 }
 
@@ -1444,15 +1465,16 @@ func (fake *FakeResourceType) Source() atc.Source {
 	ret, specificReturn := fake.sourceReturnsOnCall[len(fake.sourceArgsForCall)]
 	fake.sourceArgsForCall = append(fake.sourceArgsForCall, struct {
 	}{})
+	stub := fake.SourceStub
+	fakeReturns := fake.sourceReturns
 	fake.recordInvocation("Source", []interface{}{})
 	fake.sourceMutex.Unlock()
-	if fake.SourceStub != nil {
-		return fake.SourceStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sourceReturns
 	return fakeReturns.result1
 }
 
@@ -1496,15 +1518,16 @@ func (fake *FakeResourceType) Tags() atc.Tags {
 	ret, specificReturn := fake.tagsReturnsOnCall[len(fake.tagsArgsForCall)]
 	fake.tagsArgsForCall = append(fake.tagsArgsForCall, struct {
 	}{})
+	stub := fake.TagsStub
+	fakeReturns := fake.tagsReturns
 	fake.recordInvocation("Tags", []interface{}{})
 	fake.tagsMutex.Unlock()
-	if fake.TagsStub != nil {
-		return fake.TagsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tagsReturns
 	return fakeReturns.result1
 }
 
@@ -1548,15 +1571,16 @@ func (fake *FakeResourceType) TeamID() int {
 	ret, specificReturn := fake.teamIDReturnsOnCall[len(fake.teamIDArgsForCall)]
 	fake.teamIDArgsForCall = append(fake.teamIDArgsForCall, struct {
 	}{})
+	stub := fake.TeamIDStub
+	fakeReturns := fake.teamIDReturns
 	fake.recordInvocation("TeamID", []interface{}{})
 	fake.teamIDMutex.Unlock()
-	if fake.TeamIDStub != nil {
-		return fake.TeamIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamIDReturns
 	return fakeReturns.result1
 }
 
@@ -1600,15 +1624,16 @@ func (fake *FakeResourceType) TeamName() string {
 	ret, specificReturn := fake.teamNameReturnsOnCall[len(fake.teamNameArgsForCall)]
 	fake.teamNameArgsForCall = append(fake.teamNameArgsForCall, struct {
 	}{})
+	stub := fake.TeamNameStub
+	fakeReturns := fake.teamNameReturns
 	fake.recordInvocation("TeamName", []interface{}{})
 	fake.teamNameMutex.Unlock()
-	if fake.TeamNameStub != nil {
-		return fake.TeamNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamNameReturns
 	return fakeReturns.result1
 }
 
@@ -1652,15 +1677,16 @@ func (fake *FakeResourceType) Type() string {
 	ret, specificReturn := fake.typeReturnsOnCall[len(fake.typeArgsForCall)]
 	fake.typeArgsForCall = append(fake.typeArgsForCall, struct {
 	}{})
+	stub := fake.TypeStub
+	fakeReturns := fake.typeReturns
 	fake.recordInvocation("Type", []interface{}{})
 	fake.typeMutex.Unlock()
-	if fake.TypeStub != nil {
-		return fake.TypeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.typeReturns
 	return fakeReturns.result1
 }
 
@@ -1704,15 +1730,16 @@ func (fake *FakeResourceType) Version() atc.Version {
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
 	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
 	}{})
+	stub := fake.VersionStub
+	fakeReturns := fake.versionReturns
 	fake.recordInvocation("Version", []interface{}{})
 	fake.versionMutex.Unlock()
-	if fake.VersionStub != nil {
-		return fake.VersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.versionReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_task_cache_factory.go
+++ b/atc/db/dbfakes/fake_task_cache_factory.go
@@ -52,15 +52,16 @@ func (fake *FakeTaskCacheFactory) Find(arg1 int, arg2 string, arg3 string) (db.U
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.FindStub
+	fakeReturns := fake.findReturns
 	fake.recordInvocation("Find", []interface{}{arg1, arg2, arg3})
 	fake.findMutex.Unlock()
-	if fake.FindStub != nil {
-		return fake.FindStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -120,15 +121,16 @@ func (fake *FakeTaskCacheFactory) FindOrCreate(arg1 int, arg2 string, arg3 strin
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.FindOrCreateStub
+	fakeReturns := fake.findOrCreateReturns
 	fake.recordInvocation("FindOrCreate", []interface{}{arg1, arg2, arg3})
 	fake.findOrCreateMutex.Unlock()
-	if fake.FindOrCreateStub != nil {
-		return fake.FindOrCreateStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_team.go
+++ b/atc/db/dbfakes/fake_team.go
@@ -417,15 +417,16 @@ func (fake *FakeTeam) Admin() bool {
 	ret, specificReturn := fake.adminReturnsOnCall[len(fake.adminArgsForCall)]
 	fake.adminArgsForCall = append(fake.adminArgsForCall, struct {
 	}{})
+	stub := fake.AdminStub
+	fakeReturns := fake.adminReturns
 	fake.recordInvocation("Admin", []interface{}{})
 	fake.adminMutex.Unlock()
-	if fake.AdminStub != nil {
-		return fake.AdminStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.adminReturns
 	return fakeReturns.result1
 }
 
@@ -469,15 +470,16 @@ func (fake *FakeTeam) Auth() atc.TeamAuth {
 	ret, specificReturn := fake.authReturnsOnCall[len(fake.authArgsForCall)]
 	fake.authArgsForCall = append(fake.authArgsForCall, struct {
 	}{})
+	stub := fake.AuthStub
+	fakeReturns := fake.authReturns
 	fake.recordInvocation("Auth", []interface{}{})
 	fake.authMutex.Unlock()
-	if fake.AuthStub != nil {
-		return fake.AuthStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.authReturns
 	return fakeReturns.result1
 }
 
@@ -522,15 +524,16 @@ func (fake *FakeTeam) Builds(arg1 db.Page) ([]db.Build, db.Pagination, error) {
 	fake.buildsArgsForCall = append(fake.buildsArgsForCall, struct {
 		arg1 db.Page
 	}{arg1})
+	stub := fake.BuildsStub
+	fakeReturns := fake.buildsReturns
 	fake.recordInvocation("Builds", []interface{}{arg1})
 	fake.buildsMutex.Unlock()
-	if fake.BuildsStub != nil {
-		return fake.BuildsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -588,15 +591,16 @@ func (fake *FakeTeam) BuildsWithTime(arg1 db.Page) ([]db.Build, db.Pagination, e
 	fake.buildsWithTimeArgsForCall = append(fake.buildsWithTimeArgsForCall, struct {
 		arg1 db.Page
 	}{arg1})
+	stub := fake.BuildsWithTimeStub
+	fakeReturns := fake.buildsWithTimeReturns
 	fake.recordInvocation("BuildsWithTime", []interface{}{arg1})
 	fake.buildsWithTimeMutex.Unlock()
-	if fake.BuildsWithTimeStub != nil {
-		return fake.BuildsWithTimeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsWithTimeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -653,15 +657,16 @@ func (fake *FakeTeam) Containers() ([]db.Container, error) {
 	ret, specificReturn := fake.containersReturnsOnCall[len(fake.containersArgsForCall)]
 	fake.containersArgsForCall = append(fake.containersArgsForCall, struct {
 	}{})
+	stub := fake.ContainersStub
+	fakeReturns := fake.containersReturns
 	fake.recordInvocation("Containers", []interface{}{})
 	fake.containersMutex.Unlock()
-	if fake.ContainersStub != nil {
-		return fake.ContainersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.containersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -708,15 +713,16 @@ func (fake *FakeTeam) CreateOneOffBuild() (db.Build, error) {
 	ret, specificReturn := fake.createOneOffBuildReturnsOnCall[len(fake.createOneOffBuildArgsForCall)]
 	fake.createOneOffBuildArgsForCall = append(fake.createOneOffBuildArgsForCall, struct {
 	}{})
+	stub := fake.CreateOneOffBuildStub
+	fakeReturns := fake.createOneOffBuildReturns
 	fake.recordInvocation("CreateOneOffBuild", []interface{}{})
 	fake.createOneOffBuildMutex.Unlock()
-	if fake.CreateOneOffBuildStub != nil {
-		return fake.CreateOneOffBuildStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createOneOffBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -764,15 +770,16 @@ func (fake *FakeTeam) CreateStartedBuild(arg1 atc.Plan) (db.Build, error) {
 	fake.createStartedBuildArgsForCall = append(fake.createStartedBuildArgsForCall, struct {
 		arg1 atc.Plan
 	}{arg1})
+	stub := fake.CreateStartedBuildStub
+	fakeReturns := fake.createStartedBuildReturns
 	fake.recordInvocation("CreateStartedBuild", []interface{}{arg1})
 	fake.createStartedBuildMutex.Unlock()
-	if fake.CreateStartedBuildStub != nil {
-		return fake.CreateStartedBuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createStartedBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -826,15 +833,16 @@ func (fake *FakeTeam) Delete() error {
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 	}{})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1
 }
 
@@ -883,15 +891,16 @@ func (fake *FakeTeam) FindCheckContainers(arg1 lager.Logger, arg2 atc.PipelineRe
 		arg4 creds.Secrets
 		arg5 creds.VarSourcePool
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.FindCheckContainersStub
+	fakeReturns := fake.findCheckContainersReturns
 	fake.recordInvocation("FindCheckContainers", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.findCheckContainersMutex.Unlock()
-	if fake.FindCheckContainersStub != nil {
-		return fake.FindCheckContainersStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findCheckContainersReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -949,15 +958,16 @@ func (fake *FakeTeam) FindContainerByHandle(arg1 string) (db.Container, bool, er
 	fake.findContainerByHandleArgsForCall = append(fake.findContainerByHandleArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindContainerByHandleStub
+	fakeReturns := fake.findContainerByHandleReturns
 	fake.recordInvocation("FindContainerByHandle", []interface{}{arg1})
 	fake.findContainerByHandleMutex.Unlock()
-	if fake.FindContainerByHandleStub != nil {
-		return fake.FindContainerByHandleStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findContainerByHandleReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1015,15 +1025,16 @@ func (fake *FakeTeam) FindContainersByMetadata(arg1 db.ContainerMetadata) ([]db.
 	fake.findContainersByMetadataArgsForCall = append(fake.findContainersByMetadataArgsForCall, struct {
 		arg1 db.ContainerMetadata
 	}{arg1})
+	stub := fake.FindContainersByMetadataStub
+	fakeReturns := fake.findContainersByMetadataReturns
 	fake.recordInvocation("FindContainersByMetadata", []interface{}{arg1})
 	fake.findContainersByMetadataMutex.Unlock()
-	if fake.FindContainersByMetadataStub != nil {
-		return fake.FindContainersByMetadataStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findContainersByMetadataReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1078,15 +1089,16 @@ func (fake *FakeTeam) FindCreatedContainerByHandle(arg1 string) (db.CreatedConta
 	fake.findCreatedContainerByHandleArgsForCall = append(fake.findCreatedContainerByHandleArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindCreatedContainerByHandleStub
+	fakeReturns := fake.findCreatedContainerByHandleReturns
 	fake.recordInvocation("FindCreatedContainerByHandle", []interface{}{arg1})
 	fake.findCreatedContainerByHandleMutex.Unlock()
-	if fake.FindCreatedContainerByHandleStub != nil {
-		return fake.FindCreatedContainerByHandleStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findCreatedContainerByHandleReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1144,15 +1156,16 @@ func (fake *FakeTeam) FindVolumeForWorkerArtifact(arg1 int) (db.CreatedVolume, b
 	fake.findVolumeForWorkerArtifactArgsForCall = append(fake.findVolumeForWorkerArtifactArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.FindVolumeForWorkerArtifactStub
+	fakeReturns := fake.findVolumeForWorkerArtifactReturns
 	fake.recordInvocation("FindVolumeForWorkerArtifact", []interface{}{arg1})
 	fake.findVolumeForWorkerArtifactMutex.Unlock()
-	if fake.FindVolumeForWorkerArtifactStub != nil {
-		return fake.FindVolumeForWorkerArtifactStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findVolumeForWorkerArtifactReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1210,15 +1223,16 @@ func (fake *FakeTeam) FindWorkerForContainer(arg1 string) (db.Worker, bool, erro
 	fake.findWorkerForContainerArgsForCall = append(fake.findWorkerForContainerArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindWorkerForContainerStub
+	fakeReturns := fake.findWorkerForContainerReturns
 	fake.recordInvocation("FindWorkerForContainer", []interface{}{arg1})
 	fake.findWorkerForContainerMutex.Unlock()
-	if fake.FindWorkerForContainerStub != nil {
-		return fake.FindWorkerForContainerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findWorkerForContainerReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1276,15 +1290,16 @@ func (fake *FakeTeam) FindWorkerForVolume(arg1 string) (db.Worker, bool, error) 
 	fake.findWorkerForVolumeArgsForCall = append(fake.findWorkerForVolumeArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindWorkerForVolumeStub
+	fakeReturns := fake.findWorkerForVolumeReturns
 	fake.recordInvocation("FindWorkerForVolume", []interface{}{arg1})
 	fake.findWorkerForVolumeMutex.Unlock()
-	if fake.FindWorkerForVolumeStub != nil {
-		return fake.FindWorkerForVolumeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findWorkerForVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1341,15 +1356,16 @@ func (fake *FakeTeam) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -1394,15 +1410,16 @@ func (fake *FakeTeam) IsCheckContainer(arg1 string) (bool, error) {
 	fake.isCheckContainerArgsForCall = append(fake.isCheckContainerArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.IsCheckContainerStub
+	fakeReturns := fake.isCheckContainerReturns
 	fake.recordInvocation("IsCheckContainer", []interface{}{arg1})
 	fake.isCheckContainerMutex.Unlock()
-	if fake.IsCheckContainerStub != nil {
-		return fake.IsCheckContainerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isCheckContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1458,15 +1475,16 @@ func (fake *FakeTeam) IsContainerWithinTeam(arg1 string, arg2 bool) (bool, error
 		arg1 string
 		arg2 bool
 	}{arg1, arg2})
+	stub := fake.IsContainerWithinTeamStub
+	fakeReturns := fake.isContainerWithinTeamReturns
 	fake.recordInvocation("IsContainerWithinTeam", []interface{}{arg1, arg2})
 	fake.isContainerWithinTeamMutex.Unlock()
-	if fake.IsContainerWithinTeamStub != nil {
-		return fake.IsContainerWithinTeamStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isContainerWithinTeamReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1520,15 +1538,16 @@ func (fake *FakeTeam) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -1578,15 +1597,16 @@ func (fake *FakeTeam) OrderPipelines(arg1 []string) error {
 	fake.orderPipelinesArgsForCall = append(fake.orderPipelinesArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.OrderPipelinesStub
+	fakeReturns := fake.orderPipelinesReturns
 	fake.recordInvocation("OrderPipelines", []interface{}{arg1Copy})
 	fake.orderPipelinesMutex.Unlock()
-	if fake.OrderPipelinesStub != nil {
-		return fake.OrderPipelinesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.orderPipelinesReturns
 	return fakeReturns.result1
 }
 
@@ -1638,15 +1658,16 @@ func (fake *FakeTeam) Pipeline(arg1 atc.PipelineRef) (db.Pipeline, bool, error) 
 	fake.pipelineArgsForCall = append(fake.pipelineArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.PipelineStub
+	fakeReturns := fake.pipelineReturns
 	fake.recordInvocation("Pipeline", []interface{}{arg1})
 	fake.pipelineMutex.Unlock()
-	if fake.PipelineStub != nil {
-		return fake.PipelineStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.pipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1703,15 +1724,16 @@ func (fake *FakeTeam) Pipelines() ([]db.Pipeline, error) {
 	ret, specificReturn := fake.pipelinesReturnsOnCall[len(fake.pipelinesArgsForCall)]
 	fake.pipelinesArgsForCall = append(fake.pipelinesArgsForCall, struct {
 	}{})
+	stub := fake.PipelinesStub
+	fakeReturns := fake.pipelinesReturns
 	fake.recordInvocation("Pipelines", []interface{}{})
 	fake.pipelinesMutex.Unlock()
-	if fake.PipelinesStub != nil {
-		return fake.PipelinesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.pipelinesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1759,15 +1781,16 @@ func (fake *FakeTeam) PrivateAndPublicBuilds(arg1 db.Page) ([]db.Build, db.Pagin
 	fake.privateAndPublicBuildsArgsForCall = append(fake.privateAndPublicBuildsArgsForCall, struct {
 		arg1 db.Page
 	}{arg1})
+	stub := fake.PrivateAndPublicBuildsStub
+	fakeReturns := fake.privateAndPublicBuildsReturns
 	fake.recordInvocation("PrivateAndPublicBuilds", []interface{}{arg1})
 	fake.privateAndPublicBuildsMutex.Unlock()
-	if fake.PrivateAndPublicBuildsStub != nil {
-		return fake.PrivateAndPublicBuildsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.privateAndPublicBuildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1824,15 +1847,16 @@ func (fake *FakeTeam) PublicPipelines() ([]db.Pipeline, error) {
 	ret, specificReturn := fake.publicPipelinesReturnsOnCall[len(fake.publicPipelinesArgsForCall)]
 	fake.publicPipelinesArgsForCall = append(fake.publicPipelinesArgsForCall, struct {
 	}{})
+	stub := fake.PublicPipelinesStub
+	fakeReturns := fake.publicPipelinesReturns
 	fake.recordInvocation("PublicPipelines", []interface{}{})
 	fake.publicPipelinesMutex.Unlock()
-	if fake.PublicPipelinesStub != nil {
-		return fake.PublicPipelinesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.publicPipelinesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1880,15 +1904,16 @@ func (fake *FakeTeam) Rename(arg1 string) error {
 	fake.renameArgsForCall = append(fake.renameArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RenameStub
+	fakeReturns := fake.renameReturns
 	fake.recordInvocation("Rename", []interface{}{arg1})
 	fake.renameMutex.Unlock()
-	if fake.RenameStub != nil {
-		return fake.RenameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.renameReturns
 	return fakeReturns.result1
 }
 
@@ -1941,15 +1966,16 @@ func (fake *FakeTeam) RenamePipeline(arg1 string, arg2 string) (bool, error) {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RenamePipelineStub
+	fakeReturns := fake.renamePipelineReturns
 	fake.recordInvocation("RenamePipeline", []interface{}{arg1, arg2})
 	fake.renamePipelineMutex.Unlock()
-	if fake.RenamePipelineStub != nil {
-		return fake.RenamePipelineStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.renamePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2007,15 +2033,16 @@ func (fake *FakeTeam) SavePipeline(arg1 atc.PipelineRef, arg2 atc.Config, arg3 d
 		arg3 db.ConfigVersion
 		arg4 bool
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.SavePipelineStub
+	fakeReturns := fake.savePipelineReturns
 	fake.recordInvocation("SavePipeline", []interface{}{arg1, arg2, arg3, arg4})
 	fake.savePipelineMutex.Unlock()
-	if fake.SavePipelineStub != nil {
-		return fake.SavePipelineStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.savePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2074,15 +2101,16 @@ func (fake *FakeTeam) SaveWorker(arg1 atc.Worker, arg2 time.Duration) (db.Worker
 		arg1 atc.Worker
 		arg2 time.Duration
 	}{arg1, arg2})
+	stub := fake.SaveWorkerStub
+	fakeReturns := fake.saveWorkerReturns
 	fake.recordInvocation("SaveWorker", []interface{}{arg1, arg2})
 	fake.saveWorkerMutex.Unlock()
-	if fake.SaveWorkerStub != nil {
-		return fake.SaveWorkerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.saveWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2137,15 +2165,16 @@ func (fake *FakeTeam) UpdateProviderAuth(arg1 atc.TeamAuth) error {
 	fake.updateProviderAuthArgsForCall = append(fake.updateProviderAuthArgsForCall, struct {
 		arg1 atc.TeamAuth
 	}{arg1})
+	stub := fake.UpdateProviderAuthStub
+	fakeReturns := fake.updateProviderAuthReturns
 	fake.recordInvocation("UpdateProviderAuth", []interface{}{arg1})
 	fake.updateProviderAuthMutex.Unlock()
-	if fake.UpdateProviderAuthStub != nil {
-		return fake.UpdateProviderAuthStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateProviderAuthReturns
 	return fakeReturns.result1
 }
 
@@ -2196,15 +2225,16 @@ func (fake *FakeTeam) Workers() ([]db.Worker, error) {
 	ret, specificReturn := fake.workersReturnsOnCall[len(fake.workersArgsForCall)]
 	fake.workersArgsForCall = append(fake.workersArgsForCall, struct {
 	}{})
+	stub := fake.WorkersStub
+	fakeReturns := fake.workersReturns
 	fake.recordInvocation("Workers", []interface{}{})
 	fake.workersMutex.Unlock()
-	if fake.WorkersStub != nil {
-		return fake.WorkersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.workersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_team_factory.go
+++ b/atc/db/dbfakes/fake_team_factory.go
@@ -101,15 +101,16 @@ func (fake *FakeTeamFactory) CreateDefaultTeamIfNotExists() (db.Team, error) {
 	ret, specificReturn := fake.createDefaultTeamIfNotExistsReturnsOnCall[len(fake.createDefaultTeamIfNotExistsArgsForCall)]
 	fake.createDefaultTeamIfNotExistsArgsForCall = append(fake.createDefaultTeamIfNotExistsArgsForCall, struct {
 	}{})
+	stub := fake.CreateDefaultTeamIfNotExistsStub
+	fakeReturns := fake.createDefaultTeamIfNotExistsReturns
 	fake.recordInvocation("CreateDefaultTeamIfNotExists", []interface{}{})
 	fake.createDefaultTeamIfNotExistsMutex.Unlock()
-	if fake.CreateDefaultTeamIfNotExistsStub != nil {
-		return fake.CreateDefaultTeamIfNotExistsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createDefaultTeamIfNotExistsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -157,15 +158,16 @@ func (fake *FakeTeamFactory) CreateTeam(arg1 atc.Team) (db.Team, error) {
 	fake.createTeamArgsForCall = append(fake.createTeamArgsForCall, struct {
 		arg1 atc.Team
 	}{arg1})
+	stub := fake.CreateTeamStub
+	fakeReturns := fake.createTeamReturns
 	fake.recordInvocation("CreateTeam", []interface{}{arg1})
 	fake.createTeamMutex.Unlock()
-	if fake.CreateTeamStub != nil {
-		return fake.CreateTeamStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createTeamReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -220,15 +222,16 @@ func (fake *FakeTeamFactory) FindTeam(arg1 string) (db.Team, bool, error) {
 	fake.findTeamArgsForCall = append(fake.findTeamArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindTeamStub
+	fakeReturns := fake.findTeamReturns
 	fake.recordInvocation("FindTeam", []interface{}{arg1})
 	fake.findTeamMutex.Unlock()
-	if fake.FindTeamStub != nil {
-		return fake.FindTeamStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findTeamReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -286,15 +289,16 @@ func (fake *FakeTeamFactory) GetByID(arg1 int) db.Team {
 	fake.getByIDArgsForCall = append(fake.getByIDArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.GetByIDStub
+	fakeReturns := fake.getByIDReturns
 	fake.recordInvocation("GetByID", []interface{}{arg1})
 	fake.getByIDMutex.Unlock()
-	if fake.GetByIDStub != nil {
-		return fake.GetByIDStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getByIDReturns
 	return fakeReturns.result1
 }
 
@@ -345,15 +349,16 @@ func (fake *FakeTeamFactory) GetTeams() ([]db.Team, error) {
 	ret, specificReturn := fake.getTeamsReturnsOnCall[len(fake.getTeamsArgsForCall)]
 	fake.getTeamsArgsForCall = append(fake.getTeamsArgsForCall, struct {
 	}{})
+	stub := fake.GetTeamsStub
+	fakeReturns := fake.getTeamsReturns
 	fake.recordInvocation("GetTeams", []interface{}{})
 	fake.getTeamsMutex.Unlock()
-	if fake.GetTeamsStub != nil {
-		return fake.GetTeamsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getTeamsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -400,15 +405,16 @@ func (fake *FakeTeamFactory) NotifyCacher() error {
 	ret, specificReturn := fake.notifyCacherReturnsOnCall[len(fake.notifyCacherArgsForCall)]
 	fake.notifyCacherArgsForCall = append(fake.notifyCacherArgsForCall, struct {
 	}{})
+	stub := fake.NotifyCacherStub
+	fakeReturns := fake.notifyCacherReturns
 	fake.recordInvocation("NotifyCacher", []interface{}{})
 	fake.notifyCacherMutex.Unlock()
-	if fake.NotifyCacherStub != nil {
-		return fake.NotifyCacherStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.notifyCacherReturns
 	return fakeReturns.result1
 }
 
@@ -452,15 +458,16 @@ func (fake *FakeTeamFactory) NotifyResourceScanner() error {
 	ret, specificReturn := fake.notifyResourceScannerReturnsOnCall[len(fake.notifyResourceScannerArgsForCall)]
 	fake.notifyResourceScannerArgsForCall = append(fake.notifyResourceScannerArgsForCall, struct {
 	}{})
+	stub := fake.NotifyResourceScannerStub
+	fakeReturns := fake.notifyResourceScannerReturns
 	fake.recordInvocation("NotifyResourceScanner", []interface{}{})
 	fake.notifyResourceScannerMutex.Unlock()
-	if fake.NotifyResourceScannerStub != nil {
-		return fake.NotifyResourceScannerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.notifyResourceScannerReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_tx.go
+++ b/atc/db/dbfakes/fake_tx.go
@@ -172,15 +172,16 @@ func (fake *FakeTx) Commit() error {
 	ret, specificReturn := fake.commitReturnsOnCall[len(fake.commitArgsForCall)]
 	fake.commitArgsForCall = append(fake.commitArgsForCall, struct {
 	}{})
+	stub := fake.CommitStub
+	fakeReturns := fake.commitReturns
 	fake.recordInvocation("Commit", []interface{}{})
 	fake.commitMutex.Unlock()
-	if fake.CommitStub != nil {
-		return fake.CommitStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.commitReturns
 	return fakeReturns.result1
 }
 
@@ -224,15 +225,16 @@ func (fake *FakeTx) EncryptionStrategy() encryption.Strategy {
 	ret, specificReturn := fake.encryptionStrategyReturnsOnCall[len(fake.encryptionStrategyArgsForCall)]
 	fake.encryptionStrategyArgsForCall = append(fake.encryptionStrategyArgsForCall, struct {
 	}{})
+	stub := fake.EncryptionStrategyStub
+	fakeReturns := fake.encryptionStrategyReturns
 	fake.recordInvocation("EncryptionStrategy", []interface{}{})
 	fake.encryptionStrategyMutex.Unlock()
-	if fake.EncryptionStrategyStub != nil {
-		return fake.EncryptionStrategyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.encryptionStrategyReturns
 	return fakeReturns.result1
 }
 
@@ -278,15 +280,16 @@ func (fake *FakeTx) Exec(arg1 string, arg2 ...interface{}) (sql.Result, error) {
 		arg1 string
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.ExecStub
+	fakeReturns := fake.execReturns
 	fake.recordInvocation("Exec", []interface{}{arg1, arg2})
 	fake.execMutex.Unlock()
-	if fake.ExecStub != nil {
-		return fake.ExecStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.execReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -343,15 +346,16 @@ func (fake *FakeTx) ExecContext(arg1 context.Context, arg2 string, arg3 ...inter
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.ExecContextStub
+	fakeReturns := fake.execContextReturns
 	fake.recordInvocation("ExecContext", []interface{}{arg1, arg2, arg3})
 	fake.execContextMutex.Unlock()
-	if fake.ExecContextStub != nil {
-		return fake.ExecContextStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.execContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -406,15 +410,16 @@ func (fake *FakeTx) Prepare(arg1 string) (*sql.Stmt, error) {
 	fake.prepareArgsForCall = append(fake.prepareArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PrepareStub
+	fakeReturns := fake.prepareReturns
 	fake.recordInvocation("Prepare", []interface{}{arg1})
 	fake.prepareMutex.Unlock()
-	if fake.PrepareStub != nil {
-		return fake.PrepareStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.prepareReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -470,15 +475,16 @@ func (fake *FakeTx) PrepareContext(arg1 context.Context, arg2 string) (*sql.Stmt
 		arg1 context.Context
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.PrepareContextStub
+	fakeReturns := fake.prepareContextReturns
 	fake.recordInvocation("PrepareContext", []interface{}{arg1, arg2})
 	fake.prepareContextMutex.Unlock()
-	if fake.PrepareContextStub != nil {
-		return fake.PrepareContextStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.prepareContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -534,15 +540,16 @@ func (fake *FakeTx) Query(arg1 string, arg2 ...interface{}) (*sql.Rows, error) {
 		arg1 string
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.QueryStub
+	fakeReturns := fake.queryReturns
 	fake.recordInvocation("Query", []interface{}{arg1, arg2})
 	fake.queryMutex.Unlock()
-	if fake.QueryStub != nil {
-		return fake.QueryStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.queryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -599,15 +606,16 @@ func (fake *FakeTx) QueryContext(arg1 context.Context, arg2 string, arg3 ...inte
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.QueryContextStub
+	fakeReturns := fake.queryContextReturns
 	fake.recordInvocation("QueryContext", []interface{}{arg1, arg2, arg3})
 	fake.queryContextMutex.Unlock()
-	if fake.QueryContextStub != nil {
-		return fake.QueryContextStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.queryContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -663,15 +671,16 @@ func (fake *FakeTx) QueryRow(arg1 string, arg2 ...interface{}) squirrel.RowScann
 		arg1 string
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.QueryRowStub
+	fakeReturns := fake.queryRowReturns
 	fake.recordInvocation("QueryRow", []interface{}{arg1, arg2})
 	fake.queryRowMutex.Unlock()
-	if fake.QueryRowStub != nil {
-		return fake.QueryRowStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.queryRowReturns
 	return fakeReturns.result1
 }
 
@@ -725,15 +734,16 @@ func (fake *FakeTx) QueryRowContext(arg1 context.Context, arg2 string, arg3 ...i
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.QueryRowContextStub
+	fakeReturns := fake.queryRowContextReturns
 	fake.recordInvocation("QueryRowContext", []interface{}{arg1, arg2, arg3})
 	fake.queryRowContextMutex.Unlock()
-	if fake.QueryRowContextStub != nil {
-		return fake.QueryRowContextStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.queryRowContextReturns
 	return fakeReturns.result1
 }
 
@@ -784,15 +794,16 @@ func (fake *FakeTx) Rollback() error {
 	ret, specificReturn := fake.rollbackReturnsOnCall[len(fake.rollbackArgsForCall)]
 	fake.rollbackArgsForCall = append(fake.rollbackArgsForCall, struct {
 	}{})
+	stub := fake.RollbackStub
+	fakeReturns := fake.rollbackReturns
 	fake.recordInvocation("Rollback", []interface{}{})
 	fake.rollbackMutex.Unlock()
-	if fake.RollbackStub != nil {
-		return fake.RollbackStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.rollbackReturns
 	return fakeReturns.result1
 }
 
@@ -837,15 +848,16 @@ func (fake *FakeTx) Stmt(arg1 *sql.Stmt) *sql.Stmt {
 	fake.stmtArgsForCall = append(fake.stmtArgsForCall, struct {
 		arg1 *sql.Stmt
 	}{arg1})
+	stub := fake.StmtStub
+	fakeReturns := fake.stmtReturns
 	fake.recordInvocation("Stmt", []interface{}{arg1})
 	fake.stmtMutex.Unlock()
-	if fake.StmtStub != nil {
-		return fake.StmtStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stmtReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_used_resource_cache.go
+++ b/atc/db/dbfakes/fake_used_resource_cache.go
@@ -71,15 +71,16 @@ func (fake *FakeUsedResourceCache) BaseResourceType() *db.UsedBaseResourceType {
 	ret, specificReturn := fake.baseResourceTypeReturnsOnCall[len(fake.baseResourceTypeArgsForCall)]
 	fake.baseResourceTypeArgsForCall = append(fake.baseResourceTypeArgsForCall, struct {
 	}{})
+	stub := fake.BaseResourceTypeStub
+	fakeReturns := fake.baseResourceTypeReturns
 	fake.recordInvocation("BaseResourceType", []interface{}{})
 	fake.baseResourceTypeMutex.Unlock()
-	if fake.BaseResourceTypeStub != nil {
-		return fake.BaseResourceTypeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.baseResourceTypeReturns
 	return fakeReturns.result1
 }
 
@@ -124,15 +125,16 @@ func (fake *FakeUsedResourceCache) Destroy(arg1 db.Tx) (bool, error) {
 	fake.destroyArgsForCall = append(fake.destroyArgsForCall, struct {
 		arg1 db.Tx
 	}{arg1})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{arg1})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -186,15 +188,16 @@ func (fake *FakeUsedResourceCache) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -238,15 +241,16 @@ func (fake *FakeUsedResourceCache) ResourceConfig() db.ResourceConfig {
 	ret, specificReturn := fake.resourceConfigReturnsOnCall[len(fake.resourceConfigArgsForCall)]
 	fake.resourceConfigArgsForCall = append(fake.resourceConfigArgsForCall, struct {
 	}{})
+	stub := fake.ResourceConfigStub
+	fakeReturns := fake.resourceConfigReturns
 	fake.recordInvocation("ResourceConfig", []interface{}{})
 	fake.resourceConfigMutex.Unlock()
-	if fake.ResourceConfigStub != nil {
-		return fake.ResourceConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceConfigReturns
 	return fakeReturns.result1
 }
 
@@ -290,15 +294,16 @@ func (fake *FakeUsedResourceCache) Version() atc.Version {
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
 	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
 	}{})
+	stub := fake.VersionStub
+	fakeReturns := fake.versionReturns
 	fake.recordInvocation("Version", []interface{}{})
 	fake.versionMutex.Unlock()
-	if fake.VersionStub != nil {
-		return fake.VersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.versionReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_user.go
+++ b/atc/db/dbfakes/fake_user.go
@@ -68,15 +68,16 @@ func (fake *FakeUser) Connector() string {
 	ret, specificReturn := fake.connectorReturnsOnCall[len(fake.connectorArgsForCall)]
 	fake.connectorArgsForCall = append(fake.connectorArgsForCall, struct {
 	}{})
+	stub := fake.ConnectorStub
+	fakeReturns := fake.connectorReturns
 	fake.recordInvocation("Connector", []interface{}{})
 	fake.connectorMutex.Unlock()
-	if fake.ConnectorStub != nil {
-		return fake.ConnectorStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.connectorReturns
 	return fakeReturns.result1
 }
 
@@ -120,15 +121,16 @@ func (fake *FakeUser) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -172,15 +174,16 @@ func (fake *FakeUser) LastLogin() time.Time {
 	ret, specificReturn := fake.lastLoginReturnsOnCall[len(fake.lastLoginArgsForCall)]
 	fake.lastLoginArgsForCall = append(fake.lastLoginArgsForCall, struct {
 	}{})
+	stub := fake.LastLoginStub
+	fakeReturns := fake.lastLoginReturns
 	fake.recordInvocation("LastLogin", []interface{}{})
 	fake.lastLoginMutex.Unlock()
-	if fake.LastLoginStub != nil {
-		return fake.LastLoginStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.lastLoginReturns
 	return fakeReturns.result1
 }
 
@@ -224,15 +227,16 @@ func (fake *FakeUser) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -276,15 +280,16 @@ func (fake *FakeUser) Sub() string {
 	ret, specificReturn := fake.subReturnsOnCall[len(fake.subArgsForCall)]
 	fake.subArgsForCall = append(fake.subArgsForCall, struct {
 	}{})
+	stub := fake.SubStub
+	fakeReturns := fake.subReturns
 	fake.recordInvocation("Sub", []interface{}{})
 	fake.subMutex.Unlock()
-	if fake.SubStub != nil {
-		return fake.SubStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.subReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_user_factory.go
+++ b/atc/db/dbfakes/fake_user_factory.go
@@ -59,15 +59,16 @@ func (fake *FakeUserFactory) CreateOrUpdateUser(arg1 string, arg2 string, arg3 s
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.CreateOrUpdateUserStub
+	fakeReturns := fake.createOrUpdateUserReturns
 	fake.recordInvocation("CreateOrUpdateUser", []interface{}{arg1, arg2, arg3})
 	fake.createOrUpdateUserMutex.Unlock()
-	if fake.CreateOrUpdateUserStub != nil {
-		return fake.CreateOrUpdateUserStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createOrUpdateUserReturns
 	return fakeReturns.result1
 }
 
@@ -118,15 +119,16 @@ func (fake *FakeUserFactory) GetAllUsers() ([]db.User, error) {
 	ret, specificReturn := fake.getAllUsersReturnsOnCall[len(fake.getAllUsersArgsForCall)]
 	fake.getAllUsersArgsForCall = append(fake.getAllUsersArgsForCall, struct {
 	}{})
+	stub := fake.GetAllUsersStub
+	fakeReturns := fake.getAllUsersReturns
 	fake.recordInvocation("GetAllUsers", []interface{}{})
 	fake.getAllUsersMutex.Unlock()
-	if fake.GetAllUsersStub != nil {
-		return fake.GetAllUsersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getAllUsersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -174,15 +176,16 @@ func (fake *FakeUserFactory) GetAllUsersByLoginDate(arg1 time.Time) ([]db.User, 
 	fake.getAllUsersByLoginDateArgsForCall = append(fake.getAllUsersByLoginDateArgsForCall, struct {
 		arg1 time.Time
 	}{arg1})
+	stub := fake.GetAllUsersByLoginDateStub
+	fakeReturns := fake.getAllUsersByLoginDateReturns
 	fake.recordInvocation("GetAllUsersByLoginDate", []interface{}{arg1})
 	fake.getAllUsersByLoginDateMutex.Unlock()
-	if fake.GetAllUsersByLoginDateStub != nil {
-		return fake.GetAllUsersByLoginDateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getAllUsersByLoginDateReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_volume_repository.go
+++ b/atc/db/dbfakes/fake_volume_repository.go
@@ -304,15 +304,16 @@ func (fake *FakeVolumeRepository) CreateBaseResourceTypeVolume(arg1 *db.UsedWork
 	fake.createBaseResourceTypeVolumeArgsForCall = append(fake.createBaseResourceTypeVolumeArgsForCall, struct {
 		arg1 *db.UsedWorkerBaseResourceType
 	}{arg1})
+	stub := fake.CreateBaseResourceTypeVolumeStub
+	fakeReturns := fake.createBaseResourceTypeVolumeReturns
 	fake.recordInvocation("CreateBaseResourceTypeVolume", []interface{}{arg1})
 	fake.createBaseResourceTypeVolumeMutex.Unlock()
-	if fake.CreateBaseResourceTypeVolumeStub != nil {
-		return fake.CreateBaseResourceTypeVolumeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createBaseResourceTypeVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -370,15 +371,16 @@ func (fake *FakeVolumeRepository) CreateContainerVolume(arg1 int, arg2 string, a
 		arg3 db.CreatingContainer
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CreateContainerVolumeStub
+	fakeReturns := fake.createContainerVolumeReturns
 	fake.recordInvocation("CreateContainerVolume", []interface{}{arg1, arg2, arg3, arg4})
 	fake.createContainerVolumeMutex.Unlock()
-	if fake.CreateContainerVolumeStub != nil {
-		return fake.CreateContainerVolumeStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createContainerVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -434,15 +436,16 @@ func (fake *FakeVolumeRepository) CreateResourceCertsVolume(arg1 string, arg2 *d
 		arg1 string
 		arg2 *db.UsedWorkerResourceCerts
 	}{arg1, arg2})
+	stub := fake.CreateResourceCertsVolumeStub
+	fakeReturns := fake.createResourceCertsVolumeReturns
 	fake.recordInvocation("CreateResourceCertsVolume", []interface{}{arg1, arg2})
 	fake.createResourceCertsVolumeMutex.Unlock()
-	if fake.CreateResourceCertsVolumeStub != nil {
-		return fake.CreateResourceCertsVolumeStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createResourceCertsVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -498,15 +501,16 @@ func (fake *FakeVolumeRepository) CreateTaskCacheVolume(arg1 int, arg2 *db.UsedW
 		arg1 int
 		arg2 *db.UsedWorkerTaskCache
 	}{arg1, arg2})
+	stub := fake.CreateTaskCacheVolumeStub
+	fakeReturns := fake.createTaskCacheVolumeReturns
 	fake.recordInvocation("CreateTaskCacheVolume", []interface{}{arg1, arg2})
 	fake.createTaskCacheVolumeMutex.Unlock()
-	if fake.CreateTaskCacheVolumeStub != nil {
-		return fake.CreateTaskCacheVolumeStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createTaskCacheVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -563,15 +567,16 @@ func (fake *FakeVolumeRepository) CreateVolume(arg1 int, arg2 string, arg3 db.Vo
 		arg2 string
 		arg3 db.VolumeType
 	}{arg1, arg2, arg3})
+	stub := fake.CreateVolumeStub
+	fakeReturns := fake.createVolumeReturns
 	fake.recordInvocation("CreateVolume", []interface{}{arg1, arg2, arg3})
 	fake.createVolumeMutex.Unlock()
-	if fake.CreateVolumeStub != nil {
-		return fake.CreateVolumeStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -625,15 +630,16 @@ func (fake *FakeVolumeRepository) DestroyFailedVolumes() (int, error) {
 	ret, specificReturn := fake.destroyFailedVolumesReturnsOnCall[len(fake.destroyFailedVolumesArgsForCall)]
 	fake.destroyFailedVolumesArgsForCall = append(fake.destroyFailedVolumesArgsForCall, struct {
 	}{})
+	stub := fake.DestroyFailedVolumesStub
+	fakeReturns := fake.destroyFailedVolumesReturns
 	fake.recordInvocation("DestroyFailedVolumes", []interface{}{})
 	fake.destroyFailedVolumesMutex.Unlock()
-	if fake.DestroyFailedVolumesStub != nil {
-		return fake.DestroyFailedVolumesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyFailedVolumesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -687,15 +693,16 @@ func (fake *FakeVolumeRepository) DestroyUnknownVolumes(arg1 string, arg2 []stri
 		arg1 string
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.DestroyUnknownVolumesStub
+	fakeReturns := fake.destroyUnknownVolumesReturns
 	fake.recordInvocation("DestroyUnknownVolumes", []interface{}{arg1, arg2Copy})
 	fake.destroyUnknownVolumesMutex.Unlock()
-	if fake.DestroyUnknownVolumesStub != nil {
-		return fake.DestroyUnknownVolumesStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.destroyUnknownVolumesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -750,15 +757,16 @@ func (fake *FakeVolumeRepository) FindBaseResourceTypeVolume(arg1 *db.UsedWorker
 	fake.findBaseResourceTypeVolumeArgsForCall = append(fake.findBaseResourceTypeVolumeArgsForCall, struct {
 		arg1 *db.UsedWorkerBaseResourceType
 	}{arg1})
+	stub := fake.FindBaseResourceTypeVolumeStub
+	fakeReturns := fake.findBaseResourceTypeVolumeReturns
 	fake.recordInvocation("FindBaseResourceTypeVolume", []interface{}{arg1})
 	fake.findBaseResourceTypeVolumeMutex.Unlock()
-	if fake.FindBaseResourceTypeVolumeStub != nil {
-		return fake.FindBaseResourceTypeVolumeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findBaseResourceTypeVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -819,15 +827,16 @@ func (fake *FakeVolumeRepository) FindContainerVolume(arg1 int, arg2 string, arg
 		arg3 db.CreatingContainer
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.FindContainerVolumeStub
+	fakeReturns := fake.findContainerVolumeReturns
 	fake.recordInvocation("FindContainerVolume", []interface{}{arg1, arg2, arg3, arg4})
 	fake.findContainerVolumeMutex.Unlock()
-	if fake.FindContainerVolumeStub != nil {
-		return fake.FindContainerVolumeStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findContainerVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -885,15 +894,16 @@ func (fake *FakeVolumeRepository) FindCreatedVolume(arg1 string) (db.CreatedVolu
 	fake.findCreatedVolumeArgsForCall = append(fake.findCreatedVolumeArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindCreatedVolumeStub
+	fakeReturns := fake.findCreatedVolumeReturns
 	fake.recordInvocation("FindCreatedVolume", []interface{}{arg1})
 	fake.findCreatedVolumeMutex.Unlock()
-	if fake.FindCreatedVolumeStub != nil {
-		return fake.FindCreatedVolumeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findCreatedVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -952,15 +962,16 @@ func (fake *FakeVolumeRepository) FindResourceCacheVolume(arg1 string, arg2 db.U
 		arg1 string
 		arg2 db.UsedResourceCache
 	}{arg1, arg2})
+	stub := fake.FindResourceCacheVolumeStub
+	fakeReturns := fake.findResourceCacheVolumeReturns
 	fake.recordInvocation("FindResourceCacheVolume", []interface{}{arg1, arg2})
 	fake.findResourceCacheVolumeMutex.Unlock()
-	if fake.FindResourceCacheVolumeStub != nil {
-		return fake.FindResourceCacheVolumeStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findResourceCacheVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1019,15 +1030,16 @@ func (fake *FakeVolumeRepository) FindResourceCertsVolume(arg1 string, arg2 *db.
 		arg1 string
 		arg2 *db.UsedWorkerResourceCerts
 	}{arg1, arg2})
+	stub := fake.FindResourceCertsVolumeStub
+	fakeReturns := fake.findResourceCertsVolumeReturns
 	fake.recordInvocation("FindResourceCertsVolume", []interface{}{arg1, arg2})
 	fake.findResourceCertsVolumeMutex.Unlock()
-	if fake.FindResourceCertsVolumeStub != nil {
-		return fake.FindResourceCertsVolumeStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findResourceCertsVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1087,15 +1099,16 @@ func (fake *FakeVolumeRepository) FindTaskCacheVolume(arg1 int, arg2 string, arg
 		arg2 string
 		arg3 db.UsedTaskCache
 	}{arg1, arg2, arg3})
+	stub := fake.FindTaskCacheVolumeStub
+	fakeReturns := fake.findTaskCacheVolumeReturns
 	fake.recordInvocation("FindTaskCacheVolume", []interface{}{arg1, arg2, arg3})
 	fake.findTaskCacheVolumeMutex.Unlock()
-	if fake.FindTaskCacheVolumeStub != nil {
-		return fake.FindTaskCacheVolumeStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findTaskCacheVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1153,15 +1166,16 @@ func (fake *FakeVolumeRepository) FindVolumesForContainer(arg1 db.CreatedContain
 	fake.findVolumesForContainerArgsForCall = append(fake.findVolumesForContainerArgsForCall, struct {
 		arg1 db.CreatedContainer
 	}{arg1})
+	stub := fake.FindVolumesForContainerStub
+	fakeReturns := fake.findVolumesForContainerReturns
 	fake.recordInvocation("FindVolumesForContainer", []interface{}{arg1})
 	fake.findVolumesForContainerMutex.Unlock()
-	if fake.FindVolumesForContainerStub != nil {
-		return fake.FindVolumesForContainerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findVolumesForContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1216,15 +1230,16 @@ func (fake *FakeVolumeRepository) GetDestroyingVolumes(arg1 string) ([]string, e
 	fake.getDestroyingVolumesArgsForCall = append(fake.getDestroyingVolumesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetDestroyingVolumesStub
+	fakeReturns := fake.getDestroyingVolumesReturns
 	fake.recordInvocation("GetDestroyingVolumes", []interface{}{arg1})
 	fake.getDestroyingVolumesMutex.Unlock()
-	if fake.GetDestroyingVolumesStub != nil {
-		return fake.GetDestroyingVolumesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getDestroyingVolumesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1278,15 +1293,16 @@ func (fake *FakeVolumeRepository) GetOrphanedVolumes() ([]db.CreatedVolume, erro
 	ret, specificReturn := fake.getOrphanedVolumesReturnsOnCall[len(fake.getOrphanedVolumesArgsForCall)]
 	fake.getOrphanedVolumesArgsForCall = append(fake.getOrphanedVolumesArgsForCall, struct {
 	}{})
+	stub := fake.GetOrphanedVolumesStub
+	fakeReturns := fake.getOrphanedVolumesReturns
 	fake.recordInvocation("GetOrphanedVolumes", []interface{}{})
 	fake.getOrphanedVolumesMutex.Unlock()
-	if fake.GetOrphanedVolumesStub != nil {
-		return fake.GetOrphanedVolumesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getOrphanedVolumesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1334,15 +1350,16 @@ func (fake *FakeVolumeRepository) GetTeamVolumes(arg1 int) ([]db.CreatedVolume, 
 	fake.getTeamVolumesArgsForCall = append(fake.getTeamVolumesArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.GetTeamVolumesStub
+	fakeReturns := fake.getTeamVolumesReturns
 	fake.recordInvocation("GetTeamVolumes", []interface{}{arg1})
 	fake.getTeamVolumesMutex.Unlock()
-	if fake.GetTeamVolumesStub != nil {
-		return fake.GetTeamVolumesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getTeamVolumesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1403,15 +1420,16 @@ func (fake *FakeVolumeRepository) RemoveDestroyingVolumes(arg1 string, arg2 []st
 		arg1 string
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.RemoveDestroyingVolumesStub
+	fakeReturns := fake.removeDestroyingVolumesReturns
 	fake.recordInvocation("RemoveDestroyingVolumes", []interface{}{arg1, arg2Copy})
 	fake.removeDestroyingVolumesMutex.Unlock()
-	if fake.RemoveDestroyingVolumesStub != nil {
-		return fake.RemoveDestroyingVolumesStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.removeDestroyingVolumesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1466,15 +1484,16 @@ func (fake *FakeVolumeRepository) RemoveMissingVolumes(arg1 time.Duration) (int,
 	fake.removeMissingVolumesArgsForCall = append(fake.removeMissingVolumesArgsForCall, struct {
 		arg1 time.Duration
 	}{arg1})
+	stub := fake.RemoveMissingVolumesStub
+	fakeReturns := fake.removeMissingVolumesReturns
 	fake.recordInvocation("RemoveMissingVolumes", []interface{}{arg1})
 	fake.removeMissingVolumesMutex.Unlock()
-	if fake.RemoveMissingVolumesStub != nil {
-		return fake.RemoveMissingVolumesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.removeMissingVolumesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1535,15 +1554,16 @@ func (fake *FakeVolumeRepository) UpdateVolumesMissingSince(arg1 string, arg2 []
 		arg1 string
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.UpdateVolumesMissingSinceStub
+	fakeReturns := fake.updateVolumesMissingSinceReturns
 	fake.recordInvocation("UpdateVolumesMissingSince", []interface{}{arg1, arg2Copy})
 	fake.updateVolumesMissingSinceMutex.Unlock()
-	if fake.UpdateVolumesMissingSinceStub != nil {
-		return fake.UpdateVolumesMissingSinceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateVolumesMissingSinceReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_wall.go
+++ b/atc/db/dbfakes/fake_wall.go
@@ -51,15 +51,16 @@ func (fake *FakeWall) Clear() error {
 	ret, specificReturn := fake.clearReturnsOnCall[len(fake.clearArgsForCall)]
 	fake.clearArgsForCall = append(fake.clearArgsForCall, struct {
 	}{})
+	stub := fake.ClearStub
+	fakeReturns := fake.clearReturns
 	fake.recordInvocation("Clear", []interface{}{})
 	fake.clearMutex.Unlock()
-	if fake.ClearStub != nil {
-		return fake.ClearStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.clearReturns
 	return fakeReturns.result1
 }
 
@@ -103,15 +104,16 @@ func (fake *FakeWall) GetWall() (atc.Wall, error) {
 	ret, specificReturn := fake.getWallReturnsOnCall[len(fake.getWallArgsForCall)]
 	fake.getWallArgsForCall = append(fake.getWallArgsForCall, struct {
 	}{})
+	stub := fake.GetWallStub
+	fakeReturns := fake.getWallReturns
 	fake.recordInvocation("GetWall", []interface{}{})
 	fake.getWallMutex.Unlock()
-	if fake.GetWallStub != nil {
-		return fake.GetWallStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getWallReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -159,15 +161,16 @@ func (fake *FakeWall) SetWall(arg1 atc.Wall) error {
 	fake.setWallArgsForCall = append(fake.setWallArgsForCall, struct {
 		arg1 atc.Wall
 	}{arg1})
+	stub := fake.SetWallStub
+	fakeReturns := fake.setWallReturns
 	fake.recordInvocation("SetWall", []interface{}{arg1})
 	fake.setWallMutex.Unlock()
-	if fake.SetWallStub != nil {
-		return fake.SetWallStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setWallReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_worker.go
+++ b/atc/db/dbfakes/fake_worker.go
@@ -336,15 +336,16 @@ func (fake *FakeWorker) ActiveContainers() int {
 	ret, specificReturn := fake.activeContainersReturnsOnCall[len(fake.activeContainersArgsForCall)]
 	fake.activeContainersArgsForCall = append(fake.activeContainersArgsForCall, struct {
 	}{})
+	stub := fake.ActiveContainersStub
+	fakeReturns := fake.activeContainersReturns
 	fake.recordInvocation("ActiveContainers", []interface{}{})
 	fake.activeContainersMutex.Unlock()
-	if fake.ActiveContainersStub != nil {
-		return fake.ActiveContainersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.activeContainersReturns
 	return fakeReturns.result1
 }
 
@@ -388,15 +389,16 @@ func (fake *FakeWorker) ActiveTasks() (int, error) {
 	ret, specificReturn := fake.activeTasksReturnsOnCall[len(fake.activeTasksArgsForCall)]
 	fake.activeTasksArgsForCall = append(fake.activeTasksArgsForCall, struct {
 	}{})
+	stub := fake.ActiveTasksStub
+	fakeReturns := fake.activeTasksReturns
 	fake.recordInvocation("ActiveTasks", []interface{}{})
 	fake.activeTasksMutex.Unlock()
-	if fake.ActiveTasksStub != nil {
-		return fake.ActiveTasksStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.activeTasksReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -443,15 +445,16 @@ func (fake *FakeWorker) ActiveVolumes() int {
 	ret, specificReturn := fake.activeVolumesReturnsOnCall[len(fake.activeVolumesArgsForCall)]
 	fake.activeVolumesArgsForCall = append(fake.activeVolumesArgsForCall, struct {
 	}{})
+	stub := fake.ActiveVolumesStub
+	fakeReturns := fake.activeVolumesReturns
 	fake.recordInvocation("ActiveVolumes", []interface{}{})
 	fake.activeVolumesMutex.Unlock()
-	if fake.ActiveVolumesStub != nil {
-		return fake.ActiveVolumesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.activeVolumesReturns
 	return fakeReturns.result1
 }
 
@@ -495,15 +498,16 @@ func (fake *FakeWorker) BaggageclaimURL() *string {
 	ret, specificReturn := fake.baggageclaimURLReturnsOnCall[len(fake.baggageclaimURLArgsForCall)]
 	fake.baggageclaimURLArgsForCall = append(fake.baggageclaimURLArgsForCall, struct {
 	}{})
+	stub := fake.BaggageclaimURLStub
+	fakeReturns := fake.baggageclaimURLReturns
 	fake.recordInvocation("BaggageclaimURL", []interface{}{})
 	fake.baggageclaimURLMutex.Unlock()
-	if fake.BaggageclaimURLStub != nil {
-		return fake.BaggageclaimURLStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.baggageclaimURLReturns
 	return fakeReturns.result1
 }
 
@@ -547,15 +551,16 @@ func (fake *FakeWorker) CertsPath() *string {
 	ret, specificReturn := fake.certsPathReturnsOnCall[len(fake.certsPathArgsForCall)]
 	fake.certsPathArgsForCall = append(fake.certsPathArgsForCall, struct {
 	}{})
+	stub := fake.CertsPathStub
+	fakeReturns := fake.certsPathReturns
 	fake.recordInvocation("CertsPath", []interface{}{})
 	fake.certsPathMutex.Unlock()
-	if fake.CertsPathStub != nil {
-		return fake.CertsPathStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.certsPathReturns
 	return fakeReturns.result1
 }
 
@@ -601,15 +606,16 @@ func (fake *FakeWorker) CreateContainer(arg1 db.ContainerOwner, arg2 db.Containe
 		arg1 db.ContainerOwner
 		arg2 db.ContainerMetadata
 	}{arg1, arg2})
+	stub := fake.CreateContainerStub
+	fakeReturns := fake.createContainerReturns
 	fake.recordInvocation("CreateContainer", []interface{}{arg1, arg2})
 	fake.createContainerMutex.Unlock()
-	if fake.CreateContainerStub != nil {
-		return fake.CreateContainerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -663,15 +669,16 @@ func (fake *FakeWorker) DecreaseActiveTasks() error {
 	ret, specificReturn := fake.decreaseActiveTasksReturnsOnCall[len(fake.decreaseActiveTasksArgsForCall)]
 	fake.decreaseActiveTasksArgsForCall = append(fake.decreaseActiveTasksArgsForCall, struct {
 	}{})
+	stub := fake.DecreaseActiveTasksStub
+	fakeReturns := fake.decreaseActiveTasksReturns
 	fake.recordInvocation("DecreaseActiveTasks", []interface{}{})
 	fake.decreaseActiveTasksMutex.Unlock()
-	if fake.DecreaseActiveTasksStub != nil {
-		return fake.DecreaseActiveTasksStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.decreaseActiveTasksReturns
 	return fakeReturns.result1
 }
 
@@ -715,15 +722,16 @@ func (fake *FakeWorker) Delete() error {
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 	}{})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1
 }
 
@@ -767,15 +775,16 @@ func (fake *FakeWorker) Ephemeral() bool {
 	ret, specificReturn := fake.ephemeralReturnsOnCall[len(fake.ephemeralArgsForCall)]
 	fake.ephemeralArgsForCall = append(fake.ephemeralArgsForCall, struct {
 	}{})
+	stub := fake.EphemeralStub
+	fakeReturns := fake.ephemeralReturns
 	fake.recordInvocation("Ephemeral", []interface{}{})
 	fake.ephemeralMutex.Unlock()
-	if fake.EphemeralStub != nil {
-		return fake.EphemeralStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.ephemeralReturns
 	return fakeReturns.result1
 }
 
@@ -819,15 +828,16 @@ func (fake *FakeWorker) ExpiresAt() time.Time {
 	ret, specificReturn := fake.expiresAtReturnsOnCall[len(fake.expiresAtArgsForCall)]
 	fake.expiresAtArgsForCall = append(fake.expiresAtArgsForCall, struct {
 	}{})
+	stub := fake.ExpiresAtStub
+	fakeReturns := fake.expiresAtReturns
 	fake.recordInvocation("ExpiresAt", []interface{}{})
 	fake.expiresAtMutex.Unlock()
-	if fake.ExpiresAtStub != nil {
-		return fake.ExpiresAtStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.expiresAtReturns
 	return fakeReturns.result1
 }
 
@@ -872,15 +882,16 @@ func (fake *FakeWorker) FindContainer(arg1 db.ContainerOwner) (db.CreatingContai
 	fake.findContainerArgsForCall = append(fake.findContainerArgsForCall, struct {
 		arg1 db.ContainerOwner
 	}{arg1})
+	stub := fake.FindContainerStub
+	fakeReturns := fake.findContainerReturns
 	fake.recordInvocation("FindContainer", []interface{}{arg1})
 	fake.findContainerMutex.Unlock()
-	if fake.FindContainerStub != nil {
-		return fake.FindContainerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findContainerReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -937,15 +948,16 @@ func (fake *FakeWorker) GardenAddr() *string {
 	ret, specificReturn := fake.gardenAddrReturnsOnCall[len(fake.gardenAddrArgsForCall)]
 	fake.gardenAddrArgsForCall = append(fake.gardenAddrArgsForCall, struct {
 	}{})
+	stub := fake.GardenAddrStub
+	fakeReturns := fake.gardenAddrReturns
 	fake.recordInvocation("GardenAddr", []interface{}{})
 	fake.gardenAddrMutex.Unlock()
-	if fake.GardenAddrStub != nil {
-		return fake.GardenAddrStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.gardenAddrReturns
 	return fakeReturns.result1
 }
 
@@ -989,15 +1001,16 @@ func (fake *FakeWorker) HTTPProxyURL() string {
 	ret, specificReturn := fake.hTTPProxyURLReturnsOnCall[len(fake.hTTPProxyURLArgsForCall)]
 	fake.hTTPProxyURLArgsForCall = append(fake.hTTPProxyURLArgsForCall, struct {
 	}{})
+	stub := fake.HTTPProxyURLStub
+	fakeReturns := fake.hTTPProxyURLReturns
 	fake.recordInvocation("HTTPProxyURL", []interface{}{})
 	fake.hTTPProxyURLMutex.Unlock()
-	if fake.HTTPProxyURLStub != nil {
-		return fake.HTTPProxyURLStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hTTPProxyURLReturns
 	return fakeReturns.result1
 }
 
@@ -1041,15 +1054,16 @@ func (fake *FakeWorker) HTTPSProxyURL() string {
 	ret, specificReturn := fake.hTTPSProxyURLReturnsOnCall[len(fake.hTTPSProxyURLArgsForCall)]
 	fake.hTTPSProxyURLArgsForCall = append(fake.hTTPSProxyURLArgsForCall, struct {
 	}{})
+	stub := fake.HTTPSProxyURLStub
+	fakeReturns := fake.hTTPSProxyURLReturns
 	fake.recordInvocation("HTTPSProxyURL", []interface{}{})
 	fake.hTTPSProxyURLMutex.Unlock()
-	if fake.HTTPSProxyURLStub != nil {
-		return fake.HTTPSProxyURLStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hTTPSProxyURLReturns
 	return fakeReturns.result1
 }
 
@@ -1093,15 +1107,16 @@ func (fake *FakeWorker) IncreaseActiveTasks() error {
 	ret, specificReturn := fake.increaseActiveTasksReturnsOnCall[len(fake.increaseActiveTasksArgsForCall)]
 	fake.increaseActiveTasksArgsForCall = append(fake.increaseActiveTasksArgsForCall, struct {
 	}{})
+	stub := fake.IncreaseActiveTasksStub
+	fakeReturns := fake.increaseActiveTasksReturns
 	fake.recordInvocation("IncreaseActiveTasks", []interface{}{})
 	fake.increaseActiveTasksMutex.Unlock()
-	if fake.IncreaseActiveTasksStub != nil {
-		return fake.IncreaseActiveTasksStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.increaseActiveTasksReturns
 	return fakeReturns.result1
 }
 
@@ -1145,15 +1160,16 @@ func (fake *FakeWorker) Land() error {
 	ret, specificReturn := fake.landReturnsOnCall[len(fake.landArgsForCall)]
 	fake.landArgsForCall = append(fake.landArgsForCall, struct {
 	}{})
+	stub := fake.LandStub
+	fakeReturns := fake.landReturns
 	fake.recordInvocation("Land", []interface{}{})
 	fake.landMutex.Unlock()
-	if fake.LandStub != nil {
-		return fake.LandStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.landReturns
 	return fakeReturns.result1
 }
 
@@ -1197,15 +1213,16 @@ func (fake *FakeWorker) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -1249,15 +1266,16 @@ func (fake *FakeWorker) NoProxy() string {
 	ret, specificReturn := fake.noProxyReturnsOnCall[len(fake.noProxyArgsForCall)]
 	fake.noProxyArgsForCall = append(fake.noProxyArgsForCall, struct {
 	}{})
+	stub := fake.NoProxyStub
+	fakeReturns := fake.noProxyReturns
 	fake.recordInvocation("NoProxy", []interface{}{})
 	fake.noProxyMutex.Unlock()
-	if fake.NoProxyStub != nil {
-		return fake.NoProxyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.noProxyReturns
 	return fakeReturns.result1
 }
 
@@ -1301,15 +1319,16 @@ func (fake *FakeWorker) Platform() string {
 	ret, specificReturn := fake.platformReturnsOnCall[len(fake.platformArgsForCall)]
 	fake.platformArgsForCall = append(fake.platformArgsForCall, struct {
 	}{})
+	stub := fake.PlatformStub
+	fakeReturns := fake.platformReturns
 	fake.recordInvocation("Platform", []interface{}{})
 	fake.platformMutex.Unlock()
-	if fake.PlatformStub != nil {
-		return fake.PlatformStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.platformReturns
 	return fakeReturns.result1
 }
 
@@ -1353,15 +1372,16 @@ func (fake *FakeWorker) Prune() error {
 	ret, specificReturn := fake.pruneReturnsOnCall[len(fake.pruneArgsForCall)]
 	fake.pruneArgsForCall = append(fake.pruneArgsForCall, struct {
 	}{})
+	stub := fake.PruneStub
+	fakeReturns := fake.pruneReturns
 	fake.recordInvocation("Prune", []interface{}{})
 	fake.pruneMutex.Unlock()
-	if fake.PruneStub != nil {
-		return fake.PruneStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pruneReturns
 	return fakeReturns.result1
 }
 
@@ -1405,15 +1425,16 @@ func (fake *FakeWorker) Reload() (bool, error) {
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
 	fake.reloadArgsForCall = append(fake.reloadArgsForCall, struct {
 	}{})
+	stub := fake.ReloadStub
+	fakeReturns := fake.reloadReturns
 	fake.recordInvocation("Reload", []interface{}{})
 	fake.reloadMutex.Unlock()
-	if fake.ReloadStub != nil {
-		return fake.ReloadStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.reloadReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1460,15 +1481,16 @@ func (fake *FakeWorker) ResourceCerts() (*db.UsedWorkerResourceCerts, bool, erro
 	ret, specificReturn := fake.resourceCertsReturnsOnCall[len(fake.resourceCertsArgsForCall)]
 	fake.resourceCertsArgsForCall = append(fake.resourceCertsArgsForCall, struct {
 	}{})
+	stub := fake.ResourceCertsStub
+	fakeReturns := fake.resourceCertsReturns
 	fake.recordInvocation("ResourceCerts", []interface{}{})
 	fake.resourceCertsMutex.Unlock()
-	if fake.ResourceCertsStub != nil {
-		return fake.ResourceCertsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.resourceCertsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1518,15 +1540,16 @@ func (fake *FakeWorker) ResourceTypes() []atc.WorkerResourceType {
 	ret, specificReturn := fake.resourceTypesReturnsOnCall[len(fake.resourceTypesArgsForCall)]
 	fake.resourceTypesArgsForCall = append(fake.resourceTypesArgsForCall, struct {
 	}{})
+	stub := fake.ResourceTypesStub
+	fakeReturns := fake.resourceTypesReturns
 	fake.recordInvocation("ResourceTypes", []interface{}{})
 	fake.resourceTypesMutex.Unlock()
-	if fake.ResourceTypesStub != nil {
-		return fake.ResourceTypesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceTypesReturns
 	return fakeReturns.result1
 }
 
@@ -1570,15 +1593,16 @@ func (fake *FakeWorker) Retire() error {
 	ret, specificReturn := fake.retireReturnsOnCall[len(fake.retireArgsForCall)]
 	fake.retireArgsForCall = append(fake.retireArgsForCall, struct {
 	}{})
+	stub := fake.RetireStub
+	fakeReturns := fake.retireReturns
 	fake.recordInvocation("Retire", []interface{}{})
 	fake.retireMutex.Unlock()
-	if fake.RetireStub != nil {
-		return fake.RetireStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.retireReturns
 	return fakeReturns.result1
 }
 
@@ -1622,15 +1646,16 @@ func (fake *FakeWorker) StartTime() time.Time {
 	ret, specificReturn := fake.startTimeReturnsOnCall[len(fake.startTimeArgsForCall)]
 	fake.startTimeArgsForCall = append(fake.startTimeArgsForCall, struct {
 	}{})
+	stub := fake.StartTimeStub
+	fakeReturns := fake.startTimeReturns
 	fake.recordInvocation("StartTime", []interface{}{})
 	fake.startTimeMutex.Unlock()
-	if fake.StartTimeStub != nil {
-		return fake.StartTimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.startTimeReturns
 	return fakeReturns.result1
 }
 
@@ -1674,15 +1699,16 @@ func (fake *FakeWorker) State() db.WorkerState {
 	ret, specificReturn := fake.stateReturnsOnCall[len(fake.stateArgsForCall)]
 	fake.stateArgsForCall = append(fake.stateArgsForCall, struct {
 	}{})
+	stub := fake.StateStub
+	fakeReturns := fake.stateReturns
 	fake.recordInvocation("State", []interface{}{})
 	fake.stateMutex.Unlock()
-	if fake.StateStub != nil {
-		return fake.StateStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stateReturns
 	return fakeReturns.result1
 }
 
@@ -1726,15 +1752,16 @@ func (fake *FakeWorker) Tags() []string {
 	ret, specificReturn := fake.tagsReturnsOnCall[len(fake.tagsArgsForCall)]
 	fake.tagsArgsForCall = append(fake.tagsArgsForCall, struct {
 	}{})
+	stub := fake.TagsStub
+	fakeReturns := fake.tagsReturns
 	fake.recordInvocation("Tags", []interface{}{})
 	fake.tagsMutex.Unlock()
-	if fake.TagsStub != nil {
-		return fake.TagsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tagsReturns
 	return fakeReturns.result1
 }
 
@@ -1778,15 +1805,16 @@ func (fake *FakeWorker) TeamID() int {
 	ret, specificReturn := fake.teamIDReturnsOnCall[len(fake.teamIDArgsForCall)]
 	fake.teamIDArgsForCall = append(fake.teamIDArgsForCall, struct {
 	}{})
+	stub := fake.TeamIDStub
+	fakeReturns := fake.teamIDReturns
 	fake.recordInvocation("TeamID", []interface{}{})
 	fake.teamIDMutex.Unlock()
-	if fake.TeamIDStub != nil {
-		return fake.TeamIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamIDReturns
 	return fakeReturns.result1
 }
 
@@ -1830,15 +1858,16 @@ func (fake *FakeWorker) TeamName() string {
 	ret, specificReturn := fake.teamNameReturnsOnCall[len(fake.teamNameArgsForCall)]
 	fake.teamNameArgsForCall = append(fake.teamNameArgsForCall, struct {
 	}{})
+	stub := fake.TeamNameStub
+	fakeReturns := fake.teamNameReturns
 	fake.recordInvocation("TeamName", []interface{}{})
 	fake.teamNameMutex.Unlock()
-	if fake.TeamNameStub != nil {
-		return fake.TeamNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamNameReturns
 	return fakeReturns.result1
 }
 
@@ -1882,15 +1911,16 @@ func (fake *FakeWorker) Version() *string {
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
 	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
 	}{})
+	stub := fake.VersionStub
+	fakeReturns := fake.versionReturns
 	fake.recordInvocation("Version", []interface{}{})
 	fake.versionMutex.Unlock()
-	if fake.VersionStub != nil {
-		return fake.VersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.versionReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_worker_artifact.go
+++ b/atc/db/dbfakes/fake_worker_artifact.go
@@ -73,15 +73,16 @@ func (fake *FakeWorkerArtifact) BuildID() int {
 	ret, specificReturn := fake.buildIDReturnsOnCall[len(fake.buildIDArgsForCall)]
 	fake.buildIDArgsForCall = append(fake.buildIDArgsForCall, struct {
 	}{})
+	stub := fake.BuildIDStub
+	fakeReturns := fake.buildIDReturns
 	fake.recordInvocation("BuildID", []interface{}{})
 	fake.buildIDMutex.Unlock()
-	if fake.BuildIDStub != nil {
-		return fake.BuildIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.buildIDReturns
 	return fakeReturns.result1
 }
 
@@ -125,15 +126,16 @@ func (fake *FakeWorkerArtifact) CreatedAt() time.Time {
 	ret, specificReturn := fake.createdAtReturnsOnCall[len(fake.createdAtArgsForCall)]
 	fake.createdAtArgsForCall = append(fake.createdAtArgsForCall, struct {
 	}{})
+	stub := fake.CreatedAtStub
+	fakeReturns := fake.createdAtReturns
 	fake.recordInvocation("CreatedAt", []interface{}{})
 	fake.createdAtMutex.Unlock()
-	if fake.CreatedAtStub != nil {
-		return fake.CreatedAtStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createdAtReturns
 	return fakeReturns.result1
 }
 
@@ -177,15 +179,16 @@ func (fake *FakeWorkerArtifact) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -229,15 +232,16 @@ func (fake *FakeWorkerArtifact) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -282,15 +286,16 @@ func (fake *FakeWorkerArtifact) Volume(arg1 int) (db.CreatedVolume, bool, error)
 	fake.volumeArgsForCall = append(fake.volumeArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.VolumeStub
+	fakeReturns := fake.volumeReturns
 	fake.recordInvocation("Volume", []interface{}{arg1})
 	fake.volumeMutex.Unlock()
-	if fake.VolumeStub != nil {
-		return fake.VolumeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.volumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/db/dbfakes/fake_worker_artifact_lifecycle.go
+++ b/atc/db/dbfakes/fake_worker_artifact_lifecycle.go
@@ -27,15 +27,16 @@ func (fake *FakeWorkerArtifactLifecycle) RemoveExpiredArtifacts() error {
 	ret, specificReturn := fake.removeExpiredArtifactsReturnsOnCall[len(fake.removeExpiredArtifactsArgsForCall)]
 	fake.removeExpiredArtifactsArgsForCall = append(fake.removeExpiredArtifactsArgsForCall, struct {
 	}{})
+	stub := fake.RemoveExpiredArtifactsStub
+	fakeReturns := fake.removeExpiredArtifactsReturns
 	fake.recordInvocation("RemoveExpiredArtifacts", []interface{}{})
 	fake.removeExpiredArtifactsMutex.Unlock()
-	if fake.RemoveExpiredArtifactsStub != nil {
-		return fake.RemoveExpiredArtifactsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeExpiredArtifactsReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/dbfakes/fake_worker_base_resource_type_factory.go
+++ b/atc/db/dbfakes/fake_worker_base_resource_type_factory.go
@@ -35,15 +35,16 @@ func (fake *FakeWorkerBaseResourceTypeFactory) Find(arg1 string, arg2 db.Worker)
 		arg1 string
 		arg2 db.Worker
 	}{arg1, arg2})
+	stub := fake.FindStub
+	fakeReturns := fake.findReturns
 	fake.recordInvocation("Find", []interface{}{arg1, arg2})
 	fake.findMutex.Unlock()
-	if fake.FindStub != nil {
-		return fake.FindStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/db/dbfakes/fake_worker_factory.go
+++ b/atc/db/dbfakes/fake_worker_factory.go
@@ -112,15 +112,16 @@ func (fake *FakeWorkerFactory) BuildContainersCountPerWorker() (map[string]int, 
 	ret, specificReturn := fake.buildContainersCountPerWorkerReturnsOnCall[len(fake.buildContainersCountPerWorkerArgsForCall)]
 	fake.buildContainersCountPerWorkerArgsForCall = append(fake.buildContainersCountPerWorkerArgsForCall, struct {
 	}{})
+	stub := fake.BuildContainersCountPerWorkerStub
+	fakeReturns := fake.buildContainersCountPerWorkerReturns
 	fake.recordInvocation("BuildContainersCountPerWorker", []interface{}{})
 	fake.buildContainersCountPerWorkerMutex.Unlock()
-	if fake.BuildContainersCountPerWorkerStub != nil {
-		return fake.BuildContainersCountPerWorkerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.buildContainersCountPerWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -168,15 +169,16 @@ func (fake *FakeWorkerFactory) FindWorkersForContainerByOwner(arg1 db.ContainerO
 	fake.findWorkersForContainerByOwnerArgsForCall = append(fake.findWorkersForContainerByOwnerArgsForCall, struct {
 		arg1 db.ContainerOwner
 	}{arg1})
+	stub := fake.FindWorkersForContainerByOwnerStub
+	fakeReturns := fake.findWorkersForContainerByOwnerReturns
 	fake.recordInvocation("FindWorkersForContainerByOwner", []interface{}{arg1})
 	fake.findWorkersForContainerByOwnerMutex.Unlock()
-	if fake.FindWorkersForContainerByOwnerStub != nil {
-		return fake.FindWorkersForContainerByOwnerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findWorkersForContainerByOwnerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -231,15 +233,16 @@ func (fake *FakeWorkerFactory) GetWorker(arg1 string) (db.Worker, bool, error) {
 	fake.getWorkerArgsForCall = append(fake.getWorkerArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetWorkerStub
+	fakeReturns := fake.getWorkerReturns
 	fake.recordInvocation("GetWorker", []interface{}{arg1})
 	fake.getWorkerMutex.Unlock()
-	if fake.GetWorkerStub != nil {
-		return fake.GetWorkerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -298,15 +301,16 @@ func (fake *FakeWorkerFactory) HeartbeatWorker(arg1 atc.Worker, arg2 time.Durati
 		arg1 atc.Worker
 		arg2 time.Duration
 	}{arg1, arg2})
+	stub := fake.HeartbeatWorkerStub
+	fakeReturns := fake.heartbeatWorkerReturns
 	fake.recordInvocation("HeartbeatWorker", []interface{}{arg1, arg2})
 	fake.heartbeatWorkerMutex.Unlock()
-	if fake.HeartbeatWorkerStub != nil {
-		return fake.HeartbeatWorkerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.heartbeatWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -362,15 +366,16 @@ func (fake *FakeWorkerFactory) SaveWorker(arg1 atc.Worker, arg2 time.Duration) (
 		arg1 atc.Worker
 		arg2 time.Duration
 	}{arg1, arg2})
+	stub := fake.SaveWorkerStub
+	fakeReturns := fake.saveWorkerReturns
 	fake.recordInvocation("SaveWorker", []interface{}{arg1, arg2})
 	fake.saveWorkerMutex.Unlock()
-	if fake.SaveWorkerStub != nil {
-		return fake.SaveWorkerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.saveWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -430,15 +435,16 @@ func (fake *FakeWorkerFactory) VisibleWorkers(arg1 []string) ([]db.Worker, error
 	fake.visibleWorkersArgsForCall = append(fake.visibleWorkersArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.VisibleWorkersStub
+	fakeReturns := fake.visibleWorkersReturns
 	fake.recordInvocation("VisibleWorkers", []interface{}{arg1Copy})
 	fake.visibleWorkersMutex.Unlock()
-	if fake.VisibleWorkersStub != nil {
-		return fake.VisibleWorkersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.visibleWorkersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -492,15 +498,16 @@ func (fake *FakeWorkerFactory) Workers() ([]db.Worker, error) {
 	ret, specificReturn := fake.workersReturnsOnCall[len(fake.workersArgsForCall)]
 	fake.workersArgsForCall = append(fake.workersArgsForCall, struct {
 	}{})
+	stub := fake.WorkersStub
+	fakeReturns := fake.workersReturns
 	fake.recordInvocation("Workers", []interface{}{})
 	fake.workersMutex.Unlock()
-	if fake.WorkersStub != nil {
-		return fake.WorkersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.workersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_worker_lifecycle.go
+++ b/atc/db/dbfakes/fake_worker_lifecycle.go
@@ -77,15 +77,16 @@ func (fake *FakeWorkerLifecycle) DeleteFinishedRetiringWorkers() ([]string, erro
 	ret, specificReturn := fake.deleteFinishedRetiringWorkersReturnsOnCall[len(fake.deleteFinishedRetiringWorkersArgsForCall)]
 	fake.deleteFinishedRetiringWorkersArgsForCall = append(fake.deleteFinishedRetiringWorkersArgsForCall, struct {
 	}{})
+	stub := fake.DeleteFinishedRetiringWorkersStub
+	fakeReturns := fake.deleteFinishedRetiringWorkersReturns
 	fake.recordInvocation("DeleteFinishedRetiringWorkers", []interface{}{})
 	fake.deleteFinishedRetiringWorkersMutex.Unlock()
-	if fake.DeleteFinishedRetiringWorkersStub != nil {
-		return fake.DeleteFinishedRetiringWorkersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.deleteFinishedRetiringWorkersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -132,15 +133,16 @@ func (fake *FakeWorkerLifecycle) DeleteUnresponsiveEphemeralWorkers() ([]string,
 	ret, specificReturn := fake.deleteUnresponsiveEphemeralWorkersReturnsOnCall[len(fake.deleteUnresponsiveEphemeralWorkersArgsForCall)]
 	fake.deleteUnresponsiveEphemeralWorkersArgsForCall = append(fake.deleteUnresponsiveEphemeralWorkersArgsForCall, struct {
 	}{})
+	stub := fake.DeleteUnresponsiveEphemeralWorkersStub
+	fakeReturns := fake.deleteUnresponsiveEphemeralWorkersReturns
 	fake.recordInvocation("DeleteUnresponsiveEphemeralWorkers", []interface{}{})
 	fake.deleteUnresponsiveEphemeralWorkersMutex.Unlock()
-	if fake.DeleteUnresponsiveEphemeralWorkersStub != nil {
-		return fake.DeleteUnresponsiveEphemeralWorkersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.deleteUnresponsiveEphemeralWorkersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -187,15 +189,16 @@ func (fake *FakeWorkerLifecycle) GetWorkerStateByName() (map[string]db.WorkerSta
 	ret, specificReturn := fake.getWorkerStateByNameReturnsOnCall[len(fake.getWorkerStateByNameArgsForCall)]
 	fake.getWorkerStateByNameArgsForCall = append(fake.getWorkerStateByNameArgsForCall, struct {
 	}{})
+	stub := fake.GetWorkerStateByNameStub
+	fakeReturns := fake.getWorkerStateByNameReturns
 	fake.recordInvocation("GetWorkerStateByName", []interface{}{})
 	fake.getWorkerStateByNameMutex.Unlock()
-	if fake.GetWorkerStateByNameStub != nil {
-		return fake.GetWorkerStateByNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getWorkerStateByNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -242,15 +245,16 @@ func (fake *FakeWorkerLifecycle) LandFinishedLandingWorkers() ([]string, error) 
 	ret, specificReturn := fake.landFinishedLandingWorkersReturnsOnCall[len(fake.landFinishedLandingWorkersArgsForCall)]
 	fake.landFinishedLandingWorkersArgsForCall = append(fake.landFinishedLandingWorkersArgsForCall, struct {
 	}{})
+	stub := fake.LandFinishedLandingWorkersStub
+	fakeReturns := fake.landFinishedLandingWorkersReturns
 	fake.recordInvocation("LandFinishedLandingWorkers", []interface{}{})
 	fake.landFinishedLandingWorkersMutex.Unlock()
-	if fake.LandFinishedLandingWorkersStub != nil {
-		return fake.LandFinishedLandingWorkersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.landFinishedLandingWorkersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -297,15 +301,16 @@ func (fake *FakeWorkerLifecycle) StallUnresponsiveWorkers() ([]string, error) {
 	ret, specificReturn := fake.stallUnresponsiveWorkersReturnsOnCall[len(fake.stallUnresponsiveWorkersArgsForCall)]
 	fake.stallUnresponsiveWorkersArgsForCall = append(fake.stallUnresponsiveWorkersArgsForCall, struct {
 	}{})
+	stub := fake.StallUnresponsiveWorkersStub
+	fakeReturns := fake.stallUnresponsiveWorkersReturns
 	fake.recordInvocation("StallUnresponsiveWorkers", []interface{}{})
 	fake.stallUnresponsiveWorkersMutex.Unlock()
-	if fake.StallUnresponsiveWorkersStub != nil {
-		return fake.StallUnresponsiveWorkersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.stallUnresponsiveWorkersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/dbfakes/fake_worker_task_cache_factory.go
+++ b/atc/db/dbfakes/fake_worker_task_cache_factory.go
@@ -46,15 +46,16 @@ func (fake *FakeWorkerTaskCacheFactory) Find(arg1 db.WorkerTaskCache) (*db.UsedW
 	fake.findArgsForCall = append(fake.findArgsForCall, struct {
 		arg1 db.WorkerTaskCache
 	}{arg1})
+	stub := fake.FindStub
+	fakeReturns := fake.findReturns
 	fake.recordInvocation("Find", []interface{}{arg1})
 	fake.findMutex.Unlock()
-	if fake.FindStub != nil {
-		return fake.FindStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -112,15 +113,16 @@ func (fake *FakeWorkerTaskCacheFactory) FindOrCreate(arg1 db.WorkerTaskCache) (*
 	fake.findOrCreateArgsForCall = append(fake.findOrCreateArgsForCall, struct {
 		arg1 db.WorkerTaskCache
 	}{arg1})
+	stub := fake.FindOrCreateStub
+	fakeReturns := fake.findOrCreateReturns
 	fake.recordInvocation("FindOrCreate", []interface{}{arg1})
 	fake.findOrCreateMutex.Unlock()
-	if fake.FindOrCreateStub != nil {
-		return fake.FindOrCreateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/encryption/encryptionfakes/fake_strategy.go
+++ b/atc/db/encryption/encryptionfakes/fake_strategy.go
@@ -48,15 +48,16 @@ func (fake *FakeStrategy) Decrypt(arg1 string, arg2 *string) ([]byte, error) {
 		arg1 string
 		arg2 *string
 	}{arg1, arg2})
+	stub := fake.DecryptStub
+	fakeReturns := fake.decryptReturns
 	fake.recordInvocation("Decrypt", []interface{}{arg1, arg2})
 	fake.decryptMutex.Unlock()
-	if fake.DecryptStub != nil {
-		return fake.DecryptStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.decryptReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -116,15 +117,16 @@ func (fake *FakeStrategy) Encrypt(arg1 []byte) (string, *string, error) {
 	fake.encryptArgsForCall = append(fake.encryptArgsForCall, struct {
 		arg1 []byte
 	}{arg1Copy})
+	stub := fake.EncryptStub
+	fakeReturns := fake.encryptReturns
 	fake.recordInvocation("Encrypt", []interface{}{arg1Copy})
 	fake.encryptMutex.Unlock()
-	if fake.EncryptStub != nil {
-		return fake.EncryptStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.encryptReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/db/lock/lockfakes/fake_lock.go
+++ b/atc/db/lock/lockfakes/fake_lock.go
@@ -27,15 +27,16 @@ func (fake *FakeLock) Release() error {
 	ret, specificReturn := fake.releaseReturnsOnCall[len(fake.releaseArgsForCall)]
 	fake.releaseArgsForCall = append(fake.releaseArgsForCall, struct {
 	}{})
+	stub := fake.ReleaseStub
+	fakeReturns := fake.releaseReturns
 	fake.recordInvocation("Release", []interface{}{})
 	fake.releaseMutex.Unlock()
-	if fake.ReleaseStub != nil {
-		return fake.ReleaseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.releaseReturns
 	return fakeReturns.result1
 }
 

--- a/atc/db/lock/lockfakes/fake_lock_db.go
+++ b/atc/db/lock/lockfakes/fake_lock_db.go
@@ -44,15 +44,16 @@ func (fake *FakeLockDB) Acquire(arg1 lock.LockID) (bool, error) {
 	fake.acquireArgsForCall = append(fake.acquireArgsForCall, struct {
 		arg1 lock.LockID
 	}{arg1})
+	stub := fake.AcquireStub
+	fakeReturns := fake.acquireReturns
 	fake.recordInvocation("Acquire", []interface{}{arg1})
 	fake.acquireMutex.Unlock()
-	if fake.AcquireStub != nil {
-		return fake.AcquireStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.acquireReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -107,15 +108,16 @@ func (fake *FakeLockDB) Release(arg1 lock.LockID) (bool, error) {
 	fake.releaseArgsForCall = append(fake.releaseArgsForCall, struct {
 		arg1 lock.LockID
 	}{arg1})
+	stub := fake.ReleaseStub
+	fakeReturns := fake.releaseReturns
 	fake.recordInvocation("Release", []interface{}{arg1})
 	fake.releaseMutex.Unlock()
-	if fake.ReleaseStub != nil {
-		return fake.ReleaseStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.releaseReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/db/lock/lockfakes/fake_lock_factory.go
+++ b/atc/db/lock/lockfakes/fake_lock_factory.go
@@ -36,15 +36,16 @@ func (fake *FakeLockFactory) Acquire(arg1 lager.Logger, arg2 lock.LockID) (lock.
 		arg1 lager.Logger
 		arg2 lock.LockID
 	}{arg1, arg2})
+	stub := fake.AcquireStub
+	fakeReturns := fake.acquireReturns
 	fake.recordInvocation("Acquire", []interface{}{arg1, arg2})
 	fake.acquireMutex.Unlock()
-	if fake.AcquireStub != nil {
-		return fake.AcquireStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.acquireReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/engine/enginefakes/fake_core_step_factory.go
+++ b/atc/engine/enginefakes/fake_core_step_factory.go
@@ -128,15 +128,16 @@ func (fake *FakeCoreStepFactory) ArtifactInputStep(arg1 atc.Plan, arg2 db.Build)
 		arg1 atc.Plan
 		arg2 db.Build
 	}{arg1, arg2})
+	stub := fake.ArtifactInputStepStub
+	fakeReturns := fake.artifactInputStepReturns
 	fake.recordInvocation("ArtifactInputStep", []interface{}{arg1, arg2})
 	fake.artifactInputStepMutex.Unlock()
-	if fake.ArtifactInputStepStub != nil {
-		return fake.ArtifactInputStepStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.artifactInputStepReturns
 	return fakeReturns.result1
 }
 
@@ -189,15 +190,16 @@ func (fake *FakeCoreStepFactory) ArtifactOutputStep(arg1 atc.Plan, arg2 db.Build
 		arg1 atc.Plan
 		arg2 db.Build
 	}{arg1, arg2})
+	stub := fake.ArtifactOutputStepStub
+	fakeReturns := fake.artifactOutputStepReturns
 	fake.recordInvocation("ArtifactOutputStep", []interface{}{arg1, arg2})
 	fake.artifactOutputStepMutex.Unlock()
-	if fake.ArtifactOutputStepStub != nil {
-		return fake.ArtifactOutputStepStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.artifactOutputStepReturns
 	return fakeReturns.result1
 }
 
@@ -252,15 +254,16 @@ func (fake *FakeCoreStepFactory) CheckStep(arg1 atc.Plan, arg2 exec.StepMetadata
 		arg3 db.ContainerMetadata
 		arg4 engine.DelegateFactory
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CheckStepStub
+	fakeReturns := fake.checkStepReturns
 	fake.recordInvocation("CheckStep", []interface{}{arg1, arg2, arg3, arg4})
 	fake.checkStepMutex.Unlock()
-	if fake.CheckStepStub != nil {
-		return fake.CheckStepStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkStepReturns
 	return fakeReturns.result1
 }
 
@@ -315,15 +318,16 @@ func (fake *FakeCoreStepFactory) GetStep(arg1 atc.Plan, arg2 exec.StepMetadata, 
 		arg3 db.ContainerMetadata
 		arg4 engine.DelegateFactory
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.GetStepStub
+	fakeReturns := fake.getStepReturns
 	fake.recordInvocation("GetStep", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getStepMutex.Unlock()
-	if fake.GetStepStub != nil {
-		return fake.GetStepStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getStepReturns
 	return fakeReturns.result1
 }
 
@@ -377,15 +381,16 @@ func (fake *FakeCoreStepFactory) LoadVarStep(arg1 atc.Plan, arg2 exec.StepMetada
 		arg2 exec.StepMetadata
 		arg3 engine.DelegateFactory
 	}{arg1, arg2, arg3})
+	stub := fake.LoadVarStepStub
+	fakeReturns := fake.loadVarStepReturns
 	fake.recordInvocation("LoadVarStep", []interface{}{arg1, arg2, arg3})
 	fake.loadVarStepMutex.Unlock()
-	if fake.LoadVarStepStub != nil {
-		return fake.LoadVarStepStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.loadVarStepReturns
 	return fakeReturns.result1
 }
 
@@ -440,15 +445,16 @@ func (fake *FakeCoreStepFactory) PutStep(arg1 atc.Plan, arg2 exec.StepMetadata, 
 		arg3 db.ContainerMetadata
 		arg4 engine.DelegateFactory
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.PutStepStub
+	fakeReturns := fake.putStepReturns
 	fake.recordInvocation("PutStep", []interface{}{arg1, arg2, arg3, arg4})
 	fake.putStepMutex.Unlock()
-	if fake.PutStepStub != nil {
-		return fake.PutStepStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.putStepReturns
 	return fakeReturns.result1
 }
 
@@ -502,15 +508,16 @@ func (fake *FakeCoreStepFactory) SetPipelineStep(arg1 atc.Plan, arg2 exec.StepMe
 		arg2 exec.StepMetadata
 		arg3 engine.DelegateFactory
 	}{arg1, arg2, arg3})
+	stub := fake.SetPipelineStepStub
+	fakeReturns := fake.setPipelineStepReturns
 	fake.recordInvocation("SetPipelineStep", []interface{}{arg1, arg2, arg3})
 	fake.setPipelineStepMutex.Unlock()
-	if fake.SetPipelineStepStub != nil {
-		return fake.SetPipelineStepStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setPipelineStepReturns
 	return fakeReturns.result1
 }
 
@@ -565,15 +572,16 @@ func (fake *FakeCoreStepFactory) TaskStep(arg1 atc.Plan, arg2 exec.StepMetadata,
 		arg3 db.ContainerMetadata
 		arg4 engine.DelegateFactory
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.TaskStepStub
+	fakeReturns := fake.taskStepReturns
 	fake.recordInvocation("TaskStep", []interface{}{arg1, arg2, arg3, arg4})
 	fake.taskStepMutex.Unlock()
-	if fake.TaskStepStub != nil {
-		return fake.TaskStepStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.taskStepReturns
 	return fakeReturns.result1
 }
 

--- a/atc/engine/enginefakes/fake_engine.go
+++ b/atc/engine/enginefakes/fake_engine.go
@@ -35,9 +35,10 @@ func (fake *FakeEngine) Drain(arg1 context.Context) {
 	fake.drainArgsForCall = append(fake.drainArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.DrainStub
 	fake.recordInvocation("Drain", []interface{}{arg1})
 	fake.drainMutex.Unlock()
-	if fake.DrainStub != nil {
+	if stub != nil {
 		fake.DrainStub(arg1)
 	}
 }
@@ -67,15 +68,16 @@ func (fake *FakeEngine) NewBuild(arg1 db.Build) engine.Runnable {
 	fake.newBuildArgsForCall = append(fake.newBuildArgsForCall, struct {
 		arg1 db.Build
 	}{arg1})
+	stub := fake.NewBuildStub
+	fakeReturns := fake.newBuildReturns
 	fake.recordInvocation("NewBuild", []interface{}{arg1})
 	fake.newBuildMutex.Unlock()
-	if fake.NewBuildStub != nil {
-		return fake.NewBuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newBuildReturns
 	return fakeReturns.result1
 }
 

--- a/atc/engine/enginefakes/fake_rate_limiter.go
+++ b/atc/engine/enginefakes/fake_rate_limiter.go
@@ -30,15 +30,16 @@ func (fake *FakeRateLimiter) Wait(arg1 context.Context) error {
 	fake.waitArgsForCall = append(fake.waitArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.WaitStub
+	fakeReturns := fake.waitReturns
 	fake.recordInvocation("Wait", []interface{}{arg1})
 	fake.waitMutex.Unlock()
-	if fake.WaitStub != nil {
-		return fake.WaitStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitReturns
 	return fakeReturns.result1
 }
 

--- a/atc/engine/enginefakes/fake_runnable.go
+++ b/atc/engine/enginefakes/fake_runnable.go
@@ -23,9 +23,10 @@ func (fake *FakeRunnable) Run(arg1 context.Context) {
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.RunStub
 	fake.recordInvocation("Run", []interface{}{arg1})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
+	if stub != nil {
 		fake.RunStub(arg1)
 	}
 }

--- a/atc/engine/enginefakes/fake_stepper_factory.go
+++ b/atc/engine/enginefakes/fake_stepper_factory.go
@@ -33,15 +33,16 @@ func (fake *FakeStepperFactory) StepperForBuild(arg1 db.Build) (exec.Stepper, er
 	fake.stepperForBuildArgsForCall = append(fake.stepperForBuildArgsForCall, struct {
 		arg1 db.Build
 	}{arg1})
+	stub := fake.StepperForBuildStub
+	fakeReturns := fake.stepperForBuildReturns
 	fake.recordInvocation("StepperForBuild", []interface{}{arg1})
 	fake.stepperForBuildMutex.Unlock()
-	if fake.StepperForBuildStub != nil {
-		return fake.StepperForBuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.stepperForBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/exec/build/buildfakes/fake_registerable_artifact.go
+++ b/atc/exec/build/buildfakes/fake_registerable_artifact.go
@@ -27,15 +27,16 @@ func (fake *FakeRegisterableArtifact) ID() string {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_build_step_delegate.go
+++ b/atc/exec/execfakes/fake_build_step_delegate.go
@@ -104,9 +104,10 @@ func (fake *FakeBuildStepDelegate) Errored(arg1 lager.Logger, arg2 string) {
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ErroredStub
 	fake.recordInvocation("Errored", []interface{}{arg1, arg2})
 	fake.erroredMutex.Unlock()
-	if fake.ErroredStub != nil {
+	if stub != nil {
 		fake.ErroredStub(arg1, arg2)
 	}
 }
@@ -139,15 +140,16 @@ func (fake *FakeBuildStepDelegate) FetchImage(arg1 context.Context, arg2 atc.Ima
 		arg3 atc.VersionedResourceTypes
 		arg4 bool
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.FetchImageStub
+	fakeReturns := fake.fetchImageReturns
 	fake.recordInvocation("FetchImage", []interface{}{arg1, arg2, arg3, arg4})
 	fake.fetchImageMutex.Unlock()
-	if fake.FetchImageStub != nil {
-		return fake.FetchImageStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.fetchImageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -202,9 +204,10 @@ func (fake *FakeBuildStepDelegate) Finished(arg1 lager.Logger, arg2 bool) {
 		arg1 lager.Logger
 		arg2 bool
 	}{arg1, arg2})
+	stub := fake.FinishedStub
 	fake.recordInvocation("Finished", []interface{}{arg1, arg2})
 	fake.finishedMutex.Unlock()
-	if fake.FinishedStub != nil {
+	if stub != nil {
 		fake.FinishedStub(arg1, arg2)
 	}
 }
@@ -233,9 +236,10 @@ func (fake *FakeBuildStepDelegate) Initializing(arg1 lager.Logger) {
 	fake.initializingArgsForCall = append(fake.initializingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.InitializingStub
 	fake.recordInvocation("Initializing", []interface{}{arg1})
 	fake.initializingMutex.Unlock()
-	if fake.InitializingStub != nil {
+	if stub != nil {
 		fake.InitializingStub(arg1)
 	}
 }
@@ -265,9 +269,10 @@ func (fake *FakeBuildStepDelegate) SelectedWorker(arg1 lager.Logger, arg2 string
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SelectedWorkerStub
 	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
 	fake.selectedWorkerMutex.Unlock()
-	if fake.SelectedWorkerStub != nil {
+	if stub != nil {
 		fake.SelectedWorkerStub(arg1, arg2)
 	}
 }
@@ -299,15 +304,16 @@ func (fake *FakeBuildStepDelegate) StartSpan(arg1 context.Context, arg2 string, 
 		arg2 string
 		arg3 tracing.Attrs
 	}{arg1, arg2, arg3})
+	stub := fake.StartSpanStub
+	fakeReturns := fake.startSpanReturns
 	fake.recordInvocation("StartSpan", []interface{}{arg1, arg2, arg3})
 	fake.startSpanMutex.Unlock()
-	if fake.StartSpanStub != nil {
-		return fake.StartSpanStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.startSpanReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -361,9 +367,10 @@ func (fake *FakeBuildStepDelegate) Starting(arg1 lager.Logger) {
 	fake.startingArgsForCall = append(fake.startingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.StartingStub
 	fake.recordInvocation("Starting", []interface{}{arg1})
 	fake.startingMutex.Unlock()
-	if fake.StartingStub != nil {
+	if stub != nil {
 		fake.StartingStub(arg1)
 	}
 }
@@ -392,15 +399,16 @@ func (fake *FakeBuildStepDelegate) Stderr() io.Writer {
 	ret, specificReturn := fake.stderrReturnsOnCall[len(fake.stderrArgsForCall)]
 	fake.stderrArgsForCall = append(fake.stderrArgsForCall, struct {
 	}{})
+	stub := fake.StderrStub
+	fakeReturns := fake.stderrReturns
 	fake.recordInvocation("Stderr", []interface{}{})
 	fake.stderrMutex.Unlock()
-	if fake.StderrStub != nil {
-		return fake.StderrStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stderrReturns
 	return fakeReturns.result1
 }
 
@@ -444,15 +452,16 @@ func (fake *FakeBuildStepDelegate) Stdout() io.Writer {
 	ret, specificReturn := fake.stdoutReturnsOnCall[len(fake.stdoutArgsForCall)]
 	fake.stdoutArgsForCall = append(fake.stdoutArgsForCall, struct {
 	}{})
+	stub := fake.StdoutStub
+	fakeReturns := fake.stdoutReturns
 	fake.recordInvocation("Stdout", []interface{}{})
 	fake.stdoutMutex.Unlock()
-	if fake.StdoutStub != nil {
-		return fake.StdoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stdoutReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_build_step_delegate_factory.go
+++ b/atc/exec/execfakes/fake_build_step_delegate_factory.go
@@ -29,15 +29,16 @@ func (fake *FakeBuildStepDelegateFactory) BuildStepDelegate(arg1 exec.RunState) 
 	fake.buildStepDelegateArgsForCall = append(fake.buildStepDelegateArgsForCall, struct {
 		arg1 exec.RunState
 	}{arg1})
+	stub := fake.BuildStepDelegateStub
+	fakeReturns := fake.buildStepDelegateReturns
 	fake.recordInvocation("BuildStepDelegate", []interface{}{arg1})
 	fake.buildStepDelegateMutex.Unlock()
-	if fake.BuildStepDelegateStub != nil {
-		return fake.BuildStepDelegateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.buildStepDelegateReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_check_delegate.go
+++ b/atc/exec/execfakes/fake_check_delegate.go
@@ -146,9 +146,10 @@ func (fake *FakeCheckDelegate) Errored(arg1 lager.Logger, arg2 string) {
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ErroredStub
 	fake.recordInvocation("Errored", []interface{}{arg1, arg2})
 	fake.erroredMutex.Unlock()
-	if fake.ErroredStub != nil {
+	if stub != nil {
 		fake.ErroredStub(arg1, arg2)
 	}
 }
@@ -181,15 +182,16 @@ func (fake *FakeCheckDelegate) FetchImage(arg1 context.Context, arg2 atc.ImageRe
 		arg3 atc.VersionedResourceTypes
 		arg4 bool
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.FetchImageStub
+	fakeReturns := fake.fetchImageReturns
 	fake.recordInvocation("FetchImage", []interface{}{arg1, arg2, arg3, arg4})
 	fake.fetchImageMutex.Unlock()
-	if fake.FetchImageStub != nil {
-		return fake.FetchImageStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.fetchImageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -244,15 +246,16 @@ func (fake *FakeCheckDelegate) FindOrCreateScope(arg1 db.ResourceConfig) (db.Res
 	fake.findOrCreateScopeArgsForCall = append(fake.findOrCreateScopeArgsForCall, struct {
 		arg1 db.ResourceConfig
 	}{arg1})
+	stub := fake.FindOrCreateScopeStub
+	fakeReturns := fake.findOrCreateScopeReturns
 	fake.recordInvocation("FindOrCreateScope", []interface{}{arg1})
 	fake.findOrCreateScopeMutex.Unlock()
-	if fake.FindOrCreateScopeStub != nil {
-		return fake.FindOrCreateScopeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateScopeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -307,9 +310,10 @@ func (fake *FakeCheckDelegate) Finished(arg1 lager.Logger, arg2 bool) {
 		arg1 lager.Logger
 		arg2 bool
 	}{arg1, arg2})
+	stub := fake.FinishedStub
 	fake.recordInvocation("Finished", []interface{}{arg1, arg2})
 	fake.finishedMutex.Unlock()
-	if fake.FinishedStub != nil {
+	if stub != nil {
 		fake.FinishedStub(arg1, arg2)
 	}
 }
@@ -338,9 +342,10 @@ func (fake *FakeCheckDelegate) Initializing(arg1 lager.Logger) {
 	fake.initializingArgsForCall = append(fake.initializingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.InitializingStub
 	fake.recordInvocation("Initializing", []interface{}{arg1})
 	fake.initializingMutex.Unlock()
-	if fake.InitializingStub != nil {
+	if stub != nil {
 		fake.InitializingStub(arg1)
 	}
 }
@@ -370,15 +375,16 @@ func (fake *FakeCheckDelegate) PointToCheckedConfig(arg1 db.ResourceConfigScope)
 	fake.pointToCheckedConfigArgsForCall = append(fake.pointToCheckedConfigArgsForCall, struct {
 		arg1 db.ResourceConfigScope
 	}{arg1})
+	stub := fake.PointToCheckedConfigStub
+	fakeReturns := fake.pointToCheckedConfigReturns
 	fake.recordInvocation("PointToCheckedConfig", []interface{}{arg1})
 	fake.pointToCheckedConfigMutex.Unlock()
-	if fake.PointToCheckedConfigStub != nil {
-		return fake.PointToCheckedConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pointToCheckedConfigReturns
 	return fakeReturns.result1
 }
 
@@ -430,9 +436,10 @@ func (fake *FakeCheckDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SelectedWorkerStub
 	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
 	fake.selectedWorkerMutex.Unlock()
-	if fake.SelectedWorkerStub != nil {
+	if stub != nil {
 		fake.SelectedWorkerStub(arg1, arg2)
 	}
 }
@@ -464,15 +471,16 @@ func (fake *FakeCheckDelegate) StartSpan(arg1 context.Context, arg2 string, arg3
 		arg2 string
 		arg3 tracing.Attrs
 	}{arg1, arg2, arg3})
+	stub := fake.StartSpanStub
+	fakeReturns := fake.startSpanReturns
 	fake.recordInvocation("StartSpan", []interface{}{arg1, arg2, arg3})
 	fake.startSpanMutex.Unlock()
-	if fake.StartSpanStub != nil {
-		return fake.StartSpanStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.startSpanReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -526,9 +534,10 @@ func (fake *FakeCheckDelegate) Starting(arg1 lager.Logger) {
 	fake.startingArgsForCall = append(fake.startingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.StartingStub
 	fake.recordInvocation("Starting", []interface{}{arg1})
 	fake.startingMutex.Unlock()
-	if fake.StartingStub != nil {
+	if stub != nil {
 		fake.StartingStub(arg1)
 	}
 }
@@ -557,15 +566,16 @@ func (fake *FakeCheckDelegate) Stderr() io.Writer {
 	ret, specificReturn := fake.stderrReturnsOnCall[len(fake.stderrArgsForCall)]
 	fake.stderrArgsForCall = append(fake.stderrArgsForCall, struct {
 	}{})
+	stub := fake.StderrStub
+	fakeReturns := fake.stderrReturns
 	fake.recordInvocation("Stderr", []interface{}{})
 	fake.stderrMutex.Unlock()
-	if fake.StderrStub != nil {
-		return fake.StderrStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stderrReturns
 	return fakeReturns.result1
 }
 
@@ -609,15 +619,16 @@ func (fake *FakeCheckDelegate) Stdout() io.Writer {
 	ret, specificReturn := fake.stdoutReturnsOnCall[len(fake.stdoutArgsForCall)]
 	fake.stdoutArgsForCall = append(fake.stdoutArgsForCall, struct {
 	}{})
+	stub := fake.StdoutStub
+	fakeReturns := fake.stdoutReturns
 	fake.recordInvocation("Stdout", []interface{}{})
 	fake.stdoutMutex.Unlock()
-	if fake.StdoutStub != nil {
-		return fake.StdoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stdoutReturns
 	return fakeReturns.result1
 }
 
@@ -663,15 +674,16 @@ func (fake *FakeCheckDelegate) WaitToRun(arg1 context.Context, arg2 db.ResourceC
 		arg1 context.Context
 		arg2 db.ResourceConfigScope
 	}{arg1, arg2})
+	stub := fake.WaitToRunStub
+	fakeReturns := fake.waitToRunReturns
 	fake.recordInvocation("WaitToRun", []interface{}{arg1, arg2})
 	fake.waitToRunMutex.Unlock()
-	if fake.WaitToRunStub != nil {
-		return fake.WaitToRunStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.waitToRunReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/exec/execfakes/fake_check_delegate_factory.go
+++ b/atc/exec/execfakes/fake_check_delegate_factory.go
@@ -29,15 +29,16 @@ func (fake *FakeCheckDelegateFactory) CheckDelegate(arg1 exec.RunState) exec.Che
 	fake.checkDelegateArgsForCall = append(fake.checkDelegateArgsForCall, struct {
 		arg1 exec.RunState
 	}{arg1})
+	stub := fake.CheckDelegateStub
+	fakeReturns := fake.checkDelegateReturns
 	fake.recordInvocation("CheckDelegate", []interface{}{arg1})
 	fake.checkDelegateMutex.Unlock()
-	if fake.CheckDelegateStub != nil {
-		return fake.CheckDelegateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkDelegateReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_get_delegate.go
+++ b/atc/exec/execfakes/fake_get_delegate.go
@@ -113,9 +113,10 @@ func (fake *FakeGetDelegate) Errored(arg1 lager.Logger, arg2 string) {
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ErroredStub
 	fake.recordInvocation("Errored", []interface{}{arg1, arg2})
 	fake.erroredMutex.Unlock()
-	if fake.ErroredStub != nil {
+	if stub != nil {
 		fake.ErroredStub(arg1, arg2)
 	}
 }
@@ -148,15 +149,16 @@ func (fake *FakeGetDelegate) FetchImage(arg1 context.Context, arg2 atc.ImageReso
 		arg3 atc.VersionedResourceTypes
 		arg4 bool
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.FetchImageStub
+	fakeReturns := fake.fetchImageReturns
 	fake.recordInvocation("FetchImage", []interface{}{arg1, arg2, arg3, arg4})
 	fake.fetchImageMutex.Unlock()
-	if fake.FetchImageStub != nil {
-		return fake.FetchImageStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.fetchImageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -212,9 +214,10 @@ func (fake *FakeGetDelegate) Finished(arg1 lager.Logger, arg2 exec.ExitStatus, a
 		arg2 exec.ExitStatus
 		arg3 runtime.VersionResult
 	}{arg1, arg2, arg3})
+	stub := fake.FinishedStub
 	fake.recordInvocation("Finished", []interface{}{arg1, arg2, arg3})
 	fake.finishedMutex.Unlock()
-	if fake.FinishedStub != nil {
+	if stub != nil {
 		fake.FinishedStub(arg1, arg2, arg3)
 	}
 }
@@ -243,9 +246,10 @@ func (fake *FakeGetDelegate) Initializing(arg1 lager.Logger) {
 	fake.initializingArgsForCall = append(fake.initializingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.InitializingStub
 	fake.recordInvocation("Initializing", []interface{}{arg1})
 	fake.initializingMutex.Unlock()
-	if fake.InitializingStub != nil {
+	if stub != nil {
 		fake.InitializingStub(arg1)
 	}
 }
@@ -275,9 +279,10 @@ func (fake *FakeGetDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SelectedWorkerStub
 	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
 	fake.selectedWorkerMutex.Unlock()
-	if fake.SelectedWorkerStub != nil {
+	if stub != nil {
 		fake.SelectedWorkerStub(arg1, arg2)
 	}
 }
@@ -309,15 +314,16 @@ func (fake *FakeGetDelegate) StartSpan(arg1 context.Context, arg2 string, arg3 t
 		arg2 string
 		arg3 tracing.Attrs
 	}{arg1, arg2, arg3})
+	stub := fake.StartSpanStub
+	fakeReturns := fake.startSpanReturns
 	fake.recordInvocation("StartSpan", []interface{}{arg1, arg2, arg3})
 	fake.startSpanMutex.Unlock()
-	if fake.StartSpanStub != nil {
-		return fake.StartSpanStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.startSpanReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -371,9 +377,10 @@ func (fake *FakeGetDelegate) Starting(arg1 lager.Logger) {
 	fake.startingArgsForCall = append(fake.startingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.StartingStub
 	fake.recordInvocation("Starting", []interface{}{arg1})
 	fake.startingMutex.Unlock()
-	if fake.StartingStub != nil {
+	if stub != nil {
 		fake.StartingStub(arg1)
 	}
 }
@@ -402,15 +409,16 @@ func (fake *FakeGetDelegate) Stderr() io.Writer {
 	ret, specificReturn := fake.stderrReturnsOnCall[len(fake.stderrArgsForCall)]
 	fake.stderrArgsForCall = append(fake.stderrArgsForCall, struct {
 	}{})
+	stub := fake.StderrStub
+	fakeReturns := fake.stderrReturns
 	fake.recordInvocation("Stderr", []interface{}{})
 	fake.stderrMutex.Unlock()
-	if fake.StderrStub != nil {
-		return fake.StderrStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stderrReturns
 	return fakeReturns.result1
 }
 
@@ -454,15 +462,16 @@ func (fake *FakeGetDelegate) Stdout() io.Writer {
 	ret, specificReturn := fake.stdoutReturnsOnCall[len(fake.stdoutArgsForCall)]
 	fake.stdoutArgsForCall = append(fake.stdoutArgsForCall, struct {
 	}{})
+	stub := fake.StdoutStub
+	fakeReturns := fake.stdoutReturns
 	fake.recordInvocation("Stdout", []interface{}{})
 	fake.stdoutMutex.Unlock()
-	if fake.StdoutStub != nil {
-		return fake.StdoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stdoutReturns
 	return fakeReturns.result1
 }
 
@@ -508,9 +517,10 @@ func (fake *FakeGetDelegate) UpdateVersion(arg1 lager.Logger, arg2 atc.GetPlan, 
 		arg2 atc.GetPlan
 		arg3 runtime.VersionResult
 	}{arg1, arg2, arg3})
+	stub := fake.UpdateVersionStub
 	fake.recordInvocation("UpdateVersion", []interface{}{arg1, arg2, arg3})
 	fake.updateVersionMutex.Unlock()
-	if fake.UpdateVersionStub != nil {
+	if stub != nil {
 		fake.UpdateVersionStub(arg1, arg2, arg3)
 	}
 }

--- a/atc/exec/execfakes/fake_get_delegate_factory.go
+++ b/atc/exec/execfakes/fake_get_delegate_factory.go
@@ -29,15 +29,16 @@ func (fake *FakeGetDelegateFactory) GetDelegate(arg1 exec.RunState) exec.GetDele
 	fake.getDelegateArgsForCall = append(fake.getDelegateArgsForCall, struct {
 		arg1 exec.RunState
 	}{arg1})
+	stub := fake.GetDelegateStub
+	fakeReturns := fake.getDelegateReturns
 	fake.recordInvocation("GetDelegate", []interface{}{arg1})
 	fake.getDelegateMutex.Unlock()
-	if fake.GetDelegateStub != nil {
-		return fake.GetDelegateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getDelegateReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_put_delegate.go
+++ b/atc/exec/execfakes/fake_put_delegate.go
@@ -115,9 +115,10 @@ func (fake *FakePutDelegate) Errored(arg1 lager.Logger, arg2 string) {
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ErroredStub
 	fake.recordInvocation("Errored", []interface{}{arg1, arg2})
 	fake.erroredMutex.Unlock()
-	if fake.ErroredStub != nil {
+	if stub != nil {
 		fake.ErroredStub(arg1, arg2)
 	}
 }
@@ -150,15 +151,16 @@ func (fake *FakePutDelegate) FetchImage(arg1 context.Context, arg2 atc.ImageReso
 		arg3 atc.VersionedResourceTypes
 		arg4 bool
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.FetchImageStub
+	fakeReturns := fake.fetchImageReturns
 	fake.recordInvocation("FetchImage", []interface{}{arg1, arg2, arg3, arg4})
 	fake.fetchImageMutex.Unlock()
-	if fake.FetchImageStub != nil {
-		return fake.FetchImageStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.fetchImageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -214,9 +216,10 @@ func (fake *FakePutDelegate) Finished(arg1 lager.Logger, arg2 exec.ExitStatus, a
 		arg2 exec.ExitStatus
 		arg3 runtime.VersionResult
 	}{arg1, arg2, arg3})
+	stub := fake.FinishedStub
 	fake.recordInvocation("Finished", []interface{}{arg1, arg2, arg3})
 	fake.finishedMutex.Unlock()
-	if fake.FinishedStub != nil {
+	if stub != nil {
 		fake.FinishedStub(arg1, arg2, arg3)
 	}
 }
@@ -245,9 +248,10 @@ func (fake *FakePutDelegate) Initializing(arg1 lager.Logger) {
 	fake.initializingArgsForCall = append(fake.initializingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.InitializingStub
 	fake.recordInvocation("Initializing", []interface{}{arg1})
 	fake.initializingMutex.Unlock()
-	if fake.InitializingStub != nil {
+	if stub != nil {
 		fake.InitializingStub(arg1)
 	}
 }
@@ -280,9 +284,10 @@ func (fake *FakePutDelegate) SaveOutput(arg1 lager.Logger, arg2 atc.PutPlan, arg
 		arg4 atc.VersionedResourceTypes
 		arg5 runtime.VersionResult
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.SaveOutputStub
 	fake.recordInvocation("SaveOutput", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.saveOutputMutex.Unlock()
-	if fake.SaveOutputStub != nil {
+	if stub != nil {
 		fake.SaveOutputStub(arg1, arg2, arg3, arg4, arg5)
 	}
 }
@@ -312,9 +317,10 @@ func (fake *FakePutDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SelectedWorkerStub
 	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
 	fake.selectedWorkerMutex.Unlock()
-	if fake.SelectedWorkerStub != nil {
+	if stub != nil {
 		fake.SelectedWorkerStub(arg1, arg2)
 	}
 }
@@ -346,15 +352,16 @@ func (fake *FakePutDelegate) StartSpan(arg1 context.Context, arg2 string, arg3 t
 		arg2 string
 		arg3 tracing.Attrs
 	}{arg1, arg2, arg3})
+	stub := fake.StartSpanStub
+	fakeReturns := fake.startSpanReturns
 	fake.recordInvocation("StartSpan", []interface{}{arg1, arg2, arg3})
 	fake.startSpanMutex.Unlock()
-	if fake.StartSpanStub != nil {
-		return fake.StartSpanStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.startSpanReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -408,9 +415,10 @@ func (fake *FakePutDelegate) Starting(arg1 lager.Logger) {
 	fake.startingArgsForCall = append(fake.startingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.StartingStub
 	fake.recordInvocation("Starting", []interface{}{arg1})
 	fake.startingMutex.Unlock()
-	if fake.StartingStub != nil {
+	if stub != nil {
 		fake.StartingStub(arg1)
 	}
 }
@@ -439,15 +447,16 @@ func (fake *FakePutDelegate) Stderr() io.Writer {
 	ret, specificReturn := fake.stderrReturnsOnCall[len(fake.stderrArgsForCall)]
 	fake.stderrArgsForCall = append(fake.stderrArgsForCall, struct {
 	}{})
+	stub := fake.StderrStub
+	fakeReturns := fake.stderrReturns
 	fake.recordInvocation("Stderr", []interface{}{})
 	fake.stderrMutex.Unlock()
-	if fake.StderrStub != nil {
-		return fake.StderrStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stderrReturns
 	return fakeReturns.result1
 }
 
@@ -491,15 +500,16 @@ func (fake *FakePutDelegate) Stdout() io.Writer {
 	ret, specificReturn := fake.stdoutReturnsOnCall[len(fake.stdoutArgsForCall)]
 	fake.stdoutArgsForCall = append(fake.stdoutArgsForCall, struct {
 	}{})
+	stub := fake.StdoutStub
+	fakeReturns := fake.stdoutReturns
 	fake.recordInvocation("Stdout", []interface{}{})
 	fake.stdoutMutex.Unlock()
-	if fake.StdoutStub != nil {
-		return fake.StdoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stdoutReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_put_delegate_factory.go
+++ b/atc/exec/execfakes/fake_put_delegate_factory.go
@@ -29,15 +29,16 @@ func (fake *FakePutDelegateFactory) PutDelegate(arg1 exec.RunState) exec.PutDele
 	fake.putDelegateArgsForCall = append(fake.putDelegateArgsForCall, struct {
 		arg1 exec.RunState
 	}{arg1})
+	stub := fake.PutDelegateStub
+	fakeReturns := fake.putDelegateReturns
 	fake.recordInvocation("PutDelegate", []interface{}{arg1})
 	fake.putDelegateMutex.Unlock()
-	if fake.PutDelegateStub != nil {
-		return fake.PutDelegateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.putDelegateReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_run_state.go
+++ b/atc/exec/execfakes/fake_run_state.go
@@ -134,9 +134,10 @@ func (fake *FakeRunState) AddLocalVar(arg1 string, arg2 interface{}, arg3 bool) 
 		arg2 interface{}
 		arg3 bool
 	}{arg1, arg2, arg3})
+	stub := fake.AddLocalVarStub
 	fake.recordInvocation("AddLocalVar", []interface{}{arg1, arg2, arg3})
 	fake.addLocalVarMutex.Unlock()
-	if fake.AddLocalVarStub != nil {
+	if stub != nil {
 		fake.AddLocalVarStub(arg1, arg2, arg3)
 	}
 }
@@ -165,15 +166,16 @@ func (fake *FakeRunState) ArtifactRepository() *build.Repository {
 	ret, specificReturn := fake.artifactRepositoryReturnsOnCall[len(fake.artifactRepositoryArgsForCall)]
 	fake.artifactRepositoryArgsForCall = append(fake.artifactRepositoryArgsForCall, struct {
 	}{})
+	stub := fake.ArtifactRepositoryStub
+	fakeReturns := fake.artifactRepositoryReturns
 	fake.recordInvocation("ArtifactRepository", []interface{}{})
 	fake.artifactRepositoryMutex.Unlock()
-	if fake.ArtifactRepositoryStub != nil {
-		return fake.ArtifactRepositoryStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.artifactRepositoryReturns
 	return fakeReturns.result1
 }
 
@@ -218,15 +220,16 @@ func (fake *FakeRunState) Get(arg1 vars.Reference) (interface{}, bool, error) {
 	fake.getArgsForCall = append(fake.getArgsForCall, struct {
 		arg1 vars.Reference
 	}{arg1})
+	stub := fake.GetStub
+	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1})
 	fake.getMutex.Unlock()
-	if fake.GetStub != nil {
-		return fake.GetStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -283,9 +286,10 @@ func (fake *FakeRunState) IterateInterpolatedCreds(arg1 vars.TrackedVarsIterator
 	fake.iterateInterpolatedCredsArgsForCall = append(fake.iterateInterpolatedCredsArgsForCall, struct {
 		arg1 vars.TrackedVarsIterator
 	}{arg1})
+	stub := fake.IterateInterpolatedCredsStub
 	fake.recordInvocation("IterateInterpolatedCreds", []interface{}{arg1})
 	fake.iterateInterpolatedCredsMutex.Unlock()
-	if fake.IterateInterpolatedCredsStub != nil {
+	if stub != nil {
 		fake.IterateInterpolatedCredsStub(arg1)
 	}
 }
@@ -314,15 +318,16 @@ func (fake *FakeRunState) List() ([]vars.Reference, error) {
 	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 	}{})
+	stub := fake.ListStub
+	fakeReturns := fake.listReturns
 	fake.recordInvocation("List", []interface{}{})
 	fake.listMutex.Unlock()
-	if fake.ListStub != nil {
-		return fake.ListStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -369,15 +374,16 @@ func (fake *FakeRunState) NewLocalScope() exec.RunState {
 	ret, specificReturn := fake.newLocalScopeReturnsOnCall[len(fake.newLocalScopeArgsForCall)]
 	fake.newLocalScopeArgsForCall = append(fake.newLocalScopeArgsForCall, struct {
 	}{})
+	stub := fake.NewLocalScopeStub
+	fakeReturns := fake.newLocalScopeReturns
 	fake.recordInvocation("NewLocalScope", []interface{}{})
 	fake.newLocalScopeMutex.Unlock()
-	if fake.NewLocalScopeStub != nil {
-		return fake.NewLocalScopeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newLocalScopeReturns
 	return fakeReturns.result1
 }
 
@@ -421,15 +427,16 @@ func (fake *FakeRunState) Parent() exec.RunState {
 	ret, specificReturn := fake.parentReturnsOnCall[len(fake.parentArgsForCall)]
 	fake.parentArgsForCall = append(fake.parentArgsForCall, struct {
 	}{})
+	stub := fake.ParentStub
+	fakeReturns := fake.parentReturns
 	fake.recordInvocation("Parent", []interface{}{})
 	fake.parentMutex.Unlock()
-	if fake.ParentStub != nil {
-		return fake.ParentStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.parentReturns
 	return fakeReturns.result1
 }
 
@@ -473,15 +480,16 @@ func (fake *FakeRunState) RedactionEnabled() bool {
 	ret, specificReturn := fake.redactionEnabledReturnsOnCall[len(fake.redactionEnabledArgsForCall)]
 	fake.redactionEnabledArgsForCall = append(fake.redactionEnabledArgsForCall, struct {
 	}{})
+	stub := fake.RedactionEnabledStub
+	fakeReturns := fake.redactionEnabledReturns
 	fake.recordInvocation("RedactionEnabled", []interface{}{})
 	fake.redactionEnabledMutex.Unlock()
-	if fake.RedactionEnabledStub != nil {
-		return fake.RedactionEnabledStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.redactionEnabledReturns
 	return fakeReturns.result1
 }
 
@@ -527,15 +535,16 @@ func (fake *FakeRunState) Result(arg1 atc.PlanID, arg2 interface{}) bool {
 		arg1 atc.PlanID
 		arg2 interface{}
 	}{arg1, arg2})
+	stub := fake.ResultStub
+	fakeReturns := fake.resultReturns
 	fake.recordInvocation("Result", []interface{}{arg1, arg2})
 	fake.resultMutex.Unlock()
-	if fake.ResultStub != nil {
-		return fake.ResultStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resultReturns
 	return fakeReturns.result1
 }
 
@@ -588,15 +597,16 @@ func (fake *FakeRunState) Run(arg1 context.Context, arg2 atc.Plan) (bool, error)
 		arg1 context.Context
 		arg2 atc.Plan
 	}{arg1, arg2})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1, arg2})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -651,9 +661,10 @@ func (fake *FakeRunState) StoreResult(arg1 atc.PlanID, arg2 interface{}) {
 		arg1 atc.PlanID
 		arg2 interface{}
 	}{arg1, arg2})
+	stub := fake.StoreResultStub
 	fake.recordInvocation("StoreResult", []interface{}{arg1, arg2})
 	fake.storeResultMutex.Unlock()
-	if fake.StoreResultStub != nil {
+	if stub != nil {
 		fake.StoreResultStub(arg1, arg2)
 	}
 }

--- a/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
+++ b/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
@@ -110,9 +110,10 @@ func (fake *FakeSetPipelineStepDelegate) Errored(arg1 lager.Logger, arg2 string)
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ErroredStub
 	fake.recordInvocation("Errored", []interface{}{arg1, arg2})
 	fake.erroredMutex.Unlock()
-	if fake.ErroredStub != nil {
+	if stub != nil {
 		fake.ErroredStub(arg1, arg2)
 	}
 }
@@ -145,15 +146,16 @@ func (fake *FakeSetPipelineStepDelegate) FetchImage(arg1 context.Context, arg2 a
 		arg3 atc.VersionedResourceTypes
 		arg4 bool
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.FetchImageStub
+	fakeReturns := fake.fetchImageReturns
 	fake.recordInvocation("FetchImage", []interface{}{arg1, arg2, arg3, arg4})
 	fake.fetchImageMutex.Unlock()
-	if fake.FetchImageStub != nil {
-		return fake.FetchImageStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.fetchImageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -208,9 +210,10 @@ func (fake *FakeSetPipelineStepDelegate) Finished(arg1 lager.Logger, arg2 bool) 
 		arg1 lager.Logger
 		arg2 bool
 	}{arg1, arg2})
+	stub := fake.FinishedStub
 	fake.recordInvocation("Finished", []interface{}{arg1, arg2})
 	fake.finishedMutex.Unlock()
-	if fake.FinishedStub != nil {
+	if stub != nil {
 		fake.FinishedStub(arg1, arg2)
 	}
 }
@@ -239,9 +242,10 @@ func (fake *FakeSetPipelineStepDelegate) Initializing(arg1 lager.Logger) {
 	fake.initializingArgsForCall = append(fake.initializingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.InitializingStub
 	fake.recordInvocation("Initializing", []interface{}{arg1})
 	fake.initializingMutex.Unlock()
-	if fake.InitializingStub != nil {
+	if stub != nil {
 		fake.InitializingStub(arg1)
 	}
 }
@@ -271,9 +275,10 @@ func (fake *FakeSetPipelineStepDelegate) SelectedWorker(arg1 lager.Logger, arg2 
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SelectedWorkerStub
 	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
 	fake.selectedWorkerMutex.Unlock()
-	if fake.SelectedWorkerStub != nil {
+	if stub != nil {
 		fake.SelectedWorkerStub(arg1, arg2)
 	}
 }
@@ -303,9 +308,10 @@ func (fake *FakeSetPipelineStepDelegate) SetPipelineChanged(arg1 lager.Logger, a
 		arg1 lager.Logger
 		arg2 bool
 	}{arg1, arg2})
+	stub := fake.SetPipelineChangedStub
 	fake.recordInvocation("SetPipelineChanged", []interface{}{arg1, arg2})
 	fake.setPipelineChangedMutex.Unlock()
-	if fake.SetPipelineChangedStub != nil {
+	if stub != nil {
 		fake.SetPipelineChangedStub(arg1, arg2)
 	}
 }
@@ -337,15 +343,16 @@ func (fake *FakeSetPipelineStepDelegate) StartSpan(arg1 context.Context, arg2 st
 		arg2 string
 		arg3 tracing.Attrs
 	}{arg1, arg2, arg3})
+	stub := fake.StartSpanStub
+	fakeReturns := fake.startSpanReturns
 	fake.recordInvocation("StartSpan", []interface{}{arg1, arg2, arg3})
 	fake.startSpanMutex.Unlock()
-	if fake.StartSpanStub != nil {
-		return fake.StartSpanStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.startSpanReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -399,9 +406,10 @@ func (fake *FakeSetPipelineStepDelegate) Starting(arg1 lager.Logger) {
 	fake.startingArgsForCall = append(fake.startingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.StartingStub
 	fake.recordInvocation("Starting", []interface{}{arg1})
 	fake.startingMutex.Unlock()
-	if fake.StartingStub != nil {
+	if stub != nil {
 		fake.StartingStub(arg1)
 	}
 }
@@ -430,15 +438,16 @@ func (fake *FakeSetPipelineStepDelegate) Stderr() io.Writer {
 	ret, specificReturn := fake.stderrReturnsOnCall[len(fake.stderrArgsForCall)]
 	fake.stderrArgsForCall = append(fake.stderrArgsForCall, struct {
 	}{})
+	stub := fake.StderrStub
+	fakeReturns := fake.stderrReturns
 	fake.recordInvocation("Stderr", []interface{}{})
 	fake.stderrMutex.Unlock()
-	if fake.StderrStub != nil {
-		return fake.StderrStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stderrReturns
 	return fakeReturns.result1
 }
 
@@ -482,15 +491,16 @@ func (fake *FakeSetPipelineStepDelegate) Stdout() io.Writer {
 	ret, specificReturn := fake.stdoutReturnsOnCall[len(fake.stdoutArgsForCall)]
 	fake.stdoutArgsForCall = append(fake.stdoutArgsForCall, struct {
 	}{})
+	stub := fake.StdoutStub
+	fakeReturns := fake.stdoutReturns
 	fake.recordInvocation("Stdout", []interface{}{})
 	fake.stdoutMutex.Unlock()
-	if fake.StdoutStub != nil {
-		return fake.StdoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stdoutReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_set_pipeline_step_delegate_factory.go
+++ b/atc/exec/execfakes/fake_set_pipeline_step_delegate_factory.go
@@ -29,15 +29,16 @@ func (fake *FakeSetPipelineStepDelegateFactory) SetPipelineStepDelegate(arg1 exe
 	fake.setPipelineStepDelegateArgsForCall = append(fake.setPipelineStepDelegateArgsForCall, struct {
 		arg1 exec.RunState
 	}{arg1})
+	stub := fake.SetPipelineStepDelegateStub
+	fakeReturns := fake.setPipelineStepDelegateReturns
 	fake.recordInvocation("SetPipelineStepDelegate", []interface{}{arg1})
 	fake.setPipelineStepDelegateMutex.Unlock()
-	if fake.SetPipelineStepDelegateStub != nil {
-		return fake.SetPipelineStepDelegateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setPipelineStepDelegateReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_step.go
+++ b/atc/exec/execfakes/fake_step.go
@@ -34,15 +34,16 @@ func (fake *FakeStep) Run(arg1 context.Context, arg2 exec.RunState) (bool, error
 		arg1 context.Context
 		arg2 exec.RunState
 	}{arg1, arg2})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1, arg2})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/exec/execfakes/fake_task_config_source.go
+++ b/atc/exec/execfakes/fake_task_config_source.go
@@ -49,15 +49,16 @@ func (fake *FakeTaskConfigSource) FetchConfig(arg1 context.Context, arg2 lager.L
 		arg2 lager.Logger
 		arg3 *build.Repository
 	}{arg1, arg2, arg3})
+	stub := fake.FetchConfigStub
+	fakeReturns := fake.fetchConfigReturns
 	fake.recordInvocation("FetchConfig", []interface{}{arg1, arg2, arg3})
 	fake.fetchConfigMutex.Unlock()
-	if fake.FetchConfigStub != nil {
-		return fake.FetchConfigStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.fetchConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -111,15 +112,16 @@ func (fake *FakeTaskConfigSource) Warnings() []string {
 	ret, specificReturn := fake.warningsReturnsOnCall[len(fake.warningsArgsForCall)]
 	fake.warningsArgsForCall = append(fake.warningsArgsForCall, struct {
 	}{})
+	stub := fake.WarningsStub
+	fakeReturns := fake.warningsReturns
 	fake.recordInvocation("Warnings", []interface{}{})
 	fake.warningsMutex.Unlock()
-	if fake.WarningsStub != nil {
-		return fake.WarningsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.warningsReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_task_delegate.go
+++ b/atc/exec/execfakes/fake_task_delegate.go
@@ -133,9 +133,10 @@ func (fake *FakeTaskDelegate) Errored(arg1 lager.Logger, arg2 string) {
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ErroredStub
 	fake.recordInvocation("Errored", []interface{}{arg1, arg2})
 	fake.erroredMutex.Unlock()
-	if fake.ErroredStub != nil {
+	if stub != nil {
 		fake.ErroredStub(arg1, arg2)
 	}
 }
@@ -168,15 +169,16 @@ func (fake *FakeTaskDelegate) FetchImage(arg1 context.Context, arg2 atc.ImageRes
 		arg3 atc.VersionedResourceTypes
 		arg4 bool
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.FetchImageStub
+	fakeReturns := fake.fetchImageReturns
 	fake.recordInvocation("FetchImage", []interface{}{arg1, arg2, arg3, arg4})
 	fake.fetchImageMutex.Unlock()
-	if fake.FetchImageStub != nil {
-		return fake.FetchImageStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.fetchImageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -233,9 +235,10 @@ func (fake *FakeTaskDelegate) Finished(arg1 lager.Logger, arg2 exec.ExitStatus, 
 		arg3 worker.ContainerPlacementStrategy
 		arg4 worker.Client
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.FinishedStub
 	fake.recordInvocation("Finished", []interface{}{arg1, arg2, arg3, arg4})
 	fake.finishedMutex.Unlock()
-	if fake.FinishedStub != nil {
+	if stub != nil {
 		fake.FinishedStub(arg1, arg2, arg3, arg4)
 	}
 }
@@ -264,9 +267,10 @@ func (fake *FakeTaskDelegate) Initializing(arg1 lager.Logger) {
 	fake.initializingArgsForCall = append(fake.initializingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.InitializingStub
 	fake.recordInvocation("Initializing", []interface{}{arg1})
 	fake.initializingMutex.Unlock()
-	if fake.InitializingStub != nil {
+	if stub != nil {
 		fake.InitializingStub(arg1)
 	}
 }
@@ -303,15 +307,16 @@ func (fake *FakeTaskDelegate) SelectWorker(arg1 context.Context, arg2 worker.Poo
 		arg7 time.Duration
 		arg8 time.Duration
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
+	stub := fake.SelectWorkerStub
+	fakeReturns := fake.selectWorkerReturns
 	fake.recordInvocation("SelectWorker", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
 	fake.selectWorkerMutex.Unlock()
-	if fake.SelectWorkerStub != nil {
-		return fake.SelectWorkerStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.selectWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -366,9 +371,10 @@ func (fake *FakeTaskDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SelectedWorkerStub
 	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
 	fake.selectedWorkerMutex.Unlock()
-	if fake.SelectedWorkerStub != nil {
+	if stub != nil {
 		fake.SelectedWorkerStub(arg1, arg2)
 	}
 }
@@ -397,9 +403,10 @@ func (fake *FakeTaskDelegate) SetTaskConfig(arg1 atc.TaskConfig) {
 	fake.setTaskConfigArgsForCall = append(fake.setTaskConfigArgsForCall, struct {
 		arg1 atc.TaskConfig
 	}{arg1})
+	stub := fake.SetTaskConfigStub
 	fake.recordInvocation("SetTaskConfig", []interface{}{arg1})
 	fake.setTaskConfigMutex.Unlock()
-	if fake.SetTaskConfigStub != nil {
+	if stub != nil {
 		fake.SetTaskConfigStub(arg1)
 	}
 }
@@ -431,15 +438,16 @@ func (fake *FakeTaskDelegate) StartSpan(arg1 context.Context, arg2 string, arg3 
 		arg2 string
 		arg3 tracing.Attrs
 	}{arg1, arg2, arg3})
+	stub := fake.StartSpanStub
+	fakeReturns := fake.startSpanReturns
 	fake.recordInvocation("StartSpan", []interface{}{arg1, arg2, arg3})
 	fake.startSpanMutex.Unlock()
-	if fake.StartSpanStub != nil {
-		return fake.StartSpanStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.startSpanReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -493,9 +501,10 @@ func (fake *FakeTaskDelegate) Starting(arg1 lager.Logger) {
 	fake.startingArgsForCall = append(fake.startingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.StartingStub
 	fake.recordInvocation("Starting", []interface{}{arg1})
 	fake.startingMutex.Unlock()
-	if fake.StartingStub != nil {
+	if stub != nil {
 		fake.StartingStub(arg1)
 	}
 }
@@ -524,15 +533,16 @@ func (fake *FakeTaskDelegate) Stderr() io.Writer {
 	ret, specificReturn := fake.stderrReturnsOnCall[len(fake.stderrArgsForCall)]
 	fake.stderrArgsForCall = append(fake.stderrArgsForCall, struct {
 	}{})
+	stub := fake.StderrStub
+	fakeReturns := fake.stderrReturns
 	fake.recordInvocation("Stderr", []interface{}{})
 	fake.stderrMutex.Unlock()
-	if fake.StderrStub != nil {
-		return fake.StderrStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stderrReturns
 	return fakeReturns.result1
 }
 
@@ -576,15 +586,16 @@ func (fake *FakeTaskDelegate) Stdout() io.Writer {
 	ret, specificReturn := fake.stdoutReturnsOnCall[len(fake.stdoutArgsForCall)]
 	fake.stdoutArgsForCall = append(fake.stdoutArgsForCall, struct {
 	}{})
+	stub := fake.StdoutStub
+	fakeReturns := fake.stdoutReturns
 	fake.recordInvocation("Stdout", []interface{}{})
 	fake.stdoutMutex.Unlock()
-	if fake.StdoutStub != nil {
-		return fake.StdoutStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stdoutReturns
 	return fakeReturns.result1
 }
 

--- a/atc/exec/execfakes/fake_task_delegate_factory.go
+++ b/atc/exec/execfakes/fake_task_delegate_factory.go
@@ -29,15 +29,16 @@ func (fake *FakeTaskDelegateFactory) TaskDelegate(arg1 exec.RunState) exec.TaskD
 	fake.taskDelegateArgsForCall = append(fake.taskDelegateArgsForCall, struct {
 		arg1 exec.RunState
 	}{arg1})
+	stub := fake.TaskDelegateStub
+	fakeReturns := fake.taskDelegateReturns
 	fake.recordInvocation("TaskDelegate", []interface{}{arg1})
 	fake.taskDelegateMutex.Unlock()
-	if fake.TaskDelegateStub != nil {
-		return fake.TaskDelegateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.taskDelegateReturns
 	return fakeReturns.result1
 }
 

--- a/atc/gc/gcfakes/fake_destroyer.go
+++ b/atc/gc/gcfakes/fake_destroyer.go
@@ -61,15 +61,16 @@ func (fake *FakeDestroyer) DestroyContainers(arg1 string, arg2 []string) error {
 		arg1 string
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.DestroyContainersStub
+	fakeReturns := fake.destroyContainersReturns
 	fake.recordInvocation("DestroyContainers", []interface{}{arg1, arg2Copy})
 	fake.destroyContainersMutex.Unlock()
-	if fake.DestroyContainersStub != nil {
-		return fake.DestroyContainersStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destroyContainersReturns
 	return fakeReturns.result1
 }
 
@@ -127,15 +128,16 @@ func (fake *FakeDestroyer) DestroyVolumes(arg1 string, arg2 []string) error {
 		arg1 string
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.DestroyVolumesStub
+	fakeReturns := fake.destroyVolumesReturns
 	fake.recordInvocation("DestroyVolumes", []interface{}{arg1, arg2Copy})
 	fake.destroyVolumesMutex.Unlock()
-	if fake.DestroyVolumesStub != nil {
-		return fake.DestroyVolumesStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destroyVolumesReturns
 	return fakeReturns.result1
 }
 
@@ -187,15 +189,16 @@ func (fake *FakeDestroyer) FindDestroyingVolumesForGc(arg1 string) ([]string, er
 	fake.findDestroyingVolumesForGcArgsForCall = append(fake.findDestroyingVolumesForGcArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindDestroyingVolumesForGcStub
+	fakeReturns := fake.findDestroyingVolumesForGcReturns
 	fake.recordInvocation("FindDestroyingVolumesForGc", []interface{}{arg1})
 	fake.findDestroyingVolumesForGcMutex.Unlock()
-	if fake.FindDestroyingVolumesForGcStub != nil {
-		return fake.FindDestroyingVolumesForGcStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findDestroyingVolumesForGcReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/metric/emitter/emitterfakes/fake_influx_dbclient.go
+++ b/atc/metric/emitter/emitterfakes/fake_influx_dbclient.go
@@ -81,15 +81,16 @@ func (fake *FakeInfluxDBClient) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -134,15 +135,16 @@ func (fake *FakeInfluxDBClient) Ping(arg1 time.Duration) (time.Duration, string,
 	fake.pingArgsForCall = append(fake.pingArgsForCall, struct {
 		arg1 time.Duration
 	}{arg1})
+	stub := fake.PingStub
+	fakeReturns := fake.pingReturns
 	fake.recordInvocation("Ping", []interface{}{arg1})
 	fake.pingMutex.Unlock()
-	if fake.PingStub != nil {
-		return fake.PingStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.pingReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -200,15 +202,16 @@ func (fake *FakeInfluxDBClient) Query(arg1 client.Query) (*client.Response, erro
 	fake.queryArgsForCall = append(fake.queryArgsForCall, struct {
 		arg1 client.Query
 	}{arg1})
+	stub := fake.QueryStub
+	fakeReturns := fake.queryReturns
 	fake.recordInvocation("Query", []interface{}{arg1})
 	fake.queryMutex.Unlock()
-	if fake.QueryStub != nil {
-		return fake.QueryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.queryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -263,15 +266,16 @@ func (fake *FakeInfluxDBClient) QueryAsChunk(arg1 client.Query) (*client.Chunked
 	fake.queryAsChunkArgsForCall = append(fake.queryAsChunkArgsForCall, struct {
 		arg1 client.Query
 	}{arg1})
+	stub := fake.QueryAsChunkStub
+	fakeReturns := fake.queryAsChunkReturns
 	fake.recordInvocation("QueryAsChunk", []interface{}{arg1})
 	fake.queryAsChunkMutex.Unlock()
-	if fake.QueryAsChunkStub != nil {
-		return fake.QueryAsChunkStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.queryAsChunkReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -326,15 +330,16 @@ func (fake *FakeInfluxDBClient) Write(arg1 client.BatchPoints) error {
 	fake.writeArgsForCall = append(fake.writeArgsForCall, struct {
 		arg1 client.BatchPoints
 	}{arg1})
+	stub := fake.WriteStub
+	fakeReturns := fake.writeReturns
 	fake.recordInvocation("Write", []interface{}{arg1})
 	fake.writeMutex.Unlock()
-	if fake.WriteStub != nil {
-		return fake.WriteStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.writeReturns
 	return fakeReturns.result1
 }
 

--- a/atc/metric/emitter/emitterfakes/fake_prometheus_garbage_collectable.go
+++ b/atc/metric/emitter/emitterfakes/fake_prometheus_garbage_collectable.go
@@ -78,15 +78,16 @@ func (fake *FakePrometheusGarbageCollectable) WorkerContainers() *prometheus.Gau
 	ret, specificReturn := fake.workerContainersReturnsOnCall[len(fake.workerContainersArgsForCall)]
 	fake.workerContainersArgsForCall = append(fake.workerContainersArgsForCall, struct {
 	}{})
+	stub := fake.WorkerContainersStub
+	fakeReturns := fake.workerContainersReturns
 	fake.recordInvocation("WorkerContainers", []interface{}{})
 	fake.workerContainersMutex.Unlock()
-	if fake.WorkerContainersStub != nil {
-		return fake.WorkerContainersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerContainersReturns
 	return fakeReturns.result1
 }
 
@@ -130,15 +131,16 @@ func (fake *FakePrometheusGarbageCollectable) WorkerContainersLabels() map[strin
 	ret, specificReturn := fake.workerContainersLabelsReturnsOnCall[len(fake.workerContainersLabelsArgsForCall)]
 	fake.workerContainersLabelsArgsForCall = append(fake.workerContainersLabelsArgsForCall, struct {
 	}{})
+	stub := fake.WorkerContainersLabelsStub
+	fakeReturns := fake.workerContainersLabelsReturns
 	fake.recordInvocation("WorkerContainersLabels", []interface{}{})
 	fake.workerContainersLabelsMutex.Unlock()
-	if fake.WorkerContainersLabelsStub != nil {
-		return fake.WorkerContainersLabelsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerContainersLabelsReturns
 	return fakeReturns.result1
 }
 
@@ -182,15 +184,16 @@ func (fake *FakePrometheusGarbageCollectable) WorkerTasks() *prometheus.GaugeVec
 	ret, specificReturn := fake.workerTasksReturnsOnCall[len(fake.workerTasksArgsForCall)]
 	fake.workerTasksArgsForCall = append(fake.workerTasksArgsForCall, struct {
 	}{})
+	stub := fake.WorkerTasksStub
+	fakeReturns := fake.workerTasksReturns
 	fake.recordInvocation("WorkerTasks", []interface{}{})
 	fake.workerTasksMutex.Unlock()
-	if fake.WorkerTasksStub != nil {
-		return fake.WorkerTasksStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerTasksReturns
 	return fakeReturns.result1
 }
 
@@ -234,15 +237,16 @@ func (fake *FakePrometheusGarbageCollectable) WorkerTasksLabels() map[string]map
 	ret, specificReturn := fake.workerTasksLabelsReturnsOnCall[len(fake.workerTasksLabelsArgsForCall)]
 	fake.workerTasksLabelsArgsForCall = append(fake.workerTasksLabelsArgsForCall, struct {
 	}{})
+	stub := fake.WorkerTasksLabelsStub
+	fakeReturns := fake.workerTasksLabelsReturns
 	fake.recordInvocation("WorkerTasksLabels", []interface{}{})
 	fake.workerTasksLabelsMutex.Unlock()
-	if fake.WorkerTasksLabelsStub != nil {
-		return fake.WorkerTasksLabelsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerTasksLabelsReturns
 	return fakeReturns.result1
 }
 
@@ -286,15 +290,16 @@ func (fake *FakePrometheusGarbageCollectable) WorkerVolumes() *prometheus.GaugeV
 	ret, specificReturn := fake.workerVolumesReturnsOnCall[len(fake.workerVolumesArgsForCall)]
 	fake.workerVolumesArgsForCall = append(fake.workerVolumesArgsForCall, struct {
 	}{})
+	stub := fake.WorkerVolumesStub
+	fakeReturns := fake.workerVolumesReturns
 	fake.recordInvocation("WorkerVolumes", []interface{}{})
 	fake.workerVolumesMutex.Unlock()
-	if fake.WorkerVolumesStub != nil {
-		return fake.WorkerVolumesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerVolumesReturns
 	return fakeReturns.result1
 }
 
@@ -338,15 +343,16 @@ func (fake *FakePrometheusGarbageCollectable) WorkerVolumesLabels() map[string]m
 	ret, specificReturn := fake.workerVolumesLabelsReturnsOnCall[len(fake.workerVolumesLabelsArgsForCall)]
 	fake.workerVolumesLabelsArgsForCall = append(fake.workerVolumesLabelsArgsForCall, struct {
 	}{})
+	stub := fake.WorkerVolumesLabelsStub
+	fakeReturns := fake.workerVolumesLabelsReturns
 	fake.recordInvocation("WorkerVolumesLabels", []interface{}{})
 	fake.workerVolumesLabelsMutex.Unlock()
-	if fake.WorkerVolumesLabelsStub != nil {
-		return fake.WorkerVolumesLabelsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerVolumesLabelsReturns
 	return fakeReturns.result1
 }
 

--- a/atc/metric/metricfakes/fake_emitter.go
+++ b/atc/metric/metricfakes/fake_emitter.go
@@ -25,9 +25,10 @@ func (fake *FakeEmitter) Emit(arg1 lager.Logger, arg2 metric.Event) {
 		arg1 lager.Logger
 		arg2 metric.Event
 	}{arg1, arg2})
+	stub := fake.EmitStub
 	fake.recordInvocation("Emit", []interface{}{arg1, arg2})
 	fake.emitMutex.Unlock()
-	if fake.EmitStub != nil {
+	if stub != nil {
 		fake.EmitStub(arg1, arg2)
 	}
 }

--- a/atc/metric/metricfakes/fake_emitter_factory.go
+++ b/atc/metric/metricfakes/fake_emitter_factory.go
@@ -49,15 +49,16 @@ func (fake *FakeEmitterFactory) Description() string {
 	ret, specificReturn := fake.descriptionReturnsOnCall[len(fake.descriptionArgsForCall)]
 	fake.descriptionArgsForCall = append(fake.descriptionArgsForCall, struct {
 	}{})
+	stub := fake.DescriptionStub
+	fakeReturns := fake.descriptionReturns
 	fake.recordInvocation("Description", []interface{}{})
 	fake.descriptionMutex.Unlock()
-	if fake.DescriptionStub != nil {
-		return fake.DescriptionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.descriptionReturns
 	return fakeReturns.result1
 }
 
@@ -101,15 +102,16 @@ func (fake *FakeEmitterFactory) IsConfigured() bool {
 	ret, specificReturn := fake.isConfiguredReturnsOnCall[len(fake.isConfiguredArgsForCall)]
 	fake.isConfiguredArgsForCall = append(fake.isConfiguredArgsForCall, struct {
 	}{})
+	stub := fake.IsConfiguredStub
+	fakeReturns := fake.isConfiguredReturns
 	fake.recordInvocation("IsConfigured", []interface{}{})
 	fake.isConfiguredMutex.Unlock()
-	if fake.IsConfiguredStub != nil {
-		return fake.IsConfiguredStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isConfiguredReturns
 	return fakeReturns.result1
 }
 
@@ -153,15 +155,16 @@ func (fake *FakeEmitterFactory) NewEmitter() (metric.Emitter, error) {
 	ret, specificReturn := fake.newEmitterReturnsOnCall[len(fake.newEmitterArgsForCall)]
 	fake.newEmitterArgsForCall = append(fake.newEmitterArgsForCall, struct {
 	}{})
+	stub := fake.NewEmitterStub
+	fakeReturns := fake.newEmitterReturns
 	fake.recordInvocation("NewEmitter", []interface{}{})
 	fake.newEmitterMutex.Unlock()
-	if fake.NewEmitterStub != nil {
-		return fake.NewEmitterStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newEmitterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/policy/policyfakes/fake_agent.go
+++ b/atc/policy/policyfakes/fake_agent.go
@@ -31,15 +31,16 @@ func (fake *FakeAgent) Check(arg1 policy.PolicyCheckInput) (policy.PolicyCheckOu
 	fake.checkArgsForCall = append(fake.checkArgsForCall, struct {
 		arg1 policy.PolicyCheckInput
 	}{arg1})
+	stub := fake.CheckStub
+	fakeReturns := fake.checkReturns
 	fake.recordInvocation("Check", []interface{}{arg1})
 	fake.checkMutex.Unlock()
-	if fake.CheckStub != nil {
-		return fake.CheckStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checkReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/policy/policyfakes/fake_agent_factory.go
+++ b/atc/policy/policyfakes/fake_agent_factory.go
@@ -51,15 +51,16 @@ func (fake *FakeAgentFactory) Description() string {
 	ret, specificReturn := fake.descriptionReturnsOnCall[len(fake.descriptionArgsForCall)]
 	fake.descriptionArgsForCall = append(fake.descriptionArgsForCall, struct {
 	}{})
+	stub := fake.DescriptionStub
+	fakeReturns := fake.descriptionReturns
 	fake.recordInvocation("Description", []interface{}{})
 	fake.descriptionMutex.Unlock()
-	if fake.DescriptionStub != nil {
-		return fake.DescriptionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.descriptionReturns
 	return fakeReturns.result1
 }
 
@@ -103,15 +104,16 @@ func (fake *FakeAgentFactory) IsConfigured() bool {
 	ret, specificReturn := fake.isConfiguredReturnsOnCall[len(fake.isConfiguredArgsForCall)]
 	fake.isConfiguredArgsForCall = append(fake.isConfiguredArgsForCall, struct {
 	}{})
+	stub := fake.IsConfiguredStub
+	fakeReturns := fake.isConfiguredReturns
 	fake.recordInvocation("IsConfigured", []interface{}{})
 	fake.isConfiguredMutex.Unlock()
-	if fake.IsConfiguredStub != nil {
-		return fake.IsConfiguredStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isConfiguredReturns
 	return fakeReturns.result1
 }
 
@@ -156,15 +158,16 @@ func (fake *FakeAgentFactory) NewAgent(arg1 lager.Logger) (policy.Agent, error) 
 	fake.newAgentArgsForCall = append(fake.newAgentArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.NewAgentStub
+	fakeReturns := fake.newAgentReturns
 	fake.recordInvocation("NewAgent", []interface{}{arg1})
 	fake.newAgentMutex.Unlock()
-	if fake.NewAgentStub != nil {
-		return fake.NewAgentStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newAgentReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/policy/policyfakes/fake_checker.go
+++ b/atc/policy/policyfakes/fake_checker.go
@@ -64,15 +64,16 @@ func (fake *FakeChecker) Check(arg1 policy.PolicyCheckInput) (policy.PolicyCheck
 	fake.checkArgsForCall = append(fake.checkArgsForCall, struct {
 		arg1 policy.PolicyCheckInput
 	}{arg1})
+	stub := fake.CheckStub
+	fakeReturns := fake.checkReturns
 	fake.recordInvocation("Check", []interface{}{arg1})
 	fake.checkMutex.Unlock()
-	if fake.CheckStub != nil {
-		return fake.CheckStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checkReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -127,15 +128,16 @@ func (fake *FakeChecker) ShouldCheckAction(arg1 string) bool {
 	fake.shouldCheckActionArgsForCall = append(fake.shouldCheckActionArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ShouldCheckActionStub
+	fakeReturns := fake.shouldCheckActionReturns
 	fake.recordInvocation("ShouldCheckAction", []interface{}{arg1})
 	fake.shouldCheckActionMutex.Unlock()
-	if fake.ShouldCheckActionStub != nil {
-		return fake.ShouldCheckActionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.shouldCheckActionReturns
 	return fakeReturns.result1
 }
 
@@ -187,15 +189,16 @@ func (fake *FakeChecker) ShouldCheckHttpMethod(arg1 string) bool {
 	fake.shouldCheckHttpMethodArgsForCall = append(fake.shouldCheckHttpMethodArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ShouldCheckHttpMethodStub
+	fakeReturns := fake.shouldCheckHttpMethodReturns
 	fake.recordInvocation("ShouldCheckHttpMethod", []interface{}{arg1})
 	fake.shouldCheckHttpMethodMutex.Unlock()
-	if fake.ShouldCheckHttpMethodStub != nil {
-		return fake.ShouldCheckHttpMethodStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.shouldCheckHttpMethodReturns
 	return fakeReturns.result1
 }
 
@@ -247,15 +250,16 @@ func (fake *FakeChecker) ShouldSkipAction(arg1 string) bool {
 	fake.shouldSkipActionArgsForCall = append(fake.shouldSkipActionArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ShouldSkipActionStub
+	fakeReturns := fake.shouldSkipActionReturns
 	fake.recordInvocation("ShouldSkipAction", []interface{}{arg1})
 	fake.shouldSkipActionMutex.Unlock()
-	if fake.ShouldSkipActionStub != nil {
-		return fake.ShouldSkipActionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.shouldSkipActionReturns
 	return fakeReturns.result1
 }
 

--- a/atc/resource/resourcefakes/fake_resource.go
+++ b/atc/resource/resourcefakes/fake_resource.go
@@ -80,15 +80,16 @@ func (fake *FakeResource) Check(arg1 context.Context, arg2 runtime.ProcessSpec, 
 		arg2 runtime.ProcessSpec
 		arg3 runtime.Runner
 	}{arg1, arg2, arg3})
+	stub := fake.CheckStub
+	fakeReturns := fake.checkReturns
 	fake.recordInvocation("Check", []interface{}{arg1, arg2, arg3})
 	fake.checkMutex.Unlock()
-	if fake.CheckStub != nil {
-		return fake.CheckStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checkReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -145,15 +146,16 @@ func (fake *FakeResource) Get(arg1 context.Context, arg2 runtime.ProcessSpec, ar
 		arg2 runtime.ProcessSpec
 		arg3 runtime.Runner
 	}{arg1, arg2, arg3})
+	stub := fake.GetStub
+	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3})
 	fake.getMutex.Unlock()
-	if fake.GetStub != nil {
-		return fake.GetStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -210,15 +212,16 @@ func (fake *FakeResource) Put(arg1 context.Context, arg2 runtime.ProcessSpec, ar
 		arg2 runtime.ProcessSpec
 		arg3 runtime.Runner
 	}{arg1, arg2, arg3})
+	stub := fake.PutStub
+	fakeReturns := fake.putReturns
 	fake.recordInvocation("Put", []interface{}{arg1, arg2, arg3})
 	fake.putMutex.Unlock()
-	if fake.PutStub != nil {
-		return fake.PutStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.putReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -272,15 +275,16 @@ func (fake *FakeResource) Signature() ([]byte, error) {
 	ret, specificReturn := fake.signatureReturnsOnCall[len(fake.signatureArgsForCall)]
 	fake.signatureArgsForCall = append(fake.signatureArgsForCall, struct {
 	}{})
+	stub := fake.SignatureStub
+	fakeReturns := fake.signatureReturns
 	fake.recordInvocation("Signature", []interface{}{})
 	fake.signatureMutex.Unlock()
-	if fake.SignatureStub != nil {
-		return fake.SignatureStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.signatureReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/resource/resourcefakes/fake_resource_factory.go
+++ b/atc/resource/resourcefakes/fake_resource_factory.go
@@ -34,15 +34,16 @@ func (fake *FakeResourceFactory) NewResource(arg1 atc.Source, arg2 atc.Params, a
 		arg2 atc.Params
 		arg3 atc.Version
 	}{arg1, arg2, arg3})
+	stub := fake.NewResourceStub
+	fakeReturns := fake.newResourceReturns
 	fake.recordInvocation("NewResource", []interface{}{arg1, arg2, arg3})
 	fake.newResourceMutex.Unlock()
-	if fake.NewResourceStub != nil {
-		return fake.NewResourceStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newResourceReturns
 	return fakeReturns.result1
 }
 

--- a/atc/runtime/runtimefakes/fake_artifact.go
+++ b/atc/runtime/runtimefakes/fake_artifact.go
@@ -27,15 +27,16 @@ func (fake *FakeArtifact) ID() string {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 

--- a/atc/runtime/runtimefakes/fake_runner.go
+++ b/atc/runtime/runtimefakes/fake_runner.go
@@ -53,15 +53,16 @@ func (fake *FakeRunner) RunScript(arg1 context.Context, arg2 string, arg3 []stri
 		arg6 io.Writer
 		arg7 bool
 	}{arg1, arg2, arg3Copy, arg4Copy, arg5, arg6, arg7})
+	stub := fake.RunScriptStub
+	fakeReturns := fake.runScriptReturns
 	fake.recordInvocation("RunScript", []interface{}{arg1, arg2, arg3Copy, arg4Copy, arg5, arg6, arg7})
 	fake.runScriptMutex.Unlock()
-	if fake.RunScriptStub != nil {
-		return fake.RunScriptStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.runScriptReturns
 	return fakeReturns.result1
 }
 

--- a/atc/runtime/runtimefakes/fake_starting_event_delegate.go
+++ b/atc/runtime/runtimefakes/fake_starting_event_delegate.go
@@ -9,12 +9,6 @@ import (
 )
 
 type FakeStartingEventDelegate struct {
-	SelectedWorkerStub        func(lager.Logger, string)
-	selectedWorkerMutex       sync.RWMutex
-	selectedWorkerArgsForCall []struct {
-		arg1 lager.Logger
-		arg2 string
-	}
 	StartingStub        func(lager.Logger)
 	startingMutex       sync.RWMutex
 	startingArgsForCall []struct {
@@ -24,46 +18,15 @@ type FakeStartingEventDelegate struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeStartingEventDelegate) SelectedWorker(arg1 lager.Logger, arg2 string) {
-	fake.selectedWorkerMutex.Lock()
-	fake.selectedWorkerArgsForCall = append(fake.selectedWorkerArgsForCall, struct {
-		arg1 lager.Logger
-		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("SelectedWorker", []interface{}{arg1, arg2})
-	fake.selectedWorkerMutex.Unlock()
-	if fake.SelectedWorkerStub != nil {
-		fake.SelectedWorkerStub(arg1, arg2)
-	}
-}
-
-func (fake *FakeStartingEventDelegate) SelectedWorkerCallCount() int {
-	fake.selectedWorkerMutex.RLock()
-	defer fake.selectedWorkerMutex.RUnlock()
-	return len(fake.selectedWorkerArgsForCall)
-}
-
-func (fake *FakeStartingEventDelegate) SelectedWorkerCalls(stub func(lager.Logger, string)) {
-	fake.selectedWorkerMutex.Lock()
-	defer fake.selectedWorkerMutex.Unlock()
-	fake.SelectedWorkerStub = stub
-}
-
-func (fake *FakeStartingEventDelegate) SelectedWorkerArgsForCall(i int) (lager.Logger, string) {
-	fake.selectedWorkerMutex.RLock()
-	defer fake.selectedWorkerMutex.RUnlock()
-	argsForCall := fake.selectedWorkerArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
 func (fake *FakeStartingEventDelegate) Starting(arg1 lager.Logger) {
 	fake.startingMutex.Lock()
 	fake.startingArgsForCall = append(fake.startingArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.StartingStub
 	fake.recordInvocation("Starting", []interface{}{arg1})
 	fake.startingMutex.Unlock()
-	if fake.StartingStub != nil {
+	if stub != nil {
 		fake.StartingStub(arg1)
 	}
 }
@@ -90,8 +53,6 @@ func (fake *FakeStartingEventDelegate) StartingArgsForCall(i int) lager.Logger {
 func (fake *FakeStartingEventDelegate) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.selectedWorkerMutex.RLock()
-	defer fake.selectedWorkerMutex.RUnlock()
 	fake.startingMutex.RLock()
 	defer fake.startingMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/scheduler/schedulerfakes/fake_algorithm.go
+++ b/atc/scheduler/schedulerfakes/fake_algorithm.go
@@ -41,15 +41,16 @@ func (fake *FakeAlgorithm) Compute(arg1 context.Context, arg2 db.Job, arg3 db.In
 		arg2 db.Job
 		arg3 db.InputConfigs
 	}{arg1, arg2, arg3})
+	stub := fake.ComputeStub
+	fakeReturns := fake.computeReturns
 	fake.recordInvocation("Compute", []interface{}{arg1, arg2, arg3})
 	fake.computeMutex.Unlock()
-	if fake.ComputeStub != nil {
-		return fake.ComputeStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.computeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 

--- a/atc/scheduler/schedulerfakes/fake_build_planner.go
+++ b/atc/scheduler/schedulerfakes/fake_build_planner.go
@@ -44,15 +44,16 @@ func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResou
 		arg3 atc.VersionedResourceTypes
 		arg4 []db.BuildInput
 	}{arg1, arg2, arg3, arg4Copy})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4Copy})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/scheduler/schedulerfakes/fake_build_scheduler.go
+++ b/atc/scheduler/schedulerfakes/fake_build_scheduler.go
@@ -38,15 +38,16 @@ func (fake *FakeBuildScheduler) Schedule(arg1 context.Context, arg2 lager.Logger
 		arg2 lager.Logger
 		arg3 db.SchedulerJob
 	}{arg1, arg2, arg3})
+	stub := fake.ScheduleStub
+	fakeReturns := fake.scheduleReturns
 	fake.recordInvocation("Schedule", []interface{}{arg1, arg2, arg3})
 	fake.scheduleMutex.Unlock()
-	if fake.ScheduleStub != nil {
-		return fake.ScheduleStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.scheduleReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/scheduler/schedulerfakes/fake_build_starter.go
+++ b/atc/scheduler/schedulerfakes/fake_build_starter.go
@@ -37,15 +37,16 @@ func (fake *FakeBuildStarter) TryStartPendingBuildsForJob(arg1 lager.Logger, arg
 		arg2 db.SchedulerJob
 		arg3 db.InputConfigs
 	}{arg1, arg2, arg3})
+	stub := fake.TryStartPendingBuildsForJobStub
+	fakeReturns := fake.tryStartPendingBuildsForJobReturns
 	fake.recordInvocation("TryStartPendingBuildsForJob", []interface{}{arg1, arg2, arg3})
 	fake.tryStartPendingBuildsForJobMutex.Unlock()
-	if fake.TryStartPendingBuildsForJobStub != nil {
-		return fake.TryStartPendingBuildsForJobStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.tryStartPendingBuildsForJobReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/syslog/syslogfakes/fake_drainer.go
+++ b/atc/syslog/syslogfakes/fake_drainer.go
@@ -30,15 +30,16 @@ func (fake *FakeDrainer) Run(arg1 context.Context) error {
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/gclient/connection/connectionfakes/fake_connection.go
+++ b/atc/worker/gclient/connection/connectionfakes/fake_connection.go
@@ -363,15 +363,16 @@ func (fake *FakeConnection) Attach(arg1 context.Context, arg2 string, arg3 strin
 		arg3 string
 		arg4 garden.ProcessIO
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.AttachStub
+	fakeReturns := fake.attachReturns
 	fake.recordInvocation("Attach", []interface{}{arg1, arg2, arg3, arg4})
 	fake.attachMutex.Unlock()
-	if fake.AttachStub != nil {
-		return fake.AttachStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.attachReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -431,15 +432,16 @@ func (fake *FakeConnection) BulkInfo(arg1 []string) (map[string]garden.Container
 	fake.bulkInfoArgsForCall = append(fake.bulkInfoArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.BulkInfoStub
+	fakeReturns := fake.bulkInfoReturns
 	fake.recordInvocation("BulkInfo", []interface{}{arg1Copy})
 	fake.bulkInfoMutex.Unlock()
-	if fake.BulkInfoStub != nil {
-		return fake.BulkInfoStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.bulkInfoReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -499,15 +501,16 @@ func (fake *FakeConnection) BulkMetrics(arg1 []string) (map[string]garden.Contai
 	fake.bulkMetricsArgsForCall = append(fake.bulkMetricsArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.BulkMetricsStub
+	fakeReturns := fake.bulkMetricsReturns
 	fake.recordInvocation("BulkMetrics", []interface{}{arg1Copy})
 	fake.bulkMetricsMutex.Unlock()
-	if fake.BulkMetricsStub != nil {
-		return fake.BulkMetricsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.bulkMetricsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -568,15 +571,16 @@ func (fake *FakeConnection) BulkNetOut(arg1 string, arg2 []garden.NetOutRule) er
 		arg1 string
 		arg2 []garden.NetOutRule
 	}{arg1, arg2Copy})
+	stub := fake.BulkNetOutStub
+	fakeReturns := fake.bulkNetOutReturns
 	fake.recordInvocation("BulkNetOut", []interface{}{arg1, arg2Copy})
 	fake.bulkNetOutMutex.Unlock()
-	if fake.BulkNetOutStub != nil {
-		return fake.BulkNetOutStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.bulkNetOutReturns
 	return fakeReturns.result1
 }
 
@@ -627,15 +631,16 @@ func (fake *FakeConnection) Capacity() (garden.Capacity, error) {
 	ret, specificReturn := fake.capacityReturnsOnCall[len(fake.capacityArgsForCall)]
 	fake.capacityArgsForCall = append(fake.capacityArgsForCall, struct {
 	}{})
+	stub := fake.CapacityStub
+	fakeReturns := fake.capacityReturns
 	fake.recordInvocation("Capacity", []interface{}{})
 	fake.capacityMutex.Unlock()
-	if fake.CapacityStub != nil {
-		return fake.CapacityStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.capacityReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -683,15 +688,16 @@ func (fake *FakeConnection) Create(arg1 garden.ContainerSpec) (string, error) {
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
 		arg1 garden.ContainerSpec
 	}{arg1})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -746,15 +752,16 @@ func (fake *FakeConnection) CurrentBandwidthLimits(arg1 string) (garden.Bandwidt
 	fake.currentBandwidthLimitsArgsForCall = append(fake.currentBandwidthLimitsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CurrentBandwidthLimitsStub
+	fakeReturns := fake.currentBandwidthLimitsReturns
 	fake.recordInvocation("CurrentBandwidthLimits", []interface{}{arg1})
 	fake.currentBandwidthLimitsMutex.Unlock()
-	if fake.CurrentBandwidthLimitsStub != nil {
-		return fake.CurrentBandwidthLimitsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentBandwidthLimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -809,15 +816,16 @@ func (fake *FakeConnection) CurrentCPULimits(arg1 string) (garden.CPULimits, err
 	fake.currentCPULimitsArgsForCall = append(fake.currentCPULimitsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CurrentCPULimitsStub
+	fakeReturns := fake.currentCPULimitsReturns
 	fake.recordInvocation("CurrentCPULimits", []interface{}{arg1})
 	fake.currentCPULimitsMutex.Unlock()
-	if fake.CurrentCPULimitsStub != nil {
-		return fake.CurrentCPULimitsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentCPULimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -872,15 +880,16 @@ func (fake *FakeConnection) CurrentDiskLimits(arg1 string) (garden.DiskLimits, e
 	fake.currentDiskLimitsArgsForCall = append(fake.currentDiskLimitsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CurrentDiskLimitsStub
+	fakeReturns := fake.currentDiskLimitsReturns
 	fake.recordInvocation("CurrentDiskLimits", []interface{}{arg1})
 	fake.currentDiskLimitsMutex.Unlock()
-	if fake.CurrentDiskLimitsStub != nil {
-		return fake.CurrentDiskLimitsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentDiskLimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -935,15 +944,16 @@ func (fake *FakeConnection) CurrentMemoryLimits(arg1 string) (garden.MemoryLimit
 	fake.currentMemoryLimitsArgsForCall = append(fake.currentMemoryLimitsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CurrentMemoryLimitsStub
+	fakeReturns := fake.currentMemoryLimitsReturns
 	fake.recordInvocation("CurrentMemoryLimits", []interface{}{arg1})
 	fake.currentMemoryLimitsMutex.Unlock()
-	if fake.CurrentMemoryLimitsStub != nil {
-		return fake.CurrentMemoryLimitsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentMemoryLimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -998,15 +1008,16 @@ func (fake *FakeConnection) Destroy(arg1 string) error {
 	fake.destroyArgsForCall = append(fake.destroyArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{arg1})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1
 }
 
@@ -1058,15 +1069,16 @@ func (fake *FakeConnection) Info(arg1 string) (garden.ContainerInfo, error) {
 	fake.infoArgsForCall = append(fake.infoArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.InfoStub
+	fakeReturns := fake.infoReturns
 	fake.recordInvocation("Info", []interface{}{arg1})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
-		return fake.InfoStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.infoReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1121,15 +1133,16 @@ func (fake *FakeConnection) List(arg1 garden.Properties) ([]string, error) {
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 		arg1 garden.Properties
 	}{arg1})
+	stub := fake.ListStub
+	fakeReturns := fake.listReturns
 	fake.recordInvocation("List", []interface{}{arg1})
 	fake.listMutex.Unlock()
-	if fake.ListStub != nil {
-		return fake.ListStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1184,15 +1197,16 @@ func (fake *FakeConnection) Metrics(arg1 string) (garden.Metrics, error) {
 	fake.metricsArgsForCall = append(fake.metricsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.MetricsStub
+	fakeReturns := fake.metricsReturns
 	fake.recordInvocation("Metrics", []interface{}{arg1})
 	fake.metricsMutex.Unlock()
-	if fake.MetricsStub != nil {
-		return fake.MetricsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.metricsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1249,15 +1263,16 @@ func (fake *FakeConnection) NetIn(arg1 string, arg2 uint32, arg3 uint32) (uint32
 		arg2 uint32
 		arg3 uint32
 	}{arg1, arg2, arg3})
+	stub := fake.NetInStub
+	fakeReturns := fake.netInReturns
 	fake.recordInvocation("NetIn", []interface{}{arg1, arg2, arg3})
 	fake.netInMutex.Unlock()
-	if fake.NetInStub != nil {
-		return fake.NetInStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.netInReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1316,15 +1331,16 @@ func (fake *FakeConnection) NetOut(arg1 string, arg2 garden.NetOutRule) error {
 		arg1 string
 		arg2 garden.NetOutRule
 	}{arg1, arg2})
+	stub := fake.NetOutStub
+	fakeReturns := fake.netOutReturns
 	fake.recordInvocation("NetOut", []interface{}{arg1, arg2})
 	fake.netOutMutex.Unlock()
-	if fake.NetOutStub != nil {
-		return fake.NetOutStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.netOutReturns
 	return fakeReturns.result1
 }
 
@@ -1375,15 +1391,16 @@ func (fake *FakeConnection) Ping() error {
 	ret, specificReturn := fake.pingReturnsOnCall[len(fake.pingArgsForCall)]
 	fake.pingArgsForCall = append(fake.pingArgsForCall, struct {
 	}{})
+	stub := fake.PingStub
+	fakeReturns := fake.pingReturns
 	fake.recordInvocation("Ping", []interface{}{})
 	fake.pingMutex.Unlock()
-	if fake.PingStub != nil {
-		return fake.PingStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pingReturns
 	return fakeReturns.result1
 }
 
@@ -1428,15 +1445,16 @@ func (fake *FakeConnection) Properties(arg1 string) (garden.Properties, error) {
 	fake.propertiesArgsForCall = append(fake.propertiesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PropertiesStub
+	fakeReturns := fake.propertiesReturns
 	fake.recordInvocation("Properties", []interface{}{arg1})
 	fake.propertiesMutex.Unlock()
-	if fake.PropertiesStub != nil {
-		return fake.PropertiesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.propertiesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1492,15 +1510,16 @@ func (fake *FakeConnection) Property(arg1 string, arg2 string) (string, error) {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.PropertyStub
+	fakeReturns := fake.propertyReturns
 	fake.recordInvocation("Property", []interface{}{arg1, arg2})
 	fake.propertyMutex.Unlock()
-	if fake.PropertyStub != nil {
-		return fake.PropertyStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.propertyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1556,15 +1575,16 @@ func (fake *FakeConnection) RemoveProperty(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RemovePropertyStub
+	fakeReturns := fake.removePropertyReturns
 	fake.recordInvocation("RemoveProperty", []interface{}{arg1, arg2})
 	fake.removePropertyMutex.Unlock()
-	if fake.RemovePropertyStub != nil {
-		return fake.RemovePropertyStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removePropertyReturns
 	return fakeReturns.result1
 }
 
@@ -1619,15 +1639,16 @@ func (fake *FakeConnection) Run(arg1 context.Context, arg2 string, arg3 garden.P
 		arg3 garden.ProcessSpec
 		arg4 garden.ProcessIO
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1, arg2, arg3, arg4})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1683,15 +1704,16 @@ func (fake *FakeConnection) SetGraceTime(arg1 string, arg2 time.Duration) error 
 		arg1 string
 		arg2 time.Duration
 	}{arg1, arg2})
+	stub := fake.SetGraceTimeStub
+	fakeReturns := fake.setGraceTimeReturns
 	fake.recordInvocation("SetGraceTime", []interface{}{arg1, arg2})
 	fake.setGraceTimeMutex.Unlock()
-	if fake.SetGraceTimeStub != nil {
-		return fake.SetGraceTimeStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setGraceTimeReturns
 	return fakeReturns.result1
 }
 
@@ -1745,15 +1767,16 @@ func (fake *FakeConnection) SetProperty(arg1 string, arg2 string, arg3 string) e
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.SetPropertyStub
+	fakeReturns := fake.setPropertyReturns
 	fake.recordInvocation("SetProperty", []interface{}{arg1, arg2, arg3})
 	fake.setPropertyMutex.Unlock()
-	if fake.SetPropertyStub != nil {
-		return fake.SetPropertyStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setPropertyReturns
 	return fakeReturns.result1
 }
 
@@ -1806,15 +1829,16 @@ func (fake *FakeConnection) Stop(arg1 string, arg2 bool) error {
 		arg1 string
 		arg2 bool
 	}{arg1, arg2})
+	stub := fake.StopStub
+	fakeReturns := fake.stopReturns
 	fake.recordInvocation("Stop", []interface{}{arg1, arg2})
 	fake.stopMutex.Unlock()
-	if fake.StopStub != nil {
-		return fake.StopStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stopReturns
 	return fakeReturns.result1
 }
 
@@ -1867,15 +1891,16 @@ func (fake *FakeConnection) StreamIn(arg1 string, arg2 garden.StreamInSpec) erro
 		arg1 string
 		arg2 garden.StreamInSpec
 	}{arg1, arg2})
+	stub := fake.StreamInStub
+	fakeReturns := fake.streamInReturns
 	fake.recordInvocation("StreamIn", []interface{}{arg1, arg2})
 	fake.streamInMutex.Unlock()
-	if fake.StreamInStub != nil {
-		return fake.StreamInStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.streamInReturns
 	return fakeReturns.result1
 }
 
@@ -1928,15 +1953,16 @@ func (fake *FakeConnection) StreamOut(arg1 string, arg2 garden.StreamOutSpec) (i
 		arg1 string
 		arg2 garden.StreamOutSpec
 	}{arg1, arg2})
+	stub := fake.StreamOutStub
+	fakeReturns := fake.streamOutReturns
 	fake.recordInvocation("StreamOut", []interface{}{arg1, arg2})
 	fake.streamOutMutex.Unlock()
-	if fake.StreamOutStub != nil {
-		return fake.StreamOutStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.streamOutReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/gclient/connection/connectionfakes/fake_hijack_streamer.go
+++ b/atc/worker/gclient/connection/connectionfakes/fake_hijack_streamer.go
@@ -66,15 +66,16 @@ func (fake *FakeHijackStreamer) Hijack(arg1 context.Context, arg2 string, arg3 i
 		arg5 url.Values
 		arg6 string
 	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	stub := fake.HijackStub
+	fakeReturns := fake.hijackReturns
 	fake.recordInvocation("Hijack", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.hijackMutex.Unlock()
-	if fake.HijackStub != nil {
-		return fake.HijackStub(arg1, arg2, arg3, arg4, arg5, arg6)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.hijackReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -136,15 +137,16 @@ func (fake *FakeHijackStreamer) Stream(arg1 string, arg2 io.Reader, arg3 rata.Pa
 		arg4 url.Values
 		arg5 string
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.StreamStub
+	fakeReturns := fake.streamReturns
 	fake.recordInvocation("Stream", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.streamMutex.Unlock()
-	if fake.StreamStub != nil {
-		return fake.StreamStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.streamReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/gclient/gclientfakes/fake_client.go
+++ b/atc/worker/gclient/gclientfakes/fake_client.go
@@ -122,15 +122,16 @@ func (fake *FakeClient) BulkInfo(arg1 []string) (map[string]garden.ContainerInfo
 	fake.bulkInfoArgsForCall = append(fake.bulkInfoArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.BulkInfoStub
+	fakeReturns := fake.bulkInfoReturns
 	fake.recordInvocation("BulkInfo", []interface{}{arg1Copy})
 	fake.bulkInfoMutex.Unlock()
-	if fake.BulkInfoStub != nil {
-		return fake.BulkInfoStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.bulkInfoReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -190,15 +191,16 @@ func (fake *FakeClient) BulkMetrics(arg1 []string) (map[string]garden.ContainerM
 	fake.bulkMetricsArgsForCall = append(fake.bulkMetricsArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.BulkMetricsStub
+	fakeReturns := fake.bulkMetricsReturns
 	fake.recordInvocation("BulkMetrics", []interface{}{arg1Copy})
 	fake.bulkMetricsMutex.Unlock()
-	if fake.BulkMetricsStub != nil {
-		return fake.BulkMetricsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.bulkMetricsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -252,15 +254,16 @@ func (fake *FakeClient) Capacity() (garden.Capacity, error) {
 	ret, specificReturn := fake.capacityReturnsOnCall[len(fake.capacityArgsForCall)]
 	fake.capacityArgsForCall = append(fake.capacityArgsForCall, struct {
 	}{})
+	stub := fake.CapacityStub
+	fakeReturns := fake.capacityReturns
 	fake.recordInvocation("Capacity", []interface{}{})
 	fake.capacityMutex.Unlock()
-	if fake.CapacityStub != nil {
-		return fake.CapacityStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.capacityReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -308,15 +311,16 @@ func (fake *FakeClient) Containers(arg1 garden.Properties) ([]gclient.Container,
 	fake.containersArgsForCall = append(fake.containersArgsForCall, struct {
 		arg1 garden.Properties
 	}{arg1})
+	stub := fake.ContainersStub
+	fakeReturns := fake.containersReturns
 	fake.recordInvocation("Containers", []interface{}{arg1})
 	fake.containersMutex.Unlock()
-	if fake.ContainersStub != nil {
-		return fake.ContainersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.containersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -371,15 +375,16 @@ func (fake *FakeClient) Create(arg1 garden.ContainerSpec) (gclient.Container, er
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
 		arg1 garden.ContainerSpec
 	}{arg1})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -434,15 +439,16 @@ func (fake *FakeClient) Destroy(arg1 string) error {
 	fake.destroyArgsForCall = append(fake.destroyArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{arg1})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1
 }
 
@@ -494,15 +500,16 @@ func (fake *FakeClient) Lookup(arg1 string) (gclient.Container, error) {
 	fake.lookupArgsForCall = append(fake.lookupArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.LookupStub
+	fakeReturns := fake.lookupReturns
 	fake.recordInvocation("Lookup", []interface{}{arg1})
 	fake.lookupMutex.Unlock()
-	if fake.LookupStub != nil {
-		return fake.LookupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.lookupReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -556,15 +563,16 @@ func (fake *FakeClient) Ping() error {
 	ret, specificReturn := fake.pingReturnsOnCall[len(fake.pingArgsForCall)]
 	fake.pingArgsForCall = append(fake.pingArgsForCall, struct {
 	}{})
+	stub := fake.PingStub
+	fakeReturns := fake.pingReturns
 	fake.recordInvocation("Ping", []interface{}{})
 	fake.pingMutex.Unlock()
-	if fake.PingStub != nil {
-		return fake.PingStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pingReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/gclient/gclientfakes/fake_container.go
+++ b/atc/worker/gclient/gclientfakes/fake_container.go
@@ -268,15 +268,16 @@ func (fake *FakeContainer) Attach(arg1 context.Context, arg2 string, arg3 garden
 		arg2 string
 		arg3 garden.ProcessIO
 	}{arg1, arg2, arg3})
+	stub := fake.AttachStub
+	fakeReturns := fake.attachReturns
 	fake.recordInvocation("Attach", []interface{}{arg1, arg2, arg3})
 	fake.attachMutex.Unlock()
-	if fake.AttachStub != nil {
-		return fake.AttachStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.attachReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -336,15 +337,16 @@ func (fake *FakeContainer) BulkNetOut(arg1 []garden.NetOutRule) error {
 	fake.bulkNetOutArgsForCall = append(fake.bulkNetOutArgsForCall, struct {
 		arg1 []garden.NetOutRule
 	}{arg1Copy})
+	stub := fake.BulkNetOutStub
+	fakeReturns := fake.bulkNetOutReturns
 	fake.recordInvocation("BulkNetOut", []interface{}{arg1Copy})
 	fake.bulkNetOutMutex.Unlock()
-	if fake.BulkNetOutStub != nil {
-		return fake.BulkNetOutStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.bulkNetOutReturns
 	return fakeReturns.result1
 }
 
@@ -395,15 +397,16 @@ func (fake *FakeContainer) CurrentBandwidthLimits() (garden.BandwidthLimits, err
 	ret, specificReturn := fake.currentBandwidthLimitsReturnsOnCall[len(fake.currentBandwidthLimitsArgsForCall)]
 	fake.currentBandwidthLimitsArgsForCall = append(fake.currentBandwidthLimitsArgsForCall, struct {
 	}{})
+	stub := fake.CurrentBandwidthLimitsStub
+	fakeReturns := fake.currentBandwidthLimitsReturns
 	fake.recordInvocation("CurrentBandwidthLimits", []interface{}{})
 	fake.currentBandwidthLimitsMutex.Unlock()
-	if fake.CurrentBandwidthLimitsStub != nil {
-		return fake.CurrentBandwidthLimitsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentBandwidthLimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -450,15 +453,16 @@ func (fake *FakeContainer) CurrentCPULimits() (garden.CPULimits, error) {
 	ret, specificReturn := fake.currentCPULimitsReturnsOnCall[len(fake.currentCPULimitsArgsForCall)]
 	fake.currentCPULimitsArgsForCall = append(fake.currentCPULimitsArgsForCall, struct {
 	}{})
+	stub := fake.CurrentCPULimitsStub
+	fakeReturns := fake.currentCPULimitsReturns
 	fake.recordInvocation("CurrentCPULimits", []interface{}{})
 	fake.currentCPULimitsMutex.Unlock()
-	if fake.CurrentCPULimitsStub != nil {
-		return fake.CurrentCPULimitsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentCPULimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -505,15 +509,16 @@ func (fake *FakeContainer) CurrentDiskLimits() (garden.DiskLimits, error) {
 	ret, specificReturn := fake.currentDiskLimitsReturnsOnCall[len(fake.currentDiskLimitsArgsForCall)]
 	fake.currentDiskLimitsArgsForCall = append(fake.currentDiskLimitsArgsForCall, struct {
 	}{})
+	stub := fake.CurrentDiskLimitsStub
+	fakeReturns := fake.currentDiskLimitsReturns
 	fake.recordInvocation("CurrentDiskLimits", []interface{}{})
 	fake.currentDiskLimitsMutex.Unlock()
-	if fake.CurrentDiskLimitsStub != nil {
-		return fake.CurrentDiskLimitsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentDiskLimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -560,15 +565,16 @@ func (fake *FakeContainer) CurrentMemoryLimits() (garden.MemoryLimits, error) {
 	ret, specificReturn := fake.currentMemoryLimitsReturnsOnCall[len(fake.currentMemoryLimitsArgsForCall)]
 	fake.currentMemoryLimitsArgsForCall = append(fake.currentMemoryLimitsArgsForCall, struct {
 	}{})
+	stub := fake.CurrentMemoryLimitsStub
+	fakeReturns := fake.currentMemoryLimitsReturns
 	fake.recordInvocation("CurrentMemoryLimits", []interface{}{})
 	fake.currentMemoryLimitsMutex.Unlock()
-	if fake.CurrentMemoryLimitsStub != nil {
-		return fake.CurrentMemoryLimitsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentMemoryLimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -615,15 +621,16 @@ func (fake *FakeContainer) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -667,15 +674,16 @@ func (fake *FakeContainer) Info() (garden.ContainerInfo, error) {
 	ret, specificReturn := fake.infoReturnsOnCall[len(fake.infoArgsForCall)]
 	fake.infoArgsForCall = append(fake.infoArgsForCall, struct {
 	}{})
+	stub := fake.InfoStub
+	fakeReturns := fake.infoReturns
 	fake.recordInvocation("Info", []interface{}{})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
-		return fake.InfoStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.infoReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -722,15 +730,16 @@ func (fake *FakeContainer) Metrics() (garden.Metrics, error) {
 	ret, specificReturn := fake.metricsReturnsOnCall[len(fake.metricsArgsForCall)]
 	fake.metricsArgsForCall = append(fake.metricsArgsForCall, struct {
 	}{})
+	stub := fake.MetricsStub
+	fakeReturns := fake.metricsReturns
 	fake.recordInvocation("Metrics", []interface{}{})
 	fake.metricsMutex.Unlock()
-	if fake.MetricsStub != nil {
-		return fake.MetricsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.metricsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -779,15 +788,16 @@ func (fake *FakeContainer) NetIn(arg1 uint32, arg2 uint32) (uint32, uint32, erro
 		arg1 uint32
 		arg2 uint32
 	}{arg1, arg2})
+	stub := fake.NetInStub
+	fakeReturns := fake.netInReturns
 	fake.recordInvocation("NetIn", []interface{}{arg1, arg2})
 	fake.netInMutex.Unlock()
-	if fake.NetInStub != nil {
-		return fake.NetInStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.netInReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -845,15 +855,16 @@ func (fake *FakeContainer) NetOut(arg1 garden.NetOutRule) error {
 	fake.netOutArgsForCall = append(fake.netOutArgsForCall, struct {
 		arg1 garden.NetOutRule
 	}{arg1})
+	stub := fake.NetOutStub
+	fakeReturns := fake.netOutReturns
 	fake.recordInvocation("NetOut", []interface{}{arg1})
 	fake.netOutMutex.Unlock()
-	if fake.NetOutStub != nil {
-		return fake.NetOutStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.netOutReturns
 	return fakeReturns.result1
 }
 
@@ -904,15 +915,16 @@ func (fake *FakeContainer) Properties() (garden.Properties, error) {
 	ret, specificReturn := fake.propertiesReturnsOnCall[len(fake.propertiesArgsForCall)]
 	fake.propertiesArgsForCall = append(fake.propertiesArgsForCall, struct {
 	}{})
+	stub := fake.PropertiesStub
+	fakeReturns := fake.propertiesReturns
 	fake.recordInvocation("Properties", []interface{}{})
 	fake.propertiesMutex.Unlock()
-	if fake.PropertiesStub != nil {
-		return fake.PropertiesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.propertiesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -960,15 +972,16 @@ func (fake *FakeContainer) Property(arg1 string) (string, error) {
 	fake.propertyArgsForCall = append(fake.propertyArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PropertyStub
+	fakeReturns := fake.propertyReturns
 	fake.recordInvocation("Property", []interface{}{arg1})
 	fake.propertyMutex.Unlock()
-	if fake.PropertyStub != nil {
-		return fake.PropertyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.propertyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1023,15 +1036,16 @@ func (fake *FakeContainer) RemoveProperty(arg1 string) error {
 	fake.removePropertyArgsForCall = append(fake.removePropertyArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RemovePropertyStub
+	fakeReturns := fake.removePropertyReturns
 	fake.recordInvocation("RemoveProperty", []interface{}{arg1})
 	fake.removePropertyMutex.Unlock()
-	if fake.RemovePropertyStub != nil {
-		return fake.RemovePropertyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removePropertyReturns
 	return fakeReturns.result1
 }
 
@@ -1085,15 +1099,16 @@ func (fake *FakeContainer) Run(arg1 context.Context, arg2 garden.ProcessSpec, ar
 		arg2 garden.ProcessSpec
 		arg3 garden.ProcessIO
 	}{arg1, arg2, arg3})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1, arg2, arg3})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1148,15 +1163,16 @@ func (fake *FakeContainer) SetGraceTime(arg1 time.Duration) error {
 	fake.setGraceTimeArgsForCall = append(fake.setGraceTimeArgsForCall, struct {
 		arg1 time.Duration
 	}{arg1})
+	stub := fake.SetGraceTimeStub
+	fakeReturns := fake.setGraceTimeReturns
 	fake.recordInvocation("SetGraceTime", []interface{}{arg1})
 	fake.setGraceTimeMutex.Unlock()
-	if fake.SetGraceTimeStub != nil {
-		return fake.SetGraceTimeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setGraceTimeReturns
 	return fakeReturns.result1
 }
 
@@ -1209,15 +1225,16 @@ func (fake *FakeContainer) SetProperty(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SetPropertyStub
+	fakeReturns := fake.setPropertyReturns
 	fake.recordInvocation("SetProperty", []interface{}{arg1, arg2})
 	fake.setPropertyMutex.Unlock()
-	if fake.SetPropertyStub != nil {
-		return fake.SetPropertyStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setPropertyReturns
 	return fakeReturns.result1
 }
 
@@ -1269,15 +1286,16 @@ func (fake *FakeContainer) Stop(arg1 bool) error {
 	fake.stopArgsForCall = append(fake.stopArgsForCall, struct {
 		arg1 bool
 	}{arg1})
+	stub := fake.StopStub
+	fakeReturns := fake.stopReturns
 	fake.recordInvocation("Stop", []interface{}{arg1})
 	fake.stopMutex.Unlock()
-	if fake.StopStub != nil {
-		return fake.StopStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stopReturns
 	return fakeReturns.result1
 }
 
@@ -1329,15 +1347,16 @@ func (fake *FakeContainer) StreamIn(arg1 garden.StreamInSpec) error {
 	fake.streamInArgsForCall = append(fake.streamInArgsForCall, struct {
 		arg1 garden.StreamInSpec
 	}{arg1})
+	stub := fake.StreamInStub
+	fakeReturns := fake.streamInReturns
 	fake.recordInvocation("StreamIn", []interface{}{arg1})
 	fake.streamInMutex.Unlock()
-	if fake.StreamInStub != nil {
-		return fake.StreamInStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.streamInReturns
 	return fakeReturns.result1
 }
 
@@ -1389,15 +1408,16 @@ func (fake *FakeContainer) StreamOut(arg1 garden.StreamOutSpec) (io.ReadCloser, 
 	fake.streamOutArgsForCall = append(fake.streamOutArgsForCall, struct {
 		arg1 garden.StreamOutSpec
 	}{arg1})
+	stub := fake.StreamOutStub
+	fakeReturns := fake.streamOutReturns
 	fake.recordInvocation("StreamOut", []interface{}{arg1})
 	fake.streamOutMutex.Unlock()
-	if fake.StreamOutStub != nil {
-		return fake.StreamOutStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.streamOutReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/transport/transportfakes/fake_read_closer.go
+++ b/atc/worker/transport/transportfakes/fake_read_closer.go
@@ -40,15 +40,16 @@ func (fake *FakeReadCloser) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -98,15 +99,16 @@ func (fake *FakeReadCloser) Read(arg1 []byte) (int, error) {
 	fake.readArgsForCall = append(fake.readArgsForCall, struct {
 		arg1 []byte
 	}{arg1Copy})
+	stub := fake.ReadStub
+	fakeReturns := fake.readReturns
 	fake.recordInvocation("Read", []interface{}{arg1Copy})
 	fake.readMutex.Unlock()
-	if fake.ReadStub != nil {
-		return fake.ReadStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/transport/transportfakes/fake_request_generator.go
+++ b/atc/worker/transport/transportfakes/fake_request_generator.go
@@ -38,15 +38,16 @@ func (fake *FakeRequestGenerator) CreateRequest(arg1 string, arg2 rata.Params, a
 		arg2 rata.Params
 		arg3 io.Reader
 	}{arg1, arg2, arg3})
+	stub := fake.CreateRequestStub
+	fakeReturns := fake.createRequestReturns
 	fake.recordInvocation("CreateRequest", []interface{}{arg1, arg2, arg3})
 	fake.createRequestMutex.Unlock()
-	if fake.CreateRequestStub != nil {
-		return fake.CreateRequestStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createRequestReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/transport/transportfakes/fake_round_tripper.go
+++ b/atc/worker/transport/transportfakes/fake_round_tripper.go
@@ -32,15 +32,16 @@ func (fake *FakeRoundTripper) RoundTrip(arg1 *http.Request) (*http.Response, err
 	fake.roundTripArgsForCall = append(fake.roundTripArgsForCall, struct {
 		arg1 *http.Request
 	}{arg1})
+	stub := fake.RoundTripStub
+	fakeReturns := fake.roundTripReturns
 	fake.recordInvocation("RoundTrip", []interface{}{arg1})
 	fake.roundTripMutex.Unlock()
-	if fake.RoundTripStub != nil {
-		return fake.RoundTripStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.roundTripReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/transport/transportfakes/fake_transport_db.go
+++ b/atc/worker/transport/transportfakes/fake_transport_db.go
@@ -34,15 +34,16 @@ func (fake *FakeTransportDB) GetWorker(arg1 string) (db.Worker, bool, error) {
 	fake.getWorkerArgsForCall = append(fake.getWorkerArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetWorkerStub
+	fakeReturns := fake.getWorkerReturns
 	fake.recordInvocation("GetWorker", []interface{}{arg1})
 	fake.getWorkerMutex.Unlock()
-	if fake.GetWorkerStub != nil {
-		return fake.GetWorkerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/worker/workerfakes/fake_artifact_destination.go
+++ b/atc/worker/workerfakes/fake_artifact_destination.go
@@ -50,15 +50,16 @@ func (fake *FakeArtifactDestination) GetStreamInP2pUrl(arg1 context.Context, arg
 		arg1 context.Context
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetStreamInP2pUrlStub
+	fakeReturns := fake.getStreamInP2pUrlReturns
 	fake.recordInvocation("GetStreamInP2pUrl", []interface{}{arg1, arg2})
 	fake.getStreamInP2pUrlMutex.Unlock()
-	if fake.GetStreamInP2pUrlStub != nil {
-		return fake.GetStreamInP2pUrlStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getStreamInP2pUrlReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -116,15 +117,16 @@ func (fake *FakeArtifactDestination) StreamIn(arg1 context.Context, arg2 string,
 		arg3 baggageclaim.Encoding
 		arg4 io.Reader
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.StreamInStub
+	fakeReturns := fake.streamInReturns
 	fake.recordInvocation("StreamIn", []interface{}{arg1, arg2, arg3, arg4})
 	fake.streamInMutex.Unlock()
-	if fake.StreamInStub != nil {
-		return fake.StreamInStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.streamInReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/workerfakes/fake_artifact_source.go
+++ b/atc/worker/workerfakes/fake_artifact_source.go
@@ -36,15 +36,16 @@ func (fake *FakeArtifactSource) ExistsOn(arg1 lager.Logger, arg2 worker.Worker) 
 		arg1 lager.Logger
 		arg2 worker.Worker
 	}{arg1, arg2})
+	stub := fake.ExistsOnStub
+	fakeReturns := fake.existsOnReturns
 	fake.recordInvocation("ExistsOn", []interface{}{arg1, arg2})
 	fake.existsOnMutex.Unlock()
-	if fake.ExistsOnStub != nil {
-		return fake.ExistsOnStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.existsOnReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/worker/workerfakes/fake_artifact_sourcer.go
+++ b/atc/worker/workerfakes/fake_artifact_sourcer.go
@@ -50,15 +50,16 @@ func (fake *FakeArtifactSourcer) SourceImage(arg1 lager.Logger, arg2 runtime.Art
 		arg1 lager.Logger
 		arg2 runtime.Artifact
 	}{arg1, arg2})
+	stub := fake.SourceImageStub
+	fakeReturns := fake.sourceImageReturns
 	fake.recordInvocation("SourceImage", []interface{}{arg1, arg2})
 	fake.sourceImageMutex.Unlock()
-	if fake.SourceImageStub != nil {
-		return fake.SourceImageStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sourceImageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -115,15 +116,16 @@ func (fake *FakeArtifactSourcer) SourceInputsAndCaches(arg1 lager.Logger, arg2 i
 		arg2 int
 		arg3 map[string]runtime.Artifact
 	}{arg1, arg2, arg3})
+	stub := fake.SourceInputsAndCachesStub
+	fakeReturns := fake.sourceInputsAndCachesReturns
 	fake.recordInvocation("SourceInputsAndCaches", []interface{}{arg1, arg2, arg3})
 	fake.sourceInputsAndCachesMutex.Unlock()
-	if fake.SourceInputsAndCachesStub != nil {
-		return fake.SourceInputsAndCachesStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sourceInputsAndCachesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/workerfakes/fake_artifact_streamer.go
+++ b/atc/worker/workerfakes/fake_artifact_streamer.go
@@ -38,15 +38,16 @@ func (fake *FakeArtifactStreamer) StreamFileFromArtifact(arg1 context.Context, a
 		arg2 runtime.Artifact
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.StreamFileFromArtifactStub
+	fakeReturns := fake.streamFileFromArtifactReturns
 	fake.recordInvocation("StreamFileFromArtifact", []interface{}{arg1, arg2, arg3})
 	fake.streamFileFromArtifactMutex.Unlock()
-	if fake.StreamFileFromArtifactStub != nil {
-		return fake.StreamFileFromArtifactStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.streamFileFromArtifactReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/workerfakes/fake_bind_mount_source.go
+++ b/atc/worker/workerfakes/fake_bind_mount_source.go
@@ -34,15 +34,16 @@ func (fake *FakeBindMountSource) VolumeOn(arg1 worker.Worker) (garden.BindMount,
 	fake.volumeOnArgsForCall = append(fake.volumeOnArgsForCall, struct {
 		arg1 worker.Worker
 	}{arg1})
+	stub := fake.VolumeOnStub
+	fakeReturns := fake.volumeOnReturns
 	fake.recordInvocation("VolumeOn", []interface{}{arg1})
 	fake.volumeOnMutex.Unlock()
-	if fake.VolumeOnStub != nil {
-		return fake.VolumeOnStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.volumeOnReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/worker/workerfakes/fake_client.go
+++ b/atc/worker/workerfakes/fake_client.go
@@ -107,15 +107,16 @@ func (fake *FakeClient) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -166,15 +167,16 @@ func (fake *FakeClient) RunCheckStep(arg1 context.Context, arg2 db.ContainerOwne
 		arg6 runtime.StartingEventDelegate
 		arg7 resource.Resource
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	stub := fake.RunCheckStepStub
+	fakeReturns := fake.runCheckStepReturns
 	fake.recordInvocation("RunCheckStep", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	fake.runCheckStepMutex.Unlock()
-	if fake.RunCheckStepStub != nil {
-		return fake.RunCheckStepStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runCheckStepReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -236,15 +238,16 @@ func (fake *FakeClient) RunGetStep(arg1 context.Context, arg2 db.ContainerOwner,
 		arg7 db.UsedResourceCache
 		arg8 resource.Resource
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
+	stub := fake.RunGetStepStub
+	fakeReturns := fake.runGetStepReturns
 	fake.recordInvocation("RunGetStep", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
 	fake.runGetStepMutex.Unlock()
-	if fake.RunGetStepStub != nil {
-		return fake.RunGetStepStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runGetStepReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -305,15 +308,16 @@ func (fake *FakeClient) RunPutStep(arg1 context.Context, arg2 db.ContainerOwner,
 		arg6 runtime.StartingEventDelegate
 		arg7 resource.Resource
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	stub := fake.RunPutStepStub
+	fakeReturns := fake.runPutStepReturns
 	fake.recordInvocation("RunPutStep", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	fake.runPutStepMutex.Unlock()
-	if fake.RunPutStepStub != nil {
-		return fake.RunPutStepStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runPutStepReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -373,15 +377,16 @@ func (fake *FakeClient) RunTaskStep(arg1 context.Context, arg2 db.ContainerOwner
 		arg5 runtime.ProcessSpec
 		arg6 runtime.StartingEventDelegate
 	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	stub := fake.RunTaskStepStub
+	fakeReturns := fake.runTaskStepReturns
 	fake.recordInvocation("RunTaskStep", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.runTaskStepMutex.Unlock()
-	if fake.RunTaskStepStub != nil {
-		return fake.RunTaskStepStub(arg1, arg2, arg3, arg4, arg5, arg6)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runTaskStepReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/workerfakes/fake_container.go
+++ b/atc/worker/workerfakes/fake_container.go
@@ -325,15 +325,16 @@ func (fake *FakeContainer) Attach(arg1 context.Context, arg2 string, arg3 garden
 		arg2 string
 		arg3 garden.ProcessIO
 	}{arg1, arg2, arg3})
+	stub := fake.AttachStub
+	fakeReturns := fake.attachReturns
 	fake.recordInvocation("Attach", []interface{}{arg1, arg2, arg3})
 	fake.attachMutex.Unlock()
-	if fake.AttachStub != nil {
-		return fake.AttachStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.attachReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -393,15 +394,16 @@ func (fake *FakeContainer) BulkNetOut(arg1 []garden.NetOutRule) error {
 	fake.bulkNetOutArgsForCall = append(fake.bulkNetOutArgsForCall, struct {
 		arg1 []garden.NetOutRule
 	}{arg1Copy})
+	stub := fake.BulkNetOutStub
+	fakeReturns := fake.bulkNetOutReturns
 	fake.recordInvocation("BulkNetOut", []interface{}{arg1Copy})
 	fake.bulkNetOutMutex.Unlock()
-	if fake.BulkNetOutStub != nil {
-		return fake.BulkNetOutStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.bulkNetOutReturns
 	return fakeReturns.result1
 }
 
@@ -452,15 +454,16 @@ func (fake *FakeContainer) CurrentBandwidthLimits() (garden.BandwidthLimits, err
 	ret, specificReturn := fake.currentBandwidthLimitsReturnsOnCall[len(fake.currentBandwidthLimitsArgsForCall)]
 	fake.currentBandwidthLimitsArgsForCall = append(fake.currentBandwidthLimitsArgsForCall, struct {
 	}{})
+	stub := fake.CurrentBandwidthLimitsStub
+	fakeReturns := fake.currentBandwidthLimitsReturns
 	fake.recordInvocation("CurrentBandwidthLimits", []interface{}{})
 	fake.currentBandwidthLimitsMutex.Unlock()
-	if fake.CurrentBandwidthLimitsStub != nil {
-		return fake.CurrentBandwidthLimitsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentBandwidthLimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -507,15 +510,16 @@ func (fake *FakeContainer) CurrentCPULimits() (garden.CPULimits, error) {
 	ret, specificReturn := fake.currentCPULimitsReturnsOnCall[len(fake.currentCPULimitsArgsForCall)]
 	fake.currentCPULimitsArgsForCall = append(fake.currentCPULimitsArgsForCall, struct {
 	}{})
+	stub := fake.CurrentCPULimitsStub
+	fakeReturns := fake.currentCPULimitsReturns
 	fake.recordInvocation("CurrentCPULimits", []interface{}{})
 	fake.currentCPULimitsMutex.Unlock()
-	if fake.CurrentCPULimitsStub != nil {
-		return fake.CurrentCPULimitsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentCPULimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -562,15 +566,16 @@ func (fake *FakeContainer) CurrentDiskLimits() (garden.DiskLimits, error) {
 	ret, specificReturn := fake.currentDiskLimitsReturnsOnCall[len(fake.currentDiskLimitsArgsForCall)]
 	fake.currentDiskLimitsArgsForCall = append(fake.currentDiskLimitsArgsForCall, struct {
 	}{})
+	stub := fake.CurrentDiskLimitsStub
+	fakeReturns := fake.currentDiskLimitsReturns
 	fake.recordInvocation("CurrentDiskLimits", []interface{}{})
 	fake.currentDiskLimitsMutex.Unlock()
-	if fake.CurrentDiskLimitsStub != nil {
-		return fake.CurrentDiskLimitsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentDiskLimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -617,15 +622,16 @@ func (fake *FakeContainer) CurrentMemoryLimits() (garden.MemoryLimits, error) {
 	ret, specificReturn := fake.currentMemoryLimitsReturnsOnCall[len(fake.currentMemoryLimitsArgsForCall)]
 	fake.currentMemoryLimitsArgsForCall = append(fake.currentMemoryLimitsArgsForCall, struct {
 	}{})
+	stub := fake.CurrentMemoryLimitsStub
+	fakeReturns := fake.currentMemoryLimitsReturns
 	fake.recordInvocation("CurrentMemoryLimits", []interface{}{})
 	fake.currentMemoryLimitsMutex.Unlock()
-	if fake.CurrentMemoryLimitsStub != nil {
-		return fake.CurrentMemoryLimitsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentMemoryLimitsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -672,15 +678,16 @@ func (fake *FakeContainer) Destroy() error {
 	ret, specificReturn := fake.destroyReturnsOnCall[len(fake.destroyArgsForCall)]
 	fake.destroyArgsForCall = append(fake.destroyArgsForCall, struct {
 	}{})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1
 }
 
@@ -724,15 +731,16 @@ func (fake *FakeContainer) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -776,15 +784,16 @@ func (fake *FakeContainer) Info() (garden.ContainerInfo, error) {
 	ret, specificReturn := fake.infoReturnsOnCall[len(fake.infoArgsForCall)]
 	fake.infoArgsForCall = append(fake.infoArgsForCall, struct {
 	}{})
+	stub := fake.InfoStub
+	fakeReturns := fake.infoReturns
 	fake.recordInvocation("Info", []interface{}{})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
-		return fake.InfoStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.infoReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -831,15 +840,16 @@ func (fake *FakeContainer) Metrics() (garden.Metrics, error) {
 	ret, specificReturn := fake.metricsReturnsOnCall[len(fake.metricsArgsForCall)]
 	fake.metricsArgsForCall = append(fake.metricsArgsForCall, struct {
 	}{})
+	stub := fake.MetricsStub
+	fakeReturns := fake.metricsReturns
 	fake.recordInvocation("Metrics", []interface{}{})
 	fake.metricsMutex.Unlock()
-	if fake.MetricsStub != nil {
-		return fake.MetricsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.metricsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -888,15 +898,16 @@ func (fake *FakeContainer) NetIn(arg1 uint32, arg2 uint32) (uint32, uint32, erro
 		arg1 uint32
 		arg2 uint32
 	}{arg1, arg2})
+	stub := fake.NetInStub
+	fakeReturns := fake.netInReturns
 	fake.recordInvocation("NetIn", []interface{}{arg1, arg2})
 	fake.netInMutex.Unlock()
-	if fake.NetInStub != nil {
-		return fake.NetInStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.netInReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -954,15 +965,16 @@ func (fake *FakeContainer) NetOut(arg1 garden.NetOutRule) error {
 	fake.netOutArgsForCall = append(fake.netOutArgsForCall, struct {
 		arg1 garden.NetOutRule
 	}{arg1})
+	stub := fake.NetOutStub
+	fakeReturns := fake.netOutReturns
 	fake.recordInvocation("NetOut", []interface{}{arg1})
 	fake.netOutMutex.Unlock()
-	if fake.NetOutStub != nil {
-		return fake.NetOutStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.netOutReturns
 	return fakeReturns.result1
 }
 
@@ -1013,15 +1025,16 @@ func (fake *FakeContainer) Properties() (garden.Properties, error) {
 	ret, specificReturn := fake.propertiesReturnsOnCall[len(fake.propertiesArgsForCall)]
 	fake.propertiesArgsForCall = append(fake.propertiesArgsForCall, struct {
 	}{})
+	stub := fake.PropertiesStub
+	fakeReturns := fake.propertiesReturns
 	fake.recordInvocation("Properties", []interface{}{})
 	fake.propertiesMutex.Unlock()
-	if fake.PropertiesStub != nil {
-		return fake.PropertiesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.propertiesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1069,15 +1082,16 @@ func (fake *FakeContainer) Property(arg1 string) (string, error) {
 	fake.propertyArgsForCall = append(fake.propertyArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PropertyStub
+	fakeReturns := fake.propertyReturns
 	fake.recordInvocation("Property", []interface{}{arg1})
 	fake.propertyMutex.Unlock()
-	if fake.PropertyStub != nil {
-		return fake.PropertyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.propertyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1132,15 +1146,16 @@ func (fake *FakeContainer) RemoveProperty(arg1 string) error {
 	fake.removePropertyArgsForCall = append(fake.removePropertyArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RemovePropertyStub
+	fakeReturns := fake.removePropertyReturns
 	fake.recordInvocation("RemoveProperty", []interface{}{arg1})
 	fake.removePropertyMutex.Unlock()
-	if fake.RemovePropertyStub != nil {
-		return fake.RemovePropertyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removePropertyReturns
 	return fakeReturns.result1
 }
 
@@ -1194,15 +1209,16 @@ func (fake *FakeContainer) Run(arg1 context.Context, arg2 garden.ProcessSpec, ar
 		arg2 garden.ProcessSpec
 		arg3 garden.ProcessIO
 	}{arg1, arg2, arg3})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1, arg2, arg3})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1273,15 +1289,16 @@ func (fake *FakeContainer) RunScript(arg1 context.Context, arg2 string, arg3 []s
 		arg6 io.Writer
 		arg7 bool
 	}{arg1, arg2, arg3Copy, arg4Copy, arg5, arg6, arg7})
+	stub := fake.RunScriptStub
+	fakeReturns := fake.runScriptReturns
 	fake.recordInvocation("RunScript", []interface{}{arg1, arg2, arg3Copy, arg4Copy, arg5, arg6, arg7})
 	fake.runScriptMutex.Unlock()
-	if fake.RunScriptStub != nil {
-		return fake.RunScriptStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.runScriptReturns
 	return fakeReturns.result1
 }
 
@@ -1333,15 +1350,16 @@ func (fake *FakeContainer) SetGraceTime(arg1 time.Duration) error {
 	fake.setGraceTimeArgsForCall = append(fake.setGraceTimeArgsForCall, struct {
 		arg1 time.Duration
 	}{arg1})
+	stub := fake.SetGraceTimeStub
+	fakeReturns := fake.setGraceTimeReturns
 	fake.recordInvocation("SetGraceTime", []interface{}{arg1})
 	fake.setGraceTimeMutex.Unlock()
-	if fake.SetGraceTimeStub != nil {
-		return fake.SetGraceTimeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setGraceTimeReturns
 	return fakeReturns.result1
 }
 
@@ -1394,15 +1412,16 @@ func (fake *FakeContainer) SetProperty(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SetPropertyStub
+	fakeReturns := fake.setPropertyReturns
 	fake.recordInvocation("SetProperty", []interface{}{arg1, arg2})
 	fake.setPropertyMutex.Unlock()
-	if fake.SetPropertyStub != nil {
-		return fake.SetPropertyStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setPropertyReturns
 	return fakeReturns.result1
 }
 
@@ -1454,15 +1473,16 @@ func (fake *FakeContainer) Stop(arg1 bool) error {
 	fake.stopArgsForCall = append(fake.stopArgsForCall, struct {
 		arg1 bool
 	}{arg1})
+	stub := fake.StopStub
+	fakeReturns := fake.stopReturns
 	fake.recordInvocation("Stop", []interface{}{arg1})
 	fake.stopMutex.Unlock()
-	if fake.StopStub != nil {
-		return fake.StopStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stopReturns
 	return fakeReturns.result1
 }
 
@@ -1514,15 +1534,16 @@ func (fake *FakeContainer) StreamIn(arg1 garden.StreamInSpec) error {
 	fake.streamInArgsForCall = append(fake.streamInArgsForCall, struct {
 		arg1 garden.StreamInSpec
 	}{arg1})
+	stub := fake.StreamInStub
+	fakeReturns := fake.streamInReturns
 	fake.recordInvocation("StreamIn", []interface{}{arg1})
 	fake.streamInMutex.Unlock()
-	if fake.StreamInStub != nil {
-		return fake.StreamInStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.streamInReturns
 	return fakeReturns.result1
 }
 
@@ -1574,15 +1595,16 @@ func (fake *FakeContainer) StreamOut(arg1 garden.StreamOutSpec) (io.ReadCloser, 
 	fake.streamOutArgsForCall = append(fake.streamOutArgsForCall, struct {
 		arg1 garden.StreamOutSpec
 	}{arg1})
+	stub := fake.StreamOutStub
+	fakeReturns := fake.streamOutReturns
 	fake.recordInvocation("StreamOut", []interface{}{arg1})
 	fake.streamOutMutex.Unlock()
-	if fake.StreamOutStub != nil {
-		return fake.StreamOutStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.streamOutReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1636,15 +1658,16 @@ func (fake *FakeContainer) UpdateLastHijack() error {
 	ret, specificReturn := fake.updateLastHijackReturnsOnCall[len(fake.updateLastHijackArgsForCall)]
 	fake.updateLastHijackArgsForCall = append(fake.updateLastHijackArgsForCall, struct {
 	}{})
+	stub := fake.UpdateLastHijackStub
+	fakeReturns := fake.updateLastHijackReturns
 	fake.recordInvocation("UpdateLastHijack", []interface{}{})
 	fake.updateLastHijackMutex.Unlock()
-	if fake.UpdateLastHijackStub != nil {
-		return fake.UpdateLastHijackStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateLastHijackReturns
 	return fakeReturns.result1
 }
 
@@ -1688,15 +1711,16 @@ func (fake *FakeContainer) VolumeMounts() []worker.VolumeMount {
 	ret, specificReturn := fake.volumeMountsReturnsOnCall[len(fake.volumeMountsArgsForCall)]
 	fake.volumeMountsArgsForCall = append(fake.volumeMountsArgsForCall, struct {
 	}{})
+	stub := fake.VolumeMountsStub
+	fakeReturns := fake.volumeMountsReturns
 	fake.recordInvocation("VolumeMounts", []interface{}{})
 	fake.volumeMountsMutex.Unlock()
-	if fake.VolumeMountsStub != nil {
-		return fake.VolumeMountsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.volumeMountsReturns
 	return fakeReturns.result1
 }
 
@@ -1740,15 +1764,16 @@ func (fake *FakeContainer) WorkerName() string {
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
 	fake.workerNameArgsForCall = append(fake.workerNameArgsForCall, struct {
 	}{})
+	stub := fake.WorkerNameStub
+	fakeReturns := fake.workerNameReturns
 	fake.recordInvocation("WorkerName", []interface{}{})
 	fake.workerNameMutex.Unlock()
-	if fake.WorkerNameStub != nil {
-		return fake.WorkerNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerNameReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/workerfakes/fake_container_placement_strategy.go
+++ b/atc/worker/workerfakes/fake_container_placement_strategy.go
@@ -51,15 +51,16 @@ func (fake *FakeContainerPlacementStrategy) Choose(arg1 lager.Logger, arg2 []wor
 		arg2 []worker.Worker
 		arg3 worker.ContainerSpec
 	}{arg1, arg2Copy, arg3})
+	stub := fake.ChooseStub
+	fakeReturns := fake.chooseReturns
 	fake.recordInvocation("Choose", []interface{}{arg1, arg2Copy, arg3})
 	fake.chooseMutex.Unlock()
-	if fake.ChooseStub != nil {
-		return fake.ChooseStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.chooseReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -113,15 +114,16 @@ func (fake *FakeContainerPlacementStrategy) ModifiesActiveTasks() bool {
 	ret, specificReturn := fake.modifiesActiveTasksReturnsOnCall[len(fake.modifiesActiveTasksArgsForCall)]
 	fake.modifiesActiveTasksArgsForCall = append(fake.modifiesActiveTasksArgsForCall, struct {
 	}{})
+	stub := fake.ModifiesActiveTasksStub
+	fakeReturns := fake.modifiesActiveTasksReturns
 	fake.recordInvocation("ModifiesActiveTasks", []interface{}{})
 	fake.modifiesActiveTasksMutex.Unlock()
-	if fake.ModifiesActiveTasksStub != nil {
-		return fake.ModifiesActiveTasksStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.modifiesActiveTasksReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/workerfakes/fake_fetch_source.go
+++ b/atc/worker/workerfakes/fake_fetch_source.go
@@ -50,15 +50,16 @@ func (fake *FakeFetchSource) Create(arg1 context.Context) (worker.GetResult, wor
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -115,15 +116,16 @@ func (fake *FakeFetchSource) Find() (worker.GetResult, worker.Volume, bool, erro
 	ret, specificReturn := fake.findReturnsOnCall[len(fake.findArgsForCall)]
 	fake.findArgsForCall = append(fake.findArgsForCall, struct {
 	}{})
+	stub := fake.FindStub
+	fakeReturns := fake.findReturns
 	fake.recordInvocation("Find", []interface{}{})
 	fake.findMutex.Unlock()
-	if fake.FindStub != nil {
-		return fake.FindStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.findReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 

--- a/atc/worker/workerfakes/fake_fetch_source_factory.go
+++ b/atc/worker/workerfakes/fake_fetch_source_factory.go
@@ -47,15 +47,16 @@ func (fake *FakeFetchSourceFactory) NewFetchSource(arg1 lager.Logger, arg2 worke
 		arg7 runtime.ProcessSpec
 		arg8 db.ContainerMetadata
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
+	stub := fake.NewFetchSourceStub
+	fakeReturns := fake.newFetchSourceReturns
 	fake.recordInvocation("NewFetchSource", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
 	fake.newFetchSourceMutex.Unlock()
-	if fake.NewFetchSourceStub != nil {
-		return fake.NewFetchSourceStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newFetchSourceReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/workerfakes/fake_fetcher.go
+++ b/atc/worker/workerfakes/fake_fetcher.go
@@ -56,15 +56,16 @@ func (fake *FakeFetcher) Fetch(arg1 context.Context, arg2 lager.Logger, arg3 db.
 		arg9  db.UsedResourceCache
 		arg10 string
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10})
+	stub := fake.FetchStub
+	fakeReturns := fake.fetchReturns
 	fake.recordInvocation("Fetch", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10})
 	fake.fetchMutex.Unlock()
-	if fake.FetchStub != nil {
-		return fake.FetchStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.fetchReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/worker/workerfakes/fake_image.go
+++ b/atc/worker/workerfakes/fake_image.go
@@ -38,15 +38,16 @@ func (fake *FakeImage) FetchForContainer(arg1 context.Context, arg2 lager.Logger
 		arg2 lager.Logger
 		arg3 db.CreatingContainer
 	}{arg1, arg2, arg3})
+	stub := fake.FetchForContainerStub
+	fakeReturns := fake.fetchForContainerReturns
 	fake.recordInvocation("FetchForContainer", []interface{}{arg1, arg2, arg3})
 	fake.fetchForContainerMutex.Unlock()
-	if fake.FetchForContainerStub != nil {
-		return fake.FetchForContainerStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.fetchForContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/workerfakes/fake_image_factory.go
+++ b/atc/worker/workerfakes/fake_image_factory.go
@@ -40,15 +40,16 @@ func (fake *FakeImageFactory) GetImage(arg1 lager.Logger, arg2 worker.Worker, ar
 		arg4 worker.ImageSpec
 		arg5 int
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.GetImageStub
+	fakeReturns := fake.getImageReturns
 	fake.recordInvocation("GetImage", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.getImageMutex.Unlock()
-	if fake.GetImageStub != nil {
-		return fake.GetImageStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getImageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/workerfakes/fake_input_source.go
+++ b/atc/worker/workerfakes/fake_input_source.go
@@ -37,15 +37,16 @@ func (fake *FakeInputSource) DestinationPath() string {
 	ret, specificReturn := fake.destinationPathReturnsOnCall[len(fake.destinationPathArgsForCall)]
 	fake.destinationPathArgsForCall = append(fake.destinationPathArgsForCall, struct {
 	}{})
+	stub := fake.DestinationPathStub
+	fakeReturns := fake.destinationPathReturns
 	fake.recordInvocation("DestinationPath", []interface{}{})
 	fake.destinationPathMutex.Unlock()
-	if fake.DestinationPathStub != nil {
-		return fake.DestinationPathStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destinationPathReturns
 	return fakeReturns.result1
 }
 
@@ -89,15 +90,16 @@ func (fake *FakeInputSource) Source() worker.ArtifactSource {
 	ret, specificReturn := fake.sourceReturnsOnCall[len(fake.sourceArgsForCall)]
 	fake.sourceArgsForCall = append(fake.sourceArgsForCall, struct {
 	}{})
+	stub := fake.SourceStub
+	fakeReturns := fake.sourceReturns
 	fake.recordInvocation("Source", []interface{}{})
 	fake.sourceMutex.Unlock()
-	if fake.SourceStub != nil {
-		return fake.SourceStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sourceReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/workerfakes/fake_pool.go
+++ b/atc/worker/workerfakes/fake_pool.go
@@ -105,15 +105,16 @@ func (fake *FakePool) ContainerInWorker(arg1 lager.Logger, arg2 db.ContainerOwne
 		arg2 db.ContainerOwner
 		arg3 worker.WorkerSpec
 	}{arg1, arg2, arg3})
+	stub := fake.ContainerInWorkerStub
+	fakeReturns := fake.containerInWorkerReturns
 	fake.recordInvocation("ContainerInWorker", []interface{}{arg1, arg2, arg3})
 	fake.containerInWorkerMutex.Unlock()
-	if fake.ContainerInWorkerStub != nil {
-		return fake.ContainerInWorkerStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.containerInWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -171,15 +172,16 @@ func (fake *FakePool) CreateVolume(arg1 lager.Logger, arg2 worker.VolumeSpec, ar
 		arg3 worker.WorkerSpec
 		arg4 db.VolumeType
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CreateVolumeStub
+	fakeReturns := fake.createVolumeReturns
 	fake.recordInvocation("CreateVolume", []interface{}{arg1, arg2, arg3, arg4})
 	fake.createVolumeMutex.Unlock()
-	if fake.CreateVolumeStub != nil {
-		return fake.CreateVolumeStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -236,15 +238,16 @@ func (fake *FakePool) FindContainer(arg1 lager.Logger, arg2 int, arg3 string) (w
 		arg2 int
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.FindContainerStub
+	fakeReturns := fake.findContainerReturns
 	fake.recordInvocation("FindContainer", []interface{}{arg1, arg2, arg3})
 	fake.findContainerMutex.Unlock()
-	if fake.FindContainerStub != nil {
-		return fake.FindContainerStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findContainerReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -304,15 +307,16 @@ func (fake *FakePool) FindVolume(arg1 lager.Logger, arg2 int, arg3 string) (work
 		arg2 int
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.FindVolumeStub
+	fakeReturns := fake.findVolumeReturns
 	fake.recordInvocation("FindVolume", []interface{}{arg1, arg2, arg3})
 	fake.findVolumeMutex.Unlock()
-	if fake.FindVolumeStub != nil {
-		return fake.FindVolumeStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -374,15 +378,16 @@ func (fake *FakePool) SelectWorker(arg1 context.Context, arg2 db.ContainerOwner,
 		arg4 worker.WorkerSpec
 		arg5 worker.ContainerPlacementStrategy
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.SelectWorkerStub
+	fakeReturns := fake.selectWorkerReturns
 	fake.recordInvocation("SelectWorker", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.selectWorkerMutex.Unlock()
-	if fake.SelectWorkerStub != nil {
-		return fake.SelectWorkerStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.selectWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/worker/workerfakes/fake_streamable_artifact_source.go
+++ b/atc/worker/workerfakes/fake_streamable_artifact_source.go
@@ -64,15 +64,16 @@ func (fake *FakeStreamableArtifactSource) ExistsOn(arg1 lager.Logger, arg2 worke
 		arg1 lager.Logger
 		arg2 worker.Worker
 	}{arg1, arg2})
+	stub := fake.ExistsOnStub
+	fakeReturns := fake.existsOnReturns
 	fake.recordInvocation("ExistsOn", []interface{}{arg1, arg2})
 	fake.existsOnMutex.Unlock()
-	if fake.ExistsOnStub != nil {
-		return fake.ExistsOnStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.existsOnReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -131,15 +132,16 @@ func (fake *FakeStreamableArtifactSource) StreamFile(arg1 context.Context, arg2 
 		arg1 context.Context
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.StreamFileStub
+	fakeReturns := fake.streamFileReturns
 	fake.recordInvocation("StreamFile", []interface{}{arg1, arg2})
 	fake.streamFileMutex.Unlock()
-	if fake.StreamFileStub != nil {
-		return fake.StreamFileStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.streamFileReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -195,15 +197,16 @@ func (fake *FakeStreamableArtifactSource) StreamTo(arg1 context.Context, arg2 wo
 		arg1 context.Context
 		arg2 worker.ArtifactDestination
 	}{arg1, arg2})
+	stub := fake.StreamToStub
+	fakeReturns := fake.streamToReturns
 	fake.recordInvocation("StreamTo", []interface{}{arg1, arg2})
 	fake.streamToMutex.Unlock()
-	if fake.StreamToStub != nil {
-		return fake.StreamToStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.streamToReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/workerfakes/fake_volume.go
+++ b/atc/worker/workerfakes/fake_volume.go
@@ -228,15 +228,16 @@ func (fake *FakeVolume) COWStrategy() baggageclaim.COWStrategy {
 	ret, specificReturn := fake.cOWStrategyReturnsOnCall[len(fake.cOWStrategyArgsForCall)]
 	fake.cOWStrategyArgsForCall = append(fake.cOWStrategyArgsForCall, struct {
 	}{})
+	stub := fake.COWStrategyStub
+	fakeReturns := fake.cOWStrategyReturns
 	fake.recordInvocation("COWStrategy", []interface{}{})
 	fake.cOWStrategyMutex.Unlock()
-	if fake.COWStrategyStub != nil {
-		return fake.COWStrategyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cOWStrategyReturns
 	return fakeReturns.result1
 }
 
@@ -282,15 +283,16 @@ func (fake *FakeVolume) CreateChildForContainer(arg1 db.CreatingContainer, arg2 
 		arg1 db.CreatingContainer
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.CreateChildForContainerStub
+	fakeReturns := fake.createChildForContainerReturns
 	fake.recordInvocation("CreateChildForContainer", []interface{}{arg1, arg2})
 	fake.createChildForContainerMutex.Unlock()
-	if fake.CreateChildForContainerStub != nil {
-		return fake.CreateChildForContainerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createChildForContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -344,15 +346,16 @@ func (fake *FakeVolume) Destroy() error {
 	ret, specificReturn := fake.destroyReturnsOnCall[len(fake.destroyArgsForCall)]
 	fake.destroyArgsForCall = append(fake.destroyArgsForCall, struct {
 	}{})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1
 }
 
@@ -396,15 +399,16 @@ func (fake *FakeVolume) GetResourceCacheID() int {
 	ret, specificReturn := fake.getResourceCacheIDReturnsOnCall[len(fake.getResourceCacheIDArgsForCall)]
 	fake.getResourceCacheIDArgsForCall = append(fake.getResourceCacheIDArgsForCall, struct {
 	}{})
+	stub := fake.GetResourceCacheIDStub
+	fakeReturns := fake.getResourceCacheIDReturns
 	fake.recordInvocation("GetResourceCacheID", []interface{}{})
 	fake.getResourceCacheIDMutex.Unlock()
-	if fake.GetResourceCacheIDStub != nil {
-		return fake.GetResourceCacheIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getResourceCacheIDReturns
 	return fakeReturns.result1
 }
 
@@ -450,15 +454,16 @@ func (fake *FakeVolume) GetStreamInP2pUrl(arg1 context.Context, arg2 string) (st
 		arg1 context.Context
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetStreamInP2pUrlStub
+	fakeReturns := fake.getStreamInP2pUrlReturns
 	fake.recordInvocation("GetStreamInP2pUrl", []interface{}{arg1, arg2})
 	fake.getStreamInP2pUrlMutex.Unlock()
-	if fake.GetStreamInP2pUrlStub != nil {
-		return fake.GetStreamInP2pUrlStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getStreamInP2pUrlReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -512,15 +517,16 @@ func (fake *FakeVolume) Handle() string {
 	ret, specificReturn := fake.handleReturnsOnCall[len(fake.handleArgsForCall)]
 	fake.handleArgsForCall = append(fake.handleArgsForCall, struct {
 	}{})
+	stub := fake.HandleStub
+	fakeReturns := fake.handleReturns
 	fake.recordInvocation("Handle", []interface{}{})
 	fake.handleMutex.Unlock()
-	if fake.HandleStub != nil {
-		return fake.HandleStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.handleReturns
 	return fakeReturns.result1
 }
 
@@ -566,15 +572,16 @@ func (fake *FakeVolume) InitializeArtifact(arg1 string, arg2 int) (db.WorkerArti
 		arg1 string
 		arg2 int
 	}{arg1, arg2})
+	stub := fake.InitializeArtifactStub
+	fakeReturns := fake.initializeArtifactReturns
 	fake.recordInvocation("InitializeArtifact", []interface{}{arg1, arg2})
 	fake.initializeArtifactMutex.Unlock()
-	if fake.InitializeArtifactStub != nil {
-		return fake.InitializeArtifactStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.initializeArtifactReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -629,15 +636,16 @@ func (fake *FakeVolume) InitializeResourceCache(arg1 db.UsedResourceCache) error
 	fake.initializeResourceCacheArgsForCall = append(fake.initializeResourceCacheArgsForCall, struct {
 		arg1 db.UsedResourceCache
 	}{arg1})
+	stub := fake.InitializeResourceCacheStub
+	fakeReturns := fake.initializeResourceCacheReturns
 	fake.recordInvocation("InitializeResourceCache", []interface{}{arg1})
 	fake.initializeResourceCacheMutex.Unlock()
-	if fake.InitializeResourceCacheStub != nil {
-		return fake.InitializeResourceCacheStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.initializeResourceCacheReturns
 	return fakeReturns.result1
 }
 
@@ -693,15 +701,16 @@ func (fake *FakeVolume) InitializeTaskCache(arg1 lager.Logger, arg2 int, arg3 st
 		arg4 string
 		arg5 bool
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.InitializeTaskCacheStub
+	fakeReturns := fake.initializeTaskCacheReturns
 	fake.recordInvocation("InitializeTaskCache", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.initializeTaskCacheMutex.Unlock()
-	if fake.InitializeTaskCacheStub != nil {
-		return fake.InitializeTaskCacheStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.initializeTaskCacheReturns
 	return fakeReturns.result1
 }
 
@@ -752,15 +761,16 @@ func (fake *FakeVolume) Path() string {
 	ret, specificReturn := fake.pathReturnsOnCall[len(fake.pathArgsForCall)]
 	fake.pathArgsForCall = append(fake.pathArgsForCall, struct {
 	}{})
+	stub := fake.PathStub
+	fakeReturns := fake.pathReturns
 	fake.recordInvocation("Path", []interface{}{})
 	fake.pathMutex.Unlock()
-	if fake.PathStub != nil {
-		return fake.PathStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pathReturns
 	return fakeReturns.result1
 }
 
@@ -804,15 +814,16 @@ func (fake *FakeVolume) Properties() (baggageclaim.VolumeProperties, error) {
 	ret, specificReturn := fake.propertiesReturnsOnCall[len(fake.propertiesArgsForCall)]
 	fake.propertiesArgsForCall = append(fake.propertiesArgsForCall, struct {
 	}{})
+	stub := fake.PropertiesStub
+	fakeReturns := fake.propertiesReturns
 	fake.recordInvocation("Properties", []interface{}{})
 	fake.propertiesMutex.Unlock()
-	if fake.PropertiesStub != nil {
-		return fake.PropertiesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.propertiesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -860,15 +871,16 @@ func (fake *FakeVolume) SetPrivileged(arg1 bool) error {
 	fake.setPrivilegedArgsForCall = append(fake.setPrivilegedArgsForCall, struct {
 		arg1 bool
 	}{arg1})
+	stub := fake.SetPrivilegedStub
+	fakeReturns := fake.setPrivilegedReturns
 	fake.recordInvocation("SetPrivileged", []interface{}{arg1})
 	fake.setPrivilegedMutex.Unlock()
-	if fake.SetPrivilegedStub != nil {
-		return fake.SetPrivilegedStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setPrivilegedReturns
 	return fakeReturns.result1
 }
 
@@ -921,15 +933,16 @@ func (fake *FakeVolume) SetProperty(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SetPropertyStub
+	fakeReturns := fake.setPropertyReturns
 	fake.recordInvocation("SetProperty", []interface{}{arg1, arg2})
 	fake.setPropertyMutex.Unlock()
-	if fake.SetPropertyStub != nil {
-		return fake.SetPropertyStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setPropertyReturns
 	return fakeReturns.result1
 }
 
@@ -984,15 +997,16 @@ func (fake *FakeVolume) StreamIn(arg1 context.Context, arg2 string, arg3 baggage
 		arg3 baggageclaim.Encoding
 		arg4 io.Reader
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.StreamInStub
+	fakeReturns := fake.streamInReturns
 	fake.recordInvocation("StreamIn", []interface{}{arg1, arg2, arg3, arg4})
 	fake.streamInMutex.Unlock()
-	if fake.StreamInStub != nil {
-		return fake.StreamInStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.streamInReturns
 	return fakeReturns.result1
 }
 
@@ -1046,15 +1060,16 @@ func (fake *FakeVolume) StreamOut(arg1 context.Context, arg2 string, arg3 baggag
 		arg2 string
 		arg3 baggageclaim.Encoding
 	}{arg1, arg2, arg3})
+	stub := fake.StreamOutStub
+	fakeReturns := fake.streamOutReturns
 	fake.recordInvocation("StreamOut", []interface{}{arg1, arg2, arg3})
 	fake.streamOutMutex.Unlock()
-	if fake.StreamOutStub != nil {
-		return fake.StreamOutStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.streamOutReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1112,15 +1127,16 @@ func (fake *FakeVolume) StreamP2pOut(arg1 context.Context, arg2 string, arg3 str
 		arg3 string
 		arg4 baggageclaim.Encoding
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.StreamP2pOutStub
+	fakeReturns := fake.streamP2pOutReturns
 	fake.recordInvocation("StreamP2pOut", []interface{}{arg1, arg2, arg3, arg4})
 	fake.streamP2pOutMutex.Unlock()
-	if fake.StreamP2pOutStub != nil {
-		return fake.StreamP2pOutStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.streamP2pOutReturns
 	return fakeReturns.result1
 }
 
@@ -1171,15 +1187,16 @@ func (fake *FakeVolume) WorkerName() string {
 	ret, specificReturn := fake.workerNameReturnsOnCall[len(fake.workerNameArgsForCall)]
 	fake.workerNameArgsForCall = append(fake.workerNameArgsForCall, struct {
 	}{})
+	stub := fake.WorkerNameStub
+	fakeReturns := fake.workerNameReturns
 	fake.recordInvocation("WorkerName", []interface{}{})
 	fake.workerNameMutex.Unlock()
-	if fake.WorkerNameStub != nil {
-		return fake.WorkerNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.workerNameReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/workerfakes/fake_volume_client.go
+++ b/atc/worker/workerfakes/fake_volume_client.go
@@ -176,15 +176,16 @@ func (fake *FakeVolumeClient) CreateVolume(arg1 lager.Logger, arg2 worker.Volume
 		arg4 string
 		arg5 db.VolumeType
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.CreateVolumeStub
+	fakeReturns := fake.createVolumeReturns
 	fake.recordInvocation("CreateVolume", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.createVolumeMutex.Unlock()
-	if fake.CreateVolumeStub != nil {
-		return fake.CreateVolumeStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -244,15 +245,16 @@ func (fake *FakeVolumeClient) CreateVolumeForTaskCache(arg1 lager.Logger, arg2 w
 		arg5 string
 		arg6 string
 	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	stub := fake.CreateVolumeForTaskCacheStub
+	fakeReturns := fake.createVolumeForTaskCacheReturns
 	fake.recordInvocation("CreateVolumeForTaskCache", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.createVolumeForTaskCacheMutex.Unlock()
-	if fake.CreateVolumeForTaskCacheStub != nil {
-		return fake.CreateVolumeForTaskCacheStub(arg1, arg2, arg3, arg4, arg5, arg6)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createVolumeForTaskCacheReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -312,15 +314,16 @@ func (fake *FakeVolumeClient) FindOrCreateCOWVolumeForContainer(arg1 lager.Logge
 		arg5 int
 		arg6 string
 	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	stub := fake.FindOrCreateCOWVolumeForContainerStub
+	fakeReturns := fake.findOrCreateCOWVolumeForContainerReturns
 	fake.recordInvocation("FindOrCreateCOWVolumeForContainer", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.findOrCreateCOWVolumeForContainerMutex.Unlock()
-	if fake.FindOrCreateCOWVolumeForContainerStub != nil {
-		return fake.FindOrCreateCOWVolumeForContainerStub(arg1, arg2, arg3, arg4, arg5, arg6)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateCOWVolumeForContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -378,15 +381,16 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForBaseResourceType(arg1 lager.L
 		arg3 int
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.FindOrCreateVolumeForBaseResourceTypeStub
+	fakeReturns := fake.findOrCreateVolumeForBaseResourceTypeReturns
 	fake.recordInvocation("FindOrCreateVolumeForBaseResourceType", []interface{}{arg1, arg2, arg3, arg4})
 	fake.findOrCreateVolumeForBaseResourceTypeMutex.Unlock()
-	if fake.FindOrCreateVolumeForBaseResourceTypeStub != nil {
-		return fake.FindOrCreateVolumeForBaseResourceTypeStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateVolumeForBaseResourceTypeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -445,15 +449,16 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForContainer(arg1 lager.Logger, 
 		arg4 int
 		arg5 string
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.FindOrCreateVolumeForContainerStub
+	fakeReturns := fake.findOrCreateVolumeForContainerReturns
 	fake.recordInvocation("FindOrCreateVolumeForContainer", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.findOrCreateVolumeForContainerMutex.Unlock()
-	if fake.FindOrCreateVolumeForContainerStub != nil {
-		return fake.FindOrCreateVolumeForContainerStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateVolumeForContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -508,15 +513,16 @@ func (fake *FakeVolumeClient) FindOrCreateVolumeForResourceCerts(arg1 lager.Logg
 	fake.findOrCreateVolumeForResourceCertsArgsForCall = append(fake.findOrCreateVolumeForResourceCertsArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.FindOrCreateVolumeForResourceCertsStub
+	fakeReturns := fake.findOrCreateVolumeForResourceCertsReturns
 	fake.recordInvocation("FindOrCreateVolumeForResourceCerts", []interface{}{arg1})
 	fake.findOrCreateVolumeForResourceCertsMutex.Unlock()
-	if fake.FindOrCreateVolumeForResourceCertsStub != nil {
-		return fake.FindOrCreateVolumeForResourceCertsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findOrCreateVolumeForResourceCertsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -575,15 +581,16 @@ func (fake *FakeVolumeClient) FindVolumeForResourceCache(arg1 lager.Logger, arg2
 		arg1 lager.Logger
 		arg2 db.UsedResourceCache
 	}{arg1, arg2})
+	stub := fake.FindVolumeForResourceCacheStub
+	fakeReturns := fake.findVolumeForResourceCacheReturns
 	fake.recordInvocation("FindVolumeForResourceCache", []interface{}{arg1, arg2})
 	fake.findVolumeForResourceCacheMutex.Unlock()
-	if fake.FindVolumeForResourceCacheStub != nil {
-		return fake.FindVolumeForResourceCacheStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findVolumeForResourceCacheReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -645,15 +652,16 @@ func (fake *FakeVolumeClient) FindVolumeForTaskCache(arg1 lager.Logger, arg2 int
 		arg4 string
 		arg5 string
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.FindVolumeForTaskCacheStub
+	fakeReturns := fake.findVolumeForTaskCacheReturns
 	fake.recordInvocation("FindVolumeForTaskCache", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.findVolumeForTaskCacheMutex.Unlock()
-	if fake.FindVolumeForTaskCacheStub != nil {
-		return fake.FindVolumeForTaskCacheStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findVolumeForTaskCacheReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -712,15 +720,16 @@ func (fake *FakeVolumeClient) LookupVolume(arg1 lager.Logger, arg2 string) (work
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.LookupVolumeStub
+	fakeReturns := fake.lookupVolumeReturns
 	fake.recordInvocation("LookupVolume", []interface{}{arg1, arg2})
 	fake.lookupVolumeMutex.Unlock()
-	if fake.LookupVolumeStub != nil {
-		return fake.LookupVolumeStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.lookupVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/worker/workerfakes/fake_volume_finder.go
+++ b/atc/worker/workerfakes/fake_volume_finder.go
@@ -38,15 +38,16 @@ func (fake *FakeVolumeFinder) FindVolume(arg1 lager.Logger, arg2 int, arg3 strin
 		arg2 int
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.FindVolumeStub
+	fakeReturns := fake.findVolumeReturns
 	fake.recordInvocation("FindVolume", []interface{}{arg1, arg2, arg3})
 	fake.findVolumeMutex.Unlock()
-	if fake.FindVolumeStub != nil {
-		return fake.FindVolumeStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/atc/worker/workerfakes/fake_worker.go
+++ b/atc/worker/workerfakes/fake_worker.go
@@ -327,15 +327,16 @@ func (fake *FakeWorker) ActiveContainers() int {
 	ret, specificReturn := fake.activeContainersReturnsOnCall[len(fake.activeContainersArgsForCall)]
 	fake.activeContainersArgsForCall = append(fake.activeContainersArgsForCall, struct {
 	}{})
+	stub := fake.ActiveContainersStub
+	fakeReturns := fake.activeContainersReturns
 	fake.recordInvocation("ActiveContainers", []interface{}{})
 	fake.activeContainersMutex.Unlock()
-	if fake.ActiveContainersStub != nil {
-		return fake.ActiveContainersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.activeContainersReturns
 	return fakeReturns.result1
 }
 
@@ -379,15 +380,16 @@ func (fake *FakeWorker) ActiveTasks() (int, error) {
 	ret, specificReturn := fake.activeTasksReturnsOnCall[len(fake.activeTasksArgsForCall)]
 	fake.activeTasksArgsForCall = append(fake.activeTasksArgsForCall, struct {
 	}{})
+	stub := fake.ActiveTasksStub
+	fakeReturns := fake.activeTasksReturns
 	fake.recordInvocation("ActiveTasks", []interface{}{})
 	fake.activeTasksMutex.Unlock()
-	if fake.ActiveTasksStub != nil {
-		return fake.ActiveTasksStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.activeTasksReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -434,15 +436,16 @@ func (fake *FakeWorker) ActiveVolumes() int {
 	ret, specificReturn := fake.activeVolumesReturnsOnCall[len(fake.activeVolumesArgsForCall)]
 	fake.activeVolumesArgsForCall = append(fake.activeVolumesArgsForCall, struct {
 	}{})
+	stub := fake.ActiveVolumesStub
+	fakeReturns := fake.activeVolumesReturns
 	fake.recordInvocation("ActiveVolumes", []interface{}{})
 	fake.activeVolumesMutex.Unlock()
-	if fake.ActiveVolumesStub != nil {
-		return fake.ActiveVolumesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.activeVolumesReturns
 	return fakeReturns.result1
 }
 
@@ -486,15 +489,16 @@ func (fake *FakeWorker) BuildContainers() int {
 	ret, specificReturn := fake.buildContainersReturnsOnCall[len(fake.buildContainersArgsForCall)]
 	fake.buildContainersArgsForCall = append(fake.buildContainersArgsForCall, struct {
 	}{})
+	stub := fake.BuildContainersStub
+	fakeReturns := fake.buildContainersReturns
 	fake.recordInvocation("BuildContainers", []interface{}{})
 	fake.buildContainersMutex.Unlock()
-	if fake.BuildContainersStub != nil {
-		return fake.BuildContainersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.buildContainersReturns
 	return fakeReturns.result1
 }
 
@@ -539,15 +543,16 @@ func (fake *FakeWorker) CertsVolume(arg1 lager.Logger) (worker.Volume, bool, err
 	fake.certsVolumeArgsForCall = append(fake.certsVolumeArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.CertsVolumeStub
+	fakeReturns := fake.certsVolumeReturns
 	fake.recordInvocation("CertsVolume", []interface{}{arg1})
 	fake.certsVolumeMutex.Unlock()
-	if fake.CertsVolumeStub != nil {
-		return fake.CertsVolumeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.certsVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -608,15 +613,16 @@ func (fake *FakeWorker) CreateVolume(arg1 lager.Logger, arg2 worker.VolumeSpec, 
 		arg3 int
 		arg4 db.VolumeType
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CreateVolumeStub
+	fakeReturns := fake.createVolumeReturns
 	fake.recordInvocation("CreateVolume", []interface{}{arg1, arg2, arg3, arg4})
 	fake.createVolumeMutex.Unlock()
-	if fake.CreateVolumeStub != nil {
-		return fake.CreateVolumeStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -670,15 +676,16 @@ func (fake *FakeWorker) Description() string {
 	ret, specificReturn := fake.descriptionReturnsOnCall[len(fake.descriptionArgsForCall)]
 	fake.descriptionArgsForCall = append(fake.descriptionArgsForCall, struct {
 	}{})
+	stub := fake.DescriptionStub
+	fakeReturns := fake.descriptionReturns
 	fake.recordInvocation("Description", []interface{}{})
 	fake.descriptionMutex.Unlock()
-	if fake.DescriptionStub != nil {
-		return fake.DescriptionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.descriptionReturns
 	return fakeReturns.result1
 }
 
@@ -722,15 +729,16 @@ func (fake *FakeWorker) Ephemeral() bool {
 	ret, specificReturn := fake.ephemeralReturnsOnCall[len(fake.ephemeralArgsForCall)]
 	fake.ephemeralArgsForCall = append(fake.ephemeralArgsForCall, struct {
 	}{})
+	stub := fake.EphemeralStub
+	fakeReturns := fake.ephemeralReturns
 	fake.recordInvocation("Ephemeral", []interface{}{})
 	fake.ephemeralMutex.Unlock()
-	if fake.EphemeralStub != nil {
-		return fake.EphemeralStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.ephemeralReturns
 	return fakeReturns.result1
 }
 
@@ -784,15 +792,16 @@ func (fake *FakeWorker) Fetch(arg1 context.Context, arg2 lager.Logger, arg3 db.C
 		arg9  db.UsedResourceCache
 		arg10 string
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10})
+	stub := fake.FetchStub
+	fakeReturns := fake.fetchReturns
 	fake.recordInvocation("Fetch", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10})
 	fake.fetchMutex.Unlock()
-	if fake.FetchStub != nil {
-		return fake.FetchStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.fetchReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -852,15 +861,16 @@ func (fake *FakeWorker) FindContainerByHandle(arg1 lager.Logger, arg2 int, arg3 
 		arg2 int
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.FindContainerByHandleStub
+	fakeReturns := fake.findContainerByHandleReturns
 	fake.recordInvocation("FindContainerByHandle", []interface{}{arg1, arg2, arg3})
 	fake.findContainerByHandleMutex.Unlock()
-	if fake.FindContainerByHandleStub != nil {
-		return fake.FindContainerByHandleStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findContainerByHandleReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -922,15 +932,16 @@ func (fake *FakeWorker) FindOrCreateContainer(arg1 context.Context, arg2 lager.L
 		arg4 db.ContainerMetadata
 		arg5 worker.ContainerSpec
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.FindOrCreateContainerStub
+	fakeReturns := fake.findOrCreateContainerReturns
 	fake.recordInvocation("FindOrCreateContainer", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.findOrCreateContainerMutex.Unlock()
-	if fake.FindOrCreateContainerStub != nil {
-		return fake.FindOrCreateContainerStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findOrCreateContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -985,15 +996,16 @@ func (fake *FakeWorker) FindResourceCacheForVolume(arg1 worker.Volume) (db.UsedR
 	fake.findResourceCacheForVolumeArgsForCall = append(fake.findResourceCacheForVolumeArgsForCall, struct {
 		arg1 worker.Volume
 	}{arg1})
+	stub := fake.FindResourceCacheForVolumeStub
+	fakeReturns := fake.findResourceCacheForVolumeReturns
 	fake.recordInvocation("FindResourceCacheForVolume", []interface{}{arg1})
 	fake.findResourceCacheForVolumeMutex.Unlock()
-	if fake.FindResourceCacheForVolumeStub != nil {
-		return fake.FindResourceCacheForVolumeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findResourceCacheForVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1052,15 +1064,16 @@ func (fake *FakeWorker) FindVolumeForResourceCache(arg1 lager.Logger, arg2 db.Us
 		arg1 lager.Logger
 		arg2 db.UsedResourceCache
 	}{arg1, arg2})
+	stub := fake.FindVolumeForResourceCacheStub
+	fakeReturns := fake.findVolumeForResourceCacheReturns
 	fake.recordInvocation("FindVolumeForResourceCache", []interface{}{arg1, arg2})
 	fake.findVolumeForResourceCacheMutex.Unlock()
-	if fake.FindVolumeForResourceCacheStub != nil {
-		return fake.FindVolumeForResourceCacheStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findVolumeForResourceCacheReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1122,15 +1135,16 @@ func (fake *FakeWorker) FindVolumeForTaskCache(arg1 lager.Logger, arg2 int, arg3
 		arg4 string
 		arg5 string
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.FindVolumeForTaskCacheStub
+	fakeReturns := fake.findVolumeForTaskCacheReturns
 	fake.recordInvocation("FindVolumeForTaskCache", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.findVolumeForTaskCacheMutex.Unlock()
-	if fake.FindVolumeForTaskCacheStub != nil {
-		return fake.FindVolumeForTaskCacheStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findVolumeForTaskCacheReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1187,15 +1201,16 @@ func (fake *FakeWorker) GardenClient() gclient.Client {
 	ret, specificReturn := fake.gardenClientReturnsOnCall[len(fake.gardenClientArgsForCall)]
 	fake.gardenClientArgsForCall = append(fake.gardenClientArgsForCall, struct {
 	}{})
+	stub := fake.GardenClientStub
+	fakeReturns := fake.gardenClientReturns
 	fake.recordInvocation("GardenClient", []interface{}{})
 	fake.gardenClientMutex.Unlock()
-	if fake.GardenClientStub != nil {
-		return fake.GardenClientStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.gardenClientReturns
 	return fakeReturns.result1
 }
 
@@ -1239,15 +1254,16 @@ func (fake *FakeWorker) IsOwnedByTeam() bool {
 	ret, specificReturn := fake.isOwnedByTeamReturnsOnCall[len(fake.isOwnedByTeamArgsForCall)]
 	fake.isOwnedByTeamArgsForCall = append(fake.isOwnedByTeamArgsForCall, struct {
 	}{})
+	stub := fake.IsOwnedByTeamStub
+	fakeReturns := fake.isOwnedByTeamReturns
 	fake.recordInvocation("IsOwnedByTeam", []interface{}{})
 	fake.isOwnedByTeamMutex.Unlock()
-	if fake.IsOwnedByTeamStub != nil {
-		return fake.IsOwnedByTeamStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isOwnedByTeamReturns
 	return fakeReturns.result1
 }
 
@@ -1293,15 +1309,16 @@ func (fake *FakeWorker) IsVersionCompatible(arg1 lager.Logger, arg2 version.Vers
 		arg1 lager.Logger
 		arg2 version.Version
 	}{arg1, arg2})
+	stub := fake.IsVersionCompatibleStub
+	fakeReturns := fake.isVersionCompatibleReturns
 	fake.recordInvocation("IsVersionCompatible", []interface{}{arg1, arg2})
 	fake.isVersionCompatibleMutex.Unlock()
-	if fake.IsVersionCompatibleStub != nil {
-		return fake.IsVersionCompatibleStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isVersionCompatibleReturns
 	return fakeReturns.result1
 }
 
@@ -1354,15 +1371,16 @@ func (fake *FakeWorker) LookupVolume(arg1 lager.Logger, arg2 string) (worker.Vol
 		arg1 lager.Logger
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.LookupVolumeStub
+	fakeReturns := fake.lookupVolumeReturns
 	fake.recordInvocation("LookupVolume", []interface{}{arg1, arg2})
 	fake.lookupVolumeMutex.Unlock()
-	if fake.LookupVolumeStub != nil {
-		return fake.LookupVolumeStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.lookupVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1419,15 +1437,16 @@ func (fake *FakeWorker) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -1471,15 +1490,16 @@ func (fake *FakeWorker) ResourceTypes() []atc.WorkerResourceType {
 	ret, specificReturn := fake.resourceTypesReturnsOnCall[len(fake.resourceTypesArgsForCall)]
 	fake.resourceTypesArgsForCall = append(fake.resourceTypesArgsForCall, struct {
 	}{})
+	stub := fake.ResourceTypesStub
+	fakeReturns := fake.resourceTypesReturns
 	fake.recordInvocation("ResourceTypes", []interface{}{})
 	fake.resourceTypesMutex.Unlock()
-	if fake.ResourceTypesStub != nil {
-		return fake.ResourceTypesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resourceTypesReturns
 	return fakeReturns.result1
 }
 
@@ -1525,15 +1545,16 @@ func (fake *FakeWorker) Satisfies(arg1 lager.Logger, arg2 worker.WorkerSpec) boo
 		arg1 lager.Logger
 		arg2 worker.WorkerSpec
 	}{arg1, arg2})
+	stub := fake.SatisfiesStub
+	fakeReturns := fake.satisfiesReturns
 	fake.recordInvocation("Satisfies", []interface{}{arg1, arg2})
 	fake.satisfiesMutex.Unlock()
-	if fake.SatisfiesStub != nil {
-		return fake.SatisfiesStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.satisfiesReturns
 	return fakeReturns.result1
 }
 
@@ -1584,15 +1605,16 @@ func (fake *FakeWorker) Tags() atc.Tags {
 	ret, specificReturn := fake.tagsReturnsOnCall[len(fake.tagsArgsForCall)]
 	fake.tagsArgsForCall = append(fake.tagsArgsForCall, struct {
 	}{})
+	stub := fake.TagsStub
+	fakeReturns := fake.tagsReturns
 	fake.recordInvocation("Tags", []interface{}{})
 	fake.tagsMutex.Unlock()
-	if fake.TagsStub != nil {
-		return fake.TagsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tagsReturns
 	return fakeReturns.result1
 }
 
@@ -1636,15 +1658,16 @@ func (fake *FakeWorker) Uptime() time.Duration {
 	ret, specificReturn := fake.uptimeReturnsOnCall[len(fake.uptimeArgsForCall)]
 	fake.uptimeArgsForCall = append(fake.uptimeArgsForCall, struct {
 	}{})
+	stub := fake.UptimeStub
+	fakeReturns := fake.uptimeReturns
 	fake.recordInvocation("Uptime", []interface{}{})
 	fake.uptimeMutex.Unlock()
-	if fake.UptimeStub != nil {
-		return fake.UptimeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.uptimeReturns
 	return fakeReturns.result1
 }
 

--- a/atc/worker/workerfakes/fake_worker_provider.go
+++ b/atc/worker/workerfakes/fake_worker_provider.go
@@ -96,15 +96,16 @@ func (fake *FakeWorkerProvider) FindWorkerForContainer(arg1 lager.Logger, arg2 i
 		arg2 int
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.FindWorkerForContainerStub
+	fakeReturns := fake.findWorkerForContainerReturns
 	fake.recordInvocation("FindWorkerForContainer", []interface{}{arg1, arg2, arg3})
 	fake.findWorkerForContainerMutex.Unlock()
-	if fake.FindWorkerForContainerStub != nil {
-		return fake.FindWorkerForContainerStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findWorkerForContainerReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -164,15 +165,16 @@ func (fake *FakeWorkerProvider) FindWorkerForVolume(arg1 lager.Logger, arg2 int,
 		arg2 int
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.FindWorkerForVolumeStub
+	fakeReturns := fake.findWorkerForVolumeReturns
 	fake.recordInvocation("FindWorkerForVolume", []interface{}{arg1, arg2, arg3})
 	fake.findWorkerForVolumeMutex.Unlock()
-	if fake.FindWorkerForVolumeStub != nil {
-		return fake.FindWorkerForVolumeStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.findWorkerForVolumeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -231,15 +233,16 @@ func (fake *FakeWorkerProvider) FindWorkersForContainerByOwner(arg1 lager.Logger
 		arg1 lager.Logger
 		arg2 db.ContainerOwner
 	}{arg1, arg2})
+	stub := fake.FindWorkersForContainerByOwnerStub
+	fakeReturns := fake.findWorkersForContainerByOwnerReturns
 	fake.recordInvocation("FindWorkersForContainerByOwner", []interface{}{arg1, arg2})
 	fake.findWorkersForContainerByOwnerMutex.Unlock()
-	if fake.FindWorkersForContainerByOwnerStub != nil {
-		return fake.FindWorkersForContainerByOwnerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findWorkersForContainerByOwnerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -296,15 +299,16 @@ func (fake *FakeWorkerProvider) NewGardenWorker(arg1 lager.Logger, arg2 db.Worke
 		arg2 db.Worker
 		arg3 int
 	}{arg1, arg2, arg3})
+	stub := fake.NewGardenWorkerStub
+	fakeReturns := fake.newGardenWorkerReturns
 	fake.recordInvocation("NewGardenWorker", []interface{}{arg1, arg2, arg3})
 	fake.newGardenWorkerMutex.Unlock()
-	if fake.NewGardenWorkerStub != nil {
-		return fake.NewGardenWorkerStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newGardenWorkerReturns
 	return fakeReturns.result1
 }
 
@@ -356,15 +360,16 @@ func (fake *FakeWorkerProvider) RunningWorkers(arg1 lager.Logger) ([]worker.Work
 	fake.runningWorkersArgsForCall = append(fake.runningWorkersArgsForCall, struct {
 		arg1 lager.Logger
 	}{arg1})
+	stub := fake.RunningWorkersStub
+	fakeReturns := fake.runningWorkersReturns
 	fake.recordInvocation("RunningWorkers", []interface{}{arg1})
 	fake.runningWorkersMutex.Unlock()
-	if fake.RunningWorkersStub != nil {
-		return fake.RunningWorkersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runningWorkersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/wrappa/wrappafakes/fake_concurrent_request_policy.go
+++ b/atc/wrappa/wrappafakes/fake_concurrent_request_policy.go
@@ -31,15 +31,16 @@ func (fake *FakeConcurrentRequestPolicy) HandlerPool(arg1 string) (wrappa.Pool, 
 	fake.handlerPoolArgsForCall = append(fake.handlerPoolArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.HandlerPoolStub
+	fakeReturns := fake.handlerPoolReturns
 	fake.recordInvocation("HandlerPool", []interface{}{arg1})
 	fake.handlerPoolMutex.Unlock()
-	if fake.HandlerPoolStub != nil {
-		return fake.HandlerPoolStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.handlerPoolReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/atc/wrappa/wrappafakes/fake_handler.go
+++ b/atc/wrappa/wrappafakes/fake_handler.go
@@ -23,9 +23,10 @@ func (fake *FakeHandler) ServeHTTP(arg1 http.ResponseWriter, arg2 *http.Request)
 		arg1 http.ResponseWriter
 		arg2 *http.Request
 	}{arg1, arg2})
+	stub := fake.ServeHTTPStub
 	fake.recordInvocation("ServeHTTP", []interface{}{arg1, arg2})
 	fake.serveHTTPMutex.Unlock()
-	if fake.ServeHTTPStub != nil {
+	if stub != nil {
 		fake.ServeHTTPStub(arg1, arg2)
 	}
 }

--- a/atc/wrappa/wrappafakes/fake_pool.go
+++ b/atc/wrappa/wrappafakes/fake_pool.go
@@ -40,9 +40,10 @@ func (fake *FakePool) Release() {
 	fake.releaseMutex.Lock()
 	fake.releaseArgsForCall = append(fake.releaseArgsForCall, struct {
 	}{})
+	stub := fake.ReleaseStub
 	fake.recordInvocation("Release", []interface{}{})
 	fake.releaseMutex.Unlock()
-	if fake.ReleaseStub != nil {
+	if stub != nil {
 		fake.ReleaseStub()
 	}
 }
@@ -64,15 +65,16 @@ func (fake *FakePool) Size() int {
 	ret, specificReturn := fake.sizeReturnsOnCall[len(fake.sizeArgsForCall)]
 	fake.sizeArgsForCall = append(fake.sizeArgsForCall, struct {
 	}{})
+	stub := fake.SizeStub
+	fakeReturns := fake.sizeReturns
 	fake.recordInvocation("Size", []interface{}{})
 	fake.sizeMutex.Unlock()
-	if fake.SizeStub != nil {
-		return fake.SizeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sizeReturns
 	return fakeReturns.result1
 }
 
@@ -116,15 +118,16 @@ func (fake *FakePool) TryAcquire() bool {
 	ret, specificReturn := fake.tryAcquireReturnsOnCall[len(fake.tryAcquireArgsForCall)]
 	fake.tryAcquireArgsForCall = append(fake.tryAcquireArgsForCall, struct {
 	}{})
+	stub := fake.TryAcquireStub
+	fakeReturns := fake.tryAcquireReturns
 	fake.recordInvocation("TryAcquire", []interface{}{})
 	fake.tryAcquireMutex.Unlock()
-	if fake.TryAcquireStub != nil {
-		return fake.TryAcquireStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tryAcquireReturns
 	return fakeReturns.result1
 }
 

--- a/fly/rc/rcfakes/fake_target.go
+++ b/fly/rc/rcfakes/fake_target.go
@@ -191,15 +191,16 @@ func (fake *FakeTarget) CACert() string {
 	ret, specificReturn := fake.cACertReturnsOnCall[len(fake.cACertArgsForCall)]
 	fake.cACertArgsForCall = append(fake.cACertArgsForCall, struct {
 	}{})
+	stub := fake.CACertStub
+	fakeReturns := fake.cACertReturns
 	fake.recordInvocation("CACert", []interface{}{})
 	fake.cACertMutex.Unlock()
-	if fake.CACertStub != nil {
-		return fake.CACertStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cACertReturns
 	return fakeReturns.result1
 }
 
@@ -243,15 +244,16 @@ func (fake *FakeTarget) Client() concourse.Client {
 	ret, specificReturn := fake.clientReturnsOnCall[len(fake.clientArgsForCall)]
 	fake.clientArgsForCall = append(fake.clientArgsForCall, struct {
 	}{})
+	stub := fake.ClientStub
+	fakeReturns := fake.clientReturns
 	fake.recordInvocation("Client", []interface{}{})
 	fake.clientMutex.Unlock()
-	if fake.ClientStub != nil {
-		return fake.ClientStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.clientReturns
 	return fakeReturns.result1
 }
 
@@ -295,15 +297,16 @@ func (fake *FakeTarget) ClientCertPath() string {
 	ret, specificReturn := fake.clientCertPathReturnsOnCall[len(fake.clientCertPathArgsForCall)]
 	fake.clientCertPathArgsForCall = append(fake.clientCertPathArgsForCall, struct {
 	}{})
+	stub := fake.ClientCertPathStub
+	fakeReturns := fake.clientCertPathReturns
 	fake.recordInvocation("ClientCertPath", []interface{}{})
 	fake.clientCertPathMutex.Unlock()
-	if fake.ClientCertPathStub != nil {
-		return fake.ClientCertPathStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.clientCertPathReturns
 	return fakeReturns.result1
 }
 
@@ -347,15 +350,16 @@ func (fake *FakeTarget) ClientCertificate() []tls.Certificate {
 	ret, specificReturn := fake.clientCertificateReturnsOnCall[len(fake.clientCertificateArgsForCall)]
 	fake.clientCertificateArgsForCall = append(fake.clientCertificateArgsForCall, struct {
 	}{})
+	stub := fake.ClientCertificateStub
+	fakeReturns := fake.clientCertificateReturns
 	fake.recordInvocation("ClientCertificate", []interface{}{})
 	fake.clientCertificateMutex.Unlock()
-	if fake.ClientCertificateStub != nil {
-		return fake.ClientCertificateStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.clientCertificateReturns
 	return fakeReturns.result1
 }
 
@@ -399,15 +403,16 @@ func (fake *FakeTarget) ClientKeyPath() string {
 	ret, specificReturn := fake.clientKeyPathReturnsOnCall[len(fake.clientKeyPathArgsForCall)]
 	fake.clientKeyPathArgsForCall = append(fake.clientKeyPathArgsForCall, struct {
 	}{})
+	stub := fake.ClientKeyPathStub
+	fakeReturns := fake.clientKeyPathReturns
 	fake.recordInvocation("ClientKeyPath", []interface{}{})
 	fake.clientKeyPathMutex.Unlock()
-	if fake.ClientKeyPathStub != nil {
-		return fake.ClientKeyPathStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.clientKeyPathReturns
 	return fakeReturns.result1
 }
 
@@ -452,15 +457,16 @@ func (fake *FakeTarget) FindTeam(arg1 string) (concourse.Team, error) {
 	fake.findTeamArgsForCall = append(fake.findTeamArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindTeamStub
+	fakeReturns := fake.findTeamReturns
 	fake.recordInvocation("FindTeam", []interface{}{arg1})
 	fake.findTeamMutex.Unlock()
-	if fake.FindTeamStub != nil {
-		return fake.FindTeamStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findTeamReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -515,15 +521,16 @@ func (fake *FakeTarget) IsWorkerVersionCompatible(arg1 string) (bool, error) {
 	fake.isWorkerVersionCompatibleArgsForCall = append(fake.isWorkerVersionCompatibleArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.IsWorkerVersionCompatibleStub
+	fakeReturns := fake.isWorkerVersionCompatibleReturns
 	fake.recordInvocation("IsWorkerVersionCompatible", []interface{}{arg1})
 	fake.isWorkerVersionCompatibleMutex.Unlock()
-	if fake.IsWorkerVersionCompatibleStub != nil {
-		return fake.IsWorkerVersionCompatibleStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isWorkerVersionCompatibleReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -577,15 +584,16 @@ func (fake *FakeTarget) TLSConfig() *tls.Config {
 	ret, specificReturn := fake.tLSConfigReturnsOnCall[len(fake.tLSConfigArgsForCall)]
 	fake.tLSConfigArgsForCall = append(fake.tLSConfigArgsForCall, struct {
 	}{})
+	stub := fake.TLSConfigStub
+	fakeReturns := fake.tLSConfigReturns
 	fake.recordInvocation("TLSConfig", []interface{}{})
 	fake.tLSConfigMutex.Unlock()
-	if fake.TLSConfigStub != nil {
-		return fake.TLSConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tLSConfigReturns
 	return fakeReturns.result1
 }
 
@@ -629,15 +637,16 @@ func (fake *FakeTarget) Team() concourse.Team {
 	ret, specificReturn := fake.teamReturnsOnCall[len(fake.teamArgsForCall)]
 	fake.teamArgsForCall = append(fake.teamArgsForCall, struct {
 	}{})
+	stub := fake.TeamStub
+	fakeReturns := fake.teamReturns
 	fake.recordInvocation("Team", []interface{}{})
 	fake.teamMutex.Unlock()
-	if fake.TeamStub != nil {
-		return fake.TeamStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamReturns
 	return fakeReturns.result1
 }
 
@@ -681,15 +690,16 @@ func (fake *FakeTarget) Token() *rc.TargetToken {
 	ret, specificReturn := fake.tokenReturnsOnCall[len(fake.tokenArgsForCall)]
 	fake.tokenArgsForCall = append(fake.tokenArgsForCall, struct {
 	}{})
+	stub := fake.TokenStub
+	fakeReturns := fake.tokenReturns
 	fake.recordInvocation("Token", []interface{}{})
 	fake.tokenMutex.Unlock()
-	if fake.TokenStub != nil {
-		return fake.TokenStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tokenReturns
 	return fakeReturns.result1
 }
 
@@ -733,15 +743,16 @@ func (fake *FakeTarget) TokenAuthorization() (string, bool) {
 	ret, specificReturn := fake.tokenAuthorizationReturnsOnCall[len(fake.tokenAuthorizationArgsForCall)]
 	fake.tokenAuthorizationArgsForCall = append(fake.tokenAuthorizationArgsForCall, struct {
 	}{})
+	stub := fake.TokenAuthorizationStub
+	fakeReturns := fake.tokenAuthorizationReturns
 	fake.recordInvocation("TokenAuthorization", []interface{}{})
 	fake.tokenAuthorizationMutex.Unlock()
-	if fake.TokenAuthorizationStub != nil {
-		return fake.TokenAuthorizationStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.tokenAuthorizationReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -788,15 +799,16 @@ func (fake *FakeTarget) URL() string {
 	ret, specificReturn := fake.uRLReturnsOnCall[len(fake.uRLArgsForCall)]
 	fake.uRLArgsForCall = append(fake.uRLArgsForCall, struct {
 	}{})
+	stub := fake.URLStub
+	fakeReturns := fake.uRLReturns
 	fake.recordInvocation("URL", []interface{}{})
 	fake.uRLMutex.Unlock()
-	if fake.URLStub != nil {
-		return fake.URLStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.uRLReturns
 	return fakeReturns.result1
 }
 
@@ -840,15 +852,16 @@ func (fake *FakeTarget) Validate() error {
 	ret, specificReturn := fake.validateReturnsOnCall[len(fake.validateArgsForCall)]
 	fake.validateArgsForCall = append(fake.validateArgsForCall, struct {
 	}{})
+	stub := fake.ValidateStub
+	fakeReturns := fake.validateReturns
 	fake.recordInvocation("Validate", []interface{}{})
 	fake.validateMutex.Unlock()
-	if fake.ValidateStub != nil {
-		return fake.ValidateStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.validateReturns
 	return fakeReturns.result1
 }
 
@@ -892,15 +905,16 @@ func (fake *FakeTarget) ValidateWithWarningOnly() error {
 	ret, specificReturn := fake.validateWithWarningOnlyReturnsOnCall[len(fake.validateWithWarningOnlyArgsForCall)]
 	fake.validateWithWarningOnlyArgsForCall = append(fake.validateWithWarningOnlyArgsForCall, struct {
 	}{})
+	stub := fake.ValidateWithWarningOnlyStub
+	fakeReturns := fake.validateWithWarningOnlyReturns
 	fake.recordInvocation("ValidateWithWarningOnly", []interface{}{})
 	fake.validateWithWarningOnlyMutex.Unlock()
-	if fake.ValidateWithWarningOnlyStub != nil {
-		return fake.ValidateWithWarningOnlyStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.validateWithWarningOnlyReturns
 	return fakeReturns.result1
 }
 
@@ -944,15 +958,16 @@ func (fake *FakeTarget) Version() (string, error) {
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
 	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
 	}{})
+	stub := fake.VersionStub
+	fakeReturns := fake.versionReturns
 	fake.recordInvocation("Version", []interface{}{})
 	fake.versionMutex.Unlock()
-	if fake.VersionStub != nil {
-		return fake.VersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.versionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -999,15 +1014,16 @@ func (fake *FakeTarget) WorkerVersion() (string, error) {
 	ret, specificReturn := fake.workerVersionReturnsOnCall[len(fake.workerVersionArgsForCall)]
 	fake.workerVersionArgsForCall = append(fake.workerVersionArgsForCall, struct {
 	}{})
+	stub := fake.WorkerVersionStub
+	fakeReturns := fake.workerVersionReturns
 	fake.recordInvocation("WorkerVersion", []interface{}{})
 	fake.workerVersionMutex.Unlock()
-	if fake.WorkerVersionStub != nil {
-		return fake.WorkerVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.workerVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/go-concourse/concourse/concoursefakes/fake_client.go
+++ b/go-concourse/concourse/concoursefakes/fake_client.go
@@ -300,15 +300,16 @@ func (fake *FakeClient) AbortBuild(arg1 string) error {
 	fake.abortBuildArgsForCall = append(fake.abortBuildArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.AbortBuildStub
+	fakeReturns := fake.abortBuildReturns
 	fake.recordInvocation("AbortBuild", []interface{}{arg1})
 	fake.abortBuildMutex.Unlock()
-	if fake.AbortBuildStub != nil {
-		return fake.AbortBuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.abortBuildReturns
 	return fakeReturns.result1
 }
 
@@ -360,15 +361,16 @@ func (fake *FakeClient) Build(arg1 string) (atc.Build, bool, error) {
 	fake.buildArgsForCall = append(fake.buildArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.BuildStub
+	fakeReturns := fake.buildReturns
 	fake.recordInvocation("Build", []interface{}{arg1})
 	fake.buildMutex.Unlock()
-	if fake.BuildStub != nil {
-		return fake.BuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -426,15 +428,16 @@ func (fake *FakeClient) BuildEvents(arg1 string) (concourse.Events, error) {
 	fake.buildEventsArgsForCall = append(fake.buildEventsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.BuildEventsStub
+	fakeReturns := fake.buildEventsReturns
 	fake.recordInvocation("BuildEvents", []interface{}{arg1})
 	fake.buildEventsMutex.Unlock()
-	if fake.BuildEventsStub != nil {
-		return fake.BuildEventsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.buildEventsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -489,15 +492,16 @@ func (fake *FakeClient) BuildPlan(arg1 int) (atc.PublicBuildPlan, bool, error) {
 	fake.buildPlanArgsForCall = append(fake.buildPlanArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.BuildPlanStub
+	fakeReturns := fake.buildPlanReturns
 	fake.recordInvocation("BuildPlan", []interface{}{arg1})
 	fake.buildPlanMutex.Unlock()
-	if fake.BuildPlanStub != nil {
-		return fake.BuildPlanStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildPlanReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -555,15 +559,16 @@ func (fake *FakeClient) BuildResources(arg1 int) (atc.BuildInputsOutputs, bool, 
 	fake.buildResourcesArgsForCall = append(fake.buildResourcesArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.BuildResourcesStub
+	fakeReturns := fake.buildResourcesReturns
 	fake.recordInvocation("BuildResources", []interface{}{arg1})
 	fake.buildResourcesMutex.Unlock()
-	if fake.BuildResourcesStub != nil {
-		return fake.BuildResourcesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -621,15 +626,16 @@ func (fake *FakeClient) Builds(arg1 concourse.Page) ([]atc.Build, concourse.Pagi
 	fake.buildsArgsForCall = append(fake.buildsArgsForCall, struct {
 		arg1 concourse.Page
 	}{arg1})
+	stub := fake.BuildsStub
+	fakeReturns := fake.buildsReturns
 	fake.recordInvocation("Builds", []interface{}{arg1})
 	fake.buildsMutex.Unlock()
-	if fake.BuildsStub != nil {
-		return fake.BuildsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -687,15 +693,16 @@ func (fake *FakeClient) FindTeam(arg1 string) (concourse.Team, error) {
 	fake.findTeamArgsForCall = append(fake.findTeamArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindTeamStub
+	fakeReturns := fake.findTeamReturns
 	fake.recordInvocation("FindTeam", []interface{}{arg1})
 	fake.findTeamMutex.Unlock()
-	if fake.FindTeamStub != nil {
-		return fake.FindTeamStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findTeamReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -751,15 +758,16 @@ func (fake *FakeClient) GetCLIReader(arg1 string, arg2 string) (io.ReadCloser, h
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetCLIReaderStub
+	fakeReturns := fake.getCLIReaderReturns
 	fake.recordInvocation("GetCLIReader", []interface{}{arg1, arg2})
 	fake.getCLIReaderMutex.Unlock()
-	if fake.GetCLIReaderStub != nil {
-		return fake.GetCLIReaderStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getCLIReaderReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -816,15 +824,16 @@ func (fake *FakeClient) GetInfo() (atc.Info, error) {
 	ret, specificReturn := fake.getInfoReturnsOnCall[len(fake.getInfoArgsForCall)]
 	fake.getInfoArgsForCall = append(fake.getInfoArgsForCall, struct {
 	}{})
+	stub := fake.GetInfoStub
+	fakeReturns := fake.getInfoReturns
 	fake.recordInvocation("GetInfo", []interface{}{})
 	fake.getInfoMutex.Unlock()
-	if fake.GetInfoStub != nil {
-		return fake.GetInfoStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getInfoReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -871,15 +880,16 @@ func (fake *FakeClient) HTTPClient() *http.Client {
 	ret, specificReturn := fake.hTTPClientReturnsOnCall[len(fake.hTTPClientArgsForCall)]
 	fake.hTTPClientArgsForCall = append(fake.hTTPClientArgsForCall, struct {
 	}{})
+	stub := fake.HTTPClientStub
+	fakeReturns := fake.hTTPClientReturns
 	fake.recordInvocation("HTTPClient", []interface{}{})
 	fake.hTTPClientMutex.Unlock()
-	if fake.HTTPClientStub != nil {
-		return fake.HTTPClientStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hTTPClientReturns
 	return fakeReturns.result1
 }
 
@@ -924,15 +934,16 @@ func (fake *FakeClient) LandWorker(arg1 string) error {
 	fake.landWorkerArgsForCall = append(fake.landWorkerArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.LandWorkerStub
+	fakeReturns := fake.landWorkerReturns
 	fake.recordInvocation("LandWorker", []interface{}{arg1})
 	fake.landWorkerMutex.Unlock()
-	if fake.LandWorkerStub != nil {
-		return fake.LandWorkerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.landWorkerReturns
 	return fakeReturns.result1
 }
 
@@ -984,15 +995,16 @@ func (fake *FakeClient) ListActiveUsersSince(arg1 time.Time) ([]atc.User, error)
 	fake.listActiveUsersSinceArgsForCall = append(fake.listActiveUsersSinceArgsForCall, struct {
 		arg1 time.Time
 	}{arg1})
+	stub := fake.ListActiveUsersSinceStub
+	fakeReturns := fake.listActiveUsersSinceReturns
 	fake.recordInvocation("ListActiveUsersSince", []interface{}{arg1})
 	fake.listActiveUsersSinceMutex.Unlock()
-	if fake.ListActiveUsersSinceStub != nil {
-		return fake.ListActiveUsersSinceStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listActiveUsersSinceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1046,15 +1058,16 @@ func (fake *FakeClient) ListAllJobs() ([]atc.Job, error) {
 	ret, specificReturn := fake.listAllJobsReturnsOnCall[len(fake.listAllJobsArgsForCall)]
 	fake.listAllJobsArgsForCall = append(fake.listAllJobsArgsForCall, struct {
 	}{})
+	stub := fake.ListAllJobsStub
+	fakeReturns := fake.listAllJobsReturns
 	fake.recordInvocation("ListAllJobs", []interface{}{})
 	fake.listAllJobsMutex.Unlock()
-	if fake.ListAllJobsStub != nil {
-		return fake.ListAllJobsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listAllJobsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1102,15 +1115,16 @@ func (fake *FakeClient) ListBuildArtifacts(arg1 string) ([]atc.WorkerArtifact, e
 	fake.listBuildArtifactsArgsForCall = append(fake.listBuildArtifactsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListBuildArtifactsStub
+	fakeReturns := fake.listBuildArtifactsReturns
 	fake.recordInvocation("ListBuildArtifacts", []interface{}{arg1})
 	fake.listBuildArtifactsMutex.Unlock()
-	if fake.ListBuildArtifactsStub != nil {
-		return fake.ListBuildArtifactsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listBuildArtifactsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1164,15 +1178,16 @@ func (fake *FakeClient) ListPipelines() ([]atc.Pipeline, error) {
 	ret, specificReturn := fake.listPipelinesReturnsOnCall[len(fake.listPipelinesArgsForCall)]
 	fake.listPipelinesArgsForCall = append(fake.listPipelinesArgsForCall, struct {
 	}{})
+	stub := fake.ListPipelinesStub
+	fakeReturns := fake.listPipelinesReturns
 	fake.recordInvocation("ListPipelines", []interface{}{})
 	fake.listPipelinesMutex.Unlock()
-	if fake.ListPipelinesStub != nil {
-		return fake.ListPipelinesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listPipelinesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1219,15 +1234,16 @@ func (fake *FakeClient) ListTeams() ([]atc.Team, error) {
 	ret, specificReturn := fake.listTeamsReturnsOnCall[len(fake.listTeamsArgsForCall)]
 	fake.listTeamsArgsForCall = append(fake.listTeamsArgsForCall, struct {
 	}{})
+	stub := fake.ListTeamsStub
+	fakeReturns := fake.listTeamsReturns
 	fake.recordInvocation("ListTeams", []interface{}{})
 	fake.listTeamsMutex.Unlock()
-	if fake.ListTeamsStub != nil {
-		return fake.ListTeamsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listTeamsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1274,15 +1290,16 @@ func (fake *FakeClient) ListWorkers() ([]atc.Worker, error) {
 	ret, specificReturn := fake.listWorkersReturnsOnCall[len(fake.listWorkersArgsForCall)]
 	fake.listWorkersArgsForCall = append(fake.listWorkersArgsForCall, struct {
 	}{})
+	stub := fake.ListWorkersStub
+	fakeReturns := fake.listWorkersReturns
 	fake.recordInvocation("ListWorkers", []interface{}{})
 	fake.listWorkersMutex.Unlock()
-	if fake.ListWorkersStub != nil {
-		return fake.ListWorkersStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listWorkersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1330,15 +1347,16 @@ func (fake *FakeClient) PruneWorker(arg1 string) error {
 	fake.pruneWorkerArgsForCall = append(fake.pruneWorkerArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PruneWorkerStub
+	fakeReturns := fake.pruneWorkerReturns
 	fake.recordInvocation("PruneWorker", []interface{}{arg1})
 	fake.pruneWorkerMutex.Unlock()
-	if fake.PruneWorkerStub != nil {
-		return fake.PruneWorkerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pruneWorkerReturns
 	return fakeReturns.result1
 }
 
@@ -1391,15 +1409,16 @@ func (fake *FakeClient) SaveWorker(arg1 atc.Worker, arg2 *time.Duration) (*atc.W
 		arg1 atc.Worker
 		arg2 *time.Duration
 	}{arg1, arg2})
+	stub := fake.SaveWorkerStub
+	fakeReturns := fake.saveWorkerReturns
 	fake.recordInvocation("SaveWorker", []interface{}{arg1, arg2})
 	fake.saveWorkerMutex.Unlock()
-	if fake.SaveWorkerStub != nil {
-		return fake.SaveWorkerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.saveWorkerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1454,15 +1473,16 @@ func (fake *FakeClient) Team(arg1 string) concourse.Team {
 	fake.teamArgsForCall = append(fake.teamArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.TeamStub
+	fakeReturns := fake.teamReturns
 	fake.recordInvocation("Team", []interface{}{arg1})
 	fake.teamMutex.Unlock()
-	if fake.TeamStub != nil {
-		return fake.TeamStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.teamReturns
 	return fakeReturns.result1
 }
 
@@ -1513,15 +1533,16 @@ func (fake *FakeClient) URL() string {
 	ret, specificReturn := fake.uRLReturnsOnCall[len(fake.uRLArgsForCall)]
 	fake.uRLArgsForCall = append(fake.uRLArgsForCall, struct {
 	}{})
+	stub := fake.URLStub
+	fakeReturns := fake.uRLReturns
 	fake.recordInvocation("URL", []interface{}{})
 	fake.uRLMutex.Unlock()
-	if fake.URLStub != nil {
-		return fake.URLStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.uRLReturns
 	return fakeReturns.result1
 }
 
@@ -1565,15 +1586,16 @@ func (fake *FakeClient) UserInfo() (atc.UserInfo, error) {
 	ret, specificReturn := fake.userInfoReturnsOnCall[len(fake.userInfoArgsForCall)]
 	fake.userInfoArgsForCall = append(fake.userInfoArgsForCall, struct {
 	}{})
+	stub := fake.UserInfoStub
+	fakeReturns := fake.userInfoReturns
 	fake.recordInvocation("UserInfo", []interface{}{})
 	fake.userInfoMutex.Unlock()
-	if fake.UserInfoStub != nil {
-		return fake.UserInfoStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.userInfoReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -774,15 +774,16 @@ func (fake *FakeTeam) ATCTeam() atc.Team {
 	ret, specificReturn := fake.aTCTeamReturnsOnCall[len(fake.aTCTeamArgsForCall)]
 	fake.aTCTeamArgsForCall = append(fake.aTCTeamArgsForCall, struct {
 	}{})
+	stub := fake.ATCTeamStub
+	fakeReturns := fake.aTCTeamReturns
 	fake.recordInvocation("ATCTeam", []interface{}{})
 	fake.aTCTeamMutex.Unlock()
-	if fake.ATCTeamStub != nil {
-		return fake.ATCTeamStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.aTCTeamReturns
 	return fakeReturns.result1
 }
 
@@ -827,15 +828,16 @@ func (fake *FakeTeam) ArchivePipeline(arg1 atc.PipelineRef) (bool, error) {
 	fake.archivePipelineArgsForCall = append(fake.archivePipelineArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.ArchivePipelineStub
+	fakeReturns := fake.archivePipelineReturns
 	fake.recordInvocation("ArchivePipeline", []interface{}{arg1})
 	fake.archivePipelineMutex.Unlock()
-	if fake.ArchivePipelineStub != nil {
-		return fake.ArchivePipelineStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.archivePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -889,15 +891,16 @@ func (fake *FakeTeam) Auth() atc.TeamAuth {
 	ret, specificReturn := fake.authReturnsOnCall[len(fake.authArgsForCall)]
 	fake.authArgsForCall = append(fake.authArgsForCall, struct {
 	}{})
+	stub := fake.AuthStub
+	fakeReturns := fake.authReturns
 	fake.recordInvocation("Auth", []interface{}{})
 	fake.authMutex.Unlock()
-	if fake.AuthStub != nil {
-		return fake.AuthStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.authReturns
 	return fakeReturns.result1
 }
 
@@ -943,15 +946,16 @@ func (fake *FakeTeam) BuildInputsForJob(arg1 atc.PipelineRef, arg2 string) ([]at
 		arg1 atc.PipelineRef
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.BuildInputsForJobStub
+	fakeReturns := fake.buildInputsForJobReturns
 	fake.recordInvocation("BuildInputsForJob", []interface{}{arg1, arg2})
 	fake.buildInputsForJobMutex.Unlock()
-	if fake.BuildInputsForJobStub != nil {
-		return fake.BuildInputsForJobStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildInputsForJobReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1009,15 +1013,16 @@ func (fake *FakeTeam) Builds(arg1 concourse.Page) ([]atc.Build, concourse.Pagina
 	fake.buildsArgsForCall = append(fake.buildsArgsForCall, struct {
 		arg1 concourse.Page
 	}{arg1})
+	stub := fake.BuildsStub
+	fakeReturns := fake.buildsReturns
 	fake.recordInvocation("Builds", []interface{}{arg1})
 	fake.buildsMutex.Unlock()
-	if fake.BuildsStub != nil {
-		return fake.BuildsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1077,15 +1082,16 @@ func (fake *FakeTeam) BuildsWithVersionAsInput(arg1 atc.PipelineRef, arg2 string
 		arg2 string
 		arg3 int
 	}{arg1, arg2, arg3})
+	stub := fake.BuildsWithVersionAsInputStub
+	fakeReturns := fake.buildsWithVersionAsInputReturns
 	fake.recordInvocation("BuildsWithVersionAsInput", []interface{}{arg1, arg2, arg3})
 	fake.buildsWithVersionAsInputMutex.Unlock()
-	if fake.BuildsWithVersionAsInputStub != nil {
-		return fake.BuildsWithVersionAsInputStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsWithVersionAsInputReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1145,15 +1151,16 @@ func (fake *FakeTeam) BuildsWithVersionAsOutput(arg1 atc.PipelineRef, arg2 strin
 		arg2 string
 		arg3 int
 	}{arg1, arg2, arg3})
+	stub := fake.BuildsWithVersionAsOutputStub
+	fakeReturns := fake.buildsWithVersionAsOutputReturns
 	fake.recordInvocation("BuildsWithVersionAsOutput", []interface{}{arg1, arg2, arg3})
 	fake.buildsWithVersionAsOutputMutex.Unlock()
-	if fake.BuildsWithVersionAsOutputStub != nil {
-		return fake.BuildsWithVersionAsOutputStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.buildsWithVersionAsOutputReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1213,15 +1220,16 @@ func (fake *FakeTeam) CheckResource(arg1 atc.PipelineRef, arg2 string, arg3 atc.
 		arg2 string
 		arg3 atc.Version
 	}{arg1, arg2, arg3})
+	stub := fake.CheckResourceStub
+	fakeReturns := fake.checkResourceReturns
 	fake.recordInvocation("CheckResource", []interface{}{arg1, arg2, arg3})
 	fake.checkResourceMutex.Unlock()
-	if fake.CheckResourceStub != nil {
-		return fake.CheckResourceStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.checkResourceReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1281,15 +1289,16 @@ func (fake *FakeTeam) CheckResourceType(arg1 atc.PipelineRef, arg2 string, arg3 
 		arg2 string
 		arg3 atc.Version
 	}{arg1, arg2, arg3})
+	stub := fake.CheckResourceTypeStub
+	fakeReturns := fake.checkResourceTypeReturns
 	fake.recordInvocation("CheckResourceType", []interface{}{arg1, arg2, arg3})
 	fake.checkResourceTypeMutex.Unlock()
-	if fake.CheckResourceTypeStub != nil {
-		return fake.CheckResourceTypeStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.checkResourceTypeReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1350,15 +1359,16 @@ func (fake *FakeTeam) ClearTaskCache(arg1 atc.PipelineRef, arg2 string, arg3 str
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.ClearTaskCacheStub
+	fakeReturns := fake.clearTaskCacheReturns
 	fake.recordInvocation("ClearTaskCache", []interface{}{arg1, arg2, arg3, arg4})
 	fake.clearTaskCacheMutex.Unlock()
-	if fake.ClearTaskCacheStub != nil {
-		return fake.ClearTaskCacheStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.clearTaskCacheReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1420,15 +1430,16 @@ func (fake *FakeTeam) CreateArtifact(arg1 io.Reader, arg2 string, arg3 []string)
 		arg2 string
 		arg3 []string
 	}{arg1, arg2, arg3Copy})
+	stub := fake.CreateArtifactStub
+	fakeReturns := fake.createArtifactReturns
 	fake.recordInvocation("CreateArtifact", []interface{}{arg1, arg2, arg3Copy})
 	fake.createArtifactMutex.Unlock()
-	if fake.CreateArtifactStub != nil {
-		return fake.CreateArtifactStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createArtifactReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1483,15 +1494,16 @@ func (fake *FakeTeam) CreateBuild(arg1 atc.Plan) (atc.Build, error) {
 	fake.createBuildArgsForCall = append(fake.createBuildArgsForCall, struct {
 		arg1 atc.Plan
 	}{arg1})
+	stub := fake.CreateBuildStub
+	fakeReturns := fake.createBuildReturns
 	fake.recordInvocation("CreateBuild", []interface{}{arg1})
 	fake.createBuildMutex.Unlock()
-	if fake.CreateBuildStub != nil {
-		return fake.CreateBuildStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1547,15 +1559,16 @@ func (fake *FakeTeam) CreateJobBuild(arg1 atc.PipelineRef, arg2 string) (atc.Bui
 		arg1 atc.PipelineRef
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.CreateJobBuildStub
+	fakeReturns := fake.createJobBuildReturns
 	fake.recordInvocation("CreateJobBuild", []interface{}{arg1, arg2})
 	fake.createJobBuildMutex.Unlock()
-	if fake.CreateJobBuildStub != nil {
-		return fake.CreateJobBuildStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createJobBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1610,15 +1623,16 @@ func (fake *FakeTeam) CreateOrUpdate(arg1 atc.Team) (atc.Team, bool, bool, []con
 	fake.createOrUpdateArgsForCall = append(fake.createOrUpdateArgsForCall, struct {
 		arg1 atc.Team
 	}{arg1})
+	stub := fake.CreateOrUpdateStub
+	fakeReturns := fake.createOrUpdateReturns
 	fake.recordInvocation("CreateOrUpdate", []interface{}{arg1})
 	fake.createOrUpdateMutex.Unlock()
-	if fake.CreateOrUpdateStub != nil {
-		return fake.CreateOrUpdateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4, ret.result5
 	}
-	fakeReturns := fake.createOrUpdateReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4, fakeReturns.result5
 }
 
@@ -1690,15 +1704,16 @@ func (fake *FakeTeam) CreateOrUpdatePipelineConfig(arg1 atc.PipelineRef, arg2 st
 		arg3 []byte
 		arg4 bool
 	}{arg1, arg2, arg3Copy, arg4})
+	stub := fake.CreateOrUpdatePipelineConfigStub
+	fakeReturns := fake.createOrUpdatePipelineConfigReturns
 	fake.recordInvocation("CreateOrUpdatePipelineConfig", []interface{}{arg1, arg2, arg3Copy, arg4})
 	fake.createOrUpdatePipelineConfigMutex.Unlock()
-	if fake.CreateOrUpdatePipelineConfigStub != nil {
-		return fake.CreateOrUpdatePipelineConfigStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.createOrUpdatePipelineConfigReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -1760,15 +1775,16 @@ func (fake *FakeTeam) CreatePipelineBuild(arg1 atc.PipelineRef, arg2 atc.Plan) (
 		arg1 atc.PipelineRef
 		arg2 atc.Plan
 	}{arg1, arg2})
+	stub := fake.CreatePipelineBuildStub
+	fakeReturns := fake.createPipelineBuildReturns
 	fake.recordInvocation("CreatePipelineBuild", []interface{}{arg1, arg2})
 	fake.createPipelineBuildMutex.Unlock()
-	if fake.CreatePipelineBuildStub != nil {
-		return fake.CreatePipelineBuildStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createPipelineBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1823,15 +1839,16 @@ func (fake *FakeTeam) DeletePipeline(arg1 atc.PipelineRef) (bool, error) {
 	fake.deletePipelineArgsForCall = append(fake.deletePipelineArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.DeletePipelineStub
+	fakeReturns := fake.deletePipelineReturns
 	fake.recordInvocation("DeletePipeline", []interface{}{arg1})
 	fake.deletePipelineMutex.Unlock()
-	if fake.DeletePipelineStub != nil {
-		return fake.DeletePipelineStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.deletePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1886,15 +1903,16 @@ func (fake *FakeTeam) DestroyTeam(arg1 string) error {
 	fake.destroyTeamArgsForCall = append(fake.destroyTeamArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DestroyTeamStub
+	fakeReturns := fake.destroyTeamReturns
 	fake.recordInvocation("DestroyTeam", []interface{}{arg1})
 	fake.destroyTeamMutex.Unlock()
-	if fake.DestroyTeamStub != nil {
-		return fake.DestroyTeamStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destroyTeamReturns
 	return fakeReturns.result1
 }
 
@@ -1948,15 +1966,16 @@ func (fake *FakeTeam) DisableResourceVersion(arg1 atc.PipelineRef, arg2 string, 
 		arg2 string
 		arg3 int
 	}{arg1, arg2, arg3})
+	stub := fake.DisableResourceVersionStub
+	fakeReturns := fake.disableResourceVersionReturns
 	fake.recordInvocation("DisableResourceVersion", []interface{}{arg1, arg2, arg3})
 	fake.disableResourceVersionMutex.Unlock()
-	if fake.DisableResourceVersionStub != nil {
-		return fake.DisableResourceVersionStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.disableResourceVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2013,15 +2032,16 @@ func (fake *FakeTeam) EnableResourceVersion(arg1 atc.PipelineRef, arg2 string, a
 		arg2 string
 		arg3 int
 	}{arg1, arg2, arg3})
+	stub := fake.EnableResourceVersionStub
+	fakeReturns := fake.enableResourceVersionReturns
 	fake.recordInvocation("EnableResourceVersion", []interface{}{arg1, arg2, arg3})
 	fake.enableResourceVersionMutex.Unlock()
-	if fake.EnableResourceVersionStub != nil {
-		return fake.EnableResourceVersionStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.enableResourceVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2076,15 +2096,16 @@ func (fake *FakeTeam) ExposePipeline(arg1 atc.PipelineRef) (bool, error) {
 	fake.exposePipelineArgsForCall = append(fake.exposePipelineArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.ExposePipelineStub
+	fakeReturns := fake.exposePipelineReturns
 	fake.recordInvocation("ExposePipeline", []interface{}{arg1})
 	fake.exposePipelineMutex.Unlock()
-	if fake.ExposePipelineStub != nil {
-		return fake.ExposePipelineStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.exposePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2139,15 +2160,16 @@ func (fake *FakeTeam) GetArtifact(arg1 int) (io.ReadCloser, error) {
 	fake.getArtifactArgsForCall = append(fake.getArtifactArgsForCall, struct {
 		arg1 int
 	}{arg1})
+	stub := fake.GetArtifactStub
+	fakeReturns := fake.getArtifactReturns
 	fake.recordInvocation("GetArtifact", []interface{}{arg1})
 	fake.getArtifactMutex.Unlock()
-	if fake.GetArtifactStub != nil {
-		return fake.GetArtifactStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getArtifactReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2202,15 +2224,16 @@ func (fake *FakeTeam) GetContainer(arg1 string) (atc.Container, error) {
 	fake.getContainerArgsForCall = append(fake.getContainerArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetContainerStub
+	fakeReturns := fake.getContainerReturns
 	fake.recordInvocation("GetContainer", []interface{}{arg1})
 	fake.getContainerMutex.Unlock()
-	if fake.GetContainerStub != nil {
-		return fake.GetContainerStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2265,15 +2288,16 @@ func (fake *FakeTeam) HidePipeline(arg1 atc.PipelineRef) (bool, error) {
 	fake.hidePipelineArgsForCall = append(fake.hidePipelineArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.HidePipelineStub
+	fakeReturns := fake.hidePipelineReturns
 	fake.recordInvocation("HidePipeline", []interface{}{arg1})
 	fake.hidePipelineMutex.Unlock()
-	if fake.HidePipelineStub != nil {
-		return fake.HidePipelineStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.hidePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2327,15 +2351,16 @@ func (fake *FakeTeam) ID() int {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -2381,15 +2406,16 @@ func (fake *FakeTeam) Job(arg1 atc.PipelineRef, arg2 string) (atc.Job, bool, err
 		arg1 atc.PipelineRef
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.JobStub
+	fakeReturns := fake.jobReturns
 	fake.recordInvocation("Job", []interface{}{arg1, arg2})
 	fake.jobMutex.Unlock()
-	if fake.JobStub != nil {
-		return fake.JobStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.jobReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2449,15 +2475,16 @@ func (fake *FakeTeam) JobBuild(arg1 atc.PipelineRef, arg2 string, arg3 string) (
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.JobBuildStub
+	fakeReturns := fake.jobBuildReturns
 	fake.recordInvocation("JobBuild", []interface{}{arg1, arg2, arg3})
 	fake.jobBuildMutex.Unlock()
-	if fake.JobBuildStub != nil {
-		return fake.JobBuildStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.jobBuildReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2517,15 +2544,16 @@ func (fake *FakeTeam) JobBuilds(arg1 atc.PipelineRef, arg2 string, arg3 concours
 		arg2 string
 		arg3 concourse.Page
 	}{arg1, arg2, arg3})
+	stub := fake.JobBuildsStub
+	fakeReturns := fake.jobBuildsReturns
 	fake.recordInvocation("JobBuilds", []interface{}{arg1, arg2, arg3})
 	fake.jobBuildsMutex.Unlock()
-	if fake.JobBuildsStub != nil {
-		return fake.JobBuildsStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.jobBuildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -2586,15 +2614,16 @@ func (fake *FakeTeam) ListContainers(arg1 map[string]string) ([]atc.Container, e
 	fake.listContainersArgsForCall = append(fake.listContainersArgsForCall, struct {
 		arg1 map[string]string
 	}{arg1})
+	stub := fake.ListContainersStub
+	fakeReturns := fake.listContainersReturns
 	fake.recordInvocation("ListContainers", []interface{}{arg1})
 	fake.listContainersMutex.Unlock()
-	if fake.ListContainersStub != nil {
-		return fake.ListContainersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listContainersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2649,15 +2678,16 @@ func (fake *FakeTeam) ListJobs(arg1 atc.PipelineRef) ([]atc.Job, error) {
 	fake.listJobsArgsForCall = append(fake.listJobsArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.ListJobsStub
+	fakeReturns := fake.listJobsReturns
 	fake.recordInvocation("ListJobs", []interface{}{arg1})
 	fake.listJobsMutex.Unlock()
-	if fake.ListJobsStub != nil {
-		return fake.ListJobsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listJobsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2711,15 +2741,16 @@ func (fake *FakeTeam) ListPipelines() ([]atc.Pipeline, error) {
 	ret, specificReturn := fake.listPipelinesReturnsOnCall[len(fake.listPipelinesArgsForCall)]
 	fake.listPipelinesArgsForCall = append(fake.listPipelinesArgsForCall, struct {
 	}{})
+	stub := fake.ListPipelinesStub
+	fakeReturns := fake.listPipelinesReturns
 	fake.recordInvocation("ListPipelines", []interface{}{})
 	fake.listPipelinesMutex.Unlock()
-	if fake.ListPipelinesStub != nil {
-		return fake.ListPipelinesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listPipelinesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2767,15 +2798,16 @@ func (fake *FakeTeam) ListResources(arg1 atc.PipelineRef) ([]atc.Resource, error
 	fake.listResourcesArgsForCall = append(fake.listResourcesArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.ListResourcesStub
+	fakeReturns := fake.listResourcesReturns
 	fake.recordInvocation("ListResources", []interface{}{arg1})
 	fake.listResourcesMutex.Unlock()
-	if fake.ListResourcesStub != nil {
-		return fake.ListResourcesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2829,15 +2861,16 @@ func (fake *FakeTeam) ListVolumes() ([]atc.Volume, error) {
 	ret, specificReturn := fake.listVolumesReturnsOnCall[len(fake.listVolumesArgsForCall)]
 	fake.listVolumesArgsForCall = append(fake.listVolumesArgsForCall, struct {
 	}{})
+	stub := fake.ListVolumesStub
+	fakeReturns := fake.listVolumesReturns
 	fake.recordInvocation("ListVolumes", []interface{}{})
 	fake.listVolumesMutex.Unlock()
-	if fake.ListVolumesStub != nil {
-		return fake.ListVolumesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listVolumesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2884,15 +2917,16 @@ func (fake *FakeTeam) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -2942,15 +2976,16 @@ func (fake *FakeTeam) OrderingPipelines(arg1 []string) error {
 	fake.orderingPipelinesArgsForCall = append(fake.orderingPipelinesArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.OrderingPipelinesStub
+	fakeReturns := fake.orderingPipelinesReturns
 	fake.recordInvocation("OrderingPipelines", []interface{}{arg1Copy})
 	fake.orderingPipelinesMutex.Unlock()
-	if fake.OrderingPipelinesStub != nil {
-		return fake.OrderingPipelinesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.orderingPipelinesReturns
 	return fakeReturns.result1
 }
 
@@ -3003,15 +3038,16 @@ func (fake *FakeTeam) PauseJob(arg1 atc.PipelineRef, arg2 string) (bool, error) 
 		arg1 atc.PipelineRef
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.PauseJobStub
+	fakeReturns := fake.pauseJobReturns
 	fake.recordInvocation("PauseJob", []interface{}{arg1, arg2})
 	fake.pauseJobMutex.Unlock()
-	if fake.PauseJobStub != nil {
-		return fake.PauseJobStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.pauseJobReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3066,15 +3102,16 @@ func (fake *FakeTeam) PausePipeline(arg1 atc.PipelineRef) (bool, error) {
 	fake.pausePipelineArgsForCall = append(fake.pausePipelineArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.PausePipelineStub
+	fakeReturns := fake.pausePipelineReturns
 	fake.recordInvocation("PausePipeline", []interface{}{arg1})
 	fake.pausePipelineMutex.Unlock()
-	if fake.PausePipelineStub != nil {
-		return fake.PausePipelineStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.pausePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3131,15 +3168,16 @@ func (fake *FakeTeam) PinResourceVersion(arg1 atc.PipelineRef, arg2 string, arg3
 		arg2 string
 		arg3 int
 	}{arg1, arg2, arg3})
+	stub := fake.PinResourceVersionStub
+	fakeReturns := fake.pinResourceVersionReturns
 	fake.recordInvocation("PinResourceVersion", []interface{}{arg1, arg2, arg3})
 	fake.pinResourceVersionMutex.Unlock()
-	if fake.PinResourceVersionStub != nil {
-		return fake.PinResourceVersionStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.pinResourceVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3194,15 +3232,16 @@ func (fake *FakeTeam) Pipeline(arg1 atc.PipelineRef) (atc.Pipeline, bool, error)
 	fake.pipelineArgsForCall = append(fake.pipelineArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.PipelineStub
+	fakeReturns := fake.pipelineReturns
 	fake.recordInvocation("Pipeline", []interface{}{arg1})
 	fake.pipelineMutex.Unlock()
-	if fake.PipelineStub != nil {
-		return fake.PipelineStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.pipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3261,15 +3300,16 @@ func (fake *FakeTeam) PipelineBuilds(arg1 atc.PipelineRef, arg2 concourse.Page) 
 		arg1 atc.PipelineRef
 		arg2 concourse.Page
 	}{arg1, arg2})
+	stub := fake.PipelineBuildsStub
+	fakeReturns := fake.pipelineBuildsReturns
 	fake.recordInvocation("PipelineBuilds", []interface{}{arg1, arg2})
 	fake.pipelineBuildsMutex.Unlock()
-	if fake.PipelineBuildsStub != nil {
-		return fake.PipelineBuildsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.pipelineBuildsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -3330,15 +3370,16 @@ func (fake *FakeTeam) PipelineConfig(arg1 atc.PipelineRef) (atc.Config, string, 
 	fake.pipelineConfigArgsForCall = append(fake.pipelineConfigArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.PipelineConfigStub
+	fakeReturns := fake.pipelineConfigReturns
 	fake.recordInvocation("PipelineConfig", []interface{}{arg1})
 	fake.pipelineConfigMutex.Unlock()
-	if fake.PipelineConfigStub != nil {
-		return fake.PipelineConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.pipelineConfigReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -3400,15 +3441,16 @@ func (fake *FakeTeam) RenamePipeline(arg1 string, arg2 string) (bool, []concours
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RenamePipelineStub
+	fakeReturns := fake.renamePipelineReturns
 	fake.recordInvocation("RenamePipeline", []interface{}{arg1, arg2})
 	fake.renamePipelineMutex.Unlock()
-	if fake.RenamePipelineStub != nil {
-		return fake.RenamePipelineStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.renamePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3467,15 +3509,16 @@ func (fake *FakeTeam) RenameTeam(arg1 string, arg2 string) (bool, []concourse.Co
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RenameTeamStub
+	fakeReturns := fake.renameTeamReturns
 	fake.recordInvocation("RenameTeam", []interface{}{arg1, arg2})
 	fake.renameTeamMutex.Unlock()
-	if fake.RenameTeamStub != nil {
-		return fake.RenameTeamStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.renameTeamReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3535,15 +3578,16 @@ func (fake *FakeTeam) RerunJobBuild(arg1 atc.PipelineRef, arg2 string, arg3 stri
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.RerunJobBuildStub
+	fakeReturns := fake.rerunJobBuildReturns
 	fake.recordInvocation("RerunJobBuild", []interface{}{arg1, arg2, arg3})
 	fake.rerunJobBuildMutex.Unlock()
-	if fake.RerunJobBuildStub != nil {
-		return fake.RerunJobBuildStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.rerunJobBuildReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3599,15 +3643,16 @@ func (fake *FakeTeam) Resource(arg1 atc.PipelineRef, arg2 string) (atc.Resource,
 		arg1 atc.PipelineRef
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ResourceStub
+	fakeReturns := fake.resourceReturns
 	fake.recordInvocation("Resource", []interface{}{arg1, arg2})
 	fake.resourceMutex.Unlock()
-	if fake.ResourceStub != nil {
-		return fake.ResourceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.resourceReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3668,15 +3713,16 @@ func (fake *FakeTeam) ResourceVersions(arg1 atc.PipelineRef, arg2 string, arg3 c
 		arg3 concourse.Page
 		arg4 atc.Version
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.ResourceVersionsStub
+	fakeReturns := fake.resourceVersionsReturns
 	fake.recordInvocation("ResourceVersions", []interface{}{arg1, arg2, arg3, arg4})
 	fake.resourceVersionsMutex.Unlock()
-	if fake.ResourceVersionsStub != nil {
-		return fake.ResourceVersionsStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.resourceVersionsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -3738,15 +3784,16 @@ func (fake *FakeTeam) ScheduleJob(arg1 atc.PipelineRef, arg2 string) (bool, erro
 		arg1 atc.PipelineRef
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ScheduleJobStub
+	fakeReturns := fake.scheduleJobReturns
 	fake.recordInvocation("ScheduleJob", []interface{}{arg1, arg2})
 	fake.scheduleJobMutex.Unlock()
-	if fake.ScheduleJobStub != nil {
-		return fake.ScheduleJobStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.scheduleJobReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3803,15 +3850,16 @@ func (fake *FakeTeam) SetPinComment(arg1 atc.PipelineRef, arg2 string, arg3 stri
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.SetPinCommentStub
+	fakeReturns := fake.setPinCommentReturns
 	fake.recordInvocation("SetPinComment", []interface{}{arg1, arg2, arg3})
 	fake.setPinCommentMutex.Unlock()
-	if fake.SetPinCommentStub != nil {
-		return fake.SetPinCommentStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.setPinCommentReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3867,15 +3915,16 @@ func (fake *FakeTeam) UnpauseJob(arg1 atc.PipelineRef, arg2 string) (bool, error
 		arg1 atc.PipelineRef
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.UnpauseJobStub
+	fakeReturns := fake.unpauseJobReturns
 	fake.recordInvocation("UnpauseJob", []interface{}{arg1, arg2})
 	fake.unpauseJobMutex.Unlock()
-	if fake.UnpauseJobStub != nil {
-		return fake.UnpauseJobStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.unpauseJobReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3930,15 +3979,16 @@ func (fake *FakeTeam) UnpausePipeline(arg1 atc.PipelineRef) (bool, error) {
 	fake.unpausePipelineArgsForCall = append(fake.unpausePipelineArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.UnpausePipelineStub
+	fakeReturns := fake.unpausePipelineReturns
 	fake.recordInvocation("UnpausePipeline", []interface{}{arg1})
 	fake.unpausePipelineMutex.Unlock()
-	if fake.UnpausePipelineStub != nil {
-		return fake.UnpausePipelineStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.unpausePipelineReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3994,15 +4044,16 @@ func (fake *FakeTeam) UnpinResource(arg1 atc.PipelineRef, arg2 string) (bool, er
 		arg1 atc.PipelineRef
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.UnpinResourceStub
+	fakeReturns := fake.unpinResourceReturns
 	fake.recordInvocation("UnpinResource", []interface{}{arg1, arg2})
 	fake.unpinResourceMutex.Unlock()
-	if fake.UnpinResourceStub != nil {
-		return fake.UnpinResourceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.unpinResourceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -4057,15 +4108,16 @@ func (fake *FakeTeam) VersionedResourceTypes(arg1 atc.PipelineRef) (atc.Versione
 	fake.versionedResourceTypesArgsForCall = append(fake.versionedResourceTypesArgsForCall, struct {
 		arg1 atc.PipelineRef
 	}{arg1})
+	stub := fake.VersionedResourceTypesStub
+	fakeReturns := fake.versionedResourceTypesReturns
 	fake.recordInvocation("VersionedResourceTypes", []interface{}{arg1})
 	fake.versionedResourceTypesMutex.Unlock()
-	if fake.VersionedResourceTypesStub != nil {
-		return fake.VersionedResourceTypesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.versionedResourceTypesReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/go-concourse/concourse/eventstream/eventstreamfakes/fake_event_stream.go
+++ b/go-concourse/concourse/eventstream/eventstreamfakes/fake_event_stream.go
@@ -40,15 +40,16 @@ func (fake *FakeEventStream) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -92,15 +93,16 @@ func (fake *FakeEventStream) NextEvent() (atc.Event, error) {
 	ret, specificReturn := fake.nextEventReturnsOnCall[len(fake.nextEventArgsForCall)]
 	fake.nextEventArgsForCall = append(fake.nextEventArgsForCall, struct {
 	}{})
+	stub := fake.NextEventStub
+	fakeReturns := fake.nextEventReturns
 	fake.recordInvocation("NextEvent", []interface{}{})
 	fake.nextEventMutex.Unlock()
-	if fake.NextEventStub != nil {
-		return fake.NextEventStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.nextEventReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/go-concourse/concourse/internal/internalfakes/fake_connection.go
+++ b/go-concourse/concourse/internal/internalfakes/fake_connection.go
@@ -78,15 +78,16 @@ func (fake *FakeConnection) ConnectToEventStream(arg1 internal.Request) (*sse.Ev
 	fake.connectToEventStreamArgsForCall = append(fake.connectToEventStreamArgsForCall, struct {
 		arg1 internal.Request
 	}{arg1})
+	stub := fake.ConnectToEventStreamStub
+	fakeReturns := fake.connectToEventStreamReturns
 	fake.recordInvocation("ConnectToEventStream", []interface{}{arg1})
 	fake.connectToEventStreamMutex.Unlock()
-	if fake.ConnectToEventStreamStub != nil {
-		return fake.ConnectToEventStreamStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.connectToEventStreamReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -140,15 +141,16 @@ func (fake *FakeConnection) HTTPClient() *http.Client {
 	ret, specificReturn := fake.hTTPClientReturnsOnCall[len(fake.hTTPClientArgsForCall)]
 	fake.hTTPClientArgsForCall = append(fake.hTTPClientArgsForCall, struct {
 	}{})
+	stub := fake.HTTPClientStub
+	fakeReturns := fake.hTTPClientReturns
 	fake.recordInvocation("HTTPClient", []interface{}{})
 	fake.hTTPClientMutex.Unlock()
-	if fake.HTTPClientStub != nil {
-		return fake.HTTPClientStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hTTPClientReturns
 	return fakeReturns.result1
 }
 
@@ -194,15 +196,16 @@ func (fake *FakeConnection) Send(arg1 internal.Request, arg2 *internal.Response)
 		arg1 internal.Request
 		arg2 *internal.Response
 	}{arg1, arg2})
+	stub := fake.SendStub
+	fakeReturns := fake.sendReturns
 	fake.recordInvocation("Send", []interface{}{arg1, arg2})
 	fake.sendMutex.Unlock()
-	if fake.SendStub != nil {
-		return fake.SendStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sendReturns
 	return fakeReturns.result1
 }
 
@@ -256,15 +259,16 @@ func (fake *FakeConnection) SendHTTPRequest(arg1 *http.Request, arg2 bool, arg3 
 		arg2 bool
 		arg3 *internal.Response
 	}{arg1, arg2, arg3})
+	stub := fake.SendHTTPRequestStub
+	fakeReturns := fake.sendHTTPRequestReturns
 	fake.recordInvocation("SendHTTPRequest", []interface{}{arg1, arg2, arg3})
 	fake.sendHTTPRequestMutex.Unlock()
-	if fake.SendHTTPRequestStub != nil {
-		return fake.SendHTTPRequestStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.sendHTTPRequestReturns
 	return fakeReturns.result1
 }
 
@@ -315,15 +319,16 @@ func (fake *FakeConnection) URL() string {
 	ret, specificReturn := fake.uRLReturnsOnCall[len(fake.uRLArgsForCall)]
 	fake.uRLArgsForCall = append(fake.uRLArgsForCall, struct {
 	}{})
+	stub := fake.URLStub
+	fakeReturns := fake.uRLReturns
 	fake.recordInvocation("URL", []interface{}{})
 	fake.uRLMutex.Unlock()
-	if fake.URLStub != nil {
-		return fake.URLStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.uRLReturns
 	return fakeReturns.result1
 }
 

--- a/go.mod
+++ b/go.mod
@@ -90,10 +90,12 @@ require (
 	go.opentelemetry.io/otel/exporters/trace/jaeger v0.11.0
 	go.opentelemetry.io/otel/sdk v0.11.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/mod v0.4.0 // indirect
+	golang.org/x/mod v0.4.1 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+	golang.org/x/sys v0.0.0-20210223212115-eede4237b368 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
+	golang.org/x/tools v0.1.0 // indirect
 	google.golang.org/api v0.32.0 // indirect
 	google.golang.org/grpc v1.32.0
 	gopkg.in/square/go-jose.v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -1348,8 +1348,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
-golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
+golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1501,8 +1501,10 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200821140526-fda516888d29/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210223212115-eede4237b368 h1:fDE3p0qf2V1co1vfj3/o87Ps8Hq6QTGNxJ5Xe7xSp80=
+golang.org/x/sys v0.0.0-20210223212115-eede4237b368/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1607,8 +1609,9 @@ golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200822203824-307de81be3f4/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
-golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6 h1:rbvTkL9AkFts1cgI78+gG6Yu1pwaqX6hjSJAatB78E4=
 golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/skymarshal/token/tokenfakes/fake_claims_parser.go
+++ b/skymarshal/token/tokenfakes/fake_claims_parser.go
@@ -32,15 +32,16 @@ func (fake *FakeClaimsParser) ParseClaims(arg1 string) (db.Claims, error) {
 	fake.parseClaimsArgsForCall = append(fake.parseClaimsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ParseClaimsStub
+	fakeReturns := fake.parseClaimsReturns
 	fake.recordInvocation("ParseClaims", []interface{}{arg1})
 	fake.parseClaimsMutex.Unlock()
-	if fake.ParseClaimsStub != nil {
-		return fake.ParseClaimsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.parseClaimsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/skymarshal/token/tokenfakes/fake_generator.go
+++ b/skymarshal/token/tokenfakes/fake_generator.go
@@ -32,15 +32,16 @@ func (fake *FakeGenerator) GenerateAccessToken(arg1 db.Claims) (string, error) {
 	fake.generateAccessTokenArgsForCall = append(fake.generateAccessTokenArgsForCall, struct {
 		arg1 db.Claims
 	}{arg1})
+	stub := fake.GenerateAccessTokenStub
+	fakeReturns := fake.generateAccessTokenReturns
 	fake.recordInvocation("GenerateAccessToken", []interface{}{arg1})
 	fake.generateAccessTokenMutex.Unlock()
-	if fake.GenerateAccessTokenStub != nil {
-		return fake.GenerateAccessTokenStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.generateAccessTokenReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/skymarshal/token/tokenfakes/fake_middleware.go
+++ b/skymarshal/token/tokenfakes/fake_middleware.go
@@ -107,15 +107,16 @@ func (fake *FakeMiddleware) GetAuthToken(arg1 *http.Request) string {
 	fake.getAuthTokenArgsForCall = append(fake.getAuthTokenArgsForCall, struct {
 		arg1 *http.Request
 	}{arg1})
+	stub := fake.GetAuthTokenStub
+	fakeReturns := fake.getAuthTokenReturns
 	fake.recordInvocation("GetAuthToken", []interface{}{arg1})
 	fake.getAuthTokenMutex.Unlock()
-	if fake.GetAuthTokenStub != nil {
-		return fake.GetAuthTokenStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getAuthTokenReturns
 	return fakeReturns.result1
 }
 
@@ -167,15 +168,16 @@ func (fake *FakeMiddleware) GetCSRFToken(arg1 *http.Request) string {
 	fake.getCSRFTokenArgsForCall = append(fake.getCSRFTokenArgsForCall, struct {
 		arg1 *http.Request
 	}{arg1})
+	stub := fake.GetCSRFTokenStub
+	fakeReturns := fake.getCSRFTokenReturns
 	fake.recordInvocation("GetCSRFToken", []interface{}{arg1})
 	fake.getCSRFTokenMutex.Unlock()
-	if fake.GetCSRFTokenStub != nil {
-		return fake.GetCSRFTokenStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getCSRFTokenReturns
 	return fakeReturns.result1
 }
 
@@ -227,15 +229,16 @@ func (fake *FakeMiddleware) GetStateToken(arg1 *http.Request) string {
 	fake.getStateTokenArgsForCall = append(fake.getStateTokenArgsForCall, struct {
 		arg1 *http.Request
 	}{arg1})
+	stub := fake.GetStateTokenStub
+	fakeReturns := fake.getStateTokenReturns
 	fake.recordInvocation("GetStateToken", []interface{}{arg1})
 	fake.getStateTokenMutex.Unlock()
-	if fake.GetStateTokenStub != nil {
-		return fake.GetStateTokenStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getStateTokenReturns
 	return fakeReturns.result1
 }
 
@@ -289,15 +292,16 @@ func (fake *FakeMiddleware) SetAuthToken(arg1 http.ResponseWriter, arg2 string, 
 		arg2 string
 		arg3 time.Time
 	}{arg1, arg2, arg3})
+	stub := fake.SetAuthTokenStub
+	fakeReturns := fake.setAuthTokenReturns
 	fake.recordInvocation("SetAuthToken", []interface{}{arg1, arg2, arg3})
 	fake.setAuthTokenMutex.Unlock()
-	if fake.SetAuthTokenStub != nil {
-		return fake.SetAuthTokenStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setAuthTokenReturns
 	return fakeReturns.result1
 }
 
@@ -351,15 +355,16 @@ func (fake *FakeMiddleware) SetCSRFToken(arg1 http.ResponseWriter, arg2 string, 
 		arg2 string
 		arg3 time.Time
 	}{arg1, arg2, arg3})
+	stub := fake.SetCSRFTokenStub
+	fakeReturns := fake.setCSRFTokenReturns
 	fake.recordInvocation("SetCSRFToken", []interface{}{arg1, arg2, arg3})
 	fake.setCSRFTokenMutex.Unlock()
-	if fake.SetCSRFTokenStub != nil {
-		return fake.SetCSRFTokenStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setCSRFTokenReturns
 	return fakeReturns.result1
 }
 
@@ -413,15 +418,16 @@ func (fake *FakeMiddleware) SetStateToken(arg1 http.ResponseWriter, arg2 string,
 		arg2 string
 		arg3 time.Time
 	}{arg1, arg2, arg3})
+	stub := fake.SetStateTokenStub
+	fakeReturns := fake.setStateTokenReturns
 	fake.recordInvocation("SetStateToken", []interface{}{arg1, arg2, arg3})
 	fake.setStateTokenMutex.Unlock()
-	if fake.SetStateTokenStub != nil {
-		return fake.SetStateTokenStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setStateTokenReturns
 	return fakeReturns.result1
 }
 
@@ -472,9 +478,10 @@ func (fake *FakeMiddleware) UnsetAuthToken(arg1 http.ResponseWriter) {
 	fake.unsetAuthTokenArgsForCall = append(fake.unsetAuthTokenArgsForCall, struct {
 		arg1 http.ResponseWriter
 	}{arg1})
+	stub := fake.UnsetAuthTokenStub
 	fake.recordInvocation("UnsetAuthToken", []interface{}{arg1})
 	fake.unsetAuthTokenMutex.Unlock()
-	if fake.UnsetAuthTokenStub != nil {
+	if stub != nil {
 		fake.UnsetAuthTokenStub(arg1)
 	}
 }
@@ -503,9 +510,10 @@ func (fake *FakeMiddleware) UnsetCSRFToken(arg1 http.ResponseWriter) {
 	fake.unsetCSRFTokenArgsForCall = append(fake.unsetCSRFTokenArgsForCall, struct {
 		arg1 http.ResponseWriter
 	}{arg1})
+	stub := fake.UnsetCSRFTokenStub
 	fake.recordInvocation("UnsetCSRFToken", []interface{}{arg1})
 	fake.unsetCSRFTokenMutex.Unlock()
-	if fake.UnsetCSRFTokenStub != nil {
+	if stub != nil {
 		fake.UnsetCSRFTokenStub(arg1)
 	}
 }
@@ -534,9 +542,10 @@ func (fake *FakeMiddleware) UnsetStateToken(arg1 http.ResponseWriter) {
 	fake.unsetStateTokenArgsForCall = append(fake.unsetStateTokenArgsForCall, struct {
 		arg1 http.ResponseWriter
 	}{arg1})
+	stub := fake.UnsetStateTokenStub
 	fake.recordInvocation("UnsetStateToken", []interface{}{arg1})
 	fake.unsetStateTokenMutex.Unlock()
-	if fake.UnsetStateTokenStub != nil {
+	if stub != nil {
 		fake.UnsetStateTokenStub(arg1)
 	}
 }

--- a/skymarshal/token/tokenfakes/fake_parser.go
+++ b/skymarshal/token/tokenfakes/fake_parser.go
@@ -32,15 +32,16 @@ func (fake *FakeParser) ParseExpiry(arg1 string) (time.Time, error) {
 	fake.parseExpiryArgsForCall = append(fake.parseExpiryArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ParseExpiryStub
+	fakeReturns := fake.parseExpiryReturns
 	fake.recordInvocation("ParseExpiry", []interface{}{arg1})
 	fake.parseExpiryMutex.Unlock()
-	if fake.ParseExpiryStub != nil {
-		return fake.ParseExpiryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.parseExpiryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/tracing/tracingfakes/fake_provider.go
+++ b/tracing/tracingfakes/fake_provider.go
@@ -31,15 +31,16 @@ func (fake *FakeProvider) Tracer(arg1 string, arg2 ...trace.TracerOption) trace.
 		arg1 string
 		arg2 []trace.TracerOption
 	}{arg1, arg2})
+	stub := fake.TracerStub
+	fakeReturns := fake.tracerReturns
 	fake.recordInvocation("Tracer", []interface{}{arg1, arg2})
 	fake.tracerMutex.Unlock()
-	if fake.TracerStub != nil {
-		return fake.TracerStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tracerReturns
 	return fakeReturns.result1
 }
 

--- a/tracing/tracingfakes/fake_span.go
+++ b/tracing/tracingfakes/fake_span.go
@@ -102,9 +102,10 @@ func (fake *FakeSpan) AddEvent(arg1 context.Context, arg2 string, arg3 ...label.
 		arg2 string
 		arg3 []label.KeyValue
 	}{arg1, arg2, arg3})
+	stub := fake.AddEventStub
 	fake.recordInvocation("AddEvent", []interface{}{arg1, arg2, arg3})
 	fake.addEventMutex.Unlock()
-	if fake.AddEventStub != nil {
+	if stub != nil {
 		fake.AddEventStub(arg1, arg2, arg3...)
 	}
 }
@@ -136,9 +137,10 @@ func (fake *FakeSpan) AddEventWithTimestamp(arg1 context.Context, arg2 time.Time
 		arg3 string
 		arg4 []label.KeyValue
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.AddEventWithTimestampStub
 	fake.recordInvocation("AddEventWithTimestamp", []interface{}{arg1, arg2, arg3, arg4})
 	fake.addEventWithTimestampMutex.Unlock()
-	if fake.AddEventWithTimestampStub != nil {
+	if stub != nil {
 		fake.AddEventWithTimestampStub(arg1, arg2, arg3, arg4...)
 	}
 }
@@ -167,9 +169,10 @@ func (fake *FakeSpan) End(arg1 ...trace.EndOption) {
 	fake.endArgsForCall = append(fake.endArgsForCall, struct {
 		arg1 []trace.EndOption
 	}{arg1})
+	stub := fake.EndStub
 	fake.recordInvocation("End", []interface{}{arg1})
 	fake.endMutex.Unlock()
-	if fake.EndStub != nil {
+	if stub != nil {
 		fake.EndStub(arg1...)
 	}
 }
@@ -198,15 +201,16 @@ func (fake *FakeSpan) IsRecording() bool {
 	ret, specificReturn := fake.isRecordingReturnsOnCall[len(fake.isRecordingArgsForCall)]
 	fake.isRecordingArgsForCall = append(fake.isRecordingArgsForCall, struct {
 	}{})
+	stub := fake.IsRecordingStub
+	fakeReturns := fake.isRecordingReturns
 	fake.recordInvocation("IsRecording", []interface{}{})
 	fake.isRecordingMutex.Unlock()
-	if fake.IsRecordingStub != nil {
-		return fake.IsRecordingStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isRecordingReturns
 	return fakeReturns.result1
 }
 
@@ -252,9 +256,10 @@ func (fake *FakeSpan) RecordError(arg1 context.Context, arg2 error, arg3 ...trac
 		arg2 error
 		arg3 []trace.ErrorOption
 	}{arg1, arg2, arg3})
+	stub := fake.RecordErrorStub
 	fake.recordInvocation("RecordError", []interface{}{arg1, arg2, arg3})
 	fake.recordErrorMutex.Unlock()
-	if fake.RecordErrorStub != nil {
+	if stub != nil {
 		fake.RecordErrorStub(arg1, arg2, arg3...)
 	}
 }
@@ -284,9 +289,10 @@ func (fake *FakeSpan) SetAttribute(arg1 string, arg2 interface{}) {
 		arg1 string
 		arg2 interface{}
 	}{arg1, arg2})
+	stub := fake.SetAttributeStub
 	fake.recordInvocation("SetAttribute", []interface{}{arg1, arg2})
 	fake.setAttributeMutex.Unlock()
-	if fake.SetAttributeStub != nil {
+	if stub != nil {
 		fake.SetAttributeStub(arg1, arg2)
 	}
 }
@@ -315,9 +321,10 @@ func (fake *FakeSpan) SetAttributes(arg1 ...label.KeyValue) {
 	fake.setAttributesArgsForCall = append(fake.setAttributesArgsForCall, struct {
 		arg1 []label.KeyValue
 	}{arg1})
+	stub := fake.SetAttributesStub
 	fake.recordInvocation("SetAttributes", []interface{}{arg1})
 	fake.setAttributesMutex.Unlock()
-	if fake.SetAttributesStub != nil {
+	if stub != nil {
 		fake.SetAttributesStub(arg1...)
 	}
 }
@@ -346,9 +353,10 @@ func (fake *FakeSpan) SetName(arg1 string) {
 	fake.setNameArgsForCall = append(fake.setNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SetNameStub
 	fake.recordInvocation("SetName", []interface{}{arg1})
 	fake.setNameMutex.Unlock()
-	if fake.SetNameStub != nil {
+	if stub != nil {
 		fake.SetNameStub(arg1)
 	}
 }
@@ -378,9 +386,10 @@ func (fake *FakeSpan) SetStatus(arg1 codes.Code, arg2 string) {
 		arg1 codes.Code
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SetStatusStub
 	fake.recordInvocation("SetStatus", []interface{}{arg1, arg2})
 	fake.setStatusMutex.Unlock()
-	if fake.SetStatusStub != nil {
+	if stub != nil {
 		fake.SetStatusStub(arg1, arg2)
 	}
 }
@@ -409,15 +418,16 @@ func (fake *FakeSpan) SpanContext() trace.SpanContext {
 	ret, specificReturn := fake.spanContextReturnsOnCall[len(fake.spanContextArgsForCall)]
 	fake.spanContextArgsForCall = append(fake.spanContextArgsForCall, struct {
 	}{})
+	stub := fake.SpanContextStub
+	fakeReturns := fake.spanContextReturns
 	fake.recordInvocation("SpanContext", []interface{}{})
 	fake.spanContextMutex.Unlock()
-	if fake.SpanContextStub != nil {
-		return fake.SpanContextStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.spanContextReturns
 	return fakeReturns.result1
 }
 
@@ -461,15 +471,16 @@ func (fake *FakeSpan) Tracer() trace.Tracer {
 	ret, specificReturn := fake.tracerReturnsOnCall[len(fake.tracerArgsForCall)]
 	fake.tracerArgsForCall = append(fake.tracerArgsForCall, struct {
 	}{})
+	stub := fake.TracerStub
+	fakeReturns := fake.tracerReturns
 	fake.recordInvocation("Tracer", []interface{}{})
 	fake.tracerMutex.Unlock()
-	if fake.TracerStub != nil {
-		return fake.TracerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.tracerReturns
 	return fakeReturns.result1
 }
 

--- a/tracing/tracingfakes/fake_tracer.go
+++ b/tracing/tracingfakes/fake_tracer.go
@@ -36,15 +36,16 @@ func (fake *FakeTracer) Start(arg1 context.Context, arg2 string, arg3 ...trace.S
 		arg2 string
 		arg3 []trace.StartOption
 	}{arg1, arg2, arg3})
+	stub := fake.StartStub
+	fakeReturns := fake.startReturns
 	fake.recordInvocation("Start", []interface{}{arg1, arg2, arg3})
 	fake.startMutex.Unlock()
-	if fake.StartStub != nil {
-		return fake.StartStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.startReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/tsa/tsafakes/fake_endpoint_picker.go
+++ b/tsa/tsafakes/fake_endpoint_picker.go
@@ -28,15 +28,16 @@ func (fake *FakeEndpointPicker) Pick() *rata.RequestGenerator {
 	ret, specificReturn := fake.pickReturnsOnCall[len(fake.pickArgsForCall)]
 	fake.pickArgsForCall = append(fake.pickArgsForCall, struct {
 	}{})
+	stub := fake.PickStub
+	fakeReturns := fake.pickReturns
 	fake.recordInvocation("Pick", []interface{}{})
 	fake.pickMutex.Unlock()
-	if fake.PickStub != nil {
-		return fake.PickStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pickReturns
 	return fakeReturns.result1
 }
 

--- a/vars/varsfakes/fake_variables.go
+++ b/vars/varsfakes/fake_variables.go
@@ -45,15 +45,16 @@ func (fake *FakeVariables) Get(arg1 vars.Reference) (interface{}, bool, error) {
 	fake.getArgsForCall = append(fake.getArgsForCall, struct {
 		arg1 vars.Reference
 	}{arg1})
+	stub := fake.GetStub
+	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1})
 	fake.getMutex.Unlock()
-	if fake.GetStub != nil {
-		return fake.GetStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -110,15 +111,16 @@ func (fake *FakeVariables) List() ([]vars.Reference, error) {
 	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
 	fake.listArgsForCall = append(fake.listArgsForCall, struct {
 	}{})
+	stub := fake.ListStub
+	fakeReturns := fake.listReturns
 	fake.recordInvocation("List", []interface{}{})
 	fake.listMutex.Unlock()
-	if fake.ListStub != nil {
-		return fake.ListStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/worker/runtime/iptables/iptablesfakes/fake_iptables.go
+++ b/worker/runtime/iptables/iptablesfakes/fake_iptables.go
@@ -45,15 +45,16 @@ func (fake *FakeIptables) AppendRule(arg1 string, arg2 string, arg3 ...string) e
 		arg2 string
 		arg3 []string
 	}{arg1, arg2, arg3})
+	stub := fake.AppendRuleStub
+	fakeReturns := fake.appendRuleReturns
 	fake.recordInvocation("AppendRule", []interface{}{arg1, arg2, arg3})
 	fake.appendRuleMutex.Unlock()
-	if fake.AppendRuleStub != nil {
-		return fake.AppendRuleStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.appendRuleReturns
 	return fakeReturns.result1
 }
 
@@ -106,15 +107,16 @@ func (fake *FakeIptables) CreateChainOrFlushIfExists(arg1 string, arg2 string) e
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.CreateChainOrFlushIfExistsStub
+	fakeReturns := fake.createChainOrFlushIfExistsReturns
 	fake.recordInvocation("CreateChainOrFlushIfExists", []interface{}{arg1, arg2})
 	fake.createChainOrFlushIfExistsMutex.Unlock()
-	if fake.CreateChainOrFlushIfExistsStub != nil {
-		return fake.CreateChainOrFlushIfExistsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createChainOrFlushIfExistsReturns
 	return fakeReturns.result1
 }
 

--- a/worker/runtime/libcontainerd/libcontainerdfakes/fake_client.go
+++ b/worker/runtime/libcontainerd/libcontainerdfakes/fake_client.go
@@ -109,15 +109,16 @@ func (fake *FakeClient) Containers(arg1 context.Context, arg2 ...string) ([]cont
 		arg1 context.Context
 		arg2 []string
 	}{arg1, arg2})
+	stub := fake.ContainersStub
+	fakeReturns := fake.containersReturns
 	fake.recordInvocation("Containers", []interface{}{arg1, arg2})
 	fake.containersMutex.Unlock()
-	if fake.ContainersStub != nil {
-		return fake.ContainersStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.containersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -173,15 +174,16 @@ func (fake *FakeClient) Destroy(arg1 context.Context, arg2 string) error {
 		arg1 context.Context
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.DestroyStub
+	fakeReturns := fake.destroyReturns
 	fake.recordInvocation("Destroy", []interface{}{arg1, arg2})
 	fake.destroyMutex.Unlock()
-	if fake.DestroyStub != nil {
-		return fake.DestroyStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.destroyReturns
 	return fakeReturns.result1
 }
 
@@ -234,15 +236,16 @@ func (fake *FakeClient) GetContainer(arg1 context.Context, arg2 string) (contain
 		arg1 context.Context
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetContainerStub
+	fakeReturns := fake.getContainerReturns
 	fake.recordInvocation("GetContainer", []interface{}{arg1, arg2})
 	fake.getContainerMutex.Unlock()
-	if fake.GetContainerStub != nil {
-		return fake.GetContainerStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -296,15 +299,16 @@ func (fake *FakeClient) Init() error {
 	ret, specificReturn := fake.initReturnsOnCall[len(fake.initArgsForCall)]
 	fake.initArgsForCall = append(fake.initArgsForCall, struct {
 	}{})
+	stub := fake.InitStub
+	fakeReturns := fake.initReturns
 	fake.recordInvocation("Init", []interface{}{})
 	fake.initMutex.Unlock()
-	if fake.InitStub != nil {
-		return fake.InitStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.initReturns
 	return fakeReturns.result1
 }
 
@@ -352,15 +356,16 @@ func (fake *FakeClient) NewContainer(arg1 context.Context, arg2 string, arg3 map
 		arg3 map[string]string
 		arg4 *specs.Spec
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.NewContainerStub
+	fakeReturns := fake.newContainerReturns
 	fake.recordInvocation("NewContainer", []interface{}{arg1, arg2, arg3, arg4})
 	fake.newContainerMutex.Unlock()
-	if fake.NewContainerStub != nil {
-		return fake.NewContainerStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newContainerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -414,15 +419,16 @@ func (fake *FakeClient) Stop() error {
 	ret, specificReturn := fake.stopReturnsOnCall[len(fake.stopArgsForCall)]
 	fake.stopArgsForCall = append(fake.stopArgsForCall, struct {
 	}{})
+	stub := fake.StopStub
+	fakeReturns := fake.stopReturns
 	fake.recordInvocation("Stop", []interface{}{})
 	fake.stopMutex.Unlock()
-	if fake.StopStub != nil {
-		return fake.StopStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.stopReturns
 	return fakeReturns.result1
 }
 
@@ -467,15 +473,16 @@ func (fake *FakeClient) Version(arg1 context.Context) error {
 	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.VersionStub
+	fakeReturns := fake.versionReturns
 	fake.recordInvocation("Version", []interface{}{arg1})
 	fake.versionMutex.Unlock()
-	if fake.VersionStub != nil {
-		return fake.VersionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.versionReturns
 	return fakeReturns.result1
 }
 

--- a/worker/runtime/libcontainerd/libcontainerdfakes/fake_container.go
+++ b/worker/runtime/libcontainerd/libcontainerdfakes/fake_container.go
@@ -183,15 +183,16 @@ func (fake *FakeContainer) Checkpoint(arg1 context.Context, arg2 string, arg3 ..
 		arg2 string
 		arg3 []containerd.CheckpointOpts
 	}{arg1, arg2, arg3})
+	stub := fake.CheckpointStub
+	fakeReturns := fake.checkpointReturns
 	fake.recordInvocation("Checkpoint", []interface{}{arg1, arg2, arg3})
 	fake.checkpointMutex.Unlock()
-	if fake.CheckpointStub != nil {
-		return fake.CheckpointStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checkpointReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -247,15 +248,16 @@ func (fake *FakeContainer) Delete(arg1 context.Context, arg2 ...containerd.Delet
 		arg1 context.Context
 		arg2 []containerd.DeleteOpts
 	}{arg1, arg2})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{arg1, arg2})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1
 }
 
@@ -307,15 +309,16 @@ func (fake *FakeContainer) Extensions(arg1 context.Context) (map[string]types.An
 	fake.extensionsArgsForCall = append(fake.extensionsArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.ExtensionsStub
+	fakeReturns := fake.extensionsReturns
 	fake.recordInvocation("Extensions", []interface{}{arg1})
 	fake.extensionsMutex.Unlock()
-	if fake.ExtensionsStub != nil {
-		return fake.ExtensionsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.extensionsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -369,15 +372,16 @@ func (fake *FakeContainer) ID() string {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -422,15 +426,16 @@ func (fake *FakeContainer) Image(arg1 context.Context) (containerd.Image, error)
 	fake.imageArgsForCall = append(fake.imageArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.ImageStub
+	fakeReturns := fake.imageReturns
 	fake.recordInvocation("Image", []interface{}{arg1})
 	fake.imageMutex.Unlock()
-	if fake.ImageStub != nil {
-		return fake.ImageStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.imageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -486,15 +491,16 @@ func (fake *FakeContainer) Info(arg1 context.Context, arg2 ...containerd.InfoOpt
 		arg1 context.Context
 		arg2 []containerd.InfoOpts
 	}{arg1, arg2})
+	stub := fake.InfoStub
+	fakeReturns := fake.infoReturns
 	fake.recordInvocation("Info", []interface{}{arg1, arg2})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
-		return fake.InfoStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.infoReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -549,15 +555,16 @@ func (fake *FakeContainer) Labels(arg1 context.Context) (map[string]string, erro
 	fake.labelsArgsForCall = append(fake.labelsArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.LabelsStub
+	fakeReturns := fake.labelsReturns
 	fake.recordInvocation("Labels", []interface{}{arg1})
 	fake.labelsMutex.Unlock()
-	if fake.LabelsStub != nil {
-		return fake.LabelsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.labelsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -614,15 +621,16 @@ func (fake *FakeContainer) NewTask(arg1 context.Context, arg2 cio.Creator, arg3 
 		arg2 cio.Creator
 		arg3 []containerd.NewTaskOpts
 	}{arg1, arg2, arg3})
+	stub := fake.NewTaskStub
+	fakeReturns := fake.newTaskReturns
 	fake.recordInvocation("NewTask", []interface{}{arg1, arg2, arg3})
 	fake.newTaskMutex.Unlock()
-	if fake.NewTaskStub != nil {
-		return fake.NewTaskStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newTaskReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -678,15 +686,16 @@ func (fake *FakeContainer) SetLabels(arg1 context.Context, arg2 map[string]strin
 		arg1 context.Context
 		arg2 map[string]string
 	}{arg1, arg2})
+	stub := fake.SetLabelsStub
+	fakeReturns := fake.setLabelsReturns
 	fake.recordInvocation("SetLabels", []interface{}{arg1, arg2})
 	fake.setLabelsMutex.Unlock()
-	if fake.SetLabelsStub != nil {
-		return fake.SetLabelsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.setLabelsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -741,15 +750,16 @@ func (fake *FakeContainer) Spec(arg1 context.Context) (*specs.Spec, error) {
 	fake.specArgsForCall = append(fake.specArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.SpecStub
+	fakeReturns := fake.specReturns
 	fake.recordInvocation("Spec", []interface{}{arg1})
 	fake.specMutex.Unlock()
-	if fake.SpecStub != nil {
-		return fake.SpecStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.specReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -805,15 +815,16 @@ func (fake *FakeContainer) Task(arg1 context.Context, arg2 cio.Attach) (containe
 		arg1 context.Context
 		arg2 cio.Attach
 	}{arg1, arg2})
+	stub := fake.TaskStub
+	fakeReturns := fake.taskReturns
 	fake.recordInvocation("Task", []interface{}{arg1, arg2})
 	fake.taskMutex.Unlock()
-	if fake.TaskStub != nil {
-		return fake.TaskStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.taskReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -869,15 +880,16 @@ func (fake *FakeContainer) Update(arg1 context.Context, arg2 ...containerd.Updat
 		arg1 context.Context
 		arg2 []containerd.UpdateContainerOpts
 	}{arg1, arg2})
+	stub := fake.UpdateStub
+	fakeReturns := fake.updateReturns
 	fake.recordInvocation("Update", []interface{}{arg1, arg2})
 	fake.updateMutex.Unlock()
-	if fake.UpdateStub != nil {
-		return fake.UpdateStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateReturns
 	return fakeReturns.result1
 }
 

--- a/worker/runtime/libcontainerd/libcontainerdfakes/fake_io.go
+++ b/worker/runtime/libcontainerd/libcontainerdfakes/fake_io.go
@@ -44,9 +44,10 @@ func (fake *FakeIO) Cancel() {
 	fake.cancelMutex.Lock()
 	fake.cancelArgsForCall = append(fake.cancelArgsForCall, struct {
 	}{})
+	stub := fake.CancelStub
 	fake.recordInvocation("Cancel", []interface{}{})
 	fake.cancelMutex.Unlock()
-	if fake.CancelStub != nil {
+	if stub != nil {
 		fake.CancelStub()
 	}
 }
@@ -68,15 +69,16 @@ func (fake *FakeIO) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -120,15 +122,16 @@ func (fake *FakeIO) Config() cio.Config {
 	ret, specificReturn := fake.configReturnsOnCall[len(fake.configArgsForCall)]
 	fake.configArgsForCall = append(fake.configArgsForCall, struct {
 	}{})
+	stub := fake.ConfigStub
+	fakeReturns := fake.configReturns
 	fake.recordInvocation("Config", []interface{}{})
 	fake.configMutex.Unlock()
-	if fake.ConfigStub != nil {
-		return fake.ConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.configReturns
 	return fakeReturns.result1
 }
 
@@ -171,9 +174,10 @@ func (fake *FakeIO) Wait() {
 	fake.waitMutex.Lock()
 	fake.waitArgsForCall = append(fake.waitArgsForCall, struct {
 	}{})
+	stub := fake.WaitStub
 	fake.recordInvocation("Wait", []interface{}{})
 	fake.waitMutex.Unlock()
-	if fake.WaitStub != nil {
+	if stub != nil {
 		fake.WaitStub()
 	}
 }

--- a/worker/runtime/libcontainerd/libcontainerdfakes/fake_process.go
+++ b/worker/runtime/libcontainerd/libcontainerdfakes/fake_process.go
@@ -141,15 +141,16 @@ func (fake *FakeProcess) CloseIO(arg1 context.Context, arg2 ...containerd.IOClos
 		arg1 context.Context
 		arg2 []containerd.IOCloserOpts
 	}{arg1, arg2})
+	stub := fake.CloseIOStub
+	fakeReturns := fake.closeIOReturns
 	fake.recordInvocation("CloseIO", []interface{}{arg1, arg2})
 	fake.closeIOMutex.Unlock()
-	if fake.CloseIOStub != nil {
-		return fake.CloseIOStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeIOReturns
 	return fakeReturns.result1
 }
 
@@ -202,15 +203,16 @@ func (fake *FakeProcess) Delete(arg1 context.Context, arg2 ...containerd.Process
 		arg1 context.Context
 		arg2 []containerd.ProcessDeleteOpts
 	}{arg1, arg2})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{arg1, arg2})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -264,15 +266,16 @@ func (fake *FakeProcess) ID() string {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -316,15 +319,16 @@ func (fake *FakeProcess) IO() cio.IO {
 	ret, specificReturn := fake.iOReturnsOnCall[len(fake.iOArgsForCall)]
 	fake.iOArgsForCall = append(fake.iOArgsForCall, struct {
 	}{})
+	stub := fake.IOStub
+	fakeReturns := fake.iOReturns
 	fake.recordInvocation("IO", []interface{}{})
 	fake.iOMutex.Unlock()
-	if fake.IOStub != nil {
-		return fake.IOStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iOReturns
 	return fakeReturns.result1
 }
 
@@ -371,15 +375,16 @@ func (fake *FakeProcess) Kill(arg1 context.Context, arg2 syscall.Signal, arg3 ..
 		arg2 syscall.Signal
 		arg3 []containerd.KillOpts
 	}{arg1, arg2, arg3})
+	stub := fake.KillStub
+	fakeReturns := fake.killReturns
 	fake.recordInvocation("Kill", []interface{}{arg1, arg2, arg3})
 	fake.killMutex.Unlock()
-	if fake.KillStub != nil {
-		return fake.KillStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.killReturns
 	return fakeReturns.result1
 }
 
@@ -430,15 +435,16 @@ func (fake *FakeProcess) Pid() uint32 {
 	ret, specificReturn := fake.pidReturnsOnCall[len(fake.pidArgsForCall)]
 	fake.pidArgsForCall = append(fake.pidArgsForCall, struct {
 	}{})
+	stub := fake.PidStub
+	fakeReturns := fake.pidReturns
 	fake.recordInvocation("Pid", []interface{}{})
 	fake.pidMutex.Unlock()
-	if fake.PidStub != nil {
-		return fake.PidStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pidReturns
 	return fakeReturns.result1
 }
 
@@ -485,15 +491,16 @@ func (fake *FakeProcess) Resize(arg1 context.Context, arg2 uint32, arg3 uint32) 
 		arg2 uint32
 		arg3 uint32
 	}{arg1, arg2, arg3})
+	stub := fake.ResizeStub
+	fakeReturns := fake.resizeReturns
 	fake.recordInvocation("Resize", []interface{}{arg1, arg2, arg3})
 	fake.resizeMutex.Unlock()
-	if fake.ResizeStub != nil {
-		return fake.ResizeStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resizeReturns
 	return fakeReturns.result1
 }
 
@@ -545,15 +552,16 @@ func (fake *FakeProcess) Start(arg1 context.Context) error {
 	fake.startArgsForCall = append(fake.startArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.StartStub
+	fakeReturns := fake.startReturns
 	fake.recordInvocation("Start", []interface{}{arg1})
 	fake.startMutex.Unlock()
-	if fake.StartStub != nil {
-		return fake.StartStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.startReturns
 	return fakeReturns.result1
 }
 
@@ -605,15 +613,16 @@ func (fake *FakeProcess) Status(arg1 context.Context) (containerd.Status, error)
 	fake.statusArgsForCall = append(fake.statusArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.StatusStub
+	fakeReturns := fake.statusReturns
 	fake.recordInvocation("Status", []interface{}{arg1})
 	fake.statusMutex.Unlock()
-	if fake.StatusStub != nil {
-		return fake.StatusStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.statusReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -668,15 +677,16 @@ func (fake *FakeProcess) Wait(arg1 context.Context) (<-chan containerd.ExitStatu
 	fake.waitArgsForCall = append(fake.waitArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.WaitStub
+	fakeReturns := fake.waitReturns
 	fake.recordInvocation("Wait", []interface{}{arg1})
 	fake.waitMutex.Unlock()
-	if fake.WaitStub != nil {
-		return fake.WaitStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.waitReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/worker/runtime/libcontainerd/libcontainerdfakes/fake_task.go
+++ b/worker/runtime/libcontainerd/libcontainerdfakes/fake_task.go
@@ -248,15 +248,16 @@ func (fake *FakeTask) Checkpoint(arg1 context.Context, arg2 ...containerd.Checkp
 		arg1 context.Context
 		arg2 []containerd.CheckpointTaskOpts
 	}{arg1, arg2})
+	stub := fake.CheckpointStub
+	fakeReturns := fake.checkpointReturns
 	fake.recordInvocation("Checkpoint", []interface{}{arg1, arg2})
 	fake.checkpointMutex.Unlock()
-	if fake.CheckpointStub != nil {
-		return fake.CheckpointStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checkpointReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -312,15 +313,16 @@ func (fake *FakeTask) CloseIO(arg1 context.Context, arg2 ...containerd.IOCloserO
 		arg1 context.Context
 		arg2 []containerd.IOCloserOpts
 	}{arg1, arg2})
+	stub := fake.CloseIOStub
+	fakeReturns := fake.closeIOReturns
 	fake.recordInvocation("CloseIO", []interface{}{arg1, arg2})
 	fake.closeIOMutex.Unlock()
-	if fake.CloseIOStub != nil {
-		return fake.CloseIOStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeIOReturns
 	return fakeReturns.result1
 }
 
@@ -373,15 +375,16 @@ func (fake *FakeTask) Delete(arg1 context.Context, arg2 ...containerd.ProcessDel
 		arg1 context.Context
 		arg2 []containerd.ProcessDeleteOpts
 	}{arg1, arg2})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{arg1, arg2})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -439,15 +442,16 @@ func (fake *FakeTask) Exec(arg1 context.Context, arg2 string, arg3 *specs.Proces
 		arg3 *specs.Process
 		arg4 cio.Creator
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.ExecStub
+	fakeReturns := fake.execReturns
 	fake.recordInvocation("Exec", []interface{}{arg1, arg2, arg3, arg4})
 	fake.execMutex.Unlock()
-	if fake.ExecStub != nil {
-		return fake.ExecStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.execReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -501,15 +505,16 @@ func (fake *FakeTask) ID() string {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -553,15 +558,16 @@ func (fake *FakeTask) IO() cio.IO {
 	ret, specificReturn := fake.iOReturnsOnCall[len(fake.iOArgsForCall)]
 	fake.iOArgsForCall = append(fake.iOArgsForCall, struct {
 	}{})
+	stub := fake.IOStub
+	fakeReturns := fake.iOReturns
 	fake.recordInvocation("IO", []interface{}{})
 	fake.iOMutex.Unlock()
-	if fake.IOStub != nil {
-		return fake.IOStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iOReturns
 	return fakeReturns.result1
 }
 
@@ -608,15 +614,16 @@ func (fake *FakeTask) Kill(arg1 context.Context, arg2 syscall.Signal, arg3 ...co
 		arg2 syscall.Signal
 		arg3 []containerd.KillOpts
 	}{arg1, arg2, arg3})
+	stub := fake.KillStub
+	fakeReturns := fake.killReturns
 	fake.recordInvocation("Kill", []interface{}{arg1, arg2, arg3})
 	fake.killMutex.Unlock()
-	if fake.KillStub != nil {
-		return fake.KillStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.killReturns
 	return fakeReturns.result1
 }
 
@@ -670,15 +677,16 @@ func (fake *FakeTask) LoadProcess(arg1 context.Context, arg2 string, arg3 cio.At
 		arg2 string
 		arg3 cio.Attach
 	}{arg1, arg2, arg3})
+	stub := fake.LoadProcessStub
+	fakeReturns := fake.loadProcessReturns
 	fake.recordInvocation("LoadProcess", []interface{}{arg1, arg2, arg3})
 	fake.loadProcessMutex.Unlock()
-	if fake.LoadProcessStub != nil {
-		return fake.LoadProcessStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.loadProcessReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -733,15 +741,16 @@ func (fake *FakeTask) Metrics(arg1 context.Context) (*types.Metric, error) {
 	fake.metricsArgsForCall = append(fake.metricsArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.MetricsStub
+	fakeReturns := fake.metricsReturns
 	fake.recordInvocation("Metrics", []interface{}{arg1})
 	fake.metricsMutex.Unlock()
-	if fake.MetricsStub != nil {
-		return fake.MetricsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.metricsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -796,15 +805,16 @@ func (fake *FakeTask) Pause(arg1 context.Context) error {
 	fake.pauseArgsForCall = append(fake.pauseArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.PauseStub
+	fakeReturns := fake.pauseReturns
 	fake.recordInvocation("Pause", []interface{}{arg1})
 	fake.pauseMutex.Unlock()
-	if fake.PauseStub != nil {
-		return fake.PauseStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pauseReturns
 	return fakeReturns.result1
 }
 
@@ -855,15 +865,16 @@ func (fake *FakeTask) Pid() uint32 {
 	ret, specificReturn := fake.pidReturnsOnCall[len(fake.pidArgsForCall)]
 	fake.pidArgsForCall = append(fake.pidArgsForCall, struct {
 	}{})
+	stub := fake.PidStub
+	fakeReturns := fake.pidReturns
 	fake.recordInvocation("Pid", []interface{}{})
 	fake.pidMutex.Unlock()
-	if fake.PidStub != nil {
-		return fake.PidStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pidReturns
 	return fakeReturns.result1
 }
 
@@ -908,15 +919,16 @@ func (fake *FakeTask) Pids(arg1 context.Context) ([]containerd.ProcessInfo, erro
 	fake.pidsArgsForCall = append(fake.pidsArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.PidsStub
+	fakeReturns := fake.pidsReturns
 	fake.recordInvocation("Pids", []interface{}{arg1})
 	fake.pidsMutex.Unlock()
-	if fake.PidsStub != nil {
-		return fake.PidsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.pidsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -973,15 +985,16 @@ func (fake *FakeTask) Resize(arg1 context.Context, arg2 uint32, arg3 uint32) err
 		arg2 uint32
 		arg3 uint32
 	}{arg1, arg2, arg3})
+	stub := fake.ResizeStub
+	fakeReturns := fake.resizeReturns
 	fake.recordInvocation("Resize", []interface{}{arg1, arg2, arg3})
 	fake.resizeMutex.Unlock()
-	if fake.ResizeStub != nil {
-		return fake.ResizeStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resizeReturns
 	return fakeReturns.result1
 }
 
@@ -1033,15 +1046,16 @@ func (fake *FakeTask) Resume(arg1 context.Context) error {
 	fake.resumeArgsForCall = append(fake.resumeArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.ResumeStub
+	fakeReturns := fake.resumeReturns
 	fake.recordInvocation("Resume", []interface{}{arg1})
 	fake.resumeMutex.Unlock()
-	if fake.ResumeStub != nil {
-		return fake.ResumeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.resumeReturns
 	return fakeReturns.result1
 }
 
@@ -1093,15 +1107,16 @@ func (fake *FakeTask) Start(arg1 context.Context) error {
 	fake.startArgsForCall = append(fake.startArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.StartStub
+	fakeReturns := fake.startReturns
 	fake.recordInvocation("Start", []interface{}{arg1})
 	fake.startMutex.Unlock()
-	if fake.StartStub != nil {
-		return fake.StartStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.startReturns
 	return fakeReturns.result1
 }
 
@@ -1153,15 +1168,16 @@ func (fake *FakeTask) Status(arg1 context.Context) (containerd.Status, error) {
 	fake.statusArgsForCall = append(fake.statusArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.StatusStub
+	fakeReturns := fake.statusReturns
 	fake.recordInvocation("Status", []interface{}{arg1})
 	fake.statusMutex.Unlock()
-	if fake.StatusStub != nil {
-		return fake.StatusStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.statusReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1217,15 +1233,16 @@ func (fake *FakeTask) Update(arg1 context.Context, arg2 ...containerd.UpdateTask
 		arg1 context.Context
 		arg2 []containerd.UpdateTaskOpts
 	}{arg1, arg2})
+	stub := fake.UpdateStub
+	fakeReturns := fake.updateReturns
 	fake.recordInvocation("Update", []interface{}{arg1, arg2})
 	fake.updateMutex.Unlock()
-	if fake.UpdateStub != nil {
-		return fake.UpdateStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateReturns
 	return fakeReturns.result1
 }
 
@@ -1277,15 +1294,16 @@ func (fake *FakeTask) Wait(arg1 context.Context) (<-chan containerd.ExitStatus, 
 	fake.waitArgsForCall = append(fake.waitArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.WaitStub
+	fakeReturns := fake.waitReturns
 	fake.recordInvocation("Wait", []interface{}{arg1})
 	fake.waitMutex.Unlock()
-	if fake.WaitStub != nil {
-		return fake.WaitStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.waitReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/worker/runtime/runtimefakes/fake_cni.go
+++ b/worker/runtime/runtimefakes/fake_cni.go
@@ -79,15 +79,16 @@ func (fake *FakeCNI) GetConfig() *cni.ConfigResult {
 	ret, specificReturn := fake.getConfigReturnsOnCall[len(fake.getConfigArgsForCall)]
 	fake.getConfigArgsForCall = append(fake.getConfigArgsForCall, struct {
 	}{})
+	stub := fake.GetConfigStub
+	fakeReturns := fake.getConfigReturns
 	fake.recordInvocation("GetConfig", []interface{}{})
 	fake.getConfigMutex.Unlock()
-	if fake.GetConfigStub != nil {
-		return fake.GetConfigStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getConfigReturns
 	return fakeReturns.result1
 }
 
@@ -132,15 +133,16 @@ func (fake *FakeCNI) Load(arg1 ...cni.CNIOpt) error {
 	fake.loadArgsForCall = append(fake.loadArgsForCall, struct {
 		arg1 []cni.CNIOpt
 	}{arg1})
+	stub := fake.LoadStub
+	fakeReturns := fake.loadReturns
 	fake.recordInvocation("Load", []interface{}{arg1})
 	fake.loadMutex.Unlock()
-	if fake.LoadStub != nil {
-		return fake.LoadStub(arg1...)
+	if stub != nil {
+		return stub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.loadReturns
 	return fakeReturns.result1
 }
 
@@ -195,15 +197,16 @@ func (fake *FakeCNI) Remove(arg1 context.Context, arg2 string, arg3 string, arg4
 		arg3 string
 		arg4 []cni.NamespaceOpts
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.RemoveStub
+	fakeReturns := fake.removeReturns
 	fake.recordInvocation("Remove", []interface{}{arg1, arg2, arg3, arg4})
 	fake.removeMutex.Unlock()
-	if fake.RemoveStub != nil {
-		return fake.RemoveStub(arg1, arg2, arg3, arg4...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeReturns
 	return fakeReturns.result1
 }
 
@@ -258,15 +261,16 @@ func (fake *FakeCNI) Setup(arg1 context.Context, arg2 string, arg3 string, arg4 
 		arg3 string
 		arg4 []cni.NamespaceOpts
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.SetupStub
+	fakeReturns := fake.setupReturns
 	fake.recordInvocation("Setup", []interface{}{arg1, arg2, arg3, arg4})
 	fake.setupMutex.Unlock()
-	if fake.SetupStub != nil {
-		return fake.SetupStub(arg1, arg2, arg3, arg4...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.setupReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -320,15 +324,16 @@ func (fake *FakeCNI) Status() error {
 	ret, specificReturn := fake.statusReturnsOnCall[len(fake.statusArgsForCall)]
 	fake.statusArgsForCall = append(fake.statusArgsForCall, struct {
 	}{})
+	stub := fake.StatusStub
+	fakeReturns := fake.statusReturns
 	fake.recordInvocation("Status", []interface{}{})
 	fake.statusMutex.Unlock()
-	if fake.StatusStub != nil {
-		return fake.StatusStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.statusReturns
 	return fakeReturns.result1
 }
 

--- a/worker/runtime/runtimefakes/fake_file_store.go
+++ b/worker/runtime/runtimefakes/fake_file_store.go
@@ -49,15 +49,16 @@ func (fake *FakeFileStore) Create(arg1 string, arg2 []byte) (string, error) {
 		arg1 string
 		arg2 []byte
 	}{arg1, arg2Copy})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1, arg2Copy})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -112,15 +113,16 @@ func (fake *FakeFileStore) Delete(arg1 string) error {
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{arg1})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1
 }
 

--- a/worker/runtime/runtimefakes/fake_killer.go
+++ b/worker/runtime/runtimefakes/fake_killer.go
@@ -35,15 +35,16 @@ func (fake *FakeKiller) Kill(arg1 context.Context, arg2 containerd.Task, arg3 ru
 		arg2 containerd.Task
 		arg3 runtime.KillBehaviour
 	}{arg1, arg2, arg3})
+	stub := fake.KillStub
+	fakeReturns := fake.killReturns
 	fake.recordInvocation("Kill", []interface{}{arg1, arg2, arg3})
 	fake.killMutex.Unlock()
-	if fake.KillStub != nil {
-		return fake.KillStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.killReturns
 	return fakeReturns.result1
 }
 

--- a/worker/runtime/runtimefakes/fake_network.go
+++ b/worker/runtime/runtimefakes/fake_network.go
@@ -69,15 +69,16 @@ func (fake *FakeNetwork) Add(arg1 context.Context, arg2 containerd.Task) error {
 		arg1 context.Context
 		arg2 containerd.Task
 	}{arg1, arg2})
+	stub := fake.AddStub
+	fakeReturns := fake.addReturns
 	fake.recordInvocation("Add", []interface{}{arg1, arg2})
 	fake.addMutex.Unlock()
-	if fake.AddStub != nil {
-		return fake.AddStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addReturns
 	return fakeReturns.result1
 }
 
@@ -130,15 +131,16 @@ func (fake *FakeNetwork) Remove(arg1 context.Context, arg2 containerd.Task) erro
 		arg1 context.Context
 		arg2 containerd.Task
 	}{arg1, arg2})
+	stub := fake.RemoveStub
+	fakeReturns := fake.removeReturns
 	fake.recordInvocation("Remove", []interface{}{arg1, arg2})
 	fake.removeMutex.Unlock()
-	if fake.RemoveStub != nil {
-		return fake.RemoveStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeReturns
 	return fakeReturns.result1
 }
 
@@ -190,15 +192,16 @@ func (fake *FakeNetwork) SetupMounts(arg1 string) ([]specs.Mount, error) {
 	fake.setupMountsArgsForCall = append(fake.setupMountsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SetupMountsStub
+	fakeReturns := fake.setupMountsReturns
 	fake.recordInvocation("SetupMounts", []interface{}{arg1})
 	fake.setupMountsMutex.Unlock()
-	if fake.SetupMountsStub != nil {
-		return fake.SetupMountsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.setupMountsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -252,15 +255,16 @@ func (fake *FakeNetwork) SetupRestrictedNetworks() error {
 	ret, specificReturn := fake.setupRestrictedNetworksReturnsOnCall[len(fake.setupRestrictedNetworksArgsForCall)]
 	fake.setupRestrictedNetworksArgsForCall = append(fake.setupRestrictedNetworksArgsForCall, struct {
 	}{})
+	stub := fake.SetupRestrictedNetworksStub
+	fakeReturns := fake.setupRestrictedNetworksReturns
 	fake.recordInvocation("SetupRestrictedNetworks", []interface{}{})
 	fake.setupRestrictedNetworksMutex.Unlock()
-	if fake.SetupRestrictedNetworksStub != nil {
-		return fake.SetupRestrictedNetworksStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setupRestrictedNetworksReturns
 	return fakeReturns.result1
 }
 

--- a/worker/runtime/runtimefakes/fake_process_killer.go
+++ b/worker/runtime/runtimefakes/fake_process_killer.go
@@ -39,15 +39,16 @@ func (fake *FakeProcessKiller) Kill(arg1 context.Context, arg2 containerd.Proces
 		arg3 syscall.Signal
 		arg4 time.Duration
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.KillStub
+	fakeReturns := fake.killReturns
 	fake.recordInvocation("Kill", []interface{}{arg1, arg2, arg3, arg4})
 	fake.killMutex.Unlock()
-	if fake.KillStub != nil {
-		return fake.KillStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.killReturns
 	return fakeReturns.result1
 }
 

--- a/worker/runtime/runtimefakes/fake_rootfs_manager.go
+++ b/worker/runtime/runtimefakes/fake_rootfs_manager.go
@@ -48,15 +48,16 @@ func (fake *FakeRootfsManager) LookupUser(arg1 string, arg2 string) (specs.User,
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.LookupUserStub
+	fakeReturns := fake.lookupUserReturns
 	fake.recordInvocation("LookupUser", []interface{}{arg1, arg2})
 	fake.lookupUserMutex.Unlock()
-	if fake.LookupUserStub != nil {
-		return fake.LookupUserStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.lookupUserReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -115,15 +116,16 @@ func (fake *FakeRootfsManager) SetupCwd(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.SetupCwdStub
+	fakeReturns := fake.setupCwdReturns
 	fake.recordInvocation("SetupCwd", []interface{}{arg1, arg2})
 	fake.setupCwdMutex.Unlock()
-	if fake.SetupCwdStub != nil {
-		return fake.SetupCwdStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.setupCwdReturns
 	return fakeReturns.result1
 }
 

--- a/worker/runtime/runtimefakes/fake_user_namespace.go
+++ b/worker/runtime/runtimefakes/fake_user_namespace.go
@@ -31,15 +31,16 @@ func (fake *FakeUserNamespace) MaxValidIds() (uint32, uint32, error) {
 	ret, specificReturn := fake.maxValidIdsReturnsOnCall[len(fake.maxValidIdsArgsForCall)]
 	fake.maxValidIdsArgsForCall = append(fake.maxValidIdsArgsForCall, struct {
 	}{})
+	stub := fake.MaxValidIdsStub
+	fakeReturns := fake.maxValidIdsReturns
 	fake.recordInvocation("MaxValidIds", []interface{}{})
 	fake.maxValidIdsMutex.Unlock()
-	if fake.MaxValidIdsStub != nil {
-		return fake.MaxValidIdsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.maxValidIdsReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/worker/workerfakes/fake_tsaclient.go
+++ b/worker/workerfakes/fake_tsaclient.go
@@ -115,15 +115,16 @@ func (fake *FakeTSAClient) ContainersToDestroy(arg1 context.Context) ([]string, 
 	fake.containersToDestroyArgsForCall = append(fake.containersToDestroyArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.ContainersToDestroyStub
+	fakeReturns := fake.containersToDestroyReturns
 	fake.recordInvocation("ContainersToDestroy", []interface{}{arg1})
 	fake.containersToDestroyMutex.Unlock()
-	if fake.ContainersToDestroyStub != nil {
-		return fake.ContainersToDestroyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.containersToDestroyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -178,15 +179,16 @@ func (fake *FakeTSAClient) Delete(arg1 context.Context) error {
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{arg1})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1
 }
 
@@ -238,15 +240,16 @@ func (fake *FakeTSAClient) Land(arg1 context.Context) error {
 	fake.landArgsForCall = append(fake.landArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.LandStub
+	fakeReturns := fake.landReturns
 	fake.recordInvocation("Land", []interface{}{arg1})
 	fake.landMutex.Unlock()
-	if fake.LandStub != nil {
-		return fake.LandStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.landReturns
 	return fakeReturns.result1
 }
 
@@ -299,15 +302,16 @@ func (fake *FakeTSAClient) Register(arg1 context.Context, arg2 tsa.RegisterOptio
 		arg1 context.Context
 		arg2 tsa.RegisterOptions
 	}{arg1, arg2})
+	stub := fake.RegisterStub
+	fakeReturns := fake.registerReturns
 	fake.recordInvocation("Register", []interface{}{arg1, arg2})
 	fake.registerMutex.Unlock()
-	if fake.RegisterStub != nil {
-		return fake.RegisterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.registerReturns
 	return fakeReturns.result1
 }
 
@@ -365,15 +369,16 @@ func (fake *FakeTSAClient) ReportContainers(arg1 context.Context, arg2 []string)
 		arg1 context.Context
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.ReportContainersStub
+	fakeReturns := fake.reportContainersReturns
 	fake.recordInvocation("ReportContainers", []interface{}{arg1, arg2Copy})
 	fake.reportContainersMutex.Unlock()
-	if fake.ReportContainersStub != nil {
-		return fake.ReportContainersStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.reportContainersReturns
 	return fakeReturns.result1
 }
 
@@ -431,15 +436,16 @@ func (fake *FakeTSAClient) ReportVolumes(arg1 context.Context, arg2 []string) er
 		arg1 context.Context
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.ReportVolumesStub
+	fakeReturns := fake.reportVolumesReturns
 	fake.recordInvocation("ReportVolumes", []interface{}{arg1, arg2Copy})
 	fake.reportVolumesMutex.Unlock()
-	if fake.ReportVolumesStub != nil {
-		return fake.ReportVolumesStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.reportVolumesReturns
 	return fakeReturns.result1
 }
 
@@ -491,15 +497,16 @@ func (fake *FakeTSAClient) Retire(arg1 context.Context) error {
 	fake.retireArgsForCall = append(fake.retireArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.RetireStub
+	fakeReturns := fake.retireReturns
 	fake.recordInvocation("Retire", []interface{}{arg1})
 	fake.retireMutex.Unlock()
-	if fake.RetireStub != nil {
-		return fake.RetireStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.retireReturns
 	return fakeReturns.result1
 }
 
@@ -551,15 +558,16 @@ func (fake *FakeTSAClient) VolumesToDestroy(arg1 context.Context) ([]string, err
 	fake.volumesToDestroyArgsForCall = append(fake.volumesToDestroyArgsForCall, struct {
 		arg1 context.Context
 	}{arg1})
+	stub := fake.VolumesToDestroyStub
+	fakeReturns := fake.volumesToDestroyReturns
 	fake.recordInvocation("VolumesToDestroy", []interface{}{arg1})
 	fake.volumesToDestroyMutex.Unlock()
-	if fake.VolumesToDestroyStub != nil {
-		return fake.VolumesToDestroyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.volumesToDestroyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 


### PR DESCRIPTION
Bug Fix | Feature | Documentation

It seems that `counterfeiter` has done a small change in recent version, where a newly generated fake file has some diff from previous version like:

```diff
@@ -3102,15 +3146,16 @@ func (fake *FakeBuild) Resources() ([]db.BuildInput, []db.BuildOutput, error) {
        ret, specificReturn := fake.resourcesReturnsOnCall[len(fake.resourcesArgsForCall)]
        fake.resourcesArgsForCall = append(fake.resourcesArgsForCall, struct {
        }{})
+       stub := fake.ResourcesStub
+       fakeReturns := fake.resourcesReturns
        fake.recordInvocation("Resources", []interface{}{})
        fake.resourcesMutex.Unlock()
-       if fake.ResourcesStub != nil {
-               return fake.ResourcesStub()
+       if stub != nil {
+               return stub()
        }
        if specificReturn {
                return ret.result1, ret.result2, ret.result3
        }
-       fakeReturns := fake.resourcesReturns
        return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
```

Basically we can see that the logic is the same, it just added a local var `stub`. But this change is very annoying when we update an interface and rerun `go generate`, which generates a lot of fake file changes that should not belong to a working PR.

So I'm submitting this PR to update all fake files with the latest version of `counterfetier`. I upgraded `counerfeiter` with the following command:

```
$ go install github.com/maxbrunsfeld/counterfeiter/v6@latest
```

## Changes proposed by this PR:

1. Updated to latest `master` branch
2. Just upgraded `counterfeiter` to latest version (actually I was with the latest version already for a while)
3. Ran `go generated`.

## Notes to reviewer:

No any code change included in this PR.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
