### PR TITLE
Add force_refresh to get step.

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -122,13 +122,14 @@ func (visitor *planVisitor) VisitGet(step *atc.GetStep) error {
 	visitor.plan = visitor.planFactory.NewPlan(atc.GetPlan{
 		Name: step.Name,
 
-		Type:     resource.Type,
-		Resource: resourceName,
-		Source:   resource.Source,
-		Params:   step.Params,
-		Version:  &version,
-		Tags:     step.Tags,
-		Timeout:  step.Timeout,
+		Type:         resource.Type,
+		Resource:     resourceName,
+		Source:       resource.Source,
+		Params:       step.Params,
+		Version:      &version,
+		Tags:         step.Tags,
+		Timeout:      step.Timeout,
+		ForceRefresh: step.ForceRefresh,
 
 		VersionedResourceTypes: visitor.resourceTypes,
 	})

--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -80,12 +80,13 @@ var factoryTests = []PlannerTest{
 	{
 		Title: "get step",
 		Config: &atc.GetStep{
-			Name:     "some-name",
-			Resource: "some-resource",
-			Params:   atc.Params{"some": "params"},
-			Version:  &atc.VersionConfig{Pinned: atc.Version{"doesnt": "matter"}},
-			Tags:     atc.Tags{"tag-1", "tag-2"},
-			Timeout:  "1h",
+			Name:         "some-name",
+			Resource:     "some-resource",
+			Params:       atc.Params{"some": "params"},
+			Version:      &atc.VersionConfig{Pinned: atc.Version{"doesnt": "matter"}},
+			Tags:         atc.Tags{"tag-1", "tag-2"},
+			Timeout:      "1h",
+			ForceRefresh: true,
 		},
 		Inputs: []db.BuildInput{
 			{
@@ -104,6 +105,7 @@ var factoryTests = []PlannerTest{
 				"version": {"some":"version"},
 				"tags": ["tag-1", "tag-2"],
 				"timeout": "1h",
+				"force_refresh": true,
 				"resource_types": [
 					{
 						"name": "some-resource-type",
@@ -119,11 +121,12 @@ var factoryTests = []PlannerTest{
 	{
 		Title: "get step with base resource type",
 		Config: &atc.GetStep{
-			Name:     "some-name",
-			Resource: "some-base-resource",
-			Params:   atc.Params{"some": "params"},
-			Version:  &atc.VersionConfig{Pinned: atc.Version{"doesnt": "matter"}},
-			Tags:     atc.Tags{"tag-1", "tag-2"},
+			Name:         "some-name",
+			Resource:     "some-base-resource",
+			Params:       atc.Params{"some": "params"},
+			Version:      &atc.VersionConfig{Pinned: atc.Version{"doesnt": "matter"}},
+			Tags:         atc.Tags{"tag-1", "tag-2"},
+			ForceRefresh: true,
 		},
 		Inputs: []db.BuildInput{
 			{
@@ -141,6 +144,7 @@ var factoryTests = []PlannerTest{
 				"params": {"some":"params"},
 				"version": {"some":"version"},
 				"tags": ["tag-1", "tag-2"],
+				"force_refresh": true,
 				"resource_types": [
 					{
 						"name": "some-resource-type",

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -199,7 +199,7 @@ func (step *GetStep) run(ctx context.Context, state RunState, delegate GetDelega
 	// Only get from local cache if caching streamed volumes is enabled -
 	// otherwise, we'd need to stream volumes between workers much more
 	// frequently.
-	if atc.EnableCacheStreamedVolumes {
+	if atc.EnableCacheStreamedVolumes && !step.plan.ForceRefresh {
 		getResult, found, err := step.getFromLocalCache(logger, step.metadata.TeamID, resourceCache, workerSpec)
 		if err != nil {
 			return false, err

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -351,6 +351,17 @@ var _ = Describe("GetStep", func() {
 						// Do nothing here, JustBeforeEach() will check shouldRunGetStep
 					})
 				})
+
+				Context("when force refresh is enabled", func() {
+					BeforeEach(func() {
+						getPlan.ForceRefresh = true
+						shouldRunGetStep = true
+					})
+
+					It("should run normal get step", func() {
+						// Do nothing here, JustBeforeEach() will check shouldRunGetStep
+					})
+				})
 			})
 		})
 	})

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -194,6 +194,9 @@ type GetPlan struct {
 	// A timeout to enforce on the resource `get` process. Note that fetching the
 	// resource's image does not count towards the timeout.
 	Timeout string `json:"timeout,omitempty"`
+
+	// Don't use resource cache if set to true.
+	ForceRefresh bool `json:"force_refresh,omitempty"`
 }
 
 type PutPlan struct {

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -293,14 +293,15 @@ var StepPrecedence = []StepDetector{
 }
 
 type GetStep struct {
-	Name     string         `json:"get"`
-	Resource string         `json:"resource,omitempty"`
-	Version  *VersionConfig `json:"version,omitempty"`
-	Params   Params         `json:"params,omitempty"`
-	Passed   []string       `json:"passed,omitempty"`
-	Trigger  bool           `json:"trigger,omitempty"`
-	Tags     Tags           `json:"tags,omitempty"`
-	Timeout  string         `json:"timeout,omitempty"`
+	Name         string         `json:"get"`
+	Resource     string         `json:"resource,omitempty"`
+	Version      *VersionConfig `json:"version,omitempty"`
+	Params       Params         `json:"params,omitempty"`
+	Passed       []string       `json:"passed,omitempty"`
+	Trigger      bool           `json:"trigger,omitempty"`
+	Tags         Tags           `json:"tags,omitempty"`
+	Timeout      string         `json:"timeout,omitempty"`
+	ForceRefresh bool           `json:"force_refresh,omitempty"`
 }
 
 func (step *GetStep) ResourceName() string {

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -35,14 +35,16 @@ var factoryTests = []StepTest{
 			version: {some: version}
 			tags: [tag-1, tag-2]
 			timeout: 1h
+			force_refresh: true
 		`,
 		StepConfig: &atc.GetStep{
-			Name:     "some-name",
-			Resource: "some-resource",
-			Params:   atc.Params{"some": "params"},
-			Version:  &atc.VersionConfig{Pinned: atc.Version{"some": "version"}},
-			Tags:     []string{"tag-1", "tag-2"},
-			Timeout:  "1h",
+			Name:         "some-name",
+			Resource:     "some-resource",
+			Params:       atc.Params{"some": "params"},
+			Version:      &atc.VersionConfig{Pinned: atc.Version{"some": "version"}},
+			Tags:         []string{"tag-1", "tag-2"},
+			Timeout:      "1h",
+			ForceRefresh: true,
 		},
 	},
 	{


### PR DESCRIPTION

## Changes proposed by this PR

This is a follow-up of https://github.com/concourse/concourse/pull/6660#issuecomment-872750759, providing a flag `force_refresh` to `get` step to disable local cache of specific resource-get.

* [x] done

## Notes to reviewer

NA

## Release Note

Usually given a version, `get` steps on a resource should always generate same artifacts. But if that's not true for some resource, e.g. a resource's `get` step utilizes BUILD environment variables, then use `force_refresh` to disable local cache for the resource:

```yaml
- get: some-resource
  force_refresh: true
```
