### PR TITLE
Optimize build log collector

### DIFF
--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -995,7 +995,7 @@ func (p *pipeline) DeleteBuildEventsByBuildIDs(buildIDs []int) error {
 	defer Rollback(tx)
 
 	_, err = tx.Exec(`
-   DELETE FROM build_events
+   DELETE FROM `+p.eventsTable()+`
 	 WHERE build_id IN (`+strings.Join(indexStrings, ",")+`)
 	 `, interfaceBuildIDs...)
 	if err != nil {
@@ -1013,6 +1013,10 @@ func (p *pipeline) DeleteBuildEventsByBuildIDs(buildIDs []int) error {
 
 	err = tx.Commit()
 	return err
+}
+
+func (p *pipeline) eventsTable() string {
+	return fmt.Sprintf("pipeline_build_events_%d", p.id)
 }
 
 func (p *pipeline) CreateOneOffBuild() (Build, error) {

--- a/atc/db/pipeline_test.go
+++ b/atc/db/pipeline_test.go
@@ -1352,7 +1352,7 @@ var _ = Describe("Pipeline", func() {
 
 	Describe("DeleteBuildEventsByBuildIDs", func() {
 		It("deletes all build logs corresponding to the given build ids", func() {
-			build1DB, err := team.CreateOneOffBuild()
+			build1DB, err := pipeline.CreateOneOffBuild()
 			Expect(err).ToNot(HaveOccurred())
 
 			err = build1DB.SaveEvent(event.Log{
@@ -1360,7 +1360,7 @@ var _ = Describe("Pipeline", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			build2DB, err := team.CreateOneOffBuild()
+			build2DB, err := pipeline.CreateOneOffBuild()
 			Expect(err).ToNot(HaveOccurred())
 
 			err = build2DB.SaveEvent(event.Log{
@@ -1368,7 +1368,7 @@ var _ = Describe("Pipeline", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			build3DB, err := team.CreateOneOffBuild()
+			build3DB, err := pipeline.CreateOneOffBuild()
 			Expect(err).ToNot(HaveOccurred())
 
 			err = build3DB.Finish(db.BuildStatusSucceeded)
@@ -1380,7 +1380,7 @@ var _ = Describe("Pipeline", func() {
 			err = build2DB.Finish(db.BuildStatusSucceeded)
 			Expect(err).ToNot(HaveOccurred())
 
-			build4DB, err := team.CreateOneOffBuild()
+			build4DB, err := pipeline.CreateOneOffBuild()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("doing nothing if the list is empty")


### PR DESCRIPTION
## Changes proposed by this PR

Backport #7327 to 6.7.x.

* [x] done


## Notes to reviewer

I saw there are a few pending PRs on branch 6.7.x, so just backport #7327 also. Once 6.7.8 is released, we'll upgrade to it immediately as we are now on 6.7.6.

## Release Note

* Optimized a SQL statement used to remove build logs. This optimization will specially benefit large deployments that have a lot of pipelines.