### PR TITLE
Optimize db notify.

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1078,7 +1078,7 @@ func (cmd *RunCommand) backendComponents(
 		policyChecker,
 	)
 
-	buildEventWatcher, err := db.NewBuildEventWatcher(logger, dbConn.Bus())
+	buildEventWatcher, err := db.NewBuildBeingWatchedMarker(logger, dbConn.Bus())
 	if err != nil {
 		return nil, err
 	}

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1162,8 +1162,8 @@ func (cmd *RunCommand) backendComponents(
 		},
 		{
 			Component: atc.Component{
-				Name:     "beingWatched",
-				Interval: 30 * time.Second,
+				Name:     atc.ComponentBeingWatchedBuildMarker,
+				Interval: 10 * time.Minute,
 			},
 			Runnable: buildEventWatcher,
 		},

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1078,6 +1078,11 @@ func (cmd *RunCommand) backendComponents(
 		policyChecker,
 	)
 
+	buildEventWatcher, err := db.NewBuildEventWatcher(logger, dbConn.Bus())
+	if err != nil {
+		return nil, err
+	}
+
 	// In case that a user configures resource-checking-interval, but forgets to
 	// configure resource-with-webhook-checking-interval, keep both checking-
 	// intervals consistent. Even if both intervals are configured, there is no
@@ -1154,6 +1159,13 @@ func (cmd *RunCommand) backendComponents(
 				),
 				syslogDrainConfigured,
 			),
+		},
+		{
+			Component: atc.Component{
+				Name:     "beingWatched",
+				Interval: 30 * time.Second,
+			},
+			Runnable: buildEventWatcher,
 		},
 	}
 

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1078,7 +1078,7 @@ func (cmd *RunCommand) backendComponents(
 		policyChecker,
 	)
 
-	buildEventWatcher, err := db.NewBuildBeingWatchedMarker(logger, dbConn.Bus())
+	buildEventWatcher, err := db.NewBuildBeingWatchedMarker(logger, dbConn, db.DefaultBuildBeingWatchedMarkDuration, clock.NewClock())
 	if err != nil {
 		return nil, err
 	}

