### PR TITLE
Disable connection tracker by default and provide an option to enable.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -573,10 +573,17 @@ func (cmd *RunCommand) Runner(positionalArguments []string) (ifrit.Runner, error
 		return nil, err
 	}
 
+	// Connection tracker is off by default. Can be turned on/ff at runtime.
 	http.HandleFunc("/debug/connections", func(w http.ResponseWriter, r *http.Request) {
 		for _, stack := range db.GlobalConnectionTracker.Current() {
 			fmt.Fprintln(w, stack)
 		}
+	})
+	http.HandleFunc("/debug/connections/on", func(w http.ResponseWriter, r *http.Request) {
+		db.InitConnectionTracker(true)
+	})
+	http.HandleFunc("/debug/connections/off", func(w http.ResponseWriter, r *http.Request) {
+		db.InitConnectionTracker(false)
 	})
 
 	if err := cmd.configureMetrics(logger); err != nil {

--- a/atc/db/open.go
+++ b/atc/db/open.go
@@ -214,7 +214,7 @@ func (db *db) QueryRowContext(ctx context.Context, query string, args ...interfa
 type dbTx struct {
 	*sql.Tx
 
-	session            *ConnectionSession
+	session            ConnectionSession
 	encryptionStrategy encryption.Strategy
 }
 


### PR DESCRIPTION
## Changes proposed by this PR

closes #8432

* [x] done


## Notes to reviewer

![image](https://user-images.githubusercontent.com/18585861/174220646-c2a4b088-e37b-4670-9933-82e9bfa86036.png)

After applying a private build of this PR, ATC CPU usage dropped to a reasonable level.

Once this PR is merged, I can port it to master branch.

## Release Note

* Disable [`/debug/connections`](https://github.com/concourse/concourse/commit/8425a0b4e775d52732d4a54090a0e63b236095a4) at ATC start time. It can be enabled at runtime by `/debug/connections/on` or be disabled by `/debug/connections/off` again.