### PR TITLE
feat(atc): add check build metrics.

### DIFF
--- a/atc/builds/tracker.go
+++ b/atc/builds/tracker.go
@@ -56,19 +56,19 @@ func (bt *Tracker) Run(ctx context.Context) error {
 
 				defer bt.running.Delete(build.ID())
 
-				if b.Name() == db.CheckBuildName {
+				if build.Name() == db.CheckBuildName {
 					metric.Metrics.CheckBuildsRunning.Inc()
 				} else {
 					metric.Metrics.BuildsRunning.Inc()
 				}
 
-				defer func(b db.Build) {
-					if b.Name() == db.CheckBuildName {
+				defer func(build db.Build) {
+					if build.Name() == db.CheckBuildName {
 						metric.Metrics.CheckBuildsRunning.Dec()
 					} else {
 						metric.Metrics.BuildsRunning.Dec()
 					}
-				}(b)
+				}(build)
 
 				bt.engine.NewBuild(build).Run(
 					lagerctx.NewContext(

--- a/atc/builds/tracker.go
+++ b/atc/builds/tracker.go
@@ -58,17 +58,11 @@ func (bt *Tracker) Run(ctx context.Context) error {
 
 				if build.Name() == db.CheckBuildName {
 					metric.Metrics.CheckBuildsRunning.Inc()
+					defer metric.Metrics.CheckBuildsRunning.Dec()
 				} else {
 					metric.Metrics.BuildsRunning.Inc()
+					defer metric.Metrics.BuildsRunning.Dec()
 				}
-
-				defer func(build db.Build) {
-					if build.Name() == db.CheckBuildName {
-						metric.Metrics.CheckBuildsRunning.Dec()
-					} else {
-						metric.Metrics.BuildsRunning.Dec()
-					}
-				}(build)
 
 				bt.engine.NewBuild(build).Run(
 					lagerctx.NewContext(

--- a/atc/builds/tracker.go
+++ b/atc/builds/tracker.go
@@ -56,8 +56,19 @@ func (bt *Tracker) Run(ctx context.Context) error {
 
 				defer bt.running.Delete(build.ID())
 
-				metric.Metrics.BuildsRunning.Inc()
-				defer metric.Metrics.BuildsRunning.Dec()
+				if b.Name() == db.CheckBuildName {
+					metric.Metrics.CheckBuildsRunning.Inc()
+				} else {
+					metric.Metrics.BuildsRunning.Inc()
+				}
+
+				defer func(b db.Build) {
+					if b.Name() == db.CheckBuildName {
+						metric.Metrics.CheckBuildsRunning.Dec()
+					} else {
+						metric.Metrics.BuildsRunning.Dec()
+					}
+				}(b)
 
 				bt.engine.NewBuild(build).Run(
 					lagerctx.NewContext(

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -277,9 +277,15 @@ func (b *engineBuild) saveStatus(logger lager.Logger, status atc.BuildStatus) {
 }
 
 func (b *engineBuild) trackStarted(logger lager.Logger) {
-	metric.BuildStarted{
-		Build: b.build,
-	}.Emit(logger)
+	if b.build.Name() != db.CheckBuildName {
+		metric.BuildStarted{
+			Build: b.build,
+		}.Emit(logger)
+	} else {
+		metric.CheckBuildStarted{
+			Build: b.build,
+		}.Emit(logger)
+	}
 }
 
 func (b *engineBuild) trackFinished(logger lager.Logger) {
@@ -295,9 +301,15 @@ func (b *engineBuild) trackFinished(logger lager.Logger) {
 	}
 
 	if !b.build.IsRunning() {
-		metric.BuildFinished{
-			Build: b.build,
-		}.Emit(logger)
+		if b.build.Name() != db.CheckBuildName {
+			metric.BuildFinished{
+				Build: b.build,
+			}.Emit(logger)
+		} else {
+			metric.CheckBuildFinished{
+				Build: b.build,
+			}.Emit(logger)
+		}
 	}
 }
 

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -163,6 +163,7 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 			}
 		}
 
+		// TODO: deprecate it.
 		metric.Metrics.ChecksStarted.Inc()
 
 		_, err = scope.UpdateLastCheckStartTime()
@@ -172,6 +173,7 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 
 		result, runErr := step.runCheck(ctx, logger, delegate, timeout, resourceConfig, source, resourceTypes, fromVersion)
 		if runErr != nil {
+			// TODO: deprecate it.
 			metric.Metrics.ChecksFinishedWithError.Inc()
 
 			if _, err := scope.UpdateLastCheckEndTime(); err != nil {
@@ -195,6 +197,7 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 			return false, fmt.Errorf("run check: %w", runErr)
 		}
 
+		// TODO: deprecate it.
 		metric.Metrics.ChecksFinishedWithSuccess.Inc()
 
 		err = scope.SaveVersions(db.NewSpanContext(ctx), result.Versions)

--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -57,12 +57,19 @@ type Monitor struct {
 	BuildsStarted Counter
 	BuildsRunning Gauge
 
+	CheckBuildsStarted Counter
+	CheckBuildsRunning Gauge
+
 	TasksWaiting map[TasksWaitingLabels]*Gauge
 
+	// TODO: deprecate, replaced with CheckBuildFinished
 	ChecksFinishedWithError   Counter
 	ChecksFinishedWithSuccess Counter
-	ChecksStarted             Counter
-	ChecksEnqueued            Counter
+
+	// TODO: deprecate, replaced with CheckBuildsStarted and CheckBuildStarted
+	ChecksStarted Counter
+
+	ChecksEnqueued Counter
 
 	ConcurrentRequests         map[string]*Gauge
 	ConcurrentRequestsLimitHit map[string]*Counter

--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -49,7 +49,6 @@ type Monitor struct {
 
 	ContainersDeleted Counter
 	VolumesDeleted    Counter
-	ChecksDeleted     Counter
 
 	JobsScheduled  Counter
 	JobsScheduling Gauge

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -89,8 +89,10 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	// These are the simple ones that only need a small name transformation
 	case "build started",
 		"build finished",
-		"checks finished",
-		"checks started",
+		"check build started",
+		"check build finished",
+		"checks finished", // TODO: deprecate, use "check build finished" instead.
+		"checks started",  // TODO: deprecate, use "check build started" instead.
 		"checks enqueued",
 		"checks queue size",
 		"worker containers",
@@ -110,8 +112,6 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	// periodic list, so we should have a coherent view). We do this because
 	// new relic has a hard limit on the total number of metrics in a 24h
 	// period, so batching similar data where possible makes sense.
-	case "checks deleted":
-		emitter.checks.deleted = event.Value
 	case "containers deleted":
 		emitter.containers.deleted = event.Value
 	case "containers created":

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -423,7 +423,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Namespace: "concourse",
 			Subsystem: "lidar",
 			Name:      "checks_finished_total",
-			Help:      "Total number of checks finished",
+			Help:      "Total number of checks finished. DEPRECATED: use concourse_builds_check_finished_total instead.",
 		},
 		[]string{"status"},
 	)
@@ -434,7 +434,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Namespace: "concourse",
 			Subsystem: "lidar",
 			Name:      "checks_started_total",
-			Help:      "Total number of checks started",
+			Help:      "Total number of checks started. DEPRECATED: use concourse_builds_check_started_total instead.",
 		},
 	)
 	prometheus.MustRegister(checksStarted)

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -24,6 +24,9 @@ type PrometheusEmitter struct {
 	buildsStarted prometheus.Counter
 	buildsRunning prometheus.Gauge
 
+	checkBuildsStarted prometheus.Counter
+	checkBuildsRunning prometheus.Gauge
+
 	concurrentRequestsLimitHit *prometheus.CounterVec
 	concurrentRequests         *prometheus.GaugeVec
 
@@ -38,6 +41,12 @@ type PrometheusEmitter struct {
 	buildsFinishedVec *prometheus.CounterVec
 	buildsSucceeded   prometheus.Counter
 
+	checkBuildsAborted   prometheus.Counter
+	checkBuildsErrored   prometheus.Counter
+	checkBuildsFailed    prometheus.Counter
+	checkBuildsFinished  prometheus.Counter
+	checkBuildsSucceeded prometheus.Counter
+
 	dbConnections  *prometheus.GaugeVec
 	dbQueriesTotal prometheus.Counter
 
@@ -47,10 +56,11 @@ type PrometheusEmitter struct {
 
 	locksHeld *prometheus.GaugeVec
 
-	checksFinished  *prometheus.CounterVec
-	checksQueueSize prometheus.Gauge
-	checksStarted   prometheus.Counter
-	checksEnqueued  prometheus.Counter
+	// TODO: deprecate
+	checksFinished *prometheus.CounterVec
+	checksStarted  prometheus.Counter
+
+	checksEnqueued prometheus.Counter
 
 	volumesStreamed prometheus.Counter
 
@@ -159,6 +169,22 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 	})
 	prometheus.MustRegister(buildsRunning)
 
+	checkBuildsStarted := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "check_started_total",
+		Help:      "Total number of Concourse check builds started.",
+	})
+	prometheus.MustRegister(checkBuildsStarted)
+
+	checkBuildsRunning := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "check_running",
+		Help:      "Number of Concourse check builds currently running.",
+	})
+	prometheus.MustRegister(checkBuildsRunning)
+
 	concurrentRequestsLimitHit := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "concourse",
 		Subsystem: "concurrent_requests",
@@ -253,6 +279,46 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 		[]string{"team", "pipeline", "job"},
 	)
 	prometheus.MustRegister(buildDurationsVec)
+
+	checkBuildsFinished := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "check_finished_total",
+		Help:      "Total number of Concourse check builds finished.",
+	})
+	prometheus.MustRegister(checkBuildsFinished)
+
+	checkBuildsSucceeded := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "check_succeeded_total",
+		Help:      "Total number of Concourse check builds succeeded.",
+	})
+	prometheus.MustRegister(checkBuildsSucceeded)
+
+	checkBuildsErrored := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "check_errored_total",
+		Help:      "Total number of Concourse check builds errored.",
+	})
+	prometheus.MustRegister(checkBuildsErrored)
+
+	checkBuildsFailed := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "check_failed_total",
+		Help:      "Total number of Concourse check builds failed.",
+	})
+	prometheus.MustRegister(checkBuildsFailed)
+
+	checkBuildsAborted := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "concourse",
+		Subsystem: "builds",
+		Name:      "check_aborted_total",
+		Help:      "Total number of Concourse check builds aborted.",
+	})
+	prometheus.MustRegister(checkBuildsAborted)
 
 	// worker metrics
 	workerContainers := prometheus.NewGaugeVec(
@@ -363,16 +429,6 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 	)
 	prometheus.MustRegister(checksFinished)
 
