### PR TITLE
stream: Adding new NextEventRaw method

### DIFF
--- a/go-concourse/concourse/events.go
+++ b/go-concourse/concourse/events.go
@@ -5,10 +5,12 @@ import (
 	"github.com/concourse/concourse/go-concourse/concourse/eventstream"
 	"github.com/concourse/concourse/go-concourse/concourse/internal"
 	"github.com/tedsuo/rata"
+	"github.com/vito/go-sse/sse"
 )
 
 type Events interface {
 	NextEvent() (atc.Event, error)
+	NextEventRaw() (sse.Event, error)
 	Close() error
 }
 

--- a/go-concourse/concourse/eventstream/stream.go
+++ b/go-concourse/concourse/eventstream/stream.go
@@ -50,6 +50,11 @@ func (s *SSEEventStream) NextEvent() (atc.Event, error) {
 	}
 }
 
+func (s *SSEEventStream) NextEventRaw() (sse.Event, error) {
+	se, err := s.sseReader.Next()
+	return se, err
+}
+
 func (s *SSEEventStream) Close() error {
 	return s.sseReader.Close()
 }


### PR DESCRIPTION


## Changes proposed by this PR

This method allow go-concourse users to get raw sse.Event from the eventstream.

This offers a handy way to fully get an event (payload and event_id), Instead of a decoded atc.Event.

This function also provides a workaround for https://github.com/concourse/concourse/issues/8585


## Notes to reviewer

This PR proposal offers more flexibility for go-concourse and eventstream users. It also gave a workaround for issue #8585

## Release Note

