### PR TITLE
containerd: properly populate /etc/hosts and /etc/hostname

### DIFF
--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -246,7 +246,7 @@ func (b *GardenBackend) startTask(ctx context.Context, cont containerd.Container
 		return fmt.Errorf("new task: %w", err)
 	}
 
-	err = b.network.Add(ctx, task)
+	err = b.network.Add(ctx, task, cont.ID())
 	if err != nil {
 		return fmt.Errorf("network add: %w", err)
 	}

--- a/worker/runtime/file_store.go
+++ b/worker/runtime/file_store.go
@@ -16,6 +16,10 @@ type FileStore interface {
 	//
 	Create(name string, content []byte) (absPath string, err error)
 
+	// Append appends to a file previously created in the store.
+	//
+	Append(name string, content []byte) error
+
 	// DeleteFile removes a file previously created in the store.
 	//
 	Delete(name string) (err error)
@@ -49,6 +53,24 @@ func (f fileStore) Create(name string, content []byte) (string, error) {
 
 	return absPath, nil
 }
+
+func (f fileStore) Append(name string, content []byte) error {
+	absPath := filepath.Join(f.root, name)
+
+	file, err := os.OpenFile(absPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := file.Write(content); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	return nil
+}
+
+
 
 func (f fileStore) Delete(path string) error {
 	absPath := filepath.Join(f.root, path)

--- a/worker/runtime/file_store_test.go
+++ b/worker/runtime/file_store_test.go
@@ -49,6 +49,17 @@ func (s *FileStoreSuite) TestCreateFileInDir() {
 	s.Equal("hey", string(content))
 }
 
+func (s *FileStoreSuite) TestAppendFile() {
+	fpath, err := s.store.Create("dir/name", []byte("hey"))
+	s.NoError(err)
+
+	err = s.store.Append("dir/name", []byte(" there"))
+	s.NoError(err)
+	content, err := ioutil.ReadFile(fpath)
+	s.NoError(err)
+	s.Equal("hey there", string(content))
+}
+
 func (s *FileStoreSuite) TestDeleteFile() {
 	fpath, err := s.store.Create("dir/name", []byte("hey"))
 	s.NoError(err)

--- a/worker/runtime/network.go
+++ b/worker/runtime/network.go
@@ -21,7 +21,7 @@ type Network interface {
 
 	// Add adds a task to the network.
 	//
-	Add(ctx context.Context, task containerd.Task) (err error)
+	Add(ctx context.Context, task containerd.Task, containerHandle string) (err error)
 
 	// Removes a task from the network.
 	//

--- a/worker/runtime/runtimefakes/fake_file_store.go
+++ b/worker/runtime/runtimefakes/fake_file_store.go
@@ -8,6 +8,18 @@ import (
 )
 
 type FakeFileStore struct {
+	AppendStub        func(string, []byte) error
+	appendMutex       sync.RWMutex
+	appendArgsForCall []struct {
+		arg1 string
+		arg2 []byte
+	}
+	appendReturns struct {
+		result1 error
+	}
+	appendReturnsOnCall map[int]struct {
+		result1 error
+	}
 	CreateStub        func(string, []byte) (string, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
@@ -35,6 +47,73 @@ type FakeFileStore struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeFileStore) Append(arg1 string, arg2 []byte) error {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.appendMutex.Lock()
+	ret, specificReturn := fake.appendReturnsOnCall[len(fake.appendArgsForCall)]
+	fake.appendArgsForCall = append(fake.appendArgsForCall, struct {
+		arg1 string
+		arg2 []byte
+	}{arg1, arg2Copy})
+	stub := fake.AppendStub
+	fakeReturns := fake.appendReturns
+	fake.recordInvocation("Append", []interface{}{arg1, arg2Copy})
+	fake.appendMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeFileStore) AppendCallCount() int {
+	fake.appendMutex.RLock()
+	defer fake.appendMutex.RUnlock()
+	return len(fake.appendArgsForCall)
+}
+
+func (fake *FakeFileStore) AppendCalls(stub func(string, []byte) error) {
+	fake.appendMutex.Lock()
+	defer fake.appendMutex.Unlock()
+	fake.AppendStub = stub
+}
+
+func (fake *FakeFileStore) AppendArgsForCall(i int) (string, []byte) {
+	fake.appendMutex.RLock()
+	defer fake.appendMutex.RUnlock()
+	argsForCall := fake.appendArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeFileStore) AppendReturns(result1 error) {
+	fake.appendMutex.Lock()
+	defer fake.appendMutex.Unlock()
+	fake.AppendStub = nil
+	fake.appendReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeFileStore) AppendReturnsOnCall(i int, result1 error) {
+	fake.appendMutex.Lock()
+	defer fake.appendMutex.Unlock()
+	fake.AppendStub = nil
+	if fake.appendReturnsOnCall == nil {
+		fake.appendReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.appendReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeFileStore) Create(arg1 string, arg2 []byte) (string, error) {
@@ -171,6 +250,8 @@ func (fake *FakeFileStore) DeleteReturnsOnCall(i int, result1 error) {
 func (fake *FakeFileStore) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.appendMutex.RLock()
+	defer fake.appendMutex.RUnlock()
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
 	fake.deleteMutex.RLock()

--- a/worker/runtime/runtimefakes/fake_network.go
+++ b/worker/runtime/runtimefakes/fake_network.go
@@ -11,11 +11,12 @@ import (
 )
 
 type FakeNetwork struct {
-	AddStub        func(context.Context, containerd.Task) error
+	AddStub        func(context.Context, containerd.Task, string) error
 	addMutex       sync.RWMutex
 	addArgsForCall []struct {
 		arg1 context.Context
 		arg2 containerd.Task
+		arg3 string
 	}
 	addReturns struct {
 		result1 error
@@ -62,19 +63,20 @@ type FakeNetwork struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeNetwork) Add(arg1 context.Context, arg2 containerd.Task) error {
+func (fake *FakeNetwork) Add(arg1 context.Context, arg2 containerd.Task, arg3 string) error {
 	fake.addMutex.Lock()
 	ret, specificReturn := fake.addReturnsOnCall[len(fake.addArgsForCall)]
 	fake.addArgsForCall = append(fake.addArgsForCall, struct {
 		arg1 context.Context
 		arg2 containerd.Task
-	}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.AddStub
 	fakeReturns := fake.addReturns
-	fake.recordInvocation("Add", []interface{}{arg1, arg2})
+	fake.recordInvocation("Add", []interface{}{arg1, arg2, arg3})
 	fake.addMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -88,17 +90,17 @@ func (fake *FakeNetwork) AddCallCount() int {
 	return len(fake.addArgsForCall)
 }
 
-func (fake *FakeNetwork) AddCalls(stub func(context.Context, containerd.Task) error) {
+func (fake *FakeNetwork) AddCalls(stub func(context.Context, containerd.Task, string) error) {
 	fake.addMutex.Lock()
 	defer fake.addMutex.Unlock()
 	fake.AddStub = stub
 }
 
-func (fake *FakeNetwork) AddArgsForCall(i int) (context.Context, containerd.Task) {
+func (fake *FakeNetwork) AddArgsForCall(i int) (context.Context, containerd.Task, string) {
 	fake.addMutex.RLock()
 	defer fake.addMutex.RUnlock()
 	argsForCall := fake.addArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeNetwork) AddReturns(result1 error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR
cc: @chenbh 

closes #6811

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->
* [x] add hostname to `/etc/hostname`
* [x] add container's IP and hostname to `/etc/hosts`

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->
The container's IP is only available once the network has been initialized. Therefore, the original /etc/hosts has to be updated after. The /etc/hosts on the container is bindmounted to a file on the worker.  We simply update this
file directly.

To test simply jump on to a running container and open the `/etc/hosts` and `/etc/hostname` file. You can also run `hostname -f` and `hostname -i` to validate.

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* containerd: `/etc/hosts` and `/etc/hostname` are correctly populated

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
