### PR TITLE
Ignore cached input from volume-locality's consideration

### DIFF
--- a/atc/engine/build_step_delegate.go
+++ b/atc/engine/build_step_delegate.go
@@ -285,7 +285,7 @@ func (delegate *buildStepDelegate) FetchImage(
 		return runtime.ImageSpec{}, nil, fmt.Errorf("save image version: %w", err)
 	}
 
-	artifact, found := fetchState.ArtifactRepository().ArtifactFor(build.ArtifactName(result.Name))
+	artifact, _, found := fetchState.ArtifactRepository().ArtifactFor(build.ArtifactName(result.Name))
 	if !found {
 		return runtime.ImageSpec{}, nil, fmt.Errorf("fetched artifact not found")
 	}

--- a/atc/engine/build_step_delegate_test.go
+++ b/atc/engine/build_step_delegate_test.go
@@ -152,7 +152,7 @@ var _ = Describe("BuildStepDelegate", func() {
 
 				step := new(execfakes.FakeStep)
 				step.RunStub = func(_ context.Context, state exec.RunState) (bool, error) {
-					state.ArtifactRepository().RegisterArtifact("image", volume)
+					state.ArtifactRepository().RegisterArtifact("image", volume, false)
 					state.StoreResult(expectedGetPlan.ID, exec.GetResult{
 						Name:          "image",
 						ResourceCache: fakeResourceCache,

--- a/atc/engine/task_delegate_test.go
+++ b/atc/engine/task_delegate_test.go
@@ -177,7 +177,7 @@ var _ = Describe("TaskDelegate", func() {
 				fakeResourceCache = new(dbfakes.FakeResourceCache)
 				step.RunStub = func(_ context.Context, state exec.RunState) (bool, error) {
 					if p.Get != nil {
-						state.ArtifactRepository().RegisterArtifact("image", volume)
+						state.ArtifactRepository().RegisterArtifact("image", volume, false)
 						state.StoreResult(expectedGetPlan.ID, exec.GetResult{
 							Name:          "image",
 							ResourceCache: fakeResourceCache,

--- a/atc/exec/artifact_input_step.go
+++ b/atc/exec/artifact_input_step.go
@@ -69,7 +69,7 @@ func (step *ArtifactInputStep) Run(ctx context.Context, state RunState) (bool, e
 		"handle":      volume.Handle(),
 	})
 
-	state.ArtifactRepository().RegisterArtifact(build.ArtifactName(step.plan.ArtifactInput.Name), volume)
+	state.ArtifactRepository().RegisterArtifact(build.ArtifactName(step.plan.ArtifactInput.Name), volume, false)
 
 	return true, nil
 }

--- a/atc/exec/artifact_input_step_test.go
+++ b/atc/exec/artifact_input_step_test.go
@@ -125,12 +125,13 @@ var _ = Describe("ArtifactInputStep", func() {
 				})
 
 				It("registers the artifact", func() {
-					artifact, found := state.ArtifactRepository().ArtifactFor(build.ArtifactName("some-input-artifact-name"))
+					artifact, fromCache, found := state.ArtifactRepository().ArtifactFor(build.ArtifactName("some-input-artifact-name"))
 
 					Expect(stepErr).NotTo(HaveOccurred())
 					Expect(found).To(BeTrue())
 
 					Expect(artifact).To(Equal(volume))
+					Expect(fromCache).To(BeFalse())
 				})
 
 				It("succeeds", func() {

--- a/atc/exec/artifact_output_step.go
+++ b/atc/exec/artifact_output_step.go
@@ -49,7 +49,7 @@ func (step *ArtifactOutputStep) Run(ctx context.Context, state RunState) (bool, 
 
 	outputName := step.plan.ArtifactOutput.Name
 
-	artifact, found := state.ArtifactRepository().ArtifactFor(build.ArtifactName(outputName))
+	artifact, _, found := state.ArtifactRepository().ArtifactFor(build.ArtifactName(outputName))
 	if !found {
 		return false, ArtifactNotFoundError{outputName}
 	}

--- a/atc/exec/artifact_output_step_test.go
+++ b/atc/exec/artifact_output_step_test.go
@@ -69,7 +69,7 @@ var _ = Describe("ArtifactOutputStep", func() {
 			volume = runtimetest.NewVolume("some-volume")
 			fakeWorkerPool.LocateVolumeReturns(volume, runtimetest.NewWorker("worker"), true, nil)
 
-			state.ArtifactRepository().RegisterArtifact(build.ArtifactName(artifactName), volume)
+			state.ArtifactRepository().RegisterArtifact(build.ArtifactName(artifactName), volume, false)
 		})
 
 		Context("when initializing the artifact fails", func() {

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -283,9 +283,10 @@ var _ = Describe("GetStep", func() {
 				})
 
 				It("registers the volume as an artifact", func() {
-					artifact, found := artifactRepository.ArtifactFor(build.ArtifactName(getPlan.Name))
+					artifact, fromCache, found := artifactRepository.ArtifactFor(build.ArtifactName(getPlan.Name))
 					Expect(artifact).To(Equal(cacheVolume))
 					Expect(found).To(BeTrue())
+					Expect(fromCache).To(BeTrue())
 				})
 
 				It("stores the resource cache as the step result", func() {
@@ -698,9 +699,10 @@ var _ = Describe("GetStep", func() {
 		})
 
 		It("registers the resulting artifact in the RunState.ArtifactRepository", func() {
-			artifact, found := artifactRepository.ArtifactFor(build.ArtifactName(getPlan.Name))
+			artifact, fromCache, found := artifactRepository.ArtifactFor(build.ArtifactName(getPlan.Name))
 			Expect(artifact).To(Equal(getVolume))
 			Expect(found).To(BeTrue())
+			Expect(fromCache).To(BeFalse())
 		})
 
 		It("initializes the resource cache on the get volume", func() {

--- a/atc/exec/load_var_step.go
+++ b/atc/exec/load_var_step.go
@@ -123,7 +123,7 @@ func (step *LoadVarStep) fetchVars(
 	}
 	logger.Debug("figure-out-format", lager.Data{"format": format})
 
-	art, found := state.ArtifactRepository().ArtifactFor(build.ArtifactName(artifactName))
+	art, _, found := state.ArtifactRepository().ArtifactFor(build.ArtifactName(artifactName))
 	if !found {
 		return nil, UnknownArtifactSourceError{build.ArtifactName(artifactName), filePath}
 	}

--- a/atc/exec/load_var_step_test.go
+++ b/atc/exec/load_var_step_test.go
@@ -78,7 +78,7 @@ var _ = Describe("LoadVarStep", func() {
 		state = new(execfakes.FakeRunState)
 		state.ArtifactRepositoryReturns(artifactRepository)
 
-		artifactRepository.RegisterArtifact("some-resource", runtimetest.NewVolume("some-handle"))
+		artifactRepository.RegisterArtifact("some-resource", runtimetest.NewVolume("some-handle"), false)
 
 		stdout = gbytes.NewBuffer()
 		stderr = gbytes.NewBuffer()

--- a/atc/exec/put_inputs.go
+++ b/atc/exec/put_inputs.go
@@ -111,20 +111,21 @@ func (i detectInputs) FindAll(artifacts *build.Repository) ([]runtime.Input, err
 
 	inputs := []runtime.Input{}
 	for _, name := range i.guessedNames {
-		artifact, found := artifactsMap[name]
+		artifactEntry, found := artifactsMap[name]
 		if !found {
 			// false positive; not an artifact
 			continue
 		}
-		inputs = append(inputs, putInput(name, artifact))
+		inputs = append(inputs, putInput(name, artifactEntry))
 	}
 
 	return inputs, nil
 }
 
-func putInput(name build.ArtifactName, artifact runtime.Artifact) runtime.Input {
+func putInput(name build.ArtifactName, artifactEntry build.ArtifactEntry) runtime.Input {
 	return runtime.Input{
-		Artifact:        artifact,
+		Artifact:        artifactEntry.Artifact,
 		DestinationPath: filepath.Join(resource.ResourcesDir("put"), string(name)),
+		FromCache:       artifactEntry.FromCache,
 	}
 }

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -392,14 +392,14 @@ var _ = Describe("PutStep", func() {
 				})
 			})
 
-			Context("when only some inputs are from cache ", func() {
+			Context("when only inputs are from cache ", func() {
 				BeforeEach(func() {
 					putPlan.Inputs = &atc.InputsConfig{
 						Specified: []string{"input2"},
 					}
 				})
 
-				It("runs with specified inputs", func() {
+				It("runs with cached inputs", func() {
 					Expect(chosenContainer.Spec.Inputs).To(ConsistOf([]runtime.Input{
 						{
 							Artifact:        volume2,

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -139,9 +139,9 @@ var _ = Describe("PutStep", func() {
 		volume2 = runtimetest.NewVolume("volume2")
 		volume3 = runtimetest.NewVolume("volume3")
 
-		repo.RegisterArtifact("input1", volume1)
-		repo.RegisterArtifact("input2", volume2)
-		repo.RegisterArtifact("input3", volume3)
+		repo.RegisterArtifact("input1", volume1, false)
+		repo.RegisterArtifact("input2", volume2, true)
+		repo.RegisterArtifact("input3", volume3, false)
 	})
 
 	AfterEach(func() {
@@ -238,14 +238,17 @@ var _ = Describe("PutStep", func() {
 					{
 						Artifact:        volume1,
 						DestinationPath: "/tmp/build/put/input1",
+						FromCache:       false,
 					},
 					{
 						Artifact:        volume2,
 						DestinationPath: "/tmp/build/put/input2",
+						FromCache:       true,
 					},
 					{
 						Artifact:        volume3,
 						DestinationPath: "/tmp/build/put/input3",
+						FromCache:       false,
 					},
 				}))
 			})
@@ -257,14 +260,17 @@ var _ = Describe("PutStep", func() {
 					{
 						Artifact:        volume1,
 						DestinationPath: "/tmp/build/put/input1",
+						FromCache:       false,
 					},
 					{
 						Artifact:        volume2,
 						DestinationPath: "/tmp/build/put/input2",
+						FromCache:       true,
 					},
 					{
 						Artifact:        volume3,
 						DestinationPath: "/tmp/build/put/input3",
+						FromCache:       false,
 					},
 				}))
 			})
@@ -282,10 +288,12 @@ var _ = Describe("PutStep", func() {
 					{
 						Artifact:        volume1,
 						DestinationPath: "/tmp/build/put/input1",
+						FromCache:       false,
 					},
 					{
 						Artifact:        volume3,
 						DestinationPath: "/tmp/build/put/input3",
+						FromCache:       false,
 					},
 				}))
 			})
@@ -347,10 +355,12 @@ var _ = Describe("PutStep", func() {
 						{
 							Artifact:        volume1,
 							DestinationPath: "/tmp/build/put/input1",
+							FromCache:       false,
 						},
 						{
 							Artifact:        volume2,
 							DestinationPath: "/tmp/build/put/input2",
+							FromCache:       true,
 						},
 					}))
 				})
@@ -371,10 +381,30 @@ var _ = Describe("PutStep", func() {
 						{
 							Artifact:        volume1,
 							DestinationPath: "/tmp/build/put/input1",
+							FromCache:       false,
 						},
 						{
 							Artifact:        volume2,
 							DestinationPath: "/tmp/build/put/input2",
+							FromCache:       true,
+						},
+					}))
+				})
+			})
+
+			Context("when only some inputs are from cache ", func() {
+				BeforeEach(func() {
+					putPlan.Inputs = &atc.InputsConfig{
+						Specified: []string{"input2"},
+					}
+				})
+
+				It("runs with specified inputs", func() {
+					Expect(chosenContainer.Spec.Inputs).To(ConsistOf([]runtime.Input{
+						{
+							Artifact:        volume2,
+							DestinationPath: "/tmp/build/put/input2",
+							FromCache:       true,
 						},
 					}))
 				})

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -342,7 +342,7 @@ func (s setPipelineSource) fetchPipelineBits(path string) ([]byte, error) {
 }
 
 func (s setPipelineSource) retrieveFromArtifact(name, file string) (io.ReadCloser, error) {
-	art, found := s.repo.ArtifactFor(build.ArtifactName(name))
+	art, _, found := s.repo.ArtifactFor(build.ArtifactName(name))
 	if !found {
 		return nil, UnknownArtifactSourceError{build.ArtifactName(name), file}
 	}

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -134,7 +134,7 @@ jobs:
 
 		state.GetStub = vars.StaticVariables{"source-param": "super-secret-source"}.Get
 
-		artifactRepository.RegisterArtifact("some-resource", runtimetest.NewVolume("some-handle"))
+		artifactRepository.RegisterArtifact("some-resource", runtimetest.NewVolume("some-handle"), false)
 
 		stdout = gbytes.NewBuffer()
 		stderr = gbytes.NewBuffer()

--- a/atc/exec/task_config_source.go
+++ b/atc/exec/task_config_source.go
@@ -74,7 +74,7 @@ func (configSource FileConfigSource) FetchConfig(ctx context.Context, logger lag
 	sourceName := build.ArtifactName(segs[0])
 	filePath := segs[1]
 
-	artifact, found := repo.ArtifactFor(sourceName)
+	artifact, _, found := repo.ArtifactFor(sourceName)
 	if !found {
 		return atc.TaskConfig{}, UnknownArtifactSourceError{sourceName, configSource.ConfigPath}
 	}

--- a/atc/exec/task_config_source_test.go
+++ b/atc/exec/task_config_source_test.go
@@ -118,7 +118,7 @@ var _ = Describe("TaskConfigSource", func() {
 
 			BeforeEach(func() {
 				volume = runtimetest.NewVolume("some-volume")
-				repo.RegisterArtifact(build.ArtifactName(artifactName), volume)
+				repo.RegisterArtifact(build.ArtifactName(artifactName), volume, false)
 			})
 
 			Context("when the artifact provides a proper file", func() {

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -884,7 +884,6 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 	// ensure there are no invalid characters in label names.
 	event.Attributes = sanitizePrometheusLabels(event.Attributes)
 
-
 	switch event.Name {
 	case "error log":
 		emitter.errorLogsMetric(logger, event)

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -244,6 +244,10 @@ type Input struct {
 	//
 	// May be absolute or relative to ContainerSpec.Dir.
 	DestinationPath string
+	// FromCache indicates if the artifact is found from cache or not.
+	// If an artifact is found from cache, then if it should not be considered
+	// by volume-locality strategy.
+	FromCache bool
 }
 
 // OutputPaths is a mapping from output name to its path in the container.

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -141,6 +141,10 @@ func (strategy volumeLocalityStrategy) Order(logger lager.Logger, pool Pool, wor
 	counts := make(map[string]int, len(workers))
 
 	for _, input := range spec.Inputs {
+		if input.FromCache {
+			continue
+		}
+
 		volume, ok := input.Artifact.(runtime.Volume)
 		if !ok {
 			// Non-volume artifacts don't live on workers, so don't affect


### PR DESCRIPTION
## Changes proposed by this PR

Closes #8070

* [x] Ignore cached input from `volume-locality`'s `Order()` 

## Notes to reviewer



## Release Note

* When `EnableCacheStreamedVolume` is enabled and container placement strategy is `volume-locality`, as `get` step may not fetch a resource if the resource is found in cache, following step containers may all be placed to the worker where cached resource is found. That worker might be overloaded when there are other workers available. This PR fixes the problem.