### PR TITLE
Add support for Strict-Transport-Security header

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -180,11 +180,12 @@ type RunCommand struct {
 	} `group:"Policy Checking"`
 
 	Server struct {
-		XFrameOptions         string `long:"x-frame-options" default:"deny" description:"The value to set for the X-Frame-Options header."`
-		ContentSecurityPolicy string `long:"content-security-policy" default:"frame-ancestors 'none'" description:"The value to set for the Content-Security-Policy header."`
-		ClusterName           string `long:"cluster-name" description:"A name for this Concourse cluster, to be displayed on the dashboard page."`
-		ClientID              string `long:"client-id" default:"concourse-web" description:"Client ID to use for login flow"`
-		ClientSecret          string `long:"client-secret" required:"true" description:"Client secret to use for login flow"`
+		XFrameOptions           string `long:"x-frame-options" default:"deny" description:"The value to set for the X-Frame-Options header."`
+		ContentSecurityPolicy   string `long:"content-security-policy" default:"frame-ancestors 'none'" description:"The value to set for the Content-Security-Policy header."`
+		StrictTransportSecurity string `long:"strict-transport-security" description:"The value to set for the Strict-Transport-Security header."`
+		ClusterName             string `long:"cluster-name" description:"A name for this Concourse cluster, to be displayed on the dashboard page."`
+		ClientID                string `long:"client-id" default:"concourse-web" description:"Client ID to use for login flow"`
+		ClientSecret            string `long:"client-secret" required:"true" description:"Client secret to use for login flow"`
 	} `group:"Web Server"`
 
 	LogDBQueries   bool `long:"log-db-queries" description:"Log database queries."`
@@ -1816,8 +1817,9 @@ func (cmd *RunCommand) constructHTTPHandler(
 		Logger: logger,
 
 		Handler: wrappa.SecurityHandler{
-			XFrameOptions:         cmd.Server.XFrameOptions,
-			ContentSecurityPolicy: cmd.Server.ContentSecurityPolicy,
+			XFrameOptions:           cmd.Server.XFrameOptions,
+			ContentSecurityPolicy:   cmd.Server.ContentSecurityPolicy,
+			StrictTransportSecurity: cmd.Server.StrictTransportSecurity,
 
 			// proxy Authorization header to/from auth cookie,
 			// to support auth from JS (EventSource) and custom JWT auth

--- a/atc/wrappa/security_handler.go
+++ b/atc/wrappa/security_handler.go
@@ -3,9 +3,10 @@ package wrappa
 import "net/http"
 
 type SecurityHandler struct {
-	XFrameOptions         string
-	ContentSecurityPolicy string
-	Handler               http.Handler
+	XFrameOptions           string
+	ContentSecurityPolicy   string
+	StrictTransportSecurity string
+	Handler                 http.Handler
 }
 
 func (handler SecurityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -14,6 +15,9 @@ func (handler SecurityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	if handler.ContentSecurityPolicy != "" {
 		w.Header().Set("Content-Security-Policy", handler.ContentSecurityPolicy)
+	}
+	if handler.StrictTransportSecurity != "" {
+		w.Header().Set("Strict-Transport-Security", handler.StrictTransportSecurity)
 	}
 	w.Header().Set("X-XSS-Protection", "1; mode=block")
 	w.Header().Set("X-Content-Type-Options", "nosniff")

--- a/atc/wrappa/security_handler_test.go
+++ b/atc/wrappa/security_handler_test.go
@@ -78,4 +78,22 @@ var _ = Describe("SecurityHandler", func() {
 			Expect(rw.Result().Header).NotTo(HaveKey("Content-Security-Policy"))
 		})
 	})
+
+	Context("when Strict-Transport-Security is set", func() {
+		BeforeEach(func() {
+			securityHandler = wrappa.SecurityHandler{
+				StrictTransportSecurity: "some-policy 'value'",
+				Handler:                 fakeHandler,
+			}
+		})
+		It("sets the Strict-Transport-Security to whatever it was configured with", func() {
+			Expect(rw.Header().Get("Strict-Transport-Security")).To(Equal("some-policy 'value'"))
+		})
+	})
+
+	Context("when Strict-Transport-Security is empty", func() {
+		It("does not set Strict-Transport-Security header", func() {
+			Expect(rw.Result().Header).NotTo(HaveKey("Strict-Transport-Security"))
+		})
+	})
 })


### PR DESCRIPTION
## Changes proposed by this PR

Adds a new config option on the web node: `CONCOURSE_STRICT_TRANSPORT_SECURITY`
Which can be used to set the STS header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

## Release Note

* Add `CONCOURSE_STRICT_TRANSPORT_SECURITY` to the web command which allows an operator to set the [Strict-Transport-Security header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
