### PR TITLE
containerd: recover from invalid check sessions more quickly on worker restart

### DIFF
--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -327,7 +327,7 @@ func (b *GardenBackend) Containers(properties garden.Properties) ([]garden.Conta
 	containers := make([]garden.Container, len(tasks))
 	for i, task := range tasks {
 		containers[i] = &LazyContainer{
-			ID: task.ContainerID,
+			ID: task.ID,
 
 			client:        b.client,
 			killer:        b.killer,

--- a/worker/runtime/backend_test.go
+++ b/worker/runtime/backend_test.go
@@ -304,10 +304,10 @@ func (s *BackendSuite) TestContainersWithProperProperties() {
 func (s *BackendSuite) TestContainersConversion() {
 	s.client.TasksReturns([]libcontainerd.TaskInfo{
 		{
-			ContainerID: "container1",
+			ID: "container1",
 		},
 		{
-			ContainerID: "container2",
+			ID: "container2",
 		},
 	}, nil)
 

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -207,6 +207,7 @@ func (s *IntegrationSuite) TestContainersMissingTask() {
 	containers, err := s.gardenBackend.Containers(properties)
 	s.NoError(err)
 	s.Len(containers, 1)
+	s.Equal(containers[0].Handle(), handle)
 
 	_, err = s.ctr("tasks", "kill", handle, "--signal", "SIGKILL")
 	s.NoError(err)

--- a/worker/runtime/lazy_container.go
+++ b/worker/runtime/lazy_container.go
@@ -1,0 +1,174 @@
+package runtime
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"code.cloudfoundry.org/garden"
+	"github.com/concourse/concourse/worker/runtime/libcontainerd"
+)
+
+type LazyContainer struct {
+	ID string
+
+	client        libcontainerd.Client
+	killer        Killer
+	rootfsManager RootfsManager
+
+	container *Container
+}
+
+func (c *LazyContainer) ensureContainer() error {
+	if c.container != nil {
+		return nil
+	}
+
+	ctx := context.Background()
+	container, err := c.client.GetContainer(ctx, c.ID)
+	if err != nil {
+		return err
+	}
+
+	c.container = NewContainer(container, c.killer, c.rootfsManager)
+	return nil
+}
+
+var _ garden.Container = (*LazyContainer)(nil)
+
+func (c *LazyContainer) Handle() string {
+	return c.ID
+}
+
+func (c *LazyContainer) Stop(kill bool) error {
+	if err := c.ensureContainer(); err != nil {
+		return err
+	}
+	return c.container.Stop(kill)
+}
+
+func (c *LazyContainer) Run(spec garden.ProcessSpec, processIO garden.ProcessIO) (garden.Process, error) {
+	if err := c.ensureContainer(); err != nil {
+		return nil, err
+	}
+	return c.container.Run(spec, processIO)
+}
+
+func (c *LazyContainer) Attach(pid string, processIO garden.ProcessIO) (garden.Process, error) {
+	if err := c.ensureContainer(); err != nil {
+		return nil, err
+	}
+	return c.container.Attach(pid, processIO)
+}
+
+func (c *LazyContainer) Properties() (garden.Properties, error) {
+	if err := c.ensureContainer(); err != nil {
+		return garden.Properties{}, err
+	}
+	return c.container.Properties()
+}
+
+func (c *LazyContainer) Property(name string) (string, error) {
+	if err := c.ensureContainer(); err != nil {
+		return "", err
+	}
+	return c.container.Property(name)
+}
+
+func (c *LazyContainer) SetProperty(name string, value string) error {
+	if err := c.ensureContainer(); err != nil {
+		return err
+	}
+	return c.container.SetProperty(name, value)
+}
+
+func (c *LazyContainer) RemoveProperty(name string) error {
+	if err := c.ensureContainer(); err != nil {
+		return err
+	}
+	return c.container.RemoveProperty(name)
+}
+
+func (c *LazyContainer) Info() (garden.ContainerInfo, error) {
+	if err := c.ensureContainer(); err != nil {
+		return garden.ContainerInfo{}, err
+	}
+	return c.container.Info()
+}
+
+func (c *LazyContainer) Metrics() (garden.Metrics, error) {
+	if err := c.ensureContainer(); err != nil {
+		return garden.Metrics{}, err
+	}
+	return c.container.Metrics()
+}
+
+func (c *LazyContainer) StreamIn(spec garden.StreamInSpec) error {
+	if err := c.ensureContainer(); err != nil {
+		return err
+	}
+	return c.container.StreamIn(spec)
+}
+
+func (c *LazyContainer) StreamOut(spec garden.StreamOutSpec) (io.ReadCloser, error) {
+	if err := c.ensureContainer(); err != nil {
+		return nil, err
+	}
+	return c.container.StreamOut(spec)
+}
+
+func (c *LazyContainer) SetGraceTime(graceTime time.Duration) error {
+	if err := c.ensureContainer(); err != nil {
+		return err
+	}
+	return c.container.SetGraceTime(graceTime)
+}
+
+func (c *LazyContainer) CurrentBandwidthLimits() (garden.BandwidthLimits, error) {
+	if err := c.ensureContainer(); err != nil {
+		return garden.BandwidthLimits{}, err
+	}
+	return c.container.CurrentBandwidthLimits()
+}
+
+func (c *LazyContainer) CurrentCPULimits() (garden.CPULimits, error) {
+	if err := c.ensureContainer(); err != nil {
+		return garden.CPULimits{}, err
+	}
+	return c.container.CurrentCPULimits()
+}
+
+func (c *LazyContainer) CurrentDiskLimits() (garden.DiskLimits, error) {
+	if err := c.ensureContainer(); err != nil {
+		return garden.DiskLimits{}, err
+	}
+	return c.container.CurrentDiskLimits()
+}
+
+func (c *LazyContainer) CurrentMemoryLimits() (garden.MemoryLimits, error) {
+	if err := c.ensureContainer(); err != nil {
+		return garden.MemoryLimits{}, err
+	}
+	return c.container.CurrentMemoryLimits()
+}
+
+func (c *LazyContainer) NetIn(hostPort, containerPort uint32) (uint32, uint32, error) {
+	if err := c.ensureContainer(); err != nil {
+		return 0, 0, err
+	}
+	return c.container.NetIn(hostPort, containerPort)
+}
+
+func (c *LazyContainer) NetOut(netOutRule garden.NetOutRule) error {
+	if err := c.ensureContainer(); err != nil {
+		return err
+	}
+	return c.container.NetOut(netOutRule)
+}
+
+func (c *LazyContainer) BulkNetOut(netOutRules []garden.NetOutRule) error {
+	if err := c.ensureContainer(); err != nil {
+		return err
+	}
+	return c.container.BulkNetOut(netOutRules)
+}

--- a/worker/runtime/libcontainerd/client.go
+++ b/worker/runtime/libcontainerd/client.go
@@ -79,9 +79,8 @@ type Client interface {
 }
 
 type TaskInfo struct {
-	ContainerID string
-	ID          string
-	Pid         uint32
+	ID  string
+	Pid uint32
 }
 
 type client struct {
@@ -198,9 +197,8 @@ func (c *client) Tasks(ctx context.Context, filters ...string) ([]TaskInfo, erro
 	tasks := make([]TaskInfo, len(response.Tasks))
 	for i, task := range response.Tasks {
 		tasks[i] = TaskInfo{
-			ContainerID: task.ContainerID,
-			ID:          task.ID,
-			Pid:         task.Pid,
+			ID:  task.ID,
+			Pid: task.Pid,
 		}
 	}
 

--- a/worker/runtime/libcontainerd/libcontainerdfakes/fake_client.go
+++ b/worker/runtime/libcontainerd/libcontainerdfakes/fake_client.go
@@ -87,6 +87,20 @@ type FakeClient struct {
 	stopReturnsOnCall map[int]struct {
 		result1 error
 	}
+	TasksStub        func(context.Context, ...string) ([]libcontainerd.TaskInfo, error)
+	tasksMutex       sync.RWMutex
+	tasksArgsForCall []struct {
+		arg1 context.Context
+		arg2 []string
+	}
+	tasksReturns struct {
+		result1 []libcontainerd.TaskInfo
+		result2 error
+	}
+	tasksReturnsOnCall map[int]struct {
+		result1 []libcontainerd.TaskInfo
+		result2 error
+	}
 	VersionStub        func(context.Context) error
 	versionMutex       sync.RWMutex
 	versionArgsForCall []struct {
@@ -467,6 +481,71 @@ func (fake *FakeClient) StopReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeClient) Tasks(arg1 context.Context, arg2 ...string) ([]libcontainerd.TaskInfo, error) {
+	fake.tasksMutex.Lock()
+	ret, specificReturn := fake.tasksReturnsOnCall[len(fake.tasksArgsForCall)]
+	fake.tasksArgsForCall = append(fake.tasksArgsForCall, struct {
+		arg1 context.Context
+		arg2 []string
+	}{arg1, arg2})
+	stub := fake.TasksStub
+	fakeReturns := fake.tasksReturns
+	fake.recordInvocation("Tasks", []interface{}{arg1, arg2})
+	fake.tasksMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) TasksCallCount() int {
+	fake.tasksMutex.RLock()
+	defer fake.tasksMutex.RUnlock()
+	return len(fake.tasksArgsForCall)
+}
+
+func (fake *FakeClient) TasksCalls(stub func(context.Context, ...string) ([]libcontainerd.TaskInfo, error)) {
+	fake.tasksMutex.Lock()
+	defer fake.tasksMutex.Unlock()
+	fake.TasksStub = stub
+}
+
+func (fake *FakeClient) TasksArgsForCall(i int) (context.Context, []string) {
+	fake.tasksMutex.RLock()
+	defer fake.tasksMutex.RUnlock()
+	argsForCall := fake.tasksArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeClient) TasksReturns(result1 []libcontainerd.TaskInfo, result2 error) {
+	fake.tasksMutex.Lock()
+	defer fake.tasksMutex.Unlock()
+	fake.TasksStub = nil
+	fake.tasksReturns = struct {
+		result1 []libcontainerd.TaskInfo
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) TasksReturnsOnCall(i int, result1 []libcontainerd.TaskInfo, result2 error) {
+	fake.tasksMutex.Lock()
+	defer fake.tasksMutex.Unlock()
+	fake.TasksStub = nil
+	if fake.tasksReturnsOnCall == nil {
+		fake.tasksReturnsOnCall = make(map[int]struct {
+			result1 []libcontainerd.TaskInfo
+			result2 error
+		})
+	}
+	fake.tasksReturnsOnCall[i] = struct {
+		result1 []libcontainerd.TaskInfo
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) Version(arg1 context.Context) error {
 	fake.versionMutex.Lock()
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
@@ -543,6 +622,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.newContainerMutex.RUnlock()
 	fake.stopMutex.RLock()
 	defer fake.stopMutex.RUnlock()
+	fake.tasksMutex.RLock()
+	defer fake.tasksMutex.RUnlock()
 	fake.versionMutex.RLock()
 	defer fake.versionMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

this change was spurred by seeing checks error for a while after
redeploying our workers, e.g.:

```
run check: check: backend error: Exit status: 500, message: {"Type":"","Message":"task retrieval: no running task found: task 2adc1610-b027-4b0e-41e7-a7f9ebf74ee4 not found: not found","Handle":"","ProcessID":"","Binary":""}
```

the problem is that the ATC thinks the containers are still alive, so
does not invalidate the resource_config_check_session (until it expires
naturally, which can take up to an hour). digging into the worker, I
found that the Container actually *was* still alive - however, as the
error above suggests, the Task was not alive.

in containerd, a Container is just a metadata object that can contain a
Task. a Task is what we usually think of as a Container - a namespaced
process. so, what's happening when the worker restarts is the Container
persists, but the Task (i.e. the process) unsurprisingly gets
terminated. however, that Container doesn't get GC'd until the check
session expires because we report the Container as "alive", when it's in
fact not alive (if we consider the definition of Container used in the
rest of Concourse, i.e. an environment on which processes can be run)

so, with this change, the Garden `Containers` method only reports the
list of active Tasks, so when a Task dies, its corresponding Container
will eventually get GC'd.

note that we technically *could* start up a new Task on the Container if
we find the original task has been terminated, but this requires
additional bookkeeping to ensure we clean up the allocated network
namespaces for all of the tasks created for a Container. it's easier to
just treat a Container as a single-use thing and recreate them when
their process (task) dies

* [x] `Containers` reports only the active `Tasks` rather than all `Containers`
    * It still gives a list of usable `garden.Container`s, despite us only accessing the `Handle()` method currently
    * To avoid looking up each container every time, we wrap the Container in a `LazyContainer` that only looks up the container when a method is called on it

## Notes to reviewer

This mostly comes from how we use containerd, which doesn't seem to be very typical. When we create a Container, we spawn a Task running the `gdn-init` binary and wait for Concourse to "start a process in that task", in a sense.

What the more typical approach seems to be is to:
1. Create a Container (but not a Task up-front)
2. When Concourse tries to run something, only then spawn a Task that *runs the actual process*, not the `gdn-init` binary
3. When the process exits, remove the Task

There may be good reasons why we don't do this, I'm just not too sure what they are

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
