### PR TITLE
Propagate groups between subpages of a pipeline

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -125,6 +125,7 @@ buildView session model =
                     Routes.Build
                         { id = buildId
                         , highlight = model.highlight
+                        , groups = []
                         }
     in
     Html.div
@@ -194,6 +195,7 @@ breadcrumbs session model =
                 Routes.Job
                     { id = jobId
                     , page = Nothing
+                    , groups = []
                     }
 
         ( _, JobBuildPage buildId ) ->
@@ -201,6 +203,7 @@ breadcrumbs session model =
                 Routes.Build
                     { id = buildId
                     , highlight = model.highlight
+                    , groups = []
                     }
 
         _ ->
@@ -326,7 +329,7 @@ viewBuildHeader session model build =
                 Just jobId ->
                     let
                         jobRoute =
-                            Routes.Job { id = jobId, page = Nothing }
+                            Routes.Job { id = jobId, page = Nothing, groups = [] }
                     in
                     Html.a
                         [ href <| Routes.toString jobRoute ]

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -683,6 +683,7 @@ view session model =
                     Routes.Build
                         { id = buildId
                         , highlight = model.highlight
+                        , groups = []
                         }
     in
     Html.div
@@ -745,6 +746,7 @@ breadcrumbs session model =
                 Routes.Job
                     { id = jobId
                     , page = Nothing
+                    , groups = Routes.getGroups session.route
                     }
 
         ( _, JobBuildPage buildId ) ->
@@ -752,6 +754,7 @@ breadcrumbs session model =
                 Routes.Build
                     { id = buildId
                     , highlight = model.highlight
+                    , groups = Routes.getGroups session.route
                     }
 
         _ ->

--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -379,7 +379,7 @@ viewTitle name jobID createdBy =
                     Html.a
                         [ href <|
                             Routes.toString <|
-                                Routes.Job { id = jid, page = Nothing }
+                                Routes.Job { id = jid, page = Nothing, groups = [] }
                         , onMouseEnter <| Hover <| Just Message.JobName
                         , onMouseLeave <| Hover Nothing
                         , id <| toHtmlID Message.JobName

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -989,6 +989,7 @@ viewVersion step pipelineId name =
                                         }
                                     , page = Nothing
                                     , version = Just version
+                                    , groups = []
                                     }
                         , onMouseLeave <| Hover Nothing
                         , onMouseEnter <| Hover (Just domId)

--- a/web/elm/src/Causality/Causality.elm
+++ b/web/elm/src/Causality/Causality.elm
@@ -241,6 +241,7 @@ view session model =
                 { id = model.versionId
                 , direction = model.direction
                 , version = Maybe.map .version model.fetchedVersionedResource
+                , groups = Routes.getGroups session.route
                 }
     in
     Html.div
@@ -511,7 +512,7 @@ graphvizDotNotation model =
                                     }
 
                                 link =
-                                    Routes.Build { id = build, highlight = Routes.HighlightNothing }
+                                    Routes.Build { id = build, highlight = Routes.HighlightNothing, groups = [] }
                                         |> Routes.toString
                             in
                             row (attributes [ ( "HREF", link ), ( "BGCOLOR", buildStatusColor True b.status ) ]) ("#" ++ b.name)

--- a/web/elm/src/Dashboard/InstanceGroup.elm
+++ b/web/elm/src/Dashboard/InstanceGroup.elm
@@ -186,7 +186,7 @@ bodyView session section pipelines pipelineJobs jobs =
             let
                 pipelinePage =
                     Routes.toString <|
-                        Routes.pipelineRoute p
+                        Routes.pipelineRoute p []
 
                 curPipelineJobs =
                     Dict.get p.id pipelineJobs

--- a/web/elm/src/Dashboard/Pipeline.elm
+++ b/web/elm/src/Dashboard/Pipeline.elm
@@ -93,7 +93,7 @@ hdPipelineView { pipelineRunningKeyframes } { pipeline, resourceError, existingJ
         ([ class "card"
          , attribute "data-pipeline-name" pipeline.name
          , attribute "data-team-name" pipeline.teamName
-         , href <| Routes.toString <| Routes.pipelineRoute pipeline
+         , href <| Routes.toString <| Routes.pipelineRoute pipeline []
          ]
             ++ Styles.pipelineCardHd (pipelineStatus existingJobs pipeline)
         )
@@ -291,7 +291,7 @@ headerView section pipeline resourceError headerHeight viewingInstanceGroups inI
                 []
     in
     Html.a
-        [ href <| Routes.toString <| Routes.pipelineRoute pipeline, draggable "false" ]
+        [ href <| Routes.toString <| Routes.pipelineRoute pipeline [], draggable "false" ]
         [ Html.div
             (class "card-header" :: Styles.pipelineCardHeader headerHeight)
             (rows ++ [ resourceErrorElem ])

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -183,6 +183,7 @@ handleCallback callback ( model, effects ) =
                                             , buildName = build.name
                                             }
                                         , highlight = Routes.HighlightNothing
+                                        , groups = []
                                         }
                            ]
             )
