### PR TITLE
Fix compilation error in topgun/k8s test

### DIFF
--- a/topgun/k8s/baggageclaim_drivers_test.go
+++ b/topgun/k8s/baggageclaim_drivers_test.go
@@ -132,7 +132,7 @@ func createPVC(name string, scName string) {
 			Spec: corev1.PersistentVolumeClaimSpec{
 				StorageClassName: &scName,
 				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+				Resources: corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{
 					corev1.ResourceStorage: resource.MustParse("1Gi")}},
 			}}, metav1.CreateOptions{})
 	Expect(err).To(BeNil(), "failed to create persistent volume claim "+name)


### PR DESCRIPTION
Fix the error:

```
Failed to compile k8s:


# github.com/concourse/concourse/topgun/k8s_test [github.com/concourse/concourse/topgun/k8s.test]

./baggageclaim_drivers_test.go:135:16: cannot use corev1.ResourceRequirements{…} (value of type "k8s.io/api/core/v1".ResourceRequirements) as "k8s.io/api/core/v1".VolumeResourceRequirements value in struct literal

```
