### PR TITLE
atc: Support more than one Vault path prefix simultaneously

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,7 +481,7 @@ and suite runner of choice for Go code. You'll need to install the `ginkgo` CLI
 to run the unit tests and `testflight`:
 
 ```sh
-$ go get github.com/onsi/ginkgo/ginkgo
+$ go install github.com/onsi/ginkgo/ginkgo
 ```
 
 We use [Counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) to generate

--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Pipelines API", func() {
 
 					credhubManager := &credhub.CredHubManager{
 						URL:        credServer.URL(),
-						PathPrefix: "some-prefix",
+						PathPrefix: []string{"some-prefix"},
 						TLS:        tls,
 						UAA:        uaa,
 						Client:     &credhub.LazyCredhub{},
@@ -370,7 +370,7 @@ var _ = Describe("Pipelines API", func() {
 				BeforeEach(func() {
 					credhubManager := &credhub.CredHubManager{
 						URL:        "http://wrong.inexistent.tld",
-						PathPrefix: "some-prefix",
+						PathPrefix: []string{"some-prefix"},
 						TLS:        tls,
 						UAA:        uaa,
 						Client:     &credhub.LazyCredhub{},

--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -264,7 +264,7 @@ var _ = Describe("Pipelines API", func() {
 					Expect(body).To(MatchJSON(`{
           "vault": {
             "url": "` + credServer.URL() + `",
-            "path_prefix": "[testpath]",
+            "path_prefix": ["testpath"],
             "lookup_templates": ["/{{.Team}}/{{.Pipeline}}/{{.Secret}}", "/{{.Team}}/{{.Secret}}"],
 			"shared_path": "",
 			"namespace": "testnamespace",

--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Pipelines API", func() {
 				vaultManager := &vault.VaultManager{
 					URL:             credServer.URL(),
 					Namespace:       "testnamespace",
-					PathPrefix:      "testpath",
+					PathPrefix:      []string{"testpath"},
 					LookupTemplates: []string{"/{{.Team}}/{{.Pipeline}}/{{.Secret}}", "/{{.Team}}/{{.Secret}}"},
 					TLS:             tls,
 					Auth:            authConfig,
@@ -264,7 +264,7 @@ var _ = Describe("Pipelines API", func() {
 					Expect(body).To(MatchJSON(`{
           "vault": {
             "url": "` + credServer.URL() + `",
-            "path_prefix": "testpath",
+            "path_prefix": "[testpath]",
             "lookup_templates": ["/{{.Team}}/{{.Pipeline}}/{{.Secret}}", "/{{.Team}}/{{.Secret}}"],
 			"shared_path": "",
 			"namespace": "testnamespace",

--- a/atc/creds/credhub/credhub.go
+++ b/atc/creds/credhub/credhub.go
@@ -13,18 +13,24 @@ import (
 type CredHubAtc struct {
 	CredHub *LazyCredhub
 	logger  lager.Logger
-	prefix  string
+	prefix  []string
 }
 
 // NewSecretLookupPaths defines how variables will be searched in the underlying secret manager
 func (c CredHubAtc) NewSecretLookupPaths(teamName string, pipelineName string, allowRootPath bool) []creds.SecretLookupPath {
 	lookupPaths := []creds.SecretLookupPath{}
 	if len(pipelineName) > 0 {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(c.prefix, teamName, pipelineName)+"/"))
+		for _, prefix := range c.prefix {
+			lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(prefix, teamName, pipelineName)+"/"))
+		}
 	}
-	lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(c.prefix, teamName)+"/"))
+	for _, prefix := range c.prefix {
+		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(prefix, teamName)+"/"))
+	}
 	if allowRootPath {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(c.prefix+"/"))
+		for _, prefix := range c.prefix {
+			lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(prefix+"/"))
+		}
 	}
 	return lookupPaths
 }

--- a/atc/creds/credhub/credhub_factory.go
+++ b/atc/creds/credhub/credhub_factory.go
@@ -8,10 +8,10 @@ import (
 type credhubFactory struct {
 	credhub *LazyCredhub
 	logger  lager.Logger
-	prefix  string
+	prefix  []string
 }
 
-func NewCredHubFactory(logger lager.Logger, credhub *LazyCredhub, prefix string) *credhubFactory {
+func NewCredHubFactory(logger lager.Logger, credhub *LazyCredhub, prefix []string) *credhubFactory {
 	return &credhubFactory{
 		credhub: credhub,
 		logger:  logger,

--- a/atc/creds/credhub/manager.go
+++ b/atc/creds/credhub/manager.go
@@ -16,7 +16,7 @@ import (
 type CredHubManager struct {
 	URL string `long:"url" description:"CredHub server address used to access secrets."`
 
-	PathPrefix string `long:"path-prefix" default:"/concourse" description:"Path under which to namespace credential lookup."`
+	PathPrefix []string `long:"path-prefix" default:"/concourse" description:"One or more paths (comma-delimited) under which to namespace credential lookup."`
 
 	TLS    TLS
 	UAA    UAA

--- a/atc/creds/vault/manager_test.go
+++ b/atc/creds/vault/manager_test.go
@@ -43,7 +43,7 @@ var _ = Describe("VaultManager", func() {
 			_, err := flags.ParseArgs(&manager, []string{})
 			Expect(err).To(BeNil())
 			Expect(manager.SharedPath).To(Equal(""))
-			Expect(manager.PathPrefix).To(Equal("/concourse"))
+			Expect(manager.PathPrefix).To(Equal([]string{"/concourse"}))
 			Expect(manager.LookupTemplates).To(Equal([]string{
 				"/{{.Team}}/{{.Pipeline}}/{{.Secret}}",
 				"/{{.Team}}/{{.Secret}}",
@@ -138,7 +138,7 @@ var _ = Describe("VaultManager", func() {
 			config = map[string]interface{}{
 				"url":                fakeVault.URL,
 				"disable_srv_lookup": true,
-				"path_prefix":        "/path-prefix",
+				"path_prefix":        []string{"/path-prefix"},
 				"lookup_templates": []string{
 					"/what/{{.Team}}/blah/{{.Pipeline}}/{{.Secret}}",
 					"/thing/{{.Team}}/{{.Secret}}",
@@ -185,7 +185,7 @@ var _ = Describe("VaultManager", func() {
 
 			Expect(manager.URL).To(Equal(fakeVault.URL))
 			Expect(manager.ClientConfig.DisableSRVLookup).To(Equal(true))
-			Expect(manager.PathPrefix).To(Equal("/path-prefix"))
+			Expect(manager.PathPrefix).To(Equal([]string{"/path-prefix"}))
 			Expect(manager.LookupTemplates).To(Equal([]string{
 				"/what/{{.Team}}/blah/{{.Pipeline}}/{{.Secret}}",
 				"/thing/{{.Team}}/{{.Secret}}",
@@ -219,7 +219,7 @@ var _ = Describe("VaultManager", func() {
 				Expect(configErr).ToNot(HaveOccurred())
 
 				Expect(manager.ClientConfig.DisableSRVLookup).To(Equal(false))
-				Expect(manager.PathPrefix).To(Equal("/concourse"))
+				Expect(manager.PathPrefix).To(Equal([]string{"/concourse"}))
 				Expect(manager.Auth.RetryMax).To(Equal(5 * time.Minute))
 				Expect(manager.Auth.RetryInitial).To(Equal(time.Second))
 				Expect(manager.LookupTemplates).To(Equal([]string{

--- a/atc/creds/vault/vault.go
+++ b/atc/creds/vault/vault.go
@@ -25,7 +25,7 @@ type SecretReader interface {
 // data.
 type Vault struct {
 	SecretReader    SecretReader
-	Prefix          string
+	Prefix          []string
 	LookupTemplates []*creds.SecretTemplate
 	SharedPath      string
 	LoggedIn        <-chan struct{}
@@ -40,11 +40,13 @@ func (v Vault) NewSecretLookupPaths(teamName string, pipelineName string, allowR
 			lookupPaths = append(lookupPaths, lPath)
 		}
 	}
-	if v.SharedPath != "" {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, v.SharedPath)+"/"))
-	}
-	if allowRootPath {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(v.Prefix+"/"))
+	for _, prefix := range v.Prefix {
+		if v.SharedPath != "" {
+			lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(prefix, v.SharedPath)+"/"))
+		}
+		if allowRootPath {
+			lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(prefix+"/"))
+		}
 	}
 	return lookupPaths
 }

--- a/atc/creds/vault/vault_factory.go
+++ b/atc/creds/vault/vault_factory.go
@@ -9,14 +9,14 @@ import (
 // The vaultFactory will return a vault implementation of vars.Variables.
 type vaultFactory struct {
 	sr              SecretReader
-	prefix          string
+	prefix          []string
 	sharedPath      string
 	lookupTemplates []*creds.SecretTemplate
 	loggedIn        <-chan struct{}
 	loginTimeout    time.Duration
 }
 
-func NewVaultFactory(sr SecretReader, loginTimeout time.Duration, loggedIn <-chan struct{}, prefix string, lookupTemplates []*creds.SecretTemplate, sharedPath string) *vaultFactory {
+func NewVaultFactory(sr SecretReader, loginTimeout time.Duration, loggedIn <-chan struct{}, prefix []string, lookupTemplates []*creds.SecretTemplate, sharedPath string) *vaultFactory {
 	factory := &vaultFactory{
 		sr:              sr,
 		prefix:          prefix,

--- a/atc/creds/vault/vault_test.go
+++ b/atc/creds/vault/vault_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Vault", func() {
 
 		v = &vault.Vault{
 			SecretReader:    msr,
-			Prefix:          "/concourse",
+			Prefix:          []string{"/concourse"},
 			LookupTemplates: []*creds.SecretTemplate{p, t},
 			SharedPath:      "shared",
 			LoggedIn:        loggedInCh,
@@ -220,7 +220,7 @@ var _ = Describe("Vault", func() {
 
 					v = &vault.Vault{
 						SecretReader:    sr,
-						Prefix:          "/concourse",
+						Prefix:          []string{"/concourse"},
 						LookupTemplates: []*creds.SecretTemplate{a, b, c},
 					}
 
@@ -256,7 +256,7 @@ var _ = Describe("Vault", func() {
 
 					v = &vault.Vault{
 						SecretReader:    msr,
-						Prefix:          "/concourse",
+						Prefix:          []string{"/concourse"},
 						LookupTemplates: []*creds.SecretTemplate{p, t},
 					}
 
@@ -356,7 +356,7 @@ var _ = Describe("Vault KV2", func() {
 
 		v = &vault.Vault{
 			SecretReader:    vaultApi,
-			Prefix:          "/concourse",
+			Prefix:          []string{"/concourse"},
 			LookupTemplates: []*creds.SecretTemplate{p, t},
 			SharedPath:      "shared",
 		}
@@ -629,7 +629,7 @@ var _ = Describe("Vault KV1", func() {
 
 		v = &vault.Vault{
 			SecretReader:    vaultApi,
-			Prefix:          "/concourse",
+			Prefix:          []string{"/concourse"},
 			LookupTemplates: []*creds.SecretTemplate{p, t},
 			SharedPath:      "shared",
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements
-->

## Changes proposed by this PR

Support for Vault kv2 was added in https://github.com/concourse/concourse/pull/6115. That supports both kv1 and kv2, but as [mentioned in the docs](https://concourse-ci.org/vault-credential-manager.html#configuring-the-secrets-engine), only a single prefix path is supported:
> Concourse is currently limited to looking under a single path, meaning enabling only one secrets engine is supported: `kv`, or `kv_v2`.

This PR enables multiple prefix paths and then does the lookup of the secrets in each, for each [path template](https://concourse-ci.org/vault-credential-manager.html#vault-lookup-templates) configured.

The idea in our org is to enable a smooth transition of teams from kv1 -> kv2. Without this we'd need to do a big bang release of ensuring all teams have migrated their secrets to the new engine, then update the Concourse config to point at kv2. Instead with this change we can support both, and let someone else herd the cats. 🙂 

Note this would potentially double the number of APIs to Vault. I don't see that's a reason to not do it, but something to call out in the docs at a minimum.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] support multiple Vault prefix paths
* [x] manual testing 
* [ ] unit or other tests
* [ ] update docs

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

Creating this as a draft to get feedback on the overall idea, and specifically around changing the datatype of the existing `PathPrefix` var. This seems like the shortest path but I believe technically it's a breaking change for the `/api/v1/info/creds` endpoint.

Example of current response:
```json
    "path_prefix": "/kv1",
```
Example after this change:
```json
    "path_prefix": [
        "/kv2",
        "/kv1"
    ],
```

I'm not sure how widely used this endpoint is. I believe it's only available to admins under the `main` team, so it seems a bit more plausible to sneak it in.

The alternative I'm thinking of is to create a parallel `--path-prefixes` config option, although presumably the code would have to only allow either that or `--path-prefix`, but not both.

Entirely possible there are other aspects I'm not thinking of, hence the ask for feedback. Thanks!

Btw, quick example of local testing:
```yaml
jobs:
- name: hiya
  plan:
  - task: simple-task
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: { repository: busybox }
      run:
        path: echo
        args: ["Hello world!", ((kv2-test.hello)), ((kv1-test.hello))]
```
Where `kv2-test` secret only exists in the kv2 path, and `kv1-test` secret only exists in the kv1 path. This results in `Hello world! Hello from kv2! Hello from kv1!`

## Release Note

TBD

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
