### PR TITLE
don't force resource type check on get step

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -135,7 +135,7 @@ func (visitor *planVisitor) VisitGet(step *atc.GetStep) error {
 		Timeout:  step.Timeout,
 	})
 
-	plan.Get.TypeImage = visitor.resourceTypes.ImageForType(plan.ID, resource.Type, step.Tags, visitor.manuallyTriggered)
+	plan.Get.TypeImage = visitor.resourceTypes.ImageForType(plan.ID, resource.Type, step.Tags, false)
 	visitor.plan = plan
 	return nil
 }

--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -702,7 +702,6 @@ var factoryTests = []PlannerTest{
 								 "some": "child-source"
 							},
 							"interval": "1m0s",
-							"skip_interval": true,
 							"image": {
 								"base_type": "some-base-resource-type",
 								"get_plan": {
@@ -736,7 +735,6 @@ var factoryTests = []PlannerTest{
 											"base_type": "some-base-resource-type"
 										},
 							      "interval": "1m0s",
-										"skip_interval": true,
 										"tags": [
 											 "tag-1",
 											 "tag-2"
@@ -773,7 +771,6 @@ var factoryTests = []PlannerTest{
 											"base_type": "some-base-resource-type"
 										},
 							      "interval": "1m0s",
-										"skip_interval": true,
 										"tags": [
 											 "tag-1",
 											 "tag-2"


### PR DESCRIPTION
<details><summary>Topgun failure</summary>
<p>


```
STEP: expecting a container for resource type check, resource type get, resource check, resource get in get step. expecting a container for nested resource type check, image check, image get and task run in task step. In total 8 containers.
STEP: [1652941784.939375401] running: /tmp/gexec_artifacts1826547708/g1492952240/fly -t concourse-topgun-both-1 --print-table-headers containers
handle                                worker                                pipeline  job      build #  build id  type   name     attempt
46d80322-3571-4667-6406-cb03cf99f148  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         check  image    n/a    
609b4bce-8edf-4de8-4404-be60e63ae7b9  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      none     check    2         get    my-time  n/a    
6c2b91e7-48fd-4d3a-7775-b8e9b6d0c549  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         check  my-time  n/a    
8491feb7-c119-4238-5b42-3d3b69f86c3a  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         task   fail     n/a    
8b4a3b62-3e66-40f3-6668-5650e6053e60  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         get    10m      n/a    
93a3400f-cc54-4018-473d-77c7bf642fe7  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      none     check    2         check  my-time  n/a    
b080a429-d05b-4584-47e0-b45dd07c2bb9  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         get    image    n/a    
ec080750-7804-46b8-6ddb-d3a077599b47  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      none     check    2         check  10m      n/a    
STEP: triggering the build again
STEP: [1652941784.994319677] running: /tmp/gexec_artifacts1826547708/g1492952240/fly -t concourse-topgun-both-1 trigger-job -w -j pipe/get-10m
started pipe/get-10m #2

initializing check: my-time
selected worker: 0cf29f27-fc0e-46da-a545-ff8248dd12a6
selected worker: 0cf29f27-fc0e-46da-a545-ff8248dd12a6
INFO: found existing resource cache

selected worker: 0cf29f27-fc0e-46da-a545-ff8248dd12a6
INFO: found existing resource cache

initializing
initializing check: image
selected worker: 0cf29f27-fc0e-46da-a545-ff8248dd12a6
selected worker: 0cf29f27-fc0e-46da-a545-ff8248dd12a6
INFO: found existing resource cache

selected worker: 0cf29f27-fc0e-46da-a545-ff8248dd12a6
running false
failed
STEP: expecting additional check containers for the task's image check and nested resource type check.
STEP: [1652941799.958286047] running: /tmp/gexec_artifacts1826547708/g1492952240/fly -t concourse-topgun-both-1 --print-table-headers containers
handle                                worker                                pipeline  job      build #  build id  type   name     attempt
2f238a55-889a-4f64-4f4e-e74cc42aab9e  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  2        3         task   fail     n/a    
46d80322-3571-4667-6406-cb03cf99f148  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         check  image    n/a    
56a9d953-fdd7-4356-5d70-f33fc1c53d8e  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  2        3         check  image    n/a    
609b4bce-8edf-4de8-4404-be60e63ae7b9  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      none     check    2         get    my-time  n/a    
6c2b91e7-48fd-4d3a-7775-b8e9b6d0c549  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         check  my-time  n/a    
8491feb7-c119-4238-5b42-3d3b69f86c3a  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         task   fail     n/a    
8b4a3b62-3e66-40f3-6668-5650e6053e60  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         get    10m      n/a    
8c781ee6-08d3-410f-6e9a-426e08a3eb18  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      none     check    4         check  my-time  n/a    
93a3400f-cc54-4018-473d-77c7bf642fe7  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      none     check    2         check  my-time  n/a    
9df8f11d-a8f9-4c7f-618f-8c0186122e24  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  2        3         check  my-time  n/a    
b080a429-d05b-4584-47e0-b45dd07c2bb9  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      get-10m  1        1         get    image    n/a    
ec080750-7804-46b8-6ddb-d3a077599b47  0cf29f27-fc0e-46da-a545-ff8248dd12a6  pipe      none     check    2         check  10m      n/a 
```

</p>
</details>


Ideally, we want to see a new image check container and a new resource type check container when the build got triggered again. However you can see there are 2 new my-time containers, where `93a3400f` is from the implicit check step that enforced by triggering the build and `9df8f11d` is from the get step when the build actually runs. 

We should avoid the redundant check in get step when manually triggering a build.

Changes:

Set the skip check interval to `false` for get step, so when it runs it will repect if check interval is elapsed. Versus before if the build is triggered manually, its get step will skip the check interval by PR #8342 