### PR TITLE
web: behavior: support stringable bool for GetStep.Trigger

### DIFF
--- a/atc/db/job.go
+++ b/atc/db/job.go
@@ -22,7 +22,7 @@ type InputConfigs []InputConfig
 
 type InputConfig struct {
 	Name            string
-	Trigger         bool
+	Trigger         atc.Trigger
 	Passed          JobSet
 	UseEveryVersion bool
 	PinnedVersion   atc.Version
@@ -278,7 +278,7 @@ func (j *job) AlgorithmInputs() (InputConfigs, error) {
 			Name:       inputName,
 			ResourceID: resourceID,
 			JobID:      j.id,
-			Trigger:    trigger,
+			Trigger:    atc.Trigger(trigger),
 		}
 
 		if pinnedVersionString.Valid {
@@ -366,7 +366,7 @@ func (j *job) Inputs() ([]atc.JobInput, error) {
 		inputs = append(inputs, atc.JobInput{
 			Name:     inputName,
 			Resource: resourceName,
-			Trigger:  trigger,
+			Trigger:  atc.Trigger(trigger),
 			Version:  version,
 			Passed:   passed,
 		})

--- a/atc/job.go
+++ b/atc/job.go
@@ -31,7 +31,7 @@ type Job struct {
 type JobInput struct {
 	Name     string         `json:"name"`
 	Resource string         `json:"resource"`
-	Trigger  bool           `json:"trigger"`
+	Trigger  Trigger        `json:"trigger"`
 	Passed   []string       `json:"passed,omitempty"`
 	Version  *VersionConfig `json:"version,omitempty"`
 }

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -292,13 +293,27 @@ var StepPrecedence = []StepDetector{
 	},
 }
 
+// Trigger represents if a step can be triggered by another event. Trigger
+// also supports unmarshalling from a boolean represented as a string, e.g.
+// "true", "True", "1", etc.
+type Trigger bool
+
+func (b *Trigger) UnmarshalJSON(data []byte) error {
+	converted, err := strconv.ParseBool(strings.Trim(string(data), "\""))
+	*b = Trigger(converted)
+	if err != nil {
+		return fmt.Errorf("Trigger unmarshal error: %w", err)
+	}
+	return nil
+}
+
 type GetStep struct {
 	Name     string         `json:"get"`
 	Resource string         `json:"resource,omitempty"`
 	Version  *VersionConfig `json:"version,omitempty"`
 	Params   Params         `json:"params,omitempty"`
 	Passed   []string       `json:"passed,omitempty"`
-	Trigger  bool           `json:"trigger,omitempty"`
+	Trigger  Trigger        `json:"trigger,omitempty"`
 	Tags     Tags           `json:"tags,omitempty"`
 	Timeout  string         `json:"timeout,omitempty"`
 }

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -46,6 +46,45 @@ var factoryTests = []StepTest{
 		},
 	},
 	{
+		Title: "get step with stringable trigger: true",
+		ConfigYAML: `
+			get: some-name
+			trigger: "true"
+			resource: some-resource
+		`,
+		StepConfig: &atc.GetStep{
+			Name:     "some-name",
+			Resource: "some-resource",
+			Trigger:  true,
+		},
+	},
+	{
+		Title: "get step with stringable trigger: false",
+		ConfigYAML: `
+			get: some-name
+			trigger: "False"
+			resource: some-resource
+		`,
+		StepConfig: &atc.GetStep{
+			Name:     "some-name",
+			Resource: "some-resource",
+			Trigger:  false,
+		},
+	},
+	{
+		Title: "get step with trigger: true",
+		ConfigYAML: `
+			get: some-name
+			trigger: true
+			resource: some-resource
+		`,
+		StepConfig: &atc.GetStep{
+			Name:     "some-name",
+			Resource: "some-resource",
+			Trigger:  true,
+		},
+	},
+	{
 		Title: "put step",
 
 		ConfigYAML: `
@@ -393,7 +432,7 @@ var factoryTests = []StepTest{
 			across:
 			- var: var1
 			  values: [1, 2, 3]
-			  bogus_field: lol what ru gonna do about it 
+			  bogus_field: lol what ru gonna do about it
 		`,
 
 		Err: `error unmarshaling JSON: while decoding JSON: malformed across step: json: unknown field "bogus_field"`,


### PR DESCRIPTION
## Changes proposed by this PR

* [x] support stringable bool for GetStep.Trigger (allow unmarshalling "true", "True", "false", "False" into GetStep.Trigger)

## Notes to reviewer

PR is related to [this Discord conversation](https://discord.com/channels/219899946617274369/413770960089382922/910563817161904169).

In short, today, it's not possible to interpolate the trigger field of a get step, when the source of the interpolated variable comes from sources like `--load-vars-from`, var-sources, vault, `--var`, instance vars, across steps, etc. The only exception I know of so far is `--yaml-var` which could let it be a boolean, but this clearly can't be used in all situations. This PR solves that by defining a custom unmarshaler.

Example, `((some-variable))`:

```yaml
[...]
- in_parallel:
  - { get: timer, trigger: ((some-variable)) }
```

With `fly -t target set-pipeline --var=some-variable=False` (or `false`, doesn't seem to make a difference), it causes:

```
error: error unmarshaling JSON: while decoding JSON: malformed in_parallel step: failed to unmarshal parallel steps: malformed get step: json: cannot unmarshal string into Go struct field GetStep.trigger of type bool
```

One of the primary benefits with this change, is you can now pass in a value for trigger, through across/set_pipeline, which would allow scenarios like a multi-branch workflow where non-master branches auto-run deployments but master doesn't, without having a separate pipeline or pipeline file.

This is the example pipeline I used to test, where `time-triggered.yaml` uses `((instance.trigger))` ([as seen here](https://github.com/lrstanley/concourse-test-pipeline/blob/master/time-triggered.yaml#L14)):

```yaml
deployments: &deployments
  - name: example
    trigger: true
  - name: example-2
    trigger: false

resources:
  - name: git-branch
    type: git
    icon: git
    source:
      uri: https://github.com/lrstanley/concourse-test-pipeline.git
      branch: master

jobs:
  - name: update-deployments
    public: false
    serial: true
    plan:
    - in_parallel:
        fail_fast: true
        steps:
        - get: git-branch
          trigger: true
    - across:
      - var: instance
        values: *deployments
      do:
      - set_pipeline: "example"
        file: git-branch/time-triggered.yaml
        instance_vars:
          name: ((.:instance.name))
        vars:
          instance: ((.:instance))
```

I have yet to test var-sources or vault interpolation, though suspect this should work as intended.

## Release Note

* Add better interpolation support for `trigger` within `get` steps (across, set_pipeline, etc). This is useful for multi-branch style pipelines that need to toggle things like auto-deployments for specific environments, as an example.

