### PR TITLE
fix across step states bug

### DIFF
--- a/web/elm/src/Build/StepTree/Models.elm
+++ b/web/elm/src/Build/StepTree/Models.elm
@@ -157,12 +157,16 @@ mostSevereStepState model stepTree =
     activeTreeSteps model stepTree
         |> List.foldl
             (\step state ->
-                case stepStateOrdering step.state state of
-                    LT ->
-                        step.state
-
-                    _ ->
+                case step.buildStep of
+                    Concourse.BuildStepDo _ ->
                         state
+                    _ ->
+                        case stepStateOrdering step.state state of
+                            LT ->
+                                step.state
+
+                            _ ->
+                                state
             )
             StepStateSucceeded
 


### PR DESCRIPTION
it was showing state cancelling when sub steps are all succeeded while the across step is using a `do` step to wrap multiple sub steps (so across step without using `do` works fine). 

This bug is introduced by https://github.com/concourse/concourse/pull/8015 where `do` step get assigned with step ID where a state of a Do step is not cleared. To be exact, states from sub-tree with higher severeness (failed, errored and interrupted) will be shown correctly in the across sub step; states with lower severeness (running, pending, succeeded) will not be shown, instead a cancelling state will show in the across sub step. 

This PR sets the Do step's state to its sub step instead of comparing its default state (seems to be cancelling state) to state from sub-tree. 


## Changes proposed by this PR

closes #8610



## Release Note

* Fix a bug where sub step of `across` step showing incorrect state.

