### PR TITLE
Only delete btrfs mounts if *.img exists

### DIFF
--- a/worker/baggageclaim/baggageclaimcmd/driver_linux.go
+++ b/worker/baggageclaim/baggageclaimcmd/driver_linux.go
@@ -82,7 +82,7 @@ func (cmd *BaggageclaimCommand) driver(logger lager.Logger) (volume.Driver, erro
 		}
 		// Clean up existing btrfs mount so we don't make overlay mounts inside
 		// a btrfs mount. Stuff gets flakey otherwise
-		if isMountBtrfs(volMountInfo) {
+		if _, err := os.Stat(btrfsImg); isMountBtrfs(volMountInfo) && err == nil {
 			err = btrfsFS.Delete()
 			if err != nil {
 				return nil, fmt.Errorf("failed to delete existing btrfs filesystem at %s: %s", cmd.VolumesDir.Path(), err)


### PR DESCRIPTION
## Changes proposed by this PR

closes #7875


## Notes to reviewer

I did not test this myself so I'm not 100% sure it actually fixes the issue, but I am like 98% sure that it does.

## Release Note

* Concourse worker would fail to start if it's on a btrfs filesystem and tries to use the overlay driver
