### PR TITLE
Correctly configure the garden backend in integration tests

### DIFF
--- a/worker/runtime/integration/integration_test.go
+++ b/worker/runtime/integration/integration_test.go
@@ -126,6 +126,7 @@ func (s *IntegrationSuite) BeforeTest(suiteName, testName string) {
 			requestTimeout,
 		),
 		runtime.WithNetwork(network),
+		runtime.WithRequestTimeout(requestTimeout),
 	)
 	s.NoError(err)
 	s.NoError(s.gardenBackend.Start())
@@ -298,14 +299,14 @@ func (s *IntegrationSuite) TestContainerNetworkEgressWithRestrictedNetworks() {
 
 	s.NoError(err)
 
-	networkOpt := runtime.WithNetwork(network)
 	customBackend, err := runtime.NewGardenBackend(
 		libcontainerd.New(
 			s.containerdSocket(),
 			namespace,
 			requestTimeout,
 		),
-		networkOpt,
+		runtime.WithNetwork(network),
+		runtime.WithRequestTimeout(requestTimeout),
 	)
 	s.NoError(err)
 
@@ -429,14 +430,14 @@ func (s *IntegrationSuite) TestContainerAllowsHostAccess() {
 
 	s.NoError(err)
 
-	networkOpt := runtime.WithNetwork(network)
 	customBackend, err := runtime.NewGardenBackend(
 		libcontainerd.New(
 			s.containerdSocket(),
 			namespace,
 			requestTimeout,
 		),
-		networkOpt,
+		runtime.WithNetwork(network),
+		runtime.WithRequestTimeout(requestTimeout),
 	)
 	s.NoError(err)
 
@@ -757,6 +758,10 @@ func (s *IntegrationSuite) TestAttach() {
 // TestCustomDNS verfies that when a network is setup with custom NameServers
 // those NameServers should appear in the container's etc/resolv.conf
 func (s *IntegrationSuite) TestCustomDNS() {
+	// Using custom backend, clean up BeforeTest() stuff
+	s.gardenBackend.Stop()
+	s.cleanupIptables()
+
 	namespace := "test-custom-dns"
 	requestTimeout := 3 * time.Second
 
@@ -768,14 +773,14 @@ func (s *IntegrationSuite) TestCustomDNS() {
 	)
 	s.NoError(err)
 
-	networkOpt := runtime.WithNetwork(network)
 	customBackend, err := runtime.NewGardenBackend(
 		libcontainerd.New(
 			s.containerdSocket(),
 			namespace,
 			requestTimeout,
 		),
-		networkOpt,
+		runtime.WithNetwork(network),
+		runtime.WithRequestTimeout(requestTimeout),
 	)
 	s.NoError(err)
 
@@ -864,10 +869,12 @@ func (s *IntegrationSuite) testStop(kill bool) {
 // TestMaxContainers aims at making sure that when the max container count is
 // reached, any additional Create calls will fail
 func (s *IntegrationSuite) TestMaxContainers() {
-	namespace := "test-max-containers"
-	requestTimeout := 1 * time.Second
+	// Using custom backend, clean up BeforeTest() stuff
+	s.gardenBackend.Stop()
+	s.cleanupIptables()
 
-	limit := runtime.WithMaxContainers(1)
+	namespace := "test-max-containers"
+	requestTimeout := 3 * time.Second
 
 	network, err := runtime.NewCNINetwork(
 		runtime.WithDefaultsForTesting(),
@@ -880,8 +887,9 @@ func (s *IntegrationSuite) TestMaxContainers() {
 			namespace,
 			requestTimeout,
 		),
-		limit,
+		runtime.WithMaxContainers(1),
 		runtime.WithNetwork(network),
+		runtime.WithRequestTimeout(requestTimeout),
 	)
 	s.NoError(err)
 
@@ -913,6 +921,10 @@ func (s *IntegrationSuite) TestMaxContainers() {
 }
 
 func (s *IntegrationSuite) TestRequestTimeoutZero() {
+	// Using custom backend, clean up BeforeTest() stuff
+	s.gardenBackend.Stop()
+	s.cleanupIptables()
+
 	namespace := "test-requesTimeout-zero"
 	requestTimeout := time.Duration(0)
 
@@ -928,6 +940,7 @@ func (s *IntegrationSuite) TestRequestTimeoutZero() {
 			requestTimeout,
 		),
 		runtime.WithNetwork(network),
+		runtime.WithRequestTimeout(requestTimeout),
 	)
 	s.NoError(err)
 
@@ -1019,6 +1032,7 @@ func (s *IntegrationSuite) TestNetworkMountsAreRemoved() {
 			requestTimeout,
 		),
 		runtime.WithNetwork(network),
+		runtime.WithRequestTimeout(requestTimeout),
 	)
 	s.NoError(err)
 


### PR DESCRIPTION
## Changes proposed by this PR

Unblocks #8893 

We needed to call `runtime.WithRequestTimeout()` in order to correctly configure the createContainer lock with a non-zero timeout. It's actually amazing that all the other tests in here also weren't failing in a similar manner.

I figured this out by putting `fmt.Println` statements everywhere and printing out the configured timeout. In the lock, I was seeing that it was configured with a `0s` timeout. I eventually realized that we were setting the timeout on the containerd client, but not on the Garden client (which contains the containerd client), and we create the lock with the timeout from the Garden client, not the containerd client. oops!

```go
type GardebBackend struct {
  client containerdClient // <--configured timeout in this client
  ...
  requestTimeout time.Duration // <--didn't configure timeout here using runtime.WithRequestTimeout()
}
```

We configure the garden client correctly in the actual code, which is why no user has ever had an issue with creating containers like we were seeing in this test suite.

Also took the time to ensure all the tests that made custom backends were setup in the same way.

## Notes to reviewer

N/A

## Release Note

