### PR TITLE
Allow text whitespace to be preserved in step metadata

### DIFF
--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -325,6 +325,7 @@ metadataCell cell =
             , style "vertical-align" "top"
             , style "background-color" Colors.metadataKeyBackground
             , style "padding" "8px"
+            , style "white-space" "pre-wrap"
             ]
 
         Value ->
@@ -332,6 +333,7 @@ metadataCell cell =
             , style "vertical-align" "top"
             , style "background-color" Colors.metadataValueBackground
             , style "padding" "8px"
+            , style "white-space" "pre-wrap"
             ]
 
 


### PR DESCRIPTION
Signed-off-by: Steve Sienkowski <ssienkowski@vmware.com>

Wrap text within the step-body. 

* [x] done
* [x] todo

## Notes to reviewer

I'm not sure if step-body is the most logical place for this, though it creates the intent -- wrapping text within the step metadata fields.

Example, see metadata 'contents' field:

Before:
![Screen Shot 2022-02-24 at 12 24 05 PM](https://user-images.githubusercontent.com/30511577/155576621-0ec05ccd-6a63-4263-915a-142c8164a06c.png)

After:
![Screen Shot 2022-02-24 at 12 23 37 PM](https://user-images.githubusercontent.com/30511577/155576620-de010607-5264-4e88-b623-32042a791c25.png)

## Release Note

* Wrap text of resource metadata on web view.
