### PR TITLE
worker: split linux and non-linux features

### DIFF
--- a/atc/builds/tracker_test.go
+++ b/atc/builds/tracker_test.go
@@ -91,15 +91,6 @@ func (s *TrackerSuite) TestTrackRunsStartedBuilds() {
 
 func (s *TrackerSuite) TestTrackInMemoryBuilds() {
 	inMemoryBuilds := []db.Build{}
-	for i := 0; i < 3; i++ {
-		fakeBuild := new(dbfakes.FakeBuild)
-		// When tracked, in-memory builds have no id yet, thus let's use fake
-		// team id to verify test result.
-		fakeBuild.IDReturns(0)
-		fakeBuild.TeamIDReturns(i + 1)
-		inMemoryBuilds = append(inMemoryBuilds, fakeBuild)
-		s.buildChan <- fakeBuild
-	}
 
 	running := make(chan db.Build, 3)
 	s.fakeEngine.NewBuildStub = func(build db.Build) builds.Runnable {
@@ -108,6 +99,16 @@ func (s *TrackerSuite) TestTrackInMemoryBuilds() {
 			running <- build
 		}
 		return engineBuild
+	}
+
+	for i := range 3 {
+		fakeBuild := new(dbfakes.FakeBuild)
+		// When tracked, in-memory builds have no id yet, thus let's use fake
+		// team id to verify test result.
+		fakeBuild.IDReturns(0)
+		fakeBuild.TeamIDReturns(i + 1)
+		inMemoryBuilds = append(inMemoryBuilds, fakeBuild)
+		s.buildChan <- fakeBuild
 	}
 
 	err := s.tracker.Run(context.TODO())

--- a/worker/baggageclaim/baggageclaimcmd/command.go
+++ b/worker/baggageclaim/baggageclaimcmd/command.go
@@ -2,49 +2,12 @@ package baggageclaimcmd
 
 import (
 	"fmt"
-	"net/http"
 	"os"
-	"regexp"
 
 	"code.cloudfoundry.org/lager/v3"
-	"github.com/concourse/concourse/worker/baggageclaim/api"
-	"github.com/concourse/concourse/worker/baggageclaim/uidgid"
-	"github.com/concourse/concourse/worker/baggageclaim/volume"
-	bespec "github.com/concourse/concourse/worker/runtime/spec"
-	"github.com/concourse/flag/v2"
 	"github.com/tedsuo/ifrit"
-	"github.com/tedsuo/ifrit/grouper"
-	"github.com/tedsuo/ifrit/http_server"
 	"github.com/tedsuo/ifrit/sigmon"
 )
-
-type BaggageclaimCommand struct {
-	Logger flag.Lager
-
-	BindIP   flag.IP `long:"bind-ip"   default:"127.0.0.1" description:"IP address on which to listen for API traffic."`
-	BindPort uint16  `long:"bind-port" default:"7788"      description:"Port on which to listen for API traffic."`
-
-	DebugBindIP   flag.IP `long:"debug-bind-ip"   default:"127.0.0.1" description:"IP address on which to listen for the pprof debugger endpoints."`
-	DebugBindPort uint16  `long:"debug-bind-port" default:"7787"      description:"Port on which to listen for the pprof debugger endpoints."`
-
-	P2pInterfaceNamePattern string `long:"p2p-interface-name-pattern" default:"eth0" description:"Regular expression to match a network interface for p2p streaming"`
-	P2pInterfaceFamily      int    `long:"p2p-interface-family" default:"4" choice:"4" choice:"6" description:"4 for IPv4 and 6 for IPv6"`
-
-	VolumesDir flag.Dir `long:"volumes" required:"true" description:"Directory in which to place volume data."`
-
-	Driver string `long:"driver" default:"detect" choice:"detect" choice:"naive" choice:"btrfs" choice:"overlay" description:"Driver to use for managing volumes."`
-
-	BtrfsBin string `long:"btrfs-bin" default:"btrfs" description:"Path to btrfs binary"`
-	MkfsBin  string `long:"mkfs-bin" default:"mkfs.btrfs" description:"Path to mkfs.btrfs binary"`
-
-	OverlaysDir string `long:"overlays-dir" description:"Path to directory in which to store overlay data"`
-
-	DisableUserNamespaces bool `long:"disable-user-namespaces" description:"Disable remapping of user/group IDs in unprivileged volumes."`
-
-	// We don't expose PrivilegedMode here as a flag because we want the value
-	// passed in from the Containerd struct
-	PrivilegedMode bespec.PrivilegedMode `hidden:"true"`
-}
 
 func (cmd *BaggageclaimCommand) Execute(args []string) error {
 	runner, err := cmd.Runner(args)
@@ -53,97 +16,6 @@ func (cmd *BaggageclaimCommand) Execute(args []string) error {
 	}
 
 	return <-ifrit.Invoke(sigmon.New(runner)).Wait()
-}
-
-func (cmd *BaggageclaimCommand) Runner(args []string) (ifrit.Runner, error) {
-	logger, _ := cmd.constructLogger()
-
-	listenAddr := fmt.Sprintf("%s:%d", cmd.BindIP.IP, cmd.BindPort)
-
-	privilegedNamespacer, unprivilegedNamespacer := cmd.SelectNamespacers(logger)
-
-	locker := volume.NewLockManager()
-
-	driver, err := cmd.driver(logger)
-	if err != nil {
-		logger.Error("failed-to-set-up-driver", err)
-		return nil, err
-	}
-
-	filesystem, err := volume.NewFilesystem(driver, cmd.VolumesDir.Path())
-	if err != nil {
-		logger.Error("failed-to-initialize-filesystem", err)
-		return nil, err
-	}
-
-	err = driver.Recover(filesystem)
-	if err != nil {
-		logger.Error("failed-to-recover-volume-driver", err)
-		return nil, err
-	}
-
-	volumeRepo := volume.NewRepository(
-		filesystem,
-		locker,
-		privilegedNamespacer,
-		unprivilegedNamespacer,
-	)
-
-	re, err := regexp.Compile(cmd.P2pInterfaceNamePattern)
-	if err != nil {
-		logger.Error("failed-to-compile-p2p-interface-name-pattern", err)
-		return nil, err
-	}
-	apiHandler, err := api.NewHandler(
-		logger.Session("api"),
-		volume.NewStrategerizer(),
-		volumeRepo,
-		re,
-		cmd.P2pInterfaceFamily,
-		cmd.BindPort,
-	)
-	if err != nil {
-		logger.Fatal("failed-to-create-handler", err)
-	}
-
-	members := []grouper.Member{
-		{Name: "api", Runner: http_server.New(listenAddr, apiHandler)},
-		{Name: "debug-server", Runner: http_server.New(
-			cmd.debugBindAddr(),
-			http.DefaultServeMux,
-		)},
-	}
-
-	return onReady(grouper.NewParallel(os.Interrupt, members), func() {
-		logger.Info("listening", lager.Data{
-			"addr": listenAddr,
-		})
-	}), nil
-}
-
-func (cmd *BaggageclaimCommand) SelectNamespacers(logger lager.Logger) (uidgid.Namespacer, uidgid.Namespacer) {
-	var privilegedNamespacer, unprivilegedNamespacer uidgid.Namespacer
-
-	if !cmd.DisableUserNamespaces && uidgid.Supported() {
-		privilegedNamespacer = &uidgid.UidNamespacer{
-			Translator: uidgid.NewTranslator(uidgid.NewPrivilegedMapper()),
-			Logger:     logger.Session("uid-namespacer"),
-		}
-
-		unprivilegedNamespacer = &uidgid.UidNamespacer{
-			Translator: uidgid.NewTranslator(uidgid.NewUnprivilegedMapper()),
-			Logger:     logger.Session("uid-namespacer"),
-		}
-	} else {
-		privilegedNamespacer = uidgid.NoopNamespacer{}
-		unprivilegedNamespacer = uidgid.NoopNamespacer{}
-	}
-
-	if cmd.PrivilegedMode != bespec.FullPrivilegedMode {
-		privilegedNamespacer = unprivilegedNamespacer
-	}
-
-	return privilegedNamespacer, unprivilegedNamespacer
 }
 
 func (cmd *BaggageclaimCommand) constructLogger() (lager.Logger, *lager.ReconfigurableSink) {

--- a/worker/baggageclaim/baggageclaimcmd/command_linux.go
+++ b/worker/baggageclaim/baggageclaimcmd/command_linux.go
@@ -1,0 +1,139 @@
+//go:build linux
+
+package baggageclaimcmd
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+
+	"code.cloudfoundry.org/lager/v3"
+	"github.com/concourse/concourse/worker/baggageclaim/api"
+	"github.com/concourse/concourse/worker/baggageclaim/uidgid"
+	"github.com/concourse/concourse/worker/baggageclaim/volume"
+	bespec "github.com/concourse/concourse/worker/runtime/spec"
+	"github.com/concourse/flag/v2"
+	"github.com/tedsuo/ifrit"
+	"github.com/tedsuo/ifrit/grouper"
+	"github.com/tedsuo/ifrit/http_server"
+)
+
+type BaggageclaimCommand struct {
+	Logger flag.Lager
+
+	BindIP   flag.IP `long:"bind-ip"   default:"127.0.0.1" description:"IP address on which to listen for API traffic."`
+	BindPort uint16  `long:"bind-port" default:"7788"      description:"Port on which to listen for API traffic."`
+
+	DebugBindIP   flag.IP `long:"debug-bind-ip"   default:"127.0.0.1" description:"IP address on which to listen for the pprof debugger endpoints."`
+	DebugBindPort uint16  `long:"debug-bind-port" default:"7787"      description:"Port on which to listen for the pprof debugger endpoints."`
+
+	P2pInterfaceNamePattern string `long:"p2p-interface-name-pattern" default:"eth0" description:"Regular expression to match a network interface for p2p streaming"`
+	P2pInterfaceFamily      int    `long:"p2p-interface-family" default:"4" choice:"4" choice:"6" description:"4 for IPv4 and 6 for IPv6"`
+
+	VolumesDir flag.Dir `long:"volumes" required:"true" description:"Directory in which to place volume data."`
+
+	Driver string `long:"driver" default:"detect" choice:"detect" choice:"naive" choice:"btrfs" choice:"overlay" description:"Driver to use for managing volumes."`
+
+	BtrfsBin string `long:"btrfs-bin" default:"btrfs" description:"Path to btrfs binary"`
+	MkfsBin  string `long:"mkfs-bin" default:"mkfs.btrfs" description:"Path to mkfs.btrfs binary"`
+
+	OverlaysDir string `long:"overlays-dir" description:"Path to directory in which to store overlay data"`
+
+	DisableUserNamespaces bool `long:"disable-user-namespaces" description:"Disable remapping of user/group IDs in unprivileged volumes."`
+
+	// We don't expose PrivilegedMode here as a flag because we want the value
+	// passed in from the Containerd struct
+	PrivilegedMode bespec.PrivilegedMode `hidden:"true"`
+}
+
+func (cmd *BaggageclaimCommand) Runner(args []string) (ifrit.Runner, error) {
+	logger, _ := cmd.constructLogger()
+
+	listenAddr := fmt.Sprintf("%s:%d", cmd.BindIP.IP, cmd.BindPort)
+
+	privilegedNamespacer, unprivilegedNamespacer := cmd.SelectNamespacers(logger)
+
+	locker := volume.NewLockManager()
+
+	driver, err := cmd.driver(logger)
+	if err != nil {
+		logger.Error("failed-to-set-up-driver", err)
+		return nil, err
+	}
+
+	filesystem, err := volume.NewFilesystem(driver, cmd.VolumesDir.Path())
+	if err != nil {
+		logger.Error("failed-to-initialize-filesystem", err)
+		return nil, err
+	}
+
+	err = driver.Recover(filesystem)
+	if err != nil {
+		logger.Error("failed-to-recover-volume-driver", err)
+		return nil, err
+	}
+
+	volumeRepo := volume.NewRepository(
+		filesystem,
+		locker,
+		privilegedNamespacer,
+		unprivilegedNamespacer,
+	)
+
+	re, err := regexp.Compile(cmd.P2pInterfaceNamePattern)
+	if err != nil {
+		logger.Error("failed-to-compile-p2p-interface-name-pattern", err)
+		return nil, err
+	}
+	apiHandler, err := api.NewHandler(
+		logger.Session("api"),
+		volume.NewStrategerizer(),
+		volumeRepo,
+		re,
+		cmd.P2pInterfaceFamily,
+		cmd.BindPort,
+	)
+	if err != nil {
+		logger.Fatal("failed-to-create-handler", err)
+	}
+
+	members := []grouper.Member{
+		{Name: "api", Runner: http_server.New(listenAddr, apiHandler)},
+		{Name: "debug-server", Runner: http_server.New(
+			cmd.debugBindAddr(),
+			http.DefaultServeMux,
+		)},
+	}
+
+	return onReady(grouper.NewParallel(os.Interrupt, members), func() {
+		logger.Info("listening", lager.Data{
+			"addr": listenAddr,
+		})
+	}), nil
+}
+
+func (cmd *BaggageclaimCommand) SelectNamespacers(logger lager.Logger) (uidgid.Namespacer, uidgid.Namespacer) {
+	var privilegedNamespacer, unprivilegedNamespacer uidgid.Namespacer
+
+	if !cmd.DisableUserNamespaces && uidgid.Supported() {
+		privilegedNamespacer = &uidgid.UidNamespacer{
+			Translator: uidgid.NewTranslator(uidgid.NewPrivilegedMapper()),
+			Logger:     logger.Session("uid-namespacer"),
+		}
+
+		unprivilegedNamespacer = &uidgid.UidNamespacer{
+			Translator: uidgid.NewTranslator(uidgid.NewUnprivilegedMapper()),
+			Logger:     logger.Session("uid-namespacer"),
+		}
+	} else {
+		privilegedNamespacer = uidgid.NoopNamespacer{}
+		unprivilegedNamespacer = uidgid.NoopNamespacer{}
+	}
+
+	if cmd.PrivilegedMode != bespec.FullPrivilegedMode {
+		privilegedNamespacer = unprivilegedNamespacer
+	}
+
+	return privilegedNamespacer, unprivilegedNamespacer
+}

--- a/worker/baggageclaim/baggageclaimcmd/command_nonlinux.go
+++ b/worker/baggageclaim/baggageclaimcmd/command_nonlinux.go
@@ -1,0 +1,100 @@
+//go:build !linux
+
+package baggageclaimcmd
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+
+	"code.cloudfoundry.org/lager/v3"
+	"github.com/concourse/concourse/worker/baggageclaim/api"
+	"github.com/concourse/concourse/worker/baggageclaim/uidgid"
+	"github.com/concourse/concourse/worker/baggageclaim/volume"
+	"github.com/concourse/flag/v2"
+	"github.com/tedsuo/ifrit"
+	"github.com/tedsuo/ifrit/grouper"
+	"github.com/tedsuo/ifrit/http_server"
+)
+
+type BaggageclaimCommand struct {
+	Logger flag.Lager
+
+	BindIP   flag.IP `long:"bind-ip"   default:"127.0.0.1" description:"IP address on which to listen for API traffic."`
+	BindPort uint16  `long:"bind-port" default:"7788"      description:"Port on which to listen for API traffic."`
+
+	DebugBindIP   flag.IP `long:"debug-bind-ip"   default:"127.0.0.1" description:"IP address on which to listen for the pprof debugger endpoints."`
+	DebugBindPort uint16  `long:"debug-bind-port" default:"7787"      description:"Port on which to listen for the pprof debugger endpoints."`
+
+	P2pInterfaceNamePattern string `long:"p2p-interface-name-pattern" default:"eth0" description:"Regular expression to match a network interface for p2p streaming"`
+	P2pInterfaceFamily      int    `long:"p2p-interface-family" default:"4" choice:"4" choice:"6" description:"4 for IPv4 and 6 for IPv6"`
+
+	VolumesDir flag.Dir `long:"volumes" required:"true" description:"Directory in which to place volume data."`
+
+	Driver string `long:"driver" default:"detect" choice:"detect" choice:"naive" description:"Driver to use for managing volumes."`
+}
+
+func (cmd *BaggageclaimCommand) Runner(args []string) (ifrit.Runner, error) {
+	logger, _ := cmd.constructLogger()
+
+	listenAddr := fmt.Sprintf("%s:%d", cmd.BindIP.IP, cmd.BindPort)
+
+	locker := volume.NewLockManager()
+
+	driver, err := cmd.driver(logger)
+	if err != nil {
+		logger.Error("failed-to-set-up-driver", err)
+		return nil, err
+	}
+
+	filesystem, err := volume.NewFilesystem(driver, cmd.VolumesDir.Path())
+	if err != nil {
+		logger.Error("failed-to-initialize-filesystem", err)
+		return nil, err
+	}
+
+	err = driver.Recover(filesystem)
+	if err != nil {
+		logger.Error("failed-to-recover-volume-driver", err)
+		return nil, err
+	}
+
+	volumeRepo := volume.NewRepository(
+		filesystem,
+		locker,
+		uidgid.NoopNamespacer{},
+		uidgid.NoopNamespacer{},
+	)
+
+	re, err := regexp.Compile(cmd.P2pInterfaceNamePattern)
+	if err != nil {
+		logger.Error("failed-to-compile-p2p-interface-name-pattern", err)
+		return nil, err
+	}
+	apiHandler, err := api.NewHandler(
+		logger.Session("api"),
+		volume.NewStrategerizer(),
+		volumeRepo,
+		re,
+		cmd.P2pInterfaceFamily,
+		cmd.BindPort,
+	)
+	if err != nil {
+		logger.Fatal("failed-to-create-handler", err)
+	}
+
+	members := []grouper.Member{
+		{Name: "api", Runner: http_server.New(listenAddr, apiHandler)},
+		{Name: "debug-server", Runner: http_server.New(
+			cmd.debugBindAddr(),
+			http.DefaultServeMux,
+		)},
+	}
+
+	return onReady(grouper.NewParallel(os.Interrupt, members), func() {
+		logger.Info("listening", lager.Data{
+			"addr": listenAddr,
+		})
+	}), nil
+}

--- a/worker/runtime/backend.go
+++ b/worker/runtime/backend.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 // Package backend provides the implementation of a Garden server backed by
 // containerd.
 //

--- a/worker/runtime/backend_test.go
+++ b/worker/runtime/backend_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime_test
 
 import (

--- a/worker/runtime/cni_network.go
+++ b/worker/runtime/cni_network.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (

--- a/worker/runtime/container.go
+++ b/worker/runtime/container.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (

--- a/worker/runtime/errors.go
+++ b/worker/runtime/errors.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import "errors"

--- a/worker/runtime/file_store.go
+++ b/worker/runtime/file_store.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (

--- a/worker/runtime/killer.go
+++ b/worker/runtime/killer.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (

--- a/worker/runtime/network.go
+++ b/worker/runtime/network.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (

--- a/worker/runtime/process.go
+++ b/worker/runtime/process.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (

--- a/worker/runtime/process_killer.go
+++ b/worker/runtime/process_killer.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (
@@ -37,13 +39,13 @@ func NewProcessKiller() *processKiller {
 // ErrGracePeriodTimeout is returned.
 //
 // ps.: even in the case of a SIGKILL being used as the signal, `Kill` will
-//      wait for a `waitPeriod` for a status to be reported back. This way one
-//      can detect cases where not even a SIGKILL changes the status of a
-//      process (e.g., if the process is frozen due to a blocking syscall that
-//      never returns, or because it's suspended - see [1]).
+//
+//	wait for a `waitPeriod` for a status to be reported back. This way one
+//	can detect cases where not even a SIGKILL changes the status of a
+//	process (e.g., if the process is frozen due to a blocking syscall that
+//	never returns, or because it's suspended - see [1]).
 //
 // [1]: https://github.com/concourse/concourse/issues/4477
-//
 func (p processKiller) Kill(
 	ctx context.Context,
 	proc containerd.Process,

--- a/worker/runtime/properties.go
+++ b/worker/runtime/properties.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (
@@ -20,7 +22,6 @@ import (
 // key.1: ...second chunk of value...
 // ...
 // key.n: ...last chunk of value
-//
 func propertiesToLabels(properties garden.Properties) (map[string]string, error) {
 	// Hard restriction on the total length of key + value imposed by
 	// containerd on a per-label basis.
@@ -63,7 +64,6 @@ func propertiesToLabels(properties garden.Properties) (map[string]string, error)
 // order.
 //
 // Any labels that aren't of the correct format (i.e. key.n) will be ignored.
-//
 func labelsToProperties(labels map[string]string) garden.Properties {
 	properties := garden.Properties{}
 	for len(labels) > 0 {
@@ -113,19 +113,18 @@ func labelsToProperties(labels map[string]string) garden.Properties {
 //
 // containerd filters are in the form of
 //
-//           <what>.<field><operator><value>
+//	<what>.<field><operator><value>
 //
 // which, in our very specific case of properties, means
 //
-//           labels.foo==bar
-//           |      |  | value
-//           |      |  equality
-//           |      key
-//           what
+//	labels.foo==bar
+//	|      |  | value
+//	|      |  equality
+//	|      key
+//	what
 //
 // note that the key in this case represents the label key, which is not the
 // same as the property key - refer to propertiesToLabels.
-//
 func propertiesToFilterList(properties garden.Properties) ([]string, error) {
 	for k, v := range properties {
 		if k == "" || v == "" {

--- a/worker/runtime/resolvconf_parser.go
+++ b/worker/runtime/resolvconf_parser.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (

--- a/worker/runtime/rootfs_manager.go
+++ b/worker/runtime/rootfs_manager.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (
@@ -33,7 +35,6 @@ const (
 
 // RootfsManager is responsible for mutating and reading from the rootfs of a
 // container.
-//
 type RootfsManager interface {
 	// SetupCwd mutates the root filesystem to guarantee the presence of a
 	// directory to be used as `cwd`.
@@ -48,12 +49,10 @@ type RootfsManager interface {
 
 // RootfsManagerOpt defines a functional option that when applied, modifies the
 // configuration of a rootfsManager.
-//
 type RootfsManagerOpt func(m *rootfsManager)
 
 // WithMkdirAll configures the function to be used for creating directories
 // recursively.
-//
 func WithMkdirAll(f func(path string, mode os.FileMode) error) RootfsManagerOpt {
 	return func(m *rootfsManager) {
 		m.mkdirall = f
@@ -67,7 +66,6 @@ type rootfsManager struct {
 var _ RootfsManager = (*rootfsManager)(nil)
 
 // NewRootfsManager instantiates a rootfsManager
-//
 func NewRootfsManager(opts ...RootfsManagerOpt) *rootfsManager {
 	m := &rootfsManager{
 		mkdirall: os.MkdirAll,

--- a/worker/runtime/spec/capabilities.go
+++ b/worker/runtime/spec/capabilities.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package spec
 
 import "github.com/opencontainers/runtime-spec/specs-go"
@@ -10,7 +12,7 @@ func OciCapabilities(privilegedMode PrivilegedMode, privileged bool) specs.Linux
 	if privilegedMode == FUSEOnlyPrivilegedMode {
 		return FUSEOnlyContainerCapabilities
 	}
-	
+
 	return PrivilegedContainerCapabilities
 }
 
@@ -70,7 +72,7 @@ var (
 		"CAP_SYS_CHROOT",
 		"CAP_SYS_ADMIN",
 	}
-	
+
 	privilegedCaps = []string{
 		"CAP_AUDIT_CONTROL",
 		"CAP_AUDIT_READ",

--- a/worker/runtime/spec/devices.go
+++ b/worker/runtime/spec/devices.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package spec
 
 import (

--- a/worker/runtime/spec/mounts.go
+++ b/worker/runtime/spec/mounts.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package spec
 
 import (

--- a/worker/runtime/spec/namespaces.go
+++ b/worker/runtime/spec/namespaces.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package spec
 
 import (

--- a/worker/runtime/spec/seccomp.go
+++ b/worker/runtime/spec/seccomp.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package spec
 
 import "github.com/opencontainers/runtime-spec/specs-go"

--- a/worker/runtime/spec/spec.go
+++ b/worker/runtime/spec/spec.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package spec
 
 import (

--- a/worker/runtime/spec/spec_nonlinux.go
+++ b/worker/runtime/spec/spec_nonlinux.go
@@ -1,0 +1,1 @@
+package spec

--- a/worker/runtime/timeout_lock.go
+++ b/worker/runtime/timeout_lock.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (

--- a/worker/runtime/user_namespace.go
+++ b/worker/runtime/user_namespace.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package runtime
 
 import (
@@ -44,14 +46,13 @@ func maxValidFromFile(fname string) (uint32, error) {
 //
 // For example, given the following mapping from /proc/self/uid_map:
 //
-// 	0 1001 10
-// 	| |    |
-// 	| |    max number of ids inside this mapping (3)
-// 	| id outside (usually, the host)             (2)
-// 	id inside the container                      (1)
+//	0 1001 10
+//	| |    |
+//	| |    max number of ids inside this mapping (3)
+//	| id outside (usually, the host)             (2)
+//	id inside the container                      (1)
 //
 // it determines that the maximum valid user id in this mapping is 9.
-//
 //
 // More information about semantics of `uid_map` and `gid_map` can be found in
 // [user_namespaces], but here's a summary assuming the processes reading the
@@ -60,24 +61,24 @@ func maxValidFromFile(fname string) (uint32, error) {
 //   - each line specifies a 1:1 mapping of a range of contiguous user/group IDs
 //     between two user namespaces
 //
-//       - (1) is the start of the range of ids in the user namespace of the
-//             process $pid
-//       - (2) is the start of the range of ids to which the user IDs specified
-//             in (1) map to in the parent user namespace
-//       - (3) is the length of the range of user/group IDs that is mapped
-//             between the two user namespaces
+//   - (1) is the start of the range of ids in the user namespace of the
+//     process $pid
+//
+//   - (2) is the start of the range of ids to which the user IDs specified
+//     in (1) map to in the parent user namespace
+//
+//   - (3) is the length of the range of user/group IDs that is mapped
+//     between the two user namespaces
 //
 //     where:
-//        i. (1), (2), and (3) are uint32, with (3) having to be > 0
-//       ii. the max number of lines is eiter 5 (linux <= 4.14) or 350 (linux >
-//           4.14)
-//      iii. range of ids in each line cannot overlap with the ranges in any
-//           other lines
-//       iv. at least one line must exist
-//
+//     i. (1), (2), and (3) are uint32, with (3) having to be > 0
+//     ii. the max number of lines is eiter 5 (linux <= 4.14) or 350 (linux >
+//     4.14)
+//     iii. range of ids in each line cannot overlap with the ranges in any
+//     other lines
+//     iv. at least one line must exist
 //
 // [user_namespaces]: http://man7.org/linux/man-pages/man7/user_namespaces.7.html
-//
 func MaxValid(r io.Reader) (uint32, error) {
 	scanner := bufio.NewScanner(r)
 

--- a/worker/workercmd/containerd.go
+++ b/worker/workercmd/containerd.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package workercmd
 

--- a/worker/workercmd/worker_nonlinux.go
+++ b/worker/workercmd/worker_nonlinux.go
@@ -60,7 +60,5 @@ func (cmd *WorkerCommand) baggageclaimRunner(logger lager.Logger) (ifrit.Runner,
 
 	cmd.Baggageclaim.VolumesDir = flag.Dir(volumesDir)
 
-	cmd.Baggageclaim.OverlaysDir = filepath.Join(cmd.WorkDir.Path(), "overlays")
-
 	return cmd.Baggageclaim.Runner(nil)
 }


### PR DESCRIPTION
## Changes proposed by this PR

We've had a few PR's that are specific to our linux-containerd implementation: #9017 and #9094

After these PR's, folks in the community found that they couldn't compile Concourse for non-Linux platforms. This PR tries to make it easier for future contributors to make changes to the containerd-linux runtime and not accidentally break things for non-linux platforms.


## Notes to reviewer

To locally build and verify you can run the following in the root of the main repo:
```
GOOS=windows GOARCH=amd64 go build -o ./windows.exe ./cmd/concourse
GOOS=darwin GOARCH=amd64 go build -o ./darwin ./cmd/concourse
```
