### PR TITLE
Fix failed fly integration test in darwin

### DIFF
--- a/fly/integration/hijack_test.go
+++ b/fly/integration/hijack_test.go
@@ -301,13 +301,12 @@ var _ = Describe("Hijacking", func() {
 			stdin, err := flyCmd.StdinPipe()
 			Expect(err).NotTo(HaveOccurred())
 
+			defer stdin.Close()
+
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(sess.Err.Contents).Should(ContainSubstring("no containers matched your search parameters!\n\nthey may have expired if your build hasn't recently finished.\n"))
-
-			err = stdin.Close()
-			Expect(err).NotTo(HaveOccurred())
 
 			<-sess.Exited
 			Expect(sess.ExitCode()).To(Equal(1))
@@ -915,6 +914,8 @@ var _ = Describe("Hijacking", func() {
 				stdin, err := flyCmd.StdinPipe()
 				Expect(err).NotTo(HaveOccurred())
 
+				defer stdin.Close()
+
 				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -924,9 +925,6 @@ var _ = Describe("Hijacking", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(sess.Err.Contents).Should(ContainSubstring(ansi.Color("something went wrong", "red+b") + "\n"))
-
-				err = stdin.Close()
-				Expect(err).NotTo(HaveOccurred())
 
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(255))

--- a/fly/integration/login_insecure_test.go
+++ b/fly/integration/login_insecure_test.go
@@ -58,8 +58,7 @@ var _ = Describe("login -k Command", func() {
 
 				Eventually(sess.Out).Should(gbytes.Say("target saved"))
 
-				err = stdin.Close()
-				Expect(err).NotTo(HaveOccurred())
+				defer stdin.Close()
 
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(0))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/concourse/concourse
 
-go 1.19
+go 1.20
 
 require (
 	code.cloudfoundry.org/clock v1.0.0


### PR DESCRIPTION


## Changes proposed by this PR

 - Follow the [StdinPipe example](https://pkg.go.dev/os/exec#Cmd.StdinPipe) in golang docs.
 - Also bumping Golang to v1.20 to align with go runtime in golang-builder-image that used in CI.

Closes #8680 

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note
* Bump Golang to v1.20

