### PR TITLE
Add ability to navigate to resources page from build page

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -736,6 +736,7 @@ sampleOldModel =
                     , eventSourceOpened = True
                     , eventStreamUrlPath = Nothing
                     , highlight = Routes.HighlightNothing
+                    , buildId = Nothing
                     }
             }
     , autoScroll = True
@@ -772,6 +773,7 @@ sampleModel =
             , eventSourceOpened = True
             , eventStreamUrlPath = Nothing
             , highlight = Routes.HighlightNothing
+            , buildId = Nothing
             }
     , autoScroll = True
     , isScrollToIdInProgress = False
@@ -859,6 +861,7 @@ stepsModel =
         , steps = steps
         , highlight = Routes.HighlightNothing
         , resources = { inputs = [], outputs = [] }
+        , buildId = Nothing
         }
 
 

--- a/web/elm/src/Api.elm
+++ b/web/elm/src/Api.elm
@@ -56,12 +56,12 @@ get endpoint =
     }
 
 
-paginatedGet : Endpoint -> Maybe Page -> Decoder a -> Request (Paginated a)
-paginatedGet endpoint page decoder =
+paginatedGet : Endpoint -> Maybe Page -> List Url.Builder.QueryParameter -> Decoder a -> Request (Paginated a)
+paginatedGet endpoint page additionalQueries decoder =
     { method = "GET"
     , headers = []
     , endpoint = endpoint
-    , query = Api.Pagination.params page
+    , query = Api.Pagination.params page ++ additionalQueries
     , body = Http.emptyBody
     , expect = Http.expectStringResponse (parsePagination decoder)
     }

--- a/web/elm/src/Build/Output/Models.elm
+++ b/web/elm/src/Build/Output/Models.elm
@@ -1,6 +1,7 @@
 module Build.Output.Models exposing (OutputModel, OutputState(..))
 
 import Build.StepTree.Models exposing (StepTreeModel)
+import Concourse
 import Routes exposing (Highlight)
 
 
@@ -10,6 +11,7 @@ type alias OutputModel =
     , eventSourceOpened : Bool
     , eventStreamUrlPath : Maybe String
     , highlight : Highlight
+    , buildId : Maybe Concourse.JobBuildIdentifier
     }
 
 

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -43,12 +43,25 @@ init highlight build =
             else
                 StepsLoading
 
+        buildId =
+            Maybe.map
+                (\job ->
+                    { buildName = build.name
+                    , teamName = build.teamName
+                    , pipelineName = job.pipelineName
+                    , pipelineInstanceVars = job.pipelineInstanceVars
+                    , jobName = job.jobName
+                    }
+                )
+                build.job
+
         model =
             { steps = Nothing
             , state = outputState
             , eventStreamUrlPath = Nothing
             , eventSourceOpened = False
             , highlight = highlight
+            , buildId = buildId
             }
 
         fetch =
@@ -94,6 +107,7 @@ planAndResourcesFetched buildId ( plan, resources ) model =
         | steps =
             Just
                 (Build.StepTree.StepTree.init
+                    model.buildId
                     model.highlight
                     resources
                     plan
@@ -237,12 +251,12 @@ handleEvent event ( model, effects ) =
             ( { model | steps = newSt }, effects )
 
         ImageCheck { id } plan ->
-            ( { model | steps = Maybe.map (Build.StepTree.StepTree.setImageCheck id plan) model.steps }
+            ( { model | steps = Maybe.map (Build.StepTree.StepTree.setImageCheck model.buildId id plan) model.steps }
             , effects
             )
 
         ImageGet { id } plan ->
-            ( { model | steps = Maybe.map (Build.StepTree.StepTree.setImageGet id plan) model.steps }
+            ( { model | steps = Maybe.map (Build.StepTree.StepTree.setImageGet model.buildId id plan) model.steps }
             , effects
             )
 

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -39,6 +39,7 @@ type alias StepTreeModel =
     , steps : Dict StepID Step
     , highlight : Highlight
     , resources : Concourse.BuildResources
+    , buildId : Maybe Concourse.JobBuildIdentifier
     }
 
 

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -1348,9 +1348,9 @@ tooltip model { hovered } =
                         [ Html.text "view in resources page" ]
                 , attachPosition =
                     { direction = Tooltip.Top
-                    , alignment = Tooltip.End
+                    , alignment = Tooltip.Middle 150
                     }
-                , arrow = Nothing
+                , arrow = Just 5
                 , containerAttrs = Nothing
                 }
 

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -81,6 +81,7 @@ module Concourse exposing
     , retrieveCSRFToken
     , toInstanceGroupId
     , toPipelineId
+    , versionQuery
     )
 
 import Array exposing (Array)
