### PR TITLE
Allow go 1.18 darwin error message in unit test

### DIFF
--- a/fly/integration/login_insecure_test.go
+++ b/fly/integration/login_insecure_test.go
@@ -110,7 +110,7 @@ var _ = Describe("login -k Command", func() {
 
 						<-sess.Exited
 						Expect(sess.ExitCode()).To(Equal(1))
-						Eventually(sess.Err).Should(gbytes.Say("x509: certificate signed by unknown authority"))
+						Eventually(sess.Err).Should(gbytes.Say("x509: certificate signed by unknown authority|certificate is not trusted"))
 					})
 				})
 			})
@@ -135,7 +135,7 @@ var _ = Describe("login -k Command", func() {
 
 					<-sess.Exited
 					Expect(sess.ExitCode()).To(Equal(1))
-					Eventually(sess.Err).Should(gbytes.Say("x509: certificate signed by unknown authority"))
+					Eventually(sess.Err).Should(gbytes.Say("x509: certificate signed by unknown authority|certificate is not trusted"))
 				})
 			})
 


### PR DESCRIPTION
## Changes proposed by this PR

The unit tests are failing in prod because the fly-darwin unit tests are
looking for the "x509: certificate signed by unknown authority" but the
error that is returned is "x509: “Acme Co” certificate is not trusted".
Im pretty sure it is from the darwin worker go version being bumped to
1.18 and therefore prints out a different error message.

