### PR TITLE
Fix dogstatsd UDS file configuration

### DIFF
--- a/atc/metric/emitter/dogstatsd.go
+++ b/atc/metric/emitter/dogstatsd.go
@@ -29,7 +29,9 @@ func init() {
 
 func (config *DogstatsDBConfig) Description() string { return "Datadog" }
 
-func (config *DogstatsDBConfig) IsConfigured() bool { return config.Host != "" && config.Port != "" }
+func (config *DogstatsDBConfig) IsConfigured() bool {
+	return (config.Host != "" && config.Port != "") || config.UDS != ""
+}
 
 func (config *DogstatsDBConfig) NewEmitter(_ map[string]string) (metric.Emitter, error) {
 	var client *statsd.Client


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

previously, if the --datadog-agent-uds-filepath was configured but
--datadog-agent-host/--datadog-agent-port were not, dogstatsd would not
run since Concourse would think dogstatsd wasn't configured. since
--datadog-agent-uds-filepath is an alternative to the other flags, this
should not be the case

This affects the unreleased #7338

## Notes to reviewer