### PR TITLE
run check builds GC in batch

### DIFF
--- a/atc/db/dbfakes/fake_check_lifecycle.go
+++ b/atc/db/dbfakes/fake_check_lifecycle.go
@@ -4,13 +4,15 @@ package dbfakes
 import (
 	"sync"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/db"
 )
 
 type FakeCheckLifecycle struct {
-	DeleteCompletedChecksStub        func() error
+	DeleteCompletedChecksStub        func(lager.Logger) error
 	deleteCompletedChecksMutex       sync.RWMutex
 	deleteCompletedChecksArgsForCall []struct {
+		arg1 lager.Logger
 	}
 	deleteCompletedChecksReturns struct {
 		result1 error
@@ -22,17 +24,18 @@ type FakeCheckLifecycle struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCheckLifecycle) DeleteCompletedChecks() error {
+func (fake *FakeCheckLifecycle) DeleteCompletedChecks(arg1 lager.Logger) error {
 	fake.deleteCompletedChecksMutex.Lock()
 	ret, specificReturn := fake.deleteCompletedChecksReturnsOnCall[len(fake.deleteCompletedChecksArgsForCall)]
 	fake.deleteCompletedChecksArgsForCall = append(fake.deleteCompletedChecksArgsForCall, struct {
-	}{})
+		arg1 lager.Logger
+	}{arg1})
 	stub := fake.DeleteCompletedChecksStub
 	fakeReturns := fake.deleteCompletedChecksReturns
-	fake.recordInvocation("DeleteCompletedChecks", []interface{}{})
+	fake.recordInvocation("DeleteCompletedChecks", []interface{}{arg1})
 	fake.deleteCompletedChecksMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
@@ -46,10 +49,17 @@ func (fake *FakeCheckLifecycle) DeleteCompletedChecksCallCount() int {
 	return len(fake.deleteCompletedChecksArgsForCall)
 }
 
-func (fake *FakeCheckLifecycle) DeleteCompletedChecksCalls(stub func() error) {
+func (fake *FakeCheckLifecycle) DeleteCompletedChecksCalls(stub func(lager.Logger) error) {
 	fake.deleteCompletedChecksMutex.Lock()
 	defer fake.deleteCompletedChecksMutex.Unlock()
 	fake.DeleteCompletedChecksStub = stub
+}
+
+func (fake *FakeCheckLifecycle) DeleteCompletedChecksArgsForCall(i int) lager.Logger {
+	fake.deleteCompletedChecksMutex.RLock()
+	defer fake.deleteCompletedChecksMutex.RUnlock()
+	argsForCall := fake.deleteCompletedChecksArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeCheckLifecycle) DeleteCompletedChecksReturns(result1 error) {

--- a/atc/gc/check_collector.go
+++ b/atc/gc/check_collector.go
@@ -23,7 +23,7 @@ func (c *checksCollector) Run(ctx context.Context) error {
 	logger.Debug("start")
 	defer logger.Debug("done")
 
-	err := c.lifecycle.DeleteCompletedChecks()
+	err := c.lifecycle.DeleteCompletedChecks(logger)
 	if err != nil {
 		logger.Error("failed-to-delete-completed-checks", err)
 		return err


### PR DESCRIPTION

## Changes proposed by this PR

closes #7316 

The check builds GC will run in batch with 500 in size. It should take less time for each batch to run that reduce the chance of lock competition so it could finish eventually. 

We also add a logger to the method so it can show the number of check builds got GC in each batch iteration.

## Notes to reviewer
Currentlly the batch size is a constant based on the observation from concourse CI and hush-house. We think 500 is an optimize number in similar scale. Not 100% sure how it performs in a larger deployment. Is it necessary to make it configurable?



