### PR TITLE
Emitting "latest_completed_build_status" gauge from prometheus

### DIFF
--- a/atc/db/dbfakes/fake_job.go
+++ b/atc/db/dbfakes/fake_job.go
@@ -254,6 +254,18 @@ type FakeJob struct {
 		result1 []atc.JobInput
 		result2 error
 	}
+	LatestCompletedBuildIdStub        func() (int, error)
+	latestCompletedBuildIdMutex       sync.RWMutex
+	latestCompletedBuildIdArgsForCall []struct {
+	}
+	latestCompletedBuildIdReturns struct {
+		result1 int
+		result2 error
+	}
+	latestCompletedBuildIdReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	MaxInFlightStub        func() int
 	maxInFlightMutex       sync.RWMutex
 	maxInFlightArgsForCall []struct {
@@ -1670,6 +1682,62 @@ func (fake *FakeJob) InputsReturnsOnCall(i int, result1 []atc.JobInput, result2 
 	}
 	fake.inputsReturnsOnCall[i] = struct {
 		result1 []atc.JobInput
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeJob) LatestCompletedBuildId() (int, error) {
+	fake.latestCompletedBuildIdMutex.Lock()
+	ret, specificReturn := fake.latestCompletedBuildIdReturnsOnCall[len(fake.latestCompletedBuildIdArgsForCall)]
+	fake.latestCompletedBuildIdArgsForCall = append(fake.latestCompletedBuildIdArgsForCall, struct {
+	}{})
+	stub := fake.LatestCompletedBuildIdStub
+	fakeReturns := fake.latestCompletedBuildIdReturns
+	fake.recordInvocation("LatestCompletedBuildId", []interface{}{})
+	fake.latestCompletedBuildIdMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeJob) LatestCompletedBuildIdCallCount() int {
+	fake.latestCompletedBuildIdMutex.RLock()
+	defer fake.latestCompletedBuildIdMutex.RUnlock()
+	return len(fake.latestCompletedBuildIdArgsForCall)
+}
+
+func (fake *FakeJob) LatestCompletedBuildIdCalls(stub func() (int, error)) {
+	fake.latestCompletedBuildIdMutex.Lock()
+	defer fake.latestCompletedBuildIdMutex.Unlock()
+	fake.LatestCompletedBuildIdStub = stub
+}
+
+func (fake *FakeJob) LatestCompletedBuildIdReturns(result1 int, result2 error) {
+	fake.latestCompletedBuildIdMutex.Lock()
+	defer fake.latestCompletedBuildIdMutex.Unlock()
+	fake.LatestCompletedBuildIdStub = nil
+	fake.latestCompletedBuildIdReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeJob) LatestCompletedBuildIdReturnsOnCall(i int, result1 int, result2 error) {
+	fake.latestCompletedBuildIdMutex.Lock()
+	defer fake.latestCompletedBuildIdMutex.Unlock()
+	fake.LatestCompletedBuildIdStub = nil
+	if fake.latestCompletedBuildIdReturnsOnCall == nil {
+		fake.latestCompletedBuildIdReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.latestCompletedBuildIdReturnsOnCall[i] = struct {
+		result1 int
 		result2 error
 	}{result1, result2}
 }
@@ -3169,6 +3237,8 @@ func (fake *FakeJob) Invocations() map[string][][]interface{} {
 	defer fake.iDMutex.RUnlock()
 	fake.inputsMutex.RLock()
 	defer fake.inputsMutex.RUnlock()
+	fake.latestCompletedBuildIdMutex.RLock()
+	defer fake.latestCompletedBuildIdMutex.RUnlock()
 	fake.maxInFlightMutex.RLock()
 	defer fake.maxInFlightMutex.RUnlock()
 	fake.nameMutex.RLock()

--- a/atc/db/job_test.go
+++ b/atc/db/job_test.go
@@ -355,6 +355,34 @@ var _ = Describe("Job", func() {
 		})
 	})
 
+	Describe("LatestCompletedBuildId", func() {
+		var (
+			someJob db.Job
+			build   db.Build
+			err     error
+		)
+
+		BeforeEach(func() {
+			var found bool
+			someJob, found, err = pipeline.Job("some-job")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			build, err = someJob.CreateBuild(defaultBuildCreatedBy)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("fetches latest completed build id on a job", func() {
+			By("finishing the build")
+			err = build.Finish(db.BuildStatusFailed)
+			Expect(err).NotTo(HaveOccurred())
+
+			latestCompletedBuildId, err := someJob.LatestCompletedBuildId()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(latestCompletedBuildId).To(Equal(build.ID()))
+		})
+	})
+
 	Describe("ChronoBuilds", func() {
 		var (
 			someJob                     db.Job

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -273,12 +273,15 @@ func (b *engineBuild) saveStatus(logger lager.Logger, status atc.BuildStatus) {
 		logger.Info("job-not-found")
 	}
 
-	if job.LatestCompletedBuildId() <= b.build.ID() {
+	id, err := job.LatestCompletedBuildId()
+	if err != nil {
+		logger.Error("failed-to-get-latest-completed-build-id", err)
+	} else if b.build.ID() >= id {
 		metric.JobStatus{
-			Status: status.String(),
-			JobName: job.Name(),
+			Status:       status.String(),
+			JobName:      job.Name(),
 			PipelineName: job.PipelineName(),
-			TeamName: job.TeamName(),
+			TeamName:     job.TeamName(),
 		}.Emit(logger)
 	}
 

--- a/atc/engine/engine.go
+++ b/atc/engine/engine.go
@@ -265,28 +265,37 @@ func (b *engineBuild) finish(logger lager.Logger, err error, succeeded bool) {
 }
 
 func (b *engineBuild) saveStatus(logger lager.Logger, status atc.BuildStatus) {
+	if err := b.build.Finish(db.BuildStatus(status)); err != nil {
+		logger.Error("failed-to-finish-build", err)
+		return
+	}
+
+	if b.build.JobID() == 0 {
+		return
+	}
+
 	job, found, err := b.build.Job()
 	if err != nil {
 		logger.Error("failed-to-get-job", err)
+		return
 	}
 	if !found {
-		logger.Info("job-not-found")
+		logger.Info("build-job-not-found")
+		return
 	}
 
 	id, err := job.LatestCompletedBuildId()
 	if err != nil {
 		logger.Error("failed-to-get-latest-completed-build-id", err)
-	} else if b.build.ID() >= id {
+		return
+	}
+	if b.build.ID() >= id {
 		metric.JobStatus{
 			Status:       status.String(),
 			JobName:      job.Name(),
 			PipelineName: job.PipelineName(),
 			TeamName:     job.TeamName(),
 		}.Emit(logger)
-	}
-
-	if err := b.build.Finish(db.BuildStatus(status)); err != nil {
-		logger.Error("failed-to-finish-build", err)
 	}
 }
 

--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -61,6 +61,7 @@ type Monitor struct {
 	CheckBuildsStarted Counter
 	CheckBuildsRunning Gauge
 
+	JobStatuses  map[JobStatusLabels]*Gauge
 	StepsWaiting map[StepsWaitingLabels]*Gauge
 
 	// When global resource is not enabled, ChecksStarted should equal to CheckBuildsStarted.

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -289,7 +289,7 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 		ConstLabels: attributes,
 	}, []string{"jobName", "pipelineName", "teamName"})
 	prometheus.MustRegister(jobStatus)
-	
+
 	stepsWaiting := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:   "concourse",
 		Subsystem:   "steps",

--- a/atc/metric/emitter/prometheus.go
+++ b/atc/metric/emitter/prometheus.go
@@ -45,6 +45,8 @@ type PrometheusEmitter struct {
 	buildsFinishedVec *prometheus.CounterVec
 	buildsSucceeded   prometheus.Counter
 
+	jobStatus *prometheus.GaugeVec
+
 	gcBuildCollectorDuration                      prometheus.Histogram
 	gcWorkerCollectorDuration                     prometheus.Histogram
 	gcResourceCacheUseCollectorDuration           prometheus.Histogram
@@ -132,10 +134,11 @@ func serializeLabels(labels *prometheus.Labels) string {
 // emitted labels.
 //
 // Prometheus format:
-//   > Label names may contain ASCII letters, numbers, as well as underscores.
-//   > They must match the regex [a-zA-Z_][a-zA-Z0-9_]*. Label names beginning
-//   > with __ are reserved for internal use.
-//   Link: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+//
+//	> Label names may contain ASCII letters, numbers, as well as underscores.
+//	> They must match the regex [a-zA-Z_][a-zA-Z0-9_]*. Label names beginning
+//	> with __ are reserved for internal use.
+//	Link: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
 var rePrometheusLabelInvalid = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
 
 // rePrometheusLabelClean ensures we clean any duplicate underscores.
@@ -278,6 +281,15 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 	}, []string{"action"})
 	prometheus.MustRegister(concurrentRequests)
 
+	jobStatus := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   "concourse",
+		Subsystem:   "job",
+		Name:        "status",
+		Help:        "Status of Concourse job",
+		ConstLabels: attributes,
+	}, []string{"jobName", "pipelineName", "teamName"})
+	prometheus.MustRegister(jobStatus)
+	
 	stepsWaiting := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace:   "concourse",
 		Subsystem:   "steps",
@@ -815,6 +827,7 @@ func (config *PrometheusConfig) NewEmitter(attributes map[string]string) (metric
 		concurrentRequestsLimitHit: concurrentRequestsLimitHit,
 		concurrentRequests:         concurrentRequests,
 
+		jobStatus:            jobStatus,
 		stepsWaiting:         stepsWaiting,
 		stepsWaitingDuration: stepsWaitingDuration,
 
@@ -923,6 +936,13 @@ func (emitter *PrometheusEmitter) Emit(logger lager.Logger, event metric.Event) 
 	case "concurrent requests":
 		emitter.concurrentRequests.
 			WithLabelValues(event.Attributes["action"]).Set(event.Value)
+	case "job status":
+		emitter.jobStatus.
+			WithLabelValues(
+				event.Attributes["jobName"],
+				event.Attributes["pipelineName"],
+				event.Attributes["teamName"],
+			).Set(event.Value)
 	case "steps waiting":
 		emitter.stepsWaiting.
 			WithLabelValues(
@@ -1306,7 +1326,7 @@ func (emitter *PrometheusEmitter) updateLastSeen(event metric.Event) {
 	}
 }
 
-//periodically remove stale metrics for workers
+// periodically remove stale metrics for workers
 func (emitter *PrometheusEmitter) periodicMetricGC() {
 	for {
 		emitter.mu.Lock()

--- a/atc/metric/emitter/prometheus_test.go
+++ b/atc/metric/emitter/prometheus_test.go
@@ -211,7 +211,7 @@ var _ = Describe("PrometheusEmitter", func() {
 		})
 
 		prometheusEmitter.Emit(logger, metric.Event{
-			Name:  "job status",
+			Name:  "latest completed build status",
 			Value: 0,
 			Attributes: map[string]string{
 				"jobName":      "job1",
@@ -230,6 +230,6 @@ var _ = Describe("PrometheusEmitter", func() {
 		}
 
 		Eventually(getPrometheusMetrics()).Should(ContainSubstring("concourse_steps_waiting{invalid_label=\"foo\",platform=\"darwin\",prefix_test=\"bar\",prefix_testtwo=\"baz\",teamId=\"42\",teamName=\"teamdev\",type=\"get\",workerTags=\"tester\"} 4"))
-		Eventually(getPrometheusMetrics()).Should(ContainSubstring("concourse_job_status{invalid_label=\"foo\",jobName=\"job1\",pipelineName=\"pipeline1\",prefix_test=\"bar\",prefix_testtwo=\"baz\",teamName=\"team1\"} 0"))
+		Eventually(getPrometheusMetrics()).Should(ContainSubstring("concourse_builds_latest_completed_build_status{invalid_label=\"foo\",jobName=\"job1\",pipelineName=\"pipeline1\",prefix_test=\"bar\",prefix_testtwo=\"baz\",teamName=\"team1\"} 0"))
 	})
 })

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -11,6 +11,12 @@ import (
 	"github.com/concourse/concourse/atc/db"
 )
 
+type JobStatusLabels struct {
+	JobName      string
+	TeamName     string
+	PipelineName string
+}
+
 type StepsWaitingLabels struct {
 	Platform   string
 	TeamId     string

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -433,6 +433,39 @@ func (event FailedVolumesToBeGarbageCollected) Emit(logger lager.Logger) {
 	)
 }
 
+type JobStatus struct {
+	Status       string
+	JobName      string
+	PipelineName string
+	TeamName     string
+}
+
+func (event JobStatus) Emit(logger lager.Logger) {
+	value := -1
+	switch event.Status {
+	case "succeeded":
+		value = 0
+	case "failed":
+		value = 1
+	case "aborted":
+		value = 2
+	case "errored":
+		value = 3
+	}
+	Metrics.emit(
+		logger.Session("job-status"),
+		Event{
+			Name:  "job status",
+			Value: float64(value),
+			Attributes: map[string]string{
+				"jobName":      event.JobName,
+				"pipelineName": event.PipelineName,
+				"teamName":     event.TeamName,
+			},
+		},
+	)
+}
+
 type BuildStarted struct {
 	Build db.Build
 }

--- a/atc/metric/metrics.go
+++ b/atc/metric/metrics.go
@@ -441,7 +441,7 @@ type JobStatus struct {
 }
 
 func (event JobStatus) Emit(logger lager.Logger) {
-	value := -1
+	var value int
 	switch event.Status {
 	case "succeeded":
 		value = 0
@@ -451,11 +451,14 @@ func (event JobStatus) Emit(logger lager.Logger) {
 		value = 2
 	case "errored":
 		value = 3
+	default:
+		return
 	}
+
 	Metrics.emit(
-		logger.Session("job-status"),
+		logger.Session("latest-completed-build-status"),
 		Event{
-			Name:  "job status",
+			Name:  "latest completed build status",
 			Value: float64(value),
 			Attributes: map[string]string{
 				"jobName":      event.JobName,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Ensures that the guage gets emitted
* [x] Ensure that the gauge has latest completed build status information

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

Currently, this metric is emitting the following attributes alongside the gauge: `jobName`, `pipelineName`, `teamName`. Is there any other metadata about the job or build that should be emitted?

This is how the metric will show up in the Prometheus dashboard:

![Screenshot 2023-10-03 at 11 58 02 AM](https://github.com/concourse/concourse/assets/15034841/81315f70-3f32-4c79-b7e2-49e5d4cad171)


## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Add `concourse_builds_latest_completed_build_status` metric
  * Guage = 0 for success
  * Guage = 1 for failure
  * Guage = 2 for aborted
  * Guage = 3 for error

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
