### PR TITLE
Static vars should only resolve on "" sources

### DIFF
--- a/atc/exec/build_vars.go
+++ b/atc/exec/build_vars.go
@@ -32,7 +32,7 @@ func newBuildVariables(credVars vars.Variables, enableRedaction bool) *buildVari
 func (b *buildVariables) Get(ref vars.Reference) (interface{}, bool, error) {
 	if ref.Source == "." {
 		b.lock.RLock()
-		val, found, err := b.localVars.Get(ref)
+		val, found, err := b.localVars.Get(ref.WithoutSource())
 		b.lock.RUnlock()
 		if found || err != nil {
 			return val, found, err

--- a/vars/named_vars.go
+++ b/vars/named_vars.go
@@ -12,7 +12,7 @@ func (m NamedVariables) Get(ref Reference) (interface{}, bool, error) {
 	}
 
 	if vars, ok := m[ref.Source]; ok {
-		return vars.Get(ref)
+		return vars.Get(ref.WithoutSource())
 	}
 
 	return nil, false, MissingSourceError{Name: ref.String(), Source: ref.Source}

--- a/vars/static_vars.go
+++ b/vars/static_vars.go
@@ -5,6 +5,10 @@ type StaticVariables map[string]interface{}
 var _ Variables = StaticVariables{}
 
 func (v StaticVariables) Get(ref Reference) (interface{}, bool, error) {
+	if ref.Source != "" {
+		return nil, false, nil
+	}
+
 	val, found := v[ref.Path]
 	if !found {
 		return nil, false, nil

--- a/vars/static_vars_test.go
+++ b/vars/static_vars_test.go
@@ -27,6 +27,24 @@ var _ = Describe("StaticVariables", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("returns nil and not found if source is from local vars", func() {
+			a := StaticVariables{"a": "foo"}
+
+			val, found, err := a.Get(Reference{Source: ".", Path: "a"})
+			Expect(val).To(BeNil())
+			Expect(found).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns nil and not found if source is from var source", func() {
+			a := StaticVariables{"a": "foo"}
+
+			val, found, err := a.Get(Reference{Source: "some-var-source", Path: "a"})
+			Expect(val).To(BeNil())
+			Expect(found).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("follows fields", func() {
 			v := StaticVariables{
 				"a": map[string]interface{}{

--- a/vars/template_resolver_test.go
+++ b/vars/template_resolver_test.go
@@ -270,6 +270,28 @@ jobs:
 		Expect(result).To(Equal([]byte(`"foo"="foo"`)))
 	})
 
+	It("ignores values referencing local var sources", func() {
+		byteSlice := []byte("((key))=((.:key))")
+		variables := vars.StaticVariables{
+			"key": "foo",
+		}
+
+		result, err := vars.NewTemplateResolver(byteSlice, []vars.Variables{variables}).Resolve(false, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(result)).To(Equal("foo=((.:key))\n"))
+	})
+
+	It("ignores values referencing var sources", func() {
+		byteSlice := []byte("((key))=((source:key))")
+		variables := vars.StaticVariables{
+			"key": "foo",
+		}
+
+		result, err := vars.NewTemplateResolver(byteSlice, []vars.Variables{variables}).Resolve(false, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(result)).To(Equal("foo=((source:key))\n"))
+	})
+
 	It("can template values with strange newlines", func() {
 		byteSlice := []byte("{{key}}")
 		variables := vars.StaticVariables{

--- a/vars/variables.go
+++ b/vars/variables.go
@@ -18,6 +18,13 @@ type Reference struct {
 	Fields []string
 }
 
+func (r Reference) WithoutSource() Reference {
+	return Reference{
+		Path:   r.Path,
+		Fields: r.Fields,
+	}
+}
+
 func ParseReference(name string) (Reference, error) {
 	var ref Reference
 


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #6543 

## Notes to reviewer:


## Release Note

- Fixed bug where static vars from `fly set-pipeline -v ... -y ...` were interpolated into local vars `((.:var))`

## Contributor Checklist
- [X] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [X] [Signed] all commits
- [X] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [X] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