@@ -1170,6 +1171,11 @@ decodeVersion =
 encodeVersion : Version -> Json.Encode.Value
 encodeVersion =
     Json.Encode.dict identity Json.Encode.string
+
+
+versionQuery : Version -> List String
+versionQuery v =
+    List.map (\kv -> Tuple.first kv ++ ":" ++ Tuple.second kv) <| Dict.toList v
 
 
 

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -378,13 +378,13 @@ mapBuildPlan fn plan =
                 BuildStepArtifactInput _ ->
                     []
 
-                BuildStepPut _ ->
+                BuildStepPut _ _ ->
                     []
 
                 BuildStepCheck _ ->
                     []
 
-                BuildStepGet _ _ ->
+                BuildStepGet _ _ _ ->
                     []
 
                 BuildStepArtifactOutput _ ->
@@ -430,15 +430,19 @@ type alias StepName =
     String
 
 
+type alias ResourceName =
+    String
+
+
 type BuildStep
     = BuildStepTask StepName
     | BuildStepSetPipeline StepName InstanceVars
     | BuildStepLoadVar StepName
     | BuildStepArtifactInput StepName
     | BuildStepCheck StepName
-    | BuildStepGet StepName (Maybe Version)
+    | BuildStepGet StepName (Maybe ResourceName) (Maybe Version)
     | BuildStepArtifactOutput StepName
-    | BuildStepPut StepName
+    | BuildStepPut StepName (Maybe ResourceName)
     | BuildStepInParallel (Array BuildPlan)
     | BuildStepAcross AcrossPlan
     | BuildStepDo (Array BuildPlan)
@@ -667,6 +671,7 @@ decodeBuildStepGet : Json.Decode.Decoder BuildStep
 decodeBuildStepGet =
     Json.Decode.succeed BuildStepGet
         |> andMap (Json.Decode.field "name" Json.Decode.string)
+        |> andMap (Json.Decode.maybe <| Json.Decode.field "resource" Json.Decode.string)
         |> andMap (Json.Decode.maybe <| Json.Decode.field "version" decodeVersion)
 
 
@@ -686,6 +691,7 @@ decodeBuildStepPut : Json.Decode.Decoder BuildStep
 decodeBuildStepPut =
     Json.Decode.succeed BuildStepPut
         |> andMap (Json.Decode.field "name" Json.Decode.string)
+        |> andMap (Json.Decode.maybe <| Json.Decode.field "resource" Json.Decode.string)
 
 
 decodeBuildStepInParallel : Json.Decode.Decoder BuildStep

--- a/web/elm/src/Message/Callback.elm
+++ b/web/elm/src/Message/Callback.elm
@@ -35,6 +35,7 @@ type Callback
     | BuildResourcesFetched (Fetched ( Int, Concourse.BuildResources ))
     | ResourceFetched (Fetched Concourse.Resource)
     | VersionedResourcesFetched (Fetched ( Page, Paginated Concourse.VersionedResource ))
+    | VersionedResourceIdFetched (Fetched (Maybe Concourse.VersionedResource))
     | ClusterInfoFetched (Fetched Concourse.ClusterInfo)
     | PausedToggled (Fetched ())
     | InputToFetched (Fetched ( VersionId, List Concourse.Build ))

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -48,7 +48,6 @@ import Set exposing (Set)
 import SideBar.State exposing (SideBarState, encodeSideBarState)
 import Task
 import Time
