### PR TITLE
Fix double locking in volume promise

### DIFF
--- a/worker/baggageclaim/volume/promise.go
+++ b/worker/baggageclaim/volume/promise.go
@@ -19,7 +19,6 @@ type Promise interface {
 type promise struct {
 	volume *Volume
 	err    error
-	cancel chan struct{}
 
 	sync.RWMutex
 }
@@ -28,7 +27,6 @@ func NewPromise() Promise {
 	return &promise{
 		volume: nil,
 		err:    nil,
-		cancel: make(chan struct{}),
 	}
 }
 
@@ -47,7 +45,7 @@ func (p *promise) GetValue() (Volume, error, error) {
 	p.RLock()
 	defer p.RUnlock()
 
-	if p.IsPending() {
+	if p.isPending() {
 		return Volume{}, nil, ErrPromiseStillPending
 	}
 


### PR DESCRIPTION
## Changes proposed by this PR

Fixes a bug where we would block because we try to acquire the same lock twice. Also removed an unused channel. Came across this by chance, doesn't address any known bug or issue.

## Release Note

* Fix a bug in baggageclaim where we would try to get the same lock twice