### PR TITLE
Use cursor-based pagination for build events

### DIFF
--- a/atc/db/build_event_source.go
+++ b/atc/db/build_event_source.go
@@ -3,6 +3,7 @@ package db
 import (
 	"encoding/json"
 	"errors"
+	"strconv"
 	"sync"
 
 	"github.com/concourse/concourse/atc"
@@ -81,10 +82,13 @@ func (source *buildEventSource) Close() error {
 	return source.notifier.Close()
 }
 
-func (source *buildEventSource) collectEvents(cursor uint) {
+func (source *buildEventSource) collectEvents(from uint) {
 	defer source.wg.Done()
 
-	var batchSize = cap(source.events)
+	batchSize := cap(source.events)
+	// cursor points to the last emitted event, so subtract 1
+	// (the first event is fetched using cursor == -1)
+	cursor := int(from) - 1
 
 	for {
 		select {
@@ -116,11 +120,11 @@ func (source *buildEventSource) collectEvents(cursor uint) {
 		}
 
 		rows, err := tx.Query(`
-			SELECT type, version, payload, event_id
+			SELECT event_id, type, version, payload
 			FROM `+source.table+`
-			WHERE build_id = $1 OR build_id_old = $1
+			WHERE (build_id = $1 OR build_id_old = $1)
+			AND event_id > $2
 			ORDER BY event_id ASC
-			OFFSET $2
 			LIMIT $3
 		`, source.buildID, cursor, batchSize)
 		if err != nil {
@@ -134,10 +138,8 @@ func (source *buildEventSource) collectEvents(cursor uint) {
 		for rows.Next() {
 			rowsReturned++
 
-			cursor++
-
-			var t, v, p, eid string
-			err := rows.Scan(&t, &v, &p, &eid)
+			var t, v, p string
+			err := rows.Scan(&cursor, &t, &v, &p)
 			if err != nil {
 				_ = rows.Close()
 
@@ -152,7 +154,7 @@ func (source *buildEventSource) collectEvents(cursor uint) {
 				Data:    &data,
 				Event:   atc.EventType(t),
 				Version: atc.EventVersion(v),
-				EventID: eid,
+				EventID: strconv.Itoa(cursor),
 			}
 
 			select {


### PR DESCRIPTION
<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | **Feature** | Documentation

...rather than LIMIT+OFFSET, which doesn't scale well with many build
events (see https://ivopereira.net/efficient-pagination-dont-use-offset-limit)

for instance, build 1139906 on CI has 600000 build events - fetching a
single batch with offset 500000 takes over 1s using LIMIT+OFFSET, while
only takes 10ms using the cursor-based approach (event_id > $2)

also, rather than incrementing the cursor for each row we scan, it feels
safer to set the cursor to the last event id - I'm not positive it'll
help, but I'm hoping it might prevent issues like #6828 - without a good
repro, though, it's hard to know

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Release Note
<!--
If needed, you can leave a list of detailed descriptions here which will be
used to generate the release note for the next version of Concourse. The title
of the PR will also be pulled into the release note.

Example:
* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.
-->

* Optimizes fetching build logs from the DB for builds with massive logs

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
