### PR TITLE
Fix small typo on removeAll call comment

### DIFF
--- a/worker/workercmd/guardian.go
+++ b/worker/workercmd/guardian.go
@@ -56,7 +56,7 @@ func (cmd *WorkerCommand) guardianRunner(logger lager.Logger) (ifrit.Runner, err
 	}
 
 	// guardian does not overwrite existing assets. Therefore it can end up using
-	// old versions of assets that it's packed with
+	// old versions of the assets that it was packed with.
 	os.RemoveAll("/var/gdn/assets")
 
 	members := grouper.Members{}


### PR DESCRIPTION
Signed-off-by: Esteban Foronda <eforonda@vmware.com>

closes #7195

* [x] Fixing small typo on Guardian comment