### PR TITLE
Log policy checker error messages

### DIFF
--- a/atc/api/policychecker/handler_test.go
+++ b/atc/api/policychecker/handler_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Handler", func() {
 
 			msg, err := io.ReadAll(responseWriter.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(string(msg)).To(Equal("policy check error: some-error"))
+			Expect(string(msg)).To(Equal("policy-checker: unreachable or misconfigured"))
 		})
 
 		It("not call the inner handler", func() {

--- a/atc/policy/opa/opa.go
+++ b/atc/policy/opa/opa.go
@@ -60,23 +60,23 @@ func (c opa) Check(input policy.PolicyCheckInput) (policy.PolicyCheckResult, err
 	client.Timeout = c.config.Timeout
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("OPA server: connecting: %w", err)
 	}
 	defer resp.Body.Close()
 
 	statusCode := resp.StatusCode
 	if statusCode != http.StatusOK {
-		return nil, fmt.Errorf("opa returned status: %d", statusCode)
+		return nil, fmt.Errorf("OPA server returned status: %d", statusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("opa returned no response: %s", err.Error())
+		return nil, fmt.Errorf("OPA server: reading response body: %s", err.Error())
 	}
 
 	result, err := ParseOpaResult(body, c.config)
 	if err != nil {
-		return nil, fmt.Errorf("parsing opa results: %w", err)
+		return nil, fmt.Errorf("parsing OPA results: %w", err)
 	}
 
 	return result, nil

--- a/atc/policy/opa/opa_test.go
+++ b/atc/policy/opa/opa_test.go
@@ -177,7 +177,7 @@ var _ = Describe("OPA Policy Checker", func() {
 		It("should return error", func() {
 			result, err := agent.Check(policy.PolicyCheckInput{})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(MatchRegexp("connection refused"))
+			Expect(err.Error()).To(MatchRegexp("OPA server: connecting: .* connection refused"))
 			Expect(result).To(BeNil())
 		})
 	})
@@ -190,7 +190,7 @@ var _ = Describe("OPA Policy Checker", func() {
 		It("should return error", func() {
 			result, err := agent.Check(policy.PolicyCheckInput{})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("opa returned status: 404"))
+			Expect(err.Error()).To(Equal("OPA server returned status: 404"))
 			Expect(result).To(BeNil())
 		})
 	})
@@ -205,7 +205,7 @@ var _ = Describe("OPA Policy Checker", func() {
 		It("should return error", func() {
 			result, err := agent.Check(policy.PolicyCheckInput{})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid character 'h' looking for beginning of value"))
+			Expect(err.Error()).To(ContainSubstring("parsing JSON: invalid character 'h' looking for beginning of value"))
 			Expect(result).To(BeNil())
 		})
 	})

--- a/atc/policy/opa/result.go
+++ b/atc/policy/opa/result.go
@@ -30,7 +30,7 @@ func ParseOpaResult(bytesResult []byte, opaConfig OpaConfig) (opaResult, error) 
 	var results vars.StaticVariables
 	err := json.Unmarshal(bytesResult, &results)
 	if err != nil {
-		return opaResult{}, err
+		return opaResult{}, fmt.Errorf("parsing JSON: %w", err)
 	}
 
 	var allowed, shouldBlock, ok bool


### PR DESCRIPTION
Log policy checker error messages.

* minor improvements to OPA agent error messages
* atc: log errors returned by policy checker agent

This will ensure that:
- we return a meaningful error message to the Concourse end user (`policy-checker: unreachable or misconfigured`)
- Concourse operator/maintainer has all the required information in logs and can configure automated alerting on ERROR logs...

Originally, we wanted to go a step further and also log the success and log the actual policy checker decision and reason but that turned out to be too complicated with the current code to be done in a clean way. To improve this situation, in the future we plan to open a new issue to start the discussion on the proposed changes first.

## Release Note

* Log detailed OPA error messages in web nodes logs and show a friendlier error message to the end user
