### PR TITLE
Optimize check creation in DB

### DIFF
--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -264,11 +264,6 @@ func (r *resourceType) CheckPlan(from atc.Version, interval time.Duration, resou
 }
 
 func (r *resourceType) CreateBuild(ctx context.Context, manuallyTriggered bool, plan atc.Plan) (Build, bool, error) {
-	spanContextJSON, err := json.Marshal(NewSpanContext(ctx))
-	if err != nil {
-		return nil, false, err
-	}
-
 	tx, err := r.conn.Begin()
 	if err != nil {
 		return nil, false, err
@@ -300,20 +295,17 @@ func (r *resourceType) CreateBuild(ctx context.Context, manuallyTriggered bool, 
 	}
 
 	build := newEmptyBuild(r.conn, r.lockFactory)
-	err = createBuild(tx, build, map[string]interface{}{
-		"name":               CheckBuildName,
-		"team_id":            r.teamID,
-		"pipeline_id":        r.pipelineID,
-		"resource_type_id":   r.id,
-		"status":             BuildStatusPending,
-		"manually_triggered": manuallyTriggered,
-		"span_context":       string(spanContextJSON),
+	err = createStartedBuild(tx, build, startedBuildArgs{
+		Name:              CheckBuildName,
+		PipelineID:        r.pipelineID,
+		TeamID:            r.teamID,
+		Plan:              plan,
+		ManuallyTriggered: manuallyTriggered,
+		SpanContext:       NewSpanContext(ctx),
+		ExtraValues: map[string]interface{}{
+			"resource_type_id": r.id,
+		},
 	})
-	if err != nil {
-		return nil, false, err
-	}
-
-	_, err = build.start(tx, plan)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

should hopefully help with #6589, but we'll need to see how much of an impact it has in practice

On both CI and hush-house, we're seeing the [start build query](https://github.com/concourse/concourse/blob/8c8eb0565101b287107fe9d36ef970505ad166b7/atc/db/build.go#L512-L527) consume the majority of our DB's CPU time:

<img width="1253" alt="Screen Shot 2021-04-08 at 3 32 04 PM" src="https://user-images.githubusercontent.com/26583442/114085610-96034f80-987f-11eb-8f60-b82629d1af74.png">

(green is CPU time, blue is IO wait time, and orange is lock wait time)

This PR should eliminate this call for check builds - we still call it for job builds, but that should be more performant because the `pending_builds` index is optimized for that case.

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

* Create the check builds as started rather than creating a pending build and then `UPDATE`'ing them immediately after

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