-import Url.Builder
 import Views.Styles
 
 
@@ -243,7 +242,7 @@ runEffect effect key csrfToken =
             Api.paginatedGet
                 (Endpoints.ResourceVersionsList |> Endpoints.Resource id)
                 Nothing
-                (List.map (\q -> Url.Builder.string "filter" q) (Concourse.versionQuery version))
+                (Routes.versionQueryParams version)
                 Concourse.decodeVersionedResource
                 |> Api.request
                 |> Task.map (\b -> List.head b.content)
@@ -803,6 +802,9 @@ toHtmlID domId =
 
         StepInitialization stepID ->
             stepID ++ "_image"
+
+        StepVersion stepID ->
+            stepID ++ "_version"
 
         SideBarIcon ->
             "sidebar-icon"

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -86,6 +86,7 @@ type DomID
     | StepHeader String
     | StepSubHeader String Int
     | StepInitialization String
+    | StepVersion String
     | ShowSearchButton
     | ClearSearchButton
     | LoginButton

--- a/web/elm/src/Pipeline/PinMenu/PinMenu.elm
+++ b/web/elm/src/Pipeline/PinMenu/PinMenu.elm
@@ -215,6 +215,7 @@ pinMenu { hovered } model =
                                             , resourceName = resourceName
                                             }
                                         , page = Nothing
+                                        , version = Nothing
                                         }
                             }
                         )

--- a/web/elm/src/Resource/Models.elm
+++ b/web/elm/src/Resource/Models.elm
@@ -46,6 +46,7 @@ type alias Model =
         , authorized : Bool
         , output : Maybe OutputModel
         , highlight : Routes.Highlight
+        , highlightVersion : Maybe Concourse.Version
         }
 
 

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -343,8 +343,6 @@ resourceRoute r =
             , resourceName = r.name
             }
         , page = Nothing
-
-        --- XXX: is this funciton actually used?
         , version = Nothing
         }
 

--- a/web/elm/src/Routes.elm
+++ b/web/elm/src/Routes.elm
@@ -199,8 +199,8 @@ resourceVersion key =
     let
         split s =
             case String.split ":" s of
-                [ k, v ] ->
-                    Just ( k, v )
+                x :: xs ->
+                    Just ( x, String.join ":" xs )
 
                 _ ->
                     Nothing

--- a/web/elm/src/SubPage/SubPage.elm
+++ b/web/elm/src/SubPage/SubPage.elm
@@ -67,10 +67,11 @@ init session route =
                 }
                 |> Tuple.mapFirst BuildModel
 
-        Routes.Resource { id, page } ->
+        Routes.Resource { id, page, version } ->
             Resource.init
                 { resourceId = id
                 , paging = page
+                , highlightVersion = version
                 }
                 |> Tuple.mapFirst ResourceModel
 
@@ -295,8 +296,8 @@ urlUpdate routes =
                 identity
         )
         (case routes.to of
-            Routes.Resource { id, page } ->
-                Resource.changeToResource { resourceId = id, paging = page }
+            Routes.Resource { id, page, version } ->
+                Resource.changeToResource { resourceId = id, paging = page, highlightVersion = version }
 
             _ ->
                 identity

--- a/web/elm/tests/BuildStepTests.elm
+++ b/web/elm/tests/BuildStepTests.elm
@@ -25,7 +25,6 @@ import Message.Effects as Effects
 import Message.Message as Message exposing (DomID(..))
 import Message.Subscription exposing (Delivery(..), Interval(..))
 import Message.TopLevelMessage exposing (TopLevelMessage(..))
-import Routes
 import Test exposing (Test, describe, test)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
@@ -855,6 +854,7 @@ thePlanContainsAGetStep =
                       , step =
                             Concourse.BuildStepGet
                                 "the-git-resource"
+                                (Just "the-git-resource")
                                 (Just (Dict.fromList [ ( "ref", "abc123" ) ]))
                       }
                     , { inputs = []
@@ -1329,7 +1329,7 @@ thereIsAnImageGetStep stepId =
                                 { source = ""
                                 , id = stepId
                                 }
-                                (Concourse.BuildPlan imageGetStepId (Concourse.BuildStepGet "image" Nothing))
+                                (Concourse.BuildPlan imageGetStepId (Concourse.BuildStepGet "image" Nothing Nothing))
                       , url = "http://localhost:8080/api/v1/builds/1/events"
                       }
                     ]

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -4,9 +4,7 @@ import Application.Application as Application
 import Array
 import Assets
 import Build.Build as Build
