### PR TITLE
Don't query for the entire resource in the check delegate

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1233,7 +1233,7 @@ func (b *build) SaveOutput(
 		return err
 	}
 
-	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, b.conn, b.lockFactory, rc, theResource)
+	resourceConfigScope, err := findOrCreateResourceConfigScope(tx, b.conn, b.lockFactory, rc, NewIntPtr(theResource.ID()))
 	if err != nil {
 		return err
 	}
@@ -1257,7 +1257,9 @@ func (b *build) SaveOutput(
 		}
 	}
 
-	err = theResource.(*resource).setResourceConfigScopeInTransaction(tx, resourceConfigScope)
+	err = setResourceConfigScopeForResource(tx, resourceConfigScope, sq.Eq{
+		"id": theResource.ID(),
+	})
 	if err != nil {
 		return err
 	}

--- a/atc/db/dbfakes/fake_pipeline.go
+++ b/atc/db/dbfakes/fake_pipeline.go
@@ -442,6 +442,21 @@ type FakePipeline struct {
 		result2 bool
 		result3 error
 	}
+	ResourceIDStub        func(string) (int, bool, error)
+	resourceIDMutex       sync.RWMutex
+	resourceIDArgsForCall []struct {
+		arg1 string
+	}
+	resourceIDReturns struct {
+		result1 int
+		result2 bool
+		result3 error
+	}
+	resourceIDReturnsOnCall map[int]struct {
+		result1 int
+		result2 bool
+		result3 error
+	}
 	ResourceTypeStub        func(string) (db.ResourceType, bool, error)
 	resourceTypeMutex       sync.RWMutex
 	resourceTypeArgsForCall []struct {
@@ -506,6 +521,42 @@ type FakePipeline struct {
 		result1 error
 	}
 	setParentIDsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	SetResourceConfigScopeForPrototypeStub        func(string, db.ResourceConfigScope) error
+	setResourceConfigScopeForPrototypeMutex       sync.RWMutex
+	setResourceConfigScopeForPrototypeArgsForCall []struct {
+		arg1 string
+		arg2 db.ResourceConfigScope
+	}
+	setResourceConfigScopeForPrototypeReturns struct {
+		result1 error
+	}
+	setResourceConfigScopeForPrototypeReturnsOnCall map[int]struct {
+		result1 error
+	}
+	SetResourceConfigScopeForResourceStub        func(string, db.ResourceConfigScope) error
+	setResourceConfigScopeForResourceMutex       sync.RWMutex
+	setResourceConfigScopeForResourceArgsForCall []struct {
+		arg1 string
+		arg2 db.ResourceConfigScope
+	}
+	setResourceConfigScopeForResourceReturns struct {
+		result1 error
+	}
+	setResourceConfigScopeForResourceReturnsOnCall map[int]struct {
+		result1 error
+	}
+	SetResourceConfigScopeForResourceTypeStub        func(string, db.ResourceConfigScope) error
+	setResourceConfigScopeForResourceTypeMutex       sync.RWMutex
+	setResourceConfigScopeForResourceTypeArgsForCall []struct {
+		arg1 string
+		arg2 db.ResourceConfigScope
+	}
+	setResourceConfigScopeForResourceTypeReturns struct {
+		result1 error
+	}
+	setResourceConfigScopeForResourceTypeReturnsOnCall map[int]struct {
 		result1 error
 	}
 	TeamIDStub        func() int
@@ -2692,6 +2743,73 @@ func (fake *FakePipeline) ResourceByIDReturnsOnCall(i int, result1 db.Resource, 
 	}{result1, result2, result3}
 }
 
