### PR TITLE
chore: unnecessary use of fmt.Sprintf or fmt.Sprint

### DIFF
--- a/atc/db/check_factory_test.go
+++ b/atc/db/check_factory_test.go
@@ -489,7 +489,7 @@ var _ = Describe("CheckFactory", func() {
 		})
 
 		Context("when a put-only resource", func() {
-			Context(fmt.Sprintf("has failed to check last time"), func() {
+			Context("has failed to check last time", func() {
 				BeforeEach(func() {
 					found, err := putOnlyResourceConfigScope.UpdateLastCheckStartTime(99, nil)
 					Expect(err).NotTo(HaveOccurred())

--- a/fly/integration/clear_versions_test.go
+++ b/fly/integration/clear_versions_test.go
@@ -295,7 +295,7 @@ and the following resource types:
 			})
 
 			It("errors", func() {
-				Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("can specify only one of --resource or --resource-type\n")))
+				Eventually(sess.Err).Should(gbytes.Say("can specify only one of --resource or --resource-type\n"))
 				Expect(sess.ExitCode()).ToNot(Equal(0))
 			})
 		})

--- a/fly/integration/disable_resource_version_test.go
+++ b/fly/integration/disable_resource_version_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Fly CLI", func() {
 							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 							Expect(err).NotTo(HaveOccurred())
 
-							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not find version matching {\"some\":\"value\"}\n")))
+							Eventually(sess.Err).Should(gbytes.Say("could not find version matching {\"some\":\"value\"}\n"))
 
 							<-sess.Exited
 							Expect(sess.ExitCode()).To(Equal(1))

--- a/fly/integration/enable_resource_version_test.go
+++ b/fly/integration/enable_resource_version_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Fly CLI", func() {
 							sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 							Expect(err).NotTo(HaveOccurred())
 
-							Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not find version matching {\"some\":\"value\"}\n")))
+							Eventually(sess.Err).Should(gbytes.Say("could not find version matching {\"some\":\"value\"}\n"))
 
 							<-sess.Exited
 							Expect(sess.ExitCode()).To(Equal(1))

--- a/fly/integration/pin_resource_test.go
+++ b/fly/integration/pin_resource_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Fly CLI", func() {
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
 
-					Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not find version matching {\"some\":\"value\"}\n")))
+					Eventually(sess.Err).Should(gbytes.Say("could not find version matching {\"some\":\"value\"}\n"))
 
 					<-sess.Exited
 					Expect(sess.ExitCode()).To(Equal(1))
@@ -188,7 +188,7 @@ var _ = Describe("Fly CLI", func() {
 				})
 
 				It("saves the pin comment", func() {
-					Eventually(sess.Out).Should(gbytes.Say(fmt.Sprintf("pin comment 'some pin message' is saved\n")))
+					Eventually(sess.Out).Should(gbytes.Say("pin comment 'some pin message' is saved\n"))
 					<-sess.Exited
 					Expect(sess.ExitCode()).To(Equal(0))
 				})
@@ -202,7 +202,7 @@ var _ = Describe("Fly CLI", func() {
 				})
 
 				It("errors", func() {
-					Eventually(sess.Err).Should(gbytes.Say(fmt.Sprintf("could not find version matching")))
+					Eventually(sess.Err).Should(gbytes.Say("could not find version matching"))
 					<-sess.Exited
 					Expect(sess.ExitCode()).To(Equal(1))
 				})

