### PR TITLE
Update k8s-topgun configure for external postgresql by pg v11 chart

### DIFF
--- a/topgun/k8s/external_postgres_test.go
+++ b/topgun/k8s/external_postgres_test.go
@@ -19,9 +19,9 @@ var _ = Describe("External PostgreSQL", func() {
 			"--set=livenessProbe.initialDelaySeconds=3",
 			"--set=livenessProbe.periodSeconds=3",
 			"--set=persistence.enabled=false",
-			"--set=postgresqlDatabase=pg-database",
-			"--set=postgresqlPassword=pg-password",
-			"--set=postgresqlUsername=pg-user",
+			"--set=auth.database=pg-database",
+			"--set=auth.password=pg-password",
+			"--set=auth.username=pg-user",
 			"--set=readinessProbe.initialDelaySeconds=3",
 			"--set=readinessProbe.periodSeconds=3",
 		)


### PR DESCRIPTION
Failure output
```
• Failure in Spec Setup (BeforeEach) [905.134 seconds]
External PostgreSQL
github.com/concourse/concourse/topgun/k8s/external_postgres_test.go:9
  can have pipelines set [BeforeEach]
  github.com/concourse/concourse/topgun/k8s/external_postgres_test.go:46

  Timed out after 900.006s.
  expected all pods to be running
  Expected
      <bool>: false
  to be true

  github.com/concourse/concourse/topgun/k8s/k8s_suite_test.go:378
```
Error log in k8s:
```
⟩ kubectl logs -f topgun-ep-9143306-web-577c995644-6s6jp concourse-migration -n topgun-ep-9143306
error: pq: password authentication failed for user "pg-user"
```

The root cause is by upgrading postgresql chart v10 to v11, the values configure for custom user and database has changed.