### PR TITLE
feat(atc): enhance syslog-drainer to make it more useful

### DIFF
--- a/atc/db/build_event_source.go
+++ b/atc/db/build_event_source.go
@@ -117,7 +117,7 @@ func (source *buildEventSource) collectEvents(cursor uint) {
 		}
 
 		rows, err := tx.Query(`
-			SELECT type, version, payload
+			SELECT type, version, payload, event_id
 			FROM `+source.table+`
 			WHERE build_id = $1 OR build_id_old = $1
 			ORDER BY event_id ASC
@@ -137,8 +137,8 @@ func (source *buildEventSource) collectEvents(cursor uint) {
 
 			cursor++
 
-			var t, v, p string
-			err := rows.Scan(&t, &v, &p)
+			var t, v, p, eid string
+			err := rows.Scan(&t, &v, &p, &eid)
 			if err != nil {
 				_ = rows.Close()
 
@@ -153,6 +153,7 @@ func (source *buildEventSource) collectEvents(cursor uint) {
 				Data:    &data,
 				Event:   atc.EventType(t),
 				Version: atc.EventVersion(v),
+				EventID: eid,
 			}
 
 			select {

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -416,7 +416,7 @@ var _ = Describe("Build", func() {
 				Expect(events.Next()).To(Equal(envelope(event.Status{
 					Status: atc.StatusStarted,
 					Time:   build.StartTime().Unix(),
-				})))
+				}, "0")))
 			})
 
 			It("updates build status", func() {
@@ -594,7 +594,7 @@ var _ = Describe("Build", func() {
 			Expect(events.Next()).To(Equal(envelope(event.Status{
 				Status: atc.StatusSucceeded,
 				Time:   build.EndTime().Unix(),
-			})))
+			}, "0")))
 		})
 
 		It("updates build status", func() {
@@ -1055,7 +1055,7 @@ var _ = Describe("Build", func() {
 			Expect(events.Next()).To(Equal(envelope(event.Status{
 				Status: atc.StatusStarted,
 				Time:   build.StartTime().Unix(),
-			})))
+			}, "0")))
 
 			By("emitting a status event when finished")
 			err = build.Finish(db.BuildStatusSucceeded)
@@ -1068,7 +1068,7 @@ var _ = Describe("Build", func() {
 			Expect(events.Next()).To(Equal(envelope(event.Status{
 				Status: atc.StatusSucceeded,
 				Time:   build.EndTime().Unix(),
-			})))
+			}, "1")))
 
 			By("ending the stream when finished")
 			_, err = events.Next()
@@ -1094,7 +1094,7 @@ var _ = Describe("Build", func() {
 			Expect(events.Next()).To(Equal(envelope(event.Status{
 				Status: atc.StatusStarted,
 				Time:   build.StartTime().Unix(),
-			})))
+			}, "0")))
 		})
 	})
 
@@ -1114,7 +1114,7 @@ var _ = Describe("Build", func() {
 
 			Expect(events.Next()).To(Equal(envelope(event.Log{
 				Payload: "some ",
-			})))
+			}, "0")))
 
 			err = build.SaveEvent(event.Log{
 				Payload: "log",
@@ -1123,7 +1123,7 @@ var _ = Describe("Build", func() {
 
 			Expect(events.Next()).To(Equal(envelope(event.Log{
 				Payload: "log",
-			})))
+			}, "1")))
 
 			By("allowing you to subscribe from an offset")
 			eventsFrom1, err := build.Events(1)
@@ -1133,7 +1133,7 @@ var _ = Describe("Build", func() {
 
 			Expect(eventsFrom1.Next()).To(Equal(envelope(event.Log{
 				Payload: "log",
-			})))
+			}, "1")))
 
 			By("notifying those waiting on events as soon as they're saved")
 			nextEvent := make(chan event.Envelope)
@@ -1158,7 +1158,7 @@ var _ = Describe("Build", func() {
 
 			Eventually(nextEvent).Should(Receive(Equal(envelope(event.Log{
 				Payload: "log 2",
-			}))))
+			}, "2"))))
 
 			By("returning ErrBuildEventStreamClosed for Next calls after Close")
 			events3, err := build.Events(0)
@@ -2499,7 +2499,7 @@ var _ = Describe("Build", func() {
 	})
 })
 
-func envelope(ev atc.Event) event.Envelope {
+func envelope(ev atc.Event, eventID string) event.Envelope {
 	payload, err := json.Marshal(ev)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -2509,6 +2509,7 @@ func envelope(ev atc.Event) event.Envelope {
 		Event:   ev.EventType(),
 		Version: ev.Version(),
 		Data:    &data,
+		EventID: eventID,
 	}
 }
 

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -1328,7 +1328,7 @@ var _ = Describe("Pipeline", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(build2Event1).To(Equal(envelope(event.Log{
 				Payload: "log 2",
-			})))
+			}, "0")))
 
 			_, err = events2.Next() // finish event
 			Expect(err).ToNot(HaveOccurred())
@@ -1782,7 +1782,7 @@ var _ = Describe("Pipeline", func() {
 			Expect(events.Next()).To(Equal(envelope(event.Status{
 				Status: atc.StatusStarted,
 				Time:   startedBuild.StartTime().Unix(),
-			})))
+			}, "0")))
 		})
 	})
 

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -1199,7 +1199,7 @@ var _ = Describe("Team", func() {
 			Expect(events.Next()).To(Equal(envelope(event.Status{
 				Status: atc.StatusStarted,
 				Time:   startedBuild.StartTime().Unix(),
-			})))
+			}, "0")))
 		})
 	})
 

--- a/atc/event/parser.go
+++ b/atc/event/parser.go
@@ -97,6 +97,7 @@ type Envelope struct {
 	Data    *json.RawMessage `json:"data"`
 	Event   atc.EventType    `json:"event"`
 	Version atc.EventVersion `json:"version"`
+	EventID string           `json:"event_id"`
 }
 
 func (m Message) MarshalJSON() ([]byte, error) {

--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -193,7 +193,7 @@ func (d *drainer) sendEvent(logger lager.Logger, build db.Build, syslog *Syslog,
 		message = statusEvent.Status.String()
 	}
 
-	if message != "" && tag != "" {
+	if message != "" {
 		err := syslog.Write(hostname, tag, ts, message, ev.EventID)
 		if err != nil {
 			logger.Error("failed-to-write-to-server", err)

--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -197,7 +197,7 @@ func (d *drainer) sendEvent(logger lager.Logger, build db.Build, syslog *Syslog,
 
 		version, _ := json.Marshal(finishGetEvent.FetchedVersion)
 		metadata, _ := json.Marshal(finishGetEvent.FetchedMetadata)
-		message = fmt.Sprintf("{\"version\": %s, \"metadata\": %s", string(version), string(metadata))
+		message = fmt.Sprintf("get {\"version\": %s, \"metadata\": %s", string(version), string(metadata))
 	case event.EventTypeFinishPut:
 		var finishPutEvent event.FinishPut
 		err := json.Unmarshal(*ev.Data, &finishPutEvent)
@@ -210,7 +210,7 @@ func (d *drainer) sendEvent(logger lager.Logger, build db.Build, syslog *Syslog,
 
 		version, _ := json.Marshal(finishPutEvent.CreatedVersion)
 		metadata, _ := json.Marshal(finishPutEvent.CreatedMetadata)
-		message = fmt.Sprintf("{\"version\": %s, \"metadata\": %s", string(version), string(metadata))
+		message = fmt.Sprintf("put {\"version\": %s, \"metadata\": %s", string(version), string(metadata))
 	case event.EventTypeError:
 		var errorEvent event.Error
 		err := json.Unmarshal(*ev.Data, &errorEvent)

--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -3,6 +3,8 @@ package syslog
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/lager"
@@ -85,25 +87,10 @@ func (d *drainer) drainBuild(logger lager.Logger, build db.Build, syslog *Syslog
 			return err
 		}
 
-		if ev.Event == event.EventTypeLog {
-			var log event.Log
-
-			err := json.Unmarshal(*ev.Data, &log)
-			if err != nil {
-				logger.Error("failed-to-unmarshal", err)
-				return err
-			}
-
-			err = syslog.Write(
-				d.hostname,
-				build.SyslogTag(log.Origin.ID),
-				time.Unix(log.Time, 0),
-				log.Payload,
-			)
-			if err != nil {
-				logger.Error("failed-to-write-to-server", err)
-				return err
-			}
+		err = d.sendEvent(logger, build, syslog, ev)
+		if err != nil {
+			logger.Error("failed-to-send-event", err)
+			return err
 		}
 	}
 
@@ -111,6 +98,77 @@ func (d *drainer) drainBuild(logger lager.Logger, build db.Build, syslog *Syslog
 	if err != nil {
 		logger.Error("failed-to-update-status", err)
 		return err
+	}
+
+	return nil
+}
+
+func (d *drainer) sendEvent(logger lager.Logger, build db.Build, syslog *Syslog, ev event.Envelope) error {
+	var (
+		hostname string = d.hostname
+		ts       time.Time
+		tag      string
+		message  string
+	)
+
+	switch ev.Event {
+	case event.EventTypeStartTask:
+		var startTask event.StartTask
+		err := json.Unmarshal(*ev.Data, &startTask)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(startTask.Time, 0)
+		tag = build.SyslogTag(startTask.Origin.ID)
+
+		buildConfig := startTask.TaskConfig
+		argv := strings.Join(append([]string{buildConfig.Run.Path}, buildConfig.Run.Args...), " ")
+		message = fmt.Sprintf("running %s", argv)
+	case event.EventTypeLog:
+		var log event.Log
+		err := json.Unmarshal(*ev.Data, &log)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(log.Time, 0)
+		tag = build.SyslogTag(log.Origin.ID)
+		message = log.Payload
+	case event.EventTypeFinishGet:
+		var finishGet event.FinishGet
+		err := json.Unmarshal(*ev.Data, &finishGet)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(finishGet.Time, 0)
+		tag = build.SyslogTag(finishGet.Origin.ID)
+
+		version, _ := json.Marshal(finishGet.FetchedVersion)
+		metadata, _ := json.Marshal(finishGet.FetchedMetadata)
+		message = fmt.Sprintf("{\"version\": %s, \"metadata\": %s", string(version), string(metadata))
+	case event.EventTypeFinishPut:
+		var finishPut event.FinishPut
+		err := json.Unmarshal(*ev.Data, &finishPut)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(finishPut.Time, 0)
+		tag = build.SyslogTag(finishPut.Origin.ID)
+
+		version, _ := json.Marshal(finishPut.CreatedVersion)
+		metadata, _ := json.Marshal(finishPut.CreatedMetadata)
+		message = fmt.Sprintf("{\"version\": %s, \"metadata\": %s", string(version), string(metadata))
+	}
+
+	if message != "" && tag != "" {
+		err := syslog.Write(hostname, tag, ts, message, ev.EventID)
+		if err != nil {
+			logger.Error("failed-to-write-to-server", err)
+			return err
+		}
 	}
 
 	return nil

--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -112,6 +112,46 @@ func (d *drainer) sendEvent(logger lager.Logger, build db.Build, syslog *Syslog,
 	)
 
 	switch ev.Event {
+	case event.EventTypeInitialize:
+		var initEvent event.Initialize
+		err := json.Unmarshal(*ev.Data, &initEvent)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(initEvent.Time, 0)
+		tag = build.SyslogTag(initEvent.Origin.ID)
+		message = fmt.Sprintf("initializing")
+	case event.EventTypeInitializeGet:
+		var initGetEvent event.InitializeGet
+		err := json.Unmarshal(*ev.Data, &initGetEvent)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(initGetEvent.Time, 0)
+		tag = build.SyslogTag(initGetEvent.Origin.ID)
+		message = fmt.Sprintf("get initializing")
+	case event.EventTypeInitializePut:
+		var initPutEvent event.InitializePut
+		err := json.Unmarshal(*ev.Data, &initPutEvent)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(initPutEvent.Time, 0)
+		tag = build.SyslogTag(initPutEvent.Origin.ID)
+		message = fmt.Sprintf("put initializing")
+	case event.EventTypeInitializeTask:
+		var initTaskEvent event.InitializeTask
+		err := json.Unmarshal(*ev.Data, &initTaskEvent)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(initTaskEvent.Time, 0)
+		tag = build.SyslogTag(initTaskEvent.Origin.ID)
+		message = fmt.Sprintf("task initializing")
 	case event.EventTypeSelectedWorker:
 		var selectedWorkerEvent event.SelectedWorker
 		err := json.Unmarshal(*ev.Data, &selectedWorkerEvent)

--- a/atc/syslog/drainer_test.go
+++ b/atc/syslog/drainer_test.go
@@ -44,7 +44,14 @@ func newFakeBuild(id int) db.Build {
 		EventID: "4",
 	}, nil)
 
-	fakeEventSource.NextReturnsOnCall(4, event.Envelope{}, db.ErrEndOfBuildEventStream)
+	msg5 := json.RawMessage(`{"time":1533744538}`)
+	fakeEventSource.NextReturnsOnCall(4, event.Envelope{
+		Data:    &msg5,
+		Event:   "initialize-task",
+		EventID: "5",
+	}, nil)
+
+	fakeEventSource.NextReturnsOnCall(5, event.Envelope{}, db.ErrEndOfBuildEventStream)
 
 	fakeEventSource.NextReturns(event.Envelope{}, db.ErrEndOfBuildEventStream)
 
@@ -86,6 +93,7 @@ var _ = Describe("Drainer", func() {
 				Expect(got).To(ContainSubstring("build 123 status"))
 				Expect(got).To(ContainSubstring("build 345 status"))
 				Expect(got).To(ContainSubstring("selected worker: example-worker"))
+				Expect(got).To(ContainSubstring("task initializing"))
 			}, 0.2)
 		})
 

--- a/atc/syslog/drainer_test.go
+++ b/atc/syslog/drainer_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Drainer", func() {
 				got := <-server.Messages
 				Expect(got).To(ContainSubstring("build 123 log"))
 				Expect(got).To(ContainSubstring("build 345 log"))
-				Expect(got).To(ContainSubstring(`{"version": {"version":"0.0.1"}, "metadata": [{"name":"version","value":"0.0.1"}]`))
+				Expect(got).To(ContainSubstring(`get {"version": {"version":"0.0.1"}, "metadata": [{"name":"version","value":"0.0.1"}]`))
 				Expect(got).To(ContainSubstring("build 123 status"))
 				Expect(got).To(ContainSubstring("build 345 status"))
 				Expect(got).To(ContainSubstring("selected worker: example-worker"))

--- a/atc/syslog/syslog.go
+++ b/atc/syslog/syslog.go
@@ -101,7 +101,7 @@ func getSyslogFormatter(hostname string, ts time.Time, tag string, eventID strin
 		s = strings.Replace(s, "\r", " ", -1)
 		s = strings.Replace(s, "\x00", " ", -1)
 
-		msg := fmt.Sprintf("<%d>1 %s %s %s - - [meta sequenceId=\"%s\"] %s\n",
+		msg := fmt.Sprintf("<%d>1 %s %s %s - - [concourse@0 eventId=\"%s\"] %s\n",
 			priority, ts.Format(rfc5424time), hostname, tag, eventID, s)
 		return msg
 	}

--- a/atc/syslog/syslog.go
+++ b/atc/syslog/syslog.go
@@ -65,14 +65,14 @@ func Dial(transport, address string, caCerts []string) (*Syslog, error) {
 	}, nil
 }
 
-func (s *Syslog) Write(hostname, tag string, ts time.Time, msg string) error {
+func (s *Syslog) Write(hostname, tag string, ts time.Time, msg, eventID string) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.writer == nil {
 		return errors.New("connection already closed")
 	}
 
-	s.writer.SetFormatter(getSyslogFormatter(hostname, ts, tag))
+	s.writer.SetFormatter(getSyslogFormatter(hostname, ts, tag, eventID))
 	_, err := s.writer.Write([]byte(msg))
 	return err
 }
@@ -94,15 +94,15 @@ func (s *Syslog) Close() error {
 }
 
 // generate custom formatter based on hostname and tag
-func getSyslogFormatter(hostname string, ts time.Time, tag string) sl.Formatter {
+func getSyslogFormatter(hostname string, ts time.Time, tag, eventID string) sl.Formatter {
 	return func(priority sl.Priority, _, _, content string) string {
 		// strip whitespaces
 		s := strings.Replace(content, "\n", " ", -1)
 		s = strings.Replace(s, "\r", " ", -1)
 		s = strings.Replace(s, "\x00", " ", -1)
 
-		msg := fmt.Sprintf("<%d>1 %s %s %s - - - %s\n",
-			priority, ts.Format(rfc5424time), hostname, tag, s)
+		msg := fmt.Sprintf("<%d>1 %s %s %s - - [meta sequenceId=\"%s\"] %s\n",
+			priority, ts.Format(rfc5424time), hostname, tag, eventID, s)
 		return msg
 	}
 }

--- a/atc/syslog/syslog.go
+++ b/atc/syslog/syslog.go
@@ -65,7 +65,7 @@ func Dial(transport, address string, caCerts []string) (*Syslog, error) {
 	}, nil
 }
 
-func (s *Syslog) Write(hostname, tag string, ts time.Time, msg, eventID string) error {
+func (s *Syslog) Write(hostname, tag string, ts time.Time, msg string, eventID string) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.writer == nil {
@@ -94,7 +94,7 @@ func (s *Syslog) Close() error {
 }
 
 // generate custom formatter based on hostname and tag
-func getSyslogFormatter(hostname string, ts time.Time, tag, eventID string) sl.Formatter {
+func getSyslogFormatter(hostname string, ts time.Time, tag string, eventID string) sl.Formatter {
 	return func(priority sl.Priority, _, _, content string) string {
 		// strip whitespaces
 		s := strings.Replace(content, "\n", " ", -1)

--- a/atc/syslog/syslog_test.go
+++ b/atc/syslog/syslog_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Syslog", func() {
 		hostname = "hostname"
 		tag      = "tag"
 		message  = "build 123 log"
+		eventID  = "123"
 	)
 
 	AfterEach(func() {
@@ -77,7 +78,7 @@ var _ = Describe("Syslog", func() {
 				sl, err := syslog.Dial("tls", server.Addr, []string{caFilePath})
 				Expect(err).NotTo(HaveOccurred())
 
-				err = sl.Write(hostname, tag, time.Now(), message)
+				err = sl.Write(hostname, tag, time.Now(), message, eventID)
 				Expect(err).NotTo(HaveOccurred())
 
 				got := <-server.Messages
@@ -102,7 +103,7 @@ var _ = Describe("Syslog", func() {
 
 			It("connects and writes to server", func() {
 				sl, err := syslog.Dial("tcp", server.Addr, []string{})
-				sl.Write(hostname, tag, time.Now(), message)
+				sl.Write(hostname, tag, time.Now(), message, eventID)
 				Expect(err).NotTo(HaveOccurred())
 
 				got := <-server.Messages
@@ -130,7 +131,7 @@ var _ = Describe("Syslog", func() {
 			})
 
 			It("subsequent ops will error", func() {
-				err = sl.Write(hostname, tag, time.Now(), message)
+				err = sl.Write(hostname, tag, time.Now(), message, eventID)
 				Expect(err.Error()).To(ContainSubstring("connection already closed"))
 
 				err = sl.Close()


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

We are trying to use the syslog-drainer to offload our build logs, and we noticed two issues of syslog-drainer feature
1. Even though `syslog-drainer` send the log events by `event_id` (which is the correct order), but after it dumped to another datastore we couldn't get the correct order because we could only order by `timestamp` but it only have second-level precision.
2. `syslog-drainer` only "drained" event logs with `type: log` which is missing a lot of important information for a build, like `version` and `metadata`, etc.

## Changes proposed by this PR:

For resolving these two issue, this PR added
1. Add `event_id` into the formatted syslog entry. According the `The Syslog Protocol`, I would like to add it as a structured data element `meta.sequenceId`(https://tools.ietf.org/html/rfc5424#section-7.3.1)
2. Besides `event_type: log`, I would like to add following event_type `['start-task', 'finish-get', 'finish-put']` for `syslog-drainer`

## Notes to reviewer:

## Release Note
* Add `event_id` into `syslog-drainer` entries, to get the correct order of "drained" build logs.
* Add more supported event_type for `syslog-drainer` to include more info for "drained" build logs.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
