### PR TITLE
Automatic pipeline archiver accidentally archives child pipelines during a build run

### DIFF
--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -48,8 +48,11 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 				sq.Eq{"j.id": nil},
 				// parent pipeline was archived
 				sq.Eq{"parent.archived": true},
-				// build that set the pipeline is not the most recent for the job
-				sq.Expr("p.parent_build_id != j.latest_completed_build_id"),
+				// build that set the pipeline is not the most recent for the job.
+				// parent_build_id can be later than latest_completed_build_id if this
+				// gc query runs during a run of a build, specifically between the time
+				// of a completed set pipeline step and the build finishing
+				sq.Expr("p.parent_build_id < j.latest_completed_build_id"),
 			}}).
 		RunWith(tx).
 		Query()


### PR DESCRIPTION
This shouldn't affect any released versions of concourse because the change that introduced it has not been released yet.

## Changes proposed by this PR

closes #8102

We noticed in our production environment that pr pipelines were getting archived when they were not supposed to. It was usually either all the child pipelines get archived or in some cases it was all but 1 child pipeline that gets archived. That 1 child pipeline that did not get archived was the latest one, and it also was a newly added pr so it took longer for it to complete the `set_pipeline` step for it.

I have a theory as to why is happening; I think its because of the pipeline archiver gc

https://github.com/concourse/concourse/blob/d2f724f6e30921a45a8363ace30a4624968c210e/atc/db/pipeline_lifecycle.go#L37-L55

and specifically because of this line https://github.com/concourse/concourse/blob/d2f724f6e30921a45a8363ace30a4624968c210e/atc/db/pipeline_lifecycle.go#L52

I think a situation can happen where you have a job that sets all the child pipelines and lets say that job is currently running a build. This build then has many `set_pipeline` steps for each child pipeline and some of the `set_pipeline` steps finish faster than the others. If the pipeline archiver gc component were to run right now, the `set_pipeline` steps that have already completed will have updated it's `parent_build_id` to the build id that is currently running here https://github.com/concourse/concourse/blob/4db49ebec7ebe086b55ff4b11d82703393b1c500/atc/exec/set_pipeline_step.go#L205-L208

but the `latest_completed_build_id` for the job will still be the build id of the previous build because this only gets updated when the build is finished 

https://github.com/concourse/concourse/blob/4f3bb8fb4916cf8ff8cc918ed81580f84e418420/atc/db/build.go#L791-L794

Therefore we will get a mismatch between the `parent_build_id` and the `latest_completed_build_id`.

My solution to this was to change the query to only grab child pipelines that have a `parent_build_id` that is less than the `latest_completed_build_id` rather than just querying based off of inequality. This will avoid the situation I mentioned above because in the situation above, the `parent_build_id` will always be greater than the `latest_completed_build_id`.

## Notes to reviewer

This is all just my theory by looking at the code!

Also I'm not even sure if this line is necessary because I think we already have something that will gc child pipelines that are no longer being set by the job. https://github.com/concourse/concourse/blob/4f3bb8fb4916cf8ff8cc918ed81580f84e418420/atc/db/build.go#L751-L762
Not sure if the line covers any extra cases though?

I also added some test cases: a new one and also added a missing one for covering the use case for that line I modified.
