### PR TITLE
Make caching streamed volumes opt-in

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -250,7 +250,7 @@ type RunCommand struct {
 		EnableAcrossStep                     bool `long:"enable-across-step" description:"Enable the experimental across step to be used in jobs. The API is subject to change."`
 		EnablePipelineInstances              bool `long:"enable-pipeline-instances" description:"Enable pipeline instances"`
 		EnableP2PVolumeStreaming             bool `long:"enable-p2p-volume-streaming" description:"Enable P2P volume streaming"`
-		DisableCacheStreamedVolumes          bool `long:"disable-cache-streamed-volumes" description:"By default, streamed resource volumes will be automatically cached on the destination worker. This flag opts out of that behaviour"`
+		EnableCacheStreamedVolumes           bool `long:"enable-cache-streamed-volumes" description:"When enabled, streamed resource volumes will be cached on the destination worker."`
 	} `group:"Feature Flags"`
 
 	BaseResourceTypeDefaults flag.File `long:"base-resource-type-defaults" description:"Base resource type defaults"`
@@ -521,7 +521,7 @@ func (cmd *RunCommand) Runner(positionalArguments []string) (ifrit.Runner, error
 	atc.EnableBuildRerunWhenWorkerDisappears = cmd.FeatureFlags.EnableBuildRerunWhenWorkerDisappears
 	atc.EnableAcrossStep = cmd.FeatureFlags.EnableAcrossStep
 	atc.EnablePipelineInstances = cmd.FeatureFlags.EnablePipelineInstances
-	atc.EnableCacheStreamedVolumes = !cmd.FeatureFlags.DisableCacheStreamedVolumes
+	atc.EnableCacheStreamedVolumes = cmd.FeatureFlags.EnableCacheStreamedVolumes
 
 	if cmd.BaseResourceTypeDefaults.Path() != "" {
 		content, err := ioutil.ReadFile(cmd.BaseResourceTypeDefaults.Path())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       CONCOURSE_CLUSTER_NAME: dev
       CONCOURSE_ENABLE_PIPELINE_INSTANCES: "true"
       CONCOURSE_ENABLE_ACROSS_STEP: "true"
+      CONCOURSE_ENABLE_CACHE_STREAMED_VOLUMES: "true"
 
   worker:
     build: .

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       CONCOURSE_CLUSTER_NAME: test
       CONCOURSE_ENABLE_PIPELINE_INSTANCES: "true"
       CONCOURSE_ENABLE_ACROSS_STEP: "true"
+      CONCOURSE_ENABLE_CACHE_STREAMED_VOLUMES: "true"
 
   worker:
     image: ${TEST_CONCOURSE_DEV_IMAGE:-concourse/concourse:local}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

previously, this feature was enabled by default. we found that the disk
usage on our darwin/windows workers increased significantly though,
since we now keep volumes around for much longer. to avoid users running
into issues around this, lets make the feature off by default

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
