### PR TITLE
Add --team flag to rename-pipeline command

### DIFF
--- a/fly/commands/rename_pipeline.go
+++ b/fly/commands/rename_pipeline.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/concourse/concourse/fly/commands/internal/displayhelpers"
 	"github.com/concourse/concourse/fly/rc"
+	"github.com/concourse/concourse/fly/commands/internal/flaghelpers"
 )
 
 type RenamePipelineCommand struct {
-	OldName string `short:"o"  long:"old-name" required:"true"  description:"Existing pipeline or instance group to rename"`
-	NewName string `short:"n"  long:"new-name" required:"true"  description:"New name for the pipeline or instance group"`
+	OldName string               `short:"o"  long:"old-name" required:"true"  description:"Existing pipeline or instance group to rename"`
+	NewName string               `short:"n"    long:"new-name" required:"true"  description:"New name for the pipeline or instance group"`
+	Team    flaghelpers.TeamFlag `long:"team" description:"Name of the team to which the pipeline belongs, if different from the target default"`
 }
 
 func (command *RenamePipelineCommand) Validate() error {
@@ -40,7 +42,15 @@ func (command *RenamePipelineCommand) Execute([]string) error {
 		return err
 	}
 
-	found, warnings, err := target.Team().RenamePipeline(command.OldName, command.NewName)
+	team := target.Team()
+	if command.Team != "" {
+		team, err = target.FindTeam(command.Team.Name())
+		if err != nil {
+			return err
+		}
+	}
+
+	found, warnings, err := team.RenamePipeline(command.OldName, command.NewName)
 	if err != nil {
 		return err
 	}

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -150,6 +150,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "watch", "-j", "pipeline/job", "--team", nonExistentTeam)),
 			Entry("clear-task-cache command returns an error",
 				exec.Command(flyPath, "-t", targetName, "clear-task-cache", "-j", "pipeline/job", "-s", "some-task-step", "--team", nonExistentTeam)),
+			Entry("rename-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", "brandNew", "--team", nonExistentTeam)),
 		)
 
 		DescribeTable("and you are NOT authorized to view the team",
@@ -208,6 +210,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "watch", "-j", "pipeline/job", "--team", otherTeam)),
 			Entry("clear-task-cache command returns an error",
 				exec.Command(flyPath, "-t", targetName, "clear-task-cache", "-j", "pipeline/job", "-s", "some-task-step", "--team", otherTeam)),
+			Entry("rename-pipeline command returns an error",
+				exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", "brandNew", "--team", otherTeam)),
 		)
 	})
 })

--- a/fly/integration/rename_pipeline_test.go
+++ b/fly/integration/rename_pipeline_test.go
@@ -11,129 +11,164 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
+	"github.com/concourse/concourse/atc"
 )
 
 var _ = Describe("RenamePipeline", func() {
-	var (
-		expectedURL        string
-		expectedStatusCode int
-		newName            string
-	)
-
-	BeforeEach(func() {
-		expectedURL = "/api/v1/teams/main/pipelines/some-pipeline/rename"
-		expectedStatusCode = http.StatusNoContent
-		newName = "brandnew"
-	})
-
-	JustBeforeEach(func() {
-		atcServer.AppendHandlers(
-			ghttp.CombineHandlers(
-				ghttp.VerifyRequest("PUT", expectedURL),
-				ghttp.VerifyJSON(fmt.Sprintf(`{"name":%q}`, newName)),
-				ghttp.RespondWith(expectedStatusCode, ""),
-			),
+	Context("when team is not specified", func() {
+		var (
+			expectedURL        string
+			expectedStatusCode int
+			newName            string
 		)
-	})
 
-	Context("when not specifying a pipeline name", func() {
-		It("fails and says you should provide a pipeline name", func() {
-			flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-n", "some-new-name")
-
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(sess).Should(gexec.Exit(1))
-
-			Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("o", "old-name") + "' was not specified"))
+		BeforeEach(func() {
+			expectedURL = "/api/v1/teams/main/pipelines/some-pipeline/rename"
+			expectedStatusCode = http.StatusNoContent
+			newName = "brandnew"
 		})
-	})
 
-	Context("when specifying a new pipeline name with a '/' character in it", func() {
-		It("fails and says '/' characters are not allowed", func() {
-			flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", "forbidden/pipelinename")
-
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-
-			<-sess.Exited
-			Expect(sess.ExitCode()).To(Equal(1))
-
-			Expect(sess.Err).To(gbytes.Say("error: new pipeline name cannot contain '/'"))
+		JustBeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", expectedURL),
+					ghttp.VerifyJSON(fmt.Sprintf(`{"name":%q}`, newName)),
+					ghttp.RespondWith(expectedStatusCode, ""),
+				),
+			)
 		})
-	})
 
-	Context("when the pipeline flag is invalid", func() {
-		It("fails and print invalid flag error", func() {
-			flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "pipeline/branch:master", "-n", "some-new-name")
+		Context("when not specifying a pipeline name", func() {
+			It("fails and says you should provide a pipeline name", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-n", "some-new-name")
 
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
 
-			<-sess.Exited
-			Expect(sess.ExitCode()).To(Equal(1))
+				Eventually(sess).Should(gexec.Exit(1))
 
-			Expect(sess.Err).To(gbytes.Say("error: old pipeline name cannot contain '/'"))
+				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("o", "old-name") + "' was not specified"))
+			})
 		})
-	})
 
-	Context("when not specifying a new name", func() {
-		It("fails and says you should provide a new name for the pipeline", func() {
-			flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline")
+		Context("when specifying a new pipeline name with a '/' character in it", func() {
+			It("fails and says '/' characters are not allowed", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", "forbidden/pipelinename")
 
-			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
 
-			Eventually(sess).Should(gexec.Exit(1))
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
 
-			Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("n", "new-name") + "' was not specified"))
+				Expect(sess.Err).To(gbytes.Say("error: new pipeline name cannot contain '/'"))
+			})
 		})
+
+		Context("when the pipeline flag is invalid", func() {
+			It("fails and print invalid flag error", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "pipeline/branch:master", "-n", "some-new-name")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
+
+				Expect(sess.Err).To(gbytes.Say("error: old pipeline name cannot contain '/'"))
+			})
+		})
+
+		Context("when not specifying a new name", func() {
+			It("fails and says you should provide a new name for the pipeline", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(1))
+
+				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("n", "new-name") + "' was not specified"))
+			})
+		})
+
+		Context("when all the inputs are provided", func() {
+			It("successfully renames the pipeline to the provided name", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", newName)
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(0))
+				Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
+				Expect(sess.Out).To(gbytes.Say(fmt.Sprintf("pipeline successfully renamed to '%s'", newName)))
+			})
+
+			Context("when the pipeline is not found", func() {
+				BeforeEach(func() {
+					expectedStatusCode = http.StatusNotFound
+				})
+
+				It("returns an error", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", newName)
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(1))
+					Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
+					Expect(sess.Err).To(gbytes.Say("pipeline 'some-pipeline' not found"))
+				})
+			})
+
+			Context("when an error occurs", func() {
+				BeforeEach(func() {
+					expectedStatusCode = http.StatusTeapot
+				})
+
+				It("returns an error", func() {
+					flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", newName)
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(1))
+					Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
+					Expect(sess.Err).To(gbytes.Say("418 I'm a teapot"))
+				})
+			})
+		})
+
 	})
 
-	Context("when all the inputs are provided", func() {
-		It("successfully renames the pipeline to the provided name", func() {
-			flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", newName)
+	Context("when a non-default team is specified", func() {
+		var newName = "brandNew"
+		var expectedStatusCode = http.StatusNoContent
+		BeforeEach(func() {
+			atcServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/teams/other-team"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Team{
+						Name: "other-team",
+					}),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", "/api/v1/teams/other-team/pipelines/some-pipeline/rename"),
+					ghttp.VerifyJSON(fmt.Sprintf(`{"name":%q}`, newName)),
+					ghttp.RespondWith(expectedStatusCode, ""),
+				),
+			)
+		})
+
+		It("succeeds and renames the pipeline to the provided name", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", newName, "--team", "other-team")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(sess).Should(gexec.Exit(0))
-			Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
 			Expect(sess.Out).To(gbytes.Say(fmt.Sprintf("pipeline successfully renamed to '%s'", newName)))
-		})
 
-		Context("when the pipeline is not found", func() {
-			BeforeEach(func() {
-				expectedStatusCode = http.StatusNotFound
-			})
-
-			It("returns an error", func() {
-				flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", newName)
-
-				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(sess).Should(gexec.Exit(1))
-				Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
-				Expect(sess.Err).To(gbytes.Say("pipeline 'some-pipeline' not found"))
-			})
-		})
-
-		Context("when an error occurs", func() {
-			BeforeEach(func() {
-				expectedStatusCode = http.StatusTeapot
-			})
-
-			It("returns an error", func() {
-				flyCmd := exec.Command(flyPath, "-t", targetName, "rename-pipeline", "-o", "some-pipeline", "-n", newName)
-
-				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(sess).Should(gexec.Exit(1))
-				Expect(atcServer.ReceivedRequests()).To(HaveLen(5))
-				Expect(sess.Err).To(gbytes.Say("418 I'm a teapot"))
-			})
 		})
 	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

Allow users to rename pipeline for a non-default team

closes one of the items in #5215  

* [x] add team flag to rename-pipeline
* [x] integration tests 
* [ ] update documentation

## Notes to reviewer

In rename_pipeline_test.go, it might look like there are a lot of changes made, but there are only 2 major changes:
1. Created a new context "when team is not specified" and added all the existing test cases to this one
2. Created a new context "when a non-default team is specified" and added a new test case to this one

Tested the changes by running "ginkgo -r -p" on the path: "concourse/fly/integration" 


## Release Note

* Added team flag to fly command `rename-pipeline`. Usage: `fly -t dev rename-pipeline -o some-pipeline -n new-pipeline --team other-team`
