### PR TITLE
Adding dry-run mode to `fly set-pipeline` command

### DIFF
--- a/fly/commands/internal/setpipelinehelpers/atc_config.go
+++ b/fly/commands/internal/setpipelinehelpers/atc_config.go
@@ -27,6 +27,7 @@ type ATCConfig struct {
 	Target           string
 	SkipInteraction  bool
 	CheckCredentials bool
+	DryRun           bool
 	CommandWarnings  []concourse.ConfigWarning
 	GivenTeamName    string
 }
@@ -92,6 +93,10 @@ func (atcConfig ATCConfig) Set(yamlTemplateWithParams templatehelpers.YamlTempla
 	}
 	fmt.Println()
 
+	if atcConfig.DryRun {
+		fmt.Println("Dry-run mode was set, exiting.")
+		return nil
+	}
 	pipeline, _, err := atcConfig.Team.Pipeline(atcConfig.PipelineRef)
 	if err != nil {
 		return err

--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -18,6 +18,7 @@ import (
 type SetPipelineCommand struct {
 	SkipInteractive  bool `short:"n"  long:"non-interactive"               description:"Skips interactions, uses default values"`
 	DisableAnsiColor bool `long:"no-color"               description:"Disable color output"`
+	DryRun           bool `short:"d"  long:"dry-run"               description:"Run a set pipeline step but in dry-run mode"`
 
 	CheckCredentials bool `long:"check-creds"  description:"Validate credential variables against credential manager"`
 
@@ -97,6 +98,7 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 		Target:           target.Client().URL(),
 		SkipInteraction:  command.SkipInteractive || command.Config.FromStdin(),
 		CheckCredentials: command.CheckCredentials,
+		DryRun:           command.DryRun,
 		CommandWarnings:  warnings,
 		GivenTeamName:    string(command.Team),
 	}


### PR DESCRIPTION
## Changes proposed by this PR

* [x] Add a dry-run flag to the set-pipeline step that only prints pipeline changes then exits.

## Release Note

* This adds a dry-run feature to the set-pipeline command within the Fly CLI, the main purpose of this is to allow users to check what would be changed without any interactive-prompt/danger of applying by mistake.
