### PR TITLE
Build image resource caches foreign key constraint to job ids should be on delete cascade

### DIFF
--- a/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.down.sql
+++ b/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+  ALTER TABLE build_image_resource_caches
+    DROP CONSTRAINT build_image_resource_caches_job_id_fkey,
+    ADD CONSTRAINT build_image_resource_caches_job_id_fkey FOREIGN KEY (job_id) REFERENCES jobs(id);
+COMMIT;

--- a/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.down.sql
+++ b/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.down.sql
@@ -1,4 +1,3 @@
   ALTER TABLE build_image_resource_caches
     DROP CONSTRAINT build_image_resource_caches_job_id_fkey,
     ADD CONSTRAINT build_image_resource_caches_job_id_fkey FOREIGN KEY (job_id) REFERENCES jobs(id);
-COMMIT;

--- a/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.down.sql
+++ b/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.down.sql
@@ -1,4 +1,3 @@
-BEGIN;
   ALTER TABLE build_image_resource_caches
     DROP CONSTRAINT build_image_resource_caches_job_id_fkey,
     ADD CONSTRAINT build_image_resource_caches_job_id_fkey FOREIGN KEY (job_id) REFERENCES jobs(id);

--- a/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.up.sql
+++ b/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.up.sql
@@ -1,5 +1,3 @@
-BEGIN;
   ALTER TABLE build_image_resource_caches
     DROP CONSTRAINT build_image_resource_caches_job_id_fkey,
     ADD CONSTRAINT build_image_resource_caches_job_id_fkey FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE;
-COMMIT;

--- a/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.up.sql
+++ b/atc/db/migration/migrations/1616768782_add_job_id_on_delete_cascade_to_build_image_caches.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+  ALTER TABLE build_image_resource_caches
+    DROP CONSTRAINT build_image_resource_caches_job_id_fkey,
+    ADD CONSTRAINT build_image_resource_caches_job_id_fkey FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE;
+COMMIT;


### PR DESCRIPTION
## What does this PR accomplish?

**Bug Fix** | Feature | Documentation

When the foreign key constraint was added, I forgot to add an `ON DELETE CASCADE` to the `job_id` constraint. 

https://github.com/concourse/concourse/blob/86090499939d89fe384b4a587ac47708288052fe/atc/db/migration/migrations/1609958558_add_job_id_to_build_image_resource_caches.up.sql#L2-L3

Without it, it will automatically do an `ON DELETE NO ACTION` which will restrict the parent from being deleted if a
child row references it. This caused a bug where we were unable to delete a pipeline because there were build image resource cache rows that were owned by a job within the pipeline that was trying to be deleted. By adding an `ON DELETE CASCADE`, deleting the pipeline will delete the job which will now delete any build image resource caches that references that job.

closes #6577 

## Release Note
* This change fixes a bug that was introduced in v7.1.0 where deleting a pipeline could possibly result in a `500 error`. This was caused by a foreign key constraint within the `build_image_resource_caches` table referencing a job in the `jobs` table.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
