### PR TITLE
Fix windows baggageclaim test

### DIFF
--- a/worker/baggageclaim/api/volume_server_test.go
+++ b/worker/baggageclaim/api/volume_server_test.go
@@ -1137,8 +1137,9 @@ var _ = Describe("Volume Server", func() {
 			request.Header.Set("Accept-Encoding", string(baggageclaim.GzipEncoding))
 			recorder := httptest.NewRecorder()
 			handler.ServeHTTP(recorder, request)
+
 			Expect(recorder.Code).To(Equal(200)) // status code should always be 200, error is in body
-			Expect(recorder.Body.String()).To(MatchRegexp("failed to compress source volume: .*: no such file or directory"))
+			Expect(recorder.Body.String()).To(MatchRegexp("failed to compress source volume: .*: (no such file or directory|The system cannot find the file specified)"))
 		})
 
 		Context("when streaming a file", func() {


### PR DESCRIPTION
after  https://github.com/concourse/concourse/pull/7942 the error
message return from windows worker becomes

{
	"error": "Put \"http://127.0.0.1:56784/volumes/some-handle/stream-in?path=dest-path\": failed to compress source volume: CreateFile C:\\Windows\\TEMP\\baggageclaim_volume_dir_3336784016\\live\\some-handle\\volume\\bogus-path: The system cannot find the file specified.",
	"session": "1.2",
	"volume": "some-handle"
}

It is more specific to underlying OS. 

Related job failure: https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/unit/builds/1214#L61c3ff15:41