### PR TITLE
Reduce redundant job schedule

### DIFF
--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -1259,13 +1259,67 @@ var _ = Describe("Build", func() {
 				Expect(buildOutputs[0].Version).To(Equal(outputVersion))
 			})
 
-			Context("with a job in a separate team downstream of the same resource config", func() {
+			Context("with a job in a separate team downstream of the same non-trigger resource config", func() {
 				var otherScenario *dbtest.Scenario
 
 				var beforeTime, otherJobBeforeTime time.Time
 				var otherTeamBeforeTime, otherTeamOtherJobBeforeTime time.Time
 
 				BeforeEach(func() {
+					otherScenario = dbtest.Setup(
+						builder.WithTeam("other-team"),
+						builder.WithPipeline(pipelineConfig),
+						builder.WithResourceVersions("some-resource", atc.Version{"some": "version"}),
+						builder.WithResourceVersions("some-other-resource", atc.Version{"some": "other-version"}),
+					)
+
+					beforeTime = scenario.Job("some-job").ScheduleRequestedTime()
+					otherTeamBeforeTime = otherScenario.Job("some-job").ScheduleRequestedTime()
+
+					otherJobBeforeTime = scenario.Job("some-other-job").ScheduleRequestedTime()
+					otherTeamOtherJobBeforeTime = otherScenario.Job("some-other-job").ScheduleRequestedTime()
+				})
+
+				It("requests schedule on jobs which use the same config", func() {
+					Expect(scenario.Job("some-job").ScheduleRequestedTime()).To(BeTemporally(">", beforeTime))
+					Expect(otherScenario.Job("some-job").ScheduleRequestedTime()).To(BeTemporally("==", otherTeamBeforeTime))
+
+					Expect(scenario.Job("some-other-job").ScheduleRequestedTime()).To(BeTemporally("==", otherJobBeforeTime))
+					Expect(otherScenario.Job("some-other-job").ScheduleRequestedTime()).To(BeTemporally("==", otherTeamOtherJobBeforeTime))
+				})
+			})
+
+			Context("with a job in a separate team downstream of the same trigger resource config", func() {
+				var otherScenario *dbtest.Scenario
+
+				var beforeTime, otherJobBeforeTime time.Time
+				var otherTeamBeforeTime, otherTeamOtherJobBeforeTime time.Time
+
+				BeforeEach(func() {
+					pipelineConfig.Jobs = atc.JobConfigs{
+						{
+							Name: "some-job",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:    "some-resource",
+										Trigger: true,
+									},
+								},
+							},
+						},
+						{
+							Name: "some-other-job",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:    "some-other-resource",
+										Trigger: true,
+									},
+								},
+							},
+						},
+					}
 					otherScenario = dbtest.Setup(
 						builder.WithTeam("other-team"),
 						builder.WithPipeline(pipelineConfig),

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Resource Config Scope", func() {
 			})
 
 			Context("when a new version is added for non-trigger resource", func() {
-				It("requests schedule on the jobs that use the resource", func() {
+				It("should not request schedule on the jobs that use the resource", func() {
 					err := resourceScope.SaveVersions(nil, originalVersionSlice)
 					Expect(err).ToNot(HaveOccurred())
 

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -15,46 +15,47 @@ import (
 var _ = Describe("Resource Config Scope", func() {
 	var scenario *dbtest.Scenario
 	var resourceScope db.ResourceConfigScope
+	var pipelineConfig atc.Config = atc.Config{
+		Resources: atc.ResourceConfigs{
+			{
+				Name: "some-resource",
+				Type: "some-base-resource-type",
+				Source: atc.Source{
+					"some": "source",
+				},
+			},
+		},
+		Jobs: atc.JobConfigs{
+			{
+				Name: "some-job",
+				PlanSequence: []atc.Step{
+					{
+						Config: &atc.GetStep{
+							Name: "some-resource",
+						},
+					},
+				},
+			},
+			{
+				Name: "downstream-job",
+				PlanSequence: []atc.Step{
+					{
+						Config: &atc.GetStep{
+							Name:   "some-resource",
+							Passed: []string{"some-job"},
+						},
+					},
+				},
+			},
+			{
+				Name: "some-other-job",
+			},
+		},
+	}
 
 	BeforeEach(func() {
 		scenario = dbtest.Setup(
-			builder.WithPipeline(atc.Config{
-				Resources: atc.ResourceConfigs{
-					{
-						Name: "some-resource",
-						Type: "some-base-resource-type",
-						Source: atc.Source{
-							"some": "source",
-						},
-					},
-				},
-				Jobs: atc.JobConfigs{
-					{
-						Name: "some-job",
-						PlanSequence: []atc.Step{
-							{
-								Config: &atc.GetStep{
-									Name: "some-resource",
-								},
-							},
-						},
-					},
-					{
-						Name: "downstream-job",
-						PlanSequence: []atc.Step{
-							{
-								Config: &atc.GetStep{
-									Name:   "some-resource",
-									Passed: []string{"some-job"},
-								},
-							},
-						},
-					},
-					{
-						Name: "some-other-job",
-					},
-				},
-			}),
+			builder.WithPipeline(pipelineConfig),
 			builder.WithResourceVersions("some-resource"),
 		)
 
@@ -138,7 +139,7 @@ var _ = Describe("Resource Config Scope", func() {
 				Expect(latestVR.CheckOrder()).To(Equal(2))
 			})
 
-			Context("when a new version is added", func() {
+			Context("when a new version is added for non-trigger resource", func() {
 				It("requests schedule on the jobs that use the resource", func() {
 					err := resourceScope.SaveVersions(nil, originalVersionSlice)
 					Expect(err).ToNot(HaveOccurred())
@@ -152,7 +153,7 @@ var _ = Describe("Resource Config Scope", func() {
 					err = resourceScope.SaveVersions(nil, newVersions)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(scenario.Job("some-job").ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule))
+					Expect(scenario.Job("some-job").ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
 				})
 
 				It("does not request schedule on the jobs that use the resource but through passed constraints", func() {
@@ -185,6 +186,43 @@ var _ = Describe("Resource Config Scope", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(scenario.Job("some-other-job").ScheduleRequestedTime()).Should(BeTemporally("==", requestedSchedule))
+				})
+			})
+
+			Context("when a new version is added for trigger resource", func() {
+				BeforeEach(func() {
+					pipelineConfig.Jobs = atc.JobConfigs{
+						{
+							Name: "some-job",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name:    "some-resource",
+										Trigger: true,
+									},
+								},
+							},
+						},
+					}
+					scenario.Run(
+						builder.WithPipeline(pipelineConfig),
+					)
+				})
+
+				It("requests schedule on the jobs that use the resource", func() {
+					err := resourceScope.SaveVersions(nil, originalVersionSlice)
+					Expect(err).ToNot(HaveOccurred())
+
+					requestedSchedule := scenario.Job("some-job").ScheduleRequestedTime()
+
+					newVersions := []atc.Version{
+						{"ref": "v0"},
+						{"ref": "v3"},
+					}
+					err = resourceScope.SaveVersions(nil, newVersions)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(scenario.Job("some-job").ScheduleRequestedTime()).Should(BeTemporally(">", requestedSchedule))
 				})
 			})
 		})


### PR DESCRIPTION
## Changes proposed by this PR

closes #8498 

* [ ] done

## Notes to reviewer

Our prod cluster is experiencing scheduler slowness, because a common git resource that is used in 4000 pipelines are generating a lot of new versions, which make scheduler always have 4000 jobs to schedule. But the git resource is not a trigger resource of any pipeline, so there are many redundant job scheduling for this case.

This PR is for reduce the redundant job scheduling when a new version detected for non-trigger resource without pending/running build.

## Release Note

* Avoid job schedule when a new version detected for non-trigger resource without pending/running build.