### PR TITLE
Fix bug in maxValidFromFile using hardcoded path

### DIFF
--- a/worker/runtime/user_namespace.go
+++ b/worker/runtime/user_namespace.go
@@ -31,9 +31,9 @@ func (s *userNamespace) MaxValidIds() (uint32, uint32, error) {
 }
 
 func maxValidFromFile(fname string) (uint32, error) {
-	f, err := os.Open(uidMap)
+	f, err := os.Open(fname)
 	if err != nil {
-		return 0, fmt.Errorf("open %s: %w", uidMap, err)
+		return 0, fmt.Errorf("open %s: %w", fname, err)
 	}
 	defer f.Close()
 


### PR DESCRIPTION
## Changes proposed by this PR

The `maxValidFromFile()` function was incorrectly using the `const uidMap` var regardless of the filename parameter passed to it. This caused the MaxValidIds method to always read from `/proc/self/uid_map` twice instead of reading from both uid_map and gid_map files.

Fixed by modifying maxValidFromFile to properly use the fname parameter both when opening the file and when generating error messages.

## Release Note

* Fix bug in maxValidFromFile. It was always using a hardcoded path
