### PR TITLE
Refactor pipeline lifecycle in atc/db

### DIFF
--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -723,7 +723,7 @@ func (p *pipeline) archive(tx Tx) error {
 		Set("archived", true).
 		Set("last_updated", sq.Expr("now()")).
 		Set("paused", true).
-		Set("paused_by", nil).
+		Set("paused_by", "automatic-pipeline-archiver").
 		Set("paused_at", time.Now()).
 		Set("version", 0).
 		Where(sq.Eq{"id": p.id}).

--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -35,8 +35,7 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 	defer Rollback(tx)
 
 	rows, err := pipelinesQuery.
-		LeftJoin("jobs j ON j.id = p.parent_job_id").
-		LeftJoin("pipelines p2 ON j.pipeline_id = p2.id").
+		LeftJoin("jobs j ON (j.id = p.parent_job_id AND j.pipeline_id = p.id)").
 		Where(sq.Or{
 			// parent pipeline was destroyed
 			sq.And{
@@ -46,7 +45,7 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 			// pipeline was set by a job. The job was removed from the parent pipeline
 			sq.Eq{"j.active": false},
 			// parent pipeline was archived
-			sq.Eq{"p2.archived": true},
+			sq.Eq{"p.archived": true},
 		}).
 		RunWith(tx).
 		Query()

--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -34,27 +34,31 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 
 	defer Rollback(tx)
 
-	rows, err := pipelinesQuery.
-		LeftJoin("jobs j ON (j.id = p.parent_job_id AND j.pipeline_id = p.id)").
-		Where(sq.Or{
-			// parent pipeline was destroyed
-			sq.And{
-				sq.NotEq{"p.parent_build_id": nil},
+	pipelinesToArchive, err := pipelinesQuery.
+		LeftJoin("jobs j ON (j.id = p.parent_job_id)").
+		LeftJoin("pipelines parent ON (j.pipeline_id = parent.id)").
+		Where(sq.And{
+			// pipeline was set by some build
+			sq.NotEq{"p.parent_job_id": nil},
+			sq.Or{
+				// job (that set child pipeline) from parent pipeline is
+				// removed, Concourse marks job as inactive
+				sq.Eq{"j.active": false},
+				// parent pipeline was destroyed, entire job record is gone
 				sq.Eq{"j.id": nil},
-			},
-			// pipeline was set by a job. The job was removed from the parent pipeline
-			sq.Eq{"j.active": false},
-			// parent pipeline was archived
-			sq.Eq{"p.archived": true},
-		}).
+				// parent pipeline was archived
+				sq.Eq{"parent.archived": true},
+				// build that set the pipeline is not the most recent for the job
+				sq.Expr("p.parent_build_id != j.latest_completed_build_id"),
+			}}).
 		RunWith(tx).
 		Query()
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer pipelinesToArchive.Close()
 
-	err = archivePipelines(tx, pl.conn, pl.lockFactory, rows)
+	err = archivePipelines(tx, pl.conn, pl.lockFactory, pipelinesToArchive)
 	if err != nil {
 		return err
 	}

--- a/atc/db/pipeline_lifecycle_test.go
+++ b/atc/db/pipeline_lifecycle_test.go
@@ -37,6 +37,15 @@ var _ = Describe("PipelineLifecycle", func() {
 				build.Finish(db.BuildStatusSucceeded)
 			})
 
+			Context("parent and child pipelines happily exist", func() {
+				It("neither pipeline should be archived", func() {
+					childPipeline.Reload()
+					defaultPipeline.Reload()
+					Expect(childPipeline.Archived()).To(BeFalse())
+					Expect(defaultPipeline.Archived()).To(BeFalse())
+				})
+			})
+
 			Context("parent pipeline is destroyed", func() {
 				BeforeEach(func() {
 					defaultPipeline.Destroy()


### PR DESCRIPTION
I introduced a bug in #7876 from what I thought was a simple query refactor. I include that commit in this PR for context. The second commit fixes the first commit and also does a further refactor and adds a test to guard against the bug I introduced.

From my second commit message:
> I introduced a bug with an earlier refactor. Once I figured out the bug
I went back to the query and further refactored it. I think I ended up
with a clearer version of the query.
>
> In the initial query the pipelines table was brought in via a second
LEFT JOIN, called p2. This confused me on my reading of the code today.
I was like "why is pipelines brought in again? This looks dumb!" and
there was no test guarding against this change (there is now with this
commit). I added back the second LEFT JOIN but called the second
pipelines table "parent" so its more obvious WHY the table is being
brought in again.
>
>Overall the query is a lot safer. It now only picks up pipelines that
have a parent_job_id (it didn't before for all cases, pretty crazy!) and
further filters for other criteria from that starting point. I think
it's much easier to read now too.

So this PR is a no-op but should make the code easier to understand for someone reading it for the first time.