### PR TITLE
load_var to support var interpolate

### DIFF
--- a/atc/creds/load_var_plan.go
+++ b/atc/creds/load_var_plan.go
@@ -1,0 +1,33 @@
+package creds
+
+import (
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/vars"
+)
+
+type LoadVarPlan struct {
+	variablesResolver vars.Variables
+	rawPlan           atc.LoadVarPlan
+}
+
+func NewLoadVarPlan(variables vars.Variables, plan atc.LoadVarPlan) LoadVarPlan {
+	return LoadVarPlan{
+		variablesResolver: variables,
+		rawPlan:           plan,
+	}
+}
+
+func (s LoadVarPlan) Evaluate() (atc.LoadVarPlan, error) {
+	var plan atc.LoadVarPlan
+
+	// Name of load_var should not be interpolated.
+	name := s.rawPlan.Name
+
+	err := evaluate(s.variablesResolver, s.rawPlan, &plan)
+	if err != nil {
+		return atc.LoadVarPlan{}, err
+	}
+	plan.Name = name
+
+	return plan, nil
+}

--- a/atc/creds/load_var_plan_test.go
+++ b/atc/creds/load_var_plan_test.go
@@ -1,0 +1,40 @@
+package creds_test
+
+import (
+	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/creds"
+	"github.com/concourse/concourse/vars"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Evaluate", func() {
+	var plan creds.LoadVarPlan
+
+	BeforeEach(func() {
+		variables := vars.StaticVariables{
+			"var-name":   "vn-is",
+			"filename":   "fn-is",
+			"var-format": "json",
+		}
+		plan = creds.NewLoadVarPlan(variables, atc.LoadVarPlan{
+			Name:   "some-((var-name))-ok",
+			File:   "some-((filename))-ok",
+			Format: "((var-format))",
+		})
+	})
+
+	Describe("Evaluate", func() {
+		It("parses variables", func() {
+			result, err := plan.Evaluate()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(atc.LoadVarPlan{
+				Name:   "some-((var-name))-ok", // Name should not be interpolated.
+				File:   "some-fn-is-ok",
+				Format: "json",
+			}))
+		})
+	})
+})

--- a/atc/exec/load_var_step.go
+++ b/atc/exec/load_var_step.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/creds"
 	"github.com/concourse/concourse/atc/exec/build"
 	"github.com/concourse/concourse/tracing"
 	"github.com/concourse/concourse/worker/baggageclaim"
@@ -84,8 +85,14 @@ func (step *LoadVarStep) run(ctx context.Context, state RunState, delegate Build
 	})
 
 	delegate.Initializing(logger)
-	stdout := delegate.Stdout()
 
+	interpolatedPlan, err := creds.NewLoadVarPlan(state, step.plan).Evaluate()
+	if err != nil {
+		return false, err
+	}
+	step.plan = interpolatedPlan
+
+	stdout := delegate.Stdout()
 	delegate.Starting(logger)
 
 	value, err := step.fetchVars(ctx, logger, step.plan.File, state)


### PR DESCRIPTION
## Changes proposed by this PR

closes #7625

* [x] done


## Notes to reviewer

Tested with below pipeline:

```yaml
var_sources:
- name: vars
  type: dummy
  config:
    vars:
      base_username2: alice

jobs:
- name: vars-bug
  plan:
    - task: secrets-mock
      config:
        platform: linux
        image_resource:
          type: registry-image
          source:
            repository: alpine
        run:
          path: sh
          args:
          - -xce
          - |
            echo '002' > secrets/alice
            echo 'password' > secrets/alice-002
        outputs:
        - name: secrets

    - load_var: username2
      file: secrets/((vars:base_username2))
      format: trim

    - task: debug-creds
      config:
        platform: linux
        image_resource:
          type: registry-image
          source:
            repository: alpine
        inputs:
        - name: secrets
        run:
          path: sh
          args:
          - -xce
          - |
            echo ((vars:base_username2))  # should be alice, OK - this is the correct syntax and its getting interpolated here
            echo ((.:username2)) # should be 002, OK
```

## Release Note

`load_var` step supported var interpolation for `file` and `format`.
