### PR TITLE
Fix step header key value ui in build page

### DIFF
--- a/web/elm/src/Build/Styles.elm
+++ b/web/elm/src/Build/Styles.elm
@@ -259,9 +259,7 @@ stepHeaderLabel changed =
 
 keyValuePairHeaderLabel : List (Html.Attribute msg)
 keyValuePairHeaderLabel =
-    [ style "line-height" "28px"
-    , style "padding-left" "6px"
-    ]
+    [ style "padding-left" "6px" ]
 
 
 stepStatusIcon : List (Html.Attribute msg)


### PR DESCRIPTION


closes #8392

* [x] done
* [ ] todo



## Release Note

* Fix line height of step header in build page when there is sub header like instance vars or across
