### PR TITLE
7.3.x: update regex for capturing instances

### DIFF
--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -152,14 +152,13 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() {
 	test := CurrentGinkgoTestDescription()
 	if test.Failed {
-		dir := filepath.Join("logs", fmt.Sprintf("%s.%d", filepath.Base(test.FileName), test.LineNumber))
+		dir := filepath.Join("/tmp/logs", fmt.Sprintf("%s.%d", filepath.Base(test.FileName), test.LineNumber))
 
 		err := os.MkdirAll(dir, 0755)
 		Expect(err).ToNot(HaveOccurred())
 
 		TimestampedBy("saving logs to " + dir + " due to test failure")
-		// runs at top-level topgun folders as its working dir
-		Bosh("logs", "--dir", filepath.Join(filepath.Dir(test.FileName), dir))
+		Bosh("logs", "--dir", dir)
 	}
 
 	DeleteAllContainers()
@@ -598,5 +597,5 @@ var _ = SynchronizedAfterSuite(func() {
 	gexec.CleanupBuildArtifacts()
 })
 
-var InstanceRow = regexp.MustCompile(`^([^/]+)/([^\s]+)\s+-\s+(\w+)\s+z1\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s+([^\s]+)\s*`)
+var InstanceRow = regexp.MustCompile(`^([^/]+)\/([^\s]+)\s+-\s+(\w+|-)\s+z1\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s+([^\s]+)\s*`)
 var JobRow = regexp.MustCompile(`^([^\s]+)\s+(\w+)\s+(\w+)\s+-\s+-\s+-\s*`)


### PR DESCRIPTION
Guessing the output changed. It was no longer matching lines like:

```
credhub/5dbc6e93-b081-45a1-81b7-f710a0bed591  -           -              z1  10.0.1.8  cc-credhub-test
```

because the second "-" is expected to be a word, like "runnning", like
you see in this output:
```
db/69fbf193-c3c9-4167-8aa1-4deb46cd9217       -           running        z1  10.0.1.6  cc-credhub-test
```

Also fixing log capturing again. Storing logs in /tmp because it's too
hard to figure out what the path is when the test runs on CI. /tmp
should be fine, it won't get cleared out as long as the container is
runnning.
