### PR TITLE
remove "check build started/finished" metrics.

### DIFF
--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -273,10 +273,6 @@ func (b *engineBuild) trackStarted(logger lager.Logger) {
 		metric.BuildStarted{
 			Build: b.build,
 		}.Emit(logger)
-	} else {
-		metric.CheckBuildStarted{
-			Build: b.build,
-		}.Emit(logger)
 	}
 }
 
@@ -295,10 +291,6 @@ func (b *engineBuild) trackFinished(logger lager.Logger) {
 	if !b.build.IsRunning() {
 		if b.build.Name() != db.CheckBuildName {
 			metric.BuildFinished{
-				Build: b.build,
-			}.Emit(logger)
-		} else {
-			metric.CheckBuildFinished{
 				Build: b.build,
 			}.Emit(logger)
 		}

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -89,8 +89,6 @@ func (emitter *NewRelicEmitter) Emit(logger lager.Logger, event metric.Event) {
 	// These are the simple ones that only need a small name transformation
 	case "build started",
 		"build finished",
-		"check build started",
-		"check build finished",
 		"checks finished",
 		"checks started",
 		"checks enqueued",

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -71,7 +71,6 @@ type PrometheusEmitter struct {
 
 	locksHeld *prometheus.GaugeVec
 
-	// TODO: deprecate
 	checksFinished *prometheus.CounterVec
 	checksStarted  prometheus.Counter
 
@@ -861,7 +860,6 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 
 		locksHeld: locksHeld,
 
-		// TODO: deprecate
 		checksFinished: checksFinished,
 		checksStarted:  checksStarted,
 
@@ -945,8 +943,6 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 			).Observe(event.Value)
 	case "build finished":
 		emitter.buildFinishedMetrics(logger, event)
-	case "check build finished":
-		emitter.checkBuildFinishedMetrics(logger, event)
 	case "worker containers":
 		// update last seen counters, used to gc stale timeseries
 		emitter.updateLastSeen(event)
@@ -1007,10 +1003,8 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 		emitter.databaseMetrics(logger, event)
 	case "database connections":
 		emitter.databaseMetrics(logger, event)
-	// TODO: deprecate
 	case "checks finished":
 		emitter.checksFinished.WithLabelValues(event.Attributes["status"]).Add(event.Value)
-	// TODO: deprecate
 	case "checks started":
 		emitter.checksStarted.Add(event.Value)
 	case "checks enqueued":

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -460,39 +460,6 @@ func (event BuildFinished) Emit(logger lager.Logger) {
 	)
 }
 
-type CheckBuildStarted struct {
-	Build db.Build
-}
-
-func (event CheckBuildStarted) Emit(logger lager.Logger) {
-	Metrics.emit(
-		logger.Session("check-build-started"),
-		Event{
-			Name:       "check build started",
-			Value:      float64(event.Build.ID()),
-			Attributes: event.Build.TracingAttrs(),
-		},
-	)
-}
-
-type CheckBuildFinished struct {
-	Build db.Build
-}
-
-func (event CheckBuildFinished) Emit(logger lager.Logger) {
-	attrs := event.Build.TracingAttrs()
-	attrs["build_status"] = event.Build.Status().String()
-
-	Metrics.emit(
-		logger.Session("check-build-finished"),
-		Event{
-			Name:       "check build finished",
-			Value:      ms(event.Build.EndTime().Sub(event.Build.StartTime())),
-			Attributes: attrs,
-		},
-	)
-}
-
 func ms(duration time.Duration) float64 {
 	return float64(duration) / 1000000
 }


### PR DESCRIPTION
## Changes proposed by this PR

After several weeks of upgrading to 7.8, we found that the InfluxDB are quickly filling up. Then we identified the "check build started" and "check build finished" are two significant contributors.

Actually we don't monitor those two metrics at all. Because check builds are per resources, but real checks are per resource config scopes. Most of check builds just quickly terminate without actually running anything. 

* [x] done

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

Removed "check build started" and "check build finished" metrics. To monitor checks, use "check started" and "check finished" instead.