### PR TITLE
Refactor: Pick -> Approve

### DIFF
--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -39,12 +39,12 @@ type ContainerPlacementStrategy interface {
 	Name() string
 
 	// Orders the list of candidate workers based off the configured strategies. Should only remove
-	// candidate workers which will never match the strategy. Filtering should mostly be left to Pick.
+	// candidate workers which will never match the strategy. Filtering should mostly be left to Approve().
 	Order(lager.Logger, []Worker, ContainerSpec) ([]Worker, error)
 
-	// Attempts to pick the given worker to run the specified container, checking the worker abides
+	// Attempts to approve the given worker to run the specified container, checking the worker abides
 	// by the conditions of the specific strategy.
-	Pick(lager.Logger, Worker, ContainerSpec) error
+	Approve(lager.Logger, Worker, ContainerSpec) error
 
 	// Releases any resources acquired by any configured strategies as part of
 	// picking the candidate worker.
@@ -148,7 +148,7 @@ func (strategy *ChainPlacementStrategy) Order(logger lager.Logger, workers []Wor
 	return candidates, nil
 }
 
-func (strategy *ChainPlacementStrategy) Pick(logger lager.Logger, worker Worker, spec ContainerSpec) error {
+func (strategy *ChainPlacementStrategy) Approve(logger lager.Logger, worker Worker, spec ContainerSpec) error {
 	var err error
 	var i int
 
@@ -156,7 +156,7 @@ func (strategy *ChainPlacementStrategy) Pick(logger lager.Logger, worker Worker,
 	// Release on the relevant nodes when an error occurs.
 	for i = 0; i < len(strategy.nodes); i++ {
 		node := strategy.nodes[i]
-		err = node.Pick(logger, worker, spec)
+		err = node.Approve(logger, worker, spec)
 
 		if err != nil {
 			break
@@ -165,7 +165,7 @@ func (strategy *ChainPlacementStrategy) Pick(logger lager.Logger, worker Worker,
 
 	if err != nil {
 		// On error, call Release on all stages which successfully passed
-		// Pick. Decrement "i" initially to skip stage which failed Pick.
+		// Approve. Decrement "i" initially to skip stage which failed Approve.
 		for i--; i >= 0; i-- {
 			node := strategy.nodes[i]
 			node.Release(logger, worker, spec)
@@ -231,7 +231,7 @@ func (strategy *VolumeLocalityStrategy) Order(logger lager.Logger, workers []Wor
 	return candidates, nil
 }
 
-func (strategy *VolumeLocalityStrategy) Pick(logger lager.Logger, worker Worker, spec ContainerSpec) error {
+func (strategy *VolumeLocalityStrategy) Approve(logger lager.Logger, worker Worker, spec ContainerSpec) error {
 	// This strategy doesn't have any requirements on the number of volumes which must exist
 	// on a worker for the container to be scheduled on it
 	return nil
@@ -267,7 +267,7 @@ func (strategy *FewestBuildContainersStrategy) Order(logger lager.Logger, worker
 	return candidates, nil
 }
 
-func (strategy *FewestBuildContainersStrategy) Pick(logger lager.Logger, worker Worker, spec ContainerSpec) error {
+func (strategy *FewestBuildContainersStrategy) Approve(logger lager.Logger, worker Worker, spec ContainerSpec) error {
 	return nil
 }
 
@@ -313,7 +313,7 @@ func (strategy *LimitActiveTasksStrategy) Order(logger lager.Logger, workers []W
 	return candidates, nil
 }
 
-func (strategy *LimitActiveTasksStrategy) Pick(logger lager.Logger, worker Worker, spec ContainerSpec) error {
+func (strategy *LimitActiveTasksStrategy) Approve(logger lager.Logger, worker Worker, spec ContainerSpec) error {
 	if spec.Type != db.ContainerTypeTask {
 		return nil
 	}
@@ -363,7 +363,7 @@ func (strategy *LimitActiveContainersStrategy) Order(logger lager.Logger, worker
 	return workers, nil
 }
 
-func (strategy *LimitActiveContainersStrategy) Pick(logger lager.Logger, worker Worker, spec ContainerSpec) error {
+func (strategy *LimitActiveContainersStrategy) Approve(logger lager.Logger, worker Worker, spec ContainerSpec) error {
 	if strategy.maxContainers > 0 && worker.ActiveContainers() > strategy.maxContainers {
 		return ErrTooManyContainers
 	}
@@ -390,7 +390,7 @@ func (strategy *LimitActiveVolumesStrategy) Order(logger lager.Logger, workers [
 	return workers, nil
 }
 
-func (strategy *LimitActiveVolumesStrategy) Pick(logger lager.Logger, worker Worker, spec ContainerSpec) error {
+func (strategy *LimitActiveVolumesStrategy) Approve(logger lager.Logger, worker Worker, spec ContainerSpec) error {
 	if strategy.maxVolumes > 0 && worker.ActiveVolumes() > strategy.maxVolumes {
 		return ErrTooManyVolumes
 	}

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -83,7 +83,7 @@ var _ = Describe("ContainerPlacementStrategy", func() {
 		pickedWorker = nil
 
 		for _, worker := range orderedWorkers {
-			pickErr = strategy.Pick(logger, worker, containerSpec)
+			pickErr = strategy.Approve(logger, worker, containerSpec)
 
 			if pickErr == nil {
 				pickedWorker = worker
@@ -404,7 +404,7 @@ var _ = Describe("ContainerPlacementStrategy", func() {
 				})
 			})
 
-			Describe("strategy.Pick and strategy.Release", func() {
+			Describe("strategy.Approve and strategy.Release", func() {
 				JustBeforeEach(func() {
 					pickAndRelease()
 				})
@@ -517,7 +517,7 @@ var _ = Describe("ContainerPlacementStrategy", func() {
 			})
 		})
 
-		Describe("strategy.Pick and strategy.Release", func() {
+		Describe("strategy.Approve and strategy.Release", func() {
 			JustBeforeEach(func() {
 				pickAndRelease()
 			})
@@ -629,7 +629,7 @@ var _ = Describe("ContainerPlacementStrategy", func() {
 			})
 		})
 
-		Describe("strategy.Pick and strategy.Release", func() {
+		Describe("strategy.Approve and strategy.Release", func() {
 			JustBeforeEach(func() {
 				pickAndRelease()
 			})
@@ -768,7 +768,7 @@ var _ = Describe("ContainerPlacementStrategy", func() {
 			})
 		})
 
-		Describe("strategy.Pick and strategy.Release", func() {
+		Describe("strategy.Approve and strategy.Release", func() {
 			Context("limit-active-containers,limit-active-tasks", func() {
 				JustBeforeEach(func() {
 					strategy, strategyErr = NewChainPlacementStrategy(ContainerPlacementStrategyOptions{
@@ -785,7 +785,7 @@ var _ = Describe("ContainerPlacementStrategy", func() {
 					pickAndRelease()
 				})
 
-				It("calls .Pick and .Release on chained strategies", func() {
+				It("calls .Approve and .Release on chained strategies", func() {
 					// From "limit-active-containers" strategy
 					Expect(workerFakes[0].ActiveContainersCallCount()).To(Equal(1))
 
@@ -796,11 +796,11 @@ var _ = Describe("ContainerPlacementStrategy", func() {
 
 				Context("when first strategy rejects worker", func() {
 					BeforeEach(func() {
-						// Causes "limit-active-containers" strategy to fail in .Pick
+						// Causes "limit-active-containers" strategy to fail in .Approve
 						workerFakes[0].ActiveContainersReturns(2)
 					})
 
-					It("exits early and doesn't call .Pick on later strategies", func() {
+					It("exits early and doesn't call .Approve on later strategies", func() {
 						// From "limit-active-containers" strategy
 						Expect(workerFakes[0].ActiveContainersCallCount()).To(Equal(1))
 

--- a/atc/worker/pool.go
+++ b/atc/worker/pool.go
@@ -145,7 +145,7 @@ func (pool *pool) findWorkerFromStrategy(
 
 	var strategyError error
 	for _, candidate := range orderedWorkers {
-		err := strategy.Pick(logger, candidate, containerSpec)
+		err := strategy.Approve(logger, candidate, containerSpec)
 
 		if err == nil {
 			return candidate, nil

--- a/atc/worker/pool_test.go
+++ b/atc/worker/pool_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Pool", func() {
 			fakeStrategy.OrderCalls(func(_ lager.Logger, workers []Worker, _ ContainerSpec) ([]Worker, error) {
 				return append([]Worker(nil), workers...), nil
 			})
-			fakeStrategy.PickReturns(nil)
+			fakeStrategy.ApproveReturns(nil)
 
 			fmt.Fprintln(GinkgoWriter, "init-complete")
 		})
@@ -326,7 +326,7 @@ var _ = Describe("Pool", func() {
 
 					It("succeeds and returns the compatible worker with the container", func() {
 						Expect(fakeStrategy.OrderCallCount()).To(Equal(0))
-						Expect(fakeStrategy.PickCallCount()).To(Equal(0))
+						Expect(fakeStrategy.ApproveCallCount()).To(Equal(0))
 
 						Expect(selectErr).NotTo(HaveOccurred())
 						Expect(selectedWorker.Name()).To(Equal(workers[0].Name()))
@@ -342,7 +342,7 @@ var _ = Describe("Pool", func() {
 
 					It("succeeds and returns the first compatible worker with the container", func() {
 						Expect(fakeStrategy.OrderCallCount()).To(Equal(0))
-						Expect(fakeStrategy.PickCallCount()).To(Equal(0))
+						Expect(fakeStrategy.ApproveCallCount()).To(Equal(0))
 
 						Expect(selectErr).NotTo(HaveOccurred())
 						Expect(selectedWorker.Name()).To(Equal(workers[0].Name()))
@@ -360,9 +360,9 @@ var _ = Describe("Pool", func() {
 
 					It("chooses a satisfying worker", func() {
 						Expect(fakeStrategy.OrderCallCount()).To(Equal(1))
-						Expect(fakeStrategy.PickCallCount()).To(Equal(1))
+						Expect(fakeStrategy.ApproveCallCount()).To(Equal(1))
 
-						_, pickedWorker, _ := fakeStrategy.PickArgsForCall(0)
+						_, pickedWorker, _ := fakeStrategy.ApproveArgsForCall(0)
 						Expect(pickedWorker.Name()).To(Equal(workers[1].Name()))
 
 						Expect(selectErr).NotTo(HaveOccurred())
@@ -502,7 +502,7 @@ var _ = Describe("Pool", func() {
 						It("chooses first worker", func() {
 							Expect(fakeStrategy.OrderCallCount()).To(Equal(1))
 
-							_, pickedWorker, _ := fakeStrategy.PickArgsForCall(0)
+							_, pickedWorker, _ := fakeStrategy.ApproveArgsForCall(0)
 							Expect(pickedWorker.Name()).To(Equal(workers[2].Name()))
 
 							Expect(selectErr).ToNot(HaveOccurred())
@@ -512,16 +512,16 @@ var _ = Describe("Pool", func() {
 
 					Context("when picking the first worker errors", func() {
 						BeforeEach(func() {
-							fakeStrategy.PickReturnsOnCall(0, errors.New("cannot-pick-for-arbitrary-reason"))
+							fakeStrategy.ApproveReturnsOnCall(0, errors.New("cannot-pick-for-arbitrary-reason"))
 						})
 
 						It("succeeds and picks the next worker", func() {
-							Expect(fakeStrategy.PickCallCount()).To(Equal(2))
+							Expect(fakeStrategy.ApproveCallCount()).To(Equal(2))
 
-							_, pickedWorkerA, _ := fakeStrategy.PickArgsForCall(0)
+							_, pickedWorkerA, _ := fakeStrategy.ApproveArgsForCall(0)
 							Expect(pickedWorkerA.Name()).To(Equal(workers[0].Name()))
 
-							_, pickedWorkerB, _ := fakeStrategy.PickArgsForCall(1)
+							_, pickedWorkerB, _ := fakeStrategy.ApproveArgsForCall(1)
 							Expect(pickedWorkerB.Name()).To(Equal(workers[1].Name()))
 
 							Expect(selectErr).NotTo(HaveOccurred())

--- a/atc/worker/workerfakes/fake_container_placement_strategy.go
+++ b/atc/worker/workerfakes/fake_container_placement_strategy.go
@@ -9,6 +9,19 @@ import (
 )
 
 type FakeContainerPlacementStrategy struct {
+	ApproveStub        func(lager.Logger, worker.Worker, worker.ContainerSpec) error
+	approveMutex       sync.RWMutex
+	approveArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 worker.Worker
+		arg3 worker.ContainerSpec
+	}
+	approveReturns struct {
+		result1 error
+	}
+	approveReturnsOnCall map[int]struct {
+		result1 error
+	}
 	NameStub        func() string
 	nameMutex       sync.RWMutex
 	nameArgsForCall []struct {
@@ -34,19 +47,6 @@ type FakeContainerPlacementStrategy struct {
 		result1 []worker.Worker
 		result2 error
 	}
-	PickStub        func(lager.Logger, worker.Worker, worker.ContainerSpec) error
-	pickMutex       sync.RWMutex
-	pickArgsForCall []struct {
-		arg1 lager.Logger
-		arg2 worker.Worker
-		arg3 worker.ContainerSpec
-	}
-	pickReturns struct {
-		result1 error
-	}
-	pickReturnsOnCall map[int]struct {
-		result1 error
-	}
 	ReleaseStub        func(lager.Logger, worker.Worker, worker.ContainerSpec)
 	releaseMutex       sync.RWMutex
 	releaseArgsForCall []struct {
@@ -56,6 +56,69 @@ type FakeContainerPlacementStrategy struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeContainerPlacementStrategy) Approve(arg1 lager.Logger, arg2 worker.Worker, arg3 worker.ContainerSpec) error {
+	fake.approveMutex.Lock()
+	ret, specificReturn := fake.approveReturnsOnCall[len(fake.approveArgsForCall)]
+	fake.approveArgsForCall = append(fake.approveArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 worker.Worker
+		arg3 worker.ContainerSpec
+	}{arg1, arg2, arg3})
+	stub := fake.ApproveStub
+	fakeReturns := fake.approveReturns
+	fake.recordInvocation("Approve", []interface{}{arg1, arg2, arg3})
+	fake.approveMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeContainerPlacementStrategy) ApproveCallCount() int {
+	fake.approveMutex.RLock()
+	defer fake.approveMutex.RUnlock()
+	return len(fake.approveArgsForCall)
+}
+
+func (fake *FakeContainerPlacementStrategy) ApproveCalls(stub func(lager.Logger, worker.Worker, worker.ContainerSpec) error) {
+	fake.approveMutex.Lock()
+	defer fake.approveMutex.Unlock()
+	fake.ApproveStub = stub
+}
+
+func (fake *FakeContainerPlacementStrategy) ApproveArgsForCall(i int) (lager.Logger, worker.Worker, worker.ContainerSpec) {
+	fake.approveMutex.RLock()
+	defer fake.approveMutex.RUnlock()
+	argsForCall := fake.approveArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeContainerPlacementStrategy) ApproveReturns(result1 error) {
+	fake.approveMutex.Lock()
+	defer fake.approveMutex.Unlock()
+	fake.ApproveStub = nil
+	fake.approveReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeContainerPlacementStrategy) ApproveReturnsOnCall(i int, result1 error) {
+	fake.approveMutex.Lock()
+	defer fake.approveMutex.Unlock()
+	fake.ApproveStub = nil
+	if fake.approveReturnsOnCall == nil {
+		fake.approveReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.approveReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeContainerPlacementStrategy) Name() string {
@@ -182,69 +245,6 @@ func (fake *FakeContainerPlacementStrategy) OrderReturnsOnCall(i int, result1 []
 	}{result1, result2}
 }
 
-func (fake *FakeContainerPlacementStrategy) Pick(arg1 lager.Logger, arg2 worker.Worker, arg3 worker.ContainerSpec) error {
-	fake.pickMutex.Lock()
-	ret, specificReturn := fake.pickReturnsOnCall[len(fake.pickArgsForCall)]
-	fake.pickArgsForCall = append(fake.pickArgsForCall, struct {
-		arg1 lager.Logger
-		arg2 worker.Worker
-		arg3 worker.ContainerSpec
-	}{arg1, arg2, arg3})
-	stub := fake.PickStub
-	fakeReturns := fake.pickReturns
-	fake.recordInvocation("Pick", []interface{}{arg1, arg2, arg3})
-	fake.pickMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeContainerPlacementStrategy) PickCallCount() int {
-	fake.pickMutex.RLock()
-	defer fake.pickMutex.RUnlock()
-	return len(fake.pickArgsForCall)
-}
-
-func (fake *FakeContainerPlacementStrategy) PickCalls(stub func(lager.Logger, worker.Worker, worker.ContainerSpec) error) {
-	fake.pickMutex.Lock()
-	defer fake.pickMutex.Unlock()
-	fake.PickStub = stub
-}
-
-func (fake *FakeContainerPlacementStrategy) PickArgsForCall(i int) (lager.Logger, worker.Worker, worker.ContainerSpec) {
-	fake.pickMutex.RLock()
-	defer fake.pickMutex.RUnlock()
-	argsForCall := fake.pickArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *FakeContainerPlacementStrategy) PickReturns(result1 error) {
-	fake.pickMutex.Lock()
-	defer fake.pickMutex.Unlock()
-	fake.PickStub = nil
-	fake.pickReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeContainerPlacementStrategy) PickReturnsOnCall(i int, result1 error) {
-	fake.pickMutex.Lock()
-	defer fake.pickMutex.Unlock()
-	fake.PickStub = nil
-	if fake.pickReturnsOnCall == nil {
-		fake.pickReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.pickReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeContainerPlacementStrategy) Release(arg1 lager.Logger, arg2 worker.Worker, arg3 worker.ContainerSpec) {
 	fake.releaseMutex.Lock()
 	fake.releaseArgsForCall = append(fake.releaseArgsForCall, struct {
@@ -282,12 +282,12 @@ func (fake *FakeContainerPlacementStrategy) ReleaseArgsForCall(i int) (lager.Log
 func (fake *FakeContainerPlacementStrategy) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.approveMutex.RLock()
+	defer fake.approveMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
 	fake.orderMutex.RLock()
 	defer fake.orderMutex.RUnlock()
-	fake.pickMutex.RLock()
-	defer fake.pickMutex.RUnlock()
 	fake.releaseMutex.RLock()
 	defer fake.releaseMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | Feature | Documentation | **Refactor**

## Changes proposed by this PR:
Rename `Pick` to `Approve`.

We're not asking `strategy.Pick()` to "pick" a worker (it's only given one worker at a time), we're asking "Do all the strategies `Approve()` this worker?"

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] ~Added tests (Unit and/or Integration)~
- [ ] ~Updated [Documentation]~
- [ ] ~Added release note (Optional)~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

