### PR TITLE
Implement skeleton for Prototypes

### DIFF
--- a/atc/api/accessor/roles.go
+++ b/atc/api/accessor/roles.go
@@ -47,6 +47,7 @@ var DefaultRoles = map[string]string{
 	atc.CheckResource:                 OperatorRole,
 	atc.CheckResourceWebHook:          OperatorRole,
 	atc.CheckResourceType:             OperatorRole,
+	atc.CheckPrototype:                OperatorRole,
 	atc.ListResourceVersions:          ViewerRole,
 	atc.GetResourceVersion:            ViewerRole,
 	atc.EnableResourceVersion:         OperatorRole,

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -165,6 +165,7 @@ func NewHandler(
 		atc.CheckResource:           pipelineHandlerFactory.HandlerFor(resourceServer.CheckResource),
 		atc.CheckResourceWebHook:    pipelineHandlerFactory.HandlerFor(resourceServer.CheckResourceWebHook),
 		atc.CheckResourceType:       pipelineHandlerFactory.HandlerFor(resourceServer.CheckResourceType),
+		atc.CheckPrototype:          pipelineHandlerFactory.HandlerFor(resourceServer.CheckPrototype),
 		atc.ClearResourceCache:      pipelineHandlerFactory.HandlerFor(resourceServer.ClearResourceCache),
 
 		atc.ListResourceVersions:          pipelineHandlerFactory.HandlerFor(versionServer.ListResourceVersions),

--- a/atc/api/resourceserver/check_prototype.go
+++ b/atc/api/resourceserver/check_prototype.go
@@ -13,12 +13,12 @@ import (
 	"github.com/tedsuo/rata"
 )
 
-func (s *Server) CheckResourceType(dbPipeline db.Pipeline) http.Handler {
+func (s *Server) CheckPrototype(dbPipeline db.Pipeline) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resourceTypeName := rata.Param(r, "resource_type_name")
+		prototypeName := rata.Param(r, "prototype_name")
 
-		logger := s.logger.Session("check-resource-type", lager.Data{
-			"resource-type": resourceTypeName,
+		logger := s.logger.Session("check-prototype", lager.Data{
+			"prototype": prototypeName,
 		})
 
 		var reqBody atc.CheckRequestBody
@@ -29,15 +29,15 @@ func (s *Server) CheckResourceType(dbPipeline db.Pipeline) http.Handler {
 			return
 		}
 
-		dbResourceType, found, err := dbPipeline.ResourceType(resourceTypeName)
+		dbPrototype, found, err := dbPipeline.Prototype(prototypeName)
 		if err != nil {
-			logger.Error("failed-to-get-resource-type", err)
+			logger.Error("failed-to-get-prototype", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
 		if !found {
-			logger.Info("resource-type-not-found")
+			logger.Info("prototype-not-found")
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -51,7 +51,7 @@ func (s *Server) CheckResourceType(dbPipeline db.Pipeline) http.Handler {
 
 		build, created, err := s.checkFactory.TryCreateCheck(
 			lagerctx.NewContext(context.Background(), logger),
-			dbResourceType,
+			dbPrototype,
 			dbResourceTypes,
 			reqBody.From,
 			true,

--- a/atc/api/resourceserver/check_resource_type.go
+++ b/atc/api/resourceserver/check_resource_type.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tedsuo/rata"
 )
 
+// XXX(prototypes): will need a CheckPrototype (and corresponding fly check-prototype)
 func (s *Server) CheckResourceType(dbPipeline db.Pipeline) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resourceTypeName := rata.Param(r, "resource_type_name")

--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -115,6 +115,7 @@ func (a *auditor) ValidateAction(action string) bool {
 		atc.CheckResource,
 		atc.CheckResourceWebHook,
 		atc.CheckResourceType,
+		atc.CheckPrototype,
 		atc.ListResourceVersions,
 		atc.GetResourceVersion,
 		atc.EnableResourceVersion,

--- a/atc/builds/errors.go
+++ b/atc/builds/errors.go
@@ -14,6 +14,16 @@ func (err UnknownResourceError) Error() string {
 	return fmt.Sprintf("unknown resource: %s", err.Resource)
 }
 
+// UnknownPrototypeError is returned when a 'run' step refers to a
+// prototypes which is not in the set of prototypes provided to the Planner.
+type UnknownPrototypeError struct {
+	Prototype string
+}
+
+func (err UnknownPrototypeError) Error() string {
+	return fmt.Sprintf("unknown prototype: %s", err.Prototype)
+}
+
 // VersionNotProvidedError is returned when a 'get' step does not have a
 // corresponding input provided to the Planner.
 type VersionNotProvidedError struct {

--- a/atc/config.go
+++ b/atc/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	VarSources    VarSourceConfigs `json:"var_sources,omitempty"`
 	Resources     ResourceConfigs  `json:"resources,omitempty"`
 	ResourceTypes ResourceTypes    `json:"resource_types,omitempty"`
+	Prototypes    Prototypes       `json:"prototypes,omitempty"`
 	Jobs          JobConfigs       `json:"jobs,omitempty"`
 	Display       *DisplayConfig   `json:"display,omitempty"`
 }
@@ -35,6 +36,7 @@ func UnmarshalConfig(payload []byte, config interface{}) error {
 		VarSources    interface{} `json:"var_sources,omitempty"`
 		Resources     interface{} `json:"resources,omitempty"`
 		ResourceTypes interface{} `json:"resource_types,omitempty"`
+		Prototypes    interface{} `json:"prototypes,omitempty"`
 		Jobs          interface{} `json:"jobs,omitempty"`
 		Display       interface{} `json:"display,omitempty"`
 	}
@@ -201,6 +203,17 @@ type ResourceType struct {
 	Params     Params      `json:"params,omitempty"`
 }
 
+type Prototype struct {
+	Name       string      `json:"name"`
+	Type       string      `json:"type"`
+	Source     Source      `json:"source"`
+	Defaults   Source      `json:"defaults,omitempty"`
+	Privileged bool        `json:"privileged,omitempty"`
+	CheckEvery *CheckEvery `json:"check_every,omitempty"`
+	Tags       Tags        `json:"tags,omitempty"`
+	Params     Params      `json:"params,omitempty"`
+}
+
 type DisplayConfig struct {
 	BackgroundImage string `json:"background_image,omitempty"`
 }
@@ -247,6 +260,8 @@ func (c *CheckEvery) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal("")
 }
+
+type Prototypes []Prototype
 
 type ResourceTypes []ResourceType
 

--- a/atc/config.go
+++ b/atc/config.go
@@ -263,6 +263,16 @@ func (c *CheckEvery) MarshalJSON() ([]byte, error) {
 
 type Prototypes []Prototype
 
+func (types Prototypes) Lookup(name string) (Prototype, bool) {
+	for _, t := range types {
+		if t.Name == name {
+			return t, true
+		}
+	}
+
+	return Prototype{}, false
+}
+
 type ResourceTypes []ResourceType
 
 func (types ResourceTypes) Lookup(name string) (ResourceType, bool) {

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -69,6 +69,7 @@ var buildsQuery = psql.Select(`
 		b.job_id,
 		b.resource_id,
 		b.resource_type_id,
+		b.prototype_id,
 		b.team_id,
 		b.status,
 		b.manually_triggered,
@@ -84,6 +85,7 @@ var buildsQuery = psql.Select(`
 		j.name,
 		r.name,
 		rt.name,
+		pt.name,
 		b.pipeline_id,
 		p.name,
 		p.instance_vars,
@@ -102,6 +104,7 @@ var buildsQuery = psql.Select(`
 	JoinClause("LEFT OUTER JOIN jobs j ON b.job_id = j.id").
 	JoinClause("LEFT OUTER JOIN resources r ON b.resource_id = r.id").
 	JoinClause("LEFT OUTER JOIN resource_types rt ON b.resource_type_id = rt.id").
+	JoinClause("LEFT OUTER JOIN prototypes pt ON b.prototype_id = pt.id").
 	JoinClause("LEFT OUTER JOIN pipelines p ON b.pipeline_id = p.id").
 	JoinClause("LEFT OUTER JOIN teams t ON b.team_id = t.id").
 	JoinClause("LEFT OUTER JOIN builds rb ON rb.id = b.rerun_of")
@@ -131,6 +134,9 @@ type Build interface {
 
 	ResourceTypeID() int
 	ResourceTypeName() string
+
+	PrototypeID() int
+	PrototypeName() string
 
 	Schema() string
 	PrivatePlan() atc.Plan
@@ -226,6 +232,9 @@ type build struct {
 	resourceTypeID   int
 	resourceTypeName string
 
+	prototypeID   int
+	prototypeName string
+
 	isManuallyTriggered bool
 
 	createdBy *string
@@ -282,6 +291,8 @@ func (b *build) SyslogTag(origin event.OriginID) string {
 		segments = append(segments, b.resourceName, strconv.Itoa(b.id))
 	} else if b.resourceTypeID != 0 {
 		segments = append(segments, b.resourceTypeName, strconv.Itoa(b.id))
+	} else if b.prototypeID != 0 {
+		segments = append(segments, b.prototypeName, strconv.Itoa(b.id))
 	} else {
 		segments = append(segments, strconv.Itoa(b.id))
 	}
@@ -316,6 +327,10 @@ func (b *build) LagerData() lager.Data {
 		data["resource_type"] = b.resourceTypeName
 	}
 
+	if b.prototypeID != 0 {
+		data["prototype"] = b.prototypeName
+	}
+
 	return data
 }
 
@@ -345,6 +360,10 @@ func (b *build) TracingAttrs() tracing.Attrs {
 		data["resource_type"] = b.resourceTypeName
 	}
 
+	if b.prototypeID != 0 {
+		data["prototype"] = b.prototypeName
+	}
+
 	return data
 }
 
@@ -356,6 +375,8 @@ func (b *build) ResourceID() int              { return b.resourceID }
 func (b *build) ResourceName() string         { return b.resourceName }
 func (b *build) ResourceTypeID() int          { return b.resourceTypeID }
 func (b *build) ResourceTypeName() string     { return b.resourceTypeName }
+func (b *build) PrototypeID() int             { return b.prototypeID }
+func (b *build) PrototypeName() string        { return b.prototypeName }
 func (b *build) TeamID() int                  { return b.teamID }
 func (b *build) TeamName() string             { return b.teamName }
 func (b *build) IsManuallyTriggered() bool    { return b.isManuallyTriggered }
@@ -1765,13 +1786,13 @@ func buildEventSeq(buildid int) string {
 
 func scanBuild(b *build, row scannable, encryptionStrategy encryption.Strategy) error {
 	var (
-		jobID, resourceID, resourceTypeID, pipelineID, rerunOf, rerunNumber                                 sql.NullInt64
-		schema, privatePlan, jobName, resourceName, resourceTypeName, pipelineName, publicPlan, rerunOfName sql.NullString
-		createTime, startTime, endTime, reapTime                                                            pq.NullTime
-		nonce, spanContext, createdBy                                                                       sql.NullString
-		drained, aborted, completed                                                                         bool
-		status                                                                                              string
-		pipelineInstanceVars                                                                                sql.NullString
+		jobID, resourceID, resourceTypeID, prototypeID, pipelineID, rerunOf, rerunNumber                                   sql.NullInt64
+		schema, privatePlan, jobName, resourceName, resourceTypeName, prototypeName, pipelineName, publicPlan, rerunOfName sql.NullString
+		createTime, startTime, endTime, reapTime                                                                           pq.NullTime
+		nonce, spanContext, createdBy                                                                                      sql.NullString
+		drained, aborted, completed                                                                                        bool
+		status                                                                                                             string
+		pipelineInstanceVars                                                                                               sql.NullString
 	)
 
 	err := row.Scan(
@@ -1780,6 +1801,7 @@ func scanBuild(b *build, row scannable, encryptionStrategy encryption.Strategy) 
 		&jobID,
 		&resourceID,
 		&resourceTypeID,
+		&prototypeID,
 		&b.teamID,
 		&status,
 		&b.isManuallyTriggered,
@@ -1795,6 +1817,7 @@ func scanBuild(b *build, row scannable, encryptionStrategy encryption.Strategy) 
 		&jobName,
 		&resourceName,
 		&resourceTypeName,
+		&prototypeName,
 		&pipelineID,
 		&pipelineName,
 		&pipelineInstanceVars,
@@ -1820,6 +1843,8 @@ func scanBuild(b *build, row scannable, encryptionStrategy encryption.Strategy) 
 	b.resourceName = resourceName.String
 	b.resourceTypeID = int(resourceTypeID.Int64)
 	b.resourceTypeName = resourceTypeName.String
+	b.prototypeID = int(prototypeID.Int64)
+	b.prototypeName = prototypeName.String
 	b.pipelineID = int(pipelineID.Int64)
 	b.pipelineName = pipelineName.String
 	b.schema = schema.String
@@ -1899,7 +1924,7 @@ func (b *build) saveEvent(tx Tx, event atc.Event) error {
 }
 
 func (b *build) isForCheck() bool {
-	return b.resourceTypeID != 0 || b.resourceID != 0
+	return b.resourceTypeID != 0 || b.resourceID != 0 || b.prototypeID != 0
 }
 
 func (b *build) eventsTable() string {

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Build", func() {
 		Expect(build.HasPlan()).To(BeFalse())
 	})
 
-	It("create_time is current time", func(){
+	It("create_time is current time", func() {
 		Expect(build.CreateTime()).To(BeTemporally("<", time.Now(), 1*time.Second))
 	})
 
@@ -163,6 +163,26 @@ var _ = Describe("Build", func() {
 				}))
 			})
 		})
+
+		Context("for a prototype build", func() {
+			BeforeEach(func() {
+				var err error
+				var created bool
+				build, created, err = defaultPrototype.CreateBuild(context.TODO(), false, atc.Plan{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(created).To(BeTrue())
+			})
+
+			It("includes build, team, and pipeline", func() {
+				Expect(data).To(Equal(lager.Data{
+					"build_id":  build.ID(),
+					"build":     build.Name(),
+					"team":      build.TeamName(),
+					"pipeline":  build.PipelineName(),
+					"prototype": defaultPrototype.Name(),
+				}))
+			})
+		})
 	})
 
 	Describe("SyslogTag", func() {
@@ -224,6 +244,20 @@ var _ = Describe("Build", func() {
 
 			It("includes build, team, and pipeline", func() {
 				Expect(tag).To(Equal(fmt.Sprintf("%s/%s/%s/%d/%s", defaultResourceType.TeamName(), defaultResourceType.PipelineName(), defaultResourceType.Name(), build.ID(), originID)))
+			})
+		})
+
+		Context("for a prototype build", func() {
+			BeforeEach(func() {
+				var err error
+				var created bool
+				build, created, err = defaultPrototype.CreateBuild(context.TODO(), false, atc.Plan{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(created).To(BeTrue())
+			})
+
+			It("includes build, team, and pipeline", func() {
+				Expect(tag).To(Equal(fmt.Sprintf("%s/%s/%s/%d/%s", defaultPrototype.TeamName(), defaultPrototype.PipelineName(), defaultPrototype.Name(), build.ID(), originID)))
 			})
 		})
 	})
@@ -307,6 +341,26 @@ var _ = Describe("Build", func() {
 					"team_name":     build.TeamName(),
 					"pipeline":      build.PipelineName(),
 					"resource_type": defaultResourceType.Name(),
+				}))
+			})
+		})
+
+		Context("for a prototype build", func() {
+			BeforeEach(func() {
+				var err error
+				var created bool
+				build, created, err = defaultPrototype.CreateBuild(context.TODO(), false, atc.Plan{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(created).To(BeTrue())
+			})
+
+			It("includes build, team, and pipeline", func() {
+				Expect(attrs).To(Equal(tracing.Attrs{
+					"build_id":  strconv.Itoa(build.ID()),
+					"build":     build.Name(),
+					"team_name": build.TeamName(),
+					"pipeline":  build.PipelineName(),
+					"prototype": defaultPrototype.Name(),
 				}))
 			})
 		})

--- a/atc/db/check_lifecycle.go
+++ b/atc/db/check_lifecycle.go
@@ -33,11 +33,15 @@ func (cl *checkLifecycle) DeleteCompletedChecks() error {
           FROM builds b
           WHERE completed AND resource_type_id IS NOT NULL
           AND EXISTS (SELECT * FROM builds b2 WHERE b.resource_type_id = b2.resource_type_id AND b.id < b2.id)
+            UNION ALL
+          SELECT id
+          FROM builds b
+          WHERE completed AND prototype_id IS NOT NULL
+          AND EXISTS (SELECT * FROM builds b2 WHERE b.prototype_id = b2.prototype_id AND b.id < b2.id)
 		) AS deletable_builds WHERE builds.id = deletable_builds.id
 		RETURNING builds.id
       )
       DELETE FROM check_build_events USING deleted_builds WHERE build_id = deleted_builds.id
     `)
-	// TODO: delete prototype checks
 	return err
 }

--- a/atc/db/check_lifecycle.go
+++ b/atc/db/check_lifecycle.go
@@ -38,5 +38,6 @@ func (cl *checkLifecycle) DeleteCompletedChecks() error {
       )
       DELETE FROM check_build_events USING deleted_builds WHERE build_id = deleted_builds.id
     `)
+	// TODO: delete prototype checks
 	return err
 }

--- a/atc/db/check_lifecycle_test.go
+++ b/atc/db/check_lifecycle_test.go
@@ -58,12 +58,14 @@ var _ = Describe("Check Lifecycle", func() {
 	It("removes completed check builds when there is a new completed check", func() {
 		resourceBuild := createFinishedCheck(defaultResource, plan)
 		resourceTypeBuild := createFinishedCheck(defaultResourceType, plan)
+		prototypeBuild := createFinishedCheck(defaultPrototype, plan)
 
 		By("attempting to delete completed checks when there are no newer checks")
 		err := lifecycle.DeleteCompletedChecks()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exists(resourceBuild)).To(BeTrue())
 		Expect(exists(resourceTypeBuild)).To(BeTrue())
+		Expect(exists(prototypeBuild)).To(BeTrue())
 
 		By("creating a new check for the resource")
 		createFinishedCheck(defaultResource, plan)
@@ -76,6 +78,7 @@ var _ = Describe("Check Lifecycle", func() {
 		Expect(numBuildEventsForCheck(resourceBuild)).To(Equal(0))
 
 		Expect(exists(resourceTypeBuild)).To(BeTrue())
+		Expect(exists(prototypeBuild)).To(BeTrue())
 
 		By("creating a new check for the resource type")
 		createFinishedCheck(defaultResourceType, plan)
@@ -86,6 +89,18 @@ var _ = Describe("Check Lifecycle", func() {
 
 		Expect(exists(resourceTypeBuild)).To(BeFalse())
 		Expect(numBuildEventsForCheck(resourceTypeBuild)).To(Equal(0))
+
+		Expect(exists(prototypeBuild)).To(BeTrue())
+
+		By("creating a new check for the prototype")
+		createFinishedCheck(defaultPrototype, plan)
+
+		By("deleting completed checks")
+		err = lifecycle.DeleteCompletedChecks()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(exists(prototypeBuild)).To(BeFalse())
+		Expect(numBuildEventsForCheck(prototypeBuild)).To(Equal(0))
 	})
 
 	It("ignores incomplete checks", func() {

--- a/atc/db/container_metadata.go
+++ b/atc/db/container_metadata.go
@@ -28,6 +28,7 @@ const (
 	ContainerTypeGet   ContainerType = "get"
 	ContainerTypePut   ContainerType = "put"
 	ContainerTypeTask  ContainerType = "task"
+	ContainerTypeRun   ContainerType = "run"
 )
 
 func ContainerTypeFromString(containerType string) (ContainerType, error) {
@@ -40,6 +41,8 @@ func ContainerTypeFromString(containerType string) (ContainerType, error) {
 		return ContainerTypePut, nil
 	case "task":
 		return ContainerTypeTask, nil
+	case "run":
+		return ContainerTypeRun, nil
 	default:
 		return "", fmt.Errorf("unrecognized containerType: %s", containerType)
 	}

--- a/atc/db/db_suite_test.go
+++ b/atc/db/db_suite_test.go
@@ -58,6 +58,7 @@ var (
 	defaultWorker             db.Worker
 	otherWorker               db.Worker
 	otherWorkerPayload        atc.Worker
+	defaultPrototype          db.Prototype
 	defaultResourceType       db.ResourceType
 	defaultResource           db.Resource
 	defaultPipelineConfig     atc.Config
@@ -201,6 +202,15 @@ var _ = BeforeEach(func() {
 				},
 			},
 		},
+		Prototypes: atc.Prototypes{
+			{
+				Name: "some-prototype",
+				Type: "some-base-resource-type",
+				Source: atc.Source{
+					"some-prototype": "source",
+				},
+			},
+		},
 	}
 
 	defaultPipelineRef = atc.PipelineRef{Name: "default-pipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
@@ -214,6 +224,10 @@ var _ = BeforeEach(func() {
 	Expect(found).To(BeTrue())
 
 	defaultResource, found, err = defaultPipeline.Resource("some-resource")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
+
+	defaultPrototype, found, err = defaultPipeline.Prototype("some-prototype")
 	Expect(err).NotTo(HaveOccurred())
 	Expect(found).To(BeTrue())
 

--- a/atc/db/dbfakes/fake_build.go
+++ b/atc/db/dbfakes/fake_build.go
@@ -406,6 +406,26 @@ type FakeBuild struct {
 	privatePlanReturnsOnCall map[int]struct {
 		result1 atc.Plan
 	}
+	PrototypeIDStub        func() int
+	prototypeIDMutex       sync.RWMutex
+	prototypeIDArgsForCall []struct {
+	}
+	prototypeIDReturns struct {
+		result1 int
+	}
+	prototypeIDReturnsOnCall map[int]struct {
+		result1 int
+	}
+	PrototypeNameStub        func() string
+	prototypeNameMutex       sync.RWMutex
+	prototypeNameArgsForCall []struct {
+	}
+	prototypeNameReturns struct {
+		result1 string
+	}
+	prototypeNameReturnsOnCall map[int]struct {
+		result1 string
+	}
 	PublicPlanStub        func() *json.RawMessage
 	publicPlanMutex       sync.RWMutex
 	publicPlanArgsForCall []struct {
@@ -2671,6 +2691,112 @@ func (fake *FakeBuild) PrivatePlanReturnsOnCall(i int, result1 atc.Plan) {
 	}{result1}
 }
 
+func (fake *FakeBuild) PrototypeID() int {
+	fake.prototypeIDMutex.Lock()
+	ret, specificReturn := fake.prototypeIDReturnsOnCall[len(fake.prototypeIDArgsForCall)]
+	fake.prototypeIDArgsForCall = append(fake.prototypeIDArgsForCall, struct {
+	}{})
+	stub := fake.PrototypeIDStub
+	fakeReturns := fake.prototypeIDReturns
+	fake.recordInvocation("PrototypeID", []interface{}{})
+	fake.prototypeIDMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBuild) PrototypeIDCallCount() int {
+	fake.prototypeIDMutex.RLock()
+	defer fake.prototypeIDMutex.RUnlock()
+	return len(fake.prototypeIDArgsForCall)
+}
+
+func (fake *FakeBuild) PrototypeIDCalls(stub func() int) {
+	fake.prototypeIDMutex.Lock()
+	defer fake.prototypeIDMutex.Unlock()
+	fake.PrototypeIDStub = stub
+}
+
+func (fake *FakeBuild) PrototypeIDReturns(result1 int) {
+	fake.prototypeIDMutex.Lock()
+	defer fake.prototypeIDMutex.Unlock()
+	fake.PrototypeIDStub = nil
+	fake.prototypeIDReturns = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeBuild) PrototypeIDReturnsOnCall(i int, result1 int) {
+	fake.prototypeIDMutex.Lock()
+	defer fake.prototypeIDMutex.Unlock()
+	fake.PrototypeIDStub = nil
+	if fake.prototypeIDReturnsOnCall == nil {
+		fake.prototypeIDReturnsOnCall = make(map[int]struct {
+			result1 int
+		})
+	}
+	fake.prototypeIDReturnsOnCall[i] = struct {
+		result1 int
+	}{result1}
+}
+
+func (fake *FakeBuild) PrototypeName() string {
+	fake.prototypeNameMutex.Lock()
+	ret, specificReturn := fake.prototypeNameReturnsOnCall[len(fake.prototypeNameArgsForCall)]
+	fake.prototypeNameArgsForCall = append(fake.prototypeNameArgsForCall, struct {
+	}{})
+	stub := fake.PrototypeNameStub
+	fakeReturns := fake.prototypeNameReturns
+	fake.recordInvocation("PrototypeName", []interface{}{})
+	fake.prototypeNameMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeBuild) PrototypeNameCallCount() int {
+	fake.prototypeNameMutex.RLock()
+	defer fake.prototypeNameMutex.RUnlock()
+	return len(fake.prototypeNameArgsForCall)
+}
+
+func (fake *FakeBuild) PrototypeNameCalls(stub func() string) {
+	fake.prototypeNameMutex.Lock()
+	defer fake.prototypeNameMutex.Unlock()
+	fake.PrototypeNameStub = stub
+}
+
+func (fake *FakeBuild) PrototypeNameReturns(result1 string) {
+	fake.prototypeNameMutex.Lock()
+	defer fake.prototypeNameMutex.Unlock()
+	fake.PrototypeNameStub = nil
+	fake.prototypeNameReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeBuild) PrototypeNameReturnsOnCall(i int, result1 string) {
+	fake.prototypeNameMutex.Lock()
+	defer fake.prototypeNameMutex.Unlock()
+	fake.PrototypeNameStub = nil
+	if fake.prototypeNameReturnsOnCall == nil {
+		fake.prototypeNameReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.prototypeNameReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakeBuild) PublicPlan() *json.RawMessage {
 	fake.publicPlanMutex.Lock()
 	ret, specificReturn := fake.publicPlanReturnsOnCall[len(fake.publicPlanArgsForCall)]
@@ -4336,6 +4462,10 @@ func (fake *FakeBuild) Invocations() map[string][][]interface{} {
 	defer fake.preparationMutex.RUnlock()
 	fake.privatePlanMutex.RLock()
 	defer fake.privatePlanMutex.RUnlock()
+	fake.prototypeIDMutex.RLock()
+	defer fake.prototypeIDMutex.RUnlock()
+	fake.prototypeNameMutex.RLock()
+	defer fake.prototypeNameMutex.RUnlock()
 	fake.publicPlanMutex.RLock()
 	defer fake.publicPlanMutex.RUnlock()
 	fake.reapTimeMutex.RLock()

--- a/atc/db/dbfakes/fake_pipeline.go
+++ b/atc/db/dbfakes/fake_pipeline.go
@@ -355,6 +355,33 @@ type FakePipeline struct {
 	pausedReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	PrototypeStub        func(string) (db.Prototype, bool, error)
+	prototypeMutex       sync.RWMutex
+	prototypeArgsForCall []struct {
+		arg1 string
+	}
+	prototypeReturns struct {
+		result1 db.Prototype
+		result2 bool
+		result3 error
+	}
+	prototypeReturnsOnCall map[int]struct {
+		result1 db.Prototype
+		result2 bool
+		result3 error
+	}
+	PrototypesStub        func() (db.Prototypes, error)
+	prototypesMutex       sync.RWMutex
+	prototypesArgsForCall []struct {
+	}
+	prototypesReturns struct {
+		result1 db.Prototypes
+		result2 error
+	}
+	prototypesReturnsOnCall map[int]struct {
+		result1 db.Prototypes
+		result2 error
+	}
 	PublicStub        func() bool
 	publicMutex       sync.RWMutex
 	publicArgsForCall []struct {
@@ -418,21 +445,6 @@ type FakePipeline struct {
 		result3 error
 	}
 	resourceTypeReturnsOnCall map[int]struct {
-		result1 db.ResourceType
-		result2 bool
-		result3 error
-	}
-	ResourceTypeByIDStub        func(int) (db.ResourceType, bool, error)
-	resourceTypeByIDMutex       sync.RWMutex
-	resourceTypeByIDArgsForCall []struct {
-		arg1 int
-	}
-	resourceTypeByIDReturns struct {
-		result1 db.ResourceType
-		result2 bool
-		result3 error
-	}
-	resourceTypeByIDReturnsOnCall map[int]struct {
 		result1 db.ResourceType
 		result2 bool
 		result3 error
@@ -2256,6 +2268,129 @@ func (fake *FakePipeline) PausedReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
+func (fake *FakePipeline) Prototype(arg1 string) (db.Prototype, bool, error) {
+	fake.prototypeMutex.Lock()
+	ret, specificReturn := fake.prototypeReturnsOnCall[len(fake.prototypeArgsForCall)]
+	fake.prototypeArgsForCall = append(fake.prototypeArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.PrototypeStub
+	fakeReturns := fake.prototypeReturns
+	fake.recordInvocation("Prototype", []interface{}{arg1})
+	fake.prototypeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakePipeline) PrototypeCallCount() int {
+	fake.prototypeMutex.RLock()
+	defer fake.prototypeMutex.RUnlock()
+	return len(fake.prototypeArgsForCall)
+}
+
+func (fake *FakePipeline) PrototypeCalls(stub func(string) (db.Prototype, bool, error)) {
+	fake.prototypeMutex.Lock()
+	defer fake.prototypeMutex.Unlock()
+	fake.PrototypeStub = stub
+}
+
+func (fake *FakePipeline) PrototypeArgsForCall(i int) string {
+	fake.prototypeMutex.RLock()
+	defer fake.prototypeMutex.RUnlock()
+	argsForCall := fake.prototypeArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakePipeline) PrototypeReturns(result1 db.Prototype, result2 bool, result3 error) {
+	fake.prototypeMutex.Lock()
+	defer fake.prototypeMutex.Unlock()
+	fake.PrototypeStub = nil
+	fake.prototypeReturns = struct {
+		result1 db.Prototype
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakePipeline) PrototypeReturnsOnCall(i int, result1 db.Prototype, result2 bool, result3 error) {
+	fake.prototypeMutex.Lock()
+	defer fake.prototypeMutex.Unlock()
+	fake.PrototypeStub = nil
+	if fake.prototypeReturnsOnCall == nil {
+		fake.prototypeReturnsOnCall = make(map[int]struct {
+			result1 db.Prototype
+			result2 bool
+			result3 error
+		})
+	}
+	fake.prototypeReturnsOnCall[i] = struct {
+		result1 db.Prototype
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakePipeline) Prototypes() (db.Prototypes, error) {
+	fake.prototypesMutex.Lock()
+	ret, specificReturn := fake.prototypesReturnsOnCall[len(fake.prototypesArgsForCall)]
+	fake.prototypesArgsForCall = append(fake.prototypesArgsForCall, struct {
+	}{})
+	stub := fake.PrototypesStub
+	fakeReturns := fake.prototypesReturns
+	fake.recordInvocation("Prototypes", []interface{}{})
+	fake.prototypesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakePipeline) PrototypesCallCount() int {
+	fake.prototypesMutex.RLock()
+	defer fake.prototypesMutex.RUnlock()
+	return len(fake.prototypesArgsForCall)
+}
+
+func (fake *FakePipeline) PrototypesCalls(stub func() (db.Prototypes, error)) {
+	fake.prototypesMutex.Lock()
+	defer fake.prototypesMutex.Unlock()
+	fake.PrototypesStub = stub
+}
+
+func (fake *FakePipeline) PrototypesReturns(result1 db.Prototypes, result2 error) {
+	fake.prototypesMutex.Lock()
+	defer fake.prototypesMutex.Unlock()
+	fake.PrototypesStub = nil
+	fake.prototypesReturns = struct {
+		result1 db.Prototypes
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePipeline) PrototypesReturnsOnCall(i int, result1 db.Prototypes, result2 error) {
+	fake.prototypesMutex.Lock()
+	defer fake.prototypesMutex.Unlock()
+	fake.PrototypesStub = nil
+	if fake.prototypesReturnsOnCall == nil {
+		fake.prototypesReturnsOnCall = make(map[int]struct {
+			result1 db.Prototypes
+			result2 error
+		})
+	}
+	fake.prototypesReturnsOnCall[i] = struct {
+		result1 db.Prototypes
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakePipeline) Public() bool {
 	fake.publicMutex.Lock()
 	ret, specificReturn := fake.publicReturnsOnCall[len(fake.publicArgsForCall)]
@@ -2560,73 +2695,6 @@ func (fake *FakePipeline) ResourceTypeReturnsOnCall(i int, result1 db.ResourceTy
 		})
 	}
 	fake.resourceTypeReturnsOnCall[i] = struct {
-		result1 db.ResourceType
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakePipeline) ResourceTypeByID(arg1 int) (db.ResourceType, bool, error) {
-	fake.resourceTypeByIDMutex.Lock()
-	ret, specificReturn := fake.resourceTypeByIDReturnsOnCall[len(fake.resourceTypeByIDArgsForCall)]
-	fake.resourceTypeByIDArgsForCall = append(fake.resourceTypeByIDArgsForCall, struct {
-		arg1 int
-	}{arg1})
-	stub := fake.ResourceTypeByIDStub
-	fakeReturns := fake.resourceTypeByIDReturns
-	fake.recordInvocation("ResourceTypeByID", []interface{}{arg1})
-	fake.resourceTypeByIDMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *FakePipeline) ResourceTypeByIDCallCount() int {
-	fake.resourceTypeByIDMutex.RLock()
-	defer fake.resourceTypeByIDMutex.RUnlock()
-	return len(fake.resourceTypeByIDArgsForCall)
-}
-
-func (fake *FakePipeline) ResourceTypeByIDCalls(stub func(int) (db.ResourceType, bool, error)) {
-	fake.resourceTypeByIDMutex.Lock()
-	defer fake.resourceTypeByIDMutex.Unlock()
-	fake.ResourceTypeByIDStub = stub
-}
-
-func (fake *FakePipeline) ResourceTypeByIDArgsForCall(i int) int {
-	fake.resourceTypeByIDMutex.RLock()
-	defer fake.resourceTypeByIDMutex.RUnlock()
-	argsForCall := fake.resourceTypeByIDArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakePipeline) ResourceTypeByIDReturns(result1 db.ResourceType, result2 bool, result3 error) {
-	fake.resourceTypeByIDMutex.Lock()
-	defer fake.resourceTypeByIDMutex.Unlock()
-	fake.ResourceTypeByIDStub = nil
-	fake.resourceTypeByIDReturns = struct {
-		result1 db.ResourceType
-		result2 bool
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *FakePipeline) ResourceTypeByIDReturnsOnCall(i int, result1 db.ResourceType, result2 bool, result3 error) {
-	fake.resourceTypeByIDMutex.Lock()
-	defer fake.resourceTypeByIDMutex.Unlock()
-	fake.ResourceTypeByIDStub = nil
-	if fake.resourceTypeByIDReturnsOnCall == nil {
-		fake.resourceTypeByIDReturnsOnCall = make(map[int]struct {
-			result1 db.ResourceType
-			result2 bool
-			result3 error
-		})
-	}
-	fake.resourceTypeByIDReturnsOnCall[i] = struct {
 		result1 db.ResourceType
 		result2 bool
 		result3 error
@@ -3215,6 +3283,10 @@ func (fake *FakePipeline) Invocations() map[string][][]interface{} {
 	defer fake.pauseMutex.RUnlock()
 	fake.pausedMutex.RLock()
 	defer fake.pausedMutex.RUnlock()
+	fake.prototypeMutex.RLock()
+	defer fake.prototypeMutex.RUnlock()
+	fake.prototypesMutex.RLock()
+	defer fake.prototypesMutex.RUnlock()
 	fake.publicMutex.RLock()
 	defer fake.publicMutex.RUnlock()
 	fake.reloadMutex.RLock()
@@ -3225,8 +3297,6 @@ func (fake *FakePipeline) Invocations() map[string][][]interface{} {
 	defer fake.resourceByIDMutex.RUnlock()
 	fake.resourceTypeMutex.RLock()
 	defer fake.resourceTypeMutex.RUnlock()
-	fake.resourceTypeByIDMutex.RLock()
-	defer fake.resourceTypeByIDMutex.RUnlock()
 	fake.resourceTypesMutex.RLock()
 	defer fake.resourceTypesMutex.RUnlock()
 	fake.resourceVersionMutex.RLock()

--- a/atc/db/dbfakes/fake_prototype.go
+++ b/atc/db/dbfakes/fake_prototype.go
@@ -10,7 +10,7 @@ import (
 	"github.com/concourse/concourse/atc/db"
 )
 
-type FakeResourceType struct {
+type FakePrototype struct {
 	CheckEveryStub        func() *atc.CheckEvery
 	checkEveryMutex       sync.RWMutex
 	checkEveryArgsForCall []struct {
@@ -313,7 +313,7 @@ type FakeResourceType struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeResourceType) CheckEvery() *atc.CheckEvery {
+func (fake *FakePrototype) CheckEvery() *atc.CheckEvery {
 	fake.checkEveryMutex.Lock()
 	ret, specificReturn := fake.checkEveryReturnsOnCall[len(fake.checkEveryArgsForCall)]
 	fake.checkEveryArgsForCall = append(fake.checkEveryArgsForCall, struct {
@@ -331,19 +331,19 @@ func (fake *FakeResourceType) CheckEvery() *atc.CheckEvery {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) CheckEveryCallCount() int {
+func (fake *FakePrototype) CheckEveryCallCount() int {
 	fake.checkEveryMutex.RLock()
 	defer fake.checkEveryMutex.RUnlock()
 	return len(fake.checkEveryArgsForCall)
 }
 
-func (fake *FakeResourceType) CheckEveryCalls(stub func() *atc.CheckEvery) {
+func (fake *FakePrototype) CheckEveryCalls(stub func() *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = stub
 }
 
-func (fake *FakeResourceType) CheckEveryReturns(result1 *atc.CheckEvery) {
+func (fake *FakePrototype) CheckEveryReturns(result1 *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = nil
@@ -352,7 +352,7 @@ func (fake *FakeResourceType) CheckEveryReturns(result1 *atc.CheckEvery) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) CheckEveryReturnsOnCall(i int, result1 *atc.CheckEvery) {
+func (fake *FakePrototype) CheckEveryReturnsOnCall(i int, result1 *atc.CheckEvery) {
 	fake.checkEveryMutex.Lock()
 	defer fake.checkEveryMutex.Unlock()
 	fake.CheckEveryStub = nil
@@ -366,7 +366,7 @@ func (fake *FakeResourceType) CheckEveryReturnsOnCall(i int, result1 *atc.CheckE
 	}{result1}
 }
 
-func (fake *FakeResourceType) CheckPlan(arg1 atc.Version, arg2 time.Duration, arg3 db.ResourceTypes, arg4 atc.Source) atc.CheckPlan {
+func (fake *FakePrototype) CheckPlan(arg1 atc.Version, arg2 time.Duration, arg3 db.ResourceTypes, arg4 atc.Source) atc.CheckPlan {
 	fake.checkPlanMutex.Lock()
 	ret, specificReturn := fake.checkPlanReturnsOnCall[len(fake.checkPlanArgsForCall)]
 	fake.checkPlanArgsForCall = append(fake.checkPlanArgsForCall, struct {
@@ -388,26 +388,26 @@ func (fake *FakeResourceType) CheckPlan(arg1 atc.Version, arg2 time.Duration, ar
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) CheckPlanCallCount() int {
+func (fake *FakePrototype) CheckPlanCallCount() int {
 	fake.checkPlanMutex.RLock()
 	defer fake.checkPlanMutex.RUnlock()
 	return len(fake.checkPlanArgsForCall)
 }
 
-func (fake *FakeResourceType) CheckPlanCalls(stub func(atc.Version, time.Duration, db.ResourceTypes, atc.Source) atc.CheckPlan) {
+func (fake *FakePrototype) CheckPlanCalls(stub func(atc.Version, time.Duration, db.ResourceTypes, atc.Source) atc.CheckPlan) {
 	fake.checkPlanMutex.Lock()
 	defer fake.checkPlanMutex.Unlock()
 	fake.CheckPlanStub = stub
 }
 
-func (fake *FakeResourceType) CheckPlanArgsForCall(i int) (atc.Version, time.Duration, db.ResourceTypes, atc.Source) {
+func (fake *FakePrototype) CheckPlanArgsForCall(i int) (atc.Version, time.Duration, db.ResourceTypes, atc.Source) {
 	fake.checkPlanMutex.RLock()
 	defer fake.checkPlanMutex.RUnlock()
 	argsForCall := fake.checkPlanArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeResourceType) CheckPlanReturns(result1 atc.CheckPlan) {
+func (fake *FakePrototype) CheckPlanReturns(result1 atc.CheckPlan) {
 	fake.checkPlanMutex.Lock()
 	defer fake.checkPlanMutex.Unlock()
 	fake.CheckPlanStub = nil
@@ -416,7 +416,7 @@ func (fake *FakeResourceType) CheckPlanReturns(result1 atc.CheckPlan) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) CheckPlanReturnsOnCall(i int, result1 atc.CheckPlan) {
+func (fake *FakePrototype) CheckPlanReturnsOnCall(i int, result1 atc.CheckPlan) {
 	fake.checkPlanMutex.Lock()
 	defer fake.checkPlanMutex.Unlock()
 	fake.CheckPlanStub = nil
@@ -430,7 +430,7 @@ func (fake *FakeResourceType) CheckPlanReturnsOnCall(i int, result1 atc.CheckPla
 	}{result1}
 }
 
-func (fake *FakeResourceType) CheckTimeout() string {
+func (fake *FakePrototype) CheckTimeout() string {
 	fake.checkTimeoutMutex.Lock()
 	ret, specificReturn := fake.checkTimeoutReturnsOnCall[len(fake.checkTimeoutArgsForCall)]
 	fake.checkTimeoutArgsForCall = append(fake.checkTimeoutArgsForCall, struct {
@@ -448,19 +448,19 @@ func (fake *FakeResourceType) CheckTimeout() string {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) CheckTimeoutCallCount() int {
+func (fake *FakePrototype) CheckTimeoutCallCount() int {
 	fake.checkTimeoutMutex.RLock()
 	defer fake.checkTimeoutMutex.RUnlock()
 	return len(fake.checkTimeoutArgsForCall)
 }
 
-func (fake *FakeResourceType) CheckTimeoutCalls(stub func() string) {
+func (fake *FakePrototype) CheckTimeoutCalls(stub func() string) {
 	fake.checkTimeoutMutex.Lock()
 	defer fake.checkTimeoutMutex.Unlock()
 	fake.CheckTimeoutStub = stub
 }
 
-func (fake *FakeResourceType) CheckTimeoutReturns(result1 string) {
+func (fake *FakePrototype) CheckTimeoutReturns(result1 string) {
 	fake.checkTimeoutMutex.Lock()
 	defer fake.checkTimeoutMutex.Unlock()
 	fake.CheckTimeoutStub = nil
@@ -469,7 +469,7 @@ func (fake *FakeResourceType) CheckTimeoutReturns(result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) CheckTimeoutReturnsOnCall(i int, result1 string) {
+func (fake *FakePrototype) CheckTimeoutReturnsOnCall(i int, result1 string) {
 	fake.checkTimeoutMutex.Lock()
 	defer fake.checkTimeoutMutex.Unlock()
 	fake.CheckTimeoutStub = nil
@@ -483,7 +483,7 @@ func (fake *FakeResourceType) CheckTimeoutReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) CreateBuild(arg1 context.Context, arg2 bool, arg3 atc.Plan) (db.Build, bool, error) {
+func (fake *FakePrototype) CreateBuild(arg1 context.Context, arg2 bool, arg3 atc.Plan) (db.Build, bool, error) {
 	fake.createBuildMutex.Lock()
 	ret, specificReturn := fake.createBuildReturnsOnCall[len(fake.createBuildArgsForCall)]
 	fake.createBuildArgsForCall = append(fake.createBuildArgsForCall, struct {
@@ -504,26 +504,26 @@ func (fake *FakeResourceType) CreateBuild(arg1 context.Context, arg2 bool, arg3 
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
-func (fake *FakeResourceType) CreateBuildCallCount() int {
+func (fake *FakePrototype) CreateBuildCallCount() int {
 	fake.createBuildMutex.RLock()
 	defer fake.createBuildMutex.RUnlock()
 	return len(fake.createBuildArgsForCall)
 }
 
-func (fake *FakeResourceType) CreateBuildCalls(stub func(context.Context, bool, atc.Plan) (db.Build, bool, error)) {
+func (fake *FakePrototype) CreateBuildCalls(stub func(context.Context, bool, atc.Plan) (db.Build, bool, error)) {
 	fake.createBuildMutex.Lock()
 	defer fake.createBuildMutex.Unlock()
 	fake.CreateBuildStub = stub
 }
 
-func (fake *FakeResourceType) CreateBuildArgsForCall(i int) (context.Context, bool, atc.Plan) {
+func (fake *FakePrototype) CreateBuildArgsForCall(i int) (context.Context, bool, atc.Plan) {
 	fake.createBuildMutex.RLock()
 	defer fake.createBuildMutex.RUnlock()
 	argsForCall := fake.createBuildArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeResourceType) CreateBuildReturns(result1 db.Build, result2 bool, result3 error) {
+func (fake *FakePrototype) CreateBuildReturns(result1 db.Build, result2 bool, result3 error) {
 	fake.createBuildMutex.Lock()
 	defer fake.createBuildMutex.Unlock()
 	fake.CreateBuildStub = nil
@@ -534,7 +534,7 @@ func (fake *FakeResourceType) CreateBuildReturns(result1 db.Build, result2 bool,
 	}{result1, result2, result3}
 }
 
-func (fake *FakeResourceType) CreateBuildReturnsOnCall(i int, result1 db.Build, result2 bool, result3 error) {
+func (fake *FakePrototype) CreateBuildReturnsOnCall(i int, result1 db.Build, result2 bool, result3 error) {
 	fake.createBuildMutex.Lock()
 	defer fake.createBuildMutex.Unlock()
 	fake.CreateBuildStub = nil
@@ -552,7 +552,7 @@ func (fake *FakeResourceType) CreateBuildReturnsOnCall(i int, result1 db.Build, 
 	}{result1, result2, result3}
 }
 
-func (fake *FakeResourceType) CurrentPinnedVersion() atc.Version {
+func (fake *FakePrototype) CurrentPinnedVersion() atc.Version {
 	fake.currentPinnedVersionMutex.Lock()
 	ret, specificReturn := fake.currentPinnedVersionReturnsOnCall[len(fake.currentPinnedVersionArgsForCall)]
 	fake.currentPinnedVersionArgsForCall = append(fake.currentPinnedVersionArgsForCall, struct {
@@ -570,19 +570,19 @@ func (fake *FakeResourceType) CurrentPinnedVersion() atc.Version {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) CurrentPinnedVersionCallCount() int {
+func (fake *FakePrototype) CurrentPinnedVersionCallCount() int {
 	fake.currentPinnedVersionMutex.RLock()
 	defer fake.currentPinnedVersionMutex.RUnlock()
 	return len(fake.currentPinnedVersionArgsForCall)
 }
 
-func (fake *FakeResourceType) CurrentPinnedVersionCalls(stub func() atc.Version) {
+func (fake *FakePrototype) CurrentPinnedVersionCalls(stub func() atc.Version) {
 	fake.currentPinnedVersionMutex.Lock()
 	defer fake.currentPinnedVersionMutex.Unlock()
 	fake.CurrentPinnedVersionStub = stub
 }
 
-func (fake *FakeResourceType) CurrentPinnedVersionReturns(result1 atc.Version) {
+func (fake *FakePrototype) CurrentPinnedVersionReturns(result1 atc.Version) {
 	fake.currentPinnedVersionMutex.Lock()
 	defer fake.currentPinnedVersionMutex.Unlock()
 	fake.CurrentPinnedVersionStub = nil
@@ -591,7 +591,7 @@ func (fake *FakeResourceType) CurrentPinnedVersionReturns(result1 atc.Version) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) CurrentPinnedVersionReturnsOnCall(i int, result1 atc.Version) {
+func (fake *FakePrototype) CurrentPinnedVersionReturnsOnCall(i int, result1 atc.Version) {
 	fake.currentPinnedVersionMutex.Lock()
 	defer fake.currentPinnedVersionMutex.Unlock()
 	fake.CurrentPinnedVersionStub = nil
@@ -605,7 +605,7 @@ func (fake *FakeResourceType) CurrentPinnedVersionReturnsOnCall(i int, result1 a
 	}{result1}
 }
 
-func (fake *FakeResourceType) Defaults() atc.Source {
+func (fake *FakePrototype) Defaults() atc.Source {
 	fake.defaultsMutex.Lock()
 	ret, specificReturn := fake.defaultsReturnsOnCall[len(fake.defaultsArgsForCall)]
 	fake.defaultsArgsForCall = append(fake.defaultsArgsForCall, struct {
@@ -623,19 +623,19 @@ func (fake *FakeResourceType) Defaults() atc.Source {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) DefaultsCallCount() int {
+func (fake *FakePrototype) DefaultsCallCount() int {
 	fake.defaultsMutex.RLock()
 	defer fake.defaultsMutex.RUnlock()
 	return len(fake.defaultsArgsForCall)
 }
 
-func (fake *FakeResourceType) DefaultsCalls(stub func() atc.Source) {
+func (fake *FakePrototype) DefaultsCalls(stub func() atc.Source) {
 	fake.defaultsMutex.Lock()
 	defer fake.defaultsMutex.Unlock()
 	fake.DefaultsStub = stub
 }
 
-func (fake *FakeResourceType) DefaultsReturns(result1 atc.Source) {
+func (fake *FakePrototype) DefaultsReturns(result1 atc.Source) {
 	fake.defaultsMutex.Lock()
 	defer fake.defaultsMutex.Unlock()
 	fake.DefaultsStub = nil
@@ -644,7 +644,7 @@ func (fake *FakeResourceType) DefaultsReturns(result1 atc.Source) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) DefaultsReturnsOnCall(i int, result1 atc.Source) {
+func (fake *FakePrototype) DefaultsReturnsOnCall(i int, result1 atc.Source) {
 	fake.defaultsMutex.Lock()
 	defer fake.defaultsMutex.Unlock()
 	fake.DefaultsStub = nil
@@ -658,7 +658,7 @@ func (fake *FakeResourceType) DefaultsReturnsOnCall(i int, result1 atc.Source) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) HasWebhook() bool {
+func (fake *FakePrototype) HasWebhook() bool {
 	fake.hasWebhookMutex.Lock()
 	ret, specificReturn := fake.hasWebhookReturnsOnCall[len(fake.hasWebhookArgsForCall)]
 	fake.hasWebhookArgsForCall = append(fake.hasWebhookArgsForCall, struct {
@@ -676,19 +676,19 @@ func (fake *FakeResourceType) HasWebhook() bool {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) HasWebhookCallCount() int {
+func (fake *FakePrototype) HasWebhookCallCount() int {
 	fake.hasWebhookMutex.RLock()
 	defer fake.hasWebhookMutex.RUnlock()
 	return len(fake.hasWebhookArgsForCall)
 }
 
-func (fake *FakeResourceType) HasWebhookCalls(stub func() bool) {
+func (fake *FakePrototype) HasWebhookCalls(stub func() bool) {
 	fake.hasWebhookMutex.Lock()
 	defer fake.hasWebhookMutex.Unlock()
 	fake.HasWebhookStub = stub
 }
 
-func (fake *FakeResourceType) HasWebhookReturns(result1 bool) {
+func (fake *FakePrototype) HasWebhookReturns(result1 bool) {
 	fake.hasWebhookMutex.Lock()
 	defer fake.hasWebhookMutex.Unlock()
 	fake.HasWebhookStub = nil
@@ -697,7 +697,7 @@ func (fake *FakeResourceType) HasWebhookReturns(result1 bool) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) HasWebhookReturnsOnCall(i int, result1 bool) {
+func (fake *FakePrototype) HasWebhookReturnsOnCall(i int, result1 bool) {
 	fake.hasWebhookMutex.Lock()
 	defer fake.hasWebhookMutex.Unlock()
 	fake.HasWebhookStub = nil
@@ -711,7 +711,7 @@ func (fake *FakeResourceType) HasWebhookReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) ID() int {
+func (fake *FakePrototype) ID() int {
 	fake.iDMutex.Lock()
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
@@ -729,19 +729,19 @@ func (fake *FakeResourceType) ID() int {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) IDCallCount() int {
+func (fake *FakePrototype) IDCallCount() int {
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
 	return len(fake.iDArgsForCall)
 }
 
-func (fake *FakeResourceType) IDCalls(stub func() int) {
+func (fake *FakePrototype) IDCalls(stub func() int) {
 	fake.iDMutex.Lock()
 	defer fake.iDMutex.Unlock()
 	fake.IDStub = stub
 }
 
-func (fake *FakeResourceType) IDReturns(result1 int) {
+func (fake *FakePrototype) IDReturns(result1 int) {
 	fake.iDMutex.Lock()
 	defer fake.iDMutex.Unlock()
 	fake.IDStub = nil
@@ -750,7 +750,7 @@ func (fake *FakeResourceType) IDReturns(result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) IDReturnsOnCall(i int, result1 int) {
+func (fake *FakePrototype) IDReturnsOnCall(i int, result1 int) {
 	fake.iDMutex.Lock()
 	defer fake.iDMutex.Unlock()
 	fake.IDStub = nil
@@ -764,7 +764,7 @@ func (fake *FakeResourceType) IDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) LastCheckEndTime() time.Time {
+func (fake *FakePrototype) LastCheckEndTime() time.Time {
 	fake.lastCheckEndTimeMutex.Lock()
 	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
 	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
@@ -782,19 +782,19 @@ func (fake *FakeResourceType) LastCheckEndTime() time.Time {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) LastCheckEndTimeCallCount() int {
+func (fake *FakePrototype) LastCheckEndTimeCallCount() int {
 	fake.lastCheckEndTimeMutex.RLock()
 	defer fake.lastCheckEndTimeMutex.RUnlock()
 	return len(fake.lastCheckEndTimeArgsForCall)
 }
 
-func (fake *FakeResourceType) LastCheckEndTimeCalls(stub func() time.Time) {
+func (fake *FakePrototype) LastCheckEndTimeCalls(stub func() time.Time) {
 	fake.lastCheckEndTimeMutex.Lock()
 	defer fake.lastCheckEndTimeMutex.Unlock()
 	fake.LastCheckEndTimeStub = stub
 }
 
-func (fake *FakeResourceType) LastCheckEndTimeReturns(result1 time.Time) {
+func (fake *FakePrototype) LastCheckEndTimeReturns(result1 time.Time) {
 	fake.lastCheckEndTimeMutex.Lock()
 	defer fake.lastCheckEndTimeMutex.Unlock()
 	fake.LastCheckEndTimeStub = nil
@@ -803,7 +803,7 @@ func (fake *FakeResourceType) LastCheckEndTimeReturns(result1 time.Time) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time) {
+func (fake *FakePrototype) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time) {
 	fake.lastCheckEndTimeMutex.Lock()
 	defer fake.lastCheckEndTimeMutex.Unlock()
 	fake.LastCheckEndTimeStub = nil
@@ -817,7 +817,7 @@ func (fake *FakeResourceType) LastCheckEndTimeReturnsOnCall(i int, result1 time.
 	}{result1}
 }
 
-func (fake *FakeResourceType) LastCheckStartTime() time.Time {
+func (fake *FakePrototype) LastCheckStartTime() time.Time {
 	fake.lastCheckStartTimeMutex.Lock()
 	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
 	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
@@ -835,19 +835,19 @@ func (fake *FakeResourceType) LastCheckStartTime() time.Time {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) LastCheckStartTimeCallCount() int {
+func (fake *FakePrototype) LastCheckStartTimeCallCount() int {
 	fake.lastCheckStartTimeMutex.RLock()
 	defer fake.lastCheckStartTimeMutex.RUnlock()
 	return len(fake.lastCheckStartTimeArgsForCall)
 }
 
-func (fake *FakeResourceType) LastCheckStartTimeCalls(stub func() time.Time) {
+func (fake *FakePrototype) LastCheckStartTimeCalls(stub func() time.Time) {
 	fake.lastCheckStartTimeMutex.Lock()
 	defer fake.lastCheckStartTimeMutex.Unlock()
 	fake.LastCheckStartTimeStub = stub
 }
 
-func (fake *FakeResourceType) LastCheckStartTimeReturns(result1 time.Time) {
+func (fake *FakePrototype) LastCheckStartTimeReturns(result1 time.Time) {
 	fake.lastCheckStartTimeMutex.Lock()
 	defer fake.lastCheckStartTimeMutex.Unlock()
 	fake.LastCheckStartTimeStub = nil
@@ -856,7 +856,7 @@ func (fake *FakeResourceType) LastCheckStartTimeReturns(result1 time.Time) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time) {
+func (fake *FakePrototype) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time) {
 	fake.lastCheckStartTimeMutex.Lock()
 	defer fake.lastCheckStartTimeMutex.Unlock()
 	fake.LastCheckStartTimeStub = nil
@@ -870,7 +870,7 @@ func (fake *FakeResourceType) LastCheckStartTimeReturnsOnCall(i int, result1 tim
 	}{result1}
 }
 
-func (fake *FakeResourceType) Name() string {
+func (fake *FakePrototype) Name() string {
 	fake.nameMutex.Lock()
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
@@ -888,19 +888,19 @@ func (fake *FakeResourceType) Name() string {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) NameCallCount() int {
+func (fake *FakePrototype) NameCallCount() int {
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
 	return len(fake.nameArgsForCall)
 }
 
-func (fake *FakeResourceType) NameCalls(stub func() string) {
+func (fake *FakePrototype) NameCalls(stub func() string) {
 	fake.nameMutex.Lock()
 	defer fake.nameMutex.Unlock()
 	fake.NameStub = stub
 }
 
-func (fake *FakeResourceType) NameReturns(result1 string) {
+func (fake *FakePrototype) NameReturns(result1 string) {
 	fake.nameMutex.Lock()
 	defer fake.nameMutex.Unlock()
 	fake.NameStub = nil
@@ -909,7 +909,7 @@ func (fake *FakeResourceType) NameReturns(result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) NameReturnsOnCall(i int, result1 string) {
+func (fake *FakePrototype) NameReturnsOnCall(i int, result1 string) {
 	fake.nameMutex.Lock()
 	defer fake.nameMutex.Unlock()
 	fake.NameStub = nil
@@ -923,7 +923,7 @@ func (fake *FakeResourceType) NameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) Params() atc.Params {
+func (fake *FakePrototype) Params() atc.Params {
 	fake.paramsMutex.Lock()
 	ret, specificReturn := fake.paramsReturnsOnCall[len(fake.paramsArgsForCall)]
 	fake.paramsArgsForCall = append(fake.paramsArgsForCall, struct {
@@ -941,19 +941,19 @@ func (fake *FakeResourceType) Params() atc.Params {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) ParamsCallCount() int {
+func (fake *FakePrototype) ParamsCallCount() int {
 	fake.paramsMutex.RLock()
 	defer fake.paramsMutex.RUnlock()
 	return len(fake.paramsArgsForCall)
 }
 
-func (fake *FakeResourceType) ParamsCalls(stub func() atc.Params) {
+func (fake *FakePrototype) ParamsCalls(stub func() atc.Params) {
 	fake.paramsMutex.Lock()
 	defer fake.paramsMutex.Unlock()
 	fake.ParamsStub = stub
 }
 
-func (fake *FakeResourceType) ParamsReturns(result1 atc.Params) {
+func (fake *FakePrototype) ParamsReturns(result1 atc.Params) {
 	fake.paramsMutex.Lock()
 	defer fake.paramsMutex.Unlock()
 	fake.ParamsStub = nil
@@ -962,7 +962,7 @@ func (fake *FakeResourceType) ParamsReturns(result1 atc.Params) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) ParamsReturnsOnCall(i int, result1 atc.Params) {
+func (fake *FakePrototype) ParamsReturnsOnCall(i int, result1 atc.Params) {
 	fake.paramsMutex.Lock()
 	defer fake.paramsMutex.Unlock()
 	fake.ParamsStub = nil
@@ -976,7 +976,7 @@ func (fake *FakeResourceType) ParamsReturnsOnCall(i int, result1 atc.Params) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) Pipeline() (db.Pipeline, bool, error) {
+func (fake *FakePrototype) Pipeline() (db.Pipeline, bool, error) {
 	fake.pipelineMutex.Lock()
 	ret, specificReturn := fake.pipelineReturnsOnCall[len(fake.pipelineArgsForCall)]
 	fake.pipelineArgsForCall = append(fake.pipelineArgsForCall, struct {
@@ -994,19 +994,19 @@ func (fake *FakeResourceType) Pipeline() (db.Pipeline, bool, error) {
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
-func (fake *FakeResourceType) PipelineCallCount() int {
+func (fake *FakePrototype) PipelineCallCount() int {
 	fake.pipelineMutex.RLock()
 	defer fake.pipelineMutex.RUnlock()
 	return len(fake.pipelineArgsForCall)
 }
 
-func (fake *FakeResourceType) PipelineCalls(stub func() (db.Pipeline, bool, error)) {
+func (fake *FakePrototype) PipelineCalls(stub func() (db.Pipeline, bool, error)) {
 	fake.pipelineMutex.Lock()
 	defer fake.pipelineMutex.Unlock()
 	fake.PipelineStub = stub
 }
 
-func (fake *FakeResourceType) PipelineReturns(result1 db.Pipeline, result2 bool, result3 error) {
+func (fake *FakePrototype) PipelineReturns(result1 db.Pipeline, result2 bool, result3 error) {
 	fake.pipelineMutex.Lock()
 	defer fake.pipelineMutex.Unlock()
 	fake.PipelineStub = nil
@@ -1017,7 +1017,7 @@ func (fake *FakeResourceType) PipelineReturns(result1 db.Pipeline, result2 bool,
 	}{result1, result2, result3}
 }
 
-func (fake *FakeResourceType) PipelineReturnsOnCall(i int, result1 db.Pipeline, result2 bool, result3 error) {
+func (fake *FakePrototype) PipelineReturnsOnCall(i int, result1 db.Pipeline, result2 bool, result3 error) {
 	fake.pipelineMutex.Lock()
 	defer fake.pipelineMutex.Unlock()
 	fake.PipelineStub = nil
@@ -1035,7 +1035,7 @@ func (fake *FakeResourceType) PipelineReturnsOnCall(i int, result1 db.Pipeline, 
 	}{result1, result2, result3}
 }
 
-func (fake *FakeResourceType) PipelineID() int {
+func (fake *FakePrototype) PipelineID() int {
 	fake.pipelineIDMutex.Lock()
 	ret, specificReturn := fake.pipelineIDReturnsOnCall[len(fake.pipelineIDArgsForCall)]
 	fake.pipelineIDArgsForCall = append(fake.pipelineIDArgsForCall, struct {
@@ -1053,19 +1053,19 @@ func (fake *FakeResourceType) PipelineID() int {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) PipelineIDCallCount() int {
+func (fake *FakePrototype) PipelineIDCallCount() int {
 	fake.pipelineIDMutex.RLock()
 	defer fake.pipelineIDMutex.RUnlock()
 	return len(fake.pipelineIDArgsForCall)
 }
 
-func (fake *FakeResourceType) PipelineIDCalls(stub func() int) {
+func (fake *FakePrototype) PipelineIDCalls(stub func() int) {
 	fake.pipelineIDMutex.Lock()
 	defer fake.pipelineIDMutex.Unlock()
 	fake.PipelineIDStub = stub
 }
 
-func (fake *FakeResourceType) PipelineIDReturns(result1 int) {
+func (fake *FakePrototype) PipelineIDReturns(result1 int) {
 	fake.pipelineIDMutex.Lock()
 	defer fake.pipelineIDMutex.Unlock()
 	fake.PipelineIDStub = nil
@@ -1074,7 +1074,7 @@ func (fake *FakeResourceType) PipelineIDReturns(result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) PipelineIDReturnsOnCall(i int, result1 int) {
+func (fake *FakePrototype) PipelineIDReturnsOnCall(i int, result1 int) {
 	fake.pipelineIDMutex.Lock()
 	defer fake.pipelineIDMutex.Unlock()
 	fake.PipelineIDStub = nil
@@ -1088,7 +1088,7 @@ func (fake *FakeResourceType) PipelineIDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) PipelineInstanceVars() atc.InstanceVars {
+func (fake *FakePrototype) PipelineInstanceVars() atc.InstanceVars {
 	fake.pipelineInstanceVarsMutex.Lock()
 	ret, specificReturn := fake.pipelineInstanceVarsReturnsOnCall[len(fake.pipelineInstanceVarsArgsForCall)]
 	fake.pipelineInstanceVarsArgsForCall = append(fake.pipelineInstanceVarsArgsForCall, struct {
@@ -1106,19 +1106,19 @@ func (fake *FakeResourceType) PipelineInstanceVars() atc.InstanceVars {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) PipelineInstanceVarsCallCount() int {
+func (fake *FakePrototype) PipelineInstanceVarsCallCount() int {
 	fake.pipelineInstanceVarsMutex.RLock()
 	defer fake.pipelineInstanceVarsMutex.RUnlock()
 	return len(fake.pipelineInstanceVarsArgsForCall)
 }
 
-func (fake *FakeResourceType) PipelineInstanceVarsCalls(stub func() atc.InstanceVars) {
+func (fake *FakePrototype) PipelineInstanceVarsCalls(stub func() atc.InstanceVars) {
 	fake.pipelineInstanceVarsMutex.Lock()
 	defer fake.pipelineInstanceVarsMutex.Unlock()
 	fake.PipelineInstanceVarsStub = stub
 }
 
-func (fake *FakeResourceType) PipelineInstanceVarsReturns(result1 atc.InstanceVars) {
+func (fake *FakePrototype) PipelineInstanceVarsReturns(result1 atc.InstanceVars) {
 	fake.pipelineInstanceVarsMutex.Lock()
 	defer fake.pipelineInstanceVarsMutex.Unlock()
 	fake.PipelineInstanceVarsStub = nil
@@ -1127,7 +1127,7 @@ func (fake *FakeResourceType) PipelineInstanceVarsReturns(result1 atc.InstanceVa
 	}{result1}
 }
 
-func (fake *FakeResourceType) PipelineInstanceVarsReturnsOnCall(i int, result1 atc.InstanceVars) {
+func (fake *FakePrototype) PipelineInstanceVarsReturnsOnCall(i int, result1 atc.InstanceVars) {
 	fake.pipelineInstanceVarsMutex.Lock()
 	defer fake.pipelineInstanceVarsMutex.Unlock()
 	fake.PipelineInstanceVarsStub = nil
@@ -1141,7 +1141,7 @@ func (fake *FakeResourceType) PipelineInstanceVarsReturnsOnCall(i int, result1 a
 	}{result1}
 }
 
-func (fake *FakeResourceType) PipelineName() string {
+func (fake *FakePrototype) PipelineName() string {
 	fake.pipelineNameMutex.Lock()
 	ret, specificReturn := fake.pipelineNameReturnsOnCall[len(fake.pipelineNameArgsForCall)]
 	fake.pipelineNameArgsForCall = append(fake.pipelineNameArgsForCall, struct {
@@ -1159,19 +1159,19 @@ func (fake *FakeResourceType) PipelineName() string {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) PipelineNameCallCount() int {
+func (fake *FakePrototype) PipelineNameCallCount() int {
 	fake.pipelineNameMutex.RLock()
 	defer fake.pipelineNameMutex.RUnlock()
 	return len(fake.pipelineNameArgsForCall)
 }
 
-func (fake *FakeResourceType) PipelineNameCalls(stub func() string) {
+func (fake *FakePrototype) PipelineNameCalls(stub func() string) {
 	fake.pipelineNameMutex.Lock()
 	defer fake.pipelineNameMutex.Unlock()
 	fake.PipelineNameStub = stub
 }
 
-func (fake *FakeResourceType) PipelineNameReturns(result1 string) {
+func (fake *FakePrototype) PipelineNameReturns(result1 string) {
 	fake.pipelineNameMutex.Lock()
 	defer fake.pipelineNameMutex.Unlock()
 	fake.PipelineNameStub = nil
@@ -1180,7 +1180,7 @@ func (fake *FakeResourceType) PipelineNameReturns(result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) PipelineNameReturnsOnCall(i int, result1 string) {
+func (fake *FakePrototype) PipelineNameReturnsOnCall(i int, result1 string) {
 	fake.pipelineNameMutex.Lock()
 	defer fake.pipelineNameMutex.Unlock()
 	fake.PipelineNameStub = nil
@@ -1194,7 +1194,7 @@ func (fake *FakeResourceType) PipelineNameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) PipelineRef() atc.PipelineRef {
+func (fake *FakePrototype) PipelineRef() atc.PipelineRef {
 	fake.pipelineRefMutex.Lock()
 	ret, specificReturn := fake.pipelineRefReturnsOnCall[len(fake.pipelineRefArgsForCall)]
 	fake.pipelineRefArgsForCall = append(fake.pipelineRefArgsForCall, struct {
@@ -1212,19 +1212,19 @@ func (fake *FakeResourceType) PipelineRef() atc.PipelineRef {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) PipelineRefCallCount() int {
+func (fake *FakePrototype) PipelineRefCallCount() int {
 	fake.pipelineRefMutex.RLock()
 	defer fake.pipelineRefMutex.RUnlock()
 	return len(fake.pipelineRefArgsForCall)
 }
 
-func (fake *FakeResourceType) PipelineRefCalls(stub func() atc.PipelineRef) {
+func (fake *FakePrototype) PipelineRefCalls(stub func() atc.PipelineRef) {
 	fake.pipelineRefMutex.Lock()
 	defer fake.pipelineRefMutex.Unlock()
 	fake.PipelineRefStub = stub
 }
 
-func (fake *FakeResourceType) PipelineRefReturns(result1 atc.PipelineRef) {
+func (fake *FakePrototype) PipelineRefReturns(result1 atc.PipelineRef) {
 	fake.pipelineRefMutex.Lock()
 	defer fake.pipelineRefMutex.Unlock()
 	fake.PipelineRefStub = nil
@@ -1233,7 +1233,7 @@ func (fake *FakeResourceType) PipelineRefReturns(result1 atc.PipelineRef) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) PipelineRefReturnsOnCall(i int, result1 atc.PipelineRef) {
+func (fake *FakePrototype) PipelineRefReturnsOnCall(i int, result1 atc.PipelineRef) {
 	fake.pipelineRefMutex.Lock()
 	defer fake.pipelineRefMutex.Unlock()
 	fake.PipelineRefStub = nil
@@ -1247,7 +1247,7 @@ func (fake *FakeResourceType) PipelineRefReturnsOnCall(i int, result1 atc.Pipeli
 	}{result1}
 }
 
-func (fake *FakeResourceType) Privileged() bool {
+func (fake *FakePrototype) Privileged() bool {
 	fake.privilegedMutex.Lock()
 	ret, specificReturn := fake.privilegedReturnsOnCall[len(fake.privilegedArgsForCall)]
 	fake.privilegedArgsForCall = append(fake.privilegedArgsForCall, struct {
@@ -1265,19 +1265,19 @@ func (fake *FakeResourceType) Privileged() bool {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) PrivilegedCallCount() int {
+func (fake *FakePrototype) PrivilegedCallCount() int {
 	fake.privilegedMutex.RLock()
 	defer fake.privilegedMutex.RUnlock()
 	return len(fake.privilegedArgsForCall)
 }
 
-func (fake *FakeResourceType) PrivilegedCalls(stub func() bool) {
+func (fake *FakePrototype) PrivilegedCalls(stub func() bool) {
 	fake.privilegedMutex.Lock()
 	defer fake.privilegedMutex.Unlock()
 	fake.PrivilegedStub = stub
 }
 
-func (fake *FakeResourceType) PrivilegedReturns(result1 bool) {
+func (fake *FakePrototype) PrivilegedReturns(result1 bool) {
 	fake.privilegedMutex.Lock()
 	defer fake.privilegedMutex.Unlock()
 	fake.PrivilegedStub = nil
@@ -1286,7 +1286,7 @@ func (fake *FakeResourceType) PrivilegedReturns(result1 bool) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) PrivilegedReturnsOnCall(i int, result1 bool) {
+func (fake *FakePrototype) PrivilegedReturnsOnCall(i int, result1 bool) {
 	fake.privilegedMutex.Lock()
 	defer fake.privilegedMutex.Unlock()
 	fake.PrivilegedStub = nil
@@ -1300,7 +1300,7 @@ func (fake *FakeResourceType) PrivilegedReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) Reload() (bool, error) {
+func (fake *FakePrototype) Reload() (bool, error) {
 	fake.reloadMutex.Lock()
 	ret, specificReturn := fake.reloadReturnsOnCall[len(fake.reloadArgsForCall)]
 	fake.reloadArgsForCall = append(fake.reloadArgsForCall, struct {
@@ -1318,19 +1318,19 @@ func (fake *FakeResourceType) Reload() (bool, error) {
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeResourceType) ReloadCallCount() int {
+func (fake *FakePrototype) ReloadCallCount() int {
 	fake.reloadMutex.RLock()
 	defer fake.reloadMutex.RUnlock()
 	return len(fake.reloadArgsForCall)
 }
 
-func (fake *FakeResourceType) ReloadCalls(stub func() (bool, error)) {
+func (fake *FakePrototype) ReloadCalls(stub func() (bool, error)) {
 	fake.reloadMutex.Lock()
 	defer fake.reloadMutex.Unlock()
 	fake.ReloadStub = stub
 }
 
-func (fake *FakeResourceType) ReloadReturns(result1 bool, result2 error) {
+func (fake *FakePrototype) ReloadReturns(result1 bool, result2 error) {
 	fake.reloadMutex.Lock()
 	defer fake.reloadMutex.Unlock()
 	fake.ReloadStub = nil
@@ -1340,7 +1340,7 @@ func (fake *FakeResourceType) ReloadReturns(result1 bool, result2 error) {
 	}{result1, result2}
 }
 
-func (fake *FakeResourceType) ReloadReturnsOnCall(i int, result1 bool, result2 error) {
+func (fake *FakePrototype) ReloadReturnsOnCall(i int, result1 bool, result2 error) {
 	fake.reloadMutex.Lock()
 	defer fake.reloadMutex.Unlock()
 	fake.ReloadStub = nil
@@ -1356,7 +1356,7 @@ func (fake *FakeResourceType) ReloadReturnsOnCall(i int, result1 bool, result2 e
 	}{result1, result2}
 }
 
-func (fake *FakeResourceType) ResourceConfigID() int {
+func (fake *FakePrototype) ResourceConfigID() int {
 	fake.resourceConfigIDMutex.Lock()
 	ret, specificReturn := fake.resourceConfigIDReturnsOnCall[len(fake.resourceConfigIDArgsForCall)]
 	fake.resourceConfigIDArgsForCall = append(fake.resourceConfigIDArgsForCall, struct {
@@ -1374,19 +1374,19 @@ func (fake *FakeResourceType) ResourceConfigID() int {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) ResourceConfigIDCallCount() int {
+func (fake *FakePrototype) ResourceConfigIDCallCount() int {
 	fake.resourceConfigIDMutex.RLock()
 	defer fake.resourceConfigIDMutex.RUnlock()
 	return len(fake.resourceConfigIDArgsForCall)
 }
 
-func (fake *FakeResourceType) ResourceConfigIDCalls(stub func() int) {
+func (fake *FakePrototype) ResourceConfigIDCalls(stub func() int) {
 	fake.resourceConfigIDMutex.Lock()
 	defer fake.resourceConfigIDMutex.Unlock()
 	fake.ResourceConfigIDStub = stub
 }
 
-func (fake *FakeResourceType) ResourceConfigIDReturns(result1 int) {
+func (fake *FakePrototype) ResourceConfigIDReturns(result1 int) {
 	fake.resourceConfigIDMutex.Lock()
 	defer fake.resourceConfigIDMutex.Unlock()
 	fake.ResourceConfigIDStub = nil
@@ -1395,7 +1395,7 @@ func (fake *FakeResourceType) ResourceConfigIDReturns(result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) ResourceConfigIDReturnsOnCall(i int, result1 int) {
+func (fake *FakePrototype) ResourceConfigIDReturnsOnCall(i int, result1 int) {
 	fake.resourceConfigIDMutex.Lock()
 	defer fake.resourceConfigIDMutex.Unlock()
 	fake.ResourceConfigIDStub = nil
@@ -1409,7 +1409,7 @@ func (fake *FakeResourceType) ResourceConfigIDReturnsOnCall(i int, result1 int) 
 	}{result1}
 }
 
-func (fake *FakeResourceType) ResourceConfigScopeID() int {
+func (fake *FakePrototype) ResourceConfigScopeID() int {
 	fake.resourceConfigScopeIDMutex.Lock()
 	ret, specificReturn := fake.resourceConfigScopeIDReturnsOnCall[len(fake.resourceConfigScopeIDArgsForCall)]
 	fake.resourceConfigScopeIDArgsForCall = append(fake.resourceConfigScopeIDArgsForCall, struct {
@@ -1427,19 +1427,19 @@ func (fake *FakeResourceType) ResourceConfigScopeID() int {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) ResourceConfigScopeIDCallCount() int {
+func (fake *FakePrototype) ResourceConfigScopeIDCallCount() int {
 	fake.resourceConfigScopeIDMutex.RLock()
 	defer fake.resourceConfigScopeIDMutex.RUnlock()
 	return len(fake.resourceConfigScopeIDArgsForCall)
 }
 
-func (fake *FakeResourceType) ResourceConfigScopeIDCalls(stub func() int) {
+func (fake *FakePrototype) ResourceConfigScopeIDCalls(stub func() int) {
 	fake.resourceConfigScopeIDMutex.Lock()
 	defer fake.resourceConfigScopeIDMutex.Unlock()
 	fake.ResourceConfigScopeIDStub = stub
 }
 
-func (fake *FakeResourceType) ResourceConfigScopeIDReturns(result1 int) {
+func (fake *FakePrototype) ResourceConfigScopeIDReturns(result1 int) {
 	fake.resourceConfigScopeIDMutex.Lock()
 	defer fake.resourceConfigScopeIDMutex.Unlock()
 	fake.ResourceConfigScopeIDStub = nil
@@ -1448,7 +1448,7 @@ func (fake *FakeResourceType) ResourceConfigScopeIDReturns(result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) ResourceConfigScopeIDReturnsOnCall(i int, result1 int) {
+func (fake *FakePrototype) ResourceConfigScopeIDReturnsOnCall(i int, result1 int) {
 	fake.resourceConfigScopeIDMutex.Lock()
 	defer fake.resourceConfigScopeIDMutex.Unlock()
 	fake.ResourceConfigScopeIDStub = nil
@@ -1462,7 +1462,7 @@ func (fake *FakeResourceType) ResourceConfigScopeIDReturnsOnCall(i int, result1 
 	}{result1}
 }
 
-func (fake *FakeResourceType) SetResourceConfigScope(arg1 db.ResourceConfigScope) error {
+func (fake *FakePrototype) SetResourceConfigScope(arg1 db.ResourceConfigScope) error {
 	fake.setResourceConfigScopeMutex.Lock()
 	ret, specificReturn := fake.setResourceConfigScopeReturnsOnCall[len(fake.setResourceConfigScopeArgsForCall)]
 	fake.setResourceConfigScopeArgsForCall = append(fake.setResourceConfigScopeArgsForCall, struct {
@@ -1481,26 +1481,26 @@ func (fake *FakeResourceType) SetResourceConfigScope(arg1 db.ResourceConfigScope
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) SetResourceConfigScopeCallCount() int {
+func (fake *FakePrototype) SetResourceConfigScopeCallCount() int {
 	fake.setResourceConfigScopeMutex.RLock()
 	defer fake.setResourceConfigScopeMutex.RUnlock()
 	return len(fake.setResourceConfigScopeArgsForCall)
 }
 
-func (fake *FakeResourceType) SetResourceConfigScopeCalls(stub func(db.ResourceConfigScope) error) {
+func (fake *FakePrototype) SetResourceConfigScopeCalls(stub func(db.ResourceConfigScope) error) {
 	fake.setResourceConfigScopeMutex.Lock()
 	defer fake.setResourceConfigScopeMutex.Unlock()
 	fake.SetResourceConfigScopeStub = stub
 }
 
-func (fake *FakeResourceType) SetResourceConfigScopeArgsForCall(i int) db.ResourceConfigScope {
+func (fake *FakePrototype) SetResourceConfigScopeArgsForCall(i int) db.ResourceConfigScope {
 	fake.setResourceConfigScopeMutex.RLock()
 	defer fake.setResourceConfigScopeMutex.RUnlock()
 	argsForCall := fake.setResourceConfigScopeArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *FakeResourceType) SetResourceConfigScopeReturns(result1 error) {
+func (fake *FakePrototype) SetResourceConfigScopeReturns(result1 error) {
 	fake.setResourceConfigScopeMutex.Lock()
 	defer fake.setResourceConfigScopeMutex.Unlock()
 	fake.SetResourceConfigScopeStub = nil
@@ -1509,7 +1509,7 @@ func (fake *FakeResourceType) SetResourceConfigScopeReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) SetResourceConfigScopeReturnsOnCall(i int, result1 error) {
+func (fake *FakePrototype) SetResourceConfigScopeReturnsOnCall(i int, result1 error) {
 	fake.setResourceConfigScopeMutex.Lock()
 	defer fake.setResourceConfigScopeMutex.Unlock()
 	fake.SetResourceConfigScopeStub = nil
@@ -1523,7 +1523,7 @@ func (fake *FakeResourceType) SetResourceConfigScopeReturnsOnCall(i int, result1
 	}{result1}
 }
 
-func (fake *FakeResourceType) Source() atc.Source {
+func (fake *FakePrototype) Source() atc.Source {
 	fake.sourceMutex.Lock()
 	ret, specificReturn := fake.sourceReturnsOnCall[len(fake.sourceArgsForCall)]
 	fake.sourceArgsForCall = append(fake.sourceArgsForCall, struct {
@@ -1541,19 +1541,19 @@ func (fake *FakeResourceType) Source() atc.Source {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) SourceCallCount() int {
+func (fake *FakePrototype) SourceCallCount() int {
 	fake.sourceMutex.RLock()
 	defer fake.sourceMutex.RUnlock()
 	return len(fake.sourceArgsForCall)
 }
 
-func (fake *FakeResourceType) SourceCalls(stub func() atc.Source) {
+func (fake *FakePrototype) SourceCalls(stub func() atc.Source) {
 	fake.sourceMutex.Lock()
 	defer fake.sourceMutex.Unlock()
 	fake.SourceStub = stub
 }
 
-func (fake *FakeResourceType) SourceReturns(result1 atc.Source) {
+func (fake *FakePrototype) SourceReturns(result1 atc.Source) {
 	fake.sourceMutex.Lock()
 	defer fake.sourceMutex.Unlock()
 	fake.SourceStub = nil
@@ -1562,7 +1562,7 @@ func (fake *FakeResourceType) SourceReturns(result1 atc.Source) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) SourceReturnsOnCall(i int, result1 atc.Source) {
+func (fake *FakePrototype) SourceReturnsOnCall(i int, result1 atc.Source) {
 	fake.sourceMutex.Lock()
 	defer fake.sourceMutex.Unlock()
 	fake.SourceStub = nil
@@ -1576,7 +1576,7 @@ func (fake *FakeResourceType) SourceReturnsOnCall(i int, result1 atc.Source) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) Tags() atc.Tags {
+func (fake *FakePrototype) Tags() atc.Tags {
 	fake.tagsMutex.Lock()
 	ret, specificReturn := fake.tagsReturnsOnCall[len(fake.tagsArgsForCall)]
 	fake.tagsArgsForCall = append(fake.tagsArgsForCall, struct {
@@ -1594,19 +1594,19 @@ func (fake *FakeResourceType) Tags() atc.Tags {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) TagsCallCount() int {
+func (fake *FakePrototype) TagsCallCount() int {
 	fake.tagsMutex.RLock()
 	defer fake.tagsMutex.RUnlock()
 	return len(fake.tagsArgsForCall)
 }
 
-func (fake *FakeResourceType) TagsCalls(stub func() atc.Tags) {
+func (fake *FakePrototype) TagsCalls(stub func() atc.Tags) {
 	fake.tagsMutex.Lock()
 	defer fake.tagsMutex.Unlock()
 	fake.TagsStub = stub
 }
 
-func (fake *FakeResourceType) TagsReturns(result1 atc.Tags) {
+func (fake *FakePrototype) TagsReturns(result1 atc.Tags) {
 	fake.tagsMutex.Lock()
 	defer fake.tagsMutex.Unlock()
 	fake.TagsStub = nil
@@ -1615,7 +1615,7 @@ func (fake *FakeResourceType) TagsReturns(result1 atc.Tags) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) TagsReturnsOnCall(i int, result1 atc.Tags) {
+func (fake *FakePrototype) TagsReturnsOnCall(i int, result1 atc.Tags) {
 	fake.tagsMutex.Lock()
 	defer fake.tagsMutex.Unlock()
 	fake.TagsStub = nil
@@ -1629,7 +1629,7 @@ func (fake *FakeResourceType) TagsReturnsOnCall(i int, result1 atc.Tags) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) TeamID() int {
+func (fake *FakePrototype) TeamID() int {
 	fake.teamIDMutex.Lock()
 	ret, specificReturn := fake.teamIDReturnsOnCall[len(fake.teamIDArgsForCall)]
 	fake.teamIDArgsForCall = append(fake.teamIDArgsForCall, struct {
@@ -1647,19 +1647,19 @@ func (fake *FakeResourceType) TeamID() int {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) TeamIDCallCount() int {
+func (fake *FakePrototype) TeamIDCallCount() int {
 	fake.teamIDMutex.RLock()
 	defer fake.teamIDMutex.RUnlock()
 	return len(fake.teamIDArgsForCall)
 }
 
-func (fake *FakeResourceType) TeamIDCalls(stub func() int) {
+func (fake *FakePrototype) TeamIDCalls(stub func() int) {
 	fake.teamIDMutex.Lock()
 	defer fake.teamIDMutex.Unlock()
 	fake.TeamIDStub = stub
 }
 
-func (fake *FakeResourceType) TeamIDReturns(result1 int) {
+func (fake *FakePrototype) TeamIDReturns(result1 int) {
 	fake.teamIDMutex.Lock()
 	defer fake.teamIDMutex.Unlock()
 	fake.TeamIDStub = nil
@@ -1668,7 +1668,7 @@ func (fake *FakeResourceType) TeamIDReturns(result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) TeamIDReturnsOnCall(i int, result1 int) {
+func (fake *FakePrototype) TeamIDReturnsOnCall(i int, result1 int) {
 	fake.teamIDMutex.Lock()
 	defer fake.teamIDMutex.Unlock()
 	fake.TeamIDStub = nil
@@ -1682,7 +1682,7 @@ func (fake *FakeResourceType) TeamIDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) TeamName() string {
+func (fake *FakePrototype) TeamName() string {
 	fake.teamNameMutex.Lock()
 	ret, specificReturn := fake.teamNameReturnsOnCall[len(fake.teamNameArgsForCall)]
 	fake.teamNameArgsForCall = append(fake.teamNameArgsForCall, struct {
@@ -1700,19 +1700,19 @@ func (fake *FakeResourceType) TeamName() string {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) TeamNameCallCount() int {
+func (fake *FakePrototype) TeamNameCallCount() int {
 	fake.teamNameMutex.RLock()
 	defer fake.teamNameMutex.RUnlock()
 	return len(fake.teamNameArgsForCall)
 }
 
-func (fake *FakeResourceType) TeamNameCalls(stub func() string) {
+func (fake *FakePrototype) TeamNameCalls(stub func() string) {
 	fake.teamNameMutex.Lock()
 	defer fake.teamNameMutex.Unlock()
 	fake.TeamNameStub = stub
 }
 
-func (fake *FakeResourceType) TeamNameReturns(result1 string) {
+func (fake *FakePrototype) TeamNameReturns(result1 string) {
 	fake.teamNameMutex.Lock()
 	defer fake.teamNameMutex.Unlock()
 	fake.TeamNameStub = nil
@@ -1721,7 +1721,7 @@ func (fake *FakeResourceType) TeamNameReturns(result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) TeamNameReturnsOnCall(i int, result1 string) {
+func (fake *FakePrototype) TeamNameReturnsOnCall(i int, result1 string) {
 	fake.teamNameMutex.Lock()
 	defer fake.teamNameMutex.Unlock()
 	fake.TeamNameStub = nil
@@ -1735,7 +1735,7 @@ func (fake *FakeResourceType) TeamNameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) Type() string {
+func (fake *FakePrototype) Type() string {
 	fake.typeMutex.Lock()
 	ret, specificReturn := fake.typeReturnsOnCall[len(fake.typeArgsForCall)]
 	fake.typeArgsForCall = append(fake.typeArgsForCall, struct {
@@ -1753,19 +1753,19 @@ func (fake *FakeResourceType) Type() string {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) TypeCallCount() int {
+func (fake *FakePrototype) TypeCallCount() int {
 	fake.typeMutex.RLock()
 	defer fake.typeMutex.RUnlock()
 	return len(fake.typeArgsForCall)
 }
 
-func (fake *FakeResourceType) TypeCalls(stub func() string) {
+func (fake *FakePrototype) TypeCalls(stub func() string) {
 	fake.typeMutex.Lock()
 	defer fake.typeMutex.Unlock()
 	fake.TypeStub = stub
 }
 
-func (fake *FakeResourceType) TypeReturns(result1 string) {
+func (fake *FakePrototype) TypeReturns(result1 string) {
 	fake.typeMutex.Lock()
 	defer fake.typeMutex.Unlock()
 	fake.TypeStub = nil
@@ -1774,7 +1774,7 @@ func (fake *FakeResourceType) TypeReturns(result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) TypeReturnsOnCall(i int, result1 string) {
+func (fake *FakePrototype) TypeReturnsOnCall(i int, result1 string) {
 	fake.typeMutex.Lock()
 	defer fake.typeMutex.Unlock()
 	fake.TypeStub = nil
@@ -1788,7 +1788,7 @@ func (fake *FakeResourceType) TypeReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) Version() atc.Version {
+func (fake *FakePrototype) Version() atc.Version {
 	fake.versionMutex.Lock()
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
 	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
@@ -1806,19 +1806,19 @@ func (fake *FakeResourceType) Version() atc.Version {
 	return fakeReturns.result1
 }
 
-func (fake *FakeResourceType) VersionCallCount() int {
+func (fake *FakePrototype) VersionCallCount() int {
 	fake.versionMutex.RLock()
 	defer fake.versionMutex.RUnlock()
 	return len(fake.versionArgsForCall)
 }
 
-func (fake *FakeResourceType) VersionCalls(stub func() atc.Version) {
+func (fake *FakePrototype) VersionCalls(stub func() atc.Version) {
 	fake.versionMutex.Lock()
 	defer fake.versionMutex.Unlock()
 	fake.VersionStub = stub
 }
 
-func (fake *FakeResourceType) VersionReturns(result1 atc.Version) {
+func (fake *FakePrototype) VersionReturns(result1 atc.Version) {
 	fake.versionMutex.Lock()
 	defer fake.versionMutex.Unlock()
 	fake.VersionStub = nil
@@ -1827,7 +1827,7 @@ func (fake *FakeResourceType) VersionReturns(result1 atc.Version) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) VersionReturnsOnCall(i int, result1 atc.Version) {
+func (fake *FakePrototype) VersionReturnsOnCall(i int, result1 atc.Version) {
 	fake.versionMutex.Lock()
 	defer fake.versionMutex.Unlock()
 	fake.VersionStub = nil
@@ -1841,7 +1841,7 @@ func (fake *FakeResourceType) VersionReturnsOnCall(i int, result1 atc.Version) {
 	}{result1}
 }
 
-func (fake *FakeResourceType) Invocations() map[string][][]interface{} {
+func (fake *FakePrototype) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.checkEveryMutex.RLock()
@@ -1907,7 +1907,7 @@ func (fake *FakeResourceType) Invocations() map[string][][]interface{} {
 	return copiedInvocations
 }
 
-func (fake *FakeResourceType) recordInvocation(key string, args []interface{}) {
+func (fake *FakePrototype) recordInvocation(key string, args []interface{}) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
@@ -1919,4 +1919,4 @@ func (fake *FakeResourceType) recordInvocation(key string, args []interface{}) {
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ db.ResourceType = new(FakeResourceType)
+var _ db.Prototype = new(FakePrototype)

--- a/atc/db/dbtest/scenario.go
+++ b/atc/db/dbtest/scenario.go
@@ -62,6 +62,16 @@ func (scenario Scenario) ResourceType(name string) db.ResourceType {
 	return resourceType
 }
 
+func (scenario Scenario) Prototype(name string) db.Prototype {
+	Expect(scenario.Pipeline).ToNot(BeNil(), "pipeline not set in scenario")
+
+	resourceType, found, err := scenario.Pipeline.Prototype(name)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue(), "prototype '%s' not found", name)
+
+	return resourceType
+}
+
 func (scenario Scenario) ResourceVersion(name string, version atc.Version) db.ResourceConfigVersion {
 	Expect(scenario.Pipeline).ToNot(BeNil(), "pipeline not set in scenario")
 

--- a/atc/db/migration/encryption.go
+++ b/atc/db/migration/encryption.go
@@ -13,6 +13,7 @@ var encryptedColumns = []encryptedColumn{
 	{"resources", "config", "id"},
 	{"jobs", "config", "id"},
 	{"resource_types", "config", "id"},
+	{"prototypes", "config", "id"},
 	{"builds", "private_plan", "id"},
 	{"cert_cache", "cert", "domain"},
 	{"pipelines", "var_sources", "id"},

--- a/atc/db/migration/migrations/1621273969_add_prototypes.down.sql
+++ b/atc/db/migration/migrations/1621273969_add_prototypes.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX builds_prototype_id_idx;
+ALTER TABLE builds DROP COLUMN prototype_id;
+
+DROP INDEX prototypes_resource_config_id;
+DROP INDEX prototypes_pipeline_id;
+DROP INDEX prototypes_pipeline_id_name_uniq;
+DROP TABLE prototypes;

--- a/atc/db/migration/migrations/1621273969_add_prototypes.up.sql
+++ b/atc/db/migration/migrations/1621273969_add_prototypes.up.sql
@@ -1,0 +1,24 @@
+CREATE TABLE prototypes (
+    id serial PRIMARY KEY,
+    pipeline_id integer NOT NULL REFERENCES pipelines (id) ON DELETE CASCADE,
+    name text NOT NULL,
+    type text NOT NULL,
+    config text,
+    active boolean DEFAULT false NOT NULL,
+    nonce text,
+    resource_config_id integer REFERENCES resource_configs (id)
+);
+
+CREATE UNIQUE INDEX prototypes_pipeline_id_name_uniq
+    ON prototypes (pipeline_id, name);
+
+CREATE INDEX prototypes_pipeline_id
+    ON prototypes (pipeline_id);
+
+CREATE INDEX prototypes_resource_config_id
+    ON prototypes (resource_config_id);
+
+ALTER TABLE builds
+    ADD COLUMN prototype_id integer REFERENCES prototypes (id) ON DELETE CASCADE;
+
+CREATE INDEX builds_prototype_id_idx ON builds (prototype_id);

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -77,7 +77,6 @@ type Pipeline interface {
 
 	ResourceTypes() (ResourceTypes, error)
 	ResourceType(name string) (ResourceType, bool, error)
-	ResourceTypeByID(id int) (ResourceType, bool, error)
 
 	Job(name string) (Job, bool, error)
 	Jobs() (Jobs, error)
@@ -512,13 +511,6 @@ func (p *pipeline) ResourceType(name string) (ResourceType, bool, error) {
 	return p.resourceType(sq.Eq{
 		"r.pipeline_id": p.id,
 		"r.name":        name,
-	})
-}
-
-func (p *pipeline) ResourceTypeByID(id int) (ResourceType, bool, error) {
-	return p.resourceType(sq.Eq{
-		"r.pipeline_id": p.id,
-		"r.id":          id,
 	})
 }
 

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -159,6 +159,18 @@ var _ = Describe("Pipeline", func() {
 					Source: atc.Source{"some": "type-soure"},
 				},
 			},
+			Prototypes: atc.Prototypes{
+				{
+					Name:   "some-other-prototype",
+					Type:   "base-type",
+					Source: atc.Source{"some": "other-type-source"},
+				},
+				{
+					Name:   "some-prototype",
+					Type:   "base-type",
+					Source: atc.Source{"some": "type-source"},
+				},
+			},
 		}
 		var created bool
 		pipeline, created, err = team.SavePipeline(atc.PipelineRef{Name: "fake-pipeline"}, pipelineConfig, db.ConfigVersion(0), false)
@@ -289,6 +301,19 @@ var _ = Describe("Pipeline", func() {
 				{Name: "some-resource-type", Type: "base-type"},
 			}
 			Expect(resourceTypeConfigs).To(Equal(emptyResourceTypeConfigs))
+		})
+
+		It("removes the config of each prototype", func() {
+			prototypes, err := pipeline.Prototypes()
+			Expect(err).ToNot(HaveOccurred())
+
+			prototypeConfigs := prototypes.Configs()
+
+			emptyPrototypeConfigs := atc.Prototypes{
+				{Name: "some-other-prototype", Type: "base-type"},
+				{Name: "some-prototype", Type: "base-type"},
+			}
+			Expect(prototypeConfigs).To(Equal(emptyPrototypeConfigs))
 		})
 	})
 

--- a/atc/db/prototype.go
+++ b/atc/db/prototype.go
@@ -1,0 +1,332 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/lock"
+	"github.com/lib/pq"
+)
+
+//counterfeiter:generate . Prototype
+type Prototype interface {
+	PipelineRef
+
+	ID() int
+	TeamID() int
+	TeamName() string
+	Name() string
+	Type() string
+	Privileged() bool
+	Source() atc.Source
+	Defaults() atc.Source
+	Params() atc.Params
+	Tags() atc.Tags
+	CheckEvery() *atc.CheckEvery
+	CheckTimeout() string
+	LastCheckStartTime() time.Time
+	LastCheckEndTime() time.Time
+	CurrentPinnedVersion() atc.Version
+	ResourceConfigID() int
+	ResourceConfigScopeID() int
+
+	HasWebhook() bool
+
+	SetResourceConfigScope(ResourceConfigScope) error
+
+	CheckPlan(atc.Version, time.Duration, ResourceTypes, atc.Source) atc.CheckPlan
+	CreateBuild(context.Context, bool, atc.Plan) (Build, bool, error)
+
+	Version() atc.Version
+
+	Reload() (bool, error)
+}
+
+type Prototypes []Prototype
+
+func (prototypes Prototypes) Configs() atc.Prototypes {
+	var configs atc.Prototypes
+
+	for _, p := range prototypes {
+		configs = append(configs, atc.Prototype{
+			Name:       p.Name(),
+			Type:       p.Type(),
+			Source:     p.Source(),
+			Defaults:   p.Defaults(),
+			Privileged: p.Privileged(),
+			CheckEvery: p.CheckEvery(),
+			Tags:       p.Tags(),
+			Params:     p.Params(),
+		})
+	}
+
+	return configs
+}
+
+var prototypesQuery = psql.Select(
+	"pt.id",
+	"pt.pipeline_id",
+	"pt.name",
+	"pt.type",
+	"pt.config",
+	"rcv.version",
+	"p.nonce",
+	"p.name",
+	"p.instance_vars",
+	"t.id",
+	"t.name",
+	"pt.resource_config_id",
+	"ro.id",
+	"ro.last_check_start_time",
+	"ro.last_check_end_time",
+).
+	From("prototypes pt").
+	Join("pipelines p ON p.id = pt.pipeline_id").
+	Join("teams t ON t.id = p.team_id").
+	LeftJoin("resource_configs c ON c.id = pt.resource_config_id").
+	LeftJoin("resource_config_scopes ro ON ro.resource_config_id = c.id").
+	LeftJoin(`LATERAL (
+		SELECT rcv.*
+		FROM resource_config_versions rcv
+		WHERE rcv.resource_config_scope_id = ro.id
+		ORDER BY rcv.check_order DESC
+		LIMIT 1
+	) AS rcv ON true`).
+	Where(sq.Eq{"pt.active": true})
+
+type prototype struct {
+	pipelineRef
+
+	id                    int
+	teamID                int
+	resourceConfigID      int
+	resourceConfigScopeID int
+	teamName              string
+	name                  string
+	type_                 string
+	privileged            bool
+	source                atc.Source
+	defaults              atc.Source
+	params                atc.Params
+	tags                  atc.Tags
+	version               atc.Version
+	checkEvery            *atc.CheckEvery
+	lastCheckStartTime    time.Time
+	lastCheckEndTime      time.Time
+}
+
+func (p *prototype) ID() int                       { return p.id }
+func (p *prototype) TeamID() int                   { return p.teamID }
+func (p *prototype) TeamName() string              { return p.teamName }
+func (p *prototype) Name() string                  { return p.name }
+func (p *prototype) Type() string                  { return p.type_ }
+func (p *prototype) Privileged() bool              { return p.privileged }
+func (p *prototype) CheckEvery() *atc.CheckEvery   { return p.checkEvery }
+func (p *prototype) CheckTimeout() string          { return "" }
+func (p *prototype) LastCheckStartTime() time.Time { return p.lastCheckStartTime }
+func (p *prototype) LastCheckEndTime() time.Time   { return p.lastCheckEndTime }
+func (p *prototype) Source() atc.Source            { return p.source }
+func (p *prototype) Defaults() atc.Source          { return p.defaults }
+func (p *prototype) Params() atc.Params            { return p.params }
+func (p *prototype) Tags() atc.Tags                { return p.tags }
+func (p *prototype) ResourceConfigID() int         { return p.resourceConfigID }
+func (p *prototype) ResourceConfigScopeID() int    { return p.resourceConfigScopeID }
+
+func (p *prototype) Version() atc.Version              { return p.version }
+func (p *prototype) CurrentPinnedVersion() atc.Version { return nil }
+
+func (p *prototype) HasWebhook() bool { return false }
+
+func newEmptyPrototype(conn Conn, lockFactory lock.LockFactory) *prototype {
+	return &prototype{pipelineRef: pipelineRef{conn: conn, lockFactory: lockFactory}}
+}
+
+func (p *prototype) Reload() (bool, error) {
+	row := prototypesQuery.Where(sq.Eq{"pt.id": p.id}).RunWith(p.conn).QueryRow()
+
+	err := scanPrototype(p, row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (p *prototype) SetResourceConfigScope(scope ResourceConfigScope) error {
+	_, err := psql.Update("prototypes").
+		Set("resource_config_id", scope.ResourceConfig().ID()).
+		Where(sq.Eq{"id": p.id}).
+		Where(sq.Or{
+			sq.Eq{"resource_config_id": nil},
+			sq.NotEq{"resource_config_id": scope.ResourceConfig().ID()},
+		}).
+		RunWith(p.conn).
+		Exec()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *prototype) CheckPlan(from atc.Version, interval time.Duration, resourceTypes ResourceTypes, sourceDefaults atc.Source) atc.CheckPlan {
+	return atc.CheckPlan{
+		Name:   p.Name(),
+		Type:   p.Type(),
+		Source: sourceDefaults.Merge(p.Source()),
+		Tags:   p.Tags(),
+
+		FromVersion:            from,
+		Interval:               interval.String(),
+		VersionedResourceTypes: resourceTypes.Deserialize(),
+
+		Prototype: p.Name(),
+	}
+}
+
+func (p *prototype) CreateBuild(ctx context.Context, manuallyTriggered bool, plan atc.Plan) (Build, bool, error) {
+	tx, err := p.conn.Begin()
+	if err != nil {
+		return nil, false, err
+	}
+
+	defer Rollback(tx)
+
+	if !manuallyTriggered {
+		var buildID int
+		var completed, noBuild bool
+		err = psql.Select("id", "completed").
+			From("builds").
+			Where(sq.Eq{"prototype_id": p.id}).
+			RunWith(tx).
+			QueryRow().
+			Scan(&buildID, &completed)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				noBuild = true
+			} else {
+				return nil, false, err
+			}
+		}
+
+		if !noBuild && !completed {
+			// a build is already running; leave it be
+			return nil, false, nil
+		}
+	}
+
+	build := newEmptyBuild(p.conn, p.lockFactory)
+	err = createStartedBuild(tx, build, startedBuildArgs{
+		Name:              CheckBuildName,
+		PipelineID:        p.pipelineID,
+		TeamID:            p.teamID,
+		Plan:              plan,
+		ManuallyTriggered: manuallyTriggered,
+		SpanContext:       NewSpanContext(ctx),
+		ExtraValues: map[string]interface{}{
+			"prototype_id": p.id,
+		},
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, false, err
+	}
+
+	err = p.conn.Bus().Notify(atc.ComponentBuildTracker)
+	if err != nil {
+		return nil, false, err
+	}
+
+	_, err = build.Reload()
+	if err != nil {
+		return nil, false, err
+	}
+
+	return build, true, nil
+}
+
+func scanPrototype(p *prototype, row scannable) error {
+	var (
+		configJSON                           sql.NullString
+		rcsID, version, nonce                sql.NullString
+		lastCheckStartTime, lastCheckEndTime pq.NullTime
+		pipelineInstanceVars                 sql.NullString
+		resourceConfigID                     sql.NullInt64
+	)
+
+	err := row.Scan(&p.id, &p.pipelineID, &p.name, &p.type_, &configJSON, &version, &nonce, &p.pipelineName, &pipelineInstanceVars, &p.teamID, &p.teamName, &resourceConfigID, &rcsID, &lastCheckStartTime, &lastCheckEndTime)
+	if err != nil {
+		return err
+	}
+
+	p.lastCheckStartTime = lastCheckStartTime.Time
+	p.lastCheckEndTime = lastCheckEndTime.Time
+
+	if version.Valid {
+		err = json.Unmarshal([]byte(version.String), &p.version)
+		if err != nil {
+			return err
+		}
+	}
+
+	es := p.conn.EncryptionStrategy()
+
+	var noncense *string
+	if nonce.Valid {
+		noncense = &nonce.String
+	}
+
+	var config atc.Prototype
+	if configJSON.Valid {
+		decryptedConfig, err := es.Decrypt(configJSON.String, noncense)
+		if err != nil {
+			return err
+		}
+
+		err = json.Unmarshal(decryptedConfig, &config)
+		if err != nil {
+			return err
+		}
+	} else {
+		config = atc.Prototype{}
+	}
+
+	p.source = config.Source
+	p.defaults = config.Defaults
+	p.params = config.Params
+	p.privileged = config.Privileged
+	p.tags = config.Tags
+	p.checkEvery = config.CheckEvery
+
+	if resourceConfigID.Valid {
+		p.resourceConfigID = int(resourceConfigID.Int64)
+	}
+
+	if rcsID.Valid {
+		p.resourceConfigScopeID, err = strconv.Atoi(rcsID.String)
+		if err != nil {
+			return err
+		}
+	}
+
+	if pipelineInstanceVars.Valid {
+		err = json.Unmarshal([]byte(pipelineInstanceVars.String), &p.pipelineInstanceVars)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/atc/db/prototype_test.go
+++ b/atc/db/prototype_test.go
@@ -1,0 +1,346 @@
+package db_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/concourse/concourse/atc/db/dbtest"
+	"github.com/concourse/concourse/atc/event"
+	"github.com/concourse/concourse/tracing"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/otel/oteltest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var _ = Describe("Prototype", func() {
+	var pipeline db.Pipeline
+
+	BeforeEach(func() {
+		var (
+			created bool
+			err     error
+		)
+
+		pipeline, created, err = defaultTeam.SavePipeline(
+			atc.PipelineRef{Name: "pipeline-with-types"},
+			atc.Config{
+				Prototypes: atc.Prototypes{
+					{
+						Name:     "some-type",
+						Type:     "registry-image",
+						Source:   atc.Source{"some": "repository"},
+						Defaults: atc.Source{"some-default-k1": "some-default-v1"},
+					},
+					{
+						Name:       "some-other-type",
+						Type:       "some-type",
+						Privileged: true,
+						Source:     atc.Source{"some": "other-repository"},
+					},
+					{
+						Name:   "some-type-with-params",
+						Type:   "s3",
+						Source: atc.Source{"some": "repository"},
+						Params: atc.Params{"unpack": "true"},
+					},
+					{
+						Name:       "some-type-with-custom-check",
+						Type:       "registry-image",
+						Source:     atc.Source{"some": "repository"},
+						CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
+					},
+				},
+			},
+			0,
+			false,
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(created).To(BeTrue())
+	})
+
+	Describe("(Pipeline).Prototypes", func() {
+		var prototypes db.Prototypes
+
+		JustBeforeEach(func() {
+			var err error
+			prototypes, err = pipeline.Prototypes()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns the prototypes", func() {
+			Expect(prototypes.Configs()).To(ConsistOf(
+				atc.Prototypes{
+					{
+						Name:     "some-type",
+						Type:     "registry-image",
+						Source:   atc.Source{"some": "repository"},
+						Defaults: atc.Source{"some-default-k1": "some-default-v1"},
+					},
+					{
+						Name:       "some-other-type",
+						Type:       "some-type",
+						Privileged: true,
+						Source:     atc.Source{"some": "other-repository"},
+					},
+					{
+						Name:   "some-type-with-params",
+						Type:   "s3",
+						Source: atc.Source{"some": "repository"},
+						Params: atc.Params{"unpack": "true"},
+					},
+					{
+						Name:       "some-type-with-custom-check",
+						Type:       "registry-image",
+						Source:     atc.Source{"some": "repository"},
+						CheckEvery: &atc.CheckEvery{Interval: 10 * time.Millisecond},
+					},
+				},
+			))
+
+			for _, prototype := range prototypes {
+				Expect(prototype.Version()).To(BeNil())
+			}
+		})
+
+		Context("when a prototype becomes inactive", func() {
+			BeforeEach(func() {
+				var (
+					created bool
+					err     error
+				)
+
+				pipeline, created, err = defaultTeam.SavePipeline(
+					atc.PipelineRef{Name: "pipeline-with-types"},
+					atc.Config{
+						Prototypes: atc.Prototypes{
+							{
+								Name:   "some-type",
+								Type:   "registry-image",
+								Source: atc.Source{"some": "repository"},
+							},
+						},
+					},
+					pipeline.ConfigVersion(),
+					false,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(created).To(BeFalse())
+			})
+
+			It("does not return inactive prototypes", func() {
+				Expect(prototypes).To(HaveLen(1))
+				Expect(prototypes[0].Name()).To(Equal("some-type"))
+			})
+		})
+	})
+
+	Describe("Prototype version", func() {
+		var (
+			scenario *dbtest.Scenario
+			scope    db.ResourceConfigScope
+		)
+
+		BeforeEach(func() {
+			scenario = dbtest.Setup(
+				builder.WithPipeline(atc.Config{
+					Prototypes: atc.Prototypes{
+						{
+							Name:   "some-type",
+							Type:   "some-base-resource-type",
+							Source: atc.Source{"some": "repository"},
+						},
+					},
+				}),
+			)
+			Expect(scenario.Prototype("some-type").Version()).To(BeNil())
+
+			scenario.Run(builder.WithPrototypeVersions("some-type"))
+
+			prototypeResourceConfig, err := resourceConfigFactory.FindOrCreateResourceConfig(
+				scenario.Prototype("some-type").Type(),
+				scenario.Prototype("some-type").Source(),
+				nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			scope, err = prototypeResourceConfig.FindOrCreateScope(nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		JustBeforeEach(func() {
+			ok, err := scenario.Prototype("some-type").Reload()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("creates a shared scope for the prototype", func() {
+			Expect(scope.Resource()).To(BeNil())
+			Expect(scope.ResourceConfig()).ToNot(BeNil())
+		})
+
+		It("returns the resource config scope id", func() {
+			Expect(scenario.Prototype("some-type").ResourceConfigScopeID()).To(Equal(scope.ID()))
+		})
+
+		Context("when the prototype has proper versions", func() {
+			BeforeEach(func() {
+				scenario.Run(builder.WithPrototypeVersions("some-type",
+					atc.Version{"version": "1"},
+					atc.Version{"version": "2"},
+				))
+			})
+
+			It("returns the version", func() {
+				Expect(scenario.Prototype("some-type").Version()).To(Equal(atc.Version{"version": "2"}))
+			})
+		})
+	})
+
+	Describe("CheckPlan", func() {
+		var prototype db.Prototype
+		var resourceTypes db.ResourceTypes
+
+		BeforeEach(func() {
+			var err error
+			var found bool
+			prototype, found, err = pipeline.Prototype("some-type")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			resourceTypes, err = pipeline.ResourceTypes()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns a plan which will update the prototype", func() {
+			defaults := atc.Source{"sdk": "sdv"}
+			Expect(prototype.CheckPlan(atc.Version{"some": "version"}, time.Minute, resourceTypes, defaults)).To(Equal(atc.CheckPlan{
+				Name:   prototype.Name(),
+				Type:   prototype.Type(),
+				Source: defaults.Merge(prototype.Source()),
+				Tags:   prototype.Tags(),
+
+				FromVersion:            atc.Version{"some": "version"},
+				Interval:               "1m0s",
+				VersionedResourceTypes: resourceTypes.Deserialize(),
+
+				Prototype: prototype.Name(),
+			}))
+		})
+	})
+
+	Describe("CreateBuild", func() {
+		var prototype db.Prototype
+		var ctx context.Context
+		var manuallyTriggered bool
+		var plan atc.Plan
+
+		var build db.Build
+		var created bool
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+
+			var found bool
+			var err error
+			prototype, found, err = pipeline.Prototype("some-type")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			manuallyTriggered = false
+			plan = atc.Plan{
+				ID: "some-plan",
+				Check: &atc.CheckPlan{
+					Name: "wreck",
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			build, created, err = prototype.CreateBuild(ctx, manuallyTriggered, plan)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("creates a started build for a prototype", func() {
+			Expect(created).To(BeTrue())
+			Expect(build).ToNot(BeNil())
+			Expect(build.Name()).To(Equal(db.CheckBuildName))
+			Expect(build.PrototypeID()).To(Equal(prototype.ID()))
+			Expect(build.PipelineID()).To(Equal(prototype.PipelineID()))
+			Expect(build.TeamID()).To(Equal(prototype.TeamID()))
+			Expect(build.IsManuallyTriggered()).To(BeFalse())
+			Expect(build.Status()).To(Equal(db.BuildStatusStarted))
+			Expect(build.PrivatePlan()).To(Equal(plan))
+		})
+
+		It("logs to the check_build_events partition", func() {
+			err := build.SaveEvent(event.Log{Payload: "log"})
+			Expect(err).ToNot(HaveOccurred())
+			// created + log events
+			Expect(numBuildEventsForCheck(build)).To(Equal(2))
+		})
+
+		Context("when tracing is configured", func() {
+			var span trace.Span
+
+			BeforeEach(func() {
+				tracing.ConfigureTraceProvider(oteltest.NewTracerProvider())
+
+				ctx, span = tracing.StartSpan(context.Background(), "fake-operation", nil)
+			})
+
+			AfterEach(func() {
+				tracing.Configured = false
+			})
+
+			It("propagates span context", func() {
+				traceID := span.SpanContext().TraceID().String()
+				buildContext := build.SpanContext()
+				traceParent := buildContext.Get("traceparent")
+				Expect(traceParent).To(ContainSubstring(traceID))
+			})
+		})
+
+		Context("when another build already exists", func() {
+			var prevBuild db.Build
+
+			BeforeEach(func() {
+				var err error
+				var prevCreated bool
+				prevBuild, prevCreated, err = prototype.CreateBuild(ctx, false, plan)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(prevCreated).To(BeTrue())
+			})
+
+			It("does not create the second build", func() {
+				Expect(created).To(BeFalse())
+			})
+
+			Context("when manually triggered", func() {
+				BeforeEach(func() {
+					manuallyTriggered = true
+				})
+
+				It("creates a manually triggered resource build", func() {
+					Expect(created).To(BeTrue())
+					Expect(build.IsManuallyTriggered()).To(BeTrue())
+					Expect(build.PrototypeID()).To(Equal(prototype.ID()))
+				})
+			})
+
+			Context("when the previous build is finished", func() {
+				BeforeEach(func() {
+					Expect(prevBuild.Finish(db.BuildStatusSucceeded)).To(Succeed())
+				})
+
+				It("creates the build", func() {
+					Expect(created).To(BeTrue())
+					Expect(build.PrototypeID()).To(Equal(prototype.ID()))
+				})
+			})
+		})
+	})
+})

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -198,10 +198,6 @@ func (r *resource) Reload() (bool, error) {
 	return true, nil
 }
 
-func (r *resource) SetResourceConfig(atc.Source, atc.VersionedResourceTypes) (ResourceConfigScope, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
 func (r *resource) SetResourceConfigScope(scope ResourceConfigScope) error {
 	tx, err := r.conn.Begin()
 	if err != nil {

--- a/atc/db/resource_config_factory.go
+++ b/atc/db/resource_config_factory.go
@@ -174,7 +174,7 @@ func (f *resourceConfigFactory) CleanUnreferencedConfigs(gracePeriod time.Durati
 		Where("id NOT IN (" +
 			usedByResourceCachesIds + " UNION " +
 			usedByResourcesIds + " UNION " +
-			usedByResourceTypesIds + "UNION" +
+			usedByResourceTypesIds + " UNION " +
 			usedByPrototypesIds + ")").
 		Where(sq.Expr(fmt.Sprintf("now() - last_referenced > '%d seconds'::interval", int(gracePeriod.Seconds())))).
 		PlaceholderFormat(sq.Dollar).

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -226,10 +226,6 @@ func (t *resourceType) Reload() (bool, error) {
 	return true, nil
 }
 
-func (r *resourceType) SetResourceConfig(atc.Source, atc.VersionedResourceTypes) (ResourceConfigScope, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
 func (r *resourceType) SetResourceConfigScope(scope ResourceConfigScope) error {
 	_, err := psql.Update("resource_types").
 		Set("resource_config_id", scope.ResourceConfig().ID()).

--- a/atc/engine/builder_test.go
+++ b/atc/engine/builder_test.go
@@ -557,6 +557,22 @@ var _ = Describe("Builder", func() {
 						})
 					})
 
+					Context("that contains a run step", func() {
+						BeforeEach(func() {
+							expectedPlan = planFactory.NewPlan(atc.RunPlan{
+								Message: "some-message",
+								Type:    "some-prototype",
+								Object:  atc.Params{"some": "params"},
+							})
+						})
+
+						It("constructs run step correctly", func() {
+							plan, stepMetadata, _, _ := fakeCoreStepFactory.RunStepArgsForCall(0)
+							Expect(plan).To(Equal(expectedPlan))
+							Expect(stepMetadata).To(Equal(expectedMetadataWithoutCreatedBy))
+						})
+					})
+
 					Context("that contains a set_pipeline step", func() {
 						BeforeEach(func() {
 							expectedPlan = planFactory.NewPlan(atc.SetPipelinePlan{

--- a/atc/engine/builder_test.go
+++ b/atc/engine/builder_test.go
@@ -875,7 +875,7 @@ var _ = Describe("Builder", func() {
 							},
 						}
 
-						expectedPlan, err = planner.Create(step, nil, nil, nil)
+						expectedPlan, err = planner.Create(step, nil, nil, nil, nil)
 						Expect(err).ToNot(HaveOccurred())
 					})
 

--- a/atc/engine/delegate_factory.go
+++ b/atc/engine/delegate_factory.go
@@ -33,6 +33,10 @@ func (delegate DelegateFactory) TaskDelegate(state exec.RunState) exec.TaskDeleg
 	return NewTaskDelegate(delegate.build, delegate.plan.ID, state, clock.NewClock(), delegate.policyChecker, delegate.artifactSourcer, delegate.dbWorkerFactory, delegate.lockFactory)
 }
 
+func (delegate DelegateFactory) RunDelegate(state exec.RunState) exec.RunDelegate {
+	return NewBuildStepDelegate(delegate.build, delegate.plan.ID, state, clock.NewClock(), delegate.policyChecker, delegate.artifactSourcer)
+}
+
 func (delegate DelegateFactory) CheckDelegate(state exec.RunState) exec.CheckDelegate {
 	return NewCheckDelegate(delegate.build, delegate.plan, state, clock.NewClock(), delegate.rateLimiter, delegate.policyChecker, delegate.artifactSourcer)
 }

--- a/atc/engine/enginefakes/fake_core_step_factory.go
+++ b/atc/engine/enginefakes/fake_core_step_factory.go
@@ -90,6 +90,20 @@ type FakeCoreStepFactory struct {
 	putStepReturnsOnCall map[int]struct {
 		result1 exec.Step
 	}
+	RunStepStub        func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step
+	runStepMutex       sync.RWMutex
+	runStepArgsForCall []struct {
+		arg1 atc.Plan
+		arg2 exec.StepMetadata
+		arg3 db.ContainerMetadata
+		arg4 engine.DelegateFactory
+	}
+	runStepReturns struct {
+		result1 exec.Step
+	}
+	runStepReturnsOnCall map[int]struct {
+		result1 exec.Step
+	}
 	SetPipelineStepStub        func(atc.Plan, exec.StepMetadata, engine.DelegateFactory) exec.Step
 	setPipelineStepMutex       sync.RWMutex
 	setPipelineStepArgsForCall []struct {
@@ -500,6 +514,70 @@ func (fake *FakeCoreStepFactory) PutStepReturnsOnCall(i int, result1 exec.Step) 
 	}{result1}
 }
 
+func (fake *FakeCoreStepFactory) RunStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 db.ContainerMetadata, arg4 engine.DelegateFactory) exec.Step {
+	fake.runStepMutex.Lock()
+	ret, specificReturn := fake.runStepReturnsOnCall[len(fake.runStepArgsForCall)]
+	fake.runStepArgsForCall = append(fake.runStepArgsForCall, struct {
+		arg1 atc.Plan
+		arg2 exec.StepMetadata
+		arg3 db.ContainerMetadata
+		arg4 engine.DelegateFactory
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.RunStepStub
+	fakeReturns := fake.runStepReturns
+	fake.recordInvocation("RunStep", []interface{}{arg1, arg2, arg3, arg4})
+	fake.runStepMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeCoreStepFactory) RunStepCallCount() int {
+	fake.runStepMutex.RLock()
+	defer fake.runStepMutex.RUnlock()
+	return len(fake.runStepArgsForCall)
+}
+
+func (fake *FakeCoreStepFactory) RunStepCalls(stub func(atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) exec.Step) {
+	fake.runStepMutex.Lock()
+	defer fake.runStepMutex.Unlock()
+	fake.RunStepStub = stub
+}
+
+func (fake *FakeCoreStepFactory) RunStepArgsForCall(i int) (atc.Plan, exec.StepMetadata, db.ContainerMetadata, engine.DelegateFactory) {
+	fake.runStepMutex.RLock()
+	defer fake.runStepMutex.RUnlock()
+	argsForCall := fake.runStepArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeCoreStepFactory) RunStepReturns(result1 exec.Step) {
+	fake.runStepMutex.Lock()
+	defer fake.runStepMutex.Unlock()
+	fake.RunStepStub = nil
+	fake.runStepReturns = struct {
+		result1 exec.Step
+	}{result1}
+}
+
+func (fake *FakeCoreStepFactory) RunStepReturnsOnCall(i int, result1 exec.Step) {
+	fake.runStepMutex.Lock()
+	defer fake.runStepMutex.Unlock()
+	fake.RunStepStub = nil
+	if fake.runStepReturnsOnCall == nil {
+		fake.runStepReturnsOnCall = make(map[int]struct {
+			result1 exec.Step
+		})
+	}
+	fake.runStepReturnsOnCall[i] = struct {
+		result1 exec.Step
+	}{result1}
+}
+
 func (fake *FakeCoreStepFactory) SetPipelineStep(arg1 atc.Plan, arg2 exec.StepMetadata, arg3 engine.DelegateFactory) exec.Step {
 	fake.setPipelineStepMutex.Lock()
 	ret, specificReturn := fake.setPipelineStepReturnsOnCall[len(fake.setPipelineStepArgsForCall)]
@@ -642,6 +720,8 @@ func (fake *FakeCoreStepFactory) Invocations() map[string][][]interface{} {
 	defer fake.loadVarStepMutex.RUnlock()
 	fake.putStepMutex.RLock()
 	defer fake.putStepMutex.RUnlock()
+	fake.runStepMutex.RLock()
+	defer fake.runStepMutex.RUnlock()
 	fake.setPipelineStepMutex.RLock()
 	defer fake.setPipelineStepMutex.RUnlock()
 	fake.taskStepMutex.RLock()

--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -138,6 +138,27 @@ func (factory *coreStepFactory) CheckStep(
 	return checkStep
 }
 
+func (factory *coreStepFactory) RunStep(
+	plan atc.Plan,
+	stepMetadata exec.StepMetadata,
+	containerMetadata db.ContainerMetadata,
+	delegateFactory DelegateFactory,
+) exec.Step {
+	containerMetadata.WorkingDirectory = "/tmp/build/run"
+
+	runStep := exec.NewRunStep(
+		plan.ID,
+		*plan.Run,
+		delegateFactory,
+	)
+
+	runStep = exec.LogError(runStep, delegateFactory)
+	if atc.EnableBuildRerunWhenWorkerDisappears {
+		runStep = exec.RetryError(runStep, delegateFactory)
+	}
+	return runStep
+}
+
 func (factory *coreStepFactory) TaskStep(
 	plan atc.Plan,
 	stepMetadata exec.StepMetadata,

--- a/atc/exec/run_step.go
+++ b/atc/exec/run_step.go
@@ -1,0 +1,61 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagerctx"
+	"github.com/concourse/concourse/atc"
+)
+
+// RunStep will run a message against a prototype.
+type RunStep struct {
+	planID          atc.PlanID
+	plan            atc.RunPlan
+	delegateFactory RunDelegateFactory
+}
+
+type RunDelegateFactory interface {
+	RunDelegate(state RunState) RunDelegate
+}
+
+type RunDelegate interface {
+	Stdout() io.Writer
+	Stderr() io.Writer
+
+	Initializing(lager.Logger)
+	Starting(lager.Logger)
+	Finished(lager.Logger, bool)
+}
+
+func NewRunStep(
+	planID atc.PlanID,
+	plan atc.RunPlan,
+	delegateFactory RunDelegateFactory,
+) Step {
+	return &RunStep{
+		planID:          planID,
+		plan:            plan,
+		delegateFactory: delegateFactory,
+	}
+}
+
+func (step *RunStep) Run(ctx context.Context, state RunState) (bool, error) {
+	logger := lagerctx.FromContext(ctx)
+
+	delegate := step.delegateFactory.RunDelegate(state)
+	delegate.Initializing(logger)
+
+	stderr := delegate.Stderr()
+	fmt.Fprint(stderr, "\x1b[1;33mthe run step is not yet implemented\x1b[0m\n\n")
+
+	delegate.Starting(logger)
+
+	fmt.Fprintf(stderr, "\x1b[1;34mpretending to run %s on prototype %s...\x1b[0m\n", step.plan.Message, step.plan.Type)
+
+	delegate.Finished(logger, true)
+
+	return true, nil
+}

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -244,8 +244,7 @@ type CheckPlan struct {
 	// A pipeline resource, resource type, or prototype to assign the config to.
 	Resource     string `json:"resource,omitempty"`
 	ResourceType string `json:"resource_type,omitempty"`
-	// XXX(prototypes): use this to check prototypes
-	Prototype string `json:"prototype,omitempty"`
+	Prototype    string `json:"prototype,omitempty"`
 
 	// The interval on which to check - if it has not elapsed since the config
 	// was last checked, and the build has not been manually triggered, the check

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -241,9 +241,11 @@ type CheckPlan struct {
 	// version of the config.
 	FromVersion Version `json:"from_version,omitempty"`
 
-	// A pipeline resource or resource type to assign the config to.
+	// A pipeline resource, resource type, or prototype to assign the config to.
 	Resource     string `json:"resource,omitempty"`
 	ResourceType string `json:"resource_type,omitempty"`
+	// XXX(prototypes): use this to check prototypes
+	Prototype string `json:"prototype,omitempty"`
 
 	// The interval on which to check - if it has not elapsed since the config
 	// was last checked, and the build has not been manually triggered, the check
@@ -259,7 +261,7 @@ type CheckPlan struct {
 }
 
 func (plan CheckPlan) IsPeriodic() bool {
-	return plan.Resource != "" || plan.ResourceType != ""
+	return plan.Resource != "" || plan.ResourceType != "" || plan.Prototype != ""
 }
 
 type TaskPlan struct {

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -8,6 +8,7 @@ type Plan struct {
 	Put         *PutPlan         `json:"put,omitempty"`
 	Check       *CheckPlan       `json:"check,omitempty"`
 	Task        *TaskPlan        `json:"task,omitempty"`
+	Run         *RunPlan         `json:"run,omitempty"`
 	SetPipeline *SetPipelinePlan `json:"set_pipeline,omitempty"`
 	LoadVar     *LoadVarPlan     `json:"load_var,omitempty"`
 
@@ -298,7 +299,7 @@ type TaskPlan struct {
 	InputMapping  map[string]string `json:"input_mapping,omitempty"`
 	OutputMapping map[string]string `json:"output_mapping,omitempty"`
 
-	// A timeout to enforce on the task's process. Note that etching the task's
+	// A timeout to enforce on the task's process. Note that fetching the task's
 	// image does not count towards the timeout.
 	Timeout string `json:"timeout,omitempty"`
 
@@ -311,6 +312,32 @@ type TaskPlan struct {
 	// difficult to do because we don't even know what image resource to fetch
 	// until the task step runs and fetches its ConfigPath.
 	VersionedResourceTypes VersionedResourceTypes `json:"resource_types,omitempty"`
+}
+
+type RunPlan struct {
+	// The message to run on the prototype.
+	Message string `json:"message"`
+
+	// The prototype name.
+	Type string `json:"type"`
+
+	// Object to provide to the prototype. Result of merging run.params with
+	// prototype.defaults.
+	Object Params `json:"object,omitempty"`
+
+	// Run in 'privileged' mode. What this means depends on the platform, but
+	// typically you expose your workers to more risk by enabling this.
+	Privileged bool `json:"privileged"`
+
+	// Worker tags to influence placement of the container.
+	Tags Tags `json:"tags,omitempty"`
+
+	// Limits to set on the Container
+	Limits *ContainerLimits `json:"container_limits,omitempty"`
+
+	// A timeout to enforce on the run step's process. Note that fetching the
+	// prototype's image does not count towards the timeout.
+	Timeout string `json:"timeout,omitempty"`
 }
 
 type SetPipelinePlan struct {

--- a/atc/plan_factory.go
+++ b/atc/plan_factory.go
@@ -37,6 +37,8 @@ func (factory PlanFactory) NewPlan(step PlanConfig) Plan {
 		plan.Put = &t
 	case TaskPlan:
 		plan.Task = &t
+	case RunPlan:
+		plan.Run = &t
 	case SetPipelinePlan:
 		plan.SetPipeline = &t
 	case LoadVarPlan:

--- a/atc/public_plan.go
+++ b/atc/public_plan.go
@@ -13,6 +13,7 @@ func (plan Plan) Public() *json.RawMessage {
 		Put            *json.RawMessage `json:"put,omitempty"`
 		Check          *json.RawMessage `json:"check,omitempty"`
 		Task           *json.RawMessage `json:"task,omitempty"`
+		Run            *json.RawMessage `json:"run,omitempty"`
 		SetPipeline    *json.RawMessage `json:"set_pipeline,omitempty"`
 		LoadVar        *json.RawMessage `json:"load_var,omitempty"`
 		OnAbort        *json.RawMessage `json:"on_abort,omitempty"`
@@ -56,6 +57,10 @@ func (plan Plan) Public() *json.RawMessage {
 
 	if plan.Task != nil {
 		public.Task = plan.Task.Public()
+	}
+
+	if plan.Run != nil {
+		public.Run = plan.Run.Public()
 	}
 
 	if plan.SetPipeline != nil {
@@ -270,6 +275,18 @@ func (plan TaskPlan) Public() *json.RawMessage {
 		Privileged bool   `json:"privileged"`
 	}{
 		Name:       plan.Name,
+		Privileged: plan.Privileged,
+	})
+}
+
+func (plan RunPlan) Public() *json.RawMessage {
+	return enc(struct {
+		Message    string `json:"message"`
+		Type       string `json:"type"`
+		Privileged bool   `json:"privileged"`
+	}{
+		Message:    plan.Message,
+		Type:       plan.Type,
 		Privileged: plan.Privileged,
 	})
 }

--- a/atc/routes.go
+++ b/atc/routes.go
@@ -39,6 +39,7 @@ const (
 	CheckResource        = "CheckResource"
 	CheckResourceWebHook = "CheckResourceWebHook"
 	CheckResourceType    = "CheckResourceType"
+	CheckPrototype       = "CheckPrototype"
 
 	ListResourceVersions          = "ListResourceVersions"
 	GetResourceVersion            = "GetResourceVersion"
@@ -174,6 +175,7 @@ var Routes = rata.Routes([]rata.Route{
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/check", Method: "POST", Name: CheckResource},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/check/webhook", Method: "POST", Name: CheckResourceWebHook},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resource-types/:resource_type_name/check", Method: "POST", Name: CheckResourceType},
+	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/prototypes/:prototype_name/check", Method: "POST", Name: CheckPrototype},
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/cache", Method: "DELETE", Name: ClearResourceCache},
 
 	{Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions", Method: "GET", Name: ListResourceVersions},

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -21,7 +21,7 @@ type BuildStarter interface {
 
 //counterfeiter:generate . BuildPlanner
 type BuildPlanner interface {
-	Create(atc.StepConfig, db.SchedulerResources, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)
+	Create(atc.StepConfig, db.SchedulerResources, atc.VersionedResourceTypes, atc.Prototypes, []db.BuildInput) (atc.Plan, error)
 }
 
 type Build interface {
@@ -196,7 +196,7 @@ func (s *buildStarter) tryStartNextPendingBuild(
 		return startResults{}, fmt.Errorf("config: %w", err)
 	}
 
-	plan, err := s.planner.Create(config.StepConfig(), job.Resources, job.ResourceTypes, buildInputs)
+	plan, err := s.planner.Create(config.StepConfig(), job.Resources, job.ResourceTypes, job.Prototypes, buildInputs)
 	if err != nil {
 		logger.Error("failed-to-create-build-plan", err)
 

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -46,6 +46,7 @@ var _ = Describe("BuildStarter", func() {
 		var job *dbfakes.FakeJob
 		var resources db.SchedulerResources
 		var versionedResourceTypes atc.VersionedResourceTypes
+		var prototypes atc.Prototypes
 
 		BeforeEach(func() {
 			versionedResourceTypes = atc.VersionedResourceTypes{
@@ -58,6 +59,12 @@ var _ = Describe("BuildStarter", func() {
 			resources = db.SchedulerResources{
 				{
 					Name: "some-resource",
+				},
+			}
+
+			prototypes = atc.Prototypes{
+				{
+					Name: "some-prototype",
 				},
 			}
 		})
@@ -119,6 +126,7 @@ var _ = Describe("BuildStarter", func() {
 							Job:           job,
 							Resources:     resources,
 							ResourceTypes: versionedResourceTypes,
+							Prototypes:    prototypes,
 						},
 						jobInputs,
 					)
@@ -440,16 +448,10 @@ var _ = Describe("BuildStarter", func() {
 					needsReschedule, tryStartErr = buildStarter.TryStartPendingBuildsForJob(
 						lagertest.NewTestLogger("test"),
 						db.SchedulerJob{
-							Job:       job,
-							Resources: resources,
-							ResourceTypes: atc.VersionedResourceTypes{
-								{
-									ResourceType: atc.ResourceType{
-										Name: "some-resource-type",
-									},
-									Version: atc.Version{"some": "version"},
-								},
-							},
+							Job:           job,
+							Resources:     resources,
+							ResourceTypes: versionedResourceTypes,
+							Prototypes:    prototypes,
 						},
 						jobInputs,
 					)
@@ -661,22 +663,25 @@ var _ = Describe("BuildStarter", func() {
 									It("creates build plans for all builds", func() {
 										Expect(fakePlanner.CreateCallCount()).To(Equal(3))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualBuildInputs := fakePlanner.CreateArgsForCall(0)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs := fakePlanner.CreateArgsForCall(0)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(versionedResourceTypes))
+										Expect(actualPrototypes).To(Equal(prototypes))
 										Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualBuildInputs = fakePlanner.CreateArgsForCall(1)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs = fakePlanner.CreateArgsForCall(1)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(versionedResourceTypes))
+										Expect(actualPrototypes).To(Equal(prototypes))
 										Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualBuildInputs = fakePlanner.CreateArgsForCall(2)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs = fakePlanner.CreateArgsForCall(2)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(versionedResourceTypes))
+										Expect(actualPrototypes).To(Equal(prototypes))
 										Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
 									})
 

--- a/atc/scheduler/schedulerfakes/fake_build_planner.go
+++ b/atc/scheduler/schedulerfakes/fake_build_planner.go
@@ -10,13 +10,14 @@ import (
 )
 
 type FakeBuildPlanner struct {
-	CreateStub        func(atc.StepConfig, db.SchedulerResources, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)
+	CreateStub        func(atc.StepConfig, db.SchedulerResources, atc.VersionedResourceTypes, atc.Prototypes, []db.BuildInput) (atc.Plan, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
 		arg1 atc.StepConfig
 		arg2 db.SchedulerResources
 		arg3 atc.VersionedResourceTypes
-		arg4 []db.BuildInput
+		arg4 atc.Prototypes
+		arg5 []db.BuildInput
 	}
 	createReturns struct {
 		result1 atc.Plan
@@ -30,11 +31,11 @@ type FakeBuildPlanner struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResources, arg3 atc.VersionedResourceTypes, arg4 []db.BuildInput) (atc.Plan, error) {
-	var arg4Copy []db.BuildInput
-	if arg4 != nil {
-		arg4Copy = make([]db.BuildInput, len(arg4))
-		copy(arg4Copy, arg4)
+func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResources, arg3 atc.VersionedResourceTypes, arg4 atc.Prototypes, arg5 []db.BuildInput) (atc.Plan, error) {
+	var arg5Copy []db.BuildInput
+	if arg5 != nil {
+		arg5Copy = make([]db.BuildInput, len(arg5))
+		copy(arg5Copy, arg5)
 	}
 	fake.createMutex.Lock()
 	ret, specificReturn := fake.createReturnsOnCall[len(fake.createArgsForCall)]
@@ -42,14 +43,15 @@ func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResou
 		arg1 atc.StepConfig
 		arg2 db.SchedulerResources
 		arg3 atc.VersionedResourceTypes
-		arg4 []db.BuildInput
-	}{arg1, arg2, arg3, arg4Copy})
+		arg4 atc.Prototypes
+		arg5 []db.BuildInput
+	}{arg1, arg2, arg3, arg4, arg5Copy})
 	stub := fake.CreateStub
 	fakeReturns := fake.createReturns
-	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4Copy})
+	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4, arg5Copy})
 	fake.createMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -63,17 +65,17 @@ func (fake *FakeBuildPlanner) CreateCallCount() int {
 	return len(fake.createArgsForCall)
 }
 
-func (fake *FakeBuildPlanner) CreateCalls(stub func(atc.StepConfig, db.SchedulerResources, atc.VersionedResourceTypes, []db.BuildInput) (atc.Plan, error)) {
+func (fake *FakeBuildPlanner) CreateCalls(stub func(atc.StepConfig, db.SchedulerResources, atc.VersionedResourceTypes, atc.Prototypes, []db.BuildInput) (atc.Plan, error)) {
 	fake.createMutex.Lock()
 	defer fake.createMutex.Unlock()
 	fake.CreateStub = stub
 }
 
-func (fake *FakeBuildPlanner) CreateArgsForCall(i int) (atc.StepConfig, db.SchedulerResources, atc.VersionedResourceTypes, []db.BuildInput) {
+func (fake *FakeBuildPlanner) CreateArgsForCall(i int) (atc.StepConfig, db.SchedulerResources, atc.VersionedResourceTypes, atc.Prototypes, []db.BuildInput) {
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
 	argsForCall := fake.createArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeBuildPlanner) CreateReturns(result1 atc.Plan, result2 error) {

--- a/atc/step_recursor.go
+++ b/atc/step_recursor.go
@@ -17,6 +17,9 @@ type StepRecursor struct {
 	// OnPut will be invoked for any *PutStep present in the StepConfig.
 	OnPut func(*PutStep) error
 
+	// OnRun will be invoked for any *RunStep present in the StepConfig.
+	OnRun func(*RunStep) error
+
 	// OnSetPipeline will be invoked for any *SetPipelineStep present in the StepConfig.
 	OnSetPipeline func(*SetPipelineStep) error
 
@@ -46,6 +49,15 @@ func (recursor StepRecursor) VisitGet(step *GetStep) error {
 func (recursor StepRecursor) VisitPut(step *PutStep) error {
 	if recursor.OnPut != nil {
 		return recursor.OnPut(step)
+	}
+
+	return nil
+}
+
+// VisitRun calls the OnRun hook if configured.
+func (recursor StepRecursor) VisitRun(step *RunStep) error {
+	if recursor.OnRun != nil {
+		return recursor.OnRun(step)
 	}
 
 	return nil

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -191,6 +191,7 @@ type StepVisitor interface {
 	VisitTask(*TaskStep) error
 	VisitGet(*GetStep) error
 	VisitPut(*PutStep) error
+	VisitRun(*RunStep) error
 	VisitSetPipeline(*SetPipelineStep) error
 	VisitLoadVar(*LoadVarStep) error
 	VisitTry(*TryStep) error
@@ -248,6 +249,10 @@ var StepPrecedence = []StepDetector{
 	{
 		Key: "attempts",
 		New: func() StepConfig { return &RetryStep{} },
+	},
+	{
+		Key: "run",
+		New: func() StepConfig { return &RunStep{} },
 	},
 	{
 		Key: "task",
@@ -349,6 +354,28 @@ type TaskStep struct {
 
 func (step *TaskStep) Visit(v StepVisitor) error {
 	return v.VisitTask(step)
+}
+
+type RunStep struct {
+	Message    string           `json:"run"`
+	Type       string           `json:"type"`
+	Params     Params           `json:"params,omitempty"`
+	Privileged bool             `json:"privileged,omitempty"`
+	Tags       Tags             `json:"tags,omitempty"`
+	Limits     *ContainerLimits `json:"container_limits,omitempty"`
+	Timeout    string           `json:"timeout,omitempty"`
+
+	// XXX(prototypes): inputs, outputs, input_mapping, output_mapping?
+	// see https://github.com/concourse/rfcs/pull/103
+
+	// XXX(prototypes): set_vars?
+
+	// XXX(prototypes): image? That way, you can build a prototype and run it
+	// in the same pipeline. This would be in place of type.
+}
+
+func (step *RunStep) Visit(v StepVisitor) error {
+	return v.VisitRun(step)
 }
 
 type SetPipelineStep struct {

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -166,6 +166,36 @@ var factoryTests = []StepTest{
 		},
 	},
 	{
+		Title: "run step",
+
+		ConfigYAML: `
+			run: some-message
+			type: some-prototype
+			privileged: true
+			params:
+			  foo: {bar: [123, 456]}
+			  baz: qux
+			tags: [tag-1, tag-2]
+			container_limits: {cpu: 10, memory: 1024}
+			timeout: 1h
+		`,
+
+		StepConfig: &atc.RunStep{
+			Message:    "some-message",
+			Type:       "some-prototype",
+			Privileged: true,
+			Params: atc.Params{
+				"foo": map[string]interface{}{
+					"bar": []interface{}{123.0, 456.0},
+				},
+				"baz": "qux",
+			},
+			Tags:    []string{"tag-1", "tag-2"},
+			Limits:  &atc.ContainerLimits{CPU: newCPULimit(10), Memory: newMemoryLimit(1024)},
+			Timeout: "1h",
+		},
+	},
+	{
 		Title: "set_pipeline step",
 
 		ConfigYAML: `

--- a/atc/wrappa/api_auth_wrappa.go
+++ b/atc/wrappa/api_auth_wrappa.go
@@ -127,6 +127,7 @@ func (wrappa *APIAuthWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.CreateBuild,
 			atc.CheckResource,
 			atc.CheckResourceType,
+			atc.CheckPrototype,
 			atc.CreateJobBuild,
 			atc.RerunJobBuild,
 			atc.CreatePipelineBuild,

--- a/atc/wrappa/reject_archived_wrappa.go
+++ b/atc/wrappa/reject_archived_wrappa.go
@@ -30,6 +30,7 @@ func (rw *RejectArchivedWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 			atc.ScheduleJob,
 			atc.CheckResource,
 			atc.CheckResourceType,
+			atc.CheckPrototype,
 			atc.DisableResourceVersion,
 			atc.EnableResourceVersion,
 			atc.PinResourceVersion,

--- a/atc/wrappa/reject_archived_wrappa_test.go
+++ b/atc/wrappa/reject_archived_wrappa_test.go
@@ -37,6 +37,7 @@ var _ = Describe("RejectArchivedWrappa", func() {
 			atc.ScheduleJob,
 			atc.CheckResource,
 			atc.CheckResourceType,
+			atc.CheckPrototype,
 			atc.DisableResourceVersion,
 			atc.EnableResourceVersion,
 			atc.PinResourceVersion,

--- a/go-concourse/concourse/check_prototype.go
+++ b/go-concourse/concourse/check_prototype.go
@@ -1,0 +1,51 @@
+package concourse
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/go-concourse/concourse/internal"
+	"github.com/tedsuo/rata"
+)
+
+func (team *team) CheckPrototype(pipelineRef atc.PipelineRef, prototypeName string, version atc.Version) (atc.Build, bool, error) {
+	params := rata.Params{
+		"pipeline_name":  pipelineRef.Name,
+		"prototype_name": prototypeName,
+		"team_name":      team.Name(),
+	}
+
+	var build atc.Build
+
+	jsonBytes, err := json.Marshal(atc.CheckRequestBody{From: version})
+	if err != nil {
+		return build, false, err
+	}
+
+	err = team.connection.Send(internal.Request{
+		RequestName: atc.CheckPrototype,
+		Params:      params,
+		Query:       pipelineRef.QueryParams(),
+		Body:        bytes.NewBuffer(jsonBytes),
+		Header:      http.Header{"Content-Type": []string{"application/json"}},
+	}, &internal.Response{
+		Result: &build,
+	})
+
+	switch e := err.(type) {
+	case nil:
+		return build, true, nil
+	case internal.ResourceNotFoundError:
+		return build, false, nil
+	case internal.UnexpectedResponseError:
+		if e.StatusCode == http.StatusInternalServerError {
+			return build, false, GenericError{e.Body}
+		} else {
+			return build, false, err
+		}
+	default:
+		return build, false, err
+	}
+}

--- a/go-concourse/concourse/check_prototype_test.go
+++ b/go-concourse/concourse/check_prototype_test.go
@@ -1,0 +1,49 @@
+package concourse_test
+
+import (
+	"net/http"
+
+	"github.com/concourse/concourse/atc"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("CheckPrototype", func() {
+	var (
+		expectedURL   = "/api/v1/teams/some-team/pipelines/mypipeline/prototypes/myprototype/check"
+		expectedQuery = "vars.branch=%22master%22"
+		pipelineRef   = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
+	)
+
+	Context("when ATC request succeeds", func() {
+		var expectedCheck atc.Build
+
+		BeforeEach(func() {
+			expectedCheck = atc.Build{
+				ID:        123,
+				Status:    "started",
+				StartTime: 100000000000,
+				EndTime:   100000000000,
+			}
+
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", expectedURL, expectedQuery),
+					ghttp.VerifyJSON(`{"from":{"ref":"fake-ref"}}`),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, expectedCheck),
+				),
+			)
+		})
+
+		It("sends check resource request to ATC", func() {
+			check, found, err := team.CheckPrototype(pipelineRef, "myprototype", atc.Version{"ref": "fake-ref"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(check).To(Equal(expectedCheck))
+
+			Expect(atcServer.ReceivedRequests()).To(HaveLen(1))
+		})
+	})
+})

--- a/go-concourse/concourse/concoursefakes/fake_team.go
+++ b/go-concourse/concourse/concoursefakes/fake_team.go
@@ -108,6 +108,23 @@ type FakeTeam struct {
 		result2 bool
 		result3 error
 	}
+	CheckPrototypeStub        func(atc.PipelineRef, string, atc.Version) (atc.Build, bool, error)
+	checkPrototypeMutex       sync.RWMutex
+	checkPrototypeArgsForCall []struct {
+		arg1 atc.PipelineRef
+		arg2 string
+		arg3 atc.Version
+	}
+	checkPrototypeReturns struct {
+		result1 atc.Build
+		result2 bool
+		result3 error
+	}
+	checkPrototypeReturnsOnCall map[int]struct {
+		result1 atc.Build
+		result2 bool
+		result3 error
+	}
 	CheckResourceStub        func(atc.PipelineRef, string, atc.Version) (atc.Build, bool, error)
 	checkResourceMutex       sync.RWMutex
 	checkResourceArgsForCall []struct {
@@ -1234,6 +1251,75 @@ func (fake *FakeTeam) BuildsWithVersionAsOutputReturnsOnCall(i int, result1 []at
 	}
 	fake.buildsWithVersionAsOutputReturnsOnCall[i] = struct {
 		result1 []atc.Build
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeTeam) CheckPrototype(arg1 atc.PipelineRef, arg2 string, arg3 atc.Version) (atc.Build, bool, error) {
+	fake.checkPrototypeMutex.Lock()
+	ret, specificReturn := fake.checkPrototypeReturnsOnCall[len(fake.checkPrototypeArgsForCall)]
+	fake.checkPrototypeArgsForCall = append(fake.checkPrototypeArgsForCall, struct {
+		arg1 atc.PipelineRef
+		arg2 string
+		arg3 atc.Version
+	}{arg1, arg2, arg3})
+	stub := fake.CheckPrototypeStub
+	fakeReturns := fake.checkPrototypeReturns
+	fake.recordInvocation("CheckPrototype", []interface{}{arg1, arg2, arg3})
+	fake.checkPrototypeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeTeam) CheckPrototypeCallCount() int {
+	fake.checkPrototypeMutex.RLock()
+	defer fake.checkPrototypeMutex.RUnlock()
+	return len(fake.checkPrototypeArgsForCall)
+}
+
+func (fake *FakeTeam) CheckPrototypeCalls(stub func(atc.PipelineRef, string, atc.Version) (atc.Build, bool, error)) {
+	fake.checkPrototypeMutex.Lock()
+	defer fake.checkPrototypeMutex.Unlock()
+	fake.CheckPrototypeStub = stub
+}
+
+func (fake *FakeTeam) CheckPrototypeArgsForCall(i int) (atc.PipelineRef, string, atc.Version) {
+	fake.checkPrototypeMutex.RLock()
+	defer fake.checkPrototypeMutex.RUnlock()
+	argsForCall := fake.checkPrototypeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeTeam) CheckPrototypeReturns(result1 atc.Build, result2 bool, result3 error) {
+	fake.checkPrototypeMutex.Lock()
+	defer fake.checkPrototypeMutex.Unlock()
+	fake.CheckPrototypeStub = nil
+	fake.checkPrototypeReturns = struct {
+		result1 atc.Build
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeTeam) CheckPrototypeReturnsOnCall(i int, result1 atc.Build, result2 bool, result3 error) {
+	fake.checkPrototypeMutex.Lock()
+	defer fake.checkPrototypeMutex.Unlock()
+	fake.CheckPrototypeStub = nil
+	if fake.checkPrototypeReturnsOnCall == nil {
+		fake.checkPrototypeReturnsOnCall = make(map[int]struct {
+			result1 atc.Build
+			result2 bool
+			result3 error
+		})
+	}
+	fake.checkPrototypeReturnsOnCall[i] = struct {
+		result1 atc.Build
 		result2 bool
 		result3 error
 	}{result1, result2, result3}
@@ -4346,6 +4432,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.buildsWithVersionAsInputMutex.RUnlock()
 	fake.buildsWithVersionAsOutputMutex.RLock()
 	defer fake.buildsWithVersionAsOutputMutex.RUnlock()
+	fake.checkPrototypeMutex.RLock()
+	defer fake.checkPrototypeMutex.RUnlock()
 	fake.checkResourceMutex.RLock()
 	defer fake.checkResourceMutex.RUnlock()
 	fake.checkResourceTypeMutex.RLock()

--- a/go-concourse/concourse/team.go
+++ b/go-concourse/concourse/team.go
@@ -54,6 +54,7 @@ type Team interface {
 	ResourceVersions(pipelineRef atc.PipelineRef, resourceName string, page Page, filter atc.Version) ([]atc.ResourceVersion, Pagination, bool, error)
 	CheckResource(pipelineRef atc.PipelineRef, resourceName string, version atc.Version) (atc.Build, bool, error)
 	CheckResourceType(pipelineRef atc.PipelineRef, resourceTypeName string, version atc.Version) (atc.Build, bool, error)
+	CheckPrototype(pipelineRef atc.PipelineRef, prototypeName string, version atc.Version) (atc.Build, bool, error)
 	DisableResourceVersion(pipelineRef atc.PipelineRef, resourceName string, resourceVersionID int) (bool, error)
 	EnableResourceVersion(pipelineRef atc.PipelineRef, resourceName string, resourceVersionID int) (bool, error)
 	ClearResourceCache(pipelineRef atc.PipelineRef, ResourceName string, version atc.Version) (int64, error)

--- a/testflight/fixtures/prototype.yml
+++ b/testflight/fixtures/prototype.yml
@@ -1,0 +1,13 @@
+---
+prototypes:
+- name: some-prototype
+  type: mock
+  source:
+    mirror_self: true
+
+jobs:
+- name: job
+  plan:
+  - run: some-message
+    type: some-prototype
+

--- a/testflight/prototype_test.go
+++ b/testflight/prototype_test.go
@@ -1,0 +1,23 @@
+package testflight_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Pipeline with prototypes", func() {
+	BeforeEach(func() {
+		setAndUnpausePipeline("fixtures/prototype.yml")
+	})
+
+	It("executes the build plan correctly", func() {
+		watch := spawnFly("trigger-job", "-j", inPipeline("job"), "-w")
+		<-watch.Exited
+		Expect(watch).To(gexec.Exit(0))
+
+		// XXX(prototypes): eventually, this'll need to test the real implementation
+		Expect(watch).To(gbytes.Say("run some-message on prototype some-prototype"))
+	})
+})

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -47,6 +47,7 @@ type StepTree
     = Task StepID
     | Check StepID
     | Get StepID
+    | Run StepID
     | Put StepID
     | SetPipeline StepID
     | LoadVar StepID
@@ -256,6 +257,9 @@ activeStepIds model tree =
             [ stepId ]
 
         Get stepId ->
+            [ stepId ]
+
+        Run stepId ->
             [ stepId ]
 
         Put stepId ->

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -83,6 +83,9 @@ init buildId hl resources plan =
                 |> setupGetStep resources name version
                 |> initBottom buildId hl resources plan Get
 
+        Concourse.BuildStepRun _ ->
+            step |> initBottom buildId hl resources plan Run
+
         Concourse.BuildStepPut _ _ ->
             step |> initBottom buildId hl resources plan Put
 
@@ -496,6 +499,9 @@ viewTree session model tree depth =
             viewStep model session depth stepId
 
         Get stepId ->
+            viewStep model session depth stepId
+
+        Run stepId ->
             viewStep model session depth stepId
 
         Put stepId ->
@@ -1164,6 +1170,9 @@ viewStepHeader step =
         Concourse.BuildStepCheck name ->
             simpleHeader "check:" Nothing name
 
+        Concourse.BuildStepRun message ->
+            simpleHeader "run:" Nothing message
+
         Concourse.BuildStepGet name _ _ ->
             simpleHeader "get:" (Just "new version") name
 
@@ -1230,6 +1239,9 @@ stepName header =
 
         Concourse.BuildStepCheck name ->
             Just name
+
+        Concourse.BuildStepRun message ->
+            Just message
 
         Concourse.BuildStepGet name _ _ ->
             Just name

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -387,6 +387,9 @@ mapBuildPlan fn plan =
                 BuildStepGet _ _ _ ->
                     []
 
+                BuildStepRun _ ->
+                    []
+
                 BuildStepArtifactOutput _ ->
                     []
 
@@ -441,6 +444,7 @@ type BuildStep
     | BuildStepArtifactInput StepName
     | BuildStepCheck StepName
     | BuildStepGet StepName (Maybe ResourceName) (Maybe Version)
+    | BuildStepRun StepName
     | BuildStepArtifactOutput StepName
     | BuildStepPut StepName (Maybe ResourceName)
     | BuildStepInParallel (Array BuildPlan)
@@ -617,6 +621,8 @@ decodeBuildPlan =
                     lazy (\_ -> decodeBuildStepCheck)
                 , Json.Decode.field "get" <|
                     lazy (\_ -> decodeBuildStepGet)
+                , Json.Decode.field "run" <|
+                    lazy (\_ -> decodeBuildStepRun)
                 , Json.Decode.field "artifact_input" <|
                     lazy (\_ -> decodeBuildStepArtifactInput)
                 , Json.Decode.field "put" <|
@@ -673,6 +679,12 @@ decodeBuildStepGet =
         |> andMap (Json.Decode.field "name" Json.Decode.string)
         |> andMap (Json.Decode.maybe <| Json.Decode.field "resource" Json.Decode.string)
         |> andMap (Json.Decode.maybe <| Json.Decode.field "version" decodeVersion)
+
+
+decodeBuildStepRun : Json.Decode.Decoder BuildStep
+decodeBuildStepRun =
+    Json.Decode.succeed BuildStepRun
+        |> andMap (Json.Decode.field "message" Json.Decode.string)
 
 
 decodeBuildStepCheck : Json.Decode.Decoder BuildStep
@@ -1264,6 +1276,7 @@ decodeUser =
         |> andMap (Json.Decode.field "is_admin" Json.Decode.bool)
         |> andMap (Json.Decode.field "teams" (Json.Decode.dict (Json.Decode.list Json.Decode.string)))
         |> andMap (Json.Decode.field "display_user_id" Json.Decode.string)
+
 
 
 -- Cause

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -2672,6 +2672,21 @@ all =
                                 )
                             >> Tuple.first
 
+                    fetchPlanWithRunStep : () -> Application.Model
+                    fetchPlanWithRunStep =
+                        givenBuildStarted
+                            >> Tuple.first
+                            >> Application.handleCallback
+                                (Callback.PlanAndResourcesFetched 1 <|
+                                    Ok <|
+                                        ( { id = "plan"
+                                          , step = Concourse.BuildStepRun "message"
+                                          }
+                                        , { inputs = [], outputs = [] }
+                                        )
+                                )
+                            >> Tuple.first
+
                     fetchPlanWithTaskStep : () -> Application.Model
                     fetchPlanWithTaskStep =
                         givenBuildStarted
@@ -2921,6 +2936,10 @@ all =
                     fetchPlanWithArtifactInputStep
                         >> Common.queryView
                         >> Query.has getStepLabel
+                , test "run step shows run label" <|
+                    fetchPlanWithRunStep
+                        >> Common.queryView
+                        >> Query.has runStepLabel
                 , test "task step shows task label" <|
                     fetchPlanWithTaskStep
                         >> Common.queryView
@@ -3824,6 +3843,14 @@ all =
                 ]
             ]
         ]
+
+
+runStepLabel =
+    [ style "color" Colors.pending
+    , style "line-height" "28px"
+    , style "padding-left" "6px"
+    , containing [ text "run:" ]
+    ]
 
 
 getStepLabel =

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -30,6 +30,7 @@ all =
         , initSetPipeline
         , initLoadVar
         , initCheck
+        , initRun
         , initGet
         , initPut
         , initAcross
@@ -177,6 +178,30 @@ initCheck =
         [ test "the tree" <|
             \_ ->
                 Expect.equal (Models.Check "some-id") tree
+        , test "the step" <|
+            \_ ->
+                assertSteps [ someStep "some-id" step Models.StepStatePending ] steps
+        ]
+
+
+initRun : Test
+initRun =
+    let
+        step =
+            BuildStepRun "some-message"
+
+        { tree, steps } =
+            StepTree.init Nothing
+                Routes.HighlightNothing
+                emptyResources
+                { id = "some-id"
+                , step = step
+                }
+    in
+    describe "init with Run"
+        [ test "the tree" <|
+            \_ ->
+                Expect.equal (Models.Run "some-id") tree
         , test "the step" <|
             \_ ->
                 assertSteps [ someStep "some-id" step Models.StepStatePending ] steps


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #7060 

* [x] Allow prototypes to be configured in the pipeline config
    * They are stored in the DB and are used for build planning
     * A prototype and a resource_type cannot share a name
* [x] Prototype images can be checked. However, there is no automated checking done for prototypes in e.g. lidar
     * The reason for this is that #6274 will change the way resource types are checked (they will no longer be checked directly in lidar, but will be checked when checking the resources that use the resource type). Similarly, resource prototypes will be checked when checking resources that use it, and regular prototypes will be checked when invoking the `run` step
     * I also didn't implement a `fly check-prototype` command for a similar reason - #6274 simplifies the recursive checking flow. After that work gets merged, we can easily add such a fly command
     * I did however implement an API endpoint for checking prototypes, so you can run e.g. `fly -t dev curl /api/v1/teams/main/pipelines/my-pipeline/prototypes/some-prototype/check -- -X POST -H "Content-Type: application/json" --data '{}'` to manually check a prototype
* [x] Allow configuring a `run:` step in the build plan
    * ...which currently doesn't actually do anything special - it just prints a message to the terminal
        <img width="626" alt="Screen Shot 2021-05-21 at 3 18 08 PM" src="https://user-images.githubusercontent.com/26583442/119187745-c2e27f00-ba47-11eb-8519-5d81521c51af.png">
    * The reason for this "dumb" implementation is twofold:
        1. I'm waiting on #6597 to get merged, which will simplify the implementation
        2. We still need to figure out how best to represent inputs/outputs - see concourse/rfcs#103


## Notes to reviewer

You can test this out using the following pipeline:

```yaml
prototypes:
- name: some-prototype
  type: mock
  source: {mirror_self: true}

jobs:
- name: job
  plan:
  - run: some-message
    type: some-prototype
    params:
      foo: bar
```

Note that the config of the prototype doesn't really matter (unless you want to check the prototype image manually) since we never run anything on the prototype image.