### PR TITLE
Added a maximum volume size that can be streamed

### DIFF
--- a/atc/api/artifacts_test.go
+++ b/atc/api/artifacts_test.go
@@ -253,7 +253,7 @@ var _ = Describe("ArtifactRepository API", func() {
 					It("streams out the contents of the volume from the root path", func() {
 						tarStream := runtimetest.VolumeContent{}
 
-						err := tarStream.StreamIn(context.Background(), ".", baggageclaim.GzipEncoding, response.Body)
+						err := tarStream.StreamIn(context.Background(), ".", baggageclaim.GzipEncoding, 0, response.Body)
 						Expect(err).ToNot(HaveOccurred())
 
 						Expect(tarStream).To(Equal(volume.Content))

--- a/atc/api/artifactserver/create.go
+++ b/atc/api/artifactserver/create.go
@@ -2,8 +2,8 @@ package artifactserver
 
 import (
 	"encoding/json"
-	"net/http"
 	"fmt"
+	"net/http"
 
 	"github.com/concourse/concourse/atc/api/present"
 	"github.com/concourse/concourse/atc/compression"
@@ -31,14 +31,14 @@ func (s *Server) CreateArtifact(team db.Team) http.Handler {
 		volume, artifact, err := s.workerPool.CreateVolumeForArtifact(ctx, workerSpec)
 		if err != nil {
 			hLog.Error("failed-to-create-volume", err)
-			http.Error(w, fmt.Sprintf("%v",err), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)
 			return
 		}
 
-		err = volume.StreamIn(r.Context(), "/", compression.NewGzipCompression(), r.Body)
+		err = volume.StreamIn(r.Context(), "/", compression.NewGzipCompression(), 0, r.Body)
 		if err != nil {
 			hLog.Error("failed-to-stream-volume-contents", err)
-			http.Error(w, fmt.Sprintf("%v",err), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("%v", err), http.StatusInternalServerError)
 			return
 		}
 

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -158,6 +158,7 @@ type RunCommand struct {
 
 	BaggageclaimResponseHeaderTimeout time.Duration `long:"baggageclaim-response-header-timeout" default:"1m" description:"How long to wait for Baggageclaim to send the response header."`
 	StreamingArtifactsCompression     string        `long:"streaming-artifacts-compression" default:"gzip" choice:"gzip" choice:"zstd" choice:"raw" description:"Compression algorithm for internal streaming."`
+	StreamingSizeLimitationInMB       int           `long:"streaming-size-limitation" default:"0" description:"Internal volume streaming size limitation in MB"`
 
 	GardenRequestTimeout time.Duration `long:"garden-request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
 
@@ -1187,10 +1188,14 @@ func (cmd *RunCommand) compression() compression.Compression {
 }
 
 func (cmd *RunCommand) streamer(cacheFactory db.ResourceCacheFactory) worker.Streamer {
-	return worker.NewStreamer(cacheFactory, cmd.compression(), worker.P2PConfig{
-		Enabled: cmd.FeatureFlags.EnableP2PVolumeStreaming,
-		Timeout: cmd.P2pVolumeStreamingTimeout,
-	})
+	return worker.NewStreamer(cacheFactory,
+		cmd.compression(),
+		cmd.StreamingSizeLimitationInMB,
+		worker.P2PConfig{
+			Enabled: cmd.FeatureFlags.EnableP2PVolumeStreaming,
+			Timeout: cmd.P2pVolumeStreamingTimeout,
+		},
+	)
 }
 
 func (cmd *RunCommand) constructPool(dbConn db.Conn, lockFactory lock.LockFactory, workerCache *db.WorkerCache) (worker.Pool, error) {

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -158,7 +158,7 @@ type RunCommand struct {
 
 	BaggageclaimResponseHeaderTimeout time.Duration `long:"baggageclaim-response-header-timeout" default:"1m" description:"How long to wait for Baggageclaim to send the response header."`
 	StreamingArtifactsCompression     string        `long:"streaming-artifacts-compression" default:"gzip" choice:"gzip" choice:"zstd" choice:"raw" description:"Compression algorithm for internal streaming."`
-	StreamingSizeLimitationInMB       int           `long:"streaming-size-limitation" default:"0" description:"Internal volume streaming size limitation in MB"`
+	StreamingSizeLimitationInMB       float64       `long:"streaming-size-limitation" default:"0.0" description:"Internal volume streaming size limitation in MB. In case of small limitation needed, float can be used like 0.01."`
 
 	GardenRequestTimeout time.Duration `long:"garden-request-timeout" default:"5m" description:"How long to wait for requests to Garden to complete. 0 means no timeout."`
 

--- a/atc/runtime/runtimetest/volume.go
+++ b/atc/runtime/runtimetest/volume.go
@@ -54,7 +54,7 @@ func (v Volume) Source() string {
 	return fmt.Sprintf("%s-worker", v.Handle())
 }
 
-func (v Volume) StreamIn(ctx context.Context, path string, compression compression.Compression, limitInMB int, reader io.Reader) error {
+func (v Volume) StreamIn(ctx context.Context, path string, compression compression.Compression, limitInMB float64, reader io.Reader) error {
 	return v.Content.StreamIn(ctx, path, compression.Encoding(), limitInMB, reader)
 }
 
@@ -82,7 +82,7 @@ func (v Volume) DBVolume() db.CreatedVolume {
 	return v.DBVolume_
 }
 
-func (vc VolumeContent) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, _ int, tarStream io.Reader) error {
+func (vc VolumeContent) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, _ float64, tarStream io.Reader) error {
 	if encoding != baggageclaim.GzipEncoding {
 		return errors.New("only gzip is supported for runtimetest.VolumeContent")
 	}

--- a/atc/runtime/runtimetest/volume.go
+++ b/atc/runtime/runtimetest/volume.go
@@ -54,8 +54,8 @@ func (v Volume) Source() string {
 	return fmt.Sprintf("%s-worker", v.Handle())
 }
 
-func (v Volume) StreamIn(ctx context.Context, path string, compression compression.Compression, reader io.Reader) error {
-	return v.Content.StreamIn(ctx, path, compression.Encoding(), reader)
+func (v Volume) StreamIn(ctx context.Context, path string, compression compression.Compression, limitInMB int, reader io.Reader) error {
+	return v.Content.StreamIn(ctx, path, compression.Encoding(), limitInMB, reader)
 }
 
 func (v Volume) StreamOut(ctx context.Context, path string, compression compression.Compression) (io.ReadCloser, error) {
@@ -82,7 +82,7 @@ func (v Volume) DBVolume() db.CreatedVolume {
 	return v.DBVolume_
 }
 
-func (vc VolumeContent) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, tarStream io.Reader) error {
+func (vc VolumeContent) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, _ int, tarStream io.Reader) error {
 	if encoding != baggageclaim.GzipEncoding {
 		return errors.New("only gzip is supported for runtimetest.VolumeContent")
 	}

--- a/atc/runtime/runtimetest/volume_test.go
+++ b/atc/runtime/runtimetest/volume_test.go
@@ -23,7 +23,7 @@ func TestVolume_StreamInOut_Root(t *testing.T) {
 	stream, err := volume1.StreamOut(ctx, "/", gzipCompression)
 	require.NoError(t, err)
 
-	err = volume2.StreamIn(ctx, ".", gzipCompression, stream)
+	err = volume2.StreamIn(ctx, ".", gzipCompression, 0, stream)
 	require.NoError(t, err)
 
 	require.Equal(t, content, volume2.Content)
@@ -40,7 +40,7 @@ func TestVolume_StreamInOut_File(t *testing.T) {
 	stream, err := volume1.StreamOut(ctx, "file1", gzipCompression)
 	require.NoError(t, err)
 
-	err = volume2.StreamIn(ctx, "/", gzipCompression, stream)
+	err = volume2.StreamIn(ctx, "/", gzipCompression, 0, stream)
 	require.NoError(t, err)
 
 	require.Equal(t, content, volume2.Content)

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -314,7 +314,7 @@ type Volume interface {
 	// result of a StreamOut call for another Volume.
 	//
 	// path is a relative path - "." indicates using the root of the Volume.
-	StreamIn(ctx context.Context, path string, compression compression.Compression, limitInMB int, reader io.Reader) error
+	StreamIn(ctx context.Context, path string, compression compression.Compression, limitInMB float64, reader io.Reader) error
 
 	// InitializeResourceCache is called upon a successful run of the get step
 	// to register this Volume as a resource cache.

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -314,7 +314,7 @@ type Volume interface {
 	// result of a StreamOut call for another Volume.
 	//
 	// path is a relative path - "." indicates using the root of the Volume.
-	StreamIn(ctx context.Context, path string, compression compression.Compression, reader io.Reader) error
+	StreamIn(ctx context.Context, path string, compression compression.Compression, limitInMB int, reader io.Reader) error
 
 	// InitializeResourceCache is called upon a successful run of the get step
 	// to register this Volume as a resource cache.
@@ -353,7 +353,7 @@ type P2PVolume interface {
 	// specified by the `Content-Encoding` header (either "gzip" or "zstd").
 	//
 	// path is a relative path - "." indicates using the root of the Volume.
-	StreamP2POut(ctx context.Context, path string, destURL string, compression compression.Compression) error
+	StreamP2POut(ctx context.Context, path string, destURL string, compression compression.Compression, limitInMB int) error
 }
 
 // VolumeMount defines a Volume mounted at a particular path in a Container.

--- a/atc/runtime/types.go
+++ b/atc/runtime/types.go
@@ -353,7 +353,7 @@ type P2PVolume interface {
 	// specified by the `Content-Encoding` header (either "gzip" or "zstd").
 	//
 	// path is a relative path - "." indicates using the root of the Volume.
-	StreamP2POut(ctx context.Context, path string, destURL string, compression compression.Compression, limitInMB int) error
+	StreamP2POut(ctx context.Context, path string, destURL string, compression compression.Compression) error
 }
 
 // VolumeMount defines a Volume mounted at a particular path in a Container.

--- a/atc/worker/gardenruntime/gardenruntimetest/baggageclaim.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/baggageclaim.go
@@ -144,8 +144,8 @@ func (v *Volume) SetPrivileged(_ context.Context, p bool) error {
 }
 func (v Volume) GetPrivileged(_ context.Context) (bool, error) { return v.Spec.Privileged, nil }
 
-func (v Volume) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, tarStream io.Reader) error {
-	return v.Content.StreamIn(ctx, path, encoding, tarStream)
+func (v Volume) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, limitInMB float64, tarStream io.Reader) error {
+	return v.Content.StreamIn(ctx, path, encoding, limitInMB, tarStream)
 }
 
 func (v Volume) StreamOut(ctx context.Context, path string, encoding baggageclaim.Encoding) (io.ReadCloser, error) {
@@ -157,7 +157,7 @@ func (v Volume) GetStreamInP2pUrl(_ context.Context, path string) (string, error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer close(closeCh)
 		path := strings.TrimPrefix(r.URL.Path, "/")
-		if err := v.StreamIn(r.Context(), path, baggageclaim.GzipEncoding, r.Body); err != nil {
+		if err := v.StreamIn(r.Context(), path, baggageclaim.GzipEncoding, 0, r.Body); err != nil {
 			panic(err)
 		}
 	}))

--- a/atc/worker/gardenruntime/gardenruntimetest/worker.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/worker.go
@@ -65,7 +65,7 @@ func (w Worker) Build(db worker.DB, dbWorker db.Worker) runtime.Worker {
 		&Garden{ContainerList: w.Containers},
 		&Baggageclaim{Volumes: w.Volumes, Mutex: sync.Mutex{}},
 		db.ToGardenRuntimeDB(),
-		worker.NewStreamer(db.ResourceCacheFactory, compression.NewGzipCompression(), worker.P2PConfig{
+		worker.NewStreamer(db.ResourceCacheFactory, compression.NewGzipCompression(), 0, worker.P2PConfig{
 			Enabled: false,
 		}),
 	)

--- a/atc/worker/gardenruntime/volume.go
+++ b/atc/worker/gardenruntime/volume.go
@@ -113,7 +113,7 @@ func (v Volume) StreamOut(ctx context.Context, path string, compression compress
 	return v.bcVolume.StreamOut(ctx, path, compression.Encoding())
 }
 
-func (v Volume) StreamIn(ctx context.Context, path string, compression compression.Compression, limitInMB int, reader io.Reader) error {
+func (v Volume) StreamIn(ctx context.Context, path string, compression compression.Compression, limitInMB float64, reader io.Reader) error {
 	return v.bcVolume.StreamIn(ctx, path, compression.Encoding(), limitInMB, reader)
 }
 

--- a/atc/worker/gardenruntime/volume.go
+++ b/atc/worker/gardenruntime/volume.go
@@ -121,8 +121,8 @@ func (v Volume) GetStreamInP2PURL(ctx context.Context, path string) (string, err
 	return v.bcVolume.GetStreamInP2pUrl(ctx, path)
 }
 
-func (v Volume) StreamP2POut(ctx context.Context, path string, destURL string, compression compression.Compression, limitInMB int) error {
-	return v.bcVolume.StreamP2pOut(ctx, path, destURL, compression.Encoding(), limitInMB)
+func (v Volume) StreamP2POut(ctx context.Context, path string, destURL string, compression compression.Compression) error {
+	return v.bcVolume.StreamP2pOut(ctx, path, destURL, compression.Encoding())
 }
 
 var _ runtime.P2PVolume = Volume{}

--- a/atc/worker/gardenruntime/volume.go
+++ b/atc/worker/gardenruntime/volume.go
@@ -113,16 +113,16 @@ func (v Volume) StreamOut(ctx context.Context, path string, compression compress
 	return v.bcVolume.StreamOut(ctx, path, compression.Encoding())
 }
 
-func (v Volume) StreamIn(ctx context.Context, path string, compression compression.Compression, reader io.Reader) error {
-	return v.bcVolume.StreamIn(ctx, path, compression.Encoding(), reader)
+func (v Volume) StreamIn(ctx context.Context, path string, compression compression.Compression, limitInMB int, reader io.Reader) error {
+	return v.bcVolume.StreamIn(ctx, path, compression.Encoding(), limitInMB, reader)
 }
 
 func (v Volume) GetStreamInP2PURL(ctx context.Context, path string) (string, error) {
 	return v.bcVolume.GetStreamInP2pUrl(ctx, path)
 }
 
-func (v Volume) StreamP2POut(ctx context.Context, path string, destURL string, compression compression.Compression) error {
-	return v.bcVolume.StreamP2pOut(ctx, path, destURL, compression.Encoding())
+func (v Volume) StreamP2POut(ctx context.Context, path string, destURL string, compression compression.Compression, limitInMB int) error {
+	return v.bcVolume.StreamP2pOut(ctx, path, destURL, compression.Encoding(), limitInMB)
 }
 
 var _ runtime.P2PVolume = Volume{}
@@ -367,17 +367,17 @@ func (worker *Worker) createVolumeForTaskCache(
 // Artifact, if one exists, preferring Volumes that are closer to the current
 // worker. It checks for the following things, in order of preference:
 //
-// 1. The Artifact is a Volume on the current worker (return the input Volume)
-// 2. The Artifact is a Volume on another worker, but there is an equivalent
-//    resource cache Volume on the current worker (return the local resource
-//    cache Volume). In this case, worker_resource_cache on the other worker
-//    should be valid before the time of volumeShouldBeValidBefore. In other
-//    words, if a worker resource cache has been invalidated, then later build
-//    should never use it, but builds started before the cache is invalidated
-//    may still use it.
-// 3. The Artifact is a Volume on another worker with no local resource cache
-//    Volume (return the input Volume)
-// 4. The Artifact is not a Volume (return not ok)
+//  1. The Artifact is a Volume on the current worker (return the input Volume)
+//  2. The Artifact is a Volume on another worker, but there is an equivalent
+//     resource cache Volume on the current worker (return the local resource
+//     cache Volume). In this case, worker_resource_cache on the other worker
+//     should be valid before the time of volumeShouldBeValidBefore. In other
+//     words, if a worker resource cache has been invalidated, then later build
+//     should never use it, but builds started before the cache is invalidated
+//     may still use it.
+//  3. The Artifact is a Volume on another worker with no local resource cache
+//     Volume (return the input Volume)
+//  4. The Artifact is not a Volume (return not ok)
 func (worker *Worker) findVolumeForArtifact(
 	ctx context.Context,
 	teamID int,

--- a/atc/worker/streamer.go
+++ b/atc/worker/streamer.go
@@ -145,8 +145,8 @@ func (s Streamer) p2pStream(ctx context.Context, src runtime.P2PVolume, dst runt
 	if err != nil {
 		return fmt.Errorf("invalid stream-in-url: %w", err)
 	}
-	// If stream limit is set, append the limit to stream-in url
-	if s.limitInMB > 0.00000094 {
+	// If stream limit is set to greater than 1 byte, append the limit to stream-in url
+	if s.limitInMB > float64(1)/1024/1024 {
 		query := rawUrl.Query()
 		query.Add("limit", fmt.Sprintf("%f", s.limitInMB))
 		rawUrl.RawQuery = query.Encode()

--- a/atc/worker/streamer.go
+++ b/atc/worker/streamer.go
@@ -21,7 +21,7 @@ import (
 
 type Streamer struct {
 	compression compression.Compression
-	limitInMB   int
+	limitInMB   float64
 	p2p         P2PConfig
 
 	resourceCacheFactory db.ResourceCacheFactory
@@ -32,7 +32,7 @@ type P2PConfig struct {
 	Timeout time.Duration
 }
 
-func NewStreamer(cacheFactory db.ResourceCacheFactory, compression compression.Compression, limitInMB int, p2p P2PConfig) Streamer {
+func NewStreamer(cacheFactory db.ResourceCacheFactory, compression compression.Compression, limitInMB float64, p2p P2PConfig) Streamer {
 	return Streamer{
 		resourceCacheFactory: cacheFactory,
 		compression:          compression,
@@ -146,9 +146,9 @@ func (s Streamer) p2pStream(ctx context.Context, src runtime.P2PVolume, dst runt
 		return fmt.Errorf("invalid stream-in-url: %w", err)
 	}
 	// If stream limit is set, append the limit to stream-in url
-	if s.limitInMB > 0 {
+	if s.limitInMB > 0.00000094 {
 		query := rawUrl.Query()
-		query.Add("limit", fmt.Sprintf("%d", s.limitInMB))
+		query.Add("limit", fmt.Sprintf("%f", s.limitInMB))
 		rawUrl.RawQuery = query.Encode()
 	}
 	streamInUrl = rawUrl.String()

--- a/atc/worker/workertest/scenario.go
+++ b/atc/worker/workertest/scenario.go
@@ -155,5 +155,5 @@ func (s *Scenario) ContainerVolume(workerName string, containerHandle string, mo
 }
 
 func (s *Scenario) Streamer(p2p worker.P2PConfig) worker.Streamer {
-	return worker.NewStreamer(s.Factory.DB.ResourceCacheFactory, compression.NewGzipCompression(), p2p)
+	return worker.NewStreamer(s.Factory.DB.ResourceCacheFactory, compression.NewGzipCompression(), 0, p2p)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       CONCOURSE_ENABLE_ACROSS_STEP: "true"
       CONCOURSE_ENABLE_CACHE_STREAMED_VOLUMES: "true"
       CONCOURSE_ENABLE_RESOURCE_CAUSALITY: "true"
+      CONCOURSE_STREAMING_SIZE_LIMITATION: 10
+      CONCOURSE_ENABLE_P2P_VOLUME_STREAMING: "true"
 
   worker:
     build: .
@@ -47,6 +49,35 @@ services:
     ports:
     - 7777:7777
     - 7788:7788
+    volumes: ["./hack/keys:/concourse-keys"]
+    stop_signal: SIGUSR2
+    environment:
+      CONCOURSE_RUNTIME: containerd
+
+      CONCOURSE_TSA_PUBLIC_KEY: /concourse-keys/tsa_host_key.pub
+      CONCOURSE_TSA_WORKER_PRIVATE_KEY: /concourse-keys/worker_key
+
+      CONCOURSE_LOG_LEVEL: debug
+      CONCOURSE_TSA_HOST: web:2222
+
+      CONCOURSE_BIND_IP: 0.0.0.0
+      CONCOURSE_BAGGAGECLAIM_BIND_IP: 0.0.0.0
+
+      # avoid using loopbacks
+      CONCOURSE_BAGGAGECLAIM_DRIVER: overlay
+
+      # work with docker-compose's dns
+      CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE: "true"
+
+  worker2:
+    build: .
+    image: concourse/concourse:local
+    command: worker
+    privileged: true
+    depends_on: [web]
+    ports:
+      - 8777:7777
+      - 8788:7788
     volumes: ["./hack/keys:/concourse-keys"]
     stop_signal: SIGUSR2
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,6 @@ services:
       CONCOURSE_ENABLE_ACROSS_STEP: "true"
       CONCOURSE_ENABLE_CACHE_STREAMED_VOLUMES: "true"
       CONCOURSE_ENABLE_RESOURCE_CAUSALITY: "true"
-      CONCOURSE_STREAMING_SIZE_LIMITATION: 10
-      CONCOURSE_ENABLE_P2P_VOLUME_STREAMING: "true"
 
   worker:
     build: .
@@ -49,35 +47,6 @@ services:
     ports:
     - 7777:7777
     - 7788:7788
-    volumes: ["./hack/keys:/concourse-keys"]
-    stop_signal: SIGUSR2
-    environment:
-      CONCOURSE_RUNTIME: containerd
-
-      CONCOURSE_TSA_PUBLIC_KEY: /concourse-keys/tsa_host_key.pub
-      CONCOURSE_TSA_WORKER_PRIVATE_KEY: /concourse-keys/worker_key
-
-      CONCOURSE_LOG_LEVEL: debug
-      CONCOURSE_TSA_HOST: web:2222
-
-      CONCOURSE_BIND_IP: 0.0.0.0
-      CONCOURSE_BAGGAGECLAIM_BIND_IP: 0.0.0.0
-
-      # avoid using loopbacks
-      CONCOURSE_BAGGAGECLAIM_DRIVER: overlay
-
-      # work with docker-compose's dns
-      CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE: "true"
-
-  worker2:
-    build: .
-    image: concourse/concourse:local
-    command: worker
-    privileged: true
-    depends_on: [web]
-    ports:
-      - 8777:7777
-      - 8788:7788
     volumes: ["./hack/keys:/concourse-keys"]
     stop_signal: SIGUSR2
     environment:

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -481,10 +481,11 @@ func (vs *VolumeServer) StreamIn(w http.ResponseWriter, req *http.Request) {
 		subPath = queryPath[0]
 	}
 
-	var limitInMB int
+	// Parsing limit as a float value which allows to use a small limit less than MB in tests.
+	var limitInMB float64
 	if queryLimit, ok := req.URL.Query()["limit"]; ok {
 		var err error
-		limitInMB, err = strconv.Atoi(queryLimit[0])
+		limitInMB, err = strconv.ParseFloat(queryLimit[0], 64)
 		if err != nil || limitInMB < 0 {
 			RespondWithError(w, fmt.Errorf("invalid limit %s", queryLimit[0]), http.StatusBadRequest)
 			return

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -559,11 +559,6 @@ func (vs *VolumeServer) StreamOut(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		var errExceedStreamLimit volume.ErrExceedStreamLimit
-		if errors.As(err, &errExceedStreamLimit) {
-			RespondWithError(w, err, http.StatusForbidden)
-		}
-
 		if os.IsNotExist(err) {
 			hLog.Info("source-path-not-found")
 			RespondWithError(w, ErrStreamOutNotFound, http.StatusNotFound)

--- a/worker/baggageclaim/baggageclaimfakes/fake_volume.go
+++ b/worker/baggageclaim/baggageclaimfakes/fake_volume.go
@@ -136,14 +136,13 @@ type FakeVolume struct {
 		result1 io.ReadCloser
 		result2 error
 	}
-	StreamP2pOutStub        func(context.Context, string, string, baggageclaim.Encoding, int) error
+	StreamP2pOutStub        func(context.Context, string, string, baggageclaim.Encoding) error
 	streamP2pOutMutex       sync.RWMutex
 	streamP2pOutArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
 		arg4 baggageclaim.Encoding
-		arg5 int
 	}
 	streamP2pOutReturns struct {
 		result1 error
@@ -771,7 +770,7 @@ func (fake *FakeVolume) StreamOutReturnsOnCall(i int, result1 io.ReadCloser, res
 	}{result1, result2}
 }
 
-func (fake *FakeVolume) StreamP2pOut(arg1 context.Context, arg2 string, arg3 string, arg4 baggageclaim.Encoding, arg5 int) error {
+func (fake *FakeVolume) StreamP2pOut(arg1 context.Context, arg2 string, arg3 string, arg4 baggageclaim.Encoding) error {
 	fake.streamP2pOutMutex.Lock()
 	ret, specificReturn := fake.streamP2pOutReturnsOnCall[len(fake.streamP2pOutArgsForCall)]
 	fake.streamP2pOutArgsForCall = append(fake.streamP2pOutArgsForCall, struct {
@@ -779,14 +778,13 @@ func (fake *FakeVolume) StreamP2pOut(arg1 context.Context, arg2 string, arg3 str
 		arg2 string
 		arg3 string
 		arg4 baggageclaim.Encoding
-		arg5 int
-	}{arg1, arg2, arg3, arg4, arg5})
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.StreamP2pOutStub
 	fakeReturns := fake.streamP2pOutReturns
-	fake.recordInvocation("StreamP2pOut", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("StreamP2pOut", []interface{}{arg1, arg2, arg3, arg4})
 	fake.streamP2pOutMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -800,17 +798,17 @@ func (fake *FakeVolume) StreamP2pOutCallCount() int {
 	return len(fake.streamP2pOutArgsForCall)
 }
 
-func (fake *FakeVolume) StreamP2pOutCalls(stub func(context.Context, string, string, baggageclaim.Encoding, int) error) {
+func (fake *FakeVolume) StreamP2pOutCalls(stub func(context.Context, string, string, baggageclaim.Encoding) error) {
 	fake.streamP2pOutMutex.Lock()
 	defer fake.streamP2pOutMutex.Unlock()
 	fake.StreamP2pOutStub = stub
 }
 
-func (fake *FakeVolume) StreamP2pOutArgsForCall(i int) (context.Context, string, string, baggageclaim.Encoding, int) {
+func (fake *FakeVolume) StreamP2pOutArgsForCall(i int) (context.Context, string, string, baggageclaim.Encoding) {
 	fake.streamP2pOutMutex.RLock()
 	defer fake.streamP2pOutMutex.RUnlock()
 	argsForCall := fake.streamP2pOutArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeVolume) StreamP2pOutReturns(result1 error) {

--- a/worker/baggageclaim/baggageclaimfakes/fake_volume.go
+++ b/worker/baggageclaim/baggageclaimfakes/fake_volume.go
@@ -106,13 +106,14 @@ type FakeVolume struct {
 	setPropertyReturnsOnCall map[int]struct {
 		result1 error
 	}
-	StreamInStub        func(context.Context, string, baggageclaim.Encoding, io.Reader) error
+	StreamInStub        func(context.Context, string, baggageclaim.Encoding, int, io.Reader) error
 	streamInMutex       sync.RWMutex
 	streamInArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 baggageclaim.Encoding
-		arg4 io.Reader
+		arg4 int
+		arg5 io.Reader
 	}
 	streamInReturns struct {
 		result1 error
@@ -135,13 +136,14 @@ type FakeVolume struct {
 		result1 io.ReadCloser
 		result2 error
 	}
-	StreamP2pOutStub        func(context.Context, string, string, baggageclaim.Encoding) error
+	StreamP2pOutStub        func(context.Context, string, string, baggageclaim.Encoding, int) error
 	streamP2pOutMutex       sync.RWMutex
 	streamP2pOutArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
 		arg4 baggageclaim.Encoding
+		arg5 int
 	}
 	streamP2pOutReturns struct {
 		result1 error
@@ -638,21 +640,22 @@ func (fake *FakeVolume) SetPropertyReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeVolume) StreamIn(arg1 context.Context, arg2 string, arg3 baggageclaim.Encoding, arg4 io.Reader) error {
+func (fake *FakeVolume) StreamIn(arg1 context.Context, arg2 string, arg3 baggageclaim.Encoding, arg4 int, arg5 io.Reader) error {
 	fake.streamInMutex.Lock()
 	ret, specificReturn := fake.streamInReturnsOnCall[len(fake.streamInArgsForCall)]
 	fake.streamInArgsForCall = append(fake.streamInArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
 		arg3 baggageclaim.Encoding
-		arg4 io.Reader
-	}{arg1, arg2, arg3, arg4})
+		arg4 int
+		arg5 io.Reader
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.StreamInStub
 	fakeReturns := fake.streamInReturns
-	fake.recordInvocation("StreamIn", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("StreamIn", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.streamInMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -666,17 +669,17 @@ func (fake *FakeVolume) StreamInCallCount() int {
 	return len(fake.streamInArgsForCall)
 }
 
-func (fake *FakeVolume) StreamInCalls(stub func(context.Context, string, baggageclaim.Encoding, io.Reader) error) {
+func (fake *FakeVolume) StreamInCalls(stub func(context.Context, string, baggageclaim.Encoding, int, io.Reader) error) {
 	fake.streamInMutex.Lock()
 	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = stub
 }
 
-func (fake *FakeVolume) StreamInArgsForCall(i int) (context.Context, string, baggageclaim.Encoding, io.Reader) {
+func (fake *FakeVolume) StreamInArgsForCall(i int) (context.Context, string, baggageclaim.Encoding, int, io.Reader) {
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
 	argsForCall := fake.streamInArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeVolume) StreamInReturns(result1 error) {
@@ -768,7 +771,7 @@ func (fake *FakeVolume) StreamOutReturnsOnCall(i int, result1 io.ReadCloser, res
 	}{result1, result2}
 }
 
-func (fake *FakeVolume) StreamP2pOut(arg1 context.Context, arg2 string, arg3 string, arg4 baggageclaim.Encoding) error {
+func (fake *FakeVolume) StreamP2pOut(arg1 context.Context, arg2 string, arg3 string, arg4 baggageclaim.Encoding, arg5 int) error {
 	fake.streamP2pOutMutex.Lock()
 	ret, specificReturn := fake.streamP2pOutReturnsOnCall[len(fake.streamP2pOutArgsForCall)]
 	fake.streamP2pOutArgsForCall = append(fake.streamP2pOutArgsForCall, struct {
@@ -776,13 +779,14 @@ func (fake *FakeVolume) StreamP2pOut(arg1 context.Context, arg2 string, arg3 str
 		arg2 string
 		arg3 string
 		arg4 baggageclaim.Encoding
-	}{arg1, arg2, arg3, arg4})
+		arg5 int
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.StreamP2pOutStub
 	fakeReturns := fake.streamP2pOutReturns
-	fake.recordInvocation("StreamP2pOut", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("StreamP2pOut", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.streamP2pOutMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
@@ -796,17 +800,17 @@ func (fake *FakeVolume) StreamP2pOutCallCount() int {
 	return len(fake.streamP2pOutArgsForCall)
 }
 
-func (fake *FakeVolume) StreamP2pOutCalls(stub func(context.Context, string, string, baggageclaim.Encoding) error) {
+func (fake *FakeVolume) StreamP2pOutCalls(stub func(context.Context, string, string, baggageclaim.Encoding, int) error) {
 	fake.streamP2pOutMutex.Lock()
 	defer fake.streamP2pOutMutex.Unlock()
 	fake.StreamP2pOutStub = stub
 }
 
-func (fake *FakeVolume) StreamP2pOutArgsForCall(i int) (context.Context, string, string, baggageclaim.Encoding) {
+func (fake *FakeVolume) StreamP2pOutArgsForCall(i int) (context.Context, string, string, baggageclaim.Encoding, int) {
 	fake.streamP2pOutMutex.RLock()
 	defer fake.streamP2pOutMutex.RUnlock()
 	argsForCall := fake.streamP2pOutArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeVolume) StreamP2pOutReturns(result1 error) {

--- a/worker/baggageclaim/baggageclaimfakes/fake_volume.go
+++ b/worker/baggageclaim/baggageclaimfakes/fake_volume.go
@@ -106,13 +106,13 @@ type FakeVolume struct {
 	setPropertyReturnsOnCall map[int]struct {
 		result1 error
 	}
-	StreamInStub        func(context.Context, string, baggageclaim.Encoding, int, io.Reader) error
+	StreamInStub        func(context.Context, string, baggageclaim.Encoding, float64, io.Reader) error
 	streamInMutex       sync.RWMutex
 	streamInArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 baggageclaim.Encoding
-		arg4 int
+		arg4 float64
 		arg5 io.Reader
 	}
 	streamInReturns struct {
@@ -639,14 +639,14 @@ func (fake *FakeVolume) SetPropertyReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeVolume) StreamIn(arg1 context.Context, arg2 string, arg3 baggageclaim.Encoding, arg4 int, arg5 io.Reader) error {
+func (fake *FakeVolume) StreamIn(arg1 context.Context, arg2 string, arg3 baggageclaim.Encoding, arg4 float64, arg5 io.Reader) error {
 	fake.streamInMutex.Lock()
 	ret, specificReturn := fake.streamInReturnsOnCall[len(fake.streamInArgsForCall)]
 	fake.streamInArgsForCall = append(fake.streamInArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
 		arg3 baggageclaim.Encoding
-		arg4 int
+		arg4 float64
 		arg5 io.Reader
 	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.StreamInStub
@@ -668,13 +668,13 @@ func (fake *FakeVolume) StreamInCallCount() int {
 	return len(fake.streamInArgsForCall)
 }
 
-func (fake *FakeVolume) StreamInCalls(stub func(context.Context, string, baggageclaim.Encoding, int, io.Reader) error) {
+func (fake *FakeVolume) StreamInCalls(stub func(context.Context, string, baggageclaim.Encoding, float64, io.Reader) error) {
 	fake.streamInMutex.Lock()
 	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = stub
 }
 
-func (fake *FakeVolume) StreamInArgsForCall(i int) (context.Context, string, baggageclaim.Encoding, int, io.Reader) {
+func (fake *FakeVolume) StreamInArgsForCall(i int) (context.Context, string, baggageclaim.Encoding, float64, io.Reader) {
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
 	argsForCall := fake.streamInArgsForCall[i]

--- a/worker/baggageclaim/client.go
+++ b/worker/baggageclaim/client.go
@@ -97,7 +97,7 @@ type Volume interface {
 
 	// StreamIn calls BaggageClaim API endpoint in order to initialize tarStream
 	// to stream the contents of the Reader into this volume at the specified path.
-	StreamIn(ctx context.Context, path string, encoding Encoding, tarStream io.Reader) error
+	StreamIn(ctx context.Context, path string, encoding Encoding, limitInMB int, tarStream io.Reader) error
 
 	StreamOut(ctx context.Context, path string, encoding Encoding) (io.ReadCloser, error)
 
@@ -118,7 +118,7 @@ type Volume interface {
 
 	// StreamP2pOut streams the contents of this volume directly to another
 	// baggageclaim server on the same network.
-	StreamP2pOut(ctx context.Context, path string, streamInURL string, encoding Encoding) error
+	StreamP2pOut(ctx context.Context, path string, streamInURL string, encoding Encoding, limitInMB int) error
 }
 
 // Volumes represents a list of Volume object.

--- a/worker/baggageclaim/client.go
+++ b/worker/baggageclaim/client.go
@@ -118,7 +118,7 @@ type Volume interface {
 
 	// StreamP2pOut streams the contents of this volume directly to another
 	// baggageclaim server on the same network.
-	StreamP2pOut(ctx context.Context, path string, streamInURL string, encoding Encoding, limitInMB int) error
+	StreamP2pOut(ctx context.Context, path string, streamInURL string, encoding Encoding) error
 }
 
 // Volumes represents a list of Volume object.

--- a/worker/baggageclaim/client.go
+++ b/worker/baggageclaim/client.go
@@ -97,7 +97,7 @@ type Volume interface {
 
 	// StreamIn calls BaggageClaim API endpoint in order to initialize tarStream
 	// to stream the contents of the Reader into this volume at the specified path.
-	StreamIn(ctx context.Context, path string, encoding Encoding, limitInMB int, tarStream io.Reader) error
+	StreamIn(ctx context.Context, path string, encoding Encoding, limitInMB float64, tarStream io.Reader) error
 
 	StreamOut(ctx context.Context, path string, encoding Encoding) (io.ReadCloser, error)
 

--- a/worker/baggageclaim/client/client.go
+++ b/worker/baggageclaim/client/client.go
@@ -359,7 +359,7 @@ func (c *client) streamOut(ctx context.Context, srcHandle string, encoding bagga
 	return response.Body, nil
 }
 
-func (c *client) streamP2pOut(ctx context.Context, srcHandle string, encoding baggageclaim.Encoding, limitInMB int, path string, streamInURL string) error {
+func (c *client) streamP2pOut(ctx context.Context, srcHandle string, encoding baggageclaim.Encoding, path string, streamInURL string) error {
 	ctx, span := tracing.StartSpan(ctx, "volumeClient.streamP2pOut", tracing.Attrs{
 		"volume":   srcHandle,
 		"encoding": string(encoding),
@@ -374,7 +374,6 @@ func (c *client) streamP2pOut(ctx context.Context, srcHandle string, encoding ba
 		"path":        []string{path},
 		"streamInURL": []string{streamInURL},
 		"encoding":    []string{string(encoding)},
-		"limit":       []string{fmt.Sprintf("%d", limitInMB)},
 	}.Encode()
 	if err != nil {
 		return err

--- a/worker/baggageclaim/client/client.go
+++ b/worker/baggageclaim/client/client.go
@@ -250,7 +250,7 @@ func (c *client) newVolume(apiVolume baggageclaim.VolumeResponse) baggageclaim.V
 	return volume
 }
 
-func (c *client) streamIn(ctx context.Context, destHandle string, path string, encoding baggageclaim.Encoding, limitInMB int, tarContent io.Reader) error {
+func (c *client) streamIn(ctx context.Context, destHandle string, path string, encoding baggageclaim.Encoding, limitInMB float64, tarContent io.Reader) error {
 	ctx, span := tracing.StartSpan(ctx, "volumeClient.streamIn", tracing.Attrs{
 		"volume":   destHandle,
 		"encoding": string(encoding),
@@ -263,7 +263,7 @@ func (c *client) streamIn(ctx context.Context, destHandle string, path string, e
 
 	request.URL.RawQuery = url.Values{
 		"path":  []string{path},
-		"limit": []string{fmt.Sprintf("%d", limitInMB)},
+		"limit": []string{fmt.Sprintf("%f", limitInMB)},
 	}.Encode()
 	if err != nil {
 		return err

--- a/worker/baggageclaim/client/client.go
+++ b/worker/baggageclaim/client/client.go
@@ -250,7 +250,7 @@ func (c *client) newVolume(apiVolume baggageclaim.VolumeResponse) baggageclaim.V
 	return volume
 }
 
-func (c *client) streamIn(ctx context.Context, destHandle string, path string, encoding baggageclaim.Encoding, tarContent io.Reader) error {
+func (c *client) streamIn(ctx context.Context, destHandle string, path string, encoding baggageclaim.Encoding, limitInMB int, tarContent io.Reader) error {
 	ctx, span := tracing.StartSpan(ctx, "volumeClient.streamIn", tracing.Attrs{
 		"volume":   destHandle,
 		"encoding": string(encoding),
@@ -261,7 +261,10 @@ func (c *client) streamIn(ctx context.Context, destHandle string, path string, e
 		"handle": destHandle,
 	}, tarContent)
 
-	request.URL.RawQuery = url.Values{"path": []string{path}}.Encode()
+	request.URL.RawQuery = url.Values{
+		"path":  []string{path},
+		"limit": []string{fmt.Sprintf("%d", limitInMB)},
+	}.Encode()
 	if err != nil {
 		return err
 	}
@@ -356,7 +359,7 @@ func (c *client) streamOut(ctx context.Context, srcHandle string, encoding bagga
 	return response.Body, nil
 }
 
-func (c *client) streamP2pOut(ctx context.Context, srcHandle string, encoding baggageclaim.Encoding, path string, streamInURL string) error {
+func (c *client) streamP2pOut(ctx context.Context, srcHandle string, encoding baggageclaim.Encoding, limitInMB int, path string, streamInURL string) error {
 	ctx, span := tracing.StartSpan(ctx, "volumeClient.streamP2pOut", tracing.Attrs{
 		"volume":   srcHandle,
 		"encoding": string(encoding),
@@ -371,6 +374,7 @@ func (c *client) streamP2pOut(ctx context.Context, srcHandle string, encoding ba
 		"path":        []string{path},
 		"streamInURL": []string{streamInURL},
 		"encoding":    []string{string(encoding)},
+		"limit":       []string{fmt.Sprintf("%d", limitInMB)},
 	}.Encode()
 	if err != nil {
 		return err

--- a/worker/baggageclaim/client/volume.go
+++ b/worker/baggageclaim/client/volume.go
@@ -35,8 +35,8 @@ func (cv *clientVolume) Properties(ctx context.Context) (baggageclaim.VolumeProp
 	return vr.Properties, nil
 }
 
-func (cv *clientVolume) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, tarStream io.Reader) error {
-	return cv.bcClient.streamIn(ctx, cv.handle, path, encoding, tarStream)
+func (cv *clientVolume) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, limitInMB int, tarStream io.Reader) error {
+	return cv.bcClient.streamIn(ctx, cv.handle, path, encoding, limitInMB, tarStream)
 }
 
 func (cv *clientVolume) StreamOut(ctx context.Context, path string, encoding baggageclaim.Encoding) (io.ReadCloser, error) {
@@ -63,6 +63,6 @@ func (cv *clientVolume) GetStreamInP2pUrl(ctx context.Context, path string) (str
 	return cv.bcClient.getStreamInP2pUrl(ctx, cv.handle, path)
 }
 
-func (cv *clientVolume) StreamP2pOut(ctx context.Context, path, url string, encoding baggageclaim.Encoding) error {
-	return cv.bcClient.streamP2pOut(ctx, cv.handle, encoding, path, url)
+func (cv *clientVolume) StreamP2pOut(ctx context.Context, path, url string, encoding baggageclaim.Encoding, limitInMB int) error {
+	return cv.bcClient.streamP2pOut(ctx, cv.handle, encoding, limitInMB, path, url)
 }

--- a/worker/baggageclaim/client/volume.go
+++ b/worker/baggageclaim/client/volume.go
@@ -35,7 +35,7 @@ func (cv *clientVolume) Properties(ctx context.Context) (baggageclaim.VolumeProp
 	return vr.Properties, nil
 }
 
-func (cv *clientVolume) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, limitInMB int, tarStream io.Reader) error {
+func (cv *clientVolume) StreamIn(ctx context.Context, path string, encoding baggageclaim.Encoding, limitInMB float64, tarStream io.Reader) error {
 	return cv.bcClient.streamIn(ctx, cv.handle, path, encoding, limitInMB, tarStream)
 }
 

--- a/worker/baggageclaim/client/volume.go
+++ b/worker/baggageclaim/client/volume.go
@@ -63,6 +63,6 @@ func (cv *clientVolume) GetStreamInP2pUrl(ctx context.Context, path string) (str
 	return cv.bcClient.getStreamInP2pUrl(ctx, cv.handle, path)
 }
 
-func (cv *clientVolume) StreamP2pOut(ctx context.Context, path, url string, encoding baggageclaim.Encoding, limitInMB int) error {
-	return cv.bcClient.streamP2pOut(ctx, cv.handle, encoding, limitInMB, path, url)
+func (cv *clientVolume) StreamP2pOut(ctx context.Context, path, url string, encoding baggageclaim.Encoding) error {
+	return cv.bcClient.streamP2pOut(ctx, cv.handle, encoding, path, url)
 }

--- a/worker/baggageclaim/client_test.go
+++ b/worker/baggageclaim/client_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Baggage Claim Client", func() {
 						ghttp.RespondWith(http.StatusNoContent, ""),
 					),
 				)
-				err := vol.StreamIn(context.TODO(), ".", baggageclaim.GzipEncoding, strings.NewReader("some tar content"))
+				err := vol.StreamIn(context.TODO(), ".", baggageclaim.GzipEncoding, 0, strings.NewReader("some tar content"))
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(bodyChan).To(Receive(Equal([]byte("some tar content"))))
@@ -238,7 +238,7 @@ var _ = Describe("Baggage Claim Client", func() {
 			Context("when unexpected error occurs", func() {
 				It("returns error code and useful message", func() {
 					mockErrorResponse("PUT", "/volumes/some-handle/stream-in", "lost baggage", http.StatusInternalServerError)
-					err := vol.StreamIn(context.TODO(), "./some/path/", baggageclaim.GzipEncoding, strings.NewReader("even more tar"))
+					err := vol.StreamIn(context.TODO(), "./some/path/", baggageclaim.GzipEncoding, 0, strings.NewReader("even more tar"))
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("lost baggage"))
 				})

--- a/worker/baggageclaim/integration/baggageclaim/privileges_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/privileges_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Privileges", func() {
 				})
 
 				It("maps uid 0 to uid 0", func() {
-					err := privilegedVolume.StreamIn(context.TODO(), ".", baggageclaim.GzipEncoding, tgzStream)
+					err := privilegedVolume.StreamIn(context.TODO(), ".", baggageclaim.GzipEncoding, 0, tgzStream)
 					Expect(err).ToNot(HaveOccurred())
 
 					stat, err := os.Stat(filepath.Join(privilegedVolume.Path(), dataFilename))
@@ -332,7 +332,7 @@ var _ = Describe("Privileges", func() {
 				})
 
 				It("maps uid 0 to (MAX_UID)", func() {
-					err := unprivilegedVolume.StreamIn(ctx, ".", baggageclaim.GzipEncoding, tgzStream)
+					err := unprivilegedVolume.StreamIn(ctx, ".", baggageclaim.GzipEncoding, 0, tgzStream)
 					Expect(err).ToNot(HaveOccurred())
 
 					stat, err := os.Stat(filepath.Join(unprivilegedVolume.Path(), dataFilename))

--- a/worker/baggageclaim/volume/repository.go
+++ b/worker/baggageclaim/volume/repository.go
@@ -570,12 +570,12 @@ func (repo *repository) StreamP2pOut(ctx context.Context, handle string, path st
 	}
 
 	// Upon stream-in failure, decode error message from stream-in api.
-	var errorResponse *struct {
+	var errorResponse struct {
 		Message string `json:"error"`
 	}
 	err = json.NewDecoder(resp.Body).Decode(&errorResponse)
 	if err != nil {
-		return err
+		errorResponse.Message = err.Error()
 	}
 
 	return fmt.Errorf("p2p-stream-in %d: %s", resp.StatusCode, errorResponse.Message)

--- a/worker/baggageclaim/volume/repository_test.go
+++ b/worker/baggageclaim/volume/repository_test.go
@@ -4,8 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1107,7 +1106,7 @@ var _ = Describe("Repository", func() {
 		)
 		BeforeEach(func() {
 			var err error
-			tempFile, err = ioutil.TempFile("", "StreamP2pOutTest")
+			tempFile, err = os.CreateTemp("", "StreamP2pOutTest")
 			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
@@ -1127,7 +1126,7 @@ var _ = Describe("Repository", func() {
 				serverCalled = true
 
 				var err error
-				serverReadBytes, err = ioutil.ReadAll(r.Body)
+				serverReadBytes, err = io.ReadAll(r.Body)
 				Expect(err).ToNot(HaveOccurred())
 			}))
 			streamErr = repository.StreamP2pOut(context.Background(), "some-handle", filepath.Base(tempFile.Name()), baggageclaim.GzipEncoding, server.URL)
@@ -1196,7 +1195,7 @@ var _ = Describe("Repository", func() {
 					})
 					It("should fail", func() {
 						Expect(streamErr).To(HaveOccurred())
-						Expect(streamErr).To(Equal(fmt.Errorf("p2p streaming error %d", http.StatusInternalServerError)))
+						Expect(streamErr.Error()).To(ContainSubstring("p2p-stream-in 500:"))
 					})
 					It("should http request", func() {
 						Expect(serverCalled).To(BeTrue())

--- a/worker/baggageclaim/volume/volumefakes/fake_repository.go
+++ b/worker/baggageclaim/volume/volumefakes/fake_repository.go
@@ -125,14 +125,15 @@ type FakeRepository struct {
 	setPropertyReturnsOnCall map[int]struct {
 		result1 error
 	}
-	StreamInStub        func(context.Context, string, string, baggageclaim.Encoding, io.Reader) (bool, error)
+	StreamInStub        func(context.Context, string, string, baggageclaim.Encoding, float64, io.Reader) (bool, error)
 	streamInMutex       sync.RWMutex
 	streamInArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
 		arg4 baggageclaim.Encoding
-		arg5 io.Reader
+		arg5 float64
+		arg6 io.Reader
 	}
 	streamInReturns struct {
 		result1 bool
@@ -712,7 +713,7 @@ func (fake *FakeRepository) SetPropertyReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeRepository) StreamIn(arg1 context.Context, arg2 string, arg3 string, arg4 baggageclaim.Encoding, arg5 io.Reader) (bool, error) {
+func (fake *FakeRepository) StreamIn(arg1 context.Context, arg2 string, arg3 string, arg4 baggageclaim.Encoding, arg5 float64, arg6 io.Reader) (bool, error) {
 	fake.streamInMutex.Lock()
 	ret, specificReturn := fake.streamInReturnsOnCall[len(fake.streamInArgsForCall)]
 	fake.streamInArgsForCall = append(fake.streamInArgsForCall, struct {
@@ -720,14 +721,15 @@ func (fake *FakeRepository) StreamIn(arg1 context.Context, arg2 string, arg3 str
 		arg2 string
 		arg3 string
 		arg4 baggageclaim.Encoding
-		arg5 io.Reader
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg5 float64
+		arg6 io.Reader
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.StreamInStub
 	fakeReturns := fake.streamInReturns
-	fake.recordInvocation("StreamIn", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("StreamIn", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.streamInMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -741,17 +743,17 @@ func (fake *FakeRepository) StreamInCallCount() int {
 	return len(fake.streamInArgsForCall)
 }
 
-func (fake *FakeRepository) StreamInCalls(stub func(context.Context, string, string, baggageclaim.Encoding, io.Reader) (bool, error)) {
+func (fake *FakeRepository) StreamInCalls(stub func(context.Context, string, string, baggageclaim.Encoding, float64, io.Reader) (bool, error)) {
 	fake.streamInMutex.Lock()
 	defer fake.streamInMutex.Unlock()
 	fake.StreamInStub = stub
 }
 
-func (fake *FakeRepository) StreamInArgsForCall(i int) (context.Context, string, string, baggageclaim.Encoding, io.Reader) {
+func (fake *FakeRepository) StreamInArgsForCall(i int) (context.Context, string, string, baggageclaim.Encoding, float64, io.Reader) {
 	fake.streamInMutex.RLock()
 	defer fake.streamInMutex.RUnlock()
 	argsForCall := fake.streamInArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeRepository) StreamInReturns(result1 bool, result2 error) {

--- a/worker/baggageclaim/volume/volumefakes/fake_strategy.go
+++ b/worker/baggageclaim/volume/volumefakes/fake_strategy.go
@@ -4,7 +4,7 @@ package volumefakes
 import (
 	"sync"
 
-	"code.cloudfoundry.org/lager/v3"
+	lager "code.cloudfoundry.org/lager/v3"
 	"github.com/concourse/concourse/worker/baggageclaim/volume"
 )
 


### PR DESCRIPTION
## Changes proposed by this PR

Our prod cluster experienced worker unstable issues, the cause is like:

1 A pipeline incidentally generated a very large volume (>130GB), which filled up the current step's worker's disk
2 The worker is auto retired by our worker manager as its disk usage is close to full
3 The next step is scheduled to the other worker, as the first worker is retired
4 The next step requires the large volume as input, so that the large volume is streamed to the worker, so that the other worker is filled up also

So, as we can see, a large volume may bring up multiple workers, and even worse, there is no way to find out the pipeline that generates such large volumes.

This feature adds a threshold for maximum size of volumes that can be streamed. So that, in above step 4, volume streaming should fail, so that prevents from filling up another worker, and when users report the issue to us, we know which pipeline is the bad boy.

UI will show the error:

Non-p2p streaming:
![image](https://github.com/concourse/concourse/assets/18585861/46247abe-4b87-49ca-a0ae-7c37a476ab43)

P2p streaming:
![image](https://github.com/concourse/concourse/assets/18585861/7f151c86-9c70-4c20-aa9a-f8383221d280)



* [x] poc
* [x] functionality 
* [x] add tests
* [x] clean up code


## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

Add a new ATC option `CONCOURSE_STREAMING_SIZE_LIMITATION" that restricts maximum size in MB of volumes can be streamed between workers. This is a mechanism to prevent rogue pipeline pipelines from hurting multiple workers.