### PR TITLE
fix windows baggageclaim test

### DIFF
--- a/worker/baggageclaim/api/volume_server_test.go
+++ b/worker/baggageclaim/api/volume_server_test.go
@@ -1140,7 +1140,6 @@ var _ = Describe("Volume Server", func() {
 			var responseError *api.ErrorResponse
 			err := json.NewDecoder(recorder.Body).Decode(&responseError)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(responseError.Message).To(Equal("no such file or directory"))
 		})
 
 		Context("when streaming a file", func() {


### PR DESCRIPTION
CI failure https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/unit/builds/1214#L61c3ff15:41

after windows worker on CI bumped from widnows server 2004 to
2016, the returned error message is changed to

{
	"error": "Put \"http://127.0.0.1:56784/volumes/some-handle/stream-in?path=dest-path\": failed to compress source volume: CreateFile C:\\Windows\\TEMP\\baggageclaim_volume_dir_3336784016\\live\\some-handle\\volume\\bogus-path: The system cannot find the file specified.",
	"session": "1.2",
	"volume": "some-handle"
}

assert on error code should be good enough
