### PR TITLE
Build page spacing and color theme in general

### DIFF
--- a/web/assets/css/_vars.less
+++ b/web/assets/css/_vars.less
@@ -39,12 +39,12 @@
 @grey90: #262626;
 @grey100: #151515;
 @success10: #DFF7EA;
-@success20: #9AF5C2;
-@success30: #5AE095;
+@success20: #B4F0CE;
+@success30: #70DB9F;
 @success40: #1CBD63;
-@success50: #0D9448;
+@success50: #70DB9F;
 @success60: #0B7539;
-@success70: #0F5930;
+@success70: #0D9448;
 @success80: #0D3D22;
 @success90: #0F2B1C;
 @success100: #0B1710;

--- a/web/assets/css/build.less
+++ b/web/assets/css/build.less
@@ -1,16 +1,13 @@
-// the following is a work-around a performance issue in Chrome wherein
-// updating the values of the duration fields forces a repaint of the entire
-// page.
-//
-// firefox and safari are unaffected.
-.dict-value {
-  position: relative;
+.horizontal-cell {
+  padding-left: 32px;
+}
 
-  span {
-    /* "remove" element from layout to prevent repainting entire page */
-    position: absolute;
-    width: 180px;
-    top: 0;
+.history-item:first-child {
+  padding-left: 16px;
+
+  a {
+    padding-left: 0 !important;
+    min-width: 0 !important;
   }
 }
 

--- a/web/assets/css/layout.less
+++ b/web/assets/css/layout.less
@@ -39,7 +39,7 @@ body,
   .scrollable-body {
     width: 100%;
     box-sizing: border-box;
-    padding: 10px;
+    padding: 16px;
   }
 }
 

--- a/web/assets/css/production.less
+++ b/web/assets/css/production.less
@@ -7,7 +7,7 @@
     line-height: 60px;
     float: left;
     margin: 0;
-    margin-left: 18px;
+    margin-left: 16px;
   }
 }
 
@@ -19,7 +19,7 @@
     line-height: 60px;
     float: left;
     margin: 0;
-    margin-left: 18px;
+    margin-left: 16px;
   }
 }
 
