### PR TITLE
atc: Various small fixes

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -1120,6 +1120,7 @@ func (cmd *RunCommand) backendComponents(
 			Runnable: lidar.NewScanner(
 				dbCheckFactory,
 				atc.NewPlanFactory(time.Now().Unix()),
+				50,
 			),
 		},
 		{

--- a/atc/util/seq_generator.go
+++ b/atc/util/seq_generator.go
@@ -1,28 +1,23 @@
 package util
 
-import "sync"
+import (
+	"sync/atomic"
+)
 
 type SequenceGenerator interface {
 	Next() int
 }
 
 type seqGenerator struct {
-	current int
-	lock    *sync.Mutex
+	current atomic.Int64
 }
 
 func NewSequenceGenerator(start int) SequenceGenerator {
-	return &seqGenerator{
-		current: start,
-		lock:    &sync.Mutex{},
-	}
+	gen := &seqGenerator{}
+	gen.current.Store(int64(start - 1))
+	return gen
 }
 
 func (g *seqGenerator) Next() int {
-	g.lock.Lock()
-	defer g.lock.Unlock()
-
-	next := g.current
-	g.current++
-	return next
+	return int(g.current.Add(1))
 }

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -77,7 +77,7 @@ func newPlaceStrategy(options PlacementOptions, chain []string) (PlacementStrate
 			}
 			strategy = append(strategy, limitActiveVolumesStrategy{MaxVolumes: options.MaxActiveVolumesPerWorker})
 		default:
-			return nil, fmt.Errorf("invalid container placement strategy %s", strategy)
+			return nil, fmt.Errorf("invalid container placement strategy %s", s)
 		}
 	}
 
@@ -133,9 +133,7 @@ func (strategy PlacementStrategy) Order(logger lager.Logger, pool Pool, workers 
 
 func (strategy PlacementStrategy) Approve(logger lager.Logger, worker db.Worker, spec runtime.ContainerSpec) error {
 	var err error
-	var i int
-
-	for i = 0; i < len(strategy); i++ {
+	for i := range len(strategy) {
 		err = strategy[i].Approve(logger, worker, spec)
 
 		if err != nil {

--- a/vars/tracker.go
+++ b/vars/tracker.go
@@ -24,7 +24,7 @@ func NewTracker(on bool) *Tracker {
 	}
 }
 
-func (t *Tracker) Track(varRef Reference, val interface{}) {
+func (t *Tracker) Track(varRef Reference, val any) {
 	if !t.Enabled {
 		return
 	}
@@ -35,16 +35,16 @@ func (t *Tracker) Track(varRef Reference, val interface{}) {
 	t.track(varRef, val)
 }
 
-func (t *Tracker) track(varRef Reference, val interface{}) {
+func (t *Tracker) track(varRef Reference, val any) {
 	switch v := val.(type) {
-	case map[interface{}]interface{}:
+	case map[any]any:
 		for kk, vv := range v {
 			t.track(Reference{
 				Path:   varRef.Path,
 				Fields: append(varRef.Fields, kk.(string)),
 			}, vv)
 		}
-	case map[string]interface{}:
+	case map[string]any:
 		for kk, vv := range v {
 			t.track(Reference{
 				Path:   varRef.Path,
@@ -62,10 +62,10 @@ func (t *Tracker) track(varRef Reference, val interface{}) {
 
 func (t *Tracker) IterateInterpolatedCreds(iter TrackedVarsIterator) {
 	t.lock.RLock()
+	defer t.lock.RUnlock()
 	for k, v := range t.interpolatedCreds {
 		iter.YieldCred(k, v)
 	}
-	t.lock.RUnlock()
 }
 
 type CredVarsTracker struct {
@@ -73,7 +73,7 @@ type CredVarsTracker struct {
 	CredVars Variables
 }
 
-func (t *CredVarsTracker) Get(ref Reference) (interface{}, bool, error) {
+func (t *CredVarsTracker) Get(ref Reference) (any, bool, error) {
 	val, found, err := t.CredVars.Get(ref)
 	if found {
 		t.Tracker.Track(ref, val)


### PR DESCRIPTION
## Changes proposed by this PR

This is a collection of small fixes across various parts of the atc package.

## Release Note

* Fix unbounded goroutine creation in resource scanner (lidar)
* Fix potential race condition in `Tracker.IterateInterpolatedCreds`
* Optimize `SequenceGenerator` using atomic types
* Fix error message in container placement strategy. Previously an unknown placement strategy would result in an error which showed the successfully parsed part of the chain. Now the error will show the unknown strategy that was passed in.
* Fix: redirect var source diffs to output writer & improve nil handling
