### PR TITLE
Simplify clearing resource config ids

### DIFF
--- a/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.up.sql
+++ b/atc/db/migration/migrations/1630514494_clear_resource_configs_on_update.up.sql
@@ -11,10 +11,7 @@ CREATE TRIGGER resources_config_update_clears_config_ids_trigger
 	AFTER UPDATE on resources
 	FOR EACH ROW
 	WHEN (
-		(
-			(NEW.config::jsonb->'source' IS DISTINCT FROM OLD.config::jsonb->'source') OR
-			(NEW.config::jsonb->'type' IS DISTINCT FROM OLD.config::jsonb->'type')
-		)
-		AND (NEW.active IS TRUE)
+		(NEW.config IS DISTINCT FROM OLD.config) AND
+		(NEW.active IS TRUE)
 	)
 	EXECUTE PROCEDURE clear_resource_config_ids();


### PR DESCRIPTION
## Changes proposed by this PR

closes #7697 and #7468

The config column in the resource table contains a json object with
three top-level keys: name, type, source

We only want to clear the config when type and source change. When those
two change the row itself is updated, so the job has the same ID
whenever the type or source changes.

When the name changes that results in a new row being inserted with a
new ID. In that case this trigger will not run. Therefore we can
simplify the code to simply compare the new and old configs regardless
of it being encrypted or not.