-import Build.Models as Models
 import Build.StepTree.Models as STModels
-import Char
 import Colors
 import Common
     exposing
@@ -19,12 +17,11 @@ import Common
 import Concourse exposing (BuildPrepStatus(..))
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Concourse.Pagination exposing (Direction(..))
-import DashboardTests exposing (iconSelector, middleGrey)
+import DashboardTests exposing (iconSelector)
 import Data
 import Dict
 import Expect
 import Html.Attributes as Attr
-import Http
 import Json.Encode as Encode
 import Keyboard
 import Message.Callback as Callback
@@ -50,16 +47,12 @@ import Test.Html.Selector
         )
 import Time
 import Url
-import UserState
 
 
 all : Test
 all =
     describe "build page" <|
         let
-            buildId =
-                Data.jobBuildId
-
             flags =
                 { turbulenceImgSrc = ""
                 , notFoundImgSrc = ""
@@ -3138,6 +3131,46 @@ all =
                         >> Query.children []
                         >> Query.index -1
                         >> Query.has [ text "v3.1.4" ]
+                , test "get step resource version links to resource page" <|
+                    fetchPlanWithGetStep
+                        >> Application.handleDelivery
+                            (EventsReceived <|
+                                Ok <|
+                                    [ { url = eventsUrl
+                                      , data =
+                                            STModels.FinishGet
+                                                { source = "stdout", id = "plan" }
+                                                0
+                                                (Dict.fromList [ ( "version", "v3.1.4" ) ])
+                                                []
+                                                Nothing
+                                      }
+                                    ]
+                            )
+                        >> Tuple.first
+                        >> Common.queryView
+                        >> Query.find [ id "plan_version" ]
+                        >> Query.has [ attribute <| Attr.href "/teams/team/pipelines/p/resources/step?filter=version%3Av3.1.4" ]
+                , test "put step resource version links to resource page" <|
+                    fetchPlanWithPutStep
+                        >> Application.handleDelivery
+                            (EventsReceived <|
+                                Ok <|
+                                    [ { url = eventsUrl
+                                      , data =
+                                            STModels.FinishPut
+                                                { source = "stdout", id = "plan" }
+                                                0
+                                                (Dict.fromList [ ( "version", "v3.1.4" ) ])
+                                                []
+                                                Nothing
+                                      }
+                                    ]
+                            )
+                        >> Tuple.first
+                        >> Common.queryView
+                        >> Query.find [ id "plan_version" ]
+                        >> Query.has [ attribute <| Attr.href "/teams/team/pipelines/p/resources/step?filter=version%3Av3.1.4" ]
                 , test "one tick after hovering step state, GetElement fires" <|
                     fetchPlanWithGetStep
                         >> Application.handleDelivery

--- a/web/elm/tests/PinMenu/PinMenuTests.elm
+++ b/web/elm/tests/PinMenu/PinMenuTests.elm
@@ -153,6 +153,7 @@ all =
                                                 Routes.Resource
                                                     { id = Data.resourceId |> Data.withResourceName "test"
                                                     , page = Nothing
+                                                    , version = Nothing
                                                     }
                                       }
                                     ]