-	checksQueueSize := prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "concourse",
-			Subsystem: "lidar",
-			Name:      "check_queue_size",
-			Help:      "The size of the checks queue",
-		},
-	)
-	prometheus.MustRegister(checksQueueSize)
-
 	checksStarted := prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: "concourse",
@@ -417,6 +473,9 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 		buildsStarted: buildsStarted,
 		buildsRunning: buildsRunning,
 
+		checkBuildsStarted: checkBuildsStarted,
+		checkBuildsRunning: checkBuildsRunning,
+
 		concurrentRequestsLimitHit: concurrentRequestsLimitHit,
 		concurrentRequests:         concurrentRequests,
 
@@ -431,6 +490,12 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 		buildsFinishedVec: buildsFinishedVec,
 		buildsSucceeded:   buildsSucceeded,
 
+		checkBuildsAborted:   checkBuildsAborted,
+		checkBuildsErrored:   checkBuildsErrored,
+		checkBuildsFailed:    checkBuildsFailed,
+		checkBuildsFinished:  checkBuildsFinished,
+		checkBuildsSucceeded: checkBuildsSucceeded,
+
 		dbConnections:  dbConnections,
 		dbQueriesTotal: dbQueriesTotal,
 
@@ -440,10 +505,11 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 
 		locksHeld: locksHeld,
 
