### PR TITLE
check build should not auto retry.

### DIFF
--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -220,7 +220,9 @@ func (b *engineBuild) Run(ctx context.Context) {
 		logger.Info("releasing")
 
 	case <-done:
-		if errors.As(runErr, &exec.Retriable{}) {
+		// Don't retry check build because if a check build drops into endless retry,
+		// there is no way to abort it.
+		if b.build.Name() != db.CheckBuildName && errors.As(runErr, &exec.Retriable{}) {
 			return
 		}
 

--- a/atc/engine/engine_test.go
+++ b/atc/engine/engine_test.go
@@ -261,14 +261,41 @@ var _ = Describe("Engine", func() {
 								})
 
 								Context("when the build finishes with error", func() {
-									BeforeEach(func() {
-										fakeStep.RunReturns(false, errors.New("nope"))
+									Context("when the error is not retryable", func() {
+										BeforeEach(func() {
+											fakeStep.RunReturns(false, errors.New("nope"))
+										})
+
+										It("finishes the build", func() {
+											waitGroup.Wait()
+											Expect(fakeBuild.FinishCallCount()).To(Equal(1))
+											Expect(fakeBuild.FinishArgsForCall(0)).To(Equal(db.BuildStatusErrored))
+										})
 									})
 
-									It("finishes the build", func() {
-										waitGroup.Wait()
-										Expect(fakeBuild.FinishCallCount()).To(Equal(1))
-										Expect(fakeBuild.FinishArgsForCall(0)).To(Equal(db.BuildStatusErrored))
+									Context("when the error is retryable", func() {
+										BeforeEach(func() {
+											fakeStep.RunReturns(false, exec.Retriable{Cause: errors.New("nope")})
+										})
+
+										Context("when this is a check build", func() {
+											BeforeEach(func() {
+												fakeBuild.NameReturns(db.CheckBuildName)
+											})
+
+											It("should not retry, thus finishes the build", func() {
+												waitGroup.Wait()
+												Expect(fakeBuild.FinishCallCount()).To(Equal(1))
+												Expect(fakeBuild.FinishArgsForCall(0)).To(Equal(db.BuildStatusErrored))
+											})
+										})
+
+										Context("when this is a normal build", func() {
+											It("should retry, thus not finishe the build", func() {
+												waitGroup.Wait()
+												Expect(fakeBuild.FinishCallCount()).To(Equal(0))
+											})
+										})
 									})
 								})
 


### PR DESCRIPTION
## Changes proposed by this PR

We noticed a weird problem on one of our clusters, where a pipeline has been destroyed but it's resource checks kept running again and again.

Then I further noticed that, the resource was configured with a bad URL, and the bad URL always returned 503. And the check logs showed constantly `pre_build_id: 240`, which clearly indicated the check build was rerun build.

As there is no way to abort check build, if a check build happens to drop into endless retry, it would have to restart ATC to stop the retry, which is bad. Thus this PR makes check build to not retry.


## Release Note

* Fixed a bug where check build should not be auto retried because if a check happens to drop into endless retry, there is no way to abort a check build.