### PR TITLE
web: behavior: Add "recently viewed pipelines" section to the sidebar

### DIFF
--- a/web/elm/src/Application/Application.elm
+++ b/web/elm/src/Application/Application.elm
@@ -87,6 +87,26 @@ init flags url =
                 { isOpen = False
                 , width = 275
                 }
+            , recentlyViewed =
+                let
+                    toPipelineIdentifier =
+                        \p -> { teamName = p.teamName, pipelineName = p.pipelineName, pipelineInstanceVars = p.pipelineInstanceVars }
+                in
+                case route of
+                    Routes.Pipeline { id } ->
+                        [ id ]
+
+                    Routes.Job { id } ->
+                        [ toPipelineIdentifier id ]
+
+                    Routes.Build { id } ->
+                        [ toPipelineIdentifier id ]
+
+                    Routes.Resource { id } ->
+                        [ toPipelineIdentifier id ]
+
+                    _ ->
+                        []
             , draggingSideBar = False
             , screenSize = ScreenSize.Desktop
             , timeZone = Time.utc

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -740,6 +740,9 @@ runEffect effect key csrfToken =
 pipelinesSectionName : PipelinesSection -> String
 pipelinesSectionName section =
     case section of
+        RecentlyViewedSection ->
+            "RecentlyViewed"
+
         FavoritesSection ->
             "Favorites"
 

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -123,7 +123,8 @@ type DomID
 
 
 type PipelinesSection
-    = FavoritesSection
+    = RecentlyViewedSection
+    | FavoritesSection
     | AllPipelinesSection
 
 

--- a/web/elm/src/SideBar/InstanceGroup.elm
+++ b/web/elm/src/SideBar/InstanceGroup.elm
@@ -23,7 +23,7 @@ instanceGroup :
         | hovered : HoverState.HoverState
         , currentPipeline : Maybe (PipelineScoped b)
         , favoritedInstanceGroups : Set ( Concourse.TeamName, Concourse.PipelineName )
-        , isFavoritesSection : Bool
+        , section : PipelinesSection
     }
     -> Concourse.Pipeline
     -> List Concourse.Pipeline
@@ -43,15 +43,7 @@ instanceGroup params p ps =
                     False
 
         domID =
-            SideBarInstanceGroup
-                (if params.isFavoritesSection then
-                    FavoritesSection
-
-                 else
-                    AllPipelinesSection
-                )
-                p.teamName
-                p.name
+            SideBarInstanceGroup params.section p.teamName p.name
 
         isHovered =
             HoverState.isHovered domID params.hovered

--- a/web/elm/src/SideBar/Pipeline.elm
+++ b/web/elm/src/SideBar/Pipeline.elm
@@ -25,7 +25,7 @@ type alias Params a b =
         | hovered : HoverState.HoverState
         , currentPipeline : Maybe (PipelineScoped b)
         , favoritedPipelines : Set Int
-        , isFavoritesSection : Bool
+        , section : PipelinesSection
     }
 
 
@@ -53,14 +53,7 @@ pipeline isInstancedPipeline params p =
                 SideBarPipeline
 
         domID =
-            domIDFn
-                (if params.isFavoritesSection then
-                    FavoritesSection
-
-                 else
-                    AllPipelinesSection
-                )
-                p.id
+            domIDFn params.section p.id
 
         isHovered =
             HoverState.isHovered domID params.hovered

--- a/web/elm/src/SideBar/Team.elm
+++ b/web/elm/src/SideBar/Team.elm
@@ -32,21 +32,14 @@ team :
         , currentPipeline : Maybe (PipelineScoped b)
         , favoritedPipelines : Set Int
         , favoritedInstanceGroups : Set ( Concourse.TeamName, Concourse.PipelineName )
-        , isFavoritesSection : Bool
+        , section : PipelinesSection
     }
     -> { name : String, isExpanded : Bool }
     -> Views.Team
 team params t =
     let
         domID =
-            SideBarTeam
-                (if params.isFavoritesSection then
-                    FavoritesSection
-
-                 else
-                    AllPipelinesSection
-                )
-                t.name
+            SideBarTeam params.section t.name
 
         isHovered =
             HoverState.isHovered domID params.hovered

--- a/web/elm/src/SideBar/Views.elm
+++ b/web/elm/src/SideBar/Views.elm
@@ -4,6 +4,8 @@ module SideBar.Views exposing
     , Pipeline
     , Team
     , TeamListItem(..)
+    , viewInstanceGroup
+    , viewPipeline
     , viewTeam
     )
 

--- a/web/elm/tests/ApplicationTests.elm
+++ b/web/elm/tests/ApplicationTests.elm
@@ -258,4 +258,10 @@ all =
                         |> Routes.getGroups
                         |> Expect.equal []
             ]
