### PR TITLE
backport #6332 to 6.7.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@
 ARG base_image=concourse/dev
 FROM ${base_image} AS base
 
+ARG goproxy
+ENV GOPROXY=$goproxy
+
 # download go modules separately so this doesn't re-run on every change
 WORKDIR /src
 COPY go.mod .

--- a/atc/api/handler.go
+++ b/atc/api/handler.go
@@ -48,6 +48,7 @@ func NewHandler(
 	dbJobFactory db.JobFactory,
 	dbResourceFactory db.ResourceFactory,
 	dbWorkerFactory db.WorkerFactory,
+	workerTeamFactory db.TeamFactory,
 	volumeRepository db.VolumeRepository,
 	containerRepository db.ContainerRepository,
 	destroyer gc.Destroyer,
@@ -94,7 +95,7 @@ func NewHandler(
 	pipelineServer := pipelineserver.NewServer(logger, dbTeamFactory, dbPipelineFactory, externalURL)
 	configServer := configserver.NewServer(logger, dbTeamFactory, secretManager)
 	ccServer := ccserver.NewServer(logger, dbTeamFactory, externalURL)
-	workerServer := workerserver.NewServer(logger, dbTeamFactory, dbWorkerFactory)
+	workerServer := workerserver.NewServer(logger, workerTeamFactory, dbWorkerFactory)
 	logLevelServer := loglevelserver.NewServer(logger, sink)
 	cliServer := cliserver.NewServer(logger, absCLIDownloadsDir)
 	containerServer := containerserver.NewServer(logger, workerClient, secretManager, varSourcePool, interceptTimeoutFactory, interceptUpdateInterval, containerRepository, destroyer, clock)


### PR DESCRIPTION
## Changes proposed by this PR

Our prod cluster runs 6.7.8, but we are encountering slow worker registration problem, sometime worker registration takes several minutes, which in turn lead to slow worker selection and garden connection.

* [x] done

## Notes to reviewer



## Release Note

Backport #6332. Give worker registration its own database connection pool .
* Give the worker registration endpoint its own database connection pool to avoid the situation where the API connection pool is maxed out and workers fail to register and stall

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
