### PR TITLE
Build page shows name of who triggered the build in header line of build page

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -727,6 +727,7 @@ sampleOldModel =
                     , finishedAt = Nothing
                     }
                 , reapTime = Nothing
+                , createdBy = Nothing
                 }
             , prep = Nothing
             , output =
@@ -789,6 +790,7 @@ sampleModel =
     , hasLoadedYet = True
     , notFound = False
     , reapTime = Nothing
+    , createdBy = Nothing
     }
 
 

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -123,6 +123,7 @@ init flags =
           , hasLoadedYet = False
           , notFound = False
           , reapTime = Nothing
+          , createdBy = Nothing
           }
         , [ GetCurrentTime
           , GetCurrentTimeZone

--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -201,6 +201,7 @@ historyItem model =
     , name = model.name
     , status = model.status
     , duration = model.duration
+    , createdBy = model.createdBy
     }
 
 
@@ -217,6 +218,7 @@ changeToBuild pageType ( model, effects ) =
                             , status = b.status
                             , duration = b.duration
                             , name = b.name
+                            , createdBy = b.createdBy
                         }
                     )
                 |> Maybe.withDefault model
@@ -518,6 +520,7 @@ handleCallback callback ( model, effects ) =
                      , name = b.name
                      , status = b.status
                      , duration = b.duration
+                     , createdBy = b.createdBy
                      }
                         :: model.history
                     )
@@ -564,6 +567,7 @@ handleBuildFetched b ( model, effects ) =
                     , name = b.name
                     , status = b.status
                     , duration = b.duration
+                    , createdBy = b.createdBy
                     }
                     model.history
             , fetchingHistory = True
@@ -608,6 +612,7 @@ handleHistoryFetched history ( model, effects ) =
                                         , name = b.name
                                         , status = b.status
                                         , duration = b.duration
+                                        , createdBy = b.createdBy
                                         }
                                     )
                            )

--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -59,7 +59,7 @@ header session model =
                     False
     in
     { leftWidgets =
-        [ Views.Title model.name model.job
+        [ Views.Title model.name model.job model.createdBy
         , Views.Duration (duration session model)
         ]
     , rightWidgets =
@@ -572,6 +572,7 @@ handleBuildFetched b ( model, effects ) =
             , job = b.job
             , id = b.id
             , name = b.name
+            , createdBy = b.createdBy
           }
         , effects
         )

--- a/web/elm/src/Build/Header/Models.elm
+++ b/web/elm/src/Build/Header/Models.elm
@@ -20,7 +20,7 @@ type alias Model r =
         , scrolledToCurrentBuild : Bool
         , history : List HistoryItem
         , duration : Concourse.BuildDuration
-        , createdBy: Concourse.BuildCreatedBy
+        , createdBy : Concourse.BuildCreatedBy
         , status : BuildStatus.BuildStatus
         , disableManualTrigger : Bool
         , now : Maybe Time.Posix
@@ -35,6 +35,7 @@ type alias HistoryItem =
     , name : String
     , status : BuildStatus.BuildStatus
     , duration : Concourse.BuildDuration
+    , createdBy : Concourse.BuildCreatedBy
     }
 
 

--- a/web/elm/src/Build/Header/Models.elm
+++ b/web/elm/src/Build/Header/Models.elm
@@ -20,6 +20,7 @@ type alias Model r =
         , scrolledToCurrentBuild : Bool
         , history : List HistoryItem
         , duration : Concourse.BuildDuration
+        , createdBy: Concourse.BuildCreatedBy
         , status : BuildStatus.BuildStatus
         , disableManualTrigger : Bool
         , now : Maybe Time.Posix

--- a/web/elm/src/Build/Models.elm
+++ b/web/elm/src/Build/Models.elm
@@ -49,6 +49,7 @@ type alias ShortcutsModel r =
         , status : BuildStatus.BuildStatus
         , isTriggerBuildKeyDown : Bool
         , duration : Concourse.BuildDuration
+        , createdBy : Concourse.BuildCreatedBy
     }
 
 

