### PR TITLE
containerd: Clean up networking files in /tmp

### DIFF
--- a/worker/integration/integration_test.go
+++ b/worker/integration/integration_test.go
@@ -45,6 +45,8 @@ func (s *WorkerRunnerSuite) BeforeTest(suiteName, testName string) {
 func (s *WorkerRunnerSuite) TestWorkDirIsCreated() {
 	s.wrkcmd.WorkDir = "somedir"
 	s.wrkcmd.Runtime = "containerd"
+	s.wrkcmd.Containerd.CNIPluginsDir = "somedir"
+	s.wrkcmd.Containerd.InitBin = "somedir"
 
 	_, err := s.wrkcmd.Runner([]string{})
 	s.NoError(err)

--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -287,7 +287,7 @@ func (b *GardenBackend) Destroy(handle string) error {
 		return fmt.Errorf("gracefully killing task: %w", err)
 	}
 
-	err = b.network.Remove(ctx, task)
+	err = b.network.Remove(ctx, task, handle)
 	if err != nil {
 		return fmt.Errorf("network remove: %w", err)
 	}

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -43,11 +43,6 @@ const (
 	//
 	networkMountsDir = "networkmounts"
 
-	// binariesDir corresponds to the directory where CNI plugins have their
-	// binaries in.
-	//
-	binariesDir = "/usr/local/concourse/bin"
-
 	ipTablesAdminChainName = "CONCOURSE-OPERATOR"
 )
 
@@ -184,6 +179,19 @@ func WithIptables(ipt iptables.Iptables) CNINetworkOpt {
 	}
 }
 
+// WithDefaultsForTesting testing damage
+//
+func WithDefaultsForTesting() CNINetworkOpt {
+	return func(n *cniNetwork) {
+		if n.binariesDir == "" {
+			n.binariesDir = "/usr/local/concourse/bin"
+		}
+		if n.store == nil {
+			n.store = NewFileStore("/tmp")
+		}
+	}
+}
+
 type cniNetwork struct {
 	client             cni.CNI
 	store              FileStore
@@ -209,11 +217,11 @@ func NewCNINetwork(opts ...CNINetworkOpt) (*cniNetwork, error) {
 	}
 
 	if n.binariesDir == "" {
-		n.binariesDir = binariesDir
+		return nil, fmt.Errorf("missing binaries dir")
 	}
 
 	if n.store == nil {
-		n.store = NewFileStore(fileStoreWorkDir)
+		return nil, fmt.Errorf("no file store initialized")
 	}
 
 	if n.client == nil {

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -36,6 +36,7 @@ func (s *CNINetworkSuite) SetupTest() {
 	s.iptables = new(iptablesfakes.FakeIptables)
 
 	s.network, err = runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
 		runtime.WithCNIFileStore(s.store),
 		runtime.WithCNIClient(s.cni),
 		runtime.WithIptables(s.iptables),
@@ -48,6 +49,7 @@ func (s *CNINetworkSuite) TestNewCNINetworkWithInvalidConfigDoesntFail() {
 	// the plugins.
 	//
 	_, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
 		runtime.WithCNINetworkConfig(runtime.CNINetworkConfig{
 			Subnet: "_____________",
 		}),
@@ -130,6 +132,7 @@ func (s *CNINetworkSuite) TestSetupMountsReturnsMountpoints() {
 
 func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithNameServers() {
 	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
 		runtime.WithCNIFileStore(s.store),
 		runtime.WithNameServers([]string{"6.6.7.7", "1.2.3.4"}),
 		runtime.WithIptables(s.iptables),
@@ -145,6 +148,7 @@ func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithNameServers() {
 
 func (s *CNINetworkSuite) TestSetupMountsCallsStoreWithoutNameServers() {
 	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
 		runtime.WithCNIFileStore(s.store),
 		runtime.WithIptables(s.iptables),
 	)
@@ -172,6 +176,7 @@ func (s *CNINetworkSuite) TestSetupHostNetwork() {
 		"flushes the CONCOURSE-OPERATOR chain": {
 			cniNetworkSetup: func() (runtime.Network, error) {
 				return runtime.NewCNINetwork(
+					runtime.WithDefaultsForTesting(),
 					runtime.WithIptables(s.iptables),
 				)
 			},
@@ -181,6 +186,7 @@ func (s *CNINetworkSuite) TestSetupHostNetwork() {
 		"adds rule to CONCOURSE-OPERATOR chain for accepting established connections": {
 			cniNetworkSetup: func() (runtime.Network, error) {
 				return runtime.NewCNINetwork(
+					runtime.WithDefaultsForTesting(),
 					runtime.WithIptables(s.iptables),
 				)
 			},
@@ -191,6 +197,7 @@ func (s *CNINetworkSuite) TestSetupHostNetwork() {
 		"adds rule to CONCOURSE-OPERATOR chain to reject IP 1.1.1.1": {
 			cniNetworkSetup: func() (runtime.Network, error) {
 				return runtime.NewCNINetwork(
+					runtime.WithDefaultsForTesting(),
 					runtime.WithRestrictedNetworks([]string{"1.1.1.1", "8.8.8.8"}),
 					runtime.WithIptables(s.iptables),
 				)
@@ -202,6 +209,7 @@ func (s *CNINetworkSuite) TestSetupHostNetwork() {
 		"adds rule to CONCOURSE-OPERATOR chain to reject IP 8.8.8.8": {
 			cniNetworkSetup: func() (runtime.Network, error) {
 				return runtime.NewCNINetwork(
+					runtime.WithDefaultsForTesting(),
 					runtime.WithRestrictedNetworks([]string{"1.1.1.1", "8.8.8.8"}),
 					runtime.WithIptables(s.iptables),
 				)
@@ -213,6 +221,7 @@ func (s *CNINetworkSuite) TestSetupHostNetwork() {
 		"flushes the INPUT chain": {
 			cniNetworkSetup: func() (runtime.Network, error) {
 				return runtime.NewCNINetwork(
+					runtime.WithDefaultsForTesting(),
 					runtime.WithIptables(s.iptables),
 				)
 			},
@@ -222,6 +231,7 @@ func (s *CNINetworkSuite) TestSetupHostNetwork() {
 		"adds rule to INPUT chain to block host access by default": {
 			cniNetworkSetup: func() (runtime.Network, error) {
 				return runtime.NewCNINetwork(
+					runtime.WithDefaultsForTesting(),
 					runtime.WithIptables(s.iptables),
 				)
 			},

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -111,12 +111,19 @@ func (s *IntegrationSuite) BeforeTest(suiteName, testName string) {
 		requestTimeout = 3 * time.Second
 	)
 
+	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
+	)
+
+	s.NoError(err)
+
 	s.gardenBackend, err = runtime.NewGardenBackend(
 		libcontainerd.New(
 			s.containerdSocket(),
 			namespace,
 			requestTimeout,
 		),
+		runtime.WithNetwork(network),
 	)
 	s.NoError(err)
 	s.NoError(s.gardenBackend.Start())
@@ -245,6 +252,7 @@ func (s *IntegrationSuite) TestContainerNetworkEgressWithRestrictedNetworks() {
 	requestTimeout := 3 * time.Second
 
 	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
 		runtime.WithRestrictedNetworks([]string{"1.1.1.1"}),
 	)
 
@@ -373,7 +381,10 @@ func (s *IntegrationSuite) TestContainerAllowsHostAccess() {
 	namespace := "test-allow-host-access"
 	requestTimeout := 3 * time.Second
 
-	network, err := runtime.NewCNINetwork(runtime.WithAllowHostAccess())
+	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
+		runtime.WithAllowHostAccess(),
+	)
 
 	s.NoError(err)
 
@@ -715,6 +726,7 @@ func (s *IntegrationSuite) TestCustomDNS() {
 	requestTimeout := 3 * time.Second
 
 	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
 		runtime.WithNameServers([]string{
 			"1.1.1.1", "1.2.3.4",
 		}),
@@ -895,6 +907,7 @@ func (s *IntegrationSuite) TestNetworkMountsAreRemoved() {
 
 	networkMountsDir := s.T().TempDir()
 	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
 		runtime.WithCNIFileStore(runtime.FileStoreWithWorkDir(networkMountsDir)),
 	)
 

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -837,6 +837,11 @@ func (s *IntegrationSuite) TestMaxContainers() {
 
 	limit := runtime.WithMaxContainers(1)
 
+	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
+	)
+	s.NoError(err)
+
 	customBackend, err := runtime.NewGardenBackend(
 		libcontainerd.New(
 			s.containerdSocket(),
@@ -844,6 +849,7 @@ func (s *IntegrationSuite) TestMaxContainers() {
 			requestTimeout,
 		),
 		limit,
+		runtime.WithNetwork(network),
 	)
 	s.NoError(err)
 
@@ -878,12 +884,18 @@ func (s *IntegrationSuite) TestRequestTimeoutZero() {
 	namespace := "test-requesTimeout-zero"
 	requestTimeout := time.Duration(0)
 
+	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
+	)
+	s.NoError(err)
+
 	customBackend, err := runtime.NewGardenBackend(
 		libcontainerd.New(
 			s.containerdSocket(),
 			namespace,
 			requestTimeout,
 		),
+		runtime.WithNetwork(network),
 	)
 	s.NoError(err)
 
@@ -910,17 +922,15 @@ func (s *IntegrationSuite) TestNetworkMountsAreRemoved() {
 		runtime.WithDefaultsForTesting(),
 		runtime.WithCNIFileStore(runtime.FileStoreWithWorkDir(networkMountsDir)),
 	)
-
 	s.NoError(err)
 
-	networkOpt := runtime.WithNetwork(network)
 	customBackend, err := runtime.NewGardenBackend(
 		libcontainerd.New(
 			s.containerdSocket(),
 			namespace,
 			requestTimeout,
 		),
-		networkOpt,
+		runtime.WithNetwork(network),
 	)
 	s.NoError(err)
 

--- a/worker/runtime/network.go
+++ b/worker/runtime/network.go
@@ -25,5 +25,5 @@ type Network interface {
 
 	// Removes a task from the network.
 	//
-	Remove(ctx context.Context, task containerd.Task) (err error)
+	Remove(ctx context.Context, task containerd.Task, handle string) (err error)
 }

--- a/worker/runtime/runtimefakes/fake_network.go
+++ b/worker/runtime/runtimefakes/fake_network.go
@@ -24,11 +24,12 @@ type FakeNetwork struct {
 	addReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RemoveStub        func(context.Context, containerd.Task) error
+	RemoveStub        func(context.Context, containerd.Task, string) error
 	removeMutex       sync.RWMutex
 	removeArgsForCall []struct {
 		arg1 context.Context
 		arg2 containerd.Task
+		arg3 string
 	}
 	removeReturns struct {
 		result1 error
@@ -126,19 +127,20 @@ func (fake *FakeNetwork) AddReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeNetwork) Remove(arg1 context.Context, arg2 containerd.Task) error {
+func (fake *FakeNetwork) Remove(arg1 context.Context, arg2 containerd.Task, arg3 string) error {
 	fake.removeMutex.Lock()
 	ret, specificReturn := fake.removeReturnsOnCall[len(fake.removeArgsForCall)]
 	fake.removeArgsForCall = append(fake.removeArgsForCall, struct {
 		arg1 context.Context
 		arg2 containerd.Task
-	}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.RemoveStub
 	fakeReturns := fake.removeReturns
-	fake.recordInvocation("Remove", []interface{}{arg1, arg2})
+	fake.recordInvocation("Remove", []interface{}{arg1, arg2, arg3})
 	fake.removeMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -152,17 +154,17 @@ func (fake *FakeNetwork) RemoveCallCount() int {
 	return len(fake.removeArgsForCall)
 }
 
-func (fake *FakeNetwork) RemoveCalls(stub func(context.Context, containerd.Task) error) {
+func (fake *FakeNetwork) RemoveCalls(stub func(context.Context, containerd.Task, string) error) {
 	fake.removeMutex.Lock()
 	defer fake.removeMutex.Unlock()
 	fake.RemoveStub = stub
 }
 
-func (fake *FakeNetwork) RemoveArgsForCall(i int) (context.Context, containerd.Task) {
+func (fake *FakeNetwork) RemoveArgsForCall(i int) (context.Context, containerd.Task, string) {
 	fake.removeMutex.RLock()
 	defer fake.removeMutex.RUnlock()
 	argsForCall := fake.removeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeNetwork) RemoveReturns(result1 error) {

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -95,6 +95,14 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 		return nil, fmt.Errorf("new cni network: %w", err)
 	}
 
+	if cmd.Containerd.InitBin == "" {
+		initBin := concourseCmd.DiscoverAsset("bin/init")
+		if initBin == "" {
+			return nil, fmt.Errorf("could not find init binary. Try setting the --containerd-init-bin flag")
+		}
+		cmd.Containerd.InitBin = initBin
+	}
+
 	backendOpts = append(backendOpts,
 		runtime.WithNetwork(cniNetwork),
 		runtime.WithRequestTimeout(cmd.Containerd.RequestTimeout),

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -60,7 +60,43 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 ) (ifrit.Runner, error) {
 	const graceTime = 0
 
-	backendOpts := []runtime.GardenBackendOpt{}
+	cniNetwork, err := cmd.buildUpNetworkOpts(logger, dnsServers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CNI network opts: %w", err)
+	}
+
+	backendOpts, err := cmd.buildUpBackendOpts(logger, cniNetwork)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create contianerd backend opts: %w", err)
+	}
+
+	gardenBackend, err := runtime.NewGardenBackend(
+		libcontainerd.New(containerdAddr, containerdNamespace, cmd.Containerd.RequestTimeout),
+		backendOpts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("containerd containerd init: %w", err)
+	}
+
+	return newGardenServerRunner(
+		"tcp",
+		cmd.bindAddr(),
+		graceTime,
+		&gardenBackend,
+		logger,
+	), nil
+}
+
+func (cmd *WorkerCommand) buildUpNetworkOpts(logger lager.Logger, dnsServers []string) (runtime.Network, error) {
+	logger.Debug("create-cni-network-opts")
+	if cmd.Containerd.CNIPluginsDir == "" {
+		pluginsDir := concourseCmd.DiscoverAsset("bin")
+		if pluginsDir == "" {
+			return nil, fmt.Errorf("could not find CNI Plugins dir. Try setting the --containerd-cni-plugins-dir flag")
+		}
+		cmd.Containerd.CNIPluginsDir = pluginsDir
+	}
+
 	networkOpts := []runtime.CNINetworkOpt{
 		runtime.WithCNIBinariesDir(cmd.Containerd.CNIPluginsDir),
 		runtime.WithCNIFileStore(runtime.FileStoreWithWorkDir(cmd.WorkDir.Path())),
@@ -90,10 +126,11 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 	}
 	networkOpts = append(networkOpts, runtime.WithCNINetworkConfig(networkConfig))
 
-	cniNetwork, err := runtime.NewCNINetwork(networkOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("new cni network: %w", err)
-	}
+	return runtime.NewCNINetwork(networkOpts...)
+}
+
+func (cmd *WorkerCommand) buildUpBackendOpts(logger lager.Logger, cniNetwork runtime.Network) ([]runtime.GardenBackendOpt, error) {
+	logger.Debug("create-containerd-backendOpts")
 
 	if cmd.Containerd.InitBin == "" {
 		initBin := concourseCmd.DiscoverAsset("bin/init")
@@ -103,28 +140,12 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 		cmd.Containerd.InitBin = initBin
 	}
 
-	backendOpts = append(backendOpts,
+	return []runtime.GardenBackendOpt{
 		runtime.WithNetwork(cniNetwork),
 		runtime.WithRequestTimeout(cmd.Containerd.RequestTimeout),
 		runtime.WithMaxContainers(cmd.Containerd.MaxContainers),
 		runtime.WithInitBinPath(cmd.Containerd.InitBin),
-	)
-
-	gardenBackend, err := runtime.NewGardenBackend(
-		libcontainerd.New(containerdAddr, containerdNamespace, cmd.Containerd.RequestTimeout),
-		backendOpts...,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("containerd containerd init: %w", err)
-	}
-
-	return newGardenServerRunner(
-		"tcp",
-		cmd.bindAddr(),
-		graceTime,
-		&gardenBackend,
-		logger,
-	), nil
+	}, nil
 }
 
 // containerdRunner spawns a containerd and a Garden server process for use as the container

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -61,7 +61,10 @@ func (cmd *WorkerCommand) containerdGardenServerRunner(
 	const graceTime = 0
 
 	backendOpts := []runtime.GardenBackendOpt{}
-	networkOpts := []runtime.CNINetworkOpt{runtime.WithCNIBinariesDir(cmd.Containerd.CNIPluginsDir)}
+	networkOpts := []runtime.CNINetworkOpt{
+		runtime.WithCNIBinariesDir(cmd.Containerd.CNIPluginsDir),
+		runtime.WithCNIFileStore(runtime.FileStoreWithWorkDir(cmd.WorkDir.Path())),
+	}
 
 	if len(dnsServers) > 0 {
 		networkOpts = append(networkOpts, runtime.WithNameServers(dnsServers))

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -40,7 +40,7 @@ type GuardianRuntime struct {
 type ContainerdRuntime struct {
 	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Containerd daemon."`
 	Bin            string        `long:"bin"        description:"Path to a containerd executable (non-absolute names get resolved from $PATH)."`
-	InitBin        string        `long:"init-bin"   default:"/usr/local/concourse/bin/init" description:"Path to an init executable (non-absolute names get resolved from $PATH)."`
+	InitBin        string        `long:"init-bin"   description:"Path to an init executable (non-absolute names get resolved from $PATH)."`
 	CNIPluginsDir  string        `long:"cni-plugins-dir" default:"/usr/local/concourse/bin" description:"Path to CNI network plugins."`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
 
@@ -133,7 +133,7 @@ func trySetConcourseDirInPATH() {
 
 	err := os.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 	if err != nil {
-		// programming mistake
+		// syscall error
 		panic(fmt.Errorf("failed to set PATH environment variable: %w", err))
 	}
 }

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -40,7 +40,7 @@ type GuardianRuntime struct {
 type ContainerdRuntime struct {
 	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Containerd daemon."`
 	Bin            string        `long:"bin"        description:"Path to a containerd executable (non-absolute names get resolved from $PATH)."`
-	InitBin        string        `long:"init-bin"   description:"Path to an init executable (non-absolute names get resolved from $PATH)."`
+	InitBin        string        `long:"init-bin"   description:"Path to an init executable".`
 	CNIPluginsDir  string        `long:"cni-plugins-dir" default:"/usr/local/concourse/bin" description:"Path to CNI network plugins."`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
 

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -40,8 +40,8 @@ type GuardianRuntime struct {
 type ContainerdRuntime struct {
 	Config         flag.File     `long:"config"     description:"Path to a config file to use for the Containerd daemon."`
 	Bin            string        `long:"bin"        description:"Path to a containerd executable (non-absolute names get resolved from $PATH)."`
-	InitBin        string        `long:"init-bin"   description:"Path to an init executable".`
-	CNIPluginsDir  string        `long:"cni-plugins-dir" default:"/usr/local/concourse/bin" description:"Path to CNI network plugins."`
+	InitBin        string        `long:"init-bin"   description:"Path to an init executable. By default will search within the concourse/bin directory the concourse binary is in."`
+	CNIPluginsDir  string        `long:"cni-plugins-dir" description:"Path to CNI network plugins. By default will set to the concourse/bin directory the concourse binary is in."`
 	RequestTimeout time.Duration `long:"request-timeout" default:"5m" description:"How long to wait for requests to Containerd to complete. 0 means no timeout."`
 
 	Network struct {


### PR DESCRIPTION
## Changes proposed by this PR

closes #7267

cc @chenbh 

This PR has two changes:

1. Create network files in the worker's work dir AND clean up those files when deleting the container
1. Behind-the-scenes change for how some containerd flag defaults are made.

## Notes to reviewer

In regards to the flag changes, from a users perspective this should be a
no-op. Someone upgrading and using containerd should not have to change
anything in their installation

## Release Note

* Fixed a bug where the containerd runtime would create networking related files under `/tmp` and never delete them. They are now made under the `--work-dir` set for the worker and are cleaned up when the container is deleted. You can delete any lingering network files under your workers `/tmp` directory after upgrading.