### PR TITLE
Add team to resource commands and archive pipeline command

### DIFF
--- a/fly/commands/check_resource.go
+++ b/fly/commands/check_resource.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"github.com/concourse/concourse/go-concourse/concourse"
 	"os"
 	"strconv"
 
@@ -17,6 +18,7 @@ type CheckResourceCommand struct {
 	Version  *atc.Version             `short:"f" long:"from"                     value-name:"VERSION"           description:"Version of the resource to check from, e.g. ref:abcd or path:thing-1.2.3.tgz"`
 	Async    bool                     `short:"a" long:"async"                    value-name:"ASYNC"             description:"Return the check without waiting for its result"`
 	Shallow  bool                     `long:"shallow"                          value-name:"SHALLOW"         description:"Check the resource itself only"`
+	Team  flaghelpers.TeamFlag  `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *CheckResourceCommand) Execute(args []string) error {
@@ -30,12 +32,18 @@ func (command *CheckResourceCommand) Execute(args []string) error {
 		return err
 	}
 
+	var team concourse.Team
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
+	}
+
 	var version atc.Version
 	if command.Version != nil {
 		version = *command.Version
 	}
 
-	build, found, err := target.Team().CheckResource(command.Resource.PipelineRef, command.Resource.ResourceName, version, command.Shallow)
+	build, found, err := team.CheckResource(command.Resource.PipelineRef, command.Resource.ResourceName, version, command.Shallow)
 	if err != nil {
 		return err
 	}

--- a/fly/commands/check_resource_type.go
+++ b/fly/commands/check_resource_type.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"github.com/concourse/concourse/go-concourse/concourse"
 	"os"
 	"strconv"
 
@@ -17,6 +18,8 @@ type CheckResourceTypeCommand struct {
 	Version      *atc.Version             `short:"f" long:"from"                     value-name:"VERSION"           description:"Version of the resource type to check from, e.g. digest:sha256@..."`
 	Async        bool                     `short:"a" long:"async"                    value-name:"ASYNC"             description:"Return the check without waiting for its result"`
 	Shallow      bool                     `long:"shallow"                          value-name:"SHALLOW"         description:"Check the resource type itself only"`
+	Team  flaghelpers.TeamFlag  `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
+
 }
 
 func (command *CheckResourceTypeCommand) Execute(args []string) error {
@@ -31,12 +34,18 @@ func (command *CheckResourceTypeCommand) Execute(args []string) error {
 		return err
 	}
 
+	var team concourse.Team
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
+	}
+
 	var version atc.Version
 	if command.Version != nil {
 		version = *command.Version
 	}
 
-	build, found, err := target.Team().CheckResourceType(command.ResourceType.PipelineRef, command.ResourceType.ResourceName, version, command.Shallow)
+	build, found, err := team.CheckResourceType(command.ResourceType.PipelineRef, command.ResourceType.ResourceName, version, command.Shallow)
 	if err != nil {
 		return err
 	}

--- a/fly/commands/resource_versions.go
+++ b/fly/commands/resource_versions.go
@@ -19,6 +19,7 @@ type ResourceVersionsCommand struct {
 	Count    int                      `short:"c" long:"count" default:"50" description:"Number of versions you want to limit the return to"`
 	Resource flaghelpers.ResourceFlag `short:"r" long:"resource" required:"true" value-name:"PIPELINE/RESOURCE" description:"Name of a resource to get versions for"`
 	Json     bool                     `long:"json" description:"Print command result as JSON"`
+	Team  flaghelpers.TeamFlag  `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *ResourceVersionsCommand) Execute([]string) error {
@@ -32,9 +33,14 @@ func (command *ResourceVersionsCommand) Execute([]string) error {
 		return err
 	}
 
+	var team concourse.Team
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
+	}
+
 	page := concourse.Page{Limit: command.Count}
 
-	team := target.Team()
 
 	versions, _, _, err := team.ResourceVersions(command.Resource.PipelineRef, command.Resource.ResourceName, page, atc.Version{})
 	if err != nil {

--- a/fly/commands/resources.go
+++ b/fly/commands/resources.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/concourse/concourse/go-concourse/concourse"
 	"os"
 
 	"github.com/concourse/concourse/atc"
@@ -14,6 +15,8 @@ import (
 type ResourcesCommand struct {
 	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Get resources in this pipeline"`
 	Json     bool                     `long:"json" description:"Print command result as JSON"`
+	Team  flaghelpers.TeamFlag  `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
+
 }
 
 func (command *ResourcesCommand) Execute([]string) error {
@@ -29,8 +32,14 @@ func (command *ResourcesCommand) Execute([]string) error {
 
 	var headers []string
 	var resources []atc.Resource
+	var team concourse.Team
 
-	resources, err = target.Team().ListResources(command.Pipeline.Ref())
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
+	}
+
+	resources, err = team.ListResources(command.Pipeline.Ref())
 	if err != nil {
 		return err
 	}

--- a/fly/integration/archive_pipeline_test.go
+++ b/fly/integration/archive_pipeline_test.go
@@ -332,5 +332,92 @@ var _ = Describe("Fly CLI", func() {
 				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag `" + osFlag("p", "pipeline")))
 			})
 		})
