### PR TITLE
fix ginkgo warning and k8s topgun failure

### DIFF
--- a/atc/scheduler/algorithm/table_helpers_test.go
+++ b/atc/scheduler/algorithm/table_helpers_test.go
@@ -108,9 +108,9 @@ func (mapping StringMapping) Name(id int) string {
 const CurrentJobName = "current"
 
 func (example Example) Run() {
-	currentTest := ginkgo.CurrentGinkgoTestDescription()
+	currentTest := ginkgo.CurrentSpecReport()
 
-	ctx, span := tracing.StartSpan(context.Background(), currentTest.TestText, tracing.Attrs{})
+	ctx, span := tracing.StartSpan(context.Background(), currentTest.LeafNodeText, tracing.Attrs{})
 	defer span.End()
 
 	setup := setupDB{

--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -157,9 +157,9 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	test := CurrentGinkgoTestDescription()
-	if test.Failed {
-		dir := filepath.Join("/tmp/logs", fmt.Sprintf("%s.%d", filepath.Base(test.FileName), test.LineNumber))
+	test := CurrentSpecReport()
+	if test.Failed() {
+		dir := filepath.Join("/tmp/logs", fmt.Sprintf("%s.%d", filepath.Base(test.FileName()), test.LineNumber()))
 
 		err := os.MkdirAll(dir, 0755)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The k8s test for failure case is no long valid since the node on k8s topgun cluster is now upgraded to GKE 1.25.5 that will make the deployment success.


