### PR TITLE
Optimise fake generation

### DIFF
--- a/atc/db/encryption/strategy.go
+++ b/atc/db/encryption/strategy.go
@@ -2,11 +2,12 @@ package encryption
 
 import "errors"
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 var ErrDataIsEncrypted = errors.New("failed to decrypt data that is encrypted")
 var ErrDataIsNotEncrypted = errors.New("failed to decrypt data that is not encrypted")
 
-//go:generate counterfeiter . Strategy
-
+//counterfeiter:generate . Strategy
 type Strategy interface {
 	Encrypt([]byte) (string, *string, error)
 	Decrypt(string, *string) ([]byte, error)

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -12,6 +12,8 @@ import (
 	"code.cloudfoundry.org/lager"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 const (
 	LockTypeResourceConfigChecking = iota
 	LockTypeBuildTracking
@@ -53,8 +55,7 @@ func NewJobSchedulingLockID(jobID int) LockID {
 	return LockID{LockTypeJobScheduling, jobID}
 }
 
-//go:generate counterfeiter . LockFactory
-
+//counterfeiter:generate . LockFactory
 type LockFactory interface {
 	Acquire(logger lager.Logger, ids LockID) (Lock, bool, error)
 }
@@ -126,8 +127,7 @@ func (f *lockFactory) Acquire(logger lager.Logger, id LockID) (Lock, bool, error
 	return l, true, nil
 }
 
-//go:generate counterfeiter . Lock
-
+//counterfeiter:generate . Lock
 type Lock interface {
 	Release() error
 }
@@ -138,8 +138,7 @@ type NoopLock struct{}
 // Release does nothing. Successfully.
 func (NoopLock) Release() error { return nil }
 
-//go:generate counterfeiter . LockDB
-
+//counterfeiter:generate . LockDB
 type LockDB interface {
 	Acquire(id LockID) (bool, error)
 	Release(id LockID) (bool, error)


### PR DESCRIPTION
## What does this PR accomplish?

_Bug Fix_ | Feature | Documentation

## Changes proposed by this PR:

Counterfeiter fake generation is faster for a few example packages. By using the counterfeiter directive, fakes are generated at a rate of one package per counterfeiter invocation as opposed to one fake per invocation. For packages with many faked interfaces this will drastically improve the speed of fake generation. This method of fake generation is suggested by the counterfeiter docs.

## Notes to reviewer:

I have only modified a few trivial example packages as a demonstration. If this change is desirable I am happy to open another PR to move all counterfeiter fake generation to counterfeiter directives.

A great side effect of this change is that fakes are generated with `go run ...` rather than with the counterfeiter binary directly. Since concourse already specifies counterfeiter in `tools.go`, the counterfeiter binary is no longer a development requirement.

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