+        , test "adds initial page to recently viewed pages" <|
+            \_ ->
+                Common.init "/teams/t/pipelines/p"
+                    |> .session
+                    |> .recentlyViewed
+                    |> Expect.equal [ { teamName = "t", pipelineName = "p", pipelineInstanceVars = Dict.empty } ]
         ]

--- a/web/elm/tests/Build/HeaderTests.elm
+++ b/web/elm/tests/Build/HeaderTests.elm
@@ -465,6 +465,7 @@ session =
     , timeZone = Time.utc
     , favoritedPipelines = Set.empty
     , favoritedInstanceGroups = Set.empty
+    , recentlyViewed = []
     , route = Routes.Build { id = Data.jobBuildId, highlight = Routes.HighlightNothing, groups = [] }
     }
 

--- a/web/elm/tests/ResourceTests.elm
+++ b/web/elm/tests/ResourceTests.elm
@@ -4058,6 +4058,7 @@ session =
     , expandedTeamsInAllPipelines = Set.empty
     , collapsedTeamsInFavorites = Set.empty
     , pipelines = RemoteData.NotAsked
+    , recentlyViewed = []
     , sideBarState =
         { isOpen = False
         , width = 275

--- a/web/elm/tests/SideBar/InstanceGroupTests.elm
+++ b/web/elm/tests/SideBar/InstanceGroupTests.elm
@@ -23,7 +23,7 @@ defaultState =
     { active = False
     , hovered = False
     , favorited = False
-    , isFavoritesSection = False
+    , section = AllPipelinesSection
     }
 
 
@@ -147,16 +147,23 @@ all =
         , describe "when in all pipelines section"
             [ test "domID is for AllPipelines section" <|
                 \_ ->
-                    viewInstanceGroup { defaultState | isFavoritesSection = False }
+                    viewInstanceGroup { defaultState | section = AllPipelinesSection }
                         |> .domID
                         |> Expect.equal (SideBarInstanceGroup AllPipelinesSection "team" "group")
             ]
         , describe "when in favorites section"
             [ test "domID is for Favorites section" <|
                 \_ ->
-                    viewInstanceGroup { defaultState | isFavoritesSection = True }
+                    viewInstanceGroup { defaultState | section = FavoritesSection }
                         |> .domID
                         |> Expect.equal (SideBarInstanceGroup FavoritesSection "team" "group")
+            ]
+        , describe "when in recently viewed section"
+            [ test "domID is for RecentlyViewed section" <|
+                \_ ->
+                    viewInstanceGroup { defaultState | section = RecentlyViewedSection }
+                        |> .domID
+                        |> Expect.equal (SideBarInstanceGroup RecentlyViewedSection "team" "group")
             ]
         ]
 
@@ -165,10 +172,10 @@ viewInstanceGroup :
     { active : Bool
     , hovered : Bool
     , favorited : Bool
-    , isFavoritesSection : Bool
+    , section : PipelinesSection
     }
     -> Views.InstanceGroup
-viewInstanceGroup { active, hovered, favorited, isFavoritesSection } =
+viewInstanceGroup { active, hovered, favorited, section } =
     let
         hoveredDomId =
             if hovered then
@@ -195,7 +202,7 @@ viewInstanceGroup { active, hovered, favorited, isFavoritesSection } =
         { hovered = hoveredDomId
         , currentPipeline = activePipeline
         , favoritedInstanceGroups = favoritedInstanceGroups
-        , isFavoritesSection = isFavoritesSection
+        , section = section
         }
         (pipeline 1)
         [ pipeline 2, pipeline 3 ]

--- a/web/elm/tests/SideBar/PipelineTests.elm
+++ b/web/elm/tests/SideBar/PipelineTests.elm
@@ -22,7 +22,7 @@ defaultState =
     { active = False
     , hovered = False
     , favorited = False
-    , isFavoritesSection = False
+    , section = AllPipelinesSection
     }
 
 
@@ -165,7 +165,7 @@ regularPipeline =
             [ test "domID is for AllPipelines section" <|
                 \_ ->
                     pipeline
-                        |> viewPipeline { defaultState | isFavoritesSection = False }
+                        |> viewPipeline { defaultState | section = AllPipelinesSection }
                         |> .domID
                         |> Expect.equal
                             (SideBarPipeline AllPipelinesSection pipeline.id)
@@ -174,10 +174,19 @@ regularPipeline =
             [ test "domID is for Favorites section" <|
                 \_ ->
                     pipeline
-                        |> viewPipeline { defaultState | isFavoritesSection = True }
+                        |> viewPipeline { defaultState | section = FavoritesSection }
                         |> .domID
                         |> Expect.equal
                             (SideBarPipeline FavoritesSection pipeline.id)
+            ]
+        , describe "when in recently viewed section"
+            [ test "domID is for RecentlyViewed section" <|
+                \_ ->
+                    pipeline
+                        |> viewPipeline { defaultState | section = RecentlyViewedSection }
+                        |> .domID
+                        |> Expect.equal
+                            (SideBarPipeline RecentlyViewedSection pipeline.id)
             ]
         ]
 