+
+		Context("user is NOT targeting the same team the pipeline belongs to", func() {
+			team := "diff-team"
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", team)),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+							Name: team,
+						}),
+					),
+				)
+			})
+
+			Context("when the pipeline name is specified", func() {
+				var (
+					path        string
+					queryParams string
+					err         error
+				)
+
+				BeforeEach(func() {
+					path, err = atc.Routes.CreatePathForRoute(atc.ArchivePipeline, rata.Params{"pipeline_name": "awesome-pipeline", "team_name": team})
+					Expect(err).NotTo(HaveOccurred())
+
+					queryParams = "vars.branch=%22master%22"
+				})
+
+				Context("when the pipeline exists", func() {
+					BeforeEach(func() {
+						atcServer.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("PUT", path, queryParams),
+								ghttp.RespondWith(http.StatusOK, nil),
+							),
+						)
+					})
+					It("archives the pipeline", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-p", "awesome-pipeline/branch:master", "--team", team)
+							stdin, err := flyCmd.StdinPipe()
+							Expect(err).NotTo(HaveOccurred())
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess).Should(gbytes.Say("!!! archiving the pipeline will remove its configuration. Build history will be retained.\n\n"))
+							Eventually(sess).Should(gbytes.Say("archive pipeline 'awesome-pipeline/branch:master'?"))
+							yes(stdin)
+
+							Eventually(sess).Should(gbytes.Say(`archived 'awesome-pipeline/branch:master'`))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(0))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(3))
+					})
+				})
+				Context("when the pipeline doesn't exist", func() {
+					BeforeEach(func() {
+						atcServer.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("PUT", path),
+								ghttp.RespondWith(http.StatusNotFound, nil),
+							),
+						)
+					})
+
+					It("prints helpful message", func() {
+						Expect(func() {
+							flyCmd := exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-n", "-p", "awesome-pipeline", "--team", team)
+
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess.Err).Should(gbytes.Say(`pipeline 'awesome-pipeline' not found`))
+
+							<-sess.Exited
+							Expect(sess.ExitCode()).To(Equal(1))
+						}).To(Change(func() int {
+							return len(atcServer.ReceivedRequests())
+						}).By(3))
+					})
+				})
+			})
+		})
 	})
 })

--- a/fly/integration/check_resource_test.go
+++ b/fly/integration/check_resource_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"net/http"
 	"os/exec"
 
