### PR TITLE
Add no-input-strategy and let get/check use it.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1027,7 +1027,7 @@ func (cmd *RunCommand) backendComponents(
 		return nil, err
 	}
 
-	buildContainerStrategy, err := cmd.chooseBuildContainerStrategy()
+	buildContainerStrategy, noInputBuildContainerStrategy, err := cmd.chooseBuildContainerStrategy()
 	if err != nil {
 		return nil, err
 	}
@@ -1051,6 +1051,7 @@ func (cmd *RunCommand) backendComponents(
 		secretManager,
 		defaultLimits,
 		buildContainerStrategy,
+		noInputBuildContainerStrategy,
 		lockFactory,
 		rateLimiter,
 		policyChecker,
@@ -1657,7 +1658,7 @@ func constructLockConn(driverName, connectionString string) (*sql.DB, error) {
 	return dbConn, nil
 }
 
-func (cmd *RunCommand) chooseBuildContainerStrategy() (worker.PlacementStrategy, error) {
+func (cmd *RunCommand) chooseBuildContainerStrategy() (worker.PlacementStrategy, worker.PlacementStrategy, error) {
 	return worker.NewPlacementStrategy(cmd.ContainerPlacementStrategyOptions)
 }
 
@@ -1694,6 +1695,7 @@ func (cmd *RunCommand) constructEngine(
 	secretManager creds.Secrets,
 	defaultLimits atc.ContainerLimits,
 	strategy worker.PlacementStrategy,
+	noInputStrategy worker.PlacementStrategy,
 	lockFactory lock.LockFactory,
 	rateLimiter engine.RateLimiter,
 	policyChecker policy.Checker,
@@ -1710,6 +1712,7 @@ func (cmd *RunCommand) constructEngine(
 				resourceConfigFactory,
 				defaultLimits,
 				strategy,
+				noInputStrategy,
 				cmd.GlobalResourceCheckTimeout,
 				cmd.DefaultGetTimeout,
 				cmd.DefaultPutTimeout,

--- a/atc/engine/step_factory.go
+++ b/atc/engine/step_factory.go
@@ -24,6 +24,7 @@ type coreStepFactory struct {
 	resourceConfigFactory db.ResourceConfigFactory
 	defaultLimits         atc.ContainerLimits
 	strategy              worker.PlacementStrategy
+	noInputStrategy       worker.PlacementStrategy
 	defaultCheckTimeout   time.Duration
 	defaultGetTimeout     time.Duration
 	defaultPutTimeout     time.Duration
@@ -40,6 +41,7 @@ func NewCoreStepFactory(
 	resourceConfigFactory db.ResourceConfigFactory,
 	defaultLimits atc.ContainerLimits,
 	strategy worker.PlacementStrategy,
+	noInputStrategy worker.PlacementStrategy,
 	defaultCheckTimeout time.Duration,
 	defaultGetTimeout time.Duration,
 	defaultPutTimeout time.Duration,
@@ -55,6 +57,7 @@ func NewCoreStepFactory(
 		resourceConfigFactory: resourceConfigFactory,
 		defaultLimits:         defaultLimits,
 		strategy:              strategy,
+		noInputStrategy:       noInputStrategy,
 		defaultCheckTimeout:   defaultCheckTimeout,
 		defaultGetTimeout:     defaultGetTimeout,
 		defaultPutTimeout:     defaultPutTimeout,
@@ -77,7 +80,7 @@ func (factory *coreStepFactory) GetStep(
 		containerMetadata,
 		factory.lockFactory,
 		factory.resourceCacheFactory,
-		factory.strategy,
+		factory.noInputStrategy,
 		delegateFactory,
 		factory.pool,
 		factory.defaultGetTimeout,
@@ -130,7 +133,7 @@ func (factory *coreStepFactory) CheckStep(
 		stepMetadata,
 		factory.resourceConfigFactory,
 		containerMetadata,
-		nil,
+		factory.noInputStrategy,
 		factory.pool,
 		delegateFactory,
 		factory.defaultCheckTimeout,

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -273,7 +273,12 @@ func (step *CheckStep) runCheck(
 		return nil, runtime.ProcessResult{}, err
 	}
 
-	worker, err := step.workerPool.FindOrSelectWorker(ctx, containerOwner, containerSpec, workerSpec, step.strategy, delegate)
+	strategy := step.strategy
+	if step.plan.IsResourceCheck() {
+		// Resource check containers should be placed randomly. Refer to PR#3251.
+		strategy = nil
+	}
+	worker, err := step.workerPool.FindOrSelectWorker(ctx, containerOwner, containerSpec, workerSpec, strategy, delegate)
 	if err != nil {
 		return nil, runtime.ProcessResult{}, err
 	}
@@ -285,7 +290,7 @@ func (step *CheckStep) runCheck(
 			logger,
 			containerSpec,
 			worker,
-			step.strategy,
+			strategy,
 		)
 	}()
 

--- a/atc/exec/check_step.go
+++ b/atc/exec/check_step.go
@@ -275,7 +275,7 @@ func (step *CheckStep) runCheck(
 
 	strategy := step.strategy
 	if step.plan.IsResourceCheck() {
-		// Resource check containers should be placed randomly. Refer to PR#3251.
+		// Resource check containers should be placed randomly. Refer to issue #3251.
 		strategy = nil
 	}
 	worker, err := step.workerPool.FindOrSelectWorker(ctx, containerOwner, containerSpec, workerSpec, strategy, delegate)

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -14,6 +14,7 @@ import (
 
 type PlacementOptions struct {
 	Strategies                   []string `long:"container-placement-strategy" default:"volume-locality" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" choice:"limit-active-containers" choice:"limit-active-volumes" description:"Method by which a worker is selected during container placement. If multiple methods are specified, they will be applied in order. Random strategy should only be used alone."`
+	NoInputStrategies            []string `long:"no-input-container-placement-strategy" default:"fewest-build-containers" choice:"volume-locality" choice:"random" choice:"fewest-build-containers" choice:"limit-active-tasks" choice:"limit-active-containers" choice:"limit-active-volumes" description:"Method by which a worker is selected during container placement. If multiple methods are specified, they will be applied in order. Random strategy should only be used alone."`
 	MaxActiveTasksPerWorker      int      `long:"max-active-tasks-per-worker" default:"0" description:"Maximum allowed number of active build tasks per worker. Has effect only when used with limit-active-tasks placement strategy. 0 means no limit."`
 	MaxActiveContainersPerWorker int      `long:"max-active-containers-per-worker" default:"0" description:"Maximum allowed number of active containers per worker. Has effect only when used with limit-active-containers placement strategy. 0 means no limit."`
 	MaxActiveVolumesPerWorker    int      `long:"max-active-volumes-per-worker" default:"0" description:"Maximum allowed number of active volumes per worker. Has effect only when used with limit-active-volumes placement strategy. 0 means no limit."`
@@ -24,9 +25,21 @@ var (
 	ErrTooManyVolumes    = errors.New("worker has too many volumes")
 )
 
-func NewPlacementStrategy(options PlacementOptions) (PlacementStrategy, error) {
+func NewPlacementStrategy(options PlacementOptions) (PlacementStrategy, PlacementStrategy, error) {
+	strategy, err := newPlaceStrategy(options, options.Strategies)
+	if err != nil {
+		return nil, nil, err
+	}
+	noInputStrategy, err := newPlaceStrategy(options, options.NoInputStrategies)
+	if err != nil {
+		return nil, nil, err
+	}
+	return strategy, noInputStrategy, nil
+}
+
+func newPlaceStrategy(options PlacementOptions, chain []string) (PlacementStrategy, error) {
 	var strategy PlacementStrategy
-	for _, s := range options.Strategies {
+	for _, s := range chain {
 		switch strings.TrimSpace(s) {
 		case "random":
 			// Add nothing - since worker order is already randomized

--- a/atc/worker/placement_test.go
+++ b/atc/worker/placement_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Container Placement Strategies", func() {
 	Describe("Volume Locality", func() {
 		volumeLocalityStrategy := func() worker.PlacementStrategy {
-			strategy, err := worker.NewPlacementStrategy(worker.PlacementOptions{
+			strategy, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
 				Strategies: []string{"volume-locality"},
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -469,7 +469,7 @@ var _ = Describe("Container Placement Strategies", func() {
 
 	Describe("Fewest Build Containers", func() {
 		fewestBuildContainersStrategy := func() worker.PlacementStrategy {
-			strategy, err := worker.NewPlacementStrategy(worker.PlacementOptions{
+			strategy, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
 				Strategies: []string{"fewest-build-containers"},
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -505,7 +505,7 @@ var _ = Describe("Container Placement Strategies", func() {
 
 	Describe("Limit Active Tasks", func() {
 		limitActiveTasksStrategy := func(max int) worker.PlacementStrategy {
-			strategy, err := worker.NewPlacementStrategy(worker.PlacementOptions{
+			strategy, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
 				Strategies:              []string{"limit-active-tasks"},
 				MaxActiveTasksPerWorker: max,
 			})
@@ -582,7 +582,7 @@ var _ = Describe("Container Placement Strategies", func() {
 
 	Describe("Limit Active Containers", func() {
 		limitActiveContainersStrategy := func(max int) worker.PlacementStrategy {
-			strategy, err := worker.NewPlacementStrategy(worker.PlacementOptions{
+			strategy, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
 				Strategies:                   []string{"limit-active-containers"},
 				MaxActiveContainersPerWorker: max,
 			})
@@ -670,7 +670,7 @@ var _ = Describe("Container Placement Strategies", func() {
 
 	Describe("Limit Active Volumes", func() {
 		limitActiveVolumesStrategy := func(max int) worker.PlacementStrategy {
-			strategy, err := worker.NewPlacementStrategy(worker.PlacementOptions{
+			strategy, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
 				Strategies:                []string{"limit-active-volumes"},
 				MaxActiveVolumesPerWorker: max,
 			})

--- a/atc/worker/pool_test.go
+++ b/atc/worker/pool_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Pool", func() {
 				),
 			)
 
-			strategy, err := worker.NewPlacementStrategy(worker.PlacementOptions{
+			strategy, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
 				Strategies: []string{"fewest-build-containers"},
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -268,7 +268,7 @@ var _ = Describe("Pool", func() {
 				),
 			)
 
-			strategy, err := worker.NewPlacementStrategy(worker.PlacementOptions{
+			strategy, _, err := worker.NewPlacementStrategy(worker.PlacementOptions{
 				Strategies:              []string{"limit-active-tasks"},
 				MaxActiveTasksPerWorker: 1,
 			})


### PR DESCRIPTION
## Changes proposed by this PR

Currently `check` step use random container placement strategy, which is because of issue #3251. But at the time of #3251, there was not step nested check yet. If a nested check happens to be placed on a busy worker, then the build would be stuck at the nested `check` step.

The other thing is, `get` and `check` step has no input, thus `volume-locality` doesn't fit them at all, but `volume-locality` is good for `put` and `task` steps as they need input volumes, `volume-locality` helps avoid volume streaming, thus reduce build time.

This PR adds a new ATC CLI opiton: `--no-input-container-placement-strategy` which allows to specify a second placement strategy, and the strategy will be used for `get` and nested `check` steps. Resource checks will be still using random strategy.

* [x] done

## Notes to reviewer

This is a resubmit of #8142 as I consider the change is important for nested `checks`.

@clarafu To address your concern of https://github.com/concourse/concourse/pull/8142#issuecomment-1059486155:

1. This PR doesn't force `get`, `check` to use `fewest-build-containers`, instead, it's configurable.
2. Resource check will be still using random strategy.
3. For `get` step, this PR make `get` step's strategy configurable, so that we can try in real deployment to see which strategy is better. Also I'm thinking for `get` step, a new strategy `fewer-build-containers` (worker having containers less than mean are all candidate) might be better, I may create the new strategy in a separate PR.

## Release Note

Enhanced container placement strategy:

* Add optional flag `--no-input-container-placement-strategy` for configuring a container placement strategy used for only `get` and **nested** `check` steps.