### PR TITLE
Fix incorrect log message

### DIFF
--- a/atc/api/jobserver/create_build.go
+++ b/atc/api/jobserver/create_build.go
@@ -21,7 +21,7 @@ func (s *Server) CreateJobBuild(pipeline db.Pipeline) http.Handler {
 
 		job, found, err := pipeline.Job(jobName)
 		if err != nil {
-			logger.Error("failed-to-get-resource-types", err)
+			logger.Error("failed-to-get-job", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

Fix the incorrect log message. The `pipeline.Job` function fetches job instead of resource-types