### PR TITLE
AWS Secrets Manager will treat secret with marked for deletion as deleted

### DIFF
--- a/atc/creds/secretsmanager/secretsmanager.go
+++ b/atc/creds/secretsmanager/secretsmanager.go
@@ -73,7 +73,9 @@ func (s *SecretsManager) getSecretById(path string) (interface{}, *time.Time, bo
 			}
 			return values, nil, true, nil
 		}
-	} else if errObj, ok := err.(awserr.Error); ok && errObj.Code() == secretsmanager.ErrCodeResourceNotFoundException {
+	} else if errObj, ok := err.(awserr.Error); ok && (errObj.Code() == secretsmanager.ErrCodeResourceNotFoundException ||
+		// a secret that's marked for deletion will return an invalid request exception as an error
+		errObj.Code() == secretsmanager.ErrCodeInvalidRequestException) {
 		return nil, nil, false, nil
 	}
 

--- a/atc/creds/secretsmanager/secretsmanager_test.go
+++ b/atc/creds/secretsmanager/secretsmanager_test.go
@@ -133,5 +133,15 @@ var _ = Describe("SecretsManager", func() {
 			Expect(found).To(BeTrue())
 			Expect(err).To(BeNil())
 		})
+
+		It("should treat marked for deletion as deleted", func() {
+			mockService.stubGetParameter = func(input string) (*secretsmanager.GetSecretValueOutput, error) {
+				return nil, awserr.New(secretsmanager.ErrCodeInvalidRequestException, "", nil)
+			}
+			value, found, err := variables.Get(varRef)
+			Expect(value).To(BeNil())
+			Expect(found).To(BeFalse())
+			Expect(err).To(BeNil())
+		})
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

AWS Secrets Manager doesn't allow the user to delete a secret, instead it marks it for deletion (marked for deletion).  
Right now, concourse doesn't treat a secret in such state as deleted, but throws an error instead.

So instead of seeing 
![image](https://user-images.githubusercontent.com/15989650/148638481-2e72853b-8a15-46be-a146-2759aa1e1e6a.png)

I see
![image](https://user-images.githubusercontent.com/15989650/148638486-e67a4aef-8000-436a-98e6-72eacafb8a4d.png)

this is problematic, because if I have for example a pipeline specific secret `/concourse/myteam/mypipeline/mysecret` and a team specific secret with the same name `/concourse/myteam/mysecret`, when I delete the pipeline secret, I expect concourse to fall back to the team specific secret, but instead, it throws the error you see in the screenshot (`InvalidRequestException`)

This PR fixes it.