### PR TITLE
Check log retention max days & max builds is set globally

### DIFF
--- a/atc/gc/build_log_retention_calculator.go
+++ b/atc/gc/build_log_retention_calculator.go
@@ -57,13 +57,13 @@ func (blrc *buildLogRetentionCalculator) BuildLogsToRetain(jobConfig atc.JobConf
 
 	var logRetention atc.BuildLogRetention
 	// If we have a value set, and we're less than the max, then return
-	if buildLogsToRetain > 0 && buildLogsToRetain < int(blrc.maxBuildLogsToRetain) {
+	if buildLogsToRetain > 0 && (buildLogsToRetain < int(blrc.maxBuildLogsToRetain) || int(blrc.maxBuildLogsToRetain) > 0) {
 		logRetention.Builds = buildLogsToRetain
 	} else {
 		logRetention.Builds = int(blrc.maxBuildLogsToRetain)
 	}
 
-	if daysToRetainBuildLogs > 0 && daysToRetainBuildLogs < int(blrc.maxDaysToRetainBuildLogs) {
+	if daysToRetainBuildLogs > 0 && (daysToRetainBuildLogs < int(blrc.maxDaysToRetainBuildLogs) || int(blrc.maxDaysToRetainBuildLogs) > 0) {
 		logRetention.Days = daysToRetainBuildLogs
 	} else {
 		logRetention.Days = int(blrc.maxDaysToRetainBuildLogs)


### PR DESCRIPTION
## Summary

closes #8943

`build_log_retention.days` is being ignored and defaulting to `0` if `CONCOURSE_MAX_BUILD_LOGS_TO_RETAIN` is set but `CONCOURSE_MAX_DAYS_TO_RETAIN_BUILD_LOGS` is not.

The same applies the other way round, `build_log_retention.builds` is ignored and defaults to `0` if `CONCOURSE_MAX_DAYS_TO_RETAIN_BUILD_LOGS` is set but `CONCOURSE_MAX_BUILD_LOGS_TO_RETAIN` is not.


## Steps to reproduce

1.  set `CONCOURSE_MAX_BUILD_LOGS_TO_RETAIN: 5` in `docker-compose.yml`
2. create a pipeline and set `build_log_retention.builds` to 3 and set `build_log_retention.days` to 7 (see example below).
3. run the test jobs 10 times.
4. wait for `atc.reaper.tick.build-reaper.start` log
5. see that only 3 logs are kept, not 7 days

## Expected results
Logs should not be reaped until 7 days later.


## Actual results
Logs are reaped at 0 days!


## Additional context
Example pipeline for testing...
```yaml
---
jobs:
  - name: job
    build_log_retention:
      builds: 3
      days: 7
    public: true
    plan:
      - task: simple-task
        config:
          platform: linux
          image_resource:
            type: mock
            source: { mirror_self: true }
          run:
            path: echo
            args: ["Hello world!"]
```


## Triaging info

* Concourse version: `v7.9.1`
* Browser (if applicable):
* Did this used to work?