@@ -206,6 +207,207 @@ var _ = Describe("CheckResource", func() {
 
 			Expect(sess.Err).To(gbytes.Say("unknown server error"))
 
+		})
+	})
+
+	Context("user is NOT targeting the same team the resource type belongs to", func() {
+		team := "diff-team"
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", team)),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+						Name: team,
+					}),
+				),
+			)
+		})
+		BeforeEach(func() {
+			build = atc.Build{
+				ID:        123,
+				Status:    "started",
+				StartTime: 100000000000,
+			}
+
+			expectedURL = "/api/v1/teams/diff-team/pipelines/mypipeline/resources/myresource/check"
+			expectedQueryParams = "vars.branch=%22master%22"
+		})
+
+		Context("when ATC request succeeds", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.VerifyJSON(`{"from":{"ref":"fake-ref"},"shallow":false}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, build),
+					),
+				)
+			})
+
+			It("sends check resource request to ATC", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "-f", "ref:fake-ref", "-a", "--team", team)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+					Eventually(sess.Out).Should(gbytes.Say("checking mypipeline/branch:master/myresource in build 123"))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(3))
+			})
+		})
+
+		Context("when version is omitted", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.VerifyJSON(`{"from":null,"shallow":false}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, build),
+					),
+				)
+			})
+
+			It("sends check resource request to ATC", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "-a", "--team", team)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+					Eventually(sess.Out).Should(gbytes.Say("checking mypipeline/branch:master/myresource in build 123"))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(3))
+			})
+		})
+
+		Context("when running without --async", func() {
+			var streaming chan struct{}
+			var events chan atc.Event
+
+			BeforeEach(func() {
+				streaming = make(chan struct{})
+				events = make(chan atc.Event)
+
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.VerifyJSON(`{"from":null,"shallow":false}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, build),
+					),
+					BuildEventsHandler(123, streaming, events),
+				)
+			})
+
+			It("checks and watches the build", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "--team", team)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess.Out).Should(gbytes.Say("checking mypipeline/branch:master/myresource in build 123"))
+
+					AssertEvents(sess, streaming, events)
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(4))
+			})
+		})
+
+		Context("when specifying the --shallow flag", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.VerifyJSON(`{"from":null,"shallow":true}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, build),
+					),
+				)
+			})
+
+			It("sends correct check resource request to ATC", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "--shallow", "-a", "--team", team)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+
+					Eventually(sess.Out).Should(gbytes.Say("checking mypipeline/branch:master/myresource in build 123"))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(3))
+			})
+		})
+
+		Context("when specifying multiple versions", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.VerifyJSON(`{"from":{"ref1":"fake-ref-1","ref2":"fake-ref-2"},"shallow":false}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, build),
+					),
+				)
+			})
+
+			It("sends correct check resource request to ATC", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "-f", "ref1:fake-ref-1", "-f", "ref2:fake-ref-2", "-a", "--team", team)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+
+					Eventually(sess.Out).Should(gbytes.Say("checking mypipeline/branch:master/myresource in build 123"))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(3))
+			})
+		})
+
+		Context("when pipeline or resource is not found", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.RespondWithJSONEncoded(http.StatusNotFound, ""),
+					),
+				)
+			})
+
+			It("fails with error", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "--shallow", "--team", team)
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(1))
+
+				Expect(sess.Err).To(gbytes.Say("pipeline 'mypipeline/branch:master' or resource 'myresource' not found"))
+			})
+		})
+
+		Context("When resource check returns internal server error", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.RespondWith(http.StatusInternalServerError, "unknown server error"),
+					),
+				)
+			})
+
+			It("outputs error in response body", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "--shallow", "--team", team)
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(1))
+
+				Expect(sess.Err).To(gbytes.Say("unknown server error"))
+
+			})
 		})
 	})
 })

--- a/fly/integration/check_resource_type_test.go
+++ b/fly/integration/check_resource_type_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"net/http"
 	"os/exec"
 
@@ -179,6 +180,181 @@ var _ = Describe("CheckResourceType", func() {
 			Eventually(sess).Should(gexec.Exit(1))
 
 			Expect(sess.Err).To(gbytes.Say("unknown server error"))
+		})
+	})
+
+	Context("user is NOT targeting the same team the resource type belongs to", func() {
+		team := "diff-team"
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", team)),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+						Name: team,
+					}),
+				),
+			)
+		})
+
+		BeforeEach(func() {
+			build = atc.Build{
+				ID:     123,
+				Status: "started",
+			}
+
+			expectedURL = "/api/v1/teams/diff-team/pipelines/mypipeline/resource-types/myresource/check"
+			expectedQueryParams = "vars.branch=%22master%22"
+		})
+
+		Context("when version is specified", func() {
+			BeforeEach(func() {
+
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.VerifyJSON(`{"from":{"ref":"fake-ref"},"shallow":false}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, build),
+					),
+				)
+			})
+
+			It("sends check resource request to ATC", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource-type", "-r", "mypipeline/branch:master/myresource", "-f", "ref:fake-ref", "-a", "--team", team)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+					Eventually(sess.Out).Should(gbytes.Say("checking mypipeline/branch:master/myresource in build 123"))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(3))
+			})
+		})
+
+		Context("when version is omitted", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.VerifyJSON(`{"from":null,"shallow":false}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, build),
+					),
+				)
+			})
+
+			It("sends check resource request to ATC", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource-type", "-r", "mypipeline/branch:master/myresource", "-a", "--team", team)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+					Eventually(sess.Out).Should(gbytes.Say("checking mypipeline/branch:master/myresource in build 123"))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(3))
+			})
+		})
+
+		Context("when running without --async", func() {
+			var streaming chan struct{}
+			var events chan atc.Event
+
+			BeforeEach(func() {
+				streaming = make(chan struct{})
+				events = make(chan atc.Event)
+
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.VerifyJSON(`{"from":null,"shallow":false}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, build),
+					),
+					BuildEventsHandler(123, streaming, events),
+				)
+			})
+
+			It("checks and watches the build", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource-type", "-r", "mypipeline/branch:master/myresource", "--team", team)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess.Out).Should(gbytes.Say("checking mypipeline/branch:master/myresource in build 123"))
+
+					AssertEvents(sess, streaming, events)
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(4))
+			})
+		})
+
+		Context("when specifying the --shallow flag", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.VerifyJSON(`{"from":null,"shallow":true}`),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, build),
+					),
+				)
+			})
+
+			It("sends correct check resource request to ATC", func() {
+				Expect(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource-type", "-r", "mypipeline/branch:master/myresource", "--shallow", "-a", "--team", team)
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+
+					Eventually(sess.Out).Should(gbytes.Say("checking mypipeline/branch:master/myresource in build 123"))
+				}).To(Change(func() int {
+					return len(atcServer.ReceivedRequests())
+				}).By(3))
+			})
+		})
+
+		Context("when pipeline or resource-type is not found", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.RespondWithJSONEncoded(http.StatusNotFound, ""),
+					),
+				)
+			})
+
+			It("fails with error", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource-type", "-r", "mypipeline/branch:master/myresource", "--shallow", "--team", team)
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(1))
+
+				Expect(sess.Err).To(gbytes.Say("pipeline 'mypipeline/branch:master' or resource-type 'myresource' not found"))
+			})
+		})
+
+		Context("When resource-type check returns internal server error", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", expectedURL, expectedQueryParams),
+						ghttp.RespondWith(http.StatusInternalServerError, "unknown server error"),
+					),
+				)
+			})
+
+			It("outputs error in response body", func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "check-resource-type", "-r", "mypipeline/branch:master/myresource", "--shallow", "--team", team)
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(1))
+
+				Expect(sess.Err).To(gbytes.Say("unknown server error"))
+			})
 		})
 	})
 })

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -137,6 +137,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "order-pipelines", "-p", "pipeline", "--team", nonExistentTeam)),
 			Entry("abort-build command returns an error",
 				exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "pipeline/job", "-b", "4", "--team", nonExistentTeam)),
