### PR TITLE
optimize worker selection

### DIFF
--- a/atc/worker/pool.go
+++ b/atc/worker/pool.go
@@ -231,17 +231,15 @@ func (pool Pool) findWorkerForContainer(logger lager.Logger, owner db.ContainerO
 		return nil, nil, false, err
 	}
 
+	for _, w := range workersWithContainer {
+		if pool.isWorkerCompatibleAndRunning(logger, w, workerSpec) {
+			return w, nil, true, nil
+		}
+	}
+
 	compatibleWorkers, err := pool.allCompatibleAndRunningWorkers(logger, workerSpec)
 	if err != nil {
 		return nil, nil, false, err
-	}
-
-	for _, w := range workersWithContainer {
-		for _, c := range compatibleWorkers {
-			if w.Name() == c.Name() {
-				return w, compatibleWorkers, true, nil
-			}
-		}
 	}
 
 	return nil, compatibleWorkers, false, nil

--- a/atc/worker/pool.go
+++ b/atc/worker/pool.go
@@ -232,8 +232,9 @@ func (pool Pool) findWorkerForContainer(logger lager.Logger, owner db.ContainerO
 		return nil, nil, false, err
 	}
 
-	// When global-resources is enabled, a check-container may run on any team
-	// worker, which enables this optimization. Details refer to PR#8184.
+	// When global-resources is enabled, a check-container may run on any worker
+	// as long as the scope is the same, which enables this optimization. Details
+	// refer to PR#8184.
 	if atc.EnableGlobalResources {
 		for _, w := range workersWithContainer {
 			if pool.isWorkerCompatibleAndRunning(logger, w, workerSpec) {

--- a/atc/worker/pool.go
+++ b/atc/worker/pool.go
@@ -10,6 +10,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagerctx"
+	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/metric"
 	"github.com/concourse/concourse/atc/runtime"
@@ -231,15 +232,29 @@ func (pool Pool) findWorkerForContainer(logger lager.Logger, owner db.ContainerO
 		return nil, nil, false, err
 	}
 
-	for _, w := range workersWithContainer {
-		if pool.isWorkerCompatibleAndRunning(logger, w, workerSpec) {
-			return w, nil, true, nil
+	// When global-resources is enabled, a check-container may run on any team
+	// worker, which enables this optimization. Details refer to PR#8184.
+	if atc.EnableGlobalResources {
+		for _, w := range workersWithContainer {
+			if pool.isWorkerCompatibleAndRunning(logger, w, workerSpec) {
+				return w, nil, true, nil
+			}
 		}
 	}
 
 	compatibleWorkers, err := pool.allCompatibleAndRunningWorkers(logger, workerSpec)
 	if err != nil {
 		return nil, nil, false, err
+	}
+
+	if !atc.EnableGlobalResources {
+		for _, w := range workersWithContainer {
+			for _, c := range compatibleWorkers {
+				if w.Name() == c.Name() {
+					return w, compatibleWorkers, true, nil
+				}
+			}
+		}
 	}
 
 	return nil, compatibleWorkers, false, nil


### PR DESCRIPTION
## Changes proposed by this PR

https://github.com/concourse/concourse/blob/4647d76409117172e4e265b068d5e9bcb58db5c8/atc/worker/pool.go#L111-L141

This function is not implement efficiently. It finds out worker containing the container, then list all compatible workers, then uses a double loop to decide if a found worker should be returned.

This PR optimize the function. The change should be easy to understand. Though the optimization is small, but given all resource checks suppose to reuse containers, this optimization will get rid of listing workers for most of resource check steps. Given resource check builds are the most significant part of total workloads, this optimization should improve big. 

* [x] done

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

* Optimized worker selection when `global-resources` is enabled