### PR TITLE
Run dependabot at midnight UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,25 +3,35 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: /
-  schedule: {interval: daily}
+  schedule:
+    interval: daily
+    time: "00:00"
   labels: ["go", "dependencies", "misc", "release/undocumented"]
 
 - package-ecosystem: elm
   directory: /web/elm
-  schedule: {interval: daily}
+  schedule:
+    interval: daily
+    time: "00:00"
   labels: ["elm", "dependencies", "misc", "release/undocumented"]
 
 - package-ecosystem: npm
   directory: /
-  schedule: {interval: daily}
+  schedule:
+    interval: daily
+    time: "00:00"
   labels: ["javascript", "dependencies", "misc", "release/undocumented"]
 
 - package-ecosystem: npm
   directory: /web/wats
-  schedule: {interval: daily}
+  schedule:
+    interval: daily
+    time: "00:00"
   labels: ["javascript", "dependencies", "misc", "release/undocumented"]
 
 - package-ecosystem: github-actions
   directory: /
-  schedule: {interval: daily}
+  schedule:
+    interval: daily
+    time: "00:00"
   labels: ["github-actions", "dependencies", "misc", "release/undocumented"]


### PR DESCRIPTION
According to [the default behaviour](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#scheduletime), it should run at 5:00am UTC (which is 1:00am EDT), but for some reason it always creates the PR around 9:00am EDT.

Hopefully the bot will create PRs earlier and allow time for the tests to run before standup