### PR TITLE
Correct policy-checker test suite names

### DIFF
--- a/atc/api/policychecker/policychecker_suite_test.go
+++ b/atc/api/policychecker/policychecker_suite_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccessor(t *testing.T) {
+func TestPolicyChecker(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "API PolicyChecker Suite")
 }

--- a/atc/policy/opa/agent_suite_test.go
+++ b/atc/policy/opa/agent_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestVault(t *testing.T) {
+func TestPolicyAgent(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Policy Agent Suite")
 }


### PR DESCRIPTION
Correct policy-checker test suite names

* a very minor PR, correcting what seems to be a copy-paste mistake in test suite names.