### PR TITLE
fix topgun runtime test failure

### DIFF
--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -294,10 +294,10 @@ func LoadJobInstances() (map[string][]BoshInstance, map[string][]BoshInstance) {
 
 			instance = BoshInstance{
 				Name:  group + "/" + id,
-				Group: group,
-				ID:    id,
-				IP:    instanceMatch[4],
-				DNS:   instanceMatch[5],
+				Group: group,            // web, worker or db
+				ID:    id,               // 6248cb3b-7e24-4b97-b609-d79722c3276d
+				IP:    instanceMatch[4], // 10.0.0.29
+				DNS:   instanceMatch[5], // concourse-topgun-runtime-6
 			}
 
 			instances[group] = append(instances[group], instance)

--- a/topgun/runtime/atc_rebalance_test.go
+++ b/topgun/runtime/atc_rebalance_test.go
@@ -36,17 +36,17 @@ var _ = Describe("Rebalancing workers", func() {
 		It("rotates the worker to between both web nodes over a period of time", func() {
 			Eventually(func() string {
 				workers := FlyTable("workers", "-d")
-				return strings.Split(workers[0]["garden address"], ":")[0]
+				return parseInstanceID(workers[0])
 			}).Should(SatisfyAny(
-				Equal(webInstances[0].IP),
+				Equal(webInstances[0].ID),
 				Equal(webInstances[0].DNS),
 			))
 
 			Eventually(func() string {
 				workers := FlyTable("workers", "-d")
-				return strings.Split(workers[0]["garden address"], ":")[0]
+				return parseInstanceID(workers[0])
 			}).Should(SatisfyAny(
-				Equal(webInstances[1].IP),
+				Equal(webInstances[1].ID),
 				Equal(webInstances[1].DNS),
 			))
 		})
@@ -86,3 +86,7 @@ var _ = Describe("Rebalancing workers", func() {
 		})
 	})
 })
+
+func parseInstanceID(output map[string]string) string {
+	return strings.Split(strings.Split(output["garden address"], ":")[0], ".")[0]
+}


### PR DESCRIPTION
## Changes proposed by this PR

update the test assertion to match by worker instance ID rather than IP address


## Notes to reviewer

Context is our topgun bosh worker is now deployed with v7.5 and newer BBL (thus newer version of google CPI). The old cloud config that used for last external worker bosh deployment doesn't work anymore since the bosh networks was with `type: manual` (https://bosh.io/docs/networks/), it now causes errors like [IP address conflict](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/bosh-topgun-core/builds/893#L615c058d:977).

So the `type:dynamic` has to be used instead. The side effect of that then becomes the `bosh instance` outputs instance address by address url instead of ip address.

<img width="1648" alt="Screen Shot 2021-10-18 at 11 31 25 AM" src="https://user-images.githubusercontent.com/1585949/137762996-78d2e038-2a7d-48b4-8c3c-e16f2ec2801b.png">

<img width="1656" alt="Screen Shot 2021-10-18 at 11 32 30 AM" src="https://user-images.githubusercontent.com/1585949/137763026-b8ac586a-c262-4141-a5f4-6d6bab8bc3fb.png">

