### PR TITLE
add Vault path-prefixes config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,7 +481,7 @@ and suite runner of choice for Go code. You'll need to install the `ginkgo` CLI
 to run the unit tests and `testflight`:
 
 ```sh
-$ go get github.com/onsi/ginkgo/ginkgo
+$ go install github.com/onsi/ginkgo/ginkgo
 ```
 
 We use [Counterfeiter](https://github.com/maxbrunsfeld/counterfeiter) to generate

--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -265,6 +265,7 @@ var _ = Describe("Pipelines API", func() {
           "vault": {
             "url": "` + credServer.URL() + `",
             "path_prefix": "testpath",
+			"path_prefixes": null,
             "lookup_templates": ["/{{.Team}}/{{.Pipeline}}/{{.Secret}}", "/{{.Team}}/{{.Secret}}"],
 			"shared_path": "",
 			"namespace": "testnamespace",
@@ -344,6 +345,7 @@ var _ = Describe("Pipelines API", func() {
 							"method": "/health"
 						},
 						"path_prefix": "some-prefix",
+						"path_prefixes": null,
 						"uaa_client_id": "client-id"
 						}
 					}`))
@@ -362,18 +364,20 @@ var _ = Describe("Pipelines API", func() {
 							} `json:"response"`
 							Method string `json:"method"`
 						} `json:"health"`
-						PathPrefix  string `json:"path_prefix"`
-						UAAClientId string `json:"uaa_client_id"`
+						PathPrefix   string   `json:"path_prefix"`
+						PathPrefixes []string `json:"path_prefixes"`
+						UAAClientId  string   `json:"uaa_client_id"`
 					} `json:"credhub"`
 				}
 
 				BeforeEach(func() {
 					credhubManager := &credhub.CredHubManager{
-						URL:        "http://wrong.inexistent.tld",
-						PathPrefix: "some-prefix",
-						TLS:        tls,
-						UAA:        uaa,
-						Client:     &credhub.LazyCredhub{},
+						URL:          "http://wrong.inexistent.tld",
+						PathPrefix:   "some-prefix",
+						PathPrefixes: []string{},
+						TLS:          tls,
+						UAA:          uaa,
+						Client:       &credhub.LazyCredhub{},
 					}
 
 					credsManagers["credhub"] = credhubManager

--- a/atc/creds/credhub/credhub_factory.go
+++ b/atc/creds/credhub/credhub_factory.go
@@ -6,23 +6,26 @@ import (
 )
 
 type credhubFactory struct {
-	credhub *LazyCredhub
-	logger  lager.Logger
-	prefix  string
+	credhub  *LazyCredhub
+	logger   lager.Logger
+	prefix   string
+	prefixes []string
 }
 
-func NewCredHubFactory(logger lager.Logger, credhub *LazyCredhub, prefix string) *credhubFactory {
+func NewCredHubFactory(logger lager.Logger, credhub *LazyCredhub, prefix string, prefixes []string) *credhubFactory {
 	return &credhubFactory{
-		credhub: credhub,
-		logger:  logger,
-		prefix:  prefix,
+		credhub:  credhub,
+		logger:   logger,
+		prefix:   prefix,
+		prefixes: prefixes,
 	}
 }
 
 func (factory *credhubFactory) NewSecrets() creds.Secrets {
 	return &CredHubAtc{
-		CredHub: factory.credhub,
-		logger:  factory.logger,
-		prefix:  factory.prefix,
+		CredHub:  factory.credhub,
+		logger:   factory.logger,
+		prefix:   factory.prefix,
+		prefixes: factory.prefixes,
 	}
 }

--- a/atc/creds/credhub/manager.go
+++ b/atc/creds/credhub/manager.go
@@ -16,7 +16,8 @@ import (
 type CredHubManager struct {
 	URL string `long:"url" description:"CredHub server address used to access secrets."`
 
-	PathPrefix string `long:"path-prefix" default:"/concourse" description:"Path under which to namespace credential lookup."`
+	PathPrefix   string   `long:"path-prefix" default:"/concourse" description:"Path under which to namespace credential lookup."`
+	PathPrefixes []string `long:"path-prefixes" description:"Multiple paths under which to namespace credential lookup."`
 
 	TLS    TLS
 	UAA    UAA
@@ -44,6 +45,7 @@ func (manager *CredHubManager) MarshalJSON() ([]byte, error) {
 	response := map[string]interface{}{
 		"url":           manager.URL,
 		"path_prefix":   manager.PathPrefix,
+		"path_prefixes": manager.PathPrefixes,
 		"ca_certs":      manager.TLS.CACerts,
 		"uaa_client_id": manager.UAA.ClientId,
 		"health":        health,
@@ -149,7 +151,7 @@ func (manager CredHubManager) Health() (*creds.HealthResponse, error) {
 }
 
 func (manager CredHubManager) NewSecretsFactory(logger lager.Logger) (creds.SecretsFactory, error) {
-	return NewCredHubFactory(logger, manager.Client, manager.PathPrefix), nil
+	return NewCredHubFactory(logger, manager.Client, manager.PathPrefix, manager.PathPrefixes), nil
 }
 
 type LazyCredhub struct {

--- a/atc/creds/vault/vault.go
+++ b/atc/creds/vault/vault.go
@@ -26,6 +26,7 @@ type SecretReader interface {
 type Vault struct {
 	SecretReader    SecretReader
 	Prefix          string
+	Prefixes        []string
 	LookupTemplates []*creds.SecretTemplate
 	SharedPath      string
 	LoggedIn        <-chan struct{}
@@ -40,11 +41,13 @@ func (v Vault) NewSecretLookupPaths(teamName string, pipelineName string, allowR
 			lookupPaths = append(lookupPaths, lPath)
 		}
 	}
-	if v.SharedPath != "" {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(v.Prefix, v.SharedPath)+"/"))
-	}
-	if allowRootPath {
-		lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(v.Prefix+"/"))
+	for _, prefix := range getPrefixes(v.Prefixes, v.Prefix) {
+		if v.SharedPath != "" {
+			lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(path.Join(prefix, v.SharedPath)+"/"))
+		}
+		if allowRootPath {
+			lookupPaths = append(lookupPaths, creds.NewSecretLookupWithPrefix(prefix+"/"))
+		}
 	}
 	return lookupPaths
 }

--- a/atc/creds/vault/vault_factory.go
+++ b/atc/creds/vault/vault_factory.go
@@ -10,16 +10,18 @@ import (
 type vaultFactory struct {
 	sr              SecretReader
 	prefix          string
+	prefixes        []string
 	sharedPath      string
 	lookupTemplates []*creds.SecretTemplate
 	loggedIn        <-chan struct{}
 	loginTimeout    time.Duration
 }
 
-func NewVaultFactory(sr SecretReader, loginTimeout time.Duration, loggedIn <-chan struct{}, prefix string, lookupTemplates []*creds.SecretTemplate, sharedPath string) *vaultFactory {
+func NewVaultFactory(sr SecretReader, loginTimeout time.Duration, loggedIn <-chan struct{}, prefix string, prefixes []string, lookupTemplates []*creds.SecretTemplate, sharedPath string) *vaultFactory {
 	factory := &vaultFactory{
 		sr:              sr,
 		prefix:          prefix,
+		prefixes:        prefixes,
 		lookupTemplates: lookupTemplates,
 		sharedPath:      sharedPath,
 		loggedIn:        loggedIn,
@@ -33,6 +35,7 @@ func (factory *vaultFactory) NewSecrets() creds.Secrets {
 	return &Vault{
 		SecretReader:    factory.sr,
 		Prefix:          factory.prefix,
+		Prefixes:        factory.prefixes,
 		LookupTemplates: factory.lookupTemplates,
 		SharedPath:      factory.sharedPath,
 		LoginTimeout:    factory.loginTimeout,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements
-->

## Changes proposed by this PR

_Closing https://github.com/concourse/concourse/pull/8712 in favor of this approach. Copying the bulk of the description here because the intent is the same._

Support for Vault kv2 was added in https://github.com/concourse/concourse/pull/6115. That supports both kv1 and kv2, but as [mentioned in the docs](https://concourse-ci.org/vault-credential-manager.html#configuring-the-secrets-engine), only a single prefix path is supported:
> Concourse is currently limited to looking under a single path, meaning enabling only one secrets engine is supported: `kv`, or `kv_v2`.

This PR enables multiple prefix paths and then does the lookup of the secrets in each, for each [path template](https://concourse-ci.org/vault-credential-manager.html#vault-lookup-templates) configured.

The idea in our org is to enable a smooth transition of teams from kv1 -> kv2. Without this we'd need to do a big bang release of ensuring all teams have migrated their secrets to the new engine, then update the Concourse config to point at kv2. Instead with this change we can support both, and let someone else herd the cats. 🙂 

Note this would potentially double the number of API calls to Vault. I don't see that's a reason to not do it, but something to call out in the docs at a minimum.

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] support multiple Vault prefix paths
* [x] limited manual testing 
* [x] unit or other tests
* [ ] update docs

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

Believe the approach in #8712 isn't viable due to `var_sources`. Instead trying the creation of a separate `--path-prefixes` config option. I tested locally with the following config:
```yaml
      CONCOURSE_VAULT_PATH_PREFIX: ""
      CONCOURSE_VAULT_PATH_PREFIXES: "/kv2,/kv1"
```

Quick example of local testing:
```yaml
jobs:
- name: hiya
  plan:
  - task: simple-task
    config:
      platform: linux
      image_resource:
        type: registry-image
        source: { repository: busybox }
      run:
        path: echo
        args: ["Hello world!", ((kv2-test.hello)), ((kv1-test.hello))]
```
Where `kv2-test` secret only exists in the kv2 path, and `kv1-test` secret only exists in the kv1 path. This results in `Hello world! Hello from kv2! Hello from kv1!`

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Add support for multiple Vault path prefixes. This allows for simultaneous support of multiple secret engines, allowing teams to transition between Vault locations at their own pace.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