+			Entry("archive-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -181,6 +183,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", otherTeam)),
 			Entry("abort-build command returns an error",
 				exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "pipeline/job", "-b", "4", "--team", otherTeam)),
+			Entry("archive-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-p", "pipeline", "--team", otherTeam)),
 		)
 	})
 })

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -139,6 +139,14 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "pipeline/job", "-b", "4", "--team", nonExistentTeam)),
 			Entry("archive-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-p", "pipeline", "--team", nonExistentTeam)),
+			Entry("resources command returns an error",
+				exec.Command(flyPath, "-t", targetName, "resources", "-p", "pipeline", "--team", nonExistentTeam)),
+			Entry("check-resource-type command returns an error",
+				exec.Command(flyPath, "-t", targetName, "check-resource-type", "-r", "mypipeline/branch:master/myresource", "--shallow", "-a", "--team", nonExistentTeam)),
+			Entry("check-resource command returns an error",
+				exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "--shallow", "-a", "--team", nonExistentTeam)),
+			Entry("resource-versions command returns an error",
+				exec.Command(flyPath, "-t", targetName, "resource-versions", "-r", "pipeline/branch:master/foo", "--team", nonExistentTeam)),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -185,6 +193,14 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "pipeline/job", "-b", "4", "--team", otherTeam)),
 			Entry("archive-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "archive-pipeline", "-p", "pipeline", "--team", otherTeam)),
+			Entry("resources command returns an error",
+				exec.Command(flyPath, "-t", targetName, "resources", "-p", "pipeline", "--team", otherTeam)),
+			Entry("check-resource-type command returns an error",
+				exec.Command(flyPath, "-t", targetName, "check-resource-type", "-r", "mypipeline/branch:master/myresource", "--shallow", "-a", "--team", otherTeam)),
+			Entry("check-resource command returns an error",
+				exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "--shallow", "-a", "--team", otherTeam)),
+			Entry("resource-versions command returns an error",
+				exec.Command(flyPath, "-t", targetName, "resource-versions", "-r", "pipeline/branch:master/foo", "--team", otherTeam)),
 		)
 	})
 })

