### PR TITLE
Improve build duration visibility

### DIFF
--- a/web/assets/css/production.less
+++ b/web/assets/css/production.less
@@ -225,7 +225,7 @@ li.prep-status {
 }
 
 .dict-key {
- color: #000000
+ color: #000000;
 }
 
 .build-step .dictionary {

--- a/web/assets/css/production.less
+++ b/web/assets/css/production.less
@@ -225,7 +225,7 @@ li.prep-status {
 }
 
 .dict-key {
-  #000000
+ color: #000000
 }
 
 .build-step .dictionary {

--- a/web/assets/css/production.less
+++ b/web/assets/css/production.less
@@ -224,6 +224,10 @@ li.prep-status {
   padding-right: 16px;
 }
 
+.dict-key {
+  #000000
+}
+
 .build-step .dictionary {
   float: right;
 }


### PR DESCRIPTION
Looking at build duration before 
![](https://wompampsupport.azureedge.net/fetchimage?siteId=7575&v=2&jpgQuality=100&width=700&url=https%3A%2F%2Fi.kym-cdn.com%2Fentries%2Ficons%2Foriginal%2F000%2F006%2F026%2FNOTSUREIF.jpg)

Looking at build duration now 
![](https://clasebcn.com/wp-content/uploads/2020/04/harold-03.jpg)

This is a small UI change, but a crucial one for UX. Where before, the 'build duration' data was hard to parse at a glance, let alone when it has been compressed down a Zoom share screen, changing the text to black allows the user to get information quickly, without ruining the aesthetic of concourse.
