### PR TITLE
ignore patch release update for aws-sdk-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     interval: daily
     time: "00:00"
   labels: ["go", "dependencies", "misc", "release/undocumented"]
+  ignore:
+      # For AWS SDK, ignore all patch updates
+    - dependency-name: "aws-sdk-go"
+      update-types: ["version-update:semver-patch"]
 
 - package-ecosystem: elm
   directory: /web/elm


### PR DESCRIPTION
aws-sdk-go has frequent patch releases that Concourse doesn't need to be kept up-to-date.

For reference the semver update customization of dependabot could be found here at [dependabot ignore](
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore)