### PR TITLE
7.3.x: Fix capture of failing topgun tests logs

### DIFF
--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -158,7 +158,8 @@ var _ = AfterEach(func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		TimestampedBy("saving logs to " + dir + " due to test failure")
-		Bosh("logs", "--dir", dir)
+		// runs at top-level topgun folders as its working dir
+		Bosh("logs", "--dir", filepath.Join(filepath.Dir(test.FileName), dir))
 	}
 
 	DeleteAllContainers()


### PR DESCRIPTION
Working dir's got confusing, bosh executes one-level up from where the
test creates the "logs" dir.

Fixes this in the tests:
```
Moving to final destination:
    rename /root/.bosh/tmp/director-resource-20a1668f-a418-499a-a1ec-01b6c208e815025435329 logs/creds_test.go.112/concourse-topgun-7.3-6-20210520-195925-7744989.tgz: no such file or directory
```