### PR TITLE
CI: only run baggageclaimcmd test on linux

### DIFF
--- a/worker/baggageclaim/baggageclaimcmd/command_linux_test.go
+++ b/worker/baggageclaim/baggageclaimcmd/command_linux_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package baggageclaimcmd_test
 
 import (


### PR DESCRIPTION
More follow-up from #9017

These new tests can only be run on Linux workers. They don't apply to Windows or Darwin.