### PR TITLE
Don't mount Concourse source directory in `integration` tests

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     depends_on: [db]
     ports: [8080]
     volumes:
-    - ..:/src
     - ../hack/keys:/concourse-keys
     environment:
       CONCOURSE_SESSION_SIGNING_KEY: /concourse-keys/session_signing_key
@@ -43,7 +42,6 @@ services:
     depends_on: [web]
     ports: [7777, 7788]
     volumes:
-    - ..:/src
     - ../hack/keys:/concourse-keys
     stop_signal: SIGUSR2
     environment:

--- a/integration/worker/overrides/restartable.yml
+++ b/integration/worker/overrides/restartable.yml
@@ -2,4 +2,7 @@ version: '3'
 
 services:
   worker:
-    entrypoint: /src/integration/worker/overrides/restartable-entrypoint.sh
+    entrypoint: /overrides/restartable-entrypoint.sh
+    volumes:
+    - ../hack/keys:/concourse-keys
+    - ./worker/overrides:/overrides


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

We've been seeing some errors like https://ci.concourse-ci.org/teams/contributor/pipelines/pr/jobs/integration/builds/2?vars.number=7344#L61001b43:73:75

There's some indication that this error can come up when you have volume mounts with many files: https://github.com/docker/compose/issues/3927#issuecomment-252795000

There's no obvious reason to me why we need to mount the source directory here, and I suspect it's causing flakiness in our integration suite trying to mount this volume to so many containers.

[x] Remove the `..:/src` mount in the integration tests

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->