### PR TITLE
Properly close process IO

### DIFF
--- a/worker/runtime/process.go
+++ b/worker/runtime/process.go
@@ -28,14 +28,12 @@ func NewProcess(
 var _ garden.Process = (*Process)(nil)
 
 // Id retrieves the ID associated with this process.
-//
 func (p *Process) ID() string {
 	return p.process.ID()
 }
 
 // Wait for the process to terminate (either naturally, or from a signal), and
 // once done, delete it.
-//
 func (p *Process) Wait() (int, error) {
 	status := <-p.exitStatusC
 	err := status.Error()
@@ -48,7 +46,9 @@ func (p *Process) Wait() (int, error) {
 		return 0, fmt.Errorf("proc closeio: %w", err)
 	}
 
+	p.process.IO().Cancel()
 	p.process.IO().Wait()
+	p.process.IO().Close()
 
 	_, err = p.process.Delete(context.Background())
 	// ignore "not found" errors - the process was already deleted
@@ -60,7 +60,6 @@ func (p *Process) Wait() (int, error) {
 }
 
 // SetTTY resizes the process' terminal dimensions.
-//
 func (p *Process) SetTTY(spec garden.TTYSpec) error {
 	if spec.WindowSize == nil {
 		return nil
@@ -78,7 +77,6 @@ func (p *Process) SetTTY(spec garden.TTYSpec) error {
 }
 
 // Signal - Not Implemented
-//
 func (p *Process) Signal(signal garden.Signal) (err error) {
 	err = ErrNotImplemented
 	return

--- a/worker/runtime/process_test.go
+++ b/worker/runtime/process_test.go
@@ -81,9 +81,11 @@ func (s *ProcessSuite) TestProcessWaitBlocksUntilIOFinishes() {
 	_, err := s.process.Wait()
 	s.NoError(err)
 
-	s.Equal(1, s.containerdProcess.DeleteCallCount())
-	s.Equal(1, s.containerdProcess.IOCallCount())
+	s.Equal(3, s.containerdProcess.IOCallCount())
+	s.Equal(1, s.io.CancelCallCount())
 	s.Equal(1, s.io.WaitCallCount())
+	s.Equal(1, s.io.CloseCallCount())
+	s.Equal(1, s.containerdProcess.DeleteCallCount())
 }
 
 func (s *ProcessSuite) TestSetTTYWithNilWindowSize() {


### PR DESCRIPTION
## Changes proposed by this PR

closes #8462

Properly close IO of a containerd process.

## Notes to reviewer

After reviewing how other projects use the containerd client, I saw that no one ever calls _just_ the `Wait()` func. They always call `Cancel()`, `Wait()`, and `Close()` in that sequence. I think this was us improperly using the containerd client.

I'm actually not even sure we need to call any of the functions on `IO()` at all. After digging into the containerd client code I noticed that the `process.Delete()` we call right after also calls those three functions on the `IO` struct. So what we're doing might be completely redundant!

I did test the issues in #8462 and #6775. I made sure I could get the code in a state where I could reproduce both issues.

When I reverted the change made to fix #6775 I was still able to reproduce the error reported in that issue. The bug in #8462 also disappeared.

When I removed all of our calls to the `IO()` functions I was unable to reproduce either of the bugs.

When I added the `Cancel()` and `Close()` functions I was again unable to reproduce either of the bugs.

So I _think_ it would be fine to remove all of the `IO()` calls here. I am erring on the side of caution though. I wasn't involved in the initial implementation of the containerd runtime in Concourse so I don't know why we make a call to manually close `IO()` at all. Reviewing git history doesn't shed anymore light as to why.

Anyways, it seems fine for us to close IO on our own, as long as we do it properly :)

## Release Note

* Fix a bug where builds could not be aborted because the underlying process had a lock on stdout that Concourse would wait for the process to release. If the underlying process never released it then Concourse would wait forever and the build would never be aborted.
