### PR TITLE
Fix topgun resource types test failure

### DIFF
--- a/topgun/both/resource_types_test.go
+++ b/topgun/both/resource_types_test.go
@@ -22,11 +22,11 @@ var _ = Describe("A pipeline-provided resource type", func() {
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(1))
 
-		By("expecting a container for the resource check and task image check")
-		Expect(ContainersBy("type", "check")).To(HaveLen(2))
+		By("expecting a container for the resource check, resource type check, and task image check")
+		Expect(ContainersBy("type", "check")).To(HaveLen(3))
 
-		By("expecting a container for the resource check, build get, build task image check, build task image get, and build task")
-		expectedContainersBefore := 5
+		By("expecting a container for the resource check, resource type check, build resource image get, build get, build task image check, build task image get, and build task")
+		expectedContainersBefore := 7
 		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore))
 
 		By("triggering the build again")
@@ -35,7 +35,7 @@ var _ = Describe("A pipeline-provided resource type", func() {
 		Expect(buildSession.ExitCode()).To(Equal(1))
 
 		By("expecting only one additional check container for the task's image check")
-		Expect(ContainersBy("type", "check")).To(HaveLen(3))
+		Expect(ContainersBy("type", "check")).To(HaveLen(4))
 
 		By("expecting to only have new containers for build task image check and build task")
 		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore + 2))

--- a/topgun/pipelines/custom-types.yml
+++ b/topgun/pipelines/custom-types.yml
@@ -7,6 +7,7 @@ resource_types:
 resources:
 - name: 10m
   type: my-time
+  check_every: never
   source: {interval: 1h}
 
 jobs:


### PR DESCRIPTION
reverting previous changes https://github.com/concourse/concourse/pull/7707 as it turned out to be a fix on a flake that happened to be worked for a while. Now with 7.7 performance improvement on lidar, the flake seems gone. Thus the topgun test started to fail (in a good way).

Plus the resource will not do lidar check anymore it should reduce the chance of flake to minimum.