### PR TITLE
Optimize limit active tasks strategy logic

### DIFF
--- a/atc/db/dbfakes/fake_worker.go
+++ b/atc/db/dbfakes/fake_worker.go
@@ -163,9 +163,10 @@ type FakeWorker struct {
 	hTTPSProxyURLReturnsOnCall map[int]struct {
 		result1 string
 	}
-	IncreaseActiveTasksStub        func() (int, error)
+	IncreaseActiveTasksStub        func(int) (int, error)
 	increaseActiveTasksMutex       sync.RWMutex
 	increaseActiveTasksArgsForCall []struct {
+		arg1 int
 	}
 	increaseActiveTasksReturns struct {
 		result1 int
@@ -1109,17 +1110,18 @@ func (fake *FakeWorker) HTTPSProxyURLReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *FakeWorker) IncreaseActiveTasks() (int, error) {
+func (fake *FakeWorker) IncreaseActiveTasks(arg1 int) (int, error) {
 	fake.increaseActiveTasksMutex.Lock()
 	ret, specificReturn := fake.increaseActiveTasksReturnsOnCall[len(fake.increaseActiveTasksArgsForCall)]
 	fake.increaseActiveTasksArgsForCall = append(fake.increaseActiveTasksArgsForCall, struct {
-	}{})
+		arg1 int
+	}{arg1})
 	stub := fake.IncreaseActiveTasksStub
 	fakeReturns := fake.increaseActiveTasksReturns
-	fake.recordInvocation("IncreaseActiveTasks", []interface{}{})
+	fake.recordInvocation("IncreaseActiveTasks", []interface{}{arg1})
 	fake.increaseActiveTasksMutex.Unlock()
 	if stub != nil {
-		return stub()
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1133,10 +1135,17 @@ func (fake *FakeWorker) IncreaseActiveTasksCallCount() int {
 	return len(fake.increaseActiveTasksArgsForCall)
 }
 
-func (fake *FakeWorker) IncreaseActiveTasksCalls(stub func() (int, error)) {
+func (fake *FakeWorker) IncreaseActiveTasksCalls(stub func(int) (int, error)) {
 	fake.increaseActiveTasksMutex.Lock()
 	defer fake.increaseActiveTasksMutex.Unlock()
 	fake.IncreaseActiveTasksStub = stub
+}
+
+func (fake *FakeWorker) IncreaseActiveTasksArgsForCall(i int) int {
+	fake.increaseActiveTasksMutex.RLock()
+	defer fake.increaseActiveTasksMutex.RUnlock()
+	argsForCall := fake.increaseActiveTasksArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeWorker) IncreaseActiveTasksReturns(result1 int, result2 error) {

--- a/atc/db/worker_test.go
+++ b/atc/db/worker_test.go
@@ -427,7 +427,7 @@ var _ = Describe("Worker", func() {
 
 		Context("when the active task is increased", func() {
 			BeforeEach(func() {
-				at, err := worker.IncreaseActiveTasks()
+				at, err := worker.IncreaseActiveTasks(1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(at).To(Equal(1))
 			})
@@ -436,6 +436,20 @@ var _ = Describe("Worker", func() {
 				at, err := worker.ActiveTasks()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(at).To(Equal(1))
+			})
+
+			Context("when max active task reached", func() {
+				It("errors when increasing the active tasks counter", func() {
+					at, err := worker.IncreaseActiveTasks(1)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("worker has too many active tasks"))
+					Expect(at).To(Equal(0))
+
+					By("it does not increase worker active tasks count")
+					at, err = worker.ActiveTasks()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(at).To(Equal(1))
+				})
 			})
 
 			Context("when the active task is decreased", func() {

--- a/atc/worker/gardenruntime/gardenruntimetest/worker.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/worker.go
@@ -182,7 +182,7 @@ func (w Worker) WithActiveTasks(activeTasks int) *Worker {
 	return w.WithSetup(func(s *workertest.Scenario) {
 		worker := s.DB.Worker(w.Name())
 		for i := 0; i < activeTasks; i++ {
-			_, err := worker.IncreaseActiveTasks()
+			_, err := worker.IncreaseActiveTasks(activeTasks)
 			Expect(err).ToNot(HaveOccurred())
 		}
 	})

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -20,9 +20,8 @@ type PlacementOptions struct {
 }
 
 var (
-	ErrTooManyActiveTasks = errors.New("worker has too many active tasks")
-	ErrTooManyContainers  = errors.New("worker has too many containers")
-	ErrTooManyVolumes     = errors.New("worker has too many volumes")
+	ErrTooManyContainers = errors.New("worker has too many containers")
+	ErrTooManyVolumes    = errors.New("worker has too many volumes")
 )
 
 func NewPlacementStrategy(options PlacementOptions) (PlacementStrategy, error) {
@@ -285,16 +284,7 @@ func (strategy limitActiveTasksStrategy) Approve(logger lager.Logger, worker db.
 		return nil
 	}
 
-	activeTasks, err := worker.ActiveTasks()
-	if err != nil {
-		return err
-	}
-
-	if activeTasks >= strategy.MaxTasks {
-		return ErrTooManyActiveTasks
-	}
-
-	_, err = worker.IncreaseActiveTasks()
+	_, err := worker.IncreaseActiveTasks(strategy.MaxTasks)
 
 	return err
 }

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -365,7 +365,7 @@ var _ = Describe("Container Placement Strategies", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			err = strategy.Approve(logger, workers[0], spec)
-			Expect(err).To(MatchError(worker.ErrTooManyActiveTasks))
+			Expect(err).To(MatchError(db.ErrTooManyActiveTasks))
 
 			By("validating the limit only applies to task containers", func() {
 				spec.Type = db.ContainerTypeCheck


### PR DESCRIPTION
## Changes proposed by this PR

 * return early to avoid unnecessary query
 * use get instead of update to reduce DB lock on rows
 * only increase the count in the end

It should help reducing the DB load and the chance of dead lock, especially under heavy load.

closes #7791 

## Release Note

* Optimize limit-active-tasks strategy to reduce DB load and avoid deadlocking when under heavy load.
