### PR TITLE
containerd: infer MTU from host's network interface

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     volumes: ["../hack/keys:/concourse-keys"]
     stop_signal: SIGUSR2
     environment:
+      CONCOURSE_RUNTIME: containerd
+
       CONCOURSE_TSA_PUBLIC_KEY: /concourse-keys/tsa_host_key.pub
       CONCOURSE_TSA_WORKER_PRIVATE_KEY: /concourse-keys/worker_key
 
@@ -54,4 +56,4 @@ services:
       CONCOURSE_BAGGAGECLAIM_DRIVER: overlay
 
       # work with docker-compose's dns
-      CONCOURSE_GARDEN_DNS_PROXY_ENABLE: "true"
+      CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE: "true"

--- a/integration/worker/mtu_test.go
+++ b/integration/worker/mtu_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/concourse/concourse/integration/internal/dctest"
+	"github.com/concourse/concourse/integration/internal/flytest"
+)
+
+func TestMTU_Infer(t *testing.T) {
+	t.Parallel()
+
+	dc := dctest.Init(t, "../docker-compose.yml", "overrides/bridge_mtu.yml")
+
+	t.Run("deploy with MTU set on bridge network", func(t *testing.T) {
+		dc.Run(t, "up", "-d")
+	})
+
+	fly := flytest.Init(t, dc)
+	fly.WithEnv("EXPECTED_MTU=1480").Run(t, "execute", "-c", "tasks/assert_mtu.yml")
+}
+
+func TestMTU_Manual(t *testing.T) {
+	t.Parallel()
+
+	dc := dctest.Init(t, "../docker-compose.yml", "overrides/custom_mtu.yml")
+
+	t.Run("deploy with custom MTU", func(t *testing.T) {
+		dc.Run(t, "up", "-d")
+	})
+
+	fly := flytest.Init(t, dc)
+	fly.WithEnv("EXPECTED_MTU=1234").Run(t, "execute", "-c", "tasks/assert_mtu.yml")
+}

--- a/integration/worker/overrides/bridge_mtu.yml
+++ b/integration/worker/overrides/bridge_mtu.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      com.docker.network.driver.mtu: 1480

--- a/integration/worker/overrides/custom_mtu.yml
+++ b/integration/worker/overrides/custom_mtu.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+services:
+  worker:
+    environment:
+      CONCOURSE_CONTAINERD_MTU: 1234

--- a/integration/worker/tasks/assert_mtu.yml
+++ b/integration/worker/tasks/assert_mtu.yml
@@ -1,0 +1,19 @@
+platform: linux
+
+image_resource:
+  type: mock
+  source: {mirror_self: true}
+
+params:
+  INTERFACE: eth0
+  EXPECTED_MTU:
+
+run:
+  path: sh
+  args:
+  - -c
+  - |
+    set -ex
+
+    actual_mtu="$(cat /sys/class/net/$INTERFACE/mtu)"
+    test "$actual_mtu" = "$EXPECTED_MTU"

