### PR TITLE
Do not duplicate streaming of volumes in parallel when EnableCacheStreamedVolumes is true

### DIFF
--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -60,6 +60,10 @@ func NewInMemoryCheckBuildTrackingLockID(checkableType string, checkableId int) 
 	return LockID{LockTypeInMemoryCheckBuildTracking, lockIDFromString(fmt.Sprintf("%s-%d", checkableType, checkableId))}
 }
 
+func NewVolumeStreamingLockID(volume string, worker string) LockID {
+	return LockID{LockTypeJobScheduling, lockIDFromString(fmt.Sprintf("%s-%s", volume, worker))}
+}
+
 //counterfeiter:generate . LockFactory
 type LockFactory interface {
 	Acquire(logger lager.Logger, ids LockID) (Lock, bool, error)

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -60,8 +60,8 @@ func NewInMemoryCheckBuildTrackingLockID(checkableType string, checkableId int) 
 	return LockID{LockTypeInMemoryCheckBuildTracking, lockIDFromString(fmt.Sprintf("%s-%d", checkableType, checkableId))}
 }
 
-func NewVolumeStreamingLockID(volume string, worker string) LockID {
-	return LockID{LockTypeJobScheduling, lockIDFromString(fmt.Sprintf("%s-%s", volume, worker))}
+func NewVolumeStreamingLockID(resourceCacheID int, worker string) LockID {
+	return LockID{LockTypeJobScheduling, lockIDFromString(fmt.Sprintf("%d-%s", resourceCacheID, worker))}
 }
 
 //counterfeiter:generate . LockFactory

--- a/atc/engine/build_step_delegate.go
+++ b/atc/engine/build_step_delegate.go
@@ -229,6 +229,22 @@ func (delegate *buildStepDelegate) StreamingVolume(logger lager.Logger, volume s
 	}
 }
 
+func (delegate *buildStepDelegate) WaitingForStreamedVolume(logger lager.Logger, volume string, destWorker string) {
+	err := delegate.build.SaveEvent(event.WaitingForStreamedVolume{
+		Time: time.Now().Unix(),
+		Origin: event.Origin{
+			ID: event.OriginID(delegate.planID),
+		},
+		Volume:     volume,
+		DestWorker: destWorker,
+	})
+
+	if err != nil {
+		logger.Error("failed-to-save-waiting-for-streamed-volume-event", err)
+		return
+	}
+}
+
 func (delegate *buildStepDelegate) Errored(logger lager.Logger, message string) {
 	err := delegate.build.SaveEvent(event.Error{
 		Message: message,

--- a/atc/engine/build_step_delegate_test.go
+++ b/atc/engine/build_step_delegate_test.go
@@ -1079,4 +1079,18 @@ var _ = Describe("BuildStepDelegate", func() {
 			Expect(e.(event.StreamingVolume).DestWorker).To(Equal("dest-worker"))
 		})
 	})
+
+	Describe("WaitingForStreamedVolume", func() {
+		JustBeforeEach(func() {
+			delegate.WaitingForStreamedVolume(logger, "some-volume", "dest-worker")
+		})
+
+		It("saves an event", func() {
+			Expect(fakeBuild.SaveEventCallCount()).To(Equal(1))
+			e := fakeBuild.SaveEventArgsForCall(0)
+			Expect(e.EventType()).To(Equal(atc.EventType("waiting-for-streamed-volume")))
+			Expect(e.(event.WaitingForStreamedVolume).Volume).To(Equal("some-volume"))
+			Expect(e.(event.WaitingForStreamedVolume).DestWorker).To(Equal("dest-worker"))
+		})
+	})
 })

