### PR TITLE
Introduce OIDC get user info flag

### DIFF
--- a/skymarshal/skycmd/oidc_flags.go
+++ b/skymarshal/skycmd/oidc_flags.go
@@ -30,7 +30,7 @@ type OIDCFlags struct {
 	InsecureSkipVerify        bool        `long:"skip-ssl-validation" description:"Skip SSL validation"`
 	DisableGroups             bool        `long:"disable-groups" description:"Disable OIDC groups claims"`
 	InsecureSkipEmailVerified bool        `long:"skip-email-verified-validation" description:"Ignore the email_verified claim from the upstream provider, treating all users as if email_verified were true."`
-	GetUserInfo               bool        `long:"get-user-info" description:"When enabled, the OpenID Connector will query the UserInfo endpoint for additional claims, e.g. groups"`
+	DisableGetUserInfo        bool        `long:"disable-get-user-info" description:"When disabled, the OpenID Connector will not query the UserInfo endpoint for additional claims, e.g. groups"`
 }
 
 func (flag *OIDCFlags) Name() string {
@@ -80,7 +80,7 @@ func (flag *OIDCFlags) Serialize(redirectURI string) ([]byte, error) {
 		RedirectURI:               redirectURI,
 		InsecureEnableGroups:      !flag.DisableGroups,
 		InsecureSkipEmailVerified: flag.InsecureSkipEmailVerified,
-		GetUserInfo:               flag.GetUserInfo,
+		GetUserInfo:               !flag.DisableGetUserInfo,
 	}
 
 	config.ClaimMapping.GroupsKey = flag.GroupsKey

--- a/skymarshal/skycmd/oidc_flags.go
+++ b/skymarshal/skycmd/oidc_flags.go
@@ -30,6 +30,7 @@ type OIDCFlags struct {
 	InsecureSkipVerify        bool        `long:"skip-ssl-validation" description:"Skip SSL validation"`
 	DisableGroups             bool        `long:"disable-groups" description:"Disable OIDC groups claims"`
 	InsecureSkipEmailVerified bool        `long:"skip-email-verified-validation" description:"Ignore the email_verified claim from the upstream provider, treating all users as if email_verified were true."`
+	GetUserInfo               bool        `long:"get-user-info" description:"When enabled, the OpenID Connector will query the UserInfo endpoint for additional claims, e.g. groups"`
 }
 
 func (flag *OIDCFlags) Name() string {
@@ -79,6 +80,7 @@ func (flag *OIDCFlags) Serialize(redirectURI string) ([]byte, error) {
 		RedirectURI:               redirectURI,
 		InsecureEnableGroups:      !flag.DisableGroups,
 		InsecureSkipEmailVerified: flag.InsecureSkipEmailVerified,
+		GetUserInfo:               flag.GetUserInfo,
 	}
 
 	config.ClaimMapping.GroupsKey = flag.GroupsKey


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Add `CONCOURSE_OIDC_DISABLE_GET_USER_INFO` flag

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

This PR adds the `dex` GetUserInfo flag which is required to get extra user info e.g. groups claim from an OIDC provider (Okta in this case). Please see https://github.com/dexidp/dex/blob/9cd29bdee04ca38104a4488b211208694501d54f/connector/oidc/oidc.go#L48-L51 without this flag, we cannot get groups from Okta and fail to authenticate to `fly` successfully.

Notably, you can see from this issue https://github.com/concourse/concourse/issues/3486 that other people have the same problem.

## Release Note

* Add `CONCOURSE_OIDC_DISABLE_GET_USER_INFO` flag. OIDC connector will now fetch additional claims from [OpenID UserInfo endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo). This should fix the problem of configuring Concourse team auth by OIDC user groups due to groups claims missing in some identity providers' auth response. 