### PR TITLE
Check parent resource types

### DIFF
--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -58,10 +58,6 @@ func (s *scanner) Run(ctx context.Context) error {
 			}()
 			defer waitGroup.Done()
 
-			if resource.CheckEvery() != nil && resource.CheckEvery().Never {
-				return
-			}
-
 			s.check(spanCtx, resource, resourceTypes, resourceTypesChecked)
 		}(resource, resourceTypes)
 	}
@@ -92,6 +88,10 @@ func (s *scanner) check(ctx context.Context, checkable db.Checkable, resourceTyp
 	}
 
 	version := checkable.CurrentPinnedVersion()
+
+	if checkable.CheckEvery() != nil && checkable.CheckEvery().Never {
+		return
+	}
 
 	_, created, err := s.checkFactory.TryCreateCheck(lagerctx.NewContext(spanCtx, logger), checkable, resourceTypes, version, false)
 	if err != nil {

--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -72,10 +72,17 @@ var _ = Describe("Scanner", func() {
 			Context("when CheckEvery is never", func() {
 				BeforeEach(func() {
 					fakeResource.CheckEveryReturns(&atc.CheckEvery{Never: true})
+
+					fakeResource.TypeReturns("parent")
+					fakeResource.PipelineIDReturns(1)
+					fakeResourceType := new(dbfakes.FakeResourceType)
+					fakeResourceType.NameReturns("parent")
+					fakeResourceType.PipelineIDReturns(1)
+					fakeCheckFactory.ResourceTypesReturns([]db.ResourceType{fakeResourceType}, nil)
 				})
 
-				It("does not check", func() {
-					Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(0))
+				It("does not check the resource but still checks the parent", func() {
+					Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(1))
 				})
 			})
 


### PR DESCRIPTION
## What does this PR accomplish?

**Bug Fix** | Feature | Documentation

closes #6582

## Changes proposed by this PR:
Lidar creates checks for parent resource types even if the resource has check_every set to true

## Notes to reviewer:

Issue has steps to reproduce so you can do a before/after.

There are some other edge cases related to this issue, but to keep scope to a minimum and fix the most common situation I think people will run into, this PR should be enough.

## Release Note
* Resources that had `check_every: never` who's type was defined in `resource_types` in their pipeline, would fail to check because the parent resource type would never be checked

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

