### PR TITLE
Removing un-needed loop

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -2011,15 +2011,8 @@ func (b *build) eventsTable() string {
 func createBuild(tx Tx, build *build, vals map[string]interface{}) error {
 	var buildID int
 
-	buildVals := make(map[string]interface{})
-	for name, value := range vals {
-		buildVals[name] = value
-	}
-
-	buildVals["needs_v6_migration"] = false
-
 	err := psql.Insert("builds").
-		SetMap(buildVals).
+		SetMap(vals).
 		Suffix("RETURNING id").
 		RunWith(tx).
 		QueryRow().
@@ -2080,6 +2073,7 @@ func createStartedBuild(tx Tx, build *build, args startedBuildArgs) error {
 	buildVals["status"] = BuildStatusStarted
 	buildVals["start_time"] = sq.Expr("now()")
 	buildVals["schema"] = schema
+	buildVals["needs_v6_migration"] = false
 
 	for name, value := range args.ExtraValues {
 		buildVals[name] = value


### PR DESCRIPTION
By moving the `buildVals["needs_v6_migration"] = false` to the start
build function this will allow the need to remove an iteration over the
build values to write.

Signed-off-by: Max Knee <Max_Knee@comcast.com>

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR
By moving the `buildVals["needs_v6_migration"] = false` to the start
build function this will allow the need to remove an iteration over the
build values to write.
