### PR TITLE
Add exception handling in bigint migration

### DIFF
--- a/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.up.sql
+++ b/atc/db/migration/migrations/1606068653_build_events_partitions_bigint.up.sql
@@ -7,12 +7,12 @@ BEGIN
 FOR pipeline IN
   SELECT id, name FROM pipelines
 LOOP
-  BEGIN
-    RAISE NOTICE 'renaming old indexes for pipeline % (%)', pipeline.id, pipeline.name;
-    EXECUTE format('DROP INDEX IF EXISTS pipeline_build_events_%s_build_id', pipeline.id);
-    EXECUTE format('ALTER INDEX IF EXISTS pipeline_build_events_%s_build_id_event_id RENAME TO pipeline_build_events_%s_build_id_old_event_id', pipeline.id, pipeline.id);
+  RAISE NOTICE 'renaming old indexes for pipeline % (%)', pipeline.id, pipeline.name;
+  EXECUTE format('DROP INDEX IF EXISTS pipeline_build_events_%s_build_id', pipeline.id);
+  EXECUTE format('ALTER INDEX IF EXISTS pipeline_build_events_%s_build_id_event_id RENAME TO pipeline_build_events_%s_build_id_old_event_id', pipeline.id, pipeline.id);
 
-    RAISE NOTICE 'creating new indexes for pipeline % (%)', pipeline.id, pipeline.name;
+  RAISE NOTICE 'creating new indexes for pipeline % (%)', pipeline.id, pipeline.name;
+  BEGIN
     EXECUTE format('CREATE UNIQUE INDEX IF NOT EXISTS pipeline_build_events_%s_build_id_event_id ON pipeline_build_events_%s (build_id, event_id)', pipeline.id, pipeline.id);
   EXCEPTION
   WHEN undefined_table then


### PR DESCRIPTION
sumbitting as draft for getting feedbacks of the solution while waiting for user response.

## What does this PR accomplish
Change the migration so it can ignore the error that caused by race condition. We don't really care about the error(table not exist) since ultimately it should be an no-op when pipeline is deleted. 

Bug Fix | Feature | Documentation

fixes #6725 

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
