### PR TITLE
Fix overlapping between inputs and jobs in UI

### DIFF
--- a/web/public/graph.mjs
+++ b/web/public/graph.mjs
@@ -514,7 +514,7 @@ RankGroup.prototype.layout = function() {
 
     node._keyOffset = rollingKeyOffset;
 
-    this.ordering.fill(rollingKeyOffset, node._edgeKeys.length);
+    this.ordering.fill(rollingKeyOffset, Math.max(node._edgeKeys.length, 1));
 
     rollingKeyOffset += Math.max(node._edgeKeys.length, 1);
   }


### PR DESCRIPTION
Fixes #7207 

## Changes proposed by this PR

The .tug function will try to align input with its connecting job (to make the line straigh instead of bezier) while it doesn't consider the spacing of next node(job). This PR makes node in a rank group at least occupy 1 space even without any edge key (no input/output edge).


* [x] done
* [ ] todo

## Release Note

- Fixes an edge case that might overlap an input and job node in the pipeline view.

