### PR TITLE
Disable garden renovate update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,8 +28,9 @@
       "allowedVersions": "<2.0.0"
     },
     {
-      "matchPackageNames": ["code.cloudfoundry.org/garden"],
-      "allowedVersions": "<=v0.0.0-20241106020650-8b5ced818ad7"
+      "matchPackageNames": ["/garden/"],
+      "matchManagers": ["gomod"],
+      "enabled": false
     }
   ],
   "ignoreDeps": ["elm", "client-go"],


### PR DESCRIPTION
- Version pinning was not matching correctly. We can re-enable this once we resolve the compatability issue with houdini
