### PR TITLE
 fly: add --team flag to checklist

### DIFF
--- a/fly/integration/checklist_test.go
+++ b/fly/integration/checklist_test.go
@@ -148,6 +148,17 @@ job-2: concourse.check %s main some-pipeline/branch:master job-2
 
 		Context("when a team name is specified alongwith pipeline name", func() {
 			JustBeforeEach(func() {
+				config = atc.Config{
+					Jobs: atc.JobConfigs{
+						{
+							Name: "job-1",
+						},
+						{
+							Name: "job-2",
+						},
+					},
+				}
+
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
@@ -166,37 +177,21 @@ job-2: concourse.check %s main some-pipeline/branch:master job-2
 				)
 			})
 
-			Context("when there are no groups", func() {
-				BeforeEach(func() {
-					config = atc.Config{
-						Jobs: atc.JobConfigs{
-							{
-								Name: "job-1",
-							},
-							{
-								Name: "job-2",
-							},
-						},
-					}
+			It("prints the config as yaml to stdout, and uses the pipeline name and the specified team as header", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "checklist", "-p", "some-pipeline/branch:master", "--team", "other-team")
 
-				})
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
 
-				It("prints the config as yaml to stdout, and uses the pipeline name as header", func() {
-					flyCmd := exec.Command(flyPath, "-t", targetName, "checklist", "-p", "some-pipeline/branch:master", "--team", "other-team")
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
 
-					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-					Expect(err).NotTo(HaveOccurred())
-
-					<-sess.Exited
-					Expect(sess.ExitCode()).To(Equal(0))
-
-					Expect(string(sess.Out.Contents())).To(Equal(fmt.Sprintf(
-						`#- some-pipeline/branch:master
+				Expect(string(sess.Out.Contents())).To(Equal(fmt.Sprintf(
+					`#- some-pipeline/branch:master
 job-1: concourse.check %s other-team some-pipeline/branch:master job-1
 job-2: concourse.check %s other-team some-pipeline/branch:master job-2
 
 `, atcServer.URL(), atcServer.URL())))
-				})
 			})
 		})
 	})

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -107,6 +107,8 @@ var _ = Describe("Fly CLI", func() {
 
 				Eventually(sess.Err.Contents).Should(ContainSubstring(`error: team 'doesnotexist' does not exist`))
 			},
+			Entry("checklist command returns an error",
+				exec.Command(flyPath, "-t", targetName, "checklist", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("trigger-job command returns an error",
 				exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", nonExistentTeam)),
 			Entry("expose-pipeline command returns an error",
@@ -149,6 +151,8 @@ var _ = Describe("Fly CLI", func() {
 
 				Eventually(sess.Err.Contents).Should(ContainSubstring(`error: you do not have a role on team 'other-team'`))
 			},
+			Entry("checklist command returns an error",
+				exec.Command(flyPath, "-t", targetName, "checklist", "-p", "pipeline", "--team", otherTeam)),
 			Entry("trigger-job command returns an error",
 				exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "pipeline/job", "--team", otherTeam)),
 			Entry("expose-pipeline command returns an error",


### PR DESCRIPTION
document DCO process

Signed-off-by: rishabh.jain.cs14@gmail.com

## Why is this PR needed?
Currently the checklist command does not support teams option. This PR provides that functionality. See #5215

## How does it accomplish that?
Adds --team flag to checklist command which overrides the default configured for the target.

## Contributor Checklist
- [ ] Unit tests
- [x] Integration tests
- [ ] Updated documentation (located at https://github.com/concourse/docs)
- [ ] Updated release notes (located at https://github.com/concourse/concourse/tree/master/release-notes)

##  Code reviewed
- [ ] Tests reviewed
- [ ] Documentation reviewed
- [ ] Release notes reviewed
- [ ] PR acceptance performed
- [ ] New config flags added? Ensure that they are added to the BOSH
       and Helm packaging; otherwise, ignored for the integration tests (for example, if they are Garden configs that are not 
      displayed in the --help text).
