### PR TITLE
Use github.com/google/uuid to generate UUIDv4

### DIFF
--- a/atc/db/dbtest/builder.go
+++ b/atc/db/dbtest/builder.go
@@ -14,7 +14,7 @@ import (
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/concourse/atc/db"
 	"github.com/concourse/concourse/atc/db/lock"
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 )
 
 const BaseResourceType = "global-base-type"
@@ -998,7 +998,7 @@ func (builder Builder) WithBaseResourceType(dbConn db.DbConn, resourceTypeName s
 }
 
 func unique(kind string) string {
-	id, err := uuid.NewV4()
+	id, err := uuid.NewRandom()
 	if err != nil {
 		panic(err)
 	}

--- a/atc/db/volume.go
+++ b/atc/db/volume.go
@@ -11,7 +11,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/concourse/concourse/atc"
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 )
 
 var (
@@ -623,7 +623,7 @@ func (volume *createdVolume) CreateChildForContainer(container CreatingContainer
 
 	defer Rollback(tx)
 
-	handle, err := uuid.NewV4()
+	handle, err := uuid.NewRandom()
 	if err != nil {
 		return nil, err
 	}

--- a/atc/db/volume_repository.go
+++ b/atc/db/volume_repository.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 )
 
 //counterfeiter:generate . VolumeRepository
@@ -704,7 +704,7 @@ func (repository *volumeRepository) createVolume(
 	columns map[string]interface{},
 	volumeType VolumeType,
 ) (*creatingVolume, error) {
-	handle, err := uuid.NewV4()
+	handle, err := uuid.NewRandom()
 	if err != nil {
 		return nil, err
 	}

--- a/atc/metric/emitter/newrelic_test.go
+++ b/atc/metric/emitter/newrelic_test.go
@@ -61,30 +61,30 @@ var _ = Describe("NewRelicEmitter", func() {
 			})
 			It("should write one batch to NewRelic", func() {
 				server.RouteToHandler(http.MethodPost, "/", verifyEvents(2))
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					testEmitter.Emit(testLogger, testEvent)
 				}
 				Eventually(server.ReceivedRequests).Should(HaveLen(1))
-				Expect(testEmitter.NewRelicBatch).To(HaveLen(1))
+				Expect(testEmitter.Batch()).To(HaveLen(1))
 			})
 			It("should write two batches to NewRelic", func() {
 				server.RouteToHandler(http.MethodPost, "/", verifyEvents(2))
 				server.RouteToHandler(http.MethodPost, "/", verifyEvents(2))
-				for i := 0; i < 4; i++ {
+				for range 4 {
 					testEmitter.Emit(testLogger, testEvent)
 				}
 				Eventually(server.ReceivedRequests).Should(HaveLen(2))
-				Expect(testEmitter.NewRelicBatch).To(HaveLen(0))
+				Expect(testEmitter.Batch()).To(HaveLen(0))
 			})
 			It("should write no batches to NewRelic", func() {
 				testEmitter.Emit(testLogger, testEvent)
 
 				time.Sleep(500 * time.Millisecond)
 				Eventually(server.ReceivedRequests).Should(HaveLen(0))
-				Expect(testEmitter.NewRelicBatch).To(HaveLen(1))
+				Expect(testEmitter.Batch()).To(HaveLen(1))
 			})
 		})