@@ -394,6 +395,7 @@ handleJobBuildsFetched requestedPage paginatedBuilds ( model, effects ) =
                         Routes.Job
                             { id = model.jobIdentifier
                             , page = Just startingPage
+                            , groups = []
                             }
                ]
         )
@@ -419,24 +421,17 @@ documentTitle model =
 
 view : Session -> Model -> Html Message
 view session model =
-    let
-        route =
-            Routes.Job
-                { id = model.jobIdentifier
-                , page = Just model.currentPage
-                }
-    in
     Html.div
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
         [ Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
             [ SideBar.sideBarIcon session
             , TopBar.concourseLogo
-            , TopBar.breadcrumbs session route
+            , TopBar.breadcrumbs session session.route
             , Login.view session.userState model
             ]
         , Html.div
-            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
+            (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.route)
             [ SideBar.view session
                 (Just
                     { pipelineName = model.jobIdentifier.pipelineName
@@ -681,7 +676,7 @@ viewPaginationBar session model =
                     Just page ->
                         let
                             jobRoute =
-                                Routes.Job { id = model.jobIdentifier, page = Just page }
+                                Routes.Job { id = model.jobIdentifier, page = Just page, groups = [] }
                         in
                         Html.div
                             ([ onMouseEnter <| Hover <| Just PreviousPageButton
@@ -721,7 +716,7 @@ viewPaginationBar session model =
                     Just page ->
                         let
                             jobRoute =
-                                Routes.Job { id = model.jobIdentifier, page = Just page }
+                                Routes.Job { id = model.jobIdentifier, page = Just page, groups = [] }
                         in
                         Html.div
                             ([ onMouseEnter <| Hover <| Just NextPageButton

--- a/web/elm/src/Pipeline/PinMenu/PinMenu.elm
+++ b/web/elm/src/Pipeline/PinMenu/PinMenu.elm
@@ -216,6 +216,7 @@ pinMenu { hovered } model =
                                             }
                                         , page = Nothing
                                         , version = Nothing
+                                        , groups = []
                                         }
                             }
                         )

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -479,6 +479,7 @@ handleCallback callback session ( model, effects ) =
                                         { id = model.resourceIdentifier
                                         , page = Just startingPage
                                         , version = Nothing
+                                        , groups = []
                                         }
                            ]
 
@@ -730,6 +731,7 @@ update msg ( model, effects ) =
                                 { id = model.resourceIdentifier
                                 , page = Just page
                                 , version = Nothing
+                                , groups = []
                                 }
                    ]
             )
@@ -997,6 +999,7 @@ view session model =
                 { id = model.resourceIdentifier
                 , page = Nothing
                 , version = Nothing
+                , groups = Routes.getGroups session.route
                 }
     in
     Html.div
@@ -1322,6 +1325,7 @@ paginationMenu { hovered } model =
                                     { id = model.resourceIdentifier
                                     , page = Just page
                                     , version = Nothing
+                                    , groups = []
                                     }
                          , attribute "aria-label" "Previous Page"
                          , id <| toHtmlID PreviousPageButton
@@ -1361,6 +1365,7 @@ paginationMenu { hovered } model =
                                     { id = model.resourceIdentifier
                                     , page = Just page
                                     , version = Nothing
+                                    , groups = []
                                     }
                          , attribute "aria-label" "Next Page"
                          , id <| toHtmlID NextPageButton
@@ -1994,6 +1999,7 @@ viewCausalityButton enabled dir versionId =
                 { id = versionId
                 , direction = dir
                 , version = Nothing
+                , groups = []
                 }
 
         ( domID, text ) =
@@ -2140,6 +2146,7 @@ viewBuildsByJob buildDict jobName =
                                         , buildName = build.name
                                         }
                                     , highlight = Routes.HighlightNothing
