### PR TITLE
runtime: check if swap limits is enabled

### DIFF
--- a/testflight/container_limits_test.go
+++ b/testflight/container_limits_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	"strings"
+	"regexp"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,8 +16,11 @@ var _ = Describe("A job with a task that has container limits", func() {
 		watch := spawnFly("trigger-job", "-j", inPipeline("container-limits-job"), "-w")
 		<-watch.Exited
 
+		match, _ := regexp.MatchString(`open /sys/fs/cgroup/memory/.*/memory\.memsw\.limit_in_bytes: (permission denied)?(no such file or directory)?`,
+			string(watch.Out.Contents()))
+
 		// Guardian runtime will always fail this test unless it's explicitly told not to set the swap limit
-		if strings.Contains(string(watch.Out.Contents()), "memsw.limit_in_bytes: no such file or directory") {
+		if match {
 			Skip("swap limits not enabled; skipping")
 		}
 
@@ -31,8 +34,11 @@ var _ = Describe("A job with a task that has container limits", func() {
 		watch := spawnFly("trigger-job", "-j", inPipeline("container-limits-failing-job"), "-w")
 		<-watch.Exited
 
+		match, _ := regexp.MatchString(`open /sys/fs/cgroup/memory/.*/memory\.memsw\.limit_in_bytes: (permission denied)?(no such file or directory)?`,
+			string(watch.Out.Contents()))
+
 		// Guardian runtime will always fail this test unless it's explicitly told not to set the swap limit
-		if strings.Contains(string(watch.Out.Contents()), "memsw.limit_in_bytes: no such file or directory") {
+		if match {
 			Skip("swap limits not enabled; skipping")
 		}
 

--- a/testflight/container_limits_test.go
+++ b/testflight/container_limits_test.go
@@ -16,7 +16,8 @@ var _ = Describe("A job with a task that has container limits", func() {
 		watch := spawnFly("trigger-job", "-j", inPipeline("container-limits-job"), "-w")
 		<-watch.Exited
 
-		if strings.Contains(string(watch.Out.Contents()), "memsw.limit_in_bytes: permission denied") {
+		// Guardian runtime will always fail this test unless it's explicitly told not to set the swap limit
+		if strings.Contains(string(watch.Out.Contents()), "memsw.limit_in_bytes: no such file or directory") {
 			Skip("swap limits not enabled; skipping")
 		}
 
@@ -30,7 +31,8 @@ var _ = Describe("A job with a task that has container limits", func() {
 		watch := spawnFly("trigger-job", "-j", inPipeline("container-limits-failing-job"), "-w")
 		<-watch.Exited
 
-		if strings.Contains(string(watch.Out.Contents()), "memsw.limit_in_bytes: permission denied") {
+		// Guardian runtime will always fail this test unless it's explicitly told not to set the swap limit
+		if strings.Contains(string(watch.Out.Contents()), "memsw.limit_in_bytes: no such file or directory") {
 			Skip("swap limits not enabled; skipping")
 		}
 
@@ -44,7 +46,7 @@ var _ = Describe("A job with a task that has container limits", func() {
 			"-s", "task-with-container-limits",
 			"--",
 			"cat",
-			"/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes",
+			"/sys/fs/cgroup/memory/memory.limit_in_bytes",
 		)
 		Expect(interceptS).To(gbytes.Say("1073741824"))
 

--- a/worker/runtime/spec/spec.go
+++ b/worker/runtime/spec/spec.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -150,7 +151,9 @@ func OciResources(limits garden.Limits) *specs.LinuxResources {
 	if memoryLimit > 0 {
 		memoryResources = &specs.LinuxMemory{
 			Limit: &memoryLimit,
-			Swap:  &memoryLimit,
+		}
+		if swapLimitEnabled() {
+			memoryResources.Swap = &memoryLimit
 		}
 	}
 
@@ -169,6 +172,17 @@ func OciResources(limits garden.Limits) *specs.LinuxResources {
 		Memory: memoryResources,
 		Pids:   pidLimit,
 	}
+}
+
+var SwapLimitFile string
+
+func init() {
+	SwapLimitFile = "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"
+}
+
+func swapLimitEnabled() bool {
+	_, err := os.Stat(SwapLimitFile)
+	return err == nil
 }
 
 func OciCgroupsPath(basePath, handle string, privileged bool) string {

--- a/worker/runtime/spec/spec.go
+++ b/worker/runtime/spec/spec.go
@@ -152,7 +152,7 @@ func OciResources(limits garden.Limits) *specs.LinuxResources {
 		memoryResources = &specs.LinuxMemory{
 			Limit: &memoryLimit,
 		}
-		if swapLimitEnabled() {
+		if IsSwapLimitEnabled {
 			memoryResources.Swap = &memoryLimit
 		}
 	}
@@ -174,14 +174,15 @@ func OciResources(limits garden.Limits) *specs.LinuxResources {
 	}
 }
 
-var SwapLimitFile string
+var IsSwapLimitEnabled bool
 
 func init() {
-	SwapLimitFile = "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"
+	IsSwapLimitEnabled = swapLimitEnabled()
 }
 
 func swapLimitEnabled() bool {
-	_, err := os.Stat(SwapLimitFile)
+	swapLimitFile := "/sys/fs/cgroup/memory/memory.memsw.limit_in_bytes"
+	_, err := os.Stat(swapLimitFile)
 	return err == nil
 }
 

--- a/worker/runtime/spec/spec_test.go
+++ b/worker/runtime/spec/spec_test.go
@@ -296,7 +296,7 @@ func (s *SpecSuite) TestOciResourceLimits() {
 			swapEnabled: true,
 		},
 		{
-			desc: "Swap disabled",
+			desc: "Swap memory limit disabled",
 			limits: garden.Limits{
 				Memory: garden.MemoryLimits{
 					LimitInBytes: 10000,
@@ -330,8 +330,7 @@ func (s *SpecSuite) TestOciResourceLimits() {
 		},
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			spec.IsSwapLimitEnabled = tc.swapEnabled
-			s.Equal(tc.expected, spec.OciResources(tc.limits))
+			s.Equal(tc.expected, spec.OciResources(tc.limits, tc.swapEnabled))
 		})
 	}
 }

--- a/worker/runtime/spec/spec_test.go
+++ b/worker/runtime/spec/spec_test.go
@@ -330,11 +330,7 @@ func (s *SpecSuite) TestOciResourceLimits() {
 		},
 	} {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			if tc.swapEnabled {
-				spec.SwapLimitFile = "/tmp"
-			} else {
-				spec.SwapLimitFile = "/not/a/file"
-			}
+			spec.IsSwapLimitEnabled = tc.swapEnabled
 			s.Equal(tc.expected, spec.OciResources(tc.limits))
 		})
 	}


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #6649

## Changes proposed by this PR:
The containerd runtime has been updated to check if swap limits is
enabled and will conditionally set them if they're enabled.

These testflight tests will always fail for Guardian if swap limits are
disabled on the host, unless Guardian is told to not set the swap limit.

## Notes to reviewer:
This depends on using runc-93. Anything earlier will cause the tests to fail when they should be skipped, only for the Guardian runtime though.

## Release Note

* The containerd runtime will conditionally set memory swap limits if it detects that memory swap limits are enabled

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

cc @EstebanFS 