### PR TITLE
remove no needed assertion in topgun runtime

### DIFF
--- a/topgun/runtime/resource_certs_test.go
+++ b/topgun/runtime/resource_certs_test.go
@@ -31,16 +31,10 @@ var _ = Describe("Resource Certs", func() {
 			Fly.Run("check-resource", "-r", "resources/no-certs")
 			Fly.Run("check-resource", "-r", "resources/certs")
 
-			hijackSession := Fly.Start("hijack", "-c", "resources/no-certs", "--", "ls", "/etc/ssl/certs")
+			hijackSession := Fly.Start("hijack", "-c", "resources/certs", "--", "ls", "/etc/ssl/certs")
 			<-hijackSession.Exited
 
 			certsContent := string(hijackSession.Out.Contents())
-			Expect(certsContent).To(HaveLen(0))
-
-			hijackSession = Fly.Start("hijack", "-c", "resources/certs", "--", "ls", "/etc/ssl/certs")
-			<-hijackSession.Exited
-
-			certsContent = string(hijackSession.Out.Contents())
 			Expect(certsContent).ToNot(HaveLen(0))
 		})
 


### PR DESCRIPTION
in topgun runtime tests there is a flaky tests output

```
[It] bind mounts the certs volume if the worker has one
  github.com/concourse/concourse/topgun/runtime/resource_certs_test.go:29
STEP: running the checks
STEP: [1637001157.412383795] running: /tmp/gexec_artifacts556010460/g3802796635/fly -t concourse-topgun-runtime-5 check-resource -r resources/no-certs
checking resources/no-certs in build 2
initializing check: no-certs
selected worker: e34daddf-cd90-489e-b796-b99bff343089
succeeded
STEP: [1637001159.324979305] running: /tmp/gexec_artifacts556010460/g3802796635/fly -t concourse-topgun-runtime-5 check-resource -r resources/certs
checking resources/certs in build 3
initializing check: certs
selected worker: 27282700-3d16-41f8-afcb-ad0942f150e8
succeeded
STEP: [1637001159.692276955] running: /tmp/gexec_artifacts556010460/g3802796635/fly -t concourse-topgun-runtime-5 hijack -c resources/no-certs -- ls /etc/ssl/certs
ca-certificates.crt
```

the check for no cert listing is not necessary and it doesn't actually work. `etc/ssl/certs` will always include worker certs that setting `CONCOURSE_CERTS_PATH` to null won't affect the behaviour.