### PR TITLE
Adding team option to archive pipeline fly command

### DIFF
--- a/fly/integration/archive_pipeline_test.go
+++ b/fly/integration/archive_pipeline_test.go
@@ -332,5 +332,92 @@ var _ = Describe("Fly CLI", func() {
 				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
+
+		Context("user is NOT targeting the same team the pipeline belongs to", func() {
+			team := "diff-team"
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", team)),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+							Name: team,
+						}),
+					),
+				)
+			})
+
+			Context("when the pipeline name is specified", func() {
+				var (
+					path        string
+					queryParams string
+					err         error
+				)
+
+				BeforeEach(func() {
+					path, err = atc.Routes.CreatePathForRoute(atc.ArchivePipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": team})
+					Expect(err).NotTo(HaveOccurred())
+
+					queryParams = "vars.branch=%22master%22"
+				})
+
+				Context("when the pipeline exists", func() {
+					BeforeEach(func() {
+						atcServer.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("PUT", path, queryParams),
+								ghttp.RespondWith(http.StatusOK, nil),
+							),
+						)
+					})
+					It("archives the pipeline", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-p", "awesome-pipeline/branch:master", "--team", team)
+							stdin, err := flyCmd.StdinPipe()
+							Expect(err).NotTo(HaveOccurred())
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess).Should(gbytes.Say("!!! archiving the pipeline will remove its configuration. Build history will be retained.\n\n"))
+							Eventually(sess).Should(gbytes.Say("archive pipeline 'awesome-pipeline/branch:master'?"))
+							yes(stdin)
+
+							Eventually(sess).Should(gbytes.Say(`archived 'awesome-pipeline/branch:master'`))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(0))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(3))
+					})
+				})
+				Context("when the pipeline doesn't exist", func() {
+					BeforeEach(func() {
+						atcServer.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("PUT", path),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+					})
+
+					It("prints helpful message", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-n", "-p", "awesome-pipeline", "--team", team)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Err).Should(gbytes.Say(`pipeline 'awesome-pipeline' not found`))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(1))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(3))
+					})
+				})
+			})
+		})
 	})
 })

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -137,6 +137,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "order-pipelines", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("abort-build command returns an error",
 				exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "pipeline/job", "-b", "4", "--team", nonExistentTeam)),
+			Entry("archive-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -181,6 +183,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", otherTeam)),
 			Entry("abort-build command returns an error",
 				exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "pipeline/job", "-b", "4", "--team", otherTeam)),
+			Entry("archive-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-p", "pipeline", "--team", otherTeam)),
 		)
 	})
 })


### PR DESCRIPTION
Follows the format laid out in this #7492 

## Changes proposed by this PR

closes one item off in  #5215 

- [x] Added team flag to the archive pipeline command

## Notes to reviewer

Added team flag to the archive-pipeline command

## Release Note

* Added team flag to fly command archive-pipeline, you could use this following the next format
fly -t dev archive-pipeline --pipeline some-pipeline --team test
