### PR TITLE
Add `--team` flag to `clear-task-cache` command

### DIFF
--- a/fly/commands/clear_task_cache.go
+++ b/fly/commands/clear_task_cache.go
@@ -9,10 +9,11 @@ import (
 )
 
 type ClearTaskCacheCommand struct {
-	Job             flaghelpers.JobFlag `short:"j" long:"job"  required:"true"  description:"Job to clear cache from"`
-	StepName        string              `short:"s" long:"step"  required:"true" description:"Step name to clear cache from"`
-	CachePath       string              `short:"c" long:"cache-path"  default:"" description:"Cache directory to clear out"`
-	SkipInteractive bool                `short:"n"  long:"non-interactive"          description:"Destroy the task cache(s) without confirmation"`
+	Job             flaghelpers.JobFlag  `short:"j" long:"job"  required:"true"  description:"Job to clear cache from"`
+	StepName        string               `short:"s" long:"step"  required:"true" description:"Step name to clear cache from"`
+	CachePath       string               `short:"c" long:"cache-path"  default:"" description:"Cache directory to clear out"`
+	SkipInteractive bool                 `short:"n"  long:"non-interactive"          description:"Destroy the task cache(s) without confirmation"`
+	Team            flaghelpers.TeamFlag `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *ClearTaskCacheCommand) Execute([]string) error {
@@ -24,6 +25,14 @@ func (command *ClearTaskCacheCommand) Execute([]string) error {
 	err = target.Validate()
 	if err != nil {
 		return err
+	}
+
+	team := target.Team()
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team.Name())
+		if err != nil {
+			return err
+		}
 	}
 
 	warningMsg := fmt.Sprintf("!!! this will remove the task cache(s) for `%s/%s`, task step `%s`",
@@ -43,7 +52,7 @@ func (command *ClearTaskCacheCommand) Execute([]string) error {
 		}
 	}
 
-	numRemoved, err := target.Team().ClearTaskCache(command.Job.PipelineRef, command.Job.JobName, command.StepName, command.CachePath)
+	numRemoved, err := team.ClearTaskCache(command.Job.PipelineRef, command.Job.JobName, command.StepName, command.CachePath)
 
 	if err != nil {
 		fmt.Println(err.Error())

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -148,6 +148,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "resource-versions", "-r", "pipeline/branch:master/foo", "--team", nonExistentTeam)),
 			Entry("watch command returns an error",
 				exec.Command(flyPath, "-t", targetName, "watch", "-j", "pipeline/job", "--team", nonExistentTeam)),
+			Entry("clear-task-cache command returns an error",
+				exec.Command(flyPath, "-t", targetName, "clear-task-cache", "-j", "pipeline/job", "-s", "some-task-step", "--team", nonExistentTeam)),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -204,6 +206,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "resource-versions", "-r", "pipeline/branch:master/foo", "--team", otherTeam)),
 			Entry("watch command returns an error",
 				exec.Command(flyPath, "-t", targetName, "watch", "-j", "pipeline/job", "--team", otherTeam)),
+			Entry("clear-task-cache command returns an error",
+				exec.Command(flyPath, "-t", targetName, "clear-task-cache", "-j", "pipeline/job", "-s", "some-task-step", "--team", otherTeam)),
 		)
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

Allow users to clear cache for a task on a non-default team

closes one of the items in #5215 

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] add team flag to `clear-task-cache`
* [x] integration tests
* [ ] update documentation

## Notes to reviewer

<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->
This is a `good first issue` PR as a first contribution to the project.

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Added team flag to fly command clear-task-cache. Use:
`fly -t dev clear-task-cache --job pipeline/job --step some-task-step --team other-team`

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
