### PR TITLE
change sync.mutex to a pointer

### DIFF
--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1983,7 +1983,10 @@ func (b *build) saveEvent(tx Tx, event atc.Event) error {
 	}
 
 	if b.eventIdSeq == nil {
-		b.refreshEventIdSeq(tx)
+		err = b.refreshEventIdSeq(tx)
+		if err != nil {
+			return err
+		}
 	}
 
 	_, err = psql.Insert(b.eventsTable()).

--- a/atc/util/seq_generator.go
+++ b/atc/util/seq_generator.go
@@ -8,12 +8,13 @@ type SequenceGenerator interface {
 
 type seqGenerator struct {
 	current int
-	lock    sync.Mutex
+	lock    *sync.Mutex
 }
 
 func NewSequenceGenerator(start int) SequenceGenerator {
 	return &seqGenerator{
 		current: start,
+		lock:    &sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
just to avoid any memory-related funny business. We want to guarantee
that it's always using the same lock.

Also, not ignoring the error returned by `refreshEventIdSeq()`