### PR TITLE
Don't check resource-types from paused pipelines

### DIFF
--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -179,6 +179,9 @@ func (c *checkFactory) ResourceTypes() ([]ResourceType, error) {
 	var resourceTypes []ResourceType
 
 	rows, err := resourceTypesQuery.
+		Where(sq.And{
+			sq.Eq{"p.paused": false},
+		}).
 		RunWith(c.conn).
 		Query()
 

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -391,5 +391,16 @@ var _ = Describe("CheckFactory", func() {
 				Expect(resourceTypes).To(HaveLen(0))
 			})
 		})
+
+		Context("when the pipeline is paused", func() {
+			BeforeEach(func() {
+				_, err = dbConn.Exec(`UPDATE pipelines SET paused = true`)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("does not return resource types from paused pipelines", func() {
+				Expect(resourceTypes).To(HaveLen(0))
+			})
+		})
 	})
 })


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

## Changes proposed by this PR:
A follow-up to PR #6923. See @clarafu's comment https://github.com/concourse/concourse/pull/6923#issuecomment-829474249. This does not impact any released version of Concourse.

## Contributor Checklist
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

