### PR TITLE
Add default get/put/task timeout

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -258,9 +258,9 @@ type RunCommand struct {
 
 	DisplayUserIdPerConnector map[string]string `long:"display-user-id-per-connector" description:"Define how to display user ID for each authentication connector. Format is <connector>:<fieldname>. Valid field names are user_id, name, username and email, where name maps to claims field username, and username maps to claims field preferred username"`
 
-	DefaultGetTimeout  time.Duration `long:"default-get-timeout" description:"Default timeout of get steps" default:"1h"`
-	DefaultPutTimeout  time.Duration `long:"default-put-timeout" description:"Default timeout of put steps" default:"1h"`
-	DefaultTaskTimeout time.Duration `long:"default-task-timeout" description:"Default timeout of task steps" default:"10h"`
+	DefaultGetTimeout  time.Duration `long:"default-get-timeout" description:"Default timeout of get steps"`
+	DefaultPutTimeout  time.Duration `long:"default-put-timeout" description:"Default timeout of put steps"`
+	DefaultTaskTimeout time.Duration `long:"default-task-timeout" description:"Default timeout of task steps"`
 }
 
 type Migration struct {

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -257,6 +257,10 @@ type RunCommand struct {
 	P2pVolumeStreamingTimeout time.Duration `long:"p2p-volume-streaming-timeout" description:"Timeout value of p2p volume streaming" default:"15m"`
 
 	DisplayUserIdPerConnector map[string]string `long:"display-user-id-per-connector" description:"Define how to display user ID for each authentication connector. Format is <connector>:<fieldname>. Valid field names are user_id, name, username and email, where name maps to claims field username, and username maps to claims field preferred username"`
+
+	DefaultGetTimeout  time.Duration `long:"default-get-timeout" description:"Default timeout of get steps" default:"1h"`
+	DefaultPutTimeout  time.Duration `long:"default-put-timeout" description:"Default timeout of put steps" default:"1h"`
+	DefaultTaskTimeout time.Duration `long:"default-task-timeout" description:"Default timeout of task steps" default:"10h"`
 }
 
 type Migration struct {
@@ -1688,6 +1692,9 @@ func (cmd *RunCommand) constructEngine(
 				defaultLimits,
 				strategy,
 				cmd.GlobalResourceCheckTimeout,
+				cmd.DefaultGetTimeout,
+				cmd.DefaultPutTimeout,
+				cmd.DefaultTaskTimeout,
 			),
 			cmd.ExternalURL.String(),
 			rateLimiter,

--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -25,6 +25,9 @@ type coreStepFactory struct {
 	defaultLimits         atc.ContainerLimits
 	strategy              worker.PlacementStrategy
 	defaultCheckTimeout   time.Duration
+	defaultGetTimeout     time.Duration
+	defaultPutTimeout     time.Duration
+	defaultTaskTimeout    time.Duration
 }
 
 func NewCoreStepFactory(
@@ -38,6 +41,9 @@ func NewCoreStepFactory(
 	defaultLimits atc.ContainerLimits,
 	strategy worker.PlacementStrategy,
 	defaultCheckTimeout time.Duration,
+	defaultGetTimeout time.Duration,
+	defaultPutTimeout time.Duration,
+	defaultTaskTimeout time.Duration,
 ) CoreStepFactory {
 	return &coreStepFactory{
 		pool:                  pool,
@@ -50,6 +56,9 @@ func NewCoreStepFactory(
 		defaultLimits:         defaultLimits,
 		strategy:              strategy,
 		defaultCheckTimeout:   defaultCheckTimeout,
+		defaultGetTimeout:     defaultGetTimeout,
+		defaultPutTimeout:     defaultPutTimeout,
+		defaultTaskTimeout:    defaultTaskTimeout,
 	}
 }
 
@@ -71,6 +80,7 @@ func (factory *coreStepFactory) GetStep(
 		factory.strategy,
 		delegateFactory,
 		factory.pool,
+		factory.defaultGetTimeout,
 	)
 
 	getStep = exec.LogError(getStep, delegateFactory)
@@ -96,6 +106,7 @@ func (factory *coreStepFactory) PutStep(
 		factory.strategy,
 		factory.pool,
 		delegateFactory,
+		factory.defaultPutTimeout,
 	)
 
 	putStep = exec.LogError(putStep, delegateFactory)
@@ -172,6 +183,7 @@ func (factory *coreStepFactory) TaskStep(
 		factory.pool,
 		factory.streamer,
 		delegateFactory,
+		factory.defaultTaskTimeout,
 	)
 
 	taskStep = exec.LogError(taskStep, delegateFactory)

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -379,6 +379,41 @@ var _ = Describe("CheckStep", func() {
 							Expect(privileged).To(BeTrue())
 						})
 					})
+
+					Context("when the timeout is bogus", func() {
+						BeforeEach(func() {
+							checkPlan.Timeout = "bogus"
+						})
+
+						It("fails miserably", func() {
+							Expect(stepErr).To(MatchError(ContainSubstring("parse timeout: time: invalid duration \"bogus\"")))
+						})
+					})
+				})
+
+				Context("when there is default check timeout", func() {
+					BeforeEach(func() {
+						defaultTimeout = time.Minute * 30
+					})
+
+					It("enforces it on the check", func() {
+						t, ok := chosenContainer.ContextOfRun().Deadline()
+						Expect(ok).To(BeTrue())
+						Expect(t).To(BeTemporally("~", time.Now().Add(time.Minute*30), time.Minute))
+					})
+				})
+
+				Context("when there is default check timeout and the plan specifies a timeout also", func() {
+					BeforeEach(func() {
+						defaultTimeout = time.Minute * 30
+						checkPlan.Timeout = "1h"
+					})
+
+					It("enforces the plan's timeout on the check", func() {
+						t, ok := chosenContainer.ContextOfRun().Deadline()
+						Expect(ok).To(BeTrue())
+						Expect(t).To(BeTemporally("~", time.Now().Add(time.Hour), time.Minute))
+					})
 				})
 
 				Context("when the plan is for a resource", func() {

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -41,7 +41,7 @@ var _ = Describe("CheckStep", func() {
 		fakeDelegate              *execfakes.FakeCheckDelegate
 		fakeDelegateFactory       *execfakes.FakeCheckDelegateFactory
 		spanCtx                   context.Context
-		defaultTimeout            = time.Hour
+		defaultTimeout            time.Duration = 0
 
 		fakePool        *execfakes.FakePool
 		chosenWorker    *runtimetest.Worker
@@ -716,16 +716,6 @@ var _ = Describe("CheckStep", func() {
 			It("errors", func() {
 				Expect(stepErr).To(HaveOccurred())
 			})
-		})
-	})
-
-	Context("when a bogus timeout is given", func() {
-		BeforeEach(func() {
-			checkPlan.Timeout = "bogus"
-		})
-
-		It("fails miserably", func() {
-			Expect(stepErr).To(MatchError("parse timeout: time: invalid duration \"bogus\""))
 		})
 	})
 })

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -87,6 +87,7 @@ type GetStep struct {
 	workerPool           Pool
 	lockFactory          lock.LockFactory
 	delegateFactory      GetDelegateFactory
+	defaultGetTimeout    time.Duration
 }
 
 func NewGetStep(
@@ -99,6 +100,7 @@ func NewGetStep(
 	strategy worker.PlacementStrategy,
 	delegateFactory GetDelegateFactory,
 	pool Pool,
+	defaultGetTimeout time.Duration,
 ) Step {
 	return &GetStep{
 		planID:               planID,
@@ -110,6 +112,7 @@ func NewGetStep(
 		lockFactory:          lockFactory,
 		delegateFactory:      delegateFactory,
 		workerPool:           pool,
+		defaultGetTimeout:    defaultGetTimeout,
 	}
 }
 
@@ -467,7 +470,7 @@ func (step *GetStep) performGetAndInitCache(
 		}()
 	}
 
-	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout)
+	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultGetTimeout)
 	if err != nil {
 		return nil, resource.VersionResult{}, runtime.ProcessResult{}, err
 	}

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -78,6 +78,8 @@ var _ = Describe("GetStep", func() {
 		planID = atc.PlanID("56")
 
 		expectedOwner = db.NewBuildStepContainerOwner(stepMetadata.BuildID, planID, stepMetadata.TeamID)
+
+		defaultGetTimeout time.Duration = 0
 	)
 
 	BeforeEach(func() {
@@ -166,6 +168,7 @@ var _ = Describe("GetStep", func() {
 			nil,
 			fakeDelegateFactory,
 			fakePool,
+			defaultGetTimeout,
 		)
 
 		stepOk, stepErr = getStep.Run(ctx, runState)
@@ -482,11 +485,11 @@ var _ = Describe("GetStep", func() {
 			Expect(ok).To(BeFalse())
 		})
 
-		It("get resource cache owner from delegate", func(){
+		It("get resource cache owner from delegate", func() {
 			Expect(fakeDelegate.ResourceCacheUserCallCount()).To(Equal(1))
 		})
 
-		It("get container owner from delegate", func(){
+		It("get container owner from delegate", func() {
 			Expect(fakeDelegate.ContainerOwnerCallCount()).To(Equal(1))
 		})
 

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -569,6 +569,31 @@ var _ = Describe("GetStep", func() {
 		})
 	})
 
+	Context("when there is default get timeout", func() {
+		BeforeEach(func() {
+			defaultGetTimeout = time.Minute * 30
+		})
+
+		It("enforces it on the get", func() {
+			t, ok := chosenContainer.ContextOfRun().Deadline()
+			Expect(ok).To(BeTrue())
+			Expect(t).To(BeTemporally("~", time.Now().Add(time.Minute*30), time.Minute))
+		})
+	})
+
+	Context("when there is default get timeout and the plan specifies a timeout also", func() {
+		BeforeEach(func() {
+			defaultGetTimeout = time.Minute * 30
+			getPlan.Timeout = "1h"
+		})
+
+		It("enforces the plan's timeout on the get step", func() {
+			t, ok := chosenContainer.ContextOfRun().Deadline()
+			Expect(ok).To(BeTrue())
+			Expect(t).To(BeTemporally("~", time.Now().Add(time.Hour), time.Minute))
+		})
+	})
+
 	Context("when using a custom resource type", func() {
 		var (
 			fetchedImageSpec       runtime.ImageSpec

--- a/atc/exec/maybe_timeout.go
+++ b/atc/exec/maybe_timeout.go
@@ -6,14 +6,18 @@ import (
 	"time"
 )
 
-func MaybeTimeout(ctx context.Context, timeoutStr string) (context.Context, func(), error) {
-	if timeoutStr == "" {
+func MaybeTimeout(ctx context.Context, timeoutStr string, defaultTimeout time.Duration) (context.Context, func(), error) {
+	if timeoutStr == "" && defaultTimeout == 0 {
 		return ctx, func() {}, nil
 	}
 
-	timeout, err := time.ParseDuration(timeoutStr)
-	if err != nil {
-		return nil, nil, fmt.Errorf("parse timeout: %w", err)
+	timeout := defaultTimeout
+	if timeoutStr != "" {
+		var err error
+		timeout, err = time.ParseDuration(timeoutStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse timeout: %w", err)
+		}
 	}
 
 	processCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
@@ -53,6 +54,7 @@ type PutStep struct {
 	strategy          worker.PlacementStrategy
 	workerPool        Pool
 	delegateFactory   PutDelegateFactory
+	defaultPutTimeout time.Duration
 }
 
 func NewPutStep(
@@ -63,6 +65,7 @@ func NewPutStep(
 	strategy worker.PlacementStrategy,
 	workerPool Pool,
 	delegateFactory PutDelegateFactory,
+	defaultPutTimeout time.Duration,
 ) Step {
 	return &PutStep{
 		planID:            planID,
@@ -72,6 +75,7 @@ func NewPutStep(
 		workerPool:        workerPool,
 		strategy:          strategy,
 		delegateFactory:   delegateFactory,
+		defaultPutTimeout: defaultPutTimeout,
 	}
 }
 
@@ -196,7 +200,7 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 
 	delegate.SelectedWorker(logger, worker.Name())
 
-	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout)
+	ctx, cancel, err := MaybeTimeout(ctx, step.plan.Timeout, step.defaultPutTimeout)
 	if err != nil {
 		return false, err
 	}

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -74,6 +74,8 @@ var _ = Describe("PutStep", func() {
 		stderrBuf *gbytes.Buffer
 
 		versionResult resource.VersionResult
+
+		defaultPutTimeout time.Duration = 0
 	)
 
 	BeforeEach(func() {
@@ -160,6 +162,7 @@ var _ = Describe("PutStep", func() {
 			nil,
 			fakePool,
 			fakeDelegateFactory,
+			defaultPutTimeout,
 		)
 
 		stepOk, stepErr = putStep.Run(ctx, state)

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -509,6 +509,31 @@ var _ = Describe("PutStep", func() {
 		})
 	})
 
+	Context("when there is default put timeout", func() {
+		BeforeEach(func() {
+			defaultPutTimeout = time.Minute * 30
+		})
+
+		It("enforces it on the put", func() {
+			t, ok := chosenContainer.ContextOfRun().Deadline()
+			Expect(ok).To(BeTrue())
+			Expect(t).To(BeTemporally("~", time.Now().Add(time.Minute*30), time.Minute))
+		})
+	})
+
+	Context("when there is default put timeout and the plan specifies a timeout also", func() {
+		BeforeEach(func() {
+			defaultPutTimeout = time.Minute * 30
+			putPlan.Timeout = "1h"
+		})
+
+		It("enforces the plan's timeout on the put", func() {
+			t, ok := chosenContainer.ContextOfRun().Deadline()
+			Expect(ok).To(BeTrue())
+			Expect(t).To(BeTemporally("~", time.Now().Add(time.Hour), time.Minute))
+		})
+	})
+
 	Context("when tracing is enabled", func() {
 		BeforeEach(func() {
 			tracing.ConfigureTraceProvider(oteltest.NewTracerProvider())

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -64,6 +64,8 @@ var _ = Describe("TaskStep", func() {
 		planID = atc.PlanID("42")
 
 		expectedOwner = db.NewBuildStepContainerOwner(stepMetadata.BuildID, planID, stepMetadata.TeamID)
+
+		defaultTaskTimeout time.Duration = 0
 	)
 
 	BeforeEach(func() {
@@ -117,6 +119,7 @@ var _ = Describe("TaskStep", func() {
 			fakePool,
 			fakeStreamer,
 			fakeDelegateFactory,
+			defaultTaskTimeout,
 		)
 
 		stepOk, stepErr = taskStep.Run(ctx, state)

--- a/atc/runtime/runtimetest/container.go
+++ b/atc/runtime/runtimetest/container.go
@@ -23,6 +23,8 @@ type Container struct {
 
 	mtx       *sync.Mutex
 	processes []*Process
+
+	runContext context.Context
 }
 
 func NewContainer() *Container {
@@ -46,6 +48,7 @@ func (c *Container) WithProcess(spec runtime.ProcessSpec, stub ProcessStub) *Con
 }
 
 func (c *Container) Run(ctx context.Context, spec runtime.ProcessSpec, io runtime.ProcessIO) (runtime.Process, error) {
+	c.runContext = ctx
 	for i, pd := range c.ProcessDefs {
 		if reflect.DeepEqual(pd.Spec, spec) {
 			// remove current ProcessDefinition
@@ -62,6 +65,10 @@ func (c *Container) Run(ctx context.Context, spec runtime.ProcessSpec, io runtim
 		}
 	}
 	return nil, fmt.Errorf("must setup a ProcessStub for process %q (%+v)", spec.ID, spec)
+}
+
+func (c *Container) ContextOfRun() context.Context {
+	return c.runContext
 }
 
 func (c *Container) RunningProcesses() []*Process {


### PR DESCRIPTION
## Changes proposed by this PR

closes #7260 
closes #2341

I frequently find stuck builds on our prod cluster, some builds lasted many days. They may be stuck at any step: `get`, `put`, `task`. And reason could be various, for example:

* Bad logic of user's task
* Worker in abnormal state
* And so on ...

Though Concourse supports `Timeout` for all steps, but not every step has `Timeout` configured. Thus, it would make sense to set global timeout values for all steps.

* [x] Initial work
* [x] Add tests

## Notes to reviewer

More tests would be added.

## Release Note

* Allows Concourse administrator to configure global timeout for `get`, `put` and `task` steps.
* Fixed a bug where global check timeout didn't work.
 