### PR TITLE
atc: exec: ignore task input/output paths that reference parent directories

### DIFF
--- a/atc/exec/task_step.go
+++ b/atc/exec/task_step.go
@@ -519,6 +519,7 @@ func resolvePath(workingDir string, path string) string {
 	if filepath.IsAbs(path) {
 		return path
 	}
+	path = strings.ReplaceAll(path, "..", "")
 	return filepath.Join(workingDir, path)
 }
 


### PR DESCRIPTION
## Changes proposed by this PR

The behaviour of this was changed back in 7.5.0 by concourse/concourse#6597 (https://github.com/concourse/concourse/commit/2ba0164e8be66100e24c727bd51f04c625398231) and was never properly captured in our release notes. It kinda snuck in with everything else in that PR.

Previously only relative paths were allowed. No tests were added to handle these new cases. In testing this I also found that paths with parent directories were also allowed and would work; You'd get the input mounted above the task's CWD. This seems like a bad thing to encourage so I've locked things down to only allow absolute and relative paths. Allowing parent directories seems like an easy footgun for users to fall onto.

We now have test coverage for:
- Allowing absolute paths in task inputs/outputs
- Ignoring paths with parent directory references in them

## Release Note

* Task inputs and outputs can be placed using absolute or relative paths inside task containers now. This was changed back in v7.5.0 (concourse/concourse#6597) but never properly announced. Paths that reference parent directories (`../`) will be treated as relative paths and no parent directory traversal will occur.
