### PR TITLE
Replace min/max helpers with built-in min/max

### DIFF
--- a/worker/baggageclaim/uidgid/max_valid_uid.go
+++ b/worker/baggageclaim/uidgid/max_valid_uid.go
@@ -47,26 +47,10 @@ func (u IDMap) MaxValid() (int, error) {
 			return 0, ParseError{Line: scanner.Text(), Err: err}
 		}
 
-		m = minUint(container+size-1, uint(maxInt))
+		m = min(container+size-1, uint(maxInt))
 	}
 
 	return int(m), nil
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
-func minUint(a, b uint) uint {
-	if a < b {
-		return a
-	}
-
-	return b
 }
 
 type ParseError struct {

--- a/worker/runtime/user_namespace.go
+++ b/worker/runtime/user_namespace.go
@@ -97,7 +97,7 @@ func MaxValid(r io.Reader) (uint32, error) {
 			return 0, fmt.Errorf("scanf: %w", err)
 		}
 
-		val = maxUint(val, inside+size-1)
+		val = max(val, inside+size-1)
 		lines++
 	}
 
@@ -111,12 +111,4 @@ func MaxValid(r io.Reader) (uint32, error) {
 	}
 
 	return val, nil
-}
-
-func maxUint(a, b uint32) uint32 {
-	if a > b {
-		return a
-	}
-
-	return b
 }


### PR DESCRIPTION
## Changes proposed by this PR

We can use the built-in `min` and `max` functions since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max



