### PR TITLE
Change host to event_host tag for Datadog integration

### DIFF
--- a/atc/metric/emitter/dogstatsd.go
+++ b/atc/metric/emitter/dogstatsd.go
@@ -66,7 +66,7 @@ func (emitter *DogstatsdEmitter) Emit(logger lager.Logger, event metric.Event) {
 	name := specialChars.ReplaceAllString(strings.Replace(strings.ToLower(event.Name), " ", "_", -1), "")
 
 	tags := []string{
-		fmt.Sprintf("host:%s", event.Host),
+		fmt.Sprintf("event_host:%s", event.Host),
 	}
 
 	for k, v := range event.Attributes {


### PR DESCRIPTION
While trying to use the concourse integration with Datadog, I noticed that concourse is adding the `host` tag by default, and in the case of Kubernetes, it uses the pod name as the value.

This messes up with the inherited tags for the instances that the pod is running, as it's overriding the host tag and thus the new host value doesn't have any tag attached to it.

Unless I'm missing something, we don't need to have this tag added to the metric, as the datadog agent will add it anyway. So I'm renaming the `host` tag to `event_host` (just in case someone still wants to use it)

## Notes to reviewer

Sadly, I wasn't able to test as I couldn't for the life of me compile the binary + web files, I know this is not ideal, but if someone can build this binary for me, I'll test it and confirm that it fixes the issues I was seeing.

EDIT:

I've confirmed that adding manually a tag into Datadog to the host (pod name) adds the tags to all metrics attached to that host. So this should fix the issue.
