### PR TITLE
Close zstd reader in load var step

### DIFF
--- a/atc/exec/load_var_step.go
+++ b/atc/exec/load_var_step.go
@@ -140,6 +140,8 @@ func (step *LoadVarStep) fetchVars(
 		return nil, err
 	}
 
+	defer stream.Close()
+
 	fileContent, err := ioutil.ReadAll(stream)
 	if err != nil {
 		return nil, err

--- a/atc/worker/streamer_test.go
+++ b/atc/worker/streamer_test.go
@@ -230,6 +230,8 @@ var _ = Describe("Streamer", func() {
 		stream, err := streamer.StreamFile(ctx, src, "folder/file")
 		Expect(err).ToNot(HaveOccurred())
 
+		defer stream.Close()
+
 		fileContent, err := ioutil.ReadAll(stream)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -250,6 +252,8 @@ var _ = Describe("Streamer", func() {
 		ctx := context.Background()
 		stream, err := streamer.StreamFile(ctx, artifact, "folder/file")
 		Expect(err).ToNot(HaveOccurred())
+
+		defer stream.Close()
 
 		fileContent, err := ioutil.ReadAll(stream)
 		Expect(err).ToNot(HaveOccurred())

--- a/worker/baggageclaim/api/volume_server_test.go
+++ b/worker/baggageclaim/api/volume_server_test.go
@@ -462,6 +462,7 @@ var _ = Describe("Volume Server", func() {
 
 					zstdReader, err := zstd.NewReader(recorder.Body)
 					Expect(err).NotTo(HaveOccurred())
+					defer zstdReader.Close()
 					err = tarfs.Extract(zstdReader, unpackedDir)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -576,9 +577,9 @@ var _ = Describe("Volume Server", func() {
 
 					tarByteReader, err := zstd.NewReader(recorder.Body)
 					Expect(err).NotTo(HaveOccurred())
+					defer tarByteReader.Close()
 					err = tarfs.Extract(tarByteReader, unpackedDir)
 					Expect(err).NotTo(HaveOccurred())
-					tarByteReader.Close()
 					fileInfo, err := os.Stat(filepath.Join(unpackedDir, "other-file"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(fileInfo.IsDir()).To(BeFalse())


### PR DESCRIPTION
## Changes proposed by this PR

part of #7542

We observed a memory leak in our ci deployment with Concourse version 7.5.0 (unreleased). Most of the findings and information is documented in the issue #7542.

One of the potential problems we found was that the load var step does not close the file stream, which is the thing that closes the zstd reader. The zstd reader needs to be manually closed versus the gzip reader, which is closed for us through golang.

* [x] done
* [ ] todo
