### PR TITLE
Enhance locks

### DIFF
--- a/atc/db/db_suite_test.go
+++ b/atc/db/db_suite_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 
@@ -109,7 +110,11 @@ var _ = BeforeEach(func() {
 	dbConn = postgresRunner.OpenConn()
 	db.CleanupBaseResourceTypesCache()
 
-	lockFactory = lock.NewLockFactory(postgresRunner.OpenSingleton(), metric.LogLockAcquired, metric.LogLockReleased)
+	var lockConns [lock.FactoryCount]*sql.DB
+	for i := 0; i < lock.FactoryCount; i++ {
+		lockConns[i] = postgresRunner.OpenSingleton()
+	}
+	lockFactory = lock.NewLockFactory(lockConns, metric.LogLockAcquired, metric.LogLockReleased)
 
 	checkBuildChan = make(chan db.Build, 10)
 	seqGenerator = util.NewSequenceGenerator(1)

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -116,7 +116,7 @@ type lockFactory struct {
 type LogFunc func(logger lager.Logger, id LockID)
 
 func NewLockFactory(
-	conn [FactoryCount]*sql.DB,
+	conns [FactoryCount]*sql.DB,
 	acquire LogFunc,
 	release LogFunc,
 ) LockFactory {
@@ -125,7 +125,7 @@ func NewLockFactory(
 	for i := 0; i < FactoryCount; i++ {
 		factories[i] = &lockFactory{
 			db: &lockDB{
-				conn:  conn[i],
+				conn:  conns[i],
 				mutex: &sync.Mutex{},
 			},
 			acquireFunc: acquire,

--- a/atc/db/migration/encryption_test.go
+++ b/atc/db/migration/encryption_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Encryption", func() {
 	var (
 		err         error
 		db          *sql.DB
-		lockDB      *sql.DB
+		lockDB      [lock.FactoryCount]*sql.DB
 		lockFactory lock.LockFactory
 		fakeLogFunc = func(logger lager.Logger, id lock.LockID) {}
 	)
@@ -29,15 +29,18 @@ var _ = Describe("Encryption", func() {
 		db, err = sql.Open("postgres", postgresRunner.DataSourceName())
 		Expect(err).NotTo(HaveOccurred())
 
-		lockDB, err = sql.Open("postgres", postgresRunner.DataSourceName())
-		Expect(err).NotTo(HaveOccurred())
-
+		for i := 0; i < lock.FactoryCount; i++ {
+			lockDB[i], err = sql.Open("postgres", postgresRunner.DataSourceName())
+			Expect(err).NotTo(HaveOccurred())
+		}
 		lockFactory = lock.NewLockFactory(lockDB, fakeLogFunc, fakeLogFunc)
 	})
 
 	AfterEach(func() {
 		_ = db.Close()
-		_ = lockDB.Close()
+		for _, closer := range lockDB {
+			closer.Close()
+		}
 	})
 
 	Context("starting with unencrypted DB", func() {

--- a/atc/db/migration/open_helper_test.go
+++ b/atc/db/migration/open_helper_test.go
@@ -15,7 +15,7 @@ var _ = Describe("OpenHelper", func() {
 	var (
 		err         error
 		db          *sql.DB
-		lockDB      *sql.DB
+		lockDB      [lock.FactoryCount]*sql.DB
 		lockFactory lock.LockFactory
 		openHelper  *migration.OpenHelper
 		fakeLogFunc = func(logger lager.Logger, id lock.LockID) {}
@@ -25,16 +25,19 @@ var _ = Describe("OpenHelper", func() {
 		db, err = sql.Open("postgres", postgresRunner.DataSourceName())
 		Expect(err).NotTo(HaveOccurred())
 
-		lockDB, err = sql.Open("postgres", postgresRunner.DataSourceName())
-		Expect(err).NotTo(HaveOccurred())
-
+		for i := 0; i < lock.FactoryCount; i++ {
+			lockDB[i], err = sql.Open("postgres", postgresRunner.DataSourceName())
+			Expect(err).NotTo(HaveOccurred())
+		}
 		lockFactory = lock.NewLockFactory(lockDB, fakeLogFunc, fakeLogFunc)
 		openHelper = migration.NewOpenHelper("postgres", postgresRunner.DataSourceName(), lockFactory, nil, nil)
 	})
 
 	AfterEach(func() {
 		_ = db.Close()
-		_ = lockDB.Close()
+		for _, closer := range lockDB {
+			closer.Close()
+		}
 	})
 
 	Context("legacy migration_version table exists", func() {

--- a/atc/exec/get_step.go
+++ b/atc/exec/get_step.go
@@ -337,7 +337,7 @@ func (step *GetStep) retrieveFromCacheOrPerformGet(
 		}
 
 		lockLogger := logger.Session("lock", lager.Data{"lock-name": lockName})
-		lock, acquired, err := step.lockFactory.Acquire(lockLogger, lock.NewTaskLockID(lockName))
+		lock, acquired, err := step.lockFactory.Acquire(lockLogger, lock.NewResourceGetLockID(lockName))
 		if err != nil {
 			lockLogger.Error("failed-to-get-lock", err)
 			// not returning error for consistency with prior behaviour - we just

--- a/atc/gc/gc_suite_test.go
+++ b/atc/gc/gc_suite_test.go
@@ -2,6 +2,7 @@ package gc_test
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"code.cloudfoundry.org/lager"
@@ -67,7 +68,11 @@ var _ = BeforeEach(func() {
 	dbConn = postgresRunner.OpenConn()
 	db.CleanupBaseResourceTypesCache()
 
-	lockFactory = lock.NewLockFactory(postgresRunner.OpenSingleton(), fakeLogFunc, fakeLogFunc)
+	var lockConns [lock.FactoryCount]*sql.DB
+	for i := 0; i < lock.FactoryCount; i++ {
+		lockConns[i] = postgresRunner.OpenSingleton()
+	}
+	lockFactory = lock.NewLockFactory(lockConns, fakeLogFunc, fakeLogFunc)
 
 	builder = dbtest.NewBuilder(dbConn, lockFactory)
 

--- a/atc/scheduler/algorithm/suite_test.go
+++ b/atc/scheduler/algorithm/suite_test.go
@@ -2,6 +2,7 @@ package algorithm_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"testing"
 
@@ -58,7 +59,11 @@ var _ = BeforeEach(func() {
 	dbConn = postgresRunner.OpenConn()
 	db.CleanupBaseResourceTypesCache()
 
-	lockFactory = lock.NewLockFactory(postgresRunner.OpenSingleton(), metric.LogLockAcquired, metric.LogLockReleased)
+	var lockConns [lock.FactoryCount]*sql.DB
+	for i := 0; i < lock.FactoryCount; i++ {
+		lockConns[i] = postgresRunner.OpenSingleton()
+	}
+	lockFactory = lock.NewLockFactory(lockConns, metric.LogLockAcquired, metric.LogLockReleased)
 	teamFactory = db.NewTeamFactory(dbConn, lockFactory)
 })
 

--- a/atc/worker/gardenruntime/gardenruntime_suite_test.go
+++ b/atc/worker/gardenruntime/gardenruntime_suite_test.go
@@ -1,6 +1,7 @@
 package gardenruntime_test
 
 import (
+	"database/sql"
 	"testing"
 
 	"code.cloudfoundry.org/lager"
@@ -27,7 +28,11 @@ var _ = BeforeEach(func() {
 	db.CleanupBaseResourceTypesCache()
 
 	ignore := func(logger lager.Logger, id lock.LockID) {}
-	lockFactory = lock.NewLockFactory(postgresRunner.OpenSingleton(), ignore, ignore)
+	var lockConns [lock.FactoryCount]*sql.DB
+	for i := 0; i < lock.FactoryCount; i++ {
+		lockConns[i] = postgresRunner.OpenSingleton()
+	}
+	lockFactory = lock.NewLockFactory(lockConns, ignore, ignore)
 })
 
 var _ = AfterEach(func() {

--- a/atc/worker/worker_suite_test.go
+++ b/atc/worker/worker_suite_test.go
@@ -2,6 +2,7 @@ package worker_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"code.cloudfoundry.org/lager"
@@ -32,7 +33,11 @@ var _ = BeforeEach(func() {
 	db.CleanupBaseResourceTypesCache()
 
 	ignore := func(logger lager.Logger, id lock.LockID) {}
-	lockFactory = lock.NewLockFactory(postgresRunner.OpenSingleton(), ignore, ignore)
+	var lockConns [lock.FactoryCount]*sql.DB
+	for i := 0; i < lock.FactoryCount; i++ {
+		lockConns[i] = postgresRunner.OpenSingleton()
+	}
+	lockFactory = lock.NewLockFactory(lockConns, ignore, ignore)
 })
 
 var _ = AfterEach(func() {


### PR DESCRIPTION
## Changes proposed by this PR

Concourse highly relies on db locks to coordinate works across ATCs. But all locks shares a single db connection and a single mutex.

For example, when GC component is acquiring a BatchLock, the other go-routing that is trying to acquire a VolumeCreating lock has to wait the global mutex.

The global mutex is a performance bottleneck on a busy deployment. For example, on our prod cluster, step initialization were always slow, and I noticed that the more resource checking locks hold, then less volume creating locks could be acquired. Thus I created a private build that give a volume-create lock a separate mutex. The private build has been significantly reduced step initialization on our prod cluster.

This PR will give certain lock types dedicate mutex, so that one lock type won't impact others.

During my load tests, I also found that, after giving each lock type a dedicate mutex, locks could be quickly acquired, but one ATC could get extremely busy while other ATCs were idle. That was because some component might be always run on a single ATC. For example, if Lidar scanner is running on ATC1, then ATC1 needs to acquire a lot of resource checking locks, then ATC1 has less chance to acquire `BatchLock("lidar")` again because of the global mutex, so that other ATC will be more likely to run Lidar scanner in next round.

So we need to enhancement component as well to ensure each ATC to have the same chance to run a component.

* [x] Enhance locks

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
