### PR TITLE
Fix default username prompt for local logins

### DIFF
--- a/skymarshal/dexserver/web/templates/password.html
+++ b/skymarshal/dexserver/web/templates/password.html
@@ -1,7 +1,7 @@
 {{ template "header.html" . }}
 
 {{ $usernamePrompt := .UsernamePrompt | lower }}
-{{ if eq .ReqPath "/sky/issuer/auth/local" }}
+{{ if eq .ReqPath "/sky/issuer/auth/local/login" }}
   {{ $usernamePrompt = "username" }}
 {{ end }}
 


### PR DESCRIPTION
## Changes proposed by this PR

closes #8361

## Notes to reviewer

64e504b introduced an incorrect request path check which caused the default value of the username prompt for local logins (`username`) to never be set. Specifically, the path being checked was only a prefix of the full request path.

## Release Note

- Ensure the default username prompt for local logins is properly set.