### PR TITLE
Add build event for volume streaming

### DIFF
--- a/atc/engine/build_step_delegate.go
+++ b/atc/engine/build_step_delegate.go
@@ -212,6 +212,23 @@ func (delegate *buildStepDelegate) SelectedWorker(logger lager.Logger, worker st
 	}
 }
 
+func (delegate *buildStepDelegate) StreamingVolume(logger lager.Logger, volume string, sourceWorker string, destWorker string) {
+	err := delegate.build.SaveEvent(event.StreamingVolume{
+		Time: time.Now().Unix(),
+		Origin: event.Origin{
+			ID: event.OriginID(delegate.planID),
+		},
+		Volume:       volume,
+		SourceWorker: sourceWorker,
+		DestWorker:   destWorker,
+	})
+
+	if err != nil {
+		logger.Error("failed-to-save-streaming-volume-event", err)
+		return
+	}
+}
+
 func (delegate *buildStepDelegate) Errored(logger lager.Logger, message string) {
 	err := delegate.build.SaveEvent(event.Error{
 		Message: message,

--- a/atc/engine/build_step_delegate_test.go
+++ b/atc/engine/build_step_delegate_test.go
@@ -1064,4 +1064,19 @@ var _ = Describe("BuildStepDelegate", func() {
 			Expect(planId).To(Equal(atc.PlanID("some-plan")))
 		})
 	})
+
+	Describe("StreamingVolume", func() {
+		JustBeforeEach(func() {
+			delegate.StreamingVolume(logger, "some-volume", "src-worker", "dest-worker")
+		})
+
+		It("saves an event", func() {
+			Expect(fakeBuild.SaveEventCallCount()).To(Equal(1))
+			e := fakeBuild.SaveEventArgsForCall(0)
+			Expect(e.EventType()).To(Equal(atc.EventType("streaming-volume")))
+			Expect(e.(event.StreamingVolume).Volume).To(Equal("some-volume"))
+			Expect(e.(event.StreamingVolume).SourceWorker).To(Equal("src-worker"))
+			Expect(e.(event.StreamingVolume).DestWorker).To(Equal("dest-worker"))
+		})
+	})
 })