--- a/fly/integration/resource_versions_test.go
+++ b/fly/integration/resource_versions_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"fmt"
+	"net/http"
 	"os/exec"
 	"strings"
 
@@ -107,6 +109,109 @@ var _ = Describe("Fly CLI", func() {
 
 				Eventually(sess).Should(gexec.Exit(1))
 				Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
+			})
+		})
+
+		Context("user is NOT targeting the same team the resource type belongs to", func() {
+			team := "diff-team"
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", team)),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+							Name: team,
+						}),
+					),
+				)
+			})
+
+			BeforeEach(func() {
+				flyCmd = exec.Command(flyPath, "-t", targetName, "resource-versions", "-r", "pipeline/branch:master/foo", "--team", team)
+			})
+
+			Context("when pipelines are returned from the API", func() {
+				Context("when no --all flag is given", func() {
+					BeforeEach(func() {
+						atcServer.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("GET", "/api/v1/teams/diff-team/pipelines/pipeline/resources/foo/versions", strings.Join(queryParams, "&")),
+								ghttp.RespondWithJSONEncoded(200, []atc.ResourceVersion{
+									{ID: 3, Version: atc.Version{"version": "3", "another": "field"}, Enabled: true},
+									{ID: 2, Version: atc.Version{"version": "2", "another": "field"}, Enabled: false},
+									{ID: 1, Version: atc.Version{"version": "1", "another": "field"}, Enabled: true},
+								}),
+							),
+						)
+					})
+
+					Context("when --json is given", func() {
+						BeforeEach(func() {
+							flyCmd.Args = append(flyCmd.Args, "--json")
+						})
+
+						It("prints response in json as stdout", func() {
+							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+							Expect(err).NotTo(HaveOccurred())
+
+							Eventually(sess).Should(gexec.Exit(0))
+							Expect(sess.Out.Contents()).To(MatchJSON(`[
+                {
+                  "id": 3,
+									"version": {"version":"3","another":"field"},
+									"enabled": true
+                },
+                {
+                  "id": 2,
+									"version": {"version":"2","another":"field"},
+									"enabled": false
+                },
+                {
+                  "id": 1,
+									"version": {"version":"1","another":"field"},
+									"enabled": true
+                }
+              ]`))
+						})
+					})
+
+					It("lists the resource versions", func() {
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(sess).Should(gexec.Exit(0))
+
+						Expect(sess.Out).To(PrintTable(ui.Table{
+							Headers: ui.TableRow{
+								{Contents: "id", Color: color.New(color.Bold)},
+								{Contents: "version", Color: color.New(color.Bold)},
+								{Contents: "enabled", Color: color.New(color.Bold)},
+							},
+							Data: []ui.TableRow{
+								{{Contents: "3"}, {Contents: "another:field,version:3"}, {Contents: "yes"}},
+								{{Contents: "2"}, {Contents: "another:field,version:2"}, {Contents: "no"}},
+								{{Contents: "1"}, {Contents: "another:field,version:1"}, {Contents: "yes"}},
+							},
+						}))
+					})
+				})
+			})
+
+			Context("and the api returns an internal server error", func() {
+				BeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v1/teams/diff-team/pipelines/pipeline/resources/foo/versions", strings.Join(queryParams, "&")),
+							ghttp.RespondWith(500, ""),
+						),
+					)
+				})
+
+				It("writes an error message to stderr", func() {
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(1))
+					Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
+				})
 			})
 		})
 	})

