### PR TITLE
add events logging when pod is not running for k8s topgun

### DIFF
--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -337,6 +337,13 @@ func getPods(namespace string, listOptions metav1.ListOptions) []corev1.Pod {
 	return pods.Items
 }
 
+func getNotRunningPodLogs() {
+	events, _ := kubeClient.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: "status.phase!=Running", TypeMeta: metav1.TypeMeta{Kind: "Pod"}})
+	for _, item := range events.Items {
+		fmt.Println(item)
+	}
+}
+
 func isPodReady(p corev1.Pod) bool {
 	for _, condition := range p.Status.Conditions {
 		if condition.Type != corev1.ContainersReady {
@@ -355,6 +362,7 @@ func waitAllPodsInNamespaceToBeReady(namespace string) {
 		actualPods := getPods(namespace, metav1.ListOptions{FieldSelector: "status.phase=Running"})
 
 		if len(expectedPods) != len(actualPods) {
+			getNotRunningPodLogs()
 			return false
 		}
 


### PR DESCRIPTION
## Changes proposed by this PR

Currently when a test fails in [k8s topgun test](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/k8s-topgun) with error like

```
  [FAILED] Timed out after 900.000s.

  expected all pods to be running

  Expected

      <bool>: false

  to be true

  In [It] at: github.com/concourse/concourse/topgun/k8s/k8s_suite_test.go:369
```

It is hard to debug since the build logs don't include the pod initializing events that usually contains the reason of the failure e.g. docker image pull failure. 

The PR adds the method to log the pod events when pod fails to run.

* [x] done
* [ ] todo


## Release Note
 - Add method in k8s topgun test to log pod events when it is being initialized. 

