### PR TITLE
web/wats: replace deprecated waitFor usage

### DIFF
--- a/web/wats/helpers/web.js
+++ b/web/wats/helpers/web.js
@@ -49,7 +49,7 @@ class Web {
   }
 
   async waitForBackgroundColor(selector, backgroundColor, {timeout = 30000} = {}) {
-    await this.page.waitFor(({expectedBackground, selector}) => {
+    await this.page.waitForFunction(({expectedBackground, selector}) => {
       const elem = document.querySelector(selector);
       if (elem === null) return false;
       const background = elem.style.backgroundColor;
@@ -61,7 +61,7 @@ class Web {
   }
 
   async scrollIntoView(selector) {
-    await this.page.waitFor(selector);
+    await this.page.waitForSelector(selector);
     await this.page.evaluate(selector => {
       const elem = document.querySelector(selector);
       elem.scrollIntoView(true);
@@ -86,7 +86,7 @@ class Web {
   }
 
   async clickAndWait(clickSelector, waitSelector) {
-    await this.page.waitFor(clickSelector);
+    await this.page.waitForSelector(clickSelector);
     await this.page.click(clickSelector);
     await this.page.waitForSelector(waitSelector, {timeout: 90000});
   }

--- a/web/wats/test/build.js
+++ b/web/wats/test/build.js
@@ -31,14 +31,14 @@ test('shows abort hooks', async t => {
   await t.context.web.waitForText("say-bye-from-job");
   // await t.context.web.waitForText("looping");
 
-  await t.context.web.page.waitFor('button[aria-label="Abort Build"]');
+  await t.context.web.page.waitForSelector('button[aria-label="Abort Build"]');
   await t.context.web.page.click('button[aria-label="Abort Build"]');
 
   await t.context.web.waitForBackgroundColor('.build-header', palette.brown, {
     timeout: 60000,
   });
-  await t.context.web.page.waitFor('[data-step-name="say-bye-from-step"] [data-step-state="succeeded"]');
-  await t.context.web.page.waitFor('[data-step-name="say-bye-from-job"] [data-step-state="succeeded"]');
+  await t.context.web.page.waitForSelector('[data-step-name="say-bye-from-step"] [data-step-state="succeeded"]');
+  await t.context.web.page.waitForSelector('[data-step-name="say-bye-from-job"] [data-step-state="succeeded"]');
 
   await t.context.web.clickAndWait('[data-step-name="say-bye-from-step"] .header', '[data-step-name="say-bye-from-step"] .step-body:not(.step-collapsed)');
   t.regex(await t.context.web.text(), /bye from step/);

--- a/web/wats/test/dashboard.js
+++ b/web/wats/test/dashboard.js
@@ -41,7 +41,7 @@ test('does not show team name when user is logged in another non-main team and h
   await web.page.goto(web.route('/'));
   const myGroup = `.dashboard-team-group[data-team-name="${t.context.guestTeamName}"]`;
   const otherGroup = `.dashboard-team-group[data-team-name="${t.context.teamName}"]`;
-  await web.page.waitFor(myGroup);
+  await web.page.waitForSelector(myGroup);
   const element = await web.page.$(otherGroup);
   t.falsy(element);
 })
@@ -59,7 +59,7 @@ test('shows pipelines in their correct order', async t => {
   const group = `.dashboard-team-group[data-team-name="${t.context.teamName}"]`;
   await t.context.web.page.setViewport({width: 1200, height: 900});
   await t.context.web.scrollIntoView(group);
-  await t.context.web.page.waitFor(`${group} .card-wrapper:nth-child(${pipelineOrder.length}) .card`);
+  await t.context.web.page.waitForSelector(`${group} .card-wrapper:nth-child(${pipelineOrder.length}) .card`);
 
   const names = await t.context.web.page.$$eval(`${group} .dashboard-pipeline-name`, nameElements => {
     var names = [];
@@ -80,7 +80,7 @@ test('auto-refreshes to reflect state changes', async t => {
 
   const group = `.dashboard-team-group[data-team-name="${t.context.teamName}"]`;
   await t.context.web.scrollIntoView(group);
-  await t.context.web.page.waitFor(`${group} .card`);
+  await t.context.web.page.waitForSelector(`${group} .card`);
   const pipeline = await t.context.web.page.$(`${group} .card`);
   const text = await t.context.web.text(pipeline);
 
@@ -97,7 +97,7 @@ test('picks up cluster name from configuration', async t => {
   await t.context.web.page.goto(t.context.web.route('/'));
 
   const clusterNameSelector = `#top-bar-app > div:nth-child(1)`;
-  await t.context.web.page.waitFor(({selector}) => {
+  await t.context.web.page.waitForFunction(({selector}) => {
     return document.querySelector(selector).innerText.length > 0;
   }, {timeout: 10000}, {
     selector: clusterNameSelector,

--- a/web/wats/test/login.js
+++ b/web/wats/test/login.js
@@ -53,7 +53,7 @@ test('can fly login with browser and reuse same browser without CSRF issues', as
   let playButton = `${pipelineSelector} [style*="ic-play"]`;
   let pauseButton = `${pipelineSelector} [style*="ic-pause"]`;
   await t.context.web.scrollIntoView(group);
-  await t.context.web.page.waitFor(playButton);
+  await t.context.web.page.waitForSelector(playButton);
   await t.context.web.page.click(playButton);
   await t.context.web.page.waitForSelector(pauseButton, {timeout: 90000});
   t.pass();

--- a/web/wats/test/resource.js
+++ b/web/wats/test/resource.js
@@ -45,7 +45,7 @@ async function resetVersionsList(t) {
 
 async function unpinVersionUsingTopBar(t) {
   await goToResourcePage(t);
-  await t.context.web.page.waitFor(topBarPinIconSelector);
+  await t.context.web.page.waitForSelector(topBarPinIconSelector);
   await t.context.web.page.click(topBarPinIconSelector);
   await checkNoVersionInPinBar(t);
 }
@@ -62,9 +62,9 @@ async function goToResourcePage(t) {
 }
 
 async function checkNoVersionInPinBar(t) {
-  await t.context.web.page.waitFor(() => !document.querySelector('#pin-bar table'));
+  await t.context.web.page.waitForFunction(() => !document.querySelector('#pin-bar table'));
 }
 
 async function waitForPageLoad(t) {
-  await t.context.web.page.waitFor(pinButtonSelector);
+  await t.context.web.page.waitForSelector(pinButtonSelector);
 }

--- a/web/wats/test/smoke.js
+++ b/web/wats/test/smoke.js
@@ -32,7 +32,7 @@ test('running pipelines', async t => {
   await t.context.web.waitForText('say-hello');
 
   await t.context.web.page.goto(t.context.web.route(`/teams/${t.context.teamName}/pipelines/some-pipeline/jobs/say-hello/builds/1`));
-  await t.context.web.page.waitFor('.build-header[style*="rgb(17, 197, 96)"]'); // green
+  await t.context.web.page.waitForSelector('.build-header[style*="rgb(17, 197, 96)"]'); // green
   await t.context.web.clickAndWait('[data-step-name="hello"] .header', '[data-step-name="hello"] .step-body:not(.step-collapsed)');
   await t.context.web.waitForText('Hello, world!');
 


### PR DESCRIPTION
## Changes proposed by this PR:

Replaces deprecated `waitFor` usage in the `web/wats/` test suite.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [ ] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [ ] [Signed] all commits
- [ ] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [ ] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).
