### PR TITLE
Fix worker restart issue with containerd daemon and beacon

### DIFF
--- a/integration/worker/overrides/broken_containerd_socket.yml
+++ b/integration/worker/overrides/broken_containerd_socket.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  worker:
+    volumes:
+    - "../hack/keys:/concourse-keys"
+    - "/dev/null:/run/containerd/containerd.sock"
+

--- a/integration/worker/registration_test.go
+++ b/integration/worker/registration_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/concourse/concourse/integration/internal/dctest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistration_GardenServerFails(t *testing.T) {
+	t.Parallel()
+
+	dc := dctest.Init(t, "../docker-compose.yml", "overrides/broken_containerd_socket.yml")
+
+	t.Run("deploy with a broken containerd socket", func(t *testing.T) {
+		dc.Run(t, "up", "-d")
+	})
+
+	t.Run("worker container exits", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			services := dc.Output(t, "ps", "--services", "--filter", "status=stopped")
+			return strings.Contains(services, "worker")
+		}, 30*time.Second, 1*time.Second, "worker process never exited, but should have")
+	})
+}

--- a/worker/healthchecker.go
+++ b/worker/healthchecker.go
@@ -9,7 +9,6 @@ import (
 )
 
 type healthChecker struct {
-	client           *http.Client
 	baggageclaimAddr string
 	gardenAddr       string
 	timeout          time.Duration
@@ -61,6 +60,4 @@ func (h *healthChecker) CheckHealth(w http.ResponseWriter, req *http.Request) {
 		h.logger.Error("failed-to-list-volumes-on-baggageclaim-server", err)
 		return
 	}
-
-	return
 }

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"code.cloudfoundry.org/garden/server"
 	"code.cloudfoundry.org/lager"
@@ -21,6 +22,8 @@ import (
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/grouper"
 )
+
+const containerdNamespace = "concourse"
 
 // WriteDefaultContainerdConfig writes a default containerd configuration file
 // to a destination.
@@ -54,10 +57,7 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 	containerdAddr string,
 	dnsServers []string,
 ) (ifrit.Runner, error) {
-	const (
-		graceTime = 0
-		namespace = "concourse"
-	)
+	const graceTime = 0
 
 	backendOpts := []runtime.GardenBackendOpt{}
 	networkOpts := []runtime.CNINetworkOpt{runtime.WithCNIBinariesDir(cmd.Containerd.CNIPluginsDir)}
@@ -71,7 +71,7 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 	}
 
 	// DNS proxy won't work without allowing access to host network
-	if cmd.Containerd.Network.AllowHostAccess || cmd.Containerd.Network.DNS.Enable  {
+	if cmd.Containerd.Network.AllowHostAccess || cmd.Containerd.Network.DNS.Enable {
 		networkOpts = append(networkOpts, runtime.WithAllowHostAccess())
 	}
 
@@ -99,7 +99,7 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 	)
 
 	gardenBackend, err := runtime.NewGardenBackend(
-		libcontainerd.New(containerdAddr, namespace, cmd.Containerd.RequestTimeout),
+		libcontainerd.New(containerdAddr, containerdNamespace, cmd.Containerd.RequestTimeout),
 		backendOpts...,
 	)
 	if err != nil {
@@ -192,8 +192,19 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 
 	members = append(grouper.Members{
 		{
-			Name:   "containerd",
-			Runner: CmdRunner{command},
+			Name: "containerd",
+			Runner: CmdRunner{
+				Cmd: command,
+				Ready: func() bool {
+					client := libcontainerd.New(sock, containerdNamespace, cmd.Containerd.RequestTimeout)
+					err := client.Init()
+					if err != nil {
+						logger.Info("failed-to-connect-to-containerd", lager.Data{"error": err.Error()})
+					}
+					return err == nil
+				},
+				Timeout: 10 * time.Second,
+			},
 		},
 		{
 			Name:   "containerd-garden-backend",


### PR DESCRIPTION
cc: @aoldershaw 
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #6752

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] beacon: cancel worker registration on signal
* [x] containerd: check that containerd daemon has started before starting Garden server

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->
The containerd client talks to the containerd daemon via a socket file. When there's something wrong with the socketfile the client will fail to talk to the daemon even if it comes up. This is okay. But what we want is for the worker to exit properly when this happens instead of keeping beacon alive.

To test this behaviour put this line near the end of the Dockerfile `RUN ln -s /run/containerd/containerd.sock /dev/null`. Then bring up Concourse and check the worker logs. You should see the worker has exited.



## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Fix worker stall issue when restarting with containerd. Exit the worker's beacon process gracefully if any other top level process like the containerd daemon fails. Wait for containerd daemon to come up before starting the containerd Garden server.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