+func (fake *FakePipeline) ResourceID(arg1 string) (int, bool, error) {
+	fake.resourceIDMutex.Lock()
+	ret, specificReturn := fake.resourceIDReturnsOnCall[len(fake.resourceIDArgsForCall)]
+	fake.resourceIDArgsForCall = append(fake.resourceIDArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ResourceIDStub
+	fakeReturns := fake.resourceIDReturns
+	fake.recordInvocation("ResourceID", []interface{}{arg1})
+	fake.resourceIDMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakePipeline) ResourceIDCallCount() int {
+	fake.resourceIDMutex.RLock()
+	defer fake.resourceIDMutex.RUnlock()
+	return len(fake.resourceIDArgsForCall)
+}
+
+func (fake *FakePipeline) ResourceIDCalls(stub func(string) (int, bool, error)) {
+	fake.resourceIDMutex.Lock()
+	defer fake.resourceIDMutex.Unlock()
+	fake.ResourceIDStub = stub
+}
+
+func (fake *FakePipeline) ResourceIDArgsForCall(i int) string {
+	fake.resourceIDMutex.RLock()
+	defer fake.resourceIDMutex.RUnlock()
+	argsForCall := fake.resourceIDArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakePipeline) ResourceIDReturns(result1 int, result2 bool, result3 error) {
+	fake.resourceIDMutex.Lock()
+	defer fake.resourceIDMutex.Unlock()
+	fake.ResourceIDStub = nil
+	fake.resourceIDReturns = struct {
+		result1 int
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakePipeline) ResourceIDReturnsOnCall(i int, result1 int, result2 bool, result3 error) {
+	fake.resourceIDMutex.Lock()
+	defer fake.resourceIDMutex.Unlock()
+	fake.ResourceIDStub = nil
+	if fake.resourceIDReturnsOnCall == nil {
+		fake.resourceIDReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 bool
+			result3 error
+		})
+	}
+	fake.resourceIDReturnsOnCall[i] = struct {
+		result1 int
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakePipeline) ResourceType(arg1 string) (db.ResourceType, bool, error) {
 	fake.resourceTypeMutex.Lock()
 	ret, specificReturn := fake.resourceTypeReturnsOnCall[len(fake.resourceTypeArgsForCall)]
@@ -2996,6 +3114,192 @@ func (fake *FakePipeline) SetParentIDsReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.setParentIDsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForPrototype(arg1 string, arg2 db.ResourceConfigScope) error {
+	fake.setResourceConfigScopeForPrototypeMutex.Lock()
+	ret, specificReturn := fake.setResourceConfigScopeForPrototypeReturnsOnCall[len(fake.setResourceConfigScopeForPrototypeArgsForCall)]
+	fake.setResourceConfigScopeForPrototypeArgsForCall = append(fake.setResourceConfigScopeForPrototypeArgsForCall, struct {
+		arg1 string
+		arg2 db.ResourceConfigScope
+	}{arg1, arg2})
+	stub := fake.SetResourceConfigScopeForPrototypeStub
+	fakeReturns := fake.setResourceConfigScopeForPrototypeReturns
+	fake.recordInvocation("SetResourceConfigScopeForPrototype", []interface{}{arg1, arg2})
+	fake.setResourceConfigScopeForPrototypeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForPrototypeCallCount() int {
+	fake.setResourceConfigScopeForPrototypeMutex.RLock()
+	defer fake.setResourceConfigScopeForPrototypeMutex.RUnlock()
+	return len(fake.setResourceConfigScopeForPrototypeArgsForCall)
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForPrototypeCalls(stub func(string, db.ResourceConfigScope) error) {
+	fake.setResourceConfigScopeForPrototypeMutex.Lock()
+	defer fake.setResourceConfigScopeForPrototypeMutex.Unlock()
+	fake.SetResourceConfigScopeForPrototypeStub = stub
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForPrototypeArgsForCall(i int) (string, db.ResourceConfigScope) {
+	fake.setResourceConfigScopeForPrototypeMutex.RLock()
+	defer fake.setResourceConfigScopeForPrototypeMutex.RUnlock()
+	argsForCall := fake.setResourceConfigScopeForPrototypeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForPrototypeReturns(result1 error) {
+	fake.setResourceConfigScopeForPrototypeMutex.Lock()
+	defer fake.setResourceConfigScopeForPrototypeMutex.Unlock()
+	fake.SetResourceConfigScopeForPrototypeStub = nil
+	fake.setResourceConfigScopeForPrototypeReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForPrototypeReturnsOnCall(i int, result1 error) {
+	fake.setResourceConfigScopeForPrototypeMutex.Lock()
+	defer fake.setResourceConfigScopeForPrototypeMutex.Unlock()
+	fake.SetResourceConfigScopeForPrototypeStub = nil
+	if fake.setResourceConfigScopeForPrototypeReturnsOnCall == nil {
+		fake.setResourceConfigScopeForPrototypeReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setResourceConfigScopeForPrototypeReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResource(arg1 string, arg2 db.ResourceConfigScope) error {
+	fake.setResourceConfigScopeForResourceMutex.Lock()
+	ret, specificReturn := fake.setResourceConfigScopeForResourceReturnsOnCall[len(fake.setResourceConfigScopeForResourceArgsForCall)]
+	fake.setResourceConfigScopeForResourceArgsForCall = append(fake.setResourceConfigScopeForResourceArgsForCall, struct {
+		arg1 string
+		arg2 db.ResourceConfigScope
+	}{arg1, arg2})
+	stub := fake.SetResourceConfigScopeForResourceStub
+	fakeReturns := fake.setResourceConfigScopeForResourceReturns
+	fake.recordInvocation("SetResourceConfigScopeForResource", []interface{}{arg1, arg2})
+	fake.setResourceConfigScopeForResourceMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceCallCount() int {
+	fake.setResourceConfigScopeForResourceMutex.RLock()
+	defer fake.setResourceConfigScopeForResourceMutex.RUnlock()
+	return len(fake.setResourceConfigScopeForResourceArgsForCall)
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceCalls(stub func(string, db.ResourceConfigScope) error) {
+	fake.setResourceConfigScopeForResourceMutex.Lock()
+	defer fake.setResourceConfigScopeForResourceMutex.Unlock()
+	fake.SetResourceConfigScopeForResourceStub = stub
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceArgsForCall(i int) (string, db.ResourceConfigScope) {
+	fake.setResourceConfigScopeForResourceMutex.RLock()
+	defer fake.setResourceConfigScopeForResourceMutex.RUnlock()
+	argsForCall := fake.setResourceConfigScopeForResourceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceReturns(result1 error) {
+	fake.setResourceConfigScopeForResourceMutex.Lock()
+	defer fake.setResourceConfigScopeForResourceMutex.Unlock()
+	fake.SetResourceConfigScopeForResourceStub = nil
+	fake.setResourceConfigScopeForResourceReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceReturnsOnCall(i int, result1 error) {
+	fake.setResourceConfigScopeForResourceMutex.Lock()
+	defer fake.setResourceConfigScopeForResourceMutex.Unlock()
+	fake.SetResourceConfigScopeForResourceStub = nil
+	if fake.setResourceConfigScopeForResourceReturnsOnCall == nil {
+		fake.setResourceConfigScopeForResourceReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setResourceConfigScopeForResourceReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceType(arg1 string, arg2 db.ResourceConfigScope) error {
+	fake.setResourceConfigScopeForResourceTypeMutex.Lock()
+	ret, specificReturn := fake.setResourceConfigScopeForResourceTypeReturnsOnCall[len(fake.setResourceConfigScopeForResourceTypeArgsForCall)]
+	fake.setResourceConfigScopeForResourceTypeArgsForCall = append(fake.setResourceConfigScopeForResourceTypeArgsForCall, struct {
+		arg1 string
+		arg2 db.ResourceConfigScope
+	}{arg1, arg2})
+	stub := fake.SetResourceConfigScopeForResourceTypeStub
+	fakeReturns := fake.setResourceConfigScopeForResourceTypeReturns
+	fake.recordInvocation("SetResourceConfigScopeForResourceType", []interface{}{arg1, arg2})
+	fake.setResourceConfigScopeForResourceTypeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceTypeCallCount() int {
+	fake.setResourceConfigScopeForResourceTypeMutex.RLock()
+	defer fake.setResourceConfigScopeForResourceTypeMutex.RUnlock()
+	return len(fake.setResourceConfigScopeForResourceTypeArgsForCall)
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceTypeCalls(stub func(string, db.ResourceConfigScope) error) {
+	fake.setResourceConfigScopeForResourceTypeMutex.Lock()
+	defer fake.setResourceConfigScopeForResourceTypeMutex.Unlock()
+	fake.SetResourceConfigScopeForResourceTypeStub = stub
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceTypeArgsForCall(i int) (string, db.ResourceConfigScope) {
+	fake.setResourceConfigScopeForResourceTypeMutex.RLock()
+	defer fake.setResourceConfigScopeForResourceTypeMutex.RUnlock()
+	argsForCall := fake.setResourceConfigScopeForResourceTypeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceTypeReturns(result1 error) {
+	fake.setResourceConfigScopeForResourceTypeMutex.Lock()
+	defer fake.setResourceConfigScopeForResourceTypeMutex.Unlock()
+	fake.SetResourceConfigScopeForResourceTypeStub = nil
+	fake.setResourceConfigScopeForResourceTypeReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) SetResourceConfigScopeForResourceTypeReturnsOnCall(i int, result1 error) {
+	fake.setResourceConfigScopeForResourceTypeMutex.Lock()
+	defer fake.setResourceConfigScopeForResourceTypeMutex.Unlock()
+	fake.SetResourceConfigScopeForResourceTypeStub = nil
+	if fake.setResourceConfigScopeForResourceTypeReturnsOnCall == nil {
+		fake.setResourceConfigScopeForResourceTypeReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setResourceConfigScopeForResourceTypeReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -3355,6 +3659,8 @@ func (fake *FakePipeline) Invocations() map[string][][]interface{} {
 	defer fake.resourceMutex.RUnlock()
 	fake.resourceByIDMutex.RLock()
 	defer fake.resourceByIDMutex.RUnlock()
+	fake.resourceIDMutex.RLock()
+	defer fake.resourceIDMutex.RUnlock()
 	fake.resourceTypeMutex.RLock()
 	defer fake.resourceTypeMutex.RUnlock()
 	fake.resourceTypesMutex.RLock()
@@ -3365,6 +3671,12 @@ func (fake *FakePipeline) Invocations() map[string][][]interface{} {
 	defer fake.resourcesMutex.RUnlock()
 	fake.setParentIDsMutex.RLock()
 	defer fake.setParentIDsMutex.RUnlock()
+	fake.setResourceConfigScopeForPrototypeMutex.RLock()
+	defer fake.setResourceConfigScopeForPrototypeMutex.RUnlock()
+	fake.setResourceConfigScopeForResourceMutex.RLock()
+	defer fake.setResourceConfigScopeForResourceMutex.RUnlock()
+	fake.setResourceConfigScopeForResourceTypeMutex.RLock()
+	defer fake.setResourceConfigScopeForResourceTypeMutex.RUnlock()
 	fake.teamIDMutex.RLock()
 	defer fake.teamIDMutex.RUnlock()
 	fake.teamNameMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_config.go
+++ b/atc/db/dbfakes/fake_resource_config.go
@@ -29,10 +29,10 @@ type FakeResourceConfig struct {
 	createdByResourceCacheReturnsOnCall map[int]struct {
 		result1 db.ResourceCache
 	}
-	FindOrCreateScopeStub        func(db.Resource) (db.ResourceConfigScope, error)
+	FindOrCreateScopeStub        func(*int) (db.ResourceConfigScope, error)
 	findOrCreateScopeMutex       sync.RWMutex
 	findOrCreateScopeArgsForCall []struct {
-		arg1 db.Resource
+		arg1 *int
 	}
 	findOrCreateScopeReturns struct {
 		result1 db.ResourceConfigScope
@@ -182,11 +182,11 @@ func (fake *FakeResourceConfig) CreatedByResourceCacheReturnsOnCall(i int, resul
 	}{result1}
 }
 
-func (fake *FakeResourceConfig) FindOrCreateScope(arg1 db.Resource) (db.ResourceConfigScope, error) {
+func (fake *FakeResourceConfig) FindOrCreateScope(arg1 *int) (db.ResourceConfigScope, error) {
 	fake.findOrCreateScopeMutex.Lock()
 	ret, specificReturn := fake.findOrCreateScopeReturnsOnCall[len(fake.findOrCreateScopeArgsForCall)]
 	fake.findOrCreateScopeArgsForCall = append(fake.findOrCreateScopeArgsForCall, struct {
-		arg1 db.Resource
+		arg1 *int
 	}{arg1})
 	stub := fake.FindOrCreateScopeStub
 	fakeReturns := fake.findOrCreateScopeReturns
@@ -207,13 +207,13 @@ func (fake *FakeResourceConfig) FindOrCreateScopeCallCount() int {
 	return len(fake.findOrCreateScopeArgsForCall)
 }
 
-func (fake *FakeResourceConfig) FindOrCreateScopeCalls(stub func(db.Resource) (db.ResourceConfigScope, error)) {
+func (fake *FakeResourceConfig) FindOrCreateScopeCalls(stub func(*int) (db.ResourceConfigScope, error)) {
 	fake.findOrCreateScopeMutex.Lock()
 	defer fake.findOrCreateScopeMutex.Unlock()
 	fake.FindOrCreateScopeStub = stub
 }
 
-func (fake *FakeResourceConfig) FindOrCreateScopeArgsForCall(i int) db.Resource {
+func (fake *FakeResourceConfig) FindOrCreateScopeArgsForCall(i int) *int {
 	fake.findOrCreateScopeMutex.RLock()
 	defer fake.findOrCreateScopeMutex.RUnlock()
 	argsForCall := fake.findOrCreateScopeArgsForCall[i]

--- a/atc/db/dbfakes/fake_resource_config_scope.go
+++ b/atc/db/dbfakes/fake_resource_config_scope.go
@@ -77,16 +77,6 @@ type FakeResourceConfigScope struct {
 		result2 bool
 		result3 error
 	}
-	ResourceStub        func() db.Resource
-	resourceMutex       sync.RWMutex
-	resourceArgsForCall []struct {
-	}
-	resourceReturns struct {
-		result1 db.Resource
-	}
-	resourceReturnsOnCall map[int]struct {
-		result1 db.Resource
-	}
 	ResourceConfigStub        func() db.ResourceConfig
 	resourceConfigMutex       sync.RWMutex
 	resourceConfigArgsForCall []struct {
@@ -96,6 +86,16 @@ type FakeResourceConfigScope struct {
 	}
 	resourceConfigReturnsOnCall map[int]struct {
 		result1 db.ResourceConfig
+	}
+	ResourceIDStub        func() *int
+	resourceIDMutex       sync.RWMutex
+	resourceIDArgsForCall []struct {
+	}
+	resourceIDReturns struct {
+		result1 *int
+	}
+	resourceIDReturnsOnCall map[int]struct {
+		result1 *int
 	}
 	SaveVersionsStub        func(db.SpanContext, []atc.Version) error
 	saveVersionsMutex       sync.RWMutex
@@ -440,59 +440,6 @@ func (fake *FakeResourceConfigScope) LatestVersionReturnsOnCall(i int, result1 d
 	}{result1, result2, result3}
 }
 
-func (fake *FakeResourceConfigScope) Resource() db.Resource {
-	fake.resourceMutex.Lock()
-	ret, specificReturn := fake.resourceReturnsOnCall[len(fake.resourceArgsForCall)]
-	fake.resourceArgsForCall = append(fake.resourceArgsForCall, struct {
-	}{})
-	stub := fake.ResourceStub
-	fakeReturns := fake.resourceReturns
-	fake.recordInvocation("Resource", []interface{}{})
-	fake.resourceMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeResourceConfigScope) ResourceCallCount() int {
-	fake.resourceMutex.RLock()
-	defer fake.resourceMutex.RUnlock()
-	return len(fake.resourceArgsForCall)
-}
-
-func (fake *FakeResourceConfigScope) ResourceCalls(stub func() db.Resource) {
-	fake.resourceMutex.Lock()
-	defer fake.resourceMutex.Unlock()
-	fake.ResourceStub = stub
-}
-
-func (fake *FakeResourceConfigScope) ResourceReturns(result1 db.Resource) {
-	fake.resourceMutex.Lock()
-	defer fake.resourceMutex.Unlock()
-	fake.ResourceStub = nil
-	fake.resourceReturns = struct {
-		result1 db.Resource
-	}{result1}
-}
-
-func (fake *FakeResourceConfigScope) ResourceReturnsOnCall(i int, result1 db.Resource) {
-	fake.resourceMutex.Lock()
-	defer fake.resourceMutex.Unlock()
-	fake.ResourceStub = nil
-	if fake.resourceReturnsOnCall == nil {
-		fake.resourceReturnsOnCall = make(map[int]struct {
-			result1 db.Resource
-		})
-	}
-	fake.resourceReturnsOnCall[i] = struct {
-		result1 db.Resource
-	}{result1}
-}
-
 func (fake *FakeResourceConfigScope) ResourceConfig() db.ResourceConfig {
 	fake.resourceConfigMutex.Lock()
 	ret, specificReturn := fake.resourceConfigReturnsOnCall[len(fake.resourceConfigArgsForCall)]
@@ -543,6 +490,59 @@ func (fake *FakeResourceConfigScope) ResourceConfigReturnsOnCall(i int, result1 
 	}
 	fake.resourceConfigReturnsOnCall[i] = struct {
 		result1 db.ResourceConfig
+	}{result1}
+}
+
+func (fake *FakeResourceConfigScope) ResourceID() *int {
+	fake.resourceIDMutex.Lock()
+	ret, specificReturn := fake.resourceIDReturnsOnCall[len(fake.resourceIDArgsForCall)]
+	fake.resourceIDArgsForCall = append(fake.resourceIDArgsForCall, struct {
+	}{})
+	stub := fake.ResourceIDStub
+	fakeReturns := fake.resourceIDReturns
+	fake.recordInvocation("ResourceID", []interface{}{})
+	fake.resourceIDMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeResourceConfigScope) ResourceIDCallCount() int {
+	fake.resourceIDMutex.RLock()
+	defer fake.resourceIDMutex.RUnlock()
+	return len(fake.resourceIDArgsForCall)
+}
+
+func (fake *FakeResourceConfigScope) ResourceIDCalls(stub func() *int) {
+	fake.resourceIDMutex.Lock()
+	defer fake.resourceIDMutex.Unlock()
+	fake.ResourceIDStub = stub
+}
+
+func (fake *FakeResourceConfigScope) ResourceIDReturns(result1 *int) {
+	fake.resourceIDMutex.Lock()
+	defer fake.resourceIDMutex.Unlock()
+	fake.ResourceIDStub = nil
+	fake.resourceIDReturns = struct {
+		result1 *int
+	}{result1}
+}
+
+func (fake *FakeResourceConfigScope) ResourceIDReturnsOnCall(i int, result1 *int) {
+	fake.resourceIDMutex.Lock()
+	defer fake.resourceIDMutex.Unlock()
+	fake.ResourceIDStub = nil
+	if fake.resourceIDReturnsOnCall == nil {
+		fake.resourceIDReturnsOnCall = make(map[int]struct {
+			result1 *int
+		})
+	}
+	fake.resourceIDReturnsOnCall[i] = struct {
+		result1 *int
 	}{result1}
 }
 
@@ -746,10 +746,10 @@ func (fake *FakeResourceConfigScope) Invocations() map[string][][]interface{} {
 	defer fake.lastCheckMutex.RUnlock()
 	fake.latestVersionMutex.RLock()
 	defer fake.latestVersionMutex.RUnlock()
-	fake.resourceMutex.RLock()
-	defer fake.resourceMutex.RUnlock()
 	fake.resourceConfigMutex.RLock()
 	defer fake.resourceConfigMutex.RUnlock()
+	fake.resourceIDMutex.RLock()
+	defer fake.resourceIDMutex.RUnlock()
 	fake.saveVersionsMutex.RLock()
 	defer fake.saveVersionsMutex.RUnlock()
 	fake.updateLastCheckEndTimeMutex.RLock()

--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -305,7 +305,7 @@ func (builder Builder) WithResourceVersions(resourceName string, versions ...atc
 			return fmt.Errorf("find or create resource config: %w", err)
 		}
 
-		scope, err := resourceConfig.FindOrCreateScope(resource)
+		scope, err := resourceConfig.FindOrCreateScope(intptr(resource.ID()))
 		if err != nil {
 			return fmt.Errorf("find or create scope: %w", err)
 		}
@@ -991,4 +991,8 @@ func (builder Builder) createResourceCache(buildID int, resourceType db.Resource
 	}
 
 	return builder.ResourceCacheFactory.FindOrCreateResourceCache(db.ForBuild(buildID), resourceType.Type(), atc.Version{"custom-type": "version"}, resourceType.Source(), resourceType.Params(), imageResourceCache)
+}
+
+func intptr(i int) *int {
+	return &i
 }

--- a/atc/db/prototype.go
+++ b/atc/db/prototype.go
@@ -161,14 +161,18 @@ func (p *prototype) Reload() (bool, error) {
 }
 
 func (p *prototype) SetResourceConfigScope(scope ResourceConfigScope) error {
+	return setResourceConfigScopeForPrototype(p.conn, scope, sq.Eq{"id": p.id})
+}
+
+func setResourceConfigScopeForPrototype(conn sq.Runner, scope ResourceConfigScope, pred interface{}, args ...interface{}) error {
 	_, err := psql.Update("prototypes").
 		Set("resource_config_id", scope.ResourceConfig().ID()).
-		Where(sq.Eq{"id": p.id}).
+		Where(pred, args...).
 		Where(sq.Or{
 			sq.Eq{"resource_config_id": nil},
 			sq.NotEq{"resource_config_id": scope.ResourceConfig().ID()},
 		}).
-		RunWith(p.conn).
+		RunWith(conn).
 		Exec()
 	if err != nil {
 		return err

--- a/atc/db/prototype_test.go
+++ b/atc/db/prototype_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Prototype", func() {
 		})
 
 		It("creates a shared scope for the prototype", func() {
-			Expect(scope.Resource()).To(BeNil())
+			Expect(scope.ResourceID()).To(BeNil())
 			Expect(scope.ResourceConfig()).ToNot(BeNil())
 		})
 

--- a/atc/db/resource_cache_lifecycle_test.go
+++ b/atc/db/resource_cache_lifecycle_test.go
@@ -282,7 +282,7 @@ var _ = Describe("ResourceCacheLifecycle", func() {
 				Expect(found).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
 
-				resourceConfigScope, err := rc.FindOrCreateScope(scenario.Resource("some-resource"))
+				resourceConfigScope, err := rc.FindOrCreateScope(intptr(scenario.Resource("some-resource").ID()))
 				Expect(err).ToNot(HaveOccurred())
 
 				build, err := defaultJob.CreateBuild(defaultBuildCreatedBy)

--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -28,7 +28,7 @@ type LastCheck struct {
 // the resource id. Resource versions will therefore be directly dependent on a resource config scope.
 type ResourceConfigScope interface {
 	ID() int
-	Resource() Resource
+	ResourceID() *int
 	ResourceConfig() ResourceConfig
 
 	SaveVersions(SpanContext, []atc.Version) error
@@ -46,7 +46,7 @@ type ResourceConfigScope interface {
 
 type resourceConfigScope struct {
 	id             int
-	resource       Resource
+	resourceID     *int
 	resourceConfig ResourceConfig
 
 	conn        Conn
@@ -54,7 +54,7 @@ type resourceConfigScope struct {
 }
 
 func (r *resourceConfigScope) ID() int                        { return r.id }
-func (r *resourceConfigScope) Resource() Resource             { return r.resource }
+func (r *resourceConfigScope) ResourceID() *int               { return r.resourceID }
 func (r *resourceConfigScope) ResourceConfig() ResourceConfig { return r.resourceConfig }
 
 func (r *resourceConfigScope) LastCheck() (LastCheck, error) {

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Resource Config Scope", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(found).To(BeTrue())
 
-		resourceScope, err = rc.FindOrCreateScope(scenario.Resource("some-resource"))
+		resourceScope, err = rc.FindOrCreateScope(intptr(scenario.Resource("some-resource").ID()))
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/atc/db/resource_config_test.go
+++ b/atc/db/resource_config_test.go
@@ -26,7 +26,7 @@ var _ = Describe("ResourceConfig", func() {
 				It("finds or creates a global scope", func() {
 					createdScope, err := resourceConfig.FindOrCreateScope(nil)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(createdScope.Resource()).To(BeNil())
+					Expect(createdScope.ResourceID()).To(BeNil())
 					Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
 
 					foundScope, err := resourceConfig.FindOrCreateScope(nil)
@@ -43,13 +43,13 @@ var _ = Describe("ResourceConfig", func() {
 					})
 
 					It("finds or creates a unique scope", func() {
-						createdScope, err := resourceConfig.FindOrCreateScope(defaultResource)
+						createdScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 						Expect(err).ToNot(HaveOccurred())
-						Expect(createdScope.Resource()).ToNot(BeNil())
-						Expect(createdScope.Resource().ID()).To(Equal(defaultResource.ID()))
+						Expect(createdScope.ResourceID()).ToNot(BeNil())
+						Expect(*createdScope.ResourceID()).To(Equal(defaultResource.ID()))
 						Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
 
-						foundScope, err := resourceConfig.FindOrCreateScope(defaultResource)
+						foundScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(foundScope.ID()).To(Equal(createdScope.ID()))
 					})
@@ -61,12 +61,12 @@ var _ = Describe("ResourceConfig", func() {
 					})
 
 					It("finds or creates a global scope", func() {
-						createdScope, err := resourceConfig.FindOrCreateScope(defaultResource)
+						createdScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 						Expect(err).ToNot(HaveOccurred())
-						Expect(createdScope.Resource()).To(BeNil())
+						Expect(createdScope.ResourceID()).To(BeNil())
 						Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
 
-						foundScope, err := resourceConfig.FindOrCreateScope(defaultResource)
+						foundScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(foundScope.ID()).To(Equal(createdScope.ID()))
 					})
@@ -91,7 +91,7 @@ var _ = Describe("ResourceConfig", func() {
 				It("finds or creates a global scope", func() {
 					createdScope, err := resourceConfig.FindOrCreateScope(nil)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(createdScope.Resource()).To(BeNil())
+					Expect(createdScope.ResourceID()).To(BeNil())
 					Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
 
 					foundScope, err := resourceConfig.FindOrCreateScope(nil)
@@ -102,13 +102,13 @@ var _ = Describe("ResourceConfig", func() {
 
 			Context("given a resource", func() {
 				It("finds or creates a unique scope", func() {
-					createdScope, err := resourceConfig.FindOrCreateScope(defaultResource)
+					createdScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 					Expect(err).ToNot(HaveOccurred())
-					Expect(createdScope.Resource()).ToNot(BeNil())
-					Expect(createdScope.Resource().ID()).To(Equal(defaultResource.ID()))
+					Expect(createdScope.ResourceID()).ToNot(BeNil())
+					Expect(*createdScope.ResourceID()).To(Equal(defaultResource.ID()))
 					Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
 
-					foundScope, err := resourceConfig.FindOrCreateScope(defaultResource)
+					foundScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(foundScope.ID()).To(Equal(createdScope.ID()))
 				})

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -377,7 +377,7 @@ var _ = Describe("Resource", func() {
 			resourceConfig, err := resourceConfigFactory.FindOrCreateResourceConfig(resource.Type(), resource.Source(), nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			scope, err = resourceConfig.FindOrCreateScope(resource)
+			scope, err = resourceConfig.FindOrCreateScope(intptr(resource.ID()))
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -227,14 +227,18 @@ func (t *resourceType) Reload() (bool, error) {
 }
 
 func (r *resourceType) SetResourceConfigScope(scope ResourceConfigScope) error {
+	return setResourceConfigScopeForResourceType(r.conn, scope, sq.Eq{"id": r.id})
+}
+
+func setResourceConfigScopeForResourceType(conn sq.Runner, scope ResourceConfigScope, pred interface{}, args ...interface{}) error {
 	_, err := psql.Update("resource_types").
 		Set("resource_config_id", scope.ResourceConfig().ID()).
-		Where(sq.Eq{"id": r.id}).
+		Where(pred, args...).
 		Where(sq.Or{
 			sq.Eq{"resource_config_id": nil},
 			sq.NotEq{"resource_config_id": scope.ResourceConfig().ID()},
 		}).
-		RunWith(r.conn).
+		RunWith(conn).
 		Exec()
 	if err != nil {
 		return err

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -3669,7 +3669,7 @@ var _ = Describe("Team", func() {
 						)
 						Expect(err).ToNot(HaveOccurred())
 
-						scope, err := resourceConfig.FindOrCreateScope(defaultResource)
+						scope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 						Expect(err).ToNot(HaveOccurred())
 
 						err = defaultResource.SetResourceConfigScope(scope)
@@ -3731,7 +3731,7 @@ var _ = Describe("Team", func() {
 							)
 							Expect(err).ToNot(HaveOccurred())
 
-							scope, err := resourceConfig.FindOrCreateScope(otherResource)
+							scope, err := resourceConfig.FindOrCreateScope(intptr(otherResource.ID()))
 							Expect(err).ToNot(HaveOccurred())
 
 							err = otherResource.SetResourceConfigScope(scope)


### PR DESCRIPTION
[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

we found the resource query to be the most expensive in our stress test
environment (testing against the in-memory check builds - on master,
there are more expensive queries, but it's high up in the list). each
query performs a seq scan on resource_config_scopes. the query is still
very fast (hence the optimizer choosing to use a seq scan), but it's
very much in the hot-path so gets called frequently.

however, there's no need to query the whole resource - all we need it
for is to create a scope and to update it on the resource. for this, all
we need is the resource id and the (pipeline_id, name). if we reduce our
queries to this minimal set, we should make things more performant.

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->
This is *not* related to the worker refactor - it's just an optimization from what we observed in stress