### PR TITLE
Support a way to skip implied get after put.

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -170,6 +170,11 @@ func (visitor *planVisitor) VisitPut(step *atc.PutStep) error {
 
 	plan.Put.TypeImage = visitor.resourceTypes.ImageForType(plan.ID, resource.Type, step.Tags, visitor.manuallyTriggered)
 
+	if step.NoGet {
+		visitor.plan = plan
+		return nil
+	}
+
 	dependentGetPlan := visitor.planFactory.NewPlan(atc.GetPlan{
 		Type:        resource.Type,
 		Name:        logicalName,

--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -1169,6 +1169,77 @@ var factoryTests = []PlannerTest{
 		}`,
 	},
 	{
+		Title: "put step with no_get",
+		Config: &atc.PutStep{
+			Name:      "some-name",
+			Resource:  "some-resource",
+			Params:    atc.Params{"some": "params"},
+			Tags:      atc.Tags{"tag-1", "tag-2"},
+			Inputs:    &atc.InputsConfig{All: true},
+			NoGet: true,
+		},
+		Inputs: []db.BuildInput{
+			{
+				Name:    "some-name",
+				Version: atc.Version{"some": "version"},
+			},
+		},
+		ManuallyTriggered: true,
+		CompareIDs:        true,
+		PlanJSON: `{
+			"id": "1",
+			"put": {
+				"name": "some-name",
+				"type": "some-resource-type",
+				"resource": "some-resource",
+				"source": {
+					 "some": "source",
+					 "default-key": "default-value"
+				},
+				"params": {"some":"params"},
+				"tags": ["tag-1", "tag-2"],
+				"inputs": "all",
+				"image": {
+					"base_type": "some-base-resource-type",
+					"check_plan": {
+						"id": "1/image-check",
+						"check": {
+							"name": "some-resource-type",
+							"type": "some-base-resource-type",
+							"resource_type": "some-resource-type",
+							"source": { "some": "type-source" },
+							"image": {
+								"base_type": "some-base-resource-type"
+							},
+						"interval": "1m0s",
+							"skip_interval": true,
+							"tags": [
+								 "tag-1",
+								 "tag-2"
+							]
+						}
+					},
+					"get_plan": {
+						"id": "1/image-get",
+						"get": {
+							"name": "some-resource-type",
+							"type": "some-base-resource-type",
+							"source": { "some": "type-source" },
+							"image": {
+								"base_type": "some-base-resource-type"
+							},
+							"version_from": "1/image-check",
+							"tags": [
+								 "tag-1",
+								 "tag-2"
+							]
+						}
+					}
+				}
+			}
+		}`,
+	},
+	{
 		Title: "task step",
 
 		Config: &atc.TaskStep{

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -323,6 +323,7 @@ type PutStep struct {
 	Tags      Tags          `json:"tags,omitempty"`
 	GetParams Params        `json:"get_params,omitempty"`
 	Timeout   string        `json:"timeout,omitempty"`
+	NoGet     bool          `json:"no_get,omitempty"`
 }
 
 func (step *PutStep) ResourceName() string {


### PR DESCRIPTION
## Changes proposed by this PR

closes #3299


* [x] done


## Notes to reviewer

There have been much such requests, and I fully understood why implied `get` is needed in order to keep a resource fresh.

But we may also honor reality. There are a lot of put only resources running in pipelines, mostly about notifications, like `put: email`, `put: slack`, etc. Implied `get` just run an empty container, and plug nested `image-check` + `image-get`. We have noticed that Intermittently implied `get` happened to be placed on a busy worker thus stuck for some time, but they didn't do anything, which hurts stability of build execution. 

Adding such an option to opt-out implied `get` will

* eliminate unnecessary failure points, thus improve build stability
* reduce build execute time
* save worker resources

The other reason I reopen the issue is that, Concourse proposed other approaches to solve the problem, but now those approaches seem to be no ETA anymore.

If you agree to merge this PR, I can update docs as well.

## Release Note

- Added `no_get` option to `put` step to skip implied `get`. For example:
    ```yaml
    - put: email
      no_get: true
      params:
        ...
    ```