-		checksFinished:  checksFinished,
-		checksQueueSize: checksQueueSize,
-		checksStarted:   checksStarted,
-		checksEnqueued:  checksEnqueued,
+		// TODO: deprecate
+		checksFinished: checksFinished,
+		checksStarted:  checksStarted,
+
+		checksEnqueued: checksEnqueued,
 
 		workerContainers:        workerContainers,
 		workersRegistered:       workersRegistered,
@@ -485,6 +551,10 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 		emitter.buildsStarted.Add(event.Value)
 	case "builds running":
 		emitter.buildsRunning.Set(event.Value)
+	case "check builds started":
+		emitter.checkBuildsStarted.Add(event.Value)
+	case "check builds running":
+		emitter.checkBuildsRunning.Set(event.Value)
 	case "concurrent requests limit hit":
 		emitter.concurrentRequestsLimitHit.WithLabelValues(event.Attributes["action"]).Add(event.Value)
 	case "concurrent requests":
@@ -506,6 +576,8 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 			).Observe(event.Value)
 	case "build finished":
 		emitter.buildFinishedMetrics(logger, event)
+	case "check build finished":
+		emitter.checkBuildFinishedMetrics(logger, event)
 	case "worker containers":
 		emitter.workerContainersMetric(logger, event)
 	case "worker volumes":
