### PR TITLE
containerd: allow use of non-existent uids

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0
+	github.com/opencontainers/runc v1.0.0-rc93
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/peterhellberg/link v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -429,6 +429,7 @@ github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL9
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=


### PR DESCRIPTION
## Changes proposed by this PR

closes #6836 

Some images do not have an `/etc/passwd` file and need to be run with non-existent uids.  Guardian [accommodates](https://github.com/cloudfoundry/guardian/blob/bf4c737f2bc490aa82b8883e2c8964680236a8df/rundmc/users/lookup_linux.go#L24) for this by using runc's `user.GetExecUserPath` method.

Here, we can do the same. This method also takes care of all the uid and gid parsing logic we were doing before as well as the case when the username is root but the `/etc/passwd` file does not exist.

_Alternative and testing:_
An alternative would've been to implement the non-existent uid logic alongside the existing lookup. I felt it was best to hand this off to the runc method as we had been previously skeptical of having to maintain this logic ourselves. There are no unit tests as the logic is all taken care of by an external package. We could wrap this method behind an interface in order to have a basic i/o test but that feels excessive for something invoked only once.

* [x] when username is a UID simply set UID to that value
* [x] use runc's `user.GetExecUserPath` to handle all user lookup logic

## Notes to reviewer

The following tests involve creating a `task.yml` and then running it with `fly execute`. The first case is new behaviour and the rest are existing behaviour.

1. Check that image runs with non-existent uid
```
platform: linux
image_resource:
  type: registry-image
  source:
    repository: bitnami/kubectl
    tag: 1.20.4
run:
  path: id
``` 

Expected Result with `containerd` and `guardian`:
```
uid=1001 gid=0(root) groups=0(root)
```

This would previously break on `containerd`.

2. Check that when username is set to "root" and `etc/passwd` doesn't exist UID is still set to 0:

```
platform: linux
image_resource:
  type: registry-image
  source:
    repository: bitnami/kubectl
    tag: 1.20.4
run:
  path: id
  user: root
``` 

Expected Result:
```
uid=0(root) gid=0(root) groups=0(root)
```

3. Check if regular uid lookup still works by using a non-root user in busybox
```
platform: linux
image_resource:
  type: registry-image
  source:
    repository: busybox
run:
  path: id
  user: mail
```

Expected Result:
```
uid=8(mail) gid=8(mail)
```
## Release Note

* `containerd` supports running images with non-existent UIDs such as [distroless](https://github.com/GoogleContainerTools/distroless) images.
