### PR TITLE
Prefer `FLY_HOME` over `HOME` (if set) as the directory for storing .flyrc

### DIFF
--- a/fly/rc/targets.go
+++ b/fly/rc/targets.go
@@ -162,7 +162,12 @@ func selectTarget(selectedTarget TargetName) (TargetProps, error) {
 }
 
 func userHomeDir() string {
-	home := os.Getenv("HOME")
+	home := os.Getenv("FLY_HOME")
+	if home != "" {
+		return home
+	}
+
+	home = os.Getenv("HOME")
 	if home != "" {
 		return home
 	}


### PR DESCRIPTION
Submitting a PR as per the discussion on: https://github.com/concourse/rfcs/discussions/115

## Changes proposed by this PR

* [x] When loading `.flyrc`, prefer the path pointed to by `FLY_HOME` over `HOME`. If `FLY_HOME` is not set (or empty), use `HOME` instead

## Notes to reviewer

I toyed with a few different ways to test the new behaviour. My PR contains what I think is the simplest approach, but I'm aware this path is used for more than just loading targets from a file. 

Some other ideas I had:
* Export `userHomeDir()` from the package, then test it in isolation
* Extract the `Targets` tests into a shared behaviour and run it once with `FLY_HOME` set and a second time with `HOME` set
* No tests (as the other logic in `userHomeDir()` is untested) - I wasn't too keen on this option!

Happy to update the PR to switch to an alternative if there is a preference for another solution