@@ -524,14 +596,14 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 		emitter.databaseMetrics(logger, event)
 	case "database connections":
 		emitter.databaseMetrics(logger, event)
+	// TODO: deprecate
 	case "checks finished":
 		emitter.checksFinished.WithLabelValues(event.Attributes["status"]).Add(event.Value)
+	// TODO: deprecate
 	case "checks started":
 		emitter.checksStarted.Add(event.Value)
 	case "checks enqueued":
 		emitter.checksEnqueued.Add(event.Value)
-	case "checks queue size":
-		emitter.checksQueueSize.Set(event.Value)
 	case "volumes streamed":
 		emitter.volumesStreamed.Add(event.Value)
 	default:
@@ -613,6 +685,33 @@ func (emitter *PrometheusEmitter) buildFinishedMetrics(logger lager.Logger, even
 	// seconds are the standard prometheus base unit for time
 	duration := event.Value / 1000
 	emitter.buildDurationsVec.WithLabelValues(team, pipeline, job).Observe(duration)
+}
+
+func (emitter *PrometheusEmitter) checkBuildFinishedMetrics(logger lager.Logger, event metric.Event) {
+	// concourse_builds_finished_total
+	emitter.checkBuildsFinished.Inc()
+
+	buildStatus, exists := event.Attributes["build_status"]
+	if !exists {
+		logger.Error("failed-to-find-check-build_status-in-event", fmt.Errorf("expected build_status to exist in event.Attributes"))
+		return
+	}
+
+	// concourse_builds_(aborted|succeeded|failed|errored)_total
+	switch buildStatus {
+	case string(db.BuildStatusAborted):
+		// concourse_builds_check_aborted_total
+		emitter.checkBuildsAborted.Inc()
+	case string(db.BuildStatusSucceeded):
+		// concourse_builds_check_succeeded_total
+		emitter.checkBuildsSucceeded.Inc()
+	case string(db.BuildStatusFailed):
+		// concourse_builds_check_failed_total
+		emitter.checkBuildsFailed.Inc()
+	case string(db.BuildStatusErrored):
+		// concourse_builds_check_errored_total
+		emitter.checkBuildsErrored.Inc()
+	}
 }
 
 func (emitter *PrometheusEmitter) workerContainersMetric(logger lager.Logger, event metric.Event) {

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -459,6 +459,39 @@ func (event BuildFinished) Emit(logger lager.Logger) {
 	)
 }
 
