### PR TITLE
Fixes cf authentication fails on 7.9.1 #8696

### DIFF
--- a/atc/api/accessor/accessor.go
+++ b/atc/api/accessor/accessor.go
@@ -94,6 +94,11 @@ func contains(arr []string, val string) bool {
 
 func (a *access) rolesForTeam(auth atc.TeamAuth) []string {
 	connectorID := a.connectorID()
+
+	if connectorID == "cloudfoundry" {
+		connectorID = "cf"
+	}
+
 	userID := a.userID()
 	if userID != "" {
 		userID = fmt.Sprintf("%v:%v", connectorID, userID)

--- a/skymarshal/dexserver/dexserver.go
+++ b/skymarshal/dexserver/dexserver.go
@@ -72,10 +72,14 @@ func NewDexServerConfig(config *DexConfig) (server.Config, error) {
 	redirectURI := strings.TrimRight(config.IssuerURL, "/") + "/callback"
 
 	for _, connector := range skycmd.GetConnectors() {
+		var id = connector.ID()
+		if id == "cf" {
+			id = "cloudfoundry"
+		}
 		if c, err := connector.Serialize(redirectURI); err == nil {
 			connectors = append(connectors, storage.Connector{
-				ID:     connector.ID(),
-				Type:   connector.ID(),
+				ID:     id,
+				Type:   id,
 				Name:   connector.Name(),
 				Config: c,
 			})

--- a/skymarshal/skycmd/cf_flags.go
+++ b/skymarshal/skycmd/cf_flags.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	RegisterConnector(&Connector{
-		id:         "cloudfoundry",
+		id:         "cf",
 		config:     &CFFlags{},
 		teamConfig: &CFTeamFlags{},
 	})

--- a/skymarshal/skycmd/flags.go
+++ b/skymarshal/skycmd/flags.go
@@ -212,10 +212,6 @@ type Connector struct {
 }
 
 func (con *Connector) ID() string {
-	if con.id == "cloudfoundry" {
-		return "cf"
-	}
-
 	return con.id
 }
 


### PR DESCRIPTION
This also ensures that prior "cf" named teams also work with "cloudfoundry" naming from DEX

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

closes #8696 

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

The changes in `skymarshal/dexserver/dexserver.go` are not covered in unit tests. This is because the `skycmd.GetConnectors()` is not exposable to the public. 

We did run an integration scenario locally by 1) using fly to create a `cf` labeled team-auth, and 2) logging on using a version of DEX that's configured for `cloudfoundry` labels. Our mapping worked.

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Fix CF connector regression bug introduced on 7.9.1

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