--- a/atc/component.go
+++ b/atc/component.go
@@ -22,6 +22,7 @@ const (
 	ComponentCollectorWorkers           = "collector_workers"
 	ComponentCollectorPipelines         = "collector_pipelines"
 	ComponentPipelinePauser             = "pipeline_pauser"
+	ComponentBeingWatchedBuildMarker    = "being_watched_build_marker"
 )
 
 type Component struct {

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -1142,22 +1142,14 @@ func (b *build) Preparation() (BuildPreparation, bool, error) {
 }
 
 func (b *build) Events(from uint) (EventSource, error) {
-	notifier, err := newConditionNotifier(b.conn.Bus(), buildEventsChannel(b.id), func() (bool, error) {
-		return true, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	return newBuildEventSource(
 		b.id,
 		b.eventsTable(),
 		b.conn,
-		notifier,
 		from,
 		func(tx Tx, buildID int) (bool, error) {
 			completed := false
-			err = psql.Select("completed").
+			err := psql.Select("completed").
 				From("builds").
 				Where(sq.Eq{"id": buildID}).
 				RunWith(tx).
@@ -1168,7 +1160,7 @@ func (b *build) Events(from uint) (EventSource, error) {
 			}
 			return completed, nil
 		},
-	), nil
+	)
 }
 
 func (b *build) SaveEvent(event atc.Event) error {

--- a/atc/db/build.go
+++ b/atc/db/build.go
@@ -2102,8 +2102,10 @@ func buildStartedChannel() string {
 	return atc.ComponentBuildTracker
 }
 
+const buildEventChannelPrefix = "build_events_"
+
 func buildEventsChannel(buildID int) string {
-	return fmt.Sprintf("build_events_%d", buildID)
+	return fmt.Sprintf("%s%d", buildEventChannelPrefix, buildID)
 }
 
 func buildAbortChannel(buildID int) string {

--- a/atc/db/build_being_watched_marker.go
+++ b/atc/db/build_being_watched_marker.go
@@ -1,0 +1,152 @@
+package db
+
+import (
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagerctx"
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// beingWatchedBuildEventChannelMap stores build event notifier channel names
+// for those builds that are being watched. The way to know if a build is being
+// watched is that, when a build is watched on UI, then build.Events() will be
+// called. So that we can mark a build as BeingWatched from build.Events(). Note
+// that, as build event notification should only be sent from running builds,
+// this map should only store running builds' event channel names.
+type beingWatchedBuildEventChannelMap struct {
+	sync.RWMutex
+	internal map[string]time.Time
+}
+
+var (
+	beingWatchedBuildEventMap *beingWatchedBuildEventChannelMap
+	once                      sync.Once
+)
+
+// NewBeingWatchedBuildEventChannelMap returns a singleton instance of
+// beingWatchedBuildEventChannelMap.
+func NewBeingWatchedBuildEventChannelMap() *beingWatchedBuildEventChannelMap {
+	once.Do(func() {
+		beingWatchedBuildEventMap = &beingWatchedBuildEventChannelMap{
+			internal: make(map[string]time.Time),
+		}
+	})
+	return beingWatchedBuildEventMap
+}
+
+func (m *beingWatchedBuildEventChannelMap) load(key string) (value time.Time, ok bool) {
+	m.RLock()
+	result, ok := m.internal[key]
+	m.RUnlock()
+	return result, ok
+}
+
+func (m *beingWatchedBuildEventChannelMap) delete(key string) {
+	m.Lock()
+	delete(m.internal, key)
+	m.Unlock()
+}
+
+func (m *beingWatchedBuildEventChannelMap) store(key string, value time.Time) {
+	m.Lock()
+	m.internal[key] = value
+	m.Unlock()
+}
+
+// BeingWatched returns true if given buildEventChannel is being watched.
+func (m *beingWatchedBuildEventChannelMap) BeingWatched(buildEventChannel string) bool {
+	_, ok := beingWatchedBuildEventMap.load(buildEventChannel)
+	return ok
+}
+
+func (m *beingWatchedBuildEventChannelMap) Clean(conditionFunc func(k string, v time.Time) (string, bool)) {
+	var toClean []string
+	m.RLock()
+	for k, v := range m.internal {
+		kk, do := conditionFunc(k, v)
+		if do {
+			toClean = append(toClean, kk)
+		}
+	}
+	m.RUnlock()
+
+	for _, k := range toClean {
+		m.delete(k)
+	}
+}
+
+const beingWatchedNotifyChannelName = "being_watched_build_event_channel"
+
+// markBuildAsBeingWatched marks a build as BeingWatched by sending a db
+// notification to channel beingWatchedNotifyChannelName with payload of
+// the build's event channel name. This is because a build may be watched
+// from any ATCs, while the build may be running in a separate ATC.
+func markBuildAsBeingWatched(db Conn, buildEventChannel string) error {
+	_, err := db.Exec(fmt.Sprintf("NOTIFY %s, '%s'", beingWatchedNotifyChannelName, buildEventChannel))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// BuildBeingWatchedMarker listens to channel beingWatchedNotifyChannelName and
+// mark builds as BeingWatched accordingly in a singleton map. And it periodically
+// cleans up the map.
+type BuildBeingWatchedMarker struct {
+	bus        NotificationsBus
+	watchedMap *beingWatchedBuildEventChannelMap
+	notifier   chan Notification
+}
+
+func NewBuildEventWatcher(logger lager.Logger, bus NotificationsBus) (*BuildBeingWatchedMarker, error) {
+	w := &BuildBeingWatchedMarker{
+		bus:        bus,
+		watchedMap: NewBeingWatchedBuildEventChannelMap(),
+	}
+
+	notifier, err := w.bus.Listen(beingWatchedNotifyChannelName, 100)
+	if err != nil {
+		return nil, err
+	}
+	w.notifier = notifier
+
+	go func(logger lager.Logger, notifier chan Notification) {
+		defer w.bus.Unlisten(beingWatchedNotifyChannelName, notifier)
+
+		for {
+			notification, ok := <-notifier
+			if !ok {
+				return
+			}
+
+			beingWatchedBuildEventMap.store(notification.Payload, time.Now())
+			logger.Debug("EVAN: start-to-watch-build", lager.Data{"channel": notification.Payload})
+		}
+	}(logger, w.notifier)
+
+	return w, nil
+}
+
+func (bt *BuildBeingWatchedMarker) Run(ctx context.Context) error {
+	logger := lagerctx.FromContext(ctx)
+
+	logger.Debug("start")
+	defer logger.Debug("done")
+
+	bt.watchedMap.Clean(func(k string, v time.Time) (string, bool) {
+		if v.Before(time.Now().Add(-2 * time.Hour)) {
+			return k, true
+		}
+		return k, false
+	})
+
+	return nil
+}
+
+func (bt *BuildBeingWatchedMarker) Drain(ctx context.Context) {
+	logger := lagerctx.FromContext(ctx)
+	logger.Info("close-being-watched-build-marker")
+	close(bt.notifier)
+}

--- a/atc/db/build_being_watched_marker_test.go
+++ b/atc/db/build_being_watched_marker_test.go
@@ -1,0 +1,27 @@
+package db_test
+
+import (
+	"github.com/concourse/concourse/atc/db"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BeingWatchedBuildEventChannelMap", func() {
+	It("should marked channel be queried", func() {
+		m := db.NewBeingWatchedBuildEventChannelMap()
+
+		m.Mark("channel-1")
+		Expect(m.BeingWatched("channel-1")).To(BeTrue())
+		Expect(m.BeingWatched("channel-2")).To(BeFalse())
+
+		// Condition func always return false, thus no entry should be deleted.
+		m.Clean(func(k string, _ time.Time) (string, bool) { return k, false })
+		Expect(m.BeingWatched("channel-1")).To(BeTrue())
+
+		// Condition func always return true, thus no entry should be deleted.
+		m.Clean(func(k string, _ time.Time) (string, bool) { return k, true })
+		Expect(m.BeingWatched("channel-1")).To(BeFalse())
+	})
+})

--- a/atc/db/build_being_watched_marker_test.go
+++ b/atc/db/build_being_watched_marker_test.go
@@ -1,6 +1,10 @@
 package db_test
 
 import (
+	"code.cloudfoundry.org/clock/fakeclock"
+	"code.cloudfoundry.org/lager/v3/lagerctx"
+	"context"
+	"fmt"
 	"github.com/concourse/concourse/atc/db"
 	"time"
 
@@ -12,16 +16,130 @@ var _ = Describe("BeingWatchedBuildEventChannelMap", func() {
 	It("should marked channel be queried", func() {
 		m := db.NewBeingWatchedBuildEventChannelMap()
 
-		m.Mark("channel-1")
+		m.Mark("channel-1", time.Now())
 		Expect(m.BeingWatched("channel-1")).To(BeTrue())
 		Expect(m.BeingWatched("channel-2")).To(BeFalse())
 
 		// Condition func always return false, thus no entry should be deleted.
-		m.Clean(func(k string, _ time.Time) (string, bool) { return k, false })
+		m.Clean(func(k string, _ time.Time) bool { return false })
 		Expect(m.BeingWatched("channel-1")).To(BeTrue())
 
 		// Condition func always return true, thus no entry should be deleted.
-		m.Clean(func(k string, _ time.Time) (string, bool) { return k, true })
+		m.Clean(func(k string, _ time.Time) bool { return true })
 		Expect(m.BeingWatched("channel-1")).To(BeFalse())
+	})
+})
+
+var _ = Describe("BuildBeingWatchedMarker", func() {
+	var (
+		bm        *db.BuildBeingWatchedMarker
+		fakeClock *fakeclock.FakeClock
+	)
+
+	BeforeEach(func() {
+		var err error
+		fakeClock = fakeclock.NewFakeClock(time.Now())
+		bm, err = db.NewBuildBeingWatchedMarker(logger, dbConn, db.DefaultBuildBeingWatchedMarkDuration, fakeClock)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		bm.Drain(context.Background())
+	})
+
+	Context("Cleanup", func() {
+		BeforeEach(func() {
+			err := db.MarkBuildAsBeingWatched(dbConn, "build_events_10000")
+			Expect(err).NotTo(HaveOccurred())
+
+			err = db.MarkBuildAsBeingWatched(dbConn, "build_events_20000")
+			Expect(err).NotTo(HaveOccurred())
+
+			// As MarkBuildAsBeingWatched is async, sleep a second to wait for mark done.
+			time.Sleep(time.Second)
+		})
+
+		JustBeforeEach(func() {
+			err := bm.Run(lagerctx.NewContext(context.Background(), logger))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not delete before retain duration expired ", func() {
+			Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched("build_events_10000")).To(BeTrue())
+			Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched("build_events_20000")).To(BeTrue())
+		})
+
+		Context("when reach to retain duration expired", func() {
+			BeforeEach(func() {
+				fakeClock.Increment(db.DefaultBuildBeingWatchedMarkDuration + time.Second)
+			})
+
+			It("should delete before retain duration expired ", func() {
+				Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched("build_events_10000")).To(BeFalse())
+				Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched("build_events_20000")).To(BeFalse())
+			})
+		})
+	})
+
+	Context("Cleanup with existing builds", func() {
+		var (
+			build1   db.Build
+			build2   db.Build
+			channel1 string
+			channel2 string
+			err      error
+		)
+		BeforeEach(func() {
+			build1, err = defaultTeam.CreateOneOffBuild()
+			Expect(err).NotTo(HaveOccurred())
+
+			build2, err = defaultTeam.CreateOneOffBuild()
+			Expect(err).NotTo(HaveOccurred())
+
+			channel1 = fmt.Sprintf("build_events_%d", build1.ID())
+			channel2 = fmt.Sprintf("build_events_%d", build2.ID())
+
+			err := db.MarkBuildAsBeingWatched(dbConn, channel1)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = db.MarkBuildAsBeingWatched(dbConn, channel2)
+			Expect(err).NotTo(HaveOccurred())
+
+			// As MarkBuildAsBeingWatched is async, sleep a second to wait for mark done.
+			time.Sleep(time.Second)
+		})
+
+		JustBeforeEach(func() {
+			err := bm.Run(lagerctx.NewContext(context.Background(), logger))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not delete before retain duration expired ", func() {
+			Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched(channel1)).To(BeTrue())
+			Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched(channel2)).To(BeTrue())
+		})
+
+		Context("when retain duration expired", func() {
+			BeforeEach(func() {
+				fakeClock.Increment(db.DefaultBuildBeingWatchedMarkDuration + time.Second)
+			})
+
+			It("should not delete", func() {
+				Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched(channel1)).To(BeTrue())
+				Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched(channel2)).To(BeTrue())
+			})
+
+			Context("when a build is completed", func() {
+				BeforeEach(func() {
+					err := build1.Finish(db.BuildStatusAborted)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should delete build1", func() {
+					Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched(channel1)).To(BeFalse())
+					Expect(db.NewBeingWatchedBuildEventChannelMap().BeingWatched(channel2)).To(BeTrue())
+				})
+			})
+		})
 	})
 })

