### PR TITLE
Fix bug in testflight suite env var assignment

### DIFF
--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -96,7 +96,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	atcGuestUsername := os.Getenv("ATC_GUEST_USERNAME")
 	if atcGuestUsername != "" {
-		config.ATCGuestUsername = atcUsername
+		config.ATCGuestUsername = atcGuestUsername
 	}
 
 	atcGuestPassword := os.Getenv("ATC_GUEST_PASSWORD")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #8591

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->
The wrong variable name was being used when assigning the atcGuestUser value from the environment.
https://github.com/concourse/concourse/blob/582941fa3f47e64a2e4187462fa6dd31855c6a4b/testflight/suite_test.go#L99

* [x] Corrected env var assignment to `config.ATCGuestUsername = atcGuestUsername`

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Fixing bug in tesflight suite which should allow users to use environment variables to override local user credentials properly.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