@@ -200,6 +201,7 @@ all =
                                                 Routes.Resource
                                                     { id = Data.resourceId |> Data.withResourceName "test"
                                                     , page = Nothing
+                                                    , version = Nothing
                                                     }
                                       }
                                     ]

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -294,7 +294,7 @@ all =
         , describe "when the url contains a version" <|
             let
                 initWithVersion =
-                    initQuery "version={\"version\":\"v2\"}"
+                    initQuery "filter=version:v2"
             in
             [ describe "when the version is valid"
                 [ test "it navigates to that page" <|

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -291,6 +291,78 @@ all =
                     |> queryView
                     |> Query.find (versionSelector version)
                     |> Query.has [ text "some-build" ]
+        , describe "when the url contains a version" <|
+            let
+                initWithVersion =
+                    initQuery "version={\"version\":\"v2\"}"
+            in
+            [ describe "when the version is valid"
+                [ test "it navigates to that page" <|
+                    \_ ->
+                        initWithVersion
+                            |> Application.handleCallback
+                                (Callback.VersionedResourceIdFetched
+                                    (Ok
+                                        (Just <| Data.versionedResource otherVersion 42)
+                                    )
+                                )
+                            |> Tuple.second
+                            |> Common.contains
+                                (Effects.FetchVersionedResources Data.resourceId
+                                    { direction = To 42
+                                    , limit = 100
+                                    }
+                                )
+                , test "it expands the correct version" <|
+                    let
+                        givenVersionIsValid =
+                            Application.handleCallback
+                                (Callback.VersionedResourceIdFetched
+                                    (Ok
+                                        (Just <| Data.versionedResource otherVersion 42)
+                                    )
+                                )
+                                >> Tuple.first
+                    in
+                    \_ ->
+                        initWithVersion
+                            |> givenResourceIsNotPinned
+                            |> givenVersionIsValid
+                            |> Application.handleCallback
+                                (Callback.VersionedResourcesFetched
+                                    (Ok
+                                        ( { direction = To 42
+                                          , limit = 100
+                                          }
+                                        , { content = [ Data.versionedResource otherVersion 42 ]
+                                          , pagination = { previousPage = Nothing, nextPage = Nothing }
+                                          }
+                                        )
+                                    )
+                                )
+                            |> Tuple.first
+                            |> queryView
+                            |> Query.find (versionSelector otherVersion)
+                            |> Query.has [ text "metadata" ]
+                ]
+            , describe "when the version is invalid" <|
+                [ test "it defaults to the most recent versions" <|
+                    let
+                        givenVersionIsInvalid =
+                            Application.handleCallback
+                                (Callback.VersionedResourceIdFetched
+                                    (Ok Nothing)
+                                )
+                    in
+                    \_ ->
+                        initWithVersion
+                            |> givenResourceIsNotPinned
+                            |> givenVersionIsInvalid
+                            |> Tuple.second
+                            |> Common.contains
+                                (Effects.FetchVersionedResources Data.resourceId Resource.startingPage)
+                ]
+            ]
         , describe "page header with icon" <|
             let
                 pageHeader =
@@ -1113,6 +1185,7 @@ all =
                         Resource.init
                             { resourceId = Data.resourceId
                             , paging = Nothing
+                            , highlightVersion = Nothing
                             }
                             |> Resource.handleCallback
                                 (Callback.ResourceFetched <|
@@ -1158,6 +1231,7 @@ all =
                         Resource.init
                             { resourceId = Data.resourceId
                             , paging = Nothing
+                            , highlightVersion = Nothing
                             }
                             |> Resource.handleCallback
                                 (Callback.ResourceFetched <|
@@ -1204,6 +1278,7 @@ all =
                         Resource.init
                             { resourceId = Data.resourceId
                             , paging = Nothing
+                            , highlightVersion = Nothing
                             }
                             |> Resource.handleDelivery session (ClockTicked OneSecond (Time.millisToPosix 1000))
                             |> Resource.handleCallback
@@ -1254,6 +1329,7 @@ all =
                         Resource.init
                             { resourceId = Data.resourceId
                             , paging = Nothing
+                            , highlightVersion = Nothing
                             }
                             |> Resource.handleDelivery session (ClockTicked OneSecond (Time.millisToPosix 1000))
                             |> Resource.handleCallback
@@ -3388,6 +3464,19 @@ flags =
     }
 
 
+initQuery : String -> Application.Model
+initQuery query =
+    Common.initQuery
+        ("/teams/"
+            ++ teamName
+            ++ "/pipelines/"
+            ++ pipelineName
+            ++ "/resources/"
+            ++ resourceName
+        )
+        (Just query)
+
+
 init : Application.Model
 init =
     Common.init
@@ -3882,5 +3971,5 @@ session =
     , favoritedInstanceGroups = Set.empty
     , screenSize = ScreenSize.Desktop
     , timeZone = Time.utc
-    , route = Routes.Resource { id = Data.resourceId, page = Nothing }
+    , route = Routes.Resource { id = Data.resourceId, page = Nothing, version = Nothing }
     }

--- a/web/elm/tests/RoutesTests.elm
+++ b/web/elm/tests/RoutesTests.elm
@@ -277,4 +277,22 @@ all =
                     |> Url.fromString
                     |> Maybe.andThen Routes.parsePath
                     |> Expect.equal (Just <| Routes.FlySuccess True Nothing)
+        , test "resources" <|
+            \_ ->
+                "http://example.com/teams/team/pipelines/pipeline/resources/resource?version={\"version\":\"v1\"}"
+                    |> Url.fromString
+                    |> Maybe.andThen Routes.parsePath
+                    |> Expect.equal
+                        (Just <|
+                            Routes.Resource
+                                { id =
+                                    { teamName = "team"
+                                    , pipelineName = "pipeline"
+                                    , pipelineInstanceVars = Dict.empty
+                                    , resourceName = "resource"
+                                    }
+                                , page = Nothing
+                                , version = Just <| Dict.fromList [ ( "version", "v1" ) ]
+                                }
+                        )
         ]

--- a/web/elm/tests/RoutesTests.elm
+++ b/web/elm/tests/RoutesTests.elm
@@ -279,7 +279,7 @@ all =
                     |> Expect.equal (Just <| Routes.FlySuccess True Nothing)
         , test "resources" <|
             \_ ->
-                "http://example.com/teams/team/pipelines/pipeline/resources/resource?filter=version:v1"
+                "http://example.com/teams/team/pipelines/pipeline/resources/resource?filter=version:sha:123abc"
                     |> Url.fromString
                     |> Maybe.andThen Routes.parsePath
                     |> Expect.equal
@@ -292,7 +292,7 @@ all =
                                     , resourceName = "resource"
                                     }
                                 , page = Nothing
