### PR TITLE
Allow AARCH64 syscalls for worker runtime

### DIFF
--- a/worker/runtime/spec/seccomp.go
+++ b/worker/runtime/spec/seccomp.go
@@ -8,6 +8,7 @@ var seccomp = &specs.LinuxSeccomp{
 		specs.ArchX86_64,
 		specs.ArchX86,
 		specs.ArchX32,
+		specs.ArchAARCH64,
 	},
 	Syscalls: []specs.LinuxSyscall{
 		AllowSyscall("accept"),


### PR DESCRIPTION
Signed-off-by: Rodrigo Menezes <brdude@gmail.com>

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

As AARCH64 becomes more popular allow the worker runtime to execute syscalls for it (ex. Mac M1 or AWS Graviton machines). 

Another option is to completely remove the seccomp architectural limitation as per https://github.com/opencontainers/runtime-spec/blob/72c1f0b44f7976960febe9e48e36c88d12ec9b72/specs-go/config.go#L635 by default only the native architecture of the kernel is permitted.

Relates to https://github.com/concourse/concourse/discussions/8451


[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