@@ -215,11 +224,11 @@ viewPipeline :
     { active : Bool
     , hovered : Bool
     , favorited : Bool
-    , isFavoritesSection : Bool
+    , section : PipelinesSection
     }
     -> Concourse.Pipeline
     -> Views.Pipeline
-viewPipeline { active, hovered, favorited, isFavoritesSection } p =
+viewPipeline { active, hovered, favorited, section } p =
     let
         hoveredDomId =
             if hovered then
@@ -246,7 +255,7 @@ viewPipeline { active, hovered, favorited, isFavoritesSection } p =
         { hovered = hoveredDomId
         , currentPipeline = activePipeline
         , favoritedPipelines = favoritedPipelines
-        , isFavoritesSection = isFavoritesSection
+        , section = section
         }
         p
 
@@ -255,11 +264,11 @@ viewInstancedPipeline :
     { active : Bool
     , hovered : Bool
     , favorited : Bool
-    , isFavoritesSection : Bool
+    , section : PipelinesSection
     }
     -> Concourse.Pipeline
     -> Views.Pipeline
-viewInstancedPipeline { active, hovered, favorited, isFavoritesSection } p =
+viewInstancedPipeline { active, hovered, favorited, section } p =
     let
         hoveredDomId =
             if hovered then
@@ -286,7 +295,7 @@ viewInstancedPipeline { active, hovered, favorited, isFavoritesSection } p =
         { hovered = hoveredDomId
         , currentPipeline = activePipeline
         , favoritedPipelines = favoritedPipelines
-        , isFavoritesSection = isFavoritesSection
+        , section = section
         }
         p
 

--- a/web/elm/tests/SideBar/TeamTests.elm
+++ b/web/elm/tests/SideBar/TeamTests.elm
@@ -22,7 +22,7 @@ defaultState =
     , expanded = False
     , hovered = False
     , hasFavorited = False
-    , isFavoritesSection = False
+    , section = AllPipelinesSection
     }
 
 
@@ -284,7 +284,7 @@ all =
         , describe "when in all pipelines section"
             [ test "domID is for AllPipelines section" <|
                 \_ ->
-                    team { defaultState | isFavoritesSection = False }
+                    team { defaultState | section = AllPipelinesSection }
                         |> .name
                         |> .domID
                         |> Expect.equal (SideBarTeam AllPipelinesSection "team")
@@ -292,10 +292,18 @@ all =
         , describe "when in favorites section"
             [ test "domID is for Favorites section" <|
                 \_ ->
-                    team { defaultState | isFavoritesSection = True }
+                    team { defaultState | section = FavoritesSection }
                         |> .name
                         |> .domID
                         |> Expect.equal (SideBarTeam FavoritesSection "team")
+            ]
+        , describe "when in recently viewed section"
+            [ test "domID is for RecentlyViewed section" <|
+                \_ ->
+                    team { defaultState | section = RecentlyViewedSection }
+                        |> .name
+                        |> .domID
+                        |> Expect.equal (SideBarTeam RecentlyViewedSection "team")
             ]
         ]
 
@@ -305,10 +313,10 @@ team :
     , expanded : Bool
     , hovered : Bool
     , hasFavorited : Bool
-    , isFavoritesSection : Bool
+    , section : PipelinesSection
     }
     -> Views.Team
-team { active, expanded, hovered, hasFavorited, isFavoritesSection } =
+team { active, expanded, hovered, hasFavorited, section } =
     let
         hoveredDomId =
             if hovered then
@@ -343,7 +351,7 @@ team { active, expanded, hovered, hasFavorited, isFavoritesSection } =
         , currentPipeline = activePipeline
         , favoritedPipelines = favoritedPipelines
         , favoritedInstanceGroups = Set.empty
-        , isFavoritesSection = isFavoritesSection
+        , section = section
         }
         { name = "team"
         , isExpanded = expanded


### PR DESCRIPTION
## Changes proposed by this PR

relates to #4279

Adds a section to the sidebar listing the last 5 pipelines (or instances pipelines) that a user has visited. It doesn't include them on the dashboard, only in the sidebar, but should help navigation as I find myself at times jumping between 2 or 3 different pipelines to keep an eye on them.

![image](https://user-images.githubusercontent.com/354845/132117527-477076da-a1a3-4c22-b67b-81bc083625ea.png)

* [x] UI work
* [ ] Tests

## Notes to reviewer

Just looking for thoughts and feedback at the moment. This change has borked a number of tests in `SideBarFeatures.elm` which I will need to fix up (and add relevant tests for the new "recently viewed" section).

While the "favorites" section could also be used to solve the problem of jumping between a couple of different pipelines, it requires the user to remember to favorite each pipeline they visit, and unfavorite them when they no longer need to bounce between them.

## Release Note

Sidebar now shows the 5 most recently visited pipelines.