### PR TITLE
Allow override of container limits in task config

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -52,6 +52,7 @@ func (visitor *planVisitor) VisitTask(step *atc.TaskStep) error {
 		Name:              step.Name,
 		Privileged:        step.Privileged,
 		Config:            step.Config,
+		Limits:            step.Limits,
 		ConfigPath:        step.ConfigPath,
 		Vars:              step.Vars,
 		Tags:              step.Tags,

--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -275,6 +275,60 @@ var factoryTests = []PlannerTest{
 		}`,
 	},
 	{
+		Title: "task step with top level container limits",
+
+		Config: &atc.TaskStep{
+			Name:       "some-task",
+			Privileged: true,
+			Config: &atc.TaskConfig{
+				Platform: "linux",
+				Run:      atc.TaskRunConfig{Path: "hello"},
+			},
+			Limits: &atc.ContainerLimits{
+				CPU:    newCPULimit(456),
+				Memory: newMemoryLimit(2048),
+			},
+			ConfigPath:        "some-task-file",
+			Vars:              atc.Params{"some": "vars"},
+			Params:            atc.TaskEnv{"SOME": "PARAMS"},
+			Tags:              atc.Tags{"tag-1", "tag-2"},
+			InputMapping:      map[string]string{"generic": "specific"},
+			OutputMapping:     map[string]string{"specific": "generic"},
+			ImageArtifactName: "some-image",
+			Timeout:           "1h",
+		},
+
+		PlanJSON: `{
+			"id": "(unique)",
+			"task": {
+				"name": "some-task",
+				"privileged": true,
+				"config": {
+					"platform": "linux",
+					"run": {"path": "hello"}
+				},
+				"config_path": "some-task-file",
+				"vars": {"some": "vars"},
+				"container_limits": {"cpu": 456, "memory": 2048},
+				"params": {"SOME": "PARAMS"},
+				"tags": ["tag-1", "tag-2"],
+				"input_mapping": {"generic": "specific"},
+				"output_mapping": {"specific": "generic"},
+				"image": "some-image",
+				"timeout": "1h",
+				"resource_types": [
+					{
+						"name": "some-resource-type",
+						"type": "some-base-resource-type",
+						"source": {"some": "type-source"},
+						"defaults": {"default-key":"default-value"},
+						"version": {"some": "type-version"}
+					}
+				]
+			}
+		}`,
+	},
+	{
 		Title: "set_pipeline step",
 
 		Config: &atc.SetPipelineStep{
@@ -798,4 +852,14 @@ func (s *PlannerSuite) TestFactory() {
 		})
 	}
 	atc.LoadBaseResourceTypeDefaults(map[string]atc.Source{})
+}
+
+func newCPULimit(cpuLimit uint64) *atc.CPULimit {
+	limit := atc.CPULimit(cpuLimit)
+	return &limit
+}
+
+func newMemoryLimit(memoryLimit uint64) *atc.MemoryLimit {
+	limit := atc.MemoryLimit(memoryLimit)
+	return &limit
 }

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -19,7 +19,6 @@ func ValidateIdentifier(identifier string, context ...string) (*ConfigWarning, e
 	if identifier == "" {
 		return nil, fmt.Errorf("%s: identifier cannot be an empty string", strings.Join(context, ""))
 	}
-
 	if !validIdentifiers.MatchString(identifier) {
 		var reason string
 		if startsWithLetter.MatchString(identifier) {

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -184,6 +184,9 @@ func (step *TaskStep) run(ctx context.Context, state RunState, delegate TaskDele
 		ResourceTypes: step.plan.VersionedResourceTypes,
 	}
 
+	// override limits
+	taskConfigSource = &OverrideContainerLimitsSource{ConfigSource: taskConfigSource, Limits: step.plan.Limits}
+
 	// override params
 	taskConfigSource = &OverrideParamsConfigSource{ConfigSource: taskConfigSource, Params: step.plan.Params}
 

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -275,6 +275,9 @@ type TaskPlan struct {
 	ConfigPath string      `json:"config_path,omitempty"`
 	Config     *TaskConfig `json:"config,omitempty"`
 
+	// Limits to set on the Task Container
+	Limits *ContainerLimits `json:"container_limits,omitempty"`
+
 	// An artifact in the build plan to use as the task's image. Overrides any
 	// image set in the task's config.
 	ImageArtifactName string `json:"image,omitempty"`

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -336,6 +336,7 @@ type TaskStep struct {
 	Name              string            `json:"task"`
 	Privileged        bool              `json:"privileged,omitempty"`
 	ConfigPath        string            `json:"file,omitempty"`
+	Limits            *ContainerLimits  `json:"container_limits,omitempty"`
 	Config            *TaskConfig       `json:"config,omitempty"`
 	Params            TaskEnv           `json:"params,omitempty"`
 	Vars              Params            `json:"vars,omitempty"`

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -104,6 +104,44 @@ var factoryTests = []StepTest{
 		},
 	},
 	{
+		Title: "task step with container limits",
+
+		ConfigYAML: `
+			task: some-task
+			privileged: true
+			config:
+			  platform: linux
+			  run: {path: hello}
+			file: some-task-file
+			vars: {some: vars}
+			container_limits: {cpu: 10, memory: 1024}
+			params: {SOME: PARAMS}
+			tags: [tag-1, tag-2]
+			input_mapping: {generic: specific}
+			output_mapping: {specific: generic}
+			image: some-image
+			timeout: 1h
+		`,
+
+		StepConfig: &atc.TaskStep{
+			Name:       "some-task",
+			Privileged: true,
+			Config: &atc.TaskConfig{
+				Platform: "linux",
+				Run:      atc.TaskRunConfig{Path: "hello"},
+			},
+			ConfigPath:        "some-task-file",
+			Vars:              atc.Params{"some": "vars"},
+			Params:            atc.TaskEnv{"SOME": "PARAMS"},
+			Limits:            &atc.ContainerLimits{CPU: newCPULimit(10), Memory: newMemoryLimit(1024)},
+			Tags:              []string{"tag-1", "tag-2"},
+			InputMapping:      map[string]string{"generic": "specific"},
+			OutputMapping:     map[string]string{"specific": "generic"},
+			ImageArtifactName: "some-image",
+			Timeout:           "1h",
+		},
+	},
+	{
 		Title: "task step with non-string params",
 
 		ConfigYAML: `
@@ -544,4 +582,14 @@ func (s *StepsSuite) TestFactory() {
 func rawMessage(s string) *json.RawMessage {
 	raw := json.RawMessage(s)
 	return &raw
+}
+
+func newCPULimit(cpuLimit uint64) *atc.CPULimit {
+	limit := atc.CPULimit(cpuLimit)
+	return &limit
+}
+
+func newMemoryLimit(memoryLimit uint64) *atc.MemoryLimit {
+	limit := atc.MemoryLimit(memoryLimit)
+	return &limit
 }


### PR DESCRIPTION
## What does this PR accomplish?

### Feature

[Allow users of reusable concourse task files to set container limits in pipeline definitions](https://github.com/concourse/concourse/discussions/6646). Since it is not possible to set container limits for tasks using the `file` syntax, it means that reusable tasks effectively cannot have container limits.


## Changes proposed by this PR

Allow pipeline authors to set container limits on `file` tasks like so:

```yaml
jobs:
- name: build
  plan:
  - get: concourse-tasks
  - task: build-image
    file: concourse-tasks/build-oci-image-unprivileged/task.yml
    input_mapping: {dockerfile-repo: concourse-tasks}
    container_limits:
      cpu: 2
      memory: 519430400
    params:
      CONTEXT: dockerfile-repo/build-oci-image-unprivileged/fixtures/example-dockerfiles/
      IMAGE_NAME: my-image
      TAG: "1.0"
```

## Release Note

Pipeline authors can now set `container_limits` for reusable tasks in pipelines. Any limits set in the pipeline will override the limits set within the reusable task file.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
