### PR TITLE
Fix automatic pipeline archive bug

### DIFF
--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -48,8 +48,11 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 				sq.Eq{"j.id": nil},
 				// parent pipeline was archived
 				sq.Eq{"parent.archived": true},
-				// build that set the pipeline is not the most recent for the job
-				sq.Expr("p.parent_build_id != j.latest_completed_build_id"),
+				// build that set the pipeline is not the most recent for the job.
+				// parent_build_id can be later than latest_completed_build_id if this
+				// gc query runs during a run of a build, specifically between the time
+				// of a completed set pipeline step and the build finishing
+				sq.Expr("p.parent_build_id < j.latest_completed_build_id"),
 			}}).
 		RunWith(tx).
 		Query()

--- a/atc/db/pipeline_lifecycle.go
+++ b/atc/db/pipeline_lifecycle.go
@@ -50,21 +50,6 @@ func (pl *pipelineLifecycle) ArchiveAbandonedPipelines() error {
 				sq.Eq{"j.id": nil},
 				// parent pipeline was archived
 				sq.Eq{"parent.archived": true},
-				// build that set the pipeline is not the most recent for the job.
-				// parent_build_id can be later than latest_completed_build_id if this
-				// gc query runs during a run of a build, specifically between the time
-				// of a completed set pipeline step and the build finishing. Also only
-				// take into account successful builds in order to know if this child
-				// pipeline had its set_pipeline step removed from parent job.
-				sq.And{
-					sq.Expr("p.parent_build_id < j.latest_completed_build_id"),
-					sq.Expr(`EXISTS (
-						SELECT 1
-						FROM builds lb
-						WHERE lb.id = j.latest_completed_build_id
-						AND lb.status = ?
-					)`, BuildStatusSucceeded),
-				},
 			},
 		}).
 		RunWith(tx).

--- a/atc/db/pipeline_lifecycle_test.go
+++ b/atc/db/pipeline_lifecycle_test.go
@@ -114,42 +114,6 @@ var _ = Describe("PipelineLifecycle", func() {
 					Expect(childPipeline.Archived()).To(BeTrue())
 				})
 			})
-
-			Context("when build that set child pipeline is later than latest completed build", func() {
-				BeforeEach(func() {
-					err := childPipeline.SetParentIDs(defaultJob.ID(), setChildBuild.ID()+1)
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				It("should not archive child pipeline", func() {
-					childPipeline.Reload()
-					Expect(childPipeline.Archived()).To(BeFalse())
-				})
-			})
-
-			Context("when build that set child pipeline is not most recent", func() {
-				BeforeEach(func() {
-					setChildBuild, _ = defaultJob.CreateBuild(defaultBuildCreatedBy)
-					setChildBuild.Finish(db.BuildStatusSucceeded)
-				})
-
-				It("should archive child pipeline", func() {
-					childPipeline.Reload()
-					Expect(childPipeline.Archived()).To(BeTrue())
-				})
-			})
-
-			Context("when build that set child pipeline is not most recent but was not successful", func() {
-				BeforeEach(func() {
-					setChildBuild, _ = defaultJob.CreateBuild(defaultBuildCreatedBy)
-					setChildBuild.Finish(db.BuildStatusFailed)
-				})
-
-				It("should not archive child pipeline", func() {
-					childPipeline.Reload()
-					Expect(childPipeline.Archived()).To(BeFalse())
-				})
-			})
 		})
 
 		Context("pipeline does not have a parent job and build ID", func() {


### PR DESCRIPTION
## Changes proposed by this PR

~~Port over the code from https://github.com/concourse/concourse/pull/8137 and https://github.com/concourse/concourse/pull/8179 that help fix a few bugs found in the automatic pipeline archiver logic.~~

Actually I'm just going to remove the line that introduced the bugs for now and have more time to think about how we want to achieve the behaviour we want. The `sq.Expr("p.parent_build_id != j.latest_completed_build_id")` is not super necessary because we already have a query when a build successfully finishes that will help gc child pipelines that are no longer set.

https://github.com/concourse/concourse/blob/4f3bb8fb4916cf8ff8cc918ed81580f84e418420/atc/db/build.go#L751-L762

It is not perfect because it relies on a build finishing successfully to archive the child pipelines, which is what the line that introduced the bug was trying to improve. But since the line has brought up so much risk, let's take a step back and think about it and for now we can remove it from the 7.7.x release.

## Release Note

* Removes the line that introduced a bug in 7.7.0 where child pipelines can get archived accidentally. 
* Fixes a bug where pipelines that are already archived get re-archived

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
