### PR TITLE
Update gzhttp library

### DIFF
--- a/atc/wrappa/compression_wrappa.go
+++ b/atc/wrappa/compression_wrappa.go
@@ -2,8 +2,8 @@ package wrappa
 
 import (
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/NYTimes/gziphandler"
 	"github.com/concourse/concourse/atc"
+	"github.com/klauspost/compress/gzhttp"
 	"github.com/tedsuo/rata"
 )
 
@@ -24,7 +24,7 @@ func (wrappa CompressionWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 		switch name {
 		// always gzip for events
 		case atc.BuildEvents:
-			gzipEnforcedHandler, err := gziphandler.GzipHandlerWithOpts(gziphandler.MinSize(0))
+			gzipEnforcedHandler, err := gzhttp.NewWrapper(gzhttp.MinSize(0))
 			if err != nil {
 				wrappa.Logger.Error("failed-to-create-gzip-handler", err)
 			}
@@ -34,7 +34,7 @@ func (wrappa CompressionWrappa) Wrap(handlers rata.Handlers) rata.Handlers {
 		case atc.DownloadCLI:
 			wrapped[name] = handler
 		default:
-			wrapped[name] = gziphandler.GzipHandler(handler)
+			wrapped[name] = gzhttp.GzipHandler(handler)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.26.0
 	github.com/Masterminds/squirrel v1.5.4
-	github.com/NYTimes/gziphandler v1.1.1
 	github.com/aryann/difflib v0.0.0-20210328193216-ff5ff6dc229b
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/caarlos0/env/v11 v11.3.1

--- a/go.sum
+++ b/go.sum
@@ -663,8 +663,6 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=
 github.com/Microsoft/hcsshim v0.12.9/go.mod h1:fJ0gkFAna6ukt0bLdKB8djt4XIJhF/vEPuoIWYVvZ8Y=
-github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
-github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=

--- a/web/cache_handler.go
+++ b/web/cache_handler.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/NYTimes/gziphandler"
+	"github.com/klauspost/compress/gzhttp"
 )
 
 const yearInSeconds = 31536000
@@ -14,5 +14,5 @@ func CacheNearlyForever(handler http.Handler) http.Handler {
 		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, private", yearInSeconds))
 		handler.ServeHTTP(w, r)
 	})
-	return gziphandler.GzipHandler(withoutGz)
+	return gzhttp.GzipHandler(withoutGz)
 }


### PR DESCRIPTION
## Changes proposed by this PR

See https://github.com/klauspost/compress/pull/383.

Removes the dead nytimes/gziphandler project. klauspost/compress picked up where they left off and updated the project which is why it makes sense for us to switch to this library.

## Release Note

* Replace the unmaintained [NYTimes/gziphandler](https://github.com/NYTimes/gziphandler) with [klauspost/compress](https://github.com/klauspost/compress/) giving a performance boost to all HTTP endpoints
