### PR TITLE
Unhide the --instance-var option in fly set-pipeline

### DIFF
--- a/fly/commands/set_pipeline.go
+++ b/fly/commands/set_pipeline.go
@@ -27,7 +27,7 @@ type SetPipelineCommand struct {
 
 	Var          []flaghelpers.VariablePairFlag     `short:"v"  long:"var"           unquote:"false"  value-name:"[NAME=STRING]"  description:"Specify a string value to set for a variable in the pipeline"`
 	YAMLVar      []flaghelpers.YAMLVariablePairFlag `short:"y"  long:"yaml-var"      unquote:"false"  value-name:"[NAME=YAML]"    description:"Specify a YAML value to set for a variable in the pipeline"`
-	InstanceVars []flaghelpers.YAMLVariablePairFlag `short:"i"  long:"instance-var"  unquote:"false"  hidden:"true"  value-name:"[NAME=STRING]"  description:"Specify a YAML value to set for an instance variable"`
+	InstanceVars []flaghelpers.YAMLVariablePairFlag `short:"i"  long:"instance-var"  unquote:"false"  value-name:"[NAME=STRING]"  description:"Specify a YAML value to set for an instance variable"`
 
 	VarsFrom []atc.PathFlag `short:"l"  long:"load-vars-from"  description:"Variable flag that can be used for filling in template values in configuration from a YAML file"`
 


### PR DESCRIPTION
## Changes proposed by this PR

Closes #8777

Brings `fly set-pipeline` into line with the [documentation](https://concourse-ci.org/instanced-pipelines.html#instanced-pipelines).

## Notes to reviewer

This reverts a revert. See 20c66c1db687b13ea71ec94cfb76b5b8610a4c8c.