### PR TITLE
use stable website for internet test in watsjs

### DIFF
--- a/web/wats/fixtures/smoke-internet-pipeline.yml
+++ b/web/wats/fixtures/smoke-internet-pipeline.yml
@@ -12,4 +12,4 @@ jobs:
 
       run:
         path: wget
-        args: [https://example.com]
+        args: [https://google.com]


### PR DESCRIPTION
We have seen test failures in watsjs 
```
    running wget https://example.com␊

    Connecting to example.com (93.184.216.34:443)␍␊

    wget: note: TLS certificate validation not implemented␍␊

    wget: TLS error from peer (alert code 80): internal error␍␊

    wget: error getting response: Connection reset by peer␍␊

    failed␊

```

## Changes proposed by this PR

replace example.com with google.com

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] done
* [ ] todo

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