--- a/web/elm/src/Build/Shortcuts.elm
+++ b/web/elm/src/Build/Shortcuts.elm
@@ -61,6 +61,7 @@ historyItem model =
     , name = model.name
     , status = model.status
     , duration = model.duration
+    , createdBy = model.createdBy
     }
 
 

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -2,6 +2,7 @@ module Concourse exposing
     ( AuthSession
     , AuthToken
     , Build
+    , BuildCreatedBy
     , BuildDuration
     , BuildId
     , BuildName
@@ -172,6 +173,8 @@ type alias BuildId =
 type alias BuildName =
     String
 
+type alias BuildCreatedBy =
+    Maybe String
 
 type alias JobBuildIdentifier =
     { teamName : TeamName
@@ -190,6 +193,7 @@ type alias Build =
     , status : BuildStatus
     , duration : BuildDuration
     , reapTime : Maybe Time.Posix
+    , createdBy: BuildCreatedBy
     }
 
 
@@ -212,6 +216,7 @@ encodeBuild build =
          , optionalField "start_time" (secondsFromDate >> Json.Encode.int) build.duration.startedAt
          , optionalField "end_time" (secondsFromDate >> Json.Encode.int) build.duration.finishedAt
          , optionalField "reap_time" (secondsFromDate >> Json.Encode.int) build.reapTime
+         , optionalField "created_by" Json.Encode.string build.createdBy
          ]
             |> List.filterMap identity
         )
@@ -249,6 +254,7 @@ decodeBuild =
                 |> andMap (Json.Decode.maybe (Json.Decode.field "end_time" (Json.Decode.map dateFromSeconds Json.Decode.int)))
             )
         |> andMap (Json.Decode.maybe (Json.Decode.field "reap_time" (Json.Decode.map dateFromSeconds Json.Decode.int)))
+        |> andMap (Json.Decode.maybe (Json.Decode.field "created_by" Json.Decode.string))
 
 
 

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -57,7 +57,7 @@ all =
                     \_ ->
                         Header.header session jobBuildModel
                             |> .leftWidgets
-                            |> Common.contains (Views.Title "123" (Just job))
+                            |> Common.contains (Views.Title "123" (Just job) Nothing)
                 , test "shows job and build name as number" <|
                     \_ ->
                         Header.view session jobBuildModel
@@ -76,7 +76,7 @@ all =
                     \_ ->
                         Header.header session nonJobBuild
                             |> .leftWidgets
-                            |> Common.contains (Views.Title "check" Nothing)
+                            |> Common.contains (Views.Title "check" Nothing Nothing)
                 , test "shows build name, not as a number" <|
                     \_ ->
                         Header.view session nonJobBuild
@@ -362,7 +362,7 @@ all =
                             >> Expect.equal BuildStatusStarted
                         , .leftWidgets
                             >> Expect.equal
-                                [ Views.Title "1" (Just jobId)
+                                [ Views.Title "1" (Just jobId) Nothing
                                 , Views.Duration <|
                                     Views.Running <|
                                         Views.Absolute
@@ -412,6 +412,7 @@ model =
     , scrolledToCurrentBuild = False
     , history = []
     , duration = { startedAt = Nothing, finishedAt = Nothing }
+    , createdBy = Nothing
     , status = BuildStatusPending
     , disableManualTrigger = False
     , now = Nothing

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -339,6 +339,7 @@ all =
                                         | id = 1
                                         , name = "1"
                                         , status = BuildStatusStarted
+                                        , createdBy = Just <| "some-one"
                                         , duration =
                                             { startedAt =
                                                 Just <|
@@ -362,7 +363,7 @@ all =
                             >> Expect.equal BuildStatusStarted
                         , .leftWidgets
                             >> Expect.equal
-                                [ Views.Title "1" (Just jobId) Nothing
+                                [ Views.Title "1" (Just jobId) (Just "some-one")
                                 , Views.Duration <|
                                     Views.Running <|
                                         Views.Absolute

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -644,6 +644,7 @@ all =
                                         , finishedAt = Nothing
                                         }
                                     , reapTime = Nothing
+                                    , createdBy = Nothing
                                     }
                             )
                         |> Tuple.first

--- a/web/elm/tests/Common.elm
+++ b/web/elm/tests/Common.elm
@@ -213,6 +213,7 @@ myBrowserFetchedTheBuild =
                         , finishedAt = Nothing
                         }
                     , reapTime = Nothing
+                    , createdBy = Nothing
                     }
             )
 

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -2221,6 +2221,7 @@ jobWithNameTransitionedAt jobName transitionedAt status =
                 , finishedAt = Nothing
                 }
             , reapTime = Nothing
