### PR TITLE
add shared path to SSM parameters

### DIFF
--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Pipelines API", func() {
 				fakeAccess.IsAuthenticatedReturns(true)
 				fakeAccess.IsAdminReturns(true)
 
-				ssmAccess := ssm.NewSsm(lager.NewLogger("ssm_test"), &mockService, nil)
+				ssmAccess := ssm.NewSsm(lager.NewLogger("ssm_test"), &mockService, nil, "")
 				ssmManager := &ssm.SsmManager{
 					AwsAccessKeyID:         "",
 					AwsSecretAccessKey:     "",
@@ -140,6 +140,7 @@ var _ = Describe("Pipelines API", func() {
 							"method": "GetParameter"
 						},
 						"pipeline_secret_template": "pipeline-secret-template",
+            "shared_path": "",
 						"team_secret_template": "team-secret-template"
           }
         }`))
@@ -165,6 +166,7 @@ var _ = Describe("Pipelines API", func() {
 							"method": "GetParameter"
 						},
 						"pipeline_secret_template": "pipeline-secret-template",
+            "shared_path": "",
 						"team_secret_template": "team-secret-template"
           }
         }`))

--- a/atc/creds/ssm/manager.go
+++ b/atc/creds/ssm/manager.go
@@ -24,6 +24,7 @@ type SsmManager struct {
 	AwsRegion              string `mapstructure:"region" long:"region" description:"AWS region to send requests to"`
 	PipelineSecretTemplate string `mapstructure:"pipeline_secret_template" long:"pipeline-secret-template" description:"AWS SSM parameter name template used for pipeline specific parameter" default:"/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"`
 	TeamSecretTemplate     string `mapstructure:"team_secret_template" long:"team-secret-template" description:"AWS SSM parameter name template used for team specific parameter" default:"/concourse/{{.Team}}/{{.Secret}}"`
+	SharedPath             string `mapstructure:"shared_path" long:"shared-path" description:"AWS SSM parameter path used for shared parameters"`
 	Ssm                    *Ssm
 }
 
@@ -37,6 +38,7 @@ func (manager *SsmManager) MarshalJSON() ([]byte, error) {
 		"aws_region":               manager.AwsRegion,
 		"pipeline_secret_template": manager.PipelineSecretTemplate,
 		"team_secret_template":     manager.TeamSecretTemplate,
+		"shared_path":              manager.SharedPath,
 		"health":                   health,
 	})
 }
@@ -139,7 +141,7 @@ func (manager *SsmManager) NewSecretsFactory(log lager.Logger) (creds.SecretsFac
 		return nil, err
 	}
 
-	return NewSsmFactory(log, session, []*creds.SecretTemplate{pipelineSecretTemplate, teamSecretTemplate}), nil
+	return NewSsmFactory(log, session, []*creds.SecretTemplate{pipelineSecretTemplate, teamSecretTemplate}, manager.SharedPath), nil
 }
 
 func (manager *SsmManager) Close(logger lager.Logger) {

--- a/atc/creds/ssm/ssm.go
+++ b/atc/creds/ssm/ssm.go
@@ -17,13 +17,15 @@ type Ssm struct {
 	log             lager.Logger
 	api             ssmiface.SSMAPI
 	secretTemplates []*creds.SecretTemplate
+	sharedPath      string
 }
 
-func NewSsm(log lager.Logger, api ssmiface.SSMAPI, secretTemplates []*creds.SecretTemplate) *Ssm {
+func NewSsm(log lager.Logger, api ssmiface.SSMAPI, secretTemplates []*creds.SecretTemplate, sharedPath string) *Ssm {
 	return &Ssm{
 		log:             log,
 		api:             api,
 		secretTemplates: secretTemplates,
+		sharedPath:      sharedPath,
 	}
 }
 
@@ -34,6 +36,9 @@ func (s *Ssm) NewSecretLookupPaths(teamName string, pipelineName string, allowRo
 		if lPath := creds.NewSecretLookupWithTemplate(tmpl, teamName, pipelineName); lPath != nil {
 			lookupPaths = append(lookupPaths, lPath)
 		}
+	}
+	if s.sharedPath != "" {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(s.sharedPath+"/"))
 	}
 	return lookupPaths
 }

--- a/atc/creds/ssm/ssm_factory.go
+++ b/atc/creds/ssm/ssm_factory.go
@@ -11,16 +11,18 @@ type ssmFactory struct {
 	log             lager.Logger
 	api             *ssm.SSM
 	secretTemplates []*creds.SecretTemplate
+	sharedPath      string
 }
 
-func NewSsmFactory(log lager.Logger, session *session.Session, secretTemplates []*creds.SecretTemplate) *ssmFactory {
+func NewSsmFactory(log lager.Logger, session *session.Session, secretTemplates []*creds.SecretTemplate, sharedPath string) *ssmFactory {
 	return &ssmFactory{
 		log:             log,
 		api:             ssm.New(session),
 		secretTemplates: secretTemplates,
+		sharedPath:      sharedPath,
 	}
 }
 
 func (factory *ssmFactory) NewSecrets() creds.Secrets {
-	return NewSsm(factory.log, factory.api, factory.secretTemplates)
+	return NewSsm(factory.log, factory.api, factory.secretTemplates, factory.sharedPath)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->
As of now, it is not possible to configure shared paths for AWS SSM cred manager as opposed to other cred managers such as Vault. Since it is easy to implement and useful, I propose to add a new parameter `--aws-ssm-shared-path` similar to the Vault cred manager. A path prefix rather than template (as for AWS SecretsManager) makes sense since in this case no default is needed and this parameter can be optional (as with Vault). This PR provides all the changes needed for this functionality.

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed --> Added `--aws-ssm-shared-path` to configure shared secret paths for AWS SSM cred manager similarly to the one for Vault.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
