### PR TITLE
Add tooltip to username if overflow

### DIFF
--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -23,6 +23,7 @@ import HoverState
 import Html exposing (Html)
 import Html.Attributes exposing (style)
 import List.Extra
+import Login.Login as Login
 import Maybe.Extra
 import Message.Callback exposing (Callback(..))
 import Message.Effects as Effects exposing (Effect(..), toHtmlID)
@@ -271,6 +272,9 @@ tooltip model session =
                                         }
                                     )
                     )
+
+        HoverState.Tooltip (UserDisplayName username) _ ->
+            Login.tooltip username
 
         _ ->
             Nothing

--- a/web/elm/src/Build/Header/Header.elm
+++ b/web/elm/src/Build/Header/Header.elm
@@ -276,6 +276,9 @@ tooltip model session =
         HoverState.Tooltip (UserDisplayName username) _ ->
             Login.tooltip username
 
+        HoverState.Tooltip (CreatedBy text) _ ->
+            Views.tooltip text
+
         _ ->
             Nothing
 

--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -439,22 +439,20 @@ viewTitle name textColor jobID createdBy =
                             "created by " ++ who
                     in
                     Html.span
-                        (id "created-by"
-                            :: [ style "position" "absolute"
-                               , style "font-size" "12px"
-                               , style "bottom" "6px"
-                               , style "line-height" "16px"
-                               , style "right" "0"
-                               , style "left" "0"
-                               , style "text-overflow" "ellipsis"
-                               , style "white-space" "nowrap"
-                               , style "overflow" "hidden"
-                               , style "color" textColor
-                               ]
-                            ++ [ onMouseEnter <| Hover <| Just (CreatedBy text)
-                               , onMouseLeave <| Hover Nothing
-                               ]
-                        )
+                        [ id "created-by"
+                        , style "position" "absolute"
+                        , style "font-size" "12px"
+                        , style "bottom" "6px"
+                        , style "line-height" "16px"
+                        , style "right" "0"
+                        , style "left" "0"
+                        , style "text-overflow" "ellipsis"
+                        , style "white-space" "nowrap"
+                        , style "overflow" "hidden"
+                        , style "color" textColor
+                        , onMouseEnter <| Hover <| Just (CreatedBy text)
+                        , onMouseLeave <| Hover Nothing
+                        ]
                         [ Html.text text ]
 
                 Nothing ->

--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -119,7 +119,7 @@ viewHeader header =
              ]
                 ++ Styles.header header.backgroundColor
             )
-            [ Html.div [] (List.map (viewWidget header.backgroundColor) header.leftWidgets)
+            [ Html.div [ style "overflow-x" "auto" ] (List.map (viewWidget header.backgroundColor) header.leftWidgets)
             , Html.div [ style "display" "flex" ] (List.map (viewWidget header.backgroundColor) header.rightWidgets)
             ]
          , viewHistory header.backgroundColor header.tabs
@@ -204,7 +204,7 @@ viewDuration buildDuration textColor =
                     Finished { duration } ->
                         [ Html.tr []
                             [ Html.td [ class "dict-key" ] [ Html.text "duration" ]
-                            , Html.td [ class "dict-value" ] [ Html.text <| viewTimespan duration ]
+                            , Html.td Styles.time [ Html.text <| viewTimespan duration ]
                             ]
                         ]
 
@@ -219,22 +219,21 @@ viewTimestamp timestamp =
     case timestamp of
         Relative timespan formatted ->
             Html.td
-                [ class "dict-value"
-                , title formatted
-                ]
+                (title formatted
+                    :: Styles.time
+                )
                 [ Html.span [] [ Html.text <| viewTimespan timespan ++ " ago" ] ]
 
         Absolute formatted (Just timespan) ->
             Html.td
-                [ class "dict-value"
-                , title <| viewTimespan timespan
-                ]
+                (title (viewTimespan timespan)
+                    :: Styles.time
+                )
                 [ Html.span [] [ Html.text formatted ] ]
 
         Absolute formatted Nothing ->
             Html.td
-                [ class "dict-value"
-                ]
+                Styles.time
                 [ Html.span [] [ Html.text formatted ] ]
 
 

--- a/web/elm/src/Build/Header/Views.elm
+++ b/web/elm/src/Build/Header/Views.elm
@@ -7,6 +7,7 @@ module Build.Header.Views exposing
     , Timespan(..)
     , Timestamp(..)
     , Widget(..)
+    , tooltip
     , viewHeader
     )
 
