### PR TITLE
Avoid task specific error in `load_var` `file` artifact look-up

### DIFF
--- a/atc/exec/load_var_step.go
+++ b/atc/exec/load_var_step.go
@@ -131,7 +131,10 @@ func (step *LoadVarStep) fetchVars(
 
 	art, found := state.ArtifactRepository().ArtifactFor(build.ArtifactName(artifactName))
 	if !found {
-		return nil, UnknownArtifactSourceError{build.ArtifactName(artifactName), filePath}
+		return nil, artifact.UnknownArtifactSourceError{
+			Name: artifactName,
+			Path: filePath,
+		}
 	}
 
 	stream, err := step.artifactStreamer.StreamFileFromArtifact(lagerctx.NewContext(ctx, logger), art, filePath)

--- a/atc/exec/load_var_step_test.go
+++ b/atc/exec/load_var_step_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/exec"
+	"github.com/concourse/concourse/atc/exec/artifact"
 	"github.com/concourse/concourse/atc/exec/build"
 	"github.com/concourse/concourse/atc/exec/build/buildfakes"
 	"github.com/concourse/concourse/atc/exec/execfakes"
@@ -360,6 +361,27 @@ var _ = Describe("LoadVarStep", func() {
 			It("step should fail", func() {
 				Expect(stepErr).To(HaveOccurred())
 				Expect(stepErr).To(MatchError(ContainSubstring("failed to parse some-resource/a.yaml in format yaml")))
+			})
+		})
+
+		Context("when file path artifact is not registered", func() {
+			BeforeEach(func() {
+				loadVarPlan = &atc.LoadVarPlan{
+					Name: "some-var",
+					File: "some-resource-not-in-the-registry/a.json",
+				}
+
+				fakeArtifactStreamer.StreamFileFromArtifactReturns(&fakeReadCloser{str: plainString}, nil)
+			})
+
+			It("step should fail", func() {
+				Expect(stepErr).To(HaveOccurred())
+				Expect(stepErr).To(
+					Equal(artifact.UnknownArtifactSourceError{
+						Name: "some-resource-not-in-the-registry",
+						Path: "a.json",
+					}))
+				Expect(stepErr).To(MatchError("unknown artifact source: 'some-resource-not-in-the-registry' in file path 'a.json'"))
 			})
 		})
 	})


### PR DESCRIPTION
Presently when a `load_var` step is used where the `file` refers to an artifact
which is not in the registry (in my case, due to a typo), the error message
erroneously refers to a task config - for example:

```
unknown artifact source: 'xyz' in task config file path 'file.json'
```

This seems to be because we are referring to the `UnknownArtifactSourceError`
defined in `atc/task_config_source.go`, which has a task config specific
`Error()`.

Helpfully (and confusingly), there is _also_ an `UnknownArtifactSourceError`
defined in the `artifact` package with a less specific message.

As such, returning `artifact.UnknownArtifactSourceError` will return an error
message like

```
unknown artifact source: 'xyz' in file path 'file.json'
```

Signed-off-by: Kieran Gorman <kieran@kjgorman.com>

<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix 

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

Update error struct type to one whose `Error()` message does not refer
specifically to `task config`, as it does not make sense for a `load_var` step.

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

My first commit to `concourse/concourse` — let me know if there's anything else I need to do, or have missed from reading CONTRIBUTING.md etc. 🙏

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
