### PR TITLE
Fix log line in stream out

### DIFF
--- a/worker/baggageclaim/volume/repository.go
+++ b/worker/baggageclaim/volume/repository.go
@@ -431,7 +431,7 @@ func (repo *repository) StreamOut(ctx context.Context, handle string, path strin
 	})
 	defer span.End()
 
-	logger := lagerctx.FromContext(ctx).Session("stream-in", lager.Data{
+	logger := lagerctx.FromContext(ctx).Session("stream-out", lager.Data{
 		"volume":   handle,
 		"sub-path": path,
 	})


### PR DESCRIPTION
## Changes proposed by this PR
Fix logging session name for StreamOut (think this was a copy-paste error)

Log lines currently say e.g. `baggageclaim.api.volume-server.stream-out.stream-in.volume-not-found` which is kinda weird

* [x] fix log line
