### PR TITLE
Fix bosh-topgun-both failure

### DIFF
--- a/topgun/pipelines/custom-types.yml
+++ b/topgun/pipelines/custom-types.yml
@@ -2,6 +2,7 @@
 resource_types:
 - name: my-time
   type: registry-image
+  check_every: never
   source: {repository: concourse/time-resource}
 
 resources:


### PR DESCRIPTION
the test fails with one extra check on resource type "my-time". 

```
• Failure [355.954 seconds]
A pipeline-provided resource type
github.com/concourse/concourse/topgun/both/resource_types_test.go:10
  does not result in redundant containers when running resource actions [It]
  github.com/concourse/concourse/topgun/both/resource_types_test.go:15

  Expected
      <[]string | len:4, cap:4>: [
          "1ae3afcc-93ac-444d-4bb4-9b0edb047104",
          "4089b68d-f4b3-48bb-7769-9ba1ef90b5ca",
          "843cc72b-e2a7-437f-5e8c-b7d225f832cb",
          "d5f09319-2dbb-4c0c-5179-4eea4e7b4ef6",
      ]
  to have length 3
```
while those containers are 
```
1ae3afcc-93ac-444d-4bb4-9b0edb047104  51b2198a-ae2a-4b0d-aacd-194e312145dc  pipe      get-10m  1        1         check  my-time  n/a     
4089b68d-f4b3-48bb-7769-9ba1ef90b5ca  51b2198a-ae2a-4b0d-aacd-194e312145dc  pipe      none     check    2         check  my-time  n/a    
843cc72b-e2a7-437f-5e8c-b7d225f832cb  51b2198a-ae2a-4b0d-aacd-194e312145dc  pipe      none     check    2         check  10m      n/a      
d5f09319-2dbb-4c0c-5179-4eea4e7b4ef6  51b2198a-ae2a-4b0d-aacd-194e312145dc  pipe      get-10m  1        1         check  image    n/a  
```

So this commit disable the self check to hopefully get ride of `4089b68d-f4b3-48bb-7769-9ba1ef90b5ca` in above case.


* [x] done
* [ ] todo

