### PR TITLE
Pulling go version other than relying on runner image in CodeQL scan

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

Refer to https://github.com/github/codeql-action/issues/1842#issuecomment-1704398087. If we don't do that, codeql build will fail by following error:

```
  2024/01/03 03:40:56 Error running go tooling: err: exit status 1: stderr: go: errors parsing go.mod:
  /home/runner/work/concourse/concourse/go.mod:3: invalid go version '1.21.5': must match format 1.23
```

* [x] done
* [ ] todo

