### PR TITLE
Don't run resource type check if within check interval

### DIFF
--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -175,9 +175,11 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 
 		// If last check succeeded and the end of the last check is after the start
 		// of this check, OR the check interval has no elapsed since the last check
-		// end time and it is not a manual check then don't run
-		if lastCheck.Succeeded && lastCheck.EndTime.After(d.build.StartTime()) || (d.clock.Now().Before(lastCheck.EndTime.Add(interval)) && !d.plan.SkipInterval) {
-			return nil, false, nil
+		// end time of a successful check and it is not a manual check then don't run
+		if lastCheck.Succeeded {
+			if lastCheck.EndTime.After(d.build.StartTime()) || (d.clock.Now().Before(lastCheck.EndTime.Add(interval)) && !d.plan.SkipInterval) {
+				return nil, false, nil
+			}
 		}
 	}
 

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -174,8 +174,9 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 		}
 
 		// If last check succeeded and the end of the last check is after the start
-		// of this check, then don't run
-		if lastCheck.Succeeded && lastCheck.EndTime.After(d.build.StartTime()) {
+		// of this check, OR the check interval has no elapsed since the last check
+		// end time then don't run
+		if lastCheck.Succeeded && lastCheck.EndTime.After(d.build.StartTime()) || d.clock.Now().Before(lastCheck.EndTime.Add(interval)) {
 			return nil, false, nil
 		}
 	}

--- a/atc/engine/check_delegate.go
+++ b/atc/engine/check_delegate.go
@@ -175,8 +175,8 @@ func (d *checkDelegate) WaitToRun(ctx context.Context, scope db.ResourceConfigSc
 
 		// If last check succeeded and the end of the last check is after the start
 		// of this check, OR the check interval has no elapsed since the last check
-		// end time then don't run
-		if lastCheck.Succeeded && lastCheck.EndTime.After(d.build.StartTime()) || d.clock.Now().Before(lastCheck.EndTime.Add(interval)) {
+		// end time and it is not a manual check then don't run
+		if lastCheck.Succeeded && lastCheck.EndTime.After(d.build.StartTime()) || (d.clock.Now().Before(lastCheck.EndTime.Add(interval)) && !d.plan.SkipInterval) {
 			return nil, false, nil
 		}
 	}

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -440,6 +440,37 @@ var _ = Describe("CheckDelegate", func() {
 					Expect(run).To(BeFalse())
 				})
 			})
+
+			Context("when the checking interval has elapsed since the last check end time", func() {
+				BeforeEach(func() {
+					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
+						StartTime: now.Add(-6 * time.Minute),
+						EndTime:   now.Add(-5 * time.Minute),
+						Succeeded: true,
+					}, nil)
+					fakeBuild.StartTimeReturns(now)
+				})
+
+				It("returns true", func() {
+					Expect(run).To(BeTrue())
+				})
+			})
+
+			Context("when the checking interval has not elapsed since the last check end time", func() {
+				BeforeEach(func() {
+					plan.Check.Interval.Interval = time.Hour
+					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
+						StartTime: now,
+						EndTime:   now,
+						Succeeded: true,
+					}, nil)
+					fakeBuild.StartTimeReturns(now.Add(1 * time.Minute))
+				})
+
+				It("returns false", func() {
+					Expect(run).To(BeFalse())
+				})
+			})
 		})
 	})
 

--- a/atc/engine/check_delegate_test.go
+++ b/atc/engine/check_delegate_test.go
@@ -479,7 +479,7 @@ var _ = Describe("CheckDelegate", func() {
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
 						StartTime: now,
 						EndTime:   now,
-						Succeeded: false,
+						Succeeded: true,
 					}, nil)
 					fakeBuild.StartTimeReturns(now.Add(1 * time.Minute))
 				})
@@ -493,6 +493,22 @@ var _ = Describe("CheckDelegate", func() {
 				BeforeEach(func() {
 					plan.Check.Interval.Interval = time.Hour
 					plan.Check.SkipInterval = true
+					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
+						StartTime: now,
+						EndTime:   now,
+						Succeeded: true,
+					}, nil)
+					fakeBuild.StartTimeReturns(now.Add(1 * time.Minute))
+				})
+
+				It("returns true", func() {
+					Expect(run).To(BeTrue())
+				})
+			})
+
+			Context("when the last check is not successful and checking interval has not elapsed since the last check end time", func() {
+				BeforeEach(func() {
+					plan.Check.Interval.Interval = time.Hour
 					fakeResourceConfigScope.LastCheckReturns(db.LastCheck{
 						StartTime: now,
 						EndTime:   now,


### PR DESCRIPTION
## Changes proposed by this PR

closes #8244

We seemed to be running a check for resource types for every build because we didn't have anything within the `WaitToRun` code for checking if the check interval had elapsed.

This fix will help reduce the number of resource type checks, since it is not really necessary to run a resource type check for every build.

## Notes to reviewer

I'm still thinking about whether we want to make resource types get force checked if you submit a manual build. I think initially when this was implemented, we decided not to in order to not spam a ton of resource type checks if the user creates a lot of manual builds. Especially if a lot of resources use the same resource type within the job. I am leaning towards keeping it as is, where we don't force resource type checks on manual builds. The way you can force a resource type check is by running `fly check-resource` which can recursively check the resource types or `fly check-resource-type`.

## Release Note

* Fixes a bug where resource types were getting checked every build. Now they will respect the resource checking interval and not run a check if the interval has not elapsed.
