### PR TITLE
Bump baggageclaim to v1.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e // indirect
 	github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2 // indirect
-	github.com/concourse/baggageclaim v1.10.0
+	github.com/concourse/baggageclaim v1.11.0
 	github.com/concourse/dex v0.3.0
 	github.com/concourse/flag v1.1.0
 	github.com/concourse/go-archive v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/cloudfoundry/socks5-proxy v0.0.0-20180530211953-3659db090cb2/go.mod h
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/concourse/baggageclaim v1.10.0 h1:YVSn50fs/N9psN0cQ1AOwntw70FTr376KOvz4Q6qHlo=
-github.com/concourse/baggageclaim v1.10.0/go.mod h1:UdvVE2W8LgXcCz0ZdKBwUbpKZ0KN4Fx1OeY1xtZOUvY=
+github.com/concourse/baggageclaim v1.11.0 h1:/2WtecK6KZ0Zw3zyc3MApTZIxUh1568aKW+dKT3OeOU=
+github.com/concourse/baggageclaim v1.11.0/go.mod h1:UdvVE2W8LgXcCz0ZdKBwUbpKZ0KN4Fx1OeY1xtZOUvY=
 github.com/concourse/dex v0.3.0 h1:H8aq2xcBMEHK17FVYWXECZxTtAI/kSQQXYOnTbw5dr0=
 github.com/concourse/dex v0.3.0/go.mod h1:Q8YPkw98XIkeTWO6Jm2ZMycdaf1NrNrPdvUOnpjYXtA=
 github.com/concourse/flag v0.0.0-20180907155614-cb47f24fff1c/go.mod h1:ngs845OZCESOe8vgeK5fsCNIiS0vUSqB8MGQMS9+4og=


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

closes #6620

## Changes proposed by this PR:
Bump baggageclaim to v1.11.0

New version uses overlay's metacopy feature when creating COW volumes.
This will result in faster initialization time for privileged tasks.

From testing on my machine:
- (Before) privileged container initialization: 51s
- (After metacopy enabled) privileged container initialization: 3s

## Release Note

* Privileged container initialization will be much faster for workers using OverlayFS as the baggageclaim driver and if their kernel supports OverlayFS's metacopy feature

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

cc @muntac 