### PR TITLE
Change Lidar scanner to not use go-routines.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -145,7 +145,8 @@ type RunCommand struct {
 
 	ComponentRunnerInterval time.Duration `long:"component-runner-interval" default:"10s" description:"Interval on which runners are kicked off for builds, locks, scans, and checks"`
 
-	LidarScannerInterval time.Duration `long:"lidar-scanner-interval" default:"10s" description:"Interval on which the resource scanner will run to see if new checks need to be scheduled"`
+	LidarScannerInterval  time.Duration `long:"lidar-scanner-interval" default:"10s" description:"Interval on which the resource scanner will run to see if new checks need to be scheduled"`
+	LidarScannerBatchSize int           `long:"lidar-scanner-batch-size" default:"0" description:"Max resources to scan in a round. 0 means no limit."`
 
 	GlobalResourceCheckTimeout          time.Duration `long:"global-resource-check-timeout" default:"1h" description:"Time limit on checking for new versions of resources."`
 	ResourceCheckingInterval            time.Duration `long:"resource-checking-interval" default:"1m" description:"Interval on which to check for new versions of resources."`
@@ -1079,6 +1080,7 @@ func (cmd *RunCommand) backendComponents(
 			Runnable: lidar.NewScanner(
 				dbCheckFactory,
 				atc.NewPlanFactory(time.Now().Unix()),
+				cmd.LidarScannerBatchSize,
 			),
 		},
 		{


### PR DESCRIPTION
## Changes proposed by this PR

Changed Lidar Scanner to not use go-routines. Because with in-memory-check, Lidar scanner will only create build objects and push them to a channel, as there is no db operations, no IO operations, it doesn't have to scan resource in a go-routine. This way will save a lot of go-routines.

Added `--lidar-scanner-batch-size` to limit max resources to scan in a round. To emphasize, batch size will only count created checks. Say there are resource 1-10, and batch size is 3. In first round, resource 1-3 are scanned. Then in second round, since 1-3 has not reached to next scan interval, 4-6 will be scanned, and so on. This way helps distribute resource scans across ATCs. The reason why I must add `--lidar-scanner-batch-size` is that, our cluster now have more than 80K resources, without a limitation, I'm afraid ATC might be exhausted when it takes turn to run Lidar scanner. With this batch size setting, we will have a weapon in hand.

* [x] done

## Notes to reviewer

My only afraid that, with go-routine mode, if a resource causes a crash, the go-routine will be recovered, so that entire ATC process won't crash. But I searched over our ATC logs for "panic-in-scanner-run" and didn't find any match.

Though there is a rate limit in `checkDelegate.WaitToRun()`, but I think that is too later. When reached to that rate limit, too much CPU cyles and IOs have been wasted.

Metrics show reduced go-routes after applying this PR:

![8056](https://user-images.githubusercontent.com/18585861/154032673-1bfca6d4-1bb2-4065-b657-81435eb317a6.png)

## Release Note

* Optimized ATC performance by getting rid of go-routines from Lidar scanner.
* Add `--lidar-scanner-batch-size`. When a deployment has too many resources, this option may limit how many resources to scan in a round.