### PR TITLE
Fix integration upgrade/downgrade tests

### DIFF
--- a/integration/ops/overrides/fast-gc.yml
+++ b/integration/ops/overrides/fast-gc.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  web:
+    environment:
+      CONCOURSE_GC_MISSING_GRACE_PERIOD: "0"
+      CONCOURSE_GC_INTERVAL: 10s
+
+  worker:
+    environment:
+      CONCOURSE_SWEEP_INTERVAL: 10s

--- a/integration/ops/suite_test.go
+++ b/integration/ops/suite_test.go
@@ -2,6 +2,7 @@ package ops_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/concourse/concourse/integration/internal/flytest"
 	"github.com/stretchr/testify/require"
@@ -36,4 +37,11 @@ func verifyUpgradeDowngrade(t *testing.T, fly flytest.Cmd) {
 		out := fly.Output(t, "execute", "-c", "tasks/hello.yml")
 		require.Contains(t, out, "hello")
 	})
+}
+
+func waitForVolumesGC(t *testing.T, fly flytest.Cmd) {
+	require.Eventually(t, func() bool {
+		volumes := fly.Table(t, "volumes")
+		return len(volumes) == 0
+	}, 1*time.Minute, 5*time.Second)
 }

--- a/integration/ops/upgrade_test.go
+++ b/integration/ops/upgrade_test.go
@@ -8,11 +8,9 @@ import (
 )
 
 func TestUpgrade(t *testing.T) {
-	t.Skip("See https://github.com/concourse/concourse/issues/7397")
-
 	t.Parallel()
 
-	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/latest.yml")
+	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/latest.yml", "overrides/fast-gc.yml")
 
 	t.Run("deploy latest", func(t *testing.T) {
 		latestDC.Run(t, "up", "-d")
@@ -21,12 +19,13 @@ func TestUpgrade(t *testing.T) {
 	fly := flytest.Init(t, latestDC)
 	setupUpgradeDowngrade(t, fly)
 
-	devDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml")
+	devDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/fast-gc.yml")
 
 	t.Run("upgrade to dev", func(t *testing.T) {
 		devDC.Run(t, "up", "-d")
 	})
-
 	fly = flytest.Init(t, devDC)
+	waitForVolumesGC(t, fly)
+
 	verifyUpgradeDowngrade(t, fly)
 }


### PR DESCRIPTION
[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #7397 

* [x] Wait for volumes to get GC'd after redeploying Concourse so as not to use stale volumes