### PR TITLE
Remove BeforeSelectWorker

### DIFF
--- a/atc/engine/build_step_delegate.go
+++ b/atc/engine/build_step_delegate.go
@@ -168,21 +168,21 @@ func (delegate *buildStepDelegate) Finished(logger lager.Logger, succeeded bool)
 	logger.Info("finished")
 }
 
-func (delegate *buildStepDelegate) BeforeSelectWorker(logger lager.Logger) error {
-	if delegate.build.ResourceID() != 0 {
-		// For check builds, once a check build needs to select a worker, then
-		// we consider it needs to do run a real check. If it runs a real check,
-		// then we want to log it, so we call OnCheckBuildStart here to ensure
-		// the build can be logged. Note that, OnCheckBuildStart can be safely
-		// called multiple times.
-		err := delegate.build.OnCheckBuildStart()
-		if err != nil {
-			logger.Error("failed-to-call-on-check-build-start", err)
-			return err
-		}
-	}
-	return nil
-}
+//func (delegate *buildStepDelegate) BeforeSelectWorker(logger lager.Logger) error {
+//	if delegate.build.ResourceID() != 0 {
+//		// For check builds, once a check build needs to select a worker, then
+//		// we consider it needs to do run a real check. If it runs a real check,
+//		// then we want to log it, so we call OnCheckBuildStart here to ensure
+//		// the build can be logged. Note that, OnCheckBuildStart can be safely
+//		// called multiple times.
+//		err := delegate.build.OnCheckBuildStart()
+//		if err != nil {
+//			logger.Error("failed-to-call-on-check-build-start", err)
+//			return err
+//		}
+//	}
+//	return nil
+//}
 
 func (delegate *buildStepDelegate) WaitingForWorker(logger lager.Logger) {
 	err := delegate.build.SaveEvent(event.WaitingForWorker{

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -250,18 +249,16 @@ func (d *checkDelegate) PointToCheckedConfig(scope db.ResourceConfigScope) error
 	return nil
 }
 
-func (d *checkDelegate) UpdateScopeLastCheckStartTime(scope db.ResourceConfigScope, nestedCheck bool) (bool, int, error) {
-	var publicPlan *json.RawMessage
-	var buildId int
-	if !nestedCheck {
-		if err := d.build.OnCheckBuildStart(); err != nil {
-			return false, 0, err
-		}
-		publicPlan = d.build.PublicPlan()
-		buildId = d.build.ID()
+func (d *checkDelegate) OnCheckBuildStart() (int, error) {
+	err := d.build.OnCheckBuildStart()
+	if err != nil {
+		return 0, err
 	}
-	found, err := scope.UpdateLastCheckStartTime(buildId, publicPlan)
-	return found, buildId, err
+	return d.build.ID(), nil
+}
+
+func (d *checkDelegate) UpdateScopeLastCheckStartTime(scope db.ResourceConfigScope) (bool, error) {
+	return scope.UpdateLastCheckStartTime(d.build.ID(), d.build.PublicPlan())
 }
 
 func (d *checkDelegate) UpdateScopeLastCheckEndTime(scope db.ResourceConfigScope, succeeded bool) (bool, error) {

--- a/atc/exec/build_step_delegate.go
+++ b/atc/exec/build_step_delegate.go
@@ -32,7 +32,6 @@ type BuildStepDelegate interface {
 	Finished(lager.Logger, bool)
 	Errored(lager.Logger, string)
 
-	BeforeSelectWorker(lager.Logger) error
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
 	StreamingVolume(lager.Logger, string, string, string)

--- a/atc/exec/check_step_test.go
+++ b/atc/exec/check_step_test.go
@@ -114,9 +114,9 @@ var _ = Describe("CheckStep", func() {
 
 		fakeResourceConfigScope = new(dbfakes.FakeResourceConfigScope)
 		fakeDelegate.FindOrCreateScopeReturns(fakeResourceConfigScope, nil)
-		fakeDelegate.UpdateScopeLastCheckStartTimeStub = func(scope db.ResourceConfigScope, nestedCheck bool) (bool, int, error) {
+		fakeDelegate.UpdateScopeLastCheckStartTimeStub = func(scope db.ResourceConfigScope) (bool, error) {
 			found, err := scope.UpdateLastCheckStartTime(int(time.Now().Unix()), nil)
-			return found, 678, err
+			return found, err
 		}
 		fakeDelegate.UpdateScopeLastCheckEndTimeStub = func(scope db.ResourceConfigScope, succeeded bool) (bool, error) {
 			return scope.UpdateLastCheckEndTime(succeeded)
@@ -288,10 +288,6 @@ var _ = Describe("CheckStep", func() {
 					})
 				})
 
-				It("emits a BeforeSelectWorker event", func() {
-					Expect(fakeDelegate.BeforeSelectWorkerCallCount()).To(Equal(1))
-				})
-
 				It("emits a SelectedWorker event", func() {
 					Expect(fakeDelegate.SelectedWorkerCallCount()).To(Equal(1))
 					_, workerName := fakeDelegate.SelectedWorkerArgsForCall(0)
@@ -451,11 +447,14 @@ var _ = Describe("CheckStep", func() {
 						Expect(chosenContainer.RunningProcesses()).To(HaveLen(1))
 					})
 
+					It("call OnCheckBuildStart", func(){
+						Expect(fakeDelegate.OnCheckBuildStartCallCount()).To(Equal(1))
+					})
+
 					It("update scope's check start time", func() {
 						Expect(fakeDelegate.UpdateScopeLastCheckStartTimeCallCount()).To(Equal(1))
-						scope, nestedStep := fakeDelegate.UpdateScopeLastCheckStartTimeArgsForCall(0)
+						scope := fakeDelegate.UpdateScopeLastCheckStartTimeArgsForCall(0)
 						Expect(scope).To(Equal(fakeResourceConfigScope))
-						Expect(nestedStep).To(BeFalse())
 					})
 				})
 
@@ -495,11 +494,14 @@ var _ = Describe("CheckStep", func() {
 						Expect(chosenContainer.RunningProcesses()).To(HaveLen(1))
 					})
 
+					It("not call OnCheckBuildStart", func(){
+						Expect(fakeDelegate.OnCheckBuildStartCallCount()).To(Equal(0))
+					})
+
 					It("update scope's check start time", func() {
 						Expect(fakeDelegate.UpdateScopeLastCheckStartTimeCallCount()).To(Equal(1))
-						scope, nestedStep := fakeDelegate.UpdateScopeLastCheckStartTimeArgsForCall(0)
+						scope := fakeDelegate.UpdateScopeLastCheckStartTimeArgsForCall(0)
 						Expect(scope).To(Equal(fakeResourceConfigScope))
-						Expect(nestedStep).To(BeTrue())
 					})
 				})
 

--- a/atc/exec/execfakes/fake_build_step_delegate.go
+++ b/atc/exec/execfakes/fake_build_step_delegate.go
@@ -16,17 +16,6 @@ import (
 )
 
 type FakeBuildStepDelegate struct {
-	BeforeSelectWorkerStub        func(lager.Logger) error
-	beforeSelectWorkerMutex       sync.RWMutex
-	beforeSelectWorkerArgsForCall []struct {
-		arg1 lager.Logger
-	}
-	beforeSelectWorkerReturns struct {
-		result1 error
-	}
-	beforeSelectWorkerReturnsOnCall map[int]struct {
-		result1 error
-	}
 	ConstructAcrossSubstepsStub        func([]byte, []atc.AcrossVar, [][]interface{}) ([]atc.VarScopedPlan, error)
 	constructAcrossSubstepsMutex       sync.RWMutex
 	constructAcrossSubstepsArgsForCall []struct {
@@ -149,67 +138,6 @@ type FakeBuildStepDelegate struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeBuildStepDelegate) BeforeSelectWorker(arg1 lager.Logger) error {
-	fake.beforeSelectWorkerMutex.Lock()
-	ret, specificReturn := fake.beforeSelectWorkerReturnsOnCall[len(fake.beforeSelectWorkerArgsForCall)]
-	fake.beforeSelectWorkerArgsForCall = append(fake.beforeSelectWorkerArgsForCall, struct {
-		arg1 lager.Logger
-	}{arg1})
-	stub := fake.BeforeSelectWorkerStub
-	fakeReturns := fake.beforeSelectWorkerReturns
-	fake.recordInvocation("BeforeSelectWorker", []interface{}{arg1})
-	fake.beforeSelectWorkerMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeBuildStepDelegate) BeforeSelectWorkerCallCount() int {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	return len(fake.beforeSelectWorkerArgsForCall)
-}
-
-func (fake *FakeBuildStepDelegate) BeforeSelectWorkerCalls(stub func(lager.Logger) error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = stub
-}
-
-func (fake *FakeBuildStepDelegate) BeforeSelectWorkerArgsForCall(i int) lager.Logger {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	argsForCall := fake.beforeSelectWorkerArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeBuildStepDelegate) BeforeSelectWorkerReturns(result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	fake.beforeSelectWorkerReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeBuildStepDelegate) BeforeSelectWorkerReturnsOnCall(i int, result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	if fake.beforeSelectWorkerReturnsOnCall == nil {
-		fake.beforeSelectWorkerReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.beforeSelectWorkerReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakeBuildStepDelegate) ConstructAcrossSubsteps(arg1 []byte, arg2 []atc.AcrossVar, arg3 [][]interface{}) ([]atc.VarScopedPlan, error) {
@@ -829,8 +757,6 @@ func (fake *FakeBuildStepDelegate) WaitingForWorkerArgsForCall(i int) lager.Logg
 func (fake *FakeBuildStepDelegate) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
 	fake.constructAcrossSubstepsMutex.RLock()
 	defer fake.constructAcrossSubstepsMutex.RUnlock()
 	fake.containerOwnerMutex.RLock()

--- a/atc/exec/execfakes/fake_check_delegate.go
+++ b/atc/exec/execfakes/fake_check_delegate.go
@@ -17,17 +17,6 @@ import (
 )
 
 type FakeCheckDelegate struct {
-	BeforeSelectWorkerStub        func(lager.Logger) error
-	beforeSelectWorkerMutex       sync.RWMutex
-	beforeSelectWorkerArgsForCall []struct {
-		arg1 lager.Logger
-	}
-	beforeSelectWorkerReturns struct {
-		result1 error
-	}
-	beforeSelectWorkerReturnsOnCall map[int]struct {
-		result1 error
-	}
 	ConstructAcrossSubstepsStub        func([]byte, []atc.AcrossVar, [][]interface{}) ([]atc.VarScopedPlan, error)
 	constructAcrossSubstepsMutex       sync.RWMutex
 	constructAcrossSubstepsArgsForCall []struct {
@@ -101,6 +90,18 @@ type FakeCheckDelegate struct {
 	initializingMutex       sync.RWMutex
 	initializingArgsForCall []struct {
 		arg1 lager.Logger
+	}
+	OnCheckBuildStartStub        func() (int, error)
+	onCheckBuildStartMutex       sync.RWMutex
+	onCheckBuildStartArgsForCall []struct {
+	}
+	onCheckBuildStartReturns struct {
+		result1 int
+		result2 error
+	}
+	onCheckBuildStartReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
 	}
 	PointToCheckedConfigStub        func(db.ResourceConfigScope) error
 	pointToCheckedConfigMutex       sync.RWMutex
@@ -181,21 +182,18 @@ type FakeCheckDelegate struct {
 		result1 bool
 		result2 error
 	}
-	UpdateScopeLastCheckStartTimeStub        func(db.ResourceConfigScope, bool) (bool, int, error)
+	UpdateScopeLastCheckStartTimeStub        func(db.ResourceConfigScope) (bool, error)
 	updateScopeLastCheckStartTimeMutex       sync.RWMutex
 	updateScopeLastCheckStartTimeArgsForCall []struct {
 		arg1 db.ResourceConfigScope
-		arg2 bool
 	}
 	updateScopeLastCheckStartTimeReturns struct {
 		result1 bool
-		result2 int
-		result3 error
+		result2 error
 	}
 	updateScopeLastCheckStartTimeReturnsOnCall map[int]struct {
 		result1 bool
-		result2 int
-		result3 error
+		result2 error
 	}
 	WaitToRunStub        func(context.Context, db.ResourceConfigScope) (lock.Lock, bool, error)
 	waitToRunMutex       sync.RWMutex
@@ -220,67 +218,6 @@ type FakeCheckDelegate struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeCheckDelegate) BeforeSelectWorker(arg1 lager.Logger) error {
-	fake.beforeSelectWorkerMutex.Lock()
-	ret, specificReturn := fake.beforeSelectWorkerReturnsOnCall[len(fake.beforeSelectWorkerArgsForCall)]
-	fake.beforeSelectWorkerArgsForCall = append(fake.beforeSelectWorkerArgsForCall, struct {
-		arg1 lager.Logger
-	}{arg1})
-	stub := fake.BeforeSelectWorkerStub
-	fakeReturns := fake.beforeSelectWorkerReturns
-	fake.recordInvocation("BeforeSelectWorker", []interface{}{arg1})
-	fake.beforeSelectWorkerMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeCheckDelegate) BeforeSelectWorkerCallCount() int {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	return len(fake.beforeSelectWorkerArgsForCall)
-}
-
-func (fake *FakeCheckDelegate) BeforeSelectWorkerCalls(stub func(lager.Logger) error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = stub
-}
-
-func (fake *FakeCheckDelegate) BeforeSelectWorkerArgsForCall(i int) lager.Logger {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	argsForCall := fake.beforeSelectWorkerArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeCheckDelegate) BeforeSelectWorkerReturns(result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	fake.beforeSelectWorkerReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeCheckDelegate) BeforeSelectWorkerReturnsOnCall(i int, result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	if fake.beforeSelectWorkerReturnsOnCall == nil {
-		fake.beforeSelectWorkerReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.beforeSelectWorkerReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakeCheckDelegate) ConstructAcrossSubsteps(arg1 []byte, arg2 []atc.AcrossVar, arg3 [][]interface{}) ([]atc.VarScopedPlan, error) {
@@ -655,6 +592,62 @@ func (fake *FakeCheckDelegate) InitializingArgsForCall(i int) lager.Logger {
 	defer fake.initializingMutex.RUnlock()
 	argsForCall := fake.initializingArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeCheckDelegate) OnCheckBuildStart() (int, error) {
+	fake.onCheckBuildStartMutex.Lock()
+	ret, specificReturn := fake.onCheckBuildStartReturnsOnCall[len(fake.onCheckBuildStartArgsForCall)]
+	fake.onCheckBuildStartArgsForCall = append(fake.onCheckBuildStartArgsForCall, struct {
+	}{})
+	stub := fake.OnCheckBuildStartStub
+	fakeReturns := fake.onCheckBuildStartReturns
+	fake.recordInvocation("OnCheckBuildStart", []interface{}{})
+	fake.onCheckBuildStartMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeCheckDelegate) OnCheckBuildStartCallCount() int {
+	fake.onCheckBuildStartMutex.RLock()
+	defer fake.onCheckBuildStartMutex.RUnlock()
+	return len(fake.onCheckBuildStartArgsForCall)
+}
+
+func (fake *FakeCheckDelegate) OnCheckBuildStartCalls(stub func() (int, error)) {
+	fake.onCheckBuildStartMutex.Lock()
+	defer fake.onCheckBuildStartMutex.Unlock()
+	fake.OnCheckBuildStartStub = stub
+}
+
+func (fake *FakeCheckDelegate) OnCheckBuildStartReturns(result1 int, result2 error) {
+	fake.onCheckBuildStartMutex.Lock()
+	defer fake.onCheckBuildStartMutex.Unlock()
+	fake.OnCheckBuildStartStub = nil
+	fake.onCheckBuildStartReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCheckDelegate) OnCheckBuildStartReturnsOnCall(i int, result1 int, result2 error) {
+	fake.onCheckBuildStartMutex.Lock()
+	defer fake.onCheckBuildStartMutex.Unlock()
+	fake.OnCheckBuildStartStub = nil
+	if fake.onCheckBuildStartReturnsOnCall == nil {
+		fake.onCheckBuildStartReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.onCheckBuildStartReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeCheckDelegate) PointToCheckedConfig(arg1 db.ResourceConfigScope) error {
@@ -1055,24 +1048,23 @@ func (fake *FakeCheckDelegate) UpdateScopeLastCheckEndTimeReturnsOnCall(i int, r
 	}{result1, result2}
 }
 
-func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTime(arg1 db.ResourceConfigScope, arg2 bool) (bool, int, error) {
+func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTime(arg1 db.ResourceConfigScope) (bool, error) {
 	fake.updateScopeLastCheckStartTimeMutex.Lock()
 	ret, specificReturn := fake.updateScopeLastCheckStartTimeReturnsOnCall[len(fake.updateScopeLastCheckStartTimeArgsForCall)]
 	fake.updateScopeLastCheckStartTimeArgsForCall = append(fake.updateScopeLastCheckStartTimeArgsForCall, struct {
 		arg1 db.ResourceConfigScope
-		arg2 bool
-	}{arg1, arg2})
+	}{arg1})
 	stub := fake.UpdateScopeLastCheckStartTimeStub
 	fakeReturns := fake.updateScopeLastCheckStartTimeReturns
-	fake.recordInvocation("UpdateScopeLastCheckStartTime", []interface{}{arg1, arg2})
+	fake.recordInvocation("UpdateScopeLastCheckStartTime", []interface{}{arg1})
 	fake.updateScopeLastCheckStartTimeMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeCallCount() int {
@@ -1081,46 +1073,43 @@ func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeCallCount() int {
 	return len(fake.updateScopeLastCheckStartTimeArgsForCall)
 }
 
-func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeCalls(stub func(db.ResourceConfigScope, bool) (bool, int, error)) {
+func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeCalls(stub func(db.ResourceConfigScope) (bool, error)) {
 	fake.updateScopeLastCheckStartTimeMutex.Lock()
 	defer fake.updateScopeLastCheckStartTimeMutex.Unlock()
 	fake.UpdateScopeLastCheckStartTimeStub = stub
 }
 
-func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeArgsForCall(i int) (db.ResourceConfigScope, bool) {
+func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeArgsForCall(i int) db.ResourceConfigScope {
 	fake.updateScopeLastCheckStartTimeMutex.RLock()
 	defer fake.updateScopeLastCheckStartTimeMutex.RUnlock()
 	argsForCall := fake.updateScopeLastCheckStartTimeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1
 }
 
-func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeReturns(result1 bool, result2 int, result3 error) {
+func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeReturns(result1 bool, result2 error) {
 	fake.updateScopeLastCheckStartTimeMutex.Lock()
 	defer fake.updateScopeLastCheckStartTimeMutex.Unlock()
 	fake.UpdateScopeLastCheckStartTimeStub = nil
 	fake.updateScopeLastCheckStartTimeReturns = struct {
 		result1 bool
-		result2 int
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeReturnsOnCall(i int, result1 bool, result2 int, result3 error) {
+func (fake *FakeCheckDelegate) UpdateScopeLastCheckStartTimeReturnsOnCall(i int, result1 bool, result2 error) {
 	fake.updateScopeLastCheckStartTimeMutex.Lock()
 	defer fake.updateScopeLastCheckStartTimeMutex.Unlock()
 	fake.UpdateScopeLastCheckStartTimeStub = nil
 	if fake.updateScopeLastCheckStartTimeReturnsOnCall == nil {
 		fake.updateScopeLastCheckStartTimeReturnsOnCall = make(map[int]struct {
 			result1 bool
-			result2 int
-			result3 error
+			result2 error
 		})
 	}
 	fake.updateScopeLastCheckStartTimeReturnsOnCall[i] = struct {
 		result1 bool
-		result2 int
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeCheckDelegate) WaitToRun(arg1 context.Context, arg2 db.ResourceConfigScope) (lock.Lock, bool, error) {
@@ -1226,8 +1215,6 @@ func (fake *FakeCheckDelegate) WaitingForWorkerArgsForCall(i int) lager.Logger {
 func (fake *FakeCheckDelegate) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
 	fake.constructAcrossSubstepsMutex.RLock()
 	defer fake.constructAcrossSubstepsMutex.RUnlock()
 	fake.containerOwnerMutex.RLock()
@@ -1242,6 +1229,8 @@ func (fake *FakeCheckDelegate) Invocations() map[string][][]interface{} {
 	defer fake.finishedMutex.RUnlock()
 	fake.initializingMutex.RLock()
 	defer fake.initializingMutex.RUnlock()
+	fake.onCheckBuildStartMutex.RLock()
+	defer fake.onCheckBuildStartMutex.RUnlock()
 	fake.pointToCheckedConfigMutex.RLock()
 	defer fake.pointToCheckedConfigMutex.RUnlock()
 	fake.selectedWorkerMutex.RLock()

--- a/atc/exec/execfakes/fake_get_delegate.go
+++ b/atc/exec/execfakes/fake_get_delegate.go
@@ -17,17 +17,6 @@ import (
 )
 
 type FakeGetDelegate struct {
-	BeforeSelectWorkerStub        func(lager.Logger) error
-	beforeSelectWorkerMutex       sync.RWMutex
-	beforeSelectWorkerArgsForCall []struct {
-		arg1 lager.Logger
-	}
-	beforeSelectWorkerReturns struct {
-		result1 error
-	}
-	beforeSelectWorkerReturnsOnCall map[int]struct {
-		result1 error
-	}
 	ContainerOwnerStub        func(atc.PlanID) db.ContainerOwner
 	containerOwnerMutex       sync.RWMutex
 	containerOwnerArgsForCall []struct {
@@ -153,67 +142,6 @@ type FakeGetDelegate struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeGetDelegate) BeforeSelectWorker(arg1 lager.Logger) error {
-	fake.beforeSelectWorkerMutex.Lock()
-	ret, specificReturn := fake.beforeSelectWorkerReturnsOnCall[len(fake.beforeSelectWorkerArgsForCall)]
-	fake.beforeSelectWorkerArgsForCall = append(fake.beforeSelectWorkerArgsForCall, struct {
-		arg1 lager.Logger
-	}{arg1})
-	stub := fake.BeforeSelectWorkerStub
-	fakeReturns := fake.beforeSelectWorkerReturns
-	fake.recordInvocation("BeforeSelectWorker", []interface{}{arg1})
-	fake.beforeSelectWorkerMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeGetDelegate) BeforeSelectWorkerCallCount() int {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	return len(fake.beforeSelectWorkerArgsForCall)
-}
-
-func (fake *FakeGetDelegate) BeforeSelectWorkerCalls(stub func(lager.Logger) error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = stub
-}
-
-func (fake *FakeGetDelegate) BeforeSelectWorkerArgsForCall(i int) lager.Logger {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	argsForCall := fake.beforeSelectWorkerArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeGetDelegate) BeforeSelectWorkerReturns(result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	fake.beforeSelectWorkerReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeGetDelegate) BeforeSelectWorkerReturnsOnCall(i int, result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	if fake.beforeSelectWorkerReturnsOnCall == nil {
-		fake.beforeSelectWorkerReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.beforeSelectWorkerReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakeGetDelegate) ContainerOwner(arg1 atc.PlanID) db.ContainerOwner {
@@ -840,8 +768,6 @@ func (fake *FakeGetDelegate) WaitingForWorkerArgsForCall(i int) lager.Logger {
 func (fake *FakeGetDelegate) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
 	fake.containerOwnerMutex.RLock()
 	defer fake.containerOwnerMutex.RUnlock()
 	fake.erroredMutex.RLock()

--- a/atc/exec/execfakes/fake_put_delegate.go
+++ b/atc/exec/execfakes/fake_put_delegate.go
@@ -17,17 +17,6 @@ import (
 )
 
 type FakePutDelegate struct {
-	BeforeSelectWorkerStub        func(lager.Logger) error
-	beforeSelectWorkerMutex       sync.RWMutex
-	beforeSelectWorkerArgsForCall []struct {
-		arg1 lager.Logger
-	}
-	beforeSelectWorkerReturns struct {
-		result1 error
-	}
-	beforeSelectWorkerReturnsOnCall map[int]struct {
-		result1 error
-	}
 	ErroredStub        func(lager.Logger, string)
 	erroredMutex       sync.RWMutex
 	erroredArgsForCall []struct {
@@ -134,67 +123,6 @@ type FakePutDelegate struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakePutDelegate) BeforeSelectWorker(arg1 lager.Logger) error {
-	fake.beforeSelectWorkerMutex.Lock()
-	ret, specificReturn := fake.beforeSelectWorkerReturnsOnCall[len(fake.beforeSelectWorkerArgsForCall)]
-	fake.beforeSelectWorkerArgsForCall = append(fake.beforeSelectWorkerArgsForCall, struct {
-		arg1 lager.Logger
-	}{arg1})
-	stub := fake.BeforeSelectWorkerStub
-	fakeReturns := fake.beforeSelectWorkerReturns
-	fake.recordInvocation("BeforeSelectWorker", []interface{}{arg1})
-	fake.beforeSelectWorkerMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakePutDelegate) BeforeSelectWorkerCallCount() int {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	return len(fake.beforeSelectWorkerArgsForCall)
-}
-
-func (fake *FakePutDelegate) BeforeSelectWorkerCalls(stub func(lager.Logger) error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = stub
-}
-
-func (fake *FakePutDelegate) BeforeSelectWorkerArgsForCall(i int) lager.Logger {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	argsForCall := fake.beforeSelectWorkerArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakePutDelegate) BeforeSelectWorkerReturns(result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	fake.beforeSelectWorkerReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakePutDelegate) BeforeSelectWorkerReturnsOnCall(i int, result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	if fake.beforeSelectWorkerReturnsOnCall == nil {
-		fake.beforeSelectWorkerReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.beforeSelectWorkerReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakePutDelegate) Errored(arg1 lager.Logger, arg2 string) {
@@ -709,8 +637,6 @@ func (fake *FakePutDelegate) WaitingForWorkerArgsForCall(i int) lager.Logger {
 func (fake *FakePutDelegate) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
 	fake.erroredMutex.RLock()
 	defer fake.erroredMutex.RUnlock()
 	fake.fetchImageMutex.RLock()

--- a/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
+++ b/atc/exec/execfakes/fake_set_pipeline_step_delegate.go
@@ -16,17 +16,6 @@ import (
 )
 
 type FakeSetPipelineStepDelegate struct {
-	BeforeSelectWorkerStub        func(lager.Logger) error
-	beforeSelectWorkerMutex       sync.RWMutex
-	beforeSelectWorkerArgsForCall []struct {
-		arg1 lager.Logger
-	}
-	beforeSelectWorkerReturns struct {
-		result1 error
-	}
-	beforeSelectWorkerReturnsOnCall map[int]struct {
-		result1 error
-	}
 	CheckRunSetPipelinePolicyStub        func(*atc.Config) error
 	checkRunSetPipelinePolicyMutex       sync.RWMutex
 	checkRunSetPipelinePolicyArgsForCall []struct {
@@ -166,67 +155,6 @@ type FakeSetPipelineStepDelegate struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeSetPipelineStepDelegate) BeforeSelectWorker(arg1 lager.Logger) error {
-	fake.beforeSelectWorkerMutex.Lock()
-	ret, specificReturn := fake.beforeSelectWorkerReturnsOnCall[len(fake.beforeSelectWorkerArgsForCall)]
-	fake.beforeSelectWorkerArgsForCall = append(fake.beforeSelectWorkerArgsForCall, struct {
-		arg1 lager.Logger
-	}{arg1})
-	stub := fake.BeforeSelectWorkerStub
-	fakeReturns := fake.beforeSelectWorkerReturns
-	fake.recordInvocation("BeforeSelectWorker", []interface{}{arg1})
-	fake.beforeSelectWorkerMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeSetPipelineStepDelegate) BeforeSelectWorkerCallCount() int {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	return len(fake.beforeSelectWorkerArgsForCall)
-}
-
-func (fake *FakeSetPipelineStepDelegate) BeforeSelectWorkerCalls(stub func(lager.Logger) error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = stub
-}
-
-func (fake *FakeSetPipelineStepDelegate) BeforeSelectWorkerArgsForCall(i int) lager.Logger {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	argsForCall := fake.beforeSelectWorkerArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeSetPipelineStepDelegate) BeforeSelectWorkerReturns(result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	fake.beforeSelectWorkerReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeSetPipelineStepDelegate) BeforeSelectWorkerReturnsOnCall(i int, result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	if fake.beforeSelectWorkerReturnsOnCall == nil {
-		fake.beforeSelectWorkerReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.beforeSelectWorkerReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakeSetPipelineStepDelegate) CheckRunSetPipelinePolicy(arg1 *atc.Config) error {
@@ -940,8 +868,6 @@ func (fake *FakeSetPipelineStepDelegate) WaitingForWorkerArgsForCall(i int) lage
 func (fake *FakeSetPipelineStepDelegate) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
 	fake.checkRunSetPipelinePolicyMutex.RLock()
 	defer fake.checkRunSetPipelinePolicyMutex.RUnlock()
 	fake.constructAcrossSubstepsMutex.RLock()

--- a/atc/exec/execfakes/fake_task_delegate.go
+++ b/atc/exec/execfakes/fake_task_delegate.go
@@ -15,17 +15,6 @@ import (
 )
 
 type FakeTaskDelegate struct {
-	BeforeSelectWorkerStub        func(lager.Logger) error
-	beforeSelectWorkerMutex       sync.RWMutex
-	beforeSelectWorkerArgsForCall []struct {
-		arg1 lager.Logger
-	}
-	beforeSelectWorkerReturns struct {
-		result1 error
-	}
-	beforeSelectWorkerReturnsOnCall map[int]struct {
-		result1 error
-	}
 	ErroredStub        func(lager.Logger, string)
 	erroredMutex       sync.RWMutex
 	erroredArgsForCall []struct {
@@ -126,67 +115,6 @@ type FakeTaskDelegate struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeTaskDelegate) BeforeSelectWorker(arg1 lager.Logger) error {
-	fake.beforeSelectWorkerMutex.Lock()
-	ret, specificReturn := fake.beforeSelectWorkerReturnsOnCall[len(fake.beforeSelectWorkerArgsForCall)]
-	fake.beforeSelectWorkerArgsForCall = append(fake.beforeSelectWorkerArgsForCall, struct {
-		arg1 lager.Logger
-	}{arg1})
-	stub := fake.BeforeSelectWorkerStub
-	fakeReturns := fake.beforeSelectWorkerReturns
-	fake.recordInvocation("BeforeSelectWorker", []interface{}{arg1})
-	fake.beforeSelectWorkerMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeTaskDelegate) BeforeSelectWorkerCallCount() int {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	return len(fake.beforeSelectWorkerArgsForCall)
-}
-
-func (fake *FakeTaskDelegate) BeforeSelectWorkerCalls(stub func(lager.Logger) error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = stub
-}
-
-func (fake *FakeTaskDelegate) BeforeSelectWorkerArgsForCall(i int) lager.Logger {
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
-	argsForCall := fake.beforeSelectWorkerArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeTaskDelegate) BeforeSelectWorkerReturns(result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	fake.beforeSelectWorkerReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeTaskDelegate) BeforeSelectWorkerReturnsOnCall(i int, result1 error) {
-	fake.beforeSelectWorkerMutex.Lock()
-	defer fake.beforeSelectWorkerMutex.Unlock()
-	fake.BeforeSelectWorkerStub = nil
-	if fake.beforeSelectWorkerReturnsOnCall == nil {
-		fake.beforeSelectWorkerReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.beforeSelectWorkerReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakeTaskDelegate) Errored(arg1 lager.Logger, arg2 string) {
@@ -694,8 +622,6 @@ func (fake *FakeTaskDelegate) WaitingForWorkerArgsForCall(i int) lager.Logger {
 func (fake *FakeTaskDelegate) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.beforeSelectWorkerMutex.RLock()
-	defer fake.beforeSelectWorkerMutex.RUnlock()
 	fake.erroredMutex.RLock()
 	defer fake.erroredMutex.RUnlock()
 	fake.fetchImageMutex.RLock()

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -65,7 +65,6 @@ type GetDelegate interface {
 	Finished(lager.Logger, ExitStatus, resource.VersionResult)
 	Errored(lager.Logger, string)
 
-	BeforeSelectWorker(lager.Logger) error
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
 	StreamingVolume(lager.Logger, string, string, string)
@@ -282,12 +281,6 @@ func (step *GetStep) retrieveFromCacheOrPerformGet(
 	// ton of streaming out.
 	if !atc.EnableCacheStreamedVolumes {
 		var err error
-
-		err = delegate.BeforeSelectWorker(logger)
-		if err != nil {
-			return nil, false, resource.VersionResult{}, runtime.ProcessResult{}, err
-		}
-
 		worker, err = step.workerPool.FindOrSelectWorker(ctx, containerOwner, containerSpec, workerSpec, step.strategy, delegate)
 		if err != nil {
 			logger.Error("failed-to-select-worker", err)
@@ -448,11 +441,6 @@ func (step *GetStep) performGetAndInitCache(
 	// front.
 	if worker == nil {
 		var err error
-
-		err = delegate.BeforeSelectWorker(logger)
-		if err != nil {
-			return nil, resource.VersionResult{}, runtime.ProcessResult{}, err
-		}
 
 		worker, err = step.workerPool.FindOrSelectWorker(ctx, containerOwner, containerSpec, workerSpec, step.strategy, delegate)
 		if err != nil {

--- a/atc/exec/get_step_test.go
+++ b/atc/exec/get_step_test.go
@@ -494,10 +494,6 @@ var _ = Describe("GetStep", func() {
 			Expect(fakeDelegate.ContainerOwnerCallCount()).To(Equal(1))
 		})
 
-		It("emits a BeforeSelectWorker event", func() {
-			Expect(fakeDelegate.BeforeSelectWorkerCallCount()).To(Equal(1))
-		})
-
 		It("calls SelectWorker with the correct WorkerSpec", func() {
 			Expect(workerSpec).To(Equal(
 				worker.Spec{

--- a/atc/exec/put_step.go
+++ b/atc/exec/put_step.go
@@ -37,7 +37,6 @@ type PutDelegate interface {
 	Finished(lager.Logger, ExitStatus, resource.VersionResult)
 	Errored(lager.Logger, string)
 
-	BeforeSelectWorker(lager.Logger) error
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
 	StreamingVolume(lager.Logger, string, string, string)
@@ -179,11 +178,6 @@ func (step *PutStep) run(ctx context.Context, state RunState, delegate PutDelega
 	tracing.Inject(ctx, &containerSpec)
 
 	owner := db.NewBuildStepContainerOwner(step.metadata.BuildID, step.planID, step.metadata.TeamID)
-
-	err = delegate.BeforeSelectWorker(logger)
-	if err != nil {
-		return false, err
-	}
 
 	worker, err := step.workerPool.FindOrSelectWorker(ctx, owner, containerSpec, workerSpec, step.strategy, delegate)
 	if err != nil {

--- a/atc/exec/put_step_test.go
+++ b/atc/exec/put_step_test.go
@@ -185,10 +185,6 @@ var _ = Describe("PutStep", func() {
 			Expect(ok).To(BeFalse())
 		})
 
-		It("emits a BeforeSelectWorker event", func() {
-			Expect(fakeDelegate.BeforeSelectWorkerCallCount()).To(Equal(1))
-		})
-
 		It("calls SelectWorker with the correct WorkerSpec", func() {
 			Expect(workerSpec).To(Equal(
 				worker.Spec{

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -73,7 +73,6 @@ type TaskDelegate interface {
 	Finished(lager.Logger, ExitStatus)
 	Errored(lager.Logger, string)
 
-	BeforeSelectWorker(lager.Logger) error
 	WaitingForWorker(lager.Logger)
 	SelectedWorker(lager.Logger, string)
 	StreamingVolume(lager.Logger, string, string, string)
@@ -239,11 +238,6 @@ func (step *TaskStep) run(ctx context.Context, state RunState, delegate TaskDele
 	tracing.Inject(ctx, &containerSpec)
 
 	owner := db.NewBuildStepContainerOwner(step.metadata.BuildID, step.planID, step.metadata.TeamID)
-
-	err = delegate.BeforeSelectWorker(logger)
-	if err != nil {
-		return false, err
-	}
 
 	worker, err := step.workerPool.FindOrSelectWorker(
 		ctx,

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -206,10 +206,6 @@ var _ = Describe("TaskStep", func() {
 				Expect(ok).To(BeFalse())
 			})
 
-			It("emits a BeforeSelectWorker event", func() {
-				Expect(fakeDelegate.BeforeSelectWorkerCallCount()).To(Equal(1))
-			})
-
 			It("emits a SelectedWorker event", func() {
 				Expect(fakeDelegate.SelectedWorkerCallCount()).To(Equal(1))
 				_, workerName := fakeDelegate.SelectedWorkerArgsForCall(0)


### PR DESCRIPTION
## Changes proposed by this PR

This is a small refactor.

`BeforeSelectWorker()` was added purely for having a place to call `OnCheckBuildStart()`. But ended up that `OnCheckBuildStart()` is called in two places. Now, I think it would be better to explicitly call `OnCheckBuildStart()` in check step rather than wrapping it in `BeforeSelectWorker()`, so that `BeforeSelectWorker()` is no longer needed. Removing it helps reducing code complexity.

* [x] Code change
* [x] Update tests
* [ ] Cleanup dirty code

## Notes to reviewer

This is a dirty change yet, I haven't run any test. I'm quickly creating this PR to prevent me from forgetting the idea.

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
