### PR TITLE
add resource check before smoke tests

### DIFF
--- a/web/wats/test/smoke.js
+++ b/web/wats/test/smoke.js
@@ -19,6 +19,8 @@ test('running pipelines', async t => {
   await t.context.fly.run('set-pipeline -n -p some-pipeline -c fixtures/smoke-pipeline.yml');
   await t.context.fly.run('unpause-pipeline -p some-pipeline');
 
+  await t.context.fly.run('check-resource -r some-pipeline/mockery');
+
   var result = await t.context.fly.run('trigger-job -j some-pipeline/say-hello -w');
   t.regex(result.stdout, /Hello, world!/);
   t.regex(result.stdout, /pushing version: put-version/);


### PR DESCRIPTION
if a worker registered to ATC but not functional e.g. failed to run
baggageclaim activity the smoke tests will hang. This additional
resource check makes sure the worker is healthy. If not, it will fail
fast and also expose the worker error instead of just showing timing
out in the test.

refer https://github.com/concourse/concourse/issues/8535