### PR TITLE
atc/db: fix dropped error

### DIFF
--- a/atc/db/resource.go
+++ b/atc/db/resource.go
@@ -491,7 +491,9 @@ func (r *resource) ClearVersions() (int64, error) {
 		}).
 		RunWith(r.conn).
 		Exec()
-
+	if err != nil {
+		return 0, err
+	}
 	rowsDeleted, err := results.RowsAffected()
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Changes proposed by this PR

This fixes a dropped `err` variable in the `atc/db` package.