### PR TITLE
Allow team members to archive pipelines

### DIFF
--- a/atc/api/accessor/roles.go
+++ b/atc/api/accessor/roles.go
@@ -66,7 +66,7 @@ var DefaultRoles = map[string]string{
 	atc.OrderPipelines:                 MemberRole,
 	atc.OrderPipelinesWithinGroup:      MemberRole,
 	atc.PausePipeline:                  OperatorRole,
-	atc.ArchivePipeline:                OwnerRole,
+	atc.ArchivePipeline:                MemberRole,
 	atc.UnpausePipeline:                OperatorRole,
 	atc.ExposePipeline:                 MemberRole,
 	atc.HidePipeline:                   MemberRole,


### PR DESCRIPTION
# Why
Team members [can delete pipelines](https://github.com/concourse/concourse/blob/b8658106da5ff6c7434eb17b2c7e60738afcb82b/atc/api/accessor/roles.go#L65) but they can't archive them. I think deleting pipelines should be more restricted than archiving them. 

# What
This PR gives team members `archive-pipeline` permissions.

## Release Note

* Users with the `member` role on a team can now archive pipelines by default. The "archive pipeline" action was previously assigned to the `owner` role. If you've [configured your own RBAC](https://concourse-ci.org/user-roles.html) this change will not effect you.