### PR TITLE
feat/cli: allow to extract the default seccomp profile

### DIFF
--- a/cmd/concourse/command.go
+++ b/cmd/concourse/command.go
@@ -21,6 +21,8 @@ type ConcourseCommand struct {
 	RetireWorker retire.RetireWorkerCommand `command:"retire-worker" description:"Safely remove a worker from the cluster permanently."`
 
 	GenerateKey GenerateKeyCommand `command:"generate-key" description:"Generate RSA key for use with Concourse components."`
+
+	ExtractInternalConfig ExtractInternalConfigCommand `command:"dump-internal-config" description:"Extract internal built in configuration as files that can be modified."`
 }
 
 func (cmd ConcourseCommand) LessenRequirements(parser *flags.Parser) {

--- a/cmd/concourse/generate_key.go
+++ b/cmd/concourse/generate_key.go
@@ -4,9 +4,13 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io/ioutil"
 	"os"
+
+	bespec "github.com/concourse/concourse/worker/runtime/spec"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -73,4 +77,28 @@ func (cmd *GenerateKeyCommand) Execute(args []string) error {
 	}
 
 	return nil
+}
+
+type ExtractInternalConfigCommand struct {
+	FilePath string `short:"f"  long:"filename"  required:"true"  description:"File path where the key shall be created. When generating ssh keys, the public key will be stored in a file with the same name but with '.pub' appended."`
+
+	Seccomp bool `long:"seccomp" required:"false"  description:"Extract the default builtin seccomp filter"`
+}
+
+func (cmd *ExtractInternalConfigCommand) Execute(args []string) error {
+	var dest = cmd.FilePath
+	if cmd.Seccomp {
+		seccompfilter := bespec.GetDefaultSeccompProfile()
+		bytes, err := json.Marshal(seccompfilter)
+		if err != nil {
+			return fmt.Errorf("failed to serialize key file: %s", err)
+		}
+		err = ioutil.WriteFile(dest, bytes, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to write json to file: %s @ %s", err, dest)
+		}
+		return nil
+	} else {
+		return fmt.Errorf("Nothing to extract, use one of the optional flags for the subcommand")
+	}
 }


### PR DESCRIPTION
[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* Adds a subcommand to allow extracting the default seccomp filter set


## Notes to reviewer

The main use-case is to extend/modify/limit these based on requirements, but provide them as a reasonable baseline for custom modifications. Prime use case is performance counters.

## Release Note

* Add a cli sub-command to allow extracting the default seccomp filter set

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