-		Context("when batch duration is 1 millisecond", func() {
+		Context("when batch duration is 1 second", func() {
 			var testEmitter emitter.NewRelicEmitter
 			BeforeEach(func() {
 				testEmitter = emitter.NewRelicEmitter{
@@ -98,25 +98,25 @@ var _ = Describe("NewRelicEmitter", func() {
 			})
 			It("should write one batch to NewRelic", func() {
 				server.RouteToHandler(http.MethodPost, "/", verifyEvents(1))
-				time.Sleep(1 * time.Millisecond)
+				time.Sleep(1 * time.Second)
 				testEmitter.Emit(testLogger, testEvent)
 				Eventually(server.ReceivedRequests).Should(HaveLen(1))
-				Expect(testEmitter.NewRelicBatch).To(HaveLen(0))
+				Expect(testEmitter.Batch()).To(HaveLen(0))
 			})
 			It("should write two batches to NewRelic", func() {
 				server.RouteToHandler(http.MethodPost, "/", verifyEvents(1))
 				server.RouteToHandler(http.MethodPost, "/", verifyEvents(1))
-				for i := 0; i < 2; i++ {
-					time.Sleep(1 * time.Millisecond)
+				for range 2 {
+					time.Sleep(1 * time.Second)
 					testEmitter.Emit(testLogger, testEvent)
 				}
 				Eventually(server.ReceivedRequests).Should(HaveLen(2))
-				Expect(testEmitter.NewRelicBatch).To(HaveLen(0))
+				Expect(testEmitter.Batch()).To(HaveLen(0))
 			})
 			It("should write no batches to NewRelic", func() {
 				testEmitter.Emit(testLogger, testEvent)
 				Eventually(server.ReceivedRequests).Should(HaveLen(0))
-				Expect(testEmitter.NewRelicBatch).To(HaveLen(1))
+				Expect(testEmitter.Batch()).To(HaveLen(1))
 
 			})
 		})

--- a/atc/worker/gardenruntime/gardenruntimetest/garden.go
+++ b/atc/worker/gardenruntime/gardenruntimetest/garden.go
@@ -11,7 +11,7 @@ import (
 
 	"code.cloudfoundry.org/garden"
 	"github.com/concourse/concourse/atc/worker/gardenruntime/gclient"
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 )
 
 type Garden struct {
@@ -324,7 +324,7 @@ func (p *Process) Signal(sig garden.Signal) error {
 }
 
 func generateID() string {
-	uuid, err := uuid.NewV4()
+	uuid, err := uuid.NewRandom()
 	if err != nil {
 		panic(err)
 	}

--- a/atc/worker/gardenruntime/worker.go
+++ b/atc/worker/gardenruntime/worker.go
@@ -146,8 +146,6 @@ func (worker *Worker) findOrCreateContainer(
 	if gardenContainer == nil {
 		gardenContainer, err = worker.createGardenContainer(ctx, containerSpec, creatingContainer, delegate)
 		if err != nil {
-			logger.Error("failed-to-create-container-in-garden", err)
-			markContainerAsFailed(logger, creatingContainer)
 			return nil, nil, err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/concourse/dex v1.9.0
 	github.com/concourse/flag/v2 v2.2.0
-	github.com/concourse/houdini v1.2.0
+	github.com/concourse/houdini v1.3.0
 	github.com/concourse/retryhttp v1.2.4
 	github.com/containerd/containerd v1.7.25
 	github.com/containerd/containerd/api v1.8.0
@@ -58,7 +58,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/miekg/dns v1.1.63
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/opencontainers/runc v1.2.5
@@ -127,7 +126,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -739,8 +739,8 @@ github.com/concourse/flag/v2 v2.2.0 h1:gKalNjiAQ/kajq2oPtiGeRLCYsvPsFzMUKj8h1OuZ
 github.com/concourse/flag/v2 v2.2.0/go.mod h1:Crz1peofKdtySScA89xQ7GPa3dX7LnlDUq2Q37EUWrg=
 github.com/concourse/go-archive v1.0.1 h1:6jQk0VDiE4G6lNJQ0mLZ7XmxbqI3spO4x0wgVwk4pfo=
 github.com/concourse/go-archive v1.0.1/go.mod h1:Xfo080IPQBmVz3I5ehjCddW3phA2mwv0NFwlpjf5CO8=
-github.com/concourse/houdini v1.2.0 h1:sL9WITdVs4uOb/8dRqGd55fxK57P29kXde/V7svwkkQ=
-github.com/concourse/houdini v1.2.0/go.mod h1:1xkwc7aQDRE4jVswAg5/Pb6CUQUCB0jmzAuhoTjqsvM=
+github.com/concourse/houdini v1.3.0 h1:JzxY0p0algYdydonCG/7SSAkDOWNXpaG37TRbVwY2Io=
+github.com/concourse/houdini v1.3.0/go.mod h1:+iygT0c7+YYv+tE1lbLZnaHt5DOh9BIj67Oo7Kq7Slk=
 github.com/concourse/retryhttp v1.2.4 h1:eo1DhK3ZaW7lWm846Y9R8/91LpETTWA6/YtBhxabclY=
 github.com/concourse/retryhttp v1.2.4/go.mod h1:OdmoHwj4SdbCWGnoHMvar5lcsLVQNpUkOI3uLgLBS8Q=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
@@ -1188,7 +1188,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/testflight/image_resource_caching_test.go
+++ b/testflight/image_resource_caching_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -11,12 +11,12 @@ var _ = Describe("image resource caching", func() {
 	var version string
 
 	BeforeEach(func() {
-		u, err := uuid.NewV4()
+		u, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		version = u.String()
 
-		hash, err := uuid.NewV4()
+		hash, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		setAndUnpausePipeline(

--- a/testflight/input_overriding_test.go
+++ b/testflight/input_overriding_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -20,10 +20,10 @@ var _ = Describe("A job with multiple inputs", func() {
 	)
 
 	BeforeEach(func() {
-		hash, err := uuid.NewV4()
+		hash, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
-		hash2, err := uuid.NewV4()
+		hash2, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		setAndUnpausePipeline(

--- a/testflight/matrix_test.go
+++ b/testflight/matrix_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -11,7 +11,7 @@ var _ = Describe("A job with a complicated build plan", func() {
 	var initialVersion string
 
 	BeforeEach(func() {
-		u, err := uuid.NewV4()
+		u, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		initialVersion = u.String()

--- a/testflight/pinned_version_check_test.go
+++ b/testflight/pinned_version_check_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -10,7 +10,7 @@ import (
 var _ = Describe("A resource pinned with a version during initial set of the pipeline", func() {
 	Context("when a resource is pinned in the pipeline config before the check is run", func() {
 		BeforeEach(func() {
-			hash, err := uuid.NewV4()
+			hash, err := uuid.NewRandom()
 			Expect(err).ToNot(HaveOccurred())
 
 			setAndUnpausePipeline(

--- a/testflight/rerun_build_test.go
+++ b/testflight/rerun_build_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -12,7 +12,7 @@ var _ = Describe("Rerunning a build", func() {
 	var hash string
 
 	BeforeEach(func() {
-		u, err := uuid.NewV4()
+		u, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		hash = u.String()

--- a/testflight/resource_cache_test.go
+++ b/testflight/resource_cache_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -9,7 +9,7 @@ import (
 
 var _ = Describe("Resource caching", func() {
 	It("takes params into account when determining a cache hit", func() {
-		guid, err := uuid.NewV4()
+		guid, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		setAndUnpausePipeline(

--- a/testflight/resource_check_test.go
+++ b/testflight/resource_check_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -13,7 +13,7 @@ var _ = Describe("Checking a resource", func() {
 	var checkFailure string
 
 	BeforeEach(func() {
-		u, err := uuid.NewV4()
+		u, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		hash = u.String()

--- a/testflight/resource_config_versions_test.go
+++ b/testflight/resource_config_versions_test.go
@@ -1,14 +1,14 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Resource config versions", func() {
 	BeforeEach(func() {
-		hash, err := uuid.NewV4()
+		hash, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		setAndUnpausePipeline(
@@ -26,7 +26,7 @@ var _ = Describe("Resource config versions", func() {
 			fly("trigger-job", "-j", inPipeline("initial-job"), "-w")
 
 			By("checking the a new version of the custom resource type")
-			u, err := uuid.NewV4()
+			u, err := uuid.NewRandom()
 			Expect(err).ToNot(HaveOccurred())
 
 			newVersion := u.String()

--- a/testflight/resource_containers_gc_test.go
+++ b/testflight/resource_containers_gc_test.go
@@ -3,7 +3,7 @@ package testflight_test
 import (
 	"time"
 
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +12,7 @@ var _ = Describe("Resource container GC", func() {
 	var checkContainerHandle string
 
 	BeforeEach(func() {
-		uuid, err := uuid.NewV4()
+		uuid, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		setAndUnpausePipeline(
@@ -50,7 +50,7 @@ var _ = Describe("Resource container GC", func() {
 
 	Describe("changing the resource config", func() {
 		BeforeEach(func() {
-			uuid, err := uuid.NewV4()
+			uuid, err := uuid.NewRandom()
 			Expect(err).ToNot(HaveOccurred())
 
 			setAndUnpausePipeline(

--- a/testflight/resource_reconfigure_test.go
+++ b/testflight/resource_reconfigure_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -9,10 +9,10 @@ import (
 
 var _ = Describe("Reconfiguring a resource", func() {
 	It("picks up the new configuration immediately", func() {
-		guid1, err := uuid.NewV4()
+		guid1, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
-		guid2, err := uuid.NewV4()
+		guid2, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		setAndUnpausePipeline(

--- a/testflight/resource_type_check_test.go
+++ b/testflight/resource_type_check_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -10,7 +10,7 @@ import (
 
 var _ = Describe("Resource-types checks", func() {
 	BeforeEach(func() {
-		hash, err := uuid.NewV4()
+		hash, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		setAndUnpausePipeline(
@@ -31,7 +31,7 @@ var _ = Describe("Resource-types checks", func() {
 		var newVersion string
 
 		BeforeEach(func() {
-			u, err := uuid.NewV4()
+			u, err := uuid.NewRandom()
 			Expect(err).ToNot(HaveOccurred())
 
 			newVersion = u.String()

--- a/testflight/resource_type_privileged_test.go
+++ b/testflight/resource_type_privileged_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -15,7 +15,7 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 	})
 
 	JustBeforeEach(func() {
-		unique, err := uuid.NewV4()
+		unique, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		setAndUnpausePipeline(

--- a/testflight/resource_type_test.go
+++ b/testflight/resource_type_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -11,7 +11,7 @@ var _ = Describe("Configuring a resource type in a pipeline config", func() {
 	var hash string
 
 	BeforeEach(func() {
-		u, err := uuid.NewV4()
+		u, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		hash = u.String()

--- a/testflight/resource_version_test.go
+++ b/testflight/resource_version_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -11,7 +11,7 @@ var _ = Describe("Resource version", func() {
 	var hash string
 
 	BeforeEach(func() {
-		u, err := uuid.NewV4()
+		u, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		hash = u.String()

--- a/testflight/serial_groups_test.go
+++ b/testflight/serial_groups_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -15,7 +15,7 @@ var _ = Describe("serial groups", func() {
 	var hash string
 
 	BeforeEach(func() {
-		u, err := uuid.NewV4()
+		u, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		hash = u.String()
@@ -45,7 +45,7 @@ var _ = Describe("serial groups", func() {
 		var hash2 string
 
 		BeforeEach(func() {
-			u, err := uuid.NewV4()
+			u, err := uuid.NewRandom()
 			Expect(err).ToNot(HaveOccurred())
 
 			hash2 = u.String()

--- a/testflight/suite_test.go
+++ b/testflight/suite_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/concourse/concourse/go-concourse/concourse"
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	"github.com/onsi/gomega/gexec"
 )
 
@@ -186,7 +186,7 @@ func downloadFly(atcUrl string) (string, error) {
 }
 
 func randomPipelineName() string {
-	guid, err := uuid.NewV4()
+	guid, err := uuid.NewRandom()
 	Expect(err).ToNot(HaveOccurred())
 
 	return fmt.Sprintf("%s-%d-%s", pipelinePrefix, GinkgoParallelProcess(), guid)
@@ -339,7 +339,7 @@ func inPipeline(thing string) string {
 }
 
 func newMockVersion(resourceName string, tag string) string {
-	guid, err := uuid.NewV4()
+	guid, err := uuid.NewRandom()
 	Expect(err).ToNot(HaveOccurred())
 
 	version := guid.String() + "-" + tag

--- a/testflight/trigger_test.go
+++ b/testflight/trigger_test.go
@@ -1,7 +1,7 @@
 package testflight_test
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -11,7 +11,7 @@ var _ = Describe("A job with an input with trigger: true", func() {
 	var hash string
 
 	BeforeEach(func() {
-		u, err := uuid.NewV4()
+		u, err := uuid.NewRandom()
 		Expect(err).ToNot(HaveOccurred())
 
 		hash = u.String()

--- a/worker/baggageclaim/api/volume_server.go
+++ b/worker/baggageclaim/api/volume_server.go
@@ -13,7 +13,7 @@ import (
 
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagerctx"
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	"github.com/tedsuo/rata"
 	"go.opentelemetry.io/otel/propagation"
 
@@ -648,7 +648,7 @@ func (vs *VolumeServer) StreamP2pOut(w http.ResponseWriter, req *http.Request) {
 }
 
 func (vs *VolumeServer) generateHandle() (string, error) {
-	handle, err := uuid.NewV4()
+	handle, err := uuid.NewRandom()
 	if err != nil {
 		return "", err
 	}

--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -10,7 +10,7 @@ import (
 	"code.cloudfoundry.org/garden"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
-	uuid "github.com/nu7hatch/gouuid"
+	"github.com/google/uuid"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -54,7 +54,6 @@ func (c *Container) Handle() string {
 }
 
 // Stop stops a container.
-//
 func (c *Container) Stop(kill bool) error {
 	ctx := context.Background()
 
@@ -77,7 +76,6 @@ func (c *Container) Stop(kill bool) error {
 }
 
 // Run a process inside the container.
-//
 func (c *Container) Run(
 	spec garden.ProcessSpec,
 	processIO garden.ProcessIO,
@@ -150,7 +148,6 @@ func (c *Container) Run(
 }
 
 // Attach starts streaming the output back to the client from a specified process.
-//
 func (c *Container) Attach(pid string, processIO garden.ProcessIO) (process garden.Process, err error) {
 	ctx := context.Background()
 
@@ -188,7 +185,6 @@ func (c *Container) Attach(pid string, processIO garden.ProcessIO) (process gard
 }
 
 // Properties returns the current set of properties
-//
 func (c *Container) Properties() (garden.Properties, error) {
 	ctx := context.Background()
 
@@ -201,7 +197,6 @@ func (c *Container) Properties() (garden.Properties, error) {
 }
 
 // Property returns the value of the property with the specified name.
-//
 func (c *Container) Property(name string) (string, error) {
 	properties, err := c.Properties()
 	if err != nil {
@@ -217,7 +212,6 @@ func (c *Container) Property(name string) (string, error) {
 }
 
 // Set a named property on a container to a specified value.
-//
 func (c *Container) SetProperty(name string, value string) error {
 	labelSet, err := propertiesToLabels(garden.Properties{name: value})
 	if err != nil {
@@ -262,7 +256,6 @@ func (c *Container) StreamOut(spec garden.StreamOutSpec) (readCloser io.ReadClos
 }
 
 // SetGraceTime stores the grace time as a containerd label with key "garden.grace-time"
-//
 func (c *Container) SetGraceTime(graceTime time.Duration) error {
 	err := c.SetProperty(GraceTimeKey, fmt.Sprintf("%d", graceTime))
 	if err != nil {
@@ -343,7 +336,7 @@ func (c *Container) BulkNetOut(netOutRules []garden.NetOutRule) (err error) {
 func procID(gdnProcSpec garden.ProcessSpec) string {
 	id := gdnProcSpec.ID
 	if id == "" {
-		uuid, err := uuid.NewV4()
+		uuid, err := uuid.NewRandom()
 		if err != nil {
 			panic(fmt.Errorf("uuid gen: %w", err))
 		}
@@ -401,7 +394,6 @@ func (c *Container) setupContainerdProcSpec(gdnProcSpec garden.ProcessSpec, cont
 }
 
 // Set a default path based on the UID if no existing PATH is found
-//
 func envWithDefaultPath(uid uint32, currentEnv []string) string {
 	pathRegexp := regexp.MustCompile("^PATH=.*$")
 	for _, envVar := range currentEnv {

--- a/worker/runtime/file_store.go
+++ b/worker/runtime/file_store.go
@@ -97,9 +97,6 @@ func (f fileStore) ContainerIpLookup(handle string) (string, error) {
 	if !found {
 		return "", fmt.Errorf("ip not found for container handle: %s", handle)
 	}
-	if err != nil {
-		return "", fmt.Errorf("error finding container ip: %w", err)
-	}
 
 	return ip, nil
 }

--- a/worker/runtime/integration/suite_test.go
+++ b/worker/runtime/integration/suite_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	gouuid "github.com/nu7hatch/gouuid"
+	guuid "github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -28,7 +28,7 @@ func (m *buffer) String() string {
 }
 
 func uuid() string {
-	u4, err := gouuid.NewV4()
+	u4, err := guuid.NewRandom()
 	if err != nil {
 		panic("couldn't create new uuid")
 	}


### PR DESCRIPTION
## Changes proposed by this PR

We found UUID collisions occurring in our cluster. We thought it was
impossible but I decided to look into the library we were using for UUID
generation and found this issue: https://github.com/nu7hatch/gouuid/issues/28

Which would explain some of the errors I've seen where the only possible
explanation was that we got the same UUID twice.

## Notes to reviewer

The error we were seeing was this:

```
atc.tracker.notify.run.get-step.perform-get.failed-to-create-container-in-garden:
new container: container "bba06975-46f6-4bbe-73f5-9e39a869719a": already exists
```

I dug into how we generate this handle and found we use the `nu7hatch/gouuid` to generate the UUID. We trusted that this UUID would be truly random so of course the database doesn't have any protections against two containers being made with the same handle. We also don't do any checks ourselves that the handle has been used. Doing so would be a waste of CPU for the web and database _assuming_ that your UUID library generates unique UUID's.

I'm trusting this new library more since it is maintained by Google and they're probably using this in their own production apps.

Related PR https://github.com/concourse/houdini/pull/2

## Release Note

* Use [github.com/google/uuid](https://github.com/google/uuid) to generate UUID's (v4). The previous library incorrectly implemented UUID generation and would sometimes generate the same UUID twice. Therefore it was possible for two containers or volumes to be created with the same UUID. The second container/volume would fail to create due to the UUID collision.
