### PR TITLE
Set Content-Security-Policy and Cache-Control Headers

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -177,10 +177,11 @@ type RunCommand struct {
 	} `group:"Policy Checking"`
 
 	Server struct {
-		XFrameOptions string `long:"x-frame-options" default:"deny" description:"The value to set for X-Frame-Options."`
-		ClusterName   string `long:"cluster-name" description:"A name for this Concourse cluster, to be displayed on the dashboard page."`
-		ClientID      string `long:"client-id" default:"concourse-web" description:"Client ID to use for login flow"`
-		ClientSecret  string `long:"client-secret" required:"true" description:"Client secret to use for login flow"`
+		XFrameOptions         string `long:"x-frame-options" default:"deny" description:"The value to set for the X-Frame-Options header."`
+		ContentSecurityPolicy string `long:"content-security-policy" default:"frame-ancestors 'none'" description:"The value to set for the Content-Security-Policy header."`
+		ClusterName           string `long:"cluster-name" description:"A name for this Concourse cluster, to be displayed on the dashboard page."`
+		ClientID              string `long:"client-id" default:"concourse-web" description:"Client ID to use for login flow"`
+		ClientSecret          string `long:"client-secret" required:"true" description:"Client secret to use for login flow"`
 	} `group:"Web Server"`
 
 	LogDBQueries   bool `long:"log-db-queries" description:"Log database queries."`