-                                , version = Just <| Dict.fromList [ ( "version", "v1" ) ]
+                                , version = Just <| Dict.fromList [ ( "version", "sha:123abc" ) ]
                                 }
                         )
         ]

--- a/web/elm/tests/RoutesTests.elm
+++ b/web/elm/tests/RoutesTests.elm
@@ -279,7 +279,7 @@ all =
                     |> Expect.equal (Just <| Routes.FlySuccess True Nothing)
         , test "resources" <|
             \_ ->
-                "http://example.com/teams/team/pipelines/pipeline/resources/resource?version={\"version\":\"v1\"}"
+                "http://example.com/teams/team/pipelines/pipeline/resources/resource?filter=version:v1"
                     |> Url.fromString
                     |> Maybe.andThen Routes.parsePath
                     |> Expect.equal

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -190,7 +190,7 @@ initGet =
             Dict.fromList [ ( "some", "version" ) ]
 
         step =
-            BuildStepGet "some-name" (Just version)
+            BuildStepGet "some-name" (Just "some-resource") (Just version)
 
         { tree, steps } =
             StepTree.init Nothing
@@ -214,7 +214,7 @@ initPut : Test
 initPut =
     let
         step =
-            BuildStepPut "some-name"
+            BuildStepPut "some-name" (Just "some-resource")
 
         { tree, steps } =
             StepTree.init Nothing

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -92,7 +92,8 @@ initTask : Test
 initTask =
     let
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "some-id"
                 , step = task "some-name"
