### PR TITLE
Treat resource types as checkable in rate limiter

### DIFF
--- a/atc/db/resource_check_rate_limiter.go
+++ b/atc/db/resource_check_rate_limiter.go
@@ -3,9 +3,10 @@ package db
 import (
 	"context"
 	"fmt"
-	sq "github.com/Masterminds/squirrel"
 	"sync"
 	"time"
+
+	sq "github.com/Masterminds/squirrel"
 
 	"code.cloudfoundry.org/clock"
 	"golang.org/x/time/rate"
@@ -87,17 +88,28 @@ func (limiter *ResourceCheckRateLimiter) Limit() rate.Limit {
 }
 
 func (limiter *ResourceCheckRateLimiter) refreshCheckLimiter() error {
-	var count int
+	var resourceCount int
+	var resourceTypeCount int
 	err := psql.Select("COUNT(id)").
 		From("resources").
 		Where(sq.Eq{"active": true}).
 		RunWith(limiter.refreshConn).
 		QueryRow().
-		Scan(&count)
+		Scan(&resourceCount)
+	if err != nil {
+		return err
+	}
+	err = psql.Select("COUNT(id)").
+		From("resource_types").
+		Where(sq.Eq{"active": true}).
+		RunWith(limiter.refreshConn).
+		QueryRow().
+		Scan(&resourceTypeCount)
 	if err != nil {
 		return err
 	}
 
+	count := resourceCount + resourceTypeCount
 	limit := rate.Limit(float64(count) / limiter.checkInterval.Seconds())
 	if count == 0 {
 		// don't bother waiting if there aren't any checkables


### PR DESCRIPTION
## Changes proposed by this PR

Follow-up from #7102 
Will be made irrelevant by #7176

check builds are created for resources and custom resource types. The
resource types were not being considered in the rate limit, so as soon
as you have any custom resource types there would always be check builds
that would get stuck by the rate limiter.
