### PR TITLE
GC builds based on chronological order

### DIFF
--- a/atc/db/build_factory.go
+++ b/atc/db/build_factory.go
@@ -164,7 +164,7 @@ func (f *buildFactory) VisibleBuilds(teamNames []string, page Page) ([]BuildForA
 			f.lockFactory)
 	}
 	return getBuildsWithPagination(newBuildsQuery, minMaxIdQuery, page, f.conn,
-		f.lockFactory)
+		f.lockFactory, false)
 }
 
 func (f *buildFactory) AllBuilds(page Page) ([]BuildForAPI, Pagination, error) {
@@ -173,13 +173,13 @@ func (f *buildFactory) AllBuilds(page Page) ([]BuildForAPI, Pagination, error) {
 			f.lockFactory)
 	}
 	return getBuildsWithPagination(buildsQuery, minMaxIdQuery,
-		page, f.conn, f.lockFactory)
+		page, f.conn, f.lockFactory, false)
 }
 
 func (f *buildFactory) PublicBuilds(page Page) ([]BuildForAPI, Pagination, error) {
 	return getBuildsWithPagination(
 		buildsQuery.Where(sq.Eq{"p.public": true}), minMaxIdQuery,
-		page, f.conn, f.lockFactory)
+		page, f.conn, f.lockFactory, false)
 }
 
 func (f *buildFactory) MarkNonInterceptibleBuilds() error {
@@ -353,10 +353,10 @@ func getBuildsWithDates(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, 
 		return nil, Pagination{}, err
 	}
 
-	return getBuildsWithPagination(buildsQuery, minMaxIdQuery, newPage, conn, lockFactory)
+	return getBuildsWithPagination(buildsQuery, minMaxIdQuery, newPage, conn, lockFactory, false)
 }
 
