### PR TITLE
more lenient context deadline checking for containerd graceful process termination

### DIFF
--- a/worker/runtime/process_killer.go
+++ b/worker/runtime/process_killer.go
@@ -3,8 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"strings"
 	"syscall"
 	"time"
 
@@ -77,12 +76,7 @@ func (p processKiller) Kill(
 	case exitStatus := <-procWaitStatus:
 		err = exitStatus.Error()
 		if err != nil {
-			grpcErr := status.Convert(err)
-			// grpc error is passed back as a string so we can't do the regular errors.Is() check
-			// but if we convert the error to an RPC Status object we get a standard status code
-			// to check against
-
-			if grpcErr.Code() == codes.DeadlineExceeded {
+			if strings.Contains(err.Error(), "context deadline exceeded") {
 				return ErrGracePeriodTimeout
 			}
 			return fmt.Errorf("waiting for exit status from grpc: %w", err)


### PR DESCRIPTION
concourse/concourse#6668 added a check for a specific gRPC error code
that indicates context deadline exceeded. however, as our containerd
integration tests show us, gRPC doesn't always give us that error code.

instead, this commit does the dumb thing of just looking for the
substring "context deadline exceeded", which is hacky but should be good
enough in practice

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>

<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | Feature | Documentation

closes #6587 .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note

Very rarely graceful shutdowns will return a context timeout error instead of gracefully shutting down.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
