### PR TITLE
update k8s-topgun configure for external postgresql by v11 chart

### DIFF
--- a/topgun/k8s/external_postgres_test.go
+++ b/topgun/k8s/external_postgres_test.go
@@ -19,9 +19,9 @@ var _ = Describe("External PostgreSQL", func() {
 			"--set=livenessProbe.initialDelaySeconds=3",
 			"--set=livenessProbe.periodSeconds=3",
 			"--set=persistence.enabled=false",
-			"--set=postgresqlDatabase=pg-database",
-			"--set=postgresqlPassword=pg-password",
-			"--set=postgresqlUsername=pg-user",
+			"--set=auth.database=pg-database",
+			"--set=auth.password=pg-password",
+			"--set=auth.username=pg-user",
 			"--set=readinessProbe.initialDelaySeconds=3",
 			"--set=readinessProbe.periodSeconds=3",
 		)


### PR DESCRIPTION
backport fix for https://github.com/concourse/concourse/pull/8400