### PR TITLE
Bump timeout for volume gc in integration tests

### DIFF
--- a/integration/ops/suite_test.go
+++ b/integration/ops/suite_test.go
@@ -43,5 +43,5 @@ func waitForVolumesGC(t *testing.T, fly flytest.Cmd) {
 	require.Eventually(t, func() bool {
 		volumes := fly.Table(t, "volumes")
 		return len(volumes) == 0
-	}, 1*time.Minute, 5*time.Second)
+	}, 2*time.Minute, 5*time.Second)
 }


### PR DESCRIPTION
## Changes proposed by this PR

closes #7563

The integration tests in our ci deployment flake on waiting for the volumes to gc in the upgrade/downgrade tests. But when we run the tests locally, it never flakes. Therefore we thought that possibly the reason why it is flaky on ci is the extra load on the workers is causing the volumes gc to take longer. We wanted to try allowing more time for the volume gc to run for those tests and see if that fixes the flaky tests in ci.

* [x] done
* [ ] todo