+                                    , groups = []
                                     }
                         in
                         Html.li [ class <| Concourse.BuildStatus.show build.status ]

--- a/web/elm/src/Views/TopBar.elm
+++ b/web/elm/src/Views/TopBar.elm
@@ -55,37 +55,37 @@ breadcrumbs session route =
                             []
 
                         Just pipeline ->
-                            pipelineBreadcrumbs session pipeline
+                            pipelineBreadcrumbs session pipeline []
 
-                Routes.Build { id } ->
+                Routes.Build { id, groups } ->
                     case lookupPipeline (byPipelineId id) session of
                         Nothing ->
                             []
 
                         Just pipeline ->
-                            pipelineBreadcrumbs session pipeline
+                            pipelineBreadcrumbs session pipeline groups
                                 ++ [ breadcrumbSeparator
                                    , jobBreadcrumb id.jobName
                                    ]
 
-                Routes.Resource { id } ->
+                Routes.Resource { id, groups } ->
                     case lookupPipeline (byPipelineId id) session of
                         Nothing ->
                             []
 
                         Just pipeline ->
-                            pipelineBreadcrumbs session pipeline
+                            pipelineBreadcrumbs session pipeline groups
                                 ++ [ breadcrumbSeparator
                                    , resourceBreadcrumb id
                                    ]
 
-                Routes.Job { id } ->
+                Routes.Job { id, groups } ->
                     case lookupPipeline (byPipelineId id) session of
                         Nothing ->
                             []
 
                         Just pipeline ->
-                            pipelineBreadcrumbs session pipeline
+                            pipelineBreadcrumbs session pipeline groups
                                 ++ [ breadcrumbSeparator
                                    , jobBreadcrumb id.jobName
                                    ]
@@ -93,13 +93,13 @@ breadcrumbs session route =
                 Routes.Dashboard _ ->
                     [ clusterNameBreadcrumb session ]
 
-                Routes.Causality { id, direction, version } ->
+                Routes.Causality { id, direction, version, groups } ->
                     case lookupPipeline (byPipelineId id) session of
                         Nothing ->
                             []
 
                         Just pipeline ->
-                            pipelineBreadcrumbs session pipeline
+                            pipelineBreadcrumbs session pipeline groups
                                 ++ [ breadcrumbSeparator
                                    , resourceBreadcrumb <| Concourse.resourceIdFromVersionedResourceId id
                                    , breadcrumbSeparator
@@ -149,8 +149,8 @@ clusterNameBreadcrumb session _ =
         [ Html.text session.clusterName ]
 
 
-pipelineBreadcrumbs : Session -> Concourse.Pipeline -> List (Bool -> Html Message)
-pipelineBreadcrumbs session pipeline =
+pipelineBreadcrumbs : Session -> Concourse.Pipeline -> List String -> List (Bool -> Html Message)
+pipelineBreadcrumbs session pipeline groups =
     let
         pipelineGroup =
             session.pipelines
@@ -185,11 +185,11 @@ pipelineBreadcrumbs session pipeline =
      else
         []
     )
-        ++ [ pipelineBreadcrumb inInstanceGroup pipeline ]
+        ++ [ pipelineBreadcrumb inInstanceGroup pipeline groups ]
 
 
-pipelineBreadcrumb : Bool -> Concourse.Pipeline -> Bool -> Html Message
-pipelineBreadcrumb inInstanceGroup pipeline isLastBreadcrumb =
+pipelineBreadcrumb : Bool -> Concourse.Pipeline -> List String -> Bool -> Html Message
+pipelineBreadcrumb inInstanceGroup pipeline groups isLastBreadcrumb =
     let
         text =
             if inInstanceGroup then
@@ -202,7 +202,7 @@ pipelineBreadcrumb inInstanceGroup pipeline isLastBreadcrumb =
         ([ id "breadcrumb-pipeline"
          , href <|
             Routes.toString <|
-                Routes.pipelineRoute pipeline
+                Routes.pipelineRoute pipeline groups
          ]
             ++ Styles.breadcrumbItem True isLastBreadcrumb
         )

--- a/web/elm/tests/ApplicationTests.elm
+++ b/web/elm/tests/ApplicationTests.elm
@@ -3,8 +3,12 @@ module ApplicationTests exposing (all)
 import Application.Application as Application
 import Browser
 import Common exposing (queryView)
+import Concourse
+import Data
+import Dict
 import Expect
 import HoverState
