### PR TITLE
Prevent UI from stalling when you keep the resource page open for a while

### DIFF
--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -195,7 +195,7 @@ initBuild mbuild ( model, effects ) =
                         Build.Output.Output.init model.highlight build
                 in
                 ( { model | build = Just build, output = Just output }
-                , effects ++ outputCmd
+                , effects ++ [ CloseBuildEventStream ] ++ outputCmd
                 )
 
 

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -195,7 +195,7 @@ initBuild mbuild ( model, effects ) =
                         Build.Output.Output.init model.highlight build
                 in
                 ( { model | build = Just build, output = Just output }
-                , effects ++ [ CloseBuildEventStream ] ++ outputCmd
+                , effects ++ CloseBuildEventStream :: outputCmd
                 )
 
 

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -2881,6 +2881,18 @@ all =
                             )
                         |> Tuple.second
                         |> Common.contains (Effects.FetchBuildPlan 2)
+            , test "check with build closes build event stream when build changes" <|
+                \_ ->
+                    init
+                        |> Application.handleCallback
+                            (Callback.ResourceFetched <| Ok resource)
+                        |> Tuple.first
+                        |> Application.handleCallback
+                            (Callback.ResourceFetched <|
+                                Ok { resource | build = Just { baseBuild | id = 2 } }
+                            )
+                        |> Tuple.second
+                        |> Common.contains (Effects.CloseBuildEventStream)
             , describe "build events subscription" <|
                 [ test "after build plan is received, opens event stream" <|
                     \_ ->

--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -242,9 +242,11 @@ app.ports.openEventStream.subscribe(function(config) {
   config.eventTypes.forEach(function(eventType) {
     es.addEventListener(eventType, dispatchEvent);
   });
-  app.ports.closeEventStream.subscribe(function() {
+  let closeFunc = function() {
     es.close();
-  });
+    app.ports.closeEventStream.unsubscribe(closeFunc);
+  }
+  app.ports.closeEventStream.subscribe(closeFunc);
   setInterval(flush, 200);
 });
 


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

Fixes a bug I noticed on the resource page, but couldn't pin down for a while. When you keep the resource page open for a while (or just manually trigger a bunch of builds), the UI eventually starts hanging, and all requests become pending. This persists across new tabs - the only way to fix it is to close all your tabs


https://user-images.githubusercontent.com/26583442/111858975-b3de3400-8913-11eb-84e1-14c4bbb5bee4.mov

This is because we don't close the build event stream when we receive a new check build. I suspect browsers limit the number of active connections a particular domain is making, and since we never close the event stream requests, that limit eventually gets reached, meaning no other API requests can be completed

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->
* Close build event stream when a new check build is loaded
* Prevent close build event stream queue from growing without bound

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
