### PR TITLE
atc(fix): fixed a bug in resource check rate limiter.

### DIFF
--- a/atc/db/resource_check_rate_limiter.go
+++ b/atc/db/resource_check_rate_limiter.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	sq "github.com/Masterminds/squirrel"
 	"sync"
 	"time"
 
@@ -88,7 +89,8 @@ func (limiter *ResourceCheckRateLimiter) Limit() rate.Limit {
 func (limiter *ResourceCheckRateLimiter) refreshCheckLimiter() error {
 	var count int
 	err := psql.Select("COUNT(id)").
-		From("resource_config_scopes").
+		From("resources").
+		Where(sq.Eq{"active": true}).
 		RunWith(limiter.refreshConn).
 		QueryRow().
 		Scan(&count)


### PR DESCRIPTION
## Changes proposed by this PR

closes #7077

In pre-7.x, checks are created per resource scope, so check rate limit is calculated by `total resource scopes / check interval`.

In 7.x, check builds are created per resource, but rate limit is still calculated by resource scope count, which leads to smaller rate limit, and causes slow checks.

## Notes to reviewer

I also proposed the other solution in #7103, and I feel that one is better.

## Release Note

* Fixed a bug in check rate limiter that caused slow checks.
