### PR TITLE
Gracefully recover from containerd TaskNotFound errors

### DIFF
--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -10,6 +10,7 @@ import (
 	"code.cloudfoundry.org/garden"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/google/uuid"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -99,7 +100,23 @@ func (c *Container) Run(
 
 	task, err := c.container.Task(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("task retrieval: %w", err)
+		if errdefs.IsNotFound(err) {
+			// The containerd task is usually made during container creation.
+			// The task may have been killed if the containerd daemon was
+			// restarted. We can recover from this error by recreating the task
+			// and continuing as usual
+			initTask, err := c.container.NewTask(ctx, cio.NullIO, containerd.WithNoNewKeyring)
+			if err != nil {
+				return nil, fmt.Errorf("recreating init task: %w", err)
+			}
+			err = initTask.Start(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("restarting init task: %w", err)
+			}
+			task = initTask
+		} else {
+			return nil, fmt.Errorf("task retrieval: %w", err)
+		}
 	}
 
 	id := procID(spec)
@@ -157,7 +174,7 @@ func (c *Container) Attach(pid string, processIO garden.ProcessIO) (process gard
 
 	task, err := c.container.Task(ctx, cio.Load)
 	if err != nil {
-		return nil, fmt.Errorf("task: %w", err)
+		return nil, fmt.Errorf("task attach: %w", err)
 	}
 
 	cioOpts := containerdCIO(processIO, false)

--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"time"
 
 	"code.cloudfoundry.org/garden"
@@ -413,10 +414,9 @@ func (c *Container) setupContainerdProcSpec(gdnProcSpec garden.ProcessSpec, cont
 // Set a default path based on the UID if no existing PATH is found
 func envWithDefaultPath(uid uint32, currentEnv []string) string {
 	pathRegexp := regexp.MustCompile("^PATH=.*$")
-	for _, envVar := range currentEnv {
-		if pathRegexp.MatchString(envVar) {
-			return ""
-		}
+	pathFound := slices.ContainsFunc(currentEnv, pathRegexp.MatchString)
+	if pathFound {
+		return ""
 	}
 
 	if uid == 0 {


### PR DESCRIPTION
## Changes proposed by this PR

closes #8172

We found that when the worker is restarted that all containers would be
present, but any tasks running in them would disappear. This would result
in TaskNotFound errors, mostly in resource checks because these containers
are long running and therefore have a higher chance of having their task
killed.

Resource checks are more prone to this type of error because we re-use
their containers over a long period of time. The other types of
containers we make (get, put, task) usually don't hang around that long.

We initially create a Task during container creation and assume that
task would still be there when we go to exec the actual executable that
we wanted to run (e.g. /opt/resource/{in,out,check}). For long running
containers this may not be true but we can gracefully recover in this
scenario.

## Notes to reviewer

Can reproduce the error following these steps: https://github.com/concourse/concourse/issues/8172#issuecomment-2704469315

More details here: https://github.com/concourse/concourse/issues/8172#issuecomment-2704861646

## Release Note

* Gracefully recover from `task retrieval: no running task found` errors
