### PR TITLE
feat: increase footer hide delay from 4 to 8 seconds

### DIFF
--- a/web/elm/src/Dashboard/Footer.elm
+++ b/web/elm/src/Dashboard/Footer.elm
@@ -61,7 +61,7 @@ handleDelivery delivery ( model, effects ) =
             ( { model | hideFooter = False, hideFooterCounter = 0 }, effects )
 
         ClockTicked OneSecond _ ->
-            ( if model.hideFooterCounter > 4 then
+            ( if model.hideFooterCounter > 8 then
                 { model | hideFooter = True }
 
               else

--- a/web/elm/tests/DashboardTests.elm
+++ b/web/elm/tests/DashboardTests.elm
@@ -597,7 +597,7 @@ all =
                                 [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                         )
                     |> Tuple.first
-                    |> afterSeconds 6
+                    |> afterSeconds 10
                     |> Common.queryView
                     |> Query.find [ id "page-below-top-bar" ]
                     |> Query.hasNot [ style "padding-bottom" "50px" ]
@@ -1846,7 +1846,7 @@ all =
                             |> Query.find [ id "concourse-info" ]
                             |> Query.has [ text "v1.2.3" ]
                 ]
-            , test "hides after 6 seconds" <|
+            , test "hides after 10 seconds" <|
                 \_ ->
                     Common.init "/"
                         |> givenDataUnauthenticated (apiData [ ( "team", [] ) ])
@@ -1857,7 +1857,7 @@ all =
                                     [ Data.pipeline "team" 0 |> Data.withName "pipeline" ]
                             )
                         |> Tuple.first
-                        |> afterSeconds 6
+                        |> afterSeconds 10
                         |> Common.queryView
                         |> Query.hasNot [ id "dashboard-info" ]
             , test "reappears on mouse action" <|


### PR DESCRIPTION
Users reported the footer disappearing too quickly. The extended delay provides a better experience.

# Release Note

* Web footer timeout has been increased from 4 seconds to 8 seconds