### PR TITLE
fix the policy-checker-handler logger session name

### DIFF
--- a/atc/api/policychecker/handler.go
+++ b/atc/api/policychecker/handler.go
@@ -34,7 +34,7 @@ type policyCheckingHandler struct {
 func (h policyCheckingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	acc := accessor.GetAccessor(r)
 
-	logger := h.logger.Session("policy-checker")
+	logger := h.logger.Session("handler")
 	result, err := h.policyChecker.Check(h.action, acc, r)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
fix the policy-checker-handler logger session name

Very minor log name correction.

Currently in the logs one sees:
```
{"timestamp":"2024-10-09T10:05:31.196402292Z","level":"error","source":"atc","message":"atc.policy-checker.policy-checker","data":{"error":"OPA server: connecting: Post "[http://localhost:8181/v1/data/concourse/decision\](http://localhost:8181/v1/data/concourse/decision%5C)": dial tcp [::1]:8181: connect: connection refused","session":"134","user-msg":"policy-checker: unreachable or misconfigured"}}
```

note the msg: `atc.policy-checker.policy-checker`. The `atc.policy-checker` is already there. So the session name should just be `handler`.

With the proposed change we will see: `atc.policy-checker.handler`