### PR TITLE
Fix bug of resource type checks

### DIFF
--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -72,7 +72,7 @@ func (d *checkDelegate) Initializing(logger lager.Logger) {
 
 func (d *checkDelegate) FindOrCreateScope(config db.ResourceConfig) (db.ResourceConfigScope, error) {
 	var resourceIDPtr *int
-	if d.plan.Resource != "" {
+	if d.plan.IsResourceCheck() {
 		pipeline, err := d.pipeline()
 		if err != nil {
 			return nil, fmt.Errorf("get pipeline: %w", err)
@@ -125,7 +125,7 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 	interval := d.plan.Interval.Interval
 
 	var lock lock.Lock = lock.NoopLock{}
-	if d.plan.IsPeriodic() {
+	if d.plan.IsResourceCheck() {
 		for {
 			run, err := d.shouldPeriodicCheckRun(scope, interval)
 			if err != nil {

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -110,7 +110,7 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 		if d.plan.Interval.Never {
 			// exit early if user specified to never run periodic checks
 			return nil, false, nil
-		} else if d.plan.Resource != "" {
+		} else if d.plan.IsResourceCheck() {
 			// rate limit periodic resource checks so worker load (plus load on
 			// external services) isn't too spiky. note that we don't rate limit
 			// resource type or prototype checks, because they are created every time a

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -382,6 +382,7 @@ var _ = Describe("CheckDelegate", func() {
 		Context("when not running for a resource", func() {
 			BeforeEach(func() {
 				plan.Check.Resource = ""
+				plan.Check.ResourceType = "some-resource-type"
 			})
 
 			It("does not rate limit", func() {

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -170,7 +170,7 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 
 		metric.Metrics.ChecksStarted.Inc()
 
-		_, buildId, err := delegate.UpdateScopeLastCheckStartTime(scope, (step.plan.Resource == ""))
+		_, buildId, err := delegate.UpdateScopeLastCheckStartTime(scope, !step.plan.IsResourceCheck())
 		if err != nil {
 			return false, fmt.Errorf("update check start time: %w", err)
 		}

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -136,11 +136,9 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 	// Point scope to resource before check runs. Because a resource's check build
 	// summary is associated with scope, only after pointing to scope, check status
 	// can be fetched.
-	if step.plan.Resource != "" {
-		err = delegate.PointToCheckedConfig(scope)
-		if err != nil {
-			return false, fmt.Errorf("update resource config scope: %w", err)
-		}
+	err = delegate.PointToCheckedConfig(scope)
+	if err != nil {
+		return false, fmt.Errorf("update resource config scope: %w", err)
 	}
 
 	lock, run, err := delegate.WaitToRun(ctx, scope)
@@ -309,7 +307,7 @@ func (step *CheckStep) runCheck(
 }
 
 func (step *CheckStep) containerOwner(delegate CheckDelegate, resourceConfig db.ResourceConfig) db.ContainerOwner {
-	if step.plan.Resource == "" {
+	if !step.plan.IsResourceCheck() {
 		return delegate.ContainerOwner(step.planID)
 	}
 

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -462,6 +462,7 @@ var _ = Describe("CheckStep", func() {
 				Context("when the plan is nested", func() {
 					BeforeEach(func() {
 						checkPlan.Resource = ""
+						checkPlan.ResourceType = "some-resource-type"
 
 						expectedOwner = db.NewBuildStepContainerOwner(
 							501,
@@ -485,8 +486,8 @@ var _ = Describe("CheckStep", func() {
 						fakePool.FindOrSelectWorkerReturns(chosenWorker, nil)
 					})
 
-					It("not points the resource or resource type to the scope", func() {
-						Expect(fakeDelegate.PointToCheckedConfigCallCount()).To(Equal(0))
+					It("points the resource or resource type to the scope", func() {
+						Expect(fakeDelegate.PointToCheckedConfigCallCount()).To(Equal(1))
 					})
 
 					It("uses delegate's container owner", func() {

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -300,8 +300,8 @@ type CheckPlan struct {
 	Tags Tags `json:"tags,omitempty"`
 }
 
-func (plan CheckPlan) IsPeriodic() bool {
-	return plan.Resource != "" || plan.ResourceType != "" || plan.Prototype != ""
+func (plan CheckPlan) IsResourceCheck() bool {
+	return plan.Resource != ""
 }
 
 type TaskPlan struct {


### PR DESCRIPTION
## Changes proposed by this PR

Refer to https://github.com/concourse/concourse/pull/8043#issue-1125126046
And https://github.com/concourse/concourse/pull/8043#issuecomment-1033418261

This bug causes nested resource type check to need acquiring resource-config-check-lock. One issue during our last 7.6 upgrade failure was that some step nested check took very long time to start, I think that should be due to this bug.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] done

## Notes to reviewer



## Release Note

- Remove lock on checking resource types and prototypes, this will result in a small behaviour change. For example, if you have multiple resources that use the same resource type and those resources run a check for that resource type at the same time, the resource type will be checked multiple times. This was the behaviour before 7.3.0 so we are reverting back to this behaviour.
- Fixes a bug introduced in 7.6.0 where resource type `resource_config_id` were never updated.