### PR TITLE
containerd: default to root if /etc/passwd is missing

### DIFF
--- a/testflight/fixtures/clearlinux.yml
+++ b/testflight/fixtures/clearlinux.yml
@@ -1,0 +1,12 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: clearlinux
+
+run:
+  path: sh
+  args:
+  - -c
+  - echo "running as $(whoami)"

--- a/testflight/user_lookup_test.go
+++ b/testflight/user_lookup_test.go
@@ -1,0 +1,19 @@
+package testflight_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("user lookup", func() {
+	Context("when no username is specified and the image has no /etc/passwd file", func() {
+		It("runs as root", func() {
+			// clearlinux doesn't have an /etc/passwd file
+			session := fly("execute", "-c", "fixtures/clearlinux.yml")
+			<-session.Exited
+			Expect(session.ExitCode()).To(Equal(0))
+			Expect(session.Out).To(gbytes.Say("running as root"))
+		})
+	})
+})

--- a/worker/runtime/rootfs_manager.go
+++ b/worker/runtime/rootfs_manager.go
@@ -2,10 +2,11 @@ package runtime
 
 import (
 	"fmt"
-	"github.com/opencontainers/runc/libcontainer/user"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"os"
 	"path/filepath"
+
+	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 //counterfeiter:generate . RootfsManager
@@ -104,8 +105,12 @@ func (r rootfsManager) LookupUser(rootfsPath string, username string) (specs.Use
 	passwdPath := filepath.Join(rootfsPath, "etc", "passwd")
 	groupPath := filepath.Join(rootfsPath, "etc", "group")
 
-	execUser, err := user.GetExecUserPath(username, &user.ExecUser{Uid: DefaultUid, Gid: DefaultGid}, passwdPath, groupPath)
+	_, err := os.Stat(passwdPath)
+	if os.IsNotExist(err) && username == "root" {
+		return specs.User{UID: DefaultUid, GID: DefaultGid}, true, nil
+	}
 
+	execUser, err := user.GetExecUserPath(username, &user.ExecUser{Uid: DefaultUid, Gid: DefaultGid}, passwdPath, groupPath)
 	if err != nil {
 		return specs.User{}, false, err
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #6054 

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] check if /etc/passwd is missing, and if so, don't error

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

This regressed in a38054a9fd58dba414e155ed763812e393894c4b, which likely assumed that [`GetExecUserPath`](https://github.com/opencontainers/runc/blob/13acae7376f7f3bd175f9b1a26b11d65fe2f0663/libcontainer/user/user.go#L224) would default to the `Default` user passed in if the username was not found. However, that's not the case - it doesn't *directly* error if `/etc/passwd` is missing, but still [errors](https://github.com/opencontainers/runc/blob/13acae7376f7f3bd175f9b1a26b11d65fe2f0663/libcontainer/user/user.go#L324) if you pass in a username (rather than a UID) and that username isn't found (which, y'know, it never will be if there is no `/etc/passwd` file)

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Fixes a regression introduced in 7.3.0 that prevented containers that don't have an `/etc/passwd` file from running

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
