### PR TITLE
update check metrics comments.

### DIFF
--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -163,7 +163,6 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 			}
 		}
 
-		// TODO: deprecate it.
 		metric.Metrics.ChecksStarted.Inc()
 
 		_, err = scope.UpdateLastCheckStartTime()
@@ -173,7 +172,6 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 
 		result, runErr := step.runCheck(ctx, logger, delegate, timeout, resourceConfig, source, resourceTypes, fromVersion)
 		if runErr != nil {
-			// TODO: deprecate it.
 			metric.Metrics.ChecksFinishedWithError.Inc()
 
 			if _, err := scope.UpdateLastCheckEndTime(); err != nil {
@@ -197,7 +195,6 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 			return false, fmt.Errorf("run check: %w", runErr)
 		}
 
-		// TODO: deprecate it.
 		metric.Metrics.ChecksFinishedWithSuccess.Inc()
 
 		err = scope.SaveVersions(db.NewSpanContext(ctx), result.Versions)

--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -61,12 +61,18 @@ type Monitor struct {
 
 	StepsWaiting map[StepsWaitingLabels]*Gauge
 
-	// TODO: deprecate, replaced with CheckBuildFinished
+	// When global resource is not enabled, ChecksStarted should equal to CheckBuildsStarted.
+	// But with global resource enabled, ChecksStarted measures how many checks really run.
+	// For example, there are 10 resources having exact same config, so they belong to the same
+	// resource configure scope. In each check period, 10 check builds will be created,
+	// CheckBuildsStarted should be 10. But only 1 check build should run real check, rest 9 check
+	// builds should reuse the first check's result, thus ChecksStarted will be 1.
+	// The bigger diff between ChecksStarted and CheckBuildsStarted, the more global resource benefits.
+	ChecksStarted Counter
+
+	// ChecksFinishedWithError+ChecksFinishedWithSuccess should equal to ChecksStarted.
 	ChecksFinishedWithError   Counter
 	ChecksFinishedWithSuccess Counter
-
-	// TODO: deprecate, replaced with CheckBuildsStarted and CheckBuildStarted
-	ChecksStarted Counter
 
 	ChecksEnqueued Counter
 

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -91,8 +91,8 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 		"build finished",
 		"check build started",
 		"check build finished",
-		"checks finished", // TODO: deprecate, use "check build finished" instead.
-		"checks started",  // TODO: deprecate, use "check build started" instead.
+		"checks finished",
+		"checks started",
 		"checks enqueued",
 		"checks queue size",
 		"worker containers",

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -423,7 +423,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Namespace: "concourse",
 			Subsystem: "lidar",
 			Name:      "checks_finished_total",
-			Help:      "Total number of checks finished. DEPRECATED: use concourse_builds_check_finished_total instead.",
+			Help:      "Total number of checks finished.",
 		},
 		[]string{"status"},
 	)
@@ -434,7 +434,7 @@ func (config *PrometheusConfig) NewEmitter() (metric.Emitter, error) {
 			Namespace: "concourse",
 			Subsystem: "lidar",
 			Name:      "checks_started_total",
-			Help:      "Total number of checks started. DEPRECATED: use concourse_builds_check_started_total instead.",
+			Help:      "Total number of checks started. With global resource enabled, a check build may not really run a check, thus total checks started should be less than total check builds started.",
 		},
 	)
 	prometheus.MustRegister(checksStarted)


### PR DESCRIPTION
## What does this PR accomplish?

**Bug Fix** | Feature | Documentation

In PR #6656, I added new metrics `CheckBuildsStarted`, and added code comments of "deprecate ChecksStarted`.

But when working on #6854, I realized that `ChecksStarted` is still useful. Thus removing those "deprecate" comments. 

## Changes proposed by this PR:


## Notes to reviewer:

This is a release-no-impact PR.

## Release Note

* Just update code comments, no release impact.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
