### PR TITLE
Add --param to `fly execute` (set environment variables in one-off task)

### DIFF
--- a/fly/commands/execute.go
+++ b/fly/commands/execute.go
@@ -36,6 +36,7 @@ type ExecuteCommand struct {
 	Var            []flaghelpers.VariablePairFlag     `short:"v"  long:"var"       value-name:"[NAME=STRING]"  unquote:"false"  description:"Specify a string value to set for a variable in the pipeline"`
 	YAMLVar        []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"  value-name:"[NAME=YAML]"    unquote:"false"  description:"Specify a YAML value to set for a variable in the pipeline"`
 	VarsFrom       []atc.PathFlag                     `short:"l"  long:"load-vars-from"  description:"Variable flag that can be used for filling in template values in configuration from a YAML file"`
+	Params         []flaghelpers.ParamPairFlag        `          long:"param"      value-name:"NAME=STRING" description:"Set parameter values."`
 }
 
 func (command *ExecuteCommand) Execute(args []string) error {
@@ -85,6 +86,11 @@ func (command *ExecuteCommand) Execute(args []string) error {
 		return err
 	}
 
+	params := atc.TaskEnv{}
+	for _, p := range command.Params {
+		params[p.Name] = p.Value
+	}
+
 	plan, err := executehelpers.CreateBuildPlan(
 		planFactory,
 		target,
@@ -95,6 +101,7 @@ func (command *ExecuteCommand) Execute(args []string) error {
 		outputs,
 		taskConfig,
 		command.Tags,
+		params,
 	)
 
 	if err != nil {

--- a/fly/commands/internal/executehelpers/builds.go
+++ b/fly/commands/internal/executehelpers/builds.go
@@ -15,6 +15,7 @@ func CreateBuildPlan(
 	outputs []Output,
 	config atc.TaskConfig,
 	tags []string,
+	params atc.TaskEnv,
 ) (atc.Plan, error) {
 	if err := config.Validate(); err != nil {
 		return atc.Plan{}, err
@@ -35,6 +36,10 @@ func CreateBuildPlan(
 
 	if len(tags) != 0 {
 		taskPlan.Task.Tags = tags
+	}
+
+	if len(params) != 0 {
+		taskPlan.Task.Params = params
 	}
 
 	buildOutputs := atc.InParallelPlan{}

--- a/fly/commands/internal/flaghelpers/param_pair_flag.go
+++ b/fly/commands/internal/flaghelpers/param_pair_flag.go
@@ -1,0 +1,22 @@
+package flaghelpers
+
+import (
+	"fmt"
+)
+
+type ParamPairFlag struct {
+	Name  string
+	Value string
+}
+
+func (pair *ParamPairFlag) UnmarshalFlag(value string) error {
+	name, value, ok := parseKeyValuePair(value)
+	if !ok {
+		return fmt.Errorf("invalid input pair '%s' (must be name=value)", value)
+	}
+
+	pair.Name = name
+	pair.Value = value
+
+	return nil
+}


### PR DESCRIPTION
You can use `params:` key in task step YAML to set/override environment variable values for a task.

https://concourse-ci.org/jobs.html#schema.step.task-step.params

However, there was no corresponding option to `fly execute` for this behaviour.

`--param` has been added to `fly execute` for this purpose.

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] add `--param` option to `fly execute`.

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

A very basic test seems to work:

<img width="879" alt="test fly execute --param" src="https://user-images.githubusercontent.com/81115196/122840735-d5095300-d34e-11eb-8c62-246a393d8bf0.png">

Happy to add extra unit tests if this change isn't already covered by the existing tests, but I would need some pointers on how/where to add the unit-tests.
