### PR TITLE
worker: make containerd the default runtime 🎉 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,6 @@ services:
     volumes: ["./hack/keys:/concourse-keys"]
     stop_signal: SIGUSR2
     environment:
-      CONCOURSE_RUNTIME: containerd
-
       CONCOURSE_TSA_PUBLIC_KEY: /concourse-keys/tsa_host_key.pub
       CONCOURSE_TSA_WORKER_PRIVATE_KEY: /concourse-keys/worker_key
 

--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -28,12 +28,12 @@ type GdnBinaryFlags struct {
 	Server struct {
 		Network struct {
 			Pool string `long:"network-pool" description:"Network range to use for dynamically allocated container subnets. (default:10.80.0.0/16)"`
-		} `group:"Container Networking"`
+		} `group:"Guardian Container Networking"`
 
 		Limits struct {
 			MaxContainers string `long:"max-containers" description:"Maximum container capacity. 0 means no limit. (default:250)"`
-		} `group:"Limits"`
-	} `group:"server"`
+		} `group:"Guardian Limits"`
+	} `group:"Guardian server"`
 }
 
 // Defaults for GdnBinaryFlags

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -25,7 +25,7 @@ type Certs struct {
 }
 
 type RuntimeConfiguration struct {
-	Runtime string `long:"runtime" default:"guardian" choice:"guardian" choice:"containerd" choice:"houdini" description:"Runtime to use with the worker. Please note that Houdini is insecure and doesn't run 'tasks' in containers."`
+	Runtime string `long:"runtime" default:"containerd" choice:"guardian" choice:"containerd" choice:"houdini" description:"Runtime to use with the worker. Please note that Houdini is insecure and doesn't run 'tasks' in containers."`
 }
 
 type GuardianRuntime struct {

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -30,7 +30,7 @@ type RuntimeConfiguration struct {
 
 type GuardianRuntime struct {
 	Bin            string        `long:"bin"        description:"Path to a garden server executable (non-absolute names get resolved from $PATH)."`
-	DNS            DNSConfig     `group:"DNS Proxy Configuration" namespace:"dns-proxy"`
+	DNS            DNSConfig     `group:"Guardian DNS Proxy Configuration" namespace:"dns-proxy"`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to the Garden server to complete. 0 means no timeout."`
 
 	Config      flag.File `long:"config"     description:"Path to a config file to use for the Garden backend. e.g. 'foo-bar=a,b' for '--foo-bar a --foo-bar b'."`
@@ -53,7 +53,7 @@ type ContainerdRuntime struct {
 		Pool               string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
 		MTU                int       `long:"mtu" description:"MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host."`
 		AllowHostAccess    bool      `long:"allow-host-access" description:"Allow containers to reach the host's network. This is turned off by default."`
-	} `group:"Container Networking"`
+	} `group:"Containerd Container Networking"`
 
 	MaxContainers int `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #7106 

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] set the default value for worker command's `--runtime` flag to `containerd`
* [x] call out specific runtime in group headers for runtime flags

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Make `containerd` the default runtime

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
