### PR TITLE
Speed up TSA tests

### DIFF
--- a/tsa/cmd/tsa/suite_test.go
+++ b/tsa/cmd/tsa/suite_test.go
@@ -39,7 +39,7 @@ var tsaPath string
 
 var _ = BeforeSuite(func() {
 	var err error
-	tsaPath, err = gexec.Build("github.com/concourse/concourse/tsa/cmd/tsa")
+	tsaPath, err = gexec.Build("github.com/concourse/concourse/tsa/cmd/tsa", "-ldflags", "-X 'github.com/concourse/concourse/atc/worker/gclient.idleConnTimeoutOverride=5s'")
 	Expect(err).NotTo(HaveOccurred())
 })
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

The HTTP client used by the TSA uses http.DefaultTransport, which has an
IdleConnTimeout of 90s. Some of these tests rely on this timeout being
hit, meaning that there's a minimum time of 90s for these tests. This
resulted in the tsa suite being the slowest to complete, typically
taking ~5m.

This commit compiles the tsa binary with an overridden IdleConnTimeout
of 5s in tests. This does not affect the behaviour of Concourse, as the
default behaviour is left unchanged when compiled normally.

In practice, it looks like this shaves off ~4 minutes from each run of `unit`

* [x] Compile TSA with an overridden `IdleConnTimeout` in tests