### PR TITLE
remove accidentally committed sql in migration

### DIFF
--- a/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.down.sql
+++ b/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.down.sql
@@ -44,6 +44,3 @@ LOOP
 END LOOP;
 END
 $$ LANGUAGE plpgsql;
-
-INSERT INTO migrations_history (version, tstamp, direction, status, dirty) VALUES (1606068653, current_timestamp, 'down', 'passed', false)
-

--- a/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.up.sql
+++ b/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.up.sql
@@ -53,6 +53,3 @@ BEGIN
   RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
-
-INSERT INTO migrations_history (version, tstamp, direction, status, dirty) VALUES (1606068653, current_timestamp, 'up', 'passed', false)
-


### PR DESCRIPTION
related to https://github.com/concourse/concourse/pull/6727

those `INSERT` was added during development and committed accidentally. They are not needed by doing transaction.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] PR acceptance performed

