### PR TITLE
Change nested checks to reuse check containers

### DIFF
--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -125,7 +125,7 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 	interval := d.plan.Interval.Interval
 
 	var lock lock.Lock = lock.NoopLock{}
-	if d.plan.IsPeriodic() {
+	if d.build.Name() == db.CheckBuildName {
 		for {
 			run, err := d.shouldPeriodicCheckRun(scope, interval)
 			if err != nil {

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -381,6 +381,7 @@ var _ = Describe("CheckDelegate", func() {
 
 		Context("when not running for a resource", func() {
 			BeforeEach(func() {
+				fakeBuild.NameReturns("1")
 				plan.Check.Resource = ""
 			})
 

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -136,11 +136,9 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 	// Point scope to resource before check runs. Because a resource's check build
 	// summary is associated with scope, only after pointing to scope, check status
 	// can be fetched.
-	if step.plan.Resource != "" {
-		err = delegate.PointToCheckedConfig(scope)
-		if err != nil {
-			return false, fmt.Errorf("update resource config scope: %w", err)
-		}
+	err = delegate.PointToCheckedConfig(scope)
+	if err != nil {
+		return false, fmt.Errorf("update resource config scope: %w", err)
 	}
 
 	lock, run, err := delegate.WaitToRun(ctx, scope)

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -462,6 +462,7 @@ var _ = Describe("CheckStep", func() {
 				Context("when the plan is nested", func() {
 					BeforeEach(func() {
 						checkPlan.Resource = ""
+						checkPlan.ResourceType = "some-resource-type"
 
 						expectedOwner = db.NewBuildStepContainerOwner(
 							501,
@@ -485,8 +486,8 @@ var _ = Describe("CheckStep", func() {
 						fakePool.FindOrSelectWorkerReturns(chosenWorker, nil)
 					})
 
-					It("not points the resource or resource type to the scope", func() {
-						Expect(fakeDelegate.PointToCheckedConfigCallCount()).To(Equal(0))
+					It("points the resource type to the scope", func() {
+						Expect(fakeDelegate.PointToCheckedConfigCallCount()).To(Equal(1))
 					})
 
 					It("uses delegate's container owner", func() {

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -300,10 +300,6 @@ type CheckPlan struct {
 	Tags Tags `json:"tags,omitempty"`
 }
 
-func (plan CheckPlan) IsPeriodic() bool {
-	return plan.Resource != "" || plan.ResourceType != "" || plan.Prototype != ""
-}
-
 type TaskPlan struct {
 	// The name of the step.
 	Name string `json:"name"`

--- a/go.sum
+++ b/go.sum
@@ -1110,7 +1110,6 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 h1:71vQrMauZZhcTVK6KdYM+rklehEEwb3E+ZhaE5jrPrE=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1210,6 +1209,7 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210716203947-853a461950ff/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=


### PR DESCRIPTION
## Changes proposed by this PR

This is derived from https://github.com/concourse/concourse/pull/7991. Instead of putting everything in a messy PR, I decided to wrap each piece of enhancement into a separate PR.

When `put: some-custome-resource`, the `put` step will check a nested `check` for the custom resource-type, then implied `get` should not duplicately run the check again. But without this fix, `put` and implied `get` will run check twice.

https://github.com/concourse/concourse/commit/7ef20bb8dcd623e87c8399a96c9a4377a626c7b4 has broken the logic of 

https://github.com/concourse/concourse/blob/2fc810fcc27d6edcdeb5a651b3b657b45458e739/atc/plan.go#L303-L305

because the commit inject `resource_type` to check plan in all cases.

As there could still be manual resource type checks issued by `fly check-resource-type`, and manually 

* [x] done

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

Fixed a bug where nested checks were run duplicately.