--- a/worker/mtu/mtu.go
+++ b/worker/mtu/mtu.go
@@ -1,0 +1,41 @@
+package mtu
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+func MTU(ipAddr string) (int, error) {
+	networkIface, err := findNetworkInterface(ipAddr)
+	if err != nil {
+		return 0, err
+	}
+	return networkIface.MTU, nil
+}
+
+func findNetworkInterface(ipAddr string) (net.Interface, error) {
+	networkIfaces, err := net.Interfaces()
+	if err != nil {
+		return net.Interface{}, err
+	}
+	for _, networkIface := range networkIfaces {
+		addrs, err := networkIface.Addrs()
+		if err != nil {
+			return net.Interface{}, err
+		}
+		if contains(addrs, ipAddr) {
+			return networkIface, nil
+		}
+	}
+	return net.Interface{}, fmt.Errorf("no interface found for address %s", ipAddr)
+}
+
+func contains(addresses []net.Addr, ip string) bool {
+	for _, address := range addresses {
+		if strings.HasPrefix(address.String(), ip+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/worker/mtu/mtu_test.go
+++ b/worker/mtu/mtu_test.go
@@ -1,0 +1,38 @@
+package mtu
+
+import (
+	"net"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMTU(t *testing.T) {
+	ifconfig, err := exec.LookPath("ifconfig")
+	if err != nil {
+		t.Skip("ifconfig is required")
+	}
+	iface, err := net.InterfaceByIndex(1)
+	require.NoError(t, err)
+
+	ifconfigOutput, err := exec.Command(ifconfig, iface.Name).CombinedOutput()
+	require.NoError(t, err)
+
+	groups := regexp.MustCompile(`(MTU|mtu).(\d+)`).FindStringSubmatch(string(ifconfigOutput))
+	mtuStr := groups[2]
+	expectMTU, err := strconv.Atoi(mtuStr)
+	require.NoError(t, err)
+
+	addrs, err := iface.Addrs()
+	require.NoError(t, err)
+	ipAddr := strings.Split(addrs[0].String(), "/")[0]
+
+	mtu, err := MTU(ipAddr)
+	require.NoError(t, err)
+
+	require.Equal(t, expectMTU, mtu)
+}

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -64,16 +64,16 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 		networkOpts = append(networkOpts, runtime.WithNameServers(dnsServers))
 	}
 
-	if len(cmd.Containerd.RestrictedNetworks) > 0 {
-		networkOpts = append(networkOpts, runtime.WithRestrictedNetworks(cmd.Containerd.RestrictedNetworks))
+	if len(cmd.Containerd.Network.RestrictedNetworks) > 0 {
+		networkOpts = append(networkOpts, runtime.WithRestrictedNetworks(cmd.Containerd.Network.RestrictedNetworks))
 	}
 
-	if cmd.Containerd.NetworkPool != "" {
+	if cmd.Containerd.Network.Pool != "" {
 		networkOpts = append(networkOpts, runtime.WithCNINetworkConfig(
 			runtime.CNINetworkConfig{
 				BridgeName:  "concourse0",
 				NetworkName: "concourse",
-				Subnet:      cmd.Containerd.NetworkPool,
+				Subnet:      cmd.Containerd.Network.Pool,
 			}))
 	}
 
@@ -149,8 +149,8 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 
 	members := grouper.Members{}
 
-	dnsServers := cmd.Containerd.DNSServers
-	if cmd.Containerd.DNS.Enable {
+	dnsServers := cmd.Containerd.Network.DNSServers
+	if cmd.Containerd.Network.DNS.Enable {
 		dnsProxyRunner, err := cmd.dnsProxyRunner(logger.Session("dns-proxy"))
 		if err != nil {
 			return nil, err

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -50,7 +50,7 @@ type ContainerdRuntime struct {
 		DNSServers         []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
 		RestrictedNetworks []string  `long:"restricted-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
 		Pool               string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
-		MTU                int       `long:"mtu" description:"MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host. Max allowed value is 1500."`
+		MTU                int       `long:"mtu" description:"MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host."`
 	} `group:"Container Networking"`
 
 	MaxContainers int `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -44,11 +44,13 @@ type ContainerdRuntime struct {
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
 
 	Network struct {
+		ExternalIP flag.IP `long:"external-ip" description:"IP address to use to reach container's mapped ports. Autodetected if not specified."`
 		//TODO can DNSConfig be simplifed to just a bool rather than struct with a bool?
 		DNS                DNSConfig `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
 		DNSServers         []string  `long:"dns-server" description:"DNS server IP address to use instead of automatically determined servers. Can be specified multiple times."`
 		RestrictedNetworks []string  `long:"restricted-network" description:"Network ranges to which traffic from containers will be restricted. Can be specified multiple times."`
 		Pool               string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
+		MTU                int       `long:"mtu" description:"MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host. Max allowed value is 1500."`
 	} `group:"Container Networking"`
 
 	MaxContainers int `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

closes #6613
potentially fixes #6599 

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Match Guardian's behaviour of inferring the MTU to use for the container's bridge network by finding the network interface corresponding to the host's external IP - see https://github.com/cloudfoundry/guardian/blob/15a56cca9deaa1ad04c9c10f91054e7ce82bf3c0/guardiancmd/command.go#L420-L426
  * As with Guardian, the MTU and external IP can still be configured

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note

* In prior versions of Concourse, the Containerd runtime always set the MTU of the container bridge network to the system default
* Now, the Containerd matches Guardian's behavior by:
  * Detecting the external IP of the host (can be set explicitly using `CONCOURSE_CONTAINERD_EXTERNAL_IP`)
  * Extracting the MTU from the network interface corresponding with that IP (can be set explicitly using `CONCOURSE_CONTAINERD_MTU`)

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
