### PR TITLE
Left-align job name in build header

### DIFF
--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -65,6 +65,7 @@ type BuildDuration
         , duration : Timespan
         }
 
+
 type Timestamp
     = Absolute String (Maybe Timespan)
     | Relative Timespan String
@@ -191,6 +192,7 @@ viewDuration buildDuration =
                     , Html.td [ class "dict-value" ] [ Html.text <| viewTimespan duration ]
                     ]
                 ]
+
 
 viewTimestamp : Timestamp -> Html Message
 viewTimestamp timestamp =
@@ -368,6 +370,7 @@ viewTitle name jobID createdBy =
                     style "line-height" <|
                         if hasCreatedBy then
                             "44px"
+
                         else
                             "60px"
             in
@@ -403,13 +406,13 @@ viewTitle name jobID createdBy =
                         , style "line-height" "16px"
                         , style "right" "0"
                         , style "left" "0"
-                        , style "text-align" "right"
                         , style "text-overflow" "ellipsis"
                         , style "white-space" "nowrap"
                         , style "overflow" "hidden"
                         , title text
                         ]
                         [ Html.text text ]
+
                 Nothing ->
                     Html.text ""
 
@@ -425,15 +428,14 @@ viewTitle name jobID createdBy =
                 )
             ]
                 ++ (if hasCreatedBy then
-                        [ style "min-width" "100px"
-                        , style "text-align" "right"
-                        ]
+                        [ style "min-width" "100px" ]
 
                     else
                         []
                    )
     in
     Html.h1 headerStyle [ buildName, createdByText ]
+
 
 viewHistory : BuildStatus -> List BuildTab -> Html Message
 viewHistory backgroundColor =


### PR DESCRIPTION
## Changes proposed by this PR

For some reason, I suggested that the `created by` text be right-aligned in https://github.com/concourse/concourse/pull/7112#issuecomment-852210904. I'm now thinking it looks a little nicer to left-align everything

### Short job name

Before:
<img width="363" alt="Screen Shot 2021-06-30 at 6 28 12 PM" src="https://user-images.githubusercontent.com/26583442/124039446-eeef0980-d9d0-11eb-82c2-95240712c8f2.png">

After:
<img width="358" alt="124039128-4a6cc780-d9d0-11eb-8fa4-6925ed8d4d46 copy" src="https://user-images.githubusercontent.com/26583442/124039504-0cbc6e80-d9d1-11eb-98c2-9917fb48a384.png">


### Long job name

Before:
<img width="411" alt="Screen Shot 2021-06-30 at 6 24 34 PM" src="https://user-images.githubusercontent.com/26583442/124039188-6d977700-d9d0-11eb-9850-2925ae07a1c5.png">

After:
<img width="417" alt="Screen Shot 2021-06-30 at 6 27 10 PM" src="https://user-images.githubusercontent.com/26583442/124039365-ca932d00-d9d0-11eb-978d-774bb159da62.png">
