### PR TITLE
Add `--team` to fly watch

### DIFF
--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -147,6 +147,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "--shallow", "-a", "--team", nonExistentTeam)),
 			Entry("resource-versions command returns an error",
 				exec.Command(flyPath, "-t", targetName, "resource-versions", "-r", "pipeline/branch:master/foo", "--team", nonExistentTeam)),
+			Entry("watch command returns an error",
+				exec.Command(flyPath, "-t", targetName, "watch", "-j", "pipeline/job", "--team", nonExistentTeam)),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -201,6 +203,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "check-resource", "-r", "mypipeline/branch:master/myresource", "--shallow", "-a", "--team", otherTeam)),
 			Entry("resource-versions command returns an error",
 				exec.Command(flyPath, "-t", targetName, "resource-versions", "-r", "pipeline/branch:master/foo", "--team", otherTeam)),
+			Entry("watch command returns an error",
+				exec.Command(flyPath, "-t", targetName, "watch", "-j", "pipeline/job", "--team", nonExistentTeam)),
 		)
 	})
 })

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Fly CLI", func() {
 			Entry("resource-versions command returns an error",
 				exec.Command(flyPath, "-t", targetName, "resource-versions", "-r", "pipeline/branch:master/foo", "--team", otherTeam)),
 			Entry("watch command returns an error",
-				exec.Command(flyPath, "-t", targetName, "watch", "-j", "pipeline/job", "--team", nonExistentTeam)),
+				exec.Command(flyPath, "-t", targetName, "watch", "-j", "pipeline/job", "--team", otherTeam)),
 		)
 	})
 })


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR


closes  various items in #5215 

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Add team flag to fly watch command

## Notes to reviewer

Added the team flag to fly watch command

Now you can include the `--team` flag to specify the team you want to watch if the target team is different from that team

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Added `team` flag to fly watch command, you could use this in the following format
`fly -t example watch  --job my-pipeline/tests --build 52 --team other-team`


[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
