### PR TITLE
7.4.x: add some DB optimizations

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1775,26 +1775,6 @@ func newNullInt64(i int) sql.NullInt64 {
 	}
 }
 
-func (b *build) refreshEventIdSeq(runner sq.Runner) error {
-	var currentEventID sql.NullInt64
-	err := psql.Select("max(event_id)").
-		From(b.eventsTable()).
-		Where(sq.Eq{"build_id": b.id}).
-		RunWith(runner).
-		QueryRow().
-		Scan(&currentEventID)
-	if err != nil {
-		return err
-	}
-
-	var seqIDInit uint64
-	if currentEventID.Valid {
-		seqIDInit = uint64(currentEventID.Int64) + 1
-	}
-	b.eventID = seqIDInit
-	return nil
-}
-
 func scanBuild(b *build, row scannable, encryptionStrategy encryption.Strategy) error {
 	var (
 		jobID, resourceID, resourceTypeID, pipelineID, rerunOf, rerunNumber               sql.NullInt64
@@ -1935,6 +1915,26 @@ func (b *build) saveEvent(tx Tx, event atc.Event) error {
 		RunWith(tx).
 		Exec()
 	return err
+}
+
+func (b *build) refreshEventIdSeq(runner sq.Runner) error {
+	var currentEventID sql.NullInt64
+	err := psql.Select("max(event_id)").
+		From(b.eventsTable()).
+		Where(sq.Eq{"build_id": b.id}).
+		RunWith(runner).
+		QueryRow().
+		Scan(&currentEventID)
+	if err != nil {
+		return err
+	}
+
+	var seqIDInit uint64
+	if currentEventID.Valid {
+		seqIDInit = uint64(currentEventID.Int64) + 1
+	}
+	b.eventID = seqIDInit
+	return nil
 }
 
 func (b *build) isForCheck() bool {

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"code.cloudfoundry.org/lager"
@@ -250,6 +251,8 @@ type build struct {
 	completed bool
 
 	spanContext SpanContext
+
+	eventID uint64
 }
 
 func newEmptyBuild(conn Conn, lockFactory lock.LockFactory) *build {
@@ -600,13 +603,6 @@ func (b *build) Finish(status BuildStatus) error {
 		Status: atc.BuildStatus(status),
 		Time:   endTime.Unix(),
 	})
-	if err != nil {
-		return err
-	}
-
-	_, err = tx.Exec(fmt.Sprintf(`
-		DROP SEQUENCE %s
-	`, buildEventSeq(b.id)))
 	if err != nil {
 		return err
 	}
@@ -1779,15 +1775,24 @@ func newNullInt64(i int) sql.NullInt64 {
 	}
 }
 
-func createBuildEventSeq(tx Tx, buildid int) error {
-	_, err := tx.Exec(fmt.Sprintf(`
-		CREATE SEQUENCE %s MINVALUE 0
-	`, buildEventSeq(buildid)))
-	return err
-}
+func (b *build) refreshEventIdSeq(runner sq.Runner) error {
+	var currentEventID sql.NullInt64
+	err := psql.Select("max(event_id)").
+		From(b.eventsTable()).
+		Where(sq.Eq{"build_id": b.id}).
+		RunWith(runner).
+		QueryRow().
+		Scan(&currentEventID)
+	if err != nil {
+		return err
+	}
 
-func buildEventSeq(buildid int) string {
-	return fmt.Sprintf("build_event_id_seq_%d", buildid)
+	var seqIDInit uint64
+	if currentEventID.Valid {
+		seqIDInit = uint64(currentEventID.Int64) + 1
+	}
+	b.eventID = seqIDInit
+	return nil
 }
 
 func scanBuild(b *build, row scannable, encryptionStrategy encryption.Strategy) error {
@@ -1917,9 +1922,16 @@ func (b *build) saveEvent(tx Tx, event atc.Event) error {
 		return err
 	}
 
+	if b.eventID == 0 {
+		if err := b.refreshEventIdSeq(tx); err != nil {
+			return err
+		}
+	}
+
+	eventID := atomic.AddUint64(&b.eventID, 1) - 1
 	_, err = psql.Insert(b.eventsTable()).
 		Columns("event_id", "build_id", "type", "version", "payload").
-		Values(sq.Expr("nextval('"+buildEventSeq(b.id)+"')"), b.id, string(event.EventType()), string(event.Version()), payload).
+		Values(eventID, b.id, string(event.EventType()), string(event.Version()), payload).
 		RunWith(tx).
 		Exec()
 	return err
@@ -1969,7 +1981,7 @@ func createBuild(tx Tx, build *build, vals map[string]interface{}) error {
 		return err
 	}
 
-	return createBuildEventSeq(tx, buildID)
+	return nil
 }
 
 type startedBuildArgs struct {

--- a/atc/db/build_factory_test.go
+++ b/atc/db/build_factory_test.go
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("BuildFactory", func() {
 	var (
-		team      db.Team
+		team db.Team
 	)
 
 	BeforeEach(func() {

--- a/atc/db/build_factory_test.go
+++ b/atc/db/build_factory_test.go
@@ -440,7 +440,7 @@ var _ = Describe("BuildFactory", func() {
 			_, err = build4DB.Reload()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(builds).To(ConsistOf(build4DB))
+			Expect(containsBuild(builds, build4DB)).To(BeTrue())
 		})
 	})
 
@@ -489,7 +489,8 @@ var _ = Describe("BuildFactory", func() {
 			_, err = build2DB.Reload()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(builds).To(ConsistOf(build1DB, build2DB))
+			Expect(containsBuild(builds, build1DB)).To(BeTrue())
+			Expect(containsBuild(builds, build2DB)).To(BeTrue())
 		})
 	})
 
@@ -568,3 +569,12 @@ var _ = Describe("BuildFactory", func() {
 		})
 	})
 })
