### PR TITLE
Increase color contrast on build page

### DIFF
--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -400,6 +400,7 @@ viewTitle name jobID createdBy =
                         , onMouseLeave <| Hover Nothing
                         , id <| toHtmlID Message.JobName
                         , buildNameLineHeight
+                        , style "color" Colors.buildTitleTextColor
                         ]
                         [ Html.span [ class "build-name" ] [ Html.text jid.jobName ]
                         , Html.span
@@ -429,6 +430,7 @@ viewTitle name jobID createdBy =
                         , style "text-overflow" "ellipsis"
                         , style "white-space" "nowrap"
                         , style "overflow" "hidden"
+                        , style "color" Colors.buildTitleTextColor
                         , title text
                         ]
                         [ Html.text text ]

--- a/web/elm/src/Colors.elm
+++ b/web/elm/src/Colors.elm
@@ -11,6 +11,7 @@ module Colors exposing
     , buildStatusColor
     , buildTabBorderColor
     , buildTabTextColor
+    , buildTitleTextColor
     , buildTooltipText
     , buttonDisabledGrey
     , card
@@ -334,12 +335,12 @@ failure =
 
 failureFaded : String
 failureFaded =
-    ColorValues.failure80
+    ColorValues.failure70
 
 
 failureTextFaded : String
 failureTextFaded =
-    ColorValues.failure20
+    ColorValues.failure10
 
 
 error : String
@@ -702,10 +703,23 @@ buildStatusColor isBright status =
                 abortedFaded
 
 
+buildTitleTextColor : String
+buildTitleTextColor =
+    ColorValues.grey100
+
+
 buildTabTextColor : Bool -> BuildStatus -> String
 buildTabTextColor isCurrent status =
     if isCurrent then
-        white
+        case status of
+            BuildStatusStarted ->
+                ColorValues.grey100
+
+            BuildStatusPending ->
+                ColorValues.grey100
+
+            _ ->
+                white
 
     else
         case status of

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -3990,7 +3990,7 @@ hoverSetPipelineChangedLabel =
 
 darkRed : String
 darkRed =
-    "#5E1D14"
+    "#912617"
 
 
 brightRed : String


### PR DESCRIPTION
## Changes proposed by this PR

 * current focused started and pending build name, build number and created by
will have color black instead of white to increase contrast against
bright yellow and grey background for better readability

 * add bright to failure faded and failure text color for better
 differentiation between failure and aborted build

closes #7752 

## Notes to reviewer

<p float="left">
  <img width="247" alt="Screen Shot 2021-11-02 at 3 04 52 PM" src="https://user-images.githubusercontent.com/1585949/139940055-a41dd0b5-0e41-4a8f-906f-d4d121fe23d3.png">
<img width="207" alt="Screen Shot 2021-11-02 at 3 16 23 PM" src="https://user-images.githubusercontent.com/1585949/139940074-dbaa90dd-c724-481f-86ae-8149c4623ba8.png">
<img width="188" alt="Screen Shot 2021-11-02 at 3 16 42 PM" src="https://user-images.githubusercontent.com/1585949/139940100-856e52b1-81d3-4811-bc16-12a077702b3d.png">
</p>

<p float="left">
  <img width="208" alt="Screen Shot 2021-11-02 at 3 02 52 PM" src="https://user-images.githubusercontent.com/1585949/139940037-524528c3-648c-41fd-b8b0-d16976bbd7f1.png">
<img width="248" alt="Screen Shot 2021-11-02 at 2 58 50 PM" src="https://user-images.githubusercontent.com/1585949/139940023-21f0e275-ff62-47b1-9271-cabc27dca153.png">

</p>






## Release Note

* Increase contrast of text on build page after color changes from the previous release that made it harder to read the text