### PR TITLE
Show warning for pipelines configured with 'set_pipeline' step

### DIFF
--- a/atc/api/present/pipeline.go
+++ b/atc/api/present/pipeline.go
@@ -7,15 +7,17 @@ import (
 
 func Pipeline(savedPipeline db.Pipeline) atc.Pipeline {
 	return atc.Pipeline{
-		ID:           savedPipeline.ID(),
-		Name:         savedPipeline.Name(),
-		InstanceVars: savedPipeline.InstanceVars(),
-		TeamName:     savedPipeline.TeamName(),
-		Paused:       savedPipeline.Paused(),
-		Public:       savedPipeline.Public(),
-		Archived:     savedPipeline.Archived(),
-		Groups:       savedPipeline.Groups(),
-		Display:      savedPipeline.Display(),
-		LastUpdated:  savedPipeline.LastUpdated().Unix(),
+		ID:            savedPipeline.ID(),
+		Name:          savedPipeline.Name(),
+		InstanceVars:  savedPipeline.InstanceVars(),
+		TeamName:      savedPipeline.TeamName(),
+		Paused:        savedPipeline.Paused(),
+		Public:        savedPipeline.Public(),
+		Archived:      savedPipeline.Archived(),
+		Groups:        savedPipeline.Groups(),
+		Display:       savedPipeline.Display(),
+		ParentBuildID: savedPipeline.ParentBuildID(),
+		ParentJobID:   savedPipeline.ParentJobID(),
+		LastUpdated:   savedPipeline.LastUpdated().Unix(),
 	}
 }

--- a/atc/pipeline.go
+++ b/atc/pipeline.go
@@ -12,16 +12,18 @@ import (
 )
 
 type Pipeline struct {
-	ID           int            `json:"id"`
-	Name         string         `json:"name"`
-	InstanceVars InstanceVars   `json:"instance_vars,omitempty"`
-	Paused       bool           `json:"paused"`
-	Public       bool           `json:"public"`
-	Archived     bool           `json:"archived"`
-	Groups       GroupConfigs   `json:"groups,omitempty"`
-	TeamName     string         `json:"team_name"`
-	Display      *DisplayConfig `json:"display,omitempty"`
-	LastUpdated  int64          `json:"last_updated,omitempty"`
+	ID            int            `json:"id"`
+	Name          string         `json:"name"`
+	InstanceVars  InstanceVars   `json:"instance_vars,omitempty"`
+	Paused        bool           `json:"paused"`
+	Public        bool           `json:"public"`
+	Archived      bool           `json:"archived"`
+	Groups        GroupConfigs   `json:"groups,omitempty"`
+	TeamName      string         `json:"team_name"`
+	Display       *DisplayConfig `json:"display,omitempty"`
+	ParentBuildID int            `json:"parent_build_id,omitempty"`
+	ParentJobID   int            `json:"parent_job_id,omitempty"`
+	LastUpdated   int64          `json:"last_updated,omitempty"`
 }
 
 func (p Pipeline) Ref() PipelineRef {

--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -92,6 +92,15 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 	}
 	fmt.Println()
 
+	pipeline, _, err := atcConfig.Team.Pipeline(atcConfig.PipelineRef)
+	if err != nil {
+		return err
+	}
+	if pipeline.ParentJobID != 0 && pipeline.ParentBuildID != 0 {
+		fmt.Println("\x1b[1;33mWARNING: pipeline has been configured through the 'set_pipeline' step, your changes may be overwritten on the next 'set_pipeline' step execution\x1b[0m")
+		fmt.Println()
+	}
+
 	if !atcConfig.ApplyConfigInteraction() {
 		fmt.Println("bailing out")
 		return nil

--- a/fly/integration/set_pipeline_test.go
+++ b/fly/integration/set_pipeline_test.go
@@ -189,10 +189,17 @@ var _ = Describe("Fly CLI", func() {
 				path, err := atc.Routes.CreatePathForRoute(atc.GetConfig, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
 				Expect(err).NotTo(HaveOccurred())
 
+				path_get, err := atc.Routes.CreatePathForRoute(atc.GetPipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+				Expect(err).NotTo(HaveOccurred())
+
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", path),
 						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ConfigResponse{Config: config}, http.Header{atc.ConfigVersionHeader: {"42"}}),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", path_get),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Pipeline{Name: "awesome-pipeline", Paused: false, TeamName: "main"}),
 					),
 				)
 			})
@@ -293,7 +300,7 @@ var _ = Describe("Fly CLI", func() {
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 
 				Context("when a non-stringy var is specified with -v", func() {
@@ -361,7 +368,7 @@ var _ = Describe("Fly CLI", func() {
 							Expect(sess.ExitCode()).To(Equal(0))
 						}).To(Change(func() int {
 							return len(atcServer.ReceivedRequests())
-						}).By(4))
+						}).By(5))
 					})
 				})
 
@@ -388,7 +395,7 @@ var _ = Describe("Fly CLI", func() {
 
 						}).To(Change(func() int {
 							return len(atcServer.ReceivedRequests())
-						}).By(4))
+						}).By(5))
 					})
 				})
 			})
@@ -448,7 +455,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 			})
 
@@ -510,7 +517,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 			})
 
@@ -572,7 +579,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 			})
 
@@ -625,7 +632,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 			})
 
@@ -684,7 +691,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 
 				Context("when the --check-creds option is used", func() {
@@ -708,7 +715,7 @@ this is super secure
 								Expect(sess.ExitCode()).To(Equal(0))
 							}).To(Change(func() int {
 								return len(atcServer.ReceivedRequests())
-							}).By(4))
+							}).By(5))
 						})
 					})
 
