### PR TITLE
Add renovate rule for k8s client-go lib

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,8 +16,8 @@
       "groupSlug": "go"
     },
     {
-      "matchPackagePatterns": ["k8s.io/client-go"],
-      "matchCurrentVersion": "<1.0.0"
+      "matchPackageNames": ["k8s.io/client-go"],
+      "allowedVersions": "!/1\\.(4\\.0|5\\.0|5\\.1|5\\.2)$/"
     }
   ],
   "labels": ["dependencies", "misc", "release/undocumented"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,10 @@
       "extends": ["schedule:weekly"],
       "groupName": "golang",
       "groupSlug": "go"
+    },
+    {
+      "matchPackagePatterns": ["k8s.io/client-go"],
+      "matchCurrentVersion": "<1.0.0"
     }
   ],
   "labels": ["dependencies", "misc", "release/undocumented"]


### PR DESCRIPTION
this lib has a history of tags like v1.5.2 but its currently latest
is 0.24.3. I believe it was released as a whole with other kubebetes
packages but now it has its own versioning.

The problem is renovate will always bump it to v1.5.2 despite it is not
the latest.

Adding a rule to exclude those legacy versions.

Current tags https://github.com/kubernetes/client-go/tags

Example of legacy tag
```
⟩ curl -s https://proxy.golang.org/k8s.io/client-go/@v/v1.5.2.info
{"Version":"v1.5.2","Time":"2021-02-25T12:24:29Z"}⏎
```