### PR TITLE
Add team flag to fly command `abort-build`

### DIFF
--- a/fly/commands/destroy_pipeline.go
+++ b/fly/commands/destroy_pipeline.go
@@ -12,8 +12,7 @@ import (
 type DestroyPipelineCommand struct {
 	Pipeline        flaghelpers.PipelineFlag `short:"p"  long:"pipeline" required:"true" description:"Pipeline to destroy"`
 	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Destroy the pipeline without confirmation"`
-
-	Team string `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
+	Team flaghelpers.TeamFlag 				 `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *DestroyPipelineCommand) Validate() error {
@@ -38,14 +37,9 @@ func (command *DestroyPipelineCommand) Execute(args []string) error {
 	}
 
 	var team concourse.Team
-
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	pipelineRef := command.Pipeline.Ref()

--- a/fly/commands/expose_pipeline.go
+++ b/fly/commands/expose_pipeline.go
@@ -11,7 +11,7 @@ import (
 
 type ExposePipelineCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Pipeline to expose"`
-	Team     string                   `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
+	Team     flaghelpers.TeamFlag     `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *ExposePipelineCommand) Validate() error {
@@ -36,14 +36,9 @@ func (command *ExposePipelineCommand) Execute(args []string) error {
 	}
 
 	var team concourse.Team
-
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	pipelineRef := command.Pipeline.Ref()

--- a/fly/commands/get_pipeline.go
+++ b/fly/commands/get_pipeline.go
@@ -20,7 +20,7 @@ import (
 type GetPipelineCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Get configuration of this pipeline"`
 	JSON     bool                     `short:"j" long:"json"                     description:"Print config as json instead of yaml"`
-	Team     string                   `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
+	Team     flaghelpers.TeamFlag     `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *GetPipelineCommand) Validate() error {
@@ -45,14 +45,9 @@ func (command *GetPipelineCommand) Execute(args []string) error {
 	}
 
 	var team concourse.Team
-
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	config, _, found, err := team.PipelineConfig(command.Pipeline.Ref())

--- a/fly/commands/hide_pipeline.go
+++ b/fly/commands/hide_pipeline.go
@@ -11,7 +11,7 @@ import (
 
 type HidePipelineCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p"   long:"pipeline" required:"true" description:"Pipeline to hide"`
-	Team     string                   `long:"team"                                 description:"Name of the team to which the pipeline belongs, if different from the target default"`
+	Team     flaghelpers.TeamFlag     `long:"team"                                 description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *HidePipelineCommand) Validate() error {
@@ -36,13 +36,9 @@ func (command *HidePipelineCommand) Execute(args []string) error {
 	}
 
 	var team concourse.Team
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	pipelineRef := command.Pipeline.Ref()

--- a/fly/commands/hijack.go
+++ b/fly/commands/hijack.go
@@ -35,7 +35,7 @@ type HijackCommand struct {
 	PositionalArgs struct {
 		Command []string `positional-arg-name:"command" description:"The command to run in the container (default: bash)"`
 	} `positional-args:"yes"`
-	Team string `long:"team" description:"Name of the team to which the container belongs, if different from the target default"`
+	Team 		  flaghelpers.TeamFlag 		`long:"team" description:"Name of the team to which the container belongs, if different from the target default"`
 }
 
 func (command *HijackCommand) Execute([]string) error {
@@ -69,13 +69,9 @@ func (command *HijackCommand) Execute([]string) error {
 		return err
 	}
 
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	if command.Handle != "" {

--- a/fly/commands/internal/flaghelpers/team_flag.go
+++ b/fly/commands/internal/flaghelpers/team_flag.go
@@ -38,11 +38,10 @@ func (flag TeamFlag) Name() string {
 }
 
 func (flag TeamFlag) LoadTeam(target rc.Target) (concourse.Team, error) {
-	teamFlag := string(flag)
 	team := target.Team()
 	var err error
-	if teamFlag != "" {
-		team, err = target.FindTeam(teamFlag)
+	if flag.Name() != "" {
+		team, err = target.FindTeam(flag.Name())
 		if err != nil {
 			return nil, err
 		}

--- a/fly/commands/internal/flaghelpers/team_flag.go
+++ b/fly/commands/internal/flaghelpers/team_flag.go
@@ -1,6 +1,7 @@
 package flaghelpers
 
 import (
+	"github.com/concourse/concourse/go-concourse/concourse"
 	"strings"
 
 	"github.com/concourse/concourse/fly/rc"
@@ -34,4 +35,17 @@ func (flag *TeamFlag) Complete(match string) []flags.Completion {
 
 func (flag TeamFlag) Name() string {
 	return string(flag)
+}
+
+func (flag TeamFlag) LoadTeam(target rc.Target) (concourse.Team, error) {
+	teamFlag := string(flag)
+	team := target.Team()
+	var err error
+	if teamFlag != "" {
+		team, err = target.FindTeam(teamFlag)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return team, nil
 }

--- a/fly/commands/jobs.go
+++ b/fly/commands/jobs.go
@@ -15,7 +15,7 @@ import (
 type JobsCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Get jobs in this pipeline"`
 	Json     bool                     `long:"json" description:"Print command result as JSON"`
-	Team     string                   `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
+	Team     flaghelpers.TeamFlag     `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *JobsCommand) Execute([]string) error {
@@ -34,13 +34,9 @@ func (command *JobsCommand) Execute([]string) error {
 		return err
 	}
 
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	var jobs []atc.Job

--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 	"sort"
 	"strings"
 
@@ -14,9 +15,9 @@ import (
 var ErrMissingPipelineName = errors.New("Need to specify at least one pipeline name")
 
 type OrderPipelinesCommand struct {
-	Alphabetical bool     `short:"a"  long:"alphabetical" description:"Order all pipelines alphabetically"`
-	Pipelines    []string `short:"p" long:"pipeline" description:"Name of pipeline (can be specified multiple times to provide relative ordering)"`
-	Team         string   `long:"team" description:"Name of the team to which the pipelines belong, if different from the target default"`
+	Alphabetical bool     				`short:"a"  long:"alphabetical" description:"Order all pipelines alphabetically"`
+	Pipelines    []string 				`short:"p" long:"pipeline" description:"Name of pipeline (can be specified multiple times to provide relative ordering)"`
+	Team         flaghelpers.TeamFlag   `long:"team" description:"Name of the team to which the pipelines belong, if different from the target default"`
 }
 
 func (command *OrderPipelinesCommand) Execute(args []string) error {
@@ -59,13 +60,9 @@ func (command *OrderPipelinesCommand) Execute(args []string) error {
 	}
 
 	var team concourse.Team
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	err = team.OrderingPipelines(orderedNames)

--- a/fly/commands/paused_jobs.go
+++ b/fly/commands/paused_jobs.go
@@ -16,7 +16,7 @@ import (
 type PausedJobsCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Get jobs in this pipeline"`
 	Json     bool                     `long:"json" description:"Print command result as JSON"`
-	Team     string                   `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
+	Team     flaghelpers.TeamFlag     `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *PausedJobsCommand) Execute([]string) error {
@@ -31,13 +31,9 @@ func (command *PausedJobsCommand) Execute([]string) error {
 	}
 
 	var team concourse.Team
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	var jobs []atc.Job

--- a/fly/commands/trigger_job.go
+++ b/fly/commands/trigger_job.go
@@ -15,9 +15,9 @@ import (
 )
 
 type TriggerJobCommand struct {
-	Job   flaghelpers.JobFlag `short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" description:"Name of a job to trigger"`
-	Watch bool                `short:"w" long:"watch" description:"Start watching the build output"`
-	Team  string              `long:"team" description:"Name of the team to which the job belongs, if different from the target default"`
+	Job   flaghelpers.JobFlag 	`short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" description:"Name of a job to trigger"`
+	Watch bool                	`short:"w" long:"watch" description:"Start watching the build output"`
+	Team  flaghelpers.TeamFlag  `long:"team" description:"Name of the team to which the job belongs, if different from the target default"`
 }
 
 func (command *TriggerJobCommand) Execute(args []string) error {
@@ -38,13 +38,9 @@ func (command *TriggerJobCommand) Execute(args []string) error {
 		build atc.Build
 		team  concourse.Team
 	)
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	build, err = team.CreateJobBuild(pipelineRef, jobName)

--- a/fly/commands/unpause_job.go
+++ b/fly/commands/unpause_job.go
@@ -9,8 +9,8 @@ import (
 )
 
 type UnpauseJobCommand struct {
-	Job  flaghelpers.JobFlag `short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" description:"Name of a job to unpause"`
-	Team string              `long:"team" description:"Name of the team to which the job belongs, if different from the target default"`
+	Job  flaghelpers.JobFlag 	`short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB" description:"Name of a job to unpause"`
+	Team flaghelpers.TeamFlag    `long:"team" description:"Name of the team to which the job belongs, if different from the target default"`
 }
 
 func (command *UnpauseJobCommand) Execute(args []string) error {
@@ -27,13 +27,9 @@ func (command *UnpauseJobCommand) Execute(args []string) error {
 	}
 
 	var team concourse.Team
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	found, err := team.UnpauseJob(pipelineRef, jobName)

--- a/fly/commands/unpause_pipeline.go
+++ b/fly/commands/unpause_pipeline.go
@@ -13,7 +13,7 @@ import (
 type UnpausePipelineCommand struct {
 	Pipeline *flaghelpers.PipelineFlag `short:"p" long:"pipeline" description:"Pipeline to unpause"`
 	All      bool                      `short:"a" long:"all"      description:"Unpause all pipelines"`
-	Team     string                    `long:"team"              description:"Name of the team to which the pipeline belongs, if different from the target default"`
+	Team     flaghelpers.TeamFlag      `long:"team"              description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *UnpausePipelineCommand) Validate() error {
@@ -46,14 +46,9 @@ func (command *UnpausePipelineCommand) Execute(args []string) error {
 	}
 
 	var team concourse.Team
-
-	if command.Team != "" {
-		team, err = target.FindTeam(command.Team)
-		if err != nil {
-			return err
-		}
-	} else {
-		team = target.Team()
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
 	}
 
 	var pipelineRefs []atc.PipelineRef

--- a/fly/integration/abort_build_test.go
+++ b/fly/integration/abort_build_test.go
@@ -196,7 +196,7 @@ var _ = Describe("AbortBuild", func() {
 		})
 	})
 
-	FContext("user is NOT targeting the same team the pipeline belongs to", func() {
+	Context("user is NOT targeting the same team the pipeline belongs to", func() {
 		team := "diff-team"
 		BeforeEach(func() {
 			atcServer.AppendHandlers(

--- a/fly/integration/abort_build_test.go
+++ b/fly/integration/abort_build_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"net/http"
 	"os/exec"
 
@@ -192,6 +193,81 @@ var _ = Describe("AbortBuild", func() {
 			}).To(Change(func() int {
 				return len(atcServer.ReceivedRequests())
 			}).By(2))
+		})
+	})
+
+	FContext("user is NOT targeting the same team the pipeline belongs to", func() {
+		team := "diff-team"
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", team)),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+						Name: team,
+					}),
+				),
+			)
+		})
+
+		Context("when the job id and the build id are specified", func() {
+
+
+			Context("when the job and the build exist", func() {
+				BeforeEach(func() {
+					expectedURL := "/api/v1/teams/diff-team/pipelines/my-pipeline/jobs/my-job/builds/3"
+
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", expectedURL),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, expectedBuild),
+						),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("PUT", expectedAbortURL),
+							ghttp.RespondWith(http.StatusNoContent, ""),
+						),
+					)
+				})
+
+				It("abort the build", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "my-pipeline/my-job", "-b", "3", "--team", team)
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+
+					Expect(sess.Out).To(gbytes.Say("build successfully aborted"))
+				})
+			})
+
+			Context("when the job or build doesn't exist", func() {
+				BeforeEach(func() {
+					expectedURL := "/api/v1/teams/diff-team/pipelines/my-pipeline/jobs/non-existing-job/builds/3"
+
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", expectedURL),
+							ghttp.RespondWithJSONEncoded(http.StatusNotFound, expectedBuild),
+						),
+
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("PUT", expectedAbortURL),
+							ghttp.RespondWith(http.StatusNoContent, ""),
+						),
+					)
+				})
+
+				It("returns a helpful error message", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "my-pipeline/non-existing-job", "-b", "3", "--team", team)
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(1))
+
+					Expect(sess.Err).To(gbytes.Say("error: build does not exist"))
+				})
+			})
 		})
 	})
 })

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -135,6 +135,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("order-pipelines command returns an error",
 				exec.Command(flyPath, "-t", targetName, "order-pipelines", "-p", "pipeline", "--team", nonExistentTeam)),
+			Entry("abort-build command returns an error",
+				exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "pipeline/job", "-b", "4", "--team", nonExistentTeam)),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -177,6 +179,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", otherTeam)),
 			Entry("get-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", otherTeam)),
+			Entry("abort-build command returns an error",
+				exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "pipeline/job", "-b", "4", "--team", otherTeam)),
 		)
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

closes various items in #5215

* [x] Small refactor in order to centralize find team logic
* [x] Add team flag to abort-build command (with the new refactor)

## Notes to reviewer

Added team flag to fly command abort-build

Now you could add the `--team` flag to specify the team this action will be applied

## Release Note

* Added `team` flag to fly command abort-build, you could use this following the next format
`fly -t dev abort-build --job some-pipeline/some-job -b 2 --team test`