### PR TITLE
Fixes for bugs in 7.4.2

### DIFF
--- a/atc/db/resource_config.go
+++ b/atc/db/resource_config.go
@@ -157,7 +157,7 @@ func (r *ResourceConfigDescriptor) findOrCreate(tx Tx, lockFactory lock.LockFact
 		return nil, err
 	}
 
-	if found && updateLastReferenced && rc.lastReferenced.Add(time.Minute).Before(time.Now()) {
+	if updateLastReferenced && found && rc.lastReferenced.Add(time.Minute).Before(time.Now()) {
 		found, err = r.updateLastReferenced(tx, rc, parentColumnName, parentID)
 		if err != nil {
 			return nil, err
@@ -207,11 +207,10 @@ func (r *ResourceConfigDescriptor) findWithParentID(tx Tx, rc *resourceConfig, p
 		})
 
 	if addShareLock {
-		builder.Suffix("FOR SHARE")
+		builder = builder.Suffix("FOR SHARE")
 	}
 
-	err := builder.
-		RunWith(tx).
+	err := builder.RunWith(tx).
 		QueryRow().
 		Scan(&rc.id, &rc.lastReferenced)
 	if err != nil {

--- a/atc/db/resource_config.go
+++ b/atc/db/resource_config.go
@@ -152,7 +152,7 @@ func (r *ResourceConfigDescriptor) findOrCreate(tx Tx, lockFactory lock.LockFact
 
 	var found bool
 	var err error
-	found, err = r.findWithParentID(tx, rc, parentColumnName, parentID)
+	found, err = r.findWithParentID(tx, rc, parentColumnName, parentID, !updateLastReferenced)
 	if err != nil {
 		return nil, err
 	}
@@ -198,13 +198,19 @@ func (r *ResourceConfigDescriptor) findOrCreate(tx Tx, lockFactory lock.LockFact
 	return rc, nil
 }
 
-func (r *ResourceConfigDescriptor) findWithParentID(tx Tx, rc *resourceConfig, parentColumnName string, parentID int) (bool, error) {
-	err := psql.Select("id", "last_referenced").
+func (r *ResourceConfigDescriptor) findWithParentID(tx Tx, rc *resourceConfig, parentColumnName string, parentID int, addShareLock bool) (bool, error) {
+	builder := psql.Select("id", "last_referenced").
 		From("resource_configs").
 		Where(sq.Eq{
 			parentColumnName: parentID,
 			"source_hash":    mapHash(r.Source),
-		}).
+		})
+
+	if addShareLock {
+		builder.Suffix("FOR SHARE")
+	}
+
+	err := builder.
 		RunWith(tx).
 		QueryRow().
 		Scan(&rc.id, &rc.lastReferenced)

--- a/atc/db/resource_config.go
+++ b/atc/db/resource_config.go
@@ -205,7 +205,6 @@ func (r *ResourceConfigDescriptor) findWithParentID(tx Tx, rc *resourceConfig, p
 			parentColumnName: parentID,
 			"source_hash":    mapHash(r.Source),
 		}).
-		Suffix("FOR SHARE").
 		RunWith(tx).
 		QueryRow().
 		Scan(&rc.id, &rc.lastReferenced)


### PR DESCRIPTION
## Changes proposed by this PR

closes #7683

There were a few bugs reported by users for 7.4.2 and this PR hopefully addresses them.

The way that we are doing the in memory event ID and the updating of the last referenced in the resource config is refactored from master branch. I think if this works properly then we might consider porting this refactor to master as well. But if you think the risk is high in the changes that were made, we can get the same optimization benefits without the code refactor.

* [ ] done
* [ ] todo

## Notes to reviewer

One of the bugs that were reported was `save image get event: pq: duplicate key value violates unique constraint "pipeline_build_events_22_build_id_event_id"`.

I had a suspicion that it might have something to do with this https://github.com/concourse/concourse/blob/b8f9da5b8c00b6112a7a334b3dccdc49962859f9/atc/db/build.go#L1905 because just checking `0` will result in multiple goroutines still finding that the `eventID` is `0` and trying to refresh all together (even after we did `refreshEventId` in `Reload()`). We also don't update the `eventID` here https://github.com/concourse/concourse/blob/b8f9da5b8c00b6112a7a334b3dccdc49962859f9/atc/db/build.go#L1936 or fetch here https://github.com/concourse/concourse/blob/b8f9da5b8c00b6112a7a334b3dccdc49962859f9/atc/db/build.go#L1905 using the `sync/atomic` package 

I'm still trying to reproduce this issue but not having much luck yet :( It would be best if we are able to reproduce this locally so we can properly test against it.

Currently master branch is using https://github.com/concourse/concourse/blob/45621cb6dfd46ad9d75f822fb8b2d083913e7aaf/atc/util/seq_generator.go#L5-L7 to handle the concurrency. We could just switch back to that if we think it does have to do with the `atomic` package. Personally it is my first time using the package and Aidan and I were hoping we could use that instead of the `seq_generator` as a refactor, but maybe the risks are too high for us to use it.

The other bug was `create resource config: pq: deadlock detected","pipeline` which seems to be coming from Postgres and is probably related to the change that was made with updating the last referenced column for resource configs. In #7641, we made it so that we will SELECT a row from resource configs and then update the row after in order to update the last referenced column. This made it so that we introduced an area where a deadlock can occur between the time that we grabbed the `FOR SHARE` lock during the SELECT and the time that we need to grab the row lock for the update. I'm wondering if the `FOR SHARE` lock during the SELECT is really even necessary because removing it will remove the possibility of the deadlock. I'm still not 100% if this is the right thing to do so I will try looking into this a bit further. 

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
