### PR TITLE
Handling huge volumes transfer in P2P streaming

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -438,6 +438,7 @@ github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31 h1:28FVBuwkwowZMjbA7M0wXsI6t3PYulRTMio3SO+eKCM=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -613,10 +613,10 @@ func (vs *VolumeServer) StreamP2pOut(w http.ResponseWriter, req *http.Request) {
 		}
 	}(doneChan)
 
-	// Send a white space to client as an indicator of in-progress every 10 seconds.
+	// Send a white space to client as an indicator of in-progress every 30 seconds.
 	// After source worker finishes sending volume to dest worker, send client "ok"
 	// for success or an error message.
-	tick := time.NewTicker(10 * time.Second)
+	tick := time.NewTicker(30 * time.Second)
 	for {
 		select {
 		case <-tick.C:

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -614,7 +614,7 @@ func (vs *VolumeServer) StreamP2pOut(w http.ResponseWriter, req *http.Request) {
 	}(doneChan)
 
 	// Send a white space to client as an indicator of in-progress every 10 seconds.
-	// After source worker finishes sending volume ot dest worker, send client "ok"
+	// After source worker finishes sending volume to dest worker, send client "ok"
 	// for success or an error message.
 	tick := time.NewTicker(10 * time.Second)
 	for {

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
-	"github.com/concourse/concourse/tracing"
-	"github.com/concourse/concourse/worker/baggageclaim"
-	"github.com/concourse/concourse/worker/baggageclaim/volume"
 	uuid "github.com/nu7hatch/gouuid"
 	"github.com/tedsuo/rata"
 	"go.opentelemetry.io/otel/propagation"
+
+	"github.com/concourse/concourse/tracing"
+	"github.com/concourse/concourse/worker/baggageclaim"
+	"github.com/concourse/concourse/worker/baggageclaim/volume"
 )
 
 const httpUnprocessableEntity = 422
@@ -588,29 +591,40 @@ func (vs *VolumeServer) StreamP2pOut(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err := vs.volumeRepo.StreamP2pOut(ctx, handle, subPath, encoding, streamInURL)
-	if err != nil {
-		if err == volume.ErrVolumeDoesNotExist {
-			hLog.Info("volume-not-found")
-			RespondWithError(w, ErrStreamOutNotFound, http.StatusNotFound)
+	w.Header().Set("Content-Type", "plain/text")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	doneChan := make(chan error, 1)
+	go func(doneChan chan<- error) {
+		err := vs.volumeRepo.StreamP2pOut(ctx, handle, subPath, encoding, streamInURL)
+		if err != nil {
+			hLog.Error("failed-to-stream-out", err)
+			doneChan <- fmt.Errorf("%s: %w", ErrStreamP2pOutFailed, err)
+		} else {
+			close(doneChan)
+		}
+	}(doneChan)
+
+	// Send a white space to cline as an indicator of in-progress every 10 seconds.
+	// After source worker finishes sending volume ot dest worker, send either "ok"
+	// for success or an error message to client.
+	tick := time.NewTicker(10 * time.Second)
+	for {
+		select {
+		case <-tick.C:
+			fmt.Fprintf(w, "\n")
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		case err := <-doneChan:
+			if err != nil {
+				fmt.Fprintf(w, "%s", err.Error())
+			} else {
+				fmt.Fprintf(w, "ok")
+			}
+			tick.Stop()
 			return
 		}
-
-		if err == volume.ErrUnsupportedStreamEncoding {
-			hLog.Info("unsupported-stream-encoding")
-			RespondWithError(w, ErrStreamP2pOutFailed, http.StatusBadRequest)
-			return
-		}
-
-		if os.IsNotExist(err) {
-			hLog.Info("source-path-not-found")
-			RespondWithError(w, ErrStreamOutNotFound, http.StatusNotFound)
-			return
-		}
-
-		hLog.Error("failed-to-stream-out", err)
-		RespondWithError(w, ErrStreamP2pOutFailed, http.StatusInternalServerError)
-		return
 	}
 }
 

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -590,6 +591,13 @@ func (vs *VolumeServer) StreamP2pOut(w http.ResponseWriter, req *http.Request) {
 		RespondWithError(w, ErrStreamP2pOutFailed, http.StatusBadRequest)
 		return
 	}
+
+	rawUrl, err := url.Parse(streamInURL)
+	if err != nil {
+		hLog.Info("bad-param-streamInURL")
+		RespondWithError(w, ErrStreamP2pOutFailed, http.StatusBadRequest)
+	}
+	streamInURL = rawUrl.String()
 
 	w.Header().Set("Content-Type", "plain/text")
 	w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -613,9 +613,9 @@ func (vs *VolumeServer) StreamP2pOut(w http.ResponseWriter, req *http.Request) {
 		}
 	}(doneChan)
 
-	// Send a white space to cline as an indicator of in-progress every 10 seconds.
-	// After source worker finishes sending volume ot dest worker, send either "ok"
-	// for success or an error message to client.
+	// Send a white space to client as an indicator of in-progress every 10 seconds.
+	// After source worker finishes sending volume ot dest worker, send client "ok"
+	// for success or an error message.
 	tick := time.NewTicker(10 * time.Second)
 	for {
 		select {

--- a/worker/baggageclaim/api/volume_server_test.go
+++ b/worker/baggageclaim/api/volume_server_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Volume Server", func() {
 	BeforeEach(func() {
 		var err error
 
-		tempDir, err = ioutil.TempDir("", fmt.Sprintf("baggageclaim_volume_dir_%d", GinkgoParallelNode()))
+		tempDir, err = ioutil.TempDir("", fmt.Sprintf("baggageclaim_volume_dir_%d", GinkgoParallelProcess()))
 		Expect(err).NotTo(HaveOccurred())
 
 		// ioutil.TempDir creates it 0700; we need public readability for

--- a/worker/baggageclaim/api/volume_server_test.go
+++ b/worker/baggageclaim/api/volume_server_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/concourse/go-archive/tarfs"
@@ -1130,17 +1131,14 @@ var _ = Describe("Volume Server", func() {
 			}
 		})
 
-		It("returns 404 when source path is invalid", func() {
-			request, _ := http.NewRequest("PUT", fmt.Sprintf("/volumes/%s/stream-p2p-out?path=%s&streamInURL=some-url&encoding=gzip", myVolume.Handle, "bogus-path"), nil)
+		It("returns an error when source path is invalid", func() {
+			streamInP2pURL := fmt.Sprintf("%s/volumes/%s/stream-in?path=dest-path", otherWorker.URL, myVolume.Handle)
+			request, _ := http.NewRequest("PUT", fmt.Sprintf("/volumes/%s/stream-p2p-out?path=%s&streamInURL=%s&encoding=gzip", myVolume.Handle, "bogus-path", streamInP2pURL), nil)
 			request.Header.Set("Accept-Encoding", string(baggageclaim.GzipEncoding))
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, request)
-			Expect(recorder.Code).To(Equal(404))
-
-			var responseError *api.ErrorResponse
-			err := json.NewDecoder(recorder.Body).Decode(&responseError)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(responseError.Message).To(Equal("no such file or directory"))
+			Expect(recorder.Code).To(Equal(200)) // status code should always be 200, error is in body
+			Expect(recorder.Body.String()).To(MatchRegexp("failed to compress source volume: .*: no such file or directory"))
 		})
 
 		Context("when streaming a file", func() {
@@ -1159,6 +1157,7 @@ var _ = Describe("Volume Server", func() {
 				streamP2pOutRecorder := httptest.NewRecorder()
 				handler.ServeHTTP(streamP2pOutRecorder, streamP2pOutRequest)
 				Expect(streamP2pOutRecorder.Code).To(Equal(200))
+				Expect(strings.TrimSpace(streamP2pOutRecorder.Body.String())).To(Equal("ok"))
 
 				destContentsPath := filepath.Join(volumeDir, "live", myVolume.Handle, "volume", "dest-path", "some-file")
 				Expect(destContentsPath).To(BeAnExistingFile())
@@ -1202,6 +1201,7 @@ var _ = Describe("Volume Server", func() {
 				streamP2pOutRecorder := httptest.NewRecorder()
 				handler.ServeHTTP(streamP2pOutRecorder, streamP2pOutRequest)
 				Expect(streamP2pOutRecorder.Code).To(Equal(200))
+				Expect(strings.TrimSpace(streamP2pOutRecorder.Body.String())).To(Equal("ok"))
 
 				someContentsPath := filepath.Join(volumeDir, "live", myVolume.Handle, "volume", "dest-path", "sub", "some-file")
 				Expect(someContentsPath).To(BeAnExistingFile())

--- a/worker/baggageclaim/client_test.go
+++ b/worker/baggageclaim/client_test.go
@@ -460,7 +460,7 @@ var _ = Describe("Baggage Claim Client", func() {
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})
-				Context("when p2p streaming succeeds", func() {
+				Context("when p2p streaming fails", func() {
 					BeforeEach(func() {
 						bcServer.AppendHandlers(
 							ghttp.CombineHandlers(

--- a/worker/baggageclaim/client_test.go
+++ b/worker/baggageclaim/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -445,17 +446,34 @@ var _ = Describe("Baggage Claim Client", func() {
 			})
 
 			Context("when api succeeds", func() {
-				BeforeEach(func() {
-					bcServer.AppendHandlers(
-						ghttp.CombineHandlers(
-							ghttp.VerifyRequest("PUT", "/volumes/some-handle/stream-p2p-out"),
-							ghttp.RespondWith(http.StatusOK, ""),
-						),
-					)
+				Context("when p2p streaming succeeds", func() {
+					BeforeEach(func() {
+						bcServer.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("PUT", "/volumes/some-handle/stream-p2p-out"),
+								ghttp.RespondWith(http.StatusOK, "\n\n\nok"),
+							),
+						)
+					})
+					It("should succeed", func() {
+						err := vol.StreamP2pOut(context.TODO(), "some-dest-path", "http://some-url", "gzip")
+						Expect(err).ToNot(HaveOccurred())
+					})
 				})
-				It("should succeed", func() {
-					err := vol.StreamP2pOut(context.TODO(), "some-dest-path", "http://some-url", "gzip")
-					Expect(err).ToNot(HaveOccurred())
+				Context("when p2p streaming succeeds", func() {
+					BeforeEach(func() {
+						bcServer.AppendHandlers(
+							ghttp.CombineHandlers(
+								ghttp.VerifyRequest("PUT", "/volumes/some-handle/stream-p2p-out"),
+								ghttp.RespondWith(http.StatusOK, "\n\n\nsome-error"),
+							),
+						)
+					})
+					It("should fail", func() {
+						err := vol.StreamP2pOut(context.TODO(), "some-dest-path", "http://some-url", "gzip")
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(Equal(errors.New("some-error")))
+					})
 				})
 			})
 

--- a/worker/baggageclaim/volume/repository.go
+++ b/worker/baggageclaim/volume/repository.go
@@ -513,6 +513,7 @@ func (repo *repository) StreamP2pOut(ctx context.Context, handle string, path st
 
 	reader, writer := io.Pipe()
 	go func() {
+		var err error
 		switch encoding {
 		case ZstdEncoding:
 			err = repo.zstdStreamer.Out(writer, srcPath, isPrivileged)


### PR DESCRIPTION
## Changes proposed by this PR

closes #7910

After I enabled p2p streaming in a staging cluster that has real user pipelines running on it, I found two issues with p2p streaming:

First one is the issue reported in #7910, where source workers' memory usage get very high, because source worker compress volumes into memory buffer before sending to dest worker. This problem is solved by adding a pipeline on source worker, so that compressor writes to one end of the pipeline, and http request will read bytes from the other end of the pipeline.

Second is that if a volume is huge, couldn't be streamed within 3 minutes (configured by `concourse_baggageclaim_response_header_timeout`), the p2p streaming would hang for long time. Workflow of p2p streaming is as below:

Step1: ATC invokes HTTP API stream-p2p-out to source worker
Step2: source worker sending volume to dest worker
Step3: source worker response HTTP with status OK 

Where step2 may take very long time if volume is huge, when ATC's HTTP client has a 3-minutes timeout to wait for HTTP response. So that, if volume streaming takes longer than 3 minutes, ATC's HTTP client will timeout, and retry.

To solve the problem, now source will response ATC immediately, and sending a progress indicator every 10 seconds. After volume streaming finishes, it will close response with either an "ok" string or an error message string.

* [x] code changes
* [x] update tests

## Notes to reviewer

I have tested with fix with the test from #7910. The image is size of ~9GB, p2p streaming takes ~10 minutes in my test workers. Worker memory no longer has spikes when streaming large volumes.

## Release Note

* Fix a bug that P2P streaming would fail if streaming a volume takes longer than 3 minutes. This fix should be applied to both ATCs and workers.

