### PR TITLE
indicate if a pipline is archived in pipeline view

### DIFF
--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -133,7 +133,6 @@ buildView session model =
         [ Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
             [ SideBar.sideBarIcon session
-            , TopBar.concourseLogo
             , breadcrumbs session model
             , Login.view session.userState model
             ]

--- a/web/elm/benchmarks/Benchmarks.elm
+++ b/web/elm/benchmarks/Benchmarks.elm
@@ -132,10 +132,10 @@ buildView session model =
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
         [ Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
-            [ SideBar.sideBarIcon session
-            , breadcrumbs session model
-            , Login.view session.userState model
-            ]
+            (SideBar.sideBarIcon session
+                :: breadcrumbs session model
+                ++ [ Login.view session.userState model ]
+            )
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
             [ SideBar.view session
@@ -186,7 +186,7 @@ currentJob =
         >> Maybe.andThen .job
 
 
-breadcrumbs : Session -> Model -> Html Message
+breadcrumbs : Session -> Model -> List (Html Message)
 breadcrumbs session model =
     case ( currentJob model, model.page ) of
         ( Just jobId, _ ) ->
@@ -206,7 +206,7 @@ breadcrumbs session model =
                     }
 
         _ ->
-            Html.text ""
+            [ Html.text "" ]
 
 
 body :

--- a/web/elm/src/Build/Build.elm
+++ b/web/elm/src/Build/Build.elm
@@ -690,11 +690,10 @@ view session model =
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
         [ Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
-            [ SideBar.sideBarIcon session
-            , TopBar.concourseLogo
-            , breadcrumbs session model
-            , Login.view session.userState model
-            ]
+            (SideBar.sideBarIcon session
+                :: breadcrumbs session model
+                ++ [ Login.view session.userState model ]
+            )
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
             [ SideBar.view session
@@ -738,7 +737,7 @@ tryAll maybes =
         maybes
 
 
-breadcrumbs : Session -> Model -> Html Message
+breadcrumbs : Session -> Model -> List (Html Message)
 breadcrumbs session model =
     case ( model.job, model.page ) of
         ( Just jobId, _ ) ->
@@ -758,7 +757,7 @@ breadcrumbs session model =
                     }
 
         _ ->
-            Html.text ""
+            [ Html.text "" ]
 
 
 viewBuildPage : Session -> Model -> Html Message

--- a/web/elm/src/Causality/Causality.elm
+++ b/web/elm/src/Causality/Causality.elm
@@ -244,11 +244,10 @@ view session model =
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
         [ Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
-            [ SideBar.sideBarIcon session
-            , TopBar.concourseLogo
-            , TopBar.breadcrumbs session route
-            , Login.view session.userState model
-            ]
+            (SideBar.sideBarIcon session
+                :: TopBar.breadcrumbs session route
+                ++ [ Login.view session.userState model ]
+            )
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
             [ SideBar.view session

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1070,13 +1070,11 @@ topBar session model =
     Html.div
         (id "top-bar-app" :: Views.Styles.topBar False)
     <|
-        [ Html.div [ style "display" "flex", style "align-items" "center" ]
-            [ SideBar.sideBarIcon session
-            , TopBar.concourseLogo
-            , TopBar.breadcrumbs session session.route
-            ]
-        ]
-            ++ (let
+        Html.div [ style "display" "flex", style "align-items" "center" ]
+            (SideBar.sideBarIcon session
+                :: TopBar.breadcrumbs session session.route
+            )
+            :: (let
                     isDropDownHidden =
                         model.dropdown == Hidden
 

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -427,11 +427,10 @@ view session model =
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
         [ Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
-            [ SideBar.sideBarIcon session
-            , TopBar.concourseLogo
-            , TopBar.breadcrumbs session session.route
-            , Login.view session.userState model
-            ]
+            (SideBar.sideBarIcon session
+                :: TopBar.breadcrumbs session session.route
+                ++ [ Login.view session.userState model ]
+            )
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar session.route)
             [ SideBar.view session

--- a/web/elm/src/NotFound/NotFound.elm
+++ b/web/elm/src/NotFound/NotFound.elm
@@ -56,11 +56,10 @@ view session model =
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
         [ Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
-            [ SideBar.sideBarIcon session
-            , TopBar.concourseLogo
-            , TopBar.breadcrumbs session model.route
-            , Login.view session.userState model
-            ]
+            (SideBar.sideBarIcon session
+                :: TopBar.breadcrumbs session model.route
+                ++ [ Login.view session.userState model ]
+            )
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar model.route)
             [ SideBar.view session Nothing

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -390,55 +390,55 @@ view session model =
             (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
             [ Html.div
                 (id "top-bar-app" :: Views.Styles.topBar displayPaused)
-                [ SideBar.sideBarIcon session
-                , TopBar.concourseLogo
-                , TopBar.breadcrumbs session route
-                , if isArchived model.pipeline then
-                    Html.text ""
+                (SideBar.sideBarIcon session
+                    :: TopBar.breadcrumbs session route
+                    ++ [ if isArchived model.pipeline then
+                            Html.text ""
 
-                  else
-                    TopBar.paused
-                        { paused = displayPaused
-                        , pausedBy = pausedBy model.pipeline
-                        , pausedAt = pausedAt model.pipeline
-                        , timeZone = session.timeZone
-                        }
-                , PinMenu.viewPinMenu session model
-                , Html.div
-                    Styles.favoritedIcon
-                    [ FavoritedIcon.view
-                        { isHovered = HoverState.isHovered (TopBarFavoritedIcon <| getPipelineId model.pipeline) session.hovered
-                        , isFavorited =
-                            model.pipeline
-                                |> RemoteData.map (Favorites.isPipelineFavorited session)
-                                |> RemoteData.withDefault False
-                        , isSideBar = False
-                        , domID = TopBarFavoritedIcon <| getPipelineId model.pipeline
-                        }
-                        [ style "margin" "17px" ]
-                    ]
-                , if isArchived model.pipeline then
-                    Html.text ""
+                         else
+                            TopBar.paused
+                                { paused = displayPaused
+                                , pausedBy = pausedBy model.pipeline
+                                , pausedAt = pausedAt model.pipeline
+                                , timeZone = session.timeZone
+                                }
+                       , PinMenu.viewPinMenu session model
+                       , Html.div
+                            Styles.favoritedIcon
+                            [ FavoritedIcon.view
+                                { isHovered = HoverState.isHovered (TopBarFavoritedIcon <| getPipelineId model.pipeline) session.hovered
+                                , isFavorited =
+                                    model.pipeline
+                                        |> RemoteData.map (Favorites.isPipelineFavorited session)
+                                        |> RemoteData.withDefault False
+                                , isSideBar = False
+                                , domID = TopBarFavoritedIcon <| getPipelineId model.pipeline
+                                }
+                                [ style "margin" "17px" ]
+                            ]
+                       , if isArchived model.pipeline then
+                            Html.text ""
 
-                  else
-                    Html.div
-                        Styles.pauseToggle
-                        [ PauseToggle.view
-                            { pipeline = model.pipelineLocator
-                            , isPaused = isPaused model.pipeline
-                            , isToggleHovered =
-                                HoverState.isHovered
-                                    (TopBarPauseToggle model.pipelineLocator)
-                                    session.hovered
-                            , isToggleLoading = model.isToggleLoading
-                            , tooltipPosition = Views.Styles.Below
-                            , margin = "17px"
-                            , userState = session.userState
-                            , domID = TopBarPauseToggle model.pipelineLocator
-                            }
-                        ]
-                , Login.view session.userState model
-                ]
+                         else
+                            Html.div
+                                Styles.pauseToggle
+                                [ PauseToggle.view
+                                    { pipeline = model.pipelineLocator
+                                    , isPaused = isPaused model.pipeline
+                                    , isToggleHovered =
+                                        HoverState.isHovered
+                                            (TopBarPauseToggle model.pipelineLocator)
+                                            session.hovered
+                                    , isToggleLoading = model.isToggleLoading
+                                    , tooltipPosition = Views.Styles.Below
+                                    , margin = "17px"
+                                    , userState = session.userState
+                                    , domID = TopBarPauseToggle model.pipelineLocator
+                                    }
+                                ]
+                       , Login.view session.userState model
+                       ]
+                )
             , Html.div
                 (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
               <|

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -393,12 +393,16 @@ view session model =
                 [ SideBar.sideBarIcon session
                 , TopBar.concourseLogo
                 , TopBar.breadcrumbs session route
-                , TopBar.paused
-                    { paused = displayPaused
-                    , pausedBy = pausedBy model.pipeline
-                    , pausedAt = pausedAt model.pipeline
-                    , timeZone = session.timeZone
-                    }
+                , if isArchived model.pipeline then
+                    Html.text ""
+
+                  else
+                    TopBar.paused
+                        { paused = displayPaused
+                        , pausedBy = pausedBy model.pipeline
+                        , pausedAt = pausedAt model.pipeline
+                        , timeZone = session.timeZone
+                        }
                 , PinMenu.viewPinMenu session model
                 , Html.div
                     Styles.favoritedIcon

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -1006,11 +1006,10 @@ view session model =
         (id "page-including-top-bar" :: Views.Styles.pageIncludingTopBar)
         [ Html.div
             (id "top-bar-app" :: Views.Styles.topBar False)
-            [ SideBar.sideBarIcon session
-            , TopBar.concourseLogo
-            , TopBar.breadcrumbs session route
-            , Login.view session.userState model
-            ]
+            (SideBar.sideBarIcon session
+                :: TopBar.breadcrumbs session route
+                ++ [ Login.view session.userState model ]
+            )
         , Html.div
             (id "page-below-top-bar" :: Views.Styles.pageBelowTopBar route)
             [ SideBar.view session

--- a/web/elm/src/Views/Styles.elm
+++ b/web/elm/src/Views/Styles.elm
@@ -26,6 +26,7 @@ module Views.Styles exposing
     , pauseToggleTooltip
     , separator
     , topBar
+    , topBarBackground
     )
 
 import Assets
@@ -146,8 +147,8 @@ topBar isPaused =
     ]
 
 
-concourseLogo : List (Html.Attribute msg)
-concourseLogo =
+concourseLogo : Bool -> Bool -> List (Html.Attribute msg)
+concourseLogo isPaused isArchived =
     [ style "background-image" <|
         Assets.backgroundImage <|
             Just Assets.ConcourseLogoWhite
@@ -157,6 +158,7 @@ concourseLogo =
     , style "display" "inline-block"
     , style "width" "54px"
     , style "height" "54px"
+    , topBarBackground isPaused isArchived
     ]
 
 
@@ -169,18 +171,32 @@ clusterName =
     ]
 
 
-breadcrumbContainer : Bool -> List (Html.Attribute msg)
-breadcrumbContainer isArchived =
+breadcrumbContainer : Bool -> Bool -> List (Html.Attribute msg)
+breadcrumbContainer isPaused isArchived =
     [ style "flex-grow" "1"
     , style "display" "flex"
     , style "min-width" "0"
-    , style "background-color" <|
-        if isArchived then
-            Colors.background
-
-        else
-            ""
+    , topBarBackground isPaused isArchived
     ]
+
+
+topBarBackground : Bool -> Bool -> Html.Attribute msg
+topBarBackground paused archived =
+    style
+        "background-color"
+    <|
+        case ( paused, archived ) of
+            ( True, False ) ->
+                Colors.paused
+
+            ( True, True ) ->
+                Colors.background
+
+            ( False, False ) ->
+                ""
+
+            ( False, True ) ->
+                Colors.background
 
 
 breadcrumbComponent :

--- a/web/elm/src/Views/Styles.elm
+++ b/web/elm/src/Views/Styles.elm
@@ -169,11 +169,17 @@ clusterName =
     ]
 
 
-breadcrumbContainer : List (Html.Attribute msg)
-breadcrumbContainer =
+breadcrumbContainer : Bool -> List (Html.Attribute msg)
+breadcrumbContainer isArchived =
     [ style "flex-grow" "1"
     , style "display" "flex"
     , style "min-width" "0"
+    , style "background-color" <|
+        if isArchived then
+            Colors.background
+
+        else
+            ""
     ]
 
 

--- a/web/elm/src/Views/TopBar.elm
+++ b/web/elm/src/Views/TopBar.elm
@@ -9,8 +9,8 @@ import Assets
 import ColorValues
 import Concourse exposing (hyphenNotation)
 import Dashboard.FilterBuilder exposing (instanceGroupFilter)
-import Dict
 import DateFormat
+import Dict
 import Html exposing (Html)
 import Html.Attributes
     exposing
@@ -77,81 +77,89 @@ pausedText p =
 breadcrumbs : Session -> Routes.Route -> Html Message
 breadcrumbs session route =
     let
-        buildBreadcrumbs components =
-            case List.reverse components of
-                x :: xs ->
-                    (List.map (\fn -> fn False) xs
-                        |> List.reverse
-                    )
-                        ++ [ x True ]
+        buildBreadcrumbs ( components, isArchived ) =
+            Html.div
+                (id "breadcrumbs" :: Styles.breadcrumbContainer isArchived)
+            <|
+                case List.reverse components of
+                    x :: xs ->
+                        (List.map (\fn -> fn False) xs
+                            |> List.reverse
+                        )
+                            ++ [ x True ]
 
-                [] ->
-                    []
+                    [] ->
+                        []
     in
-    Html.div
-        (id "breadcrumbs" :: Styles.breadcrumbContainer)
-    <|
-        buildBreadcrumbs <|
-            case route of
-                Routes.Pipeline { id } ->
-                    case lookupPipeline (byPipelineId id) session of
-                        Nothing ->
-                            []
+    buildBreadcrumbs <|
+        case route of
+            Routes.Pipeline { id } ->
+                case lookupPipeline (byPipelineId id) session of
+                    Nothing ->
+                        ( [], False )
 
-                        Just pipeline ->
-                            pipelineBreadcrumbs session pipeline []
+                    Just pipeline ->
+                        ( pipelineBreadcrumbs session pipeline [], pipeline.archived )
 
-                Routes.Build { id, groups } ->
-                    case lookupPipeline (byPipelineId id) session of
-                        Nothing ->
-                            []
+            Routes.Build { id, groups } ->
+                case lookupPipeline (byPipelineId id) session of
+                    Nothing ->
+                        ( [], False )
 
-                        Just pipeline ->
-                            pipelineBreadcrumbs session pipeline groups
-                                ++ [ breadcrumbSeparator
-                                   , jobBreadcrumb id.jobName
-                                   ]
+                    Just pipeline ->
+                        ( pipelineBreadcrumbs session pipeline groups
+                            ++ [ breadcrumbSeparator
+                               , jobBreadcrumb id.jobName
+                               ]
+                        , pipeline.archived
+                        )
 
-                Routes.Resource { id, groups } ->
-                    case lookupPipeline (byPipelineId id) session of
-                        Nothing ->
-                            []
+            Routes.Resource { id, groups } ->
+                case lookupPipeline (byPipelineId id) session of
+                    Nothing ->
+                        ( [], False )
 
-                        Just pipeline ->
-                            pipelineBreadcrumbs session pipeline groups
-                                ++ [ breadcrumbSeparator
-                                   , resourceBreadcrumb id
-                                   ]
+                    Just pipeline ->
+                        ( pipelineBreadcrumbs session pipeline groups
+                            ++ [ breadcrumbSeparator
+                               , resourceBreadcrumb id
+                               ]
+                        , pipeline.archived
+                        )
 
-                Routes.Job { id, groups } ->
-                    case lookupPipeline (byPipelineId id) session of
-                        Nothing ->
-                            []
+            Routes.Job { id, groups } ->
+                case lookupPipeline (byPipelineId id) session of
+                    Nothing ->
+                        ( [], False )
 
-                        Just pipeline ->
-                            pipelineBreadcrumbs session pipeline groups
-                                ++ [ breadcrumbSeparator
-                                   , jobBreadcrumb id.jobName
-                                   ]
+                    Just pipeline ->
+                        ( pipelineBreadcrumbs session pipeline groups
+                            ++ [ breadcrumbSeparator
+                               , jobBreadcrumb id.jobName
+                               ]
+                        , pipeline.archived
+                        )
 
-                Routes.Dashboard _ ->
-                    [ clusterNameBreadcrumb session ]
+            Routes.Dashboard _ ->
+                ( [ clusterNameBreadcrumb session ], False )
 
-                Routes.Causality { id, direction, version, groups } ->
-                    case lookupPipeline (byPipelineId id) session of
-                        Nothing ->
-                            []
+            Routes.Causality { id, direction, version, groups } ->
+                case lookupPipeline (byPipelineId id) session of
+                    Nothing ->
+                        ( [], False )
 
-                        Just pipeline ->
-                            pipelineBreadcrumbs session pipeline groups
-                                ++ [ breadcrumbSeparator
-                                   , resourceBreadcrumb <| Concourse.resourceIdFromVersionedResourceId id
-                                   , breadcrumbSeparator
-                                   , causalityBreadCrumb id direction (Maybe.withDefault Dict.empty version)
-                                   ]
+                    Just pipeline ->
+                        ( pipelineBreadcrumbs session pipeline groups
+                            ++ [ breadcrumbSeparator
+                               , resourceBreadcrumb <| Concourse.resourceIdFromVersionedResourceId id
+                               , breadcrumbSeparator
+                               , causalityBreadCrumb id direction (Maybe.withDefault Dict.empty version)
+                               ]
+                        , pipeline.archived
+                        )
 
-                _ ->
-                    []
+            _ ->
+                ( [], False )
 
 
 breadcrumbComponent :
@@ -218,7 +226,7 @@ pipelineBreadcrumbs session pipeline groups =
                     :: Styles.breadcrumbItem True isLastBreadcrumb
                 )
                 [ InstanceGroupBadge.view ColorValues.white (List.length pipelineGroup)
-                , Html.text pipeline.name
+                , Html.text <| pipelineNameView pipeline.name pipeline.archived
                 ]
     in
     (if inInstanceGroup then
@@ -232,6 +240,15 @@ pipelineBreadcrumbs session pipeline groups =
         ++ [ pipelineBreadcrumb inInstanceGroup pipeline groups ]
 
 
+pipelineNameView : String -> Bool -> String
+pipelineNameView pipelineName isArchived =
+    if isArchived then
+        pipelineName ++ " (archived)"
+
+    else
+        pipelineName
+
+
 pipelineBreadcrumb : Bool -> Concourse.Pipeline -> List String -> Bool -> Html Message
 pipelineBreadcrumb inInstanceGroup pipeline groups isLastBreadcrumb =
     let
@@ -240,7 +257,7 @@ pipelineBreadcrumb inInstanceGroup pipeline groups isLastBreadcrumb =
                 hyphenNotation pipeline.instanceVars
 
             else
-                pipeline.name
+                pipelineNameView pipeline.name pipeline.archived
     in
     Html.a
         ([ id "breadcrumb-pipeline"


### PR DESCRIPTION
## Changes proposed by this PR

* add "archived" to pipeline name
* change breadcrumbs background to grey

closes #7163



* [x] done

## Release Note

When viewing an archived pipeline (or any sub routes of it) in UI, the pipeline name now shows "archived" and the breadcrumbs background will change to grey so one won't confuse.

