### PR TITLE
Partly revert changes in resource types test

### DIFF
--- a/topgun/both/resource_types_test.go
+++ b/topgun/both/resource_types_test.go
@@ -22,13 +22,11 @@ var _ = Describe("A pipeline-provided resource type", func() {
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(1))
 
-		// very small chance of racing here as the resource check container could be gone if GC kick in right after
-		// check is finished, which will then result in only 3 check containers in total
-		By("expecting a container for the resource check, resource type check, get step resource type check and task image check")
-		Expect(ContainersBy("type", "check")).To(HaveLen(4))
+		By("expecting a container for the resource check, resource type check, and task image check")
+		Expect(ContainersBy("type", "check")).To(HaveLen(3))
 
-		By("expecting a container for the resource check, resource type check, resource type get, build resource type check, build resource get, build task image check, build task image get and build task")
-		expectedContainersBefore := 8
+		By("expecting a container for the resource check, resource type check, resource type get, build resource get, build task image check, build task image get and build task")
+		expectedContainersBefore := 7
 		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore))
 
 		By("triggering the build again")
@@ -37,7 +35,7 @@ var _ = Describe("A pipeline-provided resource type", func() {
 		Expect(buildSession.ExitCode()).To(Equal(1))
 
 		By("expecting only one additional check container for the task's image check")
-		Expect(ContainersBy("type", "check")).To(HaveLen(5))
+		Expect(ContainersBy("type", "check")).To(HaveLen(4))
 
 		By("expecting to only have new containers for build task image check and build task")
 		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore + 2))


### PR DESCRIPTION
since now the resource type check after job triggered will be skipped
by https://github.com/concourse/concourse/pull/8253

