### PR TITLE
`fly`: add `background` option to `execute` command

### DIFF
--- a/testflight/flying_test.go
+++ b/testflight/flying_test.go
@@ -80,6 +80,11 @@ run:
 		Expect(execS).To(gbytes.Say("ARGS are SOME ARGS"))
 	})
 
+	It("works in background", func() {
+		execS := flyIn(tmp, "execute", "-c", "task.yml", "-i", "fixture=./fixture", "-i", "input-1=./input-1", "-i", "input-2=./input-2", "--background", "--", "SOME", "ARGS",)
+		Eventually(execS).Should(gbytes.Say("executing build"))
+	})
+
 	Describe("hijacking", func() {
 		It("executes an interactive command in a running task's container", func() {
 			err := os.WriteFile(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

This patch adds a new `-b/--background` option to `fly execute`. This option tells `fly` to create the build, and exit just before watching the logs. It also means that outputs can't be retrieved. Instead, the build ID is printed, and logs can then be followed with `fly watch`.

* [x] added feature with acceptance test
* [ ] updated documentation
* [ ] left trail in contributors

## Rationale

I self-host Gitea and Drone. The application I'm making also needs some worker pool to spawn short-lived processes, and I thought it would be cool to only have one generic job framework to do both. But Drone is not flexible enough for that; besides it has been bought and shut down. I don't want to use frameworks that would lock me in K8S.

So, let's give Concourse a try! CICD works fine, however my jobs are triggered out of nowhere so I can't rely on resource checks to launch them. Although... maybe a custom resource type listing pending jobs with `version: every` could have somewhat worked, but can't be parallelized... Anyway, I feel spawning one-off tasks fits more to the idea.

I've seen on some pages that ATC's REST API is private, and on some other pages it's somewhat private only because it hasn't been documented yet. Well, my app will communicate through the API for sure, regardless of its privacy! I can't rely on spawning a process and waiting for it, my app can be restarted anytime, and jobs should not depend of that. So I prefer to independently spawn a job, and retrieve its logs.

I thought this workflow could be useful to CLI users too. Build ID is printed so that spawner process can use it (works with Bash and PowerShell).

Note that I don't need to fetch outputs back (yet), but CLI users could benefit from the complete split workflow: `fly execute --background` + `fly watch` + to-be-done `fly outputs`.

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

I don't master `flyIn`. It would have been better to test afterwards that `fly watch <buildID>` would have yield the same outputs as the preceding test, but then test times out. Maybe it's expected that `watch` keeps running if it's spawned while the build is running too, but I vaguely recall that it exits as soon as the build is completed.

Besides I'm new to Go, so I tried to fit in the code style, but have no idea how idiomatic it is.

Alternative name could have been `-d/--daemon` (like `docker run` does), but it implies the process is long-lasting, while it shouldn't.

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* `fly execute` gets new `-b/--background` option to create builds without watching them.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
