### PR TITLE
Introduce privileged-mode

### DIFF
--- a/worker/baggageclaim/baggageclaimcmd/baggageclaimcmd_suite_test.go
+++ b/worker/baggageclaim/baggageclaimcmd/baggageclaimcmd_suite_test.go
@@ -1,0 +1,13 @@
+package baggageclaimcmd_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBaggageclaimcmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Baggageclaimcmd Suite")
+}

--- a/worker/baggageclaim/baggageclaimcmd/command_test.go
+++ b/worker/baggageclaim/baggageclaimcmd/command_test.go
@@ -18,16 +18,15 @@ var _ = Describe("Baggage Claim Command Runner", func() {
 			var cmd baggageclaimcmd.BaggageclaimCommand
 			cmd.DisableUserNamespaces = true
 			It("selects the NoopNamespacer", func() {
-				priv, unpriv := cmd.SelectNamespacers(logger)
+				priv, unpriv := cmd.SelectNamespacers(logger, bespec.FullPrivilegedMode)
 				Expect(priv).To(Equal(uidgid.NoopNamespacer{}))
 				Expect(unpriv).To(Equal(uidgid.NoopNamespacer{}))
 			})
 		})
 		Context("when in full privilege mode", func() {
 			var cmd baggageclaimcmd.BaggageclaimCommand
-			cmd.PrivilegedMode = bespec.FullPrivilegedMode
 			It("selects separate privileged and unprivileged namespacers", func() {
-				priv, unpriv := cmd.SelectNamespacers(logger)
+				priv, unpriv := cmd.SelectNamespacers(logger, bespec.FullPrivilegedMode)
 				var testCmd exec.Cmd
 				priv.NamespaceCommand(&testCmd)
 				Expect(testCmd.SysProcAttr.UidMappings[0].HostID).To(Equal(0))
@@ -37,9 +36,8 @@ var _ = Describe("Baggage Claim Command Runner", func() {
 		})
 		Context("when in FUSE-only privilege mode", func() {
 			var cmd baggageclaimcmd.BaggageclaimCommand
-			cmd.PrivilegedMode = bespec.FUSEOnlyPrivilegedMode
 			It("selects the unprivileged namespacer for both privilege levels", func() {
-				priv, unpriv := cmd.SelectNamespacers(logger)
+				priv, unpriv := cmd.SelectNamespacers(logger, bespec.FUSEOnlyPrivilegedMode)
 				var testCmd exec.Cmd
 				priv.NamespaceCommand(&testCmd)
 				Expect(testCmd.SysProcAttr.UidMappings[0].HostID).To(Not(Equal(0)))
@@ -49,9 +47,8 @@ var _ = Describe("Baggage Claim Command Runner", func() {
 		})
 		Context("when in ignore privilege mode", func() {
 			var cmd baggageclaimcmd.BaggageclaimCommand
-			cmd.PrivilegedMode = bespec.IgnorePrivilegedMode
 			It("selects the unprivileged namespacer for both privilege levels", func() {
-				priv, unpriv := cmd.SelectNamespacers(logger)
+				priv, unpriv := cmd.SelectNamespacers(logger, bespec.IgnorePrivilegedMode)
 				var testCmd exec.Cmd
 				priv.NamespaceCommand(&testCmd)
 				Expect(testCmd.SysProcAttr.UidMappings[0].HostID).To(Not(Equal(0)))

--- a/worker/baggageclaim/baggageclaimcmd/command_test.go
+++ b/worker/baggageclaim/baggageclaimcmd/command_test.go
@@ -1,0 +1,63 @@
+package baggageclaimcmd_test
+
+import (
+	"os/exec"
+
+	"code.cloudfoundry.org/lager/v3/lagertest"
+	"github.com/concourse/concourse/worker/baggageclaim/baggageclaimcmd"
+	"github.com/concourse/concourse/worker/baggageclaim/uidgid"
+	bespec "github.com/concourse/concourse/worker/runtime/spec"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Baggage Claim Command Runner", func() {
+	Describe("Namespace Selector", func() {
+		logger := lagertest.NewTestLogger("test")
+		Context("when user namespaces are disabled", func() {
+			var cmd baggageclaimcmd.BaggageclaimCommand
+			cmd.DisableUserNamespaces = true
+			It("selects the NoopNamespacer", func() {
+				priv, unpriv := cmd.SelectNamespacers(logger)
+				Expect(priv).To(Equal(uidgid.NoopNamespacer{}))
+				Expect(unpriv).To(Equal(uidgid.NoopNamespacer{}))
+			})
+		})
+		Context("when in full privilege mode", func() {
+			var cmd baggageclaimcmd.BaggageclaimCommand
+			cmd.PrivilegedMode = bespec.FullPrivilegedMode
+			It("selects separate privileged and unprivileged namespacers", func() {
+				priv, unpriv := cmd.SelectNamespacers(logger)
+				var testCmd exec.Cmd
+				priv.NamespaceCommand(&testCmd)
+				Expect(testCmd.SysProcAttr.UidMappings[0].HostID).To(Equal(0))
+				unpriv.NamespaceCommand(&testCmd)
+				Expect(testCmd.SysProcAttr.UidMappings[0].HostID).To(Not(Equal(0)))
+			})
+		})
+		Context("when in FUSE-only privilege mode", func() {
+			var cmd baggageclaimcmd.BaggageclaimCommand
+			cmd.PrivilegedMode = bespec.FUSEOnlyPrivilegedMode
+			It("selects the unprivileged namespacer for both privilege levels", func() {
+				priv, unpriv := cmd.SelectNamespacers(logger)
+				var testCmd exec.Cmd
+				priv.NamespaceCommand(&testCmd)
+				Expect(testCmd.SysProcAttr.UidMappings[0].HostID).To(Not(Equal(0)))
+				unpriv.NamespaceCommand(&testCmd)
+				Expect(testCmd.SysProcAttr.UidMappings[0].HostID).To(Not(Equal(0)))
+			})
+		})
+		Context("when in ignore privilege mode", func() {
+			var cmd baggageclaimcmd.BaggageclaimCommand
+			cmd.PrivilegedMode = bespec.IgnorePrivilegedMode
+			It("selects the unprivileged namespacer for both privilege levels", func() {
+				priv, unpriv := cmd.SelectNamespacers(logger)
+				var testCmd exec.Cmd
+				priv.NamespaceCommand(&testCmd)
+				Expect(testCmd.SysProcAttr.UidMappings[0].HostID).To(Not(Equal(0)))
+				unpriv.NamespaceCommand(&testCmd)
+				Expect(testCmd.SysProcAttr.UidMappings[0].HostID).To(Not(Equal(0)))
+			})
+		})
+	})
+})

--- a/worker/baggageclaim/cmd/baggageclaim/main.go
+++ b/worker/baggageclaim/cmd/baggageclaim/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/concourse/concourse/worker/baggageclaim/baggageclaimcmd"
+	"github.com/concourse/concourse/worker/runtime/spec"
 	"github.com/jessevdk/go-flags"
 )
 
@@ -19,7 +20,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = cmd.Execute(args)
+	err = cmd.Execute(args, spec.FullPrivilegedMode)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/worker/runtime/spec/capabilities.go
+++ b/worker/runtime/spec/capabilities.go
@@ -2,11 +2,15 @@ package spec
 
 import "github.com/opencontainers/runtime-spec/specs-go"
 
-func OciCapabilities(privileged bool) specs.LinuxCapabilities {
-	if !privileged {
+func OciCapabilities(privilegedMode PrivilegedMode, privileged bool) specs.LinuxCapabilities {
+	if !privileged || privilegedMode == IgnorePrivilegedMode {
 		return UnprivilegedContainerCapabilities
 	}
 
+	if privilegedMode == FUSEOnlyPrivilegedMode {
+		return FUSEOnlyContainerCapabilities
+	}
+	
 	return PrivilegedContainerCapabilities
 }
 
@@ -16,6 +20,13 @@ var (
 		Bounding:    privilegedCaps,
 		Inheritable: privilegedCaps,
 		Permitted:   privilegedCaps,
+	}
+
+	FUSEOnlyContainerCapabilities = specs.LinuxCapabilities{
+		Effective:   fuseOnlyCaps,
+		Bounding:    fuseOnlyCaps,
+		Inheritable: fuseOnlyCaps,
+		Permitted:   fuseOnlyCaps,
 	}
 
 	UnprivilegedContainerCapabilities = specs.LinuxCapabilities{
@@ -42,6 +53,24 @@ var (
 		"CAP_SYS_CHROOT",
 	}
 
+	fuseOnlyCaps = []string{
+		"CAP_AUDIT_WRITE",
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FOWNER",
+		"CAP_FSETID",
+		"CAP_KILL",
+		"CAP_MKNOD",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_NET_RAW",
+		"CAP_SETFCAP",
+		"CAP_SETGID",
+		"CAP_SETPCAP",
+		"CAP_SETUID",
+		"CAP_SYS_CHROOT",
+		"CAP_SYS_ADMIN",
+	}
+	
 	privilegedCaps = []string{
 		"CAP_AUDIT_CONTROL",
 		"CAP_AUDIT_READ",

--- a/worker/runtime/spec/devices.go
+++ b/worker/runtime/spec/devices.go
@@ -33,8 +33,8 @@ var (
 
 func intRef(i int64) *int64 { return &i }
 
-func Devices(privileged bool) []specs.LinuxDevice {
-	if !privileged {
+func Devices(privilegedMode PrivilegedMode, privileged bool) []specs.LinuxDevice {
+	if !privileged || privilegedMode == IgnorePrivilegedMode {
 		return nil
 	}
 	return []specs.LinuxDevice{

--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -51,7 +51,7 @@ var (
 	}
 )
 
-func ContainerMounts(privileged bool, initBinPath string) []specs.Mount {
+func ContainerMounts(privilegedMode PrivilegedMode, privileged bool, initBinPath string) []specs.Mount {
 	mounts := make([]specs.Mount, 0, len(DefaultContainerMounts)+1)
 	mounts = append(mounts, DefaultContainerMounts...)
 	mounts = append(mounts, specs.Mount{
@@ -61,7 +61,7 @@ func ContainerMounts(privileged bool, initBinPath string) []specs.Mount {
 		Options:     []string{"bind"},
 	})
 	// Following the current behaviour for privileged containers in Docker
-	if privileged {
+	if privileged && privilegedMode == FullPrivilegedMode {
 		for i, ociMount := range mounts {
 			if ociMount.Destination == "/sys" || ociMount.Type == "cgroup" {
 				clearReadOnly(&mounts[i])

--- a/worker/runtime/spec/namespaces.go
+++ b/worker/runtime/spec/namespaces.go
@@ -28,8 +28,8 @@ func init() {
 	}
 }
 
-func OciNamespaces(privileged bool) []specs.LinuxNamespace {
-	if !privileged {
+func OciNamespaces(privilegedMode PrivilegedMode, privileged bool) []specs.LinuxNamespace {
+	if !privileged || privilegedMode != FullPrivilegedMode {
 		return UnprivilegedContainerNamespaces
 	}
 

--- a/worker/runtime/spec/seccomp.go
+++ b/worker/runtime/spec/seccomp.go
@@ -46,6 +46,7 @@ var seccomp = &specs.LinuxSeccomp{
 		AllowSyscall("exit"),
 		AllowSyscall("exit_group"),
 		AllowSyscall("faccessat"),
+		AllowSyscall("faccessat2"),
 		AllowSyscall("fadvise64"),
 		AllowSyscall("fadvise64_64"),
 		AllowSyscall("fallocate"),
@@ -172,6 +173,8 @@ var seccomp = &specs.LinuxSeccomp{
 		AllowSyscall("_newselect"),
 		AllowSyscall("open"),
 		AllowSyscall("openat"),
+		AllowSyscall("openat2"),
+		AllowSyscall("open_tree"),
 		AllowSyscall("pause"),
 		AllowSyscall("personality",
 			specs.LinuxSeccompArg{
@@ -332,6 +335,7 @@ var seccomp = &specs.LinuxSeccomp{
 		AllowSyscall("utime"),
 		AllowSyscall("utimensat"),
 		AllowSyscall("utimes"),
+		AllowSyscall("utimes"),
 		AllowSyscall("vfork"),
 		AllowSyscall("vmsplice"),
 		AllowSyscall("wait4"),
@@ -353,6 +357,18 @@ var seccomp = &specs.LinuxSeccomp{
 	},
 }
 
+var fuse_syscalls = []specs.LinuxSyscall{
+	AllowSyscall("clone"),
+	AllowSyscall("clone3"),
+	AllowSyscall("mount"),
+	AllowSyscall("mount_setattr"),
+	AllowSyscall("move_mount"),
+	AllowSyscall("pivot_root"),
+	AllowSyscall("unshare"),
+	AllowSyscall("umount"),
+	AllowSyscall("umount2"),
+}
+
 func AllowSyscall(syscall string, args ...specs.LinuxSeccompArg) specs.LinuxSyscall {
 	return specs.LinuxSyscall{
 		Names:  []string{syscall},
@@ -363,4 +379,13 @@ func AllowSyscall(syscall string, args ...specs.LinuxSeccompArg) specs.LinuxSysc
 
 func GetDefaultSeccompProfile() specs.LinuxSeccomp {
 	return *seccomp
+}
+
+func GetDefaultSeccompProfileFuse() specs.LinuxSeccomp {
+	merged_seccomp := *seccomp
+	s := []specs.LinuxSyscall{}
+	s = append(s, fuse_syscalls[:]...)
+	s = append(s, seccomp.Syscalls[:]...)
+	merged_seccomp.Syscalls = s
+	return merged_seccomp
 }

--- a/worker/runtime/spec/seccomp.go
+++ b/worker/runtime/spec/seccomp.go
@@ -367,6 +367,9 @@ var fuse_syscalls = []specs.LinuxSyscall{
 	AllowSyscall("unshare"),
 	AllowSyscall("umount"),
 	AllowSyscall("umount2"),
+	AllowSyscall("pidfd_open"),
+	AllowSyscall("pidfd_getfd"),
+	AllowSyscall("pidfd_send_signal"),
 }
 
 func AllowSyscall(syscall string, args ...specs.LinuxSeccompArg) specs.LinuxSyscall {

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -154,6 +154,7 @@ func (cmd *WorkerCommand) buildUpBackendOpts(logger lager.Logger, cniNetwork run
 		runtime.WithInitBinPath(cmd.Containerd.InitBin),
 		runtime.WithSeccompProfilePath(cmd.Containerd.SeccompProfilePath),
 		runtime.WithOciHooksDir(cmd.Containerd.OCIHooksDir),
+		runtime.WithPrivilegedMode(cmd.Containerd.PrivilegedMode),
 	}, nil
 }
 

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -265,5 +265,7 @@ func (cmd *WorkerCommand) baggageclaimRunner(logger lager.Logger) (ifrit.Runner,
 
 	cmd.Baggageclaim.OverlaysDir = filepath.Join(cmd.WorkDir.Path(), "overlays")
 
+	cmd.Baggageclaim.PrivilegedMode = cmd.Containerd.PrivilegedMode
+
 	return cmd.Baggageclaim.Runner(nil)
 }

--- a/worker/workercmd/worker.go
+++ b/worker/workercmd/worker.go
@@ -265,7 +265,5 @@ func (cmd *WorkerCommand) baggageclaimRunner(logger lager.Logger) (ifrit.Runner,
 
 	cmd.Baggageclaim.OverlaysDir = filepath.Join(cmd.WorkDir.Path(), "overlays")
 
-	cmd.Baggageclaim.PrivilegedMode = cmd.Containerd.PrivilegedMode
-
-	return cmd.Baggageclaim.Runner(nil)
+	return cmd.Baggageclaim.Runner(nil, cmd.Containerd.PrivilegedMode)
 }

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -63,7 +63,7 @@ type ContainerdRuntime struct {
 	} `group:"Container Networking"`
 
 	MaxContainers  int                   `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`
-	PrivilegedMode bespec.PrivilegedMode `long:"privileged-mode" default:"full" description:"How many privileges privileged containers get. full equivalent to root on host. ignore means no extra privileges. fuse-only means enough to use fuse-overlayfs."`
+	PrivilegedMode bespec.PrivilegedMode `long:"privileged-mode" default:"full" choice:"full" choice:"fuse-only" choice:"ignore" description:"How many privileges privileged containers get. full is equivalent to root on host. ignore means no extra privileges. fuse-only means enough to use fuse-overlayfs."`
 }
 
 type DNSConfig struct {

--- a/worker/workercmd/worker_linux.go
+++ b/worker/workercmd/worker_linux.go
@@ -14,6 +14,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	concourseCmd "github.com/concourse/concourse/cmd"
 	"github.com/concourse/concourse/worker/network"
+	bespec "github.com/concourse/concourse/worker/runtime/spec"
 	"github.com/concourse/flag/v2"
 	"github.com/jessevdk/go-flags"
 	"github.com/tedsuo/ifrit"
@@ -61,7 +62,8 @@ type ContainerdRuntime struct {
 		} `group:"IPv6 Configuration" namespace:"v6"`
 	} `group:"Container Networking"`
 
-	MaxContainers int `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`
+	MaxContainers  int                   `long:"max-containers" default:"250" description:"Max container capacity. 0 means no limit."`
+	PrivilegedMode bespec.PrivilegedMode `long:"privileged-mode" default:"full" description:"How many privileges privileged containers get. full equivalent to root on host. ignore means no extra privileges. fuse-only means enough to use fuse-overlayfs."`
 }
 
 type DNSConfig struct {


### PR DESCRIPTION
The privileged-mode setting lets admins decide what level of privilege tasks running as privileged should have. This gives the ability to lock down privileged access to a level that isn't equivalent to full root on the host.

There are three proposed levels:
full, the status quo. This has multiple vectors to take over the host, including by loading modules into the kernel.
fuse-only, enough to work with containers using tools like buildah and podman if they are configured appropriately. As long as the Concourse worker is run in a user namespace on an up-to-date Linux kernel, this shouldn't be enough access to escape the container. ignore - privileged tasks have the same access as normal tasks.

To get podman and buildah working, a few more syscalls need to be allowed through seccomp. A few harmless ones have been added to the general allow list, while others related to mounting and unsharing are only added for fuse-only mode.

## Changes proposed by this PR

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] Implement privileged-mode
* [x] Manual local testing: CONCOURSE_CONTAINERD_PRIVILEGED_MODE: full, can create container with buildah and run with podman.
* [x] Manual local testing: CONCOURSE_CONTAINERD_PRIVILEGED_MODE: fuse-only, can create container with buildah and run with podman. Capabilities are less.
* [x] Manual local testing: CONCOURSE_CONTAINERD_PRIVILEGED_MODE: fuse-only, cannot escape container using cgroup release_agent (note: can still escape if Worker not run in a new userns, setting release_agent fails if using a new userns).
 * [x] Manual local testing: CONCOURSE_CONTAINERD_PRIVILEGED_MODE: ignore, cannot create container with buildah and run with podman, as expected.
 * [x] Write automated tests for functionality.
 * [x] Convert from draft PR to normal PR.

## Notes to reviewer

This pipeline is helpful for manual testing:

```
jobs:
  - name: build-container
    public: false
    plan:
    - task: build
      privileged: true
      config:
        platform: linux
        image_resource:
          type: registry-image
          source:
            repository: quay.io/buildah/stable
        run:
          path: /bin/bash
          args:
            - "-c"
            - |
              capsh --print &&\
              yum -y install podman &&\
              mkdir container-storage &&\
              ls -l /dev/fuse /usr/bin/fuse-overlayfs $(pwd) $(pwd)/container-storage &&\
              PODMAN_ROOT=$(pwd)/container-storage &&\
              echo FROM mirror.gcr.io/alpine:latest >Dockerfile &&\
              echo CMD echo Hello World >>Dockerfile &&\
              buildah bud --root=$PODMAN_ROOT -t helloworld &&\
              echo "[containers]" >/etc/containers/containers.conf &&\
              echo "keyring = false" >>/etc/containers/containers.conf &&\
              podman run --rm --uts=host --network=host --userns=host --root=$PODMAN_ROOT --cgroups=disabled -it helloworld
```

## Release Note

* Added a new `--privileged-mode` option to the worker, which accepts `full` (default, original behaviour), `fuse-only` (privileged: true tasks can use tools like buildah and podman, but can't escape if user namespaces are used to run the worker), `ignore` (privileged: true tasks have no extra access compared to privileged: false tasks)