### PR TITLE
reduced in-memory checks

### DIFF
--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -67,6 +67,7 @@ var _ = Describe("CheckFactory", func() {
 			fakeBuild.LagerDataReturns(lager.Data{})
 			fakeResource.CreateBuildReturns(fakeBuild, true, nil)
 			fakeResource.CreateInMemoryBuildReturns(fakeBuild, nil)
+			fakeResource.TimeToCheckReturns(true)
 
 			fakeResourceType = new(dbfakes.FakeResourceType)
 			fakeResourceType.NameReturns("some-type")
@@ -307,6 +308,7 @@ var _ = Describe("CheckFactory", func() {
 				fakeResourceType.CheckPlanReturns(checkPlan)
 				fakeResourceType.CreateBuildReturns(fakeBuild, true, nil)
 				fakeResourceType.CreateInMemoryBuildReturns(fakeBuild, nil)
+				manuallyTriggered = true
 			})
 
 			JustBeforeEach(func() {

--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -164,7 +164,7 @@ var _ = Describe("CheckFactory", func() {
 
 				Context("when the interval has not elapsed", func() {
 					BeforeEach(func() {
-						fakeResource.LastCheckEndTimeReturns(time.Now().Add(defaultCheckInterval))
+						fakeResource.TimeToCheckReturns(false)
 					})
 
 					It("does not create a build for the resource", func() {
@@ -213,7 +213,7 @@ var _ = Describe("CheckFactory", func() {
 
 				Context("when the default webhook interval has not elapsed", func() {
 					BeforeEach(func() {
-						fakeResource.LastCheckEndTimeReturns(time.Now().Add(-(defaultWebhookCheckInterval / 2)))
+						fakeResource.TimeToCheckReturns(false)
 					})
 
 					It("does not create a build for the resource", func() {
@@ -335,7 +335,7 @@ var _ = Describe("CheckFactory", func() {
 				It("starts the build with the check plan", func() {
 					Expect(fakeResourceType.CreateBuildCallCount()).To(Equal(1))
 					_, manuallyTriggered, plan := fakeResourceType.CreateBuildArgsForCall(0)
-					Expect(manuallyTriggered).To(BeFalse())
+					Expect(manuallyTriggered).To(BeTrue())
 					Expect(plan).To(Equal(checkPlan))
 				})
 			})
@@ -364,7 +364,7 @@ var _ = Describe("CheckFactory", func() {
 				It("starts the build with the check plan", func() {
 					Expect(fakeResourceType.CreateInMemoryBuildCallCount()).To(Equal(1))
 					_, plan, seqGen := fakeResourceType.CreateInMemoryBuildArgsForCall(0)
-					Expect(manuallyTriggered).To(BeFalse())
+					Expect(manuallyTriggered).To(BeTrue())
 					Expect(plan).To(Equal(checkPlan))
 					Expect(seqGen).To(Equal(seqGenerator))
 				})

--- a/atc/db/dbfakes/fake_checkable.go
+++ b/atc/db/dbfakes/fake_checkable.go
@@ -4,7 +4,6 @@ package dbfakes
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
@@ -100,16 +99,6 @@ type FakeCheckable struct {
 	}
 	hasWebhookReturnsOnCall map[int]struct {
 		result1 bool
-	}
-	LastCheckEndTimeStub        func() time.Time
-	lastCheckEndTimeMutex       sync.RWMutex
-	lastCheckEndTimeArgsForCall []struct {
-	}
-	lastCheckEndTimeReturns struct {
-		result1 time.Time
-	}
-	lastCheckEndTimeReturnsOnCall map[int]struct {
-		result1 time.Time
 	}
 	NameStub        func() string
 	nameMutex       sync.RWMutex
@@ -224,6 +213,16 @@ type FakeCheckable struct {
 	}
 	teamNameReturnsOnCall map[int]struct {
 		result1 string
+	}
+	TimeToCheckStub        func() bool
+	timeToCheckMutex       sync.RWMutex
+	timeToCheckArgsForCall []struct {
+	}
+	timeToCheckReturns struct {
+		result1 bool
+	}
+	timeToCheckReturnsOnCall map[int]struct {
+		result1 bool
 	}
 	TypeStub        func() string
 	typeMutex       sync.RWMutex
@@ -650,59 +649,6 @@ func (fake *FakeCheckable) HasWebhookReturnsOnCall(i int, result1 bool) {
 	}
 	fake.hasWebhookReturnsOnCall[i] = struct {
 		result1 bool
-	}{result1}
-}
-
-func (fake *FakeCheckable) LastCheckEndTime() time.Time {
-	fake.lastCheckEndTimeMutex.Lock()
-	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
-	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
-	}{})
-	stub := fake.LastCheckEndTimeStub
-	fakeReturns := fake.lastCheckEndTimeReturns
-	fake.recordInvocation("LastCheckEndTime", []interface{}{})
-	fake.lastCheckEndTimeMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeCheckable) LastCheckEndTimeCallCount() int {
-	fake.lastCheckEndTimeMutex.RLock()
-	defer fake.lastCheckEndTimeMutex.RUnlock()
-	return len(fake.lastCheckEndTimeArgsForCall)
-}
-
-func (fake *FakeCheckable) LastCheckEndTimeCalls(stub func() time.Time) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = stub
-}
-
-func (fake *FakeCheckable) LastCheckEndTimeReturns(result1 time.Time) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = nil
-	fake.lastCheckEndTimeReturns = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakeCheckable) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = nil
-	if fake.lastCheckEndTimeReturnsOnCall == nil {
-		fake.lastCheckEndTimeReturnsOnCall = make(map[int]struct {
-			result1 time.Time
-		})
-	}
-	fake.lastCheckEndTimeReturnsOnCall[i] = struct {
-		result1 time.Time
 	}{result1}
 }
 
@@ -1295,6 +1241,59 @@ func (fake *FakeCheckable) TeamNameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakeCheckable) TimeToCheck() bool {
+	fake.timeToCheckMutex.Lock()
+	ret, specificReturn := fake.timeToCheckReturnsOnCall[len(fake.timeToCheckArgsForCall)]
+	fake.timeToCheckArgsForCall = append(fake.timeToCheckArgsForCall, struct {
+	}{})
+	stub := fake.TimeToCheckStub
+	fakeReturns := fake.timeToCheckReturns
+	fake.recordInvocation("TimeToCheck", []interface{}{})
+	fake.timeToCheckMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeCheckable) TimeToCheckCallCount() int {
+	fake.timeToCheckMutex.RLock()
+	defer fake.timeToCheckMutex.RUnlock()
+	return len(fake.timeToCheckArgsForCall)
+}
+
+func (fake *FakeCheckable) TimeToCheckCalls(stub func() bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = stub
+}
+
+func (fake *FakeCheckable) TimeToCheckReturns(result1 bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = nil
+	fake.timeToCheckReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeCheckable) TimeToCheckReturnsOnCall(i int, result1 bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = nil
+	if fake.timeToCheckReturnsOnCall == nil {
+		fake.timeToCheckReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.timeToCheckReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakeCheckable) Type() string {
 	fake.typeMutex.Lock()
 	ret, specificReturn := fake.typeReturnsOnCall[len(fake.typeArgsForCall)]
@@ -1365,8 +1364,6 @@ func (fake *FakeCheckable) Invocations() map[string][][]interface{} {
 	defer fake.currentPinnedVersionMutex.RUnlock()
 	fake.hasWebhookMutex.RLock()
 	defer fake.hasWebhookMutex.RUnlock()
-	fake.lastCheckEndTimeMutex.RLock()
-	defer fake.lastCheckEndTimeMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
 	fake.pipelineMutex.RLock()
@@ -1389,6 +1386,8 @@ func (fake *FakeCheckable) Invocations() map[string][][]interface{} {
 	defer fake.teamIDMutex.RUnlock()
 	fake.teamNameMutex.RLock()
 	defer fake.teamNameMutex.RUnlock()
+	fake.timeToCheckMutex.RLock()
+	defer fake.timeToCheckMutex.RUnlock()
 	fake.typeMutex.RLock()
 	defer fake.typeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/db/dbfakes/fake_prototype.go
+++ b/atc/db/dbfakes/fake_prototype.go
@@ -4,7 +4,6 @@ package dbfakes
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
@@ -120,26 +119,6 @@ type FakePrototype struct {
 	}
 	iDReturnsOnCall map[int]struct {
 		result1 int
-	}
-	LastCheckEndTimeStub        func() time.Time
-	lastCheckEndTimeMutex       sync.RWMutex
-	lastCheckEndTimeArgsForCall []struct {
-	}
-	lastCheckEndTimeReturns struct {
-		result1 time.Time
-	}
-	lastCheckEndTimeReturnsOnCall map[int]struct {
-		result1 time.Time
-	}
-	LastCheckStartTimeStub        func() time.Time
-	lastCheckStartTimeMutex       sync.RWMutex
-	lastCheckStartTimeArgsForCall []struct {
-	}
-	lastCheckStartTimeReturns struct {
-		result1 time.Time
-	}
-	lastCheckStartTimeReturnsOnCall map[int]struct {
-		result1 time.Time
 	}
 	NameStub        func() string
 	nameMutex       sync.RWMutex
@@ -307,6 +286,16 @@ type FakePrototype struct {
 	}
 	teamNameReturnsOnCall map[int]struct {
 		result1 string
+	}
+	TimeToCheckStub        func() bool
+	timeToCheckMutex       sync.RWMutex
+	timeToCheckArgsForCall []struct {
+	}
+	timeToCheckReturns struct {
+		result1 bool
+	}
+	timeToCheckReturnsOnCall map[int]struct {
+		result1 bool
 	}
 	TypeStub        func() string
 	typeMutex       sync.RWMutex
@@ -849,112 +838,6 @@ func (fake *FakePrototype) IDReturnsOnCall(i int, result1 int) {
 	}
 	fake.iDReturnsOnCall[i] = struct {
 		result1 int
-	}{result1}
-}
-
-func (fake *FakePrototype) LastCheckEndTime() time.Time {
-	fake.lastCheckEndTimeMutex.Lock()
-	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
-	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
-	}{})
-	stub := fake.LastCheckEndTimeStub
-	fakeReturns := fake.lastCheckEndTimeReturns
-	fake.recordInvocation("LastCheckEndTime", []interface{}{})
-	fake.lastCheckEndTimeMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakePrototype) LastCheckEndTimeCallCount() int {
-	fake.lastCheckEndTimeMutex.RLock()
-	defer fake.lastCheckEndTimeMutex.RUnlock()
-	return len(fake.lastCheckEndTimeArgsForCall)
-}
-
-func (fake *FakePrototype) LastCheckEndTimeCalls(stub func() time.Time) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = stub
-}
-
-func (fake *FakePrototype) LastCheckEndTimeReturns(result1 time.Time) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = nil
-	fake.lastCheckEndTimeReturns = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakePrototype) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = nil
-	if fake.lastCheckEndTimeReturnsOnCall == nil {
-		fake.lastCheckEndTimeReturnsOnCall = make(map[int]struct {
-			result1 time.Time
-		})
-	}
-	fake.lastCheckEndTimeReturnsOnCall[i] = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakePrototype) LastCheckStartTime() time.Time {
-	fake.lastCheckStartTimeMutex.Lock()
-	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
-	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
-	}{})
-	stub := fake.LastCheckStartTimeStub
-	fakeReturns := fake.lastCheckStartTimeReturns
-	fake.recordInvocation("LastCheckStartTime", []interface{}{})
-	fake.lastCheckStartTimeMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakePrototype) LastCheckStartTimeCallCount() int {
-	fake.lastCheckStartTimeMutex.RLock()
-	defer fake.lastCheckStartTimeMutex.RUnlock()
-	return len(fake.lastCheckStartTimeArgsForCall)
-}
-
-func (fake *FakePrototype) LastCheckStartTimeCalls(stub func() time.Time) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = stub
-}
-
-func (fake *FakePrototype) LastCheckStartTimeReturns(result1 time.Time) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = nil
-	fake.lastCheckStartTimeReturns = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakePrototype) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = nil
-	if fake.lastCheckStartTimeReturnsOnCall == nil {
-		fake.lastCheckStartTimeReturnsOnCall = make(map[int]struct {
-			result1 time.Time
-		})
-	}
-	fake.lastCheckStartTimeReturnsOnCall[i] = struct {
-		result1 time.Time
 	}{result1}
 }
 
@@ -1823,6 +1706,59 @@ func (fake *FakePrototype) TeamNameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakePrototype) TimeToCheck() bool {
+	fake.timeToCheckMutex.Lock()
+	ret, specificReturn := fake.timeToCheckReturnsOnCall[len(fake.timeToCheckArgsForCall)]
+	fake.timeToCheckArgsForCall = append(fake.timeToCheckArgsForCall, struct {
+	}{})
+	stub := fake.TimeToCheckStub
+	fakeReturns := fake.timeToCheckReturns
+	fake.recordInvocation("TimeToCheck", []interface{}{})
+	fake.timeToCheckMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePrototype) TimeToCheckCallCount() int {
+	fake.timeToCheckMutex.RLock()
+	defer fake.timeToCheckMutex.RUnlock()
+	return len(fake.timeToCheckArgsForCall)
+}
+
+func (fake *FakePrototype) TimeToCheckCalls(stub func() bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = stub
+}
+
+func (fake *FakePrototype) TimeToCheckReturns(result1 bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = nil
+	fake.timeToCheckReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakePrototype) TimeToCheckReturnsOnCall(i int, result1 bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = nil
+	if fake.timeToCheckReturnsOnCall == nil {
+		fake.timeToCheckReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.timeToCheckReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakePrototype) Type() string {
 	fake.typeMutex.Lock()
 	ret, specificReturn := fake.typeReturnsOnCall[len(fake.typeArgsForCall)]
@@ -1950,10 +1886,6 @@ func (fake *FakePrototype) Invocations() map[string][][]interface{} {
 	defer fake.hasWebhookMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
-	fake.lastCheckEndTimeMutex.RLock()
-	defer fake.lastCheckEndTimeMutex.RUnlock()
-	fake.lastCheckStartTimeMutex.RLock()
-	defer fake.lastCheckStartTimeMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
 	fake.paramsMutex.RLock()
@@ -1986,6 +1918,8 @@ func (fake *FakePrototype) Invocations() map[string][][]interface{} {
 	defer fake.teamIDMutex.RUnlock()
 	fake.teamNameMutex.RLock()
 	defer fake.teamNameMutex.RUnlock()
+	fake.timeToCheckMutex.RLock()
+	defer fake.timeToCheckMutex.RUnlock()
 	fake.typeMutex.RLock()
 	defer fake.typeMutex.RUnlock()
 	fake.versionMutex.RLock()

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -247,6 +247,16 @@ type FakeResource struct {
 	lastCheckStartTimeReturnsOnCall map[int]struct {
 		result1 time.Time
 	}
+	LastUpdatedTimeStub        func() time.Time
+	lastUpdatedTimeMutex       sync.RWMutex
+	lastUpdatedTimeArgsForCall []struct {
+	}
+	lastUpdatedTimeReturns struct {
+		result1 time.Time
+	}
+	lastUpdatedTimeReturnsOnCall map[int]struct {
+		result1 time.Time
+	}
 	NameStub        func() string
 	nameMutex       sync.RWMutex
 	nameArgsForCall []struct {
@@ -1673,6 +1683,59 @@ func (fake *FakeResource) LastCheckStartTimeReturnsOnCall(i int, result1 time.Ti
 	}{result1}
 }
 
+func (fake *FakeResource) LastUpdatedTime() time.Time {
+	fake.lastUpdatedTimeMutex.Lock()
+	ret, specificReturn := fake.lastUpdatedTimeReturnsOnCall[len(fake.lastUpdatedTimeArgsForCall)]
+	fake.lastUpdatedTimeArgsForCall = append(fake.lastUpdatedTimeArgsForCall, struct {
+	}{})
+	stub := fake.LastUpdatedTimeStub
+	fakeReturns := fake.lastUpdatedTimeReturns
+	fake.recordInvocation("LastUpdatedTime", []interface{}{})
+	fake.lastUpdatedTimeMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeResource) LastUpdatedTimeCallCount() int {
+	fake.lastUpdatedTimeMutex.RLock()
+	defer fake.lastUpdatedTimeMutex.RUnlock()
+	return len(fake.lastUpdatedTimeArgsForCall)
+}
+
+func (fake *FakeResource) LastUpdatedTimeCalls(stub func() time.Time) {
+	fake.lastUpdatedTimeMutex.Lock()
+	defer fake.lastUpdatedTimeMutex.Unlock()
+	fake.LastUpdatedTimeStub = stub
+}
+
+func (fake *FakeResource) LastUpdatedTimeReturns(result1 time.Time) {
+	fake.lastUpdatedTimeMutex.Lock()
+	defer fake.lastUpdatedTimeMutex.Unlock()
+	fake.LastUpdatedTimeStub = nil
+	fake.lastUpdatedTimeReturns = struct {
+		result1 time.Time
+	}{result1}
+}
+
+func (fake *FakeResource) LastUpdatedTimeReturnsOnCall(i int, result1 time.Time) {
+	fake.lastUpdatedTimeMutex.Lock()
+	defer fake.lastUpdatedTimeMutex.Unlock()
+	fake.LastUpdatedTimeStub = nil
+	if fake.lastUpdatedTimeReturnsOnCall == nil {
+		fake.lastUpdatedTimeReturnsOnCall = make(map[int]struct {
+			result1 time.Time
+		})
+	}
+	fake.lastUpdatedTimeReturnsOnCall[i] = struct {
+		result1 time.Time
+	}{result1}
+}
+
 func (fake *FakeResource) Name() string {
 	fake.nameMutex.Lock()
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
@@ -3054,6 +3117,8 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.lastCheckEndTimeMutex.RUnlock()
 	fake.lastCheckStartTimeMutex.RLock()
 	defer fake.lastCheckStartTimeMutex.RUnlock()
+	fake.lastUpdatedTimeMutex.RLock()
+	defer fake.lastUpdatedTimeMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
 	fake.notifyScanMutex.RLock()

--- a/atc/db/dbfakes/fake_resource.go
+++ b/atc/db/dbfakes/fake_resource.go
@@ -237,26 +237,6 @@ type FakeResource struct {
 	lastCheckEndTimeReturnsOnCall map[int]struct {
 		result1 time.Time
 	}
-	LastCheckStartTimeStub        func() time.Time
-	lastCheckStartTimeMutex       sync.RWMutex
-	lastCheckStartTimeArgsForCall []struct {
-	}
-	lastCheckStartTimeReturns struct {
-		result1 time.Time
-	}
-	lastCheckStartTimeReturnsOnCall map[int]struct {
-		result1 time.Time
-	}
-	LastUpdatedTimeStub        func() time.Time
-	lastUpdatedTimeMutex       sync.RWMutex
-	lastUpdatedTimeArgsForCall []struct {
-	}
-	lastUpdatedTimeReturns struct {
-		result1 time.Time
-	}
-	lastUpdatedTimeReturnsOnCall map[int]struct {
-		result1 time.Time
-	}
 	NameStub        func() string
 	nameMutex       sync.RWMutex
 	nameArgsForCall []struct {
@@ -457,6 +437,16 @@ type FakeResource struct {
 	}
 	teamNameReturnsOnCall map[int]struct {
 		result1 string
+	}
+	TimeToCheckStub        func() bool
+	timeToCheckMutex       sync.RWMutex
+	timeToCheckArgsForCall []struct {
+	}
+	timeToCheckReturns struct {
+		result1 bool
+	}
+	timeToCheckReturnsOnCall map[int]struct {
+		result1 bool
 	}
 	TypeStub        func() string
 	typeMutex       sync.RWMutex
@@ -1630,112 +1620,6 @@ func (fake *FakeResource) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time
 	}{result1}
 }
 
-func (fake *FakeResource) LastCheckStartTime() time.Time {
-	fake.lastCheckStartTimeMutex.Lock()
-	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
-	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
-	}{})
-	stub := fake.LastCheckStartTimeStub
-	fakeReturns := fake.lastCheckStartTimeReturns
-	fake.recordInvocation("LastCheckStartTime", []interface{}{})
-	fake.lastCheckStartTimeMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeResource) LastCheckStartTimeCallCount() int {
-	fake.lastCheckStartTimeMutex.RLock()
-	defer fake.lastCheckStartTimeMutex.RUnlock()
-	return len(fake.lastCheckStartTimeArgsForCall)
-}
-
-func (fake *FakeResource) LastCheckStartTimeCalls(stub func() time.Time) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = stub
-}
-
-func (fake *FakeResource) LastCheckStartTimeReturns(result1 time.Time) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = nil
-	fake.lastCheckStartTimeReturns = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakeResource) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = nil
-	if fake.lastCheckStartTimeReturnsOnCall == nil {
-		fake.lastCheckStartTimeReturnsOnCall = make(map[int]struct {
-			result1 time.Time
-		})
-	}
-	fake.lastCheckStartTimeReturnsOnCall[i] = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakeResource) LastUpdatedTime() time.Time {
-	fake.lastUpdatedTimeMutex.Lock()
-	ret, specificReturn := fake.lastUpdatedTimeReturnsOnCall[len(fake.lastUpdatedTimeArgsForCall)]
-	fake.lastUpdatedTimeArgsForCall = append(fake.lastUpdatedTimeArgsForCall, struct {
-	}{})
-	stub := fake.LastUpdatedTimeStub
-	fakeReturns := fake.lastUpdatedTimeReturns
-	fake.recordInvocation("LastUpdatedTime", []interface{}{})
-	fake.lastUpdatedTimeMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeResource) LastUpdatedTimeCallCount() int {
-	fake.lastUpdatedTimeMutex.RLock()
-	defer fake.lastUpdatedTimeMutex.RUnlock()
-	return len(fake.lastUpdatedTimeArgsForCall)
-}
-
-func (fake *FakeResource) LastUpdatedTimeCalls(stub func() time.Time) {
-	fake.lastUpdatedTimeMutex.Lock()
-	defer fake.lastUpdatedTimeMutex.Unlock()
-	fake.LastUpdatedTimeStub = stub
-}
-
-func (fake *FakeResource) LastUpdatedTimeReturns(result1 time.Time) {
-	fake.lastUpdatedTimeMutex.Lock()
-	defer fake.lastUpdatedTimeMutex.Unlock()
-	fake.LastUpdatedTimeStub = nil
-	fake.lastUpdatedTimeReturns = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakeResource) LastUpdatedTimeReturnsOnCall(i int, result1 time.Time) {
-	fake.lastUpdatedTimeMutex.Lock()
-	defer fake.lastUpdatedTimeMutex.Unlock()
-	fake.LastUpdatedTimeStub = nil
-	if fake.lastUpdatedTimeReturnsOnCall == nil {
-		fake.lastUpdatedTimeReturnsOnCall = make(map[int]struct {
-			result1 time.Time
-		})
-	}
-	fake.lastUpdatedTimeReturnsOnCall[i] = struct {
-		result1 time.Time
-	}{result1}
-}
-
 func (fake *FakeResource) Name() string {
 	fake.nameMutex.Lock()
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
@@ -2779,6 +2663,59 @@ func (fake *FakeResource) TeamNameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakeResource) TimeToCheck() bool {
+	fake.timeToCheckMutex.Lock()
+	ret, specificReturn := fake.timeToCheckReturnsOnCall[len(fake.timeToCheckArgsForCall)]
+	fake.timeToCheckArgsForCall = append(fake.timeToCheckArgsForCall, struct {
+	}{})
+	stub := fake.TimeToCheckStub
+	fakeReturns := fake.timeToCheckReturns
+	fake.recordInvocation("TimeToCheck", []interface{}{})
+	fake.timeToCheckMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeResource) TimeToCheckCallCount() int {
+	fake.timeToCheckMutex.RLock()
+	defer fake.timeToCheckMutex.RUnlock()
+	return len(fake.timeToCheckArgsForCall)
+}
+
+func (fake *FakeResource) TimeToCheckCalls(stub func() bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = stub
+}
+
+func (fake *FakeResource) TimeToCheckReturns(result1 bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = nil
+	fake.timeToCheckReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeResource) TimeToCheckReturnsOnCall(i int, result1 bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = nil
+	if fake.timeToCheckReturnsOnCall == nil {
+		fake.timeToCheckReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.timeToCheckReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakeResource) Type() string {
 	fake.typeMutex.Lock()
 	ret, specificReturn := fake.typeReturnsOnCall[len(fake.typeArgsForCall)]
@@ -3115,10 +3052,6 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.iconMutex.RUnlock()
 	fake.lastCheckEndTimeMutex.RLock()
 	defer fake.lastCheckEndTimeMutex.RUnlock()
-	fake.lastCheckStartTimeMutex.RLock()
-	defer fake.lastCheckStartTimeMutex.RUnlock()
-	fake.lastUpdatedTimeMutex.RLock()
-	defer fake.lastUpdatedTimeMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
 	fake.notifyScanMutex.RLock()
@@ -3157,6 +3090,8 @@ func (fake *FakeResource) Invocations() map[string][][]interface{} {
 	defer fake.teamIDMutex.RUnlock()
 	fake.teamNameMutex.RLock()
 	defer fake.teamNameMutex.RUnlock()
+	fake.timeToCheckMutex.RLock()
+	defer fake.timeToCheckMutex.RUnlock()
 	fake.typeMutex.RLock()
 	defer fake.typeMutex.RUnlock()
 	fake.unpinVersionMutex.RLock()

--- a/atc/db/dbfakes/fake_resource_type.go
+++ b/atc/db/dbfakes/fake_resource_type.go
@@ -4,7 +4,6 @@ package dbfakes
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
@@ -120,26 +119,6 @@ type FakeResourceType struct {
 	}
 	iDReturnsOnCall map[int]struct {
 		result1 int
-	}
-	LastCheckEndTimeStub        func() time.Time
-	lastCheckEndTimeMutex       sync.RWMutex
-	lastCheckEndTimeArgsForCall []struct {
-	}
-	lastCheckEndTimeReturns struct {
-		result1 time.Time
-	}
-	lastCheckEndTimeReturnsOnCall map[int]struct {
-		result1 time.Time
-	}
-	LastCheckStartTimeStub        func() time.Time
-	lastCheckStartTimeMutex       sync.RWMutex
-	lastCheckStartTimeArgsForCall []struct {
-	}
-	lastCheckStartTimeReturns struct {
-		result1 time.Time
-	}
-	lastCheckStartTimeReturnsOnCall map[int]struct {
-		result1 time.Time
 	}
 	NameStub        func() string
 	nameMutex       sync.RWMutex
@@ -307,6 +286,16 @@ type FakeResourceType struct {
 	}
 	teamNameReturnsOnCall map[int]struct {
 		result1 string
+	}
+	TimeToCheckStub        func() bool
+	timeToCheckMutex       sync.RWMutex
+	timeToCheckArgsForCall []struct {
+	}
+	timeToCheckReturns struct {
+		result1 bool
+	}
+	timeToCheckReturnsOnCall map[int]struct {
+		result1 bool
 	}
 	TypeStub        func() string
 	typeMutex       sync.RWMutex
@@ -839,112 +828,6 @@ func (fake *FakeResourceType) IDReturnsOnCall(i int, result1 int) {
 	}
 	fake.iDReturnsOnCall[i] = struct {
 		result1 int
-	}{result1}
-}
-
-func (fake *FakeResourceType) LastCheckEndTime() time.Time {
-	fake.lastCheckEndTimeMutex.Lock()
-	ret, specificReturn := fake.lastCheckEndTimeReturnsOnCall[len(fake.lastCheckEndTimeArgsForCall)]
-	fake.lastCheckEndTimeArgsForCall = append(fake.lastCheckEndTimeArgsForCall, struct {
-	}{})
-	stub := fake.LastCheckEndTimeStub
-	fakeReturns := fake.lastCheckEndTimeReturns
-	fake.recordInvocation("LastCheckEndTime", []interface{}{})
-	fake.lastCheckEndTimeMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeResourceType) LastCheckEndTimeCallCount() int {
-	fake.lastCheckEndTimeMutex.RLock()
-	defer fake.lastCheckEndTimeMutex.RUnlock()
-	return len(fake.lastCheckEndTimeArgsForCall)
-}
-
-func (fake *FakeResourceType) LastCheckEndTimeCalls(stub func() time.Time) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = stub
-}
-
-func (fake *FakeResourceType) LastCheckEndTimeReturns(result1 time.Time) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = nil
-	fake.lastCheckEndTimeReturns = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakeResourceType) LastCheckEndTimeReturnsOnCall(i int, result1 time.Time) {
-	fake.lastCheckEndTimeMutex.Lock()
-	defer fake.lastCheckEndTimeMutex.Unlock()
-	fake.LastCheckEndTimeStub = nil
-	if fake.lastCheckEndTimeReturnsOnCall == nil {
-		fake.lastCheckEndTimeReturnsOnCall = make(map[int]struct {
-			result1 time.Time
-		})
-	}
-	fake.lastCheckEndTimeReturnsOnCall[i] = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakeResourceType) LastCheckStartTime() time.Time {
-	fake.lastCheckStartTimeMutex.Lock()
-	ret, specificReturn := fake.lastCheckStartTimeReturnsOnCall[len(fake.lastCheckStartTimeArgsForCall)]
-	fake.lastCheckStartTimeArgsForCall = append(fake.lastCheckStartTimeArgsForCall, struct {
-	}{})
-	stub := fake.LastCheckStartTimeStub
-	fakeReturns := fake.lastCheckStartTimeReturns
-	fake.recordInvocation("LastCheckStartTime", []interface{}{})
-	fake.lastCheckStartTimeMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeResourceType) LastCheckStartTimeCallCount() int {
-	fake.lastCheckStartTimeMutex.RLock()
-	defer fake.lastCheckStartTimeMutex.RUnlock()
-	return len(fake.lastCheckStartTimeArgsForCall)
-}
-
-func (fake *FakeResourceType) LastCheckStartTimeCalls(stub func() time.Time) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = stub
-}
-
-func (fake *FakeResourceType) LastCheckStartTimeReturns(result1 time.Time) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = nil
-	fake.lastCheckStartTimeReturns = struct {
-		result1 time.Time
-	}{result1}
-}
-
-func (fake *FakeResourceType) LastCheckStartTimeReturnsOnCall(i int, result1 time.Time) {
-	fake.lastCheckStartTimeMutex.Lock()
-	defer fake.lastCheckStartTimeMutex.Unlock()
-	fake.LastCheckStartTimeStub = nil
-	if fake.lastCheckStartTimeReturnsOnCall == nil {
-		fake.lastCheckStartTimeReturnsOnCall = make(map[int]struct {
-			result1 time.Time
-		})
-	}
-	fake.lastCheckStartTimeReturnsOnCall[i] = struct {
-		result1 time.Time
 	}{result1}
 }
 
@@ -1813,6 +1696,59 @@ func (fake *FakeResourceType) TeamNameReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakeResourceType) TimeToCheck() bool {
+	fake.timeToCheckMutex.Lock()
+	ret, specificReturn := fake.timeToCheckReturnsOnCall[len(fake.timeToCheckArgsForCall)]
+	fake.timeToCheckArgsForCall = append(fake.timeToCheckArgsForCall, struct {
+	}{})
+	stub := fake.TimeToCheckStub
+	fakeReturns := fake.timeToCheckReturns
+	fake.recordInvocation("TimeToCheck", []interface{}{})
+	fake.timeToCheckMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeResourceType) TimeToCheckCallCount() int {
+	fake.timeToCheckMutex.RLock()
+	defer fake.timeToCheckMutex.RUnlock()
+	return len(fake.timeToCheckArgsForCall)
+}
+
+func (fake *FakeResourceType) TimeToCheckCalls(stub func() bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = stub
+}
+
+func (fake *FakeResourceType) TimeToCheckReturns(result1 bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = nil
+	fake.timeToCheckReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeResourceType) TimeToCheckReturnsOnCall(i int, result1 bool) {
+	fake.timeToCheckMutex.Lock()
+	defer fake.timeToCheckMutex.Unlock()
+	fake.TimeToCheckStub = nil
+	if fake.timeToCheckReturnsOnCall == nil {
+		fake.timeToCheckReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.timeToCheckReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakeResourceType) Type() string {
 	fake.typeMutex.Lock()
 	ret, specificReturn := fake.typeReturnsOnCall[len(fake.typeArgsForCall)]
@@ -1887,10 +1823,6 @@ func (fake *FakeResourceType) Invocations() map[string][][]interface{} {
 	defer fake.hasWebhookMutex.RUnlock()
 	fake.iDMutex.RLock()
 	defer fake.iDMutex.RUnlock()
-	fake.lastCheckEndTimeMutex.RLock()
-	defer fake.lastCheckEndTimeMutex.RUnlock()
-	fake.lastCheckStartTimeMutex.RLock()
-	defer fake.lastCheckStartTimeMutex.RUnlock()
 	fake.nameMutex.RLock()
 	defer fake.nameMutex.RUnlock()
 	fake.paramsMutex.RLock()
@@ -1923,6 +1855,8 @@ func (fake *FakeResourceType) Invocations() map[string][][]interface{} {
 	defer fake.teamIDMutex.RUnlock()
 	fake.teamNameMutex.RLock()
 	defer fake.teamNameMutex.RUnlock()
+	fake.timeToCheckMutex.RLock()
+	defer fake.timeToCheckMutex.RUnlock()
 	fake.typeMutex.RLock()
 	defer fake.typeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/db/prototype.go
+++ b/atc/db/prototype.go
@@ -32,8 +32,7 @@ type Prototype interface {
 	Tags() atc.Tags
 	CheckEvery() *atc.CheckEvery
 	CheckTimeout() string
-	LastCheckStartTime() time.Time
-	LastCheckEndTime() time.Time
+	TimeToCheck() bool
 	CurrentPinnedVersion() atc.Version
 	ResourceConfigID() int
 	ResourceConfigScopeID() int
@@ -125,27 +124,31 @@ type prototype struct {
 	lastCheckEndTime      time.Time
 }
 
-func (p *prototype) ID() int                       { return p.id }
-func (p *prototype) TeamID() int                   { return p.teamID }
-func (p *prototype) TeamName() string              { return p.teamName }
-func (p *prototype) Name() string                  { return p.name }
-func (p *prototype) Type() string                  { return p.type_ }
-func (p *prototype) Privileged() bool              { return p.privileged }
-func (p *prototype) CheckEvery() *atc.CheckEvery   { return p.checkEvery }
-func (p *prototype) CheckTimeout() string          { return "" }
-func (p *prototype) LastCheckStartTime() time.Time { return p.lastCheckStartTime }
-func (p *prototype) LastCheckEndTime() time.Time   { return p.lastCheckEndTime }
-func (p *prototype) Source() atc.Source            { return p.source }
-func (p *prototype) Defaults() atc.Source          { return p.defaults }
-func (p *prototype) Params() atc.Params            { return p.params }
-func (p *prototype) Tags() atc.Tags                { return p.tags }
-func (p *prototype) ResourceConfigID() int         { return p.resourceConfigID }
-func (p *prototype) ResourceConfigScopeID() int    { return p.resourceConfigScopeID }
+func (p *prototype) ID() int                     { return p.id }
+func (p *prototype) TeamID() int                 { return p.teamID }
+func (p *prototype) TeamName() string            { return p.teamName }
+func (p *prototype) Name() string                { return p.name }
+func (p *prototype) Type() string                { return p.type_ }
+func (p *prototype) Privileged() bool            { return p.privileged }
+func (p *prototype) CheckEvery() *atc.CheckEvery { return p.checkEvery }
+func (p *prototype) CheckTimeout() string        { return "" }
+func (p *prototype) Source() atc.Source          { return p.source }
+func (p *prototype) Defaults() atc.Source        { return p.defaults }
+func (p *prototype) Params() atc.Params          { return p.params }
+func (p *prototype) Tags() atc.Tags              { return p.tags }
+func (p *prototype) ResourceConfigID() int       { return p.resourceConfigID }
+func (p *prototype) ResourceConfigScopeID() int  { return p.resourceConfigScopeID }
 
 func (p *prototype) Version() atc.Version              { return p.version }
 func (p *prototype) CurrentPinnedVersion() atc.Version { return nil }
 
 func (p *prototype) HasWebhook() bool { return false }
+
+// FIXME: as prototype is not finished, Lidar doesn't check prototype yet,
+// here just returns false.
+func (p *prototype) TimeToCheck() bool {
+	return false
+}
 
 func newEmptyPrototype(conn Conn, lockFactory lock.LockFactory) *prototype {
 	return &prototype{pipelineRef: pipelineRef{conn: conn, lockFactory: lockFactory}}

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -77,6 +77,7 @@ type Resource interface {
 	Source() atc.Source
 	CheckEvery() *atc.CheckEvery
 	CheckTimeout() string
+	LastUpdatedTime() time.Time
 	LastCheckStartTime() time.Time
 	LastCheckEndTime() time.Time
 	Tags() atc.Tags
@@ -138,6 +139,7 @@ var (
 		"r.resource_config_scope_id",
 		"p.name",
 		"p.instance_vars",
+		"p.last_updated",
 		"t.id",
 		"t.name",
 		"rp.version",
@@ -163,6 +165,7 @@ type resource struct {
 	teamID                int
 	teamName              string
 	type_                 string
+	lastUpdatedTime       time.Time
 	lastCheckStartTime    time.Time
 	lastCheckEndTime      time.Time
 	config                atc.ResourceConfig
@@ -215,6 +218,7 @@ func (r *resource) Type() string                     { return r.type_ }
 func (r *resource) Source() atc.Source               { return r.config.Source }
 func (r *resource) CheckEvery() *atc.CheckEvery      { return r.config.CheckEvery }
 func (r *resource) CheckTimeout() string             { return r.config.CheckTimeout }
+func (r *resource) LastUpdatedTime() time.Time       { return r.lastUpdatedTime }
 func (r *resource) LastCheckStartTime() time.Time    { return r.lastCheckStartTime }
 func (r *resource) LastCheckEndTime() time.Time      { return r.lastCheckEndTime }
 func (r *resource) Tags() atc.Tags                   { return r.config.Tags }
@@ -846,7 +850,7 @@ func scanResource(r *resource, row scannable) error {
 	err := row.Scan(&r.id, &r.name, &r.type_, &configBlob, &buildData.lastCheckStartTime,
 		&buildData.lastCheckEndTime, &buildData.lastCheckBuildId, &buildData.lastCheckSucceeded, &buildData.lastCheckBuildPlan,
 		&r.pipelineID, &nonce, &rcID, &rcScopeID,
-		&r.pipelineName, &pipelineInstanceVars, &r.teamID, &r.teamName,
+		&r.pipelineName, &pipelineInstanceVars, &r.lastUpdatedTime, &r.teamID, &r.teamName,
 		&pinnedVersion, &pinComment, &pinnedThroughConfig,
 		&buildData.inMemoryBuildId, &buildData.inMemoryBuildStartTime, &buildData.inMemoryBuildPlan)
 	if err != nil {

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -77,8 +77,6 @@ type Resource interface {
 	Source() atc.Source
 	CheckEvery() *atc.CheckEvery
 	CheckTimeout() string
-	//LastUpdatedTime() time.Time
-	//LastCheckStartTime() time.Time
 	LastCheckEndTime() time.Time
 	TimeToCheck() bool
 	Tags() atc.Tags

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -303,7 +303,6 @@ var _ = Describe("Resource Config Scope", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("updates last check start time", func() {
-			lastTime := scenario.Resource("some-resource").LastCheckEndTime()
 			publicPlan := atc.Plan{
 				ID: atc.PlanID("1234"),
 				Check: &atc.CheckPlan{
@@ -316,8 +315,6 @@ var _ = Describe("Resource Config Scope", func() {
 			updated, err := resourceScope.UpdateLastCheckStartTime(99, &jr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated).To(BeTrue())
-
-			Expect(scenario.Resource("some-resource").LastCheckStartTime()).To(BeTemporally(">", lastTime))
 
 			buildSummary := scenario.Resource("some-resource").BuildSummary()
 			Expect(buildSummary.ID).To(Equal(99))

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -150,7 +150,6 @@ var _ = Describe("Resource", func() {
 				Expect(scenario.Resource("some-resource").Name()).To(Equal("some-resource"))
 				Expect(scenario.Resource("some-resource").Type()).To(Equal("some-base-resource-type"))
 				Expect(scenario.Resource("some-resource").Source()).To(Equal(atc.Source{"some": "repository"}))
-				Expect(scenario.Resource("some-resource").LastUpdatedTime()).To(Equal(scenario.Pipeline.LastUpdated()))
 			})
 
 			Context("when the resource has check build", func() {
@@ -184,7 +183,6 @@ var _ = Describe("Resource", func() {
 				})
 
 				It("return check build info", func() {
-					Expect(scenario.Resource("some-resource").LastCheckStartTime()).Should(BeTemporally("~", time.Now(), time.Second))
 					Expect(scenario.Resource("some-resource").LastCheckEndTime()).Should(BeTemporally("~", time.Now(), time.Second))
 
 				})

--- a/atc/db/resource_test.go
+++ b/atc/db/resource_test.go
@@ -150,6 +150,7 @@ var _ = Describe("Resource", func() {
 				Expect(scenario.Resource("some-resource").Name()).To(Equal("some-resource"))
 				Expect(scenario.Resource("some-resource").Type()).To(Equal("some-base-resource-type"))
 				Expect(scenario.Resource("some-resource").Source()).To(Equal(atc.Source{"some": "repository"}))
+				Expect(scenario.Resource("some-resource").LastUpdatedTime()).To(Equal(scenario.Pipeline.LastUpdated()))
 			})
 
 			Context("when the resource has check build", func() {

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -154,10 +154,13 @@ var resourceTypesQuery = psql.Select(
 	"t.id",
 	"t.name",
 	"r.resource_config_id",
+	"ro.id",
 ).
 	From("resource_types r").
 	Join("pipelines p ON p.id = r.pipeline_id").
 	Join("teams t ON t.id = p.team_id").
+	LeftJoin("resource_configs c ON c.id = r.resource_config_id").
+	LeftJoin("resource_config_scopes ro ON ro.resource_config_id = c.id").
 	Where(sq.Eq{"r.active": true})
 
 type resourceType struct {
@@ -335,7 +338,7 @@ func scanResourceType(t *resourceType, row scannable) error {
 
 	err := row.Scan(&t.id, &t.pipelineID, &t.name, &t.type_, &configJSON,
 		&nonce, &t.pipelineName, &pipelineInstanceVars,
-		&t.teamID, &t.teamName, &resourceConfigID)
+		&t.teamID, &t.teamName, &resourceConfigID, &rcsID)
 	if err != nil {
 		return err
 	}

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -3,13 +3,14 @@ package lidar
 import (
 	"code.cloudfoundry.org/lager/lagerctx"
 	"context"
+	"strconv"
+	"sync"
+
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/metric"
 	"github.com/concourse/concourse/atc/util"
 	"github.com/concourse/concourse/tracing"
-	"strconv"
-	"sync"
 )
 
 func NewScanner(checkFactory db.CheckFactory, planFactory atc.PlanFactory) *scanner {

--- a/atc/lidar/scanner_test.go
+++ b/atc/lidar/scanner_test.go
@@ -3,6 +3,7 @@ package lidar_test
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
@@ -171,6 +172,22 @@ var _ = Describe("Scanner", func() {
 						Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(1),
 							"one check created for the unrelated fakeResource")
 					})
+				})
+			})
+
+			Context("when resource doesn't reach to next check time", func(){
+				BeforeEach(func(){
+					now := time.Now()
+					fakeResource.LastUpdatedTimeReturns(now.Add(-10*time.Second))
+					fakeResource.LastCheckStartTimeReturns(now.Add(-5*time.Second))
+					fakeResource.LastCheckEndTimeReturns(now.Add(-4*time.Second))
+					fakeResource.CheckEveryReturns(&atc.CheckEvery{
+						Interval: time.Minute,
+					})
+				})
+
+				It("does not create check", func() {
+					Expect(fakeCheckFactory.TryCreateCheckCallCount()).To(Equal(0))
 				})
 			})
 		})

--- a/go.mod
+++ b/go.mod
@@ -167,6 +167,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/onsi/ginkgo/v2 v2.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/selinux v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -810,8 +810,9 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.0.0 h1:CcuG/HvWNkkaqCUpJifQY8z7qEMBJya6aLPx6ftGyjQ=
 github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
+github.com/onsi/ginkgo/v2 v2.1.1 h1:LCnPB85AvFNr91s0B2aDzEiiIg6MUwLYbryC1NSlWi8=
+github.com/onsi/ginkgo/v2 v2.1.1/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -1110,7 +1111,6 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 h1:71vQrMauZZhcTVK6KdYM+rklehEEwb3E+ZhaE5jrPrE=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1210,6 +1210,7 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210716203947-853a461950ff/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=


### PR DESCRIPTION
## Changes proposed by this PR

This is derived from #7991. Instead of putting everything in a messy PR, I decided to wrap each piece of enhancement into a separate PR.

This PR reduced total count of Lidar checks by pulling check-interval test to earlier before creating a check go-routine.

The reason why testing check-interval is placed inside `checkDelegate.WaitToRun()` is because resource config scope is needed. 

This PR is based a theory that if a resource is not updated, then it's resource config scope will not be changed. If a pipeline is not updated, then resources of the pipeline will not be updated. In Lidar scanner, if a resource is not updated, and it doesn't reach to next check time, then skip the resource.

This enhancement will save huge amount of unnecessary checks (go-routines, db locks, etc.)

* [x] code changes
* [x] add tests

## Notes to reviewer

NA

## Release Note

Enhanced Lidar to reduce checks so that improved ATC performance.