### PR TITLE
Implement support for IPv6 networking in tasks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: fdf1:f4a2:d53::/48
-          gateway: fdf1:f4a2:d53::1000
+        - subnet: fdf1:f4a2:d53::/64
+          gateway: fdf1:f4a2:d53::ffff
 services:
   db:
     image: postgres:${POSTGRES_TAG:-latest}
@@ -55,7 +55,7 @@ services:
     privileged: true
     networks:
       - default
-    sysctls:
+    sysctls: 
       - net.ipv6.conf.all.disable_ipv6=0
     depends_on: [web]
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
 version: '3'
 
+networks:
+  default:
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: fdf1:f4a2:d53::/48
+          gateway: fdf1:f4a2:d53::1000
 services:
   db:
     image: postgres:${POSTGRES_TAG:-latest}
@@ -16,6 +24,8 @@ services:
     command: web
     depends_on: [db]
     ports: [8080:8080]
+    networks:
+      - default
     volumes:
     - .:/src
     - "./hack/keys:/concourse-keys"
@@ -43,6 +53,10 @@ services:
     image: concourse/concourse:local
     command: worker
     privileged: true
+    networks:
+      - default
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
     depends_on: [web]
     ports:
     - 7777:7777

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     privileged: true
     networks:
       - default
-    sysctls: 
+    sysctls:
       - net.ipv6.conf.all.disable_ipv6=0
     depends_on: [web]
     ports:

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -334,8 +334,8 @@ func NewCNINetwork(opts ...CNINetworkOpt) (*cniNetwork, error) {
 		}
 		
 		opts := []cni.Opt {
-			cni.WithLoNetwork,
 			cni.WithConfListBytes([]byte(n.config.ToJSONv4())),
+			cni.WithLoNetwork,
 		}
 		if n.config.IPv6.Enabled {
 			opts = append(opts, cni.WithConfListBytes([]byte(n.config.ToJSONv6())))

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -2,13 +2,16 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net"
 	"path/filepath"
 	"strings"
 
 	"github.com/concourse/concourse/worker/runtime/iptables"
 	"github.com/containerd/containerd"
 	"github.com/containerd/go-cni"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -26,14 +29,41 @@ type CNINetworkConfig struct {
 	//
 	NetworkName string
 
-	// Subnet is the subnet (in CIDR notation) which the veths should be
+	// MTU is the MTU of the bridge network interface.
+	//
+	MTU int
+
+	// IPv4 Configuration
+	//
+	IPv4 CNIv4NetworkConfig
+
+	// IPv6 Configuration
+	//
+	IPv6 CNIv6NetworkConfig
+}
+
+type CNIv4NetworkConfig struct {
+
+
+	// The subnet (in CIDR notation) which the veths should be
+	// added to.
+	//
+	Subnet string
+}
+
+type CNIv6NetworkConfig struct {
+	// Enable IPv6 networking
+	//
+	Enabled bool
+
+	// The subnet (in CIDR notation) which the veths should be
 	// added to.
 	//
 	Subnet string
 
-	// MTU is the MTU of the bridge network interface.
-	//
-	MTU int
+	// Masquerade the traffic from the container using the worker address
+	// 
+	IPMasq bool
 }
 
 const (
@@ -52,46 +82,130 @@ var (
 	DefaultCNINetworkConfig = CNINetworkConfig{
 		BridgeName:  "concourse0",
 		NetworkName: "concourse",
-		Subnet:      "10.80.0.0/16",
+		IPv4: CNIv4NetworkConfig{
+			Subnet: "10.80.0.0/16",
+		},
+		IPv6: CNIv6NetworkConfig{
+			Enabled: true,
+			Subnet:  "fd9c:31a6:c759::/64",
+			IPMasq: true,
+		},
 	}
+	// Default firewall plugin configuration
+	//
+	defaultFirewallPlugin = FirewallPlugin{
+		Plugin: Plugin{"firewall"},
+		IPTablesChainName: ipTablesAdminChainName,
+	}
+
+	// Default IPv4 route
+	//
+	_,default_route_v4,_ = net.ParseCIDR("0.0.0.0/0")
+
+	// Default IPv6 route
+	//
+	_,default_route_v6,_ = net.ParseCIDR("::/0")
 )
 
-func (c CNINetworkConfig) ToJSON() string {
-	var mtu string
-	if c.MTU != 0 {
-		mtu = fmt.Sprintf(`
-      "mtu": %d,`, c.MTU)
-	}
-	networksConfListFormat := `{
-  "cniVersion": "0.4.0",
-  "name": "%s",
-  "plugins": [
-    {
-      "type": "bridge",
-      "bridge": "%s",
-      "isGateway": true,
-      "ipMasq": true,` +
-		mtu + `
-      "ipam": {
-        "type": "host-local",
-        "subnet": "%s",
-        "routes": [
-          {
-            "dst": "0.0.0.0/0"
-          }
-        ]
-      }
-    },
-    {
-      "type": "firewall",
-      "iptablesAdminChainName": "%s"
-    }
-  ]
-}`
+type CNINetworkConfiguration struct {
+	Name string `json:"name"`
+	CNIVersion string `json:"cniVersion"`
+	Plugins []interface{} `json:"plugins"`
+}
 
-	return fmt.Sprintf(networksConfListFormat,
-		c.NetworkName, c.BridgeName, c.Subnet, ipTablesAdminChainName,
-	)
+type Plugin struct {
+	Type string `json:"type"`
+}
+
+type BridgePlugin struct {
+	Plugin
+	Bridge string `json:"bridge"`
+	IsGateway bool `json:"isGateway"`
+	IPMasq bool `json:"ipMasq"`
+	IPAM IPAM `json:"ipam"`
+	MTU int `json:"mtu,omitempty"`
+}
+
+type FirewallPlugin struct {
+	Plugin
+	IPTablesChainName string `json:"iptablesAdminChainName"`
+}
+
+type IPAM struct {
+	Type string `json:"type"`
+	Ranges [][]Range `json:"ranges"`
+	Routes []types.Route `json:"routes"`
+}
+
+type Range struct {
+	Subnet types.IPNet `json:"subnet"`
+}
+
+func (c CNINetworkConfig) ToJSONv4() string {
+	_,subnet_v4,_ :=net.ParseCIDR(c.IPv4.Subnet)
+	ranges := [][]Range{
+		{{Subnet: types.IPNet(*subnet_v4)}},
+	}
+	routes  := []types.Route{
+		{Dst: *subnet_v4},
+		{Dst: *default_route_v4},
+	}
+
+	bridge_plugin := BridgePlugin{
+		Plugin: Plugin{"bridge"},
+		Bridge: c.BridgeName,
+		IsGateway: true,
+		IPMasq: true,
+		MTU: c.MTU,
+		IPAM: IPAM{
+			Type:"host-local",
+			Ranges: ranges,
+			Routes: routes,
+		},
+	}
+	
+	net_config := CNINetworkConfiguration{
+		Name :c.NetworkName,
+		CNIVersion: "0.4.0",
+		Plugins: []interface{}{bridge_plugin, defaultFirewallPlugin},
+	}
+
+	config_json, _ :=json.Marshal(net_config)
+	
+	return string(config_json)
+}
+
+func (c CNINetworkConfig) ToJSONv6() string {
+	_,subnet_v6,_ := net.ParseCIDR(c.IPv6.Subnet)
+	ranges := [][]Range{
+		{{Subnet:types.IPNet(*subnet_v6)}},
+	}
+	routes  := []types.Route{
+		{Dst: *subnet_v6},
+		{Dst: *default_route_v6},
+	}
+
+	bridge_plugin := BridgePlugin{
+		Plugin: Plugin{"bridge"},
+		Bridge: c.BridgeName,
+		IsGateway: true,
+		IPMasq: c.IPv6.IPMasq,
+		MTU: c.MTU,
+		IPAM: IPAM{
+			Type:"host-local",
+			Ranges: ranges,
+			Routes: routes,
+		},
+	}
+
+	net_config := CNINetworkConfiguration{
+		Name :c.NetworkName,
+		CNIVersion: "0.4.0",
+		Plugins: []interface{}{bridge_plugin, defaultFirewallPlugin},
+	}
+	config_json,_ :=json.Marshal(net_config)
+	
+	return string(config_json)
 }
 
 // CNINetworkOpt defines a functional option that when applied, modifies the
@@ -218,11 +332,16 @@ func NewCNINetwork(opts ...CNINetworkOpt) (*cniNetwork, error) {
 		if err != nil {
 			return nil, fmt.Errorf("cni init: %w", err)
 		}
-
-		err = n.client.Load(
-			cni.WithConfListBytes([]byte(n.config.ToJSON())),
+		
+		opts := []cni.Opt {
 			cni.WithLoNetwork,
-		)
+			cni.WithConfListBytes([]byte(n.config.ToJSONv4())),
+		}
+		if n.config.IPv6.Enabled {
+			opts = append(opts, cni.WithConfListBytes([]byte(n.config.ToJSONv6())))
+		}
+
+		err = n.client.Load(opts...)
 		if err != nil {
 			return nil, fmt.Errorf("cni configuration loading: %w", err)
 		}

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -142,7 +142,10 @@ type Range struct {
 }
 
 func (c CNINetworkConfig) ToJSONv4() string {
-	_,subnet_v4,_ :=net.ParseCIDR(c.IPv4.Subnet)
+	_, subnet_v4, err :=net.ParseCIDR(c.IPv4.Subnet)
+	if err != nil {
+		_, subnet_v4, _ = net.ParseCIDR(DefaultCNINetworkConfig.IPv4.Subnet);
+	}
 	ranges := [][]Range{
 		{{Subnet: types.IPNet(*subnet_v4)}},
 	}
@@ -176,7 +179,10 @@ func (c CNINetworkConfig) ToJSONv4() string {
 }
 
 func (c CNINetworkConfig) ToJSONv6() string {
-	_,subnet_v6,_ := net.ParseCIDR(c.IPv6.Subnet)
+	_,subnet_v6, err := net.ParseCIDR(c.IPv6.Subnet)
+	if err != nil {
+		_, subnet_v6, _ = net.ParseCIDR(DefaultCNINetworkConfig.IPv6.Subnet);
+	}
 	ranges := [][]Range{
 		{{Subnet:types.IPNet(*subnet_v6)}},
 	}

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -51,7 +51,7 @@ func (s *CNINetworkSuite) TestNewCNINetworkWithInvalidConfigDoesntFail() {
 	_, err := runtime.NewCNINetwork(
 		runtime.WithDefaultsForTesting(),
 		runtime.WithCNINetworkConfig(runtime.CNINetworkConfig{
-			Subnet: "_____________",
+			IPv4: runtime.CNIv4NetworkConfig{Subnet: "_____________"},
 		}),
 		runtime.WithIptables(s.iptables),
 	)

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -44,14 +44,22 @@ func (s *CNINetworkSuite) SetupTest() {
 	s.NoError(err)
 }
 
-func (s *CNINetworkSuite) TestNewCNINetworkWithInvalidConfigDoesntFail() {
-	// CNI defers the actual interpretation of the network configuration to
-	// the plugins.
-	//
+func (s *CNINetworkSuite) TestNewCNINetworkWithInvalidIPv4ConfigDoesntFail() {
 	_, err := runtime.NewCNINetwork(
 		runtime.WithDefaultsForTesting(),
 		runtime.WithCNINetworkConfig(runtime.CNINetworkConfig{
 			IPv4: runtime.CNIv4NetworkConfig{Subnet: "_____________"},
+		}),
+		runtime.WithIptables(s.iptables),
+	)
+	s.NoError(err)
+}
+
+func (s *CNINetworkSuite) TestNewCNINetworkWithInvalidIPv6ConfigDoesntFail() {
+	_, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
+		runtime.WithCNINetworkConfig(runtime.CNINetworkConfig{
+			IPv6: runtime.CNIv6NetworkConfig{Enabled: true, Subnet: "______"},
 		}),
 		runtime.WithIptables(s.iptables),
 	)

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -121,7 +121,7 @@ func (cmd *WorkerCommand) buildUpNetworkOpts(logger lager.Logger, dnsServers []s
 	}
 
 	networkConfig.IPv6 = runtime.CNIv6NetworkConfig{
-		Enabled: !cmd.Containerd.Network.IPv6.Disable,
+		Enabled: cmd.Containerd.Network.IPv6.Enable,
 		Subnet:  cmd.Containerd.Network.IPv6.Pool,
 		IPMasq:  !cmd.Containerd.Network.IPv6.DisableIPMasq,
 	}

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -117,8 +117,15 @@ func (cmd *WorkerCommand) buildUpNetworkOpts(logger lager.Logger, dnsServers []s
 
 	networkConfig := runtime.DefaultCNINetworkConfig
 	if cmd.Containerd.Network.Pool != "" {
-		networkConfig.Subnet = cmd.Containerd.Network.Pool
+		networkConfig.IPv4.Subnet = cmd.Containerd.Network.Pool
 	}
+
+	networkConfig.IPv6 = runtime.CNIv6NetworkConfig{
+		Enabled: !cmd.Containerd.Network.IPv6.Disable,
+		Subnet:  cmd.Containerd.Network.IPv6.Pool,
+		IPMasq:  !cmd.Containerd.Network.IPv6.DisableIPMasq,
+	}
+
 	var err error
 	networkConfig.MTU, err = cmd.Containerd.mtu()
 	if err != nil {

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -56,8 +56,8 @@ type ContainerdRuntime struct {
 		AllowHostAccess    bool      `long:"allow-host-access" description:"Allow containers to reach the host's network. This is turned off by default."`
 		///*
 		IPv6 struct {
-			Disable       bool   `long:"disable" description:"Disable IPv6 networking"`
-			Pool          string `long:"pool" default:"fd9c:31a6:c759::/64" description:"IPv6 network range to user for dynamically allocated container addresses."`
+			Enable        bool   `long:"enable" description:"Enable IPv6 networking"`
+			Pool          string `long:"pool" default:"fd9c:31a6:c759::/64" description:"IPv6 network range to use for dynamically allocated container addresses."`
 			DisableIPMasq bool   `long:"disable-masquerade" description:"Masquerade container traffic with worker address."`
 		} `group:"IPv6 Configuration" namespace:"v6"`
 		//*/

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -54,13 +54,11 @@ type ContainerdRuntime struct {
 		Pool               string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
 		MTU                int       `long:"mtu" description:"MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host."`
 		AllowHostAccess    bool      `long:"allow-host-access" description:"Allow containers to reach the host's network. This is turned off by default."`
-		///*
 		IPv6 struct {
 			Enable        bool   `long:"enable" description:"Enable IPv6 networking"`
 			Pool          string `long:"pool" default:"fd9c:31a6:c759::/64" description:"IPv6 network range to use for dynamically allocated container addresses."`
 			DisableIPMasq bool   `long:"disable-masquerade" description:"Masquerade container traffic with worker address."`
 		} `group:"IPv6 Configuration" namespace:"v6"`
-		//*/
 	} `group:"Container Networking"`
 
 	MaxContainers int `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -54,6 +54,13 @@ type ContainerdRuntime struct {
 		Pool               string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
 		MTU                int       `long:"mtu" description:"MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host."`
 		AllowHostAccess    bool      `long:"allow-host-access" description:"Allow containers to reach the host's network. This is turned off by default."`
+		///*
+		IPv6 struct {
+			Disable       bool   `long:"disable" description:"Disable IPv6 networking"`
+			Pool          string `long:"pool" default:"fd9c:31a6:c759::/64" description:"IPv6 network range to user for dynamically allocated container addresses."`
+			DisableIPMasq bool   `long:"disable-masquerade" description:"Masquerade container traffic with worker address."`
+		} `group:"IPv6 Configuration" namespace:"v6"`
+		//*/
 	} `group:"Container Networking"`
 
 	MaxContainers int `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -54,7 +54,7 @@ type ContainerdRuntime struct {
 		Pool               string    `long:"network-pool" default:"10.80.0.0/16" description:"Network range to use for dynamically allocated container subnets."`
 		MTU                int       `long:"mtu" description:"MTU size for container network interfaces. Defaults to the MTU of the interface used for outbound access by the host."`
 		AllowHostAccess    bool      `long:"allow-host-access" description:"Allow containers to reach the host's network. This is turned off by default."`
-		IPv6 struct {
+		IPv6               struct {
 			Enable        bool   `long:"enable" description:"Enable IPv6 networking"`
 			Pool          string `long:"pool" default:"fd9c:31a6:c759::/64" description:"IPv6 network range to use for dynamically allocated container addresses."`
 			DisableIPMasq bool   `long:"disable-masquerade" description:"Masquerade container traffic with worker address."`


### PR DESCRIPTION
## Changes proposed by this PR

closes #5919

* [x] CLI option (`--containerd-v6-enable`) to enable ipv6 in tasks
* [x] CLI option (`--containerd-v6-pool`) to configure subnet from which containers get their address
* [x] CLI option (`--containerd-v6-disable-masquerade`) to disable masquerading of ipv6 connections using the worker address

## Release Note

* Add IPv6 networking support to tasks - There's now a `CONCOURSE_CONTAINERD_V6_ENABLE`/`--containerd-v6-enable` config option on the `concourse worker` command to enable IPv6 support in containerd containers. There are two IPv6 config's you can change. `--containerd-v6-pool` to specify the IPv6 subnet to use. Default subnet is `fd9c:31a6:c759::/64`. `--containerd-v6-disable-masquerade` to disable IPMasq, which is on by default if you use IPv6.

