### PR TITLE
atc/gc: make build reaper more robust

### DIFF
--- a/atc/gc/build_log_collector.go
+++ b/atc/gc/build_log_collector.go
@@ -1,11 +1,12 @@
 package gc
 
 import (
+	"context"
+	"time"
+
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
-	"context"
 	"github.com/concourse/concourse/atc/db"
-	"time"
 )
 
 type buildLogCollector struct {
@@ -58,7 +59,7 @@ func (br *buildLogCollector) Run(ctx context.Context) error {
 		jobs, err := pipeline.Jobs()
 		if err != nil {
 			logger.Error("failed-to-get-dashboard", err)
-			return err
+			continue
 		}
 
 		for _, job := range jobs {
@@ -68,7 +69,7 @@ func (br *buildLogCollector) Run(ctx context.Context) error {
 
 			err = br.reapLogsOfJob(pipeline, job, logger)
 			if err != nil {
-				return err
+				continue
 			}
 		}
 	}
@@ -147,7 +148,6 @@ func (br *buildLogCollector) reapLogsOfJob(pipeline db.Pipeline,
 
 		maxBuildsRetained := retainedBuilds >= logRetention.Builds
 		buildHasExpired := !build.EndTime().IsZero() && build.EndTime().AddDate(0, 0, logRetention.Days).Before(time.Now())
-
 
 		if logRetention.Builds != 0 {
 			if logRetention.MinimumSucceededBuilds != 0 {


### PR DESCRIPTION
## Changes proposed by this PR

when looping over all the pipelines and jobs, if it ran into any errors
while parsing them the function would return and never finish checking
any remaining pieplines/jobs.

This commit ensures that all errors are logged but do not stop the
reaper from doing it's job for any remaining pipelines and jobs it
hasn't gone through yet

## Notes to reviewer

This might fix the issue #7505 but the OP noted they don't see the relevant logs to indicate that this is the problem they're facing.

## Release Note

* Make build log reaper more robust by not exiting early if it encounters an issue while iterating over pipelines/jobs. Before this change build logs for some pipelines could have accumulated endlessly even with a build retention policy