### PR TITLE
Fix token not being sent to fly when using Chrome to login

### DIFF
--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -249,6 +249,7 @@ func listenForTokenCallback(tokenChannel chan string, errorChannel chan error, p
 		Addr: "127.0.0.1:0",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Access-Control-Allow-Origin", targetUrl)
+			w.Header().Set("Access-Control-Allow-Private-Network", "true")
 			tokenChannel <- r.FormValue("token")
 			if r.Header.Get("Upgrade-Insecure-Requests") != "" {
 				http.Redirect(w, r, fmt.Sprintf("%s/fly_success?noop=true", targetUrl), http.StatusFound)

--- a/fly/commands/login.go
+++ b/fly/commands/login.go
@@ -249,7 +249,15 @@ func listenForTokenCallback(tokenChannel chan string, errorChannel chan error, p
 		Addr: "127.0.0.1:0",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Access-Control-Allow-Origin", targetUrl)
-			w.Header().Set("Access-Control-Allow-Private-Network", "true")
+
+			preflightAccessRequest := r.Header.Get("Access-Control-Request-Private-Network")
+			preflightRequestMethod := r.Header.Get("Access-Control-Request-Method")
+
+			if preflightAccessRequest == "true" && preflightRequestMethod == "GET" {
+				w.Header().Set("Access-Control-Allow-Private-Network", "true")
+				return
+			}
+
 			tokenChannel <- r.FormValue("token")
 			if r.Header.Get("Upgrade-Insecure-Requests") != "" {
 				http.Redirect(w, r, fmt.Sprintf("%s/fly_success?noop=true", targetUrl), http.StatusFound)

--- a/fly/integration/login_test.go
+++ b/fly/integration/login_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
@@ -458,9 +459,6 @@ var _ = Describe("login Command", func() {
 				It("sets a CORS header for the ATC being logged in to", func() {
 					corsHeader := resp.Header.Get("Access-Control-Allow-Origin")
 					Expect(corsHeader).To(Equal(loginATCServer.URL()))
-
-					corsPrivateNetwork := resp.Header.Get("Access-Control-Allow-Private-Network")
-					Expect(corsPrivateNetwork).To(Equal("true"))
 				})
 
 				It("responds successfully", func() {
@@ -476,6 +474,31 @@ var _ = Describe("login Command", func() {
 						Expect(resp.StatusCode).To(Equal(http.StatusFound))
 						locationHeader := resp.Header.Get("Location")
 						Expect(locationHeader).To(Equal(fmt.Sprintf("%s/fly_success?noop=true", loginATCServer.URL())))
+					})
+				})
+
+				Context("when the request comes from a Chromium browser", func() {
+					// Why this test exists: https://developer.chrome.com/blog/private-network-access-preflight/
+					var preflightResp *http.Response
+
+					BeforeEach(func() {
+						preflightReq := req.Clone(context.Background())
+						preflightReq.Header.Add("Access-Control-Request-Method", "GET")
+						preflightReq.Header.Add("Access-Control-Request-Private-Network", "true")
+
+						client := &http.Client{
+							CheckRedirect: func(req *http.Request, via []*http.Request) error {
+								return http.ErrUseLastResponse
+							},
+						}
+						var err error
+						preflightResp, err = client.Do(preflightReq)
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("handles the preflight request", func() {
+						Expect(preflightResp.StatusCode).To(Equal(http.StatusOK))
+						Expect(resp.StatusCode).To(Equal(http.StatusOK))
 					})
 				})
 			})

--- a/fly/integration/login_test.go
+++ b/fly/integration/login_test.go
@@ -458,6 +458,9 @@ var _ = Describe("login Command", func() {
 				It("sets a CORS header for the ATC being logged in to", func() {
 					corsHeader := resp.Header.Get("Access-Control-Allow-Origin")
 					Expect(corsHeader).To(Equal(loginATCServer.URL()))
+
+					corsPrivateNetwork := resp.Header.Get("Access-Control-Allow-Private-Network")
+					Expect(corsPrivateNetwork).To(Equal("true"))
 				})
 
 				It("responds successfully", func() {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "babel-loader": "^9.2.1",
     "child-process-promise": "2.2.1",
     "clean-css-cli": "5.6.3",
-    "elm": "0.19.1",
+    "elm": "0.19.1-6",
     "elm-analyse": "0.16.5",
     "elm-format": "0.8.7",
     "elm-test": "0.19.1-revision9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,6 +839,26 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@elm_binaries/darwin_arm64@0.19.1-0":
+  version "0.19.1-0"
+  resolved "https://registry.yarnpkg.com/@elm_binaries/darwin_arm64/-/darwin_arm64-0.19.1-0.tgz#ea09fca7cdfedad3fa517267099d78d180f01098"
+  integrity sha512-mjbsH7BNHEAmoE2SCJFcfk5fIHwFIpxtSgnEAqMsVLpBUFoEtAeX+LQ+N0vSFJB3WAh73+QYx/xSluxxLcL6dA==
+
+"@elm_binaries/darwin_x64@0.19.1-0":
+  version "0.19.1-0"
+  resolved "https://registry.yarnpkg.com/@elm_binaries/darwin_x64/-/darwin_x64-0.19.1-0.tgz#8c3254590804c35ee7b97b4d8a21a63318511c44"
+  integrity sha512-QGUtrZTPBzaxgi9al6nr+9313wrnUVHuijzUK39UsPS+pa+n6CmWyV/69sHZeX9qy6UfeugE0PzF3qcUiy2GDQ==
+
+"@elm_binaries/linux_x64@0.19.1-0":
+  version "0.19.1-0"
+  resolved "https://registry.yarnpkg.com/@elm_binaries/linux_x64/-/linux_x64-0.19.1-0.tgz#95440341eee8f6bee2d88859b3bdd99f33ca88f0"
+  integrity sha512-T1ZrWVhg2kKAsi8caOd3vp/1A3e21VuCpSG63x8rDie50fHbCytTway9B8WHEdnBFv4mYWiA68dzGxYCiFmU2w==
+
+"@elm_binaries/win32_x64@0.19.1-0":
+  version "0.19.1-0"
+  resolved "https://registry.yarnpkg.com/@elm_binaries/win32_x64/-/win32_x64-0.19.1-0.tgz#3f8decfd6f5fbc46906f3f5d50561b6e5b33ac3a"
+  integrity sha512-yDleiXqSE9EcqKtd9SkC/4RIW8I71YsXzMPL79ub2bBPHjWTcoyyeBbYjoOB9SxSlArJ74HaoBApzT6hY7Zobg==
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
@@ -1820,12 +1840,15 @@ elm-test@0.19.1-revision9:
     which "^2.0.2"
     xmlbuilder "^15.1.1"
 
-elm@0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/elm/-/elm-0.19.1.tgz#66461c49146099b866fdaf8af681331e5bec703d"
-  integrity sha512-rehOtJKZvoYDddlrd7AX5NAf0H+LUllnBg3AHaeaIOKWzw4W316d7Bkhlbo7aSG+hVUVWP2ihKwyYkDi589TfA==
-  dependencies:
-    request "^2.88.0"
+elm@0.19.1-6:
+  version "0.19.1-6"
+  resolved "https://registry.yarnpkg.com/elm/-/elm-0.19.1-6.tgz#b6f51d0add8877de70592097a8f6efc4588c476a"
+  integrity sha512-mKYyierHICPdMx/vhiIacdPmTPnh889gjHOZ75ZAoCxo3lZmSWbGP8HMw78wyctJH0HwvTmeKhlYSWboQNYPeQ==
+  optionalDependencies:
+    "@elm_binaries/darwin_arm64" "0.19.1-0"
+    "@elm_binaries/darwin_x64" "0.19.1-0"
+    "@elm_binaries/linux_x64" "0.19.1-0"
+    "@elm_binaries/win32_x64" "0.19.1-0"
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -3274,7 +3297,7 @@ request@2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-request@^2.86.0, request@^2.88.0:
+request@^2.86.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
## Changes proposed by this PR

closes #8529

Have fly correctly handle preflight requests from Chromium browsers. Details from Chrome about this change can be read here: https://developer.chrome.com/blog/private-network-access-preflight/

## Notes

I also bumped the elm package being used. During investigation I was looking at the frontend code and needed to locally compile. This was my first time doing it on an ARM Mac. The older package couldn't find the ARM release of Elm. Bumping to the latest patch of that package resolved the issue for me.

## Release Note

* Have fly handle preflight requests from Chromium browsers. Users will no longer get a "your token could not be sent to fly" error if they login to `fly` using a Chormium browser
