### PR TITLE
Expose ATC_EXTERNAL_URL to task env.

### DIFF
--- a/atc/exec/step_metadata.go
+++ b/atc/exec/step_metadata.go
@@ -69,3 +69,11 @@ func (metadata StepMetadata) Env() []string {
 
 	return env
 }
+
+func (metadata StepMetadata) TaskEnv() []string {
+	env := []string{}
+	if metadata.ExternalURL != "" {
+		env = append(env, "ATC_EXTERNAL_URL="+metadata.ExternalURL)
+	}
+	return env
+}

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -407,6 +407,9 @@ func (step *TaskStep) containerInputs(logger lager.Logger, repository *build.Rep
 }
 
 func (step *TaskStep) containerSpec(logger lager.Logger, state RunState, imageSpec runtime.ImageSpec, config atc.TaskConfig, metadata db.ContainerMetadata) (runtime.ContainerSpec, error) {
+	env := step.metadata.TaskEnv()
+	env = append(env, config.Params.Env()...)
+
 	containerSpec := runtime.ContainerSpec{
 		TeamID:   step.metadata.TeamID,
 		TeamName: step.metadata.TeamName,
@@ -414,7 +417,7 @@ func (step *TaskStep) containerSpec(logger lager.Logger, state RunState, imageSp
 		StepName: step.plan.Name,
 
 		ImageSpec: imageSpec,
-		Env:       config.Params.Env(),
+		Env:       env,
 		Type:      metadata.Type,
 
 		Dir: metadata.WorkingDirectory,

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -56,9 +56,10 @@ var _ = Describe("TaskStep", func() {
 		}
 
 		stepMetadata = exec.StepMetadata{
-			TeamID:  123,
-			BuildID: 1234,
-			JobID:   12345,
+			TeamID:      123,
+			BuildID:     1234,
+			JobID:       12345,
+			ExternalURL: "http://foo.bar",
 		}
 
 		planID = atc.PlanID("42")
@@ -174,6 +175,10 @@ var _ = Describe("TaskStep", func() {
 			chosenContainer = chosenWorker.Containers[0]
 			fakePool = new(execfakes.FakePool)
 			fakePool.FindOrSelectWorkerReturns(chosenWorker, nil)
+		})
+
+		It("Task env includes atc external url", func(){
+			Expect(chosenContainer.Spec.Env).To(ContainElement("ATC_EXTERNAL_URL=http://foo.bar"))
 		})
 
 		Context("before running the task", func() {

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -178,7 +178,7 @@ var _ = Describe("TaskStep", func() {
 		})
 
 		It("Task env includes atc external url", func(){
-			Expect(chosenContainer.Spec.Env).To(ContainElement("ATC_EXTERNAL_URL=http://foo.bar"))
+			Expect(chosenContainer.Spec.Env).To(ConsistOf("ATC_EXTERNAL_URL=http://foo.bar", "SECURE=secret-task-param"))
 		})
 
 		Context("before running the task", func() {


### PR DESCRIPTION
## Changes proposed by this PR

Expose ATC_EXTERNAL_URL to task env.

* [x] done

## Notes to reviewer

It has been a long discussion for whether or not expose step metadata to task. Many users have requested that but Concourse team considered that is an anti-pattern.

This PR exposes only ATC_EXTERNAL_URL. Hopefully, Concourse team would not consider anti-pattern.

## Release Note

* Expose ATC_EXTERNAL_URL to task env.


