### PR TITLE
Fixing the order-pipelines command to allow for selecting teams

### DIFF
--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -39,11 +39,18 @@ func (command *OrderPipelinesCommand) Execute(args []string) error {
 	var orderedNames []string
 	if command.Alphabetical {
 		seen := map[string]bool{}
-		ps, err := target.Team().ListPipelines()
+		teamName := command.Team.Name()
+		if teamName == "" {
+			teamName = target.Team().Name()
+		}
+		team, err := target.FindTeam(teamName)
 		if err != nil {
 			return err
 		}
-
+		ps, err := team.ListPipelines()
+		if err != nil {
+			return err
+		}
 		for _, p := range ps {
 			if !seen[p.Name] {
 				seen[p.Name] = true

--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/rc"
-	"github.com/concourse/concourse/go-concourse/concourse"
 )
 
 var ErrMissingPipelineName = errors.New("Need to specify at least one pipeline name")
@@ -35,15 +34,18 @@ func (command *OrderPipelinesCommand) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-
+	teamName := command.Team.Name()
+	if teamName == "" {
+		teamName = target.Team().Name()
+	}
+	team, err := target.FindTeam(teamName)
+	if err != nil {
+		return err
+	}
 	var orderedNames []string
 	if command.Alphabetical {
 		seen := map[string]bool{}
-		teamName := command.Team.Name()
-		if teamName == "" {
-			teamName = target.Team().Name()
-		}
-		team, err := target.FindTeam(teamName)
+
 		if err != nil {
 			return err
 		}
@@ -65,12 +67,6 @@ func (command *OrderPipelinesCommand) Execute(args []string) error {
 			}
 		}
 		orderedNames = command.Pipelines
-	}
-
-	var team concourse.Team
-	team, err = command.Team.LoadTeam(target)
-	if err != nil {
-		return err
 	}
 
 	err = team.OrderingPipelines(orderedNames)

--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -34,21 +34,16 @@ func (command *OrderPipelinesCommand) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	teamName := command.Team.Name()
-	if teamName == "" {
-		teamName = target.Team().Name()
-	}
-	team, err := target.FindTeam(teamName)
+
+	team, err := command.Team.LoadTeam(target)
 	if err != nil {
 		return err
 	}
+
 	var orderedNames []string
 	if command.Alphabetical {
 		seen := map[string]bool{}
 
-		if err != nil {
-			return err
-		}
 		ps, err := team.ListPipelines()
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

Allows users to specify the team that they are ordering pipelines for. Currently it errors out since it uses the default team no matter what when listing pipelines.


* [x] fixing fly ordering pipeline logic to correctly default or used passed in team param.


## Notes to reviewer

Should be relatively straightforward to test this out. Verified working against a version 7.9.0 concourse instance.

## Release Note
- fix order-pipelines command