### PR TITLE
db optimization: if scope is unchanged, check step can skip scope update

### DIFF
--- a/atc/config.go
+++ b/atc/config.go
@@ -200,7 +200,7 @@ type ResourceType struct {
 	Tags       Tags        `json:"tags,omitempty"`
 	Params     Params      `json:"params,omitempty"`
 
-	CurrentResourceConfigScope int
+	CurrentResourceConfigScope int `json:"-"`
 }
 
 type Prototype struct {

--- a/atc/config.go
+++ b/atc/config.go
@@ -199,6 +199,8 @@ type ResourceType struct {
 	CheckEvery *CheckEvery `json:"check_every,omitempty"`
 	Tags       Tags        `json:"tags,omitempty"`
 	Params     Params      `json:"params,omitempty"`
+
+	CurrentResourceConfigScope int
 }
 
 type Prototype struct {
@@ -314,6 +316,8 @@ func (types ResourceTypes) ImageForType(planID PlanID, resourceType string, step
 		Source: parent.Source,
 		Params: parent.Params,
 		Tags:   parent.Tags,
+
+		CurrentResourceConfigScope: parent.CurrentResourceConfigScope,
 	}
 
 	getPlan, checkPlan := FetchImagePlan(planID, imageResource, types.Without(parent.Name), stepTags, skipInterval, parent.CheckEvery)
@@ -386,6 +390,8 @@ func FetchImagePlan(planID PlanID, image ImageResource, resourceTypes ResourceTy
 				Tags: tags,
 
 				SkipInterval: skipInterval,
+
+				CurrentResourceConfigScope: image.CurrentResourceConfigScope,
 			},
 		}
 		maybeCheckPlan = &checkPlan

--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -311,6 +311,8 @@ func (r *resource) CheckPlan(planFactory atc.PlanFactory, imagePlanner atc.Image
 		SkipInterval: skipInterval,
 
 		Resource: r.name,
+
+		CurrentResourceConfigScope: r.resourceConfigScopeID,
 	})
 
 	plan.Check.TypeImage = imagePlanner.ImageForType(plan.ID, r.type_, r.config.Tags, skipInterval && skipIntervalRecursively)

--- a/atc/db/resource_type.go
+++ b/atc/db/resource_type.go
@@ -101,14 +101,15 @@ func (resourceTypes ResourceTypes) Deserialize() atc.ResourceTypes {
 		}
 
 		atcResourceTypes = append(atcResourceTypes, atc.ResourceType{
-			Name:       t.Name(),
-			Type:       t.Type(),
-			Source:     source,
-			Defaults:   t.Defaults(),
-			Privileged: t.Privileged(),
-			CheckEvery: t.CheckEvery(),
-			Tags:       t.Tags(),
-			Params:     t.Params(),
+			Name:                       t.Name(),
+			Type:                       t.Type(),
+			Source:                     source,
+			Defaults:                   t.Defaults(),
+			Privileged:                 t.Privileged(),
+			CheckEvery:                 t.CheckEvery(),
+			Tags:                       t.Tags(),
+			Params:                     t.Params(),
+			CurrentResourceConfigScope: t.ResourceConfigScopeID(),
 		})
 	}
 
@@ -120,14 +121,15 @@ func (resourceTypes ResourceTypes) Configs() atc.ResourceTypes {
 
 	for _, r := range resourceTypes {
 		configs = append(configs, atc.ResourceType{
-			Name:       r.Name(),
-			Type:       r.Type(),
-			Source:     r.Source(),
-			Defaults:   r.Defaults(),
-			Privileged: r.Privileged(),
-			CheckEvery: r.CheckEvery(),
-			Tags:       r.Tags(),
-			Params:     r.Params(),
+			Name:                       r.Name(),
+			Type:                       r.Type(),
+			Source:                     r.Source(),
+			Defaults:                   r.Defaults(),
+			Privileged:                 r.Privileged(),
+			CheckEvery:                 r.CheckEvery(),
+			Tags:                       r.Tags(),
+			Params:                     r.Params(),
+			CurrentResourceConfigScope: r.ResourceConfigScopeID(),
 		})
 	}
 
@@ -259,6 +261,7 @@ func (r *resourceType) CheckPlan(planFactory atc.PlanFactory, imagePlanner atc.I
 		SkipInterval: skipInterval,
 
 		ResourceType: r.name,
+		CurrentResourceConfigScope: r.resourceConfigScopeID,
 	})
 
 	plan.Check.TypeImage = imagePlanner.ImageForType(plan.ID, r.type_, r.tags, skipInterval && skipIntervalRecursively)

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -138,9 +138,11 @@ func (step *CheckStep) run(ctx context.Context, state RunState, delegate CheckDe
 	// Point scope to resource before check runs. Because a resource's check build
 	// summary is associated with scope, only after pointing to scope, check status
 	// can be fetched.
-	err = delegate.PointToCheckedConfig(scope)
-	if err != nil {
-		return false, fmt.Errorf("update resource config scope: %w", err)
+	if step.plan.CurrentResourceConfigScope != scope.ID() {
+		err = delegate.PointToCheckedConfig(scope)
+		if err != nil {
+			return false, fmt.Errorf("update resource config scope: %w", err)
+		}
 	}
 
 	lock, run, err := delegate.WaitToRun(ctx, scope)

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -441,10 +441,30 @@ var _ = Describe("CheckStep", func() {
 						fakePool.FindOrSelectWorkerReturns(chosenWorker, nil)
 					})
 
-					It("points the resource or resource type to the scope", func() {
-						Expect(fakeDelegate.PointToCheckedConfigCallCount()).To(Equal(1))
-						scope := fakeDelegate.PointToCheckedConfigArgsForCall(0)
-						Expect(scope).To(Equal(fakeResourceConfigScope))
+					Context("points the resource or resource type to the scope", func(){
+						Context("when scope changed", func(){
+							BeforeEach(func(){
+								checkPlan.CurrentResourceConfigScope = 1
+								fakeResourceConfigScope.IDReturns(2)
+							})
+
+							It("points the resource or resource type to the scope", func() {
+								Expect(fakeDelegate.PointToCheckedConfigCallCount()).To(Equal(1))
+								scope := fakeDelegate.PointToCheckedConfigArgsForCall(0)
+								Expect(scope).To(Equal(fakeResourceConfigScope))
+							})
+						})
+
+						Context("when scope unchanged", func(){
+							BeforeEach(func(){
+								checkPlan.CurrentResourceConfigScope = 1
+								fakeResourceConfigScope.IDReturns(1)
+							})
+
+							It("points the resource or resource type to the scope", func() {
+								Expect(fakeDelegate.PointToCheckedConfigCallCount()).To(Equal(0))
+							})
+						})
 					})
 
 					It("uses ResourceConfigCheckSessionOwner", func() {
@@ -463,6 +483,8 @@ var _ = Describe("CheckStep", func() {
 					BeforeEach(func() {
 						checkPlan.Resource = ""
 						checkPlan.ResourceType = "some-resource-type"
+						checkPlan.CurrentResourceConfigScope = 1
+						fakeResourceConfigScope.IDReturns(2)
 
 						expectedOwner = db.NewBuildStepContainerOwner(
 							501,

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -282,7 +282,7 @@ type CheckPlan struct {
 	ResourceType string `json:"resource_type,omitempty"`
 	Prototype    string `json:"prototype,omitempty"`
 
-	// The internal on which to check - if it has not elapsed since the config
+	// The interval on which to check - if it has not elapsed since the config
 	// was last checked, and the build has not been manually triggered, the check
 	// will be skipped. It will also be set as Never if the user has specified
 	// for it to not be checked periodically.
@@ -302,7 +302,7 @@ type CheckPlan struct {
 	// This is a internal field that carries current resource config scope id
 	// when check plan is created. So that when a new scope id is figured out,
 	// we know if scope is changed. If not, then no need to update db.
-	CurrentResourceConfigScope int
+	CurrentResourceConfigScope int `json:"-"`
 }
 
 func (plan CheckPlan) IsResourceCheck() bool {

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -282,7 +282,7 @@ type CheckPlan struct {
 	ResourceType string `json:"resource_type,omitempty"`
 	Prototype    string `json:"prototype,omitempty"`
 
-	// The interval on which to check - if it has not elapsed since the config
+	// The internal on which to check - if it has not elapsed since the config
 	// was last checked, and the build has not been manually triggered, the check
 	// will be skipped. It will also be set as Never if the user has specified
 	// for it to not be checked periodically.
@@ -298,6 +298,11 @@ type CheckPlan struct {
 
 	// Worker tags to influence placement of the container.
 	Tags Tags `json:"tags,omitempty"`
+
+	// This is a internal field that carries current resource config scope id
+	// when check plan is created. So that when a new scope id is figured out,
+	// we know if scope is changed. If not, then no need to update db.
+	CurrentResourceConfigScope int
 }
 
 func (plan CheckPlan) IsResourceCheck() bool {

--- a/atc/task.go
+++ b/atc/task.go
@@ -50,7 +50,7 @@ type ImageResource struct {
 	// was last checked, and the build has not been manually triggered, the check
 	// will be skipped. It will also be set as Never if the user has specified
 	// for it to not be checked periodically.
-	CurrentResourceConfigScope int
+	CurrentResourceConfigScope int `json:"-"`
 }
 
 func (ir *ImageResource) ApplySourceDefaults(resourceTypes ResourceTypes) {

--- a/atc/task.go
+++ b/atc/task.go
@@ -45,6 +45,12 @@ type ImageResource struct {
 	Version Version `json:"version,omitempty"`
 	Params  Params  `json:"params,omitempty"`
 	Tags    Tags    `json:"tags,omitempty"`
+
+	// The internal on which to check - if it has not elapsed since the config
+	// was last checked, and the build has not been manually triggered, the check
+	// will be skipped. It will also be set as Never if the user has specified
+	// for it to not be checked periodically.
+	CurrentResourceConfigScope int
 }
 
 func (ir *ImageResource) ApplySourceDefaults(resourceTypes ResourceTypes) {


### PR DESCRIPTION
## Changes proposed by this PR

A check step always update scope of a resource, but in most of case, a resource's scope should be unchanged. There is an optimization at SQL level:

https://github.com/concourse/concourse/blob/e1e184ee7caaf0b244209fb004d69cf074c62f77/atc/db/resource.go#L275-L279

But that there is still a SQL request sending to PG server. By recording current scope id in check plan, then check step may know if scope is changed, if not, then don't call the db function at all.

Given count of check builds is far more than normal builds, this optimization should save a lot of db transactions.

* [x] code for main logic
* [x] add tests

## Notes to reviewer

I have done a load test, comparing 6.7.8, current master branch and this PR.

In the test, I used 3 ATCs and 100 workers. There are 180 pipelines, each has two resources, all resources have different scopes, so totally 360 resources and 360 scopes. Each pipelines triggers a build every 10 minutes.

![8094](https://user-images.githubusercontent.com/18585861/153344290-b486ddf6-de3a-4e03-aaf6-951ac25705c6.png)

The test shows that 7.x has much better performance than 6.7.8. We can see that, with 6.7.8, CPU usages are almost 100%, but 7.x is mostly below 50%. For DB queries, QPS of 7.x is also much lower than 6.7.8. With this PR, QPS looks a little lower than master branch.

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

Optimized db performance by reducing unnecessary resource scope updates.
