### PR TITLE
completely revert change in topgun resource types test

### DIFF
--- a/topgun/both/resource_types_test.go
+++ b/topgun/both/resource_types_test.go
@@ -22,11 +22,11 @@ var _ = Describe("A pipeline-provided resource type", func() {
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(1))
 
-		By("expecting a container for the resource check, resource type check, task resource type check and task image check")
-		Expect(ContainersBy("type", "check")).To(HaveLen(4))
+		By("expecting a container for the resource check, resource type check and task image check")
+		Expect(ContainersBy("type", "check")).To(HaveLen(3))
 
-		By("expecting a container for resource type check, resource type get, resource check, resource get in get step. expecting a container for nested resource type check, image check, image get and task run in task step. In total 8 containers.")
-		expectedContainersBefore := 8
+		By("expecting a container for resource type check, resource type get, resource check, resource get in get step. expecting a container for image check, image get and task run in task step. In total 7 containers.")
+		expectedContainersBefore := 7
 		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore))
 
 		By("triggering the build again")
@@ -34,11 +34,11 @@ var _ = Describe("A pipeline-provided resource type", func() {
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(1))
 
-		By("expecting additional check containers for the task's image check and nested resource type check.")
-		Expect(ContainersBy("type", "check")).To(HaveLen(6))
+		By("expecting only one additional check containers for the task's image check")
+		Expect(ContainersBy("type", "check")).To(HaveLen(4))
 
-		By("expecting to only have new containers for build task image check, nested resource type check and build task")
-		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore + 3))
+		By("expecting to only have new containers for build task image check and build task")
+		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore + 2))
 	})
 })
 


### PR DESCRIPTION
With all the changes we have made for resource check behaviour, the original version of this toggun test seems still valid. So now it is reverted back to a version as before https://github.com/concourse/concourse/commit/d453da58110d500ca494deb5d4eda1620deed694