### PR TITLE
Scan unchecked resource-types

### DIFF
--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -177,10 +177,10 @@ var _ = Describe("Scanner", func() {
 					})
 
 					It("creates a check for only the parent and not the put-only resource", func() {
-						Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(2))
+						Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(2),
+							"two checks created; one for the fakeResourceType and the second for the unrelated fakeResource")
 
-						By("first check is for the default resource")
-						_, checkable, _, _, manuallyTriggered := fakeCheckFactory.TryCreateCheckArgsForCall(1)
+						_, checkable, _, _, manuallyTriggered := fakeCheckFactory.TryCreateCheckArgsForCall(0)
 						Expect(checkable).To(Equal(fakeResourceType))
 						Expect(manuallyTriggered).To(BeFalse())
 					})

--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -168,6 +168,23 @@ var _ = Describe("Scanner", func() {
 						Expect(manuallyTriggered).To(BeFalse())
 					})
 				})
+
+				Context("when a put-only resource has a parent-type", func() {
+					BeforeEach(func() {
+						By("checkFactory.Resources should not return any put-only resources")
+						fakeResourceType.NameReturns("put-only-custom-type")
+						fakeResourceType.PipelineIDReturns(1)
+					})
+
+					It("creates a check for only the parent and not the put-only resource", func() {
+						Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(2))
+
+						By("first check is for the default resource")
+						_, checkable, _, _, manuallyTriggered := fakeCheckFactory.TryCreateCheckArgsForCall(1)
+						Expect(checkable).To(Equal(fakeResourceType))
+						Expect(manuallyTriggered).To(BeFalse())
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

closes #6521

## Changes proposed by this PR:
This covers the edge case where a put-only resource's parent-type would not be check because we were only looping over everything except put-only resources

## Notes to reviewer:
If you need extra help reproducing the issue, you can check Alex's comment https://github.com/concourse/concourse/issues/6521#issuecomment-813596246

## Release Note
* Fixed an edge case where a put-only resource's parent-type would not be checked

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] ~Updated [Documentation]~
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).


cc @taylorsilva 