### PR TITLE
Unblock process deletion in worker runtime

### DIFF
--- a/worker/runtime/process.go
+++ b/worker/runtime/process.go
@@ -48,13 +48,13 @@ func (p *Process) Wait() (int, error) {
 		return 0, fmt.Errorf("proc closeio: %w", err)
 	}
 
-	p.process.IO().Wait()
-
 	_, err = p.process.Delete(context.Background())
 	// ignore "not found" errors - the process was already deleted
 	if err != nil && !errors.Is(err, errdefs.ErrNotFound) {
 		return 0, fmt.Errorf("delete process: %w", err)
 	}
+
+	p.process.IO().Wait()
 
 	return int(status.ExitCode()), nil
 }

--- a/worker/runtime/process_test.go
+++ b/worker/runtime/process_test.go
@@ -50,7 +50,6 @@ func (s *ProcessSuite) TestWaitStatusErr() {
 
 func (s *ProcessSuite) TestProcessWaitDeleteError() {
 	s.ch <- *containerd.NewExitStatus(0, time.Now(), nil)
-	s.containerdProcess.IOReturns(s.io)
 
 	expectedErr := errors.New("status-err")
 	s.containerdProcess.DeleteReturns(nil, expectedErr)
@@ -72,11 +71,6 @@ func (s *ProcessSuite) TestProcessWaitProcessAlreadyDeleted() {
 func (s *ProcessSuite) TestProcessWaitBlocksUntilIOFinishes() {
 	s.ch <- *containerd.NewExitStatus(0, time.Now(), nil)
 	s.containerdProcess.IOReturns(s.io)
-
-	s.io.WaitStub = func() {
-		// ensure Wait() is called before Delete() which cancels IO
-		s.Equal(0, s.containerdProcess.DeleteCallCount())
-	}
 
 	_, err := s.process.Wait()
 	s.NoError(err)


### PR DESCRIPTION
## Changes proposed by this PR

This reverts commit cee8ff8b8a6e84f400cdfaa7a2d8532496d5907e.

closes #8462


* [x] done
* [ ] todo

## Notes to reviewer

The root cause of the stuck is because `p.process.IO().Wait()` will block for stdin/stdout while in pool resource case the stdout is occupied for the loop of [acquring pool](https://github.com/concourse/pool-resource/blob/886aa50c19b3fc474df1fbcf956bc570a2694cc9/out/lock_pool.go#L85-L100)

It worked in v7.4.4. Then we have this [big refactor](https://github.com/concourse/concourse/pull/6597) of atc/worker  in v7.5. Not exactly sure which change cause it to not work as before, am guessing it could be some underlining changes of containerd about how it close the process IO pipes too. 

Anyway, cee8ff8b8a6e84f400cdfaa7a2d8532496d5907e was to fix a racing condition for IO closing too early due to process deletion, which is a rare edge case IMO. Since the current problem could happen to any resource type that blockes stdout (and if that happens there is no way to finish the build), I think it is fair to revert it and see if we will spot the race again.

We can merge it to master and deploy to hush-house to fix the stucking issue and keep an eye on the race condition on both CI and hush-house.

## Reproduce
I have created a temp pool repo, the private_key is just a deploy key specific to the repo only so it is safe to post here.
```
resources:
- name: mypool
  type: pool
  source:
    uri: git@github.com:xtremerui/testing-pool.git
    branch: main
    pool: aws
    private_key: |
      -----BEGIN OPENSSH PRIVATE KEY-----
      b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
      QyNTUxOQAAACAKe1lrCMqne6UwpRxuW9zTs6c4GV+ikjtti2y9wX5pOQAAAKA45n/NOOZ/
      zQAAAAtzc2gtZWQyNTUxOQAAACAKe1lrCMqne6UwpRxuW9zTs6c4GV+ikjtti2y9wX5pOQ
      AAAEC8eU4mx2Htsm9D+1Nzzk+xaM6j5F8EbbbKi610xDNV7Ap7WWsIyqd7pTClHG5b3NOz
      pzgZX6KSO22LbL3Bfmk5AAAAFnlvdXJfZW1haWxAZXhhbXBsZS5jb20BAgMEBQYH
      -----END OPENSSH PRIVATE KEY-----

jobs:
- name: do-nothing
  plan:
  - put: mypool
    params: {acquire: true}
```

Set and run the above pipeline in local concourse, you should see the get is still running after cancelling the build without this PR.

## Release Note

- Fix a bug where aborting build could stuck if a pool resource is waiting for pool available in put step