### PR TITLE
Fix `--team` flag in `order-pipelines` command 

### DIFF
--- a/fly/commands/ordering_pipeline.go
+++ b/fly/commands/ordering_pipeline.go
@@ -36,10 +36,16 @@ func (command *OrderPipelinesCommand) Execute(args []string) error {
 		return err
 	}
 
+	var team concourse.Team
+	team, err = command.Team.LoadTeam(target)
+	if err != nil {
+		return err
+	}
+
 	var orderedNames []string
 	if command.Alphabetical {
 		seen := map[string]bool{}
-		ps, err := target.Team().ListPipelines()
+		ps, err := team.ListPipelines()
 		if err != nil {
 			return err
 		}
@@ -58,12 +64,6 @@ func (command *OrderPipelinesCommand) Execute(args []string) error {
 			}
 		}
 		orderedNames = command.Pipelines
-	}
-
-	var team concourse.Team
-	team, err = command.Team.LoadTeam(target)
-	if err != nil {
-		return err
 	}
 
 	err = team.OrderingPipelines(orderedNames)

--- a/fly/integration/error_handling_test.go
+++ b/fly/integration/error_handling_test.go
@@ -194,6 +194,8 @@ var _ = Describe("Fly CLI", func() {
 				exec.Command(flyPath, "-t", targetName, "destroy-pipeline", "-p", "pipeline", "--team", otherTeam)),
 			Entry("get-pipeline command returns an error",
 				exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "pipeline", "--team", otherTeam)),
+			Entry("order-pipelines command returns an error",
+				exec.Command(flyPath, "-t", targetName, "order-pipelines", "-p", "pipeline", "--team", otherTeam)),
 			Entry("abort-build command returns an error",
 				exec.Command(flyPath, "-t", targetName, "abort-build", "-j", "pipeline/job", "-b", "4", "--team", otherTeam)),
 			Entry("archive-pipeline command returns an error",


### PR DESCRIPTION
## Changes proposed by this PR
 
The order-pipelines command with the --team option does not seem to work as expected. If you attempt to order pipelines from a team different from the one you are logged into, the operation will fail.

closes #9099
related to item in #5215

* [x] implement fix
* [x] add tests

## Notes to reviewer
Sample scenario: If you are logged into the main team (which has two pipelines: sample1 and sample2) and attempt to order pipelines from other-team (which has test1 and test2), the command will fail with the following error:
```sh
> fly -t lc order-pipelines  --alphabetical --team other-team
failed to order pipelines: pipeline 'sample' not found
```
This suggests that the --team option is not correctly switching context to the specified team, causing the command to reference pipelines from the currently logged-in team instead.


## Release Note

* Fix `order-pipelines` command with `--team` Option
