### PR TITLE
containerd: Mount `/dev/fuse` to privileged containers

### DIFF
--- a/testflight/devices_test.go
+++ b/testflight/devices_test.go
@@ -1,0 +1,24 @@
+package testflight_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("Devices", func() {
+	It("mounts the /dev/fuse device to privileged containers", func() {
+		setAndUnpausePipeline("fixtures/devices.yml")
+
+		watch := fly("trigger-job", "-j", inPipeline("check-fuse-privileged"), "-w")
+		Expect(watch).To(gbytes.Say("succeeded"))
+	})
+
+	It("does not mount the /dev/fuse device to unprivileged containers", func() {
+		setAndUnpausePipeline("fixtures/devices.yml")
+
+		watch := flyUnsafe("trigger-job", "-j", inPipeline("check-fuse-unprivileged"), "-w")
+		Expect(watch.ExitCode()).To(Equal(1))
+		Expect(watch).To(gbytes.Say("No such file or directory"))
+	})
+})

--- a/testflight/fixtures/devices.yml
+++ b/testflight/fixtures/devices.yml
@@ -1,0 +1,18 @@
+jobs:
+- name: check-fuse-privileged
+  plan:
+  - task: check-fuse
+    privileged: true
+    config: &check-fuse
+      platform: linux
+      image_resource:
+        type: mock
+        source: {mirror_self: true}
+      run:
+        path: ls
+        args: [/dev/fuse]
+
+- name: check-fuse-unprivileged
+  plan:
+  - task: check-fuse
+    config: *check-fuse

--- a/worker/runtime/spec/spec.go
+++ b/worker/runtime/spec/spec.go
@@ -209,6 +209,7 @@ func defaultGardenOciSpec(initBinPath string, privileged bool, maxUid, maxGid ui
 			Resources: &specs.LinuxResources{
 				Devices: AnyContainerDevices,
 			},
+			Devices:     Devices(privileged),
 			UIDMappings: OciIDMappings(privileged, maxUid),
 			GIDMappings: OciIDMappings(privileged, maxGid),
 		},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #7096

this is already done for guardian, but missing in our containerd runtime.

note that we already added a cgroup rule for /dev/fuse, but didn't actually mount the device

this logic is the same as in Guardian - see:
* https://github.com/cloudfoundry/guardian/blob/2f945c09a983e47325c314bf1237c31fe5acda62/guardiancmd/command.go#L528
* https://github.com/cloudfoundry/guardian/blob/2f945c09a983e47325c314bf1237c31fe5acda62/guardiancmd/command_linux.go#L229
* https://github.com/cloudfoundry/guardian/blob/2f945c09a983e47325c314bf1237c31fe5acda62/guardiancmd/server.go#L100-L106