+import Message.Callback as Callback
 import Message.Effects as Effects
 import Message.Message exposing (DomID(..), Message(..))
 import Message.Subscription as Subscription exposing (Delivery(..))
@@ -137,4 +141,122 @@ all =
                     |> .session
                     |> .hovered
                     |> Expect.equal HoverState.NoHover
+        , describe "pipeline groups propagation"
+            [ test "navigating through sub routes of a pipeline persists the groups" <|
+                \_ ->
+                    Common.initRoute
+                        (Routes.Pipeline
+                            { id =
+                                { teamName = "t"
+                                , pipelineName = "p"
+                                , pipelineInstanceVars = Dict.empty
+                                }
+                            , groups = [ "test-group" ]
+                            }
+                        )
+                        |> Application.handleCallback
+                            (Callback.AllPipelinesFetched <| Ok [ Data.pipeline "t" 1 |> Data.withName "p" ])
+                        |> Tuple.first
+                        |> Application.handleDelivery
+                            (RouteChanged <|
+                                Routes.Job
+                                    { id =
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , pipelineInstanceVars = Dict.empty
+                                        , jobName = "j"
+                                        }
+                                    , page = Nothing
+                                    , groups = []
+                                    }
+                            )
+                        |> Tuple.first
+                        |> Application.handleDelivery
+                            (RouteChanged <|
+                                Routes.Build
+                                    { id =
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , pipelineInstanceVars = Dict.empty
+                                        , jobName = "j"
+                                        , buildName = "b"
+                                        }
+                                    , highlight = Routes.HighlightNothing
+                                    , groups = []
+                                    }
+                            )
+                        |> Tuple.first
+                        |> Application.handleDelivery
+                            (RouteChanged <|
+                                Routes.Resource
+                                    { id =
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , pipelineInstanceVars = Dict.empty
+                                        , resourceName = "r"
+                                        }
+                                    , page = Nothing
+                                    , version = Nothing
+                                    , groups = []
+                                    }
+                            )
+                        |> Tuple.first
+                        |> Application.handleDelivery
+                            (RouteChanged <|
+                                Routes.Causality
+                                    { id =
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , pipelineInstanceVars = Dict.empty
+                                        , resourceName = "r"
+                                        , versionID = 1
+                                        }
+                                    , direction = Concourse.Downstream
+                                    , version = Nothing
+                                    , groups = []
+                                    }
+                            )
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find [ id "top-bar-app" ]
+                        |> Query.has
+                            [ Common.routeHref <|
+                                Routes.Pipeline
+                                    { id =
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , pipelineInstanceVars = Dict.empty
+                                        }
+                                    , groups = [ "test-group" ]
+                                    }
+                            ]
+            , test "navigating to no groups pipeline page does not propagate the groups" <|
+                \_ ->
+                    Common.initRoute
+                        (Routes.Pipeline
+                            { id =
+                                { teamName = "t"
+                                , pipelineName = "p"
+                                , pipelineInstanceVars = Dict.empty
+                                }
+                            , groups = [ "test-group" ]
+                            }
+                        )
+                        |> Application.handleDelivery
+                            (RouteChanged <|
+                                Routes.Pipeline
+                                    { id =
+                                        { teamName = "t"
+                                        , pipelineName = "p"
+                                        , pipelineInstanceVars = Dict.empty
+                                        }
+                                    , groups = []
+                                    }
+                            )
+                        |> Tuple.first
+                        |> .session
+                        |> .route
+                        |> Routes.getGroups
+                        |> Expect.equal []
+            ]
         ]

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -465,7 +465,7 @@ session =
     , timeZone = Time.utc
     , favoritedPipelines = Set.empty
     , favoritedInstanceGroups = Set.empty
-    , route = Routes.Build { id = Data.jobBuildId, highlight = Routes.HighlightNothing }
+    , route = Routes.Build { id = Data.jobBuildId, highlight = Routes.HighlightNothing, groups = [] }
     }
 
 

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1306,6 +1306,7 @@ all =
                     buildParams =
                         { id = Data.jobBuildId
                         , highlight = Routes.HighlightNothing
+                        , groups = []
                         }
                 in
                 Common.init "/"
@@ -1826,6 +1827,7 @@ all =
                                 Routes.Build
                                     { id = Data.jobBuildId |> Data.withBuildName "2"
                                     , highlight = Routes.HighlightNothing
+                                    , groups = []
                                     }
                             )
                         >> Tuple.first