+            , createdBy = Nothing
             }
     , transitionBuild =
         transitionedAt
@@ -2236,6 +2237,7 @@ jobWithNameTransitionedAt jobName transitionedAt status =
                         , finishedAt = Just <| t
                         }
                     , reapTime = Nothing
+                    , createdBy = Nothing
                     }
                 )
     , paused = False
@@ -2266,6 +2268,7 @@ circularJobs =
                     , finishedAt = Nothing
                     }
                 , reapTime = Nothing
+                , createdBy = Nothing
                 }
       , transitionBuild =
             Just
@@ -2279,6 +2282,7 @@ circularJobs =
                     , finishedAt = Just <| Time.millisToPosix 0
                     }
                 , reapTime = Nothing
+                , createdBy = Nothing
                 }
       , paused = False
       , disableManualTrigger = False
@@ -2310,6 +2314,7 @@ circularJobs =
                     , finishedAt = Nothing
                     }
                 , reapTime = Nothing
+                , createdBy = Nothing
                 }
       , transitionBuild =
             Just
@@ -2323,6 +2328,7 @@ circularJobs =
                     , finishedAt = Just <| Time.millisToPosix 0
                     }
                 , reapTime = Nothing
+                , createdBy = Nothing
                 }
       , paused = False
       , disableManualTrigger = False

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -493,6 +493,7 @@ build status =
                 Just <| Time.millisToPosix 0
         }
     , reapTime = Nothing
+    , createdBy = Nothing
     }
 
 
@@ -524,6 +525,7 @@ jobBuild status =
                 Just <| Time.millisToPosix 0
         }
     , reapTime = Nothing
+    , createdBy = Nothing
     }
 
 

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -493,7 +493,7 @@ build status =
                 Just <| Time.millisToPosix 0
         }
     , reapTime = Nothing
-    , createdBy = Nothing
+    , createdBy = Just <| "some-one"
     }
 
 
@@ -525,7 +525,7 @@ jobBuild status =
                 Just <| Time.millisToPosix 0
         }
     , reapTime = Nothing
-    , createdBy = Nothing
+    , createdBy = Just <| "some-one"
     }
 
 

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -2204,6 +2204,7 @@ iAmLookingAtAOneOffBuildPageOnANonPhoneScreen =
                     , status = BuildStatusStarted
                     , duration = { startedAt = Nothing, finishedAt = Nothing }
                     , reapTime = Nothing
+                    , createdBy = Nothing
                     }
                 )
             )


### PR DESCRIPTION
## Changes proposed by this PR

#6369 added the ability to track username who triggered a build, and the info has been stored in the db, exposed via the build api, but not display in the UI yet.

This PR shows username of who triggered the build if the build is triggered manually in the header bar.

![show-trggiered-by](https://user-images.githubusercontent.com/18585861/120285843-3e69e900-c2f0-11eb-89f5-0f0df5066f76.png)

If a build is triggered automatically, the it shows as usual:

![no-triggered-by](https://user-images.githubusercontent.com/18585861/120285982-62c5c580-c2f0-11eb-8d74-c271cc3f876d.png)


## Notes to reviewer

I'm extremely new to ELM, actually, I just spent 1 hour reading some basic guide of ELM in order to enable me to understand the code. So, feel free to raise any comment.

I haven't updated tests yet, because I want to confirm the UI design first.

## Release Note

* The build page now shows the username of who triggers the build if the build is triggered manually.
