### PR TITLE
github config updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,2 @@
-.github/           @concourse/maintainers
+*                  @concourse/maintainers
 CODE_OF_CONDUCT.md @concourse/community
-CONTRIBUTING.md    @concourse/maintainers
-web/               @concourse/maintainers
-package.json       @concourse/maintainers
-yarn.lock          @concourse/maintainers
-fly/               @concourse/maintainers
-go-concourse/      @concourse/maintainers
-atc/               @concourse/maintainers
-skymarshal/        @concourse/maintainers
-vars/              @concourse/maintainers
-atc/exec/          @concourse/maintainers
-atc/worker/        @concourse/maintainers
-atc/runtime/       @concourse/maintainers
-worker/            @concourse/maintainers
-tsa/               @concourse/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,16 @@
-.github/           @vito
-CODE_OF_CONDUCT.md @vito
-CONTRIBUTING.md    @concourse/pivotal
-web/               @concourse/ux
-package.json       @concourse/ux
-yarn.lock          @concourse/ux
-fly/               @concourse/core-api @concourse/ux
-go-concourse/      @concourse/core-api
-atc/               @concourse/core-api
-skymarshal/        @concourse/core-api
-vars/              @concourse/core-api
-atc/exec/          @concourse/runtime @concourse/core-api
-atc/worker/        @concourse/runtime
-atc/runtime/       @concourse/runtime
-worker/            @concourse/runtime
-tsa/               @concourse/runtime
+.github/           @concourse/maintainers
+CODE_OF_CONDUCT.md @concourse/community
+CONTRIBUTING.md    @concourse/maintainers
+web/               @concourse/maintainers
+package.json       @concourse/maintainers
+yarn.lock          @concourse/maintainers
+fly/               @concourse/maintainers
+go-concourse/      @concourse/maintainers
+atc/               @concourse/maintainers
+skymarshal/        @concourse/maintainers
+vars/              @concourse/maintainers
+atc/exec/          @concourse/maintainers
+atc/worker/        @concourse/maintainers
+atc/runtime/       @concourse/maintainers
+worker/            @concourse/maintainers
+tsa/               @concourse/maintainers

--- a/.github/auto_pr_team.yml
+++ b/.github/auto_pr_team.yml
@@ -1,2 +1,0 @@
-org: concourse
-team: contributors

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule: {interval: daily}
+
+- package-ecosystem: elm
+  directory: /web/elm
+  schedule: {interval: daily}
+
+- package-ecosystem: npm
+  directory: /
+  schedule: {interval: daily}
+
+- package-ecosystem: npm
+  directory: /web/wats
+  schedule: {interval: daily}
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule: {interval: daily}


### PR DESCRIPTION
## Changes proposed by this PR:

* remove no-longer-used auto-team-invite bot config
* remove no-longer-used (and empty) stale bot config
* update `CODEOWNERS` to reflect new teams from governance model
* enable dependabot


## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] ~~Added tests (Unit and/or Integration)~~
- [ ] ~~Updated [Documentation]~~
- [ ] ~~Added release note (Optional)~~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
