### PR TITLE
worker: fix baggageclaim tests on windows

### DIFF
--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -122,7 +122,6 @@ var _ = AfterSuite(func() {
 })
 
 func setReleaseNameAndNamespace(description string) {
-	rand.Seed(time.Now().UTC().UnixNano())
 	releaseName = fmt.Sprintf("topgun-"+description+"-%d", rand.Int63n(100000000))
 	namespace = releaseName
 }

--- a/tsa/random_atc_endpoint_picker.go
+++ b/tsa/random_atc_endpoint_picker.go
@@ -2,7 +2,6 @@ package tsa
 
 import (
 	"math/rand"
-	"time"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/flag/v2"
@@ -18,8 +17,6 @@ func NewRandomATCEndpointPicker(atcURLFlags []flag.URL) EndpointPicker {
 	for _, f := range atcURLFlags {
 		atcEndpoints = append(atcEndpoints, rata.NewRequestGenerator(f.String(), atc.Routes))
 	}
-
-	rand.Seed(time.Now().Unix())
 
 	return &randomATCEndpointPicker{
 		ATCEndpoints: atcEndpoints,

--- a/worker/baggageclaim/baggageclaimcmd/command_nonlinux.go
+++ b/worker/baggageclaim/baggageclaimcmd/command_nonlinux.go
@@ -32,6 +32,8 @@ type BaggageclaimCommand struct {
 
 	VolumesDir flag.Dir `long:"volumes" required:"true" description:"Directory in which to place volume data."`
 
+	OverlaysDir string `long:"overlays-dir" description:"Path to directory in which to store overlay data"`
+
 	Driver string `long:"driver" default:"detect" choice:"detect" choice:"naive" description:"Driver to use for managing volumes."`
 }
 

--- a/worker/baggageclaim/integration/baggageclaim/suite_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/suite_test.go
@@ -30,8 +30,6 @@ var ctx = context.Background()
 var baggageClaimPath string
 
 func TestIntegration(t *testing.T) {
-	rand.Seed(time.Now().Unix())
-
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Baggage Claim Suite")
 }

--- a/worker/baggageclaim/integration/fs_mounter/suite_test.go
+++ b/worker/baggageclaim/integration/fs_mounter/suite_test.go
@@ -2,10 +2,8 @@ package integration_test
 
 import (
 	"encoding/json"
-	"math/rand"
 	"runtime"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,8 +18,6 @@ func TestIntegration(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		suiteName = suiteName + " - skipping btrfs tests because non-linux"
 	}
-
-	rand.Seed(time.Now().Unix())
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, suiteName)

--- a/worker/workercmd/worker_nonlinux.go
+++ b/worker/workercmd/worker_nonlinux.go
@@ -60,5 +60,7 @@ func (cmd *WorkerCommand) baggageclaimRunner(logger lager.Logger) (ifrit.Runner,
 
 	cmd.Baggageclaim.VolumesDir = flag.Dir(volumesDir)
 
+	cmd.Baggageclaim.OverlaysDir = filepath.Join(cmd.WorkDir.Path(), "overlays")
+
 	return cmd.Baggageclaim.Runner(nil)
 }


### PR DESCRIPTION
## Changes proposed by this PR

Follow-up to #9101 which broke baggageclaim tests on windows.

Removed call to `rand.Seed()` since it's a no-op starting in Go 1.24