### PR TITLE
Inherite env proxy configure when tls enabled

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1414,6 +1414,7 @@ func (cmd *RunCommand) skyHttpClient() (*http.Client, error) {
 		}
 
 		httpClient.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs: certpool,
 			},


### PR DESCRIPTION

closes #8296

* [x] done
* [ ] todo


## Release Note

 * Fix a bug that proxy setting through env var got lost when TLS is enabled by [--tls-bind-port](https://github.com/concourse/concourse/blob/master/atc/atccmd/command.go#L117)
