### PR TITLE
atc/db: prevent creation of duplicate check builds

### DIFF
--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -537,12 +537,20 @@ var _ = Describe("Resource", func() {
 			})
 		})
 
-		Context("when another build already exists", func() {
+		Context("when another running build already exists", func() {
 			var prevBuild db.Build
 
 			BeforeEach(func() {
 				var err error
 				var prevCreated bool
+				By("creating a completed build")
+				prevBuild, prevCreated, err = defaultResource.CreateBuild(ctx, false, plan)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(prevCreated).To(BeTrue())
+				err = prevBuild.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("creating a running build")
 				prevBuild, prevCreated, err = defaultResource.CreateBuild(ctx, false, plan)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(prevCreated).To(BeTrue())
@@ -1222,8 +1230,8 @@ var _ = Describe("Resource", func() {
 	Describe("Clear resource cache", func() {
 		Context("when resource cache exists", func() {
 			var (
-				scenario *dbtest.Scenario
-				firstUsedResourceCache db.UsedResourceCache
+				scenario                *dbtest.Scenario
+				firstUsedResourceCache  db.UsedResourceCache
 				secondUsedResourceCache db.UsedResourceCache
 			)
 

--- a/atc/db/resource_type_test.go
+++ b/atc/db/resource_type_test.go
@@ -580,12 +580,20 @@ var _ = Describe("ResourceType", func() {
 			})
 		})
 
-		Context("when another build already exists", func() {
+		Context("when another running build already exists", func() {
 			var prevBuild db.Build
 
 			BeforeEach(func() {
 				var err error
 				var prevCreated bool
+				By("creating a completed build")
+				prevBuild, prevCreated, err = resourceType.CreateBuild(ctx, false, plan)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(prevCreated).To(BeTrue())
+				err = prevBuild.Finish(db.BuildStatusSucceeded)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("creating a running build")
 				prevBuild, prevCreated, err = resourceType.CreateBuild(ctx, false, plan)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(prevCreated).To(BeTrue())


### PR DESCRIPTION
## Changes proposed by this PR

closes #7094
Might solve #7128 as well, though that issue is probably specific to the time resource. This bug may have been the cause though.

## Notes to reviewer

To reproduce this issue you can set this pipeline:

```yaml
resources:
- name: some-resource
  type: mock
  check_every: 15s
  source: {initial_version: first-version}

jobs:
- name: simple-job
  plan:
  - get: some-resource
```

Optional: pause the `collector_checks` component.

Then watch the output of `fly builds`
```
watch fly builds
```

You should see two builds with the status "started" after a few lidar intervals pass. One interval is 10s by default.

## Release Note


* Prevent duplicate checks from being created for a single resource

