### PR TITLE
atc(feat): enhance webhook triggered checks

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -137,6 +137,7 @@ type Build interface {
 	PublicPlan() *json.RawMessage
 	HasPlan() bool
 	Status() BuildStatus
+	CreateTime() time.Time
 	StartTime() time.Time
 	IsNewerThanLastCheckOf(input Resource) bool
 	EndTime() time.Time
@@ -365,20 +366,21 @@ func (b *build) HasPlan() bool                { return string(*b.publicPlan) != 
 func (b *build) IsNewerThanLastCheckOf(input Resource) bool {
 	return b.createTime.After(input.LastCheckEndTime())
 }
-func (b *build) StartTime() time.Time { return b.startTime }
-func (b *build) EndTime() time.Time   { return b.endTime }
-func (b *build) ReapTime() time.Time  { return b.reapTime }
-func (b *build) Status() BuildStatus  { return b.status }
-func (b *build) IsScheduled() bool    { return b.scheduled }
-func (b *build) IsDrained() bool      { return b.drained }
-func (b *build) IsRunning() bool      { return !b.completed }
-func (b *build) IsAborted() bool      { return b.aborted }
-func (b *build) IsCompleted() bool    { return b.completed }
-func (b *build) InputsReady() bool    { return b.inputsReady }
-func (b *build) RerunOf() int         { return b.rerunOf }
-func (b *build) RerunOfName() string  { return b.rerunOfName }
-func (b *build) RerunNumber() int     { return b.rerunNumber }
-func (b *build) CreatedBy() *string   { return b.createdBy }
+func (b *build) CreateTime() time.Time { return b.createTime }
+func (b *build) StartTime() time.Time  { return b.startTime }
+func (b *build) EndTime() time.Time    { return b.endTime }
+func (b *build) ReapTime() time.Time   { return b.reapTime }
+func (b *build) Status() BuildStatus   { return b.status }
+func (b *build) IsScheduled() bool     { return b.scheduled }
+func (b *build) IsDrained() bool       { return b.drained }
+func (b *build) IsRunning() bool       { return !b.completed }
+func (b *build) IsAborted() bool       { return b.aborted }
+func (b *build) IsCompleted() bool     { return b.completed }
+func (b *build) InputsReady() bool     { return b.inputsReady }
+func (b *build) RerunOf() int          { return b.rerunOf }
+func (b *build) RerunOfName() string   { return b.rerunOfName }
+func (b *build) RerunNumber() int      { return b.rerunNumber }
+func (b *build) CreatedBy() *string    { return b.createdBy }
 
 func (b *build) Reload() (bool, error) {
 	row := buildsQuery.Where(sq.Eq{"b.id": b.id}).

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -75,6 +75,10 @@ var _ = Describe("Build", func() {
 		Expect(build.HasPlan()).To(BeFalse())
 	})
 
+	It("create_time is current time", func(){
+		Expect(build.CreateTime()).To(BeTemporally("<", time.Now(), 1*time.Second))
+	})
+
 	Describe("LagerData", func() {
 		var build db.Build
 

--- a/atc/db/dbfakes/fake_build.go
+++ b/atc/db/dbfakes/fake_build.go
@@ -99,6 +99,16 @@ type FakeBuild struct {
 		result1 []db.WorkerArtifact
 		result2 error
 	}
+	CreateTimeStub        func() time.Time
+	createTimeMutex       sync.RWMutex
+	createTimeArgsForCall []struct {
+	}
+	createTimeReturns struct {
+		result1 time.Time
+	}
+	createTimeReturnsOnCall map[int]struct {
+		result1 time.Time
+	}
 	CreatedByStub        func() *string
 	createdByMutex       sync.RWMutex
 	createdByArgsForCall []struct {
@@ -1077,6 +1087,59 @@ func (fake *FakeBuild) ArtifactsReturnsOnCall(i int, result1 []db.WorkerArtifact
 		result1 []db.WorkerArtifact
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeBuild) CreateTime() time.Time {
+	fake.createTimeMutex.Lock()
+	ret, specificReturn := fake.createTimeReturnsOnCall[len(fake.createTimeArgsForCall)]
+	fake.createTimeArgsForCall = append(fake.createTimeArgsForCall, struct {
+	}{})
+	stub := fake.CreateTimeStub
+	fakeReturns := fake.createTimeReturns
+	fake.recordInvocation("CreateTime", []interface{}{})
+	fake.createTimeMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBuild) CreateTimeCallCount() int {
+	fake.createTimeMutex.RLock()
+	defer fake.createTimeMutex.RUnlock()
+	return len(fake.createTimeArgsForCall)
+}
+
+func (fake *FakeBuild) CreateTimeCalls(stub func() time.Time) {
+	fake.createTimeMutex.Lock()
+	defer fake.createTimeMutex.Unlock()
+	fake.CreateTimeStub = stub
+}
+
+func (fake *FakeBuild) CreateTimeReturns(result1 time.Time) {
+	fake.createTimeMutex.Lock()
+	defer fake.createTimeMutex.Unlock()
+	fake.CreateTimeStub = nil
+	fake.createTimeReturns = struct {
+		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakeBuild) CreateTimeReturnsOnCall(i int, result1 time.Time) {
+	fake.createTimeMutex.Lock()
+	defer fake.createTimeMutex.Unlock()
+	fake.CreateTimeStub = nil
+	if fake.createTimeReturnsOnCall == nil {
+		fake.createTimeReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+		})
+	}
+	fake.createTimeReturnsOnCall[i] = struct {
+		result1 time.Time
+	}{result1}
 }
 
 func (fake *FakeBuild) CreatedBy() *string {
@@ -4215,6 +4278,8 @@ func (fake *FakeBuild) Invocations() map[string][][]interface{} {
 	defer fake.artifactMutex.RUnlock()
 	fake.artifactsMutex.RLock()
 	defer fake.artifactsMutex.RUnlock()
+	fake.createTimeMutex.RLock()
+	defer fake.createTimeMutex.RUnlock()
 	fake.createdByMutex.RLock()
 	defer fake.createdByMutex.RUnlock()
 	fake.deleteMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_config_scope.go
+++ b/atc/db/dbfakes/fake_resource_config_scope.go
@@ -3,7 +3,6 @@ package dbfakes
 
 import (
 	"sync"
-	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
@@ -52,33 +51,17 @@ type FakeResourceConfigScope struct {
 	iDReturnsOnCall map[int]struct {
 		result1 int
 	}
-	LastCheckEndTimeStub        func() (time.Time, bool, error)
-	lastCheckEndTimeMutex       sync.RWMutex
-	lastCheckEndTimeArgsForCall []struct {
+	LastCheckStub        func() (db.LastCheck, error)
+	lastCheckMutex       sync.RWMutex
+	lastCheckArgsForCall []struct {
 	}
-	lastCheckEndTimeReturns struct {
-		result1 time.Time
-		result2 bool
-		result3 error
+	lastCheckReturns struct {
+		result1 db.LastCheck
+		result2 error
 	}
-	lastCheckEndTimeReturnsOnCall map[int]struct {
-		result1 time.Time
-		result2 bool
-		result3 error
-	}
-	LastCheckStartTimeStub        func() (time.Time, bool, error)
-	lastCheckStartTimeMutex       sync.RWMutex
-	lastCheckStartTimeArgsForCall []struct {
-	}
-	lastCheckStartTimeReturns struct {
-		result1 time.Time
-		result2 bool
-		result3 error
-	}
-	lastCheckStartTimeReturnsOnCall map[int]struct {
-		result1 time.Time
-		result2 bool
-		result3 error
+	lastCheckReturnsOnCall map[int]struct {
+		result1 db.LastCheck
+		result2 error
 	}
 	LatestVersionStub        func() (db.ResourceConfigVersion, bool, error)
 	latestVersionMutex       sync.RWMutex
@@ -342,122 +325,60 @@ func (fake *FakeResourceConfigScope) IDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceConfigScope) LastCheckEndTime() (time.Time, bool, error) {
-	fake.lastCheckEndTimeMutex.Lock()
-	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
-	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
+func (fake *FakeResourceConfigScope) LastCheck() (db.LastCheck, error) {
+	fake.lastCheckMutex.Lock()
+	ret, specificReturn := fake.lastCheckReturnsOnCall[len(fake.lastCheckArgsForCall)]
+	fake.lastCheckArgsForCall = append(fake.lastCheckArgsForCall, struct {
 	}{})
-	stub := fake.LastCheckEndTimeStub
-	fakeReturns := fake.lastCheckEndTimeReturns
-	fake.recordInvocation("LastCheckEndTime", []interface{}{})
-	fake.lastCheckEndTimeMutex.Unlock()
+	stub := fake.LastCheckStub
+	fakeReturns := fake.lastCheckReturns
+	fake.recordInvocation("LastCheck", []interface{}{})
+	fake.lastCheckMutex.Unlock()
 	if stub != nil {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeResourceConfigScope) LastCheckEndTimeCallCount() int {
-	fake.lastCheckEndTimeMutex.RLock()
-	defer fake.lastCheckEndTimeMutex.RUnlock()
-	return len(fake.lastCheckEndTimeArgsForCall)
+func (fake *FakeResourceConfigScope) LastCheckCallCount() int {
+	fake.lastCheckMutex.RLock()
+	defer fake.lastCheckMutex.RUnlock()
+	return len(fake.lastCheckArgsForCall)
 }
 
-func (fake *FakeResourceConfigScope) LastCheckEndTimeCalls(stub func() (time.Time, bool, error)) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = stub
+func (fake *FakeResourceConfigScope) LastCheckCalls(stub func() (db.LastCheck, error)) {
+	fake.lastCheckMutex.Lock()
+	defer fake.lastCheckMutex.Unlock()
+	fake.LastCheckStub = stub
 }
 
-func (fake *FakeResourceConfigScope) LastCheckEndTimeReturns(result1 time.Time, result2 bool, result3 error) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = nil
-	fake.lastCheckEndTimeReturns = struct {
-		result1 time.Time
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
+func (fake *FakeResourceConfigScope) LastCheckReturns(result1 db.LastCheck, result2 error) {
+	fake.lastCheckMutex.Lock()
+	defer fake.lastCheckMutex.Unlock()
+	fake.LastCheckStub = nil
+	fake.lastCheckReturns = struct {
+		result1 db.LastCheck
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeResourceConfigScope) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time, result2 bool, result3 error) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = nil
-	if fake.lastCheckEndTimeReturnsOnCall == nil {
-		fake.lastCheckEndTimeReturnsOnCall = make(map[int]struct {
-			result1 time.Time
-			result2 bool
-			result3 error
+func (fake *FakeResourceConfigScope) LastCheckReturnsOnCall(i int, result1 db.LastCheck, result2 error) {
+	fake.lastCheckMutex.Lock()
+	defer fake.lastCheckMutex.Unlock()
+	fake.LastCheckStub = nil
+	if fake.lastCheckReturnsOnCall == nil {
+		fake.lastCheckReturnsOnCall = make(map[int]struct {
+			result1 db.LastCheck
+			result2 error
 		})
 	}
-	fake.lastCheckEndTimeReturnsOnCall[i] = struct {
-		result1 time.Time
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakeResourceConfigScope) LastCheckStartTime() (time.Time, bool, error) {
-	fake.lastCheckStartTimeMutex.Lock()
-	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
-	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
-	}{})
-	stub := fake.LastCheckStartTimeStub
-	fakeReturns := fake.lastCheckStartTimeReturns
-	fake.recordInvocation("LastCheckStartTime", []interface{}{})
-	fake.lastCheckStartTimeMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakeResourceConfigScope) LastCheckStartTimeCallCount() int {
-	fake.lastCheckStartTimeMutex.RLock()
-	defer fake.lastCheckStartTimeMutex.RUnlock()
-	return len(fake.lastCheckStartTimeArgsForCall)
-}
-
-func (fake *FakeResourceConfigScope) LastCheckStartTimeCalls(stub func() (time.Time, bool, error)) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = stub
-}
-
-func (fake *FakeResourceConfigScope) LastCheckStartTimeReturns(result1 time.Time, result2 bool, result3 error) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = nil
-	fake.lastCheckStartTimeReturns = struct {
-		result1 time.Time
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakeResourceConfigScope) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time, result2 bool, result3 error) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = nil
-	if fake.lastCheckStartTimeReturnsOnCall == nil {
-		fake.lastCheckStartTimeReturnsOnCall = make(map[int]struct {
-			result1 time.Time
-			result2 bool
-			result3 error
-		})
-	}
-	fake.lastCheckStartTimeReturnsOnCall[i] = struct {
-		result1 time.Time
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
+	fake.lastCheckReturnsOnCall[i] = struct {
+		result1 db.LastCheck
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeResourceConfigScope) LatestVersion() (db.ResourceConfigVersion, bool, error) {
@@ -821,10 +742,8 @@ func (fake *FakeResourceConfigScope) Invocations() map[string][][]interface{} {
 	defer fake.findVersionMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
-	fake.lastCheckEndTimeMutex.RLock()
-	defer fake.lastCheckEndTimeMutex.RUnlock()
-	fake.lastCheckStartTimeMutex.RLock()
-	defer fake.lastCheckStartTimeMutex.RUnlock()
+	fake.lastCheckMutex.RLock()
+	defer fake.lastCheckMutex.RUnlock()
 	fake.latestVersionMutex.RLock()
 	defer fake.latestVersionMutex.RUnlock()
 	fake.resourceMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_config_scope.go
+++ b/atc/db/dbfakes/fake_resource_config_scope.go
@@ -64,6 +64,18 @@ type FakeResourceConfigScope struct {
 		result1 time.Time
 		result2 error
 	}
+	LastCheckStartTimeStub        func() (time.Time, error)
+	lastCheckStartTimeMutex       sync.RWMutex
+	lastCheckStartTimeArgsForCall []struct {
+	}
+	lastCheckStartTimeReturns struct {
+		result1 time.Time
+		result2 error
+	}
+	lastCheckStartTimeReturnsOnCall map[int]struct {
+		result1 time.Time
+		result2 error
+	}
 	LatestVersionStub        func() (db.ResourceConfigVersion, bool, error)
 	latestVersionMutex       sync.RWMutex
 	latestVersionArgsForCall []struct {
@@ -376,6 +388,62 @@ func (fake *FakeResourceConfigScope) LastCheckEndTimeReturnsOnCall(i int, result
 		})
 	}
 	fake.lastCheckEndTimeReturnsOnCall[i] = struct {
+		result1 time.Time
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeResourceConfigScope) LastCheckStartTime() (time.Time, error) {
+	fake.lastCheckStartTimeMutex.Lock()
+	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
+	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
+	}{})
+	stub := fake.LastCheckStartTimeStub
+	fakeReturns := fake.lastCheckStartTimeReturns
+	fake.recordInvocation("LastCheckStartTime", []interface{}{})
+	fake.lastCheckStartTimeMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeResourceConfigScope) LastCheckStartTimeCallCount() int {
+	fake.lastCheckStartTimeMutex.RLock()
+	defer fake.lastCheckStartTimeMutex.RUnlock()
+	return len(fake.lastCheckStartTimeArgsForCall)
+}
+
+func (fake *FakeResourceConfigScope) LastCheckStartTimeCalls(stub func() (time.Time, error)) {
+	fake.lastCheckStartTimeMutex.Lock()
+	defer fake.lastCheckStartTimeMutex.Unlock()
+	fake.LastCheckStartTimeStub = stub
+}
+
+func (fake *FakeResourceConfigScope) LastCheckStartTimeReturns(result1 time.Time, result2 error) {
+	fake.lastCheckStartTimeMutex.Lock()
+	defer fake.lastCheckStartTimeMutex.Unlock()
+	fake.LastCheckStartTimeStub = nil
+	fake.lastCheckStartTimeReturns = struct {
+		result1 time.Time
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeResourceConfigScope) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time, result2 error) {
+	fake.lastCheckStartTimeMutex.Lock()
+	defer fake.lastCheckStartTimeMutex.Unlock()
+	fake.LastCheckStartTimeStub = nil
+	if fake.lastCheckStartTimeReturnsOnCall == nil {
+		fake.lastCheckStartTimeReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+			result2 error
+		})
+	}
+	fake.lastCheckStartTimeReturnsOnCall[i] = struct {
 		result1 time.Time
 		result2 error
 	}{result1, result2}
@@ -736,6 +804,8 @@ func (fake *FakeResourceConfigScope) Invocations() map[string][][]interface{} {
 	defer fake.iDMutex.RUnlock()
 	fake.lastCheckEndTimeMutex.RLock()
 	defer fake.lastCheckEndTimeMutex.RUnlock()
+	fake.lastCheckStartTimeMutex.RLock()
+	defer fake.lastCheckStartTimeMutex.RUnlock()
 	fake.latestVersionMutex.RLock()
 	defer fake.latestVersionMutex.RUnlock()
 	fake.resourceMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_config_scope.go
+++ b/atc/db/dbfakes/fake_resource_config_scope.go
@@ -52,29 +52,33 @@ type FakeResourceConfigScope struct {
 	iDReturnsOnCall map[int]struct {
 		result1 int
 	}
-	LastCheckEndTimeStub        func() (time.Time, error)
+	LastCheckEndTimeStub        func() (time.Time, bool, error)
 	lastCheckEndTimeMutex       sync.RWMutex
 	lastCheckEndTimeArgsForCall []struct {
 	}
 	lastCheckEndTimeReturns struct {
 		result1 time.Time
-		result2 error
+		result2 bool
+		result3 error
 	}
 	lastCheckEndTimeReturnsOnCall map[int]struct {
 		result1 time.Time
-		result2 error
+		result2 bool
+		result3 error
 	}
-	LastCheckStartTimeStub        func() (time.Time, error)
+	LastCheckStartTimeStub        func() (time.Time, bool, error)
 	lastCheckStartTimeMutex       sync.RWMutex
 	lastCheckStartTimeArgsForCall []struct {
 	}
 	lastCheckStartTimeReturns struct {
 		result1 time.Time
-		result2 error
+		result2 bool
+		result3 error
 	}
 	lastCheckStartTimeReturnsOnCall map[int]struct {
 		result1 time.Time
-		result2 error
+		result2 bool
+		result3 error
 	}
 	LatestVersionStub        func() (db.ResourceConfigVersion, bool, error)
 	latestVersionMutex       sync.RWMutex
@@ -122,9 +126,10 @@ type FakeResourceConfigScope struct {
 	saveVersionsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UpdateLastCheckEndTimeStub        func() (bool, error)
+	UpdateLastCheckEndTimeStub        func(bool) (bool, error)
 	updateLastCheckEndTimeMutex       sync.RWMutex
 	updateLastCheckEndTimeArgsForCall []struct {
+		arg1 bool
 	}
 	updateLastCheckEndTimeReturns struct {
 		result1 bool
@@ -337,7 +342,7 @@ func (fake *FakeResourceConfigScope) IDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceConfigScope) LastCheckEndTime() (time.Time, error) {
+func (fake *FakeResourceConfigScope) LastCheckEndTime() (time.Time, bool, error) {
 	fake.lastCheckEndTimeMutex.Lock()
 	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
 	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
@@ -350,9 +355,9 @@ func (fake *FakeResourceConfigScope) LastCheckEndTime() (time.Time, error) {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeResourceConfigScope) LastCheckEndTimeCallCount() int {
@@ -361,39 +366,42 @@ func (fake *FakeResourceConfigScope) LastCheckEndTimeCallCount() int {
 	return len(fake.lastCheckEndTimeArgsForCall)
 }
 
-func (fake *FakeResourceConfigScope) LastCheckEndTimeCalls(stub func() (time.Time, error)) {
+func (fake *FakeResourceConfigScope) LastCheckEndTimeCalls(stub func() (time.Time, bool, error)) {
 	fake.lastCheckEndTimeMutex.Lock()
 	defer fake.lastCheckEndTimeMutex.Unlock()
 	fake.LastCheckEndTimeStub = stub
 }
 
-func (fake *FakeResourceConfigScope) LastCheckEndTimeReturns(result1 time.Time, result2 error) {
+func (fake *FakeResourceConfigScope) LastCheckEndTimeReturns(result1 time.Time, result2 bool, result3 error) {
 	fake.lastCheckEndTimeMutex.Lock()
 	defer fake.lastCheckEndTimeMutex.Unlock()
 	fake.LastCheckEndTimeStub = nil
 	fake.lastCheckEndTimeReturns = struct {
 		result1 time.Time
-		result2 error
-	}{result1, result2}
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeResourceConfigScope) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time, result2 error) {
+func (fake *FakeResourceConfigScope) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time, result2 bool, result3 error) {
 	fake.lastCheckEndTimeMutex.Lock()
 	defer fake.lastCheckEndTimeMutex.Unlock()
 	fake.LastCheckEndTimeStub = nil
 	if fake.lastCheckEndTimeReturnsOnCall == nil {
 		fake.lastCheckEndTimeReturnsOnCall = make(map[int]struct {
 			result1 time.Time
-			result2 error
+			result2 bool
+			result3 error
 		})
 	}
 	fake.lastCheckEndTimeReturnsOnCall[i] = struct {
 		result1 time.Time
-		result2 error
-	}{result1, result2}
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeResourceConfigScope) LastCheckStartTime() (time.Time, error) {
+func (fake *FakeResourceConfigScope) LastCheckStartTime() (time.Time, bool, error) {
 	fake.lastCheckStartTimeMutex.Lock()
 	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
 	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
@@ -406,9 +414,9 @@ func (fake *FakeResourceConfigScope) LastCheckStartTime() (time.Time, error) {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeResourceConfigScope) LastCheckStartTimeCallCount() int {
@@ -417,36 +425,39 @@ func (fake *FakeResourceConfigScope) LastCheckStartTimeCallCount() int {
 	return len(fake.lastCheckStartTimeArgsForCall)
 }
 
-func (fake *FakeResourceConfigScope) LastCheckStartTimeCalls(stub func() (time.Time, error)) {
+func (fake *FakeResourceConfigScope) LastCheckStartTimeCalls(stub func() (time.Time, bool, error)) {
 	fake.lastCheckStartTimeMutex.Lock()
 	defer fake.lastCheckStartTimeMutex.Unlock()
 	fake.LastCheckStartTimeStub = stub
 }
 
-func (fake *FakeResourceConfigScope) LastCheckStartTimeReturns(result1 time.Time, result2 error) {
+func (fake *FakeResourceConfigScope) LastCheckStartTimeReturns(result1 time.Time, result2 bool, result3 error) {
 	fake.lastCheckStartTimeMutex.Lock()
 	defer fake.lastCheckStartTimeMutex.Unlock()
 	fake.LastCheckStartTimeStub = nil
 	fake.lastCheckStartTimeReturns = struct {
 		result1 time.Time
-		result2 error
-	}{result1, result2}
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeResourceConfigScope) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time, result2 error) {
+func (fake *FakeResourceConfigScope) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time, result2 bool, result3 error) {
 	fake.lastCheckStartTimeMutex.Lock()
 	defer fake.lastCheckStartTimeMutex.Unlock()
 	fake.LastCheckStartTimeStub = nil
 	if fake.lastCheckStartTimeReturnsOnCall == nil {
 		fake.lastCheckStartTimeReturnsOnCall = make(map[int]struct {
 			result1 time.Time
-			result2 error
+			result2 bool
+			result3 error
 		})
 	}
 	fake.lastCheckStartTimeReturnsOnCall[i] = struct {
 		result1 time.Time
-		result2 error
-	}{result1, result2}
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeResourceConfigScope) LatestVersion() (db.ResourceConfigVersion, bool, error) {
@@ -681,17 +692,18 @@ func (fake *FakeResourceConfigScope) SaveVersionsReturnsOnCall(i int, result1 er
 	}{result1}
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckEndTime() (bool, error) {
+func (fake *FakeResourceConfigScope) UpdateLastCheckEndTime(arg1 bool) (bool, error) {
 	fake.updateLastCheckEndTimeMutex.Lock()
 	ret, specificReturn := fake.updateLastCheckEndTimeReturnsOnCall[len(fake.updateLastCheckEndTimeArgsForCall)]
 	fake.updateLastCheckEndTimeArgsForCall = append(fake.updateLastCheckEndTimeArgsForCall, struct {
-	}{})
+		arg1 bool
+	}{arg1})
 	stub := fake.UpdateLastCheckEndTimeStub
 	fakeReturns := fake.updateLastCheckEndTimeReturns
-	fake.recordInvocation("UpdateLastCheckEndTime", []interface{}{})
+	fake.recordInvocation("UpdateLastCheckEndTime", []interface{}{arg1})
 	fake.updateLastCheckEndTimeMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -705,10 +717,17 @@ func (fake *FakeResourceConfigScope) UpdateLastCheckEndTimeCallCount() int {
 	return len(fake.updateLastCheckEndTimeArgsForCall)
 }
 
-func (fake *FakeResourceConfigScope) UpdateLastCheckEndTimeCalls(stub func() (bool, error)) {
+func (fake *FakeResourceConfigScope) UpdateLastCheckEndTimeCalls(stub func(bool) (bool, error)) {
 	fake.updateLastCheckEndTimeMutex.Lock()
 	defer fake.updateLastCheckEndTimeMutex.Unlock()
 	fake.UpdateLastCheckEndTimeStub = stub
+}
+
+func (fake *FakeResourceConfigScope) UpdateLastCheckEndTimeArgsForCall(i int) bool {
+	fake.updateLastCheckEndTimeMutex.RLock()
+	defer fake.updateLastCheckEndTimeMutex.RUnlock()
+	argsForCall := fake.updateLastCheckEndTimeArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeResourceConfigScope) UpdateLastCheckEndTimeReturns(result1 bool, result2 error) {

--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -199,7 +199,7 @@ func (builder Builder) WithResourceVersions(resourceName string, versions ...atc
 			return fmt.Errorf("save versions: %w", err)
 		}
 
-		_, err = scope.UpdateLastCheckEndTime()
+		_, err = scope.UpdateLastCheckEndTime(true)
 		if err != nil {
 			return fmt.Errorf("update last check end time: %w", err)
 		}

--- a/atc/db/migration/migrations/1619180097_add_last_check_succeeded_to_resource_config_scopes.down.sql
+++ b/atc/db/migration/migrations/1619180097_add_last_check_succeeded_to_resource_config_scopes.down.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE resource_config_scopes
+    DROP COLUMN last_check_succeeded;

--- a/atc/db/migration/migrations/1619180097_add_last_check_succeeded_to_resource_config_scopes.up.sql
+++ b/atc/db/migration/migrations/1619180097_add_last_check_succeeded_to_resource_config_scopes.up.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE resource_config_scopes
+    ADD COLUMN last_check_succeeded boolean DEFAULT false NOT NULL;

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -56,7 +56,7 @@ func (r *resourceConfigScope) ResourceConfig() ResourceConfig { return r.resourc
 func (r *resourceConfigScope) LastCheckStartTime() (time.Time, bool, error) {
 	var lastCheckStartTime time.Time
 	var lastCheckSucceeded bool
-	err := psql.Select("last_check_start_time, last_check_succeeded").
+	err := psql.Select("last_check_start_time", "last_check_succeeded").
 		From("resource_config_scopes").
 		Where(sq.Eq{"id": r.id}).
 		RunWith(r.conn).
@@ -72,7 +72,7 @@ func (r *resourceConfigScope) LastCheckStartTime() (time.Time, bool, error) {
 func (r *resourceConfigScope) LastCheckEndTime() (time.Time, bool, error) {
 	var lastCheckEndTime time.Time
 	var lastCheckSucceeded bool
-	err := psql.Select("last_check_end_time, last_check_succeeded").
+	err := psql.Select("last_check_end_time", "last_check_succeeded").
 		From("resource_config_scopes").
 		Where(sq.Eq{"id": r.id}).
 		RunWith(r.conn).
@@ -214,7 +214,7 @@ func (r *resourceConfigScope) UpdateLastCheckStartTime() (bool, error) {
 
 	updated, err := checkIfRowsUpdated(tx, `
 		UPDATE resource_config_scopes
-		SET last_check_start_time = now(), last_check_succeeded = false
+		SET last_check_start_time = now()
 		WHERE id = $1
 	`, r.id)
 	if err != nil {

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -33,6 +33,7 @@ type ResourceConfigScope interface {
 		logger lager.Logger,
 	) (lock.Lock, bool, error)
 
+	LastCheckStartTime() (time.Time, error)
 	UpdateLastCheckStartTime() (bool, error)
 
 	LastCheckEndTime() (time.Time, error)
@@ -51,6 +52,21 @@ type resourceConfigScope struct {
 func (r *resourceConfigScope) ID() int                        { return r.id }
 func (r *resourceConfigScope) Resource() Resource             { return r.resource }
 func (r *resourceConfigScope) ResourceConfig() ResourceConfig { return r.resourceConfig }
+
+func (r *resourceConfigScope) LastCheckStartTime() (time.Time, error) {
+	var lastCheckStartTime time.Time
+	err := psql.Select("last_check_start_time").
+		From("resource_config_scopes").
+		Where(sq.Eq{"id": r.id}).
+		RunWith(r.conn).
+		QueryRow().
+		Scan(&lastCheckStartTime)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return lastCheckStartTime, nil
+}
 
 func (r *resourceConfigScope) LastCheckEndTime() (time.Time, error) {
 	var lastCheckEndTime time.Time

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Resource Config Scope", func() {
 		It("updates last check end time", func() {
 			lastTime := scenario.Resource("some-resource").LastCheckEndTime()
 
-			updated, err := resourceScope.UpdateLastCheckEndTime()
+			updated, err := resourceScope.UpdateLastCheckEndTime(true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated).To(BeTrue())
 

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -124,8 +124,16 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 
 	shouldRun := false
 	if d.build.IsManuallyTriggered() {
-		// ignore interval for manually triggered builds
-		shouldRun = true
+		// ignore interval for manually triggered builds.
+		lastCheckStartTime, err := scope.LastCheckStartTime()
+		if err != nil {
+			return nil, false, err
+		}
+		if d.build.CreateTime().Before(lastCheckStartTime) || d.build.CreateTime().Equal(lastCheckStartTime) {
+			shouldRun = false
+		} else {
+			shouldRun = true
+		}
 	} else if !d.clock.Now().Before(runAt) {
 		// run if we're past the last check end time
 		shouldRun = true

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -123,8 +123,9 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 	runAt := end.Add(interval)
 
 	shouldRun := false
-	if d.build.Name() != db.CheckBuildName {
-		// always run for get/put/task step embedded check
+	// check delegate holds current running build in the case of step embedded check.
+	// we should always run step embedded check.
+	if d.build.ResourceID() == 0 {
 		shouldRun = true
 	} else {
 		if d.build.IsManuallyTriggered() {

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -129,11 +129,8 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 		if err != nil {
 			return nil, false, err
 		}
-		if d.build.CreateTime().Before(lastCheckStartTime) || d.build.CreateTime().Equal(lastCheckStartTime) {
-			shouldRun = false
-		} else {
-			shouldRun = true
-		}
+		// avoid running redundant checks
+		shouldRun = d.build.CreateTime().After(lastCheckStartTime)
 	} else if !d.clock.Now().Before(runAt) {
 		// run if we're past the last check end time
 		shouldRun = true

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -61,6 +61,7 @@ var _ = Describe("CheckDelegate", func() {
 		fakePolicyChecker = new(policyfakes.FakeChecker)
 
 		fakeBuild.NameReturns(db.CheckBuildName)
+		fakeBuild.ResourceIDReturns(88)
 
 		delegate = engine.NewCheckDelegate(fakeBuild, plan, state, fakeClock, fakeRateLimiter, fakePolicyChecker, fakeArtifactSourcer)
 

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -228,6 +228,16 @@ var _ = Describe("CheckDelegate", func() {
 					})
 				})
 
+				Context("when from version is given", func() {
+					BeforeEach(func() {
+						plan.Check.FromVersion = atc.Version{"some": "version"}
+					})
+
+					It("returns true", func() {
+						Expect(run).To(BeTrue())
+					})
+				})
+
 				Context("when the build create time earlier than last check start time", func() {
 					BeforeEach(func() {
 						fakeBuild.CreateTimeReturns(time.Now().Add(-5 * time.Second))

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -60,6 +60,8 @@ var _ = Describe("CheckDelegate", func() {
 
 		fakePolicyChecker = new(policyfakes.FakeChecker)
 
+		fakeBuild.NameReturns(db.CheckBuildName)
+
 		delegate = engine.NewCheckDelegate(fakeBuild, plan, state, fakeClock, fakeRateLimiter, fakePolicyChecker, fakeArtifactSourcer)
 
 		fakeResourceConfig = new(dbfakes.FakeResourceConfig)

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -183,20 +183,20 @@ var _ = Describe("CheckDelegate", func() {
 				fakeBuild.IsManuallyTriggeredReturns(true)
 			})
 
-			Context("when fail to get scope last start time", func(){
-				BeforeEach(func(){
+			Context("when fail to get scope last start time", func() {
+				BeforeEach(func() {
 					fakeResourceConfigScope.LastCheckStartTimeReturns(time.Now(), errors.New("some-error"))
 				})
 
-				It("return the error", func(){
+				It("return the error", func() {
 					Expect(runErr).To(HaveOccurred())
 					Expect(runErr).To(Equal(errors.New("some-error")))
 				})
 			})
 
-			Context("when the build create time earlier than last build start time", func(){
-				BeforeEach(func(){
-					fakeBuild.CreateTimeReturns(time.Now().Add(-5*time.Second))
+			Context("when the build create time earlier than last check start time", func() {
+				BeforeEach(func() {
+					fakeBuild.CreateTimeReturns(time.Now().Add(-5 * time.Second))
 					fakeResourceConfigScope.LastCheckStartTimeReturns(time.Now(), nil)
 				})
 
@@ -205,9 +205,9 @@ var _ = Describe("CheckDelegate", func() {
 				})
 			})
 
-			Context("when the build create time earlier than last build start time", func(){
-				BeforeEach(func(){
-					fakeBuild.CreateTimeReturns(time.Now().Add(5*time.Second))
+			Context("when the build create time after last check start time", func() {
+				BeforeEach(func() {
+					fakeBuild.CreateTimeReturns(time.Now().Add(5 * time.Second))
 					fakeResourceConfigScope.LastCheckStartTimeReturns(time.Now(), nil)
 				})
 

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -183,8 +183,37 @@ var _ = Describe("CheckDelegate", func() {
 				fakeBuild.IsManuallyTriggeredReturns(true)
 			})
 
-			It("returns true", func() {
-				Expect(run).To(BeTrue())
+			Context("when fail to get scope last start time", func(){
+				BeforeEach(func(){
+					fakeResourceConfigScope.LastCheckStartTimeReturns(time.Now(), errors.New("some-error"))
+				})
+
+				It("return the error", func(){
+					Expect(runErr).To(HaveOccurred())
+					Expect(runErr).To(Equal(errors.New("some-error")))
+				})
+			})
+
+			Context("when the build create time earlier than last build start time", func(){
+				BeforeEach(func(){
+					fakeBuild.CreateTimeReturns(time.Now().Add(-5*time.Second))
+					fakeResourceConfigScope.LastCheckStartTimeReturns(time.Now(), nil)
+				})
+
+				It("returns false", func() {
+					Expect(run).To(BeFalse())
+				})
+			})
+
+			Context("when the build create time earlier than last build start time", func(){
+				BeforeEach(func(){
+					fakeBuild.CreateTimeReturns(time.Now().Add(5*time.Second))
+					fakeResourceConfigScope.LastCheckStartTimeReturns(time.Now(), nil)
+				})
+
+				It("returns true", func() {
+					Expect(run).To(BeTrue())
+				})
 			})
 		})
 

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -311,45 +311,12 @@ var _ = Describe("CheckDelegate", func() {
 				Expect(fakeResourceConfigScope.AcquireResourceCheckingLockCallCount()).To(Equal(0))
 			})
 
-			Context("when last check starts before build start time", func() {
-				BeforeEach(func() {
-					fakeBuild.StartTimeReturns(now.Add(1))
-					fakeResourceConfigScope.LastCheckStartTimeReturns(now.Add(-1), true, nil)
-				})
-
-				It("returns a no-op lock", func() {
-					Expect(runLock).To(Equal(lock.NoopLock{}))
-				})
-
-				It("returns true", func() {
-					Expect(run).To(BeTrue())
-				})
+			It("returns a no-op lock", func() {
+				Expect(runLock).To(Equal(lock.NoopLock{}))
 			})
 
-			Context("when last check fails", func() {
-				BeforeEach(func() {
-					fakeBuild.StartTimeReturns(now.Add(-1))
-					fakeResourceConfigScope.LastCheckStartTimeReturns(now.Add(1), false, nil)
-				})
-
-				It("returns a no-op lock", func() {
-					Expect(runLock).To(Equal(lock.NoopLock{}))
-				})
-
-				It("returns true", func() {
-					Expect(run).To(BeTrue())
-				})
-			})
-
-			Context("when last check starts after build start time", func() {
-				BeforeEach(func() {
-					fakeBuild.StartTimeReturns(now.Add(-1))
-					fakeResourceConfigScope.LastCheckStartTimeReturns(now.Add(1), true, nil)
-				})
-
-				It("returns false", func() {
-					Expect(run).To(BeFalse())
-				})
+			It("returns true", func() {
+				Expect(run).To(BeTrue())
 			})
 		})
 	})

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -172,7 +172,7 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 		if runErr != nil {
 			metric.Metrics.ChecksFinishedWithError.Inc()
 
-			if _, err := scope.UpdateLastCheckEndTime(); err != nil {
+			if _, err := scope.UpdateLastCheckEndTime(false); err != nil {
 				return false, fmt.Errorf("update check end time: %w", err)
 			}
 
@@ -204,7 +204,7 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 			state.StoreResult(step.planID, result.Versions[len(result.Versions)-1])
 		}
 
-		_, err = scope.UpdateLastCheckEndTime()
+		_, err = scope.UpdateLastCheckEndTime(true)
 		if err != nil {
 			return false, fmt.Errorf("update check end time: %w", err)
 		}

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -258,6 +258,10 @@ type CheckPlan struct {
 	Tags Tags `json:"tags,omitempty"`
 }
 
+func (plan CheckPlan) IsPeriodic() bool {
+	return plan.Resource != "" || plan.ResourceType != ""
+}
+
 type TaskPlan struct {
 	// The name of the step.
 	Name string `json:"name"`


### PR DESCRIPTION
## What does this PR accomplish?

Bug Fix | **Feature** | Documentation

Say there are 100 pipelines holding a common `git` resource, with global resource enabled, it suppose to run only a single check for the resource at a time. Say the 100 pipelines all configure webhooks on the resource. When there is a commit pushed, GitLab will post 100 webhook messages as there are 100 hooks configured in GitLab. Those 100 webhooks will create 100 check builds, and as webhook triggered build is marked as "manually triggered", so these 100 check builds will all be executed, which sounds incorrect. Ideally it should run the first check build, rest 99 should reuse result of the first one.

## Changes proposed by this PR:

As those 100 checks belong to the same resource config scope, they will be invoke in serial. As 100 webhooks coming in at same time, they will have very similar check build `create-time`. After the first check build is executed, it's `check-start-time` should be later than `create-time`. So we just need to check if build `create-time` is earlier than last check start time, it can just reuse last check result.

The reason why I use `last-check-start-time` is that, consider situation:

* At time1, a commit push triggers a webhook call. A check is triggered, and started.
* At time2, very close to time1, a commit pushed again. A new check is triggered. But the first check hasn't finished yet.
* At time3, the first check finishes. And the second check is invoked. If we use `last-check-end-time`, the second check will not run, which is wrong.

In the offline discussion, @clarafu proposed an idea of avoiding queuing check builds if the scope has a pending or running check. I guess that is not feasible, because upon receiving webhook call, it cannot figure out resource config scope yet, because source is only evaluated in `check-step`, and only after source is evaluated, scope can be found.

With my solution, scope's last-check-start-time and build's create-time are there already, so it's very easy to implement.

## Notes to reviewer:

The first commit is for design review. If code looks good to reviewers, I'll quickly add tests. I wish this PR may catch up with 7.2.

## Release Note

* Enhance webhook triggered checks. When multiple pipelines hold a common resource, and webhook calls against the common resource are sent to all pipelines at same time, without this enhancement, each webhook call will cause a check to run. With this enhancement, only a single check will run, which is the expected behavior as global resource.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
