### PR TITLE
Fix race condition in `containerd` runtime resulting in lost output for quickly printing-then-exiting processes

### DIFF
--- a/worker/runtime/integration/testdata/rootfs/.gitignore
+++ b/worker/runtime/integration/testdata/rootfs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/worker/runtime/process.go
+++ b/worker/runtime/process.go
@@ -41,12 +41,12 @@ func (p *Process) Wait() (int, error) {
 		return 0, fmt.Errorf("waiting for exit status: %w", err)
 	}
 
+	p.process.IO().Wait()
+
 	_, err = p.process.Delete(context.Background())
 	if err != nil {
 		return 0, fmt.Errorf("delete process: %w", err)
 	}
-
-	p.process.IO().Wait()
 
 	return int(status.ExitCode()), nil
 }


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix

closes #6775

## Changes proposed by this PR:

just move the IO wait to before we delete the process

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~~Updated [Documentation]~~
- [ ] ~~Added release note (Optional)~~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [x] Code reviewed
- [x] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [x] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
