### PR TITLE
Porting down migration improvements for build event sequences

### DIFF
--- a/atc/db/migration/migrations/1630515499_drop_build_event_id_seq.down.sql
+++ b/atc/db/migration/migrations/1630515499_drop_build_event_id_seq.down.sql
@@ -4,7 +4,7 @@ declare
     startValue int;
 begin
     for b in
-        select id, name, pipeline_id, team_id from builds where status = 'started' and completed = false and aborted = false
+        select id, name, pipeline_id, team_id from builds where (status = 'started' OR status = 'pending') and completed = false
     loop
         raise notice 'dropping sequence build_event_id_seq_% ...', b.id;
         execute 'drop sequence if exists build_event_id_seq_' || b.id;


### PR DESCRIPTION
## Changes proposed by this PR

We made some improvements to the down migration for dropping build event ids in the 7.4.x release
https://github.com/concourse/concourse/pull/7860 so I'm just porting over these improvements to the master branch.

* [x] done
* [ ] todo

## Release Note

* If you are on v7.6.0 and want to downgrade, you might end up with some builds that never finish and run into some web log errors like `pq: relation "build_event_id_seq_<sequence-id>" does not exist`. This is because of a bug in the down migration which is fixed with this PR.
  * If you do run into this problem, you can easily fix it by running `create sequence build_event_id_seq_<sequence-id> minvalue 0 start with 0;` on your postgres database (You will need to replace <sequence-id> with the id that does not exist in the error).
