### PR TITLE
Fix json syntax error to enable Renovate bot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,14 +4,14 @@
     {
       "matchLanguages": ["js"],
       "addLabels": ["javascript"],
-      "extends": ["schedule:monthly"]
+      "extends": ["schedule:monthly"],
       "groupName": "javasript",
       "groupSlug": "js"
     },
     {
       "matchLanguages": ["go"],
       "addLabels": ["golang"],
-      "extends": ["schedule:weekly"]
+      "extends": ["schedule:weekly"],
       "groupName": "golang",
       "groupSlug": "go"
     }


### PR DESCRIPTION
Error log taken from [Renovate Dashboard](https://app.renovatebot.com/dashboard#github/concourse/concourse). This causes the bot not creating dependency bumping PRs since it was onboarded into our repo.

```
DEBUG: Found .github/renovate.json config file
INFO: Repository has invalid config
{
  "error": {
    "validationSource": ".github/renovate.json",
    "validationError": "Invalid JSON (parsing failed)",
    "validationMessage": "Syntax error: expecting end of expression or separator near      \"grou",
    "message": "config-validation",
    "stack": "Error: config-validation\n    at checkForRepoConfigError (/home/ubuntu/renovateapp/node_modules/renovate/dist/workers/repository/init/merge.js:147:19)\n    at mergeRenovateConfig (/home/ubuntu/renovateapp/node_modules/renovate/dist/workers/repository/init/merge.js:169:5)\n    at async getRepoConfig (/home/ubuntu/renovateapp/node_modules/renovate/dist/workers/repository/init/config.js:15:14)\n    at async initRepo (/home/ubuntu/renovateapp/node_modules/renovate/dist/workers/repository/init/index.js:32:14)\n    at async Object.renovateRepository (/home/ubuntu/renovateapp/node_modules/renovate/dist/workers/repository/index.js:37:18)\n    at async renovateRepository (/home/ubuntu/renovateapp/app/worker/index.js:267:26)\n    at async /home/ubuntu/renovateapp/app/worker/index.js:527:5"
  }
}
```