@@ -1731,7 +1732,8 @@ func (cmd *RunCommand) constructHTTPHandler(
 		Logger: logger,
 
 		Handler: wrappa.SecurityHandler{
-			XFrameOptions: cmd.Server.XFrameOptions,
+			XFrameOptions:         cmd.Server.XFrameOptions,
+			ContentSecurityPolicy: cmd.Server.ContentSecurityPolicy,
 
 			// proxy Authorization header to/from auth cookie,
 			// to support auth from JS (EventSource) and custom JWT auth

--- a/atc/wrappa/security_handler.go
+++ b/atc/wrappa/security_handler.go
@@ -18,6 +18,6 @@ func (handler SecurityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Download-Options", "noopen")
-	w.Header().Set("Cache-Control", "no-store, private")
+	w.Header().Set("Cache-Control", "private")
 	handler.Handler.ServeHTTP(w, r)
 }

--- a/atc/wrappa/security_handler.go
+++ b/atc/wrappa/security_handler.go
@@ -18,5 +18,6 @@ func (handler SecurityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Download-Options", "noopen")
+	w.Header().Set("Cache-Control", "no-store, private")
 	handler.Handler.ServeHTTP(w, r)
 }

--- a/atc/wrappa/security_handler.go
+++ b/atc/wrappa/security_handler.go
@@ -3,13 +3,17 @@ package wrappa
 import "net/http"
 
 type SecurityHandler struct {
-	XFrameOptions string
-	Handler       http.Handler
+	XFrameOptions         string
+	ContentSecurityPolicy string
+	Handler               http.Handler
 }
 
 func (handler SecurityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if handler.XFrameOptions != "" {
 		w.Header().Set("X-Frame-Options", handler.XFrameOptions)
+	}
+	if handler.ContentSecurityPolicy != "" {
+		w.Header().Set("Content-Security-Policy", handler.ContentSecurityPolicy)
 	}
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 	w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/atc/wrappa/security_handler.go
+++ b/atc/wrappa/security_handler.go
@@ -18,6 +18,6 @@ func (handler SecurityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Download-Options", "noopen")
-	w.Header().Set("Cache-Control", "private")
+	w.Header().Set("Cache-Control", "no-store, private")
 	handler.Handler.ServeHTTP(w, r)
 }

--- a/atc/wrappa/security_handler_test.go
+++ b/atc/wrappa/security_handler_test.go
@@ -48,7 +48,7 @@ var _ = Describe("SecurityHandler", func() {
 		})
 	})
 
-	Context("when the X-Frame-Options is non-empty", func() {
+	Context("when the X-Frame-Options is set", func() {
 		BeforeEach(func() {
 			securityHandler = wrappa.SecurityHandler{
 				XFrameOptions: "some-x-frame-options",
@@ -57,6 +57,24 @@ var _ = Describe("SecurityHandler", func() {
 		})
 		It("sets the X-Frame-Options to whatever it was configured with", func() {
 			Expect(rw.Header().Get("X-Frame-Options")).To(Equal("some-x-frame-options"))
+		})
+	})
+
+	Context("when Content-Security-Policy is set", func() {
+		BeforeEach(func() {
+			securityHandler = wrappa.SecurityHandler{
+				ContentSecurityPolicy: "some-policy 'value'",
+				Handler:               fakeHandler,
+			}
+		})
+		It("sets the Content-Security-Policy to whatever it was configured with", func() {
+			Expect(rw.Header().Get("Content-Security-Policy")).To(Equal("some-policy 'value'"))
+		})
+	})
+
+	Context("when Content-Security-Policy is empty", func() {
+		It("does not set Content-Security-Policy header", func() {
+			Expect(rw.Result().Header).NotTo(HaveKey("Content-Security-Policy"))
 		})
 	})
 })

--- a/atc/wrappa/security_handler_test.go
+++ b/atc/wrappa/security_handler_test.go
@@ -40,7 +40,7 @@ var _ = Describe("SecurityHandler", func() {
 		Expect(rw.Header().Get("X-XSS-Protection")).To(Equal("1; mode=block"))
 		Expect(rw.Header().Get("X-Content-Type-Options")).To(Equal("nosniff"))
 		Expect(rw.Header().Get("X-Download-Options")).To(Equal("noopen"))
-		Expect(rw.Header().Get("Cache-Control")).To(Equal("private"))
+		Expect(rw.Header().Get("Cache-Control")).To(Equal("no-store, private"))
 	})
 
 	Context("when the X-Frame-Options is empty", func() {

--- a/atc/wrappa/security_handler_test.go
+++ b/atc/wrappa/security_handler_test.go
@@ -40,6 +40,7 @@ var _ = Describe("SecurityHandler", func() {
 		Expect(rw.Header().Get("X-XSS-Protection")).To(Equal("1; mode=block"))
 		Expect(rw.Header().Get("X-Content-Type-Options")).To(Equal("nosniff"))
 		Expect(rw.Header().Get("X-Download-Options")).To(Equal("noopen"))
+		Expect(rw.Header().Get("Cache-Control")).To(Equal("no-store, private"))
 	})
 
 	Context("when the X-Frame-Options is empty", func() {

--- a/atc/wrappa/security_handler_test.go
+++ b/atc/wrappa/security_handler_test.go
@@ -40,7 +40,7 @@ var _ = Describe("SecurityHandler", func() {
 		Expect(rw.Header().Get("X-XSS-Protection")).To(Equal("1; mode=block"))
 		Expect(rw.Header().Get("X-Content-Type-Options")).To(Equal("nosniff"))
 		Expect(rw.Header().Get("X-Download-Options")).To(Equal("noopen"))
-		Expect(rw.Header().Get("Cache-Control")).To(Equal("no-store, private"))
+		Expect(rw.Header().Get("Cache-Control")).To(Equal("private"))
 	})
 
 	Context("when the X-Frame-Options is empty", func() {

--- a/web/cache_handler.go
+++ b/web/cache_handler.go
@@ -11,7 +11,7 @@ const yearInSeconds = 31536000
 
 func CacheNearlyForever(handler http.Handler) http.Handler {
 	withoutGz := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d, private", yearInSeconds))
+		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, private", yearInSeconds))
 		handler.ServeHTTP(w, r)
 	})
 	return gziphandler.GzipHandler(withoutGz)


### PR DESCRIPTION
## What does this PR accomplish?
Bug Fix | **Feature** | Documentation

## Changes proposed by this PR:

- Add CSP headers that are configurable. Defaults to `frame-ancestors 'none'`
- Add a default cache-control header set to `no-store, private`

## Notes to reviewer:
~I'm not 100% sure about the cache-control values, but looking at the
header of some big sites (i.e. stackoverflow) I found they do set this header
to `private`.~

## Release Note

* A Content-Security-Policy header is now set with a default value that will block framing of the Concourse web UI. This was already possible with the default value of the X-Frames-Option header.
  * The CSP header value is configurable with `CONCOURSE_CONTENT_SECURITY_POLICY`
* A Cache-Control header is set on every page with a default value of `no-store, private`. The value of the header is overwritten for some paths (i.e. web assets)

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [ ] Updated [Documentation]
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