@@ -34,7 +34,7 @@
 
 .build-header .build-duration {
   float: left;
-  margin: 6px 0 6px 24px;
+  height: 60px;
 }
 
 .pagination-header .last-checked {
@@ -109,11 +109,13 @@
 
 #builds li a,
 .builds-list li a {
-  font-size: 20px;
-  line-height: 1em;
+  font-size: 23px;
+  line-height: 24px;
   text-align: center;
   margin: 0;
-  padding: 5px;
+  padding: 4px 6px 4px 4px;
+  min-width: 24px;
+  height: 24px;
   display: block;
   font-weight: bold;
   text-decoration: none;
@@ -160,7 +162,7 @@ li.prep-status {
 }
 
 .step-body {
-  padding: 10px 0 10px 10px;
+  padding: 8px 0 8px 8px;
 }
 
 .build-step pre {
@@ -176,7 +178,7 @@ li.prep-status {
 }
 
 .seq {
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
 .steps .seq:last-child {
@@ -193,7 +195,9 @@ li.prep-status {
 .build-step .header {
   cursor: pointer;
   clear: both;
-  min-height: 28px;
+  line-height: 15px;
+  font-size: 15px;
+  padding: 8px;
   border: 1px solid transparent;
   position: sticky;
   top: 0;
@@ -201,7 +205,6 @@ li.prep-status {
 }
 
 .build-step .header i {
-  line-height: 28px;
   width: 28px;
 }
 
@@ -218,19 +221,21 @@ li.prep-status {
 .build-step .header .dict-key,
 .build-step .header .dict-value {
   font-size: 14px;
-  line-height: 28px;
-  padding: 0 6px;
+  padding-right: 16px;
 }
 
 .build-step .dictionary {
   float: right;
 }
 
+.build-step .header .dictionary tr:not(:last-child) td {
+  padding-bottom: 8px;
+}
+
 .build-step .header h3 {
   margin: 0;
-  padding: 0 6px;
+  padding: 0 16px;
   float: left;
-  line-height: 28px;
 }
 
 .step-body .dictionary {
@@ -241,10 +246,14 @@ li.prep-status {
   max-width: 100%;
 }
 
+.step-body table tr:not(:last-child) td {
+  border-bottom: 8px solid @grey70;
+}
+
 .dict-key {
   text-align: right;
   vertical-align: top;
-  padding: 0 10px 0 0;
+  padding: 0 8px 0 0;
   margin: 0;
 }
 

--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -155,43 +155,57 @@ viewWidget widget =
 
 viewDuration : BuildDuration -> Html Message
 viewDuration buildDuration =
-    Html.table [ class "dictionary build-duration" ] <|
-        case buildDuration of
-            Pending ->
-                [ Html.tr []
-                    [ Html.td [ class "dict-key" ] [ Html.text "pending" ]
-                    , Html.td [ class "dict-value" ] []
-                    ]
-                ]
+    Html.table
+        [ class "dictionary build-duration"
+        , style "color" Colors.black
+        ]
+        [ Html.tr []
+            [ Html.td [ class "horizontal-cell" ] <|
+                case buildDuration of
+                    Pending ->
+                        [ Html.tr []
+                            [ Html.td [ class "dict-key" ] [ Html.text "pending" ]
+                            , Html.td [ class "dict-value" ] []
+                            ]
+                        ]
 
-            Running timestamp ->
-                [ Html.tr []
-                    [ Html.td [ class "dict-key" ] [ Html.text "started" ]
-                    , viewTimestamp timestamp
-                    ]
-                ]
+                    Running timestamp ->
+                        [ Html.tr []
+                            [ Html.td [ class "dict-key" ] [ Html.text "started" ]
+                            , viewTimestamp timestamp
+                            ]
+                        ]
 
-            Cancelled timestamp ->
-                [ Html.tr []
-                    [ Html.td [ class "dict-key" ] [ Html.text "finished" ]
-                    , viewTimestamp timestamp
-                    ]
-                ]
+                    Cancelled timestamp ->
+                        [ Html.tr []
+                            [ Html.td [ class "dict-key" ] [ Html.text "finished" ]
+                            , viewTimestamp timestamp
+                            ]
+                        ]
 
-            Finished { started, finished, duration } ->
-                [ Html.tr []
-                    [ Html.td [ class "dict-key" ] [ Html.text "started" ]
-                    , viewTimestamp started
-                    ]
-                , Html.tr []
-                    [ Html.td [ class "dict-key" ] [ Html.text "finished" ]
-                    , viewTimestamp finished
-                    ]
-                , Html.tr []
-                    [ Html.td [ class "dict-key" ] [ Html.text "duration" ]
-                    , Html.td [ class "dict-value" ] [ Html.text <| viewTimespan duration ]
-                    ]
-                ]
+                    Finished { started, finished } ->
+                        [ Html.tr []
+                            [ Html.td [ class "dict-key" ] [ Html.text "started" ]
+                            , viewTimestamp started
+                            ]
+                        , Html.tr []
+                            [ Html.td [ class "dict-key" ] [ Html.text "finished" ]
+                            , viewTimestamp finished
+                            ]
+                        ]
+            , Html.td [ class "horizontal-cell" ] <|
+                case buildDuration of
+                    Finished { duration } ->
+                        [ Html.tr []
+                            [ Html.td [ class "dict-key" ] [ Html.text "duration" ]
+                            , Html.td [ class "dict-value" ] [ Html.text <| viewTimespan duration ]
+                            ]
+                        ]
+
+                    _ ->
+                        []
+            ]
+        ]
 
 
 viewTimestamp : Timestamp -> Html Message
@@ -247,7 +261,8 @@ viewBuildTabs backgroundColor =
 viewBuildTab : BuildStatus -> BuildTab -> Html Message
 viewBuildTab backgroundColor tab =
     Html.li
-        ((id <| toHtmlID <| Message.BuildTab tab.id tab.name)
+        (class "history-item"
+            :: (id <| toHtmlID <| Message.BuildTab tab.id tab.name)
             :: Styles.historyItem backgroundColor tab.isCurrent tab.background
         )
         ((if tab.hasComment then
@@ -257,7 +272,8 @@ viewBuildTab backgroundColor tab =
             []
          )
             ++ [ Html.a
-                    [ onLeftClick <| Click <| Message.BuildTab tab.id tab.name
+                    [ style "color" <| Colors.buildTabTextColor tab.isCurrent tab.background
+                    , onLeftClick <| Click <| Message.BuildTab tab.id tab.name
                     , onMouseEnter <| Hover <| Just <| Message.BuildTab tab.id tab.name
                     , onMouseLeave <| Hover Nothing
                     , href <| Routes.toString tab.href
@@ -313,7 +329,7 @@ viewButton { type_, backgroundColor, backgroundShade, isClickable } =
                     Message.RerunBuildButton
 
         styles =
-            [ style "padding" "10px"
+            [ style "padding" "16px"
             , style "outline" "none"
             , style "margin" "0"
             , style "border-width" "0 0 0 1px"
@@ -351,7 +367,7 @@ viewButton { type_, backgroundColor, backgroundShade, isClickable } =
             ++ styles
         )
         [ Icon.icon
-            { sizePx = 40
+            { sizePx = 28
             , image = image
             }
             []
@@ -386,7 +402,11 @@ viewTitle name jobID createdBy =
                         , buildNameLineHeight
                         ]
                         [ Html.span [ class "build-name" ] [ Html.text jid.jobName ]
-                        , Html.span [ style "letter-spacing" "-1px" ] [ Html.text (" #" ++ name) ]
+                        , Html.span
+                            [ style "letter-spacing" "-1px"
+                            , style "margin-left" "16px"
+                            ]
+                            [ Html.text ("#" ++ name) ]
                         ]
 
                 Nothing ->

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -1144,7 +1144,7 @@ viewStepState state stepID =
         StepStateRunning ->
             Spinner.spinner
                 { sizePx = 14
-                , margin = "7px"
+                , margin = "0px"
                 }
 
         StepStatePending ->

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -914,8 +914,7 @@ viewInitializationToggle step =
             { sizePx = 14
             , image = Assets.CogsIcon
             }
-            [ style "margin" "7px 0"
-            , style "background-size" "contain"
+            [ style "background-size" "contain"
             ]
         ]
 
@@ -1150,7 +1149,7 @@ viewStepState state stepID =
 
         StepStatePending ->
             Icon.icon
-                { sizePx = 28
+                { sizePx = 14
                 , image = Assets.PendingIcon
                 }
                 (attribute "data-step-state" "pending"
@@ -1160,7 +1159,7 @@ viewStepState state stepID =
 
         StepStateInterrupted ->
             Icon.icon
-                { sizePx = 28
+                { sizePx = 14
                 , image = Assets.InterruptedIcon
                 }
                 (attribute "data-step-state" "interrupted"
@@ -1170,7 +1169,7 @@ viewStepState state stepID =
 
         StepStateCancelled ->
             Icon.icon
-                { sizePx = 28
+                { sizePx = 14
                 , image = Assets.CancelledIcon
                 }
                 (attribute "data-step-state" "cancelled"
@@ -1180,7 +1179,7 @@ viewStepState state stepID =
 
         StepStateSucceeded ->
             Icon.icon
-                { sizePx = 28
+                { sizePx = 14
                 , image = Assets.SuccessCheckIcon
                 }
                 (attribute "data-step-state" "succeeded"
@@ -1190,7 +1189,7 @@ viewStepState state stepID =
 
         StepStateFailed ->
             Icon.icon
-                { sizePx = 28
+                { sizePx = 14
                 , image = Assets.FailureTimesIcon
                 }
                 (attribute "data-step-state" "failed"
@@ -1200,7 +1199,7 @@ viewStepState state stepID =
 
         StepStateErrored ->
             Icon.icon
-                { sizePx = 28
+                { sizePx = 14
                 , image = Assets.ExclamationTriangleIcon
                 }
                 (attribute "data-step-state" "errored"

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -39,7 +39,7 @@ header status =
     , style "background" <|
         case status of
             BuildStatusStarted ->
-                Colors.startedFaded
+                Colors.started
 
             BuildStatusPending ->
                 Colors.pending
@@ -69,41 +69,69 @@ body =
 
 historyItem : BuildStatus -> Bool -> BuildStatus -> List (Html.Attribute msg)
 historyItem currentBuildStatus isCurrent status =
+    let
+        borderColor =
+            Colors.buildTabBorderColor isCurrent currentBuildStatus
+    in
     [ style "position" "relative"
     , style "letter-spacing" "-1px"
-    , style "padding" "0 2px 0 2px"
-    , style "border-top" <| "1px solid " ++ Colors.buildStatusColor isCurrent currentBuildStatus
-    , style "border-right" <| "1px solid " ++ Colors.buildStatusColor False status
-    , style "opacity" <|
-        if isCurrent then
-            "1"
-
-        else
-            "0.8"
+    , style "padding-top" "0"
+    , style "padding-bottom" "0"
+    , style "border-top" <| "1px solid " ++ borderColor
+    , style "border-bottom" <| "1px solid " ++ borderColor
     ]
-        ++ (case status of
-                BuildStatusStarted ->
-                    striped
-                        { pipelineRunningKeyframes = "pipeline-running"
-                        , thickColor = Colors.startedFaded
-                        , thinColor = Colors.started
-                        }
+        ++ buildTabBackground isCurrent status
 
-                BuildStatusPending ->
-                    [ style "background" Colors.pending ]
 
-                BuildStatusSucceeded ->
-                    [ style "background" Colors.success ]
+buildTabBackground : Bool -> BuildStatus -> List (Html.Attribute msg)
+buildTabBackground isCurrent status =
+    let
+        startedBackground =
+            striped
+                { pipelineRunningKeyframes = "pipeline-running"
+                , thickColor = Colors.startedFaded
+                , thinColor = Colors.started
+                }
+    in
+    if isCurrent then
+        case status of
+            BuildStatusStarted ->
+                startedBackground
 
-                BuildStatusFailed ->
-                    [ style "background" Colors.failure ]
+            BuildStatusPending ->
+                [ style "background" Colors.pending ]
 
-                BuildStatusErrored ->
-                    [ style "background" Colors.error ]
+            BuildStatusSucceeded ->
+                [ style "background" Colors.success ]
 
-                BuildStatusAborted ->
-                    [ style "background" Colors.aborted ]
-           )
+            BuildStatusFailed ->
+                [ style "background" Colors.failure ]
+
+            BuildStatusErrored ->
+                [ style "background" Colors.error ]
+
+            BuildStatusAborted ->
+                [ style "background" Colors.aborted ]
+
+    else
+        case status of
+            BuildStatusStarted ->
+                style "opacity" "0.8" :: startedBackground
+
+            BuildStatusPending ->
+                [ style "background" Colors.pendingFaded ]
+
+            BuildStatusSucceeded ->
+                [ style "background" Colors.successFaded ]
+
+            BuildStatusFailed ->
+                [ style "background" Colors.failureFaded ]
+
+            BuildStatusErrored ->
+                [ style "background" Colors.errorFaded ]
+
+            BuildStatusAborted ->
+                [ style "background" Colors.abortedFaded ]
 
 
 historyTriangle : String -> List (Html.Attribute msg)
@@ -203,8 +231,6 @@ stepHeaderLabel changed =
 
         else
             Colors.pending
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     ]
 
 
@@ -297,17 +323,15 @@ metadataCell cell =
         Key ->
             [ style "text-align" "left"
             , style "vertical-align" "top"
-            , style "background-color" "rgb(45,45,45)"
-            , style "border-bottom" "5px solid rgb(45,45,45)"
-            , style "padding" "5px"
+            , style "background-color" Colors.metadataKeyBackground
+            , style "padding" "8px"
             ]
 
         Value ->
             [ style "text-align" "left"
             , style "vertical-align" "top"
-            , style "background-color" "rgb(30,30,30)"
-            , style "border-bottom" "5px solid rgb(45,45,45)"
-            , style "padding" "5px"
+            , style "background-color" Colors.metadataValueBackground
+            , style "padding" "8px"
             ]
 
 

--- a/web/elm/src/ColorValues.elm
+++ b/web/elm/src/ColorValues.elm
@@ -139,12 +139,12 @@ success10 =
 
 success20 : String
 success20 =
-    "#9AF5C2"
+    "#B4F0CE"
 
 
 success30 : String
 success30 =
-    "#5AE095"
+    "#70DB9F"
 
 
 success40 : String
@@ -154,7 +154,7 @@ success40 =
 
 success50 : String
 success50 =
-    "#0D9448"
+    "#70DB9F"
 
 
 success60 : String
@@ -164,7 +164,7 @@ success60 =
 
 success70 : String
 success70 =
-    "#0F5930"
+    "#0D9448"
 
 
 success80 : String

--- a/web/elm/src/Colors.elm
+++ b/web/elm/src/Colors.elm
@@ -1,12 +1,16 @@
 module Colors exposing
     ( aborted
     , abortedFaded
+    , abortedTextFaded
     , asciiArt
     , background
     , backgroundDark
+    , black
     , border
     , bottomBarText
     , buildStatusColor
+    , buildTabBorderColor
+    , buildTabTextColor
     , buildTooltipText
     , buttonDisabledGrey
     , card
@@ -21,8 +25,10 @@ module Colors exposing
     , error
     , errorFaded
     , errorLog
+    , errorTextFaded
     , failure
     , failureFaded
+    , failureTextFaded
     , flySuccessButtonHover
     , flySuccessCard
     , flySuccessTokenCopied
@@ -35,12 +41,16 @@ module Colors exposing
     , infoBarBackground
     , inputOutline
     , instanceGroupBanner
+    , metadataKeyBackground
+    , metadataValueBackground
     , noPipelinesPlaceholderBackground
     , paginationHover
     , paused
     , pausedFaded
+    , pausedTextFaded
     , pending
     , pendingFaded
+    , pendingTextFaded
     , pinIconHover
     , pinMenuBackground
     , pinMenuHover
@@ -60,9 +70,11 @@ module Colors exposing
     , sideBarTextDim
     , started
     , startedFaded
+    , startedTextFaded
     , statusColor
     , success
     , successFaded
+    , successTextFaded
     , text
     , tooltipBackground
     , tooltipText
@@ -213,6 +225,11 @@ white =
     ColorValues.white
 
 
+black : String
+black =
+    ColorValues.black
+
+
 
 ----
 
@@ -255,69 +272,104 @@ startedFaded =
     "#f1c40f"
 
 
+startedTextFaded : String
+startedTextFaded =
+    ColorValues.grey20
+
+
 success : String
 success =
-    "#11c560"
+    ColorValues.success40
 
 
 successFaded : String
 successFaded =
-    "#419867"
+    ColorValues.success70
+
+
+successTextFaded : String
+successTextFaded =
+    ColorValues.success20
 
 
 paused : String
 paused =
-    "#3498db"
+    ColorValues.paused40
 
 
 pausedFaded : String
 pausedFaded =
-    "#2776ab"
+    ColorValues.paused70
+
+
+pausedTextFaded : String
+pausedTextFaded =
+    ColorValues.paused20
 
 
 pending : String
 pending =
-    "#9b9b9b"
+    ColorValues.grey40
 
 
 pendingFaded : String
 pendingFaded =
-    "#7a7373"
+    ColorValues.grey60
+
+
+pendingTextFaded : String
+pendingTextFaded =
+    ColorValues.grey20
 
 
 unknown : String
 unknown =
-    "#9b9b9b"
+    ColorValues.grey40
 
 
 failure : String
 failure =
-    "#ed4b35"
+    ColorValues.failure50
 
 
 failureFaded : String
 failureFaded =
-    "#bd3826"
+    ColorValues.failure80
+
+
+failureTextFaded : String
+failureTextFaded =
+    ColorValues.failure20
 
 
 error : String
 error =
-    "#f5a623"
+    ColorValues.error40
 
 
 errorFaded : String
 errorFaded =
-    "#ec9910"
+    ColorValues.error50
+
+
+errorTextFaded : String
+errorTextFaded =
+    ColorValues.error20
 
 
 aborted : String
 aborted =
-    "#8b572a"
+    ColorValues.error70
 
 
 abortedFaded : String
 abortedFaded =
-    "#6a401c"
+    ColorValues.error80
+
+
+abortedTextFaded : String
+abortedTextFaded =
+    ColorValues.error50
 
 
 
@@ -401,6 +453,20 @@ asciiArt =
 paginationHover : String
 paginationHover =
     "#504b4b"
+
+
+
+----
+
+
+metadataKeyBackground : String
+metadataKeyBackground =
+    ColorValues.grey70
+
+
+metadataValueBackground : String
+metadataValueBackground =
+    ColorValues.grey90
 
 
 
@@ -567,6 +633,32 @@ statusColor isBright status =
                 abortedFaded
 
 
+buildTabBorderColor : Bool -> BuildStatus -> String
+buildTabBorderColor isBright status =
+    if isBright then
+        case status of
+            BuildStatusStarted ->
+                started
+
+            BuildStatusPending ->
+                pending
+
+            BuildStatusSucceeded ->
+                success
+
+            BuildStatusFailed ->
+                failure
+
+            BuildStatusErrored ->
+                error
+
+            BuildStatusAborted ->
+                aborted
+
+    else
+        ColorValues.grey100
+
+
 buildStatusColor : Bool -> BuildStatus -> String
 buildStatusColor isBright status =
     if isBright then
@@ -608,6 +700,32 @@ buildStatusColor isBright status =
 
             BuildStatusAborted ->
                 abortedFaded
+
+
+buildTabTextColor : Bool -> BuildStatus -> String
+buildTabTextColor isCurrent status =
+    if isCurrent then
+        white
+
+    else
+        case status of
+            BuildStatusStarted ->
+                startedTextFaded
+
+            BuildStatusPending ->
+                pendingTextFaded
+
+            BuildStatusSucceeded ->
+                successTextFaded
+
+            BuildStatusFailed ->
+                failureTextFaded
+
+            BuildStatusErrored ->
+                errorTextFaded
+
+            BuildStatusAborted ->
+                abortedTextFaded
 
 
 

--- a/web/elm/src/SideBar/SideBar.elm
+++ b/web/elm/src/SideBar/SideBar.elm
@@ -503,7 +503,7 @@ sideBarIcon model =
                    )
             )
             [ Icon.icon
-                { sizePx = 54, image = assetSideBarIcon }
+                { sizePx = 22, image = assetSideBarIcon }
                 []
             ]
 

--- a/web/elm/src/SideBar/Styles.elm
+++ b/web/elm/src/SideBar/Styles.elm
@@ -273,6 +273,7 @@ sideBarMenu :
 sideBarMenu isClickable =
     [ style "border-right" <| "1px solid " ++ Colors.border
     , style "opacity" "1"
+    , style "padding" "16px"
     , style "cursor" <|
         if isClickable then
             "pointer"

--- a/web/elm/src/Views/Icon.elm
+++ b/web/elm/src/Views/Icon.elm
@@ -18,6 +18,7 @@ icon { sizePx, image } attrs =
          , style "width" (String.fromInt sizePx ++ "px")
          , style "background-position" "50% 50%"
          , style "background-repeat" "no-repeat"
+         , style "background-size" "cover"
          ]
             ++ attrs
         )

--- a/web/elm/src/Views/LoadingIndicator.elm
+++ b/web/elm/src/Views/LoadingIndicator.elm
@@ -16,7 +16,7 @@ view =
             ]
             [ Spinner.spinner
                 { sizePx = 14
-                , margin = "7px"
+                , margin = "0 7px"
                 }
             , Html.h3 [] [ Html.text "loading..." ]
             ]

--- a/web/elm/tests/BuildStepTests.elm
+++ b/web/elm/tests/BuildStepTests.elm
@@ -62,12 +62,6 @@ all =
                     >> when iAmLookingAtTheStepBody
                     >> when iAmLookingAtTheMetadataTable
                     >> then_ iSeeABottomMargin
-            , test "has a table that has cells with bottom borders" <|
-                given iVisitABuildWithAGetStep
-                    >> given theGetStepIsExpanded
-                    >> when iAmLookingAtTheStepBody
-                    >> when iAmLookingAtTheMetadataTableCells
-                    >> then_ iSeeLightGrayBottomBorder
             , test "has a table with cells that don't have a shared border" <|
                 given iVisitABuildWithAGetStep
                     >> given theGetStepIsExpanded
@@ -1188,11 +1182,11 @@ iSeeTheyTopAlignText =
 
 
 iSeeLightGrayCellBackground =
-    Query.has [ style "background-color" "rgb(45,45,45)" ]
+    Query.has [ style "background-color" "#4D4D4D" ]
 
 
 iSeeDarkGrayCellBackground =
-    Query.has [ style "background-color" "rgb(30,30,30)" ]
+    Query.has [ style "background-color" "#262626" ]
 
 
 iSeeATableWithBorderCollapse =
@@ -1204,11 +1198,12 @@ iSeeABottomMargin =
 
 
 iSeeLightGrayBottomBorder =
-    Query.each (Query.has [ style "border-bottom" "5px solid rgb(45,45,45)" ])
+    Query.first
+        >> Query.has [ style "border-bottom" "8px solid #4D4D4D" ]
 
 
 iSeeTheyHavePaddingAllAround =
-    Query.each (Query.has [ style "padding" "5px" ])
+    Query.each (Query.has [ style "padding" "8px" ])
 
 
 iAmLookingAtTheTabList =
@@ -1279,7 +1274,7 @@ iSeeASpinner =
 iSeeStatusIcon asset =
     Query.has
         (iconSelector
-            { size = "28px"
+            { size = "14px"
             , image = asset
             }
         )

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1477,7 +1477,7 @@ all =
                         |> Tuple.first
                         |> Common.queryView
                         |> Query.find [ class "build-duration" ]
-                        |> Query.find [ tag "tr", containing [ text "finished" ] ]
+                        |> Query.find [ tag "tr", containing [ tag "tr", containing [ text "finished" ] ] ]
                         |> Query.has [ text "2s ago" ]
             , test "when build finishes succesfully, header background is green" <|
                 \_ ->
@@ -1558,42 +1558,42 @@ all =
                             |> fetchBuildWithStatus BuildStatusPending
                             |> Common.queryView
                             |> Query.find [ id "build-header" ]
-                            |> Query.has [ style "background" "#9b9b9b" ]
+                            |> Query.has [ style "background" brightGrey ]
                 , test "started build has yellow banner" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
                             |> fetchBuildWithStatus BuildStatusStarted
                             |> Common.queryView
                             |> Query.find [ id "build-header" ]
-                            |> Query.has [ style "background" "#f1c40f" ]
+                            |> Query.has [ style "background" brightYellow ]
                 , test "succeeded build has green banner" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
                             |> fetchBuildWithStatus BuildStatusSucceeded
                             |> Common.queryView
                             |> Query.find [ id "build-header" ]
-                            |> Query.has [ style "background" "#11c560" ]
+                            |> Query.has [ style "background" brightGreen ]
                 , test "failed build has red banner" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
                             |> fetchBuildWithStatus BuildStatusFailed
                             |> Common.queryView
                             |> Query.find [ id "build-header" ]
-                            |> Query.has [ style "background" "#ed4b35" ]
+                            |> Query.has [ style "background" brightRed ]
                 , test "errored build has amber banner" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
                             |> fetchBuildWithStatus BuildStatusErrored
                             |> Common.queryView
                             |> Query.find [ id "build-header" ]
-                            |> Query.has [ style "background" "#f5a623" ]
+                            |> Query.has [ style "background" brightAmber ]
                 , test "aborted build has brown banner" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
                             |> fetchBuildWithStatus BuildStatusAborted
                             |> Common.queryView
                             |> Query.find [ id "build-header" ]
-                            |> Query.has [ style "background" "#8b572a" ]
+                            |> Query.has [ style "background" brightBrown ]
                 ]
             , describe "build history tab coloration"
                 [ test "pending build has grey tab in build history" <|
@@ -1603,7 +1603,7 @@ all =
                             |> Common.queryView
                             |> Query.find [ id "builds" ]
                             |> Query.find [ tag "li" ]
-                            |> Query.has [ style "background" "#9b9b9b" ]
+                            |> Query.has [ style "background" brightGrey ]
                 , test "started build has animated striped yellow tab in build history" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -1611,7 +1611,7 @@ all =
                             |> Common.queryView
                             |> Query.find [ id "builds" ]
                             |> Query.find [ tag "li" ]
-                            |> isColorWithStripes { thick = "#f1c40f", thin = "#fad43b" }
+                            |> isColorWithStripes { thick = darkYellow, thin = brightYellow }
                 , test "succeeded build has green tab in build history" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -1619,7 +1619,7 @@ all =
                             |> Common.queryView
                             |> Query.find [ id "builds" ]
                             |> Query.find [ tag "li" ]
-                            |> Query.has [ style "background" "#11c560" ]
+                            |> Query.has [ style "background" brightGreen ]
                 , test "failed build has red tab in build history" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -1627,7 +1627,7 @@ all =
                             |> Common.queryView
                             |> Query.find [ id "builds" ]
                             |> Query.find [ tag "li" ]
-                            |> Query.has [ style "background" "#ed4b35" ]
+                            |> Query.has [ style "background" brightRed ]
                 , test "errored build has amber tab in build history" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -1635,7 +1635,7 @@ all =
                             |> Common.queryView
                             |> Query.find [ id "builds" ]
                             |> Query.find [ tag "li" ]
-                            |> Query.has [ style "background" "#f5a623" ]
+                            |> Query.has [ style "background" brightAmber ]
                 , test "aborted build has brown tab in build history" <|
                     \_ ->
                         Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
@@ -1643,7 +1643,7 @@ all =
                             |> Common.queryView
                             |> Query.find [ id "builds" ]
                             |> Query.find [ tag "li" ]
-                            |> Query.has [ style "background" "#8b572a" ]
+                            |> Query.has [ style "background" brightBrown ]
                 ]
             , test "header spreads out contents" <|
                 givenBuildFetched
@@ -1814,7 +1814,7 @@ all =
                             )
                         >> Tuple.first
                         >> Common.queryView
-                        >> Query.has [ text " #2" ]
+                        >> Query.has [ text "#2" ]
                 , test "pressing Command-L does nothing" <|
                     givenBuildFetched
                         >> Tuple.first
@@ -2213,7 +2213,7 @@ all =
                         >> Query.first
                         >> Query.has
                             (iconSelector
-                                { size = "40px"
+                                { size = "28px"
                                 , image = Assets.AddCircleIcon |> Assets.CircleOutlineIcon
                                 }
                             )
@@ -2271,7 +2271,7 @@ all =
                         { description = "grey plus icon"
                         , selector =
                             iconSelector
-                                { size = "40px"
+                                { size = "28px"
                                 , image = Assets.AddCircleIcon |> Assets.CircleOutlineIcon
                                 }
                         }
@@ -2279,7 +2279,7 @@ all =
                         { description = "grey plus icon"
                         , selector =
                             iconSelector
-                                { size = "40px"
+                                { size = "28px"
                                 , image = Assets.AddCircleIcon |> Assets.CircleOutlineIcon
                                 }
                         }
@@ -3133,7 +3133,7 @@ all =
                         >> Query.index -1
                         >> Query.has
                             (iconSelector
-                                { size = "28px"
+                                { size = "14px"
                                 , image = Assets.SuccessCheckIcon
                                 }
                                 ++ [ style "background-size" "14px 14px" ]
@@ -3416,7 +3416,7 @@ all =
                         >> Query.index -1
                         >> Query.has
                             (iconSelector
-                                { size = "28px"
+                                { size = "14px"
                                 , image = Assets.PendingIcon
                                 }
                                 ++ [ style "background-size" "14px 14px" ]
@@ -3452,7 +3452,7 @@ all =
                         >> Query.index -1
                         >> Query.has
                             (iconSelector
-                                { size = "28px"
+                                { size = "14px"
                                 , image = Assets.InterruptedIcon
                                 }
                                 ++ [ style "background-size" "14px 14px" ]
@@ -3500,7 +3500,7 @@ all =
                         >> Query.index -1
                         >> Query.has
                             (iconSelector
-                                { size = "28px"
+                                { size = "14px"
                                 , image = Assets.CancelledIcon
                                 }
                                 ++ [ style "background-size" "14px 14px" ]
@@ -3543,7 +3543,7 @@ all =
                         >> Query.index -1
                         >> Query.has
                             (iconSelector
-                                { size = "28px"
+                                { size = "14px"
                                 , image = Assets.FailureTimesIcon
                                 }
                                 ++ [ style "background-size" "14px 14px" ]
@@ -3569,7 +3569,7 @@ all =
                         >> Query.index -1
                         >> Query.has
                             (iconSelector
-                                { size = "28px"
+                                { size = "14px"
                                 , image = Assets.ExclamationTriangleIcon
                                 }
                                 ++ [ style "background-size" "14px 14px" ]
@@ -3894,7 +3894,7 @@ testHeaderButton name model { key, index, domID, backgroundColor, hoveredBackgro
         button
             >> Query.children []
             >> Query.first
-            >> Query.has (iconSelector { size = "40px", image = icon })
+            >> Query.has (iconSelector { size = "28px", image = icon })
     , test (name ++ " button has correct tooltip") <|
         model
             >> expectTooltip domID tooltip
@@ -3912,72 +3912,54 @@ testHeaderButton name model { key, index, domID, backgroundColor, hoveredBackgro
 
 getStepLabel =
     [ style "color" Colors.pending
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     , containing [ text "get:" ]
     ]
 
 
 runStepLabel =
     [ style "color" Colors.pending
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     , containing [ text "run:" ]
     ]
 
 
 firstOccurrenceGetStepLabel =
     [ style "color" Colors.started
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     , containing [ text "get:" ]
     ]
 
 
 putStepLabel =
     [ style "color" Colors.pending
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     , containing [ text "put:" ]
     ]
 
 
 taskStepLabel =
     [ style "color" Colors.pending
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     , containing [ text "task:" ]
     ]
 
 
 setPipelineStepLabel =
     [ style "color" Colors.pending
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     , containing [ text "set_pipeline:" ]
     ]
 
 
 changedSetPipelineStepLabel =
     [ style "color" Colors.started
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     , containing [ text "set_pipeline:" ]
     ]
 
 
 checkStepLabel =
     [ style "color" Colors.pending
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     , containing [ text "check:" ]
     ]
 
 
 loadVarStepLabel =
     [ style "color" Colors.pending
-    , style "line-height" "28px"
-    , style "padding-left" "8px"
     , containing [ text "load_var:" ]
     ]
 
@@ -4006,19 +3988,14 @@ hoverSetPipelineChangedLabel =
         >> Tuple.first
 
 
-tooltipGreyHex : String
-tooltipGreyHex =
-    "#9b9b9b"
-
-
 darkRed : String
 darkRed =
-    "#bd3826"
+    "#5E1D14"
 
 
 brightRed : String
 brightRed =
-    "#ed4b35"
+    "#DB5442"
 
 
 darkYellow : String
@@ -4031,19 +4008,44 @@ brightYellow =
     "#fad43b"
 
 
+brightAmber : String
+brightAmber =
+    "#DE951D"
+
+
+darkAmber : String
+darkAmber =
+    "#B57200"
+
+
 darkGreen : String
 darkGreen =
-    "#419867"
+    "#0D9448"
 
 
 brightGreen : String
 brightGreen =
-    "#11c560"
+    "#1CBD63"
+
+
+brightGrey : String
+brightGrey =
+    "#A4A4A4"
 
 
 darkGrey : String
 darkGrey =
     "#3d3c3c"
+
+
+brightBrown : String
+brightBrown =
+    "#6E4500"
+
+
+darkBrown : String
+darkBrown =
+    "#4A3107"
 
 
 receiveEvent :

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -82,17 +82,17 @@ middleGrey =
 
 lightGrey : String
 lightGrey =
-    "#9b9b9b"
+    "#A4A4A4"
 
 
 green : String
 green =
-    "#11c560"
+    "#1CBD63"
 
 
 blue : String
 blue =
-    "#3498db"
+    "#4BAFF2"
 
 
 darkGrey : String
@@ -102,17 +102,17 @@ darkGrey =
 
 red : String
 red =
-    "#ed4b35"
+    "#DB5442"
 
 
 amber : String
 amber =
-    "#f5a623"
+    "#DE951D"
 
 
 brown : String
 brown =
-    "#8b572a"
+    "#6E4500"
 
 
 white : String
@@ -122,7 +122,7 @@ white =
 
 fadedGreen : String
 fadedGreen =
-    "#419867"
+    "#0D9448"
 
 
 orange : String

--- a/web/elm/tests/JobTests.elm
+++ b/web/elm/tests/JobTests.elm
@@ -867,12 +867,12 @@ all =
 
 darkGreen : String
 darkGreen =
-    "#419867"
+    "#0D9448"
 
 
 brightGreen : String
 brightGreen =
-    "#11c560"
+    "#1CBD63"
 
 
 someJobInfo : Concourse.JobIdentifier
@@ -959,7 +959,7 @@ loadingIndicatorSelector =
         "container-rotate 1568ms linear infinite"
     , style "height" "14px"
     , style "width" "14px"
-    , style "margin" "7px"
+    , style "margin" "0 7px"
     ]
 
 

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -573,7 +573,7 @@ all =
                         |> Tuple.first
                         |> Common.queryView
                         |> Query.find [ id "top-bar-app" ]
-                        |> Query.has [ style "background-color" "#3498db" ]
+                        |> Query.has [ style "background-color" "#4BAFF2" ]
             , test "top nav bar isn't blue when pipeline is archived" <|
                 \_ ->
                     Common.init "/teams/team/pipelines/pipeline"

--- a/web/elm/tests/SideBarFeature.elm
+++ b/web/elm/tests/SideBarFeature.elm
@@ -1032,7 +1032,7 @@ hoveredSideBarIcon opened =
 
 
 sidebarIconWidth =
-    "54px"
+    "22px"
 
 
 iSeeItLaysOutHorizontally =

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -80,7 +80,7 @@ backgroundGrey =
 
 pausedBlue : String
 pausedBlue =
-    "#3498db"
+    "#4BAFF2"
 
 
 topBarHeight : String

--- a/web/wats/helpers/palette.js
+++ b/web/wats/helpers/palette.js
@@ -11,15 +11,15 @@ module.exports = {
 
   "white": color("#FFFFFF"),
 
-  "green": color("#11C560"),
+  "green": color("#1CBD63"),
   "green2": color("#419867"),
   "amber": color("#F5A623"),
   "amber2": color("#D58808"),
-  "red": color("#ED4B35"),
+  "red": color("#DB5442"),
   "red2": color("#BD3826"),
   "blue": color("#4A90E2"),
   "blue2": color("#2D76CC"),
-  "brown": color("#8B572A"),
+  "brown": color("#6E4500"),
   "brown2": color("#6A401C"),
   "grey": color("#9B9B9B"),
   "grey2": color("#7A7373"),

--- a/web/wats/test/build.js
+++ b/web/wats/test/build.js
@@ -57,8 +57,8 @@ test('can be switched between', async t => {
   await t.context.web.page.goto(t.context.web.route(`/teams/${t.context.teamName}/pipelines/some-pipeline/jobs/passing/builds/1`));
 
   await t.context.web.clickAndWait('#builds li:nth-child(1) a', '[data-build-name="2"]');
-  t.regex(await t.context.web.text(), /passing #2/);
+  t.regex(await t.context.web.text(), /passing#2/);
 
   await t.context.web.clickAndWait('#builds li:nth-child(2) a', '[data-build-name="1"]');
-  t.regex(await t.context.web.text(), /passing #1/);
+  t.regex(await t.context.web.text(), /passing#1/);
 });

--- a/web/wats/test/smoke.js
+++ b/web/wats/test/smoke.js
@@ -32,7 +32,7 @@ test('running pipelines', async t => {
   await t.context.web.waitForText('say-hello');
 
   await t.context.web.page.goto(t.context.web.route(`/teams/${t.context.teamName}/pipelines/some-pipeline/jobs/say-hello/builds/1`));
-  await t.context.web.page.waitForSelector('.build-header[style*="rgb(17, 197, 96)"]'); // green
+  await t.context.web.page.waitForSelector('.build-header[style*="rgb(28, 189, 99)"]'); // green
   await t.context.web.clickAndWait('[data-step-name="hello"] .header', '[data-step-name="hello"] .step-body:not(.step-collapsed)');
   await t.context.web.waitForText('Hello, world!');
 


### PR DESCRIPTION
## Changes proposed by this PR

closes #6029 

Following the fixture in https://www.figma.com/file/fuoFSVcTGptiS21P2POA2XbN/Concourse-UI-kit-and-Experiments?node-id=1675%3A0 mostly for the build page spacing adjustment.

Also updating the colors used for build status by the color themes here https://www.figma.com/file/fuoFSVcTGptiS21P2POA2XbN/Concourse-UI-kit-and-Experiments?node-id=0%3A1

Now the build status colors metrics look like:

"" | successed | failed | errored | aborted | paused | pending
----  | -------- | -----  | ------- | -------- | ------- | --------
 active    | success 40       | failure 50  | error 40 |  error 70 | pause 40 | grey 40
background | success 70        | failure 80 | error 50 | error 80 | pause 70 | grey 60
 tab text        | success 20 |  failure 20 | error 20 | error 50 | pause 20 | grey 20

the primary grey is replaced by `grey 40` across the app

* [x] done
* [ ] todo