@@ -27,10 +28,11 @@ import Html.Attributes
         )
 import Html.Events exposing (onBlur, onFocus, onMouseEnter, onMouseLeave)
 import Html.Lazy
-import Message.Effects exposing (toHtmlID)
-import Message.Message as Message exposing (Message(..))
+import Message.Effects exposing (Effect(..), toHtmlID)
+import Message.Message as Message exposing (DomID(..), Message(..))
 import Routes
 import StrictEvents exposing (onLeftClick, onWheel)
+import Tooltip
 import Views.CommentBar as CommentBar
 import Views.Icon as Icon
 
@@ -378,6 +380,19 @@ viewButton { type_, backgroundColor, backgroundShade, isClickable } =
         ]
 
 
+tooltip : String -> Maybe Tooltip.Tooltip
+tooltip username =
+    Just
+        { body = Html.text username
+        , attachPosition =
+            { direction = Tooltip.Bottom
+            , alignment = Tooltip.Start
+            }
+        , arrow = Just 5
+        , containerAttrs = Nothing
+        }
+
+
 viewTitle : String -> String -> Maybe Concourse.JobIdentifier -> Concourse.BuildCreatedBy -> Html Message
 viewTitle name textColor jobID createdBy =
     let
@@ -425,18 +440,22 @@ viewTitle name textColor jobID createdBy =
                             "created by " ++ who
                     in
                     Html.span
-                        [ style "position" "absolute"
-                        , style "font-size" "12px"
-                        , style "bottom" "6px"
-                        , style "line-height" "16px"
-                        , style "right" "0"
-                        , style "left" "0"
-                        , style "text-overflow" "ellipsis"
-                        , style "white-space" "nowrap"
-                        , style "overflow" "hidden"
-                        , style "color" textColor
-                        , title text
-                        ]
+                        (id "created-by"
+                            :: [ style "position" "absolute"
+                               , style "font-size" "12px"
+                               , style "bottom" "6px"
+                               , style "line-height" "16px"
+                               , style "right" "0"
+                               , style "left" "0"
+                               , style "text-overflow" "ellipsis"
+                               , style "white-space" "nowrap"
+                               , style "overflow" "hidden"
+                               , style "color" textColor
+                               ]
+                            ++ [ onMouseEnter <| Hover <| Just (CreatedBy text)
+                               , onMouseLeave <| Hover Nothing
+                               ]
+                        )
                         [ Html.text text ]
 
                 Nothing ->

--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -18,6 +18,7 @@ module Build.Styles exposing
     , stepHeaderLabel
     , stepStatusIcon
     , tab
+    , time
     , titleTextColor
     , triggerButton
     )
@@ -28,8 +29,15 @@ import Colors
 import Concourse.BuildStatus exposing (BuildStatus(..))
 import Dashboard.Styles exposing (striped)
 import Html
-import Html.Attributes exposing (style)
+import Html.Attributes exposing (class, style)
 import Views.Styles
+
+
+time : List (Html.Attribute msg)
+time =
+    [ class "dict-value"
+    , style "white-space" "nowrap"
+    ]
 
 
 header : BuildStatus -> List (Html.Attribute msg)

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1061,6 +1061,9 @@ tooltip session =
                 , containerAttrs = Just Styles.cardTooltip
                 }
 
+        HoverState.Tooltip (UserDisplayName username) _ ->
+            Login.tooltip username
+
         _ ->
             Nothing
 

--- a/web/elm/src/Job/Job.elm
+++ b/web/elm/src/Job/Job.elm
@@ -503,6 +503,9 @@ tooltip model session =
                 , containerAttrs = Nothing
                 }
 
+        ( _, HoverState.Tooltip (UserDisplayName username) _ ) ->
+            Login.tooltip username
+
         _ ->
             Nothing
 

