### PR TITLE
[POC] Expose docker socket (if it exists) for privileged containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,5 @@ FROM base
 # set up a volume so locally built web UI changes auto-propagate
 VOLUME /src
 ENV CONCOURSE_WEB_PUBLIC_DIR=/src/web/public
+
+RUN apt-get -y install docker.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       CONCOURSE_POSTGRES_USER: dev
       CONCOURSE_POSTGRES_PASSWORD: dev
       CONCOURSE_POSTGRES_DATABASE: concourse
-      CONCOURSE_EXTERNAL_URL: http://ubuntu-vm:8080
+      CONCOURSE_EXTERNAL_URL: http://localhost:8080
       CONCOURSE_ADD_LOCAL_USER: test:test,guest:guest
       CONCOURSE_MAIN_TEAM_LOCAL_USER: test
       CONCOURSE_CLUSTER_NAME: dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     ports:
     - 7777:7777
     - 7788:7788
-    volumes: ["./hack/keys:/concourse-keys"]
+    volumes: ["./hack/keys:/concourse-keys", "/var/run/docker.sock:/var/run/docker.sock"]
     stop_signal: SIGUSR2
     environment:
       CONCOURSE_RUNTIME: containerd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       CONCOURSE_POSTGRES_USER: dev
       CONCOURSE_POSTGRES_PASSWORD: dev
       CONCOURSE_POSTGRES_DATABASE: concourse
-      CONCOURSE_EXTERNAL_URL: http://localhost:8080
+      CONCOURSE_EXTERNAL_URL: http://ubuntu-vm:8080
       CONCOURSE_ADD_LOCAL_USER: test:test,guest:guest
       CONCOURSE_MAIN_TEAM_LOCAL_USER: test
       CONCOURSE_CLUSTER_NAME: dev
@@ -47,7 +47,7 @@ services:
     ports:
     - 7777:7777
     - 7788:7788
-    volumes: ["./hack/keys:/concourse-keys", "/var/run/docker.sock:/var/run/docker.sock"]
+    volumes: ["./hack/keys:/concourse-keys"]
     stop_signal: SIGUSR2
     environment:
       CONCOURSE_RUNTIME: containerd

--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -68,7 +68,7 @@ func ContainerMounts(privileged bool, initBinPath string) []specs.Mount {
 	// this is so the container can run things like docker-compose on the worker
 	const dockerSocketPath = "/var/run/docker.sock"
 	_, err := os.Stat(dockerSocketPath)
-	if privileged && err != nil {
+	if privileged && err == nil {
 		mounts = append(mounts, specs.Mount{
 			Source:      dockerSocketPath,
 			Destination: dockerSocketPath,

--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -67,7 +67,7 @@ func ContainerMounts(privileged bool, initBinPath string) []specs.Mount {
 	// If container is privileged and docker is running, expose docker socket to the container
 	// this is so the container can run things like docker-compose on the worker
 	const dockerSocketPath = "/var/run/docker.sock"
-	var _, err = os.Stat(dockerSocketPath)
+	_, err := os.Stat(dockerSocketPath)
 	if privileged && err != nil {
 		mounts = append(mounts, specs.Mount{
 			Source:      dockerSocketPath,


### PR DESCRIPTION
If docker is installed on the worker and a task container is privileged, bind mount the docker socket into the task container.

This allows the container to run docker-compose or create containers (using docker installed inside the task container itself) on the worker without using docker-in-docker.

I tried using `nerdctl` instead of `docker` but that doesn't work remotely over a socket yet.

The only problem with this approach is garbage collection. That can be mitigated with a fairly complicated logic that only reaps orphan containers if their creation time is behind the start time of all currently running tasks.

Since docker and containerd do not share the networking concepts, I imagine the user will have to manage the networking themselves. I feel like that makes this approach not worth it.

This was asked for as a feature in [discord]( https://discord.com/channels/219899946617274369/604330794898554956/1010236295664107570 ) while I tackle the greater services RFC.

Signed-off-by: Jonathan Ryan <jonathan_ryan@comcast.com>

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes # <!-- remove if no existing issue -->

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] done
* [ ] todo

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
