### PR TITLE
Enhance Vault API client to auto retry upon rate limit.

### DIFF
--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -221,9 +221,9 @@ func (ac *APIClient) baseClient() (*vaultapi.Client, error) {
 	}
 
 	config.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		retryable, err := retryablehttp.DefaultRetryPolicy(ctx, resp, err)
-		if err != nil || retryable {
-			return retryable, err
+		retryable, retryErr := retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+		if retryErr != nil || retryable {
+			return retryable, retryErr
 		}
 		// We also want to retry when hitting Vault rate limit.
 		if resp.StatusCode == 429 {
@@ -234,8 +234,8 @@ func (ac *APIClient) baseClient() (*vaultapi.Client, error) {
 
 	// Let's define retry backoff parameters explicitly
 	config.MinRetryWait = time.Millisecond * 1000
-	config.MaxRetryWait = time.Millisecond * 2000
-	config.MaxRetries = 3
+	config.MaxRetryWait = time.Millisecond * 3000
+	config.MaxRetries = 2
 
 	client, err := vaultapi.NewClient(config)
 	if err != nil {

--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -232,6 +232,11 @@ func (ac *APIClient) baseClient() (*vaultapi.Client, error) {
 		return false, nil
 	}
 
+	// Let's define retry backoff parameters explicitly
+	config.MinRetryWait = time.Millisecond * 1000
+	config.MaxRetryWait = time.Millisecond * 2000
+	config.MaxRetries = 3
+
 	client, err := vaultapi.NewClient(config)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -36,8 +36,9 @@ require (
 	github.com/google/jsonapi v0.0.0-20180618021926-5d047c6bc66b
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/go-rootcerts v1.0.2
-	github.com/hashicorp/vault/api v1.6.0
+	github.com/hashicorp/vault/api v1.7.0
 	github.com/imdario/mergo v0.3.13
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d
@@ -159,9 +160,8 @@ require (
 	github.com/hashicorp/go-hclog v1.0.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
-	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 // indirect
-	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.5 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -745,8 +745,9 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/go-plugin v1.4.3 h1:DXmvivbWD5qdiBts9TpBC7BYL1Aia5sxbRgQB+v6UZM=
 github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
-github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
@@ -754,8 +755,9 @@ github.com/hashicorp/go-secure-stdlib/base62 v0.1.1/go.mod h1:EdWO6czbmthiwZ3/PU
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 h1:cCRo8gK7oq6A2L6LICkUZ+/a5rLiRXFMf1Qd4xSwxTc=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
-github.com/hashicorp/go-secure-stdlib/parseutil v0.1.5 h1:MBgwAFPUbfuI0+tmDU/aeM1MARvdbqWmiieXIalKqDE=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.5/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 h1:om4Al8Oy7kCm/B86rLCLah4Dt5Aa0Fr5rYBG60OzwHQ=
+github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7mlMIRBpVTAUn8qPCrEclOKKWhD3U=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9CdjCtrXrXGuOpxEA7Ts=
@@ -789,8 +791,8 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
-github.com/hashicorp/vault/api v1.6.0 h1:B8UUYod1y1OoiGHq9GtpiqSnGOUEWHaA26AY8RQEDY4=
-github.com/hashicorp/vault/api v1.6.0/go.mod h1:h1K70EO2DgnBaTz5IsL6D5ERsNt5Pce93ueVS2+t0Xc=
+github.com/hashicorp/vault/api v1.7.0 h1:6ufh0FuGBq1CjF3VH9DJMOa8p8iqdgOBoqYz4D4bXrI=
+github.com/hashicorp/vault/api v1.7.0/go.mod h1:TlKWwxZySuDARVFz/H0sf6rgWddIlX4t4DO9baT2nXc=
 github.com/hashicorp/vault/sdk v0.5.0 h1:EED7p0OCU3OY5SAqJwSANofY1YKMytm+jDHDQ2EzGVQ=
 github.com/hashicorp/vault/sdk v0.5.0/go.mod h1:UJZHlfwj7qUJG8g22CuxUgkdJouFrBNvBHCyx8XAPdo=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=


### PR DESCRIPTION
## Changes proposed by this PR

After we upgraded to 7.8.1, Concourse became to faster, but the Vault became to a problem. We had to set a rate limit on Vault, thus some build may fail due to hit Vault rate limit.

It's very sad when a build has run 1 hour and fails at the last step because of hitting Vault rate limit. And every day there are a few such builds.

This PR enhanced Vault API client to auto retry upon rate limit error.

* [x] done

## Notes to reviewer

There is the other place that does retry https://github.com/concourse/concourse/blob/master/atc/creds/retryable_secrets.go. I decided to put auto retry in vault's api client level because retryable_secrets.go will lead to more retries which may make rate limit situation even worse. 

That is because, each secret will query multiple paths: pipeline path, team team, shared path, root path. Say if a secret suppose to be found under shared path, pipeline path and team path have been queried, and hit rate limit when query shared path. If retry is at vault api client level, it will only retry to query shared path; but if retry is in retryable_secrets.go, then it may retry query pipeline path and team path.

Also, Vault api client level already has retry logic and that retry cannot be turned off. Thus if a deployment only uses Vault as secret manager, then retryable_secrets can be turned off.

Once merged, I'll port it to master branch.

## Release Note

 - Enhanced Vault credential manager to auto retry when hitting Vault rate limit error. Vault started to support [rate limit](https://learn.hashicorp.com/tutorials/vault/resource-quotas) since 1.5. When setting rate limit on Vault, it's better to [enable](https://www.vaultproject.io/api-docs/system/quotas-config#enable_rate_limit_response_headers) rate limit HTTP response header by `vault write sys/quotas/config enable_rate_limit_response_headers=true`, so that the response header `Retry-After` may guide the Vault API client to retry after a reasonable duration.