--- a/go-concourse/concourse/builds_test.go
+++ b/go-concourse/concourse/builds_test.go
@@ -1,7 +1,6 @@
 package concourse_test
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/concourse/concourse/atc"
@@ -403,7 +402,7 @@ var _ = Describe("ATC Handler Builds", func() {
 		Context("pagination data", func() {
 			Context("with a link header", func() {
 				BeforeEach(func() {
-					expectedURL = fmt.Sprint("/api/v1/builds")
+					expectedURL = "/api/v1/builds"
 
 					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
@@ -428,7 +427,7 @@ var _ = Describe("ATC Handler Builds", func() {
 
 		Context("without a link header", func() {
 			BeforeEach(func() {
-				expectedURL = fmt.Sprint("/api/v1/builds")
+				expectedURL = "/api/v1/builds"
 
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(

--- a/go-concourse/concourse/jobs_test.go
+++ b/go-concourse/concourse/jobs_test.go
@@ -565,7 +565,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 
 		Context("when job step exists", func() {
 			JustBeforeEach(func() {
-				expectedURL = fmt.Sprint("/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/tasks/mystep/cache")
+				expectedURL = "/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/tasks/mystep/cache"
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(requestMethod, expectedURL, strings.Join(expectedQuery, "&")),
@@ -608,7 +608,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 
 		Context("when job step does not exist", func() {
 			BeforeEach(func() {
-				expectedURL = fmt.Sprint("/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/tasks/my-nonexistent-step/cache")
+				expectedURL = "/api/v1/teams/some-team/pipelines/mypipeline/jobs/myjob/tasks/my-nonexistent-step/cache"
 				expectedQuery = append(expectedQuery, "cache_path=mycachepath")
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(

--- a/go-concourse/concourse/pipelines_test.go
+++ b/go-concourse/concourse/pipelines_test.go
@@ -1,7 +1,6 @@
 package concourse_test
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -647,7 +646,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 				},
 			}
 
-			expectedURL = fmt.Sprint("/api/v1/teams/some-team/pipelines/mypipeline/builds")
+			expectedURL = "/api/v1/teams/some-team/pipelines/mypipeline/builds"
 			expectedQuery = []string{"vars.branch=%22master%22"}
 			pipelineRef = atc.PipelineRef{Name: "mypipeline", InstanceVars: atc.InstanceVars{"branch": "master"}}
 		})
@@ -675,7 +674,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 		Context("when from is specified", func() {
 			BeforeEach(func() {
-				expectedQuery = append(expectedQuery, fmt.Sprint("from=24"))
+				expectedQuery = append(expectedQuery, "from=24")
 			})
 
 			It("calls to get all builds from that id", func() {
@@ -687,7 +686,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 			Context("and limit is specified", func() {
 				BeforeEach(func() {
-					expectedQuery = append(expectedQuery, fmt.Sprint("limit=5"))
+					expectedQuery = append(expectedQuery, "limit=5")
 				})
 
 				It("appends limit to the url", func() {
@@ -701,7 +700,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 		Context("when to is specified", func() {
 			BeforeEach(func() {
-				expectedQuery = append(expectedQuery, fmt.Sprint("to=26"))
+				expectedQuery = append(expectedQuery, "to=26")
 			})
 
 			It("calls to get all builds to that id", func() {
@@ -713,7 +712,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 			Context("and limit is specified", func() {
 				BeforeEach(func() {
-					expectedQuery = append(expectedQuery, fmt.Sprint("limit=15"))
+					expectedQuery = append(expectedQuery, "limit=15")
 				})
 
 				It("appends limit to the url", func() {
@@ -727,7 +726,7 @@ var _ = Describe("ATC Handler Pipelines", func() {
 
 		Context("when from and to are both specified", func() {
 			BeforeEach(func() {
-				expectedQuery = append(expectedQuery, fmt.Sprint("to=26"), fmt.Sprint("from=24"))
+				expectedQuery = append(expectedQuery, "to=26", "from=24")
 			})
 
 			It("sends both from and to", func() {

--- a/topgun/both/volume_gc_test.go
+++ b/topgun/both/volume_gc_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Garbage-collecting volumes", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				if resourceCacheNum == 1 {
-					By(fmt.Sprintf("not expiring volume so long as its resource cache is there"))
+					By("not expiring volume so long as its resource cache is there")
 					Expect(volumeNum).To(Equal(1))
 				}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR
delete unnecessary use of fmt.Sprintf or fmt.Sprint
closes # <!-- remove if no existing issue -->

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] done
* [ ] todo

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
