### PR TITLE
Do not send check build events to syslog drainer

### DIFF
--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -212,10 +212,13 @@ func (f *buildFactory) constructBuildFilter() sq.Or {
 }
 
 func (f *buildFactory) GetDrainableBuilds() ([]Build, error) {
-	query := buildsQuery.Where(sq.Eq{
-		"b.completed": true,
-		"b.drained":   false,
-	})
+	query := buildsQuery.Where(
+		sq.Eq{
+			"b.completed":        true,
+			"b.drained":          false,
+			"b.resource_id":      nil,
+			"b.resource_type_id": nil,
+		})
 
 	return getBuilds(query, f.conn, f.lockFactory)
 }


### PR DESCRIPTION
closes #7915 

* [x] done
* [ ] todo

## Notes to reviewer


## Release Note
 * Since v7.0, resouce and resource type checks are ran as builds. When syslog drainer is enabled, those check build events are also sent to external server, which requires storage space (depends on amount of resources and check interval). Now this type of events will be ignored by syslog drainer.
