### PR TITLE
Shared (top level) secrets in AWS secrets manager

### DIFF
--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -413,6 +413,7 @@ var _ = Describe("Pipelines API", func() {
 					AwsRegion:              "blah",
 					PipelineSecretTemplate: "pipeline-secret-template",
 					TeamSecretTemplate:     "team-secret-template",
+					TopLevelSecretTemplate: "top-level-secret-template",
 					SecretManager:          secretsManagerAccess,
 				}
 
@@ -434,6 +435,7 @@ var _ = Describe("Pipelines API", func() {
 						"aws_region": "blah",
 						"pipeline_secret_template": "pipeline-secret-template",
 						"team_secret_template": "team-secret-template",
+						"top_level_secret_template": "top-level-secret-template",
 						"health": {
 							"error": "some error occurred",
 							"method": "GetSecretValue"
@@ -459,6 +461,7 @@ var _ = Describe("Pipelines API", func() {
 						"aws_region": "blah",
 						"pipeline_secret_template": "pipeline-secret-template",
 						"team_secret_template": "team-secret-template",
+						"top_level_secret_template": "top-level-secret-template",
 						"health": {
 							"response": {
 								"status": "UP"

--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -413,7 +413,7 @@ var _ = Describe("Pipelines API", func() {
 					AwsRegion:              "blah",
 					PipelineSecretTemplate: "pipeline-secret-template",
 					TeamSecretTemplate:     "team-secret-template",
-					TopLevelSecretTemplate: "top-level-secret-template",
+					SharedSecretTemplate:   "shared-secret-template",
 					SecretManager:          secretsManagerAccess,
 				}
 
@@ -435,7 +435,7 @@ var _ = Describe("Pipelines API", func() {
 						"aws_region": "blah",
 						"pipeline_secret_template": "pipeline-secret-template",
 						"team_secret_template": "team-secret-template",
-						"top_level_secret_template": "top-level-secret-template",
+						"shared_secret_template": "shared-secret-template",
 						"health": {
 							"error": "some error occurred",
 							"method": "GetSecretValue"
@@ -461,7 +461,7 @@ var _ = Describe("Pipelines API", func() {
 						"aws_region": "blah",
 						"pipeline_secret_template": "pipeline-secret-template",
 						"team_secret_template": "team-secret-template",
-						"top_level_secret_template": "top-level-secret-template",
+						"shared_secret_template": "shared-secret-template",
 						"health": {
 							"response": {
 								"status": "UP"

--- a/atc/creds/secretsmanager/manager.go
+++ b/atc/creds/secretsmanager/manager.go
@@ -14,7 +14,7 @@ import (
 
 const DefaultPipelineSecretTemplate = "/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"
 const DefaultTeamSecretTemplate = "/concourse/{{.Team}}/{{.Secret}}"
-const DefaultTopLevelSecretTemplate = "/concourse/{{.Secret}}"
+const DefaultSharedSecretTemplate = "/concourse/{{.Secret}}"
 
 type Manager struct {
 	AwsAccessKeyID         string `long:"access-key" description:"AWS Access key ID"`
@@ -23,7 +23,7 @@ type Manager struct {
 	AwsRegion              string `long:"region" description:"AWS region to send requests to"`
 	PipelineSecretTemplate string `long:"pipeline-secret-template" description:"AWS Secrets Manager secret identifier template used for pipeline specific parameter" default:"/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"`
 	TeamSecretTemplate     string `long:"team-secret-template" description:"AWS Secrets Manager secret identifier  template used for team specific parameter" default:"/concourse/{{.Team}}/{{.Secret}}"`
-	TopLevelSecretTemplate string `long:"top-level-secret-template" description:"AWS Secrets Manager secret identifier  template used for top level parameter that can be used by all teams" default:"/concourse/{{.Secret}}"`
+	SharedSecretTemplate   string `long:"shared-secret-template" description:"AWS Secrets Manager secret identifier  template used for shared parameter that can be used by all teams and pipelines" default:"/concourse/{{.Secret}}"`
 	SecretManager          *SecretsManager
 }
 
@@ -71,11 +71,11 @@ func (manager *Manager) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&map[string]interface{}{
-		"aws_region":                manager.AwsRegion,
-		"pipeline_secret_template":  manager.PipelineSecretTemplate,
-		"team_secret_template":      manager.TeamSecretTemplate,
-		"top_level_secret_template": manager.TopLevelSecretTemplate,
-		"health":                    health,
+		"aws_region":               manager.AwsRegion,
+		"pipeline_secret_template": manager.PipelineSecretTemplate,
+		"team_secret_template":     manager.TeamSecretTemplate,
+		"shared_secret_template":   manager.SharedSecretTemplate,
+		"health":                   health,
 	})
 }
 
@@ -90,7 +90,7 @@ func (manager *Manager) Validate() error {
 	if _, err := creds.BuildSecretTemplate("team-secret-template", manager.TeamSecretTemplate); err != nil {
 		return err
 	}
-	if _, err := creds.BuildSecretTemplate("top-level-secret-template", manager.TopLevelSecretTemplate); err != nil {
+	if _, err := creds.BuildSecretTemplate("shared-secret-template", manager.SharedSecretTemplate); err != nil {
 		return err
 	}
 
@@ -133,12 +133,12 @@ func (manager *Manager) NewSecretsFactory(log lager.Logger) (creds.SecretsFactor
 		return nil, err
 	}
 
-	topLevelSecretTemplate, err := creds.BuildSecretTemplate("top-level-secret-template", manager.TopLevelSecretTemplate)
+	sharedSecretTemplate, err := creds.BuildSecretTemplate("shared-secret-template", manager.SharedSecretTemplate)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewSecretsManagerFactory(log, sess, []*creds.SecretTemplate{pipelineSecretTemplate, teamSecretTemplate, topLevelSecretTemplate}), nil
+	return NewSecretsManagerFactory(log, sess, []*creds.SecretTemplate{pipelineSecretTemplate, teamSecretTemplate, sharedSecretTemplate}), nil
 }
 
 func (manager Manager) Close(logger lager.Logger) {

--- a/atc/creds/secretsmanager/manager.go
+++ b/atc/creds/secretsmanager/manager.go
@@ -71,10 +71,11 @@ func (manager *Manager) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&map[string]interface{}{
-		"aws_region":               manager.AwsRegion,
-		"pipeline_secret_template": manager.PipelineSecretTemplate,
-		"team_secret_template":     manager.TeamSecretTemplate,
-		"health":                   health,
+		"aws_region":                manager.AwsRegion,
+		"pipeline_secret_template":  manager.PipelineSecretTemplate,
+		"team_secret_template":      manager.TeamSecretTemplate,
+		"top_level_secret_template": manager.TopLevelSecretTemplate,
+		"health":                    health,
 	})
 }
 

--- a/atc/creds/secretsmanager/manager_test.go
+++ b/atc/creds/secretsmanager/manager_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Manager", func() {
 			Expect(err).To(BeNil())
 			Expect(manager.PipelineSecretTemplate).To(Equal(secretsmanager.DefaultPipelineSecretTemplate))
 			Expect(manager.TeamSecretTemplate).To(Equal(secretsmanager.DefaultTeamSecretTemplate))
+			Expect(manager.TopLevelSecretTemplate).To(Equal(secretsmanager.DefaultTopLevelSecretTemplate))
 		})
 
 		It("passes on default parameters", func() {
@@ -103,6 +104,16 @@ var _ = Describe("Manager", func() {
 
 		It("fails on team secret template containing invalid parameters", func() {
 			manager.TeamSecretTemplate = "{{.Teams}}"
+			Expect(manager.Validate()).ToNot(BeNil())
+		})
+
+		It("passes on top level secret template containing no specialization", func() {
+			manager.TopLevelSecretTemplate = "var"
+			Expect(manager.Validate()).To(BeNil())
+		})
+
+		It("fails on empty top level secret template", func() {
+			manager.TopLevelSecretTemplate = ""
 			Expect(manager.Validate()).ToNot(BeNil())
 		})
 	})

--- a/atc/creds/secretsmanager/manager_test.go
+++ b/atc/creds/secretsmanager/manager_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Manager", func() {
 			Expect(err).To(BeNil())
 			Expect(manager.PipelineSecretTemplate).To(Equal(secretsmanager.DefaultPipelineSecretTemplate))
 			Expect(manager.TeamSecretTemplate).To(Equal(secretsmanager.DefaultTeamSecretTemplate))
-			Expect(manager.TopLevelSecretTemplate).To(Equal(secretsmanager.DefaultTopLevelSecretTemplate))
+			Expect(manager.SharedSecretTemplate).To(Equal(secretsmanager.DefaultSharedSecretTemplate))
 		})
 
 		It("passes on default parameters", func() {
@@ -107,13 +107,13 @@ var _ = Describe("Manager", func() {
 			Expect(manager.Validate()).ToNot(BeNil())
 		})
 
-		It("passes on top level secret template containing no specialization", func() {
-			manager.TopLevelSecretTemplate = "var"
+		It("passes on shared secret template containing no specialization", func() {
+			manager.SharedSecretTemplate = "var"
 			Expect(manager.Validate()).To(BeNil())
 		})
 
-		It("fails on empty top level secret template", func() {
-			manager.TopLevelSecretTemplate = ""
+		It("fails on empty shared secret template", func() {
+			manager.SharedSecretTemplate = ""
 			Expect(manager.Validate()).ToNot(BeNil())
 		})
 	})

--- a/atc/creds/secretsmanager/secretsmanager_test.go
+++ b/atc/creds/secretsmanager/secretsmanager_test.go
@@ -51,7 +51,7 @@ var _ = Describe("SecretsManager", func() {
 		t2, err := creds.BuildSecretTemplate("t2", DefaultTeamSecretTemplate)
 		Expect(t2).NotTo(BeNil())
 		Expect(err).To(BeNil())
-		t3, err := creds.BuildSecretTemplate("t3", DefaultTopLevelSecretTemplate)
+		t3, err := creds.BuildSecretTemplate("t3", DefaultSharedSecretTemplate)
 		Expect(t3).NotTo(BeNil())
 		Expect(err).To(BeNil())
 		secretAccess = NewSecretsManager(lagertest.NewTestLogger("secretsmanager_test"), &mockService, []*creds.SecretTemplate{t1, t2, t3})
@@ -101,15 +101,15 @@ var _ = Describe("SecretsManager", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should return top level parameter if exists", func() {
+		It("should return shared parameter if exists", func() {
 			mockService.stubGetParameter = func(input string) (*secretsmanager.GetSecretValueOutput, error) {
 				if input != "/concourse/cheery" {
 					return nil, awserr.New(secretsmanager.ErrCodeResourceNotFoundException, "", nil)
 				}
-				return &secretsmanager.GetSecretValueOutput{SecretString: aws.String("top level decrypted value")}, nil
+				return &secretsmanager.GetSecretValueOutput{SecretString: aws.String("shared decrypted value")}, nil
 			}
 			value, found, err := variables.Get(varRef)
-			Expect(value).To(BeEquivalentTo("top level decrypted value"))
+			Expect(value).To(BeEquivalentTo("shared decrypted value"))
 			Expect(found).To(BeTrue())
 			Expect(err).To(BeNil())
 		})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

This PR introduces top level secrets when using AWS secrets manager. 

Pipeline specific secrets: `/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}`
Team specific secrets: `/concourse/{{.Team}}/{{.Secret}}`
Top level secrets: `/concourse/{{.Secret}}`

This is useful for cases where there are secret that should be shared across teams. 

In my case, I have multiple teams that all use common images and resource types that are stored in a common ECR instance.  
The credentials (key/secret) for that ECR registry are stored in secret manager. I don't want to maintain a separate secret for each team if it's going to be the same.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->
<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->
