### PR TITLE
Ensure stdin never errors when using containerd with TTY enabled

### DIFF
--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -353,6 +353,52 @@ func (s *IntegrationSuite) runToCompletion(privileged bool) {
 
 }
 
+// TestRunWithTerminalStdinClosed validates that when running a process with
+// TTY enabled, if the stdin of of that process is closed (i.e. network flake),
+// the process does not exit.
+//
+// Note that only (Concourse) tasks has TTY enabled
+//
+func (s *IntegrationSuite) TestRunWithTerminalStdinClosed() {
+	handle := uuid()
+	container, err := s.gardenBackend.Create(garden.ContainerSpec{
+		Handle:     handle,
+		RootFSPath: "raw://" + s.rootfs,
+		Privileged: true,
+	})
+	s.NoError(err)
+
+	stdin := &reader{fmt.Errorf("Connection closed")}
+	buf := new(buffer)
+
+	proc, err := container.Run(
+		garden.ProcessSpec{
+			Path: "/executable",
+			Args: []string{
+				"-sleep=5s",
+			},
+			TTY: &garden.TTYSpec{
+				WindowSize: &garden.WindowSize{Columns: 500, Rows: 500},
+			},
+		},
+		garden.ProcessIO{
+			Stdin:  stdin,
+			Stdout: buf,
+			Stderr: buf,
+		},
+	)
+	s.NoError(err)
+
+	exitCode, err := proc.Wait()
+	s.NoError(err)
+
+	s.Equal(exitCode, 0)
+	s.Contains(buf.String(), "slept for 5s")
+
+	err = s.gardenBackend.Destroy(container.Handle())
+	s.NoError(err)
+}
+
 // TestAttachToUnknownProc verifies that trying to attach to a process that does
 // not exist lead to an error.
 //

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+	"testing/iotest"
 	"time"
 
 	"code.cloudfoundry.org/garden"
@@ -368,7 +369,7 @@ func (s *IntegrationSuite) TestRunWithTerminalStdinClosed() {
 	})
 	s.NoError(err)
 
-	stdin := &reader{fmt.Errorf("Connection closed")}
+	stdin := iotest.ErrReader(fmt.Errorf("Connection closed"))
 	buf := new(buffer)
 
 	proc, err := container.Run(

--- a/worker/runtime/integration/sample/main.go
+++ b/worker/runtime/integration/sample/main.go
@@ -18,7 +18,7 @@ var (
 	flagHttpGet       = flag.String("http-get", "", "website to perform an HTTP GET request against")
 	flagWriteTenTimes = flag.String("write-many-times", "", "writes a string to stdout many times")
 	flagCatFile       = flag.String("cat", "", "writes contents of file to stdout")
-	flagSleep         = flag.String("sleep", "", "sleep for given numbeer of seconds")
+	flagSleep         = flag.String("sleep", "", "sleep for given golang duration")
 
 	signals = map[string]os.Signal{
 		"sighup":  syscall.SIGHUP,

--- a/worker/runtime/integration/sample/main.go
+++ b/worker/runtime/integration/sample/main.go
@@ -18,6 +18,7 @@ var (
 	flagHttpGet       = flag.String("http-get", "", "website to perform an HTTP GET request against")
 	flagWriteTenTimes = flag.String("write-many-times", "", "writes a string to stdout many times")
 	flagCatFile       = flag.String("cat", "", "writes contents of file to stdout")
+	flagSleep         = flag.String("sleep", "", "sleep for given numbeer of seconds")
 
 	signals = map[string]os.Signal{
 		"sighup":  syscall.SIGHUP,
@@ -77,6 +78,16 @@ func catFile(pathToFile string) {
 	fmt.Print(string(bytes))
 }
 
+func sleep(duration string) {
+	d, err := time.ParseDuration(duration)
+	if err != nil {
+		log.Fatal("failed to parse duration ", err)
+	}
+	time.Sleep(d)
+
+	fmt.Println("slept for", d.String())
+}
+
 func main() {
 	flag.Parse()
 
@@ -89,6 +100,8 @@ func main() {
 		writeTenTimes(*flagWriteTenTimes)
 	case *flagCatFile != "":
 		catFile(*flagCatFile)
+	case *flagSleep != "":
+		sleep(*flagSleep)
 	default:
 		fmt.Println(defaultMessage)
 	}

--- a/worker/runtime/integration/suite_test.go
+++ b/worker/runtime/integration/suite_test.go
@@ -27,6 +27,14 @@ func (m *buffer) String() string {
 	return m.content
 }
 
+type reader struct {
+	err error
+}
+
+func (r *reader) Read(p []byte) (int, error) {
+	return 0, r.err
+}
+
 func uuid() string {
 	u4, err := gouuid.NewV4()
 	if err != nil {

--- a/worker/runtime/integration/suite_test.go
+++ b/worker/runtime/integration/suite_test.go
@@ -27,14 +27,6 @@ func (m *buffer) String() string {
 	return m.content
 }
 
-type reader struct {
-	err error
-}
-
-func (r *reader) Read(p []byte) (int, error) {
-	return 0, r.err
-}
-
 func uuid() string {
 	u4, err := gouuid.NewV4()
 	if err != nil {

--- a/worker/runtime/process_test.go
+++ b/worker/runtime/process_test.go
@@ -27,7 +27,7 @@ func (s *ProcessSuite) SetupTest() {
 	s.containerdProcess = new(libcontainerdfakes.FakeProcess)
 	s.ch = make(chan containerd.ExitStatus, 1)
 
-	s.process = runtime.NewProcess(s.containerdProcess, s.ch)
+	s.process = runtime.NewProcess(s.containerdProcess, s.ch, nil)
 }
 
 func (s *ProcessSuite) TestID() {


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #6632 .

## Changes proposed by this PR:
Wrap the stdin in a dummy `io.Reader` that will never error before the container is done

## Notes to reviewer:
We probably don't need to be as fancy as [option 3](https://github.com/concourse/concourse/issues/6632#issuecomment-805272135) since we don't have a use case for it right now. But I could see this causing issues in the future if we ever need to send stuff on stdin later in the container's lifecycle. 

## Release Note
* Fixed bug with containerd runtime where builds to error out if it runs for a long time without any output

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
