### PR TITLE
Don’t use ‘here’ as link text

### DIFF
--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -1266,13 +1266,12 @@ loginInstruction userState =
                 [ id "login-instruction"
                 , style "line-height" "42px"
                 ]
-                [ Html.text "login "
-                , Html.a
+                [ Html.a
                     [ href "/login"
                     , style "text-decoration" "underline"
                     , style "color" Colors.welcomeCardText
                     ]
-                    [ Html.text "here" ]
+                    [ Html.text "login here" ]
                 ]
             ]
 


### PR DESCRIPTION
Using ‘here’ or ‘click here’ as link text is bad because such links don’t mean anything out of context.

The Web Content Accessibility guidelines say:
> Whenever possible, provide link text that identifies the purpose of the link without needing additional context

– https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html

This commit moves the word ‘login’ inside the link, so it makes sense in and of itself.