### PR TITLE
Update topgun resource type test to match actual behaviour

### DIFF
--- a/topgun/both/resource_types_test.go
+++ b/topgun/both/resource_types_test.go
@@ -22,11 +22,13 @@ var _ = Describe("A pipeline-provided resource type", func() {
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(1))
 
-		By("expecting a container for the resource check, resource type check, and task image check")
-		Expect(ContainersBy("type", "check")).To(HaveLen(3))
+		// very small chance of racing here as the resource check container could be gone if GC kick in right after
+		// check is finished, which will then result in only 3 check containers in total
+		By("expecting a container for the resource check, resource type check, get step resource type check and task image check")
+		Expect(ContainersBy("type", "check")).To(HaveLen(4))
 
-		By("expecting a container for the resource check, resource type check, build resource image get, build get, build task image check, build task image get, and build task")
-		expectedContainersBefore := 7
+		By("expecting a container for the resource check, resource type check, resource type get, build resource type check, build resource get, build task image check, build task image get and build task")
+		expectedContainersBefore := 8
 		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore))
 
 		By("triggering the build again")
@@ -35,7 +37,7 @@ var _ = Describe("A pipeline-provided resource type", func() {
 		Expect(buildSession.ExitCode()).To(Equal(1))
 
 		By("expecting only one additional check container for the task's image check")
-		Expect(ContainersBy("type", "check")).To(HaveLen(4))
+		Expect(ContainersBy("type", "check")).To(HaveLen(5))
 
 		By("expecting to only have new containers for build task image check and build task")
 		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore + 2))

--- a/topgun/pipelines/custom-types.yml
+++ b/topgun/pipelines/custom-types.yml
@@ -2,7 +2,6 @@
 resource_types:
 - name: my-time
   type: registry-image
-  check_every: never
   source: {repository: concourse/time-resource}
 
 resources:


### PR DESCRIPTION
Refer to https://github.com/concourse/concourse/pull/8236

With `check_every: never` set to resource, the triggering job will first waiting for a version of `10m`, which then trigger the check on 10m first. So there will be 2 check containers for `10m`  and `my-time`. And results resource cache of `my-time` created in DB. 

Then the build will start. In the `get` step, it sees `10m`  has a custom type `my-time` ,  so it will try to check the image and thus getting a resource cache hit. This will result 1 check container.

In the next step there is the check for the task image. So in total 4 check containers.

Removing `check_every: never` from `my-time` as it will make the build hangs forever as `10m` couldn't find a version.