--- a/web/elm/src/Login/Login.elm
+++ b/web/elm/src/Login/Login.elm
@@ -1,13 +1,14 @@
-module Login.Login exposing (Model, update, userDisplayName, view)
+module Login.Login exposing (Model, tooltip, update, userDisplayName, view)
 
 import Concourse
 import EffectTransformer exposing (ET)
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, href, id)
-import Html.Events exposing (onClick)
+import Html.Events exposing (onClick, onMouseEnter, onMouseLeave)
 import Login.Styles as Styles
 import Message.Effects exposing (Effect(..))
 import Message.Message exposing (DomID(..), Message(..))
+import Tooltip
 import UserState exposing (UserState(..))
 
 
@@ -31,6 +32,19 @@ update msg ( model, effects ) =
 
         _ ->
             ( model, effects )
+
+
+tooltip : String -> Maybe Tooltip.Tooltip
+tooltip username =
+    Just
+        { body = Html.text username
+        , attachPosition =
+            { direction = Tooltip.Bottom
+            , alignment = Tooltip.End
+            }
+        , arrow = Just 5
+        , containerAttrs = Nothing
+        }
 
 
 view : UserState -> Model r -> Html Message
@@ -65,16 +79,24 @@ viewLoginState userState isUserMenuExpanded =
             ]
 
         UserStateLoggedIn user ->
