### PR TITLE
Follow credhub-cli impl to determin find result

### DIFF
--- a/atc/creds/credhub/credhub.go
+++ b/atc/creds/credhub/credhub.go
@@ -7,7 +7,6 @@ import (
 	"github.com/concourse/concourse/atc/creds"
 
 	"code.cloudfoundry.org/credhub-cli/credhub/credentials"
-	"code.cloudfoundry.org/credhub-cli/errors"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -58,13 +57,14 @@ func (c CredHubAtc) findCred(path string) (credentials.Credential, bool, error) 
 		return cred, false, err
 	}
 
-	_, err = ch.FindByPartialName(path)
+	results, err := ch.FindByPartialName(path)
 	if err != nil {
-		if err.Error() == errors.NewNoMatchingCredentialsFoundError().Error() {
-			return cred, false, nil
-		}
-
 		return cred, false, err
+	}
+
+	// same as https://github.com/cloudfoundry/credhub-cli/blob/main/commands/find.go#L22
+	if len(results.Credentials) == 0 {
+		return cred, false, nil
 	}
 
 	cred, err = ch.GetLatestVersion(path)


### PR DESCRIPTION
https://github.com/concourse/concourse/pull/8265 didn't fix the topgun test error as credhub cli error `NewNoMatchingCredentialsFoundError` only returns when using the CLI command. In the case of Concourse here, it uses the credhub-cli client [FindByPartialName](https://github.com/cloudfoundry/credhub-cli/blob/main/credhub/find.go#L13) directly, and thus no error returned when cred doesn't exist.

Instead, we can check if the find result contains nothing just like what [credhub-cli does](https://github.com/cloudfoundry/credhub-cli/blob/main/commands/find.go#L22) and then move on to next path. This allow Concourse to not depend on a specific error from Credhub.