### PR TITLE
topgun: update regex for capturing instances

### DIFF
--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -152,14 +152,13 @@ var _ = BeforeEach(func() {
 var _ = AfterEach(func() {
 	test := CurrentGinkgoTestDescription()
 	if test.Failed {
-		dir := filepath.Join("logs", fmt.Sprintf("%s.%d", filepath.Base(test.FileName), test.LineNumber))
+		dir := filepath.Join("/tmp/logs", fmt.Sprintf("%s.%d", filepath.Base(test.FileName), test.LineNumber))
 
 		err := os.MkdirAll(dir, 0755)
 		Expect(err).ToNot(HaveOccurred())
 
 		TimestampedBy("saving logs to " + dir + " due to test failure")
-		// runs at top-level topgun folders as its working dir
-		Bosh("logs", "--dir", filepath.Join(filepath.Dir(test.FileName), dir))
+		Bosh("logs", "--dir", dir)
 	}
 
 	DeleteAllContainers()
@@ -598,5 +597,5 @@ var _ = SynchronizedAfterSuite(func() {
 	gexec.CleanupBuildArtifacts()
 })
 
-var InstanceRow = regexp.MustCompile(`^([^/]+)/([^\s]+)\s+-\s+(\w+)\s+z1\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s+([^\s]+)\s*`)
+var InstanceRow = regexp.MustCompile(`^([^/]+)\/([^\s]+)\s+-\s+(\w+|-)\s+z1\s+([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\s+([^\s]+)\s*`)
 var JobRow = regexp.MustCompile(`^([^\s]+)\s+(\w+)\s+(\w+)\s+-\s+-\s+-\s*`)


### PR DESCRIPTION
## Changes proposed by this PR

* [x] update regex to capture bosh instances with no jobs
* [x] store logs from failed tests in `/tmp`

## Notes to reviewer

We verified the regex fixes the problem by intercepting a container and changing the code and re-running the tests