+
+func containsBuild(builds []db.Build, build db.Build) bool {
+	for _, b := range builds {
+		if b.ID() == build.ID() {
+			return true
+		}
+	}
+	return false
+}

--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -708,11 +708,6 @@ func (j *job) EnsurePendingBuildExists(ctx context.Context) error {
 			return err
 		}
 
-		err = createBuildEventSeq(tx, buildID)
-		if err != nil {
-			return err
-		}
-
 		latestNonRerunID, err := latestCompletedNonRerunBuild(tx, j.id)
 		if err != nil {
 			return err

--- a/atc/db/migration/migrations/1627322257_drop_build_event_id_seq.down.sql
+++ b/atc/db/migration/migrations/1627322257_drop_build_event_id_seq.down.sql
@@ -1,0 +1,29 @@
+do $$
+declare
+    b record;
+    startValue int;
+begin
+    for b in
+        select id, name, pipeline_id, team_id from builds where status = 'started' and completed = false and aborted = false
+    loop
+        raise notice 'dropping sequence build_event_id_seq_% ...', b.id;
+        execute 'drop sequence if exists build_event_id_seq_' || b.id;
+
+        if b.name = 'check' then
+            execute 'select max(event_id) from check_build_events where build_id=' || b.id into startValue;
+        elsif b.pipeline_id is null or b.pipeline_id = 0 then
+            execute 'select max(event_id) from team_build_events_' || b.team_id || ' where build_id=' || b.id into startValue;
+        else
+            execute 'select max(event_id) from pipeline_build_events_' | b.pipeline_id || ' where build_id=' || b.id into startValue;
+        end if;
+
+        if startValue is null then
+            startValue := 0;
+        else
+            startValue := startValue + 1;
+        end if;
+
+        raise notice 'creating sequence build_event_id_seq_% ...', b.id;
+        execute 'create sequence build_event_id_seq_' || b.id || ' minvalue 0 start with ' || startValue;
+    end loop;
+end; $$

--- a/atc/db/migration/migrations/1627322257_drop_build_event_id_seq.up.sql
+++ b/atc/db/migration/migrations/1627322257_drop_build_event_id_seq.up.sql
@@ -1,0 +1,11 @@
+do $$
+declare
+    b record;
+begin
+    for b in
+        select id from builds where status = 'started'
+    loop
+        raise notice 'dropping sequence build_event_id_seq_% ...', b.id;
+        execute 'drop sequence if exists build_event_id_seq_' || b.id;
+    end loop;
+end; $$

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -298,11 +298,6 @@ func (p *pipeline) CreateJobBuild(jobName string) (Build, error) {
 		return nil, err
 	}
 
-	err = createBuildEventSeq(tx, buildID)
-	if err != nil {
-		return nil, err
-	}
-
 	err = tx.Commit()
 	if err != nil {
 		return nil, err

--- a/atc/db/resource_config_factory_test.go
+++ b/atc/db/resource_config_factory_test.go
@@ -53,9 +53,9 @@ var _ = Describe("ResourceConfigFactory", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("returns the same config, but with a newer 'last referenced' time", func() {
+			It("returns the same config, but with the same 'last referenced' time because a minute hasn't elapsed", func() {
 				Expect(sameConfig.ID()).To(Equal(resourceConfig.ID()))
-				Expect(sameConfig.LastReferenced()).To(BeTemporally(">", resourceConfig.LastReferenced()))
+				Expect(sameConfig.LastReferenced()).To(Equal(resourceConfig.LastReferenced()))
 			})
 		})
 

--- a/atc/exec/load_var_step.go
+++ b/atc/exec/load_var_step.go
@@ -151,6 +151,8 @@ func (step *LoadVarStep) fetchVars(
 		return nil, err
 	}
 
+	defer stream.Close()
+
 	fileContent, err := ioutil.ReadAll(stream)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Changes proposed by this PR

- [x] in-memory event ID's
- [x] only update resource config every minute
- [ ] ~don't update metadata if fetching from cache~
  - after reading over the code we determined this change isn't needed
- [x] close zstd in load_var_step to prevent memory leak

## Release Note

* DB optimizations
  * Increment an event ID in-memory instead of using a Postgres Sequence
  * Only update resource config if it hasn't been updated in a minute
  * Close zstd reader in load var step
