### PR TITLE
6.7.x - Add autocomplete=off to all form tags

### DIFF
--- a/skymarshal/web/templates/password.html
+++ b/skymarshal/web/templates/password.html
@@ -7,12 +7,12 @@
 {{ end }}
 
 <div class="theme-panel">
-  <form method="post" action="{{ .PostURL }}">
+  <form method="post" action="{{ .PostURL }}" autocomplete="off">
     <div class="theme-form-row">
       <div class="theme-form-label">
         <label for="userid">username</label>
       </div>
-	  <input tabindex="1" required id="login" name="login" type="text" class="theme-form-input" {{ if .Username }} value="{{ .Username }}" {{ else }} autofocus {{ end }}/>
+	  <input tabindex="1" required id="login" name="login" type="text" class="theme-form-input" autocomplete="off" {{ if .Username }} value="{{ .Username }}" {{ else }} autofocus {{ end }}/>
     </div>
     <div class="theme-form-row">
       <div class="theme-form-label">


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation


## Changes proposed by this PR:
Was already added to the password field. This commit adds it to the form
and username tags.

## Release Note

* add `autocomplete="off" to the form and username tags on the login page

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

