### PR TITLE
Use overlay driver for worker integration test [6.7.x]

### DIFF
--- a/worker/integration/integration_test.go
+++ b/worker/integration/integration_test.go
@@ -45,6 +45,7 @@ func (s *WorkerRunnerSuite) BeforeTest(suiteName, testName string) {
 func (s *WorkerRunnerSuite) TestWorkDirIsCreated() {
 	s.wrkcmd.WorkDir = "somedir"
 	s.wrkcmd.Runtime = "containerd"
+	s.wrkcmd.Baggageclaim.Driver = "overlay"
 
 	_, err := s.wrkcmd.Runner([]string{})
 	s.NoError(err)


### PR DESCRIPTION
## Changes proposed by this PR

the old unit-image didn't support btrfs, so `driver: detect` would
default to overlay. the unit image isn't equipped to run btrfs (needs
"an unused loopback"). let's just use overlay here, which is now the
default on master