### PR TITLE
Fix: job should get scheduled when job inputs/resources get resolve error

### DIFF
--- a/atc/db/resource_config_scope.go
+++ b/atc/db/resource_config_scope.go
@@ -330,7 +330,10 @@ func requestScheduleForJobsUsingResourceConfigScope(tx Tx, rcsID int) error {
 					"ji.passed_job_id":           nil,
 					"ji.trigger":                 false,
 				},
-				sq.NotEq{"j.next_build_id": nil},
+				sq.Or{
+					sq.NotEq{"j.next_build_id": nil},
+					sq.Eq{"j.inputs_determined": false},
+				},
 			},
 		}).
 		OrderBy("ji.job_id DESC").

--- a/atc/db/resource_config_scope_test.go
+++ b/atc/db/resource_config_scope_test.go
@@ -140,6 +140,16 @@ var _ = Describe("Resource Config Scope", func() {
 			})
 
 			Context("when a new version is added for non-trigger resource", func() {
+				BeforeEach(func() {
+					scenario.Run(
+						builder.WithNextInputMapping("some-job", dbtest.JobInputs{
+							{
+								Name: "some-resource",
+							},
+						}),
+					)
+				})
+
 				It("should not request schedule on the jobs that use the resource", func() {
 					err := resourceScope.SaveVersions(nil, originalVersionSlice)
 					Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Changes proposed by this PR

closes #8498 

* [ ] done

## Notes to reviewer

With PR #8504, we noticed a bug for job scheduling in following scenario
- A pipeline contains a trigger resource `a` and a non-trigger resource `b`, no build get scheduled with following conditions
    - For trigger resource `a`, if the check succeed with new versions
    - For non-trigger resource `b` , if the check failed/errored(resolve error)
- When user fix the configuration of non-trigger resource `b` and check succeed with new versions, new build still **NOT** be scheduled.
  - But the **correct** behavior should be new build get scheduled.

The root cause is, when a job inputs/resources get succeed from previous failed/errored state, job schedule got ignored. This PR is for fix this bug, when job inputs/resources get failed/errored(`BuildInput.ResolveError` is not empty or `job.inputs_determined` is false), job schedule should be triggered for checking if job inputs got resolved(`job.inputs_determined` is true).

## Release Note

* Fix: Job should get scheduled, when job inputs get resolve error