### PR TITLE
topgun/k8s: fix dropped test error

### DIFF
--- a/topgun/k8s/https_web_tls_termination_test.go
+++ b/topgun/k8s/https_web_tls_termination_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Web HTTP or HTTPS(TLS) termination at web node", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		caCertFile, err = os.CreateTemp("", "ca")
+		Expect(err).NotTo(HaveOccurred())
 		caCertFile.Write(CACertBytes)
 		caCertFile.Close()
 


### PR DESCRIPTION
This picks up a dropped test `err` variable in `topgun/k8s`.
