### PR TITLE
Remove prototype_id from builds table

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -69,7 +69,6 @@ var buildsQuery = psql.Select(`
 		b.job_id,
 		b.resource_id,
 		b.resource_type_id,
-		b.prototype_id,
 		b.team_id,
 		b.status,
 		b.manually_triggered,
@@ -129,8 +128,6 @@ type Build interface {
 	ResourceName() string
 
 	ResourceTypeID() int
-
-	PrototypeID() int
 
 	Schema() string
 	PrivatePlan() atc.Plan
@@ -224,7 +221,6 @@ type build struct {
 	resourceName string
 
 	resourceTypeID int
-	prototypeID    int
 
 	isManuallyTriggered bool
 
@@ -345,7 +341,6 @@ func (b *build) JobName() string              { return b.jobName }
 func (b *build) ResourceID() int              { return b.resourceID }
 func (b *build) ResourceName() string         { return b.resourceName }
 func (b *build) ResourceTypeID() int          { return b.resourceTypeID }
-func (b *build) PrototypeID() int             { return b.prototypeID }
 func (b *build) TeamID() int                  { return b.teamID }
 func (b *build) TeamName() string             { return b.teamName }
 func (b *build) IsManuallyTriggered() bool    { return b.isManuallyTriggered }
@@ -1755,7 +1750,7 @@ func buildEventSeq(buildid int) string {
 
 func scanBuild(b *build, row scannable, encryptionStrategy encryption.Strategy) error {
 	var (
-		jobID, resourceID, resourceTypeID, prototypeID, pipelineID, rerunOf, rerunNumber  sql.NullInt64
+		jobID, resourceID, resourceTypeID, pipelineID, rerunOf, rerunNumber               sql.NullInt64
 		schema, privatePlan, jobName, resourceName, pipelineName, publicPlan, rerunOfName sql.NullString
 		createTime, startTime, endTime, reapTime                                          pq.NullTime
 		nonce, spanContext, createdBy                                                     sql.NullString
@@ -1770,7 +1765,6 @@ func scanBuild(b *build, row scannable, encryptionStrategy encryption.Strategy) 
 		&jobID,
 		&resourceID,
 		&resourceTypeID,
-		&prototypeID,
 		&b.teamID,
 		&status,
 		&b.isManuallyTriggered,
@@ -1809,7 +1803,6 @@ func scanBuild(b *build, row scannable, encryptionStrategy encryption.Strategy) 
 	b.resourceID = int(resourceID.Int64)
 	b.resourceName = resourceName.String
 	b.resourceTypeID = int(resourceTypeID.Int64)
-	b.prototypeID = int(prototypeID.Int64)
 	b.pipelineID = int(pipelineID.Int64)
 	b.pipelineName = pipelineName.String
 	b.schema = schema.String
@@ -1889,7 +1882,7 @@ func (b *build) saveEvent(tx Tx, event atc.Event) error {
 }
 
 func (b *build) isForCheck() bool {
-	return b.resourceTypeID != 0 || b.resourceID != 0 || b.prototypeID != 0
+	return b.resourceTypeID != 0 || b.resourceID != 0
 }
 
 func (b *build) eventsTable() string {

--- a/atc/db/check_lifecycle.go
+++ b/atc/db/check_lifecycle.go
@@ -33,11 +33,6 @@ func (cl *checkLifecycle) DeleteCompletedChecks() error {
           FROM builds b
           WHERE completed AND resource_type_id IS NOT NULL
           AND EXISTS (SELECT * FROM builds b2 WHERE b.resource_type_id = b2.resource_type_id AND b.id < b2.id)
-            UNION ALL
-          SELECT id
-          FROM builds b
-          WHERE completed AND prototype_id IS NOT NULL
-          AND EXISTS (SELECT * FROM builds b2 WHERE b.prototype_id = b2.prototype_id AND b.id < b2.id)
 		) AS deletable_builds WHERE builds.id = deletable_builds.id
 		RETURNING builds.id
       )

--- a/atc/db/check_lifecycle_test.go
+++ b/atc/db/check_lifecycle_test.go
@@ -58,14 +58,12 @@ var _ = Describe("Check Lifecycle", func() {
 	It("removes completed check builds when there is a new completed check", func() {
 		resourceBuild := createFinishedCheck(defaultResource, plan)
 		resourceTypeBuild := createFinishedCheck(defaultResourceType, plan)
-		prototypeBuild := createFinishedCheck(defaultPrototype, plan)
 
 		By("attempting to delete completed checks when there are no newer checks")
 		err := lifecycle.DeleteCompletedChecks()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exists(resourceBuild)).To(BeTrue())
 		Expect(exists(resourceTypeBuild)).To(BeTrue())
-		Expect(exists(prototypeBuild)).To(BeTrue())
 
 		By("creating a new check for the resource")
 		createFinishedCheck(defaultResource, plan)
@@ -78,7 +76,6 @@ var _ = Describe("Check Lifecycle", func() {
 		Expect(numBuildEventsForCheck(resourceBuild)).To(Equal(0))
 
 		Expect(exists(resourceTypeBuild)).To(BeTrue())
-		Expect(exists(prototypeBuild)).To(BeTrue())
 
 		By("creating a new check for the resource type")
 		createFinishedCheck(defaultResourceType, plan)
@@ -90,17 +87,12 @@ var _ = Describe("Check Lifecycle", func() {
 		Expect(exists(resourceTypeBuild)).To(BeFalse())
 		Expect(numBuildEventsForCheck(resourceTypeBuild)).To(Equal(0))
 
-		Expect(exists(prototypeBuild)).To(BeTrue())
-
 		By("creating a new check for the prototype")
 		createFinishedCheck(defaultPrototype, plan)
 
 		By("deleting completed checks")
 		err = lifecycle.DeleteCompletedChecks()
 		Expect(err).ToNot(HaveOccurred())
-
-		Expect(exists(prototypeBuild)).To(BeFalse())
-		Expect(numBuildEventsForCheck(prototypeBuild)).To(Equal(0))
 	})
 
 	It("ignores incomplete checks", func() {

--- a/atc/db/dbfakes/fake_build.go
+++ b/atc/db/dbfakes/fake_build.go
@@ -406,16 +406,6 @@ type FakeBuild struct {
 	privatePlanReturnsOnCall map[int]struct {
 		result1 atc.Plan
 	}
-	PrototypeIDStub        func() int
-	prototypeIDMutex       sync.RWMutex
-	prototypeIDArgsForCall []struct {
-	}
-	prototypeIDReturns struct {
-		result1 int
-	}
-	prototypeIDReturnsOnCall map[int]struct {
-		result1 int
-	}
 	PublicPlanStub        func() *json.RawMessage
 	publicPlanMutex       sync.RWMutex
 	publicPlanArgsForCall []struct {
@@ -2671,59 +2661,6 @@ func (fake *FakeBuild) PrivatePlanReturnsOnCall(i int, result1 atc.Plan) {
 	}{result1}
 }
 
-func (fake *FakeBuild) PrototypeID() int {
-	fake.prototypeIDMutex.Lock()
-	ret, specificReturn := fake.prototypeIDReturnsOnCall[len(fake.prototypeIDArgsForCall)]
-	fake.prototypeIDArgsForCall = append(fake.prototypeIDArgsForCall, struct {
-	}{})
-	stub := fake.PrototypeIDStub
-	fakeReturns := fake.prototypeIDReturns
-	fake.recordInvocation("PrototypeID", []interface{}{})
-	fake.prototypeIDMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeBuild) PrototypeIDCallCount() int {
-	fake.prototypeIDMutex.RLock()
-	defer fake.prototypeIDMutex.RUnlock()
-	return len(fake.prototypeIDArgsForCall)
-}
-
-func (fake *FakeBuild) PrototypeIDCalls(stub func() int) {
-	fake.prototypeIDMutex.Lock()
-	defer fake.prototypeIDMutex.Unlock()
-	fake.PrototypeIDStub = stub
-}
-
-func (fake *FakeBuild) PrototypeIDReturns(result1 int) {
-	fake.prototypeIDMutex.Lock()
-	defer fake.prototypeIDMutex.Unlock()
-	fake.PrototypeIDStub = nil
-	fake.prototypeIDReturns = struct {
-		result1 int
-	}{result1}
-}
-
-func (fake *FakeBuild) PrototypeIDReturnsOnCall(i int, result1 int) {
-	fake.prototypeIDMutex.Lock()
-	defer fake.prototypeIDMutex.Unlock()
-	fake.PrototypeIDStub = nil
-	if fake.prototypeIDReturnsOnCall == nil {
-		fake.prototypeIDReturnsOnCall = make(map[int]struct {
-			result1 int
-		})
-	}
-	fake.prototypeIDReturnsOnCall[i] = struct {
-		result1 int
-	}{result1}
-}
-
 func (fake *FakeBuild) PublicPlan() *json.RawMessage {
 	fake.publicPlanMutex.Lock()
 	ret, specificReturn := fake.publicPlanReturnsOnCall[len(fake.publicPlanArgsForCall)]
@@ -4336,8 +4273,6 @@ func (fake *FakeBuild) Invocations() map[string][][]interface{} {
 	defer fake.preparationMutex.RUnlock()
 	fake.privatePlanMutex.RLock()
 	defer fake.privatePlanMutex.RUnlock()
-	fake.prototypeIDMutex.RLock()
-	defer fake.prototypeIDMutex.RUnlock()
 	fake.publicPlanMutex.RLock()
 	defer fake.publicPlanMutex.RUnlock()
 	fake.reapTimeMutex.RLock()

--- a/atc/db/migration/migrations/1621273969_add_prototypes.down.sql
+++ b/atc/db/migration/migrations/1621273969_add_prototypes.down.sql
@@ -1,6 +1,3 @@
-DROP INDEX builds_prototype_id_idx;
-ALTER TABLE builds DROP COLUMN prototype_id;
-
 DROP INDEX prototypes_resource_config_id;
 DROP INDEX prototypes_pipeline_id;
 DROP INDEX prototypes_pipeline_id_name_uniq;

--- a/atc/db/migration/migrations/1621273969_add_prototypes.up.sql
+++ b/atc/db/migration/migrations/1621273969_add_prototypes.up.sql
@@ -17,8 +17,3 @@ CREATE INDEX prototypes_pipeline_id
 
 CREATE INDEX prototypes_resource_config_id
     ON prototypes (resource_config_id);
-
-ALTER TABLE builds
-    ADD COLUMN prototype_id integer REFERENCES prototypes (id) ON DELETE CASCADE;
-
-CREATE INDEX builds_prototype_id_idx ON builds (prototype_id);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

with concourse/concourse#7176, I realize we don't gain much from keeping
track of the prototype_id or resource_type_id on the builds table, as
the only time we will ever create checks for them is when we manually
fly check-{proto,resource-}type. this ID is used:

1. to ensure we don't create unnecessary checks (for non-manually
   triggered checks)
2. to GC old checks (i.e. where there is already a newer finished
   check).
3. to emit build events to the check_build_events partition for
   optimized GC

however, given that checks for these types will be limited to only
manually triggered checks, this is no longer really worthwhile.

1. all checks are manually triggered anyway, so no difference
2. there will be far fewer checks so GC'ing likely won't be worthwhile.
   if we do want to GC these checks, however, we could add a time-based
   GC (e.g. remove check builds older than 5 days)
3. same as 2

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] remove `prototype_id` from `builds` table