### PR TITLE
containerd: update config to v2 format

### DIFF
--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -36,8 +36,10 @@ func WriteDefaultContainerdConfig(dest string) error {
 	//                   reason about potential problems down the road.
 	//
 	const config = `
+version = 2
+
 oom_score = -999
-disabled_plugins = ["cri", "aufs", "btrfs", "zfs"]
+disabled_plugins = ["io.containerd.grpc.v1.cri", "io.containerd.snapshotter.v1.aufs", "io.containerd.snapshotter.v1.btrfs", "io.containerd.snapshotter.v1.zfs"]
 `
 	err := ioutil.WriteFile(dest, []byte(config), 0755)
 	if err != nil {


### PR DESCRIPTION
cc: @aoldershaw 

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

Changes containerd config (i.e. `contairnerd.toml`) to the version 2 format as version 1 is now deprecated. v2 format has to be declared explicitly at the top. It uses long form plugin names e.g. "io.containerd.snapshotter.v1.btrfs" instead
of "btrfs".

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

## Notes to reviewer

Config guide -> https://github.com/containerd/containerd/blob/master/docs/cri/config.md
