### PR TITLE
update topgun resource types test to match behaviour

### DIFF
--- a/topgun/both/resource_types_test.go
+++ b/topgun/both/resource_types_test.go
@@ -34,11 +34,11 @@ var _ = Describe("A pipeline-provided resource type", func() {
 		<-buildSession.Exited
 		Expect(buildSession.ExitCode()).To(Equal(1))
 
-		By("expecting only one additional check containers for the task's image check")
-		Expect(ContainersBy("type", "check")).To(HaveLen(4))
+		By("expecting 2 additional check containers for the task's image check and resource type check")
+		Expect(ContainersBy("type", "check")).To(HaveLen(5))
 
-		By("expecting to only have new containers for build task image check and build task")
-		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore + 2))
+		By("expecting to only have new containers for build task image check, build task run and resource type check")
+		Expect(FlyTable("containers")).Should(HaveLen(expectedContainersBefore + 3))
 	})
 })
 


### PR DESCRIPTION

## Changes proposed by this PR

In the second build, it will create new image check and task run container. It will also create a check container for resource type. But thats expected as it is forced by the check on build inputs when manually trigger build (thus the test is updated from 2 to 3).

When the second build runs and create check for resource `10m` and resource type `my-time`, it will create a new container or reuse an old one to run the check. It depends on whether a container owner created for the plan is the same as an existing container. 

For the resource-type container, its owner is a combination of plan id, build id and team id, where plan id and build id are NEW in each build. So the container for resource-type `my-time` will be always created newly. But for resource, its owner is depends on resource config id and base resource type id. So in the second build, the check of resource will be reusing the container created in first build since resource config and base resource type are unchanged. 

Related code block is here https://github.com/concourse/concourse/blob/788a440f0f3a9d3d9b42bbf02a5033674ff823bb/atc/exec/check_step.go#L316-L334