### PR TITLE
Don't enforce step timeout during worker selection

### DIFF
--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -253,11 +253,17 @@ var _ = Describe("CheckStep", func() {
 			})
 
 			Describe("worker selection", func() {
+				var ctx context.Context
 				var workerSpec worker.WorkerSpec
 
 				JustBeforeEach(func() {
 					Expect(fakePool.SelectWorkerCallCount()).To(Equal(1))
-					_, _, _, workerSpec, _, _ = fakePool.SelectWorkerArgsForCall(0)
+					ctx, _, _, workerSpec, _, _ = fakePool.SelectWorkerArgsForCall(0)
+				})
+
+				It("doesn't enforce a timeout", func() {
+					_, ok := ctx.Deadline()
+					Expect(ok).To(BeFalse())
 				})
 
 				Describe("calls SelectWorker with the correct WorkerSpec", func() {

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -268,11 +268,17 @@ var _ = Describe("GetStep", func() {
 	})
 
 	Describe("worker selection", func() {
+		var ctx context.Context
 		var workerSpec worker.WorkerSpec
 
 		JustBeforeEach(func() {
 			Expect(fakePool.SelectWorkerCallCount()).To(Equal(1))
-			_, _, _, workerSpec, _, _ = fakePool.SelectWorkerArgsForCall(0)
+			ctx, _, _, workerSpec, _, _ = fakePool.SelectWorkerArgsForCall(0)
+		})
+
+		It("doesn't enforce a timeout", func() {
+			_, ok := ctx.Deadline()
+			Expect(ok).To(BeFalse())
 		})
 
 		It("calls SelectWorker with the correct WorkerSpec", func() {

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -252,11 +252,17 @@ var _ = Describe("PutStep", func() {
 	})
 
 	Describe("worker selection", func() {
+		var ctx context.Context
 		var workerSpec worker.WorkerSpec
 
 		JustBeforeEach(func() {
 			Expect(fakePool.SelectWorkerCallCount()).To(Equal(1))
-			_, _, _, workerSpec, _, _ = fakePool.SelectWorkerArgsForCall(0)
+			ctx, _, _, workerSpec, _, _ = fakePool.SelectWorkerArgsForCall(0)
+		})
+
+		It("doesn't enforce a timeout", func() {
+			_, ok := ctx.Deadline()
+			Expect(ok).To(BeFalse())
 		})
 
 		It("calls SelectWorker with the correct WorkerSpec", func() {

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -206,11 +206,17 @@ var _ = Describe("TaskStep", func() {
 		})
 
 		Describe("worker selection", func() {
+			var ctx context.Context
 			var workerSpec worker.WorkerSpec
 
 			JustBeforeEach(func() {
 				Expect(fakePool.SelectWorkerCallCount()).To(Equal(1))
-				_, _, _, workerSpec, _, _ = fakePool.SelectWorkerArgsForCall(0)
+				ctx, _, _, workerSpec, _, _ = fakePool.SelectWorkerArgsForCall(0)
+			})
+
+			It("doesn't enforce a timeout", func() {
+				_, ok := ctx.Deadline()
+				Expect(ok).To(BeFalse())
 			})
 
 			It("emits a SelectedWorker event", func() {


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
**Bug Fix** | Feature | Documentation

in the same vein as #6237

now that the worker pool will wait for a worker to be available under a placement strategy (as of #6635), we probably shouldn't consider the "waiting for worker" step time as a part of the step's timeout since it makes it hard to come up with a good timeout for steps (since it can vary drastically depending on what else is running at the time)

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Start the step timeout after we've selected a worker

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

To see this, configure Concourse with:

```
      CONCOURSE_CONTAINER_PLACEMENT_STRATEGY: limit-active-tasks
      CONCOURSE_MAX_ACTIVE_TASKS_PER_WORKER: 1
```

...and a single worker. Then, set the following pipeline:

```yaml
jobs:
- name: job
  plan:
  - task: echo
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: {repository: busybox}
      run:
        path: sh
        args:
        - -c
        - |
          echo starting
          sleep 40
    timeout: 1m
```

...and trigger two builds. Without this fix, the second build will timeout because it spent ~40s of its allotted 1m timeout just waiting for the worker to become available.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