--- a/atc/event/events.go
+++ b/atc/event/events.go
@@ -120,6 +120,16 @@ type StreamingVolume struct {
 func (StreamingVolume) EventType() atc.EventType  { return EventTypeStreamingVolume }
 func (StreamingVolume) Version() atc.EventVersion { return "1.0" }
 
+type WaitingForStreamedVolume struct {
+	Time       int64  `json:"time"`
+	Origin     Origin `json:"origin"`
+	Volume     string `json:"volume"`
+	DestWorker string `json:"dest_worker"`
+}
+
+func (WaitingForStreamedVolume) EventType() atc.EventType  { return EventTypeWaitingForStreamedVolume }
+func (WaitingForStreamedVolume) Version() atc.EventVersion { return "1.0" }
+
 type Log struct {
 	Time    int64  `json:"time"`
 	Origin  Origin `json:"origin"`

--- a/atc/event/parser.go
+++ b/atc/event/parser.go
@@ -49,6 +49,7 @@ func init() {
 	RegisterEvent(WaitingForWorker{})
 	RegisterEvent(SelectedWorker{})
 	RegisterEvent(StreamingVolume{})
+	RegisterEvent(WaitingForStreamedVolume{})
 	RegisterEvent(Log{})
 	RegisterEvent(Error{})
 	RegisterEvent(ImageCheck{})

--- a/atc/event/types.go
+++ b/atc/event/types.go
@@ -18,6 +18,9 @@ const (
 	// a step (get/put/task) is streaming a volume from another worker
 	EventTypeStreamingVolume atc.EventType = "streaming-volume"
 
+	// a step (get/put/task) is waiting for another step to stream the volume to this worker
+	EventTypeWaitingForStreamedVolume atc.EventType = "waiting-for-streamed-volume"
+
 	// task execution started
 	EventTypeStartTask atc.EventType = "start-task"
 

--- a/atc/exec/build_step_delegate.go
+++ b/atc/exec/build_step_delegate.go
@@ -36,6 +36,7 @@ type BuildStepDelegate interface {
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
 	StreamingVolume(lager.Logger, string, string, string)
+	WaitingForStreamedVolume(lager.Logger, string, string)
 
 	ConstructAcrossSubsteps([]byte, []atc.AcrossVar, [][]interface{}) ([]atc.VarScopedPlan, error)
 	ContainerOwner(planId atc.PlanID) db.ContainerOwner

--- a/atc/exec/execfakes/fake_build_step_delegate.go
+++ b/atc/exec/execfakes/fake_build_step_delegate.go
@@ -142,6 +142,13 @@ type FakeBuildStepDelegate struct {
 		arg3 string
 		arg4 string
 	}
+	WaitingForStreamedVolumeStub        func(lager.Logger, string, string)
+	waitingForStreamedVolumeMutex       sync.RWMutex
+	waitingForStreamedVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -794,6 +801,40 @@ func (fake *FakeBuildStepDelegate) StreamingVolumeArgsForCall(i int) (lager.Logg
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
+func (fake *FakeBuildStepDelegate) WaitingForStreamedVolume(arg1 lager.Logger, arg2 string, arg3 string) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	fake.waitingForStreamedVolumeArgsForCall = append(fake.waitingForStreamedVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.WaitingForStreamedVolumeStub
+	fake.recordInvocation("WaitingForStreamedVolume", []interface{}{arg1, arg2, arg3})
+	fake.waitingForStreamedVolumeMutex.Unlock()
+	if stub != nil {
+		fake.WaitingForStreamedVolumeStub(arg1, arg2, arg3)
+	}
+}
+
+func (fake *FakeBuildStepDelegate) WaitingForStreamedVolumeCallCount() int {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	return len(fake.waitingForStreamedVolumeArgsForCall)
+}
+
+func (fake *FakeBuildStepDelegate) WaitingForStreamedVolumeCalls(stub func(lager.Logger, string, string)) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	defer fake.waitingForStreamedVolumeMutex.Unlock()
+	fake.WaitingForStreamedVolumeStub = stub
+}
+
+func (fake *FakeBuildStepDelegate) WaitingForStreamedVolumeArgsForCall(i int) (lager.Logger, string, string) {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	argsForCall := fake.waitingForStreamedVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
 func (fake *FakeBuildStepDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -855,6 +896,8 @@ func (fake *FakeBuildStepDelegate) Invocations() map[string][][]interface{} {
 	defer fake.stdoutMutex.RUnlock()
 	fake.streamingVolumeMutex.RLock()
 	defer fake.streamingVolumeMutex.RUnlock()
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/execfakes/fake_check_delegate.go
+++ b/atc/exec/execfakes/fake_check_delegate.go
@@ -213,6 +213,13 @@ type FakeCheckDelegate struct {
 		result2 bool
 		result3 error
 	}
+	WaitingForStreamedVolumeStub        func(lager.Logger, string, string)
+	waitingForStreamedVolumeMutex       sync.RWMutex
+	waitingForStreamedVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -1191,6 +1198,40 @@ func (fake *FakeCheckDelegate) WaitToRunReturnsOnCall(i int, result1 lock.Lock, 
 	}{result1, result2, result3}
 }
 
+func (fake *FakeCheckDelegate) WaitingForStreamedVolume(arg1 lager.Logger, arg2 string, arg3 string) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	fake.waitingForStreamedVolumeArgsForCall = append(fake.waitingForStreamedVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.WaitingForStreamedVolumeStub
+	fake.recordInvocation("WaitingForStreamedVolume", []interface{}{arg1, arg2, arg3})
+	fake.waitingForStreamedVolumeMutex.Unlock()
+	if stub != nil {
+		fake.WaitingForStreamedVolumeStub(arg1, arg2, arg3)
+	}
+}
+
+func (fake *FakeCheckDelegate) WaitingForStreamedVolumeCallCount() int {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	return len(fake.waitingForStreamedVolumeArgsForCall)
+}
+
+func (fake *FakeCheckDelegate) WaitingForStreamedVolumeCalls(stub func(lager.Logger, string, string)) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	defer fake.waitingForStreamedVolumeMutex.Unlock()
+	fake.WaitingForStreamedVolumeStub = stub
+}
+
+func (fake *FakeCheckDelegate) WaitingForStreamedVolumeArgsForCall(i int) (lager.Logger, string, string) {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	argsForCall := fake.waitingForStreamedVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
 func (fake *FakeCheckDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -1262,6 +1303,8 @@ func (fake *FakeCheckDelegate) Invocations() map[string][][]interface{} {
 	defer fake.updateScopeLastCheckStartTimeMutex.RUnlock()
 	fake.waitToRunMutex.RLock()
 	defer fake.waitToRunMutex.RUnlock()
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/execfakes/fake_get_delegate.go
+++ b/atc/exec/execfakes/fake_get_delegate.go
@@ -146,6 +146,13 @@ type FakeGetDelegate struct {
 		arg2 string
 		arg3 resource.VersionResult
 	}
+	WaitingForStreamedVolumeStub        func(lager.Logger, string, string)
+	waitingForStreamedVolumeMutex       sync.RWMutex
+	waitingForStreamedVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -805,6 +812,40 @@ func (fake *FakeGetDelegate) UpdateResourceVersionArgsForCall(i int) (lager.Logg
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
+func (fake *FakeGetDelegate) WaitingForStreamedVolume(arg1 lager.Logger, arg2 string, arg3 string) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	fake.waitingForStreamedVolumeArgsForCall = append(fake.waitingForStreamedVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.WaitingForStreamedVolumeStub
+	fake.recordInvocation("WaitingForStreamedVolume", []interface{}{arg1, arg2, arg3})
+	fake.waitingForStreamedVolumeMutex.Unlock()
+	if stub != nil {
+		fake.WaitingForStreamedVolumeStub(arg1, arg2, arg3)
+	}
+}
+
+func (fake *FakeGetDelegate) WaitingForStreamedVolumeCallCount() int {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	return len(fake.waitingForStreamedVolumeArgsForCall)
+}
+
+func (fake *FakeGetDelegate) WaitingForStreamedVolumeCalls(stub func(lager.Logger, string, string)) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	defer fake.waitingForStreamedVolumeMutex.Unlock()
+	fake.WaitingForStreamedVolumeStub = stub
+}
+
+func (fake *FakeGetDelegate) WaitingForStreamedVolumeArgsForCall(i int) (lager.Logger, string, string) {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	argsForCall := fake.waitingForStreamedVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
 func (fake *FakeGetDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -868,6 +909,8 @@ func (fake *FakeGetDelegate) Invocations() map[string][][]interface{} {
 	defer fake.streamingVolumeMutex.RUnlock()
 	fake.updateResourceVersionMutex.RLock()
 	defer fake.updateResourceVersionMutex.RUnlock()
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/execfakes/fake_put_delegate.go
+++ b/atc/exec/execfakes/fake_put_delegate.go
@@ -127,6 +127,13 @@ type FakePutDelegate struct {
 		arg3 string
 		arg4 string
 	}
+	WaitingForStreamedVolumeStub        func(lager.Logger, string, string)
+	waitingForStreamedVolumeMutex       sync.RWMutex
+	waitingForStreamedVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -674,6 +681,40 @@ func (fake *FakePutDelegate) StreamingVolumeArgsForCall(i int) (lager.Logger, st
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
+func (fake *FakePutDelegate) WaitingForStreamedVolume(arg1 lager.Logger, arg2 string, arg3 string) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	fake.waitingForStreamedVolumeArgsForCall = append(fake.waitingForStreamedVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.WaitingForStreamedVolumeStub
+	fake.recordInvocation("WaitingForStreamedVolume", []interface{}{arg1, arg2, arg3})
+	fake.waitingForStreamedVolumeMutex.Unlock()
+	if stub != nil {
+		fake.WaitingForStreamedVolumeStub(arg1, arg2, arg3)
+	}
+}
+
+func (fake *FakePutDelegate) WaitingForStreamedVolumeCallCount() int {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	return len(fake.waitingForStreamedVolumeArgsForCall)
+}
+
+func (fake *FakePutDelegate) WaitingForStreamedVolumeCalls(stub func(lager.Logger, string, string)) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	defer fake.waitingForStreamedVolumeMutex.Unlock()
+	fake.WaitingForStreamedVolumeStub = stub
+}
+
+func (fake *FakePutDelegate) WaitingForStreamedVolumeArgsForCall(i int) (lager.Logger, string, string) {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	argsForCall := fake.waitingForStreamedVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
 func (fake *FakePutDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -733,6 +774,8 @@ func (fake *FakePutDelegate) Invocations() map[string][][]interface{} {
 	defer fake.stdoutMutex.RUnlock()
 	fake.streamingVolumeMutex.RLock()
 	defer fake.streamingVolumeMutex.RUnlock()
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
+++ b/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
@@ -159,6 +159,13 @@ type FakeSetPipelineStepDelegate struct {
 		arg3 string
 		arg4 string
 	}
+	WaitingForStreamedVolumeStub        func(lager.Logger, string, string)
+	waitingForStreamedVolumeMutex       sync.RWMutex
+	waitingForStreamedVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -905,6 +912,40 @@ func (fake *FakeSetPipelineStepDelegate) StreamingVolumeArgsForCall(i int) (lage
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
+func (fake *FakeSetPipelineStepDelegate) WaitingForStreamedVolume(arg1 lager.Logger, arg2 string, arg3 string) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	fake.waitingForStreamedVolumeArgsForCall = append(fake.waitingForStreamedVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.WaitingForStreamedVolumeStub
+	fake.recordInvocation("WaitingForStreamedVolume", []interface{}{arg1, arg2, arg3})
+	fake.waitingForStreamedVolumeMutex.Unlock()
+	if stub != nil {
+		fake.WaitingForStreamedVolumeStub(arg1, arg2, arg3)
+	}
+}
+
+func (fake *FakeSetPipelineStepDelegate) WaitingForStreamedVolumeCallCount() int {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	return len(fake.waitingForStreamedVolumeArgsForCall)
+}
+
+func (fake *FakeSetPipelineStepDelegate) WaitingForStreamedVolumeCalls(stub func(lager.Logger, string, string)) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	defer fake.waitingForStreamedVolumeMutex.Unlock()
+	fake.WaitingForStreamedVolumeStub = stub
+}
+
+func (fake *FakeSetPipelineStepDelegate) WaitingForStreamedVolumeArgsForCall(i int) (lager.Logger, string, string) {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	argsForCall := fake.waitingForStreamedVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
 func (fake *FakeSetPipelineStepDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -970,6 +1011,8 @@ func (fake *FakeSetPipelineStepDelegate) Invocations() map[string][][]interface{
 	defer fake.stdoutMutex.RUnlock()
 	fake.streamingVolumeMutex.RLock()
 	defer fake.streamingVolumeMutex.RUnlock()
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/execfakes/fake_task_delegate.go
+++ b/atc/exec/execfakes/fake_task_delegate.go
@@ -119,6 +119,13 @@ type FakeTaskDelegate struct {
 		arg3 string
 		arg4 string
 	}
+	WaitingForStreamedVolumeStub        func(lager.Logger, string, string)
+	waitingForStreamedVolumeMutex       sync.RWMutex
+	waitingForStreamedVolumeArgsForCall []struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}
 	WaitingForWorkerStub        func(lager.Logger)
 	waitingForWorkerMutex       sync.RWMutex
 	waitingForWorkerArgsForCall []struct {
@@ -659,6 +666,40 @@ func (fake *FakeTaskDelegate) StreamingVolumeArgsForCall(i int) (lager.Logger, s
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
+func (fake *FakeTaskDelegate) WaitingForStreamedVolume(arg1 lager.Logger, arg2 string, arg3 string) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	fake.waitingForStreamedVolumeArgsForCall = append(fake.waitingForStreamedVolumeArgsForCall, struct {
+		arg1 lager.Logger
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.WaitingForStreamedVolumeStub
+	fake.recordInvocation("WaitingForStreamedVolume", []interface{}{arg1, arg2, arg3})
+	fake.waitingForStreamedVolumeMutex.Unlock()
+	if stub != nil {
+		fake.WaitingForStreamedVolumeStub(arg1, arg2, arg3)
+	}
+}
+
+func (fake *FakeTaskDelegate) WaitingForStreamedVolumeCallCount() int {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	return len(fake.waitingForStreamedVolumeArgsForCall)
+}
+
+func (fake *FakeTaskDelegate) WaitingForStreamedVolumeCalls(stub func(lager.Logger, string, string)) {
+	fake.waitingForStreamedVolumeMutex.Lock()
+	defer fake.waitingForStreamedVolumeMutex.Unlock()
+	fake.WaitingForStreamedVolumeStub = stub
+}
+
+func (fake *FakeTaskDelegate) WaitingForStreamedVolumeArgsForCall(i int) (lager.Logger, string, string) {
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
+	argsForCall := fake.waitingForStreamedVolumeArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
 func (fake *FakeTaskDelegate) WaitingForWorker(arg1 lager.Logger) {
 	fake.waitingForWorkerMutex.Lock()
 	fake.waitingForWorkerArgsForCall = append(fake.waitingForWorkerArgsForCall, struct {
@@ -718,6 +759,8 @@ func (fake *FakeTaskDelegate) Invocations() map[string][][]interface{} {
 	defer fake.stdoutMutex.RUnlock()
 	fake.streamingVolumeMutex.RLock()
 	defer fake.streamingVolumeMutex.RUnlock()
+	fake.waitingForStreamedVolumeMutex.RLock()
+	defer fake.waitingForStreamedVolumeMutex.RUnlock()
 	fake.waitingForWorkerMutex.RLock()
 	defer fake.waitingForWorkerMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -69,6 +69,7 @@ type GetDelegate interface {
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
 	StreamingVolume(lager.Logger, string, string, string)
+	WaitingForStreamedVolume(lager.Logger, string, string)
 
 	UpdateResourceVersion(lager.Logger, string, resource.VersionResult)
 

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -41,6 +41,7 @@ type PutDelegate interface {
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
 	StreamingVolume(lager.Logger, string, string, string)
+	WaitingForStreamedVolume(lager.Logger, string, string)
 
 	SaveOutput(lager.Logger, atc.PutPlan, atc.Source, db.ResourceCache, resource.VersionResult)
 }

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -77,6 +77,7 @@ type TaskDelegate interface {
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
 	StreamingVolume(lager.Logger, string, string, string)
+	WaitingForStreamedVolume(lager.Logger, string, string)
 }
 
 // TaskStep executes a TaskConfig, whose inputs will be fetched from the

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -126,6 +126,7 @@ type ContainerSpec struct {
 
 type BuildStepDelegate interface {
 	StreamingVolume(lager.Logger, string, string, string)
+	WaitingForStreamedVolume(lager.Logger, string, string)
 }
 
 // ContainerSpec must implement propagation.TextMapCarrier so that it can be

--- a/atc/syslog/drainer.go
+++ b/atc/syslog/drainer.go
@@ -183,6 +183,16 @@ func (d *drainer) sendEvent(logger lager.Logger, build db.Build, syslog *Syslog,
 		ts = time.Unix(streamingVolumeEvent.Time, 0)
 		tag = build.SyslogTag(streamingVolumeEvent.Origin.ID)
 		message = fmt.Sprintf("streaming volume %s from worker %s", streamingVolumeEvent.Volume, streamingVolumeEvent.SourceWorker)
+	case event.EventTypeWaitingForStreamedVolume:
+		var waitingForStreamedVolumeEvent event.WaitingForStreamedVolume
+		err := json.Unmarshal(*ev.Data, &waitingForStreamedVolumeEvent)
+		if err != nil {
+			logger.Error("failed-to-unmarshal", err)
+			return err
+		}
+		ts = time.Unix(waitingForStreamedVolumeEvent.Time, 0)
+		tag = build.SyslogTag(waitingForStreamedVolumeEvent.Origin.ID)
+		message = fmt.Sprintf("waiting for volume %s to be streamed by another step", waitingForStreamedVolumeEvent.Volume)
 	case event.EventTypeStartTask:
 		var startTaskEvent event.StartTask
 		err := json.Unmarshal(*ev.Data, &startTaskEvent)

--- a/atc/worker/gardenruntime/gardenruntimetest/worker.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/worker.go
@@ -2,6 +2,7 @@ package gardenruntimetest
 
 import (
 	"strconv"
+	"sync"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/compression"
@@ -62,7 +63,7 @@ func (w Worker) Build(db worker.DB, dbWorker db.Worker) runtime.Worker {
 	return gardenruntime.NewWorker(
 		dbWorker,
 		&Garden{ContainerList: w.Containers},
-		&Baggageclaim{Volumes: w.Volumes},
+		&Baggageclaim{Volumes: w.Volumes, Mutex: sync.Mutex{}},
 		db.ToGardenRuntimeDB(),
 		worker.NewStreamer(db.ResourceCacheFactory, compression.NewGzipCompression(), worker.P2PConfig{
 			Enabled: false,

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -715,6 +715,7 @@ func (worker *Worker) findOrStreamVolume(
 		}
 
 		if tick == nil {
+			delegate.WaitingForStreamedVolume(logger, inputPath, container.WorkerName())
 			tick = time.NewTicker(WaitingForStreamedVolumePollingInterval)
 			defer tick.Stop()
 		}

--- a/atc/worker/gardenruntime/worker_test.go
+++ b/atc/worker/gardenruntime/worker_test.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/lager/lagertest"
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/dbtest"
 	"github.com/concourse/concourse/atc/db/lock"
@@ -633,6 +635,127 @@ var _ = Describe("Garden Worker", func() {
 				"/output",
 				"/remote-input",
 			}))
+		})
+	})
+
+	Describe("when parallel steps require the same remote volume", func() {
+		var (
+			delegate              *execfakes.FakeBuildStepDelegate
+			containerVolumeMounts sync.Map
+		)
+
+		JustBeforeEach(func() {
+			gardenruntime.WaitingForStreamedVolumePollingInterval = 10 * time.Millisecond
+			containerVolumeMounts = sync.Map{}
+			delegate = new(execfakes.FakeBuildStepDelegate)
+			remoteInputVolume := grt.NewVolume("remote-input").WithContent(runtimetest.VolumeContent{
+				"file1": {Data: []byte("content")},
+			})
+			scenario := Setup(
+				workertest.WithWorkers(
+					grt.NewWorker("worker1"),
+					grt.NewWorker("worker2").
+						WithVolumesCreatedInDBAndBaggageclaim(remoteInputVolume),
+				),
+			)
+
+			worker := scenario.Worker("worker1")
+			done := make(chan error, 2)
+			findOrCreateContainer := func(handle string) {
+				defer GinkgoRecover()
+				_, volumeMounts, err := worker.FindOrCreateContainer(
+					ctx,
+					db.NewFixedHandleContainerOwner(handle),
+					db.ContainerMetadata{},
+					runtime.ContainerSpec{
+						ImageSpec: runtime.ImageSpec{
+							ImageURL: "raw:///img/rootfs",
+						},
+						Inputs: []runtime.Input{
+							{
+								Artifact:        scenario.WorkerVolume("worker2", remoteInputVolume.Handle()),
+								DestinationPath: "/remote-input",
+							},
+						},
+					},
+					delegate,
+				)
+				containerVolumeMounts.Store(handle, volumeMounts)
+				done <- err
+			}
+
+			By("initializing remote input as a resource cache", func() {
+				resourceCache := scenario.FindOrCreateResourceCache("worker2")
+				err := scenario.WorkerVolume("worker2", "remote-input").InitializeResourceCache(ctx, resourceCache)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("trying to find or create two containers with the same resource in parallel", func() {
+				go findOrCreateContainer("handle-1")
+				go findOrCreateContainer("handle-2")
+				Eventually(done, 10*time.Second).Should(Receive(BeNil()))
+				Eventually(done, 10*time.Second).Should(Receive(BeNil()))
+			})
+		})
+
+		Describe("with cache streamed volumes enabled", func() {
+			BeforeEach(func() {
+				atc.EnableCacheStreamedVolumes = true
+			})
+
+			Test("volume is only streamed once", func() {
+				By("validating both volumes share a parent", func() {
+					var parents []string
+
+					for _, handle := range []string{"handle-1", "handle-2"} {
+						mount, ok := containerVolumeMounts.Load(handle)
+						Expect(ok).To(BeTrue())
+						remoteMount := volumeMount(mount.([]runtime.VolumeMount), "/remote-input").Volume.(gardenruntime.Volume)
+						Expect(remoteMount.DBVolume().WorkerName()).To(Equal("worker1"))
+						parents = append(parents, remoteMount.DBVolume().ParentHandle())
+					}
+					Expect(parents[0]).To(Equal(parents[1]))
+				})
+
+				By("validating only a single streaming-volume event is emitted", func() {
+					Expect(delegate.StreamingVolumeCallCount()).To(Equal(1))
+					_, streamedVolume, streamedSrc, streamedDest := delegate.StreamingVolumeArgsForCall(0)
+					Expect(streamedVolume).To(Equal("remote-input"))
+					Expect(streamedSrc).To(Equal("worker2"))
+					Expect(streamedDest).To(Equal("worker1"))
+				})
+			})
+		})
+
+		Describe("without cache streamed volumes enabled", func() {
+			BeforeEach(func() {
+				atc.EnableCacheStreamedVolumes = false
+			})
+
+			Test("volume is streamed multiple times", func() {
+				By("validating both volumes have unique parents", func() {
+					var parents []string
+
+					for _, handle := range []string{"handle-1", "handle-2"} {
+						mount, ok := containerVolumeMounts.Load(handle)
+						Expect(ok).To(BeTrue())
+						remoteMount := volumeMount(mount.([]runtime.VolumeMount), "/remote-input").Volume.(gardenruntime.Volume)
+						Expect(remoteMount.DBVolume().WorkerName()).To(Equal("worker1"))
+						parents = append(parents, remoteMount.DBVolume().ParentHandle())
+					}
+					Expect(parents[0]).ToNot(Equal(parents[1]))
+				})
+
+				By("validating 2 streaming-volume events are emitted", func() {
+					Expect(delegate.StreamingVolumeCallCount()).To(Equal(2))
+					for i := 0; i < 2; i++ {
+						_, volume, src, dest := delegate.StreamingVolumeArgsForCall(i)
+						Expect(volume).To(Equal("remote-input"))
+						Expect(src).To(Equal("worker2"))
+						Expect(dest).To(Equal("worker1"))
+					}
+				})
+			})
 		})
 	})
 

--- a/atc/worker/gardenruntime/worker_test.go
+++ b/atc/worker/gardenruntime/worker_test.go
@@ -605,6 +605,13 @@ var _ = Describe("Garden Worker", func() {
 					Expect(streamedSrc).To(Equal("worker2"))
 					Expect(streamedDest).To(Equal("worker1"))
 				})
+
+				By("validating a waiting-for-streamed-volume event is emitted", func() {
+					Expect(delegate.WaitingForStreamedVolumeCallCount()).To(Equal(1))
+					_, waitingVolume, waitingDest := delegate.WaitingForStreamedVolumeArgsForCall(0)
+					Expect(waitingVolume).To(Equal("for image"))
+					Expect(waitingDest).To(Equal("worker1"))
+				})
 			})
 		})
 
@@ -844,6 +851,13 @@ var _ = Describe("Garden Worker", func() {
 					Expect(streamedVolume).To(Equal("remote-input"))
 					Expect(streamedSrc).To(Equal("worker2"))
 					Expect(streamedDest).To(Equal("worker1"))
+				})
+
+				By("validating a waiting-for-streamed-volume event is emitted", func() {
+					Expect(delegate.WaitingForStreamedVolumeCallCount()).To(Equal(1))
+					_, waitingVolume, waitingDest := delegate.WaitingForStreamedVolumeArgsForCall(0)
+					Expect(waitingVolume).To(Equal("remote-input"))
+					Expect(waitingDest).To(Equal("worker1"))
 				})
 			})
 		})

--- a/fly/eventstream/render.go
+++ b/fly/eventstream/render.go
@@ -52,6 +52,10 @@ func Render(dst io.Writer, src eventstream.EventStream, options RenderOptions) i
 			dstImpl.SetTimestamp(e.Time)
 			fmt.Fprintf(dstImpl, "\x1b[1mstreaming volume\x1b[0m %s \x1b[1mfrom worker\x1b[0m %s\n", e.Volume, e.SourceWorker)
 
+		case event.WaitingForStreamedVolume:
+			dstImpl.SetTimestamp(e.Time)
+			fmt.Fprintf(dstImpl, "\x1b[1mwaiting for volume\x1b[0m %s \x1b[1mto be streamed by another step\n", e.Volume)
+
 		case event.InitializeCheck:
 			dstImpl.SetTimestamp(e.Time)
 			fmt.Fprintf(dstImpl, "\x1b[1minitializing check:\x1b[0m %s\n", e.Name)

--- a/fly/eventstream/render_test.go
+++ b/fly/eventstream/render_test.go
@@ -366,6 +366,30 @@ var _ = Describe("V1.0 Renderer", func() {
 		})
 	})
 
+	Context("when a WaitingForStreamedVolume event is received", func() {
+		BeforeEach(func() {
+			receivedEvents <- event.WaitingForStreamedVolume{
+				Time:       time.Now().Unix(),
+				Volume:     "some-volume",
+				DestWorker: "dest-worker",
+			}
+		})
+
+		It("prints the event", func() {
+			Expect(out.Contents()).To(ContainSubstring("\x1b[1mwaiting for volume\u001B[0m some-volume \x1b[1mto be streamed by another step\n"))
+		})
+
+		Context("and time configuration enabled", func() {
+			BeforeEach(func() {
+				options.ShowTimestamp = true
+			})
+
+			It("timestamp is prefixed", func() {
+				Expect(out).To(gbytes.Say(`\d{2}\:\d{2}\:\d{2}\s{2}\w*`))
+			})
+		})
+	})
+
 	Context("when an UnknownEventTypeError or UnknownEventVersionError is received", func() {
 
 		BeforeEach(func() {

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -175,6 +175,11 @@ handleEvent event ( model, effects ) =
             , effects
             )
 
+        WaitingForStreamedVolume origin volume time ->
+            ( updateStep origin.id (setRunning << appendStepLog ("\u{001B}[1mwaiting for volume \u{001B}[0m" ++ volume ++ " \u{001B}[1mto be streamed by another step\n") time) model
+            , effects
+            )
+
         Error origin message time ->
             ( updateStep origin.id (setStepError message time) model
             , effects

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -207,6 +207,7 @@ type BuildEvent
     | WaitingForWorker Origin (Maybe Time.Posix)
     | SelectedWorker Origin String (Maybe Time.Posix)
     | StreamingVolume Origin String String (Maybe Time.Posix)
+    | WaitingForStreamedVolume Origin String (Maybe Time.Posix)
     | Error Origin String Time.Posix
     | ImageCheck Origin Concourse.BuildPlan
     | ImageGet Origin Concourse.BuildPlan

--- a/web/elm/src/Concourse/BuildEvents.elm
+++ b/web/elm/src/Concourse/BuildEvents.elm
@@ -113,6 +113,15 @@ decodeBuildEvent =
                                 (Json.Decode.maybe <| Json.Decode.field "time" <| Json.Decode.map dateFromSeconds Json.Decode.int)
                             )
 
+                    "waiting-for-streamed-volume" ->
+                        Json.Decode.field
+                            "data"
+                            (Json.Decode.map3 WaitingForStreamedVolume
+                                (Json.Decode.field "origin" <| Json.Decode.lazy (\_ -> decodeOrigin))
+                                (Json.Decode.field "volume" Json.Decode.string)
+                                (Json.Decode.maybe <| Json.Decode.field "time" <| Json.Decode.map dateFromSeconds Json.Decode.int)
+                            )
+
                     "error" ->
                         Json.Decode.field "data" decodeErrorEvent
 


### PR DESCRIPTION
## Changes proposed by this PR
When many steps start in parallel on a single worker that share a volume, they will currently all attempt to stream the volume in parallel. With `atc.EnableCacheStreamedVolumes = true`, these streamed volumes will then be marked as resource caches. As these caches would then be valid local copies of the volume, we can just stream a volume to a worker once and make other steps wait for that stream to finish. This removes the likelyhood of the "ton of streaming out" from this comment as it will only stream once per worker that requires it rather than once per started task: 
https://github.com/concourse/concourse/blob/b67033906d8ef2b126b0dce0d52c8ef29b37f086/atc/exec/get_step.go#L275-L280

* [x] merge #8031 
* [x] use a lock to ensure only one step streams a volume to a worker
* [x] extend to image streaming
* [x] add a new build event so that users know what is happening  

## Notes to reviewer
Draft as it is currently based off of #8031 to reuse delegate code.

This is a relatively large refactor of the volume streaming code with a couple of changes which we think are safe to do but could do with validating. The basic idea is:
* With `atc.EnableCacheStreamedVolumes = true`, streamed volumes are marked as caches and so are effectively the same as local volumes after streaming
* Rather than have multiple steps stream an identical volume, use a global lock
* "Streaming remote volumes" is now basically "either wait or stream volumes until they all become local"

Because of this, we no longer separate between volumes that were already on the worker (no streaming or waiting necessary) and volumes that were streamed either directly or by another step. This used to be represented by the `inputDestinationPaths` map which seems to track volumes that were already local as they can be reused as outputs. It seems that this couldn't be done with streamed volumes in the past:
https://github.com/concourse/concourse/blob/b67033906d8ef2b126b0dce0d52c8ef29b37f086/atc/worker/gardenruntime/worker.go#L421-L425
but we believe that all the streamed volumes are COW-ed anyway so it should be fine to reuse the _mounted_ volume (since that is not a cache). As such, we add all inputs to the `inputDestinationPaths` rather than separate "already local" and "streamed but now local"

Other than that, things are mostly just a refactor to abstract away the idea of "already local" and "streamed but now local" into a single `findOrStreamVolume` method and goroutines are used to parallelise the streaming and/or waiting (as streaming already did).

## Release Note
* Steps that stream volumes will now use a global (per worker) lock to ensure identical volumes are not streamed more times than they need to be
* A new `waiting-for-streamed-volume`/`waiting for volume <name> to be streamed by another step` event is included in build step logs where this behaviour occurs
