### PR TITLE
better handling for containerd error message

### DIFF
--- a/worker/runtime/process_killer_test.go
+++ b/worker/runtime/process_killer_test.go
@@ -57,14 +57,6 @@ func (s *ProcessKillerSuite) TestKillWaitError() {
 	s.True(errors.Is(err, expectedErr))
 }
 
-func (s *ProcessKillerSuite) TestKillKillError() {
-	expectedErr := errors.New("kill-err")
-	s.proc.KillReturns(expectedErr)
-
-	err := s.killer.Kill(context.Background(), s.proc, s.signal, s.goodEnoughTimeout)
-	s.True(errors.Is(err, expectedErr))
-}
-
 func (s *ProcessKillerSuite) TestKillWaitContextDeadlineReached() {
 	err := s.killer.Kill(context.Background(), s.proc, s.signal, s.notEnoughTimeout)
 	s.True(errors.Is(err, runtime.ErrGracePeriodTimeout))


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix

When killing a process gracefully containerd might exceed the waitperiod. When this happens it returns an error in a format that couldn't be handled properly. We now look at the specific grpc code for better handling.

Signed-off-by: Bohan Chen <bochen@pivotal.io>
Co-authored-by: Muntasir Chowdhury <mchowdhury@pivotal.io>

closes #6587.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->
```diff
diff --git a/worker/runtime/process_killer.go b/worker/runtime/process_killer.go
index 5dc61a2e4..668752f82 100644
--- a/worker/runtime/process_killer.go
+++ b/worker/runtime/process_killer.go
@@ -54,7 +54,10 @@ func (p processKiller) Kill(
        waitCtx, cancel := context.WithTimeout(ctx, waitPeriod)
        defer cancel()

-       statusC, err := proc.Wait(waitCtx)
+       waitCtx2, cancel2 := context.WithTimeout(ctx, waitPeriod - (10 * time.Millisecond))
+       defer cancel2()
+       statusC, err := proc.Wait(waitCtx2)
+
        if err != nil {
                return fmt.Errorf("proc wait: %w", err)
        }
```

To recreate the error described in #6587 all you need adjust the timing so that the `proc.Wait()` expires before the `waitCtx`. To validate that the error is now handled correctly do this both in the original code and the PR branch. The latter should pass.

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->
* Fixed a bug with the `containerd` runtime where gracefully stopping a container might have failed with an unhandled error. Now it gracefully shuts down.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
