### PR TITLE
Fix volume GC query to not include volumes with children

### DIFF
--- a/atc/db/volume_repository.go
+++ b/atc/db/volume_repository.go
@@ -467,15 +467,18 @@ func (repository *volumeRepository) FindCreatedVolume(handle string) (CreatedVol
 	return createdVolume, true, nil
 }
 
+// GetOrphanedVolumes returns all volumes that not used by Concourse artifacts such as containers and caches and has no child volume.
 func (repository *volumeRepository) GetOrphanedVolumes() ([]CreatedVolume, error) {
 	query, args, err := psql.Select(volumeColumns...).
 		From("volumes v").
 		LeftJoin("workers w ON v.worker_name = w.name").
 		LeftJoin("containers c ON v.container_id = c.id").
 		LeftJoin("volumes pv ON v.parent_id = pv.id").
+		LeftJoin("volumes cv ON cv.parent_id = v.id").
 		LeftJoin("worker_resource_caches wrc ON wrc.id = v.worker_resource_cache_id").
 		Where(
 			sq.Eq{
+				"cv.id":                          nil,
 				"v.worker_resource_cache_id":     nil,
 				"v.worker_base_resource_type_id": nil,
 				"v.container_id":                 nil,


### PR DESCRIPTION

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative

## What does this PR accomplish?

Bug Fix 

closes #1215 and #1780.

## Changes proposed by this PR:


## Notes to reviewer:
Reproduce:
1. Create a job with get and task step like below.
```
resources:
- name: booklit
  type: git
  source: {uri: "https://github.com/vito/booklit"}

jobs:
- name: unit
  plan:
  - get: booklit
  - task: test
    file: booklit/ci/test.yml
```
2. Trigger a build and hijack into the task step (for making sure container is not GCed)
3. Change the resource's source i.e.  add a `branch` (to generate a new resource_config and resource_cache)
4. Note db and web nodes will show the error msg once gc kicks in (because it's trying to destroy the old resource_cache volume but can't since it's the parent of the container volume)

## Release Note
Fix query that causes `volume cannot be destroyed as children are present` in web and `update or delete on table "volumes" violates foreign key constraint "volumes_parent_id_fkey"` in DB.



## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
