### PR TITLE
add buildvcs=false to go build in integration tests v6.8.x

### DIFF
--- a/fly/integration/suite_test.go
+++ b/fly/integration/suite_test.go
@@ -46,7 +46,7 @@ var teams = []atc.Team{
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
-	binPath, err := gexec.Build("github.com/concourse/concourse/fly")
+	binPath, err := gexec.Build("github.com/concourse/concourse/fly", "-buildvcs=false")
 	Expect(err).NotTo(HaveOccurred())
 
 	return []byte(binPath)

--- a/worker/baggageclaim/integration/baggageclaim/suite_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/suite_test.go
@@ -40,7 +40,7 @@ type suiteData struct {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
-	bcPath, err := gexec.Build("github.com/concourse/concourse/worker/baggageclaim/cmd/baggageclaim")
+	bcPath, err := gexec.Build("github.com/concourse/concourse/worker/baggageclaim/cmd/baggageclaim", "-buildvcs=false")
 	Expect(err).NotTo(HaveOccurred())
 
 	data, err := json.Marshal(suiteData{

--- a/worker/baggageclaim/integration/fs_mounter/suite_test.go
+++ b/worker/baggageclaim/integration/fs_mounter/suite_test.go
@@ -32,7 +32,7 @@ type suiteData struct {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
-	fsmPath, err := gexec.Build("github.com/concourse/concourse/worker/baggageclaim/cmd/fs_mounter")
+	fsmPath, err := gexec.Build("github.com/concourse/concourse/worker/baggageclaim/cmd/fs_mounter", "-buildvcs=false")
 	Expect(err).NotTo(HaveOccurred())
 
 	data, err := json.Marshal(suiteData{


### PR DESCRIPTION
darwin worker had problem with external disk where we use as Concoures worker dir. It had to be reboot and unmount/mount the disk. The problem was gone since but the side effect of rebooting the machine was golang upgrade to 1.19.2, which seems now throwing error

```
error obtaining VCS status: exit status 128
      	Use -buildvcs=false to disable VCS stamping.
```

so here we are adding the flag to go builds in where errors are thrown. This change is barkporting from master.