+type CheckBuildStarted struct {
+	Build db.Build
+}
+
+func (event CheckBuildStarted) Emit(logger lager.Logger) {
+	Metrics.emit(
+		logger.Session("check-build-started"),
+		Event{
+			Name:       "check build started",
+			Value:      float64(event.Build.ID()),
+			Attributes: event.Build.TracingAttrs(),
+		},
+	)
+}
+
+type CheckBuildFinished struct {
+	Build db.Build
+}
+
+func (event CheckBuildFinished) Emit(logger lager.Logger) {
+	attrs := event.Build.TracingAttrs()
+	attrs["build_status"] = event.Build.Status().String()
+
+	Metrics.emit(
+		logger.Session("check-build-finished"),
+		Event{
+			Name:       "check build finished",
+			Value:      ms(event.Build.EndTime().Sub(event.Build.StartTime())),
+			Attributes: attrs,
+		},
+	)
+}
+
 func ms(duration time.Duration) float64 {
 	return float64(duration) / 1000000
 }

--- a/atc/metric/periodic.go
+++ b/atc/metric/periodic.go
@@ -68,14 +68,6 @@ func tick(logger lager.Logger, m *Monitor) {
 	)
 
 	m.emit(
-		logger.Session("checks-deleted"),
-		Event{
-			Name:  "checks deleted",
-			Value: m.ChecksDeleted.Delta(),
-		},
-	)
-
-	m.emit(
 		logger.Session("volumes-streamed"),
 		Event{
 			Name:  "volumes streamed",

--- a/atc/metric/periodic.go
+++ b/atc/metric/periodic.go
@@ -147,6 +147,22 @@ func tick(logger lager.Logger, m *Monitor) {
 		},
 	)
 
+	m.emit(
+		logger.Session("check-builds-started"),
+		Event{
+			Name:  "check builds started",
+			Value: m.CheckBuildsStarted.Delta(),
+		},
+	)
+
+	m.emit(
+		logger.Session("check-builds-running"),
+		Event{
+			Name:  "check builds running",
+			Value: m.CheckBuildsRunning.Max(),
+		},
+	)
+
 	for action, gauge := range m.ConcurrentRequests {
 		m.emit(
 			logger.Session("concurrent-requests"),

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -230,7 +230,12 @@ func (s *buildStarter) tryStartNextPendingBuild(
 		}, nil
 	}
 
-	metric.Metrics.BuildsStarted.Inc()
+	// To avoid breaking existing dashboards, don't count check builds into BuildsStarted.
+	if nextPendingBuild.Name() == db.CheckBuildName {
+		metric.Metrics.CheckBuildsStarted.Inc()
+	} else {
+		metric.Metrics.BuildsStarted.Inc()
+	}
 
 	return startResults{
 		finished: true,


### PR DESCRIPTION
## What does this PR accomplish?

**Bug Fix** | **Feature** | Documentation

closes #6614  .

## Changes proposed by this PR:

* Exclude check builds from existing metrics `BuildsStarted`, `BuildsRunning`, `BuildStarted`, `BuildFinsished`
* Add check build metrics: `CheckBuildsStarted`, `CheckBuildsRunning`, `CheckBuildStarted`, `CheckBuildFinsished`

We should deprecate `CheckStarted`, `ChecksFinishedWithSuccess` and `ChecksFinishedWithError`. Maybe we should only delete them after a few releases to educate users to new the check build metrics.

## Notes to reviewer:


## Release Note

* Fixed metrics `BuildsStarted`, `BuildsRunning`, `BuildStarted`, `BuildFinsished` to exclude check builds.
* Added check build metrics: `CheckBuildsStarted`, `CheckBuildsRunning`, `CheckBuildStarted`, `CheckBuildFinsished`

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
