### PR TITLE
Force get and check to use "fewest-build-containers" strategy.

### DIFF
--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -24,6 +24,7 @@ type coreStepFactory struct {
 	resourceConfigFactory db.ResourceConfigFactory
 	defaultLimits         atc.ContainerLimits
 	strategy              worker.PlacementStrategy
+	noInputStrategy       worker.PlacementStrategy
 	defaultCheckTimeout   time.Duration
 	defaultGetTimeout     time.Duration
 	defaultPutTimeout     time.Duration
@@ -40,6 +41,7 @@ func NewCoreStepFactory(
 	resourceConfigFactory db.ResourceConfigFactory,
 	defaultLimits atc.ContainerLimits,
 	strategy worker.PlacementStrategy,
+	noInputStrategy worker.PlacementStrategy,
 	defaultCheckTimeout time.Duration,
 	defaultGetTimeout time.Duration,
 	defaultPutTimeout time.Duration,
@@ -55,6 +57,7 @@ func NewCoreStepFactory(
 		resourceConfigFactory: resourceConfigFactory,
 		defaultLimits:         defaultLimits,
 		strategy:              strategy,
+		noInputStrategy:       noInputStrategy,
 		defaultCheckTimeout:   defaultCheckTimeout,
 		defaultGetTimeout:     defaultGetTimeout,
 		defaultPutTimeout:     defaultPutTimeout,
@@ -77,7 +80,7 @@ func (factory *coreStepFactory) GetStep(
 		containerMetadata,
 		factory.lockFactory,
 		factory.resourceCacheFactory,
-		factory.strategy,
+		factory.noInputStrategy,
 		delegateFactory,
 		factory.pool,
 		factory.defaultGetTimeout,
@@ -130,7 +133,7 @@ func (factory *coreStepFactory) CheckStep(
 		stepMetadata,
 		factory.resourceConfigFactory,
 		containerMetadata,
-		nil,
+		factory.noInputStrategy,
 		factory.pool,
 		delegateFactory,
 		factory.defaultCheckTimeout,

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -13,7 +13,7 @@ import (
 )
 
 type PlacementOptions struct {
-	Strategies                   []string `long:"container-placement-strategy" default:"volume-locality" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" choice:"limit-active-containers" choice:"limit-active-volumes" description:"Method by which a worker is selected during container placement. If multiple methods are specified, they will be applied in order. Random strategy should only be used alone."`
+	Strategies                   []string `long:"container-placement-strategy" default:"volume-locality" default:"fewest-build-containers" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" choice:"limit-active-containers" choice:"limit-active-volumes" description:"Method by which a worker is selected during container placement. If multiple methods are specified, they will be applied in order. Random strategy should only be used alone."`
 	MaxActiveTasksPerWorker      int      `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
 	MaxActiveContainersPerWorker int      `long:"max-active-containers-per-worker" default:"0" description:"Maximum allowed number of active containers per worker. Has effect only when used with limit-active-containers placement strategy. 0 means no limit."`
 	MaxActiveVolumesPerWorker    int      `long:"max-active-volumes-per-worker" default:"0" description:"Maximum allowed number of active volumes per worker. Has effect only when used with limit-active-volumes placement strategy. 0 means no limit."`


### PR DESCRIPTION
## Changes proposed by this PR

Currently, `check` step use random strategy to choose worker. If a check container, especially for nested checks, happened to be placed on a overloaded worker, then the entire build might be stuck.

This PR will force `get` and `check` to use `fewest-build-containers` strategy. Because `get` and `check` steps takes no input, they can always go to a least loaded worker.

* [x] done

## Notes to reviewer

@xtremerui @clarafu Code change of this PR is very simple. If possible, please make it in 7.7.

Optimize container placement strategy:
* Force `get` and `check` steps to use "fewest-build-containers" strategy. `check` step used to use random strategy. If an nested check step happens to be sent to a busy worker, that might block entire build. For `get` step, if strategy is `volume-locality`, as `get` takes no input, it will directly pass through `volume-locality` strategy and end up with random strategy. If a `get` happens to be sent to a busy worker, the following `task` and `put` steps that need the `get` as inputs may also be sent to the busy worker due to `volume-locality`, then the busy worker will get busier. With this optimization, `check` and `get` will always be placed on a relatively idle worker.
* Change default strategy from `volume-locality` to `volume-locality,fewest-build-containers`. When a `task` or `put` step takes inputs from a multiple workers, the combined strategy will choose a relatively idle one. More over, when a `task` or `put` takes no input, the combined strategy will ensure the step is placed on a relatively idle worker.

## Release Note

* Reverted in https://github.com/concourse/concourse/pull/8144
