### PR TITLE
Add prometheus emitter for jobs scheduled duration

### DIFF
--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -23,7 +23,7 @@ import (
 type PrometheusEmitter struct {
 	jobsScheduled          prometheus.Counter
 	jobsScheduling         prometheus.Gauge
-	jobsSchedulingDuration prometheus.Histogram
+	jobsSchedulingDuration *prometheus.HistogramVec
 
 	buildsStarted prometheus.Counter
 	buildsRunning prometheus.Gauge

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -907,7 +907,7 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 	case "jobs scheduling":
 		emitter.jobsScheduling.Set(event.Value)
 	case "scheduling: job duration (ms)":
-		emitter.jobsSchedulingDuration.WithLabels(
+		emitter.jobsSchedulingDuration.WithLabelValues(
 			event.Attributes["pipeline"],
 			event.Attributes["job"],
 			event.Attributes["job_id"],

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -220,7 +220,7 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 		Name:        "schedulingDuration",
 		Help:        "Duration of jobs being scheduled in milliseconds",
 		ConstLabels: attributes,
-		Buckets:     []float64{1, 60, 180, 300, 600, 900, 1200, 1800, 2700, 3600, 7200, 18000, 36000},
+		Buckets:     []float64{30, 60, 180, 300, 600, 900, 1200, 1800, 2700, 3600, 7200, 18000, 36000},
 	}, []string{"pipeline", "job", "job_id"})
 
 	prometheus.MustRegister(jobsSchedulingDuration)

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -21,9 +21,9 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 type PrometheusEmitter struct {
-	jobsScheduled  prometheus.Counter
-	jobsScheduling prometheus.Gauge
-	jobsSchedulingDuration: prometheus.Histogram
+	jobsScheduled          prometheus.Counter
+	jobsScheduling         prometheus.Gauge
+	jobsSchedulingDuration prometheus.Histogram
 
 	buildsStarted prometheus.Counter
 	buildsRunning prometheus.Gauge
@@ -215,10 +215,10 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 	prometheus.MustRegister(jobsScheduling)
 
 	jobsSchedulingDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "concourse",
-		Subsystem: "jobs",
-		Name: "schedulingDuration",
-		Help: "Duration of jobs being scheduled in milliseconds",
+		Namespace:   "concourse",
+		Subsystem:   "jobs",
+		Name:        "schedulingDuration",
+		Help:        "Duration of jobs being scheduled in milliseconds",
 		ConstLabels: attributes,
 		Buckets:     []float64{1, 60, 180, 300, 600, 900, 1200, 1800, 2700, 3600, 7200, 18000, 36000},
 	}, []string{"pipeline", "job", "job_id"})
@@ -910,7 +910,7 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 		emitter.jobsSchedulingDuration.WithLabels(
 			event.Attributes["pipeline"],
 			event.Attributes["job"],
-			event.Attributes["job_id"],	
+			event.Attributes["job_id"],
 		).Observe(event.Value)
 	case "builds started":
 		emitter.buildsStarted.Add(event.Value)

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -23,6 +23,7 @@ import (
 type PrometheusEmitter struct {
 	jobsScheduled  prometheus.Counter
 	jobsScheduling prometheus.Gauge
+	jobsSchedulingDuration: prometheus.Histogram
 
 	buildsStarted prometheus.Counter
 	buildsRunning prometheus.Gauge
@@ -212,6 +213,17 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 		ConstLabels: attributes,
 	})
 	prometheus.MustRegister(jobsScheduling)
+
+	jobsSchedulingDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "concourse",
+		Subsystem: "jobs",
+		Name: "schedulingDuration",
+		Help: "Duration of jobs being scheduled in milliseconds",
+		ConstLabels: attributes,
+		Buckets:     []float64{1, 60, 180, 300, 600, 900, 1200, 1800, 2700, 3600, 7200, 18000, 36000},
+	}, []string{"pipeline", "job", "job_id"})
+
+	prometheus.MustRegister(jobsSchedulingDuration)
 
 	// build metrics
 	buildsStarted := prometheus.NewCounter(prometheus.CounterOpts{
@@ -791,8 +803,9 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 	go http.Serve(listener, promhttp.Handler())
 
 	emitter := &PrometheusEmitter{
-		jobsScheduled:  jobsScheduled,
-		jobsScheduling: jobsScheduling,
+		jobsScheduled:          jobsScheduled,
+		jobsScheduling:         jobsScheduling,
+		jobsSchedulingDuration: jobsSchedulingDuration,
 
 		buildsStarted: buildsStarted,
 		buildsRunning: buildsRunning,
@@ -893,6 +906,12 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 		emitter.jobsScheduled.Add(event.Value)
 	case "jobs scheduling":
 		emitter.jobsScheduling.Set(event.Value)
+	case "scheduling: job duration (ms)":
+		emitter.jobsSchedulingDuration.WithLabels(
+			event.Attributes["pipeline"],
+			event.Attributes["job"],
+			event.Attributes["job_id"],	
+		).Observe(event.Value)
 	case "builds started":
 		emitter.buildsStarted.Add(event.Value)
 	case "builds running":


### PR DESCRIPTION
Signed-off-by: Max Knee <Max_Knee@comcast.com>

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes # <!-- remove if no existing issue -->

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->
Adding `jobsSchedulingDuration` for prometheus.
* [x] done
* [ ] todo

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->



[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
