### PR TITLE
Don't include check containers in worker cache

### DIFF
--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -544,7 +544,7 @@ func (builder Builder) WithCheckContainer(resourceName string, workerName string
 		}
 
 		if !found {
-			return fmt.Errorf("resource config '%d' not found", rc.ID())
+			return fmt.Errorf("resource config '%d' not found", resource.ResourceConfigID())
 		}
 
 		owner := db.NewResourceConfigCheckSessionContainerOwner(

--- a/atc/db/migration/migrations/1625844436_add_worker_cache_triggers.up.sql
+++ b/atc/db/migration/migrations/1625844436_add_worker_cache_triggers.up.sql
@@ -39,4 +39,4 @@ CREATE TRIGGER workers_upsert_or_delete_trigger AFTER INSERT OR UPDATE OR DELETE
   FOR EACH ROW EXECUTE PROCEDURE notify_trigger(worker_events_channel, name);
 
 CREATE TRIGGER containers_insert_or_delete_trigger AFTER INSERT OR DELETE ON containers
-  FOR EACH ROW EXECUTE PROCEDURE notify_trigger(container_events_channel, id, worker_name);
+  FOR EACH ROW EXECUTE PROCEDURE notify_trigger(container_events_channel, id, worker_name, build_id);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

small bug I introduced in #7268 - when we refresh the container counts
per worker, we exclude non-build containers. however, the trigger
increments/decrements the count for *all* containers, which will lead to
a drift