### PR TITLE
Don't create workdir volume for check steps

### DIFF
--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -260,8 +260,6 @@ func (step *CheckStep) runCheck(
 		Env:       step.metadata.Env(),
 		Type:      db.ContainerTypeCheck,
 
-		Dir: step.containerMetadata.WorkingDirectory,
-
 		CertsBindMount: true,
 	}
 	tracing.Inject(ctx, &containerSpec)

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -431,6 +431,10 @@ var _ = Describe("CheckStep", func() {
 						}))
 					})
 
+					It("does not set the workdir", func() {
+						Expect(chosenContainer.Spec.Dir).To(Equal(""))
+					})
+
 					Context("when tracing is enabled", func() {
 						BeforeEach(func() {
 							tracing.ConfigureTraceProvider(oteltest.NewTracerProvider())

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -178,7 +178,7 @@ func (step *GetStep) run(ctx context.Context, state RunState, delegate GetDelega
 		Env:  step.metadata.Env(),
 		Type: db.ContainerTypeGet,
 
-		Dir: step.containerMetadata.WorkingDirectory,
+		Dir: resource.ResourcesDir("get"),
 
 		CertsBindMount: true,
 	}
@@ -474,7 +474,7 @@ func (step *GetStep) performGetAndInitCache(
 		return nil, versionResult, processResult, nil
 	}
 
-	volume := resourceMountVolume(mounts)
+	volume := step.resourceMountVolume(mounts)
 
 	if err := volume.InitializeResourceCache(logger, resourceCache); err != nil {
 		logger.Error("failed-to-initialize-resource-cache", err)
@@ -484,7 +484,7 @@ func (step *GetStep) performGetAndInitCache(
 	return volume, versionResult, processResult, nil
 }
 
-func resourceMountVolume(mounts []runtime.VolumeMount) runtime.Volume {
+func (step *GetStep) resourceMountVolume(mounts []runtime.VolumeMount) runtime.Volume {
 	for _, mnt := range mounts {
 		if mnt.MountPath == resource.ResourcesDir("get") {
 			return mnt.Volume

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -347,7 +347,7 @@ func (worker *Worker) createVolumes(
 
 	// if the working dir is already mounted, we can just re-use that volume.
 	// otherwise, we must create a new empty volume
-	if !anyMountTo(spec.Dir, ioVolumeMounts) {
+	if spec.Dir != "" && !anyMountTo(spec.Dir, ioVolumeMounts) {
 		workdirVolume, err := worker.findOrCreateVolumeForContainer(
 			logger,
 			baggageclaim.VolumeSpec{

--- a/atc/worker/gardenruntime/worker_test.go
+++ b/atc/worker/gardenruntime/worker_test.go
@@ -694,6 +694,32 @@ var _ = Describe("Garden Worker", func() {
 		}))
 	})
 
+	Test("workdir volume not created if Dir not specified", func() {
+		scenario := Setup(
+			workertest.WithWorkers(
+				grt.NewWorker("worker"),
+			),
+		)
+		worker := scenario.Worker("worker")
+
+		_, volumeMounts, err := worker.FindOrCreateContainer(
+			ctx,
+			db.NewFixedHandleContainerOwner("my-handle"),
+			db.ContainerMetadata{},
+			runtime.ContainerSpec{
+				ImageSpec: runtime.ImageSpec{
+					ImageURL: "raw:///img/rootfs",
+				},
+				Dir: "",
+			},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(volumeMountMap(volumeMounts)).To(consistOfMap(expectMap{
+			"/scratch": grt.HaveStrategy(baggageclaim.EmptyStrategy{}),
+		}))
+	})
+
 	Test("task caches", func() {
 		scenario := Setup(
 			workertest.WithBasicJob(),


### PR DESCRIPTION
## Changes proposed by this PR

I gather these setting the workdir isn't required for these steps. After
concourse/concourse#6597, the number of volumes on a given worker shot
up by ~50% (on a stress testing environment that solely runs check+get
steps) - this is a result of the extra volume per check+get container.
these volumes don't have a significant impact since they're empty, but
they will mess up people's metrics and placement strategies

## Notes to reviewer

More fixes for regressions from #6597 - unreleased