### PR TITLE
Fly clear-resource-cache command

### DIFF
--- a/atc/api/accessor/roles.go
+++ b/atc/api/accessor/roles.go
@@ -55,6 +55,7 @@ var DefaultRoles = map[string]string{
 	atc.ListBuildsWithVersionAsInput:  ViewerRole,
 	atc.ListBuildsWithVersionAsOutput: ViewerRole,
 	atc.GetResourceCausality:          ViewerRole,
+	atc.ClearResourceCache: 		   OperatorRole,
 	atc.ListAllPipelines:              ViewerRole,
 	atc.ListPipelines:                 ViewerRole,
 	atc.GetPipeline:                   ViewerRole,

--- a/atc/api/accessor/roles.go
+++ b/atc/api/accessor/roles.go
@@ -55,7 +55,7 @@ var DefaultRoles = map[string]string{
 	atc.ListBuildsWithVersionAsInput:  ViewerRole,
 	atc.ListBuildsWithVersionAsOutput: ViewerRole,
 	atc.GetResourceCausality:          ViewerRole,
-	atc.ClearResourceCache: 		   OperatorRole,
+	atc.ClearResourceCache:            OperatorRole,
 	atc.ListAllPipelines:              ViewerRole,
 	atc.ListPipelines:                 ViewerRole,
 	atc.GetPipeline:                   ViewerRole,

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -165,6 +165,7 @@ func NewHandler(
 		atc.CheckResource:           pipelineHandlerFactory.HandlerFor(resourceServer.CheckResource),
 		atc.CheckResourceWebHook:    pipelineHandlerFactory.HandlerFor(resourceServer.CheckResourceWebHook),
 		atc.CheckResourceType:       pipelineHandlerFactory.HandlerFor(resourceServer.CheckResourceType),
+		atc.ClearResourceCache:      pipelineHandlerFactory.HandlerFor(resourceServer.ClearResourceCache),
 
 		atc.ListResourceVersions:          pipelineHandlerFactory.HandlerFor(versionServer.ListResourceVersions),
 		atc.GetResourceVersion:            pipelineHandlerFactory.HandlerFor(versionServer.GetResourceVersion),

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -1613,6 +1613,25 @@ var _ = Describe("Resources API", func() {
 		var response *http.Response
 		var fakeResource *dbfakes.FakeResource
 
+		executeNoVersionConnection := func() {
+			request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err = client.Do(request)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		executeVersionConnection := func() {
+			reqPayload, err := json.Marshal(atc.VersionDeleteBody{Version: atc.Version{"ref": "fake-ref"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", bytes.NewBuffer(reqPayload))
+			Expect(err).NotTo(HaveOccurred())
+
+			response, err = client.Do(request)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 		Context("when authenticated ", func() {
 			BeforeEach(func() {
 				fakeAccess.IsAuthenticatedReturns(true)
@@ -1625,13 +1644,7 @@ var _ = Describe("Resources API", func() {
 
 				Context("when it tries to find a resource", func() {
 					JustBeforeEach(func() {
-						var err error
-
-						request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
-						Expect(err).NotTo(HaveOccurred())
-
-						response, err = client.Do(request)
-						Expect(err).NotTo(HaveOccurred())
+						executeNoVersionConnection()
 					})
 
 					It("calls the resource", func() {
@@ -1651,13 +1664,7 @@ var _ = Describe("Resources API", func() {
 
 						Context("when no version is passed", func() {
 							JustBeforeEach(func() {
-								var err error
-
-								request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
-								Expect(err).NotTo(HaveOccurred())
-
-								response, err = client.Do(request)
-								Expect(err).NotTo(HaveOccurred())
+								executeNoVersionConnection()
 							})
 
 							BeforeEach(func() {
@@ -1675,7 +1682,6 @@ var _ = Describe("Resources API", func() {
 							It("it send an empty version", func() {
 								version := fakeResource.ClearResourceCacheArgsForCall(0)
 								expectedVersion := atc.VersionDeleteBody{}.Version
-								fmt.Println(version)
 								Expect(version).To(Equal(expectedVersion))
 							})
 
@@ -1710,16 +1716,7 @@ var _ = Describe("Resources API", func() {
 
 						Context("when a version is passed", func() {
 							JustBeforeEach(func() {
-								var err error
-
-								reqPayload, err := json.Marshal(atc.VersionDeleteBody{Version: atc.Version{"ref": "fake-ref"}})
-								Expect(err).NotTo(HaveOccurred())
-
-								request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", bytes.NewBuffer(reqPayload))
-								Expect(err).NotTo(HaveOccurred())
-
-								response, err = client.Do(request)
-								Expect(err).NotTo(HaveOccurred())
+								executeVersionConnection()
 							})
 
 							BeforeEach(func() {
@@ -1772,13 +1769,7 @@ var _ = Describe("Resources API", func() {
 
 					Context("when clear cache fails", func() {
 						JustBeforeEach(func() {
-							var err error
-
-							request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
-							Expect(err).NotTo(HaveOccurred())
-
-							response, err = client.Do(request)
-							Expect(err).NotTo(HaveOccurred())
+							executeNoVersionConnection()
 						})
 
 						BeforeEach(func() {
@@ -1793,13 +1784,7 @@ var _ = Describe("Resources API", func() {
 
 				Context("when it fails to find the resource", func() {
 					JustBeforeEach(func() {
-						var err error
-
-						request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
-						Expect(err).NotTo(HaveOccurred())
-
-						response, err = client.Do(request)
-						Expect(err).NotTo(HaveOccurred())
+						executeNoVersionConnection()
 					})
 
 					BeforeEach(func() {
@@ -1825,13 +1810,7 @@ var _ = Describe("Resources API", func() {
 			})
 			Context("when not authorized", func() {
 				JustBeforeEach(func() {
-					var err error
-
-					request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
-					Expect(err).NotTo(HaveOccurred())
-
-					response, err = client.Do(request)
-					Expect(err).NotTo(HaveOccurred())
+					executeNoVersionConnection()
 				})
 
 				BeforeEach(func() {
@@ -1846,13 +1825,7 @@ var _ = Describe("Resources API", func() {
 
 		Context("when not authenticated", func() {
 			JustBeforeEach(func() {
-				var err error
-
-				request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
-				Expect(err).NotTo(HaveOccurred())
-
-				response, err = client.Do(request)
-				Expect(err).NotTo(HaveOccurred())
+				executeNoVersionConnection()
 			})
 
 			BeforeEach(func() {

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -1608,4 +1608,260 @@ var _ = Describe("Resources API", func() {
 			})
 		})
 	})
+
+	Describe("DELETE /api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/cache", func() {
+		var response *http.Response
+		var fakeResource *dbfakes.FakeResource
+
+		Context("when authenticated ", func() {
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(true)
+			})
+
+			Context("when authorized", func() {
+				BeforeEach(func() {
+					fakeAccess.IsAuthorizedReturns(true)
+				})
+
+				Context("when it tries to find a resource", func() {
+					JustBeforeEach(func() {
+						var err error
+
+						request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
+						Expect(err).NotTo(HaveOccurred())
+
+						response, err = client.Do(request)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("calls the resource", func() {
+						resourceName := fakePipeline.ResourceArgsForCall(0)
+						Expect(resourceName).To(Equal("resource-name"))
+					})
+				})
+
+				Context("when finding the resource succeeds", func() {
+					BeforeEach(func() {
+						fakeResource = new(dbfakes.FakeResource)
+						fakeResource.IDReturns(1)
+						fakePipeline.ResourceReturns(fakeResource, true, nil)
+					})
+
+					Context("when clear cache succeeds", func() {
+
+						Context("when no version is passed", func() {
+							JustBeforeEach(func() {
+								var err error
+
+								request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
+								Expect(err).NotTo(HaveOccurred())
+
+								response, err = client.Do(request)
+								Expect(err).NotTo(HaveOccurred())
+							})
+
+							BeforeEach(func() {
+								fakeResource.ClearResourceCacheReturns(1,nil)
+							})
+
+							It("returns 200", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusOK))
+							})
+
+							It("it clears the db cache entries successfully", func() {
+								Expect(fakeResource.ClearResourceCacheCallCount()).To(Equal(1))
+							})
+
+							It("it send an empty version", func() {
+								version := fakeResource.ClearResourceCacheArgsForCall(0)
+								expectedVersion := atc.VersionDeleteBody{}.Version
+								fmt.Println(version)
+								Expect(version).To(Equal(expectedVersion))
+							})
+
+							It("returns Content-Type 'application/json'", func() {
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/json",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
+							})
+
+							It("it returns the number of rows deleted", func() {
+								body, err := ioutil.ReadAll(response.Body)
+								Expect(err).NotTo(HaveOccurred())
+
+								Expect(body).To(MatchJSON(`{"caches_removed": 1}`))
+							})
+
+							Context("but no rows were deleted", func() {
+								BeforeEach(func() {
+									fakeResource.ClearResourceCacheReturns(0, nil)
+								})
+
+								It("it returns that 0 rows were deleted", func() {
+									body, err := ioutil.ReadAll(response.Body)
+									Expect(err).NotTo(HaveOccurred())
+
+									Expect(body).To(MatchJSON(`{"caches_removed": 0}`))
+								})
+
+							})
+						})
+
+						Context("when a version is passed", func() {
+							JustBeforeEach(func() {
+								var err error
+
+								reqPayload, err := json.Marshal(atc.VersionDeleteBody{Version: atc.Version{"ref": "fake-ref"}})
+								Expect(err).NotTo(HaveOccurred())
+
+								request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", bytes.NewBuffer(reqPayload))
+								Expect(err).NotTo(HaveOccurred())
+
+								response, err = client.Do(request)
+								Expect(err).NotTo(HaveOccurred())
+							})
+
+							BeforeEach(func() {
+								fakeResource.ClearResourceCacheReturns(1,nil)
+							})
+
+							It("returns 200", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusOK))
+							})
+
+							It("it clears the db cache entries successfully", func() {
+								Expect(fakeResource.ClearResourceCacheCallCount()).To(Equal(1))
+							})
+
+							It("it send a non empty version", func() {
+								version := fakeResource.ClearResourceCacheArgsForCall(0)
+								expectedVersion := atc.Version{"ref": "fake-ref"}
+								Expect(version).To(Equal(expectedVersion))
+							})
+
+							It("returns Content-Type 'application/json'", func() {
+								expectedHeaderEntries := map[string]string{
+									"Content-Type": "application/json",
+								}
+								Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
+							})
+
+							It("it returns the number of rows deleted", func() {
+								body, err := ioutil.ReadAll(response.Body)
+								Expect(err).NotTo(HaveOccurred())
+
+								Expect(body).To(MatchJSON(`{"caches_removed": 1}`))
+							})
+
+							Context("but no rows were deleted", func() {
+								BeforeEach(func() {
+									fakeResource.ClearResourceCacheReturns(0, nil)
+								})
+
+								It("it returns that 0 rows were deleted", func() {
+									body, err := ioutil.ReadAll(response.Body)
+									Expect(err).NotTo(HaveOccurred())
+
+									Expect(body).To(MatchJSON(`{"caches_removed": 0}`))
+								})
+
+							})
+						})
+					})
+
+					Context("when clear cache fails", func() {
+						JustBeforeEach(func() {
+							var err error
+
+							request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
+							Expect(err).NotTo(HaveOccurred())
+
+							response, err = client.Do(request)
+							Expect(err).NotTo(HaveOccurred())
+						})
+
+						BeforeEach(func() {
+							fakeResource.ClearResourceCacheReturns(0, errors.New("welp"))
+						})
+
+						It("returns 500", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+						})
+					})
+				})
+
+				Context("when it fails to find the resource", func() {
+					JustBeforeEach(func() {
+						var err error
+
+						request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
+						Expect(err).NotTo(HaveOccurred())
+
+						response, err = client.Do(request)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					BeforeEach(func() {
+						fakePipeline.ResourceReturns(nil, false, errors.New("welp"))
+					})
+
+					It("returns Internal Server Error", func() {
+						Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
+					})
+
+					Context("when the resource is not found", func() {
+						BeforeEach(func() {
+							fakePipeline.ResourceReturns(nil, false, nil)
+						})
+
+						It("returns not found", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+						})
+					})
+				})
+
+
+			})
+			Context("when not authorized", func() {
+				JustBeforeEach(func() {
+					var err error
+
+					request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					response, err = client.Do(request)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				BeforeEach(func() {
+					fakeAccess.IsAuthorizedReturns(false)
+				})
+
+				It("returns Forbidden", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
+				})
+			})
+		})
+
+		Context("when not authenticated", func() {
+			JustBeforeEach(func() {
+				var err error
+
+				request, err := http.NewRequest("DELETE", server.URL+"/api/v1/teams/a-team/pipelines/a-pipeline/resources/resource-name/cache", nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				response, err = client.Do(request)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			BeforeEach(func() {
+				fakeAccess.IsAuthenticatedReturns(false)
+			})
+
+			It("returns Unauthorized", func() {
+				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+			})
+		})
+	})
 })

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -1658,11 +1658,12 @@ var _ = Describe("Resources API", func() {
 						fakeResource = new(dbfakes.FakeResource)
 						fakeResource.IDReturns(1)
 						fakePipeline.ResourceReturns(fakeResource, true, nil)
-
-						fakeResource.ClearResourceCacheReturns(1,nil)
 					})
 
 					Context("when clear cache succeeds", func() {
+						BeforeEach(func() {
+							fakeResource.ClearResourceCacheReturns(1,nil)
+						})
 
 						Context("when no version is passed", func() {
 							It("returns 200", func() {

--- a/atc/api/resourceserver/clear_resource_cache.go
+++ b/atc/api/resourceserver/clear_resource_cache.go
@@ -1,0 +1,79 @@
+package resourceserver
+
+import (
+	"code.cloudfoundry.org/lager"
+	"encoding/json"
+	"fmt"
+	"github.com/concourse/concourse/atc"
+	"github.com/google/jsonapi"
+	"net/http"
+
+	"github.com/concourse/concourse/atc/db"
+)
+
+func (s *Server) ClearResourceCache(pipeline db.Pipeline) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := s.logger.Session("clear-resource-cache")
+		resourceName := r.FormValue(":resource_name")
+		version := r.FormValue(":version")
+
+		resource, found, err := pipeline.Resource(resourceName)
+		if err != nil {
+			logger.Error("failed-to-get-resource", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if !found {
+			logger.Debug("could-not-find-resource", lager.Data{
+				"resource":   	  resourceName,
+				"version":    	  version,
+			})
+			w.Header().Set("Content-Type", jsonapi.MediaType)
+			w.WriteHeader(http.StatusNotFound)
+			_ = jsonapi.MarshalErrors(w, []*jsonapi.ErrorObject{{
+				Title:  "Job Not Found Error",
+				Detail: fmt.Sprintf("Resource with name '%s' not found.", resourceName),
+				Status: "404",
+			}})
+			return
+		}
+
+		rowsDeleted, err := resource.ClearResourceCache(version)
+
+		if err != nil {
+			logger.Error("failed-to-clear-resource-cache", err)
+			w.Header().Set("Content-Type", jsonapi.MediaType)
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = jsonapi.MarshalErrors(w, []*jsonapi.ErrorObject{{
+				Title:  "Clear Resource Cache Error",
+				Detail: err.Error(),
+				Status: "500",
+			}})
+			return
+		}
+
+		s.writeJSONResponse(w, atc.ClearResourceCacheResponse{CachesRemoved: rowsDeleted})
+	})
+}
+
+func (s *Server) writeJSONResponse(w http.ResponseWriter, obj interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	responseJSON, err := json.Marshal(obj)
+	if err != nil {
+		s.logger.Error("failed-to-marshal-response", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "failed to generate error response: %s", err)
+		return
+	}
+
+	_, err = w.Write(responseJSON)
+	if err != nil {
+		s.logger.Error("failed-to-write-response", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+}

--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -120,6 +120,7 @@ func (a *auditor) ValidateAction(action string) bool {
 		atc.EnableResourceVersion,
 		atc.DisableResourceVersion,
 		atc.PinResourceVersion,
+		atc.ClearResourceCache,
 		atc.GetResourceCausality:
 		return a.EnableResourceAuditLog
 	case

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -65,6 +65,19 @@ type FakeResource struct {
 	checkTimeoutReturnsOnCall map[int]struct {
 		result1 string
 	}
+	ClearResourceCacheStub        func(atc.Version) (int64, error)
+	clearResourceCacheMutex       sync.RWMutex
+	clearResourceCacheArgsForCall []struct {
+		arg1 atc.Version
+	}
+	clearResourceCacheReturns struct {
+		result1 int64
+		result2 error
+	}
+	clearResourceCacheReturnsOnCall map[int]struct {
+		result1 int64
+		result2 error
+	}
 	ConfigStub        func() atc.ResourceConfig
 	configMutex       sync.RWMutex
 	configArgsForCall []struct {
@@ -740,6 +753,70 @@ func (fake *FakeResource) CheckTimeoutReturnsOnCall(i int, result1 string) {
 	fake.checkTimeoutReturnsOnCall[i] = struct {
 		result1 string
 	}{result1}
+}
+
+func (fake *FakeResource) ClearResourceCache(arg1 atc.Version) (int64, error) {
+	fake.clearResourceCacheMutex.Lock()
+	ret, specificReturn := fake.clearResourceCacheReturnsOnCall[len(fake.clearResourceCacheArgsForCall)]
+	fake.clearResourceCacheArgsForCall = append(fake.clearResourceCacheArgsForCall, struct {
+		arg1 atc.Version
+	}{arg1})
+	stub := fake.ClearResourceCacheStub
+	fakeReturns := fake.clearResourceCacheReturns
+	fake.recordInvocation("ClearResourceCache", []interface{}{arg1})
+	fake.clearResourceCacheMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeResource) ClearResourceCacheCallCount() int {
+	fake.clearResourceCacheMutex.RLock()
+	defer fake.clearResourceCacheMutex.RUnlock()
+	return len(fake.clearResourceCacheArgsForCall)
+}
+
+func (fake *FakeResource) ClearResourceCacheCalls(stub func(atc.Version) (int64, error)) {
+	fake.clearResourceCacheMutex.Lock()
+	defer fake.clearResourceCacheMutex.Unlock()
+	fake.ClearResourceCacheStub = stub
+}
+
+func (fake *FakeResource) ClearResourceCacheArgsForCall(i int) atc.Version {
+	fake.clearResourceCacheMutex.RLock()
+	defer fake.clearResourceCacheMutex.RUnlock()
+	argsForCall := fake.clearResourceCacheArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeResource) ClearResourceCacheReturns(result1 int64, result2 error) {
+	fake.clearResourceCacheMutex.Lock()
+	defer fake.clearResourceCacheMutex.Unlock()
+	fake.ClearResourceCacheStub = nil
+	fake.clearResourceCacheReturns = struct {
+		result1 int64
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeResource) ClearResourceCacheReturnsOnCall(i int, result1 int64, result2 error) {
+	fake.clearResourceCacheMutex.Lock()
+	defer fake.clearResourceCacheMutex.Unlock()
+	fake.ClearResourceCacheStub = nil
+	if fake.clearResourceCacheReturnsOnCall == nil {
+		fake.clearResourceCacheReturnsOnCall = make(map[int]struct {
+			result1 int64
+			result2 error
+		})
+	}
+	fake.clearResourceCacheReturnsOnCall[i] = struct {
+		result1 int64
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeResource) Config() atc.ResourceConfig {
@@ -2775,6 +2852,8 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.checkPlanMutex.RUnlock()
 	fake.checkTimeoutMutex.RLock()
 	defer fake.checkTimeoutMutex.RUnlock()
+	fake.clearResourceCacheMutex.RLock()
+	defer fake.clearResourceCacheMutex.RUnlock()
 	fake.configMutex.RLock()
 	defer fake.configMutex.RUnlock()
 	fake.configPinnedVersionMutex.RLock()

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -69,7 +69,7 @@ type Resource interface {
 
 	NotifyScan() error
 
-	ClearResourceCache(string) (int64, error)
+	ClearResourceCache(atc.Version) (int64, error)
 
 	Reload() (bool, error)
 }
@@ -749,7 +749,7 @@ func (r *resource) NotifyScan() error {
 	return r.conn.Bus().Notify(fmt.Sprintf("resource_scan_%d", r.id))
 }
 
-func (r *resource) ClearResourceCache(version string) (int64, error) {
+func (r *resource) ClearResourceCache(version atc.Version) (int64, error) {
 	tx, err := r.conn.Begin()
 	if err != nil {
 		return 0, err
@@ -761,7 +761,7 @@ func (r *resource) ClearResourceCache(version string) (int64, error) {
 	selectStatement := "SELECT id FROM resource_caches WHERE resource_config_id = $1"
 	var results sql.Result
 
-	if version != "" {
+	if version != nil {
 		selectStatement += "AND version @> '$2'"
 		deleteStatement += "(" + selectStatement + ")"
 		results, err = tx.Exec(deleteStatement, r.id, version)

--- a/atc/resource_delete_body.go
+++ b/atc/resource_delete_body.go
@@ -1,0 +1,5 @@
+package atc
+
+type VersionDeleteBody struct {
+	Version Version `json:"version"`
+}

--- a/atc/responses.go
+++ b/atc/responses.go
@@ -12,3 +12,7 @@ type SaveConfigResponse struct {
 type ConfigResponse struct {
 	Config Config `json:"config"`
 }
+
+type ClearResourceCacheResponse struct {
+	CachesRemoved int64 `json:"caches_removed"`
+}

--- a/atc/routes.go
+++ b/atc/routes.go
@@ -50,6 +50,7 @@ const (
 	ListBuildsWithVersionAsInput  = "ListBuildsWithVersionAsInput"
 	ListBuildsWithVersionAsOutput = "ListBuildsWithVersionAsOutput"
 	GetResourceCausality          = "GetResourceCausality"
+	ClearResourceCache            = "ClearResourceCache"
 
 	GetCC = "GetCC"
 
@@ -173,6 +174,7 @@ var Routes = rata.Routes([]rata.Route{
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/check", Method: "POST", Name: CheckResource},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/check/webhook", Method: "POST", Name: CheckResourceWebHook},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resource-types/:resource_type_name/check", Method: "POST", Name: CheckResourceType},
+	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/cache", Method: "DELETE", Name: ClearResourceCache},
 
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions", Method: "GET", Name: ListResourceVersions},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_config_version_id", Method: "GET", Name: GetResourceVersion},

--- a/atc/wrappa/api_auth_wrappa.go
+++ b/atc/wrappa/api_auth_wrappa.go
@@ -152,6 +152,7 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.SaveConfig,
 			atc.ArchivePipeline,
 			atc.ClearTaskCache,
+			atc.ClearResourceCache,
 			atc.CreateArtifact,
 			atc.ScheduleJob,
 			atc.GetArtifact:

--- a/atc/wrappa/reject_archived_wrappa.go
+++ b/atc/wrappa/reject_archived_wrappa.go
@@ -120,6 +120,7 @@ func (rw *RejectArchivedWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.CreatePipelineBuild,
 			atc.ClearTaskCache,
 			atc.CreateArtifact,
+			atc.ClearResourceCache,
 			atc.GetArtifact:
 
 		default:

--- a/fly/commands/clear_resource_cache.go
+++ b/fly/commands/clear_resource_cache.go
@@ -33,7 +33,6 @@ func (command *ClearResourceCacheCommand) Execute(args []string) error {
 	numRemoved, err := target.Team().ClearResourceCache(command.Resource.PipelineRef, command.Resource.ResourceName, version)
 
 	if err != nil {
-		fmt.Println(err.Error())
 		return err
 	} else {
 		fmt.Printf("%d caches removed\n", numRemoved)

--- a/fly/commands/clear_resource_cache.go
+++ b/fly/commands/clear_resource_cache.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/vito/go-interact/interact"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
@@ -10,7 +12,7 @@ import (
 
 type ClearResourceCacheCommand struct {
 	Resource 	 flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to clear cache"`
-	Version      *atc.Version             `short:"v" long:"version"                  value-name:"VERSION"           description:"Version of the resource to check from, e.g. digest:sha256@..."`
+	Version      *atc.Version             `short:"v" long:"version"                  value-name:"VERSION"           description:"Version of the resource to check from, e.g. digest:sha256@..., in case a version is not specified the command will delete all the resource caches for that resource"`
 }
 
 func (command *ClearResourceCacheCommand) Execute(args []string) error {
@@ -28,6 +30,28 @@ func (command *ClearResourceCacheCommand) Execute(args []string) error {
 	var version atc.Version
 	if command.Version != nil {
 		version = *command.Version
+	}
+
+	warningMsg := fmt.Sprintf("!!! this will remove the resource cache(s) for `%s/%s`",
+		command.Resource.PipelineRef.String(), command.Resource.ResourceName)
+
+	if command.Version != nil {
+		versionJson, err := json.Marshal(version)
+		if err != nil {
+			return err
+		}
+
+		warningMsg += fmt.Sprintf(" with version: `%s`", versionJson)
+	}
+
+	warningMsg += "\n"
+	fmt.Println(warningMsg)
+
+	var confirm bool
+	err = interact.NewInteraction("are you sure?").Resolve(&confirm)
+	if err != nil || !confirm {
+		fmt.Println("bailing out")
+		return err
 	}
 
 	numRemoved, err := target.Team().ClearResourceCache(command.Resource.PipelineRef, command.Resource.ResourceName, version)

--- a/fly/commands/clear_resource_cache.go
+++ b/fly/commands/clear_resource_cache.go
@@ -11,12 +11,11 @@ import (
 )
 
 type ClearResourceCacheCommand struct {
-	Resource 	 flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to clear cache"`
-	Version      *atc.Version             `short:"v" long:"version"                  value-name:"VERSION"           description:"Version of the resource to check from, e.g. digest:sha256@..., in case a version is not specified the command will delete all the resource caches for that resource"`
+	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to clear cache"`
+	Version  *atc.Version             `short:"v" long:"version"                  value-name:"VERSION"           description:"Version of the resource to check from, e.g. digest:sha256@..., in case a version is not specified the command will delete all the resource caches for that resource"`
 }
 
 func (command *ClearResourceCacheCommand) Execute(args []string) error {
-
 	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
 	if err != nil {
 		return err
@@ -28,19 +27,15 @@ func (command *ClearResourceCacheCommand) Execute(args []string) error {
 	}
 
 	var version atc.Version
-	if command.Version != nil {
-		version = *command.Version
-	}
-
 	warningMsg := fmt.Sprintf("!!! this will remove the resource cache(s) for `%s/%s`",
 		command.Resource.PipelineRef.String(), command.Resource.ResourceName)
 
 	if command.Version != nil {
+		version = *command.Version
 		versionJson, err := json.Marshal(version)
 		if err != nil {
 			return err
 		}
-
 		warningMsg += fmt.Sprintf(" with version: `%s`", versionJson)
 	}
 

--- a/fly/commands/clear_resource_cache.go
+++ b/fly/commands/clear_resource_cache.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
+	"github.com/concourse/concourse/fly/rc"
+)
+
+type ClearResourceCacheCommand struct {
+	Resource 	 flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to clear cache"`
+	Version      *atc.Version             `short:"v" long:"version"                  value-name:"VERSION"           description:"Version of the resource to check from, e.g. digest:sha256@..."`
+}
+
+func (command *ClearResourceCacheCommand) Execute(args []string) error {
+
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	var version atc.Version
+	if command.Version != nil {
+		version = *command.Version
+	}
+
+	numRemoved, err := target.Team().ClearResourceCache(command.Resource.PipelineRef, command.Resource.ResourceName, version)
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	} else {
+		fmt.Printf("%d caches removed\n", numRemoved)
+		return nil
+	}
+}

--- a/fly/commands/fly.go
+++ b/fly/commands/fly.go
@@ -67,6 +67,7 @@ type FlyCommand struct {
 	UnpinResource          UnpinResourceCommand          `command:"unpin-resource"             alias:"ur"   description:"Unpin a resource"`
 	EnableResourceVersion  EnableResourceVersionCommand  `command:"enable-resource-version"    alias:"erv"  description:"Enable a version of a resource"`
 	DisableResourceVersion DisableResourceVersionCommand `command:"disable-resource-version"   alias:"drv"  description:"Disable a version of a resource"`
+	ClearResourceCache	   ClearResourceCacheCommand	 `command:"clear-resource-cache"       alias:"crc"  description:"Clear cache of a resource"`
 
 	CheckResourceType CheckResourceTypeCommand `command:"check-resource-type" alias:"crt"  description:"Check a resource-type"`
 

--- a/fly/integration/clear_resource_cache_test.go
+++ b/fly/integration/clear_resource_cache_test.go
@@ -1,0 +1,147 @@
+package integration_test
+
+import (
+	"net/http"
+	"os/exec"
+	"strings"
+
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Fly CLI", func() {
+	Describe("clear-resource-cache", func() {
+		var (
+			flyCmd *exec.Cmd
+			expectedQueryParams []string
+			expectedURL         = "/api/v1/teams/main/pipelines/some-pipeline/resources/some-resource/cache"
+		)
+
+		Context("when a resource is not specified", func() {
+			It("asks the user to specify a resource", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "clear-resource-cache")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(1))
+
+				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("r", "resource") + "' was not specified"))
+			})
+		})
+
+
+		Context("when resource and a version are specified", func() {
+			JustBeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("DELETE", expectedURL, strings.Join(expectedQueryParams, "&")),
+						ghttp.VerifyJSON(`{"version":{"ref":"fake-ref"}}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearResourceCacheResponse{CachesRemoved: 1}),
+					),
+				)
+			})
+
+			It("succeeds with one deletion", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "clear-resource-cache", "-r", "some-pipeline/some-resource", "-v", "ref:fake-ref")
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+					Eventually(sess).Should(gbytes.Say("1 caches removed"))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(2))
+			})
+		})
+
+		Context("when only a resource is specified", func() {
+			Context("when the resource exists", func() {
+				JustBeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", expectedURL, strings.Join(expectedQueryParams, "&")),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearResourceCacheResponse{CachesRemoved: 1}),
+						),
+					)
+				})
+
+				It("succeeds with one deletion", func() {
+					Expect(func() {
+						flyCmd = exec.Command(flyPath, "-t", targetName, "clear-resource-cache", "-r", "some-pipeline/some-resource")
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(sess).Should(gexec.Exit(0))
+						Eventually(sess).Should(gbytes.Say("1 caches removed"))
+					}).To(Change(func() int {
+						return len(atcServer.ReceivedRequests())
+					}).By(2))
+				})
+			})
+
+
+			Context("when the resource does not exist", func() {
+				var (
+					flyCmd *exec.Cmd
+					expectedQueryParams []string
+					expectedURL         = "/api/v1/teams/main/pipelines/some-pipeline/resources/no-existing-resource/cache"
+				)
+
+				JustBeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", expectedURL, strings.Join(expectedQueryParams, "&")),
+							ghttp.RespondWithJSONEncoded(http.StatusNotFound, ""),
+						),
+					)
+				})
+
+				It("writes that it did not exist", func() {
+					Expect(func() {
+						flyCmd = exec.Command(flyPath, "-t", targetName, "clear-resource-cache", "-r", "some-pipeline/no-existing-resource")
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(sess).Should(gexec.Exit(1))
+						Eventually(sess).Should(gbytes.Say("resource not found"))
+					}).To(Change(func() int {
+						return len(atcServer.ReceivedRequests())
+					}).By(2))
+				})
+			})
+
+
+
+			Context("and the api returns an unexpected status code", func() {
+				JustBeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", expectedURL, strings.Join(expectedQueryParams, "&")),
+							ghttp.RespondWith(http.StatusInternalServerError, ""),
+						),
+					)
+				})
+
+				It("writes an error message to stderr", func() {
+					Expect(func() {
+						flyCmd = exec.Command(flyPath, "-t", targetName, "clear-resource-cache", "-r", "some-pipeline/some-resource")
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
+						Eventually(sess).Should(gexec.Exit(1))
+					}).To(Change(func() int {
+						return len(atcServer.ReceivedRequests())
+					}).By(2))
+
+				})
+			})
+		})
+	})
+})

--- a/fly/integration/clear_resource_cache_test.go
+++ b/fly/integration/clear_resource_cache_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Fly CLI", func() {
 						Expect(err).NotTo(HaveOccurred())
 
 						Eventually(sess).Should(gexec.Exit(1))
-						Eventually(sess).Should(gbytes.Say("resource not found"))
+						Eventually(sess.Err).Should(gbytes.Say("resource not found"))
 					}).To(Change(func() int {
 						return len(atcServer.ReceivedRequests())
 					}).By(2))

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -142,6 +142,21 @@ type FakeTeam struct {
 		result2 bool
 		result3 error
 	}
+	ClearResourceCacheStub        func(atc.PipelineRef, string, atc.Version) (int64, error)
+	clearResourceCacheMutex       sync.RWMutex
+	clearResourceCacheArgsForCall []struct {
+		arg1 atc.PipelineRef
+		arg2 string
+		arg3 atc.Version
+	}
+	clearResourceCacheReturns struct {
+		result1 int64
+		result2 error
+	}
+	clearResourceCacheReturnsOnCall map[int]struct {
+		result1 int64
+		result2 error
+	}
 	ClearTaskCacheStub        func(atc.PipelineRef, string, string, string) (int64, error)
 	clearTaskCacheMutex       sync.RWMutex
 	clearTaskCacheArgsForCall []struct {
@@ -1360,6 +1375,72 @@ func (fake *FakeTeam) CheckResourceTypeReturnsOnCall(i int, result1 atc.Build, r
 		result2 bool
 		result3 error
 	}{result1, result2, result3}
+}
+
+func (fake *FakeTeam) ClearResourceCache(arg1 atc.PipelineRef, arg2 string, arg3 atc.Version) (int64, error) {
+	fake.clearResourceCacheMutex.Lock()
+	ret, specificReturn := fake.clearResourceCacheReturnsOnCall[len(fake.clearResourceCacheArgsForCall)]
+	fake.clearResourceCacheArgsForCall = append(fake.clearResourceCacheArgsForCall, struct {
+		arg1 atc.PipelineRef
+		arg2 string
+		arg3 atc.Version
+	}{arg1, arg2, arg3})
+	stub := fake.ClearResourceCacheStub
+	fakeReturns := fake.clearResourceCacheReturns
+	fake.recordInvocation("ClearResourceCache", []interface{}{arg1, arg2, arg3})
+	fake.clearResourceCacheMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeTeam) ClearResourceCacheCallCount() int {
+	fake.clearResourceCacheMutex.RLock()
+	defer fake.clearResourceCacheMutex.RUnlock()
+	return len(fake.clearResourceCacheArgsForCall)
+}
+
+func (fake *FakeTeam) ClearResourceCacheCalls(stub func(atc.PipelineRef, string, atc.Version) (int64, error)) {
+	fake.clearResourceCacheMutex.Lock()
+	defer fake.clearResourceCacheMutex.Unlock()
+	fake.ClearResourceCacheStub = stub
+}
+
+func (fake *FakeTeam) ClearResourceCacheArgsForCall(i int) (atc.PipelineRef, string, atc.Version) {
+	fake.clearResourceCacheMutex.RLock()
+	defer fake.clearResourceCacheMutex.RUnlock()
+	argsForCall := fake.clearResourceCacheArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTeam) ClearResourceCacheReturns(result1 int64, result2 error) {
+	fake.clearResourceCacheMutex.Lock()
+	defer fake.clearResourceCacheMutex.Unlock()
+	fake.ClearResourceCacheStub = nil
+	fake.clearResourceCacheReturns = struct {
+		result1 int64
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTeam) ClearResourceCacheReturnsOnCall(i int, result1 int64, result2 error) {
+	fake.clearResourceCacheMutex.Lock()
+	defer fake.clearResourceCacheMutex.Unlock()
+	fake.ClearResourceCacheStub = nil
+	if fake.clearResourceCacheReturnsOnCall == nil {
+		fake.clearResourceCacheReturnsOnCall = make(map[int]struct {
+			result1 int64
+			result2 error
+		})
+	}
+	fake.clearResourceCacheReturnsOnCall[i] = struct {
+		result1 int64
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeTeam) ClearTaskCache(arg1 atc.PipelineRef, arg2 string, arg3 string, arg4 string) (int64, error) {
@@ -4269,6 +4350,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.checkResourceMutex.RUnlock()
 	fake.checkResourceTypeMutex.RLock()
 	defer fake.checkResourceTypeMutex.RUnlock()
+	fake.clearResourceCacheMutex.RLock()
+	defer fake.clearResourceCacheMutex.RUnlock()
 	fake.clearTaskCacheMutex.RLock()
 	defer fake.clearTaskCacheMutex.RUnlock()
 	fake.createArtifactMutex.RLock()

--- a/go-concourse/concourse/resource_test.go
+++ b/go-concourse/concourse/resource_test.go
@@ -119,7 +119,7 @@ var _ = Describe("ATC Handler Resource", func() {
 		})
 	})
 
-	FDescribe("ClearResourceCache", func() {
+	Describe("ClearResourceCache", func() {
 		var (
 			expectedQueryParams []string
 			expectedURL = "/api/v1/teams/some-team/pipelines/some-pipeline/resources/some-resource/cache"

--- a/go-concourse/concourse/resource_test.go
+++ b/go-concourse/concourse/resource_test.go
@@ -2,6 +2,7 @@ package concourse_test
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/concourse/concourse/atc"
 	. "github.com/onsi/ginkgo"
@@ -114,6 +115,47 @@ var _ = Describe("ATC Handler Resource", func() {
 			It("returns false for found and an error", func() {
 				Expect(clientErr).To(HaveOccurred())
 				Expect(found).To(BeFalse())
+			})
+		})
+	})
+
+	FDescribe("ClearResourceCache", func() {
+		var (
+			expectedQueryParams []string
+			expectedURL = "/api/v1/teams/some-team/pipelines/some-pipeline/resources/some-resource/cache"
+			version = atc.Version{}
+			pipelineRef = atc.PipelineRef{Name: "some-pipeline"}
+		)
+
+		Context("when the API call succeeds", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("DELETE", expectedURL, strings.Join(expectedQueryParams, "&")),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearResourceCacheResponse{CachesRemoved: 1}),
+					),
+				)
+			})
+
+			It("return no error", func() {
+				rowsDeleted, err := team.ClearResourceCache(pipelineRef, "some-resource", version)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(rowsDeleted).Should(Equal(int64(1)))
+			})
+		})
+
+		Context("when the API call errors", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("DELETE", expectedURL, strings.Join(expectedQueryParams, "&")),
+						ghttp.RespondWithJSONEncoded(http.StatusInternalServerError, nil),
+					),
+				)
+			})
+			It("returns error", func() {
+				_, err := team.ClearResourceCache(pipelineRef, "some-resource", version)
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -56,6 +56,7 @@ type Team interface {
 	CheckResourceType(pipelineRef atc.PipelineRef, resourceTypeName string, version atc.Version) (atc.Build, bool, error)
 	DisableResourceVersion(pipelineRef atc.PipelineRef, resourceName string, resourceVersionID int) (bool, error)
 	EnableResourceVersion(pipelineRef atc.PipelineRef, resourceName string, resourceVersionID int) (bool, error)
+	ClearResourceCache(pipelineRef atc.PipelineRef, ResourceName string, version atc.Version) (int64, error)
 
 	PinResourceVersion(pipelineRef atc.PipelineRef, resourceName string, resourceVersionID int) (bool, error)
 	UnpinResource(pipelineRef atc.PipelineRef, resourceName string) (bool, error)


### PR DESCRIPTION
[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #1038

* [x] Added fly command `clear-resource-cache`

## Notes to reviewer
Added fly command `clear-resource-cache`
You could use this command following this structure  `fly -t ci clear-resource-cache -r pipeline/resource [--version some:version]`. 
The version flag is optional in case you want to specify the version of the resource-cache you would like to delete.
This command will return the numbers of caches deleted in the following format `1 caches removed`

## Release Note
* Added fly command `clear-resource-cache`, you could use this following the next format 
`fly -t ci clear-resource-cache -r pipeline/resource [--version some:version]`


[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
