### PR TITLE
Render build page correctly for legacy aggregate step

### DIFF
--- a/web/assets/css/modules.less
+++ b/web/assets/css/modules.less
@@ -80,6 +80,11 @@
   border-left: 1px solid @base09;
 }
 
+.aggregate {
+  margin-left: -1px;
+  border-left: 1px solid @grey10;
+}
+
 .parallel {
   margin-left: -1px;
   border-left: 1px solid @grey10;

--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -54,6 +54,7 @@ type StepTree
     | LoadVar StepID
     | ArtifactInput StepID
     | ArtifactOutput StepID
+    | Aggregate (Array StepTree)
     | InParallel (Array StepTree)
     | Across StepID (List String) (List (List Concourse.JsonValue)) (Array StepTree)
     | Retry StepID (Array StepTree)
@@ -281,6 +282,9 @@ activeStepIds model tree =
         LoadVar stepId ->
             [ stepId ]
 
+        Aggregate trees ->
+            List.concatMap (activeStepIds model) (Array.toList trees)
+
         InParallel trees ->
             List.concatMap (activeStepIds model) (Array.toList trees)
 
@@ -355,6 +359,9 @@ updateTreeNodeAt id fn tree =
 
         LoadVar stepId ->
             updateSelf stepId
+
+        Aggregate trees ->
+            Aggregate <| Array.map (updateTreeNodeAt id fn) trees
 
         InParallel trees ->
             InParallel <| Array.map (updateTreeNodeAt id fn) trees

--- a/web/elm/src/Build/StepTree/StepTree.elm
+++ b/web/elm/src/Build/StepTree/StepTree.elm
@@ -108,6 +108,9 @@ init buildId hl resources plan =
         Concourse.BuildStepLoadVar _ ->
             step |> initBottom buildId hl resources plan LoadVar
 
+        Concourse.BuildStepAggregate plans ->
+            initMultiStep buildId hl resources plan.id Aggregate plans Nothing
+
         Concourse.BuildStepInParallel plans ->
             initMultiStep buildId hl resources plan.id InParallel plans Nothing
 
@@ -656,6 +659,10 @@ viewTree session model tree depth =
 
         Timeout subTree ->
             viewTree session model subTree depth
+
+        Aggregate trees ->
+            Html.div [ class "aggregate" ]
+                (Array.toList <| Array.map (viewSeq session model depth) trees)
 
         InParallel trees ->
             Html.div [ class "parallel" ]
@@ -1264,6 +1271,9 @@ viewStepHeader step =
         Concourse.BuildStepDo _ ->
             Html.text ""
 
+        Concourse.BuildStepAggregate _ ->
+            Html.text ""
+
         Concourse.BuildStepInParallel _ ->
             Html.text ""
 
@@ -1326,6 +1336,9 @@ stepName header =
             Just <| String.join ", " vars
 
         Concourse.BuildStepDo _ ->
+            Nothing
+
+        Concourse.BuildStepAggregate _ ->
             Nothing
 
         Concourse.BuildStepInParallel _ ->

--- a/web/elm/tests/StepTreeTests.elm
+++ b/web/elm/tests/StepTreeTests.elm
@@ -1,5 +1,7 @@
 module StepTreeTests exposing
     ( all
+    , initAggregate
+    , initAggregateNested
     , initEnsure
     , initGet
     , initInParallel
@@ -33,6 +35,8 @@ all =
         , initRun
         , initGet
         , initPut
+        , initAggregate
+        , initAggregateNested
         , initAcross
         , initAcrossNested
         , initAcrossWithDo
@@ -256,6 +260,101 @@ initPut =
         , test "the step" <|
             \_ ->
                 assertSteps [ someStep "some-id" step Models.StepStatePending ] steps
+        ]
+
+
+initAggregate : Test
+initAggregate =
+    let
+        { tree, steps } =
+            StepTree.init Nothing
+                Routes.HighlightNothing
+                emptyResources
+                { id = "aggregate-id"
+                , step =
+                    BuildStepAggregate
+                        << Array.fromList
+                    <|
+                        [ { id = "task-a-id", step = BuildStepTask "task-a" }
+                        , { id = "task-b-id", step = BuildStepTask "task-b" }
+                        ]
+                }
+    in
+    describe "init with Aggregate"
+        [ test "the tree" <|
+            \_ ->
+                Expect.equal
+                    (Models.Aggregate
+                        << Array.fromList
+                     <|
+                        [ Models.Task "task-a-id"
+                        , Models.Task "task-b-id"
+                        ]
+                    )
+                    tree
+        , test "the steps" <|
+            \_ ->
+                assertSteps
+                    [ someStep "task-a-id" (BuildStepTask "task-a") Models.StepStatePending
+                    , someStep "task-b-id" (BuildStepTask "task-b") Models.StepStatePending
+                    ]
+                    steps
+        ]
+
+
+initAggregateNested : Test
+initAggregateNested =
+    let
+        { tree, steps } =
+            StepTree.init Nothing
+                Routes.HighlightNothing
+                emptyResources
+                { id = "aggregate-id"
+                , step =
+                    BuildStepAggregate
+                        << Array.fromList
+                    <|
+                        [ { id = "task-a-id", step = BuildStepTask "task-a" }
+                        , { id = "task-b-id", step = BuildStepTask "task-b" }
+                        , { id = "nested-aggregate-id"
+                          , step =
+                                BuildStepAggregate
+                                    << Array.fromList
+                                <|
+                                    [ { id = "task-c-id", step = BuildStepTask "task-c" }
+                                    , { id = "task-d-id", step = BuildStepTask "task-d" }
+                                    ]
+                          }
+                        ]
+                }
+    in
+    describe "init with Aggregate nested"
+        [ test "the tree" <|
+            \_ ->
+                Expect.equal
+                    (Models.Aggregate
+                        << Array.fromList
+                     <|
+                        [ Models.Task "task-a-id"
+                        , Models.Task "task-b-id"
+                        , Models.Aggregate
+                            << Array.fromList
+                          <|
+                            [ Models.Task "task-c-id"
+                            , Models.Task "task-d-id"
+                            ]
+                        ]
+                    )
+                    tree
+        , test "the steps" <|
+            \_ ->
+                assertSteps
+                    [ someStep "task-a-id" (BuildStepTask "task-a") Models.StepStatePending
+                    , someStep "task-b-id" (BuildStepTask "task-b") Models.StepStatePending
+                    , someStep "task-c-id" (BuildStepTask "task-c") Models.StepStatePending
+                    , someStep "task-d-id" (BuildStepTask "task-d") Models.StepStatePending
+                    ]
+                    steps
         ]
 
 


### PR DESCRIPTION

## Changes proposed by this PR

partly revert concourse/concourse#6349 so Web UI can render build page with aggregate step in build plan

closes #7788 

* [x] done
* [ ] todo

## Notes to reviewer

To verify
 1. run concourse v6.7.8 and config a pipeline (by fly v6.7.8) with aggregate step and verify its build plan in DB contains aggregate step
```
resources:
- name: booklit
  type: git
  source: {uri: "https://github.com/xtremerui/booklit"}

- name: r1
  type: git
  source: {uri: "https://github.com/xtremerui/booklit"}

- name: r2
  type: git
  source: {uri: "https://github.com/xtremerui/booklit"}

jobs:
- name: unit
  plan:
  - aggregate:
    - get: booklit
    - get: r1
    - get: r2
  - task: test
    file: booklit/ci/test.yml
```
 run the pipeline to verify UI render build page correctly 
 
2. checkout concourse v7.6 and docker compose up without stopping DB container to keep the old build plan
3. verify that build page for job `unit` is now spinning and not showing any build events
4. checkout this PR and docker compose up again
5. verify that build page for job `unit` is now rendering as it was in v6.7.8 that all 3 get steps are shown as parallel
6. update above yaml by replacing `aggregate` to `in_parallel` and config a NEW pipeline by latest fly
7. make sure the build page for job `unit` for new pipeline is showing 3 get steps the same as the old one. 

## Release Note

 * Show legacy builds with aggregate steps. Pipeline configure with aggregate step is still deprecated. This is just fixing the UI rendering error.
