### PR TITLE
Use browser cache API for dashboard caching

### DIFF
--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -460,6 +460,7 @@ subscriptions : Model -> List Subscription
 subscriptions model =
     [ OnNonHrefLinkClicked
     , OnLocalStorageReceived
+    , OnCacheReceived
     , OnWindowResize
     ]
         ++ (if model.session.draggingSideBar then

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -281,9 +281,6 @@ handleCallback callback ( model, effects ) =
                         |> Dict.fromList
                         |> Fetched
 
-                maxJobsInCache =
-                    1000
-
                 mapToJobIds jobsResult =
                     jobsResult
                         |> FetchResult.map (Dict.toList >> List.map Tuple.first)
@@ -298,7 +295,6 @@ handleCallback callback ( model, effects ) =
                 ( newModel |> precomputeJobMetadata
                 , effects
                     ++ [ allJobsInEntireCluster
-                            |> List.take maxJobsInCache
                             |> List.map removeBuild
                             |> SaveCachedJobs
                        ]

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -32,12 +32,14 @@ import Message.Message
 import Message.ScrollDirection exposing (ScrollDirection(..))
 import Message.Storage
     exposing
-        ( deleteFromLocalStorage
+        ( deleteFromCache
         , favoritedInstanceGroupsKey
         , favoritedPipelinesKey
         , jobsKey
+        , loadFromCache
         , loadFromLocalStorage
         , pipelinesKey
+        , saveToCache
         , saveToLocalStorage
         , sideBarStateKey
         , teamsKey
@@ -672,22 +674,22 @@ runEffect effect key csrfToken =
             loadFromLocalStorage sideBarStateKey
 
         SaveCachedJobs jobs ->
-            saveToLocalStorage ( jobsKey, jobs |> Json.Encode.list encodeJob )
+            saveToCache ( jobsKey, jobs |> Json.Encode.list encodeJob )
 
         LoadCachedJobs ->
-            loadFromLocalStorage jobsKey
+            loadFromCache jobsKey
 
         DeleteCachedJobs ->
-            deleteFromLocalStorage jobsKey
+            deleteFromCache jobsKey
 
         SaveCachedPipelines pipelines ->
-            saveToLocalStorage ( pipelinesKey, pipelines |> Json.Encode.list encodePipeline )
+            saveToCache ( pipelinesKey, pipelines |> Json.Encode.list encodePipeline )
 
         LoadCachedPipelines ->
-            loadFromLocalStorage pipelinesKey
+            loadFromCache pipelinesKey
 
         DeleteCachedPipelines ->
-            deleteFromLocalStorage pipelinesKey
+            deleteFromCache pipelinesKey
 
         SaveFavoritedPipelines pipelineIDs ->
             saveToLocalStorage
@@ -712,13 +714,13 @@ runEffect effect key csrfToken =
             loadFromLocalStorage favoritedInstanceGroupsKey
 
         SaveCachedTeams teams ->
-            saveToLocalStorage ( teamsKey, teams |> Json.Encode.list encodeTeam )
+            saveToCache ( teamsKey, teams |> Json.Encode.list encodeTeam )
 
         LoadCachedTeams ->
-            loadFromLocalStorage teamsKey
+            loadFromCache teamsKey
 
         DeleteCachedTeams ->
-            deleteFromLocalStorage teamsKey
+            deleteFromCache teamsKey
 
         GetViewportOf domID ->
             Browser.Dom.getViewportOf (toHtmlID domID)

--- a/web/elm/src/Message/Storage.elm
+++ b/web/elm/src/Message/Storage.elm
@@ -1,13 +1,17 @@
 port module Message.Storage exposing
     ( Key
     , Value
+    , deleteFromCache
     , deleteFromLocalStorage
     , favoritedInstanceGroupsKey
     , favoritedPipelinesKey
     , jobsKey
+    , loadFromCache
     , loadFromLocalStorage
     , pipelinesKey
+    , receivedFromCache
     , receivedFromLocalStorage
+    , saveToCache
     , saveToLocalStorage
     , sideBarStateKey
     , teamsKey
@@ -22,10 +26,14 @@ type alias Key =
 
 
 type alias Value =
-    String
+    Json.Encode.Value
 
 
-port saveToLocalStorage : ( Key, Json.Encode.Value ) -> Cmd msg
+
+-- Uses localStorage: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
+
+
+port saveToLocalStorage : ( Key, Value ) -> Cmd msg
 
 
 port deleteFromLocalStorage : Key -> Cmd msg
@@ -35,6 +43,22 @@ port loadFromLocalStorage : Key -> Cmd msg
 
 
 port receivedFromLocalStorage : (( Key, Value ) -> msg) -> Sub msg
+
+
+
+-- Uses the browser cache API: https://developer.mozilla.org/en-US/docs/Web/API/Cache
+
+
+port saveToCache : ( Key, Value ) -> Cmd msg
+
+
+port deleteFromCache : Key -> Cmd msg
+
+
+port loadFromCache : Key -> Cmd msg
+
+
+port receivedFromCache : (( Key, Value ) -> msg) -> Sub msg
 
 
 sideBarStateKey : Key

--- a/web/elm/src/Message/Subscription.elm
+++ b/web/elm/src/Message/Subscription.elm
@@ -29,6 +29,7 @@ import Message.Storage as Storage
         , favoritedPipelinesKey
         , jobsKey
         , pipelinesKey
+        , receivedFromCache
         , receivedFromLocalStorage
         , sideBarStateKey
         , teamsKey
@@ -85,6 +86,7 @@ type Subscription
     | OnElementVisible
     | OnTokenSentToFly
     | OnLocalStorageReceived
+    | OnCacheReceived
     | OnScrolledToId
 
 
@@ -175,6 +177,10 @@ runSubscription s =
             receivedFromLocalStorage <|
                 decodeStorageResponse
 
+        OnCacheReceived ->
+            receivedFromCache <|
+                decodeStorageResponse
+
         OnElementVisible ->
             reportIsVisible ElementVisible
 
@@ -196,7 +202,7 @@ decodeStorageResponse : ( Storage.Key, Storage.Value ) -> Delivery
 decodeStorageResponse ( key, value ) =
     let
         decodeValue decoder toDelivery =
-            Json.Decode.decodeString decoder >> toDelivery
+            Json.Decode.decodeValue decoder >> toDelivery
     in
     value
         |> (if key == tokenKey then

--- a/web/elm/tests/ApplicationTests.elm
+++ b/web/elm/tests/ApplicationTests.elm
@@ -29,6 +29,11 @@ all =
                 Common.init "/teams/t/pipelines/p/"
                     |> Application.subscriptions
                     |> Common.contains Subscription.OnLocalStorageReceived
+        , test "subscribes to browser cache" <|
+            \_ ->
+                Common.init "/teams/t/pipelines/p/"
+                    |> Application.subscriptions
+                    |> Common.contains Subscription.OnCacheReceived
         , test "loads favorited pipelines/instance groups on init" <|
             \_ ->
                 Application.init

--- a/web/elm/tests/DashboardCacheTests.elm
+++ b/web/elm/tests/DashboardCacheTests.elm
@@ -174,20 +174,6 @@ all =
                         )
                     |> Tuple.second
                     |> Common.notContains (SaveCachedJobs [ Data.job 0 ])
-        , test "bounds the number of cached jobs to 1000" <|
-            \_ ->
-                let
-                    firstNJobs n =
-                        List.range 0 (n - 1) |> List.map Data.job
-                in
-                whenOnDashboard { highDensity = False }
-                    |> Application.handleCallback
-                        (AllJobsFetched <|
-                            Ok <|
-                                firstNJobs 2000
-                        )
-                    |> Tuple.second
-                    |> Common.contains (SaveCachedJobs <| firstNJobs 1000)
         , test "saves pipelines to cache when fetched" <|
             \_ ->
                 whenOnDashboard { highDensity = False }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

when I first implemented #5262, I wasn't aware of the browser cache API:
https://developer.mozilla.org/en-US/docs/Web/API/Cache

instead, I used localStorage, which isn't ideal since it has a pretty
small size capacity, forcing us to artificially bound the amount of data
that gets stored (#5363). this results in us displaying only a subset of
the data, which is unfortunate.

at the time, I also experimented with indexeddb which has a larger
capacity than localStorage, but decided against it since it was
noticably slower.

the browser cache API seems to be really fast, and has even more
generous storage limits than indexeddb. it also has fairly good browser
support - the only browser that doesn't support it is IE. given that
this isn't an application critical enhancement, I think it's probably
fine to not support this in IE.

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

* The cached API responses on the dashboard no longer need to get truncated, which was previously introduced to work around `localStorage` limits