### PR TITLE
Optimize pipeline svg rendering

### DIFF
--- a/web/public/graph.mjs
+++ b/web/public/graph.mjs
@@ -602,13 +602,31 @@ GraphNode.prototype.copy = function() {
   });
 };
 
+const getTextWidth = (function () {
+  const canvas = document.createElement('canvas'),
+        context = canvas.getContext('2d');
+
+  // An arbitrary factor by which to scale the measured text width to make it
+  // consistent with the *actual* size of the text node's bounding box.
+  // Derived by measuring textNode.getBBox().width / getTextWidth() and taking
+  // an approximate average.
+  //
+  // Note that different browsers seem to have different optimal factors. The
+  // 1.1 was based on Firefox, but I also observed ~1.08 on Chrome, ~1.08 on Safari.
+  // Better to slightly overestimate to avoid overcrowding.
+  const WIDTH_FUDGE_FACTOR = 1.1;
+
+  return function(text, font) {
+    context.font = font;
+    return context.measureText(text).width * WIDTH_FUDGE_FACTOR;
+  };
+})();
+
 GraphNode.prototype.width = function() {
   if (this._cachedWidth == 0) {
     var id = this.id;
 
-    var svgNode = this.svg.selectAll("g.node").filter(function(node) {
-      return node.id == id;
-    })
+    var svgNode = this.svg.select("#node-" + id);
 
     var textNode = svgNode.select("text").node();
     var imageNode = svgNode.select("image").node();
@@ -617,13 +635,15 @@ GraphNode.prototype.width = function() {
     var width = 0;
 
     if (textNode) {
-      width += textNode.getBBox().width;
+      width += getTextWidth(textNode.innerHTML, '700 12px Inconsolata,monospace');
     }
     if (imageNode) {
-      width += imageNode.getBBox().width;
+      const PIN_ICON_WIDTH = 8;
+      width += PIN_ICON_WIDTH;
     }
     if (iconNode) {
-      width += Math.max(iconNode.getBBox().width, iconNode.width.baseVal.value);
+      const MATERIAL_DESIGN_ICON_WIDTH = 12;
+      width += MATERIAL_DESIGN_ICON_WIDTH;
     }
 
     if (textNode && imageNode && iconNode) {


### PR DESCRIPTION
[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

See #7410

Applies a number of optimizations, in approximate order of impact:

* Avoid using getBBox to compute the width of graph nodes
    * Doing so requires a forced reflow - each call was taking ~2-3ms on Chrome on my machine (and we called it for every job/resource node in the graph)
    * Instead, we use the canvas `measureText` API to measure the width of text. This required a hacky fudge factor to make things consistent, but it seems to work fairly well.
    * We also hardcode the widths of material design icons and the pin icon. Should we use different images/icons in the future, this may break - but it's beneficial to avoid the reflow
* Avoid using getBBox to compute the full width/height/position of the graph
    * Instead, we compute it directly - we already know the positions/sizes of all of the nodes, so this is easy
    * This also avoids a forced reflow, but this one took ~20-30ms
* Use DOM IDs to quickly select the node we want, rather than selecting all of them and filtering by some data attributes

All these optimizations bring the render time on Chrome on https://ci.concourse-ci.org/teams/main/pipelines/concourse?group=all from 750ms (620ms of which are in rendering, esp. reflows) down to ~100ms (35ms for rendering)

**Prior to this PR**

https://user-images.githubusercontent.com/26583442/130110095-0128f321-6d1f-4029-9473-fbbb60ed2446.mov

**After this PR**

https://user-images.githubusercontent.com/26583442/130110157-27fcbc7a-f9ce-41ba-ae88-55a64f5c427b.mov


## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

* The initial render of the pipeline page should be much faster, particularly on Chrome 92+

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
