### PR TITLE
Add trigger for deleting pipeline

### DIFF
--- a/atc/db/migration/migrations/1618347806_add_pipeline_on_delete_trigger.down.sql
+++ b/atc/db/migration/migrations/1618347806_add_pipeline_on_delete_trigger.down.sql
@@ -1,0 +1,1 @@
+DROP TRIGGER IF EXISTS deleted_pipelines_insert_trigger ON pipelines;

--- a/atc/db/migration/migrations/1618347806_add_pipeline_on_delete_trigger.up.sql
+++ b/atc/db/migration/migrations/1618347806_add_pipeline_on_delete_trigger.up.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION on_pipeline_delete() RETURNS TRIGGER AS $$
+BEGIN
+        EXECUTE format('INSERT INTO deleted_pipelines VALUES (%s)', OLD.id);
+        RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER deleted_pipelines_insert_trigger AFTER DELETE on pipelines FOR EACH ROW EXECUTE PROCEDURE on_pipeline_delete();

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -714,35 +714,14 @@ func (p *pipeline) Expose() error {
 }
 
 func (p *pipeline) Destroy() error {
-	tx, err := p.conn.Begin()
-	if err != nil {
-		return err
-	}
-
-	defer tx.Rollback()
-
-	_, err = psql.Delete("pipelines").
+	_, err := psql.Delete("pipelines").
 		Where(sq.Eq{
 			"id": p.id,
 		}).
-		RunWith(tx).
+		RunWith(p.conn).
 		Exec()
 
-	if err != nil {
-		return err
-	}
-
-	_, err = psql.Insert("deleted_pipelines").
-		Columns("id").
-		Values(p.id).
-		RunWith(tx).
-		Exec()
-
-	if err != nil {
-		return err
-	}
-
-	return tx.Commit()
+	return err
 }
 
 func (p *pipeline) LoadDebugVersionsDB() (*atc.DebugVersionsDB, error) {


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix 
closes #6821 .

## Changes proposed by this PR:
adding an on_delete trigger for pipeines table so whenever a pipeline is deleted from pipeline.Destroy() or from a delete cascade while team.Delete(), it will insert the deleted pipeline into `deleted_pipelines` table.

## Notes to reviewer:
one thing to consider also is adding another migration to clean up orphan `pipeline_build_events_*` table that left behind by previous team.Delete() 

## Release Note
Fix a bug that might leave orphan `pipeline_build_events_*` table in DB when deleting a team. Pipelines belong to the deleted team will be destroied by `DELETE CASCADE` but associated events table was not cleaned up properly.


## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

## Reviewer Checklist
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed