### PR TITLE
Garbage collect task caches from paused pipelines

### DIFF
--- a/atc/db/task_cache_lifecycle.go
+++ b/atc/db/task_cache_lifecycle.go
@@ -26,7 +26,10 @@ func (f *taskCacheLifecycle) CleanUpInvalidTaskCaches() ([]int, error) {
 		Join("pipelines p ON p.id = j.pipeline_id").
 		Where(sq.Or{
 			sq.Expr("p.archived"),
-			sq.Expr("p.paused"),
+			sq.And{
+				sq.Expr("p.paused"),
+				sq.Expr("j.next_build_id IS NULL"),
+			},
 		}).
 		ToSql()
 	if err != nil {

--- a/atc/db/task_cache_lifecycle.go
+++ b/atc/db/task_cache_lifecycle.go
@@ -30,6 +30,10 @@ func (f *taskCacheLifecycle) CleanUpInvalidTaskCaches() ([]int, error) {
 				sq.Expr("p.paused"),
 				sq.Expr("j.next_build_id IS NULL"),
 			},
+			sq.And{
+				sq.Expr("j.paused"),
+				sq.Expr("j.next_build_id IS NULL"),
+			},
 		}).
 		ToSql()
 	if err != nil {

--- a/atc/db/task_cache_lifecycle.go
+++ b/atc/db/task_cache_lifecycle.go
@@ -24,7 +24,10 @@ func (f *taskCacheLifecycle) CleanUpInvalidTaskCaches() ([]int, error) {
 		From("task_caches tc").
 		Join("jobs j ON j.id = tc.job_id").
 		Join("pipelines p ON p.id = j.pipeline_id").
-		Where(sq.Expr("p.archived")).
+		Where(sq.Or{
+			sq.Expr("p.archived"),
+			sq.Expr("p.paused"),
+		}).
 		ToSql()
 	if err != nil {
 		return nil, err

--- a/atc/db/task_cache_lifecycle_test.go
+++ b/atc/db/task_cache_lifecycle_test.go
@@ -11,9 +11,15 @@ import (
 
 var _ = Describe("TaskCacheLifecycle", func() {
 	var taskCacheLifecycle db.TaskCacheLifecycle
+	var plan atc.Plan
 
 	BeforeEach(func() {
 		taskCacheLifecycle = db.NewTaskCacheLifecycle(dbConn)
+		plan = atc.Plan{
+			Get: &atc.GetPlan{
+				Name: "some-name",
+			},
+		}
 	})
 
 	It("cleans up task caches belonging to an archived pipeline", func() {
@@ -47,12 +53,6 @@ var _ = Describe("TaskCacheLifecycle", func() {
 
 	It("cleans up task caches belonging to a paused pipeline if its jobs are not running", func() {
 		var pendingBuild, startedBuild, finishedBuild db.Build
-
-		plan := atc.Plan{
-			Get: &atc.GetPlan{
-				Name: "some-name",
-			},
-		}
 
 		pausedScenario := dbtest.Setup(
 			builder.WithPipeline(atc.Config{
@@ -89,6 +89,40 @@ var _ = Describe("TaskCacheLifecycle", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		err = otherScenario.Pipeline.Pause("tester")
+		Expect(err).ToNot(HaveOccurred())
+
+		deletedCacheIDs, err := taskCacheLifecycle.CleanUpInvalidTaskCaches()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(deletedCacheIDs).To(ConsistOf(taskCache.ID()))
+	})
+
+	It("cleans up task caches belonging to a paused job if it is not running", func() {
+		var startedBuild, finishedBuild db.Build
+
+		pausedScenario := dbtest.Setup(
+			builder.WithPipeline(atc.Config{
+				Jobs: []atc.JobConfig{
+					{Name: "some-job-1"},
+					{Name: "some-job-2"},
+				},
+			}),
+			builder.WithPendingJobBuild(&finishedBuild, "some-job-1"),
+			builder.WithStartedJobBuild(&startedBuild, "some-job-2", plan),
+		)
+
+		err := finishedBuild.Finish(db.BuildStatusSucceeded)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = pausedScenario.Job("some-job-1").Pause("tester")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = pausedScenario.Job("some-job-2").Pause("tester")
+		Expect(err).ToNot(HaveOccurred())
+
+		taskCache, err := taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-1").ID(), "some-step", "some-path")
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = taskCacheFactory.FindOrCreate(pausedScenario.Job("some-job-2").ID(), "some-step", "some-path")
 		Expect(err).ToNot(HaveOccurred())
 
 		deletedCacheIDs, err := taskCacheLifecycle.CleanUpInvalidTaskCaches()


### PR DESCRIPTION
## Changes proposed by this PR
Garbage collect task caches from jobs that in a paused pipeline 

closes #7988

* [x] done
* [ ] todo

## Notes to reviewer
It seems finding jobs in a paused pipeline that has no running builds is non-trivial, the query becomes very slow if joining with builds table. IMHO if user gonna pause a pipeline, he either first making sure all jobs in the pipeline are done or he doesn't care the result of the running builds of a pausing pipeline. So I think we could ignore the job status and just GC all task caches from a paused pipeline.

## Release Note
 * When a pipeline or a job is paused, the task caches that used in the pipeline's job will be garbage collected. This should help free up worker disk space.
