### PR TITLE
worker runtime: make container deletion more robust

### DIFF
--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -405,7 +406,9 @@ func (b *GardenBackend) Destroy(handle string) error {
 
 	err = b.network.ResumeContainerTraffic(handle)
 	if err != nil {
-		return fmt.Errorf("resume container traffic: %w", err)
+		if !errors.Is(err, ErrGettingContainerIP) {
+			return fmt.Errorf("resume container traffic: %w", err)
+		}
 	}
 
 	err = b.network.Remove(ctx, task, handle)

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -499,7 +500,7 @@ func (n cniNetwork) restrictHostAccess() error {
 func (n cniNetwork) DropContainerTraffic(containerHandle string) error {
 	containerIp, err := n.store.ContainerIpLookup(containerHandle)
 	if err != nil {
-		return fmt.Errorf("error getting container IP: %w", err)
+		return errors.Join(ErrGettingContainerIP, err)
 	}
 
 	err = n.ipt.InsertRule(filterTable, "INPUT", 1, "-s", containerIp, "-j", "DROP")
@@ -518,7 +519,7 @@ func (n cniNetwork) DropContainerTraffic(containerHandle string) error {
 func (n cniNetwork) ResumeContainerTraffic(containerHandle string) error {
 	containerIp, err := n.store.ContainerIpLookup(containerHandle)
 	if err != nil {
-		return fmt.Errorf("error getting container IP: %w", err)
+		return errors.Join(ErrGettingContainerIP, err)
 	}
 
 	err = n.ipt.DeleteRule(filterTable, "INPUT", "-s", containerIp, "-j", "DROP")

--- a/worker/runtime/cni_network_test.go
+++ b/worker/runtime/cni_network_test.go
@@ -400,6 +400,20 @@ func (s *CNINetworkSuite) TestDropContainerTraffic() {
 	s.Equal([]string{"-s", "10.8.0.1", "-j", "DROP"}, rulespec)
 }
 
+func (s *CNINetworkSuite) TestDropContainerTrafficErrors() {
+	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
+		runtime.WithCNIFileStore(s.store),
+		runtime.WithIptables(s.iptables),
+	)
+	s.NoError(err)
+
+	s.store.ContainerIpLookupReturns("", errors.New("some-error"))
+
+	err = network.DropContainerTraffic("some-handle")
+	s.ErrorIs(err, runtime.ErrGettingContainerIP)
+}
+
 func (s *CNINetworkSuite) TestResumeContainerTraffic() {
 	network, err := runtime.NewCNINetwork(
 		runtime.WithDefaultsForTesting(),
@@ -423,4 +437,19 @@ func (s *CNINetworkSuite) TestResumeContainerTraffic() {
 	s.Equal("filter", table)
 	s.Equal("FORWARD", chain)
 	s.Equal([]string{"-s", "10.8.0.1", "-j", "DROP"}, rulespec)
+}
+
+func (s *CNINetworkSuite) TestResumeContainerTrafficErrors() {
+	network, err := runtime.NewCNINetwork(
+		runtime.WithDefaultsForTesting(),
+		runtime.WithCNIFileStore(s.store),
+		runtime.WithIptables(s.iptables),
+	)
+	s.NoError(err)
+
+	s.store.ContainerIpLookupReturns("", errors.New("some-error"))
+
+	err = network.ResumeContainerTraffic("some-handle")
+	s.ErrorIs(err, runtime.ErrGettingContainerIP)
+
 }

--- a/worker/runtime/errors.go
+++ b/worker/runtime/errors.go
@@ -3,7 +3,6 @@ package runtime
 import "errors"
 
 // ErrInvalidInput indicates a bad input was supplied.
-//
 type ErrInvalidInput string
 
 func (e ErrInvalidInput) Error() string {
@@ -11,7 +10,6 @@ func (e ErrInvalidInput) Error() string {
 }
 
 // ErrNotFound indicates that something wasn't found.
-//
 type ErrNotFound string
 
 func (e ErrNotFound) Error() string {
@@ -27,4 +25,9 @@ var (
 	// ErrNotImplemented indicates that a method is not implemented.
 	//
 	ErrNotImplemented = errors.New("not implemented")
+
+	// ErrGettingContainerIP indicates that there was an error reading the host
+	// file in the container
+	//
+	ErrGettingContainerIP = errors.New("error getting container IP")
 )


### PR DESCRIPTION
## Changes proposed by this PR

We found that if a container wasn't correctly made, specifically if the `/etc/hosts` file of the container wasn't populated with the containers IP, container cleanup would fail with this error:

```
resume container traffic: error getting container IP: ip not found for container handle: 0ce036f8-aa2a-4bea-acbd-8ee48e5fa63b
```

We can ignore this error when deleting a container because it tells us there are no iptables rules to remove anyways. We can probably continue deleting the container and will delete it successfully.

## Release Note

* Make container deletion more robust by continuing to delete a container even if we get errors related to reading the containers `/etc/host` file