@@ -117,7 +118,8 @@ initSetPipeline =
             BuildStepSetPipeline "some-name" Dict.empty
 
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "some-id"
                 , step = step
@@ -140,7 +142,8 @@ initLoadVar =
             BuildStepLoadVar "some-name"
 
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "some-id"
                 , step = step
@@ -163,7 +166,8 @@ initCheck =
             BuildStepCheck "some-name"
 
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "some-id"
                 , step = step
@@ -189,7 +193,8 @@ initGet =
             BuildStepGet "some-name" (Just version)
 
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "some-id"
                 , step = step
@@ -212,7 +217,8 @@ initPut =
             BuildStepPut "some-name"
 
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "some-id"
                 , step = step
@@ -245,7 +251,8 @@ initAcross =
                 }
 
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "across-id"
                 , step = rootStep
@@ -305,7 +312,8 @@ initAcrossNested =
                 }
 
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "across-id"
                 , step = rootAcross
@@ -366,7 +374,8 @@ initAcrossWithDo =
                 }
 
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "across-id"
                 , step = across
@@ -412,7 +421,8 @@ initInParallel =
                 ]
 
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "parallel-id"
                 , step = step
@@ -444,7 +454,8 @@ initInParallelNested : Test
 initInParallelNested =
     let
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "parallel-id"
                 , step =
@@ -499,7 +510,8 @@ initOnSuccess : Test
 initOnSuccess =
     let
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =
@@ -533,7 +545,8 @@ initOnFailure : Test
 initOnFailure =
     let
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =
@@ -567,7 +580,8 @@ initEnsure : Test
 initEnsure =
     let
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =
@@ -601,7 +615,8 @@ initTry : Test
 initTry =
     let
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =
@@ -626,7 +641,8 @@ initTimeout : Test
 initTimeout =
     let
         { tree, steps } =
-            StepTree.init Routes.HighlightNothing
+            StepTree.init Nothing
+                Routes.HighlightNothing
                 emptyResources
                 { id = "on-success-id"
                 , step =

--- a/web/elm/tests/SubPageTests.elm
+++ b/web/elm/tests/SubPageTests.elm
@@ -50,6 +50,7 @@ all =
                                 (Routes.Resource
                                     { id = Data.shortResourceId
                                     , page = Nothing
+                                    , version = Nothing
                                     }
                                 )
                             )

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -303,6 +303,7 @@ all =
                             (Routes.Resource
                                 { id = Data.shortResourceId
                                 , page = Nothing
+                                , version = Nothing
                                 }
                             )
                     )
@@ -313,6 +314,7 @@ all =
                                 Routes.Resource
                                     { id = Data.shortResourceId
                                     , page = Nothing
+                                    , version = Nothing
                                     }
                         ]
             , context "when pipeline is paused"
@@ -743,6 +745,7 @@ all =
                         , resourceName = "resource"
                         }
                     , page = Nothing
+                    , version = Nothing
                     }
                 )
                 |> Application.handleCallback


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

closes # .

![Screen Shot 2021-03-12 at 5 36 40 PM](https://user-images.githubusercontent.com/17577073/111006056-0c349500-835a-11eb-9397-ce3bdda941e2.png)

## Changes proposed by this PR:

- add ability to open the Resource page to a specific version. If the version exists, then it will be displayed at the top of the page and is automatically expanded
- have the get/put steps in the Build page make use of this

## Notes to reviewer:

## Release Note

UI: clicking on the version text for a get/put step in the Build page will now navigate directly to the Resource page with the corresponding version expanded

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
