### PR TITLE
Add a drift to component interval.

### DIFF
--- a/atc/db/component.go
+++ b/atc/db/component.go
@@ -31,6 +31,7 @@ type component struct {
 	interval time.Duration
 	lastRan  time.Time
 	paused   bool
+	rander   *rand.Rand
 
 	conn Conn
 }
@@ -54,6 +55,10 @@ func (c *component) Reload() (bool, error) {
 		return false, err
 	}
 
+	if c.rander == nil {
+		c.rander = rand.New(rand.NewSource(time.Now().Unix()))
+	}
+
 	return true, nil
 }
 
@@ -63,7 +68,7 @@ func (c *component) Reload() (bool, error) {
 // component to across ATCs more evenly.
 func (c *component) IntervalElapsed() bool {
 	interval := c.interval
-	drift := time.Duration(rand.Int())%(2*time.Second) - time.Second
+	drift := time.Duration(c.rander.Int())%(2*time.Second) - time.Second
 	if interval+drift > 0 {
 		interval += drift
 	}

--- a/atc/db/component_test.go
+++ b/atc/db/component_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Component", func() {
 				err = component.UpdateLastRan()
 				Expect(err).NotTo(HaveOccurred())
 
-				time.Sleep(1 * time.Second)
+				time.Sleep(2 * time.Second)
 			})
 
 			It("returns true", func() {


### PR DESCRIPTION
## Changes proposed by this PR

We have successfully upgraded one of our heaviest loaded cluster to 7.8.1.

During the upgrade, we initially encountered one problem where one ATC got overloaded, but other ATCs were idle. Which meant that workloads were not distributed evenly.

Some metrics show that:

![image](https://user-images.githubusercontent.com/18585861/175867334-6dc1b8b3-fb84-4e4f-b03f-1483018addd5.png)

One ATC's goroutes went to very high, nearing to 1 million, but other ATCs were idle. But after 14:00, I applied this patch, goroutines dropped significantly, and multiple ATCs had similar goroutine counts.

![image](https://user-images.githubusercontent.com/18585861/175867650-140bb7dd-c8d5-4d7a-bf56-6353876f4dc6.png)

Before 14:00, each bar contained one 1 or 2 colors, meaning only 1 or 2 ATCs doing in-momory-checks; after 14:00, I applied this patch, each bar had 4 colors, each all ATCs were running in-memory-check.

The change of this PR is very simple, I just added a tiny drift time [-1 second .. 1 second] to component interval, so that other ATCs will get more chance to acquire the component's batch lock.

* [x] done


## Notes to reviewer

Without this PR, 7.8.1 couldn't work on our prod cluster, thus I submit to branch 7.8.x, and wish a release 7.8.2. I will port it to master branch once it is merged.

## Release Note

 - Enhancement of component scheduling so that workloads are distributed across ATCs more evenly.
