### PR TITLE
worker: Set PATH based on UID instead of container's privileged state

### DIFF
--- a/worker/runtime/spec/spec.go
+++ b/worker/runtime/spec/spec.go
@@ -11,11 +11,6 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-const (
-	SuperuserPath = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	Path          = "PATH=/usr/local/bin:/usr/bin:/bin"
-)
-
 const baseCgroupsPath = "garden"
 
 var isSwapLimitEnabled bool
@@ -74,8 +69,6 @@ func OciSpec(initBinPath string, gdn garden.ContainerSpec, maxUid, maxGid uint32
 			},
 		},
 	)
-
-	oci.Process.Env = envWithDefaultPath(oci.Process.Env, gdn.Privileged)
 
 	return
 }
@@ -191,24 +184,6 @@ func OciCgroupsPath(basePath, handle string, privileged bool) string {
 		return ""
 	}
 	return filepath.Join(basePath, handle)
-}
-
-// envWithDefaultPath returns the default PATH for a privileged/unprivileged
-// user based on the existence of PATH already being set in the initial
-// environment.
-//
-func envWithDefaultPath(env []string, privileged bool) []string {
-	for _, envVar := range env {
-		if strings.HasPrefix(envVar, "PATH=") {
-			return env
-		}
-	}
-
-	if privileged {
-		return append(env, SuperuserPath)
-	}
-
-	return append(env, Path)
 }
 
 // defaultGardenOciSpec represents a default set of properties necessary in

--- a/worker/runtime/spec/spec_test.go
+++ b/worker/runtime/spec/spec_test.go
@@ -418,27 +418,6 @@ func (s *SpecSuite) TestContainerSpec() {
 			},
 		},
 		{
-			desc: "env + default path",
-			gdn: garden.ContainerSpec{
-				Handle: "handle", RootFSPath: "raw:///rootfs",
-				Env: []string{"foo=bar"},
-			},
-			check: func(oci *specs.Spec) {
-				s.Equal([]string{"foo=bar", spec.Path}, oci.Process.Env)
-			},
-		},
-		{
-			desc: "env + default root path",
-			gdn: garden.ContainerSpec{
-				Handle: "handle", RootFSPath: "raw:///rootfs",
-				Env:        []string{"foo=bar"},
-				Privileged: true,
-			},
-			check: func(oci *specs.Spec) {
-				s.Equal([]string{"foo=bar", spec.SuperuserPath}, oci.Process.Env)
-			},
-		},
-		{
 			desc: "env with path already configured",
 			gdn: garden.ContainerSpec{
 				Handle: "handle", RootFSPath: "raw:///rootfs",


### PR DESCRIPTION
## What does this PR accomplish?
**Bug Fix** | Feature | Documentation

## Changes proposed by this PR:
Set a users/processes PATH based on the UID inside the container instead of the privileged state of the container. This matches what guardian does: https://github.com/cloudfoundry/guardian/blob/bf4c737f2bc490aa82b8883e2c8964680236a8df/rundmc/processes/unix_env.go#L44-L46

## Notes to reviewer:
You can test by `fly execute`'ing this task

```yaml
platform: linux
image_resource:
  type: mock
  source: {mirror_self: true}
run:
  user: root
  path: sh
  args:
  - -c
  - |
    id
    echo $PATH
```
Path should include `/sbin`.
If you run this task which run under a different UID:

```yaml
platform: linux
image_resource:
  type: mock
  source: {mirror_self: true}
run:
  user: games
  path: sh
  args:
  - -c
  - |
    id
    echo $PATH
```
You should see a shorter Path that does not contain `/sbin`.

## Release Note

* Containerd: fixed a bug where PATH did not contain directories to system tools (i.e. `/sbin`) when a user/process was root. Only effects unprivileged containers.

## Contributor Checklist
<!--
Most of the PRs should have the following added to them,
this doesn't apply to all PRs, so it is helpful to tell us what you did.
-->
- [x] Followed [Code of conduct], [Contributing Guide] & avoided [Anti-patterns]
- [x] [Signed] all commits
- [x] Added tests (Unit and/or Integration)
- [x] Added release note (Optional)

[Code of Conduct]: https://github.com/concourse/concourse/blob/master/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md
[Anti-patterns]: https://github.com/concourse/concourse/wiki/Anti-Patterns
[Signed]: https://help.github.com/en/github/authenticating-to-github/signing-commits
[Documentation]: https://github.com/concourse/docs

## Reviewer Checklist
<!--
This section is intended for the reviewers only, to track review
progress.
-->
- [ ] Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the
  [BOSH](https://github.com/concourse/concourse-bosh-release) and
  [Helm](https://github.com/concourse/helm) packaging; otherwise, ignored for
  the [integration
  tests](https://github.com/concourse/ci/tree/master/tasks/scripts/check-distribution-env)
  (for example, if they are Garden configs that are not displayed in the
  `--help` text).

