### PR TITLE
[release/7.2.x] add help text for password connector flag

### DIFF
--- a/skymarshal/skycmd/flags.go
+++ b/skymarshal/skycmd/flags.go
@@ -46,7 +46,7 @@ type AuthFlags struct {
 	SecureCookies     bool              `long:"cookie-secure" description:"Force sending secure flag on http cookies"`
 	Expiration        time.Duration     `long:"auth-duration" default:"24h" description:"Length of time for which tokens are valid. Afterwards, users will have to log back in."`
 	SigningKey        *flag.PrivateKey  `long:"session-signing-key" required:"true" description:"File containing an RSA private key, used to sign auth tokens."`
-	PasswordConnector string            `long:"password-connector" default:"local" choice:"local" choice:"ldap"`
+	PasswordConnector string            `long:"password-connector" default:"local" choice:"local" choice:"ldap" description:"Connector to use when authenticating via 'fly login -u ... -p ...'"`
 	LocalUsers        map[string]string `long:"add-local-user" description:"List of username:password combinations for all your local users. The password can be bcrypted - if so, it must have a minimum cost of 10." value-name:"USERNAME:PASSWORD"`
 	Clients           map[string]string `long:"add-client" description:"List of client_id:client_secret combinations" value-name:"CLIENT_ID:CLIENT_SECRET"`
 }


### PR DESCRIPTION
without this, the environment variable ([$CONCOURSE_PASSWORD_CONNECTOR])
doesn't appear in the help text

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>
Co-authored-by: Esteban Foronda <eforonda@vmware.com>

<!--
Hi there! Thanks for submitting a pull request to Concourse!

The title of your pull request will be used to generate the release notes.
Please provide a brief sentence that describes the PR, using the [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Examples: "Add feature to doohickey", "Fix panic during spline reticulation"

We will edit the title if needed so don't worry about getting it perfect!

To help us review your PR, please fill in the following information.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?
<!--
Choose all that apply.
Also, mention the linked issue here.
This will magically close the issue once the PR is merged.
-->
Bug Fix | Feature | Documentation

closes # .

## Changes proposed by this PR:
<!--
Tell the reviewer What changed, Why, and How were you able to accomplish that?
-->

## Notes to reviewer:
<!--
Leave a message to whoever is going to review this PR.
Mainly, pointers to review the PR, and how they can test it.
-->

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
