### PR TITLE
[7.4.x] replace atomic with mutex for event id's

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1917,6 +1917,9 @@ func (b *build) saveEvent(tx Tx, event atc.Event) error {
 }
 
 func (b *build) getNextEventId(runner sq.Runner) (uint64, error) {
+	if b.eventIDLock == nil {
+		return 0, errors.New("event id mutex lock not initialzied for build")
+	}
 	b.eventIDLock.Lock()
 	defer b.eventIDLock.Unlock()
 

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -252,7 +252,7 @@ type build struct {
 
 	spanContext SpanContext
 
-	eventID     uint64
+	eventID     uint64 // you must grab the eventIDLock before reading/writing to this var
 	eventIDLock *sync.Mutex
 }
 


### PR DESCRIPTION
## Changes proposed by this PR

Closes #7683

~Not 100% sure that this fixes the bug but it makes it easier to read and
reason about in my opinion. I think there were some potential race
conditions about `refreshEventIdSeq()` being called multiple times and
messing up the initial value (that value was not loaded atomically).
Maybe it was caused by the non-atomic `- 1` done outside the atomic
addition? They'd still have to return the same number which should not
be possible...~

After looking at Evan's PR I'm much more confident that this will fix the bug: https://github.com/concourse/concourse/commit/b400f5a3311ea525e143fe4874c7dc3bb6e8e415#diff-18aa80f145ef8097e7c1929e8ad270603bc5c8b43b5bdd0a633ab7d40dbe16c6
This PR is basically a simplified version of what he ended doing in his PR.

Like I said, not sure how to reproduce this bug but I think this should
prevent any race conditions from happening now.

This change keeps it simple by using a lock whenever we want to get the
eventID and returning the updated eventID before releasing the lock. Now
we know that nothing else could possibly be updating the eventID when
we're mutating it.

## Notes to Reviewer

It would be really nice if we could reproduce this to verify that it fixes the bug 😞 

## Release Note

* Fix a race condition when updating build event ID's in-memory