### PR TITLE
Prefer overlay over btrfs in baggageclaim when using `driver: detect`

### DIFF
--- a/worker/baggageclaim/baggageclaimcmd/driver_linux.go
+++ b/worker/baggageclaim/baggageclaimcmd/driver_linux.go
@@ -50,10 +50,10 @@ func (cmd *BaggageclaimCommand) driver(logger lager.Logger) (volume.Driver, erro
 	}
 
 	if cmd.Driver == "detect" {
-		if supportsBtrfs {
-			cmd.Driver = "btrfs"
-		} else if kernelSupportsOverlay {
+		if kernelSupportsOverlay {
 			cmd.Driver = "overlay"
+		} else if supportsBtrfs {
+			cmd.Driver = "btrfs"
 		} else {
 			cmd.Driver = "naive"
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

when using the default driver "detect", previously we defaulted to using
btrfs if it was available on the machine.

https://github.com/concourse/concourse/discussions/5463 discusses the
trade-offs between drivers. in short:

* btrfs is faster when starting up privileged containers, but tends to
  be less stable, and may require loopback devices to work (which may be
  leaked)
* overlay is slow when starting up privileged containers but is more
  stable

however, since concourse/baggageclaim#44, the slow privileged container
startup with overlay is largely mitigated, so there's no real reason to
prefer btrfs over overlay (at least as a default)

## Release Note

* Previously, when the baggageclaim driver was not specified, Concourse attempts to detect the supported drivers
* The prior driver precedence is: `btrfs -> overlay -> naive`
* The new driver precedence is: `overlay -> btrfs -> naive`

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
