### PR TITLE
Run task caches collector when ATC starts

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1213,6 +1213,7 @@ func (cmd *RunCommand) gcComponents(
 ) ([]RunnableComponent, error) {
 	dbWorkerLifecycle := db.NewWorkerLifecycle(gcConn)
 	dbResourceCacheLifecycle := db.NewResourceCacheLifecycle(gcConn)
+	dbTaskCacheLifecycle := db.NewTaskCacheLifecycle(gcConn)
 	dbContainerRepository := db.NewContainerRepository(gcConn)
 	dbArtifactLifecycle := db.NewArtifactLifecycle(gcConn)
 	dbAccessTokenLifecycle := db.NewAccessTokenLifecycle(gcConn)
@@ -1238,6 +1239,7 @@ func (cmd *RunCommand) gcComponents(
 		atc.ComponentCollectorWorkers:           gc.NewWorkerCollector(dbWorkerLifecycle),
 		atc.ComponentCollectorResourceConfigs:   gc.NewResourceConfigCollector(dbResourceConfigFactory, unreferencedConfigGracePeriod),
 		atc.ComponentCollectorResourceCaches:    gc.NewResourceCacheCollector(dbResourceCacheLifecycle),
+		atc.ComponentCollectorTaskCaches:        gc.NewTaskCacheCollector(dbTaskCacheLifecycle),
 		atc.ComponentCollectorResourceCacheUses: gc.NewResourceCacheUseCollector(dbResourceCacheLifecycle),
 		atc.ComponentCollectorArtifacts:         gc.NewArtifactCollector(dbArtifactLifecycle),
 		atc.ComponentCollectorVolumes:           gc.NewVolumeCollector(dbVolumeRepository, cmd.GC.MissingGracePeriod),

--- a/atc/component.go
+++ b/atc/component.go
@@ -16,6 +16,7 @@ const (
 	ComponentCollectorContainers        = "collector_containers"
 	ComponentCollectorResourceCacheUses = "collector_resource_cache_uses"
 	ComponentCollectorResourceCaches    = "collector_resource_caches"
+	ComponentCollectorTaskCaches        = "collector_task_caches"
 	ComponentCollectorResourceConfigs   = "collector_resource_configs"
 	ComponentCollectorVolumes           = "collector_volumes"
 	ComponentCollectorWorkers           = "collector_workers"


### PR DESCRIPTION
## Changes proposed by this PR
Run task caches collector when atc starts 

closes #7986 

* [x] done
* [ ] todo

## Release Note
 * Previously when a pipeline is archived, the [task caches](https://concourse-ci.org/tasks.html#schema.task-config.caches) used in its job will not be garbage collected, which will cause volume leaks in worker disk. Now a component for GC task caches will runs when ATC starts.