--- a/fly/integration/resources_test.go
+++ b/fly/integration/resources_test.go
@@ -1,6 +1,8 @@
 package integration_test
 
 import (
+	"fmt"
+	"net/http"
 	"os/exec"
 
 	"github.com/concourse/concourse/atc"
@@ -228,6 +230,232 @@ var _ = Describe("Fly CLI", func() {
 
 				Eventually(sess).Should(gexec.Exit(1))
 				Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
+			})
+		})
+
+		Context("user is NOT targeting the same team the resource belongs to", func() {
+			team := "diff-team"
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", fmt.Sprintf("/api/v1/teams/%s", team)),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+							Name: team,
+						}),
+					),
+				)
+			})
+
+			Context("when pipeline name is not specified", func() {
+				It("fails and says pipeline name is required", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "resources", "--team", team)
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(1))
+
+					Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("p", "pipeline") + "' was not specified"))
+				})
+			})
+
+			Context("when resources are returned from the API", func() {
+				BeforeEach(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "resources", "--pipeline", "pipeline/branch:master", "--team", team)
+					pipelineRef := atc.PipelineRef{Name: "pipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v1/teams/diff-team/pipelines/pipeline/resources", "vars.branch=%22master%22"),
+							ghttp.RespondWithJSONEncoded(200, []atc.Resource{
+								{
+									Name:                 "resource-1",
+									PipelineID:           1,
+									PipelineName:         pipelineRef.Name,
+									PipelineInstanceVars: pipelineRef.InstanceVars,
+									TeamName:             team,
+									Type:                 "time",
+									Build: &atc.BuildSummary{
+										ID:                   122,
+										Name:                 "122",
+										Status:               atc.StatusSucceeded,
+										TeamName:             team,
+										PipelineID:           1,
+										PipelineName:         pipelineRef.Name,
+										PipelineInstanceVars: pipelineRef.InstanceVars,
+									},
+								},
+								{
+									Name:                 "resource-2",
+									PipelineID:           1,
+									PipelineName:         pipelineRef.Name,
+									PipelineInstanceVars: pipelineRef.InstanceVars,
+									TeamName:             team,
+									Type:                 "custom",
+									PinnedVersion:        atc.Version{"some": "version"},
+								},
+								{
+									Name:                 "resource-3",
+									PipelineID:           1,
+									PipelineName:         pipelineRef.Name,
+									PipelineInstanceVars: pipelineRef.InstanceVars,
+									TeamName:             team,
+									Type:                 "mock",
+									Build: &atc.BuildSummary{
+										ID:                   123,
+										Name:                 "123",
+										Status:               atc.StatusFailed,
+										TeamName:             team,
+										PipelineID:           1,
+										PipelineName:         pipelineRef.Name,
+										PipelineInstanceVars: pipelineRef.InstanceVars,
+									},
+								},
+								{
+									Name:                 "resource-4",
+									PipelineID:           1,
+									PipelineName:         pipelineRef.Name,
+									PipelineInstanceVars: pipelineRef.InstanceVars,
+									TeamName:             team,
+									Type:                 "mock",
+									Build: &atc.BuildSummary{
+										ID:                   124,
+										Name:                 "124",
+										Status:               atc.StatusErrored,
+										TeamName:             team,
+										PipelineID:           1,
+										PipelineName:         pipelineRef.Name,
+										PipelineInstanceVars: pipelineRef.InstanceVars,
+									},
+								},
+							}),
+						),
+					)
+				})
+
+				Context("when --json is given", func() {
+					BeforeEach(func() {
+						flyCmd.Args = append(flyCmd.Args, "--json")
+					})
+
+					It("prints response in json as stdout", func() {
+						sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(sess).Should(gexec.Exit(0))
+						Expect(sess.Out.Contents()).To(MatchJSON(`[
+              {
+                "name": "resource-1",
+                "pipeline_id": 1,
+                "pipeline_name": "pipeline",
+                "pipeline_instance_vars": {
+                  "branch": "master"
+                },
+                "team_name": "diff-team",
+                "type": "time",
+								"build": {
+									"id": 122,
+									"name": "122",
+									"pipeline_id": 1,
+									"pipeline_name": "pipeline",
+									"pipeline_instance_vars": {
+										"branch": "master"
+									},
+									"team_name": "diff-team",
+									"status": "succeeded"
+								}
+              },
+              {
+                "name": "resource-2",
+                "pipeline_id": 1,
+                "pipeline_name": "pipeline",
+                "pipeline_instance_vars": {
+                  "branch": "master"
+                },
+                "team_name": "diff-team",
+                "type": "custom",
+                "pinned_version": {"some": "version"}
+              },
+              {
+                "name": "resource-3",
+                "pipeline_id": 1,
+                "pipeline_name": "pipeline",
+                "pipeline_instance_vars": {
+                  "branch": "master"
+                },
+                "team_name": "diff-team",
+                "type": "mock",
+								"build": {
+									"id": 123,
+									"name": "123",
+									"pipeline_id": 1,
+									"pipeline_name": "pipeline",
+									"pipeline_instance_vars": {
+										"branch": "master"
+									},
+									"team_name": "diff-team",
+									"status": "failed"
+								}
+              },
+              {
+                "name": "resource-4",
+                "pipeline_id": 1,
+                "pipeline_name": "pipeline",
+                "pipeline_instance_vars": {
+                  "branch": "master"
+                },
+                "team_name": "diff-team",
+                "type": "mock",
+								"build": {
+									"id": 124,
+									"name": "124",
+									"pipeline_id": 1,
+									"pipeline_name": "pipeline",
+									"pipeline_instance_vars": {
+										"branch": "master"
+									},
+									"team_name": "diff-team",
+									"status": "errored"
+								}
+              }
+            ]`))
+					})
+				})
+
+				It("shows the pipeline's resources", func() {
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(sess).Should(gexec.Exit(0))
+
+					Expect(sess.Out).To(PrintTable(ui.Table{
+						Data: []ui.TableRow{
+							{{Contents: "resource-1"}, {Contents: "time"}, {Contents: "n/a"}, {Contents: "succeeded", Color: color.New(color.FgGreen)}},
+							{{Contents: "resource-2"}, {Contents: "custom"}, {Contents: "some:version", Color: color.New(color.FgCyan)}, {Contents: "n/a", Color: color.New(color.Faint)}},
+							{{Contents: "resource-3"}, {Contents: "mock"}, {Contents: "n/a"}, {Contents: "failed", Color: color.New(color.FgRed)}},
+							{{Contents: "resource-4"}, {Contents: "mock"}, {Contents: "n/a"}, {Contents: "errored", Color: color.New(color.FgRed, color.Bold)}},
+						},
+					}))
+				})
+			})
+
+			Context("when the api returns an internal server error", func() {
+				BeforeEach(func() {
+					flyCmd = exec.Command(flyPath, "-t", targetName, "resources", "-p", "pipeline", "--team", team)
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v1/teams/diff-team/pipelines/pipeline/resources"),
+							ghttp.RespondWith(500, ""),
+						),
+					)
+				})
+
+				It("writes an error message to stderr", func() {
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(1))
+					Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
Follows the format laid out in this #7492 - normally if submitting PR's I would break them down into smaller commits etc. but this is basically adding more of the same thing in just different places so figured rather than PR spam if I do one big one it might make it a little easier.

## Changes proposed by this PR

Closes all resource related items off and the archive pipeline in #5215 

- [x] Added team flag to the check-resource command
- [x] Added team flag to the check-resource-type command
- [x] Added team flag to the resources command
- [x] Added team flag to the resource-versions command
- [x] Added team flag to the archive pipeline command

## Notes to reviewer

Added team flag to the following commands:

- check-resource
- check-resource-type
- resources
- resource-versions
- archive-pipeline

## Release Note

* Added `--team` flag to fly command check-resource, you can use it like this
`fly -t dev check-resource -r some-pipeline/branch:master/myresource --team test`
* Added `--team` flag to fly command check-resource-type, you can use it like this
`fly -t dev check-resource-type -r some-pipeline/branch:master/myresource --team test`
* Added `--team` flag to fly command resources, you can use it like this
`fly -t dev resources -p some-pipeline --team test`
* Added `--team` flag to fly command resource-versions, you can use it like this
`fly -t dev resource-versions -r some-pipeline/branch:master/myresource --team test`
* Added `--team` flag to fly command archive-pipeline, you can use it like this
`fly -t dev archive-pipeline --pipeline some-pipeline --team test`