### PR TITLE
Fix a bad SQL for check gc.

### DIFF
--- a/atc/db/check_lifecycle.go
+++ b/atc/db/check_lifecycle.go
@@ -61,16 +61,12 @@ func (cl *checkLifecycle) DeleteCompletedChecks(logger lager.Logger) error {
 	}
 
 	_, err2 := cl.conn.Exec(`
-      WITH resource_builds AS (
-        SELECT distinct(last_check_build_id) as build_id
-        FROM resource_config_scopes
-        WHERE last_check_build_id IS NOT NULL
-		  UNION ALL
-        SELECT distinct(in_memory_build_id) as build_id
-        FROM resources
-        WHERE in_memory_build_id IS NOT NULL
+      WITH expired_imb_ids AS (
+	    SELECT distinct(build_id) AS build_id FROM check_build_events cbe 
+		WHERE NOT EXISTS (SELECT 1 FROM resources WHERE in_memory_build_id = cbe.build_id) AND 
+		      NOT EXISTS (SELECT 1 FROM builds WHERE id = cbe.build_id) 
       )
-      DELETE FROM check_build_events WHERE build_id NOT IN (SELECT build_id FROM resource_builds)
+      DELETE FROM check_build_events cbe2 USING expired_imb_ids WHERE cbe2.build_id = expired_imb_ids.build_id;
     `)
 
 	if err1 != nil {

--- a/atc/db/check_lifecycle.go
+++ b/atc/db/check_lifecycle.go
@@ -62,11 +62,13 @@ func (cl *checkLifecycle) DeleteCompletedChecks(logger lager.Logger) error {
 
 	_, err2 := cl.conn.Exec(`
       WITH expired_imb_ids AS (
-	    SELECT distinct(build_id) AS build_id FROM check_build_events cbe 
-		WHERE NOT EXISTS (SELECT 1 FROM resources WHERE in_memory_build_id = cbe.build_id) AND 
-		      NOT EXISTS (SELECT 1 FROM builds WHERE id = cbe.build_id) 
+          SELECT distinct(build_id) AS build_id
+              FROM check_build_events cbe
+              WHERE NOT EXISTS (SELECT 1 FROM resources WHERE in_memory_build_id = cbe.build_id)
+                AND NOT EXISTS (SELECT 1 FROM builds WHERE id = cbe.build_id)
       )
-      DELETE FROM check_build_events cbe2 USING expired_imb_ids WHERE cbe2.build_id = expired_imb_ids.build_id;
+      DELETE FROM check_build_events cbe2 USING expired_imb_ids 
+          WHERE cbe2.build_id = expired_imb_ids.build_id;
     `)
 
 	if err1 != nil {


### PR DESCRIPTION
## Changes proposed by this PR

closes #8454 

* [x] done

We have noticed deadlock problems in our prod db, then we found this slow query, in the meantime we noticed `check_build_events` had reached to 20 million tuples. 

Explain the SQL, we can see its cost is huge:

![image](https://user-images.githubusercontent.com/18585861/181409736-2c43b639-2c4c-4fbb-9563-449acc845f71.png)

Then I worked out a new SQL:

![image](https://user-images.githubusercontent.com/18585861/181409856-3b891dce-7ee9-45ae-aa10-5114c101b3ec.png)

On our db, the new SQL takes only 2 seconds to run, while the old SQL might take hours.

Now, I have disabled  component `collector_checks`, and use a 1 minute timer triggered pipeline to run the new SQL to do check GC. So far, it's running well.


## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

* Optimized performance of check-build-events collector.