### PR TITLE
Sanitize prometheus metric labels

### DIFF
--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -107,6 +108,34 @@ func serializeLabels(labels *prometheus.Labels) string {
 	return key
 }
 
+// rePrometheusLabelInvalid matches any invalid characters we may have in our
+// emitted labels.
+//
+// Prometheus format:
+//   > Label names may contain ASCII letters, numbers, as well as underscores.
+//   > They must match the regex [a-zA-Z_][a-zA-Z0-9_]*. Label names beginning
+//   > with __ are reserved for internal use.
+//   Link: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+var rePrometheusLabelInvalid = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
+
+// rePrometheusLabelClean ensures we clean any duplicate underscores.
+var rePrometheusLabelClean = regexp.MustCompile(`__+`)
+
+// sanitizePrometheusLabels ensures all metric labels we register with the prometheus
+// emitter are sanitized to support Prometheus format. See rePrometheusLabelInvalid
+// for more information.
+func sanitizePrometheusLabels(labels map[string]string) map[string]string {
+	newLabels := make(map[string]string)
+
+	for k, v := range labels {
+		k = rePrometheusLabelInvalid.ReplaceAllString(k, "_")
+		k = strings.Trim(rePrometheusLabelClean.ReplaceAllString(k, "_"), "_")
+		newLabels[k] = v
+	}
+
+	return newLabels
+}
+
 func init() {
 	metric.Metrics.RegisterEmitter(&PrometheusConfig{})
 }
@@ -120,6 +149,9 @@ func (config *PrometheusConfig) bind() string {
 }
 
 func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric.Emitter, error) {
+	// ensure there are no invalid characters in label names.
+	attributes = sanitizePrometheusLabels(attributes)
+
 	// error log metrics
 	errorLogs := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -601,8 +633,10 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 // Event types (differentiated by the less-than-ideal string Name field) into different
 // Prometheus metrics.
 func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) {
+	// ensure there are no invalid characters in label names.
+	event.Attributes = sanitizePrometheusLabels(event.Attributes)
 
-	//update last seen counters, used to gc stale timeseries
+	// update last seen counters, used to gc stale timeseries
 	emitter.updateLastSeen(event)
 
 	switch event.Name {

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -704,7 +704,7 @@ func (emitter *PrometheusEmitter) errorLogsMetric(logger lager.Logger, event met
 	message, exists := event.Attributes["message"]
 	if !exists {
 		logger.Error("failed-to-find-message-in-event",
-			fmt.Errorf("expected team_name to exist in event.Attributes"))
+			fmt.Errorf("expected message to exist in event.Attributes"))
 		return
 	}
 

--- a/atc/metric/emitter/prometheus_test.go
+++ b/atc/metric/emitter/prometheus_test.go
@@ -188,7 +188,12 @@ var _ = Describe("PrometheusEmitter", func() {
 	})
 
 	JustBeforeEach(func() {
-		prometheusEmitter, err = prometheusConfig.NewEmitter(nil)
+		prometheusEmitter, err = prometheusConfig.NewEmitter(map[string]string{
+			// Ensure invalid labels are sanitized.
+			"invalid-label":     "foo",
+			"__prefix__test__":  "bar",
+			"_prefix_testtwo__": "baz",
+		})
 	})
 
 	It("emits step waiting metric", func() {
@@ -208,7 +213,7 @@ var _ = Describe("PrometheusEmitter", func() {
 		body, _ := ioutil.ReadAll(res.Body)
 		defer res.Body.Close()
 		Expect(res.StatusCode).To(Equal(http.StatusOK))
-		Expect(string(body)).To(ContainSubstring("concourse_steps_waiting{platform=\"darwin\",teamId=\"42\",teamName=\"teamdev\",type=\"get\",workerTags=\"tester\"} 4"))
+		Expect(string(body)).To(ContainSubstring("concourse_steps_waiting{invalid_label=\"foo\",platform=\"darwin\",prefix_test=\"bar\",prefix_testtwo=\"baz\",teamId=\"42\",teamName=\"teamdev\",type=\"get\",workerTags=\"tester\"} 4"))
 		Expect(err).To(BeNil())
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

closes #7367

* [x] sanitize prometheus labels to ensure any characters not supported by prometheus are replaced by `_`'s. Underscores are also  stripped from the start/end, as well as if there are any duplicate underscore characters.

## Notes to reviewer

Used the following environment variables in my docker-compose.yml to replicate the issues seen in #7367:

```console
      CONCOURSE_METRICS_ATTRIBUTE: "bosh-deployment:concourse-deployment,bosh-job:concourse-job"
      CONCOURSE_CAPTURE_ERROR_METRICS: "true"
      CONCOURSE_PROMETHEUS_BIND_IP: "0.0.0.0"
      CONCOURSE_PROMETHEUS_BIND_PORT: "8456"
```

Didn't fix this on the bosh side, as those metric names have existed for other emitters for awhile now, and changing the name may break metrics for users.

## Release Note

* Ensure Prometheus metric labels are valid. This resolves an issue with our bosh release, where web nodes would fail to start, due to a metric label that wasn't valid according to Prometheus.