### PR TITLE
[containerd integration] Make host IP parsing more robust

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d
+	github.com/jackpal/gateway v1.0.7
 	github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7
 	github.com/klauspost/compress v1.13.1
 	github.com/kr/pty v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -625,6 +625,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d h1:/WZQPMZNsjZ7IlCpsLGdQBINg5bxKQ1K1sh6awxLtkA=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+github.com/jackpal/gateway v1.0.7 h1:7tIFeCGmpyrMx9qvT0EgYUi7cxVW48a0mMvnIL17bPM=
+github.com/jackpal/gateway v1.0.7/go.mod h1:aRcO0UFKt+MgIZmRmvOmnejdDT4Y1DNiNOsSd1AcIbA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7 h1:Ug59miTxVKVg5Oi2S5uHlKOIV5jBx4Hb2u0jIxxDaSs=
 github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/concourse/concourse/worker/runtime/libcontainerd"
 	"github.com/concourse/concourse/worker/workercmd"
 	"github.com/containerd/containerd"
+	"github.com/jackpal/gateway"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -324,13 +325,13 @@ func (s *IntegrationSuite) TestContainerBlocksHostAccess() {
 		s.gardenBackend.Stop()
 	}()
 
-	hostIp, err := getHostIp()
+	hostIp, err := gateway.DiscoverInterface()
 	s.NoError(err)
 
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello, client")
 	}))
-	l, err := net.Listen("tcp", hostIp+":0")
+	l, err := net.Listen("tcp", hostIp.String()+":0")
 	ts.Listener = l
 	ts.Start()
 	defer ts.Close()
@@ -415,13 +416,13 @@ func (s *IntegrationSuite) TestContainerAllowsHostAccess() {
 		customBackend.Stop()
 	}()
 
-	hostIp, err := getHostIp()
+	hostIp, err := gateway.DiscoverInterface()
 	s.NoError(err)
 
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello, client")
 	}))
-	l, err := net.Listen("tcp", hostIp+":0")
+	l, err := net.Listen("tcp", hostIp.String()+":0")
 	ts.Listener = l
 	ts.Start()
 	defer ts.Close()

--- a/worker/runtime/integration/suite_test.go
+++ b/worker/runtime/integration/suite_test.go
@@ -1,11 +1,8 @@
 package integration_test
 
 import (
-	"errors"
 	"io/ioutil"
-	"net"
 	"os/user"
-	"regexp"
 	"sync"
 	"testing"
 
@@ -58,29 +55,4 @@ func TestSuite(t *testing.T) {
 		Assertions: req,
 		tmpDir:     tmpDir,
 	})
-}
-
-func getHostIp() (string, error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return "", err
-	}
-	ethInterface := regexp.MustCompile("eth0")
-
-	for _, i := range ifaces {
-		if ethInterface.MatchString(i.Name) {
-			addrs, err := i.Addrs()
-			if err != nil {
-				return "", err
-			}
-			for _, address := range addrs {
-				if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-					if ipnet.IP.To4() != nil {
-						return ipnet.IP.String(), nil
-					}
-				}
-			}
-		}
-	}
-	return "", errors.New("unable to find host's IP")
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

when we redeployed our PR workers with Guardian, we found that the
bridge interface was not named eth0 in the container, so we were unable
to locate the host IP.

this delegates the responsibility of locating the host IP to a package
that reads from the route table, so we'll use the interface
corresponding with the default gateway, regardless of what it's called

* [x] More robust extraction of host IP