### PR TITLE
integration: add retries to vault initialization

### DIFF
--- a/integration/internal/cmdtest/cmd.go
+++ b/integration/internal/cmdtest/cmd.go
@@ -167,7 +167,7 @@ func (cmd Cmd) TryOutput(args ...string) (string, error) {
 	return buf.String(), nil
 }
 
-func (cmd Cmd) TryOutputJSON(t *testing.T, dest interface{}, args ...string) error {
+func (cmd Cmd) TryOutputJSON(dest interface{}, args ...string) error {
 	buf := new(bytes.Buffer)
 
 	cmd.Stdout = buf


### PR DESCRIPTION
To avoid flakes like [this](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/integration/builds/239#L60bcb7c4:66), where the vault server isn't yet ready