### PR TITLE
Allow using LDAP as a password connector

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1771,14 +1771,15 @@ func (cmd *RunCommand) constructAuthHandler(
 	cmd.Auth.AuthFlags.Clients[flyClientID] = flyClientSecret
 
 	dexServer, err := dexserver.NewDexServer(&dexserver.DexConfig{
-		Logger:      logger.Session("dex"),
-		Users:       cmd.Auth.AuthFlags.LocalUsers,
-		Clients:     cmd.Auth.AuthFlags.Clients,
-		Expiration:  cmd.Auth.AuthFlags.Expiration,
-		IssuerURL:   issuerURL.String(),
-		RedirectURL: redirectURL.String(),
-		SigningKey:  cmd.Auth.AuthFlags.SigningKey.PrivateKey,
-		Storage:     storage,
+		Logger:            logger.Session("dex"),
+		PasswordConnector: cmd.Auth.AuthFlags.PasswordConnector,
+		Users:             cmd.Auth.AuthFlags.LocalUsers,
+		Clients:           cmd.Auth.AuthFlags.Clients,
+		Expiration:        cmd.Auth.AuthFlags.Expiration,
+		IssuerURL:         issuerURL.String(),
+		RedirectURL:       redirectURL.String(),
+		SigningKey:        cmd.Auth.AuthFlags.SigningKey.PrivateKey,
+		Storage:           storage,
 	})
 	if err != nil {
 		return nil, err

--- a/hack/ldap/config.ldif
+++ b/hack/ldap/config.ldif
@@ -10,7 +10,7 @@ dn: ou=People,dc=example,dc=org
 objectClass: organizationalUnit
 ou: People
 
-dn: cn=jane,ou=People,dc=example,dc=org
+dn: cn=john,ou=People,dc=example,dc=org
 objectClass: person
 objectClass: inetOrgPerson
 sn: smith
@@ -18,7 +18,7 @@ cn: john
 mail: user1@example.com
 userpassword: user1pass
 
-dn: cn=john,ou=People,dc=example,dc=org
+dn: cn=jane,ou=People,dc=example,dc=org
 objectClass: person
 objectClass: inetOrgPerson
 sn: doe

--- a/hack/overrides/ldap.yml
+++ b/hack/overrides/ldap.yml
@@ -21,6 +21,7 @@ services:
       CONCOURSE_LDAP_BIND_DN: cn=admin,dc=example,dc=org
       CONCOURSE_LDAP_BIND_PW: admin
       CONCOURSE_LDAP_INSECURE_NO_SSL: "true"
+      CONCOURSE_LDAP_USERNAME_PROMPT: Email
 
       CONCOURSE_LDAP_USER_SEARCH_BASE_DN: ou=People,dc=example,dc=org
       CONCOURSE_LDAP_USER_SEARCH_FILTER: "(objectClass=person)"

--- a/integration/auth/ldap_test.go
+++ b/integration/auth/ldap_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/concourse/concourse/integration/internal/dctest"
+	"github.com/concourse/concourse/integration/internal/flytest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLDAP_PasswordConnector(t *testing.T) {
+	t.Parallel()
+
+	dc := dctest.Init(t, "../docker-compose.yml", "overrides/ldap.yml")
+	dc.Run(t, "up", "-d")
+
+	fly, webURL := flytest.InitUnauthenticated(t, dc)
+
+	t.Run("valid credentials", func(t *testing.T) {
+		fly.Run(t, "login", "-c", webURL, "-u", "user1@example.com", "-p", "user1pass")
+	})
+
+	t.Run("invalid credentials", func(t *testing.T) {
+		err := fly.Try("login", "-c", webURL, "-u", "user1@example.com", "-p", "invalid")
+		require.Error(t, err)
+	})
+}

--- a/integration/auth/overrides/ldap.yml
+++ b/integration/auth/overrides/ldap.yml
@@ -1,0 +1,49 @@
+# ldap.yml - a docker-compose override that adds a LDAP auth to the stack
+#
+# This is basically ripped from dex's example directory
+#
+# There are 2 users and 2 groups
+# user1@example.com:user1pass;group1;admins
+# user2@example.com:user2pass;admins
+#
+# ref: https://github.com/dexidp/dex/blob/33e13c2aad9bb8a91abea6a2870dc178e3bd00de/examples/ldap/
+# ref: https://docs.docker.com/compose/extends/
+#
+version: '3'
+
+services:
+  web:
+    environment:
+      CONCOURSE_PASSWORD_CONNECTOR: ldap
+      CONCOURSE_ADD_LOCAL_USER: ~
+      CONCOURSE_MAIN_TEAM_LDAP_USER: john
+      # CONCOURSE_MAIN_TEAM_LDAP_GROUP: group1
+
+      CONCOURSE_LDAP_HOST: ldap:389
+      CONCOURSE_LDAP_BIND_DN: cn=admin,dc=example,dc=org
+      CONCOURSE_LDAP_BIND_PW: admin
+      CONCOURSE_LDAP_INSECURE_NO_SSL: "true"
+
+      CONCOURSE_LDAP_USER_SEARCH_BASE_DN: ou=People,dc=example,dc=org
+      CONCOURSE_LDAP_USER_SEARCH_FILTER: "(objectClass=person)"
+      CONCOURSE_LDAP_USER_SEARCH_USERNAME: mail
+      CONCOURSE_LDAP_USER_SEARCH_ID_ATTR: DN
+      CONCOURSE_LDAP_USER_SEARCH_EMAIL_ATTR: mail
+      CONCOURSE_LDAP_USER_SEARCH_NAME_ATTR: cn
+
+      CONCOURSE_LDAP_GROUP_SEARCH_BASE_DN: ou=Groups,dc=example,dc=org
+      CONCOURSE_LDAP_GROUP_SEARCH_FILTER: "(objectClass=groupOfNames)"
+      CONCOURSE_LDAP_GROUP_SEARCH_USER_ATTR: DN
+      CONCOURSE_LDAP_GROUP_SEARCH_GROUP_ATTR: member
+      CONCOURSE_LDAP_GROUP_SEARCH_NAME_ATTR: cn
+
+  ldap:
+    image: osixia/openldap:1.4.0
+    # Copying is required because the entrypoint modifies the *.ldif files.
+    # For verbose output, use:  command: ["--copy-service", "--loglevel", "debug"]
+    command: ["--copy-service"]
+    # https://github.com/osixia/docker-openldap#seed-ldap-database-with-ldif
+    # Option 1: Add custom seed file -> mount to         /container/service/slapd/assets/config/bootstrap/ldif/custom/
+    # Option 2: Overwrite default seed file -> mount to  /container/service/slapd/assets/config/bootstrap/ldif/
+    volumes:
+    - ../hack/ldap/:/container/service/slapd/assets/config/bootstrap/ldif/custom/

--- a/integration/internal/flytest/cmd.go
+++ b/integration/internal/flytest/cmd.go
@@ -21,7 +21,7 @@ type Cmd struct {
 	cmdtest.Cmd
 }
 
-func Init(t *testing.T, dc dctest.Cmd) Cmd {
+func InitUnauthenticated(t *testing.T, dc dctest.Cmd) (Cmd, string) {
 	webAddr := dc.Addr(t, "web", 8080)
 
 	webURL := "http://" + webAddr
@@ -57,9 +57,13 @@ func Init(t *testing.T, dc dctest.Cmd) Cmd {
 
 	cmd.Path = flyPath
 
-	fly := Cmd{
+	return Cmd{
 		Cmd: cmd,
-	}
+	}, webURL
+}
+
+func Init(t *testing.T, dc dctest.Cmd) Cmd {
+	fly, webURL := InitUnauthenticated(t, dc)
 
 	fly.Run(t, "login", "-c", webURL, "-u", "test", "-p", "test")
 

--- a/skymarshal/dexserver/dexserver.go
+++ b/skymarshal/dexserver/dexserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"embed"
+	"errors"
 	"io/fs"
 	"strings"
 	"time"
@@ -18,14 +19,15 @@ import (
 )
 
 type DexConfig struct {
-	Logger      lager.Logger
-	IssuerURL   string
-	SigningKey  *rsa.PrivateKey
-	Expiration  time.Duration
-	Clients     map[string]string
-	Users       map[string]string
-	RedirectURL string
-	Storage     s.Storage
+	Logger            lager.Logger
+	IssuerURL         string
+	SigningKey        *rsa.PrivateKey
+	Expiration        time.Duration
+	Clients           map[string]string
+	Users             map[string]string
+	PasswordConnector string
+	RedirectURL       string
+	Storage           s.Storage
 }
 
 //go:embed web
@@ -57,6 +59,9 @@ func NewDexServerConfig(config *DexConfig) (server.Config, error) {
 	}
 
 	if len(passwords) > 0 {
+		if config.PasswordConnector != "local" {
+			return server.Config{}, errors.New("can only set --add-local-user with --password-connector=local")
+		}
 		connectors = append(connectors, storage.Connector{
 			ID:   "local",
 			Type: "local",
@@ -110,7 +115,7 @@ func NewDexServerConfig(config *DexConfig) (server.Config, error) {
 	}
 
 	return server.Config{
-		PasswordConnector:      "local",
+		PasswordConnector:      config.PasswordConnector,
 		SupportedResponseTypes: []string{"code", "token", "id_token"},
 		SkipApprovalScreen:     true,
 		IDTokensValidFor:       config.Expiration,

--- a/skymarshal/dexserver/web/static/main.css
+++ b/skymarshal/dexserver/web/static/main.css
@@ -8,8 +8,8 @@ body {
 
 .dex-container {
   color: #333;
-  margin: 32px auto;
-  width: 454px;
+  margin: 50px auto;
+  width: 330px;
   text-align: center;
 }
 
@@ -34,14 +34,15 @@ body {
   background-repeat: no-repeat;
   background-size: 45%;
   float: left;
-  height: 50px;
-  width: 52px;
+  height: 36px;
+  margin-right: 5px;
+  width: 36px;
 }
 
 .dex-btn-text {
   font-weight: 600;
-  line-height: 50px;
-  padding: 15px 16px;
+  line-height: 36px;
+  padding: 6px 12px;
   text-align: center;
 }
 
@@ -64,10 +65,11 @@ body {
 
 .dex-error-box {
   color: #912617;
-  font-size: 20px;
+  font-size: 14px;
   font-weight: normal;
   max-width: 320px;
-  margin: 0 auto;
+  padding: 4px 0;
+  margin: 20px auto 0;
 }
 
 .dex-btn-icon--cf {

--- a/skymarshal/dexserver/web/static/main.css
+++ b/skymarshal/dexserver/web/static/main.css
@@ -8,8 +8,8 @@ body {
 
 .dex-container {
   color: #333;
-  margin: 50px auto;
-  width: 330px;
+  margin: 32px auto;
+  width: 454px;
   text-align: center;
 }
 
@@ -34,15 +34,14 @@ body {
   background-repeat: no-repeat;
   background-size: 45%;
   float: left;
-  height: 36px;
-  margin-right: 5px;
-  width: 36px;
+  height: 50px;
+  width: 52px;
 }
 
 .dex-btn-text {
   font-weight: 600;
-  line-height: 36px;
-  padding: 6px 12px;
+  line-height: 50px;
+  padding: 15px 16px;
   text-align: center;
 }
 
@@ -64,12 +63,11 @@ body {
 }
 
 .dex-error-box {
-  color: #E74C3C;
-  font-size: 14px;
+  color: #912617;
+  font-size: 20px;
   font-weight: normal;
   max-width: 320px;
-  padding: 4px 0;
-  margin: 20px auto 0;
+  margin: 0 auto;
 }
 
 .dex-btn-icon--cf {

--- a/skymarshal/dexserver/web/templates/error.html
+++ b/skymarshal/dexserver/web/templates/error.html
@@ -2,7 +2,7 @@
 
 <div class="theme-panel">
   <h2 class="theme-heading">{{ .ErrType }}</h2>
-  <p>{{ .ErrMsg }}</p>
+  <p class="theme-message">{{ .ErrMsg }}</p>
 </div>
 
 {{ template "footer.html" . }}

--- a/skymarshal/dexserver/web/templates/header.html
+++ b/skymarshal/dexserver/web/templates/header.html
@@ -6,11 +6,12 @@
     <title>{{ issuer }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script type="text/javascript">
+      history.pushState({}, '', document.URL);
       window.onpopstate = function(event) {
-        const url = new URL(window.location);
+        const url = new URL(document.URL);
         url.searchParams.set('req', '');
-        window.history.pushState({}, '', url);
-        window.history.back();
+        history.pushState({}, '', url);
+        history.go(-2);
       };
     </script>
     <link href="{{ url .ReqPath "static/main.css" }}" rel="stylesheet">

--- a/skymarshal/dexserver/web/templates/header.html
+++ b/skymarshal/dexserver/web/templates/header.html
@@ -5,6 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>{{ issuer }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script type="text/javascript">
+      window.onpopstate = function(event) {
+        const url = new URL(window.location);
+        url.searchParams.set('req', '');
+        window.history.pushState({}, '', url);
+        window.history.back();
+      };
+    </script>
     <link href="{{ url .ReqPath "static/main.css" }}" rel="stylesheet">
     <link href="{{ url .ReqPath "theme/styles.css" }}" rel="stylesheet">
     <link rel="icon" href="{{ url .ReqPath "theme/favicon.png" }}">

--- a/skymarshal/dexserver/web/templates/header.html
+++ b/skymarshal/dexserver/web/templates/header.html
@@ -6,13 +6,9 @@
     <title>{{ issuer }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script type="text/javascript">
-      history.pushState({}, '', document.URL);
-      window.onpopstate = function(event) {
-        const url = new URL(document.URL);
-        url.searchParams.set('req', '');
-        history.pushState({}, '', url);
-        history.go(-2);
-      };
+      if (String(performance.getEntriesByType("navigation")[0].type) === "back_forward") {
+        location.reload()
+      }
     </script>
     <link href="{{ url .ReqPath "static/main.css" }}" rel="stylesheet">
     <link href="{{ url .ReqPath "theme/styles.css" }}" rel="stylesheet">

--- a/skymarshal/dexserver/web/templates/password.html
+++ b/skymarshal/dexserver/web/templates/password.html
@@ -35,7 +35,7 @@
       </div>
       {{ if .BackLink }}
       <div class="theme-form-row">
-        <button tabindex="3" id="cancel-back" type="button" class="dex-btn theme-btn-cancel" onclick="javascript:history.back()">cancel</button>
+        <button tabindex="3" id="cancel-back" type="button" class="dex-btn theme-btn-cancel" onclick="location.href='/sky/login'">cancel</button>
       </div>
       {{ end }}
     </div>

--- a/skymarshal/dexserver/web/templates/password.html
+++ b/skymarshal/dexserver/web/templates/password.html
@@ -22,10 +22,8 @@
     </div>
 
     {{ if .Invalid }}
-      <div class="theme-form-row">
-        <div id="login-error" class="dex-error-box">
-          invalid {{ $usernamePrompt }} and password.
-        </div>
+      <div id="login-error" class="dex-error-box">
+        invalid {{ $usernamePrompt }} and password.
       </div>
     {{ end }}
 

--- a/skymarshal/dexserver/web/templates/password.html
+++ b/skymarshal/dexserver/web/templates/password.html
@@ -1,35 +1,40 @@
 {{ template "header.html" . }}
 
-{{ if .BackLink }}
-  <div class="theme-link-back">
-    <a href="/sky/login">&#60; back</a>
-  </div>
+{{ $usernamePrompt := .UsernamePrompt | lower }}
+{{ if eq .ReqPath "/sky/issuer/auth/local" }}
+  {{ $usernamePrompt = "username" }}
 {{ end }}
 
 <div class="theme-panel">
+  <h2 class="theme-heading">log in to your account</h2>
   <form method="post" action="{{ .PostURL }}">
     <div class="theme-form-row">
       <div class="theme-form-label">
-        <label for="userid">username</label>
+        <label for="userid">{{ $usernamePrompt }}</label>
       </div>
-	  <input tabindex="1" required id="login" name="login" type="text" class="theme-form-input" {{ if .Username }} value="{{ .Username }}" {{ else }} autofocus {{ end }}/>
+	  <input tabindex="1" required id="login" name="login" type="text" class="theme-form-input" placeholder="{{ $usernamePrompt }}" {{ if .Username }} value="{{ .Username }}" {{ else }} autofocus {{ end }}/>
     </div>
     <div class="theme-form-row">
       <div class="theme-form-label">
         <label for="password">password</label>
       </div>
-	  <input tabindex="2" required id="password" name="password" type="password" class="theme-form-input" autocomplete="off" {{ if .Invalid }} autofocus {{ end }}/>
+	  <input tabindex="2" required id="password" name="password" type="password" class="theme-form-input" placeholder="password" {{ if .Invalid }} autofocus {{ end }}/>
     </div>
 
     {{ if .Invalid }}
       <div id="login-error" class="dex-error-box">
-        invalid username and password
+        invalid {{ $usernamePrompt }} and password.
       </div>
     {{ end }}
 
     <button tabindex="3" id="submit-login" type="submit" class="dex-btn theme-btn--primary">login</button>
 
   </form>
+  {{ if .BackLink }}
+  <div class="theme-link-back">
+    <a class="dex-subtle-text" href="javascript:history.back()">cancel and choose a different login method</a>
+  </div>
+  {{ end }}
 </div>
 
 {{ template "footer.html" . }}

--- a/skymarshal/dexserver/web/templates/password.html
+++ b/skymarshal/dexserver/web/templates/password.html
@@ -27,13 +27,11 @@
       </div>
     {{ end }}
 
-    <button tabindex="3" id="submit-login" type="submit" class="dex-btn theme-btn--primary">login</button>
+    <button tabindex="3" id="submit-login" type="submit" class="dex-btn theme-btn-login theme-btn--primary">submit</button>
 
   </form>
   {{ if .BackLink }}
-  <div class="theme-link-back">
-    <a class="dex-subtle-text" href="javascript:history.back()">cancel and choose a different login method</a>
-  </div>
+  <button tabindex="4" type="button" onclick="location.href='/sky/login'" class="dex-btn theme-btn-cancel theme-btn--danger">cancel</a>
   {{ end }}
 </div>
 

--- a/skymarshal/dexserver/web/templates/password.html
+++ b/skymarshal/dexserver/web/templates/password.html
@@ -22,17 +22,25 @@
     </div>
 
     {{ if .Invalid }}
-      <div id="login-error" class="dex-error-box">
-        invalid {{ $usernamePrompt }} and password.
+      <div class="theme-form-row">
+        <div id="login-error" class="dex-error-box">
+          invalid {{ $usernamePrompt }} and password.
+        </div>
       </div>
     {{ end }}
 
-    <button tabindex="3" id="submit-login" type="submit" class="dex-btn theme-btn-login theme-btn--primary">submit</button>
+    <div class="theme-btn-wrapper">
+      <div class="theme-form-row">
+        <button tabindex="3" id="submit-login" type="submit" class="dex-btn theme-btn-primary">submit</button>
+      </div>
+      {{ if .BackLink }}
+      <div class="theme-form-row">
+        <button tabindex="3" id="cancel-back" type="button" class="dex-btn theme-btn-cancel" onclick="javascript:history.back()">cancel</button>
+      </div>
+      {{ end }}
+    </div>
 
   </form>
-  {{ if .BackLink }}
-  <button tabindex="4" type="button" onclick="location.href='/sky/login'" class="dex-btn theme-btn-cancel theme-btn--danger">cancel</a>
-  {{ end }}
 </div>
 
 {{ template "footer.html" . }}

--- a/skymarshal/dexserver/web/templates/password.html
+++ b/skymarshal/dexserver/web/templates/password.html
@@ -18,7 +18,7 @@
       <div class="theme-form-label">
         <label for="password">password</label>
       </div>
-	  <input tabindex="2" required id="password" name="password" type="password" class="theme-form-input" placeholder="password" {{ if .Invalid }} autofocus {{ end }}/>
+	  <input tabindex="2" required id="password" name="password" type="password" class="theme-form-input" placeholder="password" autocomplete="off" {{ if .Invalid }} autofocus {{ end }}/>
     </div>
 
     {{ if .Invalid }}

--- a/skymarshal/dexserver/web/templates/password.html
+++ b/skymarshal/dexserver/web/templates/password.html
@@ -35,7 +35,7 @@
       </div>
       {{ if .BackLink }}
       <div class="theme-form-row">
-        <button tabindex="3" id="cancel-back" type="button" class="dex-btn theme-btn-cancel" onclick="location.href='/sky/login'">cancel</button>
+        <button tabindex="3" id="cancel-back" type="button" class="dex-btn theme-btn-cancel" onclick="javascript:history.back()">cancel</button>
       </div>
       {{ end }}
     </div>

--- a/skymarshal/dexserver/web/themes/concourse/styles.css
+++ b/skymarshal/dexserver/web/themes/concourse/styles.css
@@ -48,27 +48,50 @@
 
 .theme-panel {
   background-color: #1E1D1D;
-  padding: 30px;
+  padding: 16px;
   border: 1px solid #484747;
 }
 
-.theme-btn-provider, .theme-btn--primary {
+.dex-btn {
   width: 230px;
   height: 38px;
-  border: 1px solid #196AC8;
   box-shadow: none;
   border-radius: 0;
-  background-color: #1E1D1D;
   font-size: 14px;
 }
 
+.theme-btn-provider {
+  border: 1px solid #196AC8;
+  background-color: #1E1D1D;
+}
+
+.theme-btn-login {
+  margin: 8px 0 16px;
+}
+
 .theme-btn--primary {
-  margin: 20px 0;
+  color: #F2F2F2;
+  background-color: #0969AB;
 }
 
 .theme-btn--primary:hover {
-  background-color: #196AC8;
   color: white;
+  background-color: #1586D1;
+}
+
+.theme-btn-cancel {
+  margin-bottom: 16px;
+}
+
+.theme-btn--danger {
+  color: #F2F2F2;
+  background-color: inherit;
+  border: 1px solid #912617;
+}
+
+.theme-btn--danger:hover {
+  color: white;
+  background-color: #912617;
 }
 
 .theme-btn-provider {
@@ -98,7 +121,7 @@
 
 .theme-form-row {
   display: block;
-  margin:  0 auto 15px;
+  margin:  0 auto 12px;
 }
 
 .theme-form-input {
@@ -122,18 +145,7 @@
   font-size: 14px;
   letter-spacing: 0.05em;
   width: 230px;
-  margin: 0 auto 5px;
+  margin: 0 auto 8px;
   position: relative;
   text-align: left;
-  padding: 5px;
-}
-
-.theme-link-back {
-  font-size: 16px;
-  margin: 4px 0 10px;
-  text-align: center;
-}
-
-.theme-link-back a {
-  text-decoration: none;
 }

--- a/skymarshal/dexserver/web/themes/concourse/styles.css
+++ b/skymarshal/dexserver/web/themes/concourse/styles.css
@@ -131,7 +131,7 @@
 .theme-link-back {
   font-size: 16px;
   margin: 4px 0 10px;
-  text-align: left;
+  text-align: center;
 }
 
 .theme-link-back a {

--- a/skymarshal/dexserver/web/themes/concourse/styles.css
+++ b/skymarshal/dexserver/web/themes/concourse/styles.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'Inconsolata';
   font-style: normal;
-  font-weight: 400;
+  font-weight: 600;
   src: url("../static/fonts/Inconsolata-Regular.ttf");
 }
 
@@ -16,7 +16,7 @@
 * {
   font-family: "Inconsolata", monospace;
   font-weight: normal;
-  color: #ccc;
+  color: #E2E2E2;
 }
 
 .theme-body {
@@ -42,55 +42,50 @@
 }
 
 .theme-heading {
-  font-size: 18px;
-  margin: 20px 0 40px;
+  font-size: 28px;
+  letter-spacing: 0.01em;
+}
+
+h2 {
+  margin-top: 0;
+  margin-bottom: 32px;
 }
 
 .theme-panel {
-  background-color: #1E1D1D;
-  padding: 16px;
-  border: 1px solid #484747;
+  background-color: #151515;
+  padding: 32px;
 }
 
-.dex-btn {
-  width: 230px;
-  height: 38px;
+.theme-btn-wrapper {
+  padding-top: 16px;
+}
+.theme-btn-provider, .theme-btn-primary, .theme-btn-cancel {
+  width: 390px;
+  height: 52px;
   box-shadow: none;
   border-radius: 0;
-  font-size: 14px;
+  font-size: 20px;
+  line-height: 21px;
+  letter-spacing: 0.13em;
+  color: #F2F2F2;
 }
 
 .theme-btn-provider {
-  border: 1px solid #196AC8;
-  background-color: #1E1D1D;
+  background-color: #151515;
+  border: 1px solid #0969AB;
 }
 
-.theme-btn-login {
-  margin: 8px 0 16px;
-}
-
-.theme-btn--primary {
-  color: #F2F2F2;
+.theme-btn-primary {
   background-color: #0969AB;
 }
 
-.theme-btn--primary:hover {
-  color: white;
-  background-color: #1586D1;
-}
-
-.theme-btn-cancel {
-  margin-bottom: 16px;
-}
-
-.theme-btn--danger {
-  color: #F2F2F2;
-  background-color: inherit;
+.theme-btn-cancel{
+  background-color: #151515;
   border: 1px solid #912617;
+  box-sizing: border-box;
 }
 
-.theme-btn--danger:hover {
-  color: white;
+.theme-btn-cancel:hover{
   background-color: #912617;
 }
 
@@ -119,33 +114,34 @@
   background-color: #196AC8;
 }
 
-.theme-form-row {
+.theme-form-row:not(:last-child) {
   display: block;
-  margin:  0 auto 12px;
+  margin:  0 auto 16px;
 }
 
 .theme-form-input {
-  border: 1px solid #6D6D6D;
+  border: 1px solid #A4A4A4;
   display: block;
-  width: 230px;
-  height: 38px;
-  margin: 0 auto;
-  padding: 6px 12px;
+  width: 390px;
+  height: 52px;
+  padding: 16px;
   background-color: #1E1D1D;
-  font-size: 16px;
-}
-
-.theme-form-input:focus,
-.theme-form-input:active {
-  border-color: white;
+  font-size: 20px;
+  letter-spacing: 0.13em;
   outline: none;
+  box-sizing: border-box;
 }
 
 .theme-form-label {
-  font-size: 14px;
-  letter-spacing: 0.05em;
-  width: 230px;
+  font-size: 20px;
+  letter-spacing: 0.13em;
   margin: 0 auto 8px;
   position: relative;
   text-align: left;
+  line-height: 21px;
+}
+
+.theme-message {
+  font-size: 20px;
+  margin: 0;
 }

--- a/skymarshal/dexserver/web/themes/concourse/styles.css
+++ b/skymarshal/dexserver/web/themes/concourse/styles.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'Inconsolata';
   font-style: normal;
-  font-weight: 600;
+  font-weight: 400;
   src: url("../static/fonts/Inconsolata-Regular.ttf");
 }
 
@@ -42,31 +42,24 @@
 }
 
 .theme-heading {
-  font-size: 28px;
-  letter-spacing: 0.01em;
-}
-
-h2 {
-  margin-top: 0;
-  margin-bottom: 32px;
+  font-size: 18px;
+  margin: 20px 0 40px;
 }
 
 .theme-panel {
   background-color: #151515;
-  padding: 32px;
+  padding: 30px;
 }
 
 .theme-btn-wrapper {
-  padding-top: 16px;
+  padding-top: 20px;
 }
 .theme-btn-provider, .theme-btn-primary, .theme-btn-cancel {
-  width: 390px;
-  height: 52px;
+  width: 230px;
+  height: 38px;
   box-shadow: none;
   border-radius: 0;
-  font-size: 20px;
-  line-height: 21px;
-  letter-spacing: 0.13em;
+  font-size: 14px;
   color: #F2F2F2;
 }
 
@@ -116,32 +109,33 @@ h2 {
 
 .theme-form-row:not(:last-child) {
   display: block;
-  margin:  0 auto 16px;
+  margin:  0 auto 15px;
 }
 
 .theme-form-input {
   border: 1px solid #A4A4A4;
   display: block;
-  width: 390px;
-  height: 52px;
-  padding: 16px;
+  width: 230px;
+  height: 38px;
+  margin: 0 auto;
+  padding: 6px 12px;
   background-color: #1E1D1D;
-  font-size: 20px;
-  letter-spacing: 0.13em;
+  font-size: 16px;
   outline: none;
   box-sizing: border-box;
 }
 
 .theme-form-label {
-  font-size: 20px;
-  letter-spacing: 0.13em;
-  margin: 0 auto 8px;
+  font-size: 14px;
+  letter-spacing: 0.05em;
+  width: 230px;
+  margin: 0 auto 5px;
   position: relative;
   text-align: left;
-  line-height: 21px;
+  padding: 5px;
 }
 
 .theme-message {
-  font-size: 20px;
+  font-size: 14px;
   margin: 0;
 }

--- a/skymarshal/skycmd/flags.go
+++ b/skymarshal/skycmd/flags.go
@@ -43,11 +43,12 @@ func WireTeamConnectors(group *flags.Group) {
 }
 
 type AuthFlags struct {
-	SecureCookies bool              `long:"cookie-secure" description:"Force sending secure flag on http cookies"`
-	Expiration    time.Duration     `long:"auth-duration" default:"24h" description:"Length of time for which tokens are valid. Afterwards, users will have to log back in."`
-	SigningKey    *flag.PrivateKey  `long:"session-signing-key" required:"true" description:"File containing an RSA private key, used to sign auth tokens."`
-	LocalUsers    map[string]string `long:"add-local-user" description:"List of username:password combinations for all your local users. The password can be bcrypted - if so, it must have a minimum cost of 10." value-name:"USERNAME:PASSWORD"`
-	Clients       map[string]string `long:"add-client" description:"List of client_id:client_secret combinations" value-name:"CLIENT_ID:CLIENT_SECRET"`
+	SecureCookies     bool              `long:"cookie-secure" description:"Force sending secure flag on http cookies"`
+	Expiration        time.Duration     `long:"auth-duration" default:"24h" description:"Length of time for which tokens are valid. Afterwards, users will have to log back in."`
+	SigningKey        *flag.PrivateKey  `long:"session-signing-key" required:"true" description:"File containing an RSA private key, used to sign auth tokens."`
+	PasswordConnector string            `long:"password-connector" default:"local" choice:"local" choice:"ldap"`
+	LocalUsers        map[string]string `long:"add-local-user" description:"List of username:password combinations for all your local users. The password can be bcrypted - if so, it must have a minimum cost of 10." value-name:"USERNAME:PASSWORD"`
+	Clients           map[string]string `long:"add-client" description:"List of client_id:client_secret combinations" value-name:"CLIENT_ID:CLIENT_SECRET"`
 }
 
 type AuthTeamFlags struct {

--- a/skymarshal/skycmd/ldap_flags.go
+++ b/skymarshal/skycmd/ldap_flags.go
@@ -26,6 +26,7 @@ type LDAPFlags struct {
 	InsecureSkipVerify bool      `long:"insecure-skip-verify" description:"Skip certificate verification"`
 	StartTLS           bool      `long:"start-tls" description:"Start on insecure port, then negotiate TLS"`
 	CACert             flag.File `long:"ca-cert" description:"CA certificate"`
+	UsernamePrompt     string    `long:"username-prompt" description:"The prompt when logging in through the UI when --password-connector=ldap. Defaults to 'Username'."`
 
 	UserSearch struct {
 		BaseDN    string `long:"user-search-base-dn" description:"BaseDN to start the search from. For example 'cn=users,dc=example,dc=com'"`
@@ -85,6 +86,7 @@ func (flag *LDAPFlags) Serialize(redirectURI string) ([]byte, error) {
 		InsecureSkipVerify: flag.InsecureSkipVerify,
 		StartTLS:           flag.StartTLS,
 		RootCA:             flag.CACert.Path(),
+		UsernamePrompt:     flag.UsernamePrompt,
 	}
 
 	ldapConfig.UserSearch.BaseDN = flag.UserSearch.BaseDN


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

closes #6627.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
* Add flag for configuring password connector (either ldap or local)
* Prohibit adding local users when password connector is ldap
* Update username/password login page style
* Allow configuring username prompt for ldap (appears on username/password login page)

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

Branched off of #6669 

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* By setting `--password-connector` (`$CONCOURSE_PASSWORD_CONNECTOR`) to `ldap`, you can authenticate to Concourse with `fly login -u ... -p ...` using your LDAP credentials
  * Enabling this feature prohibits the use of local users
* If you use an attribute other than username for authenticating with LDAP (e.g. email address), you can now configure `--username-prompt` (`$CONCOURSE_USERNAME_PROMPT`) to change the help text when logging in via the UI

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
