### PR TITLE
Fix test to find host name using cat cmd instead of hostname cmd

### DIFF
--- a/topgun/both/worker_landing_test.go
+++ b/topgun/both/worker_landing_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Worker landing", func() {
 					Expect(buildSession.ExitCode()).To(Equal(0))
 
 					By("getting identifier for check container")
-					hijackSession := Fly.Start("hijack", "-c", "topgun/tick-tock", "--", "hostname")
+					hijackSession := Fly.Start("hijack", "-c", "topgun/tick-tock", "--", "cat", "/proc/sys/kernel/hostname")
 					<-hijackSession.Exited
 					Expect(buildSession.ExitCode()).To(Equal(0))
 
@@ -136,7 +136,7 @@ var _ = Describe("Worker landing", func() {
 					Expect(buildSession.ExitCode()).To(Equal(0))
 
 					By("retaining check containers")
-					hijackSession := Fly.Start("hijack", "-c", "topgun/tick-tock", "--", "hostname")
+					hijackSession := Fly.Start("hijack", "-c", "topgun/tick-tock", "--", "cat", "/proc/sys/kernel/hostname")
 					<-hijackSession.Exited
 					Expect(buildSession.ExitCode()).To(Equal(0))
 


### PR DESCRIPTION
Seeing error in bosh-topgun-both 

```

  STEP: [1686889830.860861778] running: /tmp/gexec_artifacts4218925126/g3529486509/fly -t concourse-topgun-both-3 hijack -c topgun/tick-tock -- hostname @ 06/16/23 04:30:30.86

  read tcp 10.80.0.6:37554->10.0.2.12:8080: read: connection reset by peer

  start process: backend error: Exit status: 500, message: {"Type":"","Message":"runc exec: exit status 255: exec failed: unable to start container process: error adding pid 7741 to cgroups: failed to write 7741: openat2 /sys/fs/cgroup/blkio/system.slice/concourse.service/garden/d83276ac-2776-4649-6e7d-4d078c565489/cgroup.procs: no such file or directory","Handle":"","ProcessID":"","Binary":""}

  

  [FAILED] in [It] - github.com/concourse/concourse/topgun/both/worker_landing_test.go:144 @ 06/16/23 04:30:30.971
```

Running the test locally reveal that `fly hijack ... hostname` cmd returns nothing and the worker log shows
```
concourse-worker-1  | {"timestamp":"2023-06-16T21:51:08.789449835Z","level":"debug","source":"worker","message":"worker.garden.garden-server.run.running","data":{"handle":"0ff1cc30-93a1-4293-640f-e6a198e18b5f","session":"1.4.85","spec":{"Path":"hostname","Dir":"/tmp/build/check","User":"","Limits":{},"TTY":{"window_size":{"columns":154,"rows":75}}}}}
concourse-worker-1  | {"timestamp":"2023-06-16T21:51:08.830867335Z","level":"error","source":"worker","message":"worker.garden.garden-server.run.failed","data":{"error":"proc start: OCI runtime exec failed: exec failed: unable to start container process: exec: \"hostname\": executable file not found in $PATH: unknown","handle":"0ff1cc30-93a1-4293-640f-e6a198e18b5f","session":"1.4.85"}}
concourse-web-1     | {"timestamp":"2023-06-16T21:51:08.831476418Z","level":"error","source":"atc","message":"atc.hijack.hijack.failed-to-hijack","data":{"error":"start process: backend error: Exit status: 500, message: {\"Type\":\"\",\"Message\":\"proc start: OCI runtime exec failed: exec failed: unable to start container process: exec: \\\"hostname\\\": executable file not found in $PATH: unknown\",\"Handle\":\"\",\"ProcessID\":\"\",\"Binary\":\"\"}\n","handle":"0ff1cc30-93a1-4293-640f-e6a198e18b5f","process":{"path":"hostname","args":null,"env":["TERM=xterm-256color"],"dir":"/tmp/build/check","privileged":true,"user":"","tty":{"window_size":{"columns":154,"rows":75}}},"session":"680.1"}}
``` 
This is caused by time-resource not having `hostname` due to the swap to use paketo jammy static image as its base image.

This PR updates the test to use `cat /proc/sys/kernel/hostname` to print out the host name.