### PR TITLE
Use CONCOURSE_CONTAINERD_NAMESPACE_SUFFIX for containerdNamespace.

### DIFF
--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -23,7 +23,7 @@ import (
 	"github.com/tedsuo/ifrit/grouper"
 )
 
-const containerdNamespace = "concourse"
+var containerdNamespace = "concourse" + os.Getenv("CONCOURSE_CONTAINERD_NAMESPACE_SUFFIX")
 
 // WriteDefaultContainerdConfig writes a default containerd configuration file
 // to a destination.


### PR DESCRIPTION
## Changes proposed by this PR

closes #7165

## Release Note

Allow setting a namespace for Containerd.