### PR TITLE
Hermetic for task container

### DIFF
--- a/atc/builds/planner.go
+++ b/atc/builds/planner.go
@@ -59,6 +59,7 @@ func (visitor *planVisitor) VisitTask(step *atc.TaskStep) error {
 	visitor.plan = visitor.planFactory.NewPlan(atc.TaskPlan{
 		Name:              step.Name,
 		Privileged:        step.Privileged,
+		Hermetic:          step.Hermetic,
 		Limits:            step.Limits,
 		Config:            step.Config,
 		ConfigPath:        step.ConfigPath,

--- a/atc/builds/planner_test.go
+++ b/atc/builds/planner_test.go
@@ -1171,12 +1171,12 @@ var factoryTests = []PlannerTest{
 	{
 		Title: "put step with no_get",
 		Config: &atc.PutStep{
-			Name:      "some-name",
-			Resource:  "some-resource",
-			Params:    atc.Params{"some": "params"},
-			Tags:      atc.Tags{"tag-1", "tag-2"},
-			Inputs:    &atc.InputsConfig{All: true},
-			NoGet: true,
+			Name:     "some-name",
+			Resource: "some-resource",
+			Params:   atc.Params{"some": "params"},
+			Tags:     atc.Tags{"tag-1", "tag-2"},
+			Inputs:   &atc.InputsConfig{All: true},
+			NoGet:    true,
 		},
 		Inputs: []db.BuildInput{
 			{
@@ -1245,6 +1245,7 @@ var factoryTests = []PlannerTest{
 		Config: &atc.TaskStep{
 			Name:       "some-task",
 			Privileged: true,
+			Hermetic:   true,
 			Config: &atc.TaskConfig{
 				Platform: "linux",
 				Run:      atc.TaskRunConfig{Path: "hello"},
@@ -1264,6 +1265,7 @@ var factoryTests = []PlannerTest{
 			"task": {
 				"name": "some-task",
 				"privileged": true,
+				"hermetic": true,
 				"config": {
 					"platform": "linux",
 					"run": {"path": "hello"}
@@ -1316,6 +1318,7 @@ var factoryTests = []PlannerTest{
 			"task": {
 				"name": "some-task",
 				"privileged": true,
+				"hermetic": false,
 				"config": {
 					"platform": "linux",
 					"run": {"path": "hello"}
@@ -1366,6 +1369,7 @@ var factoryTests = []PlannerTest{
 			"task": {
 				"name": "some-task",
 				"privileged": true,
+				"hermetic": false,
 				"config": {
 					"platform": "linux",
 					"run": {"path": "hello"}

--- a/atc/configvalidate/validate_test.go
+++ b/atc/configvalidate/validate_test.go
@@ -1119,6 +1119,29 @@ var _ = Describe("ValidateConfig", func() {
 				})
 			})
 
+			Context("when a task plan sets hermetic", func() {
+				BeforeEach(func() {
+					job.PlanSequence = append(job.PlanSequence, atc.Step{
+						Config: &atc.TaskStep{
+							Name:     "some-resource",
+							Hermetic: true,
+							Config: &atc.TaskConfig{
+								Params: atc.TaskEnv{
+									"param1": "value1",
+								},
+							},
+						},
+					})
+
+					config.Jobs = append(config.Jobs, job)
+				})
+
+				It("returns a warning", func() {
+					Expect(warnings).To(HaveLen(1))
+					Expect(warnings[0].Message).To(ContainSubstring("specifies `hermetic:` only works against worker containerd runtime"))
+				})
+			})
+
 			Context("when a put plan has refers to a resource that does exist", func() {
 				BeforeEach(func() {
 					job.PlanSequence = append(job.PlanSequence, atc.Step{

--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -423,7 +423,8 @@ func (step *TaskStep) containerSpec(logger lager.Logger, state RunState, imageSp
 		Env:       env,
 		Type:      metadata.Type,
 
-		Dir: metadata.WorkingDirectory,
+		Dir:      metadata.WorkingDirectory,
+		Hermetic: step.plan.Hermetic,
 	}
 
 	var err error

--- a/atc/exec/task_step_test.go
+++ b/atc/exec/task_step_test.go
@@ -279,6 +279,16 @@ var _ = Describe("TaskStep", func() {
 			})
 		})
 
+		Context("when hermetic is configured", func() {
+			BeforeEach(func() {
+				taskPlan.Hermetic = true
+			})
+
+			It("returns the context.Canceled error", func() {
+				Expect(chosenContainer.Spec.Hermetic).To(Equal(true))
+			})
+		})
+
 		Context("when a timeout is configured", func() {
 			BeforeEach(func() {
 				taskPlan.Timeout = "1ms"

--- a/atc/plan.go
+++ b/atc/plan.go
@@ -313,6 +313,10 @@ type TaskPlan struct {
 	// this.
 	Privileged bool `json:"privileged"`
 
+	// Run the task in 'hermetic' mode. If set to true, network traffic from
+	// the container to external will be dropped.
+	Hermetic bool `json:"hermetic"`
+
 	// Worker tags to influence placement of the container.
 	Tags Tags `json:"tags,omitempty"`
 

--- a/atc/public_plan.go
+++ b/atc/public_plan.go
@@ -285,9 +285,11 @@ func (plan TaskPlan) Public() *json.RawMessage {
 	return enc(struct {
 		Name       string `json:"name"`
 		Privileged bool   `json:"privileged"`
+		Hermetic   bool   `json:"hermetic"`
 	}{
 		Name:       plan.Name,
 		Privileged: plan.Privileged,
+		Hermetic:   plan.Hermetic,
 	})
 }
 

--- a/atc/public_plan_test.go
+++ b/atc/public_plan_test.go
@@ -226,6 +226,7 @@ var _ = Describe("Plan", func() {
 							Task: &atc.TaskPlan{
 								Name:       "name",
 								Privileged: true,
+								Hermetic:   true,
 								Tags:       atc.Tags{"tags"},
 								ConfigPath: "some/config/path.yml",
 								Config: &atc.TaskConfig{
@@ -566,7 +567,8 @@ var _ = Describe("Plan", func() {
               "id": "2",
               "task": {
                 "name": "name",
-                "privileged": false
+                "privileged": false,
+								"hermetic": false
               }
             }
           ]
@@ -697,7 +699,8 @@ var _ = Describe("Plan", func() {
 				"id": "5",
 				"task": {
 					"name": "name",
-					"privileged": true
+					"privileged": true,
+					"hermetic": true
 				}
 			},
 			{
@@ -707,14 +710,16 @@ var _ = Describe("Plan", func() {
 						"id": "7",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					},
 					"ensure": {
 						"id": "8",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					}
 				}
@@ -726,14 +731,16 @@ var _ = Describe("Plan", func() {
 						"id": "10",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					},
 					"on_success": {
 						"id": "11",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					}
 				}
@@ -745,14 +752,16 @@ var _ = Describe("Plan", func() {
 						"id": "13",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					},
 					"on_failure": {
 						"id": "14",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					}
 				}
@@ -764,14 +773,16 @@ var _ = Describe("Plan", func() {
 						"id": "16",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					},
 					"on_abort": {
 						"id": "17",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					}
 				}
@@ -783,7 +794,8 @@ var _ = Describe("Plan", func() {
 						"id": "19",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					}
 				}
@@ -795,7 +807,8 @@ var _ = Describe("Plan", func() {
 						"id": "21",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					},
 					"duration": "lol"
@@ -808,7 +821,8 @@ var _ = Describe("Plan", func() {
 						"id": "23",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					}
 				]
@@ -820,21 +834,24 @@ var _ = Describe("Plan", func() {
 						"id": "25",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					},
 					{
 						"id": "26",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					},
 					{
 						"id": "27",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					}
 				]
@@ -846,14 +863,16 @@ var _ = Describe("Plan", func() {
 						"id": "29",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					},
 					"on_abort": {
 						"id": "30",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					}
 				}
@@ -878,14 +897,16 @@ var _ = Describe("Plan", func() {
 						"id": "34",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					},
 					"on_error": {
 						"id": "35",
 						"task": {
 							"name": "name",
-							"privileged": false
+							"privileged": false,
+							"hermetic": false
 						}
 					}
 				}
@@ -898,7 +919,8 @@ var _ = Describe("Plan", func() {
 							"id": "37",
 							"task": {
 								"name": "name",
-								"privileged": false
+								"privileged": false,
+								"hermetic": false
 							}
 						}
 					],

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -123,6 +123,9 @@ type ContainerSpec struct {
 	// CertsBindMount indicates whether or not to mount the worker's Certs
 	// volume onto the container.
 	CertsBindMount bool
+
+	// Hermetic indicates whether or not the container has external network access.
+	Hermetic bool
 }
 
 type BuildStepDelegate interface {

--- a/atc/step_validator.go
+++ b/atc/step_validator.go
@@ -87,6 +87,13 @@ func (validator *StepValidator) VisitTask(plan *TaskStep) error {
 		})
 	}
 
+	if plan.Hermetic {
+		validator.recordWarning(ConfigWarning{
+			Type:    "pipeline",
+			Message: validator.annotate("specifies `hermetic:` only works against worker containerd runtime"),
+		})
+	}
+
 	if plan.Config != nil {
 		validator.pushContext(".config")
 

--- a/atc/steps.go
+++ b/atc/steps.go
@@ -341,6 +341,7 @@ func (step *PutStep) Visit(v StepVisitor) error {
 type TaskStep struct {
 	Name              string            `json:"task"`
 	Privileged        bool              `json:"privileged,omitempty"`
+	Hermetic          bool              `json:"hermetic,omitempty"`
 	ConfigPath        string            `json:"file,omitempty"`
 	Limits            *ContainerLimits  `json:"container_limits,omitempty"`
 	Config            *TaskConfig       `json:"config,omitempty"`

--- a/atc/steps_test.go
+++ b/atc/steps_test.go
@@ -73,6 +73,7 @@ var factoryTests = []StepTest{
 		ConfigYAML: `
 			task: some-task
 			privileged: true
+			hermetic: true
 			config:
 			  platform: linux
 			  run: {path: hello}
@@ -89,6 +90,7 @@ var factoryTests = []StepTest{
 		StepConfig: &atc.TaskStep{
 			Name:       "some-task",
 			Privileged: true,
+			Hermetic:   true,
 			Config: &atc.TaskConfig{
 				Platform: "linux",
 				Run:      atc.TaskRunConfig{Path: "hello"},

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -597,12 +597,16 @@ func (worker *Worker) getBindMounts(ctx context.Context, volumeMounts []runtime.
 	return bindMounts, nil
 }
 
+// All outgoing network traffic will be dropped during runtime
+// depends on if NetOutRul is set
 func (worker *Worker) getNetOut(hermetic bool) []garden.NetOutRule {
-	// All outgoing network traffic will be dropped during runtime
+	// set NetOutRule to nil so worker runtime knows nothing is allowed
+	// to reach outside
 	if hermetic {
 		return nil
 	}
 
+	// set NetOutRule to whitelist all range of IPs
 	return []garden.NetOutRule{
 		{
 			Networks: []garden.IPRange{

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -207,19 +207,33 @@ func (worker *Worker) createGardenContainer(
 
 	logger.Debug("creating-garden-container")
 
-	gardenContainer, err := worker.gardenClient.Create(
-		garden.ContainerSpec{
-			Handle:     creatingContainer.Handle(),
-			RootFSPath: fetchedImage.URL,
-			Privileged: fetchedImage.Privileged,
-			BindMounts: bindMounts,
-			Limits:     toGardenLimits(containerSpec.Limits),
-			Env:        worker.containerEnv(containerSpec, fetchedImage),
-			Properties: garden.Properties{
-				userPropertyName: fetchedImage.Metadata.User,
+	gdnSpec := garden.ContainerSpec{
+		Handle:     creatingContainer.Handle(),
+		RootFSPath: fetchedImage.URL,
+		Privileged: fetchedImage.Privileged,
+		BindMounts: bindMounts,
+		Limits:     toGardenLimits(containerSpec.Limits),
+		Env:        worker.containerEnv(containerSpec, fetchedImage),
+		Properties: garden.Properties{
+			userPropertyName: fetchedImage.Metadata.User,
+		},
+	}
+
+	// By default set NetOutRule to whitelist all range of IPs
+	// otherwise leave NetOutRule to nil so worker runtime knows nothing is allowed
+	// to reach outside
+	if !containerSpec.Hermetic {
+		gdnSpec.NetOut = []garden.NetOutRule{{
+			Networks: []garden.IPRange{
+				{
+					Start: net.ParseIP("0.0.0.0"),
+					End:   net.ParseIP("255.255.255.255"),
+				},
 			},
-			NetOut: worker.getNetOut(containerSpec.Hermetic),
-		})
+		}}
+	}
+
+	gardenContainer, err := worker.gardenClient.Create(gdnSpec)
 	if err != nil {
 		logger.Error("failed-to-create-container-in-garden", err)
 		markContainerAsFailed(logger, creatingContainer)
@@ -239,7 +253,6 @@ func (worker *Worker) containerEnv(containerSpec runtime.ContainerSpec, fetchedI
 	if worker.dbWorker.HTTPSProxyURL() != "" {
 		env = append(env, fmt.Sprintf("https_proxy=%s", worker.dbWorker.HTTPSProxyURL()))
 	}
-
 	if worker.dbWorker.NoProxy() != "" {
 		env = append(env, fmt.Sprintf("no_proxy=%s", worker.dbWorker.NoProxy()))
 	}
@@ -595,28 +608,6 @@ func (worker *Worker) getBindMounts(ctx context.Context, volumeMounts []runtime.
 	}
 
 	return bindMounts, nil
-}
-
-// All outgoing network traffic will be dropped during runtime
-// depends on if NetOutRul is set
-func (worker *Worker) getNetOut(hermetic bool) []garden.NetOutRule {
-	// set NetOutRule to nil so worker runtime knows nothing is allowed
-	// to reach outside
-	if hermetic {
-		return nil
-	}
-
-	// set NetOutRule to whitelist all range of IPs
-	return []garden.NetOutRule{
-		{
-			Networks: []garden.IPRange{
-				{
-					Start: net.ParseIP("0.0.0.0"),
-					End:   net.ParseIP("255.255.255.255"),
-				},
-			},
-		},
-	}
 }
 
 func anyMountTo(path string, volumeMounts []runtime.VolumeMount) bool {

--- a/atc/worker/gardenruntime/worker_test.go
+++ b/atc/worker/gardenruntime/worker_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -1283,6 +1284,60 @@ var _ = Describe("Garden Worker", func() {
 				"/cache":         Not(grt.BePrivileged()),
 				"/etc/ssl/certs": Not(grt.BePrivileged()),
 			}))
+		})
+	})
+
+	FTest("hermetic container spec produces empty NetOut", func() {
+		scenario := Setup(
+			workertest.WithWorkers(
+				grt.NewWorker("worker"),
+			),
+		)
+		worker := scenario.Worker("worker")
+
+		_, _, err := worker.FindOrCreateContainer(
+			ctx,
+			db.NewFixedHandleContainerOwner("my-hermetic-handle"),
+			db.ContainerMetadata{},
+			runtime.ContainerSpec{
+				Hermetic: true,
+			},
+			delegate,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("validating the container was created with NetOut spec", func() {
+			garden := gardenServer(worker)
+			Expect(garden.ContainerList).To(HaveLen(1))
+			Expect(garden.ContainerList[0].Handle()).To(Equal("my-hermetic-handle"))
+			Expect(garden.ContainerList[0].Spec.NetOut).To(HaveLen(0))
+		})
+	})
+
+	FTest("no hermetic container spec produces NetOut with all ip range", func() {
+		scenario := Setup(
+			workertest.WithWorkers(
+				grt.NewWorker("worker"),
+			),
+		)
+		worker := scenario.Worker("worker")
+
+		_, _, err := worker.FindOrCreateContainer(
+			ctx,
+			db.NewFixedHandleContainerOwner("my-non-hermetic-handle"),
+			db.ContainerMetadata{},
+			runtime.ContainerSpec{},
+			delegate,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("validating the container was created with NetOut spec", func() {
+			garden := gardenServer(worker)
+			Expect(garden.ContainerList).To(HaveLen(1))
+			Expect(garden.ContainerList[0].Handle()).To(Equal("my-non-hermetic-handle"))
+			Expect(garden.ContainerList[0].Spec.NetOut[0].Networks).To(HaveLen(1))
+			Expect(garden.ContainerList[0].Spec.NetOut[0].Networks[0].Start).To(Equal(net.ParseIP("0.0.0.0")))
+			Expect(garden.ContainerList[0].Spec.NetOut[0].Networks[0].End).To(Equal(net.ParseIP("255.255.255.255")))
 		})
 	})
 

--- a/atc/worker/gardenruntime/worker_test.go
+++ b/atc/worker/gardenruntime/worker_test.go
@@ -1287,7 +1287,7 @@ var _ = Describe("Garden Worker", func() {
 		})
 	})
 
-	FTest("hermetic container spec produces empty NetOut", func() {
+	Test("hermetic container spec produces empty NetOut", func() {
 		scenario := Setup(
 			workertest.WithWorkers(
 				grt.NewWorker("worker"),
@@ -1314,7 +1314,7 @@ var _ = Describe("Garden Worker", func() {
 		})
 	})
 
-	FTest("no hermetic container spec produces NetOut with all ip range", func() {
+	Test("no hermetic container spec produces NetOut with all ip range", func() {
 		scenario := Setup(
 			workertest.WithWorkers(
 				grt.NewWorker("worker"),

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tedsuo/ifrit v0.0.0-20220120221754-dd274de71113
 	github.com/tedsuo/rata v1.0.1-0.20170830210128-07d200713958
+	github.com/txn2/txeh v1.3.0
 	github.com/vbauerster/mpb/v4 v4.12.2
 	github.com/vito/go-interact v1.0.1
 	github.com/vito/go-sse v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,7 @@ github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgU
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
+github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
@@ -360,6 +361,7 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4 h1:J+ghqo7ZubTzelkjo9hntpTtP/9lUCWH9icEmAW+B+Q=
 github.com/cppforlife/go-semi-semantic v0.0.0-20160921010311-576b6af77ae4/go.mod h1:socxpf5+mELPbosI149vWpNlHK6mbfWFxSWOoSndXR8=
+github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
@@ -1006,6 +1008,7 @@ github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6po
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/russellhaering/goxmldsig v1.2.0 h1:Y6GTTc9Un5hCxSzVz4UIWQ/zuVwDvzJk80guqzwx6Vg=
 github.com/russellhaering/goxmldsig v1.2.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
+github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
@@ -1045,6 +1048,7 @@ github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1053,6 +1057,7 @@ github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/square/certstrap v1.3.0 h1:N9P0ZRA+DjT8pq5fGDj0z3FjafRKnBDypP0QHpMlaAk=
 github.com/square/certstrap v1.3.0/go.mod h1:wGZo9eE1B7WX2GKBn0htJ+B3OuRl2UsdCFySNooy9hU=
@@ -1089,7 +1094,10 @@ github.com/tedsuo/rata v1.0.1-0.20170830210128-07d200713958/go.mod h1:X47ELzhOoL
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/txn2/txeh v1.3.0 h1:vnbv63htVMZCaQgLqVBxKvj2+HHHFUzNW7I183zjg3E=
+github.com/txn2/txeh v1.3.0/go.mod h1:O7M6gUTPeMF+vsa4c4Ipx3JDkOYrruB1Wry8QRsMcw8=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -1176,6 +1184,7 @@ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -1343,6 +1352,7 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/testflight/container_hermetic_test.go
+++ b/testflight/container_hermetic_test.go
@@ -1,0 +1,27 @@
+package testflight_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("A job with a task that has hermetic set to true", func() {
+	It("runs the build", func() {
+
+		setAndUnpausePipeline("fixtures/container_hermetic.yml")
+
+		watch := spawnFly("trigger-job", "-j", inPipeline("container-hermetic-job"), "-w")
+		<-watch.Exited
+
+		if config.Runtime == "containerd" {
+			By("containerd runtime it should failed on installing curl")
+			Expect(watch).To(gbytes.Say("error"))
+			Expect(watch).To(gexec.Exit(5)) // can't download libs for installing curl
+		} else {
+			By("guardian runtime it should success on curl")
+			Expect(watch).To(gbytes.Say("200"))
+		}
+	})
+})

--- a/testflight/fixtures/container_hermetic.yml
+++ b/testflight/fixtures/container_hermetic.yml
@@ -1,0 +1,18 @@
+---
+jobs:
+  - name: container-hermetic-job
+    plan:
+      - task: task-with-hermetic
+        hermetic: true
+        config:
+          platform: linux
+          image_resource:
+            type: mock
+            source: {mirror_self: true}
+          run:
+            path: sh
+            args:
+            - -exc
+            - |
+              apk add curl
+              curl -I https://1.1.1.1

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -43,6 +43,7 @@ type suiteConfig struct {
 	ATCGuestUsername string `json:"atc_guest_username"`
 	ATCGuestPassword string `json:"atc_guest_password"`
 	DownloadCLI      bool   `json:"download_cli"`
+	Runtime          string `json:"runtime"`
 }
 
 var (
@@ -102,6 +103,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	atcGuestPassword := os.Getenv("ATC_GUEST_PASSWORD")
 	if atcGuestPassword != "" {
 		config.ATCGuestPassword = atcGuestPassword
+	}
+
+	workerRuntime := os.Getenv("RUNTIME")
+	if workerRuntime != "" {
+		config.Runtime = workerRuntime
 	}
 
 	payload, err := json.Marshal(config)

--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -2,7 +2,6 @@
 // containerd.
 //
 // See https://containerd.io/, and https://github.com/cloudfoundry/garden.
-//
 package runtime
 
 import (
@@ -26,7 +25,6 @@ import (
 var _ garden.Backend = (*GardenBackend)(nil)
 
 // GardenBackend implements a Garden backend backed by `containerd`.
-//
 type GardenBackend struct {
 	client        libcontainerd.Client
 	killer        Killer
@@ -61,11 +59,9 @@ func WithUserNamespace(s UserNamespace) GardenBackendOpt {
 
 // GardenBackendOpt defines a functional option that when applied, modifies the
 // configuration of a GardenBackend.
-//
 type GardenBackendOpt func(b *GardenBackend)
 
 // WithRootfsManager configures the RootfsManager used by the backend.
-//
 func WithRootfsManager(r RootfsManager) GardenBackendOpt {
 	return func(b *GardenBackend) {
 		b.rootfsManager = r
@@ -73,7 +69,6 @@ func WithRootfsManager(r RootfsManager) GardenBackendOpt {
 }
 
 // WithKiller configures the killer used to terminate tasks.
-//
 func WithKiller(k Killer) GardenBackendOpt {
 	return func(b *GardenBackend) {
 		b.killer = k
@@ -81,7 +76,6 @@ func WithKiller(k Killer) GardenBackendOpt {
 }
 
 // WithNetwork configures the network used by the backend.
-//
 func WithNetwork(n Network) GardenBackendOpt {
 	return func(b *GardenBackend) {
 		b.network = n
@@ -89,7 +83,6 @@ func WithNetwork(n Network) GardenBackendOpt {
 }
 
 // WithMaxContainers configures the max number of containers that can be created
-//
 func WithMaxContainers(limit int) GardenBackendOpt {
 	return func(b *GardenBackend) {
 		b.maxContainers = limit
@@ -140,7 +133,6 @@ type HookFile struct {
 }
 
 // NewGardenBackend instantiates a GardenBackend with tweakable configurations passed as Config.
-//
 func NewGardenBackend(client libcontainerd.Client, opts ...GardenBackendOpt) (b GardenBackend, err error) {
 	if client == nil {
 		err = ErrInvalidInput("nil client")
@@ -247,7 +239,6 @@ func NewGardenBackend(client libcontainerd.Client, opts ...GardenBackendOpt) (b 
 }
 
 // Start initializes the client.
-//
 func (b *GardenBackend) Start() (err error) {
 	err = b.client.Init()
 	if err != nil {
@@ -264,7 +255,6 @@ func (b *GardenBackend) Start() (err error) {
 
 // Stop closes the client's underlying connections and frees any resources
 // associated with it.
-//
 func (b *GardenBackend) Stop() (err error) {
 	err = b.client.Stop()
 	if err != nil {
@@ -275,7 +265,6 @@ func (b *GardenBackend) Stop() (err error) {
 }
 
 // Ping pings the garden server in order to check connectivity.
-//
 func (b *GardenBackend) Ping() (err error) {
 	err = b.client.Version(context.Background())
 	if err != nil {
@@ -286,7 +275,6 @@ func (b *GardenBackend) Ping() (err error) {
 }
 
 // Create creates a new container.
-//
 func (b *GardenBackend) Create(gdnSpec garden.ContainerSpec) (garden.Container, error) {
 	ctx := context.Background()
 
@@ -295,7 +283,7 @@ func (b *GardenBackend) Create(gdnSpec garden.ContainerSpec) (garden.Container, 
 		return nil, fmt.Errorf("new container: %w", err)
 	}
 
-	err = b.startTask(ctx, cont)
+	err = b.startTask(ctx, cont, b.isHermetic(gdnSpec))
 	if err != nil {
 		return nil, fmt.Errorf("starting task: %w", err)
 	}
@@ -305,6 +293,14 @@ func (b *GardenBackend) Create(gdnSpec garden.ContainerSpec) (garden.Container, 
 		b.killer,
 		b.rootfsManager,
 	), nil
+}
+
+func (b *GardenBackend) isHermetic(gdnSpec garden.ContainerSpec) bool {
+	if len(gdnSpec.NetOut) != 0 {
+		return false
+	}
+
+	return true
 }
 
 func (b *GardenBackend) createContainer(ctx context.Context, gdnSpec garden.ContainerSpec) (containerd.Container, error) {
@@ -344,7 +340,7 @@ func (b *GardenBackend) createContainer(ctx context.Context, gdnSpec garden.Cont
 	return b.client.NewContainer(ctx, gdnSpec.Handle, labels, oci)
 }
 
-func (b *GardenBackend) startTask(ctx context.Context, cont containerd.Container) error {
+func (b *GardenBackend) startTask(ctx context.Context, cont containerd.Container, hermetic bool) error {
 	task, err := cont.NewTask(ctx, cio.NullIO, containerd.WithNoNewKeyring)
 	if err != nil {
 		return fmt.Errorf("new task: %w", err)
@@ -355,11 +351,17 @@ func (b *GardenBackend) startTask(ctx context.Context, cont containerd.Container
 		return fmt.Errorf("network add: %w", err)
 	}
 
+	if hermetic {
+		err = b.network.DropContainerTraffic(cont.ID())
+		if err != nil {
+			return fmt.Errorf("network drop container traffic: %w", err)
+		}
+	}
+
 	return task.Start(ctx)
 }
 
 // Destroy gracefully destroys a container.
-//
 func (b *GardenBackend) Destroy(handle string) error {
 	if handle == "" {
 		return ErrInvalidInput("empty handle")
@@ -396,6 +398,11 @@ func (b *GardenBackend) Destroy(handle string) error {
 		return fmt.Errorf("network remove: %w", err)
 	}
 
+	err = b.network.ResumeContainerTraffic(handle)
+	if err != nil {
+		return fmt.Errorf("resume container traffic: %w", err)
+	}
+
 	_, err = task.Delete(ctx, containerd.WithProcessKill)
 	if err != nil {
 		return fmt.Errorf("task remove: %w", err)
@@ -411,7 +418,6 @@ func (b *GardenBackend) Destroy(handle string) error {
 
 // Containers lists all containers filtered by properties (which are ANDed
 // together).
-//
 func (b *GardenBackend) Containers(properties garden.Properties) ([]garden.Container, error) {
 	filters, err := propertiesToFilterList(properties)
 	if err != nil {
@@ -437,7 +443,6 @@ func (b *GardenBackend) Containers(properties garden.Properties) ([]garden.Conta
 }
 
 // Lookup returns the container with the specified handle.
-//
 func (b *GardenBackend) Lookup(handle string) (garden.Container, error) {
 	if handle == "" {
 		return nil, ErrInvalidInput("empty handle")
@@ -456,7 +461,6 @@ func (b *GardenBackend) Lookup(handle string) (garden.Container, error) {
 }
 
 // GraceTime returns the value of the "garden.grace-time" property
-//
 func (b *GardenBackend) GraceTime(container garden.Container) (duration time.Duration) {
 	property, err := container.Property(GraceTimeKey)
 	if err != nil {
@@ -472,28 +476,24 @@ func (b *GardenBackend) GraceTime(container garden.Container) (duration time.Dur
 }
 
 // Capacity - Not Implemented
-//
 func (b *GardenBackend) Capacity() (capacity garden.Capacity, err error) {
 	err = ErrNotImplemented
 	return
 }
 
 // BulkInfo - Not Implemented
-//
 func (b *GardenBackend) BulkInfo(handles []string) (info map[string]garden.ContainerInfoEntry, err error) {
 	err = ErrNotImplemented
 	return
 }
 
 // BulkMetrics - Not Implemented
-//
 func (b *GardenBackend) BulkMetrics(handles []string) (metrics map[string]garden.ContainerMetricsEntry, err error) {
 	err = ErrNotImplemented
 	return
 }
 
 // checkContainerCapacity ensures that Garden.MaxContainers is respected
-//
 func (b *GardenBackend) checkContainerCapacity(ctx context.Context) error {
 	if b.maxContainers == 0 {
 		return nil

--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -393,14 +393,14 @@ func (b *GardenBackend) Destroy(handle string) error {
 		return fmt.Errorf("gracefully killing task: %w", err)
 	}
 
-	err = b.network.Remove(ctx, task, handle)
-	if err != nil {
-		return fmt.Errorf("network remove: %w", err)
-	}
-
 	err = b.network.ResumeContainerTraffic(handle)
 	if err != nil {
 		return fmt.Errorf("resume container traffic: %w", err)
+	}
+
+	err = b.network.Remove(ctx, task, handle)
+	if err != nil {
+		return fmt.Errorf("network remove: %w", err)
 	}
 
 	_, err = task.Delete(ctx, containerd.WithProcessKill)

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -10,7 +10,6 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/go-cni"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/txn2/txeh"
 )
 
 //counterfeiter:generate github.com/containerd/go-cni.CNI
@@ -363,7 +362,7 @@ func (n cniNetwork) restrictHostAccess() error {
 }
 
 func (n cniNetwork) DropContainerTraffic(containerHandle string) error {
-	containerIp, err := n.getContainerIp(containerHandle)
+	containerIp, err := n.store.ContainerIpLookup(containerHandle)
 	if err != nil {
 		return fmt.Errorf("error getting container IP: %w", err)
 	}
@@ -376,26 +375,8 @@ func (n cniNetwork) DropContainerTraffic(containerHandle string) error {
 	return nil
 }
 
-func (n cniNetwork) getContainerIp(containerHandle string) (string, error) {
-	hc := txeh.HostsConfig{ReadFilePath: filepath.Join(containerHandle, "/hosts")}
-	hosts, err := txeh.NewHosts(&hc)
-	if err != nil {
-		return "", fmt.Errorf("error reading hosts file: %w", err)
-	}
-
-	found, ip, _ := hosts.HostAddressLookup(containerHandle)
-	if !found {
-		return "", fmt.Errorf("ip not found for container handle: %s", containerHandle)
-	}
-	if err != nil {
-		return "", fmt.Errorf("error finding container ip: %w", err)
-	}
-
-	return ip, err
-}
-
 func (n cniNetwork) ResumeContainerTraffic(containerHandle string) error {
-	containerIp, err := n.getContainerIp(containerHandle)
+	containerIp, err := n.store.ContainerIpLookup(containerHandle)
 	if err != nil {
 		return fmt.Errorf("error getting container IP: %w", err)
 	}

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -369,7 +369,12 @@ func (n cniNetwork) DropContainerTraffic(containerHandle string) error {
 
 	err = n.ipt.InsertRule(filterTable, "INPUT", 1, "-s", containerIp, "-j", "DROP")
 	if err != nil {
-		return fmt.Errorf("error appending iptables rule to drop container traffic: %w", err)
+		return fmt.Errorf("error inserting iptables rule to INPUT: %w", err)
+	}
+
+	err = n.ipt.InsertRule(filterTable, "FORWARD", 1, "-s", containerIp, "-j", "DROP")
+	if err != nil {
+		return fmt.Errorf("error inserting iptables rule to FORWARD: %w", err)
 	}
 
 	return nil
@@ -383,7 +388,12 @@ func (n cniNetwork) ResumeContainerTraffic(containerHandle string) error {
 
 	err = n.ipt.DeleteRule(filterTable, "INPUT", "-s", containerIp, "-j", "DROP")
 	if err != nil {
-		return fmt.Errorf("error deleting iptables rule to resume container traffic: %w", err)
+		return fmt.Errorf("error deleting iptables rule in INPUT: %w", err)
+	}
+
+	err = n.ipt.DeleteRule(filterTable, "FORWARD", "-s", containerIp, "-j", "DROP")
+	if err != nil {
+		return fmt.Errorf("error deleting iptables rule in FORWARD: %w", err)
 	}
 
 	return nil

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -367,7 +367,7 @@ func (n cniNetwork) DropContainerTraffic(containerHandle string) error {
 		return fmt.Errorf("error getting container IP: %w", err)
 	}
 
-	err = n.ipt.AppendRule(filterTable, "INPUT", "-I", "-s", containerIp, "-j", "DROP")
+	err = n.ipt.InsertRule(filterTable, "INPUT", 1, "-s", containerIp, "-j", "DROP")
 	if err != nil {
 		return fmt.Errorf("error appending iptables rule to drop container traffic: %w", err)
 	}
@@ -381,7 +381,7 @@ func (n cniNetwork) ResumeContainerTraffic(containerHandle string) error {
 		return fmt.Errorf("error getting container IP: %w", err)
 	}
 
-	err = n.ipt.DeleteRule(filterTable, "INPUT", "-I", "-s", containerIp, "-j", "DROP")
+	err = n.ipt.DeleteRule(filterTable, "INPUT", "-s", containerIp, "-j", "DROP")
 	if err != nil {
 		return fmt.Errorf("error deleting iptables rule to resume container traffic: %w", err)
 	}

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -378,11 +378,12 @@ func (s *CNINetworkSuite) TestDropContainerTraffic() {
 	err = network.DropContainerTraffic("some-handle")
 	s.NoError(err)
 
-	s.Equal(s.iptables.AppendRuleCallCount(), 1)
-	table, chain, rulespec := s.iptables.AppendRuleArgsForCall(0)
+	s.Equal(s.iptables.InsertRuleCallCount(), 1)
+	table, chain, pos, rulespec := s.iptables.InsertRuleArgsForCall(0)
 	s.Equal(table, "filter")
 	s.Equal(chain, "INPUT")
-	s.Equal(rulespec, []string{"-I", "-s", "10.8.0.1", "-j", "DROP"})
+	s.Equal(pos, 1)
+	s.Equal(rulespec, []string{"-s", "10.8.0.1", "-j", "DROP"})
 }
 
 func (s *CNINetworkSuite) TestResumeContainerTraffic() {

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -378,12 +378,18 @@ func (s *CNINetworkSuite) TestDropContainerTraffic() {
 	err = network.DropContainerTraffic("some-handle")
 	s.NoError(err)
 
-	s.Equal(s.iptables.InsertRuleCallCount(), 1)
+	s.Equal(s.iptables.InsertRuleCallCount(), 2)
 	table, chain, pos, rulespec := s.iptables.InsertRuleArgsForCall(0)
-	s.Equal(table, "filter")
-	s.Equal(chain, "INPUT")
-	s.Equal(pos, 1)
-	s.Equal(rulespec, []string{"-s", "10.8.0.1", "-j", "DROP"})
+	s.Equal("filter", table)
+	s.Equal("INPUT", chain)
+	s.Equal(1, pos)
+	s.Equal([]string{"-s", "10.8.0.1", "-j", "DROP"}, rulespec)
+
+	table, chain, pos, rulespec = s.iptables.InsertRuleArgsForCall(1)
+	s.Equal("filter", table)
+	s.Equal("FORWARD", chain)
+	s.Equal(1, pos)
+	s.Equal([]string{"-s", "10.8.0.1", "-j", "DROP"}, rulespec)
 }
 
 func (s *CNINetworkSuite) TestResumeContainerTraffic() {
@@ -399,9 +405,14 @@ func (s *CNINetworkSuite) TestResumeContainerTraffic() {
 	err = network.ResumeContainerTraffic("some-handle")
 	s.NoError(err)
 
-	s.Equal(s.iptables.DeleteRuleCallCount(), 1)
+	s.Equal(s.iptables.DeleteRuleCallCount(), 2)
 	table, chain, rulespec := s.iptables.DeleteRuleArgsForCall(0)
-	s.Equal(table, "filter")
-	s.Equal(chain, "INPUT")
-	s.Equal(rulespec, []string{"-I", "-s", "10.8.0.1", "-j", "DROP"})
+	s.Equal("filter", table)
+	s.Equal("INPUT", chain)
+	s.Equal([]string{"-s", "10.8.0.1", "-j", "DROP"}, rulespec)
+
+	table, chain, rulespec = s.iptables.DeleteRuleArgsForCall(1)
+	s.Equal("filter", table)
+	s.Equal("FORWARD", chain)
+	s.Equal([]string{"-s", "10.8.0.1", "-j", "DROP"}, rulespec)
 }

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -375,13 +373,9 @@ func (s *CNINetworkSuite) TestDropContainerTraffic() {
 	)
 	s.NoError(err)
 
-	handle := os.TempDir()
-	content := []byte("10.8.0.1" + " " + handle + "\n")
+	s.store.ContainerIpLookupReturns("10.8.0.1", nil)
 
-	err = os.WriteFile(filepath.Join(handle, "/hosts"), content, 0644)
-	s.NoError(err)
-
-	err = network.DropContainerTraffic(handle)
+	err = network.DropContainerTraffic("some-handle")
 	s.NoError(err)
 
 	s.Equal(s.iptables.AppendRuleCallCount(), 1)
@@ -399,13 +393,9 @@ func (s *CNINetworkSuite) TestResumeContainerTraffic() {
 	)
 	s.NoError(err)
 
-	handle := os.TempDir()
-	content := []byte("10.8.0.1" + " " + handle + "\n")
+	s.store.ContainerIpLookupReturns("10.8.0.1", nil)
 
-	err = os.WriteFile(filepath.Join(handle, "/hosts"), content, 0644)
-	s.NoError(err)
-
-	err = network.ResumeContainerTraffic(handle)
+	err = network.ResumeContainerTraffic("some-handle")
 	s.NoError(err)
 
 	s.Equal(s.iptables.DeleteRuleCallCount(), 1)

--- a/worker/runtime/file_store.go
+++ b/worker/runtime/file_store.go
@@ -10,7 +10,6 @@ import (
 //counterfeiter:generate . FileStore
 
 // FileStore is responsible for managing files associated with containers.
-//
 type FileStore interface {
 	// CreateFile creates a file with a particular content in the store.
 	//

--- a/worker/runtime/file_store.go
+++ b/worker/runtime/file_store.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/txn2/txeh"
 )
 
 //counterfeiter:generate . FileStore
@@ -22,6 +24,9 @@ type FileStore interface {
 	// DeleteFile removes a file previously created in the store.
 	//
 	Delete(name string) (err error)
+
+	// ContainerIpLookup find container IP by container handle in hosts file
+	ContainerIpLookup(handle string) (string, error)
 }
 
 type fileStore struct {
@@ -78,4 +83,24 @@ func (f fileStore) Delete(path string) error {
 	}
 
 	return nil
+}
+
+func (f fileStore) ContainerIpLookup(handle string) (string, error) {
+	absPath := filepath.Join(f.root, handle)
+
+	hc := txeh.HostsConfig{ReadFilePath: filepath.Join(absPath, "/hosts")}
+	hosts, err := txeh.NewHosts(&hc)
+	if err != nil {
+		return "", fmt.Errorf("error reading hosts file: %w", err)
+	}
+
+	found, ip, _ := hosts.HostAddressLookup(handle)
+	if !found {
+		return "", fmt.Errorf("ip not found for container handle: %s", handle)
+	}
+	if err != nil {
+		return "", fmt.Errorf("error finding container ip: %w", err)
+	}
+
+	return ip, nil
 }

--- a/worker/runtime/file_store_test.go
+++ b/worker/runtime/file_store_test.go
@@ -81,3 +81,13 @@ func (s *FileStoreSuite) TestDeleteDir() {
 	_, err = os.Stat(filepath.Dir(fpath))
 	s.True(os.IsNotExist(err))
 }
+
+func (s *FileStoreSuite) TestContainerIpLookup() {
+	_, err := s.store.Create(filepath.Join("some-handle", "/hosts"), []byte("10.80.0.42 some-handle\n"))
+	s.NoError(err)
+
+	ip, err := s.store.ContainerIpLookup("some-handle")
+	s.NoError(err)
+
+	s.Equal(ip, "10.80.0.42")
+}

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-//Note: Some of these integration tests call on functionality that manipulates
-//the iptable rule set. They lack isolation and, therefore, should never be run in parallel.
+// Note: Some of these integration tests call on functionality that manipulates
+// the iptable rule set. They lack isolation and, therefore, should never be run in parallel.
 type IntegrationSuite struct {
 	suite.Suite
 	*require.Assertions
@@ -175,7 +175,6 @@ func (s *IntegrationSuite) TestPing() {
 // 2. running a process in it
 // 3. stopping the process
 // 4. deleting the container
-//
 func (s *IntegrationSuite) TestContainerCreateRunStopedDestroy() {
 	handle := uuid()
 	properties := garden.Properties{"test": uuid()}
@@ -204,7 +203,6 @@ func (s *IntegrationSuite) TestContainerCreateRunStopedDestroy() {
 // TestContainerNetworkEgress aims at verifying that a process that we run in a
 // container that we create through our gardenBackend is able to make requests to
 // external services.
-//
 func (s *IntegrationSuite) TestContainerNetworkEgress() {
 	handle := uuid()
 
@@ -244,7 +242,6 @@ func (s *IntegrationSuite) TestContainerNetworkEgress() {
 // TestContainerNetworkEgressWithRestrictedNetworks verifies that a process that we run in a
 // container that we create through our gardenBackend is not able to reach an address that
 // we have blocked access to.
-//
 func (s *IntegrationSuite) TestContainerNetworkEgressWithRestrictedNetworks() {
 	// Using custom backend, clean up BeforeTest() stuff
 	s.gardenBackend.Stop()
@@ -311,7 +308,6 @@ func (s *IntegrationSuite) TestContainerNetworkEgressWithRestrictedNetworks() {
 
 // TestContainerBlocksHostAccess verifies that a process that we run in a
 // container is not able to reach the host but is able to reach the internet.
-//
 func (s *IntegrationSuite) TestContainerBlocksHostAccess() {
 	handle := uuid()
 	container, err := s.gardenBackend.Create(garden.ContainerSpec{
@@ -409,6 +405,11 @@ func (s *IntegrationSuite) TestContainerAllowsHostAccess() {
 		Handle:     handle,
 		RootFSPath: "raw://" + s.rootfs,
 		Privileged: true,
+		NetOut: []garden.NetOutRule{
+			{
+				Log: true,
+			},
+		},
 	})
 	s.NoError(err)
 
@@ -488,7 +489,6 @@ func (s *IntegrationSuite) TestContainerNetworkHosts() {
 
 // TestRunPrivileged tests whether we're able to run a process in a privileged
 // container.
-//
 func (s *IntegrationSuite) TestRunPrivileged() {
 	s.runToCompletion(true)
 }
@@ -499,7 +499,6 @@ func (s *IntegrationSuite) TestRunPrivileged() {
 // Differently from the privileged counterpart, we first need to change the
 // ownership of the rootfs so the uid 0 inside the container has the permissions
 // to execute the executable in there.
-//
 func (s *IntegrationSuite) TestRunUnprivileged() {
 	maxUid, maxGid, err := runtime.NewUserNamespace().MaxValidIds()
 	s.NoError(err)
@@ -552,7 +551,6 @@ func (s *IntegrationSuite) runToCompletion(privileged bool) {
 // TestRunWithoutTerminalStdinReturnsEOF validates that when running a process
 // with TTY disabled, the stdin stream eventually sends an EOF (so stdin can be
 // read to completion)
-//
 func (s *IntegrationSuite) TestRunWithoutTerminalStdinReturnsEOF() {
 	handle := uuid()
 	container, err := s.gardenBackend.Create(garden.ContainerSpec{
@@ -597,7 +595,6 @@ func (s *IntegrationSuite) TestRunWithoutTerminalStdinReturnsEOF() {
 // the process does not exit.
 //
 // Note that only (Concourse) tasks has TTY enabled
-//
 func (s *IntegrationSuite) TestRunWithTerminalStdinClosed() {
 	handle := uuid()
 	container, err := s.gardenBackend.Create(garden.ContainerSpec{
@@ -640,7 +637,6 @@ func (s *IntegrationSuite) TestRunWithTerminalStdinClosed() {
 
 // TestAttachToUnknownProc verifies that trying to attach to a process that does
 // not exist lead to an error.
-//
 func (s *IntegrationSuite) TestAttachToUnknownProc() {
 	handle := uuid()
 
@@ -665,7 +661,6 @@ func (s *IntegrationSuite) TestAttachToUnknownProc() {
 // TestAttach tries to validate that we're able to start a process in a
 // container, get rid of the original client that originated the process, and
 // then attach back to that process from a new client.
-//
 func (s *IntegrationSuite) TestAttach() {
 	handle := uuid()
 
@@ -722,7 +717,6 @@ func (s *IntegrationSuite) TestAttach() {
 
 // TestCustomDNS verfies that when a network is setup with custom NameServers
 // those NameServers should appear in the container's etc/resolv.conf
-//
 func (s *IntegrationSuite) TestCustomDNS() {
 	namespace := "test-custom-dns"
 	requestTimeout := 3 * time.Second
@@ -789,7 +783,6 @@ func (s *IntegrationSuite) TestCustomDNS() {
 
 // TestUngracefulStop aims at validating that we're giving the process enough
 // opportunity to finish, but that at the same time, we don't wait forever.
-//
 func (s *IntegrationSuite) TestUngracefulStop() {
 	var ungraceful = true
 	s.testStop(ungraceful)
@@ -797,7 +790,6 @@ func (s *IntegrationSuite) TestUngracefulStop() {
 
 // TestGracefulStop aims at validating that we're giving the process enough
 // opportunity to finish, but that at the same time, we don't wait forever.
-//
 func (s *IntegrationSuite) TestGracefulStop() {
 	var ungraceful = false
 	s.testStop(ungraceful)
@@ -832,7 +824,6 @@ func (s *IntegrationSuite) testStop(kill bool) {
 
 // TestMaxContainers aims at making sure that when the max container count is
 // reached, any additional Create calls will fail
-//
 func (s *IntegrationSuite) TestMaxContainers() {
 	namespace := "test-max-containers"
 	requestTimeout := 1 * time.Second
@@ -913,7 +904,6 @@ func (s *IntegrationSuite) TestRequestTimeoutZero() {
 
 // TestPropertiesGetChunked tests that we are able to store arbitrarily long
 // properties, getting around containerd's label length restriction.
-//
 func (s *IntegrationSuite) TestPropertiesGetChunked() {
 	handle := uuid()
 

--- a/worker/runtime/iptables/iptables.go
+++ b/worker/runtime/iptables/iptables.go
@@ -10,6 +10,7 @@ import (
 type Iptables interface {
 	CreateChainOrFlushIfExists(table string, chain string) error
 	AppendRule(table string, chain string, rulespec ...string) error
+	InsertRule(table string, chain string, pos int, rulespec ...string) error
 	DeleteRule(table string, chain string, rulespec ...string) error
 }
 
@@ -39,6 +40,11 @@ func (ipt *iptables) CreateChainOrFlushIfExists(table string, chain string) erro
 
 func (ipt *iptables) AppendRule(table string, chain string, rulespec ...string) error {
 	err := ipt.goipt.Append(table, chain, rulespec...)
+	return err
+}
+
+func (ipt *iptables) InsertRule(table string, chain string, pos int, rulespec ...string) error {
+	err := ipt.goipt.Insert(table, chain, pos, rulespec...)
 	return err
 }
 

--- a/worker/runtime/iptables/iptables.go
+++ b/worker/runtime/iptables/iptables.go
@@ -10,6 +10,7 @@ import (
 type Iptables interface {
 	CreateChainOrFlushIfExists(table string, chain string) error
 	AppendRule(table string, chain string, rulespec ...string) error
+	DeleteRule(table string, chain string, rulespec ...string) error
 }
 
 type iptables struct {
@@ -38,5 +39,10 @@ func (ipt *iptables) CreateChainOrFlushIfExists(table string, chain string) erro
 
 func (ipt *iptables) AppendRule(table string, chain string, rulespec ...string) error {
 	err := ipt.goipt.Append(table, chain, rulespec...)
+	return err
+}
+
+func (ipt *iptables) DeleteRule(table string, chain string, rulespec ...string) error {
+	err := ipt.goipt.DeleteIfExists(table, chain, rulespec...)
 	return err
 }

--- a/worker/runtime/iptables/iptablesfakes/fake_iptables.go
+++ b/worker/runtime/iptables/iptablesfakes/fake_iptables.go
@@ -33,6 +33,19 @@ type FakeIptables struct {
 	createChainOrFlushIfExistsReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteRuleStub        func(string, string, ...string) error
+	deleteRuleMutex       sync.RWMutex
+	deleteRuleArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 []string
+	}
+	deleteRuleReturns struct {
+		result1 error
+	}
+	deleteRuleReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -162,6 +175,69 @@ func (fake *FakeIptables) CreateChainOrFlushIfExistsReturnsOnCall(i int, result1
 	}{result1}
 }
 
+func (fake *FakeIptables) DeleteRule(arg1 string, arg2 string, arg3 ...string) error {
+	fake.deleteRuleMutex.Lock()
+	ret, specificReturn := fake.deleteRuleReturnsOnCall[len(fake.deleteRuleArgsForCall)]
+	fake.deleteRuleArgsForCall = append(fake.deleteRuleArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 []string
+	}{arg1, arg2, arg3})
+	stub := fake.DeleteRuleStub
+	fakeReturns := fake.deleteRuleReturns
+	fake.recordInvocation("DeleteRule", []interface{}{arg1, arg2, arg3})
+	fake.deleteRuleMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeIptables) DeleteRuleCallCount() int {
+	fake.deleteRuleMutex.RLock()
+	defer fake.deleteRuleMutex.RUnlock()
+	return len(fake.deleteRuleArgsForCall)
+}
+
+func (fake *FakeIptables) DeleteRuleCalls(stub func(string, string, ...string) error) {
+	fake.deleteRuleMutex.Lock()
+	defer fake.deleteRuleMutex.Unlock()
+	fake.DeleteRuleStub = stub
+}
+
+func (fake *FakeIptables) DeleteRuleArgsForCall(i int) (string, string, []string) {
+	fake.deleteRuleMutex.RLock()
+	defer fake.deleteRuleMutex.RUnlock()
+	argsForCall := fake.deleteRuleArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeIptables) DeleteRuleReturns(result1 error) {
+	fake.deleteRuleMutex.Lock()
+	defer fake.deleteRuleMutex.Unlock()
+	fake.DeleteRuleStub = nil
+	fake.deleteRuleReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeIptables) DeleteRuleReturnsOnCall(i int, result1 error) {
+	fake.deleteRuleMutex.Lock()
+	defer fake.deleteRuleMutex.Unlock()
+	fake.DeleteRuleStub = nil
+	if fake.deleteRuleReturnsOnCall == nil {
+		fake.deleteRuleReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteRuleReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeIptables) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -169,6 +245,8 @@ func (fake *FakeIptables) Invocations() map[string][][]interface{} {
 	defer fake.appendRuleMutex.RUnlock()
 	fake.createChainOrFlushIfExistsMutex.RLock()
 	defer fake.createChainOrFlushIfExistsMutex.RUnlock()
+	fake.deleteRuleMutex.RLock()
+	defer fake.deleteRuleMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/worker/runtime/iptables/iptablesfakes/fake_iptables.go
+++ b/worker/runtime/iptables/iptablesfakes/fake_iptables.go
@@ -46,6 +46,20 @@ type FakeIptables struct {
 	deleteRuleReturnsOnCall map[int]struct {
 		result1 error
 	}
+	InsertRuleStub        func(string, string, int, ...string) error
+	insertRuleMutex       sync.RWMutex
+	insertRuleArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 int
+		arg4 []string
+	}
+	insertRuleReturns struct {
+		result1 error
+	}
+	insertRuleReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -238,6 +252,70 @@ func (fake *FakeIptables) DeleteRuleReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeIptables) InsertRule(arg1 string, arg2 string, arg3 int, arg4 ...string) error {
+	fake.insertRuleMutex.Lock()
+	ret, specificReturn := fake.insertRuleReturnsOnCall[len(fake.insertRuleArgsForCall)]
+	fake.insertRuleArgsForCall = append(fake.insertRuleArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 int
+		arg4 []string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.InsertRuleStub
+	fakeReturns := fake.insertRuleReturns
+	fake.recordInvocation("InsertRule", []interface{}{arg1, arg2, arg3, arg4})
+	fake.insertRuleMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeIptables) InsertRuleCallCount() int {
+	fake.insertRuleMutex.RLock()
+	defer fake.insertRuleMutex.RUnlock()
+	return len(fake.insertRuleArgsForCall)
+}
+
+func (fake *FakeIptables) InsertRuleCalls(stub func(string, string, int, ...string) error) {
+	fake.insertRuleMutex.Lock()
+	defer fake.insertRuleMutex.Unlock()
+	fake.InsertRuleStub = stub
+}
+
+func (fake *FakeIptables) InsertRuleArgsForCall(i int) (string, string, int, []string) {
+	fake.insertRuleMutex.RLock()
+	defer fake.insertRuleMutex.RUnlock()
+	argsForCall := fake.insertRuleArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeIptables) InsertRuleReturns(result1 error) {
+	fake.insertRuleMutex.Lock()
+	defer fake.insertRuleMutex.Unlock()
+	fake.InsertRuleStub = nil
+	fake.insertRuleReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeIptables) InsertRuleReturnsOnCall(i int, result1 error) {
+	fake.insertRuleMutex.Lock()
+	defer fake.insertRuleMutex.Unlock()
+	fake.InsertRuleStub = nil
+	if fake.insertRuleReturnsOnCall == nil {
+		fake.insertRuleReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.insertRuleReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeIptables) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -247,6 +325,8 @@ func (fake *FakeIptables) Invocations() map[string][][]interface{} {
 	defer fake.createChainOrFlushIfExistsMutex.RUnlock()
 	fake.deleteRuleMutex.RLock()
 	defer fake.deleteRuleMutex.RUnlock()
+	fake.insertRuleMutex.RLock()
+	defer fake.insertRuleMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/worker/runtime/network.go
+++ b/worker/runtime/network.go
@@ -26,4 +26,10 @@ type Network interface {
 	// Removes a task from the network.
 	//
 	Remove(ctx context.Context, task containerd.Task, handle string) (err error)
+
+	// Drop all incoming traffic from a container
+	DropContainerTraffic(containerHandle string) (err error)
+
+	// Resume all incoming traffic from a container
+	ResumeContainerTraffic(containerHandle string) (err error)
 }

--- a/worker/runtime/runtimefakes/fake_file_store.go
+++ b/worker/runtime/runtimefakes/fake_file_store.go
@@ -20,6 +20,19 @@ type FakeFileStore struct {
 	appendReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ContainerIpLookupStub        func(string) (string, error)
+	containerIpLookupMutex       sync.RWMutex
+	containerIpLookupArgsForCall []struct {
+		arg1 string
+	}
+	containerIpLookupReturns struct {
+		result1 string
+		result2 error
+	}
+	containerIpLookupReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	CreateStub        func(string, []byte) (string, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
@@ -114,6 +127,70 @@ func (fake *FakeFileStore) AppendReturnsOnCall(i int, result1 error) {
 	fake.appendReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeFileStore) ContainerIpLookup(arg1 string) (string, error) {
+	fake.containerIpLookupMutex.Lock()
+	ret, specificReturn := fake.containerIpLookupReturnsOnCall[len(fake.containerIpLookupArgsForCall)]
+	fake.containerIpLookupArgsForCall = append(fake.containerIpLookupArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ContainerIpLookupStub
+	fakeReturns := fake.containerIpLookupReturns
+	fake.recordInvocation("ContainerIpLookup", []interface{}{arg1})
+	fake.containerIpLookupMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeFileStore) ContainerIpLookupCallCount() int {
+	fake.containerIpLookupMutex.RLock()
+	defer fake.containerIpLookupMutex.RUnlock()
+	return len(fake.containerIpLookupArgsForCall)
+}
+
+func (fake *FakeFileStore) ContainerIpLookupCalls(stub func(string) (string, error)) {
+	fake.containerIpLookupMutex.Lock()
+	defer fake.containerIpLookupMutex.Unlock()
+	fake.ContainerIpLookupStub = stub
+}
+
+func (fake *FakeFileStore) ContainerIpLookupArgsForCall(i int) string {
+	fake.containerIpLookupMutex.RLock()
+	defer fake.containerIpLookupMutex.RUnlock()
+	argsForCall := fake.containerIpLookupArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeFileStore) ContainerIpLookupReturns(result1 string, result2 error) {
+	fake.containerIpLookupMutex.Lock()
+	defer fake.containerIpLookupMutex.Unlock()
+	fake.ContainerIpLookupStub = nil
+	fake.containerIpLookupReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeFileStore) ContainerIpLookupReturnsOnCall(i int, result1 string, result2 error) {
+	fake.containerIpLookupMutex.Lock()
+	defer fake.containerIpLookupMutex.Unlock()
+	fake.ContainerIpLookupStub = nil
+	if fake.containerIpLookupReturnsOnCall == nil {
+		fake.containerIpLookupReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.containerIpLookupReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeFileStore) Create(arg1 string, arg2 []byte) (string, error) {
@@ -252,6 +329,8 @@ func (fake *FakeFileStore) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.appendMutex.RLock()
 	defer fake.appendMutex.RUnlock()
+	fake.containerIpLookupMutex.RLock()
+	defer fake.containerIpLookupMutex.RUnlock()
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
 	fake.deleteMutex.RLock()

--- a/worker/runtime/runtimefakes/fake_network.go
+++ b/worker/runtime/runtimefakes/fake_network.go
@@ -24,6 +24,17 @@ type FakeNetwork struct {
 	addReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DropContainerTrafficStub        func(string) error
+	dropContainerTrafficMutex       sync.RWMutex
+	dropContainerTrafficArgsForCall []struct {
+		arg1 string
+	}
+	dropContainerTrafficReturns struct {
+		result1 error
+	}
+	dropContainerTrafficReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RemoveStub        func(context.Context, containerd.Task, string) error
 	removeMutex       sync.RWMutex
 	removeArgsForCall []struct {
@@ -35,6 +46,17 @@ type FakeNetwork struct {
 		result1 error
 	}
 	removeReturnsOnCall map[int]struct {
+		result1 error
+	}
+	ResumeContainerTrafficStub        func(string) error
+	resumeContainerTrafficMutex       sync.RWMutex
+	resumeContainerTrafficArgsForCall []struct {
+		arg1 string
+	}
+	resumeContainerTrafficReturns struct {
+		result1 error
+	}
+	resumeContainerTrafficReturnsOnCall map[int]struct {
 		result1 error
 	}
 	SetupHostNetworkStub        func() error
@@ -127,6 +149,67 @@ func (fake *FakeNetwork) AddReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeNetwork) DropContainerTraffic(arg1 string) error {
+	fake.dropContainerTrafficMutex.Lock()
+	ret, specificReturn := fake.dropContainerTrafficReturnsOnCall[len(fake.dropContainerTrafficArgsForCall)]
+	fake.dropContainerTrafficArgsForCall = append(fake.dropContainerTrafficArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.DropContainerTrafficStub
+	fakeReturns := fake.dropContainerTrafficReturns
+	fake.recordInvocation("DropContainerTraffic", []interface{}{arg1})
+	fake.dropContainerTrafficMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeNetwork) DropContainerTrafficCallCount() int {
+	fake.dropContainerTrafficMutex.RLock()
+	defer fake.dropContainerTrafficMutex.RUnlock()
+	return len(fake.dropContainerTrafficArgsForCall)
+}
+
+func (fake *FakeNetwork) DropContainerTrafficCalls(stub func(string) error) {
+	fake.dropContainerTrafficMutex.Lock()
+	defer fake.dropContainerTrafficMutex.Unlock()
+	fake.DropContainerTrafficStub = stub
+}
+
+func (fake *FakeNetwork) DropContainerTrafficArgsForCall(i int) string {
+	fake.dropContainerTrafficMutex.RLock()
+	defer fake.dropContainerTrafficMutex.RUnlock()
+	argsForCall := fake.dropContainerTrafficArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeNetwork) DropContainerTrafficReturns(result1 error) {
+	fake.dropContainerTrafficMutex.Lock()
+	defer fake.dropContainerTrafficMutex.Unlock()
+	fake.DropContainerTrafficStub = nil
+	fake.dropContainerTrafficReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeNetwork) DropContainerTrafficReturnsOnCall(i int, result1 error) {
+	fake.dropContainerTrafficMutex.Lock()
+	defer fake.dropContainerTrafficMutex.Unlock()
+	fake.DropContainerTrafficStub = nil
+	if fake.dropContainerTrafficReturnsOnCall == nil {
+		fake.dropContainerTrafficReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.dropContainerTrafficReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeNetwork) Remove(arg1 context.Context, arg2 containerd.Task, arg3 string) error {
 	fake.removeMutex.Lock()
 	ret, specificReturn := fake.removeReturnsOnCall[len(fake.removeArgsForCall)]
@@ -186,6 +269,67 @@ func (fake *FakeNetwork) RemoveReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.removeReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeNetwork) ResumeContainerTraffic(arg1 string) error {
+	fake.resumeContainerTrafficMutex.Lock()
+	ret, specificReturn := fake.resumeContainerTrafficReturnsOnCall[len(fake.resumeContainerTrafficArgsForCall)]
+	fake.resumeContainerTrafficArgsForCall = append(fake.resumeContainerTrafficArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ResumeContainerTrafficStub
+	fakeReturns := fake.resumeContainerTrafficReturns
+	fake.recordInvocation("ResumeContainerTraffic", []interface{}{arg1})
+	fake.resumeContainerTrafficMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeNetwork) ResumeContainerTrafficCallCount() int {
+	fake.resumeContainerTrafficMutex.RLock()
+	defer fake.resumeContainerTrafficMutex.RUnlock()
+	return len(fake.resumeContainerTrafficArgsForCall)
+}
+
+func (fake *FakeNetwork) ResumeContainerTrafficCalls(stub func(string) error) {
+	fake.resumeContainerTrafficMutex.Lock()
+	defer fake.resumeContainerTrafficMutex.Unlock()
+	fake.ResumeContainerTrafficStub = stub
+}
+
+func (fake *FakeNetwork) ResumeContainerTrafficArgsForCall(i int) string {
+	fake.resumeContainerTrafficMutex.RLock()
+	defer fake.resumeContainerTrafficMutex.RUnlock()
+	argsForCall := fake.resumeContainerTrafficArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeNetwork) ResumeContainerTrafficReturns(result1 error) {
+	fake.resumeContainerTrafficMutex.Lock()
+	defer fake.resumeContainerTrafficMutex.Unlock()
+	fake.ResumeContainerTrafficStub = nil
+	fake.resumeContainerTrafficReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeNetwork) ResumeContainerTrafficReturnsOnCall(i int, result1 error) {
+	fake.resumeContainerTrafficMutex.Lock()
+	defer fake.resumeContainerTrafficMutex.Unlock()
+	fake.ResumeContainerTrafficStub = nil
+	if fake.resumeContainerTrafficReturnsOnCall == nil {
+		fake.resumeContainerTrafficReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.resumeContainerTrafficReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -312,8 +456,12 @@ func (fake *FakeNetwork) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.addMutex.RLock()
 	defer fake.addMutex.RUnlock()
+	fake.dropContainerTrafficMutex.RLock()
+	defer fake.dropContainerTrafficMutex.RUnlock()
 	fake.removeMutex.RLock()
 	defer fake.removeMutex.RUnlock()
+	fake.resumeContainerTrafficMutex.RLock()
+	defer fake.resumeContainerTrafficMutex.RUnlock()
 	fake.setupHostNetworkMutex.RLock()
 	defer fake.setupHostNetworkMutex.RUnlock()
 	fake.setupMountsMutex.RLock()


### PR DESCRIPTION
This PR implements a new field for task step `Hermetic: bool`. When set to true, the container that running the task will NOT have external network access, aka the container's outgoing traffic through worker host network gateway will be dropped.

Noted, only `containerd` runtime supports hermetic container. For other runtimes (houdini and guardian) it will be just no-op.

## Changes proposed by this PR



<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [ ] update Concourse doc on concourse-ci.org

## Notes to reviewer

It is possible to implement hermetic container for `guardian` runtime. Based on `deny_networks` flag [available](https://github.com/cloudfoundry/garden/issues/34#issuecomment-97941187) on garden backend. We could deny networks access for all IPs when starting up garden backend, and whitelist those IPs (like the change in atc/worker in this PR) later per container creation. 

## Release Note
 - add `Hermetic: bool` to task step configuration. When set to true, the task container will be running without external network access. Only worker runtime `containerd` supports this feature. There will be a reminder as warning when setting a pipeline contains task step that sets `hermetic: true`.
