### PR TITLE
containerd: fix mount issues with certain images

### DIFF
--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -44,15 +44,9 @@ var (
 		},
 		{
 			Destination: "/sys/fs/cgroup",
-			Type: "cgroup",
-			Source: "cgroup",
-			Options: []string{"ro", "nosuid", "noexec", "nodev"},
-		},
-		{
-			Destination: "/run",
-			Type:        "tmpfs",
-			Source:      "tmpfs",
-			Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
+			Type:        "cgroup",
+			Source:      "cgroup",
+			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
 		},
 	}
 )

--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -52,17 +52,14 @@ var (
 )
 
 func ContainerMounts(privileged bool, initBinPath string) []specs.Mount {
-	mounts := append(
-		[]specs.Mount{
-			{
-				Source:      initBinPath,
-				Destination: "/tmp/gdn-init",
-				Type:        "bind",
-				Options:     []string{"bind"},
-			},
-		},
-		DefaultContainerMounts...,
-	)
+	mounts := make([]specs.Mount, 0, len(DefaultContainerMounts)+1)
+	mounts = append(mounts, DefaultContainerMounts...)
+	mounts = append(mounts, specs.Mount{
+		Source:      initBinPath,
+		Destination: "/tmp/gdn-init",
+		Type:        "bind",
+		Options:     []string{"bind"},
+	})
 	// Following the current behaviour for privileged containers in Docker
 	if privileged {
 		for i, ociMount := range mounts {

--- a/worker/runtime/spec/spec_test.go
+++ b/worker/runtime/spec/spec_test.go
@@ -385,12 +385,6 @@ func (s *SpecSuite) TestContainerSpec() {
 					Source:      "cgroup",
 					Options:     []string{"nosuid", "noexec", "nodev"},
 				})
-				s.Contains(oci.Mounts, specs.Mount{
-					Destination: "/sys/fs/cgroup",
-					Type:        "cgroup",
-					Source:      "cgroup",
-					Options:     []string{"nosuid", "noexec", "nodev"},
-				})
 				for _, ociMount := range oci.Mounts {
 					if ociMount.Destination == "/sys" {
 						s.NotContains(ociMount.Options, "ro", "%s: %s", ociMount.Destination, ociMount.Type)

--- a/worker/runtime/spec/spec_test.go
+++ b/worker/runtime/spec/spec_test.go
@@ -362,6 +362,9 @@ func (s *SpecSuite) TestContainerSpec() {
 				s.Equal([]string{"/tmp/gdn-init"}, oci.Process.Args)
 				s.Equal(oci.Mounts, spec.ContainerMounts(false, spec.DefaultInitBinPath))
 
+				s.Equal("/tmp/gdn-init", oci.Mounts[len(oci.Mounts)-1].Destination,
+					"gdn-init mount should be mounted after all the other default mounts")
+
 				s.Equal(minimalContainerSpec.Handle, oci.Hostname)
 				s.Equal(spec.AnyContainerDevices, oci.Linux.Resources.Devices)
 			},


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #6578 (more context in the issue comments)

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Remove the `/run` mount - it's neither mounted by Guardian nor Docker (from what I can tell)
* Mount `/tmp/gdn-init` after all the other default mounts
  * The bug was fixed by removing `/run`, but would have also been fixed by mounting `/tmp/gdn-init` last
  * I figure that, while not strictly necessary for this bug fix, mounting it after the other mounts is a bit safer since it mirrors how we mount the other "normal" mounts (regular filesystem mounts, e.g. task inputs)

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* Fix an issue on the containerd runtime where processes fail to run with certain container images

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
