### PR TITLE
on_error should not run the hook when err is retriable

### DIFF
--- a/atc/exec/on_error.go
+++ b/atc/exec/on_error.go
@@ -37,8 +37,8 @@ func (o OnErrorStep) Run(ctx context.Context, state RunState) (bool, error) {
 	}
 	errs = multierror.Append(errs, stepRunErr)
 
-	// for all errors that aren't caused by an Abort, run the hook
-	if !errors.Is(stepRunErr, context.Canceled) {
+	// for all errors that aren't caused by an Abort or the retry_error's Retriable step, run the hook
+	if !(errors.Is(stepRunErr, context.Canceled) || errors.Is(stepRunErr, Retriable{})) {
 		_, err := o.hook.Run(context.Background(), state)
 		if err != nil {
 			// This causes to return both the errors as expected.

--- a/atc/exec/on_error_test.go
+++ b/atc/exec/on_error_test.go
@@ -68,6 +68,19 @@ var _ = Describe("On Error Step", func() {
 		})
 	})
 
+	Context("when the step error is retriable", func() {
+		BeforeEach(func() {
+			disaster = multierror.Append(disaster, exec.Retriable{})
+			step.RunReturns(false, disaster)
+		})
+
+		It("does not run the error hook", func() {
+			Expect(stepErr).To(Equal(disaster))
+			Expect(hook.RunCallCount()).To(Equal(0))
+			Expect(step.RunCallCount()).To(Equal(1))
+		})
+	})
+
 	Context("when the step succeeds", func() {
 		BeforeEach(func() {
 			step.RunReturns(true, nil)


### PR DESCRIPTION
## Changes proposed by this PR

closes #7532

on_error would run even when the error returned by wrapped by an
exec.Retriable{}, which happens when the
`CONCOURSE_ENABLE_RERUN_WHEN_WORKER_DISAPPEARS` is enabled. When that
feature is enabled all "core" steps (get, put, task, check,
set_pipeline) get wrapped by a RetryError() step.

The RetryError step actually returns the err from the child step but
simply wraps it in an exec.Retriable{}. In the engine.Run() there's a
check to see if any err is wrapped in a Retriable{}. If it is then the
step that returned the error doesn't receive a delegate.Finish() event
and the engine re-runs the step. That's how RetryError "loops". The
problem with this is that the on_error step was not aware of Retriable
errors and would run when it should not.

Now on_error knows about Retriable errors and won't run if it receives
one.

## Notes to reviewer

We couldn't find an easy way to reproduce a "Worker missing" error :(

## Release Note


* Fixed a bug when --enable-rerun-when-worker-disappears was enabled and a job/step had an on_error hook. If the step was retried the on_error hook would run when it should not.