@@ -758,7 +765,7 @@ this is super secure
 								Expect(sess.ExitCode()).NotTo(Equal(0))
 							}).To(Change(func() int {
 								return len(atcServer.ReceivedRequests())
-							}).By(3))
+							}).By(4))
 						})
 					})
 				})
@@ -911,7 +918,7 @@ this is super secure
 
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 			})
 
@@ -1029,7 +1036,7 @@ this is super secure
 
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 
 				It("bails if the user rejects the diff", func() {
@@ -1049,7 +1056,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(2))
+					}).By(3))
 				})
 
 				It("parses the config from stdin and sends it to the ATC", func() {
@@ -1120,7 +1127,7 @@ this is super secure
 						Expect(sess.Out.Contents()).ToNot(ContainSubstring("some-unchanged-job"))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 
 				Context("when setting an instanced pipeline", func() {
@@ -1152,6 +1159,12 @@ this is super secure
 							ghttp.VerifyRequest("GET", "/api/v1/teams/other-team/pipelines/awesome-pipeline/config"),
 							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
 								Name: "other-team",
+							}),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v1/teams/other-team/pipelines/awesome-pipeline"),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Pipeline{
+								Name: "awesome-pipeline",
 							}),
 						),
 						ghttp.CombineHandlers(
@@ -1189,7 +1202,7 @@ this is super secure
 
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(5))
+					}).By(6))
 				})
 
 				It("bails if the user rejects the configuration", func() {
@@ -1210,7 +1223,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(3))
+					}).By(4))
 				})
 			})
 
@@ -1245,6 +1258,52 @@ this is super secure
 				})
 			})
 
+			Context("when updating a pipeline that has been configured through the 'set_pipeline' step", func() {
+				BeforeEach(func() {
+					path, err := atc.Routes.CreatePathForRoute(atc.SaveConfig, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+					Expect(err).NotTo(HaveOccurred())
+
+					path_get, err := atc.Routes.CreatePathForRoute(atc.GetPipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": "main"})
+					Expect(err).NotTo(HaveOccurred())
+
+					atcServer.RouteToHandler("PUT", path, ghttp.CombineHandlers(
+						ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
+						func(w http.ResponseWriter, r *http.Request) {
+							config := getConfig(r)
+							Expect(config).To(MatchYAML(payload))
+						},
+						ghttp.RespondWith(http.StatusCreated, "{}"),
+					))
+
+					atcServer.RouteToHandler("GET", path_get, ghttp.RespondWithJSONEncoded(http.StatusOK,
+					  atc.Pipeline{ID: 1, Name: "awesome-pipeline", Paused: false, TeamName: "main", ParentBuildID: 321, ParentJobID: 123}))
+
+					config.Jobs[0].Name = "updated-name"
+				})
+
+				It("succeeds and prints a warning message", func() {
+					Expect(func() {
+						flyCmd := exec.Command(flyPath, "-t", targetName, "set-pipeline", "-p", "awesome-pipeline", "-c", configFile.Name())
+
+						stdin, err := flyCmd.StdinPipe()
+						Expect(err).NotTo(HaveOccurred())
+
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(sess).Should(gbytes.Say("WARNING: pipeline has been configured through the 'set_pipeline' step, your changes may be overwritten on the next 'set_pipeline' step execution"))
+
+						Eventually(sess).Should(gbytes.Say(`apply configuration\? \[yN\]: `))
+						yes(stdin)
+
+						<-sess.Exited
+						Expect(sess.ExitCode()).To(Equal(0))
+					}).To(Change(func() int {
+						return len(atcServer.ReceivedRequests())
+					}).By(5))
+				})
+			})
+
 			Context("when the pipeline is paused", func() {
 				AssertSuccessWithPausedPipelineHelp := func(expectCreationMessage bool) {
 					It("succeeds and prints a message to help the user", func() {
@@ -1276,7 +1335,7 @@ this is super secure
 							Expect(sess.ExitCode()).To(Equal(0))
 						}).To(Change(func() int {
 							return len(atcServer.ReceivedRequests())
-						}).By(4))
+						}).By(5))
 					})
 				}
 
@@ -1374,7 +1433,7 @@ this is super secure
 						Expect(sess.ExitCode()).To(Equal(0))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
-					}).By(4))
+					}).By(5))
 				})
 			})
 


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes https://github.com/concourse/concourse/issues/5814.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

This PR resolves the last missing piece to complete [RFC #31](https://github.com/concourse/rfcs/blob/master/031-set-pipeline-step/proposal.md). With this change `fly set-pipeline` will notify the operator that the pipeline has been configured with `set_pipeline` step and all changes may be lost on the next `set_pipeline` step execution. 

<details><summary>set-pipeline command output</summary>
<p>

```
❯ ./fly-darwin -t local sp -p hello -c pipeline.yml
resource types:
  resource type registry-image-resource has changed:
  name: registry-image-resource
  source:
-   repository: xxx/registry-image-resource1
+   repository: xxx/registry-image-resource
    tag: latest
  type: registry-image

pipeline name: hello

WARNING: pipeline has a 'set_pipeline' step configured, your changes may be blown away on the next 'step_pipeline' step execution

apply configuration? [yN]: y
configuration updated
```

</p>
</details>

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

Let me know if all 'experimental' annotations related to `set_pipeline` step can be removed as a part of this PR.

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* `fly set-pipeline` now prints warning message when a pipeline has been configured through the `set_pipeline` step.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [X] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [X] [Signed] all commits
- [X] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
