### PR TITLE
Add Quick Start Documentation for M1 Machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Creating docs_concourse_1    ... done
 Concourse will be running at [127.0.0.1:8080](http://127.0.0.1:8080). You can
 log in with the username/password as `test`/`test`.
 
+> :warning: **If you are using an M1 mac**: M1 macs are incompatible with the `containerd` runtime. After downloading the docker-compose file, change `CONCOURSE_WORKER_RUNTIME: "containerd"` to `CONCOURSE_WORKER_RUNTIME: "houdini"`.
+**This feature is experimental**
+
 Next, install `fly` by downloading it from the web UI and target your local
 Concourse as the `test` user:
 


### PR DESCRIPTION
## Changes proposed by this PR
M1 macs (and potentially intel, though I'm unable to test) are not able to run the quick start guide. While the container will start, it errors out almost immediately with `Table does not exist (do you need to insmod?)`. This is a limitation on the host OS.

Following this doc: https://concourse-ci.org/concourse-worker.html#configuring-runtimes I am able to get everything up and running by switching to the Houdini runtime.

I see this is an experimental feature, however since the existing setup will not work I figured this would be a good note to add.

* [x] add documentation for the experimental darwin runtime

## Notes to reviewer

If there is a better place to put this please let me know, just wanted to add some form of documentation for it. 
