### PR TITLE
Remove btrfs baggageclaim test over COS image

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -31,7 +31,8 @@ var _ = Describe("baggageclaim drivers", func() {
 		)
 
 		Context("cos image", func() {
-			baggageclaimWorks("btrfs", COS)
+			// See in https://github.com/concourse/concourse/issues/8669
+			// baggageclaimWorks("btrfs", COS)
 			baggageclaimWorks("overlay", COS)
 			baggageclaimWorks("naive", COS)
 		})


### PR DESCRIPTION

## Changes proposed by this PR

remove btrfs baggageclaim test over COS image on GKE since the base image of the worker node doesn't support `btrfs` anymore. Refer to issue https://github.com/concourse/concourse/issues/8669

