### PR TITLE
Fix DB integer out of range error

### DIFF
--- a/atc/db/build_event_source.go
+++ b/atc/db/build_event_source.go
@@ -3,12 +3,12 @@ package db
 import (
 	"encoding/json"
 	"errors"
+	"math"
 	"strconv"
 	"sync"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
-	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/event"
 )
 
@@ -126,7 +126,7 @@ func (source *buildEventSource) collectEvents(from uint) {
 			From(source.table)
 
 		var query sq.SelectBuilder
-		if source.buildID > lock.MaxInt {
+		if source.buildID > math.MaxInt32 {
 			query = eventsQuery.Where(sq.Eq{"build_id": source.buildID})
 		} else {
 			query = eventsQuery.Where(sq.Or{

--- a/atc/db/build_event_source.go
+++ b/atc/db/build_event_source.go
@@ -8,6 +8,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
+	"github.com/concourse/concourse/atc/db/lock"
 	"github.com/concourse/concourse/atc/event"
 )
 
@@ -121,12 +122,20 @@ func (source *buildEventSource) collectEvents(from uint) {
 			return
 		}
 
-		rows, err := psql.Select("event_id", "type", "version", "payload").
-			From(source.table).
-			Where(sq.Or{
+		eventsQuery := psql.Select("event_id", "type", "version", "payload").
+			From(source.table)
+
+		var query sq.SelectBuilder
+		if source.buildID > lock.MaxInt {
+			query = eventsQuery.Where(sq.Eq{"build_id": source.buildID})
+		} else {
+			query = eventsQuery.Where(sq.Or{
 				sq.Eq{"build_id": source.buildID},
 				sq.Eq{"build_id_old": source.buildID},
-			}).
+			})
+		}
+
+		rows, err := query.
 			Where(sq.Gt{"event_id": cursor}).
 			OrderBy("event_id ASC").
 			Limit(uint64(batchSize)).

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,7 +16,6 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 const (
-	MaxInt                         = 2147483647
 	LockTypeResourceConfigChecking = iota
 	LockTypeBuildTracking
 	LockTypeBatch
@@ -30,7 +30,7 @@ const (
 var ErrLostLock = errors.New("lock was lost while held, possibly due to connection breakage")
 
 func NewBuildTrackingLockID(buildID int) LockID {
-	return LockID{LockTypeBuildTracking, buildID % MaxInt}
+	return LockID{LockTypeBuildTracking, buildID % math.MaxInt32}
 }
 
 func NewResourceConfigCheckingLockID(resourceConfigID int) LockID {
@@ -42,7 +42,7 @@ func NewTaskLockID(taskName string) LockID {
 }
 
 func NewVolumeCreatingLockID(volumeID int) LockID {
-	return LockID{LockTypeVolumeCreating, volumeID}
+	return LockID{LockTypeVolumeCreating, volumeID % math.MaxInt32}
 }
 
 func NewDatabaseMigrationLockID() LockID {

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -29,6 +29,14 @@ const (
 
 var ErrLostLock = errors.New("lock was lost while held, possibly due to connection breakage")
 
+/*
+	When adding a new lock type or update existing ones, consider if
+	the ID will be exhausting max int32 ID pool quickly. If yes,
+	use ID % math.MaxInt32 to prevent pg_try_advisory_lock(int, int)
+	query from failing by "integer out of range" error.
+	Refer to https://github.com/concourse/concourse/pull/8390
+*/
+
 func NewBuildTrackingLockID(buildID int) LockID {
 	return LockID{LockTypeBuildTracking, buildID % math.MaxInt32}
 }

--- a/atc/db/lock/lock.go
+++ b/atc/db/lock/lock.go
@@ -15,6 +15,7 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 const (
+	MaxInt                         = 2147483647
 	LockTypeResourceConfigChecking = iota
 	LockTypeBuildTracking
 	LockTypeBatch
@@ -29,7 +30,7 @@ const (
 var ErrLostLock = errors.New("lock was lost while held, possibly due to connection breakage")
 
 func NewBuildTrackingLockID(buildID int) LockID {
-	return LockID{LockTypeBuildTracking, buildID}
+	return LockID{LockTypeBuildTracking, buildID % MaxInt}
 }
 
 func NewResourceConfigCheckingLockID(resourceConfigID int) LockID {

--- a/atc/db/migration/migrations/1653924132_int_to_bigint.down.sql
+++ b/atc/db/migration/migrations/1653924132_int_to_bigint.down.sql
@@ -1,0 +1,16 @@
+ALTER SEQUENCE resource_config_versions_id_seq AS integer;
+
+ALTER TABLE build_comments
+    ALTER COLUMN build_id TYPE integer;
+
+ALTER TABLE builds
+    ALTER COLUMN rerun_of TYPE integer;
+
+ALTER TABLE successful_build_outputs
+    ALTER COLUMN rerun_of TYPE integer;
+
+ALTER TABLE jobs
+    ALTER COLUMN first_logged_build_id TYPE integer;
+
+ALTER TABLE containers
+    ALTER COLUMN meta_build_id TYPE integer;

--- a/atc/db/migration/migrations/1653924132_int_to_bigint.up.sql
+++ b/atc/db/migration/migrations/1653924132_int_to_bigint.up.sql
@@ -1,0 +1,16 @@
+ALTER SEQUENCE resource_config_versions_id_seq AS bigint;
+
+ALTER TABLE build_comments
+    ALTER COLUMN build_id TYPE bigint;
+
+ALTER TABLE builds
+    ALTER COLUMN rerun_of TYPE bigint;
+
+ALTER TABLE successful_build_outputs
+    ALTER COLUMN rerun_of TYPE bigint;
+
+ALTER TABLE jobs
+    ALTER COLUMN first_logged_build_id TYPE bigint;
+
+ALTER TABLE containers
+    ALTER COLUMN meta_build_id TYPE bigint;


### PR DESCRIPTION
 ## Changes proposed by this PR

closes #8364 
closes #6354

 * convert build id related columns to type bigint in DB
 * build tracking lock id will be computed from build_id%max_int
 * for build events, select on build id only when it is beyond max_int so it wont query old build id (integer type) with a beyond max_int value and fail the query


* [x] done
* [ ] todo

## Release Note

 * Fix DB out of range error due to build numbers exceed the integer limit 
