### PR TITLE
fix font antialiasing issue due to `less` dependency bump

### DIFF
--- a/web/assets/css/typography.less
+++ b/web/assets/css/typography.less
@@ -32,8 +32,8 @@ body {
   font-size: 12px;
   line-height: 1.4;
   font-weight: 700;
-  -webkit-font-smoothing: "antialiased";
-  -moz-osx-font-smoothing: "grayscale";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 pre {


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

minor thing, but due to changes in our dependencies (probably the less
bump in #6698), fonts started appearing thicker than usual.

this appeared to be due to an improper value for -webkit-font-smoothing.
in our `.less` files, we quoted the value, which is invalid. I suspect
older versions of less were smart enough to strip the quotes, but the
new version no longer does that.

### With busted antialiasing
<img width="790" alt="Screen Shot 2021-03-25 at 1 13 58 PM" src="https://user-images.githubusercontent.com/26583442/112515252-7db60f80-8d6c-11eb-854e-c5cca91910b8.png">

### Fixed antialiasing
<img width="790" alt="Screen Shot 2021-03-25 at 1 14 30 PM" src="https://user-images.githubusercontent.com/26583442/112515298-873f7780-8d6c-11eb-9656-343b22e422d9.png">


## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
