### PR TITLE
Fix algorithm considering reruns as new builds

### DIFF
--- a/atc/db/versions_db.go
+++ b/atc/db/versions_db.go
@@ -661,12 +661,7 @@ func (cursor BuildCursor) NewerBuilds(idCol string) sq.Sqlizer {
 			},
 		}
 	} else {
-		return sq.Or{
-			sq.Expr("COALESCE(rerun_of, "+idCol+") > ?", cursor.ID),
-
-			// include reruns of the build
-			sq.Eq{"rerun_of": cursor.ID},
-		}
+		return sq.Expr("COALESCE(rerun_of, "+idCol+") > ?", cursor.ID)
 	}
 }
 

--- a/atc/db/versions_db_test.go
+++ b/atc/db/versions_db_test.go
@@ -602,14 +602,7 @@ var _ = Describe("VersionsDB", func() {
 				}
 			})
 
-			It("returns the rerun builds, oldest to newest, followed by the newer builds, oldest to newest, followed by the cursor build and older builds, newest to oldest", func() {
-				for i := 0; i < len(rerunBuilds); i++ {
-					buildID, ok, err := paginatedBuilds.Next(ctx)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(ok).To(BeTrue())
-					Expect(buildID).To(Equal(rerunBuilds[i].ID()))
-				}
-
+			It("returns the newer builds, oldest to newest, followed by the cursor build and older builds, newest to oldest", func() {
 				for i := 0; i < len(newerBuilds); i++ {
 					buildID, ok, err := paginatedBuilds.Next(ctx)
 					Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Changes proposed by this PR

closes #6988

## Notes to reviewer

If you want to do acceptance: https://github.com/concourse/concourse/issues/6988#issuecomment-851581234

## Release Note

* Fixes pipelines getting stuck with the same inputs when a job upstream of a job with `version: every` succeeds and is rerun
