### PR TITLE
Change id of table resource_config_scopes to bigint

### DIFF
--- a/atc/db/migration/migrations/1666743327_alter_id_on_resource_config_scopes_bigint.down.sql
+++ b/atc/db/migration/migrations/1666743327_alter_id_on_resource_config_scopes_bigint.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE resource_config_scopes ALTER COLUMN id TYPE int;
+
+ALTER TABLE resource_config_versions ALTER COLUMN resource_config_scope_id TYPE int;
+
+ALTER TABLE resources ALTER COLUMN resource_config_scope_id TYPE int;

--- a/atc/db/migration/migrations/1666743327_alter_id_on_resource_config_scopes_bigint.up.sql
+++ b/atc/db/migration/migrations/1666743327_alter_id_on_resource_config_scopes_bigint.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE resource_config_scopes ALTER COLUMN id TYPE bigint;
+
+ALTER TABLE resource_config_versions ALTER COLUMN resource_config_scope_id TYPE bigint;
+
+ALTER TABLE resources ALTER COLUMN resource_config_scope_id TYPE bigint;


### PR DESCRIPTION
## Changes proposed by this PR

closes #8605


* [x] done


## Notes to reviewer

Looks like resource_config_scope's id has been handle with `int` type in Concourse code, thus only db schema change is needed.

## Release Note

Convert `id` column of the `resource_config_scopes` table and all tables referencing `resource_config_scope_id` to a `bigint`.