### PR TITLE
Update credhub var lookup logic

### DIFF
--- a/atc/creds/credhub/credhub.go
+++ b/atc/creds/credhub/credhub.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/concourse/concourse/atc/creds"
 
-	"code.cloudfoundry.org/credhub-cli/credhub"
 	"code.cloudfoundry.org/credhub-cli/credhub/credentials"
+	"code.cloudfoundry.org/credhub-cli/errors"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -58,16 +58,16 @@ func (c CredHubAtc) findCred(path string) (credentials.Credential, bool, error) 
 		return cred, false, err
 	}
 
-	_, err = ch.FindByPath(path)
+	_, err = ch.FindByPartialName(path)
 	if err != nil {
+		if err.Error() == errors.NewNoMatchingCredentialsFoundError().Error() {
+			return cred, false, nil
+		}
+
 		return cred, false, err
 	}
 
 	cred, err = ch.GetLatestVersion(path)
-	if _, ok := err.(*credhub.Error); ok {
-		return cred, false, nil
-	}
-
 	if err != nil {
 		return cred, false, err
 	}

--- a/topgun/core/creds_test.go
+++ b/topgun/core/creds_test.go
@@ -58,7 +58,7 @@ func testCredentialManagement(
 			Fly.Run("unpause-pipeline", "-p", "pipeline-creds-test")
 		})
 
-		It("parameterizes via Vault and leaves the pipeline uninterpolated", func() {
+		It("parameterizes via creds manager and leaves the pipeline uninterpolated", func() {
 			By("triggering job")
 			watch := Fly.Start("trigger-job", "-w", "-j", "pipeline-creds-test/some-job")
 			Wait(watch)


### PR DESCRIPTION
After [bummping credhub-cli](https://github.com/concourse/concourse/pull/8219) to 2.9.3 it failed toggun creds test by
not being able to fall back to team secret when pipeline secret is
not found. It is due to this commit
https://github.com/cloudfoundry/credhub-cli/commit/e3951663d25cdc3a50c796937762e50eba4921ef

Changes in this PR:

 * update credhub var look up to find by name instead of find by path
 so it could avoid the following get request i.e. we dont need to do
 the get request if we can't find one secret already.
 * skip credhub no-credential-found error so it can continue
 searching through available paths.



* [x] done
* [ ] todo

## Notes to reviewer

It is hard to test this as running a standalone credhub instance is non-trivial (as it needs to run with UAA server or within a bosh env). The only place will be in topgun `bosh-topgun-core` where concourse test creds.

