### PR TITLE
Increasing 2px for steps on build log view

### DIFF
--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -204,7 +204,7 @@ stepHeaderLabel changed =
         else
             Colors.pending
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     ]
 
 

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -3919,7 +3919,7 @@ testHeaderButton name model { key, index, domID, backgroundColor, hoveredBackgro
 getStepLabel =
     [ style "color" Colors.pending
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     , containing [ text "get:" ]
     ]
 
@@ -3927,7 +3927,7 @@ getStepLabel =
 runStepLabel =
     [ style "color" Colors.pending
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     , containing [ text "run:" ]
     ]
 
@@ -3935,7 +3935,7 @@ runStepLabel =
 firstOccurrenceGetStepLabel =
     [ style "color" Colors.started
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     , containing [ text "get:" ]
     ]
 
@@ -3943,7 +3943,7 @@ firstOccurrenceGetStepLabel =
 putStepLabel =
     [ style "color" Colors.pending
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     , containing [ text "put:" ]
     ]
 
@@ -3951,7 +3951,7 @@ putStepLabel =
 taskStepLabel =
     [ style "color" Colors.pending
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     , containing [ text "task:" ]
     ]
 
@@ -3959,7 +3959,7 @@ taskStepLabel =
 setPipelineStepLabel =
     [ style "color" Colors.pending
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     , containing [ text "set_pipeline:" ]
     ]
 
@@ -3967,7 +3967,7 @@ setPipelineStepLabel =
 changedSetPipelineStepLabel =
     [ style "color" Colors.started
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     , containing [ text "set_pipeline:" ]
     ]
 
@@ -3975,7 +3975,7 @@ changedSetPipelineStepLabel =
 checkStepLabel =
     [ style "color" Colors.pending
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     , containing [ text "check:" ]
     ]
 
@@ -3983,7 +3983,7 @@ checkStepLabel =
 loadVarStepLabel =
     [ style "color" Colors.pending
     , style "line-height" "28px"
-    , style "padding-left" "6px"
+    , style "padding-left" "8px"
     , containing [ text "load_var:" ]
     ]
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #5964

The left padding for each step on the build log view was increased by 2 px.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] done

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
