### PR TITLE
Don't allow empty identifiers when renaming pipelines/teams

### DIFF
--- a/atc/api/configserver/get.go
+++ b/atc/api/configserver/get.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/lager"
 
 	"github.com/concourse/concourse/atc"
+	. "github.com/concourse/concourse/atc/api/helpers"
 	"github.com/tedsuo/rata"
 )
 
@@ -20,7 +21,7 @@ func (s *Server) GetConfig(w http.ResponseWriter, r *http.Request) {
 	pipelineRef.InstanceVars, err = atc.InstanceVarsFromQueryParams(r.URL.Query())
 	if err != nil {
 		logger.Error("malformed-instance-vars", err)
-		s.handleBadRequest(w, fmt.Sprintf("instance vars are malformed: %v", err))
+		HandleBadRequest(w, fmt.Sprintf("instance vars are malformed: %v", err))
 		return
 	}
 

--- a/atc/api/helpers/helpers.go
+++ b/atc/api/helpers/helpers.go
@@ -1,0 +1,32 @@
+package helpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/concourse/concourse/atc"
+)
+
+func HandleBadRequest(w http.ResponseWriter, errorMessages ...string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	WriteSaveConfigResponse(w, atc.SaveConfigResponse{
+		Errors: errorMessages,
+	})
+}
+
+func WriteSaveConfigResponse(w http.ResponseWriter, saveConfigResponse atc.SaveConfigResponse) {
+	responseJSON, err := json.Marshal(saveConfigResponse)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "failed to generate error response: %s", err)
+		return
+	}
+
+	_, err = w.Write(responseJSON)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1738,7 +1738,8 @@ var _ = Describe("Pipelines API", func() {
 							requestBody = `{"name":""}`
 						})
 
-						It("returns a warning in the response body", func() {
+						It("returns 400 Bad Request and an error in the response body", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
 							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"errors": [

--- a/atc/api/pipelineserver/rename.go
+++ b/atc/api/pipelineserver/rename.go
@@ -7,6 +7,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
+	. "github.com/concourse/concourse/atc/api/helpers"
 	"github.com/concourse/concourse/atc/db"
 )
 
@@ -32,19 +33,13 @@ func (s *Server) RenamePipeline(team db.Team) http.Handler {
 		var warnings []atc.ConfigWarning
 		var errs []string
 		warning, err := atc.ValidateIdentifier(rename.NewName, "pipeline")
-		if warning != nil {
-			warnings = append(warnings, *warning)
-		}
 		if err != nil {
 			errs = append(errs, err.Error())
-			w.WriteHeader(http.StatusBadRequest)
-			w.Header().Set("Content-Type", "application/json")
-			err = json.NewEncoder(w).Encode(atc.SaveConfigResponse{Warnings: warnings, Errors: errs})
-			if err != nil {
-				logger.Error("failed-to-encode-response", err)
-				w.WriteHeader(http.StatusInternalServerError)
-			}
+			HandleBadRequest(w, errs...)
 			return
+		}
+		if warning != nil {
+			warnings = append(warnings, *warning)
 		}
 
 		oldName := r.FormValue(":pipeline_name")

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -588,6 +588,7 @@ var _ = Describe("Teams API", func() {
 						})
 
 						It("returns a warning in the response body", func() {
+							Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
 							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"errors": [

--- a/atc/api/teamserver/rename.go
+++ b/atc/api/teamserver/rename.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/concourse/concourse/atc"
+	. "github.com/concourse/concourse/atc/api/helpers"
 	"github.com/concourse/concourse/atc/db"
 )
 
@@ -31,19 +32,13 @@ func (s *Server) RenameTeam(team db.Team) http.Handler {
 		var warnings []atc.ConfigWarning
 		var errs []string
 		warning, err := atc.ValidateIdentifier(rename.NewName, "team")
-		if warning != nil {
-			warnings = append(warnings, *warning)
-		}
 		if err != nil {
 			errs = append(errs, err.Error())
-			w.WriteHeader(http.StatusBadRequest)
-			w.Header().Set("Content-Type", "application/json")
-			err = json.NewEncoder(w).Encode(atc.SaveConfigResponse{Warnings: warnings, Errors: errs})
-			if err != nil {
-				logger.Error("failed-to-encode-response", err)
-				w.WriteHeader(http.StatusInternalServerError)
-			}
+			HandleBadRequest(w, errs...)
 			return
+		}
+		if warning != nil {
+			warnings = append(warnings, *warning)
 		}
 
 		err = team.Rename(rename.NewName)


### PR DESCRIPTION
## Changes proposed by this PR

closes #7365


## Notes to reviewer


## Release Note

* Fixed a bug where a pipeline or team could be renamed to an empty string. The team/pipeline could not be deleted through fly. An error is now returned by the API if the identifier is blank
