### PR TITLE
Validate if a Pipeline contains a cycle

### DIFF
--- a/atc/configvalidate/validate.go
+++ b/atc/configvalidate/validate.go
@@ -86,6 +86,12 @@ func Validate(c atc.Config) ([]atc.ConfigWarning, []string) {
 	}
 	warnings = append(warnings, displayWarnings...)
 
+	cycleErr := validateCycle(c)
+
+	if cycleErr != nil {
+		errorMessages = append(errorMessages, formatErr("jobs", cycleErr))
+	}
+
 	return warnings, errorMessages
 }
 
@@ -489,4 +495,63 @@ func validateDisplay(c atc.Config) ([]atc.ConfigWarning, error) {
 	}
 
 	return warnings, nil
+}
+
+func detectCycle(j atc.JobConfig, visited map[string]int, initialJobConfig atc.Config) (bool, string) {
+	const (
+		nonVisited = 0
+		semiVisited = 1
+		alreadyVisited = 2
+	)
+	visited[j.Name] = semiVisited
+	cycleExist := false
+	cycleErrorJob := ""
+	_ = j.StepConfig().Visit(atc.StepRecursor{
+		OnGet: func(step *atc.GetStep) error {
+			for _, nextJobName := range step.Passed {
+				nextJob := findJobByName(nextJobName, initialJobConfig.Jobs)
+				if visited[nextJobName] == semiVisited {
+					cycleExist = true
+					cycleErrorJob = nextJobName
+					return nil
+				} else if visited[nextJobName] == nonVisited {
+					nextState, jobErrorName := detectCycle(nextJob, visited, initialJobConfig)
+					cycleExist = cycleExist || nextState
+					if jobErrorName != "" {
+						cycleErrorJob = jobErrorName
+					}
+				}
+			}
+			return nil
+		},
+	})
+	visited[j.Name] = alreadyVisited
+	return cycleExist, cycleErrorJob
+}
+
+func findJobByName(jobName string, jobs atc.JobConfigs) atc.JobConfig {
+	for _, currJob := range jobs {
+		if jobName == currJob.Name {
+			return currJob
+		}
+	}
+	return atc.JobConfig{}
+}
+
+func validateCycle(c atc.Config) error {
+	jobs := c.Jobs
+	cycleExist := false
+	cycleErrorJob := ""
+	visitedJobsMap := make(map[string]int)
+	for _, job := range jobs {
+		cycleExist, cycleErrorJob = detectCycle(job, visitedJobsMap, c)
+		if cycleExist == true {
+			break
+		}
+	}
+
+	if cycleExist == true {
+		return fmt.Errorf("pipeline contains a cycle that starts at Job '%s'", cycleErrorJob)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

Now we can detect if the pipelines contains a cycle before creating it.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Adding cycle detection on the validate pipeline method

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

if you execute `fly set-pipeline` with the following pipeline that contains a cycle

```yml
resources:
- name: get_1
  type: mock

jobs:
- name: step_1
  plan:
  - in_parallel:
      steps:
      - get: get_1
        passed:
        - step_1
```

you should see the following error `pipeline contains a cycle that starts at Job 'step_1'`

## Release Note

* The API will reject any pipelines that contains a cycle

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
