### PR TITLE
Skip integration upgrade test

### DIFF
--- a/integration/ops/upgrade_test.go
+++ b/integration/ops/upgrade_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestUpgrade(t *testing.T) {
+	t.Skip("See https://github.com/concourse/concourse/issues/7397")
+
 	t.Parallel()
 
 	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/latest.yml")


### PR DESCRIPTION
## Changes proposed by this PR

I thought #7398 was only needed for downgrade, but it also fails on upgrade occasionally.
See #7397