### PR TITLE
Remove rerun_of int->bigint migrations

### DIFF
--- a/atc/db/migration/migrations/1653924132_int_to_bigint.down.sql
+++ b/atc/db/migration/migrations/1653924132_int_to_bigint.down.sql
@@ -3,9 +3,6 @@ ALTER SEQUENCE resource_config_versions_id_seq AS integer;
 ALTER TABLE build_comments
     ALTER COLUMN build_id TYPE integer;
 
-ALTER TABLE builds
-    ALTER COLUMN rerun_of TYPE integer;
-
 ALTER TABLE successful_build_outputs
     ALTER COLUMN rerun_of TYPE integer;
 

--- a/atc/db/migration/migrations/1653924132_int_to_bigint.up.sql
+++ b/atc/db/migration/migrations/1653924132_int_to_bigint.up.sql
@@ -3,9 +3,6 @@ ALTER SEQUENCE resource_config_versions_id_seq AS bigint;
 ALTER TABLE build_comments
     ALTER COLUMN build_id TYPE bigint;
 
-ALTER TABLE builds
-    ALTER COLUMN rerun_of TYPE bigint;
-
 ALTER TABLE successful_build_outputs
     ALTER COLUMN rerun_of TYPE bigint;
 


### PR DESCRIPTION

## Changes proposed by this PR

Remove the migration of interger to bigint for `rerun_of` column in  `builds` table. Refer to https://github.com/concourse/concourse/issues/8499, it takes a long time for the migrations to be completed due to access lock contest and table rewritten (builds table is big and with lots of index).

Similar to https://github.com/concourse/concourse/pull/6203 and https://github.com/concourse/concourse/pull/6305, we should do the migration of the column in a way to avoid downtime. We will need to push the work to future release (maybe a major or until it bites us) to make sure v7.9 is easy to upgrade to.


* [x] done
* [ ] todo