--- a/web/elm/tests/PinMenu/PinMenuTests.elm
+++ b/web/elm/tests/PinMenu/PinMenuTests.elm
@@ -154,6 +154,7 @@ all =
                                                     { id = Data.resourceId |> Data.withResourceName "test"
                                                     , page = Nothing
                                                     , version = Nothing
+                                                    , groups = []
                                                     }
                                       }
                                     ]
@@ -202,6 +203,7 @@ all =
                                                     { id = Data.resourceId |> Data.withResourceName "test"
                                                     , page = Nothing
                                                     , version = Nothing
+                                                    , groups = []
                                                     }
                                       }
                                     ]

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -317,6 +317,7 @@ all =
                                     { id = versionID
                                     , direction = Concourse.Downstream
                                     , version = Nothing
+                                    , groups = []
                                     }
                             ]
             , test "'Outputs Of' links to causality page" <|
@@ -330,6 +331,7 @@ all =
                                     { id = versionID
                                     , direction = Concourse.Upstream
                                     , version = Nothing
+                                    , groups = []
                                     }
                             ]
             ]
@@ -357,6 +359,7 @@ all =
                                     { id = versionID
                                     , direction = Concourse.Downstream
                                     , version = Nothing
+                                    , groups = []
                                     }
                             ]
             , test "'Outputs Of' links to causality page" <|
@@ -370,6 +373,7 @@ all =
                                     { id = versionID
                                     , direction = Concourse.Upstream
                                     , version = Nothing
+                                    , groups = []
                                     }
                             ]
             ]
@@ -4090,5 +4094,5 @@ session =
     , favoritedInstanceGroups = Set.empty
     , screenSize = ScreenSize.Desktop
     , timeZone = Time.utc
-    , route = Routes.Resource { id = Data.resourceId, page = Nothing, version = Nothing }
+    , route = Routes.Resource { id = Data.resourceId, page = Nothing, version = Nothing, groups = [] }
     }

--- a/web/elm/tests/RoutesTests.elm
+++ b/web/elm/tests/RoutesTests.elm
@@ -293,6 +293,7 @@ all =
                                     }
                                 , page = Nothing
                                 , version = Just <| Dict.fromList [ ( "version", "sha:123abc" ) ]
+                                , groups = []
                                 }
                         )
         ]

--- a/web/elm/tests/SubPageTests.elm
+++ b/web/elm/tests/SubPageTests.elm
@@ -34,6 +34,7 @@ all =
                                 (Routes.Job
                                     { id = Data.shortJobId
                                     , page = Nothing
+                                    , groups = []
                                     }
                                 )
                             )
@@ -51,6 +52,7 @@ all =
                                     { id = Data.shortResourceId
                                     , page = Nothing
                                     , version = Nothing
+                                    , groups = []
                                     }
                                 )
                             )

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -304,6 +304,7 @@ all =
                                 { id = Data.shortResourceId
                                 , page = Nothing
                                 , version = Nothing
+                                , groups = []
                                 }
                             )
                     )
@@ -315,6 +316,7 @@ all =
                                     { id = Data.shortResourceId
                                     , page = Nothing
                                     , version = Nothing
+                                    , groups = []
                                     }
                         ]
             , context "when pipeline is paused"
@@ -673,6 +675,7 @@ all =
                         , buildName = "1"
                         }
                     , highlight = Routes.HighlightNothing
+                    , groups = []
                     }
                 )
                 |> Application.handleCallback
@@ -770,6 +773,7 @@ all =
                         }
                     , page = Nothing
                     , version = Nothing
+                    , groups = []
                     }
                 )
                 |> Application.handleCallback
@@ -894,6 +898,7 @@ all =
                         , jobName = "job"
                         }
                     , page = Nothing
+                    , groups = []
                     }
                 )
                 |> Application.handleCallback


### PR DESCRIPTION
## Changes proposed by this PR

If the user was viewing a group within a pipeline page, the group will be propagated when the user moves
between subpages (job, build, resource, causality) of a pipeline. To explain more clearly, lets say there is a pipeline with groups A and B. A user is on group B on the pipeline page then navigates to a job page and then clicks on the pipeline breadcrumb in the topbar, it will navigate the user to group B on the pipeline rather than before it would have navigated the user to the default group on the pipeline page.

## Release Note

* If a user was initially viewing a group in the pipeline page, this will be persisted in the pipeline breadcrumb when navigating between pipeline subpages.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
