### PR TITLE
Apply a minimum rate limit for resource checking

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1076,6 +1076,7 @@ func (cmd *RunCommand) backendComponents(
 
 	rateLimiter := db.NewResourceCheckRateLimiter(
 		rate.Limit(cmd.MaxChecksPerSecond),
+		rate.Limit(1),
 		cmd.ResourceCheckingInterval,
 		dbConn,
 		time.Minute,

--- a/atc/db/resource_check_rate_limiter_test.go
+++ b/atc/db/resource_check_rate_limiter_test.go
@@ -29,8 +29,6 @@ var _ = Describe("ResourceCheckRateLimiter", func() {
 		ctx context.Context
 
 		limiter *db.ResourceCheckRateLimiter
-
-		pipelineConfig *atc.Config
 	)
 
 	BeforeEach(func() {
@@ -39,16 +37,13 @@ var _ = Describe("ResourceCheckRateLimiter", func() {
 		refreshInterval = 5 * time.Minute
 		fakeClock = fakeclock.NewFakeClock(time.Now())
 
+		_, err := dbConn.Exec("update resources set active=false")
+		Expect(err).ToNot(HaveOccurred())
+
 		checkableCount = 0
 		scenario = &dbtest.Scenario{}
 
 		ctx = context.Background()
-
-		By("Unpolluting our env")
-		err := defaultPipeline.Destroy()
-		Expect(err).NotTo(HaveOccurred())
-
-		pipelineConfig = &atc.Config{}
 	})
 
 	JustBeforeEach(func() {
@@ -69,34 +64,21 @@ var _ = Describe("ResourceCheckRateLimiter", func() {
 		return errs
 	}
 
-	createResource := func() {
+	createCheckable := func() {
 		checkableCount++
 
-		pipelineConfig.Resources = append(pipelineConfig.Resources, atc.ResourceConfig{Name: fmt.Sprintf("resource-%d", checkableCount),
-			Type:   dbtest.BaseResourceType,
-			Source: atc.Source{"some": "source"},
-		})
+		var resources atc.ResourceConfigs
+		for i := 0; i < checkableCount; i++ {
+			resources = append(resources, atc.ResourceConfig{
+				Name:   fmt.Sprintf("resource-%d", i),
+				Type:   dbtest.BaseResourceType,
+				Source: atc.Source{"some": "source"},
+			})
+		}
 
-		scenario.Run(builder.WithPipeline(*pipelineConfig))
-	}
-
-	createResourceWithCustomType := func() {
-		checkableCount++
-		customResourceType := fmt.Sprintf("resource-type-%d", checkableCount)
-
-		pipelineConfig.ResourceTypes = append(pipelineConfig.ResourceTypes, atc.ResourceType{Name: customResourceType,
-			Type:   dbtest.BaseResourceType,
-			Source: atc.Source{"some": "source"},
-		})
-
-		checkableCount++
-
-		pipelineConfig.Resources = append(pipelineConfig.Resources, atc.ResourceConfig{Name: fmt.Sprintf("resource-%d", checkableCount),
-			Type:   customResourceType,
-			Source: atc.Source{"some": "source"},
-		})
-
-		scenario.Run(builder.WithPipeline(*pipelineConfig))
+		scenario.Run(builder.WithPipeline(atc.Config{
+			Resources: resources,
+		}))
 	}
 
 	Context("with no static limit provided", func() {
@@ -110,7 +92,7 @@ var _ = Describe("ResourceCheckRateLimiter", func() {
 			Expect(limiter.Limit()).To(Equal(rate.Inf))
 
 			By("creating one checkable")
-			createResource()
+			createCheckable()
 
 			By("continuing to return immediately, as the refresh interval has not elapsed")
 			Expect(<-wait(limiter)).To(Succeed())
@@ -136,11 +118,7 @@ var _ = Describe("ResourceCheckRateLimiter", func() {
 
 			By("creating more checkables")
 			for i := 0; i < 10; i++ {
-				if i%3 == 0 {
-					createResourceWithCustomType()
-				} else {
-					createResource()
-				}
+				createCheckable()
 			}
 
 			By("waiting for the refresh interval")
@@ -196,7 +174,7 @@ var _ = Describe("ResourceCheckRateLimiter", func() {
 
 			By("creating a few (ignored) checkables")
 			for i := 0; i < 10; i++ {
-				createResource()
+				createCheckable()
 			}
 
 			By("waiting for the (ignored) refresh interval")

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -83,9 +83,11 @@ func (d *checkDelegate) FindOrCreateScope(config db.ResourceConfig) (db.Resource
 func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigScope) (lock.Lock, bool, error) {
 	logger := lagerctx.FromContext(ctx)
 
-	// rate limit periodic resource checks so worker load (plus load on external
-	// services) isn't too spiky
-	if !d.build.IsManuallyTriggered() && d.plan.IsPeriodic() {
+	// rate limit periodic resource checks so worker load (plus load on
+	// external services) isn't too spiky. note that we don't rate limit
+	// resource type or prototype checks, because they are created every time a
+	// resource is used (rather than periodically).
+	if !d.build.IsManuallyTriggered() && d.plan.Resource != "" {
 		err := d.limiter.Wait(ctx)
 		if err != nil {
 			return nil, false, fmt.Errorf("rate limit: %w", err)

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -117,7 +117,11 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 				break
 			}
 
-			d.clock.Sleep(time.Second)
+			select {
+			case <-ctx.Done():
+				return nil, false, ctx.Err()
+			case <-d.clock.After(time.Second):
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

Primarily:

* [x] Apply a minimum rate limit of 1 check/second if no maximum rate limit is provided (i.e. we're using the default of `num resources / check interval` checks/second), and the calculated rate limit is very low
  * See 14e2fdb41ebb8da5694539d24a34ac0deebbe1e8 for more details

Also, some other small adjustments:
* [x] Don't rate limit resource type checks
* [x] Don't consider resources in paused/archived pipelines for resource count
* [x] Allow aborting checks while awaiting the checking lock

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

* If `CONCOURSE_MAX_CHECKS_PER_SECOND` is unset, Concourse will try to distribute checks evenly over the course of the check interval to reduce the concurrent load on external systems.
* If there are few resources in a Concourse deployment (~1-20), checks may have to wait a substantial amount of time to run in order to space the checks out evenly. However, there's no real benefit to doing this, since having just a few resources doesn't cause significant load in the first place.
* Now, Concourse ensures that at least one check is allowed to run per second
