### PR TITLE
Fix syntax error in down migration file

### DIFF
--- a/atc/db/migration/migrations/1625844436_add_worker_cache_triggers.down.sql
+++ b/atc/db/migration/migrations/1625844436_add_worker_cache_triggers.down.sql
@@ -1,4 +1,4 @@
 DROP TRIGGER IF EXISTS workers_upsert_or_delete_trigger ON workers;
 DROP TRIGGER IF EXISTS containers_insert_or_delete_trigger ON containers;
 
-DROP FUNCTION IF EXISTS notify_trigger;
+DROP FUNCTION IF EXISTS notify_trigger();


### PR DESCRIPTION

closes #7977


* [x] done
* [ ] todo


## Release Note

 * Fix a SQL syntax error that might cause down migration failure.
