### PR TITLE
Ignore elm and client-go in renovate deps bump

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,5 +20,6 @@
       "allowedVersions": "!/1\\.(4\\.0|5\\.0|5\\.1|5\\.2)$/"
     }
   ],
+  "ignoreDeps": ["elm", "client-go"],
   "labels": ["dependencies", "misc", "release/undocumented"]
 }


### PR DESCRIPTION
client-go v11 and elm v2.0.0 are both deprecated versions long time ago.

This will allow JS deps bumping PR (e.g. https://github.com/concourse/concourse/pull/8677) created by renovate to be merged without manually remove those problematic bump.
