### PR TITLE
Add reset character in WaitingForStreamedVolume event render

### DIFF
--- a/fly/eventstream/render.go
+++ b/fly/eventstream/render.go
@@ -54,7 +54,7 @@ func Render(dst io.Writer, src eventstream.EventStream, options RenderOptions) i
 
 		case event.WaitingForStreamedVolume:
 			dstImpl.SetTimestamp(e.Time)
-			fmt.Fprintf(dstImpl, "\x1b[1mwaiting for volume\x1b[0m %s \x1b[1mto be streamed by another step\n", e.Volume)
+			fmt.Fprintf(dstImpl, "\x1b[1mwaiting for volume\x1b[0m %s \x1b[1mto be streamed by another step\x1b[0m\n", e.Volume)
 
 		case event.InitializeCheck:
 			dstImpl.SetTimestamp(e.Time)

--- a/fly/eventstream/render_test.go
+++ b/fly/eventstream/render_test.go
@@ -376,7 +376,7 @@ var _ = Describe("V1.0 Renderer", func() {
 		})
 
 		It("prints the event", func() {
-			Expect(out.Contents()).To(ContainSubstring("\x1b[1mwaiting for volume\u001B[0m some-volume \x1b[1mto be streamed by another step\n"))
+			Expect(out.Contents()).To(ContainSubstring("\x1b[1mwaiting for volume\u001B[0m some-volume \x1b[1mto be streamed by another step\u001B[0m\n"))
 		})
 
 		Context("and time configuration enabled", func() {

--- a/web/elm/src/Build/Output/Output.elm
+++ b/web/elm/src/Build/Output/Output.elm
@@ -176,7 +176,7 @@ handleEvent event ( model, effects ) =
             )
 
         WaitingForStreamedVolume origin volume time ->
-            ( updateStep origin.id (setRunning << appendStepLog ("\u{001B}[1mwaiting for volume \u{001B}[0m" ++ volume ++ " \u{001B}[1mto be streamed by another step\n") time) model
+            ( updateStep origin.id (setRunning << appendStepLog ("\u{001B}[1mwaiting for volume \u{001B}[0m" ++ volume ++ " \u{001B}[1mto be streamed by another step\u{001B}[0m\n") time) model
             , effects
             )
 


### PR DESCRIPTION
## Changes proposed by this PR

* [x] No longer bold the build output following the "to be streamed by another step" message.

## Notes to reviewer

Whenever you see a message like **waiting for volume** <repo> **to be streamed by another step**, the bolding is not terminated.  So your build looks something like:
**waiting for volume** foobar **to be streamed by another step**
**build output 1
build output 2
build output 3**

Whereas it should look like
**waiting for volume** foobar **to be streamed by another step**
build output 1
build output 2
build output 3