-func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, conn Conn, lockFactory lock.LockFactory) ([]BuildForAPI, Pagination, error) {
+func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page Page, conn Conn, lockFactory lock.LockFactory, chronological bool) ([]BuildForAPI, Pagination, error) {
 	var (
 		rows    *sql.Rows
 		err     error
@@ -374,18 +374,25 @@ func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page P
 
 	buildsQuery = buildsQuery.Limit(uint64(page.Limit))
 
+	desc := "COALESCE(b.rerun_of, b.id) DESC, b.id DESC"
+	asc := "COALESCE(b.rerun_of, b.id) ASC, b.id ASC"
+	if chronological {
+		desc = "b.id DESC"
+		asc = "b.id ASC"
+	}
+
 	if page.From == nil && page.To == nil { // none
 		buildsQuery = buildsQuery.
-			OrderBy("COALESCE(b.rerun_of, b.id) DESC, b.id DESC")
+			OrderBy(desc)
 	} else if page.From != nil && page.To == nil { // only from
 		buildsQuery = buildsQuery.
 			Where(sq.GtOrEq{"b.id": uint64(*page.From)}).
-			OrderBy("COALESCE(b.rerun_of, b.id) ASC, b.id ASC")
+			OrderBy(asc)
 		reverse = true
 	} else if page.From == nil && page.To != nil { // only to
 		buildsQuery = buildsQuery.
 			Where(sq.LtOrEq{"b.id": uint64(*page.To)}).
-			OrderBy("COALESCE(b.rerun_of, b.id) DESC, b.id DESC")
+			OrderBy(desc)
 	} else if page.From != nil && page.To != nil { // both
 		if *page.From > *page.To {
 			return nil, Pagination{}, fmt.Errorf("invalid range boundaries")
@@ -396,7 +403,7 @@ func getBuildsWithPagination(buildsQuery, minMaxIdQuery sq.SelectBuilder, page P
 				sq.GtOrEq{"b.id": uint64(*page.From)},
 				sq.LtOrEq{"b.id": uint64(*page.To)},
 			}).
-			OrderBy("COALESCE(b.rerun_of, b.id) ASC, b.id ASC")
+			OrderBy(asc)
 	}
 
 	rows, err = buildsQuery.RunWith(tx).Query()

--- a/atc/db/dbfakes/fake_job.go
+++ b/atc/db/dbfakes/fake_job.go
@@ -85,6 +85,21 @@ type FakeJob struct {
 		result2 db.Pagination
 		result3 error
 	}
+	ChronoBuildsStub        func(db.Page) ([]db.BuildForAPI, db.Pagination, error)
+	chronoBuildsMutex       sync.RWMutex
+	chronoBuildsArgsForCall []struct {
+		arg1 db.Page
+	}
+	chronoBuildsReturns struct {
+		result1 []db.BuildForAPI
+		result2 db.Pagination
+		result3 error
+	}
+	chronoBuildsReturnsOnCall map[int]struct {
+		result1 []db.BuildForAPI
+		result2 db.Pagination
+		result3 error
+	}
 	ClearTaskCacheStub        func(string, string) (int64, error)
 	clearTaskCacheMutex       sync.RWMutex
 	clearTaskCacheArgsForCall []struct {
@@ -842,6 +857,73 @@ func (fake *FakeJob) BuildsWithTimeReturnsOnCall(i int, result1 []db.BuildForAPI
 		})
 	}
 	fake.buildsWithTimeReturnsOnCall[i] = struct {
+		result1 []db.BuildForAPI
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeJob) ChronoBuilds(arg1 db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+	fake.chronoBuildsMutex.Lock()
+	ret, specificReturn := fake.chronoBuildsReturnsOnCall[len(fake.chronoBuildsArgsForCall)]
+	fake.chronoBuildsArgsForCall = append(fake.chronoBuildsArgsForCall, struct {
+		arg1 db.Page
+	}{arg1})
+	stub := fake.ChronoBuildsStub
+	fakeReturns := fake.chronoBuildsReturns
+	fake.recordInvocation("ChronoBuilds", []interface{}{arg1})
+	fake.chronoBuildsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeJob) ChronoBuildsCallCount() int {
+	fake.chronoBuildsMutex.RLock()
+	defer fake.chronoBuildsMutex.RUnlock()
+	return len(fake.chronoBuildsArgsForCall)
+}
+
+func (fake *FakeJob) ChronoBuildsCalls(stub func(db.Page) ([]db.BuildForAPI, db.Pagination, error)) {
+	fake.chronoBuildsMutex.Lock()
+	defer fake.chronoBuildsMutex.Unlock()
+	fake.ChronoBuildsStub = stub
+}
+
+func (fake *FakeJob) ChronoBuildsArgsForCall(i int) db.Page {
+	fake.chronoBuildsMutex.RLock()
+	defer fake.chronoBuildsMutex.RUnlock()
+	argsForCall := fake.chronoBuildsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeJob) ChronoBuildsReturns(result1 []db.BuildForAPI, result2 db.Pagination, result3 error) {
+	fake.chronoBuildsMutex.Lock()
+	defer fake.chronoBuildsMutex.Unlock()
+	fake.ChronoBuildsStub = nil
+	fake.chronoBuildsReturns = struct {
+		result1 []db.BuildForAPI
+		result2 db.Pagination
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeJob) ChronoBuildsReturnsOnCall(i int, result1 []db.BuildForAPI, result2 db.Pagination, result3 error) {
+	fake.chronoBuildsMutex.Lock()
+	defer fake.chronoBuildsMutex.Unlock()
+	fake.ChronoBuildsStub = nil
+	if fake.chronoBuildsReturnsOnCall == nil {
+		fake.chronoBuildsReturnsOnCall = make(map[int]struct {
+			result1 []db.BuildForAPI
+			result2 db.Pagination
+			result3 error
+		})
+	}
+	fake.chronoBuildsReturnsOnCall[i] = struct {
 		result1 []db.BuildForAPI
 		result2 db.Pagination
 		result3 error
@@ -3059,6 +3141,8 @@ func (fake *FakeJob) Invocations() map[string][][]interface{} {
 	defer fake.buildsMutex.RUnlock()
 	fake.buildsWithTimeMutex.RLock()
 	defer fake.buildsWithTimeMutex.RUnlock()
+	fake.chronoBuildsMutex.RLock()
+	defer fake.chronoBuildsMutex.RUnlock()
 	fake.clearTaskCacheMutex.RLock()
 	defer fake.clearTaskCacheMutex.RUnlock()
 	fake.configMutex.RLock()

--- a/atc/db/pipeline.go
+++ b/atc/db/pipeline.go
@@ -480,7 +480,7 @@ func (p *pipeline) resource(where map[string]interface{}) (Resource, bool, error
 
 func (p *pipeline) Builds(page Page) ([]BuildForAPI, Pagination, error) {
 	return getBuildsWithPagination(
-		buildsQuery.Where(sq.Eq{"b.pipeline_id": p.id}), minMaxIdQuery, page, p.conn, p.lockFactory)
+		buildsQuery.Where(sq.Eq{"b.pipeline_id": p.id}), minMaxIdQuery, page, p.conn, p.lockFactory, false)
 }
 
 func (p *pipeline) BuildsWithTime(page Page) ([]BuildForAPI, Pagination, error) {

--- a/atc/db/team.go
+++ b/atc/db/team.go
@@ -918,7 +918,7 @@ func (t *team) PrivateAndPublicBuilds(page Page) ([]BuildForAPI, Pagination, err
 	newBuildsQuery := buildsQuery.
 		Where(sq.Or{sq.Eq{"p.public": true}, sq.Eq{"t.id": t.id}})
 
-	return getBuildsWithPagination(newBuildsQuery, minMaxIdQuery, page, t.conn, t.lockFactory)
+	return getBuildsWithPagination(newBuildsQuery, minMaxIdQuery, page, t.conn, t.lockFactory, false)
 }
 
 func (t *team) BuildsWithTime(page Page) ([]BuildForAPI, Pagination, error) {
@@ -926,7 +926,7 @@ func (t *team) BuildsWithTime(page Page) ([]BuildForAPI, Pagination, error) {
 }
 
 func (t *team) Builds(page Page) ([]BuildForAPI, Pagination, error) {
-	return getBuildsWithPagination(buildsQuery.Where(sq.Eq{"t.id": t.id}), minMaxIdQuery, page, t.conn, t.lockFactory)
+	return getBuildsWithPagination(buildsQuery.Where(sq.Eq{"t.id": t.id}), minMaxIdQuery, page, t.conn, t.lockFactory, false)
 }
 
 func (t *team) SaveWorker(atcWorker atc.Worker, ttl time.Duration) (Worker, error) {

--- a/atc/gc/build_log_collector.go
+++ b/atc/gc/build_log_collector.go
@@ -98,7 +98,7 @@ func (br *buildLogCollector) reapLogsOfJob(pipeline db.Pipeline,
 	limit := br.batchSize
 	page := &db.Page{From: &from, Limit: limit}
 	for page != nil {
-		builds, pagination, err := job.Builds(*page)
+		builds, pagination, err := job.ChronoBuilds(*page)
 		if err != nil {
 			logger.Error("failed-to-get-job-builds-to-delete", err)
 			return err

--- a/atc/gc/build_log_collector_test.go
+++ b/atc/gc/build_log_collector_test.go
@@ -114,7 +114,7 @@ var _ = Describe("BuildLogCollector", func() {
 					)
 				})
 				BeforeEach(func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbDrained(9, false), sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, true)}, db.Pagination{Newer: &db.Page{From: db.NewIntPtr(10), Limit: 5}}, nil
 						} else if *page.From == 10 {
@@ -165,7 +165,7 @@ var _ = Describe("BuildLogCollector", func() {
 						buildLogRetainCalc,
 						false,
 					)
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbDrained(9, true), sbDrained(8, false), sbDrained(7, false), sbDrained(6, true), sbDrained(5, false)}, db.Pagination{Newer: &db.Page{From: db.NewIntPtr(10), Limit: 5}}, nil
 						} else if *page.From == 10 {
@@ -195,7 +195,7 @@ var _ = Describe("BuildLogCollector", func() {
 				var disaster error
 
 				BeforeEach(func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, false)}, db.Pagination{}, nil
 						}
@@ -224,7 +224,7 @@ var _ = Describe("BuildLogCollector", func() {
 				var disaster error
 
 				BeforeEach(func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbDrained(8, false), sbDrained(7, true), sbDrained(6, false), sbDrained(5, false)}, db.Pagination{}, nil
 						}
@@ -248,7 +248,7 @@ var _ = Describe("BuildLogCollector", func() {
 					fakeJob.ConfigReturns(atc.JobConfig{
 						BuildLogsToRetain: 3,
 					}, nil)
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{
 								runningBuild(9),
@@ -290,7 +290,7 @@ var _ = Describe("BuildLogCollector", func() {
 
 			Context("when no builds need to be reaped", func() {
 				BeforeEach(func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{runningBuild(5)}, db.Pagination{}, nil
 						} else {
@@ -320,7 +320,7 @@ var _ = Describe("BuildLogCollector", func() {
 
 			Context("when no builds exist", func() {
 				BeforeEach(func() {
-					fakeJob.BuildsReturns(nil, db.Pagination{}, nil)
+					fakeJob.ChronoBuildsReturns(nil, db.Pagination{}, nil)
 
 					fakePipeline.DeleteBuildEventsByBuildIDsReturns(nil)
 
@@ -342,7 +342,7 @@ var _ = Describe("BuildLogCollector", func() {
 				BeforeEach(func() {
 					disaster = errors.New("major malfunction")
 
-					fakeJob.BuildsReturns(nil, db.Pagination{}, disaster)
+					fakeJob.ChronoBuildsReturns(nil, db.Pagination{}, disaster)
 				})
 
 				It("logs the error", func() {
@@ -353,7 +353,7 @@ var _ = Describe("BuildLogCollector", func() {
 
 			Context("when only count is set", func() {
 				BeforeEach(func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
@@ -384,7 +384,7 @@ var _ = Describe("BuildLogCollector", func() {
 
 			Context("when only date is set", func() {
 				BeforeEach(func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
@@ -425,7 +425,7 @@ var _ = Describe("BuildLogCollector", func() {
 				})
 
 				It("should not reap if count is not satisfied", func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
@@ -440,7 +440,7 @@ var _ = Describe("BuildLogCollector", func() {
 				})
 
 				It("should not reap if days is not satisfied", func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-24*time.Hour))}, db.Pagination{}, nil
 						}
@@ -455,7 +455,7 @@ var _ = Describe("BuildLogCollector", func() {
 				})
 
 				It("should delete 1 build, because both criteria are satisfied", func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
@@ -474,7 +474,7 @@ var _ = Describe("BuildLogCollector", func() {
 
 			Context("when only date is set", func() {
 				BeforeEach(func() {
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == 5 {
 							return []db.BuildForAPI{sbTime(6, time.Now().Add(-23*time.Hour)), sbTime(5, time.Now().Add(-49*time.Hour))}, db.Pagination{}, nil
 						}
@@ -516,7 +516,7 @@ var _ = Describe("BuildLogCollector", func() {
 					page1 := db.Page{From: db.NewIntPtr(5), Limit: 5}
 					page2 := db.Page{From: db.NewIntPtr(10), Limit: 5}
 					page3 := db.Page{From: db.NewIntPtr(15), Limit: 5}
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == *page1.From {
 							return []db.BuildForAPI{sb(9), successBuild(8), sb(7), reapedBuild(6), reapedBuild(5)}, db.Pagination{Newer: &page2}, nil
 						} else if *page.From == *page2.From {
@@ -568,7 +568,7 @@ var _ = Describe("BuildLogCollector", func() {
 					page1 := db.Page{From: db.NewIntPtr(5), Limit: 5}
 					page2 := db.Page{From: db.NewIntPtr(10), Limit: 5}
 					page3 := db.Page{From: db.NewIntPtr(15), Limit: 5}
-					fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+					fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 						if *page.From == *page1.From {
 							return []db.BuildForAPI{sb(9), successBuild(8), sb(7), reapedBuild(6), reapedBuild(5)}, db.Pagination{Newer: &page2}, nil
 						} else if *page.From == *page2.From {
@@ -629,7 +629,7 @@ var _ = Describe("BuildLogCollector", func() {
 
 					yesterday := time.Now().Add(-30 * time.Hour)
 
-					fakeJob.BuildsReturns([]db.BuildForAPI{sbTime(9, yesterday), sbTime(8, yesterday), sbTime(7, yesterday), sbTime(6, yesterday), sbTime(5, yesterday)}, db.Pagination{}, nil)
+					fakeJob.ChronoBuildsReturns([]db.BuildForAPI{sbTime(9, yesterday), sbTime(8, yesterday), sbTime(7, yesterday), sbTime(6, yesterday), sbTime(5, yesterday)}, db.Pagination{}, nil)
 				})
 
 				It("FirstLoggedBuildID doesn't get reset to 0", func() {
@@ -658,7 +658,7 @@ var _ = Describe("BuildLogCollector", func() {
 					BeforeEach(func() {
 						buildLogRetainCalc = NewBuildLogRetentionCalculator(3, 3, 0, 0)
 
-						fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+						fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 							if *page.From == 1 {
 								return []db.BuildForAPI{sb(4), sb(3), sb(2), sb(1)}, db.Pagination{}, nil
 							}
@@ -684,7 +684,7 @@ var _ = Describe("BuildLogCollector", func() {
 					BeforeEach(func() {
 						disaster = errors.New("major malfunction")
 
-						fakeJob.BuildsReturns(nil, db.Pagination{}, disaster)
+						fakeJob.ChronoBuildsReturns(nil, db.Pagination{}, disaster)
 					})
 
 					It("logs the error", func() {
@@ -715,7 +715,7 @@ var _ = Describe("BuildLogCollector", func() {
 				err := buildLogCollector.Run(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(fakeJob.BuildsCallCount()).To(BeZero())
+				Expect(fakeJob.ChronoBuildsCallCount()).To(BeZero())
 				Expect(fakePipeline.DeleteBuildEventsByBuildIDsCallCount()).To(BeZero())
 				Expect(fakeJob.UpdateFirstLoggedBuildIDCallCount()).To(BeZero())
 			})
@@ -760,7 +760,7 @@ var _ = Describe("BuildLogCollector", func() {
 			}, nil)
 			fakeJob.TagsReturns([]string{})
 
-			fakeJob.BuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
+			fakeJob.ChronoBuildsStub = func(page db.Page) ([]db.BuildForAPI, db.Pagination, error) {
 				if *page.From == 1 {
 					return []db.BuildForAPI{sb(2), sb(1)}, db.Pagination{}, nil
 				}


### PR DESCRIPTION
## Changes proposed by this PR
when getting builds for GC, instead of ordering builds by rerun group (which still be the default way), order builds chronologically so a rerun build won't be reaped immediately if the parent build is reaped already.

closes #7951 

* [x] done
* [ ] todo

## Release Note
 * Fix a bug that events of a rerun build be reaped immediately if its prarent build is already reaped. Now candidate builds for GC will be ordered chronologically.