### PR TITLE
Fixed a bug of leaking resource cofig scope ids.

### DIFF
--- a/atc/db/resource_config.go
+++ b/atc/db/resource_config.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -124,15 +125,27 @@ func findOrCreateResourceConfigScope(
 	}
 
 	var scopeID int
-
-	rows, err := psql.Select("id").
-		From("resource_config_scopes").
-		Where(sq.Eq{
-			"resource_id":        resourceID,
-			"resource_config_id": resourceConfig.ID(),
-		}).
-		RunWith(tx).
-		Query()
+	var rows *sql.Rows
+	var err error
+	if uniqueResourceID == nil {
+		rows, err = psql.Select("id").
+			From("resource_config_scopes").
+			Where(sq.Eq{
+				"resource_config_id": resourceConfig.ID(),
+			}).
+			Where(sq.Expr("resource_id IS NULL")).
+			RunWith(tx).
+			Query()
+	} else {
+		rows, err = psql.Select("id").
+			From("resource_config_scopes").
+			Where(sq.Eq{
+				"resource_id":        resourceID,
+				"resource_config_id": resourceConfig.ID(),
+			}).
+			RunWith(tx).
+			Query()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/atc/db/resource_config_test.go
+++ b/atc/db/resource_config_test.go
@@ -9,16 +9,66 @@ import (
 
 var _ = Describe("ResourceConfig", func() {
 	var resourceConfig db.ResourceConfig
+	var otherResource db.Resource
 
 	Context("when non-unique", func() {
 		BeforeEach(func() {
 			var err error
+
+			// Adding a resourceTypeConfig to create a scope. The reason behind is that,
+			// when table "resource_config_scopes" is empty (just created), currentResourceConfigScopesIdSeq()
+			// will return 1; after insert the first tuple, currentResourceConfigScopesIdSeq()
+			// will also return 1. To work around the problem, adding a fake scope.
+			resourceTypeConfig, err := resourceConfigFactory.FindOrCreateResourceConfig(
+				defaultWorkerResourceType.Type,
+				atc.Source{"some": "fake-source-type"},
+				nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = resourceTypeConfig.FindOrCreateScope(nil)
+			Expect(err).ToNot(HaveOccurred())
+
 			resourceConfig, err = resourceConfigFactory.FindOrCreateResourceConfig(
 				defaultWorkerResourceType.Type,
 				atc.Source{"some": "source"},
 				nil,
 			)
 			Expect(err).ToNot(HaveOccurred())
+
+			// Add a resource with the same config.
+			otherPipeline, created, err := defaultTeam.SavePipeline(
+				atc.PipelineRef{Name: "other-pipeline-with-resources"},
+				atc.Config{
+					Resources: atc.ResourceConfigs{
+						{
+							Name:   "other-resource",
+							Type:   "some-base-resource-type",
+							Source: atc.Source{"some": "source"},
+						},
+					},
+					Jobs: atc.JobConfigs{
+						{
+							Name: "some-job",
+							PlanSequence: []atc.Step{
+								{
+									Config: &atc.GetStep{
+										Name: "other-resource",
+									},
+								},
+							},
+						},
+					},
+				},
+				0,
+				false,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(created).To(BeTrue())
+
+			var found bool
+			otherResource, found, err = otherPipeline.Resource("other-resource")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(found).To(BeTrue())
 		})
 
 		Describe("FindOrCreateScope", func() {
@@ -28,30 +78,50 @@ var _ = Describe("ResourceConfig", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(createdScope.ResourceID()).To(BeNil())
 					Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
+					seqAfterCreate, err := currentResourceConfigScopesIdSeq()
+					Expect(err).ToNot(HaveOccurred())
 
 					foundScope, err := resourceConfig.FindOrCreateScope(nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(foundScope.ID()).To(Equal(createdScope.ID()))
+					seqAfterFind, err := currentResourceConfigScopesIdSeq()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(seqAfterCreate).To(Equal(seqAfterFind))
 				})
 			})
 
 			Context("given a resource", func() {
 				Context("with global resources disabled", func() {
 					BeforeEach(func() {
-						// XXX(check-refactor): make this non global
+						// XXX(check-refactor): make this non-global
 						atc.EnableGlobalResources = false
 					})
 
 					It("finds or creates a unique scope", func() {
+						// create a scope with default resource
 						createdScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(createdScope.ResourceID()).ToNot(BeNil())
 						Expect(*createdScope.ResourceID()).To(Equal(defaultResource.ID()))
 						Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
+						seqAfterCreate, err := currentResourceConfigScopesIdSeq()
+						Expect(err).ToNot(HaveOccurred())
 
+						// should find the scope of default resource
 						foundScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(foundScope.ID()).To(Equal(createdScope.ID()))
+						seqAfterFind, err := currentResourceConfigScopesIdSeq()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(seqAfterCreate).To(Equal(seqAfterFind))
+
+						// create a new scope with the same resource config but different resource id
+						otherCreatedScope, err := resourceConfig.FindOrCreateScope(intptr(otherResource.ID()))
+						Expect(err).ToNot(HaveOccurred())
+						Expect(otherCreatedScope.ID()).To(Equal(createdScope.ID() + 1))
+						seqAfterOtherCreate, err := currentResourceConfigScopesIdSeq()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(seqAfterOtherCreate).To(Equal(seqAfterCreate + 1))
 					})
 				})
 
@@ -61,14 +131,32 @@ var _ = Describe("ResourceConfig", func() {
 					})
 
 					It("finds or creates a global scope", func() {
+						// create a scope with default resource
+						seqBeforeCreate, err := currentResourceConfigScopesIdSeq()
+						Expect(err).ToNot(HaveOccurred())
 						createdScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(createdScope.ResourceID()).To(BeNil())
 						Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
+						seqAfterCreate, err := currentResourceConfigScopesIdSeq()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(seqAfterCreate).To(Equal(seqBeforeCreate + 1))
 
+						// should find the scope of default resource
 						foundScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 						Expect(err).ToNot(HaveOccurred())
 						Expect(foundScope.ID()).To(Equal(createdScope.ID()))
+						seqAfterFind, err := currentResourceConfigScopesIdSeq()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(seqAfterCreate).To(Equal(seqAfterFind))
+
+						// should find the same scope even with a different resource id
+						foundScope, err = resourceConfig.FindOrCreateScope(intptr(otherResource.ID()))
+						Expect(err).ToNot(HaveOccurred())
+						Expect(foundScope.ID()).To(Equal(createdScope.ID()))
+						seqAfterFind, err = currentResourceConfigScopesIdSeq()
+						Expect(err).ToNot(HaveOccurred())
+						Expect(seqAfterCreate).To(Equal(seqAfterFind))
 					})
 				})
 			})
@@ -93,10 +181,15 @@ var _ = Describe("ResourceConfig", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(createdScope.ResourceID()).To(BeNil())
 					Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
+					seqAfterCreate, err := currentResourceConfigScopesIdSeq()
+					Expect(err).ToNot(HaveOccurred())
 
 					foundScope, err := resourceConfig.FindOrCreateScope(nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(foundScope.ID()).To(Equal(createdScope.ID()))
+					seqAfterFind, err := currentResourceConfigScopesIdSeq()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(seqAfterCreate).To(Equal(seqAfterFind))
 				})
 			})
 
@@ -107,12 +200,24 @@ var _ = Describe("ResourceConfig", func() {
 					Expect(createdScope.ResourceID()).ToNot(BeNil())
 					Expect(*createdScope.ResourceID()).To(Equal(defaultResource.ID()))
 					Expect(createdScope.ResourceConfig().ID()).To(Equal(resourceConfig.ID()))
+					seqAfterCreate, err := currentResourceConfigScopesIdSeq()
+					Expect(err).ToNot(HaveOccurred())
 
 					foundScope, err := resourceConfig.FindOrCreateScope(intptr(defaultResource.ID()))
 					Expect(err).ToNot(HaveOccurred())
 					Expect(foundScope.ID()).To(Equal(createdScope.ID()))
+					seqAfterFind, err := currentResourceConfigScopesIdSeq()
+					Expect(err).ToNot(HaveOccurred())
+					Expect(seqAfterCreate).To(Equal(seqAfterFind))
 				})
 			})
 		})
 	})
 })
+
+func currentResourceConfigScopesIdSeq() (int, error) {
+	var seq int
+	row := psql.Select("last_value").From("resource_config_scopes_id_seq").RunWith(dbConn).QueryRow()
+	err := row.Scan(&seq)
+	return seq, err
+}


### PR DESCRIPTION
## Changes proposed by this PR

closes #8618
closes #8619

* [x] code change
* [x] add unit tests
* [x] run more tests
* [x] done


## Notes to reviewer

This fix will lead to a breaking change, when switching global-resources from off to on, all resource histories will be lost. I think that should not be a big issue. Because:

1. Global-resources should always be turned on, actually Concourse wants to turn on the feature by default.
2. Global-resources is not such a switch that would be switched on/off frequently.

## Release Note

Fixed bugs about resource config scopes:
* When global-resources is enabled, `resource_config_scopes` tables leaked IDs. A side effect of the bug is that unnecessary `insert` will be performed (see #8618 for details). So, this fix will fix the ID leaking problem, also improve performance.
* When global-resources is enabled, old resources wouldn't be affected. This fix will ensure old resources to switch to global scopes.

__BREAKING:__ when switching global-resources from off to on, all resource histories will be lost. Losing version history usually not a big problem, for example, if you change `source` of a resource, for example, you change password/private-key of a `git` resource, its version history will be lost. But depending on a resource's `check` behavior, versions may be regenerated.

If your deployment has turned ON global-resources, or you have stay with global-resources OFF, this "breaking" won't impact your deployment.

Note that, if your cluster has turned ON global-resources, and you plan to turn OFF. In that case, after turning OFF global-resources, each resource will have an unique version history, thus shared version history will be lost. The behavior is always there, this PR doesn't change the behavior.

If you upgrade this fix, and turn on global-resources, as described, version histories will be lost. If you turn off global-resources, then old version histories will come back.
