### PR TITLE
Add error message to the create artifact API call

### DIFF
--- a/atc/api/artifactserver/create.go
+++ b/atc/api/artifactserver/create.go
@@ -3,6 +3,7 @@ package artifactserver
 import (
 	"encoding/json"
 	"net/http"
+	"fmt"
 
 	"github.com/concourse/concourse/atc/api/present"
 	"github.com/concourse/concourse/atc/compression"
@@ -30,14 +31,14 @@ func (s *Server) CreateArtifact(team db.Team) http.Handler {
 		volume, artifact, err := s.workerPool.CreateVolumeForArtifact(ctx, workerSpec)
 		if err != nil {
 			hLog.Error("failed-to-create-volume", err)
-			w.WriteHeader(http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("%v",err), http.StatusInternalServerError)
 			return
 		}
 
 		err = volume.StreamIn(r.Context(), "/", compression.NewGzipCompression(), r.Body)
 		if err != nil {
 			hLog.Error("failed-to-stream-volume-contents", err)
-			w.WriteHeader(http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("%v",err), http.StatusInternalServerError)
 			return
 		}
 

--- a/go-concourse/concourse/internal/errors.go
+++ b/go-concourse/concourse/internal/errors.go
@@ -15,7 +15,7 @@ type UnexpectedResponseError struct {
 }
 
 func (e UnexpectedResponseError) Error() string {
-	return fmt.Sprintf("Unexpected Response\nStatus: %s\nBody:\n%s", e.Status, e.Body)
+	return fmt.Sprintf("Unexpected Response\nStatus: %s\nBody: %s", e.Status, e.Body)
 }
 
 type ForbiddenError struct {


### PR DESCRIPTION
## Changes proposed by this PR

closes #7721 

* [x] Update CreateArtifact function to return a http Error with body.
* [x] Update some formatting for the UnexpectedResponseError 

## Notes to reviewer

This makes it so the methods inside CreateArtifact now return a HTTP error with a body, previously they only returned a 500 with no body attached to the HTTP response, this now provides context at least.

Some examples In relation to the issue highlighted above: 

Previous
```
 ~/go/bin/fly --target=local execute --config=task.yaml --input=source=fly --tag="something"
error: 'uploading source' failed: Unexpected Response
Status: 500 Internal Server Error
Body:
```
Now:
```
 ~/go/bin/fly --target=local execute --config=task.yaml --input=source=fly --tag="something"
uploading source ⠋ (0b/s)
error: 'uploading source' failed: Unexpected Response
Status: 500 Internal Server Error
Body: no workers satisfying: platform 'linux', tag 'something', version: '2.3'
```