### PR TITLE
Backport allow go 1.18 darwin error message in unit tests

### DIFF
--- a/fly/integration/login_insecure_test.go
+++ b/fly/integration/login_insecure_test.go
@@ -110,7 +110,7 @@ var _ = Describe("login -k Command", func() {
 
 						<-sess.Exited
 						Expect(sess.ExitCode()).To(Equal(1))
-						Eventually(sess.Err).Should(gbytes.Say("x509: certificate signed by unknown authority"))
+						Eventually(sess.Err).Should(gbytes.Say("x509: certificate signed by unknown authority|certificate is not trusted"))
 					})
 				})
 			})
@@ -135,7 +135,7 @@ var _ = Describe("login -k Command", func() {
 
 					<-sess.Exited
 					Expect(sess.ExitCode()).To(Equal(1))
-					Eventually(sess.Err).Should(gbytes.Say("x509: certificate signed by unknown authority"))
+					Eventually(sess.Err).Should(gbytes.Say("x509: certificate signed by unknown authority|certificate is not trusted"))
 				})
 			})
 


### PR DESCRIPTION
## Changes proposed by this PR

backport of https://github.com/concourse/concourse/pull/8202/commits/ae2c0bd1555d5208ac1d48c9c5a2e6bde6b4b82c in order to fix unit tests in release pipeline for v7.7.x

