### PR TITLE
runtime: timeout set to 0 means there is no timeout

### DIFF
--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"bytes"
 	"fmt"
-	"github.com/concourse/concourse/worker/workercmd"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -14,6 +13,7 @@ import (
 	"code.cloudfoundry.org/garden"
 	"github.com/concourse/concourse/worker/runtime"
 	"github.com/concourse/concourse/worker/runtime/libcontainerd"
+	"github.com/concourse/concourse/worker/workercmd"
 	"github.com/containerd/containerd"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -588,4 +588,27 @@ func (s *IntegrationSuite) TestMaxContainers() {
 	})
 	s.Error(err)
 	s.Contains(err.Error(), "max containers reached")
+}
+
+func (s *IntegrationSuite) TestRequestTimeoutZero() {
+	namespace := "test-requesTimeout-zero"
+	requestTimeout := time.Duration(0)
+
+	customBackend, err := runtime.NewGardenBackend(
+		libcontainerd.New(
+			s.containerdSocket(),
+			namespace,
+			requestTimeout,
+		),
+	)
+	s.NoError(err)
+
+	s.NoError(customBackend.Start())
+
+	_, err = customBackend.Containers(garden.Properties{})
+	s.NoError(err)
+
+	defer func() {
+		customBackend.Stop()
+	}()
 }

--- a/worker/runtime/libcontainerd/client.go
+++ b/worker/runtime/libcontainerd/client.go
@@ -117,7 +117,7 @@ func (c *client) NewContainer(
 ) (
 	containerd.Container, error,
 ) {
-	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
 	return c.containerd.NewContainer(ctx, id,
@@ -131,14 +131,14 @@ func (c *client) Containers(
 ) (
 	[]containerd.Container, error,
 ) {
-	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
 	return c.containerd.Containers(ctx, labels...)
 }
 
 func (c *client) GetContainer(ctx context.Context, handle string) (containerd.Container, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
 	cont, err := c.containerd.LoadContainer(ctx, handle)
@@ -153,14 +153,14 @@ func (c *client) GetContainer(ctx context.Context, handle string) (containerd.Co
 }
 
 func (c *client) Version(ctx context.Context) (err error) {
-	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
 	_, err = c.containerd.Version(ctx)
 	return
 }
 func (c *client) Destroy(ctx context.Context, handle string) error {
-	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
 	container, err := c.GetContainer(ctx, handle)

--- a/worker/runtime/libcontainerd/container.go
+++ b/worker/runtime/libcontainerd/container.go
@@ -31,21 +31,21 @@ func (c *container) Delete(ctx context.Context, opts ...containerd.DeleteOpts) e
 }
 
 func (c *container) NewTask(ctx context.Context, creator cio.Creator, opts ...containerd.NewTaskOpts) (containerd.Task, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
 	return c.container.NewTask(ctx, creator, opts...)
 }
 
 func (c *container) Spec(ctx context.Context) (*oci.Spec, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
 	return c.container.Spec(ctx)
 }
 
 func (c *container) Task(ctx context.Context, opt cio.Attach) (containerd.Task, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	ctx, cancel := createTimeoutContext(ctx, c.requestTimeout)
 	defer cancel()
 
 	return c.container.Task(ctx, opt)

--- a/worker/runtime/libcontainerd/helper.go
+++ b/worker/runtime/libcontainerd/helper.go
@@ -1,0 +1,13 @@
+package libcontainerd
+
+import (
+	"context"
+	"time"
+)
+
+func createTimeoutContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout == 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, timeout)
+}


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #6622 

## Changes proposed by this PR:
In case `CONCOURSE_CONTAINERD_REQUEST_TIMEOUT` is set to 0 we should get a context with no deadline

## Notes to reviewer:

## Release Note
* When `CONCOURSE_CONTAINERD_REQUEST_TIMEOUT` is set to 0 that means there is no timeout

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
