### PR TITLE
Optimize ATC performance by avoid unneccessary go-routines of no-op check notifiers

### DIFF
--- a/atc/db/build_in_memory_check.go
+++ b/atc/db/build_in_memory_check.go
@@ -521,7 +521,7 @@ func (b *inMemoryCheckBuild) SaveEvent(ev atc.Event) error {
 	return b.conn.Bus().Notify(buildEventsChannel(b.id))
 }
 
-// AbortNotifier returns NoopNotifier because there is no way to abort a in-memory
+// AbortNotifier returns nil because there is no way to abort a in-memory
 // check build. Say a in-memory build may run on ATC-a, but abort-build API call
 // might be received by ATC-b, there is not a channel for ATC-b to tell ATC-a to
 // mark the in-memory build as aborted. If we really want to abort a in-memory
@@ -529,7 +529,7 @@ func (b *inMemoryCheckBuild) SaveEvent(ev atc.Event) error {
 // and API insert in-memory build id to the table, and AbortNotifier watches the
 // table to see if current build should be aborted.
 func (b *inMemoryCheckBuild) AbortNotifier() (Notifier, error) {
-	return newNoopNotifier(), nil
+	return nil, nil
 }
 
 // ResourceCacheUser will use in-memory build's preId as key in order to avoid unnecessary

--- a/atc/db/notifier.go
+++ b/atc/db/notifier.go
@@ -89,22 +89,3 @@ func (notifier *conditionNotifier) sendNotification() {
 	default:
 	}
 }
-
-func newNoopNotifier() Notifier {
-	return &noopNotifier{
-		notify: make(chan struct{}, 1),
-	}
-}
-
-type noopNotifier struct {
-	notify chan struct{}
-}
-
-func (notifier *noopNotifier) Notify() <-chan struct{} {
-	return notifier.notify
-}
-
-func (notifier *noopNotifier) Close() error {
-	close(notifier.notify)
-	return nil
-}

--- a/atc/engine/engine_test.go
+++ b/atc/engine/engine_test.go
@@ -324,10 +324,6 @@ var _ = Describe("Engine", func() {
 									Expect(fakeLock.ReleaseCallCount()).To(Equal(1))
 								})
 
-								It("closes the notifier", func() {
-									Expect(fakeNotifier.CloseCallCount()).To(Equal(1))
-								})
-
 								It("saves an error event", func() {
 									Expect(fakeBuild.SaveEventCallCount()).To(Equal(1))
 									Expect(fakeBuild.SaveEventArgsForCall(0).EventType()).To(Equal(event.EventTypeError))
@@ -344,10 +340,6 @@ var _ = Describe("Engine", func() {
 								Expect(fakeLock.ReleaseCallCount()).To(Equal(1))
 							})
 
-							It("closes the notifier", func() {
-								Expect(fakeNotifier.CloseCallCount()).To(Equal(1))
-							})
-
 							It("saves an error event", func() {
 								Expect(fakeBuild.SaveEventCallCount()).To(Equal(1))
 								Expect(fakeBuild.SaveEventArgsForCall(0).EventType()).To(Equal(event.EventTypeError))
@@ -358,10 +350,6 @@ var _ = Describe("Engine", func() {
 					Context("when listening for aborts fails", func() {
 						BeforeEach(func() {
 							fakeBuild.AbortNotifierReturns(nil, errors.New("nope"))
-						})
-
-						It("does not build the step", func() {
-							Expect(fakeStepperFactory.StepperForBuildCallCount()).To(BeZero())
 						})
 
 						It("releases the lock", func() {


### PR DESCRIPTION
## Changes proposed by this PR

This is derived from https://github.com/concourse/concourse/pull/7991. Instead of putting everything in a messy PR, I decided to wrap each piece of enhancement into a separate PR.

Originally `inMemoryCheckBuild.AbortNotifier()` returns a no-op notifier, then `engineBuild.Run()` will create a go-route to listen to the no-op notifier. Go-routines are though light but free. Given total amount of check builds could be far larger than normal build count, each check build starts a no-op go-routine is a big waste.

This PR changed `inMemoryCheckBuild.AbortNotifier()` to return nil rather than a no-op notifier. And update `engineBuild.Run()` to not start a go-routine if notifier is nil.

* [x] done
