### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/atc/api/api_suite_test.go
+++ b/atc/api/api_suite_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -154,7 +153,7 @@ var _ = BeforeEach(func() {
 	fakeClock = fakeclock.NewFakeClock(time.Unix(123, 456))
 
 	var err error
-	cliDownloadsDir, err = ioutil.TempDir("", "cli-downloads")
+	cliDownloadsDir, err = os.MkdirTemp("", "cli-downloads")
 	Expect(err).NotTo(HaveOccurred())
 
 	constructedEventHandler = &fakeEventHandlerFactory{}

--- a/atc/api/artifacts_test.go
+++ b/atc/api/artifacts_test.go
@@ -3,7 +3,7 @@ package api_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -111,7 +111,7 @@ var _ = Describe("ArtifactRepository API", func() {
 			})
 
 			It("returns the artifact record", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`{

--- a/atc/api/auth/check_admin_handler_test.go
+++ b/atc/api/auth/check_admin_handler_test.go
@@ -3,7 +3,6 @@ package auth_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
@@ -104,7 +103,7 @@ var _ = Describe("CheckAdminHandler", func() {
 				})
 
 				It("proxies to the handler", func() {
-					responseBody, err := ioutil.ReadAll(response.Body)
+					responseBody, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(responseBody)).To(Equal("simple hello"))
 				})
@@ -124,7 +123,7 @@ var _ = Describe("CheckAdminHandler", func() {
 
 			It("rejects the request", func() {
 				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
-				responseBody, err := ioutil.ReadAll(response.Body)
+				responseBody, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(responseBody)).To(Equal("nope\n"))
 			})

--- a/atc/api/auth/check_authentication_handler_test.go
+++ b/atc/api/auth/check_authentication_handler_test.go
@@ -3,7 +3,6 @@ package auth_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 
@@ -92,7 +91,7 @@ var _ = Describe("AuthenticationHandler", func() {
 				})
 
 				It("proxies to the handler", func() {
-					responseBody, err := ioutil.ReadAll(response.Body)
+					responseBody, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(responseBody)).To(Equal("simple hello"))
 				})
@@ -108,7 +107,7 @@ var _ = Describe("AuthenticationHandler", func() {
 				})
 
 				It("rejects the request", func() {
-					responseBody, err := ioutil.ReadAll(response.Body)
+					responseBody, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(responseBody)).To(Equal("nope\n"))
 				})
@@ -155,7 +154,7 @@ var _ = Describe("AuthenticationHandler", func() {
 					})
 
 					It("rejects the request", func() {
-						responseBody, err := ioutil.ReadAll(response.Body)
+						responseBody, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(string(responseBody)).To(Equal("nope\n"))
 					})
@@ -171,7 +170,7 @@ var _ = Describe("AuthenticationHandler", func() {
 					})
 
 					It("proxies to the handler", func() {
-						responseBody, err := ioutil.ReadAll(response.Body)
+						responseBody, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(string(responseBody)).To(Equal("simple hello"))
 					})
@@ -188,7 +187,7 @@ var _ = Describe("AuthenticationHandler", func() {
 				})
 
 				It("proxies to the handler", func() {
-					responseBody, err := ioutil.ReadAll(response.Body)
+					responseBody, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(responseBody)).To(Equal("simple hello"))
 				})

--- a/atc/api/auth/check_authorization_handler_test.go
+++ b/atc/api/auth/check_authorization_handler_test.go
@@ -3,7 +3,6 @@ package auth_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -105,7 +104,7 @@ var _ = Describe("CheckAuthorizationHandler", func() {
 				})
 
 				It("proxies to the handler", func() {
-					responseBody, err := ioutil.ReadAll(response.Body)
+					responseBody, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(responseBody)).To(Equal("simple hello"))
 				})
@@ -118,7 +117,7 @@ var _ = Describe("CheckAuthorizationHandler", func() {
 
 				It("returns 403", func() {
 					Expect(response.StatusCode).To(Equal(http.StatusForbidden))
-					responseBody, err := ioutil.ReadAll(response.Body)
+					responseBody, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(responseBody)).To(Equal("nope\n"))
 				})
@@ -132,7 +131,7 @@ var _ = Describe("CheckAuthorizationHandler", func() {
 
 			It("returns 401", func() {
 				Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
-				responseBody, err := ioutil.ReadAll(response.Body)
+				responseBody, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(responseBody)).To(Equal("nope\n"))
 			})

--- a/atc/api/builds_test.go
+++ b/atc/api/builds_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -125,7 +125,7 @@ var _ = Describe("Builds API", func() {
 					})
 
 					It("returns the created build", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`{
@@ -263,7 +263,7 @@ var _ = Describe("Builds API", func() {
 				})
 
 				It("returns all builds", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`[
@@ -398,7 +398,7 @@ var _ = Describe("Builds API", func() {
 				})
 
 				It("returns all builds", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`[
@@ -623,7 +623,7 @@ var _ = Describe("Builds API", func() {
 							buildID := dbBuildFactory.BuildForAPIArgsForCall(0)
 							Expect(buildID).To(Equal(1))
 
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`{
@@ -762,7 +762,7 @@ var _ = Describe("Builds API", func() {
 					})
 
 					It("returns the build with it's input and output versioned resources", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`{
@@ -895,7 +895,7 @@ var _ = Describe("Builds API", func() {
 				})
 
 				It("serves the request via the event handler", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal("fake event handler factory was here"))
@@ -957,7 +957,7 @@ var _ = Describe("Builds API", func() {
 							})
 
 							It("serves the request via the event handler", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(string(body)).To(Equal("fake event handler factory was here"))
@@ -1271,7 +1271,7 @@ var _ = Describe("Builds API", func() {
 				})
 
 				It("returns the build preparation", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`{
@@ -1491,7 +1491,7 @@ var _ = Describe("Builds API", func() {
 					})
 
 					It("returns the plan", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`{

--- a/atc/api/cc_test.go
+++ b/atc/api/cc_test.go
@@ -2,7 +2,7 @@ package api_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -103,7 +103,7 @@ var _ = Describe("cc.xml", func() {
 							})
 
 							It("returns the CC.xml", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchXML(`
@@ -131,7 +131,7 @@ var _ = Describe("cc.xml", func() {
 							})
 
 							It("returns the CC.xml", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchXML(`
@@ -159,7 +159,7 @@ var _ = Describe("cc.xml", func() {
 							})
 
 							It("returns the CC.xml", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchXML(`
@@ -187,7 +187,7 @@ var _ = Describe("cc.xml", func() {
 							})
 
 							It("returns the CC.xml", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchXML(`
@@ -216,7 +216,7 @@ var _ = Describe("cc.xml", func() {
 							})
 
 							It("returns the CC.xml", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchXML(`
@@ -229,7 +229,7 @@ var _ = Describe("cc.xml", func() {
 
 						Context("when no last build exists", func() {
 							It("returns the CC.xml without the job", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchXML("<Projects></Projects>"))
@@ -247,7 +247,7 @@ var _ = Describe("cc.xml", func() {
 						})
 
 						It("returns the CC.xml", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchXML("<Projects></Projects>"))
@@ -292,7 +292,7 @@ var _ = Describe("cc.xml", func() {
 					})
 
 					It("returns the proper web url in the CC.xml", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchXML(`
@@ -313,7 +313,7 @@ var _ = Describe("cc.xml", func() {
 					})
 
 					It("returns the CC.xml", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchXML("<Projects></Projects>"))

--- a/atc/api/cli_test.go
+++ b/atc/api/cli_test.go
@@ -2,7 +2,7 @@ package api_test
 
 import (
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -95,7 +95,7 @@ var _ = Describe("CLI Downloads API", func() {
 		})
 
 		It("returns the file binary", func() {
-			Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("soi soi soi")))
+			Expect(io.ReadAll(response.Body)).To(Equal([]byte("soi soi soi")))
 		})
 	})
 
@@ -123,7 +123,7 @@ var _ = Describe("CLI Downloads API", func() {
 		})
 
 		It("returns the file binary", func() {
-			Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("soi soi soi.notavirus.bat")))
+			Expect(io.ReadAll(response.Body)).To(Equal([]byte("soi soi soi.notavirus.bat")))
 		})
 	})
 
@@ -141,7 +141,7 @@ var _ = Describe("CLI Downloads API", func() {
 		})
 
 		It("returns the file binary", func() {
-			Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("soi soi soi")))
+			Expect(io.ReadAll(response.Body)).To(Equal([]byte("soi soi soi")))
 		})
 	})
 
@@ -159,7 +159,7 @@ var _ = Describe("CLI Downloads API", func() {
 		})
 
 		It("returns the file binary", func() {
-			Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("soi soi soi.notavirus.bat")))
+			Expect(io.ReadAll(response.Body)).To(Equal([]byte("soi soi soi.notavirus.bat")))
 		})
 	})
 

--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -190,7 +190,7 @@ var _ = Describe("Config API", func() {
 							})
 
 							It("returns an error in the response body", func() {
-								Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+								Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 										{
 											"errors": [
 												"instance vars are malformed: unexpected end of JSON input"
@@ -371,7 +371,7 @@ var _ = Describe("Config API", func() {
 					})
 
 					It("returns warnings in the response body", func() {
-						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+						Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"warnings": [
 									{
@@ -404,7 +404,7 @@ var _ = Describe("Config API", func() {
 					})
 
 					It("returns warnings in the response body", func() {
-						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+						Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"errors": [
 										"pipeline: identifier cannot be an empty string"
@@ -439,7 +439,7 @@ var _ = Describe("Config API", func() {
 						})
 
 						It("returns error JSON", func() {
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 								{
 									"errors": [
 										"malformed config: error converting YAML to JSON: yaml: line 1: did not find expected node content"
@@ -470,7 +470,7 @@ var _ = Describe("Config API", func() {
 						})
 
 						It("returns error JSON", func() {
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 								{
 									"errors": [
 										"malformed config: error converting YAML to JSON: yaml: line 1: did not find expected node content"
@@ -530,7 +530,7 @@ var _ = Describe("Config API", func() {
 							})
 
 							It("returns the error in the response body", func() {
-								Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("failed to save config: oh no!")))
+								Expect(io.ReadAll(response.Body)).To(Equal([]byte("failed to save config: oh no!")))
 							})
 						})
 
@@ -569,7 +569,7 @@ var _ = Describe("Config API", func() {
 							})
 
 							It("returns error JSON", func() {
-								Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+								Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 								{
 									"errors": [
 										"invalid groups:\n\tgroup 'some-group' has unknown resource 'missing-resource'\n"
@@ -641,7 +641,7 @@ jobs:
         BAZ: 1.9`
 
 								request.Header.Set("Content-Type", "application/x-yaml")
-								request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))
+								request.Body = io.NopCloser(bytes.NewBufferString(payload))
 							})
 
 							It("returns 200", func() {
@@ -765,7 +765,7 @@ jobs:
     file: some/task/config.yaml`
 
 									request.Header.Set("Content-Type", "application/x-yaml")
-									request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))
+									request.Body = io.NopCloser(bytes.NewBufferString(payload))
 								})
 
 								ExpectCredsValidationPass()
@@ -786,7 +786,7 @@ jobs:
   - get: some-resource`
 
 									request.Header.Set("Content-Type", "application/x-yaml")
-									request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))
+									request.Body = io.NopCloser(bytes.NewBufferString(payload))
 								})
 
 								ExpectCredsValidationPass()
@@ -806,7 +806,7 @@ jobs:
   - get: some-resource`
 
 									request.Header.Set("Content-Type", "application/x-yaml")
-									request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))
+									request.Body = io.NopCloser(bytes.NewBufferString(payload))
 								})
 
 								ExpectCredsValidationPass()
@@ -830,7 +830,7 @@ jobs:
       FOO: ((BAR))`
 
 									request.Header.Set("Content-Type", "application/x-yaml")
-									request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))
+									request.Body = io.NopCloser(bytes.NewBufferString(payload))
 								})
 
 								ExpectCredsValidationPass()
@@ -854,7 +854,7 @@ jobs:
       FOO: ((BAR))`
 
 									request.Header.Set("Content-Type", "application/x-yaml")
-									request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))
+									request.Body = io.NopCloser(bytes.NewBufferString(payload))
 								})
 
 								ExpectCredsValidationPass()
@@ -879,7 +879,7 @@ jobs:
         FOO: ((BAR))`
 
 									request.Header.Set("Content-Type", "application/x-yaml")
-									request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))
+									request.Body = io.NopCloser(bytes.NewBufferString(payload))
 								})
 
 								ExpectCredsValidationPass()
@@ -949,7 +949,7 @@ jobs:
 								}
 
 								request.Header.Set("Content-Type", "application/x-yaml")
-								request.Body = ioutil.NopCloser(bytes.NewBufferString(payload))
+								request.Body = io.NopCloser(bytes.NewBufferString(payload))
 							})
 
 							Context("when the check_creds param is set", func() {
@@ -989,7 +989,7 @@ jobs:
 									})
 
 									It("returns the credential name that was missing", func() {
-										Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`{"errors":["credential validation failed\n\n1 error occurred:\n\t* failed to interpolate task config: undefined vars: BAR\n\n"]}`))
+										Expect(io.ReadAll(response.Body)).To(MatchJSON(`{"errors":["credential validation failed\n\n1 error occurred:\n\t* failed to interpolate task config: undefined vars: BAR\n\n"]}`))
 									})
 								})
 
@@ -1005,7 +1005,7 @@ jobs:
 									})
 
 									It("returns the credential name that was missing", func() {
-										Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`{"errors":["credential validation failed\n\n1 error occurred:\n\t* failed to interpolate task config: undefined vars: BAR\n\n"]}`))
+										Expect(io.ReadAll(response.Body)).To(MatchJSON(`{"errors":["credential validation failed\n\n1 error occurred:\n\t* failed to interpolate task config: undefined vars: BAR\n\n"]}`))
 									})
 								})
 							})
@@ -1037,7 +1037,7 @@ jobs:
 							})
 
 							It("returns the error in the response body", func() {
-								Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("failed to save config: oh no!")))
+								Expect(io.ReadAll(response.Body)).To(Equal([]byte("failed to save config: oh no!")))
 							})
 						})
 
@@ -1061,7 +1061,7 @@ jobs:
 							})
 
 							It("returns error JSON", func() {
-								Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+								Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 								{
 									"errors": [
 										"invalid groups:\n\tgroup 'some-group' has unknown resource 'missing-resource'\n"
@@ -1094,7 +1094,7 @@ jobs:
 								})
 
 								It("returns an error in the response body", func() {
-									Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+									Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 										{
 											"errors": [
 												"instance vars are malformed: unexpected end of JSON input"
@@ -1265,7 +1265,7 @@ jobs:
 					})
 
 					It("returns an error in the response body", func() {
-						Expect(ioutil.ReadAll(response.Body)).To(ContainSubstring(`malformed config: error unmarshaling JSON: while decoding JSON: json: unknown field \"pubic\"`))
+						Expect(io.ReadAll(response.Body)).To(ContainSubstring(`malformed config: error unmarshaling JSON: while decoding JSON: json: unknown field \"pubic\"`))
 					})
 
 					It("does not save it", func() {
@@ -1291,7 +1291,7 @@ jobs:
 				})
 
 				It("returns an error in the response body", func() {
-					Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+					Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"errors": [
 									"config version is malformed: expected integer"

--- a/atc/api/configserver/save.go
+++ b/atc/api/configserver/save.go
@@ -3,7 +3,7 @@ package configserver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -41,7 +41,7 @@ func (s *Server) SaveConfig(w http.ResponseWriter, r *http.Request) {
 	var config atc.Config
 	switch r.Header.Get("Content-type") {
 	case "application/json", "application/x-yaml":
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			HandleBadRequest(w, fmt.Sprintf("read failed: %s", err))
 			return

--- a/atc/api/containers_test.go
+++ b/atc/api/containers_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -133,7 +132,7 @@ var _ = Describe("Containers API", func() {
 						response, err := client.Do(req)
 						Expect(err).NotTo(HaveOccurred())
 
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`
@@ -184,7 +183,7 @@ var _ = Describe("Containers API", func() {
 						response, err := client.Do(req)
 						Expect(err).NotTo(HaveOccurred())
 
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`
@@ -473,7 +472,7 @@ var _ = Describe("Containers API", func() {
 						response, err := client.Do(req)
 						Expect(err).NotTo(HaveOccurred())
 
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`
@@ -1047,7 +1046,7 @@ var _ = Describe("Containers API", func() {
 						response, err := client.Do(req)
 						Expect(err).NotTo(HaveOccurred())
 
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`
@@ -1066,7 +1065,7 @@ var _ = Describe("Containers API", func() {
 							response, err := client.Do(req)
 							Expect(err).NotTo(HaveOccurred())
 
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`

--- a/atc/api/containerserver/report.go
+++ b/atc/api/containerserver/report.go
@@ -2,7 +2,7 @@ package containerserver
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/concourse/concourse/atc/metric"
@@ -24,7 +24,7 @@ func (s *Server) ReportWorkerContainers(w http.ResponseWriter, r *http.Request) 
 
 	defer r.Body.Close()
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		logger.Error("failed-to-read-body", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/info_test.go
+++ b/atc/api/info_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -63,7 +63,7 @@ var _ = Describe("Pipelines API", func() {
 		})
 
 		It("contains the version", func() {
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(body).To(MatchJSON(fmt.Sprintf(`{
@@ -97,7 +97,7 @@ var _ = Describe("Pipelines API", func() {
 			}
 			Expect(response).Should(IncludeHeaderEntries(expectedHeaderEntries))
 
-			body, err = ioutil.ReadAll(response.Body)
+			body, err = io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/atc/api/jobs_test.go
+++ b/atc/api/jobs_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -128,7 +128,7 @@ var _ = Describe("Jobs API", func() {
 		})
 
 		It("returns all jobs from public pipelines and pipelines in authenticated teams", func() {
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(body).To(MatchJSON(`[
@@ -195,7 +195,7 @@ var _ = Describe("Jobs API", func() {
 			})
 
 			It("returns empty array", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`[]`))
@@ -428,7 +428,7 @@ var _ = Describe("Jobs API", func() {
 							})
 
 							It("returns the job's name, if it's paused, and any running and finished builds", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchJSON(`{
@@ -599,7 +599,7 @@ var _ = Describe("Jobs API", func() {
 					response, err := client.Get(server.URL + "/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/badge?title=cov")
 					Expect(err).NotTo(HaveOccurred())
 
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(strings.Contains(string(body), `
@@ -611,7 +611,7 @@ var _ = Describe("Jobs API", func() {
 					response, err := client.Get(server.URL + "/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/badge")
 					Expect(err).NotTo(HaveOccurred())
 
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(strings.Contains(string(body), `
@@ -623,7 +623,7 @@ var _ = Describe("Jobs API", func() {
 					response, err := client.Get(server.URL + "/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/badge?title=")
 					Expect(err).NotTo(HaveOccurred())
 
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(strings.Contains(string(body), `
@@ -635,7 +635,7 @@ var _ = Describe("Jobs API", func() {
 					response, err := client.Get(server.URL + "/api/v1/teams/some-team/pipelines/some-pipeline/jobs/some-job/badge?title=%24cov")
 					Expect(err).NotTo(HaveOccurred())
 
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(strings.Contains(string(body), `
@@ -671,7 +671,7 @@ var _ = Describe("Jobs API", func() {
 				})
 
 				It("returns some SVG showing that the job is successful", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -724,7 +724,7 @@ var _ = Describe("Jobs API", func() {
 				})
 
 				It("returns some SVG showing that the job has failed", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -777,7 +777,7 @@ var _ = Describe("Jobs API", func() {
 				})
 
 				It("returns some SVG showing that the job was aborted", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -830,7 +830,7 @@ var _ = Describe("Jobs API", func() {
 				})
 
 				It("returns some SVG showing that the job has errored", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -863,7 +863,7 @@ var _ = Describe("Jobs API", func() {
 				})
 
 				It("returns an unknown badge", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="98" height="20">
@@ -1084,7 +1084,7 @@ var _ = Describe("Jobs API", func() {
 				})
 
 				It("returns each job's name and any running and finished builds", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`[
@@ -1189,7 +1189,7 @@ var _ = Describe("Jobs API", func() {
 						fakePipeline.DashboardReturns(dashboardResponse, nil)
 					})
 					It("should return an empty array", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[]`))
@@ -1348,7 +1348,7 @@ var _ = Describe("Jobs API", func() {
 					})
 
 					It("returns the builds", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -1641,7 +1641,7 @@ var _ = Describe("Jobs API", func() {
 									})
 
 									It("returns the build", func() {
-										body, err := ioutil.ReadAll(response.Body)
+										body, err := io.ReadAll(response.Body)
 										Expect(err).NotTo(HaveOccurred())
 
 										Expect(body).To(MatchJSON(`{
@@ -1847,7 +1847,7 @@ var _ = Describe("Jobs API", func() {
 								})
 
 								It("returns the inputs", func() {
-									body, err := ioutil.ReadAll(response.Body)
+									body, err := io.ReadAll(response.Body)
 									Expect(err).NotTo(HaveOccurred())
 
 									Expect(body).To(MatchJSON(`[
@@ -1936,7 +1936,7 @@ var _ = Describe("Jobs API", func() {
 					})
 
 					It("returns the build", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`{
@@ -2183,7 +2183,7 @@ var _ = Describe("Jobs API", func() {
 							})
 
 							It("returns the build", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchJSON(`{
@@ -2418,7 +2418,7 @@ var _ = Describe("Jobs API", func() {
 					})
 
 					It("it returns the number of rows deleted", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`{"caches_removed": 1}`))
@@ -2430,7 +2430,7 @@ var _ = Describe("Jobs API", func() {
 						})
 
 						It("it returns that 0 rows were deleted", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`{"caches_removed": 0}`))
@@ -2469,7 +2469,7 @@ var _ = Describe("Jobs API", func() {
 					})
 
 					It("it returns the number of rows deleted", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`{"caches_removed": 1}`))
@@ -2481,7 +2481,7 @@ var _ = Describe("Jobs API", func() {
 						})
 
 						It("it returns that 0 rows were deleted", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`{"caches_removed": 0}`))

--- a/atc/api/log_level_test.go
+++ b/atc/api/log_level_test.go
@@ -2,7 +2,7 @@ package api_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -74,7 +74,7 @@ var _ = Describe("Log Level API", func() {
 							})
 
 							It("returns the current log level", func() {
-								Expect(ioutil.ReadAll(getResponse.Body)).To(Equal([]byte(atcLevel)))
+								Expect(io.ReadAll(getResponse.Body)).To(Equal([]byte(atcLevel)))
 							})
 						})
 					})

--- a/atc/api/loglevelserver/set.go
+++ b/atc/api/loglevelserver/set.go
@@ -1,7 +1,7 @@
 package loglevelserver
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *Server) SetMinLevel(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -116,7 +116,7 @@ var _ = Describe("Pipelines API", func() {
 		})
 
 		It("returns a JSON array of pipeline objects", func() {
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(body).To(MatchJSON(`[
 				{
@@ -163,7 +163,7 @@ var _ = Describe("Pipelines API", func() {
 
 		Context("when not authenticated", func() {
 			It("returns only public pipelines", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				var pipelines []map[string]interface{}
@@ -188,7 +188,7 @@ var _ = Describe("Pipelines API", func() {
 			})
 
 			It("returns all pipelines of the team + all public pipelines", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(dbPipelineFactory.VisiblePipelinesCallCount()).To(Equal(1))
@@ -215,7 +215,7 @@ var _ = Describe("Pipelines API", func() {
 					Expect(dbPipelineFactory.AllPipelinesCallCount()).To(Equal(1),
 						"Expected AllPipelines() to be called once")
 
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					var pipelinesResponse []atc.Pipeline
@@ -273,7 +273,7 @@ var _ = Describe("Pipelines API", func() {
 			})
 
 			It("returns a JSON array of pipeline objects", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(body).To(MatchJSON(`[
 					{
@@ -315,7 +315,7 @@ var _ = Describe("Pipelines API", func() {
 			})
 
 			It("returns all team's pipelines", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 				var pipelines []map[string]interface{}
 				json.Unmarshal(body, &pipelines)
@@ -344,7 +344,7 @@ var _ = Describe("Pipelines API", func() {
 			})
 
 			It("returns only team's public pipelines", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 				var pipelines []map[string]interface{}
 				json.Unmarshal(body, &pipelines)
@@ -362,7 +362,7 @@ var _ = Describe("Pipelines API", func() {
 			})
 
 			It("returns only team's public pipelines", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 				var pipelines []map[string]interface{}
 				json.Unmarshal(body, &pipelines)
@@ -442,7 +442,7 @@ var _ = Describe("Pipelines API", func() {
 			})
 
 			It("returns a pipeline JSON", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`
@@ -637,7 +637,7 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("returns an unknown badge", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -670,7 +670,7 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("returns a successful badge", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -703,7 +703,7 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("returns an aborted badge", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -736,7 +736,7 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("returns an errored badge", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -769,7 +769,7 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("returns a failed badge", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(string(body)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
@@ -1309,7 +1309,7 @@ var _ = Describe("Pipelines API", func() {
 
 					It("returns 400", func() {
 						Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-						Expect(ioutil.ReadAll(response.Body)).To(ContainSubstring("pipeline 'a-pipeline' not found"))
+						Expect(io.ReadAll(response.Body)).To(ContainSubstring("pipeline 'a-pipeline' not found"))
 					})
 				})
 
@@ -1409,7 +1409,7 @@ var _ = Describe("Pipelines API", func() {
 
 					It("returns 400", func() {
 						Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-						Expect(ioutil.ReadAll(response.Body)).To(ContainSubstring("pipeline 'a-pipeline' not found"))
+						Expect(io.ReadAll(response.Body)).To(ContainSubstring("pipeline 'a-pipeline' not found"))
 					})
 				})
 
@@ -1553,7 +1553,7 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("returns a json representation of all the versions in the pipeline", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`{
@@ -1722,7 +1722,7 @@ var _ = Describe("Pipelines API", func() {
 						})
 
 						It("returns a warning in the response body", func() {
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"warnings": [
 									{
@@ -1740,7 +1740,7 @@ var _ = Describe("Pipelines API", func() {
 
 						It("returns 400 Bad Request and an error in the response body", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"errors": [
 										"pipeline: identifier cannot be an empty string"
@@ -1887,7 +1887,7 @@ var _ = Describe("Pipelines API", func() {
 				})
 
 				It("returns the builds", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`[
@@ -2067,7 +2067,7 @@ var _ = Describe("Pipelines API", func() {
 					})
 
 					It("returns the created build", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`{

--- a/atc/api/pipelineserver/reject_archived_handler_factory_test.go
+++ b/atc/api/pipelineserver/reject_archived_handler_factory_test.go
@@ -2,7 +2,7 @@ package pipelineserver_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -67,7 +67,7 @@ var _ = Describe("Rejected Archived Handler", func() {
 					Expect(response.StatusCode).To(Equal(http.StatusConflict))
 				})
 				It("returns an error in the body", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(body).To(ContainSubstring("action not allowed for an archived pipeline"))
 				})

--- a/atc/api/pipelineserver/rename.go
+++ b/atc/api/pipelineserver/rename.go
@@ -2,7 +2,7 @@ package pipelineserver
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -15,7 +15,7 @@ func (s *Server) RenamePipeline(team db.Team) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger := s.logger.Session("rename-pipeline")
 
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			logger.Error("failed-to-read-body", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/policychecker/checker.go
+++ b/atc/api/policychecker/checker.go
@@ -3,7 +3,7 @@ package policychecker
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"sigs.k8s.io/yaml"
@@ -57,7 +57,7 @@ func (c *checker) Check(action string, acc accessor.Access, req *http.Request) (
 
 	switch ct := req.Header.Get("Content-type"); ct {
 	case "application/json", "text/vnd.yaml", "text/yaml", "text/x-yaml", "application/x-yaml":
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		} else if len(body) > 0 {
@@ -70,7 +70,7 @@ func (c *checker) Check(action string, acc accessor.Access, req *http.Request) (
 				return nil, err
 			}
 
-			req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+			req.Body = io.NopCloser(bytes.NewBuffer(body))
 		}
 	}
 

--- a/atc/api/policychecker/checker_test.go
+++ b/atc/api/policychecker/checker_test.go
@@ -3,7 +3,7 @@ package policychecker_test
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -185,7 +185,7 @@ var _ = Describe("PolicyChecker", func() {
 				})
 
 				It("request body should still be readable", func() {
-					body, err := ioutil.ReadAll(fakeRequest.Body)
+					body, err := io.ReadAll(fakeRequest.Body)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(body).To(Equal([]byte("a: b")))
 				})

--- a/atc/api/policychecker/handler_test.go
+++ b/atc/api/policychecker/handler_test.go
@@ -2,7 +2,7 @@ package policychecker_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -79,7 +79,7 @@ var _ = Describe("Handler", func() {
 			It("return http forbidden", func() {
 				Expect(responseWriter.Code).To(Equal(http.StatusForbidden))
 
-				msg, err := ioutil.ReadAll(responseWriter.Body)
+				msg, err := io.ReadAll(responseWriter.Body)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(msg)).To(ContainSubstring("a policy says you can't do that"))
 				Expect(string(msg)).To(ContainSubstring("another policy also says you can't do that"))
@@ -115,7 +115,7 @@ var _ = Describe("Handler", func() {
 		It("return http bad request", func() {
 			Expect(responseWriter.Code).To(Equal(http.StatusBadRequest))
 
-			msg, err := ioutil.ReadAll(responseWriter.Body)
+			msg, err := io.ReadAll(responseWriter.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(msg)).To(Equal("policy check error: some-error"))
 		})

--- a/atc/api/resources_test.go
+++ b/atc/api/resources_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -100,7 +100,7 @@ var _ = Describe("Resources API", func() {
 			})
 
 			It("returns each resource, including their build", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`[
@@ -161,7 +161,7 @@ var _ = Describe("Resources API", func() {
 				})
 
 				It("returns empty array", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`[]`))
@@ -274,7 +274,7 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns each resource", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -326,7 +326,7 @@ var _ = Describe("Resources API", func() {
 				})
 
 				It("returns each resource", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`[
@@ -364,7 +364,7 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns an empty list", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[]`))
@@ -756,7 +756,7 @@ var _ = Describe("Resources API", func() {
 
 						It("returns 201", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusCreated))
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`{
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`{
 								"id": 10,
 								"name": "some-name",
 								"team_name": "some-team",
@@ -851,7 +851,7 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns each resource type", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -894,7 +894,7 @@ var _ = Describe("Resources API", func() {
 				})
 
 				It("returns each resource type", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`[
@@ -1021,7 +1021,7 @@ var _ = Describe("Resources API", func() {
 				})
 
 				It("returns the resource json", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`
@@ -1108,7 +1108,7 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns the resource json", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`
@@ -1151,7 +1151,7 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns the resource json describing the pinned version", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`
@@ -1182,7 +1182,7 @@ var _ = Describe("Resources API", func() {
 					})
 
 					It("returns the pin comment in the response json", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`
@@ -1245,7 +1245,7 @@ var _ = Describe("Resources API", func() {
 				})
 
 				It("returns the resource json", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`
@@ -1434,7 +1434,7 @@ var _ = Describe("Resources API", func() {
 
 						It("returns 201", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusCreated))
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`{
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`{
                  "id": 10,
 								 "name": "some-name",
 								 "team_name": "some-team",
@@ -1625,7 +1625,7 @@ var _ = Describe("Resources API", func() {
 
 						It("returns 201", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusCreated))
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`{
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`{
                  "id": 10,
 								 "name": "some-name",
 								 "team_name": "some-team",
@@ -1764,7 +1764,7 @@ var _ = Describe("Resources API", func() {
 
 						It("returns 201", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusCreated))
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`{
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`{
                  "id": 10,
 								 "name": "some-name",
 								 "team_name": "some-team",
@@ -1888,7 +1888,7 @@ var _ = Describe("Resources API", func() {
 							})
 
 							It("returns the number of rows deleted", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchJSON(`{"caches_removed": 1}`))
@@ -1922,7 +1922,7 @@ var _ = Describe("Resources API", func() {
 							})
 
 							It("returns the number of rows deleted", func() {
-								body, err := ioutil.ReadAll(response.Body)
+								body, err := io.ReadAll(response.Body)
 								Expect(err).NotTo(HaveOccurred())
 
 								Expect(body).To(MatchJSON(`{"caches_removed": 1}`))
@@ -1936,7 +1936,7 @@ var _ = Describe("Resources API", func() {
 						})
 
 						It("returns that 0 rows were deleted", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`{"caches_removed": 0}`))
@@ -2104,7 +2104,7 @@ var _ = Describe("Resources API", func() {
 						})
 
 						It("returns shared resources", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`{
@@ -2153,7 +2153,7 @@ var _ = Describe("Resources API", func() {
 
 						It("returns 500", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
-							Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("some-error")))
+							Expect(io.ReadAll(response.Body)).To(Equal([]byte("some-error")))
 						})
 					})
 				})
@@ -2291,7 +2291,7 @@ var _ = Describe("Resources API", func() {
 						})
 
 						It("returns shared resources and resource types", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`{
@@ -2340,7 +2340,7 @@ var _ = Describe("Resources API", func() {
 
 						It("returns 500", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
-							Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("some-error")))
+							Expect(io.ReadAll(response.Body)).To(Equal([]byte("some-error")))
 						})
 					})
 				})

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -94,7 +94,7 @@ var _ = Describe("Teams API", func() {
 			})
 
 			It("should return the teams the user is authorized for", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`[
@@ -171,7 +171,7 @@ var _ = Describe("Teams API", func() {
 			})
 
 			It("returns a team JSON", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`
@@ -356,7 +356,7 @@ var _ = Describe("Teams API", func() {
 					})
 
 					It("returns a warning in the response body", func() {
-						Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+						Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 								{
 									"warnings": [
 										{
@@ -571,7 +571,7 @@ var _ = Describe("Teams API", func() {
 						})
 
 						It("returns a warning in the response body", func() {
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"warnings": [
 									{
@@ -589,7 +589,7 @@ var _ = Describe("Teams API", func() {
 
 						It("returns a warning in the response body", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-							Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`
+							Expect(io.ReadAll(response.Body)).To(MatchJSON(`
 							{
 								"errors": [
 										"team: identifier cannot be an empty string"
@@ -733,7 +733,7 @@ var _ = Describe("Teams API", func() {
 				})
 
 				It("returns the builds", func() {
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(body).To(MatchJSON(`[

--- a/atc/api/teamserver/rename.go
+++ b/atc/api/teamserver/rename.go
@@ -2,7 +2,7 @@ package teamserver
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/concourse/concourse/atc"
@@ -14,7 +14,7 @@ func (s *Server) RenameTeam(team db.Team) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger := s.logger.Session("rename-team")
 
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			logger.Error("failed-to-read-body", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/users_test.go
+++ b/atc/api/users_test.go
@@ -2,7 +2,7 @@ package api_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -67,7 +67,7 @@ var _ = Describe("Users API", func() {
 			})
 
 			It("returns the current user", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`{
@@ -159,7 +159,7 @@ var _ = Describe("Users API", func() {
 					})
 
 					It("returns an empty array", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[]`))
@@ -182,7 +182,7 @@ var _ = Describe("Users API", func() {
 					})
 
 					It("returns all users logged in since table creation", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[{
@@ -242,7 +242,7 @@ var _ = Describe("Users API", func() {
 				dbUserFactory.GetAllUsersByLoginDateReturns([]db.User{user1}, nil)
 			})
 			It("returns users", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`[{
@@ -259,7 +259,7 @@ var _ = Describe("Users API", func() {
 				date = "1969-14-30"
 			})
 			It("returns an error message", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`{"error": "wrong date format (yyyy-mm-dd)"}`))
@@ -275,7 +275,7 @@ var _ = Describe("Users API", func() {
 				date = ""
 			})
 			It("returns an empty array", func() {
-				body, err := ioutil.ReadAll(response.Body)
+				body, err := io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(body).To(MatchJSON(`[]`))

--- a/atc/api/versions_test.go
+++ b/atc/api/versions_test.go
@@ -3,7 +3,7 @@ package api_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -129,7 +129,7 @@ var _ = Describe("Versions API", func() {
 					})
 
 					It("returns the json", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -162,7 +162,7 @@ var _ = Describe("Versions API", func() {
 				Context("when resource is not public", func() {
 					Context("when the user is not authenticated", func() {
 						It("returns the json without version metadata", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`[
@@ -186,7 +186,7 @@ var _ = Describe("Versions API", func() {
 						})
 
 						It("returns the json without version metadata", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`[
@@ -367,7 +367,7 @@ var _ = Describe("Versions API", func() {
 					})
 
 					It("returns the json", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -936,7 +936,7 @@ var _ = Describe("Versions API", func() {
 					})
 
 					It("returns the json", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -972,7 +972,7 @@ var _ = Describe("Versions API", func() {
 					})
 
 					It("returns an empty list", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[]`))
@@ -1136,7 +1136,7 @@ var _ = Describe("Versions API", func() {
 					})
 
 					It("returns the json", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -1172,7 +1172,7 @@ var _ = Describe("Versions API", func() {
 					})
 
 					It("returns an empty list", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[]`))
@@ -1261,7 +1261,7 @@ var _ = Describe("Versions API", func() {
 						})
 
 						It("returns the number of rows deleted", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`{"versions_removed": 3}`))
@@ -1275,7 +1275,7 @@ var _ = Describe("Versions API", func() {
 
 						It("returns 500", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
-							Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("failed")))
+							Expect(io.ReadAll(response.Body)).To(Equal([]byte("failed")))
 						})
 					})
 				})
@@ -1382,7 +1382,7 @@ var _ = Describe("Versions API", func() {
 						})
 
 						It("returns the number of rows deleted", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`{"versions_removed": 3}`))
@@ -1396,7 +1396,7 @@ var _ = Describe("Versions API", func() {
 
 						It("returns 500", func() {
 							Expect(response.StatusCode).To(Equal(http.StatusInternalServerError))
-							Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("failed")))
+							Expect(io.ReadAll(response.Body)).To(Equal([]byte("failed")))
 						})
 					})
 				})

--- a/atc/api/volumes_test.go
+++ b/atc/api/volumes_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -136,7 +135,7 @@ var _ = Describe("Volumes API", func() {
 					})
 
 					It("returns all volumes", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -268,7 +267,7 @@ var _ = Describe("Volumes API", func() {
 					})
 
 					It("returns a partial list of volumes", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -364,7 +363,7 @@ var _ = Describe("Volumes API", func() {
 					})
 
 					It("returns all volumes", func() {
-						body, err := ioutil.ReadAll(response.Body)
+						body, err := io.ReadAll(response.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						Expect(body).To(MatchJSON(`[
@@ -390,7 +389,7 @@ var _ = Describe("Volumes API", func() {
 						})
 
 						It("returns empty list of volumes", func() {
-							body, err := ioutil.ReadAll(response.Body)
+							body, err := io.ReadAll(response.Body)
 							Expect(err).NotTo(HaveOccurred())
 
 							Expect(body).To(MatchJSON(`[]`))

--- a/atc/api/volumeserver/report.go
+++ b/atc/api/volumeserver/report.go
@@ -2,7 +2,7 @@ package volumeserver
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/concourse/concourse/atc/metric"
@@ -25,7 +25,7 @@ func (s *Server) ReportWorkerVolumes(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
 
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		logger.Error("failed-to-read-body", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/atc/api/wall_test.go
+++ b/atc/api/wall_test.go
@@ -3,7 +3,7 @@ package api_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -44,7 +44,7 @@ var _ = Describe("Wall API", func() {
 
 			It("returns only message", func() {
 				Expect(dbWall.GetWallCallCount()).To(Equal(1))
-				Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`{"message":"test message"}`))
+				Expect(io.ReadAll(response.Body)).To(MatchJSON(`{"message":"test message"}`))
 			})
 		})
 
@@ -88,7 +88,7 @@ var _ = Describe("Wall API", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			req, err := http.NewRequest("PUT", server.URL+"/api/v1/wall",
-				ioutil.NopCloser(bytes.NewBuffer(payload)))
+				io.NopCloser(bytes.NewBuffer(payload)))
 			Expect(err).NotTo(HaveOccurred())
 
 			response, err = client.Do(req)

--- a/atc/api/workers_test.go
+++ b/atc/api/workers_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -197,7 +197,7 @@ var _ = Describe("Workers API", func() {
 			payload, err := json.Marshal(worker)
 			Expect(err).NotTo(HaveOccurred())
 
-			req, err := http.NewRequest("POST", server.URL+"/api/v1/workers?ttl="+ttl, ioutil.NopCloser(bytes.NewBuffer(payload)))
+			req, err := http.NewRequest("POST", server.URL+"/api/v1/workers?ttl="+ttl, io.NopCloser(bytes.NewBuffer(payload)))
 			Expect(err).NotTo(HaveOccurred())
 
 			response, err = client.Do(req)
@@ -425,7 +425,7 @@ var _ = Describe("Workers API", func() {
 				})
 
 				It("returns the validation error in the response body", func() {
-					Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("malformed ttl")))
+					Expect(io.ReadAll(response.Body)).To(Equal([]byte("malformed ttl")))
 				})
 
 				It("does not save it", func() {
@@ -443,7 +443,7 @@ var _ = Describe("Workers API", func() {
 				})
 
 				It("returns the validation error in the response body", func() {
-					Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("missing garden address")))
+					Expect(io.ReadAll(response.Body)).To(Equal([]byte("missing garden address")))
 				})
 
 				It("does not save it", func() {
@@ -461,7 +461,7 @@ var _ = Describe("Workers API", func() {
 				})
 
 				It("returns the validation error in the response body", func() {
-					Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("invalid worker version, only numeric characters are allowed")))
+					Expect(io.ReadAll(response.Body)).To(Equal([]byte("invalid worker version, only numeric characters are allowed")))
 				})
 
 				It("does not save it", func() {
@@ -752,7 +752,7 @@ var _ = Describe("Workers API", func() {
 
 			It("returns 400", func() {
 				Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-				Expect(ioutil.ReadAll(response.Body)).To(MatchJSON(`{"stderr":"cannot prune running worker"}`))
+				Expect(io.ReadAll(response.Body)).To(MatchJSON(`{"stderr":"cannot prune running worker"}`))
 			})
 		})
 
@@ -812,7 +812,7 @@ var _ = Describe("Workers API", func() {
 			payload, err := json.Marshal(worker)
 			Expect(err).NotTo(HaveOccurred())
 
-			req, err := http.NewRequest("PUT", server.URL+"/api/v1/workers/"+workerName+"/heartbeat?ttl="+ttlStr, ioutil.NopCloser(bytes.NewBuffer(payload)))
+			req, err := http.NewRequest("PUT", server.URL+"/api/v1/workers/"+workerName+"/heartbeat?ttl="+ttlStr, io.NopCloser(bytes.NewBuffer(payload)))
 			Expect(err).NotTo(HaveOccurred())
 
 			response, err = client.Do(req)
@@ -831,7 +831,7 @@ var _ = Describe("Workers API", func() {
 		})
 
 		It("returns saved worker", func() {
-			contents, err := ioutil.ReadAll(response.Body)
+			contents, err := io.ReadAll(response.Body)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(contents).To(MatchJSON(`{
@@ -870,7 +870,7 @@ var _ = Describe("Workers API", func() {
 			})
 
 			It("returns the validation error in the response body", func() {
-				Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("malformed ttl")))
+				Expect(io.ReadAll(response.Body)).To(Equal([]byte("malformed ttl")))
 			})
 
 			It("does not heartbeat worker", func() {

--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -540,7 +539,7 @@ func (cmd *RunCommand) Runner(positionalArguments []string) (ifrit.Runner, error
 	atc.DefaultWebhookInterval = cmd.ResourceWithWebhookCheckingInterval
 
 	if cmd.BaseResourceTypeDefaults.Path() != "" {
-		content, err := ioutil.ReadFile(cmd.BaseResourceTypeDefaults.Path())
+		content, err := os.ReadFile(cmd.BaseResourceTypeDefaults.Path())
 		if err != nil {
 			return nil, err
 		}
@@ -1300,7 +1299,7 @@ func (cmd *RunCommand) validateCustomRoles() error {
 		return nil
 	}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to open RBAC config file (%s): %w", cmd.ConfigRBAC, err)
 	}
@@ -1338,7 +1337,7 @@ func (cmd *RunCommand) parseCustomRoles() (map[string]string, error) {
 		return mapping, nil
 	}
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -1486,7 +1485,7 @@ func (cmd *RunCommand) tlsConfig(logger lager.Logger, dbConn db.Conn) (*tls.Conf
 
 		if cmd.isMTLSEnabled() {
 			tlsLogger.Debug("mTLS-Enabled")
-			clientCACert, err := ioutil.ReadFile(string(cmd.TLSCaCert))
+			clientCACert, err := os.ReadFile(string(cmd.TLSCaCert))
 			if err != nil {
 				return nil, err
 			}

--- a/atc/builds/tracker_test.go
+++ b/atc/builds/tracker_test.go
@@ -2,7 +2,7 @@ package builds_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	util.PanicSink = ioutil.Discard
+	util.PanicSink = io.Discard
 }
 
 type TrackerSuite struct {

--- a/atc/creds/credhub/manager.go
+++ b/atc/creds/credhub/manager.go
@@ -3,8 +3,8 @@ package credhub
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"sync"
 
 	"code.cloudfoundry.org/credhub-cli/credhub"
@@ -60,7 +60,7 @@ func (manager *CredHubManager) Init(log lager.Logger) error {
 
 	caCerts := []string{}
 	for _, cert := range manager.TLS.CACerts {
-		contents, err := ioutil.ReadFile(cert)
+		contents, err := os.ReadFile(cert)
 		if err != nil {
 			return err
 		}

--- a/atc/creds/secret_var_lookup_rules.go
+++ b/atc/creds/secret_var_lookup_rules.go
@@ -3,7 +3,7 @@ package creds
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"text/template"
 	"text/template/parse"
 )
@@ -53,7 +53,7 @@ func BuildSecretTemplate(name, tmpl string) (*SecretTemplate, error) {
 
 	// Validate that the template only consumes the expected keys
 	dummy := struct{ Team, Pipeline, Secret string }{"team", "pipeline", "secret"}
-	if err = t.Execute(ioutil.Discard, &dummy); err != nil {
+	if err = t.Execute(io.Discard, &dummy); err != nil {
 		return nil, err
 	}
 
@@ -61,7 +61,7 @@ func BuildSecretTemplate(name, tmpl string) (*SecretTemplate, error) {
 	// should only be expanded when there is a pipeline context
 	pipelineDependent := false
 	dummyNoPipeline := struct{ Team, Secret string }{"team", "secret"}
-	if t.Execute(ioutil.Discard, &dummyNoPipeline) != nil {
+	if t.Execute(io.Discard, &dummyNoPipeline) != nil {
 		pipelineDependent = true
 	}
 

--- a/atc/creds/vault/api_client.go
+++ b/atc/creds/vault/api_client.go
@@ -3,8 +3,8 @@ package vault
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 	"sync/atomic"
@@ -272,7 +272,7 @@ func (ac *APIClient) configureTLS(config *tls.Config) error {
 	}
 
 	if ac.tlsConfig.ClientCertFile != "" {
-		content, err := ioutil.ReadFile(ac.tlsConfig.ClientCertFile)
+		content, err := os.ReadFile(ac.tlsConfig.ClientCertFile)
 		if err != nil {
 			return err
 		}
@@ -281,7 +281,7 @@ func (ac *APIClient) configureTLS(config *tls.Config) error {
 	}
 
 	if ac.tlsConfig.ClientKeyFile != "" {
-		content, err := ioutil.ReadFile(ac.tlsConfig.ClientKeyFile)
+		content, err := os.ReadFile(ac.tlsConfig.ClientKeyFile)
 		if err != nil {
 			return err
 		}

--- a/atc/db/migration/cli/command/command.go
+++ b/atc/db/migration/cli/command/command.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"text/template"
@@ -58,11 +57,11 @@ func (c *GenerateCommand) GenerateSQLMigration() error {
 
 	contents := ""
 
-	err := ioutil.WriteFile(path.Join(c.MigrationDirectory, upMigrationFileName), []byte(contents), 0644)
+	err := os.WriteFile(path.Join(c.MigrationDirectory, upMigrationFileName), []byte(contents), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(path.Join(c.MigrationDirectory, downMigrationFileName), []byte(contents), 0644)
+	err = os.WriteFile(path.Join(c.MigrationDirectory, downMigrationFileName), []byte(contents), 0644)
 	if err != nil {
 		return err
 	}

--- a/atc/db/migration/cli/command/command_test.go
+++ b/atc/db/migration/cli/command/command_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -23,7 +22,7 @@ var _ = Describe("Migration CLI", func() {
 		)
 
 		BeforeEach(func() {
-			migrationDir, err = ioutil.TempDir("", "")
+			migrationDir, err = os.MkdirTemp("", "")
 			Expect(err).ToNot(HaveOccurred())
 
 		})
@@ -77,7 +76,7 @@ var _ = Describe("Migration CLI", func() {
 func ExpectGeneratedFilesToMatchSpecification(migrationDir, fileNamePattern, migrationName string,
 	checkContents func(migrationID string, actualFileContents string)) {
 
-	files, err := ioutil.ReadDir(migrationDir)
+	files, err := os.ReadDir(migrationDir)
 	Expect(err).ToNot(HaveOccurred())
 	var migrationFilesCount = 0
 	regex := regexp.MustCompile(fileNamePattern)
@@ -90,7 +89,7 @@ func ExpectGeneratedFilesToMatchSpecification(migrationDir, fileNamePattern, mig
 			Expect(matches).To(HaveLen(4))
 			Expect(matches[2]).To(Equal(migrationName))
 
-			fileContents, err := ioutil.ReadFile(path.Join(migrationDir, migrationFileName))
+			fileContents, err := os.ReadFile(path.Join(migrationDir, migrationFileName))
 			Expect(err).ToNot(HaveOccurred())
 			checkContents(matches[1], string(fileContents))
 			migrationFilesCount++

--- a/atc/db/migration/migration_test.go
+++ b/atc/db/migration/migration_test.go
@@ -3,7 +3,6 @@ package migration_test
 import (
 	"database/sql"
 	"io/fs"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -561,7 +560,7 @@ func SetupSchemaMigrationsTable(db *sql.DB, version int, dirty bool) {
 }
 
 func SetupSchemaFromFile(db *sql.DB, path string) {
-	migrations, err := ioutil.ReadFile(path)
+	migrations, err := os.ReadFile(path)
 	Expect(err).NotTo(HaveOccurred())
 
 	for _, migration := range strings.Split(string(migrations), ";") {

--- a/atc/exec/load_var_step.go
+++ b/atc/exec/load_var_step.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -149,7 +149,7 @@ func (step *LoadVarStep) fetchVars(
 
 	defer stream.Close()
 
-	fileContent, err := ioutil.ReadAll(stream)
+	fileContent, err := io.ReadAll(stream)
 	if err != nil {
 		return nil, err
 	}

--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -333,7 +332,7 @@ func (s setPipelineSource) fetchPipelineBits(path string) ([]byte, error) {
 	}
 	defer stream.Close()
 
-	byteConfig, err := ioutil.ReadAll(stream)
+	byteConfig, err := io.ReadAll(stream)
 	if err != nil {
 		return nil, err
 	}

--- a/atc/exec/task_config_source.go
+++ b/atc/exec/task_config_source.go
@@ -3,7 +3,7 @@ package exec
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -88,7 +88,7 @@ func (configSource FileConfigSource) FetchConfig(ctx context.Context, logger lag
 
 	defer stream.Close()
 
-	byteConfig, err := ioutil.ReadAll(stream)
+	byteConfig, err := io.ReadAll(stream)
 	if err != nil {
 		return atc.TaskConfig{}, err
 	}

--- a/atc/integration/rbac_test.go
+++ b/atc/integration/rbac_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -151,7 +150,7 @@ jobs:
 
 		BeforeEach(func() {
 			var err error
-			tmp, err = ioutil.TempDir("", fmt.Sprintf("tmp-%d", GinkgoParallelProcess()))
+			tmp, err = os.MkdirTemp("", fmt.Sprintf("tmp-%d", GinkgoParallelProcess()))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -171,7 +170,7 @@ viewer:
 
 			It("errors", func() {
 				file := filepath.Join(tmp, "rbac-not-action.yml")
-				err := ioutil.WriteFile(file, []byte(rbac), 0755)
+				err := os.WriteFile(file, []byte(rbac), 0755)
 				Expect(err).ToNot(HaveOccurred())
 
 				cmd.ConfigRBAC = flag.File(file)
@@ -195,7 +194,7 @@ not-viewer:
 
 			It("errors", func() {
 				file := filepath.Join(tmp, "rbac-not-role.yml")
-				err := ioutil.WriteFile(file, []byte(rbac), 0755)
+				err := os.WriteFile(file, []byte(rbac), 0755)
 				Expect(err).ToNot(HaveOccurred())
 
 				cmd.ConfigRBAC = flag.File(file)
@@ -216,7 +215,7 @@ viewer:
 - SaveConfig
 `
 				file := filepath.Join(tmp, "rbac.yml")
-				err := ioutil.WriteFile(file, []byte(rbac), 0755)
+				err := os.WriteFile(file, []byte(rbac), 0755)
 				Expect(err).ToNot(HaveOccurred())
 
 				cmd.ConfigRBAC = flag.File(file)

--- a/atc/metric/emitter/newrelic.go
+++ b/atc/metric/emitter/newrelic.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -222,7 +221,7 @@ func (emitter *NewRelicEmitter) emitBatch(logger lager.Logger, payload []NewReli
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			logger.Info("failed-to-read-response-body",
 				lager.Data{"error": err.Error(), "status-code": resp.StatusCode})

--- a/atc/metric/emitter/newrelic_test.go
+++ b/atc/metric/emitter/newrelic_test.go
@@ -4,7 +4,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -173,10 +173,10 @@ func verifyEvents(expectedEvents int) http.HandlerFunc {
 		if request.Header.Get("Content-Encoding") == "gzip" {
 			reader, err := gzip.NewReader(request.Body)
 			Expect(err).To(Not(HaveOccurred()))
-			givenBody, err = ioutil.ReadAll(reader)
+			givenBody, err = io.ReadAll(reader)
 			Expect(err).To(Not(HaveOccurred()))
 		} else {
-			givenBody, err = ioutil.ReadAll(request.Body)
+			givenBody, err = io.ReadAll(request.Body)
 			Expect(err).To(Not(HaveOccurred()))
 		}
 

--- a/atc/metric/emitter/prometheus_test.go
+++ b/atc/metric/emitter/prometheus_test.go
@@ -2,7 +2,7 @@ package emitter_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -211,7 +211,7 @@ var _ = Describe("PrometheusEmitter", func() {
 		})
 
 		res, _ := http.Get(fmt.Sprintf("http://%s:%s/metrics", prometheusConfig.BindIP, prometheusConfig.BindPort))
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		defer res.Body.Close()
 		Expect(res.StatusCode).To(Equal(http.StatusOK))
 		Expect(string(body)).To(ContainSubstring("concourse_steps_waiting{invalid_label=\"foo\",platform=\"darwin\",prefix_test=\"bar\",prefix_testtwo=\"baz\",teamId=\"42\",teamName=\"teamdev\",type=\"get\",workerTags=\"tester\"} 4"))

--- a/atc/path_flag.go
+++ b/atc/path_flag.go
@@ -3,7 +3,6 @@ package atc
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,7 +26,7 @@ func (path *PathFlag) UnmarshalFlag(value string) error {
 			return nil
 		}
 
-		tempf, err := ioutil.TempFile("", tempFilePattern)
+		tempf, err := os.CreateTemp("", tempFilePattern)
 		if err != nil {
 			return fmt.Errorf("failed to create a temp file")
 		}

--- a/atc/policy/opa/opa.go
+++ b/atc/policy/opa/opa.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -69,7 +69,7 @@ func (c opa) Check(input policy.PolicyCheckInput) (policy.PolicyCheckResult, err
 		return nil, fmt.Errorf("opa returned status: %d", statusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("opa returned no response: %s", err.Error())
 	}

--- a/atc/postgresrunner/postgresrunner.go
+++ b/atc/postgresrunner/postgresrunner.go
@@ -3,7 +3,6 @@ package postgresrunner
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -33,7 +32,7 @@ func (runner Runner) Run(signals <-chan os.Signal, ready chan<- struct{}) error 
 	err := os.MkdirAll(pgBase, 0755)
 	Expect(err).NotTo(HaveOccurred())
 
-	tmpdir, err := ioutil.TempDir(pgBase, "postgres")
+	tmpdir, err := os.MkdirTemp(pgBase, "postgres")
 	Expect(err).NotTo(HaveOccurred())
 
 	currentUser, err := user.Current()

--- a/atc/syslog/syslog.go
+++ b/atc/syslog/syslog.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -36,7 +36,7 @@ func Dial(transport, address string, caCerts []string) (*Syslog, error) {
 		}
 
 		for _, cert := range caCerts {
-			content, err := ioutil.ReadFile(cert)
+			content, err := os.ReadFile(cert)
 			if err != nil {
 				return nil, err
 			}

--- a/atc/syslog/syslog_test.go
+++ b/atc/syslog/syslog_test.go
@@ -2,7 +2,6 @@ package syslog_test
 
 import (
 	"crypto/tls"
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -55,7 +54,7 @@ var _ = Describe("Syslog", func() {
 				tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
 				Expect(err).NotTo(HaveOccurred())
 
-				caFile, err := ioutil.TempFile("", "ca")
+				caFile, err := os.CreateTemp("", "ca")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = caFile.Write(caPEM)

--- a/atc/worker/gardenruntime/gclient/connection/connection_hijacker.go
+++ b/atc/worker/gardenruntime/gclient/connection/connection_hijacker.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -81,7 +80,7 @@ func (h *hijackable) Hijack(ctx context.Context, handler string, body io.Reader,
 	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
 		defer httpResp.Body.Close()
 
-		errRespBytes, err := ioutil.ReadAll(httpResp.Body)
+		errRespBytes, err := io.ReadAll(httpResp.Body)
 		if err != nil {
 			return nil, nil, fmt.Errorf("backend error: Exit status: %d, Body: %s, error reading response body: %s", httpResp.StatusCode, string(errRespBytes), err)
 		}

--- a/atc/worker/gardenruntime/gclient/connection/connection_test.go
+++ b/atc/worker/gardenruntime/gclient/connection/connection_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -849,7 +848,7 @@ var _ = Describe("Connection", func() {
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("PUT", "/containers/foo-handle/files", "user=alice&destination=%2Fbar"),
 						func(w http.ResponseWriter, r *http.Request) {
-							body, err := ioutil.ReadAll(r.Body)
+							body, err := io.ReadAll(r.Body)
 							Expect(err).ToNot(HaveOccurred())
 
 							Expect(string(body)).To(Equal("chunk-1chunk-2"))
@@ -926,7 +925,7 @@ var _ = Describe("Connection", func() {
 				reader, err := connection.StreamOut("foo-handle", garden.StreamOutSpec{User: "frank", Path: "/bar"})
 				Expect(err).ToNot(HaveOccurred())
 
-				readBytes, err := ioutil.ReadAll(reader)
+				readBytes, err := io.ReadAll(reader)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(readBytes).To(Equal([]byte("hello-world!")))
 
@@ -950,7 +949,7 @@ var _ = Describe("Connection", func() {
 				reader, err := connection.StreamOut("foo-handle", garden.StreamOutSpec{User: "deandra", Path: "/bar"})
 				Expect(err).ToNot(HaveOccurred())
 
-				_, err = ioutil.ReadAll(reader)
+				_, err = io.ReadAll(reader)
 				reader.Close()
 				Expect(err).To(HaveOccurred())
 			})

--- a/atc/worker/gardenruntime/gclient/container_test.go
+++ b/atc/worker/gardenruntime/gclient/container_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"strings"
 	"time"
@@ -163,7 +163,7 @@ var _ = Describe("Container", func() {
 				Ω(spec.Path).Should(Equal("to"))
 				Ω(spec.User).Should(Equal("frank"))
 
-				content, err := ioutil.ReadAll(spec.TarStream)
+				content, err := io.ReadAll(spec.TarStream)
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(content)).Should(Equal("stuff"))
 
@@ -197,14 +197,14 @@ var _ = Describe("Container", func() {
 
 	Describe("StreamOut", func() {
 		It("sends a stream out request", func() {
-			fakeConnection.StreamOutReturns(ioutil.NopCloser(strings.NewReader("kewl")), nil)
+			fakeConnection.StreamOutReturns(io.NopCloser(strings.NewReader("kewl")), nil)
 
 			reader, err := container.StreamOut(garden.StreamOutSpec{
 				User: "deandra",
 				Path: "from",
 			})
 			Ω(err).ShouldNot(HaveOccurred())
-			bytes, err := ioutil.ReadAll(reader)
+			bytes, err := io.ReadAll(reader)
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(string(bytes)).Should(Equal("kewl"))
 

--- a/atc/worker/gardenruntime/transport/hijack_streamer.go
+++ b/atc/worker/gardenruntime/transport/hijack_streamer.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -100,7 +99,7 @@ func (h *WorkerHijackStreamer) Hijack(ctx context.Context, handler string, body 
 		defer hijackCloser.Close()
 		defer httpResp.Body.Close()
 
-		errRespBytes, err := ioutil.ReadAll(httpResp.Body)
+		errRespBytes, err := io.ReadAll(httpResp.Body)
 		if err != nil {
 			return nil, nil, fmt.Errorf("backend error: Exit status: %d, error reading response body: %s", httpResp.StatusCode, err)
 		}

--- a/atc/worker/gardenruntime/transport/hijack_streamer_test.go
+++ b/atc/worker/gardenruntime/transport/hijack_streamer_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -97,11 +96,11 @@ var _ = Describe("hijackStreamer", func() {
 
 		Context("when httpResponse is success", func() {
 			BeforeEach(func() {
-				httpResp = http.Response{StatusCode: http.StatusOK, Body: ioutil.NopCloser(body)}
+				httpResp = http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(body)}
 			})
 
 			It("returns response body", func() {
-				actualBodyBytes, err := ioutil.ReadAll(actualReadCloser)
+				actualBodyBytes, err := io.ReadAll(actualReadCloser)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(expectedString).To(Equal(string(actualBodyBytes)))
 			})
@@ -154,7 +153,7 @@ var _ = Describe("hijackStreamer", func() {
 
 		Context("when httpResponse fails", func() {
 			BeforeEach(func() {
-				httpResp = http.Response{StatusCode: http.StatusTeapot, Body: ioutil.NopCloser(body)}
+				httpResp = http.Response{StatusCode: http.StatusTeapot, Body: io.NopCloser(body)}
 			})
 
 			It("returns error", func() {
@@ -181,7 +180,7 @@ var _ = Describe("hijackStreamer", func() {
 				Expect(actualRequest.URL).To(Equal(expectedRequest.URL))
 				Expect(actualRequest.Header).To(Equal(expectedRequest.Header))
 
-				s, err := ioutil.ReadAll(actualRequest.Body)
+				s, err := io.ReadAll(actualRequest.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(s)).To(Equal("some-request-body"))
 			})
@@ -306,7 +305,7 @@ var _ = Describe("hijackStreamer", func() {
 		Context("when httpResponse fails", func() {
 			BeforeEach(func() {
 				fakeHijackableClient.DoReturns(nil, nil, errors.New("Request failed"))
-				httpResp = http.Response{StatusCode: http.StatusTeapot, Body: ioutil.NopCloser(body)}
+				httpResp = http.Response{StatusCode: http.StatusTeapot, Body: io.NopCloser(body)}
 			})
 
 			It("returns error", func() {
@@ -327,7 +326,7 @@ var _ = Describe("hijackStreamer", func() {
 				Expect(actualRequest.URL).To(Equal(expectedRequest.URL))
 				Expect(actualRequest.Header).To(Equal(expectedRequest.Header))
 
-				s, err := ioutil.ReadAll(actualRequest.Body)
+				s, err := io.ReadAll(actualRequest.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(s)).To(Equal("some-request-body"))
 			})

--- a/atc/worker/streamer_test.go
+++ b/atc/worker/streamer_test.go
@@ -2,7 +2,7 @@ package worker_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/concourse/concourse/atc"
@@ -233,7 +233,7 @@ var _ = Describe("Streamer", func() {
 
 		defer stream.Close()
 
-		fileContent, err := ioutil.ReadAll(stream)
+		fileContent, err := io.ReadAll(stream)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(fileContent).To(Equal([]byte("content 2")))
@@ -256,7 +256,7 @@ var _ = Describe("Streamer", func() {
 
 		defer stream.Close()
 
-		fileContent, err := ioutil.ReadAll(stream)
+		fileContent, err := io.ReadAll(stream)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(fileContent).To(Equal([]byte("content 2")))

--- a/cmd/concourse/concourse_test.go
+++ b/cmd/concourse/concourse_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -166,7 +165,7 @@ var _ = Describe("Web Command", func() {
 })
 
 func generateSSHKeypair() (string, string, *rsa.PrivateKey, ssh.PublicKey) {
-	path, err := ioutil.TempDir("", "tsa-key")
+	path, err := os.MkdirTemp("", "tsa-key")
 	Expect(err).NotTo(HaveOccurred())
 
 	privateKeyPath := filepath.Join(path, "id_rsa")
@@ -186,10 +185,10 @@ func generateSSHKeypair() (string, string, *rsa.PrivateKey, ssh.PublicKey) {
 
 	publicKeyBytes := ssh.MarshalAuthorizedKey(publicKeyRsa)
 
-	err = ioutil.WriteFile(privateKeyPath, privateKeyBytes, 0600)
+	err = os.WriteFile(privateKeyPath, privateKeyBytes, 0600)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = ioutil.WriteFile(publicKeyPath, publicKeyBytes, 0600)
+	err = os.WriteFile(publicKeyPath, publicKeyBytes, 0600)
 	Expect(err).NotTo(HaveOccurred())
 
 	return privateKeyPath, publicKeyPath, privateKey, publicKeyRsa

--- a/fly/commands/format_pipeline.go
+++ b/fly/commands/format_pipeline.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"sigs.k8s.io/yaml"
@@ -19,7 +18,7 @@ type FormatPipelineCommand struct {
 
 func (command *FormatPipelineCommand) Execute(args []string) error {
 	configPath := string(command.Config)
-	configBytes, err := ioutil.ReadFile(configPath)
+	configBytes, err := os.ReadFile(configPath)
 	if err != nil {
 		displayhelpers.FailWithErrorf("could not read config file", err)
 	}
@@ -46,7 +45,7 @@ func (command *FormatPipelineCommand) Execute(args []string) error {
 			displayhelpers.FailWithErrorf("could not stat config file", err)
 		}
 
-		err = ioutil.WriteFile(configPath, unwrappedConfigBytes, fi.Mode())
+		err = os.WriteFile(configPath, unwrappedConfigBytes, fi.Mode())
 		if err != nil {
 			displayhelpers.FailWithErrorf("could not write formatted config to %s", err, command.Config)
 		}

--- a/fly/commands/internal/templatehelpers/yaml_template.go
+++ b/fly/commands/internal/templatehelpers/yaml_template.go
@@ -2,7 +2,7 @@ package templatehelpers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
@@ -38,7 +38,7 @@ func (yamlTemplate YamlTemplateWithParams) Evaluate(
 	allowEmpty bool,
 	strict bool,
 ) ([]byte, error) {
-	config, err := ioutil.ReadFile(string(yamlTemplate.filePath))
+	config, err := os.ReadFile(string(yamlTemplate.filePath))
 	if err != nil {
 		return nil, fmt.Errorf("could not read file: %s", err.Error())
 	}
@@ -75,7 +75,7 @@ func (yamlTemplate YamlTemplateWithParams) Evaluate(
 	// same values in the files specified earlier on command line
 	for i := len(yamlTemplate.templateVariablesFiles) - 1; i >= 0; i-- {
 		path := yamlTemplate.templateVariablesFiles[i]
-		templateVars, err := ioutil.ReadFile(string(path))
+		templateVars, err := os.ReadFile(string(path))
 		if err != nil {
 			return nil, fmt.Errorf("could not read template variables file (%s): %s", string(path), err.Error())
 		}

--- a/fly/commands/internal/templatehelpers/yaml_template_test.go
+++ b/fly/commands/internal/templatehelpers/yaml_template_test.go
@@ -1,7 +1,6 @@
 package templatehelpers_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -23,10 +22,10 @@ var _ = Describe("YAML Template With Params", func() {
 		BeforeEach(func() {
 			var err error
 
-			tmpdir, err = ioutil.TempDir("", "yaml-template-test")
+			tmpdir, err = os.MkdirTemp("", "yaml-template-test")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = ioutil.WriteFile(
+			err = os.WriteFile(
 				filepath.Join(tmpdir, "sample.yml"),
 				[]byte(`section:
 - param1: ((param1))

--- a/fly/commands/internal/validatepipelinehelpers/validate_test.go
+++ b/fly/commands/internal/validatepipelinehelpers/validate_test.go
@@ -1,7 +1,6 @@
 package validatepipelinehelpers_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -25,10 +24,10 @@ var _ = Describe("Validate Pipeline", func() {
 		BeforeEach(func() {
 			var err error
 
-			tmpdir, err = ioutil.TempDir("", "validate-test")
+			tmpdir, err = os.MkdirTemp("", "validate-test")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = ioutil.WriteFile(
+			err = os.WriteFile(
 				filepath.Join(tmpdir, "good-pipeline.yml"),
 				[]byte(`---
 resource_types:
@@ -57,7 +56,7 @@ jobs:
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = ioutil.WriteFile(
+			err = os.WriteFile(
 				filepath.Join(tmpdir, "dupkey-pipeline.yml"),
 				[]byte(`---
 resource_types:
@@ -91,7 +90,7 @@ resource_types:
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = ioutil.WriteFile(
+			err = os.WriteFile(
 				filepath.Join(tmpdir, "good-across-pipeline.yml"),
 				[]byte(`---
 resource_types:

--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -47,7 +46,7 @@ func (command *LoginCommand) Execute(args []string) error {
 
 	var caCert string
 	if command.CACert != "" {
-		caCertBytes, err := ioutil.ReadFile(string(command.CACert))
+		caCertBytes, err := os.ReadFile(string(command.CACert))
 		if err != nil {
 			return err
 		}

--- a/fly/integration/execute_multiple_inputs_test.go
+++ b/fly/integration/execute_multiple_inputs_test.go
@@ -5,8 +5,8 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -40,13 +40,13 @@ var _ = Describe("Fly CLI", func() {
 	BeforeEach(func() {
 		var err error
 
-		buildDir, err = ioutil.TempDir("", "fly-build-dir")
+		buildDir, err = os.MkdirTemp("", "fly-build-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		otherInputDir, err = ioutil.TempDir("", "fly-s3-asset-dir")
+		otherInputDir, err = os.MkdirTemp("", "fly-s3-asset-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(buildDir, "task.yml"),
 			[]byte(`---
 platform: some-platform
@@ -73,7 +73,7 @@ run:
 		)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(otherInputDir, "s3-asset-file"),
 			[]byte(`blob`),
 			0644,

--- a/fly/integration/execute_overriding_inputs_test.go
+++ b/fly/integration/execute_overriding_inputs_test.go
@@ -5,8 +5,8 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
@@ -38,13 +38,13 @@ var _ = Describe("Fly CLI", func() {
 	BeforeEach(func() {
 		var err error
 
-		buildDir, err = ioutil.TempDir("", "fly-build-dir")
+		buildDir, err = os.MkdirTemp("", "fly-build-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		otherInputDir, err = ioutil.TempDir("", "fly-s3-asset-dir")
+		otherInputDir, err = os.MkdirTemp("", "fly-s3-asset-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(buildDir, "task.yml"),
 			[]byte(`---
 platform: some-platform
@@ -71,7 +71,7 @@ run:
 		)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(otherInputDir, "s3-asset-file"),
 			[]byte(`blob`),
 			0644,

--- a/fly/integration/execute_test.go
+++ b/fly/integration/execute_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -47,7 +46,7 @@ var _ = Describe("Fly CLI", func() {
 
 	BeforeEach(func() {
 		var err error
-		tmpdir, err = ioutil.TempDir("", "fly-build-dir")
+		tmpdir, err = os.MkdirTemp("", "fly-build-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		buildDir = filepath.Join(tmpdir, "fixture")
@@ -57,7 +56,7 @@ var _ = Describe("Fly CLI", func() {
 
 		taskConfigPath = filepath.Join(buildDir, "task.yml")
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			taskConfigPath,
 			[]byte(`---
 platform: some-platform
@@ -357,7 +356,7 @@ run:
 	Context("when the build config is invalid", func() {
 		BeforeEach(func() {
 			// missing platform and run path
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(buildDir, "task.yml"),
 				[]byte(`---
 run: {}
@@ -418,7 +417,7 @@ run: {}
 			var bardir string
 
 			BeforeEach(func() {
-				err := ioutil.WriteFile(
+				err := os.WriteFile(
 					filepath.Join(buildDir, "task.yml"),
 					[]byte(`---
 platform: some-platform
@@ -497,7 +496,7 @@ run:
 
 			Context("when the current directory name is not the same as the missing input", func() {
 				BeforeEach(func() {
-					err := ioutil.WriteFile(
+					err := os.WriteFile(
 						filepath.Join(buildDir, "task.yml"),
 						[]byte(`---
 platform: some-platform
@@ -582,11 +581,11 @@ run:
 		BeforeEach(func() {
 			gitIgnorePath := filepath.Join(buildDir, ".gitignore")
 
-			err := ioutil.WriteFile(gitIgnorePath, []byte(`*.test`), 0644)
+			err := os.WriteFile(gitIgnorePath, []byte(`*.test`), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			fileToBeIgnoredPath := filepath.Join(buildDir, "dev.test")
-			err = ioutil.WriteFile(fileToBeIgnoredPath, []byte(`test file content`), 0644)
+			err = os.WriteFile(fileToBeIgnoredPath, []byte(`test file content`), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = os.Mkdir(filepath.Join(buildDir, ".git"), 0755)
@@ -599,7 +598,7 @@ run:
 			Expect(err).NotTo(HaveOccurred())
 
 			gitHEADPath := filepath.Join(buildDir, ".git/HEAD")
-			err = ioutil.WriteFile(gitHEADPath, []byte(`ref: refs/heads/master`), 0644)
+			err = os.WriteFile(gitHEADPath, []byte(`ref: refs/heads/master`), 0644)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -769,7 +768,7 @@ run:
 		Context("when input is not a folder", func() {
 			It("prints an error", func() {
 				testFile := filepath.Join(buildDir, "test-file.txt")
-				err := ioutil.WriteFile(
+				err := os.WriteFile(
 					testFile,
 					[]byte(`test file content`),
 					0644,
@@ -807,7 +806,7 @@ run:
 
 	Context("when the task specifies no input", func() {
 		BeforeEach(func() {
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(buildDir, "task.yml"),
 				[]byte(`---
 platform: some-platform
@@ -863,7 +862,7 @@ run:
 
 	Context("when the task specifies an optional input", func() {
 		BeforeEach(func() {
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(buildDir, "task.yml"),
 				[]byte(`---
 platform: some-platform
@@ -954,7 +953,7 @@ run:
 
 	Context("when the task specifies more than one required input", func() {
 		BeforeEach(func() {
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(buildDir, "task.yml"),
 				[]byte(`---
 platform: some-platform

--- a/fly/integration/execute_with_outputs_test.go
+++ b/fly/integration/execute_with_outputs_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -39,10 +38,10 @@ var _ = Describe("Fly CLI", func() {
 
 	BeforeEach(func() {
 		var err error
-		tmpdir, err = ioutil.TempDir("", "fly-build-dir")
+		tmpdir, err = os.MkdirTemp("", "fly-build-dir")
 		Expect(err).NotTo(HaveOccurred())
 
-		outputDir, err = ioutil.TempDir("", "fly-task-output")
+		outputDir, err = os.MkdirTemp("", "fly-task-output")
 		Expect(err).NotTo(HaveOccurred())
 
 		buildDir = filepath.Join(tmpdir, "fixture")
@@ -52,7 +51,7 @@ var _ = Describe("Fly CLI", func() {
 
 		taskConfigPath = filepath.Join(buildDir, "task.yml")
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			taskConfigPath,
 			[]byte(`---
 platform: some-platform
@@ -250,13 +249,13 @@ run:
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(0))
 
-				outputFiles, err := ioutil.ReadDir(outputDir)
+				outputFiles, err := os.ReadDir(outputDir)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(outputFiles).To(HaveLen(1))
 				Expect(outputFiles[0].Name()).To(Equal("some-file"))
 
-				data, err := ioutil.ReadFile(filepath.Join(outputDir, outputFiles[0].Name()))
+				data, err := os.ReadFile(filepath.Join(outputDir, outputFiles[0].Name()))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(data).To(Equal([]byte("tar-contents")))
 			})

--- a/fly/integration/format_pipeline_test.go
+++ b/fly/integration/format_pipeline_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -21,13 +20,13 @@ var _ = Describe("Fly CLI", func() {
 
 		BeforeEach(func() {
 			var err error
-			configFile, err = ioutil.TempFile("", "format-pipeline-test-*.yml")
+			configFile, err = os.CreateTemp("", "format-pipeline-test-*.yml")
 			Expect(err).NotTo(HaveOccurred())
 
-			inputYaml, err = ioutil.ReadFile("fixtures/format-input.yml")
+			inputYaml, err = os.ReadFile("fixtures/format-input.yml")
 			Expect(err).NotTo(HaveOccurred())
 
-			expectedYaml, err = ioutil.ReadFile("fixtures/format-expected.yml")
+			expectedYaml, err = os.ReadFile("fixtures/format-expected.yml")
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = configFile.Write(inputYaml)
@@ -78,7 +77,7 @@ var _ = Describe("Fly CLI", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newFileInfo.ModTime()).To(Equal(oldFileInfo.ModTime()))
 
-			newYaml, err := ioutil.ReadFile(configFile.Name())
+			newYaml, err := os.ReadFile(configFile.Name())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newYaml).To(Equal(inputYaml))
 		})
@@ -98,7 +97,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(0))
 
-				newYaml, err := ioutil.ReadFile(configFile.Name())
+				newYaml, err := os.ReadFile(configFile.Name())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(newYaml).To(MatchYAML(expectedYaml))
 			})
@@ -117,7 +116,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(0))
 
-				firstPassYaml, err := ioutil.ReadFile(configFile.Name())
+				firstPassYaml, err := os.ReadFile(configFile.Name())
 				Expect(err).NotTo(HaveOccurred())
 
 				flyCmd2 := exec.Command(
@@ -133,7 +132,7 @@ var _ = Describe("Fly CLI", func() {
 				<-sess2.Exited
 				Expect(sess2.ExitCode()).To(Equal(0))
 
-				secondPassYaml, err := ioutil.ReadFile(configFile.Name())
+				secondPassYaml, err := os.ReadFile(configFile.Name())
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(firstPassYaml).To(MatchYAML(secondPassYaml))

--- a/fly/integration/login_insecure_test.go
+++ b/fly/integration/login_insecure_test.go
@@ -3,8 +3,8 @@ package integration_test
 import (
 	"encoding/pem"
 	"io"
-	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -149,7 +149,7 @@ var _ = Describe("login -k Command", func() {
 						Bytes: loginATCServer.HTTPTestServer.TLS.Certificates[0].Certificate[0],
 					}))
 
-					caCertFile, err := ioutil.TempFile("", "ca_cert.pem")
+					caCertFile, err := os.CreateTemp("", "ca_cert.pem")
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err = caCertFile.WriteString(sslCert)

--- a/fly/integration/login_test.go
+++ b/fly/integration/login_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -261,11 +260,11 @@ var _ = Describe("login Command", func() {
 					userInfoHandler(),
 				)
 
-				caCertFile, err := ioutil.TempFile("", "fly-login-test")
+				caCertFile, err := os.CreateTemp("", "fly-login-test")
 				Expect(err).NotTo(HaveOccurred())
 				caCertFilePath = caCertFile.Name()
 
-				err = ioutil.WriteFile(caCertFilePath, []byte(serverCert), os.ModePerm)
+				err = os.WriteFile(caCertFilePath, []byte(serverCert), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 
 				setupFlyCmd := exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "-n", "some-team", "--ca-cert", caCertFilePath, "-u", "user", "-p", "pass")
@@ -529,7 +528,7 @@ var _ = Describe("login Command", func() {
 				})
 
 				It("flyrc is backwards-compatible with pre-v5.4.0", func() {
-					flyRcContents, err := ioutil.ReadFile(homeDir + "/.flyrc")
+					flyRcContents, err := os.ReadFile(homeDir + "/.flyrc")
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(flyRcContents)).To(HavePrefix("targets:"))
 				})

--- a/fly/integration/set_pipeline_test.go
+++ b/fly/integration/set_pipeline_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -784,7 +783,7 @@ this is super secure
 			BeforeEach(func() {
 				var err error
 
-				configFile, err = ioutil.TempFile("", "fly-config-file")
+				configFile, err = os.CreateTemp("", "fly-config-file")
 				Expect(err).NotTo(HaveOccurred())
 
 				changedConfig = config
@@ -1533,7 +1532,7 @@ this is super secure
 
 func getConfig(r *http.Request) []byte {
 	defer r.Body.Close()
-	payload, err := ioutil.ReadAll(r.Body)
+	payload, err := io.ReadAll(r.Body)
 	Expect(err).NotTo(HaveOccurred())
 
 	return payload

--- a/fly/integration/suite_test.go
+++ b/fly/integration/suite_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -17,11 +16,11 @@ import (
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/fly/rc"
 	"github.com/concourse/concourse/skymarshal/token"
+	"github.com/go-jose/go-jose/v3/jwt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/go-jose/go-jose/v3/jwt"
 )
 
 var flyPath string
@@ -122,7 +121,7 @@ func createFlyRc(targets rc.Targets) {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile(flyrc, flyrcBytes, 0600)
+	err = os.WriteFile(flyrc, flyrcBytes, 0600)
 	if err != nil {
 		panic(err)
 	}
@@ -140,7 +139,7 @@ var _ = BeforeEach(func() {
 
 	var err error
 
-	homeDir, err = ioutil.TempDir("", "fly-test")
+	homeDir, err = os.MkdirTemp("", "fly-test")
 	Expect(err).NotTo(HaveOccurred())
 
 	os.Setenv("HOME", homeDir)

--- a/fly/integration/sync_test.go
+++ b/fly/integration/sync_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -28,7 +27,7 @@ var _ = Describe("Syncing", func() {
 	)
 
 	BeforeEach(func() {
-		copiedFlyDir, err := ioutil.TempDir("", "fly_sync")
+		copiedFlyDir, err := os.MkdirTemp("", "fly_sync")
 		Expect(err).ToNot(HaveOccurred())
 
 		copiedFly, err := os.Create(filepath.Join(copiedFlyDir, filepath.Base(flyPath)))
@@ -160,13 +159,13 @@ var _ = Describe("Syncing", func() {
 })
 
 func readBinary(path string) []byte {
-	expectedBinary, err := ioutil.ReadFile(flyPath)
+	expectedBinary, err := os.ReadFile(flyPath)
 	Expect(err).NotTo(HaveOccurred())
 	return expectedBinary[:8]
 }
 
 func expectBinaryToMatch(path string, expectedBinary []byte) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	Expect(err).NotTo(HaveOccurred())
 
 	// don't let ginkgo try and output the entire binary as ascii

--- a/fly/rc/target_test.go
+++ b/fly/rc/target_test.go
@@ -3,7 +3,6 @@ package rc_test
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -95,7 +94,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 
 	BeforeEach(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "fly-test")
+		tmpDir, err = os.MkdirTemp("", "fly-test")
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("HOME", tmpDir)
@@ -114,7 +113,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
   some-target-a: {}
   another-target: {}
   `
-			ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+			os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 		})
 
 		AfterEach(func() {
@@ -140,7 +139,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
     token:
       type: Bearer
       value: some-token`
-				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+				os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 			})
 
 			It("loads target with correct transport", func() {
@@ -180,7 +179,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 				flyrcContents, err := yaml.Marshal(flyrcConfig)
 				Expect(err).NotTo(HaveOccurred())
 
-				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+				os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 			})
 
 			It("loads target with correct transport", func() {
@@ -214,11 +213,11 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 				certPath := filepath.Join(userHomeDir(), "client.pem")
 				keyPath := filepath.Join(userHomeDir(), "client.key")
 
-				err := ioutil.WriteFile(certPath, []byte(clientCert), 0600)
+				err := os.WriteFile(certPath, []byte(clientCert), 0600)
 
 				Expect(err).ToNot(HaveOccurred())
 
-				err = ioutil.WriteFile(keyPath, []byte(clientKey), 0600)
+				err = os.WriteFile(keyPath, []byte(clientKey), 0600)
 				Expect(err).ToNot(HaveOccurred())
 
 				flyrcConfig := rc.RC{
@@ -238,7 +237,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 				flyrcContents, err := yaml.Marshal(flyrcConfig)
 				Expect(err).NotTo(HaveOccurred())
 
-				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+				os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 			})
 
 			It("loads target with correct transport", func() {
@@ -262,7 +261,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 			BeforeEach(func() {
 				certPath := filepath.Join(userHomeDir(), "client.pem")
 
-				err := ioutil.WriteFile(certPath, []byte(clientCert), 0600)
+				err := os.WriteFile(certPath, []byte(clientCert), 0600)
 				Expect(err).ToNot(HaveOccurred())
 
 				flyrcConfig := rc.RC{
@@ -281,7 +280,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 				flyrcContents, err := yaml.Marshal(flyrcConfig)
 				Expect(err).NotTo(HaveOccurred())
 
-				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+				os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 			})
 
 			It("warns the user and exits with failure", func() {
@@ -294,7 +293,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 			BeforeEach(func() {
 				keyPath := filepath.Join(userHomeDir(), "client.key")
 
-				err := ioutil.WriteFile(keyPath, []byte(clientKey), 0600)
+				err := os.WriteFile(keyPath, []byte(clientKey), 0600)
 				Expect(err).ToNot(HaveOccurred())
 
 				flyrcConfig := rc.RC{
@@ -313,7 +312,7 @@ Lfkzl8ebb+tt0XFMUFc42WNr
 				flyrcContents, err := yaml.Marshal(flyrcConfig)
 				Expect(err).NotTo(HaveOccurred())
 
-				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+				os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 			})
 
 			It("warns the user and exits with failure", func() {

--- a/fly/rc/targets.go
+++ b/fly/rc/targets.go
@@ -3,7 +3,6 @@ package rc
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -192,7 +191,7 @@ func LoadTargets() (Targets, error) {
 
 	flyrc := flyrcPath()
 	if _, err := os.Stat(flyrc); err == nil {
-		flyTargetsBytes, err := ioutil.ReadFile(flyrc)
+		flyTargetsBytes, err := os.ReadFile(flyrc)
 		if err != nil {
 			return nil, err
 		}
@@ -223,7 +222,7 @@ func writeTargets(configFileLocation string, targetsToWrite Targets) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(configFileLocation, yamlBytes, os.FileMode(0600))
+	err = os.WriteFile(configFileLocation, yamlBytes, os.FileMode(0600))
 	if err != nil {
 		return err
 	}

--- a/fly/rc/targets_test.go
+++ b/fly/rc/targets_test.go
@@ -1,7 +1,6 @@
 package rc_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,7 +17,7 @@ var _ = Describe("Targets", func() {
 
 	BeforeEach(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "fly-test")
+		tmpDir, err = os.MkdirTemp("", "fly-test")
 		Expect(err).ToNot(HaveOccurred())
 
 		os.Setenv("HOME", tmpDir)
@@ -39,7 +38,7 @@ var _ = Describe("Targets", func() {
     token:
       type: Bearer
       value: some-token`
-				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+				os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 			})
 
 			It("loads target with default team", func() {
@@ -64,7 +63,7 @@ var _ = Describe("Targets", func() {
   some-target:
     api: http://concourse.com
     team: main`
-				ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+				os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 			})
 
 			AfterEach(func() {
@@ -113,7 +112,7 @@ var _ = Describe("Targets", func() {
     token:
       type: Bearer
       value: some-other-token`
-			ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+			os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 		})
 		Describe("DeleteTarget", func() {
 			Context("when provided with target name to delete", func() {
@@ -160,7 +159,7 @@ var _ = Describe("Targets", func() {
     token:
       type: Bearer
       value: some-token`
-			ioutil.WriteFile(flyrc, []byte(flyrcContents), 0777)
+			os.WriteFile(flyrc, []byte(flyrcContents), 0777)
 		})
 		Context("when props are provided for update", func() {
 			It("should update target to specified prop attributes", func() {
@@ -225,7 +224,7 @@ var _ = Describe("Targets", func() {
 
 			Describe("when the file exists with 0755 permissions", func() {
 				BeforeEach(func() {
-					err := ioutil.WriteFile(flyrc, []byte{}, 0755)
+					err := os.WriteFile(flyrc, []byte{}, 0755)
 					Expect(err).ToNot(HaveOccurred())
 				})
 

--- a/go-concourse/concourse/artifacts_test.go
+++ b/go-concourse/concourse/artifacts_test.go
@@ -2,7 +2,7 @@ package concourse_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/concourse/concourse/atc"
@@ -82,7 +82,7 @@ var _ = Describe("ArtifactRepository", func() {
 			It("returns the contents", func() {
 				contents, err := team.GetArtifact(17)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(ioutil.ReadAll(contents)).To(Equal([]byte("some-other-contents")))
+				Expect(io.ReadAll(contents)).To(Equal([]byte("some-other-contents")))
 			})
 		})
 	})

--- a/go-concourse/concourse/cli_test.go
+++ b/go-concourse/concourse/cli_test.go
@@ -1,7 +1,7 @@
 package concourse_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -39,7 +39,7 @@ var _ = Describe("ATC Handler CLI", func() {
 		It("returns an unclosed io.ReaderCloser", func() {
 			readerCloser, _, err := client.GetCLIReader(expectedArch, expectedPlatform)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ioutil.ReadAll(readerCloser)).To(Equal([]byte("sup")))
+			Expect(io.ReadAll(readerCloser)).To(Equal([]byte("sup")))
 		})
 
 		It("returns response Headers", func() {

--- a/go-concourse/concourse/configs.go
+++ b/go-concourse/concourse/configs.go
@@ -3,7 +3,7 @@ package concourse
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -81,7 +81,7 @@ func (team *team) CreateOrUpdatePipelineConfig(pipelineRef atc.PipelineRef, conf
 	}
 
 	defer response.Body.Close()
-	body, _ := ioutil.ReadAll(response.Body)
+	body, _ := io.ReadAll(response.Body)
 
 	switch response.StatusCode {
 	case http.StatusOK, http.StatusCreated:

--- a/go-concourse/concourse/configs_test.go
+++ b/go-concourse/concourse/configs_test.go
@@ -1,7 +1,7 @@
 package concourse_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"sigs.k8s.io/yaml"
@@ -194,7 +194,7 @@ var _ = Describe("ATC Handler Configs", func() {
 					ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
 					func(w http.ResponseWriter, r *http.Request) {
 						defer r.Body.Close()
-						bodyConfig, err := ioutil.ReadAll(r.Body)
+						bodyConfig, err := io.ReadAll(r.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						receivedConfig := []byte("")

--- a/go-concourse/concourse/internal/connection.go
+++ b/go-concourse/concourse/internal/connection.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -209,7 +208,7 @@ func (connection *connection) populateResponse(response *http.Response, returnRe
 	}
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		body, _ := ioutil.ReadAll(response.Body)
+		body, _ := io.ReadAll(response.Body)
 
 		return UnexpectedResponseError{
 			StatusCode: response.StatusCode,

--- a/go-concourse/concourse/pipelines.go
+++ b/go-concourse/concourse/pipelines.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/concourse/concourse/atc"
@@ -68,10 +68,10 @@ func (team *team) OrderingPipelines(pipelineNames []string) error {
 	case http.StatusForbidden:
 		return fmt.Errorf("you do not have a role on team '%s'", team.Name())
 	case http.StatusBadRequest:
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf(string(body))
 	default:
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return internal.UnexpectedResponseError{
 			StatusCode: resp.StatusCode,
 			Status:     resp.Status,
@@ -112,10 +112,10 @@ func (team *team) OrderingPipelinesWithinGroup(groupName string, instanceVars []
 	case http.StatusForbidden:
 		return fmt.Errorf("you do not have a role on team '%s'", team.Name())
 	case http.StatusBadRequest:
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf(string(body))
 	default:
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return internal.UnexpectedResponseError{
 			StatusCode: resp.StatusCode,
 			Status:     resp.Status,

--- a/go-concourse/concourse/teams.go
+++ b/go-concourse/concourse/teams.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/concourse/concourse/atc"
@@ -146,7 +146,7 @@ func (client *client) FindTeam(teamName string) (Team, error) {
 	case http.StatusNotFound:
 		return nil, fmt.Errorf("team '%s' does not exist", teamName)
 	default:
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return nil, internal.UnexpectedResponseError{
 			StatusCode: resp.StatusCode,
 			Status:     resp.Status,

--- a/go-concourse/concourse/user.go
+++ b/go-concourse/concourse/user.go
@@ -2,7 +2,7 @@ package concourse
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/concourse/concourse/atc"
@@ -30,7 +30,7 @@ func (client *client) UserInfo() (atc.UserInfo, error) {
 	case http.StatusUnauthorized:
 		return atc.UserInfo{}, ErrUnauthorized
 	default:
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return atc.UserInfo{}, internal.UnexpectedResponseError{
 			StatusCode: resp.StatusCode,
 			Status:     resp.Status,

--- a/integration/internal/dctest/cmd.go
+++ b/integration/internal/dctest/cmd.go
@@ -2,7 +2,6 @@ package dctest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -64,7 +63,7 @@ func InitDynamic(t *testing.T, doc *ypath.Document, parentDir string) Cmd {
 	name := filepath.Base(t.Name())
 	fileName := filepath.Join(parentDir, fmt.Sprintf(".docker-compose.%s.yml", name))
 
-	err := ioutil.WriteFile(fileName, doc.Bytes(), os.ModePerm)
+	err := os.WriteFile(fileName, doc.Bytes(), os.ModePerm)
 	require.NoError(t, err)
 
 	cleanupOnce(t, func() {

--- a/skymarshal/logger/logger.go
+++ b/skymarshal/logger/logger.go
@@ -1,7 +1,7 @@
 package logger
 
 import (
-	"io/ioutil"
+	"io"
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/sirupsen/logrus"
@@ -9,7 +9,7 @@ import (
 
 func New(logger lager.Logger) *logrus.Logger {
 	var log = &logrus.Logger{
-		Out:       ioutil.Discard,
+		Out:       io.Discard,
 		Hooks:     make(logrus.LevelHooks),
 		Formatter: new(logrus.JSONFormatter),
 		Level:     logrus.DebugLevel,

--- a/skymarshal/skycmd/flags.go
+++ b/skymarshal/skycmd/flags.go
@@ -3,7 +3,7 @@ package skycmd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -77,7 +77,7 @@ func (flag *AuthTeamFlags) Format() (atc.TeamAuth, error) {
 
 func (flag *AuthTeamFlags) formatFromFile() (atc.TeamAuth, error) {
 
-	content, err := ioutil.ReadFile(flag.Config.Path())
+	content, err := os.ReadFile(flag.Config.Path())
 	if err != nil {
 		return nil, err
 	}

--- a/skymarshal/skyserver/skyserver_test.go
+++ b/skymarshal/skyserver/skyserver_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -212,7 +212,7 @@ var _ = Describe("Sky Server API", func() {
 				response, err = skyServer.Client().Do(request)
 				Expect(err).NotTo(HaveOccurred())
 
-				body, err = ioutil.ReadAll(response.Body)
+				body, err = io.ReadAll(response.Body)
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/testflight/flying_test.go
+++ b/testflight/flying_test.go
@@ -1,7 +1,6 @@
 package testflight_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,7 +31,7 @@ var _ = Describe("Flying", func() {
 		err = os.MkdirAll(input2, 0755)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(fixture, "run"),
 			[]byte(`#!/bin/sh
 echo some output
@@ -44,7 +43,7 @@ exit 0
 		)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(tmp, "task.yml"),
 			[]byte(`---
 platform: linux
@@ -83,7 +82,7 @@ run:
 
 	Describe("hijacking", func() {
 		It("executes an interactive command in a running task's container", func() {
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(fixture, "run"),
 				[]byte(`#!/bin/sh
 mkfifo /tmp/fifo
@@ -117,23 +116,23 @@ cat < /tmp/fifo
 		BeforeEach(func() {
 			gitIgnorePath := filepath.Join(input1, ".gitignore")
 
-			err := ioutil.WriteFile(gitIgnorePath, []byte(`*.exist`), 0644)
+			err := os.WriteFile(gitIgnorePath, []byte(`*.exist`), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			fileToBeIgnoredPath := filepath.Join(input1, "expect-not-to.exist")
-			err = ioutil.WriteFile(fileToBeIgnoredPath, []byte(`ignored file content`), 0644)
+			err = os.WriteFile(fileToBeIgnoredPath, []byte(`ignored file content`), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			fileToBeIncludedPath := filepath.Join(input2, "expect-to.exist")
-			err = ioutil.WriteFile(fileToBeIncludedPath, []byte(`included file content`), 0644)
+			err = os.WriteFile(fileToBeIncludedPath, []byte(`included file content`), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			file1 := filepath.Join(input1, "file-1")
-			err = ioutil.WriteFile(file1, []byte(`file-1 contents`), 0644)
+			err = os.WriteFile(file1, []byte(`file-1 contents`), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			file2 := filepath.Join(input2, "file-2")
-			err = ioutil.WriteFile(file2, []byte(`file-2 contents`), 0644)
+			err = os.WriteFile(file2, []byte(`file-2 contents`), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = os.Mkdir(filepath.Join(input1, ".git"), 0755)
@@ -146,10 +145,10 @@ cat < /tmp/fifo
 			Expect(err).NotTo(HaveOccurred())
 
 			gitHEADPath := filepath.Join(input1, ".git/HEAD")
-			err = ioutil.WriteFile(gitHEADPath, []byte(`ref: refs/heads/master`), 0644)
+			err = os.WriteFile(gitHEADPath, []byte(`ref: refs/heads/master`), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = ioutil.WriteFile(
+			err = os.WriteFile(
 				filepath.Join(fixture, "run"),
 				[]byte(`#!/bin/sh
 cp -a input-1/. output-1/
@@ -168,12 +167,12 @@ cp -a input-2/. output-2/
 			file1 := filepath.Join(tmp, "output-1", "file-1")
 			file2 := filepath.Join(tmp, "output-2", "file-2")
 
-			_, err := ioutil.ReadFile(fileToBeIgnoredPath)
+			_, err := os.ReadFile(fileToBeIgnoredPath)
 			Expect(err).To(HaveOccurred())
 
-			Expect(ioutil.ReadFile(fileToBeIncludedPath)).To(Equal([]byte("included file content")))
-			Expect(ioutil.ReadFile(file1)).To(Equal([]byte("file-1 contents")))
-			Expect(ioutil.ReadFile(file2)).To(Equal([]byte("file-2 contents")))
+			Expect(os.ReadFile(fileToBeIncludedPath)).To(Equal([]byte("included file content")))
+			Expect(os.ReadFile(file1)).To(Equal([]byte("file-1 contents")))
+			Expect(os.ReadFile(file2)).To(Equal([]byte("file-2 contents")))
 		})
 
 		It("uploads git repo input and non git repo input, INCLUDING things in the .gitignore for git repo inputs", func() {
@@ -184,16 +183,16 @@ cp -a input-2/. output-2/
 			file1 := filepath.Join(tmp, "output-1", "file-1")
 			file2 := filepath.Join(tmp, "output-2", "file-2")
 
-			Expect(ioutil.ReadFile(fileToBeIgnoredPath)).To(Equal([]byte("ignored file content")))
-			Expect(ioutil.ReadFile(fileToBeIncludedPath)).To(Equal([]byte("included file content")))
-			Expect(ioutil.ReadFile(file1)).To(Equal([]byte("file-1 contents")))
-			Expect(ioutil.ReadFile(file2)).To(Equal([]byte("file-2 contents")))
+			Expect(os.ReadFile(fileToBeIgnoredPath)).To(Equal([]byte("ignored file content")))
+			Expect(os.ReadFile(fileToBeIncludedPath)).To(Equal([]byte("included file content")))
+			Expect(os.ReadFile(file1)).To(Equal([]byte("file-1 contents")))
+			Expect(os.ReadFile(file2)).To(Equal([]byte("file-2 contents")))
 		})
 	})
 
 	Describe("pulling down outputs", func() {
 		It("works", func() {
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(fixture, "run"),
 				[]byte(`#!/bin/sh
 echo hello > output-1/file-1
@@ -208,14 +207,14 @@ echo world > output-2/file-2
 			file1 := filepath.Join(tmp, "output-1", "file-1")
 			file2 := filepath.Join(tmp, "output-2", "file-2")
 
-			Expect(ioutil.ReadFile(file1)).To(Equal([]byte("hello\n")))
-			Expect(ioutil.ReadFile(file2)).To(Equal([]byte("world\n")))
+			Expect(os.ReadFile(file1)).To(Equal([]byte("hello\n")))
+			Expect(os.ReadFile(file2)).To(Equal([]byte("world\n")))
 		})
 	})
 
 	Describe("aborting", func() {
 		It("terminates the running task", func() {
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(fixture, "run"),
 				[]byte(`#!/bin/sh
 trap "echo task got sigterm; exit 1" TERM
@@ -243,7 +242,7 @@ wait
 
 	Context("when an optional input is not provided", func() {
 		It("runs the task without error", func() {
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(fixture, "run"),
 				[]byte(`#!/bin/sh
 ls`),
@@ -279,7 +278,7 @@ run:
   args: [some-resource/version]
 `
 
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(tmp, "task.yml"),
 				[]byte(taskFileContents),
 				0644,
@@ -338,7 +337,7 @@ run:
   args: [mapped-resource/version]
 `
 
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(tmp, "task.yml"),
 				[]byte(taskFileContents),
 				0644,
@@ -397,7 +396,7 @@ run:
   args: [some-resource/version]
 `
 
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(tmp, "task.yml"),
 				[]byte(taskFileContents),
 				0644,
@@ -458,7 +457,7 @@ run:
   path: cat
   args: [some-resource/version]
 `
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(tmp, "task.yml"),
 				[]byte(taskFileContents),
 				0644,
@@ -482,7 +481,7 @@ run:
 
 		Context("when -j is not specified and local input in custom resource type is provided", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(
+				err := os.WriteFile(
 					filepath.Join(fixture, "version"),
 					[]byte(`#!/bin/sh
 echo hello from fixture

--- a/testflight/image_resource_test.go
+++ b/testflight/image_resource_test.go
@@ -1,7 +1,6 @@
 package testflight_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -21,7 +20,7 @@ var _ = Describe("Flying with an image_resource", func() {
 		err := os.MkdirAll(fixture, 0755)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(fixture, "run"),
 			[]byte(`#!/bin/sh
 ls /bin
@@ -32,7 +31,7 @@ ls /bin
 	})
 
 	It("propagates the rootfs and metadata to the task", func() {
-		err := ioutil.WriteFile(
+		err := os.WriteFile(
 			filepath.Join(fixture, "task.yml"),
 			[]byte(`---
 platform: linux
@@ -65,7 +64,7 @@ run:
 	})
 
 	It("allows a version to be specified", func() {
-		err := ioutil.WriteFile(
+		err := os.WriteFile(
 			filepath.Join(fixture, "task.yml"),
 			[]byte(`---
 platform: linux

--- a/testflight/input_overriding_test.go
+++ b/testflight/input_overriding_test.go
@@ -1,7 +1,6 @@
 package testflight_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -36,7 +35,7 @@ var _ = Describe("A job with multiple inputs", func() {
 		firstVersionA = newMockVersion("some-resource-a", "first-a")
 		firstVersionB = newMockVersion("some-resource-b", "first-b")
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(tmp, "task.yml"),
 			[]byte(`---
 platform: linux
@@ -67,7 +66,7 @@ run:
 		err = os.Mkdir(localGitRepoBDir, 0755)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = ioutil.WriteFile(
+		err = os.WriteFile(
 			filepath.Join(localGitRepoBDir, "version"),
 			[]byte("some-overridden-version"),
 			0644,

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -150,7 +149,7 @@ var _ = BeforeEach(func() {
 	SetDefaultConsistentlyPollingInterval(time.Second)
 
 	var err error
-	tmp, err = ioutil.TempDir("", "testflight-tmp")
+	tmp, err = os.MkdirTemp("", "testflight-tmp")
 	Expect(err).ToNot(HaveOccurred())
 
 	flyTarget = testflightFlyTarget
@@ -170,7 +169,7 @@ func downloadFly(atcUrl string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	outFile, err := ioutil.TempFile("", "fly")
+	outFile, err := os.CreateTemp("", "fly")
 	if err != nil {
 		return "", err
 	}

--- a/testflight/task_vars_test.go
+++ b/testflight/task_vars_test.go
@@ -1,7 +1,6 @@
 package testflight_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +43,7 @@ run:
 
 		JustBeforeEach(func() {
 
-			err := ioutil.WriteFile(
+			err := os.WriteFile(
 				filepath.Join(fixture, "task.yml"),
 				[]byte(taskFileContents),
 				0755,
@@ -111,7 +110,7 @@ run:
 image_resource_type: mock
 echo_text: Hello World From Command Line
 `
-				err := ioutil.WriteFile(
+				err := os.WriteFile(
 					filepath.Join(fixture, "vars.yml"),
 					[]byte(varsContents),
 					0755,

--- a/topgun/both/worker_stalling_test.go
+++ b/topgun/both/worker_stalling_test.go
@@ -1,7 +1,7 @@
 package topgun_test
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"time"
@@ -117,7 +117,7 @@ var _ = Describe("Worker stalling", func() {
 				It("resumes the build", func() {
 					By("reattaching to the build")
 					// consume all output so far
-					_, err := ioutil.ReadAll(buildSession.Out)
+					_, err := io.ReadAll(buildSession.Out)
 					Expect(err).ToNot(HaveOccurred())
 
 					// wait for new output

--- a/topgun/common/common.go
+++ b/topgun/common/common.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -135,7 +134,7 @@ var _ = BeforeEach(func() {
 	Fly.Target = DeploymentName
 
 	var err error
-	tmp, err = ioutil.TempDir("", "topgun-tmp")
+	tmp, err = os.MkdirTemp("", "topgun-tmp")
 	Expect(err).ToNot(HaveOccurred())
 
 	Fly.Home = filepath.Join(tmp, "fly-home")

--- a/topgun/core/credhub_test.go
+++ b/topgun/core/credhub_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -48,7 +47,7 @@ var _ = Describe("Credhub", func() {
 			credhubInstance = Instance("credhub")
 			postgresInstance := JobInstance("postgres")
 
-			varsDir, err := ioutil.TempDir("", "vars")
+			varsDir, err := os.MkdirTemp("", "vars")
 			Expect(err).ToNot(HaveOccurred())
 
 			defer os.RemoveAll(varsDir)
@@ -65,7 +64,7 @@ var _ = Describe("Credhub", func() {
 				"-v", "postgres_ip="+postgresInstance.IP,
 			)
 
-			varsBytes, err := ioutil.ReadFile(varsStore)
+			varsBytes, err := os.ReadFile(varsStore)
 			Expect(err).ToNot(HaveOccurred())
 
 			var vars struct {
@@ -80,11 +79,11 @@ var _ = Describe("Credhub", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			clientCert := filepath.Join(varsDir, "client.cert")
-			err = ioutil.WriteFile(clientCert, []byte(vars.CredHubClient.Certificate), 0644)
+			err = os.WriteFile(clientCert, []byte(vars.CredHubClient.Certificate), 0644)
 			Expect(err).ToNot(HaveOccurred())
 
 			clientKey := filepath.Join(varsDir, "client.key")
-			err = ioutil.WriteFile(clientKey, []byte(vars.CredHubClient.PrivateKey), 0644)
+			err = os.WriteFile(clientKey, []byte(vars.CredHubClient.PrivateKey), 0644)
 			Expect(err).ToNot(HaveOccurred())
 
 			credhubClient, err = credhub.New(
@@ -243,7 +242,7 @@ func generateCredhubCerts(filepath string) (err error) {
 	vars.CredHubClientAtc.PrivateKey = rootCaKey
 
 	varsYaml, _ := yaml.Marshal(&vars)
-	ioutil.WriteFile(filepath, varsYaml, 0644)
+	os.WriteFile(filepath, varsYaml, 0644)
 	return nil
 }
 

--- a/topgun/core/vault_test.go
+++ b/topgun/core/vault_test.go
@@ -2,7 +2,6 @@ package topgun_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -37,7 +36,7 @@ var _ = XDescribe("Vault", func() {
 		BeforeEach(func() {
 			var err error
 
-			varsStore, err = ioutil.TempFile("", "vars-store.yml")
+			varsStore, err = os.CreateTemp("", "vars-store.yml")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(varsStore.Close()).To(Succeed())
 
@@ -163,7 +162,7 @@ var _ = XDescribe("Vault", func() {
 					"-v", "web_instances=0",
 				)
 
-				vaultCACertFile, err := ioutil.TempFile("", "vault-ca.cert")
+				vaultCACertFile, err := os.CreateTemp("", "vault-ca.cert")
 				Expect(err).ToNot(HaveOccurred())
 
 				vaultCACert := vaultCACertFile.Name()

--- a/topgun/fly.go
+++ b/topgun/fly.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -171,7 +170,7 @@ func RequestCredsInfo(webUrl, token string) ([]byte, error) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(200))
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	Expect(err).NotTo(HaveOccurred())
 
 	return body, err

--- a/topgun/k8s/https_web_tls_termination_test.go
+++ b/topgun/k8s/https_web_tls_termination_test.go
@@ -1,7 +1,6 @@
 package k8s_test
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"time"
@@ -30,7 +29,7 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 		CACertBytes, err := CACert.Export()
 		Expect(err).NotTo(HaveOccurred())
 
-		caCertFile, err = ioutil.TempFile("", "ca")
+		caCertFile, err = os.CreateTemp("", "ca")
 		caCertFile.Write(CACertBytes)
 		caCertFile.Close()
 

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -86,7 +85,7 @@ var _ = BeforeEach(func() {
 	SetDefaultEventuallyTimeout(90 * time.Second)
 	SetDefaultConsistentlyDuration(30 * time.Second)
 
-	tmp, err := ioutil.TempDir("", "topgun-tmp")
+	tmp, err := os.MkdirTemp("", "topgun-tmp")
 	Expect(err).ToNot(HaveOccurred())
 
 	fly = FlyCli{

--- a/topgun/pcf/bbr_test.go
+++ b/topgun/pcf/bbr_test.go
@@ -1,7 +1,6 @@
 package topgun_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -81,7 +80,7 @@ var _ = Describe("BBR", func() {
 
 			BeforeEach(func() {
 				var err error
-				tmpDir, err = ioutil.TempDir("", "")
+				tmpDir, err = os.MkdirTemp("", "")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -110,7 +109,7 @@ var _ = Describe("BBR", func() {
 					"--artifact-path", tmpDir,
 				}
 				Run(nil, "bbr", backupArgs...)
-				entries, err := ioutil.ReadDir(tmpDir)
+				entries, err := os.ReadDir(tmpDir)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(entries).To(HaveLen(1))
 
@@ -149,7 +148,7 @@ var _ = Describe("BBR", func() {
 
 			BeforeEach(func() {
 				var err error
-				tmpDir, err = ioutil.TempDir("", "")
+				tmpDir, err = os.MkdirTemp("", "")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -178,7 +177,7 @@ var _ = Describe("BBR", func() {
 					"--artifact-path", tmpDir,
 				}
 				Run(nil, "bbr", backupArgs...)
-				entries, err := ioutil.ReadDir(tmpDir)
+				entries, err := os.ReadDir(tmpDir)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(entries).To(HaveLen(1))
 

--- a/tsa/cmd/tsa/suite_test.go
+++ b/tsa/cmd/tsa/suite_test.go
@@ -6,7 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -128,14 +128,14 @@ var _ = BeforeEach(func() {
 	teamKeyFile, teamPubKeyFile, teamKey, _ = generateSSHKeypair()
 	otherTeamKeyFile, otherTeamPubKeyFile, otherTeamKey, _ = generateSSHKeypair()
 
-	authorizedKeys, err := ioutil.TempFile("", "authorized-keys")
+	authorizedKeys, err := os.CreateTemp("", "authorized-keys")
 	Expect(err).NotTo(HaveOccurred())
 
 	defer authorizedKeys.Close()
 
 	authorizedKeysFile = authorizedKeys.Name()
 
-	userPrivateKeyBytes, err := ioutil.ReadFile(globalKeyFile)
+	userPrivateKeyBytes, err := os.ReadFile(globalKeyFile)
 	Expect(err).NotTo(HaveOccurred())
 
 	userSigner, err := ssh.ParsePrivateKey(userPrivateKeyBytes)
@@ -200,7 +200,7 @@ var _ = AfterEach(func() {
 })
 
 func generateSSHKeypair() (string, string, *rsa.PrivateKey, ssh.PublicKey) {
-	path, err := ioutil.TempDir("", "tsa-key")
+	path, err := os.MkdirTemp("", "tsa-key")
 	Expect(err).NotTo(HaveOccurred())
 
 	privateKeyPath := filepath.Join(path, "id_rsa")
@@ -220,10 +220,10 @@ func generateSSHKeypair() (string, string, *rsa.PrivateKey, ssh.PublicKey) {
 
 	publicKeyBytes := ssh.MarshalAuthorizedKey(publicKeyRsa)
 
-	err = ioutil.WriteFile(privateKeyPath, privateKeyBytes, 0600)
+	err = os.WriteFile(privateKeyPath, privateKeyBytes, 0600)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = ioutil.WriteFile(publicKeyPath, publicKeyBytes, 0600)
+	err = os.WriteFile(publicKeyPath, publicKeyBytes, 0600)
 	Expect(err).NotTo(HaveOccurred())
 
 	return privateKeyPath, publicKeyPath, privateKey, publicKeyRsa

--- a/tsa/sweeper.go
+++ b/tsa/sweeper.go
@@ -3,7 +3,7 @@ package tsa
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -80,7 +80,7 @@ func (l *Sweeper) Sweep(ctx context.Context, worker atc.Worker, resourceAction s
 		return containerBytes, fmt.Errorf("bad-response (%d): %s", response.StatusCode, string(b))
 	}
 
-	containerBytes, err = ioutil.ReadAll(response.Body)
+	containerBytes, err = io.ReadAll(response.Body)
 	if err != nil {
 		logger.Error("failed-to-read-response-body", err)
 		return containerBytes, fmt.Errorf("bad-repsonse-body (%d): %s", response.StatusCode, err.Error())

--- a/tsa/tsacmd/command.go
+++ b/tsa/tsacmd/command.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"io/ioutil"
-
 	yaml "gopkg.in/yaml.v2"
 
 	"os/signal"
@@ -211,7 +209,7 @@ func (cmd *TSACommand) loadTeamAuthorizedKeys() ([]TeamAuthKeys, error) {
 		logger, _ := cmd.constructLogger()
 		var rawTeamAuthorizedKeys []yamlTeamAuthorizedKey
 
-		authorizedKeysBytes, err := ioutil.ReadFile(cmd.TeamAuthorizedKeysFile.Path())
+		authorizedKeysBytes, err := os.ReadFile(cmd.TeamAuthorizedKeysFile.Path())
 		if err != nil {
 			return nil, fmt.Errorf("failed to read yaml authorized keys file: %s", err)
 		}

--- a/web/cache_handler_test.go
+++ b/web/cache_handler_test.go
@@ -3,7 +3,7 @@ package web_test
 import (
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -49,7 +49,7 @@ var _ = Describe("CacheNearlyForever", func() {
 
 			reader, err := gzip.NewReader(recorder.Body)
 			Expect(err).ToNot(HaveOccurred())
-			body, err := ioutil.ReadAll(reader)
+			body, err := io.ReadAll(reader)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(string(body)).To(Equal(strings.Repeat("abc123", 1000)))

--- a/worker/baggageclaim/api/volume_server_linux_test.go
+++ b/worker/baggageclaim/api/volume_server_linux_test.go
@@ -9,7 +9,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -40,10 +39,10 @@ var _ = Describe("Volume Server", func() {
 	BeforeEach(func() {
 		var err error
 
-		tempDir, err = ioutil.TempDir("", fmt.Sprintf("baggageclaim_volume_dir_%d", GinkgoParallelProcess()))
+		tempDir, err = os.MkdirTemp("", fmt.Sprintf("baggageclaim_volume_dir_%d", GinkgoParallelProcess()))
 		Expect(err).NotTo(HaveOccurred())
 
-		// ioutil.TempDir creates it 0700; we need public readability for
+		// os.MkdirTemp creates it 0700; we need public readability for
 		// unprivileged StreamIn
 		err = os.Chmod(tempDir, 0755)
 		Expect(err).NotTo(HaveOccurred())

--- a/worker/baggageclaim/api/volume_server_test.go
+++ b/worker/baggageclaim/api/volume_server_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -43,10 +42,10 @@ var _ = Describe("Volume Server", func() {
 	BeforeEach(func() {
 		var err error
 
-		tempDir, err = ioutil.TempDir("", fmt.Sprintf("baggageclaim_volume_dir_%d", GinkgoParallelProcess()))
+		tempDir, err = os.MkdirTemp("", fmt.Sprintf("baggageclaim_volume_dir_%d", GinkgoParallelProcess()))
 		Expect(err).NotTo(HaveOccurred())
 
-		// ioutil.TempDir creates it 0700; we need public readability for
+		// os.MkdirTemp creates it 0700; we need public readability for
 		// unprivileged StreamIn
 		err = os.Chmod(tempDir, 0755)
 		Expect(err).NotTo(HaveOccurred())
@@ -448,7 +447,7 @@ var _ = Describe("Volume Server", func() {
 				tarContentsPath := filepath.Join(volumeDir, "live", myVolume.Handle, "volume", "dest-path", "some-file")
 				Expect(tarContentsPath).To(BeAnExistingFile())
 
-				Expect(ioutil.ReadFile(tarContentsPath)).To(Equal([]byte("file-content")))
+				Expect(os.ReadFile(tarContentsPath)).To(Equal([]byte("file-content")))
 			})
 
 			Context("when using gzip encoding", func() {
@@ -490,7 +489,7 @@ var _ = Describe("Volume Server", func() {
 					Expect(fileInfo.IsDir()).To(BeFalse())
 					Expect(fileInfo.Size()).To(Equal(int64(len("file-content"))))
 
-					contents, err := ioutil.ReadFile(filepath.Join(unpackedDir, "./some-file"))
+					contents, err := os.ReadFile(filepath.Join(unpackedDir, "./some-file"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(contents)).To(Equal("file-content"))
 				})
@@ -539,7 +538,7 @@ var _ = Describe("Volume Server", func() {
 					Expect(fileInfo.IsDir()).To(BeFalse())
 					Expect(fileInfo.Size()).To(Equal(int64(len("file-content"))))
 
-					contents, err := ioutil.ReadFile(filepath.Join(unpackedDir, "./some-file"))
+					contents, err := os.ReadFile(filepath.Join(unpackedDir, "./some-file"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(contents)).To(Equal("file-content"))
 				})
@@ -555,10 +554,10 @@ var _ = Describe("Volume Server", func() {
 				err := os.MkdirAll(filepath.Join(tarDir, "sub"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(filepath.Join(tarDir, "sub", "some-file"), []byte("some-file-content"), os.ModePerm)
+				err = os.WriteFile(filepath.Join(tarDir, "sub", "some-file"), []byte("some-file-content"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(filepath.Join(tarDir, "other-file"), []byte("other-file-content"), os.ModePerm)
+				err = os.WriteFile(filepath.Join(tarDir, "other-file"), []byte("other-file-content"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 
 				tarBuffer = new(bytes.Buffer)
@@ -602,7 +601,7 @@ var _ = Describe("Volume Server", func() {
 					Expect(fileInfo.IsDir()).To(BeFalse())
 					Expect(fileInfo.Size()).To(Equal(int64(len("other-file-content"))))
 
-					contents, err := ioutil.ReadFile(filepath.Join(unpackedDir, "other-file"))
+					contents, err := os.ReadFile(filepath.Join(unpackedDir, "other-file"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(contents)).To(Equal("other-file-content"))
 
@@ -615,7 +614,7 @@ var _ = Describe("Volume Server", func() {
 					Expect(fileInfo.IsDir()).To(BeFalse())
 					Expect(fileInfo.Size()).To(Equal(int64(len("some-file-content"))))
 
-					contents, err = ioutil.ReadFile(filepath.Join(unpackedDir, "sub/some-file"))
+					contents, err = os.ReadFile(filepath.Join(unpackedDir, "sub/some-file"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(contents)).To(Equal("some-file-content"))
 				})
@@ -653,7 +652,7 @@ var _ = Describe("Volume Server", func() {
 					Expect(fileInfo.IsDir()).To(BeFalse())
 					Expect(fileInfo.Size()).To(Equal(int64(len("other-file-content"))))
 
-					contents, err := ioutil.ReadFile(filepath.Join(unpackedDir, "other-file"))
+					contents, err := os.ReadFile(filepath.Join(unpackedDir, "other-file"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(contents)).To(Equal("other-file-content"))
 
@@ -666,7 +665,7 @@ var _ = Describe("Volume Server", func() {
 					Expect(fileInfo.IsDir()).To(BeFalse())
 					Expect(fileInfo.Size()).To(Equal(int64(len("some-file-content"))))
 
-					contents, err = ioutil.ReadFile(filepath.Join(unpackedDir, "sub/some-file"))
+					contents, err = os.ReadFile(filepath.Join(unpackedDir, "sub/some-file"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(contents)).To(Equal("some-file-content"))
 				})
@@ -875,7 +874,7 @@ var _ = Describe("Volume Server", func() {
 					propertiesPath := filepath.Join(volumeDir, "live", response.Handle, "properties.json")
 					Expect(propertiesPath).To(BeAnExistingFile())
 
-					propertiesContents, err := ioutil.ReadFile(propertiesPath)
+					propertiesContents, err := os.ReadFile(propertiesPath)
 					Expect(err).NotTo(HaveOccurred())
 
 					var storedProperties baggageclaim.VolumeProperties
@@ -1213,7 +1212,7 @@ var _ = Describe("Volume Server", func() {
 			JustBeforeEach(func() {
 				// Create a file in the volume.
 				filePath := filepath.Join(volumeDir, "live", myVolume.Handle, "volume", "some-file")
-				err := ioutil.WriteFile(filePath, []byte("some-file-content"), os.ModePerm)
+				err := os.WriteFile(filePath, []byte("some-file-content"), os.ModePerm)
 				Expect(err).ToNot(HaveOccurred())
 
 				streamInP2pURL := fmt.Sprintf("%s/volumes/%s/stream-in?path=dest-path", otherWorker.URL, myVolume.Handle)
@@ -1229,7 +1228,7 @@ var _ = Describe("Volume Server", func() {
 
 				destContentsPath := filepath.Join(volumeDir, "live", myVolume.Handle, "volume", "dest-path", "some-file")
 				Expect(destContentsPath).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(destContentsPath)).To(Equal([]byte("some-file-content")))
+				Expect(os.ReadFile(destContentsPath)).To(Equal([]byte("some-file-content")))
 			})
 
 			Context("when using gzip encoding", func() {
@@ -1259,9 +1258,9 @@ var _ = Describe("Volume Server", func() {
 				path := filepath.Join(volumeDir, "live", myVolume.Handle, "volume", "some-dir")
 				err := os.MkdirAll(filepath.Join(path, "sub"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
-				err = ioutil.WriteFile(filepath.Join(path, "sub", "some-file"), []byte("some-file-content"), os.ModePerm)
+				err = os.WriteFile(filepath.Join(path, "sub", "some-file"), []byte("some-file-content"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
-				err = ioutil.WriteFile(filepath.Join(path, "other-file"), []byte("other-file-content"), os.ModePerm)
+				err = os.WriteFile(filepath.Join(path, "other-file"), []byte("other-file-content"), os.ModePerm)
 				Expect(err).NotTo(HaveOccurred())
 
 				streamInP2pURL := fmt.Sprintf("%s/volumes/%s/stream-in?path=dest-path", otherWorker.URL, myVolume.Handle)
@@ -1273,11 +1272,11 @@ var _ = Describe("Volume Server", func() {
 
 				someContentsPath := filepath.Join(volumeDir, "live", myVolume.Handle, "volume", "dest-path", "sub", "some-file")
 				Expect(someContentsPath).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(someContentsPath)).To(Equal([]byte("some-file-content")))
+				Expect(os.ReadFile(someContentsPath)).To(Equal([]byte("some-file-content")))
 
 				otherContentsPath := filepath.Join(volumeDir, "live", myVolume.Handle, "volume", "dest-path", "other-file")
 				Expect(otherContentsPath).To(BeAnExistingFile())
-				Expect(ioutil.ReadFile(otherContentsPath)).To(Equal([]byte("other-file-content")))
+				Expect(os.ReadFile(otherContentsPath)).To(Equal([]byte("other-file-content")))
 			})
 
 			Context("when using gzip encoding", func() {

--- a/worker/baggageclaim/client_test.go
+++ b/worker/baggageclaim/client_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -289,7 +288,7 @@ var _ = Describe("Baggage Claim Client", func() {
 				out, err := vol.StreamOut(context.TODO(), ".", baggageclaim.GzipEncoding)
 				Expect(err).NotTo(HaveOccurred())
 
-				b, err := ioutil.ReadAll(out)
+				b, err := io.ReadAll(out)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(string(b)).To(Equal("some tar content"))

--- a/worker/baggageclaim/integration/baggageclaim/import_strategy_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/import_strategy_test.go
@@ -1,7 +1,6 @@
 package integration_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -41,19 +40,19 @@ var _ = Describe("Import Strategy", func() {
 
 			BeforeEach(func() {
 				var err error
-				dir, err = ioutil.TempDir("", "host_path")
+				dir, err = os.MkdirTemp("", "host_path")
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(filepath.Join(dir, "file-with-perms"), []byte("file-with-perms-contents"), 0600)
+				err = os.WriteFile(filepath.Join(dir, "file-with-perms"), []byte("file-with-perms-contents"), 0600)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(filepath.Join(dir, "some-file"), []byte("some-file-contents"), 0644)
+				err = os.WriteFile(filepath.Join(dir, "some-file"), []byte("some-file-contents"), 0644)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = os.MkdirAll(filepath.Join(dir, "some-dir"), 0755)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(filepath.Join(dir, "some-dir", "file-in-dir"), []byte("file-in-dir-contents"), 0644)
+				err = os.WriteFile(filepath.Join(dir, "some-dir", "file-in-dir"), []byte("file-in-dir-contents"), 0644)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = os.MkdirAll(filepath.Join(dir, "empty-dir"), 0755)
@@ -82,10 +81,10 @@ var _ = Describe("Import Strategy", func() {
 					Expect(createdDir).To(BeADirectory())
 
 					Expect(filepath.Join(createdDir, "some-file")).To(BeARegularFile())
-					Expect(ioutil.ReadFile(filepath.Join(createdDir, "some-file"))).To(Equal([]byte("some-file-contents")))
+					Expect(os.ReadFile(filepath.Join(createdDir, "some-file"))).To(Equal([]byte("some-file-contents")))
 
 					Expect(filepath.Join(createdDir, "file-with-perms")).To(BeARegularFile())
-					Expect(ioutil.ReadFile(filepath.Join(createdDir, "file-with-perms"))).To(Equal([]byte("file-with-perms-contents")))
+					Expect(os.ReadFile(filepath.Join(createdDir, "file-with-perms"))).To(Equal([]byte("file-with-perms-contents")))
 					fi, err := os.Lstat(filepath.Join(createdDir, "file-with-perms"))
 					Expect(err).NotTo(HaveOccurred())
 					expectedFI, err := os.Lstat(filepath.Join(dir, "file-with-perms"))
@@ -95,7 +94,7 @@ var _ = Describe("Import Strategy", func() {
 					Expect(filepath.Join(createdDir, "some-dir")).To(BeADirectory())
 
 					Expect(filepath.Join(createdDir, "some-dir", "file-in-dir")).To(BeARegularFile())
-					Expect(ioutil.ReadFile(filepath.Join(createdDir, "some-dir", "file-in-dir"))).To(Equal([]byte("file-in-dir-contents")))
+					Expect(os.ReadFile(filepath.Join(createdDir, "some-dir", "file-in-dir"))).To(Equal([]byte("file-in-dir-contents")))
 					fi, err = os.Lstat(filepath.Join(createdDir, "some-dir", "file-in-dir"))
 					Expect(err).NotTo(HaveOccurred())
 					expectedFI, err = os.Lstat(filepath.Join(dir, "some-dir", "file-in-dir"))
@@ -127,7 +126,7 @@ var _ = Describe("Import Strategy", func() {
 
 				BeforeEach(func() {
 					var err error
-					tgz, err = ioutil.TempFile("", "host_path_archive")
+					tgz, err = os.CreateTemp("", "host_path_archive")
 					Expect(err).ToNot(HaveOccurred())
 
 					err = tgzfs.Compress(tgz, strategy.Path, ".")

--- a/worker/baggageclaim/integration/baggageclaim/privileges_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/privileges_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -42,14 +41,14 @@ var _ = Describe("Privileges", func() {
 		filename := randSeq(10)
 		newFilePath := filepath.Join(volumePath, filename)
 
-		err := ioutil.WriteFile(newFilePath, []byte(filename), mode)
+		err := os.WriteFile(newFilePath, []byte(filename), mode)
 		Expect(err).NotTo(HaveOccurred())
 
 		return filename
 	}
 
 	makeSentinel := func(volumePath string) string {
-		sentinel, err := ioutil.TempFile("",
+		sentinel, err := os.CreateTemp("",
 			fmt.Sprintf("baggageclaim_link_sentinel_%d", GinkgoParallelProcess()))
 
 		Expect(err).NotTo(HaveOccurred())

--- a/worker/baggageclaim/integration/baggageclaim/suite_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/suite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -79,7 +78,7 @@ type BaggageClaimRunner struct {
 func NewRunner(path string, driver string) *BaggageClaimRunner {
 	port := 7788 + GinkgoParallelProcess()
 
-	volumeDir, err := ioutil.TempDir("", fmt.Sprintf("baggageclaim_volume_dir_%d", GinkgoParallelProcess()))
+	volumeDir, err := os.MkdirTemp("", fmt.Sprintf("baggageclaim_volume_dir_%d", GinkgoParallelProcess()))
 	Expect(err).NotTo(HaveOccurred())
 
 	err = os.Mkdir(filepath.Join(volumeDir, "overlays"), 0700)
@@ -154,7 +153,7 @@ func writeData(volumePath string) string {
 	filename := randSeq(10)
 	newFilePath := filepath.Join(volumePath, filename)
 
-	err := ioutil.WriteFile(newFilePath, []byte(filename), 0755)
+	err := os.WriteFile(newFilePath, []byte(filename), 0755)
 	Expect(err).NotTo(HaveOccurred())
 
 	return filename

--- a/worker/baggageclaim/integration/fs_mounter/fs_mounter_test.go
+++ b/worker/baggageclaim/integration/fs_mounter/fs_mounter_test.go
@@ -2,7 +2,6 @@ package integration_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,7 +62,7 @@ var _ = Describe("FS Mounter", func() {
 
 	BeforeEach(func() {
 		var err error
-		tempDir, err = ioutil.TempDir("", "fs_mounter_test")
+		tempDir, err = os.MkdirTemp("", "fs_mounter_test")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -107,12 +106,12 @@ var _ = Describe("FS Mounter", func() {
 
 		It("is idempotent", func() {
 			path := filepath.Join(mountPath, "filez")
-			err := ioutil.WriteFile(path, []byte("contents"), 0755)
+			err := os.WriteFile(path, []byte("contents"), 0755)
 			Expect(err).NotTo(HaveOccurred())
 
 			mountPath = mountAtPath(tempDir)
 
-			contents, err := ioutil.ReadFile(path)
+			contents, err := os.ReadFile(path)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(string(contents)).To(Equal("contents"))

--- a/worker/baggageclaim/volume/driver/btrfs_test.go
+++ b/worker/baggageclaim/volume/driver/btrfs_test.go
@@ -2,7 +2,6 @@ package driver_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -35,7 +34,7 @@ var _ = Describe("BtrFS", func() {
 
 	BeforeEach(func() {
 		var err error
-		tempDir, err = ioutil.TempDir("", "baggageclaim_driver_test")
+		tempDir, err = os.MkdirTemp("", "baggageclaim_driver_test")
 		Expect(err).NotTo(HaveOccurred())
 
 		logger := lagertest.NewTestLogger("fs")

--- a/worker/baggageclaim/volume/driver/overlay_linux_test.go
+++ b/worker/baggageclaim/volume/driver/overlay_linux_test.go
@@ -2,7 +2,6 @@ package driver_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -20,7 +19,7 @@ var _ = Describe("Overlay", func() {
 
 		BeforeEach(func() {
 			var err error
-			tmpdir, err = ioutil.TempDir("", "overlay-test")
+			tmpdir, err = os.MkdirTemp("", "overlay-test")
 			Expect(err).ToNot(HaveOccurred())
 
 			overlaysDir := filepath.Join(tmpdir, "overlays")
@@ -41,12 +40,12 @@ var _ = Describe("Overlay", func() {
 
 			// write to file under rootVolData
 			rootFile := filepath.Join(rootVolInit.DataPath(), "updated-file")
-			err = ioutil.WriteFile(rootFile, []byte("depth-0"), 0644)
+			err = os.WriteFile(rootFile, []byte("depth-0"), 0644)
 			Expect(err).ToNot(HaveOccurred())
 
 			for depth := 1; depth <= 10; depth++ {
 				doomedFile := filepath.Join(rootVolInit.DataPath(), fmt.Sprintf("doomed-file-%d", depth))
-				err := ioutil.WriteFile(doomedFile, []byte(fmt.Sprintf("i will be removed at depth %d", depth)), 0644)
+				err := os.WriteFile(doomedFile, []byte(fmt.Sprintf("i will be removed at depth %d", depth)), 0644)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -91,10 +90,10 @@ var _ = Describe("Overlay", func() {
 
 				updateFilePath := filepath.Join(childLive.DataPath(), "updated-file")
 
-				content, err := ioutil.ReadFile(updateFilePath)
+				content, err := os.ReadFile(updateFilePath)
 				Expect(string(content)).To(Equal(fmt.Sprintf("depth-%d", depth-1)))
 
-				err = ioutil.WriteFile(updateFilePath, []byte(fmt.Sprintf("depth-%d", depth)), 0644)
+				err = os.WriteFile(updateFilePath, []byte(fmt.Sprintf("depth-%d", depth)), 0644)
 				Expect(err).ToNot(HaveOccurred())
 
 				nest = childLive

--- a/worker/baggageclaim/volume/filesystem.go
+++ b/worker/baggageclaim/volume/filesystem.go
@@ -1,7 +1,6 @@
 package volume
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -137,7 +136,7 @@ func (fs *filesystem) LookupVolume(handle string) (FilesystemLiveVolume, bool, e
 }
 
 func (fs *filesystem) ListVolumes() ([]FilesystemLiveVolume, error) {
-	liveDirs, err := ioutil.ReadDir(fs.liveDir)
+	liveDirs, err := os.ReadDir(fs.liveDir)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/integration/integration_test.go
+++ b/worker/integration/integration_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"io/ioutil"
 	"os"
 
 	"github.com/concourse/concourse/worker/workercmd"
@@ -20,7 +19,7 @@ type WorkerRunnerSuite struct {
 }
 
 func (s *WorkerRunnerSuite) BeforeTest(suiteName, testName string) {
-	tmpdir, err := ioutil.TempDir("", suiteName+testName)
+	tmpdir, err := os.MkdirTemp("", suiteName+testName)
 	s.NoError(err)
 
 	err = os.Chdir(tmpdir)

--- a/worker/runtime/file_store.go
+++ b/worker/runtime/file_store.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -50,7 +49,7 @@ func (f fileStore) Create(name string, content []byte) (string, error) {
 		return "", fmt.Errorf("mkdirall: %w", err)
 	}
 
-	err = ioutil.WriteFile(absPath, content, 0755)
+	err = os.WriteFile(absPath, content, 0755)
 	if err != nil {
 		return "", fmt.Errorf("write file: %w", err)
 	}

--- a/worker/runtime/file_store_test.go
+++ b/worker/runtime/file_store_test.go
@@ -1,7 +1,6 @@
 package runtime_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -21,7 +20,7 @@ type FileStoreSuite struct {
 func (s *FileStoreSuite) SetupTest() {
 	var err error
 
-	s.rootfs, err = ioutil.TempDir("", "bcknd-filestore")
+	s.rootfs, err = os.MkdirTemp("", "bcknd-filestore")
 	s.NoError(err)
 
 	s.store = runtime.NewFileStore(s.rootfs)
@@ -35,7 +34,7 @@ func (s *FileStoreSuite) TestCreateFile() {
 	fpath, err := s.store.Create("name", []byte("hey"))
 	s.NoError(err)
 
-	content, err := ioutil.ReadFile(fpath)
+	content, err := os.ReadFile(fpath)
 	s.NoError(err)
 	s.Equal("hey", string(content))
 }
@@ -44,7 +43,7 @@ func (s *FileStoreSuite) TestCreateFileInDir() {
 	fpath, err := s.store.Create("dir/name", []byte("hey"))
 	s.NoError(err)
 
-	content, err := ioutil.ReadFile(fpath)
+	content, err := os.ReadFile(fpath)
 	s.NoError(err)
 	s.Equal("hey", string(content))
 }
@@ -55,7 +54,7 @@ func (s *FileStoreSuite) TestAppendFile() {
 
 	err = s.store.Append("dir/name", []byte(" there"))
 	s.NoError(err)
-	content, err := ioutil.ReadFile(fpath)
+	content, err := os.ReadFile(fpath)
 	s.NoError(err)
 	s.Equal("hey there", string(content))
 }

--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -3,7 +3,7 @@ package integration_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -76,7 +76,7 @@ func (s *IntegrationSuite) stopContainerd() {
 
 func (s *IntegrationSuite) SetupSuite() {
 	var err error
-	s.tmpDir, err = ioutil.TempDir("", "containerd")
+	s.tmpDir, err = os.MkdirTemp("", "containerd")
 	s.NoError(err)
 
 	s.startContainerd()
@@ -136,7 +136,7 @@ func (s *IntegrationSuite) BeforeTest(suiteName, testName string) {
 func (s *IntegrationSuite) setupRootfs() {
 	var err error
 
-	s.rootfs, err = ioutil.TempDir("", "containerd-integration")
+	s.rootfs, err = os.MkdirTemp("", "containerd-integration")
 	s.NoError(err)
 
 	cmd := exec.Command("go", "build",
@@ -691,8 +691,8 @@ func (s *IntegrationSuite) TestAttachToUnknownProc() {
 	}()
 
 	_, err = container.Attach("inexistent", garden.ProcessIO{
-		Stdout: ioutil.Discard,
-		Stderr: ioutil.Discard,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
 	})
 	s.Error(err)
 }

--- a/worker/runtime/integration/sample/main.go
+++ b/worker/runtime/integration/sample/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -31,7 +30,6 @@ const defaultMessage = "hello world"
 // waitForSignal blocks until the signal we care about (`sig`) is develired.
 //
 // ps.: all other signals are ignored.
-//
 func waitForSignal(sig string) {
 	s, found := signals[strings.ToLower(sig)]
 	if !found {
@@ -72,7 +70,7 @@ func writeTenTimes(content string) {
 }
 
 func catFile(pathToFile string) {
-	bytes, err := ioutil.ReadFile(pathToFile)
+	bytes, err := os.ReadFile(pathToFile)
 	if err != nil {
 		log.Fatal("failed to read file ", err)
 	}

--- a/worker/runtime/integration/suite_test.go
+++ b/worker/runtime/integration/suite_test.go
@@ -1,7 +1,7 @@
 package integration_test
 
 import (
-	"io/ioutil"
+	"os"
 	"os/user"
 	"sync"
 	"testing"
@@ -47,7 +47,7 @@ func TestSuite(t *testing.T) {
 		return
 	}
 
-	tmpDir, err := ioutil.TempDir("", "containerd-test")
+	tmpDir, err := os.MkdirTemp("", "containerd-test")
 	if err != nil {
 		panic(err)
 	}

--- a/worker/runtime/resolvconf_parser.go
+++ b/worker/runtime/resolvconf_parser.go
@@ -2,7 +2,7 @@ package runtime
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -14,7 +14,7 @@ import (
 // here: https://github.com/cloudfoundry/guardian/blob/master/kawasaki/dns/resolv_compiler.go
 func ParseHostResolveConf(path string) ([]string, error) {
 
-	resolvConf, err := ioutil.ReadFile(path)
+	resolvConf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read host's resolv.conf: %w", err)
 	}

--- a/worker/runtime/resolvconf_parser_test.go
+++ b/worker/runtime/resolvconf_parser_test.go
@@ -1,7 +1,6 @@
 package runtime_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -24,9 +23,9 @@ nameserver something 9.9.9.9
 search something
 `
 
-	tmpDir, _ := ioutil.TempDir("", "test-resolv")
+	tmpDir, _ := os.MkdirTemp("", "test-resolv")
 	defer os.RemoveAll(tmpDir)
-	ioutil.WriteFile(path.Join(tmpDir, "resolv.conf"), []byte(file), 0644)
+	os.WriteFile(path.Join(tmpDir, "resolv.conf"), []byte(file), 0644)
 
 	entries, err := runtime.ParseHostResolveConf(path.Join(tmpDir, "resolv.conf"))
 	s.NoError(err)
@@ -37,9 +36,9 @@ search something
 func (s *ResolveconfParserSuite) TestParseHostResolvConfWithLoopback() {
 	file := `nameserver 127.0.0.1`
 
-	tmpDir, _ := ioutil.TempDir("", "test-resolv-noloopback")
+	tmpDir, _ := os.MkdirTemp("", "test-resolv-noloopback")
 	defer os.RemoveAll(tmpDir)
-	ioutil.WriteFile(path.Join(tmpDir, "resolv.conf"), []byte(file), 0644)
+	os.WriteFile(path.Join(tmpDir, "resolv.conf"), []byte(file), 0644)
 
 	entries, err := runtime.ParseHostResolveConf(path.Join(tmpDir, "resolv.conf"))
 	s.NoError(err)

--- a/worker/runtime/rootfs_manager_test.go
+++ b/worker/runtime/rootfs_manager_test.go
@@ -1,7 +1,6 @@
 package runtime_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -20,7 +19,7 @@ type RootfsManagerSuite struct {
 func (s *RootfsManagerSuite) SetupTest() {
 	var err error
 
-	s.rootfsPath, err = ioutil.TempDir("", "rootfs-mgr")
+	s.rootfsPath, err = os.MkdirTemp("", "rootfs-mgr")
 	s.NoError(err)
 }
 

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -5,7 +5,6 @@ package workercmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -44,7 +43,7 @@ version = 2
 oom_score = -999
 disabled_plugins = ["io.containerd.grpc.v1.cri", "io.containerd.snapshotter.v1.aufs", "io.containerd.snapshotter.v1.btrfs", "io.containerd.snapshotter.v1.zfs"]
 `
-	err := ioutil.WriteFile(dest, []byte(config), 0755)
+	err := os.WriteFile(dest, []byte(config), 0755)
 	if err != nil {
 		return fmt.Errorf("write file %s: %w", dest, err)
 	}

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -190,14 +189,14 @@ func (cmd *WorkerCommand) loadResources(logger lager.Logger) ([]atc.WorkerResour
 	if cmd.ResourceTypes != "" {
 		basePath := cmd.ResourceTypes.Path()
 
-		entries, err := ioutil.ReadDir(basePath)
+		entries, err := os.ReadDir(basePath)
 		if err != nil {
 			logger.Error("failed-to-read-resources-dir", err)
 			return nil, err
 		}
 
 		for _, e := range entries {
-			meta, err := ioutil.ReadFile(filepath.Join(basePath, e.Name(), "resource_metadata.json"))
+			meta, err := os.ReadFile(filepath.Join(basePath, e.Name(), "resource_metadata.json"))
 			if err != nil {
 				logger.Error("failed-to-read-resource-type-metadata", err)
 				return nil, err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir`
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

No breaking changes.
