### PR TITLE
Turn off connection tracker by default and provide an option to turn on.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -573,10 +573,17 @@ func (cmd *RunCommand) Runner(positionalArguments []string) (ifrit.Runner, error
 		return nil, err
 	}
 
+	// Connection tracker is off by default. Can be turned on/ff at runtime.
 	http.HandleFunc("/debug/connections", func(w http.ResponseWriter, r *http.Request) {
 		for _, stack := range db.GlobalConnectionTracker.Current() {
 			fmt.Fprintln(w, stack)
 		}
+	})
+	http.HandleFunc("/debug/connections/on", func(w http.ResponseWriter, r *http.Request) {
+		db.InitConnectionTracker(true)
+	})
+	http.HandleFunc("/debug/connections/off", func(w http.ResponseWriter, r *http.Request) {
+		db.InitConnectionTracker(false)
 	})
 
 	if err := cmd.configureMetrics(logger); err != nil {

--- a/atc/db/open.go
+++ b/atc/db/open.go
@@ -214,7 +214,7 @@ func (db *db) QueryRowContext(ctx context.Context, query string, args ...interfa
 type dbTx struct {
 	*sql.Tx
 
-	session            *ConnectionSession
+	session            ConnectionSession
 	encryptionStrategy encryption.Strategy
 }
 


### PR DESCRIPTION
## Changes proposed by this PR

Port #8433 from 7.8.x branch to master.

* [x] done

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

* Disable [/debug/connections](https://github.com/concourse/concourse/commit/8425a0b4e775d52732d4a54090a0e63b236095a4) at ATC start time. It can be enabled at runtime by `/debug/connections/on` or be disabled by `/debug/connections/off` again.