--- a/atc/db/build_event_source.go
+++ b/atc/db/build_event_source.go
@@ -68,7 +68,7 @@ func newBuildEventSource(
 			return nil, err
 		}
 
-		err = markBuildAsBeingWatched(conn, buildEventsChannel(buildID))
+		err = MarkBuildAsBeingWatched(conn, buildEventsChannel(buildID))
 		if err != nil {
 			notifier.Close()
 			return nil, err

--- a/atc/db/build_event_source.go
+++ b/atc/db/build_event_source.go
@@ -3,9 +3,7 @@ package db
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math"
-	"os"
 	"strconv"
 	"sync"
 
@@ -77,8 +75,6 @@ func newBuildEventSource(
 		}
 
 		source.notifier = notifier
-	} else {
-		fmt.Fprintf(os.Stderr, "EVAN: no need to notify build %d\n", buildID)
 	}
 
 	wg.Add(1)

--- a/atc/db/build_in_memory_check.go
+++ b/atc/db/build_in_memory_check.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -382,7 +381,6 @@ func (b *inMemoryCheckBuild) OnCheckBuildStart() error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "EVAN:in-memory-build start notify %s\n", buildEventsChannel(b.id))
 	return b.conn.Bus().Notify(buildEventsChannel(b.id))
 }
 

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -1017,6 +1017,11 @@ var _ = Describe("Build", func() {
 	})
 
 	Describe("Events", func() {
+		BeforeEach(func() {
+			_, err := db.NewBuildBeingWatchedMarker(logger, dbConn.Bus())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("saves and emits status events", func() {
 			By("allowing you to subscribe when no events have yet occurred")
 			events, err := build.Events(0)
@@ -1080,6 +1085,11 @@ var _ = Describe("Build", func() {
 	})
 
 	Describe("SaveEvent", func() {
+		BeforeEach(func() {
+			_, err := db.NewBuildBeingWatchedMarker(logger, dbConn.Bus())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("saves and propagates events correctly", func() {
 			By("allowing you to subscribe when no events have yet occurred")
 			events, err := build.Events(0)
@@ -1137,7 +1147,7 @@ var _ = Describe("Build", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(nextEvent).Should(Receive(Equal(envelope(event.Log{
+			Eventually(nextEvent, "2s").Should(Receive(Equal(envelope(event.Log{
 				Payload: "log 2",
 			}, "2"))))
 

--- a/atc/db/build_test.go
+++ b/atc/db/build_test.go
@@ -1,6 +1,7 @@
 package db_test
 
 import (
+	"code.cloudfoundry.org/clock/fakeclock"
 	"context"
 	"crypto/md5"
 	"encoding/hex"
@@ -1017,9 +1018,15 @@ var _ = Describe("Build", func() {
 	})
 
 	Describe("Events", func() {
+		var marker *db.BuildBeingWatchedMarker
 		BeforeEach(func() {
-			_, err := db.NewBuildBeingWatchedMarker(logger, dbConn.Bus())
+			var err error
+			marker, err = db.NewBuildBeingWatchedMarker(logger, dbConn, db.DefaultBuildBeingWatchedMarkDuration, fakeclock.NewFakeClock(time.Now()))
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			marker.Drain(context.Background())
 		})
 
 		It("saves and emits status events", func() {
@@ -1085,9 +1092,15 @@ var _ = Describe("Build", func() {
 	})
 
 	Describe("SaveEvent", func() {
+		var marker *db.BuildBeingWatchedMarker
 		BeforeEach(func() {
-			_, err := db.NewBuildBeingWatchedMarker(logger, dbConn.Bus())
+			var err error
+			marker, err = db.NewBuildBeingWatchedMarker(logger, dbConn, db.DefaultBuildBeingWatchedMarkDuration, fakeclock.NewFakeClock(time.Now()))
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			marker.Drain(context.Background())
 		})
 
 		It("saves and propagates events correctly", func() {

--- a/atc/db/check_factory.go
+++ b/atc/db/check_factory.go
@@ -41,6 +41,7 @@ type CheckFactory interface {
 	TryCreateCheck(context.Context, Checkable, ResourceTypes, atc.Version, bool, bool, bool) (Build, bool, error)
 	Resources() ([]Resource, error)
 	ResourceTypesByPipeline() (map[int]ResourceTypes, error)
+	Drain()
 }
 
 type checkFactory struct {
@@ -213,4 +214,8 @@ func (c *checkFactory) ResourceTypesByPipeline() (map[int]ResourceTypes, error) 
 	}
 
 	return resourceTypes, nil
+}
+
+func (c *checkFactory) Drain() {
+	close(c.checkBuildChan)
 }

--- a/atc/db/dbfakes/fake_check_factory.go
+++ b/atc/db/dbfakes/fake_check_factory.go
@@ -10,6 +10,10 @@ import (
 )
 
 type FakeCheckFactory struct {
+	DrainStub        func()
+	drainMutex       sync.RWMutex
+	drainArgsForCall []struct {
+	}
 	ResourceTypesByPipelineStub        func() (map[int]db.ResourceTypes, error)
 	resourceTypesByPipelineMutex       sync.RWMutex
 	resourceTypesByPipelineArgsForCall []struct {
@@ -57,6 +61,30 @@ type FakeCheckFactory struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeCheckFactory) Drain() {
+	fake.drainMutex.Lock()
+	fake.drainArgsForCall = append(fake.drainArgsForCall, struct {
+	}{})
+	stub := fake.DrainStub
+	fake.recordInvocation("Drain", []interface{}{})
+	fake.drainMutex.Unlock()
+	if stub != nil {
+		fake.DrainStub()
+	}
+}
+
+func (fake *FakeCheckFactory) DrainCallCount() int {
+	fake.drainMutex.RLock()
+	defer fake.drainMutex.RUnlock()
+	return len(fake.drainArgsForCall)
+}
+
+func (fake *FakeCheckFactory) DrainCalls(stub func()) {
+	fake.drainMutex.Lock()
+	defer fake.drainMutex.Unlock()
+	fake.DrainStub = stub
 }
 
 func (fake *FakeCheckFactory) ResourceTypesByPipeline() (map[int]db.ResourceTypes, error) {
@@ -247,6 +275,8 @@ func (fake *FakeCheckFactory) TryCreateCheckReturnsOnCall(i int, result1 db.Buil
 func (fake *FakeCheckFactory) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.drainMutex.RLock()
+	defer fake.drainMutex.RUnlock()
 	fake.resourceTypesByPipelineMutex.RLock()
 	defer fake.resourceTypesByPipelineMutex.RUnlock()
 	fake.resourcesMutex.RLock()

--- a/atc/db/notifications_bus.go
+++ b/atc/db/notifications_bus.go
@@ -130,6 +130,8 @@ func (bus *notificationsBus) wait() {
 			bus.handleReconnect()
 		}
 	}
+	close(bus.notifyChan)
+	close(bus.notifyDoneChan)
 }
 
 func (bus *notificationsBus) cacheNotify() {
@@ -147,11 +149,10 @@ func (bus *notificationsBus) cacheNotify() {
 		bus.notifyCache[channel] = struct{}{}
 		bus.notifyCacheLock.Unlock()
 	}
-	close(bus.notifyDoneChan)
 }
 
 func (bus *notificationsBus) asyncNotify() {
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(500 * time.Millisecond)
 	go func() {
 		for {
 			select {

--- a/atc/db/notifications_bus.go
+++ b/atc/db/notifications_bus.go
@@ -183,7 +183,6 @@ func (bus *notificationsBus) asyncNotify() {
 				bus.notifyCacheLock.Lock()
 				for channel, _ := range bus.notifyCache {
 					if bus.watchedMap.BeingWatched(channel) {
-						//fmt.Fprintf(os.Stderr, "EVAN: notify %s\n", channel)
 						bus.notify(channel)
 					}
 				}

--- a/atc/db/notifications_bus.go
+++ b/atc/db/notifications_bus.go
@@ -154,6 +154,7 @@ func (bus *notificationsBus) cacheNotify() {
 func (bus *notificationsBus) asyncNotify() {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	go func() {
+	async:
 		for {
 			select {
 			case <-ticker.C:
@@ -164,7 +165,8 @@ func (bus *notificationsBus) asyncNotify() {
 				bus.notifyCache = map[string]struct{}{}
 				bus.notifyCacheLock.Unlock()
 			case <-bus.notifyDoneChan:
-				break
+				ticker.Stop()
+				break async
 			}
 		}
 	}()

--- a/atc/lidar/scanner.go
+++ b/atc/lidar/scanner.go
@@ -103,3 +103,7 @@ func (s *scanner) check(ctx context.Context, checkable db.Checkable, resourceTyp
 		metric.Metrics.ChecksEnqueued.Inc()
 	}
 }
+
+func (s *scanner) Drain(ctx context.Context) {
+	s.checkFactory.Drain()
+}


### PR DESCRIPTION
## Changes proposed by this PR

### Problem

When you open a running build on the Concourse UI, you can see build logs keep growing, new logs keep scrolling down. How that is archived? In short, the workflow is like:

 * When UI open a build, the API will call `build.Events()`, and `build.Events()` will return an `EventSource` object.
 * The `EventSource` will issue a db query `LISTEN build_event_<build-id>`, upon receiving a notification over the listen, it will query the build event table to fetch new logs and streams new logs to UI over API.
 * While a build is running, for each line of log newly generated, it will send a db notification `NOTIFY build_event_<build-id>`, so that all clients that are listening will get notified to fetch new logs.

This workflow works fine, but with db performance wastes:

 * It highly relies on the db operations of `NOTIFY build_event_<build-id>` and `LISTEN build_event_<build-id>`. On our deployments, we have noticed db queries of those two statements.
 * A build may generate a lot of lines of logs in a second, it's not necessary to execute a `NOTIFY build_event_<build-id>` for every log line.
 * When a running build is not being watched over UI or `fly`, it's no need to execute a `NOTIFY build_event_<build-id>` , because no one is listening.
 * If you are watching a completed build, as no `NOTIFY` will come, it doesn't need to `LISTEN`.

### Solution

This PR optimizes usages of `NOTIFY` and `LISTEN` in the following ways:

 * For completed builds, `build.Events()` should not `LISTEN`.
 * For running builds not being watched, as there is no `LISTEN`, don't execute `NOTIFY`.
 * For running builds being watched, cache `NOTIFY`s and only `NOTIFY` once every 500ms. Based on my tests, 500ms keeps UI as smooth as no `NOTIFY` cache.

### Status

* [x] functionality
* [x] add tests
* [x] clean up code
* [x] done

## Notes to reviewer

@xtremerui We tried to apply this patch to our biggest cluster for 15 minutes during last weekend maintenance of upgrading to 7.9.1 from 7.8.2.  

From 14:30 ~ 14:45, it ran 7.9.1; and from 14:50pm to 15:05 it ran with a patch of this PR. During the entire test period, we turned off scheduler and tracker, thus no build were running, there were only Lidar checks running.

From the DB metrics, we can see, TPS was ~18K without this patch, and reduced to ~10K with this patch:

![image](https://github.com/concourse/concourse/assets/18585861/15f0d0f6-cf21-4cfe-a1f6-872a656cf0fb)

With this PR, the DB's CPU usage was also lower than without this PR:

![image](https://github.com/concourse/concourse/assets/18585861/ecc2fa79-928d-4061-bae2-4e57cebb38d4)

![image](https://github.com/concourse/concourse/assets/18585861/56a3dd42-19da-42be-aa1c-b134ac4788f2)

There were not much impact on the DB's memory usage:

![image](https://github.com/concourse/concourse/assets/18585861/daf2c9fe-1a36-4105-b602-e410d27baeca)



## Release Note

Optimized the database notifications, which will reduce TPS/QPS in the database side. A new ATC option `--db-notification-bus-queue-size` is added, defaults to 10000. If the UI doesn't load logs of running builds in time, then consider to increase value of the option.
