### PR TITLE
fix #8268 acrossStep handling for more then 3 vars

### DIFF
--- a/atc/exec/across_step.go
+++ b/atc/exec/across_step.go
@@ -155,8 +155,10 @@ func cartesianProduct(varValues [][]interface{}) [][]interface{} {
 	var product [][]interface{}
 	subProduct := cartesianProduct(varValues[:len(varValues)-1])
 	for _, vec := range subProduct {
+		vec_copy := make([]interface{}, len(vec))
+		_ = copy(vec_copy, vec)
 		for _, val := range varValues[len(varValues)-1] {
-			product = append(product, append(vec, val))
+			product = append(product, append(vec_copy, val))
 		}
 	}
 	return product


### PR DESCRIPTION
"If there is room for more elements, append reuses the underlying array."

Signed-off-by: Marcel Beck <marcel@beck.im>

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #8268 <!-- remove if no existing issue -->

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] done
* [ ] todo

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
