### PR TITLE
Increase timeout for bosh topgun

### DIFF
--- a/atc/db/notifications_bus_test.go
+++ b/atc/db/notifications_bus_test.go
@@ -365,7 +365,7 @@ var _ = Describe("NotificationBus", func() {
 				})
 			})
 
-			It("should still be able to listen for notifications", func(done Done) {
+			It("should still be able to listen for notifications", func() {
 				_, err := bus.Listen("some-channel", 1)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -374,8 +374,6 @@ var _ = Describe("NotificationBus", func() {
 
 				_, err = bus.Listen("some-new-channel", 1)
 				Expect(err).NotTo(HaveOccurred())
-
-				close(done)
 			})
 		})
 
@@ -390,15 +388,13 @@ var _ = Describe("NotificationBus", func() {
 				})
 			})
 
-			It("should still be able to unlisten for notifications", func(done Done) {
+			It("should still be able to unlisten for notifications", func() {
 
 				err := bus.Unlisten("some-channel", a)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = bus.Unlisten("some-other-channel", b)
 				Expect(err).NotTo(HaveOccurred())
-
-				close(done)
 			})
 		})
 	})

--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -67,7 +67,7 @@ var (
 )
 
 var _ = BeforeEach(func() {
-	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyTimeout(4 * time.Minute)
 	SetDefaultEventuallyPollingInterval(time.Second)
 	SetDefaultConsistentlyDuration(time.Minute)
 	SetDefaultConsistentlyPollingInterval(time.Second)


### PR DESCRIPTION
Noticing timeout failure happened on bosh topgun tests due to timing out of waiting for deployment locks releasing.

<details>

[TIMEDOUT] A grace period timeout occurred

  In [BeforeEach] at: github.com/concourse/concourse/topgun/both/resource_volumes_gc_test.go:79 @ 05/08/23 10:39:38.592


  This is the Progress Report generated when the grace period timeout occurred:

    Garbage collecting resource cache volumes A resource in paused pipeline has its resource cache, resource cache uses and resource cache volumes cleared out (Spec Runtime: 4m7.675s)

      github.com/concourse/concourse/topgun/both/resource_volumes_gc_test.go:83

      In [BeforeEach] (Node Runtime: 30.001s)

        github.com/concourse/concourse/topgun/both/resource_volumes_gc_test.go:79

        At [By Step] [1683542349.105622292] running: bosh -n -d concourse-topgun-both-1 deploy deployments/concourse.yml --vars-store /tmp/topgun-tmp1768134625/concourse-topgun-both-1-vars.yml -v suite='-both' -v deployment_name='concourse-topgun-both-1' -v concourse_release_version='7.9.2-dev.20230504T185400Z.commit.d5ae7df' -v bpm_release_version='1.2.0' -v postgres_release_version='44' -v vault_release_version='3' -v credhub_release_version='2.12.26' -v uaa_release_version='76.11.0' -v backup_and_restore_sdk_release_version='1.18.69' -v stemcell_version='1.108' -v stemcell_variant='jammy' (Step Runtime: 29.486s)

          github.com/concourse/concourse/topgun/exec.go:49


        Spec Goroutine

        goroutine 900 [chan send, 1 minutes]

          github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3.1()

            github.com/onsi/ginkgo/v2@v2.9.2/internal/suite.go:859

          github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()

            github.com/onsi/ginkgo/v2@v2.9.2/internal/suite.go:865

          github.com/onsi/ginkgo/v2/internal.(*Suite).runNode

            github.com/onsi/ginkgo/v2@v2.9.2/internal/suite.go:850


        Goroutines of Interest

        goroutine 978 [chan send]

          github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3.1()

            github.com/onsi/ginkgo/v2@v2.9.2/internal/suite.go:859

          panic({0x1169d80, 0xc000278690})

            runtime/panic.go:890

          github.com/onsi/ginkgo/v2.Fail({0xc00003e7b0, 0x2b}, {0xc000286158, 0x1, 0x4aae17?})

            github.com/onsi/ginkgo/v2@v2.9.2/core_dsl.go:374

          github.com/onsi/gomega/internal.(*Assertion).match(0xc0003f2500, {0x139b1f0, 0xc000230040}, 0x1, {0x0, 0x0, 0x0})

            github.com/onsi/gomega@v1.27.6/internal/assertion.go:106

          github.com/onsi/gomega/internal.(*Assertion).To(0xc0003f2500, {0x139b1f0, 0xc000230040}, {0x0, 0x0, 0x0})

            github.com/onsi/gomega@v1.27.6/internal/assertion.go:62

        > github.com/concourse/concourse/topgun.Wait(0xc0003bac30)

            github.com/concourse/concourse/topgun/exec.go:54

        > github.com/concourse/concourse/topgun/common.Bosh({0xc000587640, 0x3, 0x19f7210?})

            github.com/concourse/concourse/topgun/common/common.go:328

        > github.com/concourse/concourse/topgun/common.glob..func2()

            github.com/concourse/concourse/topgun/common/common.go:168
</details>

This PR doubles the timeout to 4 mins to reduce above flake.

Also update tests for deprecated ginkgo test behavior.