### PR TITLE
Fix DB performance regression with updating resource cache metadata

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1688,7 +1688,6 @@ func (cmd *RunCommand) constructEngine(
 			rateLimiter,
 			policyChecker,
 			workerFactory,
-			resourceCacheFactory,
 			lockFactory,
 		),
 		secretManager,

--- a/atc/engine/builder.go
+++ b/atc/engine/builder.go
@@ -39,28 +39,25 @@ func NewStepperFactory(
 	rateLimiter RateLimiter,
 	policyChecker policy.Checker,
 	dbWorkerFactory db.WorkerFactory,
-	dbResourceCacheFactory db.ResourceCacheFactory,
 	lockFactory lock.LockFactory,
 ) StepperFactory {
 	return &stepperFactory{
-		coreFactory:            coreFactory,
-		externalURL:            externalURL,
-		rateLimiter:            rateLimiter,
-		policyChecker:          policyChecker,
-		dbWorkerFactory:        dbWorkerFactory,
-		dbResourceCacheFactory: dbResourceCacheFactory,
-		lockFactory:            lockFactory,
+		coreFactory:     coreFactory,
+		externalURL:     externalURL,
+		rateLimiter:     rateLimiter,
+		policyChecker:   policyChecker,
+		dbWorkerFactory: dbWorkerFactory,
+		lockFactory:     lockFactory,
 	}
 }
 
 type stepperFactory struct {
-	coreFactory            CoreStepFactory
-	externalURL            string
-	rateLimiter            RateLimiter
-	policyChecker          policy.Checker
-	dbWorkerFactory        db.WorkerFactory
-	dbResourceCacheFactory db.ResourceCacheFactory
-	lockFactory            lock.LockFactory
+	coreFactory     CoreStepFactory
+	externalURL     string
+	rateLimiter     RateLimiter
+	policyChecker   policy.Checker
+	dbWorkerFactory db.WorkerFactory
+	lockFactory     lock.LockFactory
 }
 
 func (factory *stepperFactory) StepperForBuild(build db.Build) (exec.Stepper, error) {
@@ -75,13 +72,12 @@ func (factory *stepperFactory) StepperForBuild(build db.Build) (exec.Stepper, er
 
 func (factory *stepperFactory) buildDelegateFactory(build db.Build, plan atc.Plan) DelegateFactory {
 	return DelegateFactory{
-		build:                  build,
-		plan:                   plan,
-		rateLimiter:            factory.rateLimiter,
-		policyChecker:          factory.policyChecker,
-		dbWorkerFactory:        factory.dbWorkerFactory,
-		dbResourceCacheFactory: factory.dbResourceCacheFactory,
-		lockFactory:            factory.lockFactory,
+		build:           build,
+		plan:            plan,
+		rateLimiter:     factory.rateLimiter,
+		policyChecker:   factory.policyChecker,
+		dbWorkerFactory: factory.dbWorkerFactory,
+		lockFactory:     factory.lockFactory,
 	}
 }
 

--- a/atc/engine/builder_test.go
+++ b/atc/engine/builder_test.go
@@ -18,12 +18,11 @@ var _ = Describe("Builder", func() {
 	Describe("BuildStep", func() {
 
 		var (
-			fakeCoreStepFactory      *enginefakes.FakeCoreStepFactory
-			fakeRateLimiter          *enginefakes.FakeRateLimiter
-			fakePolicyChecker        *policyfakes.FakeChecker
-			fakeWorkerFactory        *dbfakes.FakeWorkerFactory
-			fakeResourceCacheFactory *dbfakes.FakeResourceCacheFactory
-			fakeLockFactory          *lockfakes.FakeLockFactory
+			fakeCoreStepFactory *enginefakes.FakeCoreStepFactory
+			fakeRateLimiter     *enginefakes.FakeRateLimiter
+			fakePolicyChecker   *policyfakes.FakeChecker
+			fakeWorkerFactory   *dbfakes.FakeWorkerFactory
+			fakeLockFactory     *lockfakes.FakeLockFactory
 
 			planFactory    atc.PlanFactory
 			stepperFactory engine.StepperFactory
@@ -34,7 +33,6 @@ var _ = Describe("Builder", func() {
 			fakeRateLimiter = new(enginefakes.FakeRateLimiter)
 			fakePolicyChecker = new(policyfakes.FakeChecker)
 			fakeWorkerFactory = new(dbfakes.FakeWorkerFactory)
-			fakeResourceCacheFactory = new(dbfakes.FakeResourceCacheFactory)
 			fakeLockFactory = new(lockfakes.FakeLockFactory)
 
 			stepperFactory = engine.NewStepperFactory(
@@ -43,7 +41,6 @@ var _ = Describe("Builder", func() {
 				fakeRateLimiter,
 				fakePolicyChecker,
 				fakeWorkerFactory,
-				fakeResourceCacheFactory,
 				fakeLockFactory,
 			)
 

--- a/atc/engine/delegate_factory.go
+++ b/atc/engine/delegate_factory.go
@@ -11,17 +11,16 @@ import (
 )
 
 type DelegateFactory struct {
-	build                  db.Build
-	plan                   atc.Plan
-	rateLimiter            RateLimiter
-	policyChecker          policy.Checker
-	dbWorkerFactory        db.WorkerFactory
-	lockFactory            lock.LockFactory
-	dbResourceCacheFactory db.ResourceCacheFactory
+	build           db.Build
+	plan            atc.Plan
+	rateLimiter     RateLimiter
+	policyChecker   policy.Checker
+	dbWorkerFactory db.WorkerFactory
+	lockFactory     lock.LockFactory
 }
 
 func (delegate DelegateFactory) GetDelegate(state exec.RunState) exec.GetDelegate {
-	return NewGetDelegate(delegate.build, delegate.plan.ID, state, clock.NewClock(), delegate.policyChecker, delegate.dbResourceCacheFactory)
+	return NewGetDelegate(delegate.build, delegate.plan.ID, state, clock.NewClock(), delegate.policyChecker)
 }
 
 func (delegate DelegateFactory) PutDelegate(state exec.RunState) exec.PutDelegate {

--- a/atc/engine/get_delegate_test.go
+++ b/atc/engine/get_delegate_test.go
@@ -22,13 +22,12 @@ import (
 
 var _ = Describe("GetDelegate", func() {
 	var (
-		logger                   *lagertest.TestLogger
-		fakeBuild                *dbfakes.FakeBuild
-		fakePipeline             *dbfakes.FakePipeline
-		fakeResource             *dbfakes.FakeResource
-		fakeClock                *fakeclock.FakeClock
-		fakePolicyChecker        *policyfakes.FakeChecker
-		fakeResourceCacheFactory *dbfakes.FakeResourceCacheFactory
+		logger            *lagertest.TestLogger
+		fakeBuild         *dbfakes.FakeBuild
+		fakePipeline      *dbfakes.FakePipeline
+		fakeResource      *dbfakes.FakeResource
+		fakeClock         *fakeclock.FakeClock
+		fakePolicyChecker *policyfakes.FakeChecker
 
 		state exec.RunState
 
@@ -45,7 +44,6 @@ var _ = Describe("GetDelegate", func() {
 		fakePipeline = new(dbfakes.FakePipeline)
 		fakeResource = new(dbfakes.FakeResource)
 		fakeClock = fakeclock.NewFakeClock(now)
-		fakeResourceCacheFactory = new(dbfakes.FakeResourceCacheFactory)
 		credVars := vars.StaticVariables{
 			"source-param": "super-secret-source",
 			"git-key":      "{\n123\n456\n789\n}\n",
@@ -59,7 +57,7 @@ var _ = Describe("GetDelegate", func() {
 
 		fakePolicyChecker = new(policyfakes.FakeChecker)
 
-		delegate = engine.NewGetDelegate(fakeBuild, "some-plan-id", state, fakeClock, fakePolicyChecker, fakeResourceCacheFactory)
+		delegate = engine.NewGetDelegate(fakeBuild, "some-plan-id", state, fakeClock, fakePolicyChecker)
 	})
 
 	Describe("Finished", func() {
@@ -79,31 +77,15 @@ var _ = Describe("GetDelegate", func() {
 		})
 	})
 
-	Describe("UpdateMetadata", func() {
-		var dummyResourceCache db.ResourceCache
+	Describe("UpdateResourceVersion", func() {
 		var resourceName string
 
 		JustBeforeEach(func() {
-			dummyResourceCache = new(dbfakes.FakeResourceCache)
-			delegate.UpdateMetadata(logger, resourceName, dummyResourceCache, info)
+			delegate.UpdateResourceVersion(logger, resourceName, info)
 		})
 
 		BeforeEach(func() {
 			resourceName = "some-resource"
-		})
-
-		It("updates the resource cache metadata", func() {
-			Expect(fakeResourceCacheFactory.UpdateResourceCacheMetadataCallCount()).To(Equal(1))
-		})
-
-		Context("when the resource is not a named resource", func() {
-			BeforeEach(func() {
-				resourceName = ""
-			})
-
-			It("doesn't try to retrieve the pipeline", func() {
-				Expect(fakeBuild.PipelineCallCount()).To(Equal(0))
-			})
 		})
 
 		Context("when retrieving the pipeline fails", func() {

--- a/atc/exec/execfakes/fake_get_delegate.go
+++ b/atc/exec/execfakes/fake_get_delegate.go
@@ -99,13 +99,12 @@ type FakeGetDelegate struct {
 	stdoutReturnsOnCall map[int]struct {
 		result1 io.Writer
 	}
-	UpdateMetadataStub        func(lager.Logger, string, db.ResourceCache, resource.VersionResult)
-	updateMetadataMutex       sync.RWMutex
-	updateMetadataArgsForCall []struct {
+	UpdateResourceVersionStub        func(lager.Logger, string, resource.VersionResult)
+	updateResourceVersionMutex       sync.RWMutex
+	updateResourceVersionArgsForCall []struct {
 		arg1 lager.Logger
 		arg2 string
-		arg3 db.ResourceCache
-		arg4 resource.VersionResult
+		arg3 resource.VersionResult
 	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
@@ -522,39 +521,38 @@ func (fake *FakeGetDelegate) StdoutReturnsOnCall(i int, result1 io.Writer) {
 	}{result1}
 }
 
-func (fake *FakeGetDelegate) UpdateMetadata(arg1 lager.Logger, arg2 string, arg3 db.ResourceCache, arg4 resource.VersionResult) {
-	fake.updateMetadataMutex.Lock()
-	fake.updateMetadataArgsForCall = append(fake.updateMetadataArgsForCall, struct {
+func (fake *FakeGetDelegate) UpdateResourceVersion(arg1 lager.Logger, arg2 string, arg3 resource.VersionResult) {
+	fake.updateResourceVersionMutex.Lock()
+	fake.updateResourceVersionArgsForCall = append(fake.updateResourceVersionArgsForCall, struct {
 		arg1 lager.Logger
 		arg2 string
-		arg3 db.ResourceCache
-		arg4 resource.VersionResult
-	}{arg1, arg2, arg3, arg4})
-	stub := fake.UpdateMetadataStub
-	fake.recordInvocation("UpdateMetadata", []interface{}{arg1, arg2, arg3, arg4})
-	fake.updateMetadataMutex.Unlock()
+		arg3 resource.VersionResult
+	}{arg1, arg2, arg3})
+	stub := fake.UpdateResourceVersionStub
+	fake.recordInvocation("UpdateResourceVersion", []interface{}{arg1, arg2, arg3})
+	fake.updateResourceVersionMutex.Unlock()
 	if stub != nil {
-		fake.UpdateMetadataStub(arg1, arg2, arg3, arg4)
+		fake.UpdateResourceVersionStub(arg1, arg2, arg3)
 	}
 }
 
-func (fake *FakeGetDelegate) UpdateMetadataCallCount() int {
-	fake.updateMetadataMutex.RLock()
-	defer fake.updateMetadataMutex.RUnlock()
-	return len(fake.updateMetadataArgsForCall)
+func (fake *FakeGetDelegate) UpdateResourceVersionCallCount() int {
+	fake.updateResourceVersionMutex.RLock()
+	defer fake.updateResourceVersionMutex.RUnlock()
+	return len(fake.updateResourceVersionArgsForCall)
 }
 
-func (fake *FakeGetDelegate) UpdateMetadataCalls(stub func(lager.Logger, string, db.ResourceCache, resource.VersionResult)) {
-	fake.updateMetadataMutex.Lock()
-	defer fake.updateMetadataMutex.Unlock()
-	fake.UpdateMetadataStub = stub
+func (fake *FakeGetDelegate) UpdateResourceVersionCalls(stub func(lager.Logger, string, resource.VersionResult)) {
+	fake.updateResourceVersionMutex.Lock()
+	defer fake.updateResourceVersionMutex.Unlock()
+	fake.UpdateResourceVersionStub = stub
 }
 
-func (fake *FakeGetDelegate) UpdateMetadataArgsForCall(i int) (lager.Logger, string, db.ResourceCache, resource.VersionResult) {
-	fake.updateMetadataMutex.RLock()
-	defer fake.updateMetadataMutex.RUnlock()
-	argsForCall := fake.updateMetadataArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+func (fake *FakeGetDelegate) UpdateResourceVersionArgsForCall(i int) (lager.Logger, string, resource.VersionResult) {
+	fake.updateResourceVersionMutex.RLock()
+	defer fake.updateResourceVersionMutex.RUnlock()
+	argsForCall := fake.updateResourceVersionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeGetDelegate) WaitingForWorker(arg1 lager.Logger) {
@@ -610,8 +608,8 @@ func (fake *FakeGetDelegate) Invocations() map[string][][]interface{} {
 	defer fake.stderrMutex.RUnlock()
 	fake.stdoutMutex.RLock()
 	defer fake.stdoutMutex.RUnlock()
-	fake.updateMetadataMutex.RLock()
-	defer fake.updateMetadataMutex.RUnlock()
+	fake.updateResourceVersionMutex.RLock()
+	defer fake.updateResourceVersionMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -136,9 +136,10 @@ var _ = Describe("GetStep", func() {
 			TypeImage: atc.TypeImage{
 				BaseType: "some-base-type",
 			},
-			Source:  atc.Source{"some": "((source-var))"},
-			Params:  atc.Params{"some": "((params-var))"},
-			Version: &atc.Version{"some": "version"},
+			Resource: "some-resource",
+			Source:   atc.Source{"some": "((source-var))"},
+			Params:   atc.Params{"some": "((params-var))"},
+			Version:  &atc.Version{"some": "version"},
 		}
 	})
 
@@ -297,8 +298,12 @@ var _ = Describe("GetStep", func() {
 					Expect(getVolume.ResourceCacheInitialized).To(BeFalse())
 				})
 
-				It("updates the version metadata", func() {
-					Expect(fakeDelegate.UpdateMetadataCallCount()).To(Equal(1))
+				It("updates the resource version", func() {
+					Expect(fakeDelegate.UpdateResourceVersionCallCount()).To(Equal(1))
+				})
+
+				It("does not update the resource cache metadata", func() {
+					Expect(fakeResourceCacheFactory.UpdateResourceCacheMetadataCallCount()).To(Equal(0))
 				})
 
 				It("finishes with the correct version result", func() {
@@ -333,8 +338,22 @@ var _ = Describe("GetStep", func() {
 					Expect(getVolume.ResourceCacheInitialized).To(BeTrue())
 				})
 
-				It("updates the version metadata", func() {
-					Expect(fakeDelegate.UpdateMetadataCallCount()).To(Equal(1))
+				It("updates the version", func() {
+					Expect(fakeDelegate.UpdateResourceVersionCallCount()).To(Equal(1))
+				})
+
+				Context("when the get step is not for a named resource", func() {
+					BeforeEach(func() {
+						getPlan.Resource = ""
+					})
+
+					It("does not update the version", func() {
+						Expect(fakeDelegate.UpdateResourceVersionCallCount()).To(Equal(0))
+					})
+				})
+
+				It("updates the resource cache metadata", func() {
+					Expect(fakeResourceCacheFactory.UpdateResourceCacheMetadataCallCount()).To(Equal(1))
 				})
 
 				It("finishes the step via the delegate", func() {
@@ -665,8 +684,8 @@ var _ = Describe("GetStep", func() {
 			Expect(info.Metadata).To(Equal([]atc.MetadataField{{Name: "some", Value: "metadata"}}))
 		})
 
-		It("saves the version metadata for the resource", func() {
-			Expect(fakeDelegate.UpdateMetadataCallCount()).To(Equal(1))
+		It("saves the version for the resource", func() {
+			Expect(fakeDelegate.UpdateResourceVersionCallCount()).To(Equal(1))
 		})
 
 		It("does not return an err", func() {
@@ -692,6 +711,10 @@ var _ = Describe("GetStep", func() {
 
 		It("does not return an err", func() {
 			Expect(stepErr).ToNot(HaveOccurred())
+		})
+
+		It("does not update the resource version", func() {
+			Expect(fakeDelegate.UpdateResourceVersionCallCount()).To(Equal(0))
 		})
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

#6597 restructured the code for the get step and introduced a performance regression where we always update the resource cache metadata, even if the get result was fetched from the cache (i.e. no `in` script actually ran).

This resulted in a ton of lock contention, particularly for the implicit `get` step of commonly used resource types.

* [x] Only update the resource cache metadata if the resource get actually runs - not if it's found in the cache

## Notes to reviewer

This doesn't affect any released version of Concourse