### PR TITLE
Clear resource config scope ID if source field changes

### DIFF
--- a/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.down.sql
+++ b/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.down.sql
@@ -1,0 +1,4 @@
+
+DROP TRIGGER IF EXISTS resources_config_update_clears_config_ids_trigger ON resources;
+
+DROP FUNCTION IF EXISTS clear_resource_configs_ids();

--- a/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.up.sql
+++ b/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.up.sql
@@ -1,0 +1,14 @@
+
+CREATE OR REPLACE FUNCTION clear_resource_config_ids() RETURNS TRIGGER AS $$
+BEGIN
+        EXECUTE format('UPDATE resources SET resource_config_id = NULL, resource_config_scope_id = NULL WHERE id=%s', NEW.id);
+        RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS resources_config_update_clears_config_ids_trigger ON resources;
+CREATE TRIGGER resources_config_update_clears_config_ids_trigger
+	AFTER UPDATE on resources
+	FOR EACH ROW
+	WHEN ((NEW.config IS DISTINCT FROM OLD.config) AND (NEW.active IS TRUE))
+	EXECUTE PROCEDURE clear_resource_config_ids();

--- a/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.up.sql
+++ b/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.up.sql
@@ -10,5 +10,5 @@ DROP TRIGGER IF EXISTS resources_config_update_clears_config_ids_trigger ON reso
 CREATE TRIGGER resources_config_update_clears_config_ids_trigger
 	AFTER UPDATE on resources
 	FOR EACH ROW
-	WHEN ((NEW.config IS DISTINCT FROM OLD.config) AND (NEW.active IS TRUE))
+	WHEN ((NEW.config::jsonb->'source' IS DISTINCT FROM OLD.config::jsonb->'source') AND (NEW.active IS TRUE))
 	EXECUTE PROCEDURE clear_resource_config_ids();

--- a/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.up.sql
+++ b/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.up.sql
@@ -10,5 +10,11 @@ DROP TRIGGER IF EXISTS resources_config_update_clears_config_ids_trigger ON reso
 CREATE TRIGGER resources_config_update_clears_config_ids_trigger
 	AFTER UPDATE on resources
 	FOR EACH ROW
-	WHEN ((NEW.config::jsonb->'source' IS DISTINCT FROM OLD.config::jsonb->'source') AND (NEW.active IS TRUE))
+	WHEN (
+		(
+			(NEW.config::jsonb->'source' IS DISTINCT FROM OLD.config::jsonb->'source') OR
+			(NEW.config::jsonb->'type' IS DISTINCT FROM OLD.config::jsonb->'type')
+		)
+		AND (NEW.active IS TRUE)
+	)
 	EXECUTE PROCEDURE clear_resource_config_ids();

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -563,18 +563,6 @@ func savePipeline(
 		return 0, false, err
 	}
 
-	_, err = psql.Update("resources").
-		Set("resource_config_id", nil).
-		Where(sq.Eq{
-			"pipeline_id": pipelineID,
-			"active":      false,
-		}).
-		RunWith(tx).
-		Exec()
-	if err != nil {
-		return 0, false, err
-	}
-
 	err = saveResourceTypes(tx, config.ResourceTypes, pipelineID)
 	if err != nil {
 		return 0, false, err

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -2509,7 +2509,7 @@ var _ = Describe("Team", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			Context("when new resource exists but is disabled", func() {
+			Context("when resource is renamed but has a disabled version", func() {
 				var scenario *dbtest.Scenario
 				var resource db.Resource
 
@@ -2530,7 +2530,7 @@ var _ = Describe("Team", func() {
 					resource = scenario.Resource("some-resource")
 				})
 
-				It("should not change the disabled version", func() {
+				It("the disabled version should still be in the resource's version history", func() {
 					config.Resources[0].Name = "disabled-resource"
 					config.Resources[0].OldName = "some-resource"
 					config.Jobs[0].PlanSequence = []atc.Step{

--- a/atc/db/team_test.go
+++ b/atc/db/team_test.go
@@ -2046,6 +2046,42 @@ var _ = Describe("Team", func() {
 			Expect(resource.ResourceConfigScopeID()).To(Equal(0))
 		})
 
+		It("clears the resource's config_id and config_scope_id if the type changed", func() {
+			pipeline, _, err := team.SavePipeline(pipelineRef, config, 0, false)
+			resource, found, err := pipeline.Resource("some-resource")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			resourceConfig, err := resourceConfigFactory.FindOrCreateResourceConfig(
+				defaultWorkerResourceType.Type, resource.Source(), nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			id := resource.ID()
+			resourceConfigScope, err := resourceConfig.FindOrCreateScope(&id)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = resource.SetResourceConfigScope(resourceConfigScope)
+			Expect(err).ToNot(HaveOccurred())
+
+			resource.Reload()
+			Expect(resource.ResourceConfigID()).ToNot(Equal(0))
+			Expect(resource.ResourceConfigScopeID()).ToNot(Equal(0))
+
+			config.Resources[0].Source = atc.Source{
+				"type": "some-other-type",
+			}
+
+			savedPipeline, _, err := team.SavePipeline(pipelineRef, config, pipeline.ConfigVersion(), false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// config_id and config_scope_id are cleared out by trigger resources_config_update_clears_config_ids_trigger
+			resource, found, err = savedPipeline.Resource("some-resource")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(resource.ResourceConfigID()).To(Equal(0))
+			Expect(resource.ResourceConfigScopeID()).To(Equal(0))
+		})
+
 		It("clears out api pinned version when resaving a pinned version on the pipeline config", func() {
 			scenario := dbtest.Setup(
 				builder.WithPipeline(config),


### PR DESCRIPTION
## Changes proposed by this PR

closes #7468

when a resources config updates it will eventually point to a new
version history, which is tied to the resource through the config_id and
config_scope_id columns.

When a resource config is initally updated the relationship between the
new and old config is not made until a check for the resource is run.
This results in a period where the algorithm may run and use a version
from the previous resource's config.

This sql trigger will set the config id's to NULL for any resources who
has their config updated. If a resource's config is not updated then the
config id columns are left as-is.

## Notes to Reviewer

- The jsonb type was introduced in postgres 9.4 and we support 9.5+
  - https://www.postgresql.org/docs/9.4/datatype-json.html
- The third commit removes a sql statement that came from the resource renaming PR (`old_name`). It was added at the same time as the test I updated the descriptions for was. It's unclear to me why this query is necessary. I don't know why we would want to remove specifically the config_id's of inactive resources. I don't think removing that saves us resources in anyway, afaik.
