### PR TITLE
enhance put.inputs detect to ingore prefixed . and ..

### DIFF
--- a/atc/exec/put_inputs.go
+++ b/atc/exec/put_inputs.go
@@ -83,8 +83,14 @@ func detectInputsFromParam(value interface{}) []build.ArtifactName {
 	switch actual := value.(type) {
 	case string:
 		input := actual
-		if idx := strings.IndexByte(actual, '/'); idx >= 0 {
-			input = actual[:idx]
+		if parts := strings.Split(actual, "/"); len(parts) > 1 {
+			for _, part := range parts {
+				if part == "." || part == ".." {
+					continue
+				}
+				input = part
+				break
+			}
 		}
 		return []build.ArtifactName{build.ArtifactName(input)}
 	case map[string]interface{}:

--- a/atc/exec/put_inputs.go
+++ b/atc/exec/put_inputs.go
@@ -45,13 +45,11 @@ func (i allInputs) FindAll(artifacts *build.Repository) (map[string]runtime.Arti
 
 type specificInputs struct {
 	inputs []string
-	params atc.Params
 }
 
-func NewSpecificInputs(inputs []string, params atc.Params) PutInputs {
+func NewSpecificInputs(inputs []string) PutInputs {
 	return &specificInputs{
 		inputs: inputs,
-		params: params,
 	}
 }
 
@@ -60,27 +58,14 @@ func (i specificInputs) FindAll(artifacts *build.Repository) (map[string]runtime
 
 	inputs := map[string]runtime.Artifact{}
 
-	for _, input := range i.inputs {
-		if input == atc.InputsDetect {
-			detectedInputs, err := NewDetectInputs(i.params).FindAll(artifacts)
-			if err != nil {
-				return nil, err
-			}
-
-			for k, v := range detectedInputs {
-				inputs[k] = v
-			}
-
-			continue
-		}
-
-		artifact, found := artifactsMap[build.ArtifactName(input)]
+	for _, i := range i.inputs {
+		artifact, found := artifactsMap[build.ArtifactName(i)]
 		if !found {
-			return nil, PutInputNotFoundError{Input: input}
+			return nil, PutInputNotFoundError{Input: i}
 		}
 
 		pi := putInput{
-			name:     build.ArtifactName(input),
+			name:     build.ArtifactName(i),
 			artifact: artifact,
 		}
 

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -134,11 +134,13 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 		putInputs = NewAllInputs()
 	} else if step.plan.Inputs.All {
 		putInputs = NewAllInputs()
+	} else if step.plan.Inputs.Detect {
+		putInputs = NewDetectInputs(step.plan.Params)
 	} else {
 		// Covers both cases where inputs are specified and when there are no
 		// inputs specified and "all" field is given a false boolean, which will
 		// result in no inputs attached
-		putInputs = NewSpecificInputs(step.plan.Inputs.Specified, step.plan.Params)
+		putInputs = NewSpecificInputs(step.plan.Inputs.Specified)
 	}
 
 	inputsMap, err := putInputs.FindAll(state.ArtifactRepository())

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -134,13 +134,11 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 		putInputs = NewAllInputs()
 	} else if step.plan.Inputs.All {
 		putInputs = NewAllInputs()
-	} else if step.plan.Inputs.Detect {
-		putInputs = NewDetectInputs(step.plan.Params)
 	} else {
 		// Covers both cases where inputs are specified and when there are no
 		// inputs specified and "all" field is given a false boolean, which will
 		// result in no inputs attached
-		putInputs = NewSpecificInputs(step.plan.Inputs.Specified)
+		putInputs = NewSpecificInputs(step.plan.Inputs.Specified, step.plan.Params)
 	}
 
 	inputsMap, err := putInputs.FindAll(state.ArtifactRepository())

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -418,25 +418,6 @@ var _ = Describe("PutStep", func() {
 				})
 			})
 		})
-
-		Context("when the inputs are detected and specified", func() {
-			BeforeEach(func() {
-				putPlan.Inputs = &atc.InputsConfig{
-					Specified: []string{atc.InputsDetect, "some-mounted-source"},
-				}
-
-				putPlan.Params = atc.Params{
-					"some-param": "some-source/source",
-				}
-			})
-
-			It("calls RunPutStep with detected inputs and specified inputs", func() {
-				_, _, inputMap := fakeArtifactSourcer.SourceInputsAndCachesArgsForCall(0)
-				Expect(inputMap).To(HaveLen(2))
-				Expect(inputMap["/tmp/build/put/some-mounted-source"]).To(Equal(fakeMountedArtifact))
-				Expect(inputMap["/tmp/build/put/some-source"]).To(Equal(fakeArtifact))
-			})
-		})
 	})
 
 	It("calls workerClient -> RunPutStep with the appropriate arguments", func() {

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -359,7 +359,7 @@ var _ = Describe("PutStep", func() {
 		Context("when the inputs are detected", func() {
 			BeforeEach(func() {
 				putPlan.Inputs = &atc.InputsConfig{
-					Specified: []string{atc.InputsDetect},
+					Detect: true,
 				}
 			})
 

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -343,7 +343,7 @@ var _ = Describe("PutStep", func() {
 		Context("when the inputs are detected", func() {
 			BeforeEach(func() {
 				putPlan.Inputs = &atc.InputsConfig{
-					Detect: true,
+					Specified: []string{atc.InputsDetect},
 				}
 			})
 

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -703,13 +703,11 @@ func (c *VersionConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal("")
 }
 
-const InputsAll = "all"
-const InputsDetect = "detect"
-
 // A InputsConfig represents the choice to include every artifact within the
 // job as an input to the put step or specific ones.
 type InputsConfig struct {
 	All       bool
+	Detect    bool
 	Specified []string
 }
 
@@ -723,13 +721,8 @@ func (c *InputsConfig) UnmarshalJSON(inputs []byte) error {
 
 	switch actual := data.(type) {
 	case string:
-		if actual == InputsAll {
-			c.All = true
-		} else if actual == InputsDetect {
-			c.Specified = []string{InputsDetect}
-		} else {
-			return fmt.Errorf("unknown for put inputs %s", actual)
-		}
+		c.All = actual == "all"
+		c.Detect = actual == "detect"
 	case []interface{}:
 		inputs := []string{}
 
@@ -750,9 +743,16 @@ func (c *InputsConfig) UnmarshalJSON(inputs []byte) error {
 	return nil
 }
 
+const InputsAll = "all"
+const InputsDetect = "detect"
+
 func (c InputsConfig) MarshalJSON() ([]byte, error) {
 	if c.All {
 		return json.Marshal(InputsAll)
+	}
+
+	if c.Detect {
+		return json.Marshal(InputsDetect)
 	}
 
 	if c.Specified != nil {

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -703,11 +703,13 @@ func (c *VersionConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal("")
 }
 
+const InputsAll = "all"
+const InputsDetect = "detect"
+
 // A InputsConfig represents the choice to include every artifact within the
 // job as an input to the put step or specific ones.
 type InputsConfig struct {
 	All       bool
-	Detect    bool
 	Specified []string
 }
 
@@ -721,8 +723,13 @@ func (c *InputsConfig) UnmarshalJSON(inputs []byte) error {
 
 	switch actual := data.(type) {
 	case string:
-		c.All = actual == "all"
-		c.Detect = actual == "detect"
+		if actual == InputsAll {
+			c.All = true
+		} else if actual == InputsDetect {
+			c.Specified = []string{InputsDetect}
+		} else {
+			return fmt.Errorf("unknown for put inputs %s", actual)
+		}
 	case []interface{}:
 		inputs := []string{}
 
@@ -743,16 +750,9 @@ func (c *InputsConfig) UnmarshalJSON(inputs []byte) error {
 	return nil
 }
 
-const InputsAll = "all"
-const InputsDetect = "detect"
-
 func (c InputsConfig) MarshalJSON() ([]byte, error) {
 	if c.All {
 		return json.Marshal(InputsAll)
-	}
-
-	if c.Detect {
-		return json.Marshal(InputsDetect)
 	}
 
 	if c.Specified != nil {

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -652,6 +652,9 @@ type VersionConfig struct {
 	Pinned Version
 }
 
+const VersionLatest = "latest"
+const VersionEvery = "every"
+
 func (c *VersionConfig) UnmarshalJSON(version []byte) error {
 	var data interface{}
 
@@ -662,8 +665,8 @@ func (c *VersionConfig) UnmarshalJSON(version []byte) error {
 
 	switch actual := data.(type) {
 	case string:
-		c.Every = actual == "every"
-		c.Latest = actual == "latest"
+		c.Every = actual == VersionEvery
+		c.Latest = actual == VersionLatest
 	case map[string]interface{}:
 		version := Version{}
 
@@ -684,9 +687,6 @@ func (c *VersionConfig) UnmarshalJSON(version []byte) error {
 	return nil
 }
 
-const VersionLatest = "latest"
-const VersionEvery = "every"
-
 func (c *VersionConfig) MarshalJSON() ([]byte, error) {
 	if c.Latest {
 		return json.Marshal(VersionLatest)
@@ -702,6 +702,9 @@ func (c *VersionConfig) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal("")
 }
+
+const InputsAll = "all"
+const InputsDetect = "detect"
 
 // A InputsConfig represents the choice to include every artifact within the
 // job as an input to the put step or specific ones.
@@ -721,8 +724,8 @@ func (c *InputsConfig) UnmarshalJSON(inputs []byte) error {
 
 	switch actual := data.(type) {
 	case string:
-		c.All = actual == "all"
-		c.Detect = actual == "detect"
+		c.All = actual == InputsAll
+		c.Detect = actual == InputsDetect
 	case []interface{}:
 		inputs := []string{}
 
@@ -742,9 +745,6 @@ func (c *InputsConfig) UnmarshalJSON(inputs []byte) error {
 
 	return nil
 }
-
-const InputsAll = "all"
-const InputsDetect = "detect"
 
 func (c InputsConfig) MarshalJSON() ([]byte, error) {
 	if c.All {


### PR DESCRIPTION
**Bug Fix** | Feature | Documentation

closes #6704 .

## Changes proposed by this PR:

Ignore prefixed `.` and `..` of put param paths.

## Notes to reviewer:


## Release Note

Enhanced `put.inputs`:
* `input: detect` now can handle paths prefixed by `.` and `..`.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
