### PR TITLE
Fixed a bug that caused time resource inaccurate.

### DIFF
--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -15,7 +15,7 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 const (
-	LockTypeResourceConfigChecking = iota
+	LockTypeResourceConfigScopeChecking = iota
 	LockTypeBuildTracking
 	LockTypeBatch
 	LockTypeVolumeCreating
@@ -31,8 +31,8 @@ func NewBuildTrackingLockID(buildID int) LockID {
 	return LockID{LockTypeBuildTracking, buildID}
 }
 
-func NewResourceConfigCheckingLockID(resourceConfigID int) LockID {
-	return LockID{LockTypeResourceConfigChecking, resourceConfigID}
+func NewResourceConfigScopeCheckingLockID(resourceConfigID int) LockID {
+	return LockID{LockTypeResourceConfigScopeChecking, resourceConfigID}
 }
 
 func NewTaskLockID(taskName string) LockID {

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -192,7 +192,7 @@ func (r *resourceConfigScope) AcquireResourceCheckingLock(
 ) (lock.Lock, bool, error) {
 	return r.lockFactory.Acquire(
 		logger,
-		lock.NewResourceConfigCheckingLockID(r.resourceConfig.ID()),
+		lock.NewResourceConfigScopeCheckingLockID(r.ID()),
 	)
 }
 

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -543,14 +543,14 @@ func (event HTTPResponseTime) Emit(logger lager.Logger, m *Monitor) {
 }
 
 var lockTypeNames = map[int]string{
-	lock.LockTypeResourceConfigChecking: "ResourceConfigChecking",
-	lock.LockTypeBuildTracking:          "BuildTracking",
-	lock.LockTypeJobScheduling:          "JobScheduling",
-	lock.LockTypeBatch:                  "Batch",
-	lock.LockTypeVolumeCreating:         "VolumeCreating",
-	lock.LockTypeContainerCreating:      "ContainerCreating",
-	lock.LockTypeDatabaseMigration:      "DatabaseMigration",
-	lock.LockTypeResourceScanning:       "ResourceScanning",
+	lock.LockTypeResourceConfigScopeChecking: "ResourceConfigScopeChecking",
+	lock.LockTypeBuildTracking:               "BuildTracking",
+	lock.LockTypeJobScheduling:               "JobScheduling",
+	lock.LockTypeBatch:                       "Batch",
+	lock.LockTypeVolumeCreating:              "VolumeCreating",
+	lock.LockTypeContainerCreating:           "ContainerCreating",
+	lock.LockTypeDatabaseMigration:           "DatabaseMigration",
+	lock.LockTypeResourceScanning:            "ResourceScanning",
 }
 
 type LockAcquired struct {


### PR DESCRIPTION
## Changes proposed by this PR

When I tested #7208 with a lot of `time` resources, I hit an issue where a many `time` resources did never got checked.

Then I found that resource config scope acquires lock by using resource config id as lock id. For `unique version history` resources, like `time`, their resource configures are same but scope are different, so it should use scope id as lock id.

* [x] done

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

Fixed a bug that caused inaccurate `time` resource, especially on deployments that container big number of short interval `time` resources.
