### PR TITLE
Fix down migration for build event sequences

### DIFF
--- a/atc/db/migration/migrations/1625844437_drop_build_event_id_seq.down.sql
+++ b/atc/db/migration/migrations/1625844437_drop_build_event_id_seq.down.sql
@@ -4,7 +4,7 @@ declare
     startValue int;
 begin
     for b in
-        select id, name, pipeline_id, team_id from builds where status = 'started' and completed = false and aborted = false
+        select id, name, pipeline_id, team_id from builds where status = 'started' and completed = false
     loop
         raise notice 'dropping sequence build_event_id_seq_% ...', b.id;
         execute 'drop sequence if exists build_event_id_seq_' || b.id;

--- a/atc/db/migration/migrations/1625844437_drop_build_event_id_seq.down.sql
+++ b/atc/db/migration/migrations/1625844437_drop_build_event_id_seq.down.sql
@@ -4,7 +4,7 @@ declare
     startValue int;
 begin
     for b in
-        select id, name, pipeline_id, team_id from builds where status = 'started' and completed = false
+        select id, name, pipeline_id, team_id from builds where (status = 'started' OR status = 'pending') and completed = false
     loop
         raise notice 'dropping sequence build_event_id_seq_% ...', b.id;
         execute 'drop sequence if exists build_event_id_seq_' || b.id;

--- a/atc/db/migration/migrations/1625844437_drop_build_event_id_seq.down.sql
+++ b/atc/db/migration/migrations/1625844437_drop_build_event_id_seq.down.sql
@@ -14,7 +14,7 @@ begin
         elsif b.pipeline_id is null or b.pipeline_id = 0 then
             execute 'select max(event_id) from team_build_events_' || b.team_id || ' where build_id=' || b.id into startValue;
         else
-            execute 'select max(event_id) from pipeline_build_events_' | b.pipeline_id || ' where build_id=' || b.id into startValue;
+            execute 'select max(event_id) from pipeline_build_events_' || b.pipeline_id || ' where build_id=' || b.id into startValue;
         end if;
 
         if startValue is null then


### PR DESCRIPTION
## Changes proposed by this PR

#7857

There was a typo in the down migration for constructing build event sequences in postgres but it was never caught because the migration only runs for started builds during the downgrade but the integration tests don't cover that use case.

* [x] done
* [ ] todo

## Release Note

* This PR fixes a typo in a down migration that affects Concourse version 7.4.1, 7.4.2 and 7.4.3. Therefore, you will be unable to downgrade from any of those listed versions.

