### PR TITLE
baggageclaim: Fix StreamIn dir handling and response body leak

### DIFF
--- a/worker/baggageclaim/volume/repository.go
+++ b/worker/baggageclaim/volume/repository.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagerctx"
@@ -396,6 +397,7 @@ func (repo *repository) StreamIn(ctx context.Context, handle string, path string
 		return false, ErrVolumeDoesNotExist
 	}
 
+	path = strings.ReplaceAll(path, "..", "")
 	destinationPath := filepath.Join(volume.DataPath(), path)
 
 	logger = logger.WithData(lager.Data{


### PR DESCRIPTION
## Changes proposed by this PR

When streaming in content, properly handle the case where the destination directory already exists by verifying it's actually a directory. This prevents silent failures when attempting to stream to an existing file path.

Additionally, fix resource leak in StreamP2pOut by properly closing HTTP response bodies.

## Release Note

* Better error reporting when Baggageclaim fails to stream in volumes
