### PR TITLE
Force checks on nested resource types when manually triggered build

### DIFF
--- a/atc/api/jobserver/create_build.go
+++ b/atc/api/jobserver/create_build.go
@@ -75,10 +75,7 @@ func (s *Server) CreateJobBuild(pipeline db.Pipeline) http.Handler {
 					resourceTypes,
 					version,
 					true,
-					// Don't recursively skip the interval for checks for parent resource
-					// types - doing so would result in a ton of checks running
-					// unnecessarily.
-					false,
+					true,
 					true,
 				)
 				if err != nil {

--- a/atc/engine/task_delegate.go
+++ b/atc/engine/task_delegate.go
@@ -109,10 +109,11 @@ func (d *taskDelegate) FetchImage(
 	types atc.ResourceTypes,
 	privileged bool,
 	stepTags atc.Tags,
+	skipInterval bool,
 ) (runtime.ImageSpec, error) {
 	image.Name = "image"
 
-	getPlan, checkPlan := atc.FetchImagePlan(d.planID, image, types, stepTags, false, nil)
+	getPlan, checkPlan := atc.FetchImagePlan(d.planID, image, types, stepTags, skipInterval, nil)
 
 	if checkPlan != nil {
 		err := d.build.SaveEvent(event.ImageCheck{

--- a/atc/engine/task_delegate_test.go
+++ b/atc/engine/task_delegate_test.go
@@ -250,7 +250,7 @@ var _ = Describe("TaskDelegate", func() {
 		})
 
 		JustBeforeEach(func() {
-			imageSpec, fetchErr = delegate.FetchImage(context.TODO(), imageResource, types, privileged, tags)
+			imageSpec, fetchErr = delegate.FetchImage(context.TODO(), imageResource, types, privileged, tags, false)
 		})
 
 		It("succeeds", func() {

--- a/atc/exec/execfakes/fake_task_delegate.go
+++ b/atc/exec/execfakes/fake_task_delegate.go
@@ -32,7 +32,7 @@ type FakeTaskDelegate struct {
 		arg1 lager.Logger
 		arg2 string
 	}
-	FetchImageStub        func(context.Context, atc.ImageResource, atc.ResourceTypes, bool, atc.Tags) (runtime.ImageSpec, error)
+	FetchImageStub        func(context.Context, atc.ImageResource, atc.ResourceTypes, bool, atc.Tags, bool) (runtime.ImageSpec, error)
 	fetchImageMutex       sync.RWMutex
 	fetchImageArgsForCall []struct {
 		arg1 context.Context
@@ -40,6 +40,7 @@ type FakeTaskDelegate struct {
 		arg3 atc.ResourceTypes
 		arg4 bool
 		arg5 atc.Tags
+		arg6 bool
 	}
 	fetchImageReturns struct {
 		result1 runtime.ImageSpec
@@ -222,7 +223,7 @@ func (fake *FakeTaskDelegate) ErroredArgsForCall(i int) (lager.Logger, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeTaskDelegate) FetchImage(arg1 context.Context, arg2 atc.ImageResource, arg3 atc.ResourceTypes, arg4 bool, arg5 atc.Tags) (runtime.ImageSpec, error) {
+func (fake *FakeTaskDelegate) FetchImage(arg1 context.Context, arg2 atc.ImageResource, arg3 atc.ResourceTypes, arg4 bool, arg5 atc.Tags, arg6 bool) (runtime.ImageSpec, error) {
 	fake.fetchImageMutex.Lock()
 	ret, specificReturn := fake.fetchImageReturnsOnCall[len(fake.fetchImageArgsForCall)]
 	fake.fetchImageArgsForCall = append(fake.fetchImageArgsForCall, struct {
@@ -231,13 +232,14 @@ func (fake *FakeTaskDelegate) FetchImage(arg1 context.Context, arg2 atc.ImageRes
 		arg3 atc.ResourceTypes
 		arg4 bool
 		arg5 atc.Tags
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg6 bool
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.FetchImageStub
 	fakeReturns := fake.fetchImageReturns
-	fake.recordInvocation("FetchImage", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("FetchImage", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.fetchImageMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -251,17 +253,17 @@ func (fake *FakeTaskDelegate) FetchImageCallCount() int {
 	return len(fake.fetchImageArgsForCall)
 }
 
-func (fake *FakeTaskDelegate) FetchImageCalls(stub func(context.Context, atc.ImageResource, atc.ResourceTypes, bool, atc.Tags) (runtime.ImageSpec, error)) {
+func (fake *FakeTaskDelegate) FetchImageCalls(stub func(context.Context, atc.ImageResource, atc.ResourceTypes, bool, atc.Tags, bool) (runtime.ImageSpec, error)) {
 	fake.fetchImageMutex.Lock()
 	defer fake.fetchImageMutex.Unlock()
 	fake.FetchImageStub = stub
 }
 
-func (fake *FakeTaskDelegate) FetchImageArgsForCall(i int) (context.Context, atc.ImageResource, atc.ResourceTypes, bool, atc.Tags) {
+func (fake *FakeTaskDelegate) FetchImageArgsForCall(i int) (context.Context, atc.ImageResource, atc.ResourceTypes, bool, atc.Tags, bool) {
 	fake.fetchImageMutex.RLock()
 	defer fake.fetchImageMutex.RUnlock()
 	argsForCall := fake.fetchImageArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeTaskDelegate) FetchImageReturns(result1 runtime.ImageSpec, result2 error) {

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -61,7 +61,7 @@ type TaskDelegateFactory interface {
 type TaskDelegate interface {
 	StartSpan(context.Context, string, tracing.Attrs) (context.Context, trace.Span)
 
-	FetchImage(context.Context, atc.ImageResource, atc.ResourceTypes, bool, atc.Tags) (runtime.ImageSpec, error)
+	FetchImage(context.Context, atc.ImageResource, atc.ResourceTypes, bool, atc.Tags, bool) (runtime.ImageSpec, error)
 
 	Stdout() io.Writer
 	Stderr() io.Writer
@@ -363,6 +363,7 @@ func (step *TaskStep) imageSpec(ctx context.Context, logger lager.Logger, state 
 			step.plan.ResourceTypes,
 			step.plan.Privileged,
 			step.plan.Tags,
+			step.plan.CheckSkipInterval,
 		)
 		return imageSpec, err
 

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -787,7 +787,7 @@ var _ = Describe("TaskStep", func() {
 
 			It("fetches the image", func() {
 				Expect(fakeDelegate.FetchImageCallCount()).To(Equal(1))
-				_, imageResource, types, privileged, tags := fakeDelegate.FetchImageArgsForCall(0)
+				_, imageResource, types, privileged, tags, skipInterval := fakeDelegate.FetchImageArgsForCall(0)
 				Expect(imageResource).To(Equal(atc.ImageResource{
 					Type:   "docker",
 					Source: atc.Source{"some": "super-secret-source"},
@@ -796,6 +796,7 @@ var _ = Describe("TaskStep", func() {
 				Expect(types).To(Equal(taskPlan.ResourceTypes))
 				Expect(privileged).To(BeFalse())
 				Expect(tags).To(Equal(atc.Tags{"some", "tags"}))
+				Expect(skipInterval).To(Equal(false))
 			})
 
 			It("creates the specs with the fetched image", func() {
@@ -809,8 +810,20 @@ var _ = Describe("TaskStep", func() {
 
 				It("fetches a privileged image", func() {
 					Expect(fakeDelegate.FetchImageCallCount()).To(Equal(1))
-					_, _, _, privileged, _ := fakeDelegate.FetchImageArgsForCall(0)
+					_, _, _, privileged, _, _ := fakeDelegate.FetchImageArgsForCall(0)
 					Expect(privileged).To(BeTrue())
+				})
+			})
+
+			Context("when check skip interval is true", func() {
+				BeforeEach(func() {
+					taskPlan.CheckSkipInterval = true
+				})
+
+				It("fetches an image with forced check", func() {
+					Expect(fakeDelegate.FetchImageCallCount()).To(Equal(1))
+					_, _, _, _, _, skipInterval := fakeDelegate.FetchImageArgsForCall(0)
+					Expect(skipInterval).To(BeTrue())
 				})
 			})
 		})

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -345,6 +345,10 @@ type TaskPlan struct {
 
 	// Resource types to have available for use when fetching the task's image.
 	ResourceTypes ResourceTypes `json:"resource_types,omitempty"`
+
+	// If set, the check plan for the image will be forced to run and not respect
+	// the checking interval
+	CheckSkipInterval bool `json:"check_skip_interval,omitempty"`
 }
 
 type RunPlan struct {

--- a/atc/scheduler/buildstarter.go
+++ b/atc/scheduler/buildstarter.go
@@ -21,7 +21,7 @@ type BuildStarter interface {
 
 //counterfeiter:generate . BuildPlanner
 type BuildPlanner interface {
-	Create(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput) (atc.Plan, error)
+	Create(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool) (atc.Plan, error)
 }
 
 type Build interface {
@@ -196,7 +196,7 @@ func (s *buildStarter) tryStartNextPendingBuild(
 		return startResults{}, fmt.Errorf("config: %w", err)
 	}
 
-	plan, err := s.planner.Create(config.StepConfig(), job.Resources, job.ResourceTypes, job.Prototypes, buildInputs)
+	plan, err := s.planner.Create(config.StepConfig(), job.Resources, job.ResourceTypes, job.Prototypes, buildInputs, nextPendingBuild.IsManuallyTriggered())
 	if err != nil {
 		logger.Error("failed-to-create-build-plan", err)
 

--- a/atc/scheduler/buildstarter_test.go
+++ b/atc/scheduler/buildstarter_test.go
@@ -381,6 +381,11 @@ var _ = Describe("BuildStarter", func() {
 								It("tries to fetch the job config", func() {
 									Expect(job.ConfigCallCount()).To(Equal(1))
 								})
+
+								It("creates the build plan with manually triggered", func() {
+									_, _, _, _, _, actualManuallyTriggered := fakePlanner.CreateArgsForCall(0)
+									Expect(actualManuallyTriggered).To(Equal(true))
+								})
 							})
 
 							Context("when adopting inputs and pipes fails", func() {
@@ -664,26 +669,29 @@ var _ = Describe("BuildStarter", func() {
 									It("creates build plans for all builds", func() {
 										Expect(fakePlanner.CreateCallCount()).To(Equal(3))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs := fakePlanner.CreateArgsForCall(0)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered := fakePlanner.CreateArgsForCall(0)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(resourceTypes))
 										Expect(actualPrototypes).To(Equal(prototypes))
 										Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
+										Expect(actualManuallyTriggered).To(Equal(false))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs = fakePlanner.CreateArgsForCall(1)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered = fakePlanner.CreateArgsForCall(1)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(resourceTypes))
 										Expect(actualPrototypes).To(Equal(prototypes))
 										Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
+										Expect(actualManuallyTriggered).To(Equal(false))
 
-										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs = fakePlanner.CreateArgsForCall(2)
+										actualPlanConfig, actualResourceConfigs, actualResourceTypes, actualPrototypes, actualBuildInputs, actualManuallyTriggered = fakePlanner.CreateArgsForCall(2)
 										Expect(actualPlanConfig).To(Equal(&atc.DoStep{Steps: jobConfig.PlanSequence}))
 										Expect(actualResourceConfigs).To(Equal(db.SchedulerResources{{Name: "some-resource"}}))
 										Expect(actualResourceTypes).To(Equal(resourceTypes))
 										Expect(actualPrototypes).To(Equal(prototypes))
 										Expect(actualBuildInputs).To(Equal([]db.BuildInput{{Name: "some-input"}}))
+										Expect(actualManuallyTriggered).To(Equal(false))
 									})
 
 									Context("when starting the build fails", func() {

--- a/atc/scheduler/schedulerfakes/fake_build_planner.go
+++ b/atc/scheduler/schedulerfakes/fake_build_planner.go
@@ -10,7 +10,7 @@ import (
 )
 
 type FakeBuildPlanner struct {
-	CreateStub        func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput) (atc.Plan, error)
+	CreateStub        func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool) (atc.Plan, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
 		arg1 atc.StepConfig
@@ -18,6 +18,7 @@ type FakeBuildPlanner struct {
 		arg3 atc.ResourceTypes
 		arg4 atc.Prototypes
 		arg5 []db.BuildInput
+		arg6 bool
 	}
 	createReturns struct {
 		result1 atc.Plan
@@ -31,7 +32,7 @@ type FakeBuildPlanner struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResources, arg3 atc.ResourceTypes, arg4 atc.Prototypes, arg5 []db.BuildInput) (atc.Plan, error) {
+func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResources, arg3 atc.ResourceTypes, arg4 atc.Prototypes, arg5 []db.BuildInput, arg6 bool) (atc.Plan, error) {
 	var arg5Copy []db.BuildInput
 	if arg5 != nil {
 		arg5Copy = make([]db.BuildInput, len(arg5))
@@ -45,13 +46,14 @@ func (fake *FakeBuildPlanner) Create(arg1 atc.StepConfig, arg2 db.SchedulerResou
 		arg3 atc.ResourceTypes
 		arg4 atc.Prototypes
 		arg5 []db.BuildInput
-	}{arg1, arg2, arg3, arg4, arg5Copy})
+		arg6 bool
+	}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
 	stub := fake.CreateStub
 	fakeReturns := fake.createReturns
-	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4, arg5Copy})
+	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
 	fake.createMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -65,17 +67,17 @@ func (fake *FakeBuildPlanner) CreateCallCount() int {
 	return len(fake.createArgsForCall)
 }
 
-func (fake *FakeBuildPlanner) CreateCalls(stub func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput) (atc.Plan, error)) {
+func (fake *FakeBuildPlanner) CreateCalls(stub func(atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool) (atc.Plan, error)) {
 	fake.createMutex.Lock()
 	defer fake.createMutex.Unlock()
 	fake.CreateStub = stub
 }
 
-func (fake *FakeBuildPlanner) CreateArgsForCall(i int) (atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput) {
+func (fake *FakeBuildPlanner) CreateArgsForCall(i int) (atc.StepConfig, db.SchedulerResources, atc.ResourceTypes, atc.Prototypes, []db.BuildInput, bool) {
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
 	argsForCall := fake.createArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeBuildPlanner) CreateReturns(result1 atc.Plan, result2 error) {


### PR DESCRIPTION
## Changes proposed by this PR

Previously we had it that manually triggered builds would not force any nested resource types or images to skip its interval for its check plan. This is because we did not want all the nested resource types to check everytime a build is manually triggered. This might cause a lot of unnecessary checks because most users don't care about its resource type versions. 

But Rui brought up a good point that image resources cannot be manually checked through fly so the only way to force a check for them is through a manual build. This PR makes it so that a manually triggered build will make the nested resource types and images skip its interval. One thing that will help alleviate the increased number of checks that this change will is result in is that we will only ever check a resource type once in the build, so forcing the checks wont result in the same resource type getting checked multiple times.

* [x] done
* [ ] todo

## Release Note

* When a build is manually triggered, it will cause any nested resource types or images to skip its checking interval, essentially forcing a check. This will not result in the same resource type getting checked multiple times if it appears multiple times in a build.