+            let
+                displayName =
+                    userDisplayName user
+            in
             [ Html.div
                 ([ id "login-container"
                  , onClick <| Click UserMenu
                  ]
                     ++ Styles.loginContainer
                 )
-                [ Html.div (id "user-id" :: Styles.loginItem)
-                    (Html.div
-                        Styles.loginText
-                        [ Html.text (userDisplayName user) ]
+                [ Html.div
+                    (id "user-id"
+                        :: Styles.loginItem
+                        ++ [ onMouseEnter <| Hover <| Just (UserDisplayName displayName)
+                           , onMouseLeave <| Hover Nothing
+                           ]
+                    )
+                    (Html.text displayName
                         :: (if isUserMenuExpanded then
                                 [ Html.div
                                     ([ id "logout-button"

--- a/web/elm/src/Login/Login.elm
+++ b/web/elm/src/Login/Login.elm
@@ -96,21 +96,18 @@ viewLoginState userState isUserMenuExpanded =
                            , onMouseLeave <| Hover Nothing
                            ]
                     )
-                    (Html.text displayName
-                        :: (if isUserMenuExpanded then
-                                [ Html.div
-                                    ([ id "logout-button"
-                                     , onClick <| Click LogoutButton
-                                     ]
-                                        ++ Styles.logoutButton
-                                    )
-                                    [ Html.text "logout" ]
-                                ]
+                    [ Html.text displayName ]
+                , if isUserMenuExpanded then
+                    Html.div
+                        ([ id "logout-button"
+                         , onClick <| Click LogoutButton
+                         ]
+                            ++ Styles.logoutButton
+                        )
+                        [ Html.text "logout" ]
 
-                            else
-                                []
-                           )
-                    )
+                  else
+                    Html.text ""
                 ]
             ]
 

--- a/web/elm/src/Login/Styles.elm
+++ b/web/elm/src/Login/Styles.elm
@@ -2,7 +2,6 @@ module Login.Styles exposing
     ( loginComponent
     , loginContainer
     , loginItem
-    , loginText
     , logoutButton
     )
 
@@ -26,25 +25,19 @@ loginContainer =
     , style "border-left" <|
         "1px solid "
             ++ Colors.background
-    , style "line-height" "54px"
     ]
 
 
 loginItem : List (Html.Attribute msg)
 loginItem =
-    [ style "padding" "0 30px"
+    [ style "margin" "19px 30px"
     , style "cursor" "pointer"
-    , style "display" "flex"
     , style "align-items" "center"
     , style "justify-content" "center"
     , style "flex-grow" "1"
-    ]
-
-
-loginText : List (Html.Attribute msg)
-loginText =
-    [ style "overflow" "hidden"
+    , style "overflow" "hidden"
     , style "text-overflow" "ellipsis"
+    , style "white-space" "nowrap"
     ]
 
 
@@ -52,6 +45,7 @@ logoutButton : List (Html.Attribute msg)
 logoutButton =
     [ style "position" "absolute"
     , style "top" "55px"
+    , style "left" "0px"
     , style "background-color" Colors.topBarBackground
     , style "height" "54px"
     , style "width" "100%"

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -806,6 +806,9 @@ toHtmlID domId =
                 ++ encodePipelineId p
                 ++ "_name"
 
+        UserDisplayName _ ->
+            "user-id"
+
         PipelineCardNameHD p ->
             "HD_"
                 ++ encodePipelineId p

--- a/web/elm/src/Message/Effects.elm
+++ b/web/elm/src/Message/Effects.elm
@@ -809,6 +809,9 @@ toHtmlID domId =
         UserDisplayName _ ->
             "user-id"
 
+        CreatedBy _ ->
+            "created-by"
+
         PipelineCardNameHD p ->
             "HD_"
                 ++ encodePipelineId p

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -102,6 +102,7 @@ type DomID
     | LoginButton
     | LogoutButton
     | UserMenu
+    | UserDisplayName String
     | PaginationButton Page
     | VersionHeader VersionId
     | VersionToggle VersionId

--- a/web/elm/src/Message/Message.elm
+++ b/web/elm/src/Message/Message.elm
@@ -103,6 +103,7 @@ type DomID
     | LogoutButton
     | UserMenu
     | UserDisplayName String
+    | CreatedBy String
     | PaginationButton Page
     | VersionHeader VersionId
     | VersionToggle VersionId

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -485,6 +485,9 @@ tooltip model session =
                 , containerAttrs = Nothing
                 }
 
+        HoverState.Tooltip (UserDisplayName username) _ ->
+            Login.tooltip username
+
         _ ->
             PinMenu.tooltip model session
 

--- a/web/elm/src/Resource/Resource.elm
+++ b/web/elm/src/Resource/Resource.elm
@@ -34,7 +34,6 @@ import Concourse.Pagination
         , chevronContainer
         , chevronLeft
         , chevronRight
-        , equal
         )
 import DateFormat
 import Dict
@@ -1171,6 +1170,9 @@ tooltip model session =
                 , arrow = Just 5
                 , containerAttrs = Nothing
                 }
+
+        HoverState.Tooltip (UserDisplayName username) _ ->
+            Login.tooltip username
 
         _ ->
             model.output

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -93,6 +93,9 @@ policy domID =
         PipelineCardName _ _ ->
             OnlyShowWhenOverflowing
 
+        UserDisplayName _ ->
+            OnlyShowWhenOverflowing
+
         InstanceGroupCardName _ _ _ ->
             OnlyShowWhenOverflowing
 

--- a/web/elm/src/Tooltip.elm
+++ b/web/elm/src/Tooltip.elm
@@ -96,6 +96,9 @@ policy domID =
         UserDisplayName _ ->
             OnlyShowWhenOverflowing
 
+        CreatedBy _ ->
+            OnlyShowWhenOverflowing
+
         InstanceGroupCardName _ _ _ ->
             OnlyShowWhenOverflowing
 

--- a/web/elm/src/Views/Styles.elm
+++ b/web/elm/src/Views/Styles.elm
@@ -386,6 +386,7 @@ ellipsedText : List (Html.Attribute msg)
 ellipsedText =
     [ style "overflow" "hidden"
     , style "text-overflow" "ellipsis"
+    , style "white-space" "nowrap"
     ]
 
 

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -54,6 +54,10 @@ all : Test
 all =
     describe "build page" <|
         let
+            sampleUser : Concourse.User
+            sampleUser =
+                { id = "1", userName = "test", name = "Bob", isAdmin = False, email = "bob@bob.com", teams = Dict.empty, displayUserId = "sample-user" }
+
             fetchPipeline : Application.Model -> ( Application.Model, List Effects.Effect )
             fetchPipeline =
                 Application.handleCallback <|
@@ -1401,6 +1405,18 @@ all =
                         |> Common.queryView
                         |> Query.find [ id "top-bar-app" ]
                         |> Query.has [ id "login-component" ]
+            , test "username text does not overflow or wrap" <|
+                \_ ->
+                    Common.init "/teams/t/pipelines/p/jobs/j/builds/1"
+                        |> Application.handleCallback
+                            (Callback.UserFetched <| Ok sampleUser)
+                        |> Tuple.first
+                        |> Common.queryView
+                        |> Query.find [ id "user-id" ]
+                        |> Query.has
+                            [ style "overflow" "hidden"
+                            , style "text-overflow" "ellipsis"
+                            ]
             ]
         , test "page below top bar has padding to accomodate top bar" <|
             \_ ->

--- a/web/elm/tests/BuildTests.elm
+++ b/web/elm/tests/BuildTests.elm
@@ -1494,7 +1494,7 @@ all =
                         |> Common.queryView
                         |> Query.find [ class "build-duration" ]
                         |> Query.find [ tag "tr", containing [ tag "tr", containing [ text "finished" ] ] ]
-                        |> Query.has [ text "2s ago" ]
+                        |> Query.has [ text "2s ago", style "white-space" "nowrap" ]
             , test "when build finishes succesfully, header background is green" <|
                 \_ ->
                     Common.init "/teams/t/pipelines/p/jobs/j/builds/1"

--- a/web/elm/tests/SubPageTests.elm
+++ b/web/elm/tests/SubPageTests.elm
@@ -3,15 +3,12 @@ module SubPageTests exposing (all)
 import Application.Application as Application
 import Common
 import Data
-import Dict exposing (Dict)
 import Expect
-import Http
 import Message.Callback exposing (Callback(..))
 import NotFound.Model
 import Routes
 import SubPage.SubPage exposing (..)
 import Test exposing (..)
-import Url
 
 
 all : Test

--- a/web/elm/tests/TopBarTests.elm
+++ b/web/elm/tests/TopBarTests.elm
@@ -237,31 +237,20 @@ all =
                         >> Query.find [ id "login-container" ]
                         >> Query.has
                             [ style "border-left" <| "1px solid " ++ borderGrey ]
-                , it "renders login container tall enough" <|
-                    Query.children []
-                        >> Query.index -1
-                        >> Query.find [ id "login-container" ]
-                        >> Query.has
-                            [ style "line-height" lineHeight ]
                 , it "has the login username styles" <|
                     Query.children []
                         >> Query.index -1
                         >> Query.find [ id "user-id" ]
                         >> Expect.all
                             [ Query.has
-                                [ style "padding" "0 30px"
+                                [ style "margin" "19px 30px"
                                 , style "cursor" "pointer"
-                                , style "display" "flex"
                                 , style "align-items" "center"
                                 , style "justify-content" "center"
                                 , style "flex-grow" "1"
+                                , style "overflow" "hidden"
+                                , style "text-overflow" "ellipsis"
                                 ]
-                            , Query.children []
-                                >> Query.index 0
-                                >> Query.has
-                                    [ style "overflow" "hidden"
-                                    , style "text-overflow" "ellipsis"
-                                    ]
                             ]
                 , it "shows the logged in displayUserId when the user is logged in" <|
                     Query.children []
@@ -582,16 +571,14 @@ all =
                         , style "display" "flex"
                         , style "flex-direction" "column"
                         , style "border-left" <| "1px solid " ++ borderGrey
-                        , style "line-height" lineHeight
                         ]
             , it "has the login username styles" <|
                 Query.children []
                     >> Query.index -1
                     >> Query.find [ id "login-item" ]
                     >> Query.has
-                        [ style "padding" "0 30px"
+                        [ style "margin" "19px 30px"
                         , style "cursor" "pointer"
-                        , style "display" "flex"
                         , style "align-items" "center"
                         , style "justify-content" "center"
                         , style "flex-grow" "1"


### PR DESCRIPTION


## Changes proposed by this PR

 * refactor login component to have uniform html and CSS like other
item in topbar
 * add overflow to username so it won't block UI below it
 * show tooltip of full username if it is too long and overflowing

closes #8316

* [x] done
* [ ] todo

## Notes to reviewer

To test it, change update env var in docker-compose.yml and resize the screen until username is overflowing. Then hover over username to see the tooltip.

```
      CONCOURSE_ADD_LOCAL_USER: user-with-a-very-long-name:test,guest:guest
      CONCOURSE_MAIN_TEAM_LOCAL_USER: user-with-a-very-long-name
```

## Release Note
 * When username is overflowing, show a hovering tooltip with full name in web UI  so it won't block buttons below it e.g. trigger build buttons in build page.  
