### PR TITLE
set_pipeline step supports detach mode

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -264,6 +264,7 @@ func (visitor *planVisitor) VisitSetPipeline(step *atc.SetPipelineStep) error {
 		Vars:         step.Vars,
 		VarFiles:     step.VarFiles,
 		InstanceVars: step.InstanceVars,
+		Detach:       step.Detach,
 	})
 
 	return nil

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -212,6 +212,7 @@ type Build interface {
 		config atc.Config,
 		from ConfigVersion,
 		initiallyPaused bool,
+		detach bool,
 	) (Pipeline, bool, error)
 
 	ResourceCacheUser() ResourceCacheUser
@@ -1799,6 +1800,7 @@ func (b *build) SavePipeline(
 	config atc.Config,
 	from ConfigVersion,
 	initiallyPaused bool,
+	detach bool,
 ) (Pipeline, bool, error) {
 	tx, err := b.conn.Begin()
 	if err != nil {
@@ -1807,8 +1809,14 @@ func (b *build) SavePipeline(
 
 	defer Rollback(tx)
 
-	jobID := newNullInt64(b.jobID)
-	buildID := newNullInt64(b.id)
+	var jobID, buildID sql.NullInt64
+	if detach {
+		jobID = sql.NullInt64{Valid: false}
+		buildID = sql.NullInt64{Valid: false}
+	} else {
+		jobID = newNullInt64(b.jobID)
+		buildID = newNullInt64(b.id)
+	}
 	pipelineID, isNewPipeline, err := savePipeline(tx, pipelineRef, config, from, initiallyPaused, teamID, jobID, buildID)
 	if err != nil {
 		return nil, false, err

--- a/atc/db/build_in_memory_check.go
+++ b/atc/db/build_in_memory_check.go
@@ -662,7 +662,7 @@ func (b *inMemoryCheckBuild) Start(atc.Plan) (bool, error) {
 func (b *inMemoryCheckBuild) ResourcesChecked() (bool, error) {
 	return false, errors.New("not implemented for in memory build")
 }
-func (b *inMemoryCheckBuild) SavePipeline(atc.PipelineRef, int, atc.Config, ConfigVersion, bool) (Pipeline, bool, error) {
+func (b *inMemoryCheckBuild) SavePipeline(atc.PipelineRef, int, atc.Config, ConfigVersion, bool, bool) (Pipeline, bool, error) {
 	return nil, false, errors.New("not implemented for in memory build")
 }
 func (b *inMemoryCheckBuild) AdoptInputsAndPipes() ([]BuildInput, bool, error) {

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -806,7 +806,7 @@ var _ = Describe("Build", func() {
 			BeforeEach(func() {
 				By("creating a child pipeline")
 				build, _ := defaultJob.CreateBuild(defaultBuildCreatedBy)
-				childPipeline, _, _ = build.SavePipeline(atc.PipelineRef{Name: "child1-pipeline"}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false)
+				childPipeline, _, _ = build.SavePipeline(atc.PipelineRef{Name: "child1-pipeline"}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false, false)
 				build.Finish(db.BuildStatusSucceeded)
 
 				childPipeline.Reload()
@@ -831,7 +831,7 @@ var _ = Describe("Build", func() {
 						for i := 0; i < 5; i++ {
 							job, _, _ := childPipeline.Job("some-job")
 							build, _ := job.CreateBuild(defaultBuildCreatedBy)
-							childPipeline, _, _ = build.SavePipeline(atc.PipelineRef{Name: "child-pipeline-" + strconv.Itoa(i)}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false)
+							childPipeline, _, _ = build.SavePipeline(atc.PipelineRef{Name: "child-pipeline-" + strconv.Itoa(i)}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false, false)
 							build.Finish(db.BuildStatusSucceeded)
 							childPipelines = append(childPipelines, childPipeline)
 						}
@@ -2393,7 +2393,7 @@ var _ = Describe("Build", func() {
 						},
 					},
 				},
-			}, db.ConfigVersion(0), false)
+			}, db.ConfigVersion(0), false, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pipeline.ParentJobID()).To(Equal(build.JobID()))
 			Expect(pipeline.ParentBuildID()).To(Equal(build.ID()))
@@ -2431,7 +2431,7 @@ var _ = Describe("Build", func() {
 						},
 					},
 				},
-			}, db.ConfigVersion(0), false)
+			}, db.ConfigVersion(0), false, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pipeline.ParentJobID()).To(Equal(buildTwo.JobID()))
 			Expect(pipeline.ParentBuildID()).To(Equal(buildTwo.ID()))
@@ -2461,7 +2461,7 @@ var _ = Describe("Build", func() {
 						},
 					},
 				},
-			}, pipeline.ConfigVersion(), false)
+			}, pipeline.ConfigVersion(), false, false)
 			Expect(err).To(Equal(db.ErrSetByNewerBuild))
 		})
 
