### PR TITLE
Fx elm data-format package hash error

### DIFF
--- a/web/elm/elm.json
+++ b/web/elm/elm.json
@@ -19,13 +19,13 @@
             "elm/url": "1.0.0",
             "elm-community/graph": "6.0.0",
             "elm-community/json-extra": "4.3.0",
-            "elm-community/list-extra": "8.5.2",
+            "elm-community/list-extra": "8.7.0",
             "elm-community/maybe-extra": "5.3.0",
             "elm-explorations/benchmark": "1.0.2",
             "fapian/elm-html-aria": "1.4.0",
             "krisajenkins/remotedata": "5.0.0",
             "matthewsj/elm-ordering": "2.0.0",
-            "ryannhg/date-format": "2.3.0",
+            "ryan-haskell/date-format": "1.0.0",
             "truqu/elm-base64": "2.0.4",
             "vito/elm-ansi": "10.0.1"
         },
@@ -33,11 +33,11 @@
             "BrianHicks/elm-trend": "2.1.3",
             "avh4/elm-fifo": "1.0.4",
             "elm/regex": "1.0.0",
-            "elm/virtual-dom": "1.0.2",
+            "elm/virtual-dom": "1.0.3",
             "elm-community/intdict": "3.0.0",
             "mdgriffith/style-elements": "5.0.2",
             "robinheghan/murmur3": "1.0.0",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.2"
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         }
     },
     "test-dependencies": {


### PR DESCRIPTION
There is error in CI 
```
Dependency problem!           

-- CORRUPT PACKAGE DATA --------------------------------------------------------


I downloaded the source code for ryannhg/date-format 2.3.0 from:


    https://github.com/ryannhg/date-format/zipball/2.3.0/


But it looks like the hash of the archive has changed since publication:


  Expected: 70c67866fed499bec685f43f23fea279556757f2

    Actual: 86534146f5a550bb8e87b87a7484ea5732090bb5

```

Refer to https://github.com/ryan-haskell/date-format/issues/40

## Changes proposed by this PR

switch to ryan-haskell/date-format

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] done
* [ ] todo

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note
- switch from elm package `ryannhg/date-format` to `ryan-haskell/date-format`

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

 <!-- remove if no additional notes needed -->

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
