### PR TITLE
re-enable k8s dns proxy test 

### DIFF
--- a/topgun/k8s/dns_proxy_test.go
+++ b/topgun/k8s/dns_proxy_test.go
@@ -52,12 +52,13 @@ var _ = Describe("DNS Resolution", func() {
 			args = append(args, `--set-string=concourse.worker.containerd.dnsProxyEnable=`+dnsProxyEnable)
 			if dnsServer != "" {
 				args = append(args,
-					`--set=worker.env[0].name=CONCOURSE_CONTAINERD_DNS_SERVER`,
-					`--set=worker.env[0].value=`+dnsServer)
+					`--set=concourse.worker.containerd.dnsServers=['`+dnsServer+`']`,
+				)
 			}
 		case runtime == guardianRuntime:
 			args = append(args, `--set-string=concourse.worker.garden.dnsProxyEnable=`+dnsProxyEnable)
 			if dnsServer != "" {
+				// garden flags aren't explicityly defined in the chart, so add them as env vars directly
 				args = append(args,
 					`--set=worker.env[0].name=CONCOURSE_GARDEN_DNS_SERVER`,
 					`--set=worker.env[0].value=`+dnsServer)
@@ -86,39 +87,43 @@ var _ = Describe("DNS Resolution", func() {
 
 				Expect(sess.ExitCode()).To(BeZero())
 			},
+			// local proxy will pass through requests to the k8s native dns
 			Entry("Proxy Enabled, with full service name", Case{
 				enableDnsProxy:  "true",
 				addressFunction: fullAddress,
 				shouldWork:      true,
 			}),
+			// the short address is expanded into the full addresses with the help of
+			// the `search` configuration in the resolv.conf. But our implementation
+			// of the proxy server kinda just ignores this configuration. So short
+			// addresses won't ever work
 			Entry("Proxy Enabled, with short service name", Case{
 				enableDnsProxy:  "true",
 				addressFunction: shortAddress,
 				shouldWork:      false,
 			}),
+			// no dns proxy = the super powerful k8s native dns
 			Entry("Proxy Disabled, with full service name", Case{
 				enableDnsProxy:  "false",
 				addressFunction: fullAddress,
 				shouldWork:      true,
 			}),
+			// no dns proxy = the super powerful k8s native dns
 			Entry("Proxy Disabled, with short service name", Case{
 				enableDnsProxy:  "false",
 				addressFunction: shortAddress,
 				shouldWork:      true,
 			}),
+			// the public 8.8.8.8 server won't be able to resolve k8s addresses
 			Entry("Adding extra dns server, with Proxy Disabled and full address", Case{
 				enableDnsProxy:  "false",
 				dnsServer:       "8.8.8.8",
 				addressFunction: fullAddress,
 				shouldWork:      false,
 			}),
-			// Skipping this test as it frequently fails - it asserts that the
-			// lookup of an internal k8s address should fail when 8.8.8.8 is
-			// provided as the DNS server, but when we generate the
-			// /etc/resolv.conf in containers, we add both 8.8.8.8 AND the
-			// local DNS proxy as nameservers, so it seems like the DNS
-			// resolution should work.
-			XEntry("Adding extra dns server, with Proxy Enabled and full address", Case{
+			// dns requests hits the 8.8.8.8 server first, as long as it doesn't time
+			// out, it should fail to resolve and end the search chain, skipping the proxy
+			Entry("Adding extra dns server, with Proxy Enabled and full address", Case{
 				enableDnsProxy:  "true",
 				dnsServer:       "8.8.8.8",
 				addressFunction: fullAddress,

--- a/topgun/tasks/dns-proxy-task.yml
+++ b/topgun/tasks/dns-proxy-task.yml
@@ -6,7 +6,10 @@ image_resource:
   source: {mirror_self: true}
 
 run:
-  path: "wget"
+  path: "bash"
   args:
-  - "-O-"
-  - "((url))"
+  - -c
+  - |
+    cat /etc/resolv.conf
+
+    wget -O- ((url))

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -298,7 +298,7 @@ func (n cniNetwork) generateResolvConfContents() ([]byte, error) {
 		resolvConfEntries, err = ParseHostResolveConf("/etc/resolv.conf")
 	}
 
-	contents = strings.Join(resolvConfEntries, "\n")
+	contents = strings.Join(resolvConfEntries, "\n") + "\n"
 
 	return []byte(contents), err
 }

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -117,7 +117,7 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithNameServers() {
 	s.NoError(err)
 
 	_, resolvConfContents := s.store.CreateArgsForCall(1)
-	s.Equal(resolvConfContents, []byte("nameserver 6.6.7.7\nnameserver 1.2.3.4"))
+	s.Equal(resolvConfContents, []byte("nameserver 6.6.7.7\nnameserver 1.2.3.4\n"))
 }
 
 func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithoutNameServers() {
@@ -133,7 +133,7 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithoutNameServers() {
 	actualResolvContents, err := runtime.ParseHostResolveConf("/etc/resolv.conf")
 	s.NoError(err)
 
-	contents := strings.Join(actualResolvContents, "\n")
+	contents := strings.Join(actualResolvContents, "\n") + "\n"
 
 	_, resolvConfContents := s.store.CreateArgsForCall(1)
 	s.Equal(resolvConfContents, []byte(contents))

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -497,7 +497,7 @@ func (s *IntegrationSuite) TestCustomDNS() {
 	s.NoError(err)
 
 	s.Equal(exitCode, 0)
-	expectedDNSServer := "nameserver 1.1.1.1\nnameserver 1.2.3.4"
+	expectedDNSServer := "nameserver 1.1.1.1\nnameserver 1.2.3.4\n"
 	s.Equal(expectedDNSServer, buf.String())
 }
 

--- a/worker/workercmd/dns.go
+++ b/worker/workercmd/dns.go
@@ -20,6 +20,8 @@ func (config DNSConfig) Server() (*dns.Server, error) {
 	mux := dns.NewServeMux()
 	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
 		for _, server := range resolvConf.Servers {
+			// TODO: support the `search` configuration
+
 			response, _, err := client.Exchange(r, fmt.Sprintf("%s:%s", server, resolvConf.Port))
 			if err == nil {
 				response.Compress = true


### PR DESCRIPTION
## What does this PR accomplish?

revert #6878 now that we somewhat know what to look for. Broader issue tracked in #6879

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [ ] ~Added release note (Optional)~

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs