### PR TITLE
Allow use of fields when using AWS Secrets Manager

### DIFF
--- a/atc/creds/secretsmanager/secretsmanager.go
+++ b/atc/creds/secretsmanager/secretsmanager.go
@@ -65,7 +65,11 @@ func (s *SecretsManager) getSecretById(path string) (interface{}, *time.Time, bo
 	if err == nil {
 		switch {
 		case value.SecretString != nil:
-			return *value.SecretString, nil, true, nil
+			values, err := decodeJsonValue([]byte(*value.SecretString))
+			if err != nil {
+				return *value.SecretString, nil, true, nil
+			}
+			return values, nil, true, nil
 		case value.SecretBinary != nil:
 			values, err := decodeJsonValue(value.SecretBinary)
 			if err != nil {

--- a/atc/creds/secretsmanager/secretsmanager_test.go
+++ b/atc/creds/secretsmanager/secretsmanager_test.go
@@ -88,6 +88,21 @@ var _ = Describe("SecretsManager", func() {
 			}))
 		})
 
+		It("should get json string parameter", func() {
+			mockService.stubGetParameter = func(path string) (*secretsmanager.GetSecretValueOutput, error) {
+				return &secretsmanager.GetSecretValueOutput{
+					SecretString: aws.String(`{"name": "yours", "pass": "truely"}`),
+				}, nil
+			}
+			value, found, err := variables.Get(vars.Reference{Path: "user"})
+			Expect(err).To(BeNil())
+			Expect(found).To(BeTrue())
+			Expect(value).To(BeEquivalentTo(map[string]interface{}{
+				"name": "yours",
+				"pass": "truely",
+			}))
+		})
+
 		It("should get team parameter if exists", func() {
 			mockService.stubGetParameter = func(input string) (*secretsmanager.GetSecretValueOutput, error) {
 				if input != "/concourse/alpha/cheery" {


### PR DESCRIPTION
This allows you to use the `((secret.field))` syntax when you have configured Concourse to use AWS secrets manager and you have defined a JSON secret in AWS Secrets Manager.

For some extra context for those who are not familiar with AWS Secrets Manager, when you create or edit a secret in the AWS Console you are presented with the following UX:

![Screenshot 2022-02-10 at 19-23-11 Secrets Manager](https://user-images.githubusercontent.com/2661907/153349825-d3357792-74bd-415f-a158-1579801b693f.png)

Behind the scenes these key value pairs are just stored as a JSON string:

![Screenshot 2022-02-10 at 19-23-23 Secrets Manager](https://user-images.githubusercontent.com/2661907/153349883-5cebc35f-6421-49a8-9629-e1aa133eeb98.png)

The current behaviour of concourse is to only allow the user to use this as a string value, even though in AWS you have created a secret with key/value pairs. I propose we change the behaviour to allow the `.field` syntax as is done with other secret providers.

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #7522

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Update behaviour to allow the use of secret fields
* [x] Update test cases 

