### PR TITLE
Fix browser back button after selecting a group

### DIFF
--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -1,9 +1,10 @@
 module Message.Message exposing
-    ( DomID(..)
+    ( CommentBarButtonKind(..)
+    , DomID(..)
     , DropTarget(..)
     , Message(..)
     , PipelinesSection(..)
-    , VersionId,CommentBarButtonKind(..)
+    , VersionId
     , VersionToggleAction(..)
     , VisibilityAction(..)
     )
@@ -23,7 +24,6 @@ type Message
     | BlurMsg
       -- Pipeline
     | ToggleGroup Concourse.PipelineGroup
-    | SetGroups (List String)
       -- Dashboard
     | DragStart Dashboard.Group.Models.Card
     | DragOver DropTarget

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -50,7 +50,7 @@ import Pipeline.Styles as Styles
 import RemoteData exposing (WebData)
 import Routes
 import SideBar.SideBar as SideBar
-import StrictEvents exposing (onLeftClickOrShiftLeftClick)
+import StrictEvents exposing (onShiftLeftClick)
 import Svg
 import Svg.Attributes as SvgAttributes
 import Tooltip
@@ -332,9 +332,6 @@ update msg ( model, effects ) =
                             model
                    ]
             )
-
-        SetGroups groups ->
-            ( model, effects ++ [ NavigateTo <| getNextUrl groups model ] )
 
         Click (TopBarPauseToggle pipelineIdentifier) ->
             let
@@ -655,9 +652,7 @@ viewGroup { selectedGroups, pipelineLocator, hovered } idx grp =
     in
     Html.a
         ([ Html.Attributes.href <| url
-         , onLeftClickOrShiftLeftClick
-            (SetGroups [ grp.name ])
-            (ToggleGroup grp)
+         , onShiftLeftClick (ToggleGroup grp)
          , onMouseEnter <| Hover <| Just <| JobGroup idx
          , onMouseLeave <| Hover Nothing
          ]

--- a/web/elm/src/StrictEvents.elm
+++ b/web/elm/src/StrictEvents.elm
@@ -10,6 +10,7 @@ module StrictEvents exposing
     , onLeftMouseDownCapturing
     , onMouseEnterStopPropagation
     , onScroll
+    , onShiftLeftClick
     , onWheel
     )
 
@@ -75,6 +76,24 @@ onLeftClickCapturing preventDefault stopPropagation captured msg =
                                         }
                                     )
                                     captured
+                            )
+                )
+        )
+
+
+onShiftLeftClick : msg -> Html.Attribute msg
+onShiftLeftClick msg =
+    Html.Events.custom "click"
+        (assertLeftButton
+            |> Json.Decode.andThen
+                (\_ ->
+                    assert "shiftKey"
+                        |> Json.Decode.map
+                            (\_ ->
+                                { message = msg
+                                , stopPropagation = False
+                                , preventDefault = True
+                                }
                             )
                 )
         )
@@ -186,6 +205,17 @@ assertNoModifier =
                                     )
                         )
             )
+
+
+assert : String -> Json.Decode.Decoder ()
+assert prop =
+    customDecoder (Json.Decode.field prop Json.Decode.bool) <|
+        \val ->
+            if val then
+                Ok ()
+
+            else
+                Err (prop ++ " not used - skipping")
 
 
 assertNo : String -> Json.Decode.Decoder ()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #7248

prior to this fix, we ended up emitting a NavigateTo effect in addition
to the href that's applied on the element, so we effectively pushed
history twice.

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

* Previously, if a pipeline group was selected in the UI, the back button would not work (you'd have to press it twice to go back)