### PR TITLE
Allow task/set_pipeline name to include `across` step var

### DIFF
--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -19,8 +19,15 @@ func ValidateIdentifier(identifier string, context ...string) (*ConfigWarning, e
 	if identifier == "" {
 		return nil, fmt.Errorf("%s: identifier cannot be an empty string", strings.Join(context, ""))
 	}
+
+	contextLen := len(context)
+	if contextLen >= 2 && (strings.Contains(context[contextLen-1], "set_pipeline") || strings.Contains(context[contextLen-1], "task")) && context[contextLen-2] == ".across" {
+		return nil, nil
+	}
+
 	if !validIdentifiers.MatchString(identifier) {
 		var reason string
+
 		if startsWithLetter.MatchString(identifier) {
 			reason = "must start with a lowercase letter"
 		} else if invalidChar := invalidCharacter.Find([]byte(identifier[1:])); invalidChar != nil {

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -11,6 +11,7 @@ var _ = Describe("ValidateIdentifier", func() {
 	type testCase struct {
 		description string
 		identifier  string
+		context     []string
 		warningMsg  string
 		warning     bool
 		errorMsg    string
@@ -73,6 +74,18 @@ var _ = Describe("ValidateIdentifier", func() {
 			identifier:  "",
 			errorMsg:    ": identifier cannot be an empty string",
 		},
+		{
+			description: "is a var from across step in task",
+			context:     []string{".across", ".task(running-((.:name)))"},
+			identifier:  "((.:name))",
+			warning:     false,
+		},
+		{
+			description: "is a var from across step in set_pipeline",
+			context:     []string{".across", ".set_pipeline(((.:name)))"},
+			identifier:  "running-((.:name))",
+			warning:     false,
+		},
 	} {
 		test := test
 
@@ -84,7 +97,7 @@ var _ = Describe("ValidateIdentifier", func() {
 				it = "runs without warning"
 			}
 			It(it, func() {
-				warning, err := atc.ValidateIdentifier(test.identifier)
+				warning, err := atc.ValidateIdentifier(test.identifier, test.context...)
 				if test.warning {
 					Expect(warning).NotTo(BeNil())
 					Expect(warning.Message).To(ContainSubstring(test.warningMsg))


### PR DESCRIPTION
close #7660 

pass name validation for step task and set_pipeline if they are taking a var from parent across step

## Release Notes

* Identifiers for `task` and `set_pipeline` steps wrapped by the `across` step can now have their identifier/step name as a var `((.:some-var))` and won't receive a warning about the name being deprecated