### PR TITLE
Fix Postgres deadlock when frequently setting pipelines

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1201,7 +1201,7 @@ func (b *build) SaveOutput(
 		return err
 	}
 
-	resourceConfig, err := resourceConfigDescriptor.findOrCreate(tx, b.lockFactory, b.conn)
+	resourceConfig, err := resourceConfigDescriptor.findOrCreate(tx, b.lockFactory, b.conn, false)
 	if err != nil {
 		return err
 	}

--- a/atc/db/resource_cache.go
+++ b/atc/db/resource_cache.go
@@ -32,7 +32,7 @@ func (cache *ResourceCacheDescriptor) findOrCreate(
 	lockFactory lock.LockFactory,
 	conn Conn,
 ) (UsedResourceCache, error) {
-	resourceConfig, err := cache.ResourceConfigDescriptor.findOrCreate(tx, lockFactory, conn)
+	resourceConfig, err := cache.ResourceConfigDescriptor.findOrCreate(tx, lockFactory, conn, false)
 	if err != nil {
 		return nil, err
 	}

--- a/atc/db/resource_config_factory.go
+++ b/atc/db/resource_config_factory.go
@@ -90,11 +90,6 @@ func (f *resourceConfigFactory) FindOrCreateResourceConfig(
 		return nil, err
 	}
 
-	err = resourceConfig.updateLastReferenced(tx)
-	if err != nil {
-		return nil, err
-	}
-
 	err = tx.Commit()
 	if err != nil {
 		return nil, err

--- a/atc/db/resource_config_factory.go
+++ b/atc/db/resource_config_factory.go
@@ -85,7 +85,7 @@ func (f *resourceConfigFactory) FindOrCreateResourceConfig(
 	}
 	defer Rollback(tx)
 
-	resourceConfig, err := resourceConfigDescriptor.findOrCreate(tx, f.lockFactory, f.conn)
+	resourceConfig, err := resourceConfigDescriptor.findOrCreate(tx, f.lockFactory, f.conn, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #6670 

* [x] update `resource_configs.last_referenced` while finding an existing `resource_config` rather than first SELECTing and then UPDATEing
* [x] explicitly lock the `resource` prior to deleting any of the existing `resource_config_scopes` for that resource

## Notes to reviewer

Details for why these changes fix the issue are included in the commit messages/in comments (to the extent we understand them, at least)

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
