### PR TITLE
Prevent open redirect to other hosts

### DIFF
--- a/skymarshal/skyserver/skyserver.go
+++ b/skymarshal/skyserver/skyserver.go
@@ -160,14 +160,14 @@ func (s *SkyServer) Callback(w http.ResponseWriter, r *http.Request) {
 func (s *SkyServer) Redirect(w http.ResponseWriter, r *http.Request, oauth2Token *oauth2.Token, redirectURI string) {
 	logger := s.config.Logger.Session("redirect")
 
-	redirectURL, err := url.ParseRequestURI(redirectURI)
+	redirectURL, err := url.ParseRequestURI("/" + strings.TrimLeft(redirectURI, "/"))
 	if err != nil {
 		logger.Error("failed-to-parse-redirect-url", err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	if redirectURL.Host != "" {
+	if redirectURL.Host != "" || redirectURL.Scheme != "" {
 		logger.Error("invalid-redirect", fmt.Errorf("Unsupported redirect uri: %s", redirectURI))
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/skymarshal/skyserver/skyserver_test.go
+++ b/skymarshal/skyserver/skyserver_test.go
@@ -344,15 +344,15 @@ var _ = Describe("Sky Server API", func() {
 								request.URL.RawQuery = "code=some-code&state=" + stateToken
 							})
 
-							It("errors", func() {
-								Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+							It("returns 404", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 							})
 						})
 
-						Context("when redirect URI is https:example.com", func() {
+						Context("when redirect URI is //example.com", func() {
 							BeforeEach(func() {
 								state, _ := json.Marshal(map[string]string{
-									"redirect_uri": "https:google.com",
+									"redirect_uri": "//example.com",
 								})
 
 								stateToken := base64.StdEncoding.EncodeToString(state)
@@ -361,7 +361,41 @@ var _ = Describe("Sky Server API", func() {
 								request.URL.RawQuery = "code=some-code&state=" + stateToken
 							})
 
-							It("doesn't error on Get https:google.com", func() {
+							It("returns 404", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+							})
+						})
+
+						Context("when redirect URI is http:///example.com/path", func() {
+							BeforeEach(func() {
+								state, _ := json.Marshal(map[string]string{
+									"redirect_uri": "http:///example.com/path",
+								})
+
+								stateToken := base64.StdEncoding.EncodeToString(state)
+								fakeTokenMiddleware.GetStateTokenReturns(stateToken)
+
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("returns 404", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+							})
+						})
+
+						Context("when redirect URI is https:example.com", func() {
+							BeforeEach(func() {
+								state, _ := json.Marshal(map[string]string{
+									"redirect_uri": "https:example.com",
+								})
+
+								stateToken := base64.StdEncoding.EncodeToString(state)
+								fakeTokenMiddleware.GetStateTokenReturns(stateToken)
+
+								request.URL.RawQuery = "code=some-code&state=" + stateToken
+							})
+
+							It("returns 404", func() {
 								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 							})
 						})
@@ -378,8 +412,8 @@ var _ = Describe("Sky Server API", func() {
 								request.URL.RawQuery = "code=some-code&state=" + stateToken
 							})
 
-							It("errors", func() {
-								Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
+							It("returns 404", func() {
+								Expect(response.StatusCode).To(Equal(http.StatusNotFound))
 							})
 						})
 


### PR DESCRIPTION
## Changes proposed by this PR

We fell victim to this behaviour: https://github.com/golang/go/issues/38642

The solution in this commit ensures that the URI we redirect to is
always a path. The TrimLeft() removes all prefixed forward slashes,
which covers the case where a redirect uri starts with two or more
slashse.

We then always add a single forward slash which will ensure that
ParseRequestURI() interprets the URI as a path.

Now if someone visits `http://ci.concourse-ci.org/sky/login?redirect_uri=//google.com/`
they'll end up redirected to `http://ci.concourse-ci.org/google.com` which
will return a 404 and redirect one more time to the homepage.

In case the behaviour of ParseRequestURI() changes or is smarter in the
future, we added a check to ensure that if either Host or Scheme is
populated that the URI is not used for redirecting. The tests have also
been updated so this change in behaviour will cause the tests to fail.

## Release Note

* Prevent an open redirect vulnerability on the `/sky/login` path
