### PR TITLE
Optimise fake generation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -492,13 +492,7 @@ $ go get github.com/onsi/ginkgo/ginkgo
 
 We use [Counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) to generate
 fakes for our unit tests. You may need to regenerate fakes if you add or modify an
-interface. To do so, you'll need to install `counterfeiter` as follows:
-
-```sh
-$ go get -u github.com/maxbrunsfeld/counterfeiter/v6
-```
-
-You can then generate the fakes by running
+interface. You can generate the fakes by running
 
 ```sh
 $ go generate ./...

--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -8,8 +8,9 @@ import (
 	"github.com/concourse/concourse/atc/db"
 )
 
-//go:generate counterfeiter . Access
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Access
 type Access interface {
 	HasToken() bool
 	IsAuthenticated() bool

--- a/atc/api/accessor/accessor_factory.go
+++ b/atc/api/accessor/accessor_factory.go
@@ -8,14 +8,12 @@ import (
 	"github.com/concourse/concourse/atc/db"
 )
 
-//go:generate counterfeiter . TokenVerifier
-
+//counterfeiter:generate . TokenVerifier
 type TokenVerifier interface {
 	Verify(req *http.Request) (map[string]interface{}, error)
 }
 
-//go:generate counterfeiter .  TeamFetcher
-
+//counterfeiter:generate . TeamFetcher
 type TeamFetcher interface {
 	GetTeams() ([]db.Team, error)
 }

--- a/atc/api/accessor/handler.go
+++ b/atc/api/accessor/handler.go
@@ -9,12 +9,11 @@ import (
 	"github.com/concourse/concourse/atc/auditor"
 )
 
-//go:generate counterfeiter net/http.Handler
-
-//go:generate counterfeiter . AccessFactory
+//counterfeiter:generate net/http.Handler
 
 const accessorContextKey atc.ContextKey = "accessor"
 
+//counterfeiter:generate . AccessFactory
 type AccessFactory interface {
 	Create(req *http.Request, role string) (Access, error)
 }

--- a/atc/api/accessor/teams_cacher.go
+++ b/atc/api/accessor/teams_cacher.go
@@ -9,8 +9,7 @@ import (
 	"github.com/patrickmn/go-cache"
 )
 
-//go:generate counterfeiter . Notifications
-
+//counterfeiter:generate . Notifications
 type Notifications interface {
 	Listen(string) (chan bool, error)
 	Unlisten(string, chan bool) error

--- a/atc/api/accessor/verifier.go
+++ b/atc/api/accessor/verifier.go
@@ -18,8 +18,7 @@ var (
 	ErrVerificationInvalidAudience = errors.New("token has invalid audience")
 )
 
-//go:generate counterfeiter .  AccessTokenFetcher
-
+//counterfeiter:generate . AccessTokenFetcher
 type AccessTokenFetcher interface {
 	GetAccessToken(rawToken string) (db.AccessToken, bool, error)
 }

--- a/atc/api/auth/unauthorized_rejector.go
+++ b/atc/api/auth/unauthorized_rejector.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-//go:generate counterfeiter . Rejector
+//counterfeiter:generate . Rejector
 type Rejector interface {
 	Unauthorized(http.ResponseWriter, *http.Request)
 	Forbidden(http.ResponseWriter, *http.Request)

--- a/atc/api/auth/web_auth_handler.go
+++ b/atc/api/auth/web_auth_handler.go
@@ -7,7 +7,8 @@ import (
 	"github.com/concourse/concourse/skymarshal/token"
 )
 
-//go:generate counterfeiter net/http.Handler
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+//counterfeiter:generate net/http.Handler
 
 func NewResponseWrapper(w http.ResponseWriter, m token.Middleware) *responseWrapper {
 	return &responseWrapper{w, m}

--- a/atc/api/containerserver/hijack.go
+++ b/atc/api/containerserver/hijack.go
@@ -16,6 +16,8 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 var upgrader = websocket.Upgrader{
 	HandshakeTimeout: 5 * time.Second,
 }
@@ -28,8 +30,7 @@ func (err InterceptTimeoutError) Error() string {
 	return fmt.Sprintf("idle timeout (%s) reached", err.duration)
 }
 
-//go:generate counterfeiter . InterceptTimeoutFactory
-
+//counterfeiter:generate . InterceptTimeoutFactory
 type InterceptTimeoutFactory interface {
 	NewInterceptTimeout() InterceptTimeout
 }
@@ -51,8 +52,7 @@ func (t *interceptTimeoutFactory) NewInterceptTimeout() InterceptTimeout {
 	}
 }
 
-//go:generate counterfeiter . InterceptTimeout
-
+//counterfeiter:generate . InterceptTimeout
 type InterceptTimeout interface {
 	Reset()
 	Channel() <-chan time.Time

--- a/atc/api/pipelineserver/archive_test.go
+++ b/atc/api/pipelineserver/archive_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/onsi/gomega/gstruct"
 )
 
-//go:generate counterfeiter code.cloudfoundry.org/lager.Logger
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+//counterfeiter:generate code.cloudfoundry.org/lager.Logger
 
 var _ = Describe("Archive Handler", func() {
 	var (

--- a/atc/api/policychecker/checker.go
+++ b/atc/api/policychecker/checker.go
@@ -12,8 +12,9 @@ import (
 	"github.com/concourse/concourse/atc/policy"
 )
 
-//go:generate counterfeiter . PolicyChecker
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . PolicyChecker
 type PolicyChecker interface {
 	Check(string, accessor.Access, *http.Request) (policy.PolicyCheckOutput, error)
 }

--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -8,8 +8,9 @@ import (
 	"github.com/concourse/concourse/atc"
 )
 
-//go:generate counterfeiter . Auditor
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Auditor
 func NewAuditor(
 	EnableBuildAuditLog bool,
 	EnableContainerAuditLog bool,

--- a/atc/compression/compression.go
+++ b/atc/compression/compression.go
@@ -6,8 +6,9 @@ import (
 	"github.com/concourse/baggageclaim"
 )
 
-//go:generate counterfeiter . Compression
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Compression
 type Compression interface {
 	NewReader(io.ReadCloser) (io.ReadCloser, error)
 	Encoding() baggageclaim.Encoding

--- a/atc/creds/pool.go
+++ b/atc/creds/pool.go
@@ -10,8 +10,9 @@ import (
 	"code.cloudfoundry.org/lager"
 )
 
-//go:generate counterfeiter . VarSourcePool
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . VarSourcePool
 type VarSourcePool interface {
 	FindOrCreate(lager.Logger, map[string]interface{}, ManagerFactory) (Secrets, error)
 	Size() int

--- a/atc/creds/secrets_factory.go
+++ b/atc/creds/secrets_factory.go
@@ -4,15 +4,13 @@ import (
 	"time"
 )
 
-//go:generate counterfeiter . SecretsFactory
-
+//counterfeiter:generate . SecretsFactory
 type SecretsFactory interface {
 	// NewSecrets returns an instance of a secret manager, capable of retrieving individual secrets
 	NewSecrets() Secrets
 }
 
-//go:generate counterfeiter . Secrets
-
+//counterfeiter:generate . Secrets
 type Secrets interface {
 	// Every credential manager needs to be able to return (secret, secret_expiration_time, exists, error) based on the secret path
 	Get(string) (interface{}, *time.Time, bool, error)

--- a/atc/db/access_token_factory.go
+++ b/atc/db/access_token_factory.go
@@ -7,8 +7,9 @@ import (
 	sq "github.com/Masterminds/squirrel"
 )
 
-//go:generate counterfeiter . AccessTokenFactory
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . AccessTokenFactory
 type AccessTokenFactory interface {
 	CreateAccessToken(token string, claims Claims) error
 	GetAccessToken(token string) (AccessToken, bool, error)

--- a/atc/db/access_token_lifecycle.go
+++ b/atc/db/access_token_lifecycle.go
@@ -7,8 +7,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 )
 
-//go:generate counterfeiter . AccessTokenLifecycle
-
+//counterfeiter:generate . AccessTokenLifecycle
 type AccessTokenLifecycle interface {
 	RemoveExpiredAccessTokens(leeway time.Duration) (int, error)
 }

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -113,8 +113,7 @@ var latestCompletedBuildQuery = psql.Select("max(id)").
 	From("builds").
 	Where(sq.Expr(`status NOT IN ('pending', 'started')`))
 
-//go:generate counterfeiter . Build
-
+//counterfeiter:generate . Build
 type Build interface {
 	PipelineRef
 

--- a/atc/db/build_event_source.go
+++ b/atc/db/build_event_source.go
@@ -12,8 +12,7 @@ import (
 var ErrEndOfBuildEventStream = errors.New("end of build event stream")
 var ErrBuildEventStreamClosed = errors.New("build event stream closed")
 
-//go:generate counterfeiter . EventSource
-
+//counterfeiter:generate . EventSource
 type EventSource interface {
 	Next() (event.Envelope, error)
 	Close() error

--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -10,8 +10,7 @@ import (
 	"github.com/concourse/concourse/atc/db/lock"
 )
 
-//go:generate counterfeiter . BuildFactory
-
+//counterfeiter:generate . BuildFactory
 type BuildFactory interface {
 	Build(int) (Build, bool, error)
 	VisibleBuilds([]string, Page) ([]Build, Pagination, error)

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -12,8 +12,7 @@ import (
 	"github.com/concourse/concourse/atc/db/lock"
 )
 
-//go:generate counterfeiter . Checkable
-
+//counterfeiter:generate . Checkable
 type Checkable interface {
 	PipelineRef
 
@@ -35,8 +34,7 @@ type Checkable interface {
 	CreateBuild(context.Context, bool, atc.Plan) (Build, bool, error)
 }
 
-//go:generate counterfeiter . CheckFactory
-
+//counterfeiter:generate . CheckFactory
 type CheckFactory interface {
 	TryCreateCheck(context.Context, Checkable, ResourceTypes, atc.Version, bool) (Build, bool, error)
 	Resources() ([]Resource, error)

--- a/atc/db/check_lifecycle.go
+++ b/atc/db/check_lifecycle.go
@@ -1,7 +1,6 @@
 package db
 
-//go:generate counterfeiter . CheckLifecycle
-
+//counterfeiter:generate . CheckLifecycle
 type CheckLifecycle interface {
 	DeleteCompletedChecks() error
 }

--- a/atc/db/clock.go
+++ b/atc/db/clock.go
@@ -2,8 +2,7 @@ package db
 
 import "time"
 
-//go:generate counterfeiter . Clock
-
+//counterfeiter:generate . Clock
 type Clock interface {
 	Now() time.Time
 	Until(time.Time) time.Duration

--- a/atc/db/component.go
+++ b/atc/db/component.go
@@ -11,8 +11,7 @@ import (
 var componentsQuery = psql.Select("c.id, c.name, c.interval, c.last_ran, c.paused").
 	From("components c")
 
-//go:generate counterfeiter . Component
-
+//counterfeiter:generate . Component
 type Component interface {
 	ID() int
 	Name() string

--- a/atc/db/component_factory.go
+++ b/atc/db/component_factory.go
@@ -7,8 +7,7 @@ import (
 	"github.com/concourse/concourse/atc"
 )
 
-//go:generate counterfeiter . ComponentFactory
-
+//counterfeiter:generate . ComponentFactory
 type ComponentFactory interface {
 	CreateOrUpdate(atc.Component) (Component, error)
 	Find(string) (Component, bool, error)

--- a/atc/db/container.go
+++ b/atc/db/container.go
@@ -12,8 +12,7 @@ var ErrContainerDisappeared = errors.New("container disappeared from db")
 
 type ContainerState string
 
-//go:generate counterfeiter . Container
-
+//counterfeiter:generate . Container
 type Container interface {
 	ID() int
 	State() string
@@ -22,8 +21,7 @@ type Container interface {
 	Metadata() ContainerMetadata
 }
 
-//go:generate counterfeiter . CreatingContainer
-
+//counterfeiter:generate . CreatingContainer
 type CreatingContainer interface {
 	Container
 
@@ -130,8 +128,7 @@ func (container *creatingContainer) Failed() (FailedContainer, error) {
 	), nil
 }
 
-//go:generate counterfeiter . CreatedContainer
-
+//counterfeiter:generate . CreatedContainer
 type CreatedContainer interface {
 	Container
 
@@ -238,8 +235,7 @@ func (container *createdContainer) UpdateLastHijack() error {
 	return nil
 }
 
-//go:generate counterfeiter . DestroyingContainer
-
+//counterfeiter:generate . DestroyingContainer
 type DestroyingContainer interface {
 	Container
 
@@ -301,8 +297,7 @@ func (container *destroyingContainer) Destroy() (bool, error) {
 	return true, nil
 }
 
-//go:generate counterfeiter . FailedContainer
-
+//counterfeiter:generate . FailedContainer
 type FailedContainer interface {
 	Container
 

--- a/atc/db/container_owner.go
+++ b/atc/db/container_owner.go
@@ -8,7 +8,7 @@ import (
 	"github.com/concourse/concourse/atc"
 )
 
-//go:generate counterfeiter . ContainerOwner
+//counterfeiter:generate . ContainerOwner
 
 // ContainerOwner designates the data the container should reference that
 // identifies its lifecycle. When the owner goes away, the container should

--- a/atc/db/container_repository.go
+++ b/atc/db/container_repository.go
@@ -9,8 +9,7 @@ import (
 	"github.com/lib/pq"
 )
 
-//go:generate counterfeiter . ContainerRepository
-
+//counterfeiter:generate . ContainerRepository
 type ContainerRepository interface {
 	FindOrphanedContainers() ([]CreatingContainer, []CreatedContainer, []DestroyingContainer, error)
 	DestroyFailedContainers() (int, error)

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -51,8 +51,7 @@ func (e InputVersionEmptyError) Error() string {
 	return fmt.Sprintf("input '%s' has successfully resolved but contains missing version information", e.InputName)
 }
 
-//go:generate counterfeiter . Job
-
+//counterfeiter:generate . Job
 type Job interface {
 	PipelineRef
 

--- a/atc/db/job_factory.go
+++ b/atc/db/job_factory.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lib/pq"
 )
 
-//go:generate counterfeiter . JobFactory
+//counterfeiter:generate . JobFactory
 
 // XXX: This job factory object is not really a job factory anymore. It is
 // holding the responsibility for two very different things: constructing a

--- a/atc/db/notifications_bus.go
+++ b/atc/db/notifications_bus.go
@@ -7,8 +7,7 @@ import (
 	"github.com/lib/pq"
 )
 
-//go:generate counterfeiter . Listener
-
+//counterfeiter:generate . Listener
 type Listener interface {
 	Close() error
 	Listen(channel string) error
@@ -16,8 +15,7 @@ type Listener interface {
 	NotificationChannel() <-chan *pq.Notification
 }
 
-//go:generate counterfeiter . Executor
-
+//counterfeiter:generate . Executor
 type Executor interface {
 	Exec(statement string, args ...interface{}) (sql.Result, error)
 }

--- a/atc/db/notifier.go
+++ b/atc/db/notifier.go
@@ -2,8 +2,7 @@ package db
 
 import "time"
 
-//go:generate counterfeiter . Notifier
-
+//counterfeiter:generate . Notifier
 type Notifier interface {
 	Notify() <-chan struct{}
 	Close() error

--- a/atc/db/open.go
+++ b/atc/db/open.go
@@ -18,8 +18,7 @@ import (
 	"github.com/lib/pq"
 )
 
-//go:generate counterfeiter . Conn
-
+//counterfeiter:generate . Conn
 type Conn interface {
 	Bus() NotificationsBus
 	EncryptionStrategy() encryption.Strategy
@@ -47,8 +46,7 @@ type Conn interface {
 	Name() string
 }
 
-//go:generate counterfeiter . Tx
-
+//counterfeiter:generate . Tx
 type Tx interface {
 	Commit() error
 	Exec(string, ...interface{}) (sql.Result, error)

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -28,8 +28,7 @@ func (e ErrResourceNotFound) Error() string {
 	return fmt.Sprintf("resource '%s' not found", e.Name)
 }
 
-//go:generate counterfeiter . Pipeline
-
+//counterfeiter:generate . Pipeline
 type Cause struct {
 	ResourceVersionID int `json:"resource_version_id"`
 	BuildID           int `json:"build_id"`

--- a/atc/db/pipeline_factory.go
+++ b/atc/db/pipeline_factory.go
@@ -5,8 +5,7 @@ import (
 	"github.com/concourse/concourse/atc/db/lock"
 )
 
-//go:generate counterfeiter . PipelineFactory
-
+//counterfeiter:generate . PipelineFactory
 type PipelineFactory interface {
 	VisiblePipelines([]string) ([]Pipeline, error)
 	AllPipelines() ([]Pipeline, error)

--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -8,8 +8,7 @@ import (
 	"github.com/concourse/concourse/atc/db/lock"
 )
 
-//go:generate counterfeiter . PipelineLifecycle
-
+//counterfeiter:generate . PipelineLifecycle
 type PipelineLifecycle interface {
 	ArchiveAbandonedPipelines() error
 	RemoveBuildEventsForDeletedPipelines() error

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -20,8 +20,7 @@ var ErrPinnedThroughConfig = errors.New("resource is pinned through config")
 
 const CheckBuildName = "check"
 
-//go:generate counterfeiter . Resource
-
+//counterfeiter:generate . Resource
 type Resource interface {
 	PipelineRef
 

--- a/atc/db/resource_cache.go
+++ b/atc/db/resource_cache.go
@@ -172,8 +172,7 @@ func paramsHash(p atc.Params) string {
 // See FindOrCreateForBuild, FindOrCreateForResource, and
 // FindOrCreateForResourceType for more information on when it becomes unused.
 
-//go:generate counterfeiter . UsedResourceCache
-
+//counterfeiter:generate . UsedResourceCache
 type UsedResourceCache interface {
 	ID() int
 	Version() atc.Version

--- a/atc/db/resource_cache_factory.go
+++ b/atc/db/resource_cache_factory.go
@@ -9,8 +9,7 @@ import (
 	"github.com/concourse/concourse/atc/db/lock"
 )
 
-//go:generate counterfeiter . ResourceCacheFactory
-
+//counterfeiter:generate . ResourceCacheFactory
 type ResourceCacheFactory interface {
 	FindOrCreateResourceCache(
 		resourceCacheUser ResourceCacheUser,

--- a/atc/db/resource_cache_lifecycle.go
+++ b/atc/db/resource_cache_lifecycle.go
@@ -8,8 +8,7 @@ import (
 	"github.com/lib/pq"
 )
 
-//go:generate counterfeiter . ResourceCacheLifecycle
-
+//counterfeiter:generate . ResourceCacheLifecycle
 type ResourceCacheLifecycle interface {
 	CleanUsesForFinishedBuilds(lager.Logger) error
 	CleanBuildImageResourceCaches(lager.Logger) error

--- a/atc/db/resource_config.go
+++ b/atc/db/resource_config.go
@@ -41,8 +41,7 @@ type ResourceConfigDescriptor struct {
 	Source atc.Source
 }
 
-//go:generate counterfeiter . ResourceConfig
-
+//counterfeiter:generate . ResourceConfig
 type ResourceConfig interface {
 	ID() int
 	LastReferenced() time.Time

--- a/atc/db/resource_config_check_session_lifecycle.go
+++ b/atc/db/resource_config_check_session_lifecycle.go
@@ -4,8 +4,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 )
 
-//go:generate counterfeiter . ResourceConfigCheckSessionLifecycle
-
+//counterfeiter:generate . ResourceConfigCheckSessionLifecycle
 type ResourceConfigCheckSessionLifecycle interface {
 	CleanInactiveResourceConfigCheckSessions() error
 	CleanExpiredResourceConfigCheckSessions() error

--- a/atc/db/resource_config_factory.go
+++ b/atc/db/resource_config_factory.go
@@ -20,8 +20,7 @@ func (e ErrCustomResourceTypeVersionNotFound) Error() string {
 	return fmt.Sprintf("custom resource type '%s' version not found", e.Name)
 }
 
-//go:generate counterfeiter . ResourceConfigFactory
-
+//counterfeiter:generate . ResourceConfigFactory
 type ResourceConfigFactory interface {
 	FindOrCreateResourceConfig(
 		resourceType string,

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -11,7 +11,7 @@ import (
 	"github.com/concourse/concourse/atc/db/lock"
 )
 
-//go:generate counterfeiter . ResourceConfigScope
+//counterfeiter:generate . ResourceConfigScope
 
 // ResourceConfigScope represents the relationship between a possible pipeline resource and a resource config.
 // When a resource is specified to have a unique version history either through its base resource type or its custom

--- a/atc/db/resource_config_version.go
+++ b/atc/db/resource_config_version.go
@@ -9,8 +9,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 )
 
-//go:generate counterfeiter . ResourceConfigVersion
-
+//counterfeiter:generate . ResourceConfigVersion
 type ResourceConfigVersion interface {
 	ID() int
 	Version() Version

--- a/atc/db/resource_factory.go
+++ b/atc/db/resource_factory.go
@@ -7,8 +7,7 @@ import (
 	"github.com/concourse/concourse/atc/db/lock"
 )
 
-//go:generate counterfeiter . ResourceFactory
-
+//counterfeiter:generate . ResourceFactory
 type ResourceFactory interface {
 	Resource(int) (Resource, bool, error)
 	VisibleResources([]string) ([]Resource, error)

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -22,8 +22,7 @@ func (e ResourceTypeNotFoundError) Error() string {
 	return fmt.Sprintf("resource type not found: %d", e.ID)
 }
 
-//go:generate counterfeiter . ResourceType
-
+//counterfeiter:generate . ResourceType
 type ResourceType interface {
 	PipelineRef
 

--- a/atc/db/resource_type_test.go
+++ b/atc/db/resource_type_test.go
@@ -341,7 +341,7 @@ var _ = Describe("ResourceType", func() {
 
 			Context("when base resource type defaults is defined", func() {
 				BeforeEach(func() {
-					atc.LoadBaseResourceTypeDefaults(map[string]atc.Source{"s3": atc.Source{"default-s3-key": "some-value"}})
+					atc.LoadBaseResourceTypeDefaults(map[string]atc.Source{"s3": {"default-s3-key": "some-value"}})
 				})
 				AfterEach(func() {
 					atc.LoadBaseResourceTypeDefaults(map[string]atc.Source{})

--- a/atc/db/task_cache_factory.go
+++ b/atc/db/task_cache_factory.go
@@ -1,7 +1,6 @@
 package db
 
-//go:generate counterfeiter . TaskCacheFactory
-
+//counterfeiter:generate . TaskCacheFactory
 type TaskCacheFactory interface {
 	Find(jobID int, stepName string, path string) (UsedTaskCache, bool, error)
 	FindOrCreate(jobID int, stepName string, path string) (UsedTaskCache, error)

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -29,8 +29,7 @@ func (e ErrPipelineNotFound) Error() string {
 	return fmt.Sprintf("pipeline '%s' not found", e.Name)
 }
 
-//go:generate counterfeiter . Team
-
+//counterfeiter:generate . Team
 type Team interface {
 	ID() int
 	Name() string

--- a/atc/db/team_factory.go
+++ b/atc/db/team_factory.go
@@ -11,8 +11,7 @@ import (
 	"github.com/concourse/concourse/atc/db/lock"
 )
 
-//go:generate counterfeiter . TeamFactory
-
+//counterfeiter:generate . TeamFactory
 type TeamFactory interface {
 	CreateTeam(atc.Team) (Team, error)
 	FindTeam(string) (Team, bool, error)

--- a/atc/db/user.go
+++ b/atc/db/user.go
@@ -12,8 +12,7 @@ type user struct {
 	lastLogin time.Time
 }
 
-//go:generate counterfeiter . User
-
+//counterfeiter:generate . User
 type User interface {
 	ID() int
 	Sub() string

--- a/atc/db/user_factory.go
+++ b/atc/db/user_factory.go
@@ -6,8 +6,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 )
 
-//go:generate counterfeiter . UserFactory
-
+//counterfeiter:generate . UserFactory
 type UserFactory interface {
 	CreateOrUpdateUser(username, connector, sub string) error
 	GetAllUsers() ([]User, error)

--- a/atc/db/volume.go
+++ b/atc/db/volume.go
@@ -56,8 +56,7 @@ const (
 	VolumeTypeUknown        VolumeType = "unknown" // for migration to life
 )
 
-//go:generate counterfeiter . CreatingVolume
-
+//counterfeiter:generate . CreatingVolume
 type CreatingVolume interface {
 	Handle() string
 	ID() int
@@ -139,7 +138,7 @@ func (volume *creatingVolume) Failed() (FailedVolume, error) {
 	}, nil
 }
 
-//go:generate counterfeiter . CreatedVolume
+//counterfeiter:generate . CreatedVolume
 // TODO-Later Consider separating CORE & Runtime concerns by breaking this abstraction up.
 type CreatedVolume interface {
 	Handle() string
@@ -614,7 +613,7 @@ func (volume *createdVolume) Destroying() (DestroyingVolume, error) {
 	}, nil
 }
 
-//go:generate counterfeiter . DestroyingVolume
+//counterfeiter:generate . DestroyingVolume
 type DestroyingVolume interface {
 	Handle() string
 	Destroy() (bool, error)

--- a/atc/db/volume_repository.go
+++ b/atc/db/volume_repository.go
@@ -9,8 +9,7 @@ import (
 	uuid "github.com/nu7hatch/gouuid"
 )
 
-//go:generate counterfeiter . VolumeRepository
-
+//counterfeiter:generate . VolumeRepository
 type VolumeRepository interface {
 	GetTeamVolumes(teamID int) ([]CreatedVolume, error)
 

--- a/atc/db/wall.go
+++ b/atc/db/wall.go
@@ -8,8 +8,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 )
 
-//go:generate counterfeiter . Wall
-
+//counterfeiter:generate . Wall
 type Wall interface {
 	SetWall(atc.Wall) error
 	GetWall() (atc.Wall, error)
@@ -23,7 +22,7 @@ type wall struct {
 
 func NewWall(conn Conn, clock Clock) Wall {
 	return &wall{
-		conn: conn,
+		conn:  conn,
 		clock: clock,
 	}
 }

--- a/atc/db/worker.go
+++ b/atc/db/worker.go
@@ -46,8 +46,7 @@ func AllWorkerStates() []WorkerState {
 	}
 }
 
-//go:generate counterfeiter . Worker
-
+//counterfeiter:generate . Worker
 type Worker interface {
 	Name() string
 	Version() *string

--- a/atc/db/worker_artifact.go
+++ b/atc/db/worker_artifact.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lib/pq"
 )
 
-//go:generate counterfeiter . WorkerArtifact
+//counterfeiter:generate . WorkerArtifact
 
 // TODO-L Can this be consolidated with atc/runtime/types.go -> Artifact OR Alternatively, there shouldn't be a volume reference here
 type WorkerArtifact interface {

--- a/atc/db/worker_artifact_lifecycle.go
+++ b/atc/db/worker_artifact_lifecycle.go
@@ -4,8 +4,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 )
 
-//go:generate counterfeiter . WorkerArtifactLifecycle
-
+//counterfeiter:generate . WorkerArtifactLifecycle
 type WorkerArtifactLifecycle interface {
 	RemoveExpiredArtifacts() error
 }

--- a/atc/db/worker_base_resource_type_factory.go
+++ b/atc/db/worker_base_resource_type_factory.go
@@ -1,7 +1,6 @@
 package db
 
-//go:generate counterfeiter . WorkerBaseResourceTypeFactory
-
+//counterfeiter:generate . WorkerBaseResourceTypeFactory
 type WorkerBaseResourceTypeFactory interface {
 	Find(name string, worker Worker) (*UsedWorkerBaseResourceType, bool, error)
 }

--- a/atc/db/worker_factory.go
+++ b/atc/db/worker_factory.go
@@ -12,8 +12,7 @@ import (
 	"github.com/lib/pq"
 )
 
-//go:generate counterfeiter . WorkerFactory
-
+//counterfeiter:generate . WorkerFactory
 type WorkerFactory interface {
 	GetWorker(name string) (Worker, bool, error)
 	SaveWorker(atcWorker atc.Worker, ttl time.Duration) (Worker, error)

--- a/atc/db/worker_lifecycle.go
+++ b/atc/db/worker_lifecycle.go
@@ -6,8 +6,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 )
 
-//go:generate counterfeiter . WorkerLifecycle
-
+//counterfeiter:generate . WorkerLifecycle
 type WorkerLifecycle interface {
 	DeleteUnresponsiveEphemeralWorkers() ([]string, error)
 	StallUnresponsiveWorkers() ([]string, error)

--- a/atc/db/worker_task_cache_factory.go
+++ b/atc/db/worker_task_cache_factory.go
@@ -1,7 +1,6 @@
 package db
 
-//go:generate counterfeiter . WorkerTaskCacheFactory
-
+//counterfeiter:generate . WorkerTaskCacheFactory
 type WorkerTaskCacheFactory interface {
 	FindOrCreate(WorkerTaskCache) (*UsedWorkerTaskCache, error)
 	Find(WorkerTaskCache) (*UsedWorkerTaskCache, bool, error)

--- a/atc/engine/builder.go
+++ b/atc/engine/builder.go
@@ -16,8 +16,7 @@ import (
 
 const supportedSchema = "exec.v2"
 
-//go:generate counterfeiter . CoreStepFactory
-
+//counterfeiter:generate . CoreStepFactory
 type CoreStepFactory interface {
 	GetStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, DelegateFactory) exec.Step
 	PutStep(atc.Plan, exec.StepMetadata, db.ContainerMetadata, DelegateFactory) exec.Step
@@ -29,8 +28,7 @@ type CoreStepFactory interface {
 	ArtifactOutputStep(atc.Plan, db.Build) exec.Step
 }
 
-//go:generate counterfeiter . StepperFactory
-
+//counterfeiter:generate . StepperFactory
 type StepperFactory interface {
 	StepperForBuild(db.Build) (exec.Stepper, error)
 }

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -16,8 +16,7 @@ import (
 	"github.com/concourse/concourse/atc/worker"
 )
 
-//go:generate counterfeiter . RateLimiter
-
+//counterfeiter:generate . RateLimiter
 type RateLimiter interface {
 	Wait(context.Context) error
 }

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -19,16 +19,16 @@ import (
 	"github.com/concourse/concourse/tracing"
 )
 
-//go:generate counterfeiter . Engine
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Engine
 type Engine interface {
 	NewBuild(db.Build) Runnable
 
 	Drain(context.Context)
 }
 
-//go:generate counterfeiter . Runnable
-
+//counterfeiter:generate . Runnable
 type Runnable interface {
 	Run(context.Context)
 }

--- a/atc/exec/build/repository.go
+++ b/atc/exec/build/repository.go
@@ -6,6 +6,8 @@ import (
 	"github.com/concourse/concourse/atc/runtime"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 // ArtifactName is just a string, with its own type to make interfaces using it
 // more self-documenting.
 type ArtifactName string
@@ -32,7 +34,7 @@ func NewRepository() *Repository {
 	}
 }
 
-//go:generate counterfeiter . RegisterableArtifact
+//counterfeiter:generate . RegisterableArtifact
 // A RegisterableArtifact is an Artifact which can be added to the registry
 type RegisterableArtifact interface {
 	runtime.Artifact

--- a/atc/exec/build_step_delegate.go
+++ b/atc/exec/build_step_delegate.go
@@ -12,14 +12,12 @@ import (
 	"github.com/concourse/concourse/tracing"
 )
 
-//go:generate counterfeiter . BuildStepDelegateFactory
-
+//counterfeiter:generate . BuildStepDelegateFactory
 type BuildStepDelegateFactory interface {
 	BuildStepDelegate(state RunState) BuildStepDelegate
 }
 
-//go:generate counterfeiter . BuildStepDelegate
-
+//counterfeiter:generate . BuildStepDelegate
 type BuildStepDelegate interface {
 	StartSpan(context.Context, string, tracing.Attrs) (context.Context, trace.Span)
 
@@ -37,14 +35,12 @@ type BuildStepDelegate interface {
 	SelectedWorker(lager.Logger, string)
 }
 
-//go:generate counterfeiter . SetPipelineStepDelegateFactory
-
+//counterfeiter:generate . SetPipelineStepDelegateFactory
 type SetPipelineStepDelegateFactory interface {
 	SetPipelineStepDelegate(state RunState) SetPipelineStepDelegate
 }
 
-//go:generate counterfeiter . SetPipelineStepDelegate
-
+//counterfeiter:generate . SetPipelineStepDelegate
 type SetPipelineStepDelegate interface {
 	BuildStepDelegate
 	SetPipelineChanged(lager.Logger, bool)

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -32,14 +32,12 @@ type CheckStep struct {
 	defaultCheckTimeout   time.Duration
 }
 
-//go:generate counterfeiter . CheckDelegateFactory
-
+//counterfeiter:generate . CheckDelegateFactory
 type CheckDelegateFactory interface {
 	CheckDelegate(state RunState) CheckDelegate
 }
 
-//go:generate counterfeiter . CheckDelegate
-
+//counterfeiter:generate . CheckDelegate
 type CheckDelegate interface {
 	BuildStepDelegate
 

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -35,14 +35,12 @@ func (e ErrResourceNotFound) Error() string {
 	return fmt.Sprintf("resource '%s' not found", e.ResourceName)
 }
 
-//go:generate counterfeiter . GetDelegateFactory
-
+//counterfeiter:generate . GetDelegateFactory
 type GetDelegateFactory interface {
 	GetDelegate(state RunState) GetDelegate
 }
 
-//go:generate counterfeiter . GetDelegate
-
+//counterfeiter:generate . GetDelegate
 type GetDelegate interface {
 	StartSpan(context.Context, string, tracing.Attrs) (context.Context, trace.Span)
 

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -17,14 +17,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-//go:generate counterfeiter . PutDelegateFactory
-
+//counterfeiter:generate . PutDelegateFactory
 type PutDelegateFactory interface {
 	PutDelegate(state RunState) PutDelegate
 }
 
-//go:generate counterfeiter . PutDelegate
-
+//counterfeiter:generate . PutDelegate
 type PutDelegate interface {
 	StartSpan(context.Context, string, tracing.Attrs) (context.Context, trace.Span)
 

--- a/atc/exec/step.go
+++ b/atc/exec/step.go
@@ -9,7 +9,9 @@ import (
 	"github.com/concourse/concourse/vars"
 )
 
-//go:generate counterfeiter . Step
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate . Step
 
 // A Step is an object that can be executed, whose result (e.g. Success) can be
 // collected, and whose dependent resources (e.g. Containers, Volumes) can be
@@ -29,12 +31,10 @@ type Step interface {
 	Run(context.Context, RunState) (bool, error)
 }
 
-//go:generate counterfeiter . BuildStepDelegate
-
+//counterfeiter:generate . BuildStepDelegate
 type BuildOutputFilter func(text string) string
 
-//go:generate counterfeiter . RunState
-
+//counterfeiter:generate . RunState
 type RunState interface {
 	vars.Variables
 

--- a/atc/exec/task_config_source.go
+++ b/atc/exec/task_config_source.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-//go:generate counterfeiter . TaskConfigSource
+//counterfeiter:generate . TaskConfigSource
 
 // TaskConfigSource is used to determine a Task step's TaskConfig.
 type TaskConfigSource interface {

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -51,14 +51,12 @@ func (err TaskImageSourceParametersError) Error() string {
 	return fmt.Sprintf("failed to evaluate image resource parameters: %s", err.Err)
 }
 
-//go:generate counterfeiter . TaskDelegateFactory
-
+//counterfeiter:generate . TaskDelegateFactory
 type TaskDelegateFactory interface {
 	TaskDelegate(state RunState) TaskDelegate
 }
 
-//go:generate counterfeiter . TaskDelegate
-
+//counterfeiter:generate . TaskDelegate
 type TaskDelegate interface {
 	StartSpan(context.Context, string, tracing.Attrs) (context.Context, trace.Span)
 

--- a/atc/gc/destroyer.go
+++ b/atc/gc/destroyer.go
@@ -8,7 +8,9 @@ import (
 	"github.com/concourse/concourse/atc/metric"
 )
 
-//go:generate counterfeiter . Destroyer
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate . Destroyer
 
 // TODO : consider making this just a struct with methods on it,
 // we don't ever use the FakeDestroyer, so we don't even need the

--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -11,6 +11,8 @@ import (
 	flags "github.com/jessevdk/go-flags"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 type Event struct {
 	Name       string
 	Value      float64
@@ -19,12 +21,12 @@ type Event struct {
 	Time       time.Time
 }
 
-//go:generate counterfeiter . Emitter
+//counterfeiter:generate . Emitter
 type Emitter interface {
 	Emit(lager.Logger, Event)
 }
 
-//go:generate counterfeiter . EmitterFactory
+//counterfeiter:generate . EmitterFactory
 type EmitterFactory interface {
 	Description() string
 	IsConfigured() bool

--- a/atc/metric/emitter/influxdb_client.go
+++ b/atc/metric/emitter/influxdb_client.go
@@ -11,7 +11,7 @@ import (
 // counterfeiter is not able to resolve github.com/influxdata/influxdb1-client/v2/client.Client, possibly due to
 // the v2 in the package name.
 
-//go:generate counterfeiter . InfluxDBClient
+//counterfeiter:generate . InfluxDBClient
 // Client is a client interface for writing & querying the database.
 type InfluxDBClient interface {
 	// Ping checks that status of cluster, and will always return 0 time and no

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -17,6 +17,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 type PrometheusEmitter struct {
 	jobsScheduled  prometheus.Counter
 	jobsScheduling prometheus.Gauge
@@ -934,7 +936,7 @@ func DoGarbageCollection(emitter PrometheusGarbageCollectable, worker string) {
 	delete(emitter.WorkerTasksLabels(), worker)
 }
 
-//go:generate counterfeiter . PrometheusGarbageCollectable
+//counterfeiter:generate . PrometheusGarbageCollectable
 type PrometheusGarbageCollectable interface {
 	WorkerContainers() *prometheus.GaugeVec
 	WorkerVolumes() *prometheus.GaugeVec

--- a/atc/policy/checker.go
+++ b/atc/policy/checker.go
@@ -8,6 +8,8 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 const ActionUseImage = "UseImage"
 
 type PolicyCheckNotPass struct {
@@ -58,7 +60,7 @@ func PassedPolicyCheck() PolicyCheckOutput {
 	}
 }
 
-//go:generate counterfeiter . Agent
+//counterfeiter:generate . Agent
 
 // Agent should be implemented by policy agents.
 type Agent interface {
@@ -67,8 +69,7 @@ type Agent interface {
 	Check(PolicyCheckInput) (PolicyCheckOutput, error)
 }
 
-//go:generate counterfeiter . AgentFactory
-
+//counterfeiter:generate . AgentFactory
 type AgentFactory interface {
 	Description() string
 	IsConfigured() bool
@@ -95,8 +96,7 @@ var (
 	clusterVersion string
 )
 
-//go:generate counterfeiter . Checker
-
+//counterfeiter:generate . Checker
 type Checker interface {
 	ShouldCheckHttpMethod(string) bool
 	ShouldCheckAction(string) bool

--- a/atc/resource/resource.go
+++ b/atc/resource/resource.go
@@ -10,7 +10,9 @@ import (
 	"github.com/concourse/concourse/atc"
 )
 
-//go:generate counterfeiter . ResourceFactory
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate . ResourceFactory
 type ResourceFactory interface {
 	NewResource(source atc.Source, params atc.Params, version atc.Version) Resource
 }
@@ -30,8 +32,7 @@ func (rf resourceFactory) NewResource(source atc.Source, params atc.Params, vers
 	}
 }
 
-//go:generate counterfeiter . Resource
-
+//counterfeiter:generate . Resource
 type Resource interface {
 	Get(context.Context, runtime.ProcessSpec, runtime.Runner) (runtime.VersionResult, error)
 	Put(context.Context, runtime.ProcessSpec, runtime.Runner) (runtime.VersionResult, error)

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -9,12 +9,14 @@ import (
 	"github.com/concourse/concourse/atc"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 const (
 	ResourceResultPropertyName = "concourse:resource-result"
 	ResourceProcessID          = "resource"
 )
 
-//go:generate counterfeiter . StartingEventDelegate
+//counterfeiter:generate . StartingEventDelegate
 type StartingEventDelegate interface {
 	Starting(lager.Logger)
 }
@@ -34,7 +36,7 @@ type GetRequest struct {
 	Params atc.Params `json:"params,omitempty"`
 }
 
-//go:generate counterfeiter . Artifact
+//counterfeiter:generate . Artifact
 type Artifact interface {
 	ID() string
 }
@@ -68,7 +70,7 @@ func (art TaskArtifact) ID() string {
 }
 
 // TODO (runtime/#4910): consider a different name as this is close to "Runnable" in atc/engine/engine
-//go:generate counterfeiter . Runner
+//counterfeiter:generate . Runner
 type Runner interface {
 	RunScript(
 		ctx context.Context,

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -10,8 +10,7 @@ import (
 	"github.com/concourse/concourse/atc/metric"
 )
 
-//go:generate counterfeiter . BuildStarter
-
+//counterfeiter:generate . BuildStarter
 type BuildStarter interface {
 	TryStartPendingBuildsForJob(
 		logger lager.Logger,
@@ -20,8 +19,7 @@ type BuildStarter interface {
 	) (bool, error)
 }
 
-//go:generate counterfeiter . BuildPlanner
-
+//counterfeiter:generate . BuildPlanner
 type BuildPlanner interface {
 	Create(atc.StepConfig, db.SchedulerResources, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)
 }

--- a/atc/scheduler/runner.go
+++ b/atc/scheduler/runner.go
@@ -14,8 +14,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-//go:generate counterfeiter . BuildScheduler
-
+//counterfeiter:generate . BuildScheduler
 type BuildScheduler interface {
 	Schedule(
 		ctx context.Context,

--- a/atc/scheduler/scheduler.go
+++ b/atc/scheduler/scheduler.go
@@ -10,8 +10,9 @@ import (
 	"github.com/concourse/concourse/tracing"
 )
 
-//go:generate counterfeiter . Algorithm
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Algorithm
 type Algorithm interface {
 	Compute(
 		context.Context,

--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -11,8 +11,9 @@ import (
 	"github.com/concourse/concourse/atc/event"
 )
 
-//go:generate counterfeiter . Drainer
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Drainer
 type Drainer interface {
 	Run(context.Context) error
 }

--- a/atc/user.go
+++ b/atc/user.go
@@ -1,5 +1,7 @@
 package atc
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 type User struct {
 	ID        int    `json:"id,omitempty"`
 	Username  string `json:"username,omitempty"`
@@ -21,8 +23,7 @@ type UserInfo struct {
 	DisplayUserId string              `json:"display_user_id"`
 }
 
-//go:generate counterfeiter . DisplayUserIdGenerator
-
+//counterfeiter:generate . DisplayUserIdGenerator
 type DisplayUserIdGenerator interface {
 	DisplayUserId(connector, userid, username, preferredUsername, email string) string
 }

--- a/atc/worker/artifact_destination.go
+++ b/atc/worker/artifact_destination.go
@@ -7,7 +7,7 @@ import (
 	"github.com/concourse/baggageclaim"
 )
 
-//go:generate counterfeiter . ArtifactDestination
+//counterfeiter:generate . ArtifactDestination
 
 // Destination is the inverse of Source. This interface allows
 // the receiving end to determine the location of the data, e.g. based on a

--- a/atc/worker/artifact_source.go
+++ b/atc/worker/artifact_source.go
@@ -17,8 +17,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-//go:generate counterfeiter . ArtifactSourcer
-
+//counterfeiter:generate . ArtifactSourcer
 type ArtifactSourcer interface {
 	SourceInputsAndCaches(logger lager.Logger, teamID int, inputMap map[string]runtime.Artifact) ([]InputSource, error)
 	SourceImage(logger lager.Logger, imageArtifact runtime.Artifact) (StreamableArtifactSource, error)
@@ -82,8 +81,7 @@ func (w artifactSourcer) SourceImage(logger lager.Logger, imageArtifact runtime.
 	return NewStreamableArtifactSource(imageArtifact, artifactVolume, w.compression, w.enableP2PStreaming, w.p2pStreamingTimeout), nil
 }
 
-//go:generate counterfeiter . ArtifactSource
-
+//counterfeiter:generate . ArtifactSource
 type ArtifactSource interface {
 	// ExistsOn attempts to locate a volume equivalent to this source on the
 	// given worker. If a volume can be found, it will be used directly. If not,
@@ -91,7 +89,7 @@ type ArtifactSource interface {
 	ExistsOn(lager.Logger, Worker) (Volume, bool, error)
 }
 
-//go:generate counterfeiter . StreamableArtifactSource
+//counterfeiter:generate . StreamableArtifactSource
 
 // Source represents data produced by the steps, that can be transferred to
 // other steps.

--- a/atc/worker/artifact_streamer.go
+++ b/atc/worker/artifact_streamer.go
@@ -10,8 +10,7 @@ import (
 	"github.com/concourse/concourse/atc/runtime"
 )
 
-//go:generate counterfeiter . ArtifactStreamer
-
+//counterfeiter:generate . ArtifactStreamer
 type ArtifactStreamer interface {
 	StreamFileFromArtifact(context.Context, runtime.Artifact, string) (io.ReadCloser, error)
 }

--- a/atc/worker/client.go
+++ b/atc/worker/client.go
@@ -19,8 +19,7 @@ import (
 const taskProcessID = "task"
 const taskExitStatusPropertyName = "concourse:exit-status"
 
-//go:generate counterfeiter . Client
-
+//counterfeiter:generate . Client
 type Client interface {
 	Name() string
 

--- a/atc/worker/container.go
+++ b/atc/worker/container.go
@@ -17,8 +17,7 @@ import (
 
 var ErrMissingVolume = errors.New("volume mounted to container is missing")
 
-//go:generate counterfeiter . Container
-
+//counterfeiter:generate . Container
 type Container interface {
 	gclient.Container
 	runtime.Runner

--- a/atc/worker/container_spec.go
+++ b/atc/worker/container_spec.go
@@ -84,15 +84,13 @@ func (cs *ContainerSpec) Keys() []string {
 	return keys
 }
 
-//go:generate counterfeiter . InputSource
-
+//counterfeiter:generate . InputSource
 type InputSource interface {
 	Source() ArtifactSource
 	DestinationPath() string
 }
 
-//go:generate counterfeiter . BindMountSource
-
+//counterfeiter:generate . BindMountSource
 type BindMountSource interface {
 	VolumeOn(Worker) (garden.BindMount, bool, error)
 }

--- a/atc/worker/db_worker_provider.go
+++ b/atc/worker/db_worker_provider.go
@@ -15,8 +15,7 @@ import (
 	"github.com/cppforlife/go-semi-semantic/version"
 )
 
-//go:generate counterfeiter . WorkerProvider
-
+//counterfeiter:generate . WorkerProvider
 type WorkerProvider interface {
 	RunningWorkers(lager.Logger) ([]Worker, error)
 

--- a/atc/worker/fetch_source.go
+++ b/atc/worker/fetch_source.go
@@ -13,15 +13,13 @@ import (
 	"github.com/concourse/concourse/atc/runtime"
 )
 
-//go:generate counterfeiter . FetchSource
-
+//counterfeiter:generate . FetchSource
 type FetchSource interface {
 	Find() (GetResult, Volume, bool, error)
 	Create(context.Context) (GetResult, Volume, error)
 }
 
-//go:generate counterfeiter . FetchSourceFactory
-
+//counterfeiter:generate . FetchSourceFactory
 type FetchSourceFactory interface {
 	NewFetchSource(
 		logger lager.Logger,

--- a/atc/worker/fetcher.go
+++ b/atc/worker/fetcher.go
@@ -17,8 +17,7 @@ const GetResourceLockInterval = 5 * time.Second
 
 var ErrFailedToGetLock = errors.New("failed to get lock")
 
-//go:generate counterfeiter . Fetcher
-
+//counterfeiter:generate . Fetcher
 type Fetcher interface {
 	Fetch(
 		ctx context.Context,

--- a/atc/worker/gclient/client.go
+++ b/atc/worker/gclient/client.go
@@ -5,7 +5,9 @@ import (
 	"github.com/concourse/concourse/atc/worker/gclient/connection"
 )
 
-//go:generate counterfeiter . Client
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate . Client
 type Client interface {
 	// Pings the garden server. Checks connectivity to the server. The server may, optionally, respond with specific
 	// errors indicating health issues.

--- a/atc/worker/gclient/connection/connection.go
+++ b/atc/worker/gclient/connection/connection.go
@@ -20,10 +20,12 @@ import (
 	"github.com/tedsuo/rata"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 var ErrDisconnected = errors.New("disconnected")
 var ErrInvalidMessage = errors.New("invalid message payload")
 
-//go:generate counterfeiter . Connection
+//counterfeiter:generate . Connection
 type Connection interface {
 	Ping() error
 
@@ -71,7 +73,7 @@ type Connection interface {
 	RemoveProperty(handle string, name string) error
 }
 
-//go:generate counterfeiter . HijackStreamer
+//counterfeiter:generate . HijackStreamer
 type HijackStreamer interface {
 	Stream(handler string, body io.Reader, params rata.Params, query url.Values, contentType string) (io.ReadCloser, error)
 	Hijack(ctx context.Context, handler string, body io.Reader, params rata.Params, query url.Values, contentType string) (net.Conn, *bufio.Reader, error)

--- a/atc/worker/gclient/container.go
+++ b/atc/worker/gclient/container.go
@@ -9,7 +9,7 @@ import (
 	"github.com/concourse/concourse/atc/worker/gclient/connection"
 )
 
-//go:generate counterfeiter . Container
+//counterfeiter:generate . Container
 type Container interface {
 	Handle() string
 

--- a/atc/worker/image_factory.go
+++ b/atc/worker/image_factory.go
@@ -9,8 +9,7 @@ import (
 	"github.com/concourse/concourse/atc/db"
 )
 
-//go:generate counterfeiter . ImageFactory
-
+//counterfeiter:generate . ImageFactory
 type ImageFactory interface {
 	GetImage(
 		logger lager.Logger,
@@ -28,8 +27,7 @@ type FetchedImage struct {
 	Privileged bool
 }
 
-//go:generate counterfeiter . Image
-
+//counterfeiter:generate . Image
 type Image interface {
 	FetchForContainer(
 		ctx context.Context,

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-//go:generate counterfeiter . ContainerPlacementStrategy
+//counterfeiter:generate . ContainerPlacementStrategy
 
 var _ = Describe("ContainerPlacementStrategy", func() {
 	var (

--- a/atc/worker/pool.go
+++ b/atc/worker/pool.go
@@ -18,8 +18,6 @@ import (
 
 const WorkerPollingInterval = 5 * time.Second
 
-//go:generate counterfeiter . Pool
-
 type NoCompatibleWorkersError struct {
 	Spec WorkerSpec
 }
@@ -28,6 +26,7 @@ func (err NoCompatibleWorkersError) Error() string {
 	return fmt.Sprintf("no workers satisfying: %s", err.Spec.Description())
 }
 
+//counterfeiter:generate . Pool
 type Pool interface {
 	FindContainer(lager.Logger, int, string) (Container, bool, error)
 	VolumeFinder
@@ -50,14 +49,12 @@ type Pool interface {
 	)
 }
 
-//go:generate counterfeiter . PoolCallbacks
-
+//counterfeiter:generate . PoolCallbacks
 type PoolCallbacks interface {
 	WaitingForWorker(lager.Logger)
 }
 
-//go:generate counterfeiter . VolumeFinder
-
+//counterfeiter:generate . VolumeFinder
 type VolumeFinder interface {
 	FindVolume(lager.Logger, int, string) (Volume, bool, error)
 }

--- a/atc/worker/transport/hijack_streamer.go
+++ b/atc/worker/transport/hijack_streamer.go
@@ -18,18 +18,18 @@ import (
 	"github.com/tedsuo/rata"
 )
 
-//go:generate counterfeiter . TransportDB
+//counterfeiter:generate . TransportDB
 type TransportDB interface {
 	GetWorker(name string) (db.Worker, bool, error)
 }
 
-//go:generate counterfeiter . ReadCloser
+//counterfeiter:generate . ReadCloser
 type ReadCloser interface {
 	Read(p []byte) (n int, err error)
 	Close() error
 }
 
-//go:generate counterfeiter . RequestGenerator
+//counterfeiter:generate . RequestGenerator
 type RequestGenerator interface {
 	CreateRequest(name string, params rata.Params, body io.Reader) (*http.Request, error)
 }

--- a/atc/worker/transport/round_tripper.go
+++ b/atc/worker/transport/round_tripper.go
@@ -2,8 +2,9 @@ package transport
 
 import "net/http"
 
-//go:generate counterfeiter . RoundTripper
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . RoundTripper
 type RoundTripper interface {
 	RoundTrip(*http.Request) (*http.Response, error)
 }

--- a/atc/worker/volume.go
+++ b/atc/worker/volume.go
@@ -2,16 +2,16 @@ package worker
 
 import (
 	"context"
-	"github.com/concourse/concourse/tracing"
 	"io"
+
+	"github.com/concourse/concourse/tracing"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/baggageclaim"
 	"github.com/concourse/concourse/atc/db"
 )
 
-//go:generate counterfeiter . Volume
-
+//counterfeiter:generate . Volume
 type Volume interface {
 	Handle() string
 	Path() string

--- a/atc/worker/volume_client.go
+++ b/atc/worker/volume_client.go
@@ -15,8 +15,7 @@ import (
 
 const creatingVolumeRetryDelay = 1 * time.Second
 
-//go:generate counterfeiter . VolumeClient
-
+//counterfeiter:generate . VolumeClient
 type VolumeClient interface {
 	FindOrCreateVolumeForContainer(
 		lager.Logger,

--- a/atc/worker/worker.go
+++ b/atc/worker/worker.go
@@ -28,12 +28,13 @@ import (
 	"github.com/concourse/concourse/tracing"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 const userPropertyName = "user"
 
 var ErrResourceConfigCheckSessionExpired = errors.New("no db container was found for owner")
 
-//go:generate counterfeiter . Worker
-
+//counterfeiter:generate . Worker
 type Worker interface {
 	BuildContainers() int
 

--- a/atc/wrappa/concurrent_request_policy.go
+++ b/atc/wrappa/concurrent_request_policy.go
@@ -36,8 +36,7 @@ func isValidAction(action string) bool {
 	return false
 }
 
-//go:generate counterfeiter . ConcurrentRequestPolicy
-
+//counterfeiter:generate . ConcurrentRequestPolicy
 type ConcurrentRequestPolicy interface {
 	HandlerPool(action string) (Pool, bool)
 }

--- a/atc/wrappa/pool.go
+++ b/atc/wrappa/pool.go
@@ -4,8 +4,7 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-//go:generate counterfeiter . Pool
-
+//counterfeiter:generate . Pool
 type Pool interface {
 	Size() int
 	TryAcquire() bool

--- a/atc/wrappa/wrappa.go
+++ b/atc/wrappa/wrappa.go
@@ -2,8 +2,9 @@ package wrappa
 
 import "github.com/tedsuo/rata"
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+//counterfeiter:generate net/http.Handler
+
 type Wrappa interface {
 	Wrap(rata.Handlers) rata.Handlers
 }
-
-//go:generate counterfeiter net/http.Handler

--- a/fly/rc/target.go
+++ b/fly/rc/target.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 var LocalVersion = conc.Version
 
 func init() {
@@ -49,8 +51,7 @@ func (e ErrVersionMismatch) Error() string {
 		ui.Embolden(e.flyVersion), ui.Embolden(e.atcVersion), os.Args[0], e.targetName)
 }
 
-//go:generate counterfeiter . Target
-
+//counterfeiter:generate . Target
 type Target interface {
 	Client() concourse.Client
 	Team() concourse.Team

--- a/go-concourse/concourse/client.go
+++ b/go-concourse/concourse/client.go
@@ -9,8 +9,9 @@ import (
 	"github.com/concourse/concourse/go-concourse/concourse/internal"
 )
 
-//go:generate counterfeiter . Client
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Client
 type Client interface {
 	URL() string
 	HTTPClient() *http.Client

--- a/go-concourse/concourse/eventstream/stream.go
+++ b/go-concourse/concourse/eventstream/stream.go
@@ -10,8 +10,9 @@ import (
 	"github.com/vito/go-sse/sse"
 )
 
-//go:generate counterfeiter . EventStream
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . EventStream
 type EventStream interface {
 	NextEvent() (atc.Event, error)
 	Close() error

--- a/go-concourse/concourse/internal/connection.go
+++ b/go-concourse/concourse/internal/connection.go
@@ -17,7 +17,9 @@ import (
 	"github.com/vito/go-sse/sse"
 )
 
-//go:generate counterfeiter . Connection
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate . Connection
 
 // Deprecated. Use HTTPAgent instead
 type Connection interface {

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -7,8 +7,7 @@ import (
 	"github.com/concourse/concourse/go-concourse/concourse/internal"
 )
 
-//go:generate counterfeiter . Team
-
+//counterfeiter:generate . Team
 type Team interface {
 	Name() string
 	ID() int

--- a/skymarshal/token/access_token.go
+++ b/skymarshal/token/access_token.go
@@ -19,20 +19,19 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-//go:generate counterfeiter . Generator
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Generator
 type Generator interface {
 	GenerateAccessToken(claims db.Claims) (string, error)
 }
 
-//go:generate counterfeiter . Parser
-
+//counterfeiter:generate . Parser
 type Parser interface {
 	ParseExpiry(raw string) (time.Time, error)
 }
 
-//go:generate counterfeiter . ClaimsParser
-
+//counterfeiter:generate . ClaimsParser
 type ClaimsParser interface {
 	ParseClaims(idToken string) (db.Claims, error)
 }

--- a/skymarshal/token/middleware.go
+++ b/skymarshal/token/middleware.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-//go:generate counterfeiter . Middleware
+//counterfeiter:generate . Middleware
 type Middleware interface {
 	SetAuthToken(http.ResponseWriter, string, time.Time) error
 	UnsetAuthToken(http.ResponseWriter)

--- a/tsa/heartbeater.go
+++ b/tsa/heartbeater.go
@@ -18,7 +18,9 @@ import (
 	"github.com/tedsuo/rata"
 )
 
-//go:generate counterfeiter . EndpointPicker
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate . EndpointPicker
 type EndpointPicker interface {
 	Pick() *rata.RequestGenerator
 }

--- a/vars/variables.go
+++ b/vars/variables.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 )
 
-//go:generate counterfeiter . Variables
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Variables
 type Variables interface {
 	Get(Reference) (interface{}, bool, error)
 	List() ([]Reference, error)

--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -18,6 +18,8 @@ import (
 	"github.com/containerd/containerd/errdefs"
 )
 
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
 var _ garden.Backend = (*GardenBackend)(nil)
 
 // GardenBackend implements a Garden backend backed by `containerd`.
@@ -35,8 +37,7 @@ type GardenBackend struct {
 	createLock     TimeoutWithByPassLock
 }
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . UserNamespace
-
+//counterfeiter:generate . UserNamespace
 type UserNamespace interface {
 	MaxValidIds() (uid, gid uint32, err error)
 }

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -12,7 +12,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 github.com/containerd/go-cni.CNI
+//counterfeiter:generate github.com/containerd/go-cni.CNI
 
 // CNINetworkConfig provides configuration for CNINetwork to override the
 // defaults.

--- a/worker/runtime/file_store.go
+++ b/worker/runtime/file_store.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . FileStore
+//counterfeiter:generate . FileStore
 
 // FileStore is responsible for managing files associated with containers.
 //

--- a/worker/runtime/iptables/iptables.go
+++ b/worker/runtime/iptables/iptables.go
@@ -4,8 +4,9 @@ import (
 	goiptables "github.com/coreos/go-iptables/iptables"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Iptables
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . Iptables
 type Iptables interface {
 	CreateChainOrFlushIfExists(table string, chain string) error
 	AppendRule(table string, chain string, rulespec ...string) error

--- a/worker/runtime/killer.go
+++ b/worker/runtime/killer.go
@@ -37,7 +37,7 @@ const (
 	KillUngracefully KillBehaviour = true
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Killer
+//counterfeiter:generate . Killer
 
 // Killer terminates tasks.
 //

--- a/worker/runtime/libcontainerd/client.go
+++ b/worker/runtime/libcontainerd/client.go
@@ -9,11 +9,13 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Client
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 github.com/containerd/containerd.Container
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 github.com/containerd/containerd.Task
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 github.com/containerd/containerd.Process
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 github.com/containerd/containerd/cio.IO
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
+
+//counterfeiter:generate . Client
+//counterfeiter:generate github.com/containerd/containerd.Container
+//counterfeiter:generate github.com/containerd/containerd.Task
+//counterfeiter:generate github.com/containerd/containerd.Process
+//counterfeiter:generate github.com/containerd/containerd/cio.IO
 
 // Client represents the minimum interface used to communicate with containerd
 // to manage containers.

--- a/worker/runtime/network.go
+++ b/worker/runtime/network.go
@@ -7,8 +7,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Network
-
+//counterfeiter:generate . Network
 type Network interface {
 	// SetupMounts prepares mounts that might be necessary for proper
 	// networking functionality.

--- a/worker/runtime/process_killer.go
+++ b/worker/runtime/process_killer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/containerd/containerd"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . ProcessKiller
+//counterfeiter:generate . ProcessKiller
 
 type ProcessKiller interface {
 

--- a/worker/runtime/rootfs_manager.go
+++ b/worker/runtime/rootfs_manager.go
@@ -11,7 +11,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . RootfsManager
+//counterfeiter:generate . RootfsManager
 
 type InvalidUidError struct {
 	UID string

--- a/worker/runtime/runtimefakes/fake_cni.go
+++ b/worker/runtime/runtimefakes/fake_cni.go
@@ -19,10 +19,10 @@ type FakeCNI struct {
 	getConfigReturnsOnCall map[int]struct {
 		result1 *cni.ConfigResult
 	}
-	LoadStub        func(...cni.CNIOpt) error
+	LoadStub        func(...cni.Opt) error
 	loadMutex       sync.RWMutex
 	loadArgsForCall []struct {
-		arg1 []cni.CNIOpt
+		arg1 []cni.Opt
 	}
 	loadReturns struct {
 		result1 error
@@ -44,7 +44,7 @@ type FakeCNI struct {
 	removeReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetupStub        func(context.Context, string, string, ...cni.NamespaceOpts) (*cni.CNIResult, error)
+	SetupStub        func(context.Context, string, string, ...cni.NamespaceOpts) (*cni.Result, error)
 	setupMutex       sync.RWMutex
 	setupArgsForCall []struct {
 		arg1 context.Context
@@ -53,11 +53,11 @@ type FakeCNI struct {
 		arg4 []cni.NamespaceOpts
 	}
 	setupReturns struct {
-		result1 *cni.CNIResult
+		result1 *cni.Result
 		result2 error
 	}
 	setupReturnsOnCall map[int]struct {
-		result1 *cni.CNIResult
+		result1 *cni.Result
 		result2 error
 	}
 	StatusStub        func() error
@@ -127,11 +127,11 @@ func (fake *FakeCNI) GetConfigReturnsOnCall(i int, result1 *cni.ConfigResult) {
 	}{result1}
 }
 
-func (fake *FakeCNI) Load(arg1 ...cni.CNIOpt) error {
+func (fake *FakeCNI) Load(arg1 ...cni.Opt) error {
 	fake.loadMutex.Lock()
 	ret, specificReturn := fake.loadReturnsOnCall[len(fake.loadArgsForCall)]
 	fake.loadArgsForCall = append(fake.loadArgsForCall, struct {
-		arg1 []cni.CNIOpt
+		arg1 []cni.Opt
 	}{arg1})
 	stub := fake.LoadStub
 	fakeReturns := fake.loadReturns
@@ -152,13 +152,13 @@ func (fake *FakeCNI) LoadCallCount() int {
 	return len(fake.loadArgsForCall)
 }
 
-func (fake *FakeCNI) LoadCalls(stub func(...cni.CNIOpt) error) {
+func (fake *FakeCNI) LoadCalls(stub func(...cni.Opt) error) {
 	fake.loadMutex.Lock()
 	defer fake.loadMutex.Unlock()
 	fake.LoadStub = stub
 }
 
-func (fake *FakeCNI) LoadArgsForCall(i int) []cni.CNIOpt {
+func (fake *FakeCNI) LoadArgsForCall(i int) []cni.Opt {
 	fake.loadMutex.RLock()
 	defer fake.loadMutex.RUnlock()
 	argsForCall := fake.loadArgsForCall[i]
@@ -252,7 +252,7 @@ func (fake *FakeCNI) RemoveReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeCNI) Setup(arg1 context.Context, arg2 string, arg3 string, arg4 ...cni.NamespaceOpts) (*cni.CNIResult, error) {
+func (fake *FakeCNI) Setup(arg1 context.Context, arg2 string, arg3 string, arg4 ...cni.NamespaceOpts) (*cni.Result, error) {
 	fake.setupMutex.Lock()
 	ret, specificReturn := fake.setupReturnsOnCall[len(fake.setupArgsForCall)]
 	fake.setupArgsForCall = append(fake.setupArgsForCall, struct {
@@ -280,7 +280,7 @@ func (fake *FakeCNI) SetupCallCount() int {
 	return len(fake.setupArgsForCall)
 }
 
-func (fake *FakeCNI) SetupCalls(stub func(context.Context, string, string, ...cni.NamespaceOpts) (*cni.CNIResult, error)) {
+func (fake *FakeCNI) SetupCalls(stub func(context.Context, string, string, ...cni.NamespaceOpts) (*cni.Result, error)) {
 	fake.setupMutex.Lock()
 	defer fake.setupMutex.Unlock()
 	fake.SetupStub = stub
@@ -293,28 +293,28 @@ func (fake *FakeCNI) SetupArgsForCall(i int) (context.Context, string, string, [
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeCNI) SetupReturns(result1 *cni.CNIResult, result2 error) {
+func (fake *FakeCNI) SetupReturns(result1 *cni.Result, result2 error) {
 	fake.setupMutex.Lock()
 	defer fake.setupMutex.Unlock()
 	fake.SetupStub = nil
 	fake.setupReturns = struct {
-		result1 *cni.CNIResult
+		result1 *cni.Result
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeCNI) SetupReturnsOnCall(i int, result1 *cni.CNIResult, result2 error) {
+func (fake *FakeCNI) SetupReturnsOnCall(i int, result1 *cni.Result, result2 error) {
 	fake.setupMutex.Lock()
 	defer fake.setupMutex.Unlock()
 	fake.SetupStub = nil
 	if fake.setupReturnsOnCall == nil {
 		fake.setupReturnsOnCall = make(map[int]struct {
-			result1 *cni.CNIResult
+			result1 *cni.Result
 			result2 error
 		})
 	}
 	fake.setupReturnsOnCall[i] = struct {
-		result1 *cni.CNIResult
+		result1 *cni.Result
 		result2 error
 	}{result1, result2}
 }

--- a/worker/tsa_client_iface.go
+++ b/worker/tsa_client_iface.go
@@ -6,8 +6,9 @@ import (
 	"github.com/concourse/concourse/tsa"
 )
 
-//go:generate counterfeiter . TSAClient
+//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
+//counterfeiter:generate . TSAClient
 type TSAClient interface {
 	Register(context.Context, tsa.RegisterOptions) error
 


### PR DESCRIPTION
## What does this PR accomplish?

_Bug Fix_ | Feature | Documentation

## Changes proposed by this PR:

Counterfeiter fake generation is faster. By using the counterfeiter directive, fakes are generated at a rate of one package per counterfeiter invocation as opposed to one fake per invocation. For packages with many faked interfaces this will drastically improve the speed of fake generation. This method of fake generation is suggested by the counterfeiter docs.

## Notes to reviewer:

As a side effect of this change, fakes are generated with `go run ...` rather than with the counterfeiter binary directly. Since concourse already specifies counterfeiter in `tools.go`, the counterfeiter binary is no longer a development requirement.

Related to https://github.com/concourse/concourse/pull/6885

## Contributor Checklist

- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [x] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist

- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
