### PR TITLE
Remove unused gc-container-collector-dropped metric

### DIFF
--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -427,23 +427,6 @@ func (event FailedVolumesToBeGarbageCollected) Emit(logger lager.Logger) {
 	)
 }
 
-type GarbageCollectionContainerCollectorJobDropped struct {
-	WorkerName string
-}
-
-func (event GarbageCollectionContainerCollectorJobDropped) Emit(logger lager.Logger) {
-	Metrics.emit(
-		logger.Session("gc-container-collector-dropped"),
-		Event{
-			Name:  "GC container collector job dropped",
-			Value: 1,
-			Attributes: map[string]string{
-				"worker": event.WorkerName,
-			},
-		},
-	)
-}
-
 type BuildStarted struct {
 	Build db.Build
 }


### PR DESCRIPTION
While trying to find the root cause for #6956 I noticed that this metric seems to be not used anywhere in the code anymore

