### PR TITLE
Render nested across steps

### DIFF
--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -364,7 +364,7 @@ updateTreeNodeAt id fn tree =
         Across stepId vars vals trees ->
             let
                 withUpdatedChildren =
-                    Across stepId vars vals <| Array.map (updateTreeNodeAt stepId fn) trees
+                    Across stepId vars vals <| Array.map (updateTreeNodeAt id fn) trees
             in
             if stepId == id then
                 fn withUpdatedChildren


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #7564 

This PR fixes a rendering issue with nested across steps.

Inside `updateTreeNodeAt`, when matching an Across node, we also update all of the nodes that are nested within that across node. When doing that, we should pass the `id` that we want to update, instead of the `id` (`stepId`) of the across node.

### Before

<img width="1918" alt="image" src="https://user-images.githubusercontent.com/15989650/153781247-0971b389-738c-40a4-9d73-50d825b39a1a.png">

### After

<img width="1917" alt="image" src="https://user-images.githubusercontent.com/15989650/153781181-a0f9fc14-3644-475a-bd97-f67d9b0826ac.png">

## Release Note

 * Fix a rendering issue with nested across steps.