### PR TITLE
make sure to drop item from secret cache after default duration if calculated duration is equal or less than 0

### DIFF
--- a/atc/creds/cached_secrets.go
+++ b/atc/creds/cached_secrets.go
@@ -61,8 +61,9 @@ func (cs *CachedSecrets) Get(secretPath string) (interface{}, *time.Time, bool, 
 		duration := cs.cacheConfig.Duration
 		if expiration != nil {
 			// if secret lease time expires sooner, make duration smaller than default duration
+			// also if the duration is less than or equal to 0, use default duration (it would cache forever)
 			itemDuration := time.Until(*expiration)
-			if itemDuration < duration {
+			if itemDuration < duration && itemDuration > 0 {
 				duration = itemDuration
 			}
 		}


### PR DESCRIPTION
## Changes proposed by this PR

closes https://github.com/concourse/concourse/issues/8705

The current implementation causes the secret cache not to be cleared for the object and it is saved for ever.

Checking the itemDuration if it is greater than 0 fixed this issue and sets the default duration.
Also changed the test duration as the tests needed 5 seconds, now they are done in 1 second.

## Notes to reviewer
hope the shortened timing does not break CI or other non local systems


## Release Notes

* Fix a bug in credential caching where a secret would be cached forever

