### PR TITLE
Fix integration test suite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   default:
     enable_ipv6: true

--- a/hack/dc
+++ b/hack/dc
@@ -11,4 +11,4 @@ for f in "${core[@]}"; do
   args+=(-f "hack/overrides/$f.yml")
 done
 
-docker-compose ${args[@]} "$@"
+docker compose ${args[@]} "$@"

--- a/hack/overrides/guardian.yml
+++ b/hack/overrides/guardian.yml
@@ -2,8 +2,6 @@
 # a container runtime
 #
 #
-version: '3'
-
 services:
   worker:
     environment:

--- a/hack/overrides/jaeger.yml
+++ b/hack/overrides/jaeger.yml
@@ -5,8 +5,6 @@
 # ref: https://www.jaegertracing.io/
 # ref: https://docs.docker.com/compose/extends/
 #
-version: "3"
-
 volumes:
   elasticsearch-data:
 services:

--- a/hack/overrides/ldap.yml
+++ b/hack/overrides/ldap.yml
@@ -9,8 +9,6 @@
 # ref: https://github.com/dexidp/dex/blob/33e13c2aad9bb8a91abea6a2870dc178e3bd00de/examples/ldap/
 # ref: https://docs.docker.com/compose/extends/
 #
-version: '3'
-
 services:
   web:
     environment:

--- a/hack/overrides/mutual-tls.yml
+++ b/hack/overrides/mutual-tls.yml
@@ -1,11 +1,9 @@
-version: '3'
-
 services:
   web:
     environment:
       CONCOURSE_EXTERNAL_URL: https://localhost:443
       CONCOURSE_TLS_BIND_PORT: 8443
-      CONCOURSE_TLS_CERT: /src/hack/mtls_certs/concourse/web.cert.pem 
+      CONCOURSE_TLS_CERT: /src/hack/mtls_certs/concourse/web.cert.pem
       CONCOURSE_TLS_CA_CERT: /src/hack/mtls_certs/concourse/ca-chain.cert.pem
       CONCOURSE_TLS_KEY: /src/hack/mtls_certs/concourse/web.key.pem
 

--- a/hack/overrides/oauth.yml
+++ b/hack/overrides/oauth.yml
@@ -7,8 +7,6 @@
 # ref: https://hub.docker.com/r/kristophjunge/test-saml-idp/
 # ref: https://docs.docker.com/compose/extends/
 #
-version: '3'
-
 services:
   web:
     environment:

--- a/hack/overrides/oidc.yml
+++ b/hack/overrides/oidc.yml
@@ -11,8 +11,6 @@
 # ref: https://hub.docker.com/r/qlik/simple-oidc-provider/
 # ref: https://docs.docker.com/compose/extends/
 #
-version: '3'
-
 services:
   web:
     environment:

--- a/hack/overrides/opa.yml
+++ b/hack/overrides/opa.yml
@@ -3,8 +3,6 @@
 # ref: https://www.openpolicyagent.org/
 # ref: https://docs.docker.com/compose/extends/
 #
-version: '3'
-
 services:
   web:
     environment:

--- a/hack/overrides/prometheus.yml
+++ b/hack/overrides/prometheus.yml
@@ -5,8 +5,6 @@
 # ref: https://prometheus.io/
 # ref: https://docs.docker.com/compose/extends/
 #
-version: '3'
-
 services:
   web:
     environment:

--- a/hack/overrides/saml.yml
+++ b/hack/overrides/saml.yml
@@ -10,8 +10,6 @@
 # ref: https://hub.docker.com/r/kristophjunge/test-saml-idp/
 # ref: https://docs.docker.com/compose/extends/
 #
-version: '3'
-
 services:
   web:
     environment:

--- a/hack/overrides/vault.yml
+++ b/hack/overrides/vault.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     volumes:

--- a/hack/overrides/with-fly.yml
+++ b/hack/overrides/with-fly.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     build:

--- a/integration/auth/overrides/ldap.yml
+++ b/integration/auth/overrides/ldap.yml
@@ -9,8 +9,6 @@
 # ref: https://github.com/dexidp/dex/blob/33e13c2aad9bb8a91abea6a2870dc178e3bd00de/examples/ldap/
 # ref: https://docs.docker.com/compose/extends/
 #
-version: '3'
-
 services:
   web:
     environment:

--- a/integration/creds/overrides/vault-token.yml
+++ b/integration/creds/overrides/vault-token.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     volumes:

--- a/integration/creds/overrides/vault.yml
+++ b/integration/creds/overrides/vault.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     volumes:

--- a/integration/creds/overrides/vault.yml
+++ b/integration/creds/overrides/vault.yml
@@ -11,7 +11,7 @@ services:
       CONCOURSE_VAULT_CLIENT_KEY: /vault-certs/concourse.key
 
   vault:
-    image: ${TEST_VAULT_IMAGE:-vault:latest}
+    image: ${TEST_VAULT_IMAGE:-hashicorp/vault:latest}
     cap_add: [IPC_LOCK]
     ports: [8200]
     volumes:

--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: ${TEST_POSTGRES_IMAGE:-postgres}

--- a/integration/internal/dctest/cmd.go
+++ b/integration/internal/dctest/cmd.go
@@ -19,7 +19,7 @@ type Cmd struct {
 }
 
 func Init(t *testing.T, composeFile string, overrides ...string) Cmd {
-	name := filepath.Base(t.Name())
+	name := strings.ToLower(filepath.Base(t.Name()))
 
 	files := append([]string{composeFile}, overrides...)
 

--- a/integration/internal/dctest/cmd.go
+++ b/integration/internal/dctest/cmd.go
@@ -24,7 +24,8 @@ func Init(t *testing.T, composeFile string, overrides ...string) Cmd {
 	files := append([]string{composeFile}, overrides...)
 
 	dc := cmdtest.Cmd{
-		Path: "docker-compose",
+		Path: "docker",
+		Args: []string{"compose"},
 		Env: []string{
 			"COMPOSE_FILE=" + strings.Join(files, ":"),
 			"COMPOSE_PROJECT_NAME=" + name,

--- a/integration/ops/overrides/fast-gc.yml
+++ b/integration/ops/overrides/fast-gc.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     environment:

--- a/integration/ops/overrides/latest.yml
+++ b/integration/ops/overrides/latest.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     image: ${TEST_CONCOURSE_LATEST_IMAGE:-concourse/concourse:latest}

--- a/integration/ops/overrides/named.yml
+++ b/integration/ops/overrides/named.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     environment:

--- a/integration/overrides/expose.yml
+++ b/integration/overrides/expose.yml
@@ -1,8 +1,5 @@
 # add this override to a failing test if you want to investigate it in the web
 # UI
-
-version: '3'
-
 services:
   web:
     ports: [8080:8080]

--- a/integration/pauser/overrides/five-days-ago.yml
+++ b/integration/pauser/overrides/five-days-ago.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: postgres:faketime

--- a/integration/pauser/overrides/pauser-config.yml
+++ b/integration/pauser/overrides/pauser-config.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     # we need to persist the db between restarts

--- a/integration/pauser/overrides/short-pauser-interval.yml
+++ b/integration/pauser/overrides/short-pauser-interval.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   web:
     environment:

--- a/integration/worker/overrides/add_extra_dns_servers.yml
+++ b/integration/worker/overrides/add_extra_dns_servers.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     environment:

--- a/integration/worker/overrides/bridge_mtu.yml
+++ b/integration/worker/overrides/bridge_mtu.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   default:
     driver: bridge

--- a/integration/worker/overrides/broken_containerd_socket.yml
+++ b/integration/worker/overrides/broken_containerd_socket.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     volumes:

--- a/integration/worker/overrides/custom_mtu.yml
+++ b/integration/worker/overrides/custom_mtu.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     environment:

--- a/integration/worker/overrides/disable_dns_proxy.yml
+++ b/integration/worker/overrides/disable_dns_proxy.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     environment:

--- a/integration/worker/overrides/empty_tag.yml
+++ b/integration/worker/overrides/empty_tag.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     environment:

--- a/integration/worker/overrides/enable_dns_proxy.yml
+++ b/integration/worker/overrides/enable_dns_proxy.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     environment:

--- a/integration/worker/overrides/garden_config.yml
+++ b/integration/worker/overrides/garden_config.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     environment:

--- a/integration/worker/overrides/garden_max_containers.yml
+++ b/integration/worker/overrides/garden_max_containers.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     environment:

--- a/integration/worker/overrides/guardian.yml
+++ b/integration/worker/overrides/guardian.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     environment:

--- a/integration/worker/overrides/restartable.yml
+++ b/integration/worker/overrides/restartable.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   worker:
     entrypoint: /overrides/restartable-entrypoint.sh

--- a/integration/worker/registration_test.go
+++ b/integration/worker/registration_test.go
@@ -20,7 +20,7 @@ func TestRegistration_GardenServerFails(t *testing.T) {
 
 	t.Run("worker container exits", func(t *testing.T) {
 		require.Eventually(t, func() bool {
-			services := dc.Output(t, "ps", "--services", "--filter", "status=stopped")
+			services := dc.Output(t, "ps", "--services", "--status", "exited")
 			return strings.Contains(services, "worker")
 		}, 30*time.Second, 1*time.Second, "worker process never exited, but should have")
 	})


### PR DESCRIPTION
Fixes #8949

Changes the `integration` test suite to use the `docker compose` plugin instead of the `docker-compose` standalone, which is also no longer the standard way to run docker-compose yaml files.