### PR TITLE
Reduce number of `JOIN`s in builds query

### DIFF
--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -143,46 +143,6 @@ var _ = Describe("Build", func() {
 				}))
 			})
 		})
-
-		Context("for a resource type build", func() {
-			BeforeEach(func() {
-				var err error
-				var created bool
-				build, created, err = defaultResourceType.CreateBuild(context.TODO(), false, atc.Plan{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(created).To(BeTrue())
-			})
-
-			It("includes build, team, and pipeline", func() {
-				Expect(data).To(Equal(lager.Data{
-					"build_id":      build.ID(),
-					"build":         build.Name(),
-					"team":          build.TeamName(),
-					"pipeline":      build.PipelineName(),
-					"resource_type": defaultResourceType.Name(),
-				}))
-			})
-		})
-
-		Context("for a prototype build", func() {
-			BeforeEach(func() {
-				var err error
-				var created bool
-				build, created, err = defaultPrototype.CreateBuild(context.TODO(), false, atc.Plan{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(created).To(BeTrue())
-			})
-
-			It("includes build, team, and pipeline", func() {
-				Expect(data).To(Equal(lager.Data{
-					"build_id":  build.ID(),
-					"build":     build.Name(),
-					"team":      build.TeamName(),
-					"pipeline":  build.PipelineName(),
-					"prototype": defaultPrototype.Name(),
-				}))
-			})
-		})
 	})
 
 	Describe("SyslogTag", func() {
@@ -230,34 +190,6 @@ var _ = Describe("Build", func() {
 
 			It("includes build, team, and pipeline", func() {
 				Expect(tag).To(Equal(fmt.Sprintf("%s/%s/%s/%d/%s", defaultResource.TeamName(), defaultResource.PipelineName(), defaultResource.Name(), build.ID(), originID)))
-			})
-		})
-
-		Context("for a resource type build", func() {
-			BeforeEach(func() {
-				var err error
-				var created bool
-				build, created, err = defaultResourceType.CreateBuild(context.TODO(), false, atc.Plan{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(created).To(BeTrue())
-			})
-
-			It("includes build, team, and pipeline", func() {
-				Expect(tag).To(Equal(fmt.Sprintf("%s/%s/%s/%d/%s", defaultResourceType.TeamName(), defaultResourceType.PipelineName(), defaultResourceType.Name(), build.ID(), originID)))
-			})
-		})
-
-		Context("for a prototype build", func() {
-			BeforeEach(func() {
-				var err error
-				var created bool
-				build, created, err = defaultPrototype.CreateBuild(context.TODO(), false, atc.Plan{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(created).To(BeTrue())
-			})
-
-			It("includes build, team, and pipeline", func() {
-				Expect(tag).To(Equal(fmt.Sprintf("%s/%s/%s/%d/%s", defaultPrototype.TeamName(), defaultPrototype.PipelineName(), defaultPrototype.Name(), build.ID(), originID)))
 			})
 		})
 	})
@@ -321,46 +253,6 @@ var _ = Describe("Build", func() {
 					"team_name": build.TeamName(),
 					"pipeline":  build.PipelineName(),
 					"resource":  defaultResource.Name(),
-				}))
-			})
-		})
-
-		Context("for a resource type build", func() {
-			BeforeEach(func() {
-				var err error
-				var created bool
-				build, created, err = defaultResourceType.CreateBuild(context.TODO(), false, atc.Plan{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(created).To(BeTrue())
-			})
-
-			It("includes build, team, and pipeline", func() {
-				Expect(attrs).To(Equal(tracing.Attrs{
-					"build_id":      strconv.Itoa(build.ID()),
-					"build":         build.Name(),
-					"team_name":     build.TeamName(),
-					"pipeline":      build.PipelineName(),
-					"resource_type": defaultResourceType.Name(),
-				}))
-			})
-		})
-
-		Context("for a prototype build", func() {
-			BeforeEach(func() {
-				var err error
-				var created bool
-				build, created, err = defaultPrototype.CreateBuild(context.TODO(), false, atc.Plan{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(created).To(BeTrue())
-			})
-
-			It("includes build, team, and pipeline", func() {
-				Expect(attrs).To(Equal(tracing.Attrs{
-					"build_id":  strconv.Itoa(build.ID()),
-					"build":     build.Name(),
-					"team_name": build.TeamName(),
-					"pipeline":  build.PipelineName(),
-					"prototype": defaultPrototype.Name(),
 				}))
 			})
 		})

--- a/atc/db/dbfakes/fake_build.go
+++ b/atc/db/dbfakes/fake_build.go
@@ -416,16 +416,6 @@ type FakeBuild struct {
 	prototypeIDReturnsOnCall map[int]struct {
 		result1 int
 	}
-	PrototypeNameStub        func() string
-	prototypeNameMutex       sync.RWMutex
-	prototypeNameArgsForCall []struct {
-	}
-	prototypeNameReturns struct {
-		result1 string
-	}
-	prototypeNameReturnsOnCall map[int]struct {
-		result1 string
-	}
 	PublicPlanStub        func() *json.RawMessage
 	publicPlanMutex       sync.RWMutex
 	publicPlanArgsForCall []struct {
@@ -517,16 +507,6 @@ type FakeBuild struct {
 	}
 	resourceTypeIDReturnsOnCall map[int]struct {
 		result1 int
-	}
-	ResourceTypeNameStub        func() string
-	resourceTypeNameMutex       sync.RWMutex
-	resourceTypeNameArgsForCall []struct {
-	}
-	resourceTypeNameReturns struct {
-		result1 string
-	}
-	resourceTypeNameReturnsOnCall map[int]struct {
-		result1 string
 	}
 	ResourcesStub        func() ([]db.BuildInput, []db.BuildOutput, error)
 	resourcesMutex       sync.RWMutex
@@ -2744,59 +2724,6 @@ func (fake *FakeBuild) PrototypeIDReturnsOnCall(i int, result1 int) {
 	}{result1}
 }
 
-func (fake *FakeBuild) PrototypeName() string {
-	fake.prototypeNameMutex.Lock()
-	ret, specificReturn := fake.prototypeNameReturnsOnCall[len(fake.prototypeNameArgsForCall)]
-	fake.prototypeNameArgsForCall = append(fake.prototypeNameArgsForCall, struct {
-	}{})
-	stub := fake.PrototypeNameStub
-	fakeReturns := fake.prototypeNameReturns
-	fake.recordInvocation("PrototypeName", []interface{}{})
-	fake.prototypeNameMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeBuild) PrototypeNameCallCount() int {
-	fake.prototypeNameMutex.RLock()
-	defer fake.prototypeNameMutex.RUnlock()
-	return len(fake.prototypeNameArgsForCall)
-}
-
-func (fake *FakeBuild) PrototypeNameCalls(stub func() string) {
-	fake.prototypeNameMutex.Lock()
-	defer fake.prototypeNameMutex.Unlock()
-	fake.PrototypeNameStub = stub
-}
-
-func (fake *FakeBuild) PrototypeNameReturns(result1 string) {
-	fake.prototypeNameMutex.Lock()
-	defer fake.prototypeNameMutex.Unlock()
-	fake.PrototypeNameStub = nil
-	fake.prototypeNameReturns = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeBuild) PrototypeNameReturnsOnCall(i int, result1 string) {
-	fake.prototypeNameMutex.Lock()
-	defer fake.prototypeNameMutex.Unlock()
-	fake.PrototypeNameStub = nil
-	if fake.prototypeNameReturnsOnCall == nil {
-		fake.prototypeNameReturnsOnCall = make(map[int]struct {
-			result1 string
-		})
-	}
-	fake.prototypeNameReturnsOnCall[i] = struct {
-		result1 string
-	}{result1}
-}
-
 func (fake *FakeBuild) PublicPlan() *json.RawMessage {
 	fake.publicPlanMutex.Lock()
 	ret, specificReturn := fake.publicPlanReturnsOnCall[len(fake.publicPlanArgsForCall)]
@@ -3274,59 +3201,6 @@ func (fake *FakeBuild) ResourceTypeIDReturnsOnCall(i int, result1 int) {
 	}
 	fake.resourceTypeIDReturnsOnCall[i] = struct {
 		result1 int
-	}{result1}
-}
-
-func (fake *FakeBuild) ResourceTypeName() string {
-	fake.resourceTypeNameMutex.Lock()
-	ret, specificReturn := fake.resourceTypeNameReturnsOnCall[len(fake.resourceTypeNameArgsForCall)]
-	fake.resourceTypeNameArgsForCall = append(fake.resourceTypeNameArgsForCall, struct {
-	}{})
-	stub := fake.ResourceTypeNameStub
-	fakeReturns := fake.resourceTypeNameReturns
-	fake.recordInvocation("ResourceTypeName", []interface{}{})
-	fake.resourceTypeNameMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeBuild) ResourceTypeNameCallCount() int {
-	fake.resourceTypeNameMutex.RLock()
-	defer fake.resourceTypeNameMutex.RUnlock()
-	return len(fake.resourceTypeNameArgsForCall)
-}
-
-func (fake *FakeBuild) ResourceTypeNameCalls(stub func() string) {
-	fake.resourceTypeNameMutex.Lock()
-	defer fake.resourceTypeNameMutex.Unlock()
-	fake.ResourceTypeNameStub = stub
-}
-
-func (fake *FakeBuild) ResourceTypeNameReturns(result1 string) {
-	fake.resourceTypeNameMutex.Lock()
-	defer fake.resourceTypeNameMutex.Unlock()
-	fake.ResourceTypeNameStub = nil
-	fake.resourceTypeNameReturns = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeBuild) ResourceTypeNameReturnsOnCall(i int, result1 string) {
-	fake.resourceTypeNameMutex.Lock()
-	defer fake.resourceTypeNameMutex.Unlock()
-	fake.ResourceTypeNameStub = nil
-	if fake.resourceTypeNameReturnsOnCall == nil {
-		fake.resourceTypeNameReturnsOnCall = make(map[int]struct {
-			result1 string
-		})
-	}
-	fake.resourceTypeNameReturnsOnCall[i] = struct {
-		result1 string
 	}{result1}
 }
 
@@ -4464,8 +4338,6 @@ func (fake *FakeBuild) Invocations() map[string][][]interface{} {
 	defer fake.privatePlanMutex.RUnlock()
 	fake.prototypeIDMutex.RLock()
 	defer fake.prototypeIDMutex.RUnlock()
-	fake.prototypeNameMutex.RLock()
-	defer fake.prototypeNameMutex.RUnlock()
 	fake.publicPlanMutex.RLock()
 	defer fake.publicPlanMutex.RUnlock()
 	fake.reapTimeMutex.RLock()
@@ -4484,8 +4356,6 @@ func (fake *FakeBuild) Invocations() map[string][][]interface{} {
 	defer fake.resourceNameMutex.RUnlock()
 	fake.resourceTypeIDMutex.RLock()
 	defer fake.resourceTypeIDMutex.RUnlock()
-	fake.resourceTypeNameMutex.RLock()
-	defer fake.resourceTypeNameMutex.RUnlock()
 	fake.resourcesMutex.RLock()
 	defer fake.resourcesMutex.RUnlock()
 	fake.resourcesCheckedMutex.RLock()

--- a/atc/postgresrunner/join_limit_conn.go
+++ b/atc/postgresrunner/join_limit_conn.go
@@ -1,0 +1,96 @@
+package postgresrunner
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/concourse/concourse/atc/db"
+	"github.com/onsi/ginkgo"
+)
+
+func validateJoinLimit(query string) error {
+	// Each subquery, split by a UNION or a UNION ALL, can have up to 8 JOINs
+	subQueries := strings.Split(query, "UNION")
+	for _, subQuery := range subQueries {
+		numJoins := strings.Count(strings.ToUpper(subQuery), "JOIN")
+		if numJoins > 8 {
+			errMsg := "the following query has too many JOINs\n\n" + subQuery
+			if len(subQueries) > 1 {
+				errMsg += "\n\nit is part of this full query:\n\n" + query
+			}
+			errMsg += fmt.Sprintf("\n\njoin_collapse_limit defaults to 8 JOINs, while this query has %d. exceeding the limit can result in really slow queries", numJoins)
+
+			return fmt.Errorf(errMsg)
+		}
+	}
+	return nil
+}
+
+type joinLimitValidatorConn struct {
+	db.Conn
+}
+
+func (c joinLimitValidatorConn) Begin() (db.Tx, error) {
+	tx, err := c.Conn.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	return joinLimitValidatorTx{Tx: tx}, nil
+}
+
+func (c joinLimitValidatorConn) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	if err := validateJoinLimit(query); err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	return c.Conn.Query(query, args...)
+}
+
+func (c joinLimitValidatorConn) QueryRow(query string, args ...interface{}) squirrel.RowScanner {
+	if err := validateJoinLimit(query); err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	return c.Conn.QueryRow(query, args...)
+}
+
+func (c joinLimitValidatorConn) Exec(query string, args ...interface{}) (sql.Result, error) {
+	if err := validateJoinLimit(query); err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	return c.Conn.Exec(query, args...)
+}
+
+type joinLimitValidatorTx struct {
+	db.Tx
+}
+
+func (t joinLimitValidatorTx) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	if err := validateJoinLimit(query); err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	return t.Tx.Query(query, args...)
+}
+
+func (t joinLimitValidatorTx) QueryRow(query string, args ...interface{}) squirrel.RowScanner {
+	if err := validateJoinLimit(query); err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	return t.Tx.QueryRow(query, args...)
+}
+
+func (t joinLimitValidatorTx) Exec(query string, args ...interface{}) (sql.Result, error) {
+	if err := validateJoinLimit(query); err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	return t.Tx.Exec(query, args...)
+}
+
+func (t joinLimitValidatorTx) QueryRowContext(ctx context.Context, query string, args ...interface{}) squirrel.RowScanner {
+	if err := validateJoinLimit(query); err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	return t.Tx.QueryRowContext(ctx, query, args...)
+}

--- a/atc/postgresrunner/join_limit_conn.go
+++ b/atc/postgresrunner/join_limit_conn.go
@@ -12,13 +12,13 @@ import (
 )
 
 func validateJoinLimit(query string) error {
-	// Each subquery, split by a UNION or a UNION ALL, can have up to 8 JOINs
-	subQueries := strings.Split(query, "UNION")
-	for _, subQuery := range subQueries {
-		numJoins := strings.Count(strings.ToUpper(subQuery), "JOIN")
+	// Each subquery can have up to 8 explicit JOINs
+	individualQueries := ExtractQueries(query)
+	for _, q := range individualQueries {
+		numJoins := strings.Count(strings.ToUpper(q), "JOIN")
 		if numJoins > 8 {
-			errMsg := "the following query has too many JOINs\n\n" + subQuery
-			if len(subQueries) > 1 {
+			errMsg := "the following query has too many JOINs\n\n" + q
+			if len(individualQueries) > 1 {
 				errMsg += "\n\nit is part of this full query:\n\n" + query
 			}
 			errMsg += fmt.Sprintf("\n\njoin_collapse_limit defaults to 8 JOINs, while this query has %d. exceeding the limit can result in really slow queries", numJoins)
@@ -27,6 +27,52 @@ func validateJoinLimit(query string) error {
 		}
 	}
 	return nil
+}
+
+// ExtractQueries is an helper to extract a list of queries from a top-level
+// query. In particular, it separates any CTE's, UNIONs, and subqueries from
+// the main query, since they are each evaluated separately when calculating
+// the number of joins.
+func ExtractQueries(query string) []string {
+	var queries []string
+
+	var recurse func(int) int
+	recurse = func(i int) int {
+		start := i
+		curQuery := ""
+		for i < len(query) {
+			if query[i] == ')' {
+				break
+			}
+			if query[i] == '(' {
+				curQuery += query[start:i] + "(...)"
+				start = recurse(i+1) + 1
+				i = start
+			}
+			i += 1
+		}
+		if start < len(query) {
+			curQuery += query[start:i]
+		}
+		j := 0
+		for j < len(curQuery) {
+			unionIndex := strings.Index(strings.ToUpper(curQuery[j:]), "UNION")
+			if unionIndex < 0 {
+				unionIndex = len(curQuery)
+			} else {
+				unionIndex += j
+			}
+			queries = append(queries, strings.TrimSpace(curQuery[j:unionIndex]))
+			j = unionIndex + 5
+		}
+		return i
+	}
+
+	i := 0
+	for i < len(query) {
+		i = recurse(i)
+	}
+	return queries
 }
 
 type joinLimitValidatorConn struct {

--- a/atc/postgresrunner/join_limit_conn_test.go
+++ b/atc/postgresrunner/join_limit_conn_test.go
@@ -1,0 +1,37 @@
+package postgresrunner_test
+
+import (
+	"github.com/concourse/concourse/atc/postgresrunner"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ExtractQueries", func() {
+	It("parses queries out of a top-level query", func() {
+		query := `WITH abc AS (
+  SELECT def FROM (SELECT 1)
+), ghi AS (
+  SELECT blah
+  UNION
+  SELECT bloo
+)
+SELECT who, cares
+FROM something
+JOIN other ON col1 = (SELECT other_col FROM something)
+	union
+SELECT something_else FROM a_table`
+
+		Expect(postgresrunner.ExtractQueries(query)).To(ConsistOf(
+			`WITH abc AS (...), ghi AS (...)
+SELECT who, cares
+FROM something
+JOIN other ON col1 = (...)`,
+			`SELECT something_else FROM a_table`,
+			`SELECT other_col FROM something`,
+			`SELECT def FROM (...)`,
+			`SELECT blah`,
+			`SELECT bloo`,
+			`SELECT 1`,
+		))
+	})
+})

--- a/atc/postgresrunner/postgresrunner.go
+++ b/atc/postgresrunner/postgresrunner.go
@@ -185,7 +185,7 @@ func (runner *Runner) openConn(dbName string) db.Conn {
 	// require more than one, which will deadlock if it's at the limit
 	dbConn.SetMaxOpenConns(1)
 
-	return dbConn
+	return joinLimitValidatorConn{dbConn}
 }
 
 func (runner *Runner) OpenSingleton() *sql.DB {

--- a/atc/postgresrunner/postgresrunner_suite_test.go
+++ b/atc/postgresrunner/postgresrunner_suite_test.go
@@ -1,0 +1,13 @@
+package postgresrunner_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPostgresrunner(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DB Suite")
+}


### PR DESCRIPTION
## Changes proposed by this PR

* [x] Don't `JOIN` on `resource_types` or `prototypes` when `SELECT`ing a build
  * The reasoning is explained more thoroughly in add3a0b, but tl;dr, we were exceeding the default `join_collapse_limit` (of 8 relations) - if you exceed this limit, then Postgres refuses to optimize the order in which it performs the `JOIN`s, so you end up with a (potentially very) suboptimal execution plan
    * When we deployed to prod, the normal "get a check build" query that normally takes <100ms was taking >5 minutes 😬 
  * We previously performed the `JOIN`s to label builds as for a particular resource type or prototype, by name. Now, builds specifically for a resource type or prototype will appear as one-off builds (in tracing, logging, and the syslog drainer)
  * With #7176, we don't generate check builds for `resource_types` (or `prototypes`), so this will only apply to `fly check-resource-type`/`-prototype`
* [x] Add a wrapper `db.Conn` to fail our test suite if we introduce a query with "too many" `JOIN`s
