### PR TITLE
Revert node selection for rendering boxes

### DIFF
--- a/web/public/graph.mjs
+++ b/web/public/graph.mjs
@@ -626,7 +626,9 @@ GraphNode.prototype.width = function() {
   if (this._cachedWidth == 0) {
     var id = this.id;
 
-    var svgNode = this.svg.select("#node-" + id);
+    var svgNode = this.svg.selectAll("g.node").filter(function(node) {
+      return node.id == id;
+    })
 
     var textNode = svgNode.select("text").node();
     var imageNode = svgNode.select("image").node();


### PR DESCRIPTION
## Changes proposed by this PR

closes #7608

For any jobs or resources whose name contained dots `.` the element
selection function could not find them.

One fix would have been wrapping the id in CSS.escape() but that
function is labelled as experimental: https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape
It is also not supported in IE 😑

We decided to simply revert that line back to its previous version of
element selection.


## Release Note

* Fixed a bug where jobs or resources whose name contained a dot `.` would not render correctly in the UI
