### PR TITLE
Cleanup gomod and skip building fly by default in Dockerfile

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-major-minor.md
+++ b/.github/ISSUE_TEMPLATE/release-major-minor.md
@@ -8,10 +8,12 @@ assignees: ''
 
 Steps for a new major/minor release:
 
+* [ ] Add this issue to the `v<M.m.x>` milestone
+
 * [ ] Create your release branch on the `concourse/concourse` github repo with the following format `release/M.m.x` (M being the major version and m being the minor version)
 
 * [ ] Create the release branch on the `concourse/concourse-bosh-release` repository. Make any missing changes to the spec of `web` or `worker` depending on if the release contains any changes that adds or modifies any flags.
-  
+
   * Any changes you make on the branch will not get automatically merged back to master so try to make the changes on master and then create the branch from there.
   * We should really have something that will merge the branch back to master. (like we do for the `concourse/concourse` branches)
 
@@ -20,7 +22,7 @@ Steps for a new major/minor release:
 * [ ] Create the release branch on `concourse/concourse-chart` repository from the `dev` branch. Make any missing changes to `values.yaml` or `templates/web-deployment.yaml` for changes to flags on web or `templates/worker-deployment.yaml` for changes to flags on the worker.
 
 * [ ] Bump the appropriate versions for resource types. Go to the releases page `https://project.concourse-ci.org/releases` and take a look at which resource type repositories have had new commits or PRs. Take a look at what those changes entail and bump the version in their respective pipeline in `ci.concourse-ci.org`.
-  
+
   * If the changes were only README or repo restructuring changes with no user impact, you don't need to bump the version
   * If the changes were small bug fixes or changes, you can do a patch version bump
   * If the changes were adding of features, you can do a minor version bump
@@ -34,9 +36,9 @@ Steps for a new major/minor release:
   * If there is no documentation and the changes have user impact that should be documented, add the documentation to `concourse/docs`(or delegate) then add a `release/documented` label after finished. E.g. the addition of a new step type ( set_pipeline step).
   * If there is no documentation and the changes have user impact that do not need to be documented, add a `release/undocumented` label. E.g. an experimental feature.
   * If there is no documentation and the changes do not have user impact, add a `release/no-impact` label. E.g. refactors.
-  
+
 * [ ] Once the all source code changes are finalized, Concourse RC version should be deployed to CI
-  
+
   * including all the external workers (pr-worker, ci-topgun-worker, darwin-worker & BOSH deployed windows worker)
 
 * [ ] If you are doing a major release (or a release that involves a risky large feature), consider creating a [drills environment](https://github.com/concourse/drills) for some stress testing to ensure that the release does not involve any performance regressions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,15 @@ COPY . .
 RUN go build -gcflags=all="-N -l" -o /usr/local/concourse/bin/concourse \
       ./cmd/concourse
 
-# build 'fly' binary and update web CLI asset
+
+# separate build target to build the linux fly binary
+FROM base AS with-fly
 RUN go build -ldflags '-extldflags "-static"' -o /tmp/fly ./fly && \
       tar -C /tmp -czf /usr/local/concourse/fly-assets/fly-$(go env GOOS)-$(go env GOARCH).tgz fly && \
       rm /tmp/fly
+VOLUME /src
+ENV CONCOURSE_WEB_PUBLIC_DIR=/src/web/public
+
 
 # extend base stage with setup for local docker-compose workflow
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ FROM ${base_image} AS base
 WORKDIR /src
 COPY go.mod .
 COPY go.sum .
-RUN grep '^replace' go.mod || go mod download
+# don't do go mod download if there's a replace directive pointing to local filepath (./, ../)
+RUN grep ' => (\.\/|\.\.\/)' go.mod || go mod download
 
 # build the init executable for containerd
 COPY ./cmd/init/init.c /tmp/init.c

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/concourse/concourse
 
+go 1.16
+
 require (
 	code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c
 	code.cloudfoundry.org/credhub-cli v0.0.0-20190415201820-e3951663d25c
@@ -103,7 +105,3 @@ require (
 	k8s.io/client-go v0.21.1
 	sigs.k8s.io/yaml v1.2.0
 )
-
-go 1.16
-
-replace github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,7 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=

--- a/hack/overrides/with-fly.yml
+++ b/hack/overrides/with-fly.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  web:
+    build:
+      context: .
+      target: with-fly
+
+  worker:
+    build:
+      context: .
+      target: with-fly
+


### PR DESCRIPTION
## Changes proposed by this PR

- get rid of that random gomod replace directive since it's causing the build to skip `go mod download`
- building fly takes over a minute for me, it's also wasted time since it builds the linux version (I think the originally use case was for test suites)
- fly can still be built using the `--target=with-fly` during docker build
- update issue template for new releases. The newly created issue should be added to the release milestone for easier tracking

## Notes to reviewer

I _think_ this shouldn't break any of our pipelines because we now build `unit-image` and `dev-image` from dedicated dockerfiles in the ci repo and [pass it in directly](https://github.com/concourse/ci/blob/master/tasks/scripts/with-docker-compose#L9-L10) to docker-compose