### PR TITLE
remov --force in k8s topgun test set up

### DIFF
--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -276,7 +276,6 @@ func helmDeploy(releaseName, namespace, chartDir string, args ...string) *gexec.
 	helmArgs := []string{
 		"upgrade",
 		"--install",
-		"--force",
 		"--namespace", namespace,
 		"--create-namespace",
 	}


### PR DESCRIPTION
this happens after postgresql chart version bumped
we don't really need it with helm3 deployment

