### PR TITLE
Fix fly integration test in window OS

### DIFF
--- a/fly/integration/clear_versions_test.go
+++ b/fly/integration/clear_versions_test.go
@@ -144,7 +144,7 @@ and the following resource types:
 				It("fails to delete versions", func() {
 					yes()
 					Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
-					Expect(sess.ExitCode()).To(Equal(1))
+					Expect(sess.ExitCode()).ToNot(Equal(0))
 				})
 			})
 
@@ -260,7 +260,7 @@ and the following resource types:
 				It("fails to delete versions", func() {
 					yes()
 					Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
-					Expect(sess.ExitCode()).To(Equal(1))
+					Expect(sess.ExitCode()).ToNot(Equal(0))
 				})
 			})
 


### PR DESCRIPTION
The expected exit code for following fly integration test is `-1` under windows OS instead of `1` of linux/darwin OS.  
```
target saved
[4] !!! this will clear the version histories for the following resources:
[4] - some-team/some-pipeline/some-resource
[4] 
[4] and the following resource types:
[4] - some-team/some-pipeline/some-resource-type
[4] - some-team/some-pipeline/other-resource-type
[4] - other-team/other-pipeline/other-resource-type-2
[4] 
[4] are you sure? [yN]: y
[4] error: Unexpected Response
[4] Status: 500 Internal Server Error
[4] Body: {"versions_removed":2}
[4] + Failure [1.396 seconds]
[4] Fly CLI clear-versions when a resource type is specified when deleting the versions fails [It] fails to delete versions 
[4] C:/work/containers/00001b0fc7o/tmp/build/fe308d31/concourse/fly/integration/clear_versions_test.go:260
[4] 
[4]   Expected
[4]       <int>: -1
[4]   to equal
[4]       <int>: 1
```

Changes:

Update the test to expect a non zero value