### PR TITLE
Fix integration flaky ops parallel upgrade/downgrade tests

### DIFF
--- a/integration/ops/downgrade_test.go
+++ b/integration/ops/downgrade_test.go
@@ -11,7 +11,7 @@ import (
 func TestDowngrade(t *testing.T) {
 	t.Parallel()
 
-	devDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/fast-gc.yml")
+	devDC := dctest.Init(t, "../docker-compose.yml", "overrides/named-downgrade.yml", "overrides/fast-gc.yml")
 
 	t.Run("deploy dev", func(t *testing.T) {
 		devDC.Run(t, "up", "-d")
@@ -20,7 +20,7 @@ func TestDowngrade(t *testing.T) {
 	fly := flytest.Init(t, devDC)
 	setupUpgradeDowngrade(t, fly)
 
-	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/latest.yml", "overrides/fast-gc.yml")
+	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/named-downgrade.yml", "overrides/latest.yml", "overrides/fast-gc.yml")
 
 	t.Run("migrate down to latest from clean deploy", func(t *testing.T) {
 		// just to see what it was before

--- a/integration/ops/overrides/named-downgrade.yml
+++ b/integration/ops/overrides/named-downgrade.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+services:
+  worker:
+    environment:
+      CONCOURSE_NAME: ops-worker-downgrade

--- a/integration/ops/overrides/named-upgrade.yml
+++ b/integration/ops/overrides/named-upgrade.yml
@@ -3,4 +3,4 @@ version: '3'
 services:
   worker:
     environment:
-      CONCOURSE_NAME: ops-worker
+      CONCOURSE_NAME: ops-worker-upgrade

--- a/integration/ops/upgrade_test.go
+++ b/integration/ops/upgrade_test.go
@@ -10,16 +10,15 @@ import (
 func TestUpgrade(t *testing.T) {
 	t.Parallel()
 
-	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/latest.yml", "overrides/fast-gc.yml")
+	latestDC := dctest.Init(t, "../docker-compose.yml", "overrides/named-upgrade.yml", "overrides/latest.yml", "overrides/fast-gc.yml")
 
 	t.Run("deploy latest", func(t *testing.T) {
 		latestDC.Run(t, "up", "-d")
 	})
-
 	fly := flytest.Init(t, latestDC)
 	setupUpgradeDowngrade(t, fly)
 
-	devDC := dctest.Init(t, "../docker-compose.yml", "overrides/named.yml", "overrides/fast-gc.yml")
+	devDC := dctest.Init(t, "../docker-compose.yml", "overrides/named-upgrade.yml", "overrides/fast-gc.yml")
 
 	t.Run("upgrade to dev", func(t *testing.T) {
 		devDC.Run(t, "up", "-d")


### PR DESCRIPTION

## Changes proposed by this PR
Use different worker name for those two tests

## Release Note