--- a/atc/event/events.go
+++ b/atc/event/events.go
@@ -109,6 +109,17 @@ type SelectedWorker struct {
 func (SelectedWorker) EventType() atc.EventType  { return EventTypeSelectedWorker }
 func (SelectedWorker) Version() atc.EventVersion { return "1.0" }
 
+type StreamingVolume struct {
+	Time         int64  `json:"time"`
+	Origin       Origin `json:"origin"`
+	Volume       string `json:"volume"`
+	SourceWorker string `json:"source_worker"`
+	DestWorker   string `json:"dest_worker"`
+}
+
+func (StreamingVolume) EventType() atc.EventType  { return EventTypeStreamingVolume }
+func (StreamingVolume) Version() atc.EventVersion { return "1.0" }
+
 type Log struct {
 	Time    int64  `json:"time"`
 	Origin  Origin `json:"origin"`

--- a/atc/event/parser.go
+++ b/atc/event/parser.go
@@ -48,6 +48,7 @@ func init() {
 	RegisterEvent(Status{})
 	RegisterEvent(WaitingForWorker{})
 	RegisterEvent(SelectedWorker{})
+	RegisterEvent(StreamingVolume{})
 	RegisterEvent(Log{})
 	RegisterEvent(Error{})
 	RegisterEvent(ImageCheck{})

--- a/atc/event/parser_test.go
+++ b/atc/event/parser_test.go
@@ -70,6 +70,7 @@ var _ = Describe("ParseEvent", func() {
 		Entry("Status", event.Status{}),
 		Entry("WaitingForWorker", event.WaitingForWorker{}),
 		Entry("SelectedWorker", event.SelectedWorker{}),
+		Entry("StreamingVolume", event.StreamingVolume{}),
 		Entry("Log", event.Log{}),
 		Entry("Error", event.Error{}),
 		Entry("ImageCheck", event.ImageCheck{}),

--- a/atc/event/types.go
+++ b/atc/event/types.go
@@ -15,6 +15,9 @@ const (
 	// a step (get/put/task) selected worker
 	EventTypeSelectedWorker atc.EventType = "selected-worker"
 
+	// a step (get/put/task) is streaming a volume from another worker
+	EventTypeStreamingVolume atc.EventType = "streaming-volume"
+
 	// task execution started
 	EventTypeStartTask atc.EventType = "start-task"
 

--- a/atc/exec/build/repository_test.go
+++ b/atc/exec/build/repository_test.go
@@ -18,6 +18,14 @@ func (a Artifact) StreamOut(_ context.Context, _ string, _ compression.Compressi
 	panic("unimplemented")
 }
 
+func (a Artifact) Handle() string {
+	panic("unimplemented")
+}
+
+func (a Artifact) Source() string {
+	panic("unimplemented")
+}
+
 var _ = Describe("ArtifactRepository", func() {
 	var (
 		repo *Repository

--- a/atc/exec/build_step_delegate.go
+++ b/atc/exec/build_step_delegate.go
@@ -35,6 +35,7 @@ type BuildStepDelegate interface {
 	BeforeSelectWorker(lager.Logger) error
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
+	StreamingVolume(lager.Logger, string, string, string)
 
 	ConstructAcrossSubsteps([]byte, []atc.AcrossVar, [][]interface{}) ([]atc.VarScopedPlan, error)
 	ContainerOwner(planId atc.PlanID) db.ContainerOwner

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -45,6 +45,8 @@ type CheckDelegate interface {
 	PointToCheckedConfig(db.ResourceConfigScope) error
 	UpdateScopeLastCheckStartTime(db.ResourceConfigScope, bool) (bool, int, error)
 	UpdateScopeLastCheckEndTime(db.ResourceConfigScope, bool) (bool, error)
+
+	StreamingVolume(lager.Logger, string, string, string)
 }
 
 func NewCheckStep(
@@ -296,7 +298,7 @@ func (step *CheckStep) runCheck(
 
 	defer cancel()
 
-	container, _, err := worker.FindOrCreateContainer(ctx, containerOwner, step.containerMetadata, containerSpec)
+	container, _, err := worker.FindOrCreateContainer(ctx, containerOwner, step.containerMetadata, containerSpec, delegate)
 	if err != nil {
 		return nil, runtime.ProcessResult{}, err
 	}

--- a/atc/exec/execfakes/fake_build_step_delegate.go
+++ b/atc/exec/execfakes/fake_build_step_delegate.go
@@ -134,6 +134,14 @@ type FakeBuildStepDelegate struct {
 	stdoutReturnsOnCall map[int]struct {
 		result1 io.Writer
 	}
+	StreamingVolumeStub        func(lager.Logger, string, string, string)
+	streamingVolumeMutex       sync.RWMutex
+	streamingVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -751,6 +759,41 @@ func (fake *FakeBuildStepDelegate) StdoutReturnsOnCall(i int, result1 io.Writer)
 	}{result1}
 }
 
+func (fake *FakeBuildStepDelegate) StreamingVolume(arg1 lager.Logger, arg2 string, arg3 string, arg4 string) {
+	fake.streamingVolumeMutex.Lock()
+	fake.streamingVolumeArgsForCall = append(fake.streamingVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.StreamingVolumeStub
+	fake.recordInvocation("StreamingVolume", []interface{}{arg1, arg2, arg3, arg4})
+	fake.streamingVolumeMutex.Unlock()
+	if stub != nil {
+		fake.StreamingVolumeStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *FakeBuildStepDelegate) StreamingVolumeCallCount() int {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	return len(fake.streamingVolumeArgsForCall)
+}
+
+func (fake *FakeBuildStepDelegate) StreamingVolumeCalls(stub func(lager.Logger, string, string, string)) {
+	fake.streamingVolumeMutex.Lock()
+	defer fake.streamingVolumeMutex.Unlock()
+	fake.StreamingVolumeStub = stub
+}
+
+func (fake *FakeBuildStepDelegate) StreamingVolumeArgsForCall(i int) (lager.Logger, string, string, string) {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	argsForCall := fake.streamingVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
 func (fake *FakeBuildStepDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -810,6 +853,8 @@ func (fake *FakeBuildStepDelegate) Invocations() map[string][][]interface{} {
 	defer fake.stderrMutex.RUnlock()
 	fake.stdoutMutex.RLock()
 	defer fake.stdoutMutex.RUnlock()
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/execfakes/fake_check_delegate.go
+++ b/atc/exec/execfakes/fake_check_delegate.go
@@ -159,6 +159,14 @@ type FakeCheckDelegate struct {
 	stdoutReturnsOnCall map[int]struct {
 		result1 io.Writer
 	}
+	StreamingVolumeStub        func(lager.Logger, string, string, string)
+	streamingVolumeMutex       sync.RWMutex
+	streamingVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}
 	UpdateScopeLastCheckEndTimeStub        func(db.ResourceConfigScope, bool) (bool, error)
 	updateScopeLastCheckEndTimeMutex       sync.RWMutex
 	updateScopeLastCheckEndTimeArgsForCall []struct {
@@ -947,6 +955,41 @@ func (fake *FakeCheckDelegate) StdoutReturnsOnCall(i int, result1 io.Writer) {
 	}{result1}
 }
 
+func (fake *FakeCheckDelegate) StreamingVolume(arg1 lager.Logger, arg2 string, arg3 string, arg4 string) {
+	fake.streamingVolumeMutex.Lock()
+	fake.streamingVolumeArgsForCall = append(fake.streamingVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.StreamingVolumeStub
+	fake.recordInvocation("StreamingVolume", []interface{}{arg1, arg2, arg3, arg4})
+	fake.streamingVolumeMutex.Unlock()
+	if stub != nil {
+		fake.StreamingVolumeStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *FakeCheckDelegate) StreamingVolumeCallCount() int {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	return len(fake.streamingVolumeArgsForCall)
+}
+
+func (fake *FakeCheckDelegate) StreamingVolumeCalls(stub func(lager.Logger, string, string, string)) {
+	fake.streamingVolumeMutex.Lock()
+	defer fake.streamingVolumeMutex.Unlock()
+	fake.StreamingVolumeStub = stub
+}
+
+func (fake *FakeCheckDelegate) StreamingVolumeArgsForCall(i int) (lager.Logger, string, string, string) {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	argsForCall := fake.streamingVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
 func (fake *FakeCheckDelegate) UpdateScopeLastCheckEndTime(arg1 db.ResourceConfigScope, arg2 bool) (bool, error) {
 	fake.updateScopeLastCheckEndTimeMutex.Lock()
 	ret, specificReturn := fake.updateScopeLastCheckEndTimeReturnsOnCall[len(fake.updateScopeLastCheckEndTimeArgsForCall)]
@@ -1211,6 +1254,8 @@ func (fake *FakeCheckDelegate) Invocations() map[string][][]interface{} {
 	defer fake.stderrMutex.RUnlock()
 	fake.stdoutMutex.RLock()
 	defer fake.stdoutMutex.RUnlock()
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
 	fake.updateScopeLastCheckEndTimeMutex.RLock()
 	defer fake.updateScopeLastCheckEndTimeMutex.RUnlock()
 	fake.updateScopeLastCheckStartTimeMutex.RLock()

--- a/atc/exec/execfakes/fake_get_delegate.go
+++ b/atc/exec/execfakes/fake_get_delegate.go
@@ -131,6 +131,14 @@ type FakeGetDelegate struct {
 	stdoutReturnsOnCall map[int]struct {
 		result1 io.Writer
 	}
+	StreamingVolumeStub        func(lager.Logger, string, string, string)
+	streamingVolumeMutex       sync.RWMutex
+	streamingVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}
 	UpdateResourceVersionStub        func(lager.Logger, string, resource.VersionResult)
 	updateResourceVersionMutex       sync.RWMutex
 	updateResourceVersionArgsForCall []struct {
@@ -728,6 +736,41 @@ func (fake *FakeGetDelegate) StdoutReturnsOnCall(i int, result1 io.Writer) {
 	}{result1}
 }
 
+func (fake *FakeGetDelegate) StreamingVolume(arg1 lager.Logger, arg2 string, arg3 string, arg4 string) {
+	fake.streamingVolumeMutex.Lock()
+	fake.streamingVolumeArgsForCall = append(fake.streamingVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.StreamingVolumeStub
+	fake.recordInvocation("StreamingVolume", []interface{}{arg1, arg2, arg3, arg4})
+	fake.streamingVolumeMutex.Unlock()
+	if stub != nil {
+		fake.StreamingVolumeStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *FakeGetDelegate) StreamingVolumeCallCount() int {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	return len(fake.streamingVolumeArgsForCall)
+}
+
+func (fake *FakeGetDelegate) StreamingVolumeCalls(stub func(lager.Logger, string, string, string)) {
+	fake.streamingVolumeMutex.Lock()
+	defer fake.streamingVolumeMutex.Unlock()
+	fake.StreamingVolumeStub = stub
+}
+
+func (fake *FakeGetDelegate) StreamingVolumeArgsForCall(i int) (lager.Logger, string, string, string) {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	argsForCall := fake.streamingVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
 func (fake *FakeGetDelegate) UpdateResourceVersion(arg1 lager.Logger, arg2 string, arg3 resource.VersionResult) {
 	fake.updateResourceVersionMutex.Lock()
 	fake.updateResourceVersionArgsForCall = append(fake.updateResourceVersionArgsForCall, struct {
@@ -821,6 +864,8 @@ func (fake *FakeGetDelegate) Invocations() map[string][][]interface{} {
 	defer fake.stderrMutex.RUnlock()
 	fake.stdoutMutex.RLock()
 	defer fake.stdoutMutex.RUnlock()
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
 	fake.updateResourceVersionMutex.RLock()
 	defer fake.updateResourceVersionMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()

--- a/atc/exec/execfakes/fake_put_delegate.go
+++ b/atc/exec/execfakes/fake_put_delegate.go
@@ -119,6 +119,14 @@ type FakePutDelegate struct {
 	stdoutReturnsOnCall map[int]struct {
 		result1 io.Writer
 	}
+	StreamingVolumeStub        func(lager.Logger, string, string, string)
+	streamingVolumeMutex       sync.RWMutex
+	streamingVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -631,6 +639,41 @@ func (fake *FakePutDelegate) StdoutReturnsOnCall(i int, result1 io.Writer) {
 	}{result1}
 }
 
+func (fake *FakePutDelegate) StreamingVolume(arg1 lager.Logger, arg2 string, arg3 string, arg4 string) {
+	fake.streamingVolumeMutex.Lock()
+	fake.streamingVolumeArgsForCall = append(fake.streamingVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.StreamingVolumeStub
+	fake.recordInvocation("StreamingVolume", []interface{}{arg1, arg2, arg3, arg4})
+	fake.streamingVolumeMutex.Unlock()
+	if stub != nil {
+		fake.StreamingVolumeStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *FakePutDelegate) StreamingVolumeCallCount() int {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	return len(fake.streamingVolumeArgsForCall)
+}
+
+func (fake *FakePutDelegate) StreamingVolumeCalls(stub func(lager.Logger, string, string, string)) {
+	fake.streamingVolumeMutex.Lock()
+	defer fake.streamingVolumeMutex.Unlock()
+	fake.StreamingVolumeStub = stub
+}
+
+func (fake *FakePutDelegate) StreamingVolumeArgsForCall(i int) (lager.Logger, string, string, string) {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	argsForCall := fake.streamingVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
 func (fake *FakePutDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -688,6 +731,8 @@ func (fake *FakePutDelegate) Invocations() map[string][][]interface{} {
 	defer fake.stderrMutex.RUnlock()
 	fake.stdoutMutex.RLock()
 	defer fake.stdoutMutex.RUnlock()
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
+++ b/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
@@ -151,6 +151,14 @@ type FakeSetPipelineStepDelegate struct {
 	stdoutReturnsOnCall map[int]struct {
 		result1 io.Writer
 	}
+	StreamingVolumeStub        func(lager.Logger, string, string, string)
+	streamingVolumeMutex       sync.RWMutex
+	streamingVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -862,6 +870,41 @@ func (fake *FakeSetPipelineStepDelegate) StdoutReturnsOnCall(i int, result1 io.W
 	}{result1}
 }
 
+func (fake *FakeSetPipelineStepDelegate) StreamingVolume(arg1 lager.Logger, arg2 string, arg3 string, arg4 string) {
+	fake.streamingVolumeMutex.Lock()
+	fake.streamingVolumeArgsForCall = append(fake.streamingVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.StreamingVolumeStub
+	fake.recordInvocation("StreamingVolume", []interface{}{arg1, arg2, arg3, arg4})
+	fake.streamingVolumeMutex.Unlock()
+	if stub != nil {
+		fake.StreamingVolumeStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *FakeSetPipelineStepDelegate) StreamingVolumeCallCount() int {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	return len(fake.streamingVolumeArgsForCall)
+}
+
+func (fake *FakeSetPipelineStepDelegate) StreamingVolumeCalls(stub func(lager.Logger, string, string, string)) {
+	fake.streamingVolumeMutex.Lock()
+	defer fake.streamingVolumeMutex.Unlock()
+	fake.StreamingVolumeStub = stub
+}
+
+func (fake *FakeSetPipelineStepDelegate) StreamingVolumeArgsForCall(i int) (lager.Logger, string, string, string) {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	argsForCall := fake.streamingVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
 func (fake *FakeSetPipelineStepDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -925,6 +968,8 @@ func (fake *FakeSetPipelineStepDelegate) Invocations() map[string][][]interface{
 	defer fake.stderrMutex.RUnlock()
 	fake.stdoutMutex.RLock()
 	defer fake.stdoutMutex.RUnlock()
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/execfakes/fake_task_delegate.go
+++ b/atc/exec/execfakes/fake_task_delegate.go
@@ -111,6 +111,14 @@ type FakeTaskDelegate struct {
 	stdoutReturnsOnCall map[int]struct {
 		result1 io.Writer
 	}
+	StreamingVolumeStub        func(lager.Logger, string, string, string)
+	streamingVolumeMutex       sync.RWMutex
+	streamingVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -616,6 +624,41 @@ func (fake *FakeTaskDelegate) StdoutReturnsOnCall(i int, result1 io.Writer) {
 	}{result1}
 }
 
+func (fake *FakeTaskDelegate) StreamingVolume(arg1 lager.Logger, arg2 string, arg3 string, arg4 string) {
+	fake.streamingVolumeMutex.Lock()
+	fake.streamingVolumeArgsForCall = append(fake.streamingVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.StreamingVolumeStub
+	fake.recordInvocation("StreamingVolume", []interface{}{arg1, arg2, arg3, arg4})
+	fake.streamingVolumeMutex.Unlock()
+	if stub != nil {
+		fake.StreamingVolumeStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *FakeTaskDelegate) StreamingVolumeCallCount() int {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	return len(fake.streamingVolumeArgsForCall)
+}
+
+func (fake *FakeTaskDelegate) StreamingVolumeCalls(stub func(lager.Logger, string, string, string)) {
+	fake.streamingVolumeMutex.Lock()
+	defer fake.streamingVolumeMutex.Unlock()
+	fake.StreamingVolumeStub = stub
+}
+
+func (fake *FakeTaskDelegate) StreamingVolumeArgsForCall(i int) (lager.Logger, string, string, string) {
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
+	argsForCall := fake.streamingVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
 func (fake *FakeTaskDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -673,6 +716,8 @@ func (fake *FakeTaskDelegate) Invocations() map[string][][]interface{} {
 	defer fake.stderrMutex.RUnlock()
 	fake.stdoutMutex.RLock()
 	defer fake.stdoutMutex.RUnlock()
+	fake.streamingVolumeMutex.RLock()
+	defer fake.streamingVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -68,6 +68,7 @@ type GetDelegate interface {
 	BeforeSelectWorker(lager.Logger) error
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
+	StreamingVolume(lager.Logger, string, string, string)
 
 	UpdateResourceVersion(lager.Logger, string, resource.VersionResult)
 
@@ -478,7 +479,7 @@ func (step *GetStep) performGetAndInitCache(
 
 	defer cancel()
 
-	container, mounts, err := worker.FindOrCreateContainer(ctx, containerOwner, step.containerMetadata, containerSpec)
+	container, mounts, err := worker.FindOrCreateContainer(ctx, containerOwner, step.containerMetadata, containerSpec, delegate)
 	if err != nil {
 		logger.Error("failed-to-create-container", err)
 		return nil, resource.VersionResult{}, runtime.ProcessResult{}, err

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -40,6 +40,7 @@ type PutDelegate interface {
 	BeforeSelectWorker(lager.Logger) error
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
+	StreamingVolume(lager.Logger, string, string, string)
 
 	SaveOutput(lager.Logger, atc.PutPlan, atc.Source, db.ResourceCache, resource.VersionResult)
 }
@@ -208,7 +209,7 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 
 	defer cancel()
 
-	container, _, err := worker.FindOrCreateContainer(ctx, owner, step.containerMetadata, containerSpec)
+	container, _, err := worker.FindOrCreateContainer(ctx, owner, step.containerMetadata, containerSpec, delegate)
 	if err != nil {
 		return false, err
 	}

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -76,6 +76,7 @@ type TaskDelegate interface {
 	BeforeSelectWorker(lager.Logger) error
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
+	StreamingVolume(lager.Logger, string, string, string)
 }
 
 // TaskStep executes a TaskConfig, whose inputs will be fetched from the
@@ -275,7 +276,7 @@ func (step *TaskStep) run(ctx context.Context, state RunState, delegate TaskDele
 
 	delegate.SelectedWorker(logger, worker.Name())
 
-	container, volumeMounts, err := worker.FindOrCreateContainer(ctx, owner, step.containerMetadata, containerSpec)
+	container, volumeMounts, err := worker.FindOrCreateContainer(ctx, owner, step.containerMetadata, containerSpec, delegate)
 	if err != nil {
 		return false, err
 	}

--- a/atc/runtime/runtimetest/artifact.go
+++ b/atc/runtime/runtimetest/artifact.go
@@ -11,6 +11,14 @@ type Artifact struct {
 	Content VolumeContent
 }
 
+func (a Artifact) Handle() string {
+	return ""
+}
+
+func (a Artifact) Source() string {
+	return ""
+}
+
 func (a Artifact) StreamOut(ctx context.Context, path string, compression compression.Compression) (io.ReadCloser, error) {
 	return a.Content.StreamOut(ctx, path, compression.Encoding())
 }

--- a/atc/runtime/runtimetest/volume.go
+++ b/atc/runtime/runtimetest/volume.go
@@ -50,6 +50,10 @@ func (v Volume) Handle() string {
 	return v.VolumeHandle
 }
 
+func (v Volume) Source() string {
+	return fmt.Sprintf("%s-worker", v.Handle())
+}
+
 func (v Volume) StreamIn(ctx context.Context, path string, compression compression.Compression, reader io.Reader) error {
 	return v.Content.StreamIn(ctx, path, compression.Encoding(), reader)
 }

--- a/atc/runtime/runtimetest/worker.go
+++ b/atc/runtime/runtimetest/worker.go
@@ -72,7 +72,7 @@ func (w Worker) CreateVolumeForArtifact(ctx context.Context, teamID int) (runtim
 	panic("unimplemented")
 }
 
-func (w *Worker) FindOrCreateContainer(ctx context.Context, owner db.ContainerOwner, metadata db.ContainerMetadata, spec runtime.ContainerSpec) (runtime.Container, []runtime.VolumeMount, error) {
+func (w *Worker) FindOrCreateContainer(ctx context.Context, owner db.ContainerOwner, metadata db.ContainerMetadata, spec runtime.ContainerSpec, delegate runtime.BuildStepDelegate) (runtime.Container, []runtime.VolumeMount, error) {
 	c, _, ok := w.FindContainerByOwner(owner)
 	if !ok {
 		panic("unimplemented: runtimetest.Worker.FindOrCreateContainer can currently only find a container.\n" +

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc/compression"
 	"github.com/concourse/concourse/atc/db"
 	"go.opentelemetry.io/otel/propagation"
@@ -27,7 +28,7 @@ type Worker interface {
 	// It can be thought of as declaratively saying "I want a container
 	// matching these specifications" - and the Worker implementation will
 	// "make it so", regardless of what Containers/Volumes already exist.
-	FindOrCreateContainer(context.Context, db.ContainerOwner, db.ContainerMetadata, ContainerSpec) (Container, []VolumeMount, error)
+	FindOrCreateContainer(context.Context, db.ContainerOwner, db.ContainerMetadata, ContainerSpec, BuildStepDelegate) (Container, []VolumeMount, error)
 	// CreateVolumeForArtifact creates a new empty Volume to be used as a
 	// WorkerArtifact. This is used for uploading local inputs to a worker via
 	// `fly execute -i ...`.
@@ -121,6 +122,10 @@ type ContainerSpec struct {
 	// CertsBindMount indicates whether or not to mount the worker's Certs
 	// volume onto the container.
 	CertsBindMount bool
+}
+
+type BuildStepDelegate interface {
+	StreamingVolume(lager.Logger, string, string, string)
 }
 
 // ContainerSpec must implement propagation.TextMapCarrier so that it can be

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -281,13 +281,23 @@ type ContainerLimits struct {
 // Artifact represents an output from a step that can be used as an input to
 // other steps.
 type Artifact interface {
+	// StreamOut converts the contents of the Artifact under path to a compressed
+	// tar stream. The result of StreamOut can be passed in to StreamIn for
+	// another Artifact.
+	//
+	// path is a relative path - "." indicates using the root of the Artifact.
 	StreamOut(ctx context.Context, path string, compression compression.Compression) (io.ReadCloser, error)
+
+	// Handle gives the globally unique ID of the Volume.
+	Handle() string
+
+	// Source gives the original source of the artifact e.g. worker name
+	Source() string
 }
 
 // Volume represents a data volume that can be mounted to a Container.
 type Volume interface {
-	// Handle gives the globally unique ID of the Volume.
-	Handle() string
+	Artifact
 
 	// StreamIn accepts a compressed tar stream and populates the contents of
 	// the Volume with the contents under path. This tar stream can be the
@@ -295,12 +305,6 @@ type Volume interface {
 	//
 	// path is a relative path - "." indicates using the root of the Volume.
 	StreamIn(ctx context.Context, path string, compression compression.Compression, reader io.Reader) error
-	// StreamOut converts the contents of the Volume under path to a compressed
-	// tar stream. The result of StreamOut can be passed in to StreamIn for
-	// another Volume.
-	//
-	// path is a relative path - "." indicates using the root of the Volume.
-	StreamOut(ctx context.Context, path string, compression compression.Compression) (io.ReadCloser, error)
 
 	// InitializeResourceCache is called upon a successful run of the get step
 	// to register this Volume as a resource cache.
@@ -317,9 +321,6 @@ type Volume interface {
 
 	DBVolume() db.CreatedVolume
 }
-
-// A Volume is a type of Artifact that is mounted to a Container.
-var _ Artifact = (Volume)(nil)
 
 // P2PVolume is an interface that may also be satisfied by Volume
 // implementations. When streaming contents from one Volume to another, if both

--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -182,7 +182,7 @@ func (d *drainer) sendEvent(logger lager.Logger, build db.Build, syslog *Syslog,
 		}
 		ts = time.Unix(streamingVolumeEvent.Time, 0)
 		tag = build.SyslogTag(streamingVolumeEvent.Origin.ID)
-		message = fmt.Sprintf("streaming volume %s from %s to %s", streamingVolumeEvent.Volume, streamingVolumeEvent.SourceWorker, streamingVolumeEvent.DestWorker)
+		message = fmt.Sprintf("streaming volume %s from worker %s", streamingVolumeEvent.Volume, streamingVolumeEvent.SourceWorker)
 	case event.EventTypeStartTask:
 		var startTaskEvent event.StartTask
 		err := json.Unmarshal(*ev.Data, &startTaskEvent)

--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -173,6 +173,16 @@ func (d *drainer) sendEvent(logger lager.Logger, build db.Build, syslog *Syslog,
 		ts = time.Unix(selectedWorkerEvent.Time, 0)
 		tag = build.SyslogTag(selectedWorkerEvent.Origin.ID)
 		message = fmt.Sprintf("selected worker: %s", selectedWorkerEvent.WorkerName)
+	case event.EventTypeStreamingVolume:
+		var streamingVolumeEvent event.StreamingVolume
+		err := json.Unmarshal(*ev.Data, &streamingVolumeEvent)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(streamingVolumeEvent.Time, 0)
+		tag = build.SyslogTag(streamingVolumeEvent.Origin.ID)
+		message = fmt.Sprintf("streaming volume %s from %s to %s", streamingVolumeEvent.Volume, streamingVolumeEvent.SourceWorker, streamingVolumeEvent.DestWorker)
 	case event.EventTypeStartTask:
 		var startTaskEvent event.StartTask
 		err := json.Unmarshal(*ev.Data, &startTaskEvent)

--- a/atc/worker/gardenruntime/image.go
+++ b/atc/worker/gardenruntime/image.go
@@ -132,10 +132,7 @@ func (worker *Worker) imageProvidedByPreviousStepOnDifferentWorker(
 		return FetchedImage{}, err
 	}
 
-	srcVolume, isSrcVolume := artifact.(runtime.Volume)
-	if isSrcVolume {
-		delegate.StreamingVolume(logger, "for image", srcVolume.DBVolume().WorkerName(), streamedVolume.DBVolume().WorkerName())
-	}
+	delegate.StreamingVolume(logger, "for image", artifact.Source(), streamedVolume.DBVolume().WorkerName())
 
 	if err := worker.streamer.Stream(ctx, artifact, streamedVolume); err != nil {
 		logger.Error("failed-to-stream-image-artifact", err)

--- a/atc/worker/gardenruntime/volume.go
+++ b/atc/worker/gardenruntime/volume.go
@@ -33,6 +33,10 @@ func (v Volume) Handle() string {
 	return v.bcVolume.Handle()
 }
 
+func (v Volume) Source() string {
+	return v.dbVolume.WorkerName()
+}
+
 func (v Volume) Path() string {
 	return v.bcVolume.Path()
 }

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -517,11 +517,8 @@ func (worker *Worker) streamRemoteInputVolumes(
 			mountPath: input.mountPath,
 		}
 
-		srcVolume, isSrcVolume := input.volume.(runtime.Volume)
-		if isSrcVolume {
-			_, inputPath := path.Split(input.mountPath)
-			delegate.StreamingVolume(logger, inputPath, srcVolume.DBVolume().WorkerName(), streamedVolume.DBVolume().WorkerName())
-		}
+		_, inputPath := path.Split(input.mountPath)
+		delegate.StreamingVolume(logger, inputPath, input.volume.Source(), streamedVolume.DBVolume().WorkerName())
 
 		g.Go(func() error {
 			return worker.streamer.Stream(groupCtx, input.volume, streamedVolume)

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -67,8 +68,9 @@ func (worker *Worker) FindOrCreateContainer(
 	owner db.ContainerOwner,
 	metadata db.ContainerMetadata,
 	containerSpec runtime.ContainerSpec,
+	delegate runtime.BuildStepDelegate,
 ) (runtime.Container, []runtime.VolumeMount, error) {
-	c, mounts, err := worker.findOrCreateContainer(ctx, owner, metadata, containerSpec)
+	c, mounts, err := worker.findOrCreateContainer(ctx, owner, metadata, containerSpec, delegate)
 	if err != nil {
 		return nil, nil, fmt.Errorf("find or create container on worker %s: %w", worker.Name(), err)
 	}
@@ -80,6 +82,7 @@ func (worker *Worker) findOrCreateContainer(
 	owner db.ContainerOwner,
 	metadata db.ContainerMetadata,
 	containerSpec runtime.ContainerSpec,
+	delegate runtime.BuildStepDelegate,
 ) (runtime.Container, []runtime.VolumeMount, error) {
 	logger := lagerctx.FromContext(ctx)
 	creatingContainer, createdContainer, err := worker.dbWorker.FindContainer(owner)
@@ -136,7 +139,7 @@ func (worker *Worker) findOrCreateContainer(
 	// will create one. If it does exist, we will transition the creatingContainer
 	// to created and return a worker.Container
 	if gardenContainer == nil {
-		gardenContainer, err = worker.createGardenContainer(ctx, containerSpec, creatingContainer)
+		gardenContainer, err = worker.createGardenContainer(ctx, containerSpec, creatingContainer, delegate)
 		if err != nil {
 			logger.Error("failed-to-create-container-in-garden", err)
 			markContainerAsFailed(logger, creatingContainer)
@@ -167,6 +170,7 @@ func (worker *Worker) createGardenContainer(
 	ctx context.Context,
 	containerSpec runtime.ContainerSpec,
 	creatingContainer db.CreatingContainer,
+	delegate runtime.BuildStepDelegate,
 ) (gclient.Container, error) {
 	logger := lagerctx.FromContext(ctx)
 	fetchedImage, err := worker.fetchImageForContainer(
@@ -174,6 +178,7 @@ func (worker *Worker) createGardenContainer(
 		containerSpec.ImageSpec,
 		containerSpec.TeamID,
 		creatingContainer,
+		delegate,
 	)
 	if err != nil {
 		logger.Error("failed-to-fetch-image-for-container", err)
@@ -181,7 +186,7 @@ func (worker *Worker) createGardenContainer(
 		return nil, err
 	}
 
-	volumeMounts, err := worker.createVolumes(ctx, fetchedImage.Privileged, creatingContainer, containerSpec)
+	volumeMounts, err := worker.createVolumes(ctx, fetchedImage.Privileged, creatingContainer, containerSpec, delegate)
 	if err != nil {
 		logger.Error("failed-to-create-volume-mounts-for-container", err)
 		markContainerAsFailed(logger, creatingContainer)
@@ -300,6 +305,7 @@ func (worker *Worker) createVolumes(
 	privileged bool,
 	creatingContainer db.CreatingContainer,
 	spec runtime.ContainerSpec,
+	delegate runtime.BuildStepDelegate,
 ) ([]runtime.VolumeMount, error) {
 	var volumeMounts []runtime.VolumeMount
 
@@ -324,7 +330,7 @@ func (worker *Worker) createVolumes(
 
 	volumeMounts = append(volumeMounts, scratchMount)
 
-	inputVolumeMounts, inputDestinationPaths, err := worker.cloneInputVolumes(ctx, spec, privileged, creatingContainer)
+	inputVolumeMounts, inputDestinationPaths, err := worker.cloneInputVolumes(ctx, spec, privileged, creatingContainer, delegate)
 	if err != nil {
 		return nil, err
 	}
@@ -386,6 +392,7 @@ func (worker *Worker) cloneInputVolumes(
 	spec runtime.ContainerSpec,
 	privileged bool,
 	container db.CreatingContainer,
+	delegate runtime.BuildStepDelegate,
 ) ([]runtime.VolumeMount, map[string]bool, error) {
 	inputDestinationPaths := make(map[string]bool)
 
@@ -414,7 +421,7 @@ func (worker *Worker) cloneInputVolumes(
 		}
 	}
 
-	locallyClonedVolumes, err := worker.streamRemoteInputVolumes(ctx, spec, privileged, container, remoteInputs)
+	locallyClonedVolumes, err := worker.streamRemoteInputVolumes(ctx, spec, privileged, container, remoteInputs, delegate)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -469,6 +476,7 @@ func (worker *Worker) streamRemoteInputVolumes(
 	privileged bool,
 	container db.CreatingContainer,
 	inputs []remoteInput,
+	delegate runtime.BuildStepDelegate,
 ) ([]mountableLocalInput, error) {
 	logger := lagerctx.FromContext(ctx)
 	if len(inputs) == 0 {
@@ -507,6 +515,12 @@ func (worker *Worker) streamRemoteInputVolumes(
 		mounts[i] = mountableLocalInput{
 			cowParent: streamedVolume,
 			mountPath: input.mountPath,
+		}
+
+		srcVolume, isSrcVolume := input.volume.(runtime.Volume)
+		if isSrcVolume {
+			_, inputPath := path.Split(input.mountPath)
+			delegate.StreamingVolume(logger, inputPath, srcVolume.DBVolume().WorkerName(), streamedVolume.DBVolume().WorkerName())
 		}
 
 		g.Go(func() error {

--- a/atc/worker/streamer.go
+++ b/atc/worker/streamer.go
@@ -39,13 +39,10 @@ func NewStreamer(cacheFactory db.ResourceCacheFactory, compression compression.C
 
 func (s Streamer) Stream(ctx context.Context, src runtime.Artifact, dst runtime.Volume) error {
 	loggerData := lager.Data{
-		"to":        dst.DBVolume().WorkerName(),
-		"to-handle": dst.Handle(),
-	}
-	srcVolume, isSrcVolume := src.(runtime.Volume)
-	if isSrcVolume {
-		loggerData["from"] = srcVolume.DBVolume().WorkerName()
-		loggerData["from-handle"] = srcVolume.Handle()
+		"to":          dst.DBVolume().WorkerName(),
+		"to-handle":   dst.Handle(),
+		"from":        src.Source(),
+		"from-handle": src.Handle(),
 	}
 	logger := lagerctx.FromContext(ctx).Session("stream", loggerData)
 	logger.Info("start")
@@ -56,6 +53,7 @@ func (s Streamer) Stream(ctx context.Context, src runtime.Artifact, dst runtime.
 		return err
 	}
 
+	srcVolume, isSrcVolume := src.(runtime.Volume)
 	if !isSrcVolume {
 		return nil
 	}

--- a/fly/eventstream/render.go
+++ b/fly/eventstream/render.go
@@ -50,7 +50,7 @@ func Render(dst io.Writer, src eventstream.EventStream, options RenderOptions) i
 
 		case event.StreamingVolume:
 			dstImpl.SetTimestamp(e.Time)
-			fmt.Fprintf(dstImpl, "\x1b[1mstreaming volume\x1b[0m %s \x1b[1mfrom\x1b[0m %s \x1b[1mto\x1b[0m %s\n", e.Volume, e.SourceWorker, e.DestWorker)
+			fmt.Fprintf(dstImpl, "\x1b[1mstreaming volume\x1b[0m %s \x1b[1mfrom worker\x1b[0m %s\n", e.Volume, e.SourceWorker)
 
 		case event.InitializeCheck:
 			dstImpl.SetTimestamp(e.Time)

--- a/fly/eventstream/render.go
+++ b/fly/eventstream/render.go
@@ -48,6 +48,10 @@ func Render(dst io.Writer, src eventstream.EventStream, options RenderOptions) i
 			dstImpl.SetTimestamp(e.Time)
 			fmt.Fprintf(dstImpl, "\x1b[1mselected worker:\x1b[0m %s\n", e.WorkerName)
 
+		case event.StreamingVolume:
+			dstImpl.SetTimestamp(e.Time)
+			fmt.Fprintf(dstImpl, "\x1b[1mstreaming volume\x1b[0m %s \x1b[1mfrom\x1b[0m %s \x1b[1mto\x1b[0m %s\n", e.Volume, e.SourceWorker, e.DestWorker)
+
 		case event.InitializeCheck:
 			dstImpl.SetTimestamp(e.Time)
 			fmt.Fprintf(dstImpl, "\x1b[1minitializing check:\x1b[0m %s\n", e.Name)

--- a/fly/eventstream/render_test.go
+++ b/fly/eventstream/render_test.go
@@ -341,6 +341,31 @@ var _ = Describe("V1.0 Renderer", func() {
 		})
 	})
 
+	Context("when a StreamingVolume event is received", func() {
+		BeforeEach(func() {
+			receivedEvents <- event.StreamingVolume{
+				Time:         time.Now().Unix(),
+				Volume:       "some-volume",
+				SourceWorker: "source-worker",
+				DestWorker:   "dest-worker",
+			}
+		})
+
+		It("prints the event", func() {
+			Expect(out.Contents()).To(ContainSubstring("\x1b[1mstreaming volume\u001B[0m some-volume \x1b[1mfrom\u001B[0m source-worker \x1b[1mto\u001B[0m dest-worker\n"))
+		})
+
+		Context("and time configuration enabled", func() {
+			BeforeEach(func() {
+				options.ShowTimestamp = true
+			})
+
+			It("timestamp is prefixed", func() {
+				Expect(out).To(gbytes.Say(`\d{2}\:\d{2}\:\d{2}\s{2}\w*`))
+			})
+		})
+	})
+
 	Context("when an UnknownEventTypeError or UnknownEventVersionError is received", func() {
 
 		BeforeEach(func() {

--- a/fly/eventstream/render_test.go
+++ b/fly/eventstream/render_test.go
@@ -352,7 +352,7 @@ var _ = Describe("V1.0 Renderer", func() {
 		})
 
 		It("prints the event", func() {
-			Expect(out.Contents()).To(ContainSubstring("\x1b[1mstreaming volume\u001B[0m some-volume \x1b[1mfrom\u001B[0m source-worker \x1b[1mto\u001B[0m dest-worker\n"))
+			Expect(out.Contents()).To(ContainSubstring("\x1b[1mstreaming volume\u001B[0m some-volume \x1b[1mfrom worker\u001B[0m source-worker\n"))
 		})
 
 		Context("and time configuration enabled", func() {

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -170,8 +170,8 @@ handleEvent event ( model, effects ) =
             , effects
             )
 
-        StreamingVolume origin volume src dest time ->
-            ( updateStep origin.id (setRunning << appendStepLog ("\u{001B}[1mstreaming volume \u{001B}[0m" ++ volume ++ " \u{001B}[1mfrom\u{001B}[0m " ++ src ++ " \u{001B}[1mto\u{001B}[0m " ++ dest ++ "\n") time) model
+        StreamingVolume origin volume src time ->
+            ( updateStep origin.id (setRunning << appendStepLog ("\u{001B}[1mstreaming volume \u{001B}[0m" ++ volume ++ " \u{001B}[1mfrom\u{001B}[0m " ++ src ++ "\n") time) model
             , effects
             )
 

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -170,6 +170,11 @@ handleEvent event ( model, effects ) =
             , effects
             )
 
+        StreamingVolume origin volume src dest time ->
+            ( updateStep origin.id (setRunning << appendStepLog ("\u{001B}[1mstreaming volume \u{001B}[0m" ++ volume ++ " \u{001B}[1mfrom\u{001B}[0m " ++ src ++ " \u{001B}[1mto\u{001B}[0m " ++ dest ++ "\n") time) model
+            , effects
+            )
+
         Error origin message time ->
             ( updateStep origin.id (setStepError message time) model
             , effects

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -206,7 +206,7 @@ type BuildEvent
     | Log Origin String (Maybe Time.Posix)
     | WaitingForWorker Origin (Maybe Time.Posix)
     | SelectedWorker Origin String (Maybe Time.Posix)
-    | StreamingVolume Origin String String String (Maybe Time.Posix)
+    | StreamingVolume Origin String String (Maybe Time.Posix)
     | Error Origin String Time.Posix
     | ImageCheck Origin Concourse.BuildPlan
     | ImageGet Origin Concourse.BuildPlan

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -206,6 +206,7 @@ type BuildEvent
     | Log Origin String (Maybe Time.Posix)
     | WaitingForWorker Origin (Maybe Time.Posix)
     | SelectedWorker Origin String (Maybe Time.Posix)
+    | StreamingVolume Origin String String String (Maybe Time.Posix)
     | Error Origin String Time.Posix
     | ImageCheck Origin Concourse.BuildPlan
     | ImageGet Origin Concourse.BuildPlan

--- a/web/elm/src/Concourse/BuildEvents.elm
+++ b/web/elm/src/Concourse/BuildEvents.elm
@@ -103,6 +103,17 @@ decodeBuildEvent =
                                 (Json.Decode.maybe <| Json.Decode.field "time" <| Json.Decode.map dateFromSeconds Json.Decode.int)
                             )
 
+                    "streaming-volume" ->
+                        Json.Decode.field
+                            "data"
+                            (Json.Decode.map5 StreamingVolume
+                                (Json.Decode.field "origin" <| Json.Decode.lazy (\_ -> decodeOrigin))
+                                (Json.Decode.field "volume" Json.Decode.string)
+                                (Json.Decode.field "source_worker" Json.Decode.string)
+                                (Json.Decode.field "dest_worker" Json.Decode.string)
+                                (Json.Decode.maybe <| Json.Decode.field "time" <| Json.Decode.map dateFromSeconds Json.Decode.int)
+                            )
+
                     "error" ->
                         Json.Decode.field "data" decodeErrorEvent
 

--- a/web/elm/src/Concourse/BuildEvents.elm
+++ b/web/elm/src/Concourse/BuildEvents.elm
@@ -106,11 +106,10 @@ decodeBuildEvent =
                     "streaming-volume" ->
                         Json.Decode.field
                             "data"
-                            (Json.Decode.map5 StreamingVolume
+                            (Json.Decode.map4 StreamingVolume
                                 (Json.Decode.field "origin" <| Json.Decode.lazy (\_ -> decodeOrigin))
                                 (Json.Decode.field "volume" Json.Decode.string)
                                 (Json.Decode.field "source_worker" Json.Decode.string)
-                                (Json.Decode.field "dest_worker" Json.Decode.string)
                                 (Json.Decode.maybe <| Json.Decode.field "time" <| Json.Decode.map dateFromSeconds Json.Decode.int)
                             )
 


### PR DESCRIPTION
## Changes proposed by this PR

Often build steps appear to "hang" in the UI after a worker is selected
which is commonly due to volumes being streamed. As these volumes can be
quite large, this can take a significant amount of time that would be
helpful to tell the user about.

This adds a "streaming-volume" event to the build logs which outputs the
"input name" (directory that it will be mounted at) and the source and
destination worker names to help users understand when jobs are waiting
for volumes to be streamed.

The current worker structure did not really have a particularly good
place to save this event so I kept the "delegate" pattern and passed
that down into the atc/worker code. Due to cyclic dependencies this has
to be in the atc/runtime package but I think that is fine anyway as the
runtime.BuildStepDelegate only specifies the delegate methods needed at
runtime etc.

closes #6575

* [x] done
* [ ] todo

## Notes to reviewer
The delegate being passed all the way down seems like an elegant-ish hack but open to other suggestions

## Release Note
* Build logs will now contain new events when a volume is being streamed to a worker
![Screenshot 2022-02-02 at 11 39 01](https://user-images.githubusercontent.com/14118619/152146829-d058dcbd-6db7-40ec-a0b0-c53306d119de.png)

