### PR TITLE
Load vault client token from file

### DIFF
--- a/atc/creds/vault/manager.go
+++ b/atc/creds/vault/manager.go
@@ -53,7 +53,8 @@ type TLSConfig struct {
 }
 
 type AuthConfig struct {
-	ClientToken string `mapstructure:"client_token" long:"client-token" description:"Client token for accessing secrets within the Vault server."`
+	ClientToken     string `mapstructure:"client_token" long:"client-token" description:"Client token for accessing secrets within the Vault server."`
+	ClientTokenPath string `mapstructure:"client_token_path" long:"client-token-path" description:"Absolute path to a file containing the Vault client token."`
 
 	Backend       string        `mapstructure:"auth_backend" long:"auth-backend"               description:"Auth backend to use for logging in to Vault."`
 	BackendMaxTTL time.Duration `mapstructure:"auth_backend_max_ttl" long:"auth-backend-max-ttl"       description:"Time after which to force a re-login. If not set, the token will just be continuously renewed."`

--- a/atc/creds/vault/manager.go
+++ b/atc/creds/vault/manager.go
@@ -157,6 +157,10 @@ func (manager VaultManager) Validate() error {
 		return nil
 	}
 
+	if manager.Auth.ClientTokenPath != "" {
+		return nil
+	}
+
 	if manager.Auth.Backend != "" {
 		return nil
 	}

--- a/atc/creds/vault/manager_test.go
+++ b/atc/creds/vault/manager_test.go
@@ -56,13 +56,16 @@ var _ = Describe("VaultManager", func() {
 		})
 
 		DescribeTable("passes if all vault credentials are specified",
-			func(backend, clientToken string) {
+			func(backend, clientToken string, tokenPath string) {
 				manager.Auth.Backend = backend
 				manager.Auth.ClientToken = clientToken
+				manager.Auth.ClientTokenPath = tokenPath
 				Expect(manager.Validate()).To(BeNil())
 			},
-			Entry("all values", "backend", "clientToken"),
-			Entry("only clientToken", "", "clientToken"),
+			Entry("all values", "backend", "clientToken", "clientTokenPath"),
+			Entry("only clientToken", "", "clientToken", ""),
+			Entry("only clientTokenPath", "", "", "clientTokenPath"),
+			Entry("only backend", "backend", "", ""),
 		)
 
 		It("fails on missing vault auth credentials", func() {

--- a/hack/vault/init
+++ b/hack/vault/init
@@ -20,6 +20,9 @@ vault write auth/cert/certs/concourse \
   policies=concourse \
   certificate=@hack/vault/certs/vault-ca.crt ttl=1h
 
+vault token create --policy=concourse --format=json > hack/vault/token.json
+jq -r .token < hack/vault/token.json > hack/vault/token
+
 echo
 echo 'to use the vault CLI, set:'
 echo

--- a/integration/creds/overrides/vault-token.yml
+++ b/integration/creds/overrides/vault-token.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  web:
+    volumes:
+    - ../hack/vault/certs:/vault-certs
+    - ../hack/vault/token:/vault/token
+    environment:
+      CONCOURSE_VAULT_URL: https://vault:8200
+      CONCOURSE_VAULT_SHARED_PATH: shared
+      CONCOURSE_VAULT_CA_CERT: /vault-certs/vault-ca.crt
+      CONCOURSE_VAULT_CLIENT_TOKEN_PATH: /vault/token
+
+  vault:
+    image: ${TEST_VAULT_IMAGE:-vault:latest}
+    cap_add: [IPC_LOCK]
+    ports: [8200]
+    volumes:
+    - ../hack/vault/certs:/vault/certs
+    - ../hack/vault/config:/vault/config
+    command: server
+    environment:
+      # for running the 'vault' CLI
+      VAULT_CACERT: /vault/certs/vault-ca.crt
+
+      # sane default for 'vault' command run by tests
+      VAULT_FORMAT: json

--- a/integration/creds/overrides/vault-token.yml
+++ b/integration/creds/overrides/vault-token.yml
@@ -4,11 +4,12 @@ services:
   web:
     volumes:
     - ../hack/vault/certs:/vault-certs
+    - ../hack/vault/token:/vault/token
     environment:
       CONCOURSE_VAULT_URL: https://vault:8200
       CONCOURSE_VAULT_SHARED_PATH: shared
       CONCOURSE_VAULT_CA_CERT: /vault-certs/vault-ca.crt
-      CONCOURSE_VAULT_CLIENT_TOKEN_PATH: /vault-token
+      CONCOURSE_VAULT_CLIENT_TOKEN_PATH: /vault/token
 
   vault:
     image: ${TEST_VAULT_IMAGE:-hashicorp/vault:latest}

--- a/integration/creds/overrides/vault-token.yml
+++ b/integration/creds/overrides/vault-token.yml
@@ -4,7 +4,6 @@ services:
   web:
     volumes:
     - ../hack/vault/certs:/vault-certs
-    - ../hack/vault/token:/vault/token
     environment:
       CONCOURSE_VAULT_URL: https://vault:8200
       CONCOURSE_VAULT_SHARED_PATH: shared

--- a/integration/creds/overrides/vault-token.yml
+++ b/integration/creds/overrides/vault-token.yml
@@ -8,10 +8,10 @@ services:
       CONCOURSE_VAULT_URL: https://vault:8200
       CONCOURSE_VAULT_SHARED_PATH: shared
       CONCOURSE_VAULT_CA_CERT: /vault-certs/vault-ca.crt
-      CONCOURSE_VAULT_CLIENT_TOKEN_PATH: /vault/token
+      CONCOURSE_VAULT_CLIENT_TOKEN_PATH: /vault-token
 
   vault:
-    image: ${TEST_VAULT_IMAGE:-vault:latest}
+    image: ${TEST_VAULT_IMAGE:-hashicorp/vault:latest}
     cap_add: [IPC_LOCK]
     ports: [8200]
     volumes:

--- a/integration/creds/vault_test.go
+++ b/integration/creds/vault_test.go
@@ -24,7 +24,7 @@ func TestVault(t *testing.T) {
 
 	vault := vaulttest.Init(t, dc)
 
-	fly := flytest.Init(t, dc)
+	fly := flytest.InitOverrideCredentials(t, dc)
 
 	// set up kv v1 store for Concourse
 	vault.Run(t, "secrets", "enable", "-version=1", "-path", "concourse/main", "kv")

--- a/integration/creds/vault_test.go
+++ b/integration/creds/vault_test.go
@@ -68,7 +68,7 @@ func TestVaultTokenPath(t *testing.T) {
 	tmp := t.TempDir()
 	err := os.WriteFile(filepath.Join(tmp, "token"), []byte(summary.Token), 0666)
 	require.NoError(t, err)
-	dc.Run(t, "exec", "web", "cp", filepath.Join(tmp, "token"), "web:/vault-token")
+	dc.Run(t, "cp", filepath.Join(tmp, "token"), "web:/vault-token")
 
 	testCredentialManagement(t, fly, dc,
 		func(team, key string, val interface{}) {

--- a/integration/creds/vault_test.go
+++ b/integration/creds/vault_test.go
@@ -24,7 +24,7 @@ func TestVault(t *testing.T) {
 
 	vault := vaulttest.Init(t, dc)
 
-	fly := flytest.InitOverrideCredentials(t, dc)
+	fly := flytest.Init(t, dc)
 
 	// set up kv v1 store for Concourse
 	vault.Run(t, "secrets", "enable", "-version=1", "-path", "concourse/main", "kv")
@@ -55,7 +55,7 @@ func TestVaultTokenPath(t *testing.T) {
 
 	vault := vaulttest.Init(t, dc)
 
-	fly := flytest.Init(t, dc)
+	fly := flytest.InitOverrideCredentials(t, dc)
 
 	// set up kv v1 store for Concourse
 	vault.Run(t, "secrets", "enable", "-version=1", "-path", "concourse/main", "kv")

--- a/integration/creds/vault_test.go
+++ b/integration/creds/vault_test.go
@@ -63,7 +63,7 @@ func TestVaultTokenPath(t *testing.T) {
 
 	// write the token as a file in the web container
 	summary := tokenSummary{}
-	vault.OutputJSON(t, summary, "token", "create", "--policy=concourse", "--format=json")
+	vault.OutputJSON(t, &summary, "token", "create", "--policy=concourse", "--format=json")
 	dc.WithInput(strings.NewReader(summary.Token)).Run(t, "exec", "web", "dd", "of=/vault/token")
 
 	testCredentialManagement(t, fly, dc,

--- a/integration/internal/flytest/cmd.go
+++ b/integration/internal/flytest/cmd.go
@@ -72,6 +72,18 @@ func Init(t *testing.T, dc dctest.Cmd) Cmd {
 	return fly
 }
 
+func InitOverrideCredentials(t *testing.T, dc dctest.Cmd) Cmd {
+	fly, webURL := InitUnauthenticated(t, dc)
+
+	fly.WithEnv("CONCOURSE_VAULT_CLIENT_CERT=/vault-certs/concourse.crt")
+	fly.WithEnv("CONCOURSE_VAULT_CLIENT_KEY=/vault-certs/concourse.key")
+	fly.Run(t, "login", "-c", webURL, "-u", "test", "-p", "test")
+
+	fly.WaitForRunningWorker(t)
+
+	return fly
+}
+
 func (cmd Cmd) WaitForRunningWorker(t *testing.T) {
 	require.Eventually(t, func() bool {
 		for _, w := range cmd.Table(t, "workers") {


### PR DESCRIPTION
The k8s Vault Agent can automatically handle authentication to Vault, and inject a client token into a shared volume. The Vault agent manages the token lifecycle and refreshes the file contents as necessary. This change enables Concourse to read that token file, and take advantage of the agent's managed token.

<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Read vault client token from file
* [x] Update config?
* [x] Tests?

## Notes to reviewer

- I think this is a very straightforward change, but the vault API client doesn't appear to have much test coverage, and I'm not sure how I would go about adding it.
- Does anything else have to be done to add the appropriate CLI args and env vars? It didn't seem like it, but I'm not entirely sure.

## Release Note

* This allows Concourse to use the client tokens provided by the K8s Vault-Agent sidecar by setting `CONCOURSE_VAULT_CLIENT_TOKEN_PATH`