@@ -2472,7 +2472,7 @@ var _ = Describe("Build", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("re-saving the default pipeline with the build")
-				pipeline, _, err := build.SavePipeline(defaultPipelineRef, build.TeamID(), defaultPipelineConfig, db.ConfigVersion(1), false)
+				pipeline, _, err := build.SavePipeline(defaultPipelineRef, build.TeamID(), defaultPipelineConfig, db.ConfigVersion(1), false, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pipeline.ParentJobID()).To(Equal(build.JobID()))
 				Expect(pipeline.ParentBuildID()).To(Equal(build.ID()))
@@ -2493,7 +2493,7 @@ var _ = Describe("Build", func() {
 			By("setting the pipeline again via a build")
 			build, err := defaultJob.CreateBuild(defaultBuildCreatedBy)
 			Expect(err).ToNot(HaveOccurred())
-			pipeline, _, err = build.SavePipeline(defaultPipelineRef, build.TeamID(), defaultPipelineConfig, pipeline.ConfigVersion(), false)
+			pipeline, _, err = build.SavePipeline(defaultPipelineRef, build.TeamID(), defaultPipelineConfig, pipeline.ConfigVersion(), false, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(pipeline.Paused()).To(BeFalse())
@@ -2513,7 +2513,7 @@ var _ = Describe("Build", func() {
 			By("setting the pipeline again via a build")
 			build, err := defaultJob.CreateBuild(defaultBuildCreatedBy)
 			Expect(err).ToNot(HaveOccurred())
-			pipeline, _, err = build.SavePipeline(defaultPipelineRef, build.TeamID(), defaultPipelineConfig, pipeline.ConfigVersion(), false)
+			pipeline, _, err = build.SavePipeline(defaultPipelineRef, build.TeamID(), defaultPipelineConfig, pipeline.ConfigVersion(), false, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(pipeline.Paused()).To(BeTrue())

--- a/atc/db/dbfakes/fake_build.go
+++ b/atc/db/dbfakes/fake_build.go
@@ -627,7 +627,7 @@ type FakeBuild struct {
 	saveOutputReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SavePipelineStub        func(atc.PipelineRef, int, atc.Config, db.ConfigVersion, bool) (db.Pipeline, bool, error)
+	SavePipelineStub        func(atc.PipelineRef, int, atc.Config, db.ConfigVersion, bool, bool) (db.Pipeline, bool, error)
 	savePipelineMutex       sync.RWMutex
 	savePipelineArgsForCall []struct {
 		arg1 atc.PipelineRef
@@ -635,6 +635,7 @@ type FakeBuild struct {
 		arg3 atc.Config
 		arg4 db.ConfigVersion
 		arg5 bool
+		arg6 bool
 	}
 	savePipelineReturns struct {
 		result1 db.Pipeline
@@ -3844,7 +3845,7 @@ func (fake *FakeBuild) SaveOutputReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeBuild) SavePipeline(arg1 atc.PipelineRef, arg2 int, arg3 atc.Config, arg4 db.ConfigVersion, arg5 bool) (db.Pipeline, bool, error) {
+func (fake *FakeBuild) SavePipeline(arg1 atc.PipelineRef, arg2 int, arg3 atc.Config, arg4 db.ConfigVersion, arg5 bool, arg6 bool) (db.Pipeline, bool, error) {
 	fake.savePipelineMutex.Lock()
 	ret, specificReturn := fake.savePipelineReturnsOnCall[len(fake.savePipelineArgsForCall)]
 	fake.savePipelineArgsForCall = append(fake.savePipelineArgsForCall, struct {
@@ -3853,13 +3854,14 @@ func (fake *FakeBuild) SavePipeline(arg1 atc.PipelineRef, arg2 int, arg3 atc.Con
 		arg3 atc.Config
 		arg4 db.ConfigVersion
 		arg5 bool
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg6 bool
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.SavePipelineStub
 	fakeReturns := fake.savePipelineReturns
-	fake.recordInvocation("SavePipeline", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("SavePipeline", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.savePipelineMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -3873,17 +3875,17 @@ func (fake *FakeBuild) SavePipelineCallCount() int {
 	return len(fake.savePipelineArgsForCall)
 }
 
-func (fake *FakeBuild) SavePipelineCalls(stub func(atc.PipelineRef, int, atc.Config, db.ConfigVersion, bool) (db.Pipeline, bool, error)) {
+func (fake *FakeBuild) SavePipelineCalls(stub func(atc.PipelineRef, int, atc.Config, db.ConfigVersion, bool, bool) (db.Pipeline, bool, error)) {
 	fake.savePipelineMutex.Lock()
 	defer fake.savePipelineMutex.Unlock()
 	fake.SavePipelineStub = stub
 }
 
-func (fake *FakeBuild) SavePipelineArgsForCall(i int) (atc.PipelineRef, int, atc.Config, db.ConfigVersion, bool) {
+func (fake *FakeBuild) SavePipelineArgsForCall(i int) (atc.PipelineRef, int, atc.Config, db.ConfigVersion, bool, bool) {
 	fake.savePipelineMutex.RLock()
 	defer fake.savePipelineMutex.RUnlock()
 	argsForCall := fake.savePipelineArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeBuild) SavePipelineReturns(result1 db.Pipeline, result2 bool, result3 error) {

--- a/atc/db/dbfakes/fake_pipeline.go
+++ b/atc/db/dbfakes/fake_pipeline.go
@@ -155,6 +155,16 @@ type FakePipeline struct {
 	destroyReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DetachParentStub        func() error
+	detachParentMutex       sync.RWMutex
+	detachParentArgsForCall []struct {
+	}
+	detachParentReturns struct {
+		result1 error
+	}
+	detachParentReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DisplayStub        func() *atc.DisplayConfig
 	displayMutex       sync.RWMutex
 	displayArgsForCall []struct {
@@ -1314,6 +1324,59 @@ func (fake *FakePipeline) DestroyReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.destroyReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) DetachParent() error {
+	fake.detachParentMutex.Lock()
+	ret, specificReturn := fake.detachParentReturnsOnCall[len(fake.detachParentArgsForCall)]
+	fake.detachParentArgsForCall = append(fake.detachParentArgsForCall, struct {
+	}{})
+	stub := fake.DetachParentStub
+	fakeReturns := fake.detachParentReturns
+	fake.recordInvocation("DetachParent", []interface{}{})
+	fake.detachParentMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakePipeline) DetachParentCallCount() int {
+	fake.detachParentMutex.RLock()
+	defer fake.detachParentMutex.RUnlock()
+	return len(fake.detachParentArgsForCall)
+}
+
+func (fake *FakePipeline) DetachParentCalls(stub func() error) {
+	fake.detachParentMutex.Lock()
+	defer fake.detachParentMutex.Unlock()
+	fake.DetachParentStub = stub
+}
+
+func (fake *FakePipeline) DetachParentReturns(result1 error) {
+	fake.detachParentMutex.Lock()
+	defer fake.detachParentMutex.Unlock()
+	fake.DetachParentStub = nil
+	fake.detachParentReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakePipeline) DetachParentReturnsOnCall(i int, result1 error) {
+	fake.detachParentMutex.Lock()
+	defer fake.detachParentMutex.Unlock()
+	fake.DetachParentStub = nil
+	if fake.detachParentReturnsOnCall == nil {
+		fake.detachParentReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.detachParentReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -3609,6 +3672,8 @@ func (fake *FakePipeline) Invocations() map[string][][]interface{} {
 	defer fake.deleteBuildEventsByBuildIDsMutex.RUnlock()
 	fake.destroyMutex.RLock()
 	defer fake.destroyMutex.RUnlock()
+	fake.detachParentMutex.RLock()
+	defer fake.detachParentMutex.RUnlock()
 	fake.displayMutex.RLock()
 	defer fake.displayMutex.RUnlock()
 	fake.exposeMutex.RLock()

--- a/atc/db/pipeline_lifecycle_test.go
+++ b/atc/db/pipeline_lifecycle_test.go
@@ -35,7 +35,7 @@ var _ = Describe("PipelineLifecycle", func() {
 
 			BeforeEach(func() {
 				setChildBuild, _ = defaultJob.CreateBuild(defaultBuildCreatedBy)
-				childPipeline, _, _ = setChildBuild.SavePipeline(atc.PipelineRef{Name: "child-pipeline"}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false)
+				childPipeline, _, _ = setChildBuild.SavePipeline(atc.PipelineRef{Name: "child-pipeline"}, defaultTeam.ID(), defaultPipelineConfig, db.ConfigVersion(0), false, false)
 				setChildBuild.Finish(db.BuildStatusSucceeded)
 			})
 

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -384,6 +384,7 @@ type SetPipelinePlan struct {
 	Vars         map[string]interface{} `json:"vars,omitempty"`
 	VarFiles     []string               `json:"var_files,omitempty"`
 	InstanceVars map[string]interface{} `json:"instance_vars,omitempty"`
+	Detach       bool                   `json:"detach,omitempty"`
 }
 
 type LoadVarPlan struct {

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -385,6 +385,7 @@ type SetPipelineStep struct {
 	Vars         Params       `json:"vars,omitempty"`
 	VarFiles     []string     `json:"var_files,omitempty"`
 	InstanceVars InstanceVars `json:"instance_vars,omitempty"`
+	Detach       bool         `json:"detach,omitempty"`
 }
 
 func (step *SetPipelineStep) Visit(v StepVisitor) error {

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -204,6 +204,7 @@ var factoryTests = []StepTest{
 			vars: {some: vars}
 			var_files: [file-1, file-2]
 			instance_vars: {branch: feature/foo}
+			detach: true
 		`,
 
 		StepConfig: &atc.SetPipelineStep{
@@ -212,6 +213,7 @@ var factoryTests = []StepTest{
 			Vars:         atc.Params{"some": "vars"},
 			VarFiles:     []string{"file-1", "file-2"},
 			InstanceVars: atc.InstanceVars{"branch": "feature/foo"},
+			Detach:       true,
 		},
 	},
 	{


### PR DESCRIPTION
## Changes proposed by this PR

If jobA of pipelineA call `set_pipeline` step to set pipelineB, then jobA is pipelineB's parent job. Currently Concourse has a logic that, if jobA sets another pipeline than pipelineB, then pipelineB will be automatically archived, which helps prevent from orphan pipelines.

`set_pipeline` step supports parameter `team` only when parent job runs from `main` team. We have a use case where a service pipeline running from `main` team may set child parent pipelines per needs. In other words, build-1 may set a child pipeline to teamA, then build-2 may set another child pipeline to teamB, and so on ... The behavior will trigger auto pipeline archive, thus this use case doesn't work with `set_pipeline` step.

I think my use case makes sense from `main` team. To not break the current logic, I am adding a `detach` flag to `set_pipeline` step. A parent job needs to explicitly turn on the flag so that child pipeline will be set in detach mode (same as set via `fly set-pipeline`, so that child pipeline will never be auto archived.

* [x] done


## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

* Add `detach` flag to `set_pipeline` step. Only the `main` team can set child pipelines in detach mode. In detach mode, child pipelines will never be automatically archived.
