### PR TITLE
Enhance Vault API client to auto retry upon rate limit.

### DIFF
--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -221,9 +221,9 @@ func (ac *APIClient) baseClient() (*vaultapi.Client, error) {
 	}
 
 	config.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		retryable, err := retryablehttp.DefaultRetryPolicy(ctx, resp, err)
-		if err != nil || retryable {
-			return retryable, err
+		retryable, retryErr := retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+		if retryErr != nil || retryable {
+			return retryable, retryErr
 		}
 		// We also want to retry when hitting Vault rate limit.
 		if resp.StatusCode == 429 {
@@ -234,8 +234,8 @@ func (ac *APIClient) baseClient() (*vaultapi.Client, error) {
 
 	// Let's define retry backoff parameters explicitly
 	config.MinRetryWait = time.Millisecond * 1000
-	config.MaxRetryWait = time.Millisecond * 2000
-	config.MaxRetries = 3
+	config.MaxRetryWait = time.Millisecond * 3000
+	config.MaxRetries = 2
 
 	client, err := vaultapi.NewClient(config)
 	if err != nil {

--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -232,6 +232,11 @@ func (ac *APIClient) baseClient() (*vaultapi.Client, error) {
 		return false, nil
 	}
 
+	// Let's define retry backoff parameters explicitly
+	config.MinRetryWait = time.Millisecond * 1000
+	config.MaxRetryWait = time.Millisecond * 2000
+	config.MaxRetries = 3
+
 	client, err := vaultapi.NewClient(config)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/google/jsonapi v0.0.0-20180618021926-5d047c6bc66b
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/vault/api v1.7.2
 	github.com/imdario/mergo v0.3.13
@@ -159,7 +160,6 @@ require (
 	github.com/hashicorp/go-hclog v1.0.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
-	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -746,8 +746,9 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/go-plugin v1.4.3 h1:DXmvivbWD5qdiBts9TpBC7BYL1Aia5sxbRgQB+v6UZM=
 github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
-github.com/hashicorp/go-retryablehttp v0.6.6 h1:HJunrbHTDDbBb/ay4kxa1n+dLmttUlnP3V9oNE4hmsM=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=


### PR DESCRIPTION
## Changes proposed by this PR

Port #8461 from 7.8.x branch to master.

* [x] done


## Notes to reviewer



## Release Note

* Enhanced Vault credential manager to auto retry when hitting Vault rate limit error. Vault started to support [rate limit](https://learn.hashicorp.com/tutorials/vault/resource-quotas) since 1.5. When setting rate limit on Vault, it's better to enable rate limit HTTP response header by `vault write sys/quotas/config enable_rate_limit_response_headers=true`, so that the response header `Retry-After` may guide the Vault API client to retry after a reasonable duration.
