### PR TITLE
improve the error message given to the end user when setting the pipeline

### DIFF
--- a/fly/integration/set_pipeline_test.go
+++ b/fly/integration/set_pipeline_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Fly CLI", func() {
 
 						Expect(receivedConfig).To(Equal(config))
 
+						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusOK)
 						w.Write([]byte(`{}`))
 					},
@@ -341,6 +342,7 @@ var _ = Describe("Fly CLI", func() {
 									Expect(err).NotTo(HaveOccurred())
 
 									Expect(receivedConfig).To(Equal(config))
+									w.Header().Set("Content-Type", "application/json")
 
 									w.WriteHeader(http.StatusOK)
 									w.Write([]byte(`{}`))
@@ -885,6 +887,7 @@ this is super secure
 						ghttp.CombineHandlers(
 							ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
 							func(w http.ResponseWriter, r *http.Request) {
+								w.Header().Set("Content-Type", "application/json")
 								config := getConfig(r)
 								Expect(config).To(MatchYAML(payload))
 							},
@@ -961,6 +964,7 @@ this is super secure
 						ghttp.CombineHandlers(
 							ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
 							func(w http.ResponseWriter, r *http.Request) {
+								w.Header().Set("Content-Type", "application/json")
 								config := getConfig(r)
 								Expect(config).To(MatchYAML(payload))
 							},
@@ -1268,6 +1272,7 @@ this is super secure
 					atcServer.RouteToHandler("PUT", path, ghttp.CombineHandlers(
 						ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
 						func(w http.ResponseWriter, r *http.Request) {
+							w.Header().Set("Content-Type", "application/json")
 							config := getConfig(r)
 							Expect(config).To(MatchYAML(payload))
 						},
@@ -1393,8 +1398,10 @@ this is super secure
 							ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
 							func(w http.ResponseWriter, r *http.Request) {
 								config := getConfig(r)
+								w.Header().Set("Content-Type", "application/json")
 								Expect(config).To(MatchYAML(payload))
 							},
+
 							ghttp.RespondWith(http.StatusOK, "{}"),
 						))
 
@@ -1419,6 +1426,7 @@ this is super secure
 							ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
 							func(w http.ResponseWriter, r *http.Request) {
 								config := getConfig(r)
+								w.Header().Set("Content-Type", "application/json")
 								Expect(config).To(MatchYAML(payload))
 							},
 							ghttp.RespondWith(http.StatusCreated, "{}"),
@@ -1443,6 +1451,7 @@ this is super secure
 						ghttp.VerifyHeaderKV(atc.ConfigVersionHeader, "42"),
 						func(w http.ResponseWriter, r *http.Request) {
 							config := getConfig(r)
+							w.Header().Set("Content-Type", "application/json")
 							Expect(config).To(MatchYAML(payload))
 						},
 						ghttp.RespondWith(http.StatusCreated, `{"warnings":[


### PR DESCRIPTION
**go-concourse: SaveConfig endpoint**: Improve the error message given to the end user when setting the pipeline.

When content type of the server response differs from `application/json` the `fly set-pipeline` (`CreateOrUpdatePipelineConfig` method) would always return the same error message to the end user. The error message is confusing (`error: invalid character 'p' looking for beginning of value`) and not very useful or understandable by everyone (actually anyone).

Before the policy check (OPA) feature was added to the Concourse it was reasonable that client assumed that the response is always of JSON format. This is not a valid assumption anymore. In case when the policy check fails e.g. due to OPA server being unreachable or some other misconfiguration of the OPA from Concourse operator side, the  end user would always see the invalid character error message. Furthermore, the error is never logged from the server (web node) side, so neither the Concourse user or Concourse operator knows what is happening. 

The server side issue will be fixed in a separate PR.

**Example:**
**BEFORE:**
```
$ fly -t main set-pipeline -c pipeline.yml -p test
jobs:
  job job-1 has been added:
+ name: job-1
+ plan: null
  
pipeline name: test

apply configuration? [yN]: y

error: invalid character 'p' looking for beginning of value
```

At this point, the Concourse end user is left wondering what it did wrong when configuring the pipeline. At the same time Concourse operator has no clue that the Concourse OPA configuration is probably misconfigured.

**AFTER:**
```
$ fly -t main set-pipeline -c pipeline.yml -p test
jobs:
  job job-1 has been added:
+ name: job-1
+ plan: null
  
pipeline name: test

apply configuration? [yN]: y
error: Unexpected Response
Status: 400 Bad Request
Body: < reason for the error from the server >
```