### PR TITLE
explicit error messeges in p2p streaming

### DIFF
--- a/worker/baggageclaim/api/p2p_server.go
+++ b/worker/baggageclaim/api/p2p_server.go
@@ -11,7 +11,10 @@ import (
 	"code.cloudfoundry.org/lager"
 )
 
-var ErrGetP2pUrlFailed = errors.New("failed to get p2p url")
+var ErrGetP2pUrlFailed = errors.New("failed to get p2p url, network interface list is empty")
+var ErrGetListSysNetworkInterface = errors.New("failed to get a list of the system's network interface")
+var ErrGetNetworkInterfaceAddr = errors.New("failed to get network interface addr for given interface")
+
 
 func NewP2pServer(
 	logger lager.Logger,
@@ -42,7 +45,7 @@ func (server *P2pServer) GetP2pUrl(w http.ResponseWriter, req *http.Request) {
 
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		RespondWithError(w, ErrGetP2pUrlFailed, http.StatusInternalServerError)
+		RespondWithError(w, ErrGetListSysNetworkInterface, http.StatusInternalServerError)
 		return
 	}
 
@@ -53,7 +56,7 @@ func (server *P2pServer) GetP2pUrl(w http.ResponseWriter, req *http.Request) {
 
 		addrs, err := i.Addrs()
 		if err != nil {
-			RespondWithError(w, ErrGetP2pUrlFailed, http.StatusInternalServerError)
+			RespondWithError(w, ErrGetNetworkInterfaceAddr, http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
Signed-off-by: dhantha <dhantha_gunarathna@comcast.com>

Adding more explicit error messages for the `p2p_server.go`

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes # <!-- remove if no existing issue -->

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] done
* [ ] todo

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
