### PR TITLE
Adds remoteAddr IP to audit logs.

### DIFF
--- a/atc/auditor/auditor.go
+++ b/atc/auditor/auditor.go
@@ -2,7 +2,9 @@ package auditor
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"strings"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/concourse/concourse/atc"
@@ -174,6 +176,14 @@ func (a *auditor) ValidateAction(action string) bool {
 func (a *auditor) Audit(action string, userName string, r *http.Request) {
 	err := r.ParseForm()
 	if err == nil && a.ValidateAction(action) {
-		a.logger.Info("audit", lager.Data{"action": action, "user": userName, "parameters": r.Form})
+		a.logger.Info("audit", lager.Data{"action": action, "user": userName, "ip": getRemoteAddrIP(r.RemoteAddr), "parameters": r.Form})
 	}
+}
+
+func getRemoteAddrIP(remoteAddr string) string {
+	remoteIP := remoteAddr
+	if strings.Contains(remoteAddr, ":") {
+		remoteIP, _, _ = net.SplitHostPort(remoteAddr)
+	}
+	return remoteIP
 }

--- a/atc/auditor/auditor_test.go
+++ b/atc/auditor/auditor_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Audit", func() {
 		var err error
 		req, err = http.NewRequest("GET", "localhost:8080", nil)
 		Expect(err).NotTo(HaveOccurred())
+		req.RemoteAddr = "127.0.0.1:44056"
 	})
 
 	JustBeforeEach(func() {
@@ -84,6 +85,20 @@ var _ = Describe("Audit", func() {
 			}
 			logs := logger.Logs()
 			Expect(len(logs)).ToNot(Equal(0))
+		})
+		It("logs the action, user, ip, and parameters", func() {
+			for _, route := range atc.Routes {
+				aud.Audit(route.Name, userName, req)
+				logs := logger.Logs()
+				latestLog := logs[len(logs)-1].Data
+
+				Expect(len(latestLog)).To(Equal(4))
+				Expect(latestLog["action"]).To(Equal(route.Name))
+				Expect(latestLog["user"]).To(Equal(userName))
+				Expect(latestLog["ip"]).To(Equal("127.0.0.1"))
+				_, exist := latestLog["parameters"]
+				Expect(exist).To(BeTrue())
+			}
 		})
 	})
 


### PR DESCRIPTION
[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR
Having audit logs without address of request origin isn't very helpful for security audit, so having at least remoteAddr would improve situation a lot.

related to: https://github.com/concourse/concourse/issues/6604

Adds remoteAddr IP to audit logs.

## Release Note

* Adds remoteAddr IP to audit logs.


