### PR TITLE
containerd: keep tasks running after `concourse worker` restarts gracefully

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -42,7 +42,9 @@ services:
     privileged: true
     depends_on: [web]
     ports: [7777, 7788]
-    volumes: ["../hack/keys:/concourse-keys"]
+    volumes:
+    - ..:/src
+    - ../hack/keys:/concourse-keys
     stop_signal: SIGUSR2
     environment:
       CONCOURSE_RUNTIME: containerd

--- a/integration/internal/flytest/cmd.go
+++ b/integration/internal/flytest/cmd.go
@@ -67,8 +67,14 @@ func Init(t *testing.T, dc dctest.Cmd) Cmd {
 
 	fly.Run(t, "login", "-c", webURL, "-u", "test", "-p", "test")
 
+	fly.WaitForRunningWorker(t)
+
+	return fly
+}
+
+func (cmd Cmd) WaitForRunningWorker(t *testing.T) {
 	require.Eventually(t, func() bool {
-		for _, w := range fly.Table(t, "workers") {
+		for _, w := range cmd.Table(t, "workers") {
 			if w["state"] == "running" {
 				return true
 			}
@@ -76,8 +82,6 @@ func Init(t *testing.T, dc dctest.Cmd) Cmd {
 
 		return false
 	}, time.Minute, time.Second, "should have a running worker")
-
-	return fly
 }
 
 type Table []map[string]string

--- a/integration/ops/downgrade_test.go
+++ b/integration/ops/downgrade_test.go
@@ -11,7 +11,7 @@ import (
 func TestDowngrade(t *testing.T) {
 	t.Parallel()
 
-	devDC := dctest.Init(t, "../docker-compose.yml")
+	devDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml")
 
 	t.Run("deploy dev", func(t *testing.T) {
 		devDC.Run(t, "up", "-d")
@@ -20,7 +20,7 @@ func TestDowngrade(t *testing.T) {
 	fly := flytest.Init(t, devDC)
 	setupUpgradeDowngrade(t, fly)
 
-	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/latest.yml")
+	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/latest.yml")
 
 	t.Run("migrate down to latest from clean deploy", func(t *testing.T) {
 		// just to see what it was before

--- a/integration/ops/overrides/named.yml
+++ b/integration/ops/overrides/named.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+services:
+  worker:
+    environment:
+      CONCOURSE_NAME: ops-worker

--- a/integration/ops/upgrade_test.go
+++ b/integration/ops/upgrade_test.go
@@ -10,7 +10,7 @@ import (
 func TestUpgrade(t *testing.T) {
 	t.Parallel()
 
-	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/latest.yml")
+	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/latest.yml")
 
 	t.Run("deploy latest", func(t *testing.T) {
 		latestDC.Run(t, "up", "-d")
@@ -19,7 +19,7 @@ func TestUpgrade(t *testing.T) {
 	fly := flytest.Init(t, latestDC)
 	setupUpgradeDowngrade(t, fly)
 
-	devDC := dctest.Init(t, "../docker-compose.yml")
+	devDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml")
 
 	t.Run("upgrade to dev", func(t *testing.T) {
 		devDC.Run(t, "up", "-d")

--- a/integration/worker/overrides/broken_containerd_socket.yml
+++ b/integration/worker/overrides/broken_containerd_socket.yml
@@ -5,4 +5,3 @@ services:
     volumes:
     - "../hack/keys:/concourse-keys"
     - "/dev/null:/run/containerd/containerd.sock"
-

--- a/integration/worker/overrides/restartable-entrypoint.sh
+++ b/integration/worker/overrides/restartable-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+trap 'restart=1' HUP
+
+while true; do
+  /usr/local/concourse/bin/concourse worker & pid="$!"
+
+  restart=0
+
+  while [ "$restart" -ne 1 ]; do sleep 1; done
+  rm -f /ready
+  kill -TERM "$pid"
+  # wait for the existing process to exit
+  while ps -p $pid > /dev/null; do
+    sleep 1
+    echo "concourse is still running at pid $pid"
+  done
+  touch /ready
+done

--- a/integration/worker/overrides/restartable.yml
+++ b/integration/worker/overrides/restartable.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+services:
+  worker:
+    entrypoint: /src/integration/worker/overrides/restartable-entrypoint.sh

--- a/integration/worker/restart_test.go
+++ b/integration/worker/restart_test.go
@@ -1,0 +1,90 @@
+package worker_test
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/concourse/concourse/integration/internal/dctest"
+	"github.com/concourse/concourse/integration/internal/flytest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestart_AttachToRunningBuild(t *testing.T) {
+	t.Parallel()
+
+	dc := dctest.Init(t, "../docker-compose.yml", "overrides/restartable.yml")
+
+	t.Run("deploy", func(t *testing.T) {
+		dc.Run(t, "up", "-d")
+	})
+
+	fly := flytest.Init(t, dc)
+	buf := new(Buffer)
+	executeCmd := fly.OutputTo(buf).Start(t, "execute", "-c", "tasks/wait.yml")
+
+	waitForBuildOutput := func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			return strings.Contains(buf.String(), "waiting for /tmp/stop-waiting to exist")
+		}, 1*time.Minute, 1*time.Second)
+	}
+
+	waitForBuildOutput(t)
+
+	buildRegex := regexp.MustCompile(`executing build (\d+)`)
+	matches := buildRegex.FindStringSubmatch(buf.String())
+	buildID := string(matches[1])
+
+	t.Run("restart worker process", func(t *testing.T) {
+		// entrypoint script traps SIGHUP and restarts the process
+		dc.Run(t, "kill", "-s", "SIGHUP", "worker")
+
+		workerReady := func() bool {
+			err := dc.Silence().Try("exec", "-T", "worker", "stat", "/ready")
+			return err == nil
+		}
+
+		require.Eventually(t, workerReady, 1*time.Minute, 1*time.Second)
+	})
+
+	t.Run("task can be re-attached to", func(t *testing.T) {
+		// Wait for build logs to appear again
+		buf.Reset()
+		waitForBuildOutput(t)
+
+		fly.Run(t, "hijack", "-b", buildID, "-s", "one-off", "--", "touch", "/tmp/stop-waiting")
+
+		// assert exits successfully
+		err := executeCmd.Wait()
+		require.NoError(t, err)
+
+		require.Contains(t, buf.String(), "done")
+	})
+}
+
+// Thread-safe version of bytes.Buffer
+type Buffer struct {
+	buffer bytes.Buffer
+	mtx    sync.Mutex
+}
+
+func (buf *Buffer) Write(p []byte) (n int, err error) {
+	buf.mtx.Lock()
+	defer buf.mtx.Unlock()
+	return buf.buffer.Write(p)
+}
+
+func (buf *Buffer) String() string {
+	buf.mtx.Lock()
+	defer buf.mtx.Unlock()
+	return buf.buffer.String()
+}
+
+func (buf *Buffer) Reset() {
+	buf.mtx.Lock()
+	defer buf.mtx.Unlock()
+	buf.buffer.Reset()
+}

--- a/integration/worker/tasks/wait.yml
+++ b/integration/worker/tasks/wait.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+
+image_resource:
+  type: mock
+  source: {mirror_self: true}
+
+run:
+  path: sh
+  args:
+  - -c
+  - |
+    until test -f /tmp/stop-waiting; do
+      echo 'waiting for /tmp/stop-waiting to exist'
+      sleep 1
+    done
+
+    echo done

--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -105,10 +105,7 @@ func (c *Container) Run(
 	}
 
 	id := procID(spec)
-	// NOTE: if stdin is ever closed (network issues), it can't be reattached to
-	// again. This isn't a problem since we only send stdin once at the very
-	// beginning for resource scripts, but this might bite us in the future.
-	cioOpts, stdinWrapper := containerdCIO(processIO, spec.TTY != nil)
+	cioOpts := containerdCIO(processIO, spec.TTY != nil)
 
 	proc, err := task.Exec(ctx, id, &procSpec, cio.NewCreator(cioOpts...))
 	if err != nil {
@@ -128,12 +125,7 @@ func (c *Container) Run(
 		return nil, fmt.Errorf("proc start: %w", err)
 	}
 
-	err = proc.CloseIO(ctx, containerd.WithStdinCloser)
-	if err != nil {
-		return nil, fmt.Errorf("proc closeio: %w", err)
-	}
-
-	return NewProcess(proc, exitStatusC, stdinWrapper), nil
+	return NewProcess(proc, exitStatusC), nil
 }
 
 // Attach starts streaming the output back to the client from a specified process.
@@ -150,7 +142,7 @@ func (c *Container) Attach(pid string, processIO garden.ProcessIO) (process gard
 		return nil, fmt.Errorf("task: %w", err)
 	}
 
-	cioOpts, stdinWrapper := containerdCIO(processIO, false)
+	cioOpts := containerdCIO(processIO, false)
 
 	proc, err := task.LoadProcess(ctx, pid, cio.NewAttach(cioOpts...))
 	if err != nil {
@@ -171,7 +163,7 @@ func (c *Container) Attach(pid string, processIO garden.ProcessIO) (process gard
 		return nil, fmt.Errorf("proc wait: %w", err)
 	}
 
-	return NewProcess(proc, exitStatusC, stdinWrapper), nil
+	return NewProcess(proc, exitStatusC), nil
 }
 
 // Properties returns the current set of properties
@@ -404,34 +396,7 @@ func envWithDefaultPath(uid uint32, currentEnv []string) string {
 	return Path
 }
 
-// stdinWrapper will normally transparently pass Reads through to the underlying
-// reader, but if a read fails, it will nop (block) until the process has
-// exited.
-//
-// This is because it's possible for network flakes or worker rebalancing to
-// kill the current connection, which causes the stdin io.Reader to return an
-// error. If the container is created with terminal: true, then containerd will
-// treat that as a hang up and send a SIGHUP to the container
-//
-type stdinWrapper struct {
-	in io.Reader
-	c  chan struct{}
-}
-
-func (s *stdinWrapper) Read(p []byte) (int, error) {
-	n, err := s.in.Read(p)
-	if err != nil {
-		<-s.c
-		return n, err
-	}
-	return n, err
-}
-
-func (s *stdinWrapper) Close() {
-	s.c <- struct{}{}
-}
-
-func containerdCIO(gdnProcIO garden.ProcessIO, tty bool) ([]cio.Opt, *stdinWrapper) {
+func containerdCIO(gdnProcIO garden.ProcessIO, tty bool) []cio.Opt {
 	if !tty {
 		return []cio.Opt{
 			cio.WithStreams(
@@ -439,23 +404,18 @@ func containerdCIO(gdnProcIO garden.ProcessIO, tty bool) ([]cio.Opt, *stdinWrapp
 				gdnProcIO.Stdout,
 				gdnProcIO.Stderr,
 			),
-		}, nil
-	}
-
-	stdin := &stdinWrapper{
-		in: gdnProcIO.Stdin,
-		c:  make(chan struct{}, 1),
+		}
 	}
 
 	cioOpts := []cio.Opt{
 		cio.WithStreams(
-			stdin,
+			gdnProcIO.Stdin,
 			gdnProcIO.Stdout,
 			gdnProcIO.Stderr,
 		),
 		cio.WithTerminal,
 	}
-	return cioOpts, stdin
+	return cioOpts
 }
 
 func isNoSuchExecutable(err error) bool {

--- a/worker/runtime/process_test.go
+++ b/worker/runtime/process_test.go
@@ -29,7 +29,7 @@ func (s *ProcessSuite) SetupTest() {
 	s.containerdProcess = new(libcontainerdfakes.FakeProcess)
 	s.ch = make(chan containerd.ExitStatus, 1)
 
-	s.process = runtime.NewProcess(s.containerdProcess, s.ch, nil)
+	s.process = runtime.NewProcess(s.containerdProcess, s.ch)
 }
 
 func (s *ProcessSuite) TestID() {

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -155,6 +155,7 @@ func (cmd *WorkerCommand) containerdRunner(logger lager.Logger) (ifrit.Runner, e
 	command.Stderr = os.Stderr
 	command.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGKILL,
+		Setpgid:   true,
 	}
 
 	members := grouper.Members{}

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"code.cloudfoundry.org/garden/server"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/localip"
 	concourseCmd "github.com/concourse/concourse/cmd"
@@ -108,13 +107,13 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 		return nil, fmt.Errorf("containerd containerd init: %w", err)
 	}
 
-	server := server.New("tcp", cmd.bindAddr(),
+	return newGardenServerRunner(
+		"tcp",
+		cmd.bindAddr(),
 		graceTime,
 		&gardenBackend,
 		logger,
-	)
-
-	return gardenServerRunner{logger, server}, nil
+	), nil
 }
 
 // containerdRunner spawns a containerd and a Garden server process for use as the container

--- a/worker/workercmd/garden_server_runner.go
+++ b/worker/workercmd/garden_server_runner.go
@@ -1,28 +1,65 @@
 package workercmd
 
 import (
+	"net"
 	"os"
+	"time"
 
+	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/garden/server"
 	"code.cloudfoundry.org/lager"
 )
 
 type gardenServerRunner struct {
-	logger       lager.Logger
-	gardenServer *server.GardenServer
+	logger        lager.Logger
+	backend       garden.Backend
+	gardenServer  *server.GardenServer
+	listenNetwork string
+	listenAddr    string
+}
+
+func newGardenServerRunner(
+	listenNetwork, listenAddr string,
+	containerGraceTime time.Duration,
+	backend garden.Backend,
+	logger lager.Logger,
+) gardenServerRunner {
+	return gardenServerRunner{
+		gardenServer:  server.New(listenNetwork, listenAddr, containerGraceTime, backend, logger),
+		listenNetwork: listenNetwork,
+		listenAddr:    listenAddr,
+		backend:       backend,
+		logger:        logger,
+	}
 }
 
 func (runner gardenServerRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
-	err := runner.gardenServer.Start()
+	if err := runner.backend.Start(); err != nil {
+		return err
+	}
+	if err := runner.gardenServer.SetupBomberman(); err != nil {
+		return err
+	}
+	listener, err := net.Listen(runner.listenNetwork, runner.listenAddr)
 	if err != nil {
 		return err
 	}
+	errs := make(chan error, 1)
+	go func() {
+		errs <- runner.gardenServer.Serve(listener)
+	}()
 
 	close(ready)
 
 	runner.logger.Info("started")
+	defer runner.logger.Info("stopped")
 
-	<-signals
-	runner.gardenServer.Stop()
-	return nil
+	select {
+	case <-signals:
+		runner.logger.Info("signaled")
+		runner.gardenServer.Stop()
+		return nil
+	case err := <-errs:
+		return err
+	}
 }

--- a/worker/workercmd/houdini.go
+++ b/worker/workercmd/houdini.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"code.cloudfoundry.org/garden/server"
 	"code.cloudfoundry.org/lager"
 	"github.com/tedsuo/ifrit"
 	"github.com/vito/houdini"
@@ -21,15 +20,13 @@ func (cmd *WorkerCommand) houdiniRunner(logger lager.Logger) (ifrit.Runner, erro
 
 	backend := houdini.NewBackend(depotDir)
 
-	server := server.New(
+	return newGardenServerRunner(
 		"tcp",
 		cmd.bindAddr(),
 		0,
 		backend,
 		logger,
-	)
-
-	return gardenServerRunner{logger, server}, nil
+	), nil
 }
 
 func (cmd *WorkerCommand) bindAddr() string {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

* Call `Process.CloseIO` after the process exits
* Properly start the garden server so that it can be gracefully stopped (currently, `gardenServer.Stop()` is a noop - see 2fa6b76aec201ec7b51ef4d9db5391bc08c962e0)
* `Setpgid` on the `containerd` process so that signals to the `concourse` process don't propagate to `containerd` (until we propagate the signal explicitly via ifrit)

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

* The containerd runtime is now more resilient to the `concourse worker` process gracefully restarting (e.g. via `monit restart`)
  * Tasks that were started prior to restart will continue to run when the worker process comes back up
  * This matches the behaviour of the Guardian runtime