### PR TITLE
Fix missing label in metric `concourse_steps_waiting`

### DIFF
--- a/atc/metric/periodic.go
+++ b/atc/metric/periodic.go
@@ -206,6 +206,7 @@ func tick(logger lager.Logger, m *Monitor) {
 				Attributes: map[string]string{
 					"platform":   labels.Platform,
 					"teamId":     labels.TeamId,
+					"teamName":   labels.TeamName,
 					"type":       labels.Type,
 					"workerTags": labels.WorkerTags,
 				},

--- a/atc/metric/periodic_test.go
+++ b/atc/metric/periodic_test.go
@@ -144,6 +144,7 @@ var _ = Describe("Periodic emission of metrics", func() {
 		labels := metric.StepsWaitingLabels{
 			Platform:   "darwin",
 			TeamId:     "42",
+			TeamName:   "teamdev",
 			Type:       "task",
 			WorkerTags: "tester",
 		}
@@ -163,6 +164,7 @@ var _ = Describe("Periodic emission of metrics", func() {
 						"Attributes": Equal(map[string]string{
 							"platform":   labels.Platform,
 							"teamId":     labels.TeamId,
+							"teamName":   labels.TeamName,
 							"type":       labels.Type,
 							"workerTags": labels.WorkerTags,
 						}),


### PR DESCRIPTION
Signed-off-by: Andrea Cristalli <andrea.cristalli@pix4d.com>

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

complete #7154

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->


## Notes to reviewer
`teamName` label is still missing in periodic metrics.  This bug has been raised after 7.4 release 
 [here](https://github.com/concourse/concourse/issues/6751#issuecomment-900194990). The PR aims to fix it.
<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note
* Fix missing label in metric `concourse_steps_waiting`
