### PR TITLE
Fix: Preserve existing browser session during `fly login`

### DIFF
--- a/web/public/elm-setup.js
+++ b/web/public/elm-setup.js
@@ -116,7 +116,7 @@ window.addEventListener('storage', function(event) {
   if (event.key === csrfTokenKey || event.key === favoritedPipelinesKey || event.key === favoritedInstanceGroupsKey) {
     const value = localStorage.getItem(event.key);
     setTimeout(function() {
-      app.ports.receivedFromLocalStorage.send([event.key, value]);
+      app.ports.receivedFromLocalStorage.send([event.key, JSON.parse(value)]);
     }, 0);
   }
 }, false);


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to Concourse!

If you haven't already, feel free to [add yourself] as a contributor so that
you can add labels to your PR and re-trigger its builds if they fail.

Also check the [PR requirements] if you haven't already!
-->

[add yourself]: https://github.com/concourse/governance#individual-contributors
[PR requirements]: https://github.com/concourse/concourse/blob/master/CONTRIBUTING.md#pull-request-requirements

## Changes proposed by this PR
This PR addresses the issue where logging in through the browser UI via `fly login` would invalidate the existing browser session. The solution ensures that existing sessions remain active after the login process, preventing users from being logged out unexpectedly.

closes #8868

<!--
Summarize your changes as a checklist, leaving any unfinished work as unchecked
items. Please include reasoning and key decisions to help the reviewer
understand the changes.
-->

* [x] update parsing of `csrf_token` to Elm app

## Notes to reviewer

The implementation enhances the process of sending the `csrf_token` to the Elm app, which then forwards the token to the web server. Previously, the value sent in the `X-Csrf-Token` header was enclosed in quotes, like this:
```sh
X-Csrf-Token: "redacted"
```
This caused an error when comparing the CSRF token from the cookie and the header in the [web server](https://github.com/concourse/concourse/blob/6984e4d30a35f378d31d5897c5a6da2606b62f58/atc/api/auth/csrf_validation_handler.go#L50).   
After the change, the `X-Csrf-Token` header now looks like:
```sh
X-Csrf-Token: redacted
```
This adjustment ensures that the server can properly validate the token.
<!--
If needed, leave any special pointers for reviewing or testing your PR.
-->

## Release Note

<!--
Your PR title will be directly included in the release notes when it ships in
the next Concourse release. It should briefly describe the PR in [imperative
mood]. Please refrain from adding prefixes like 'feature:', and don't include a
period at the end.

Within this section you may supply a list of extra information to include in
the release notes in addition to the pull request title.

Example title: Introduce new pipeline UI algorithm

Example notes:

* Reticulating splines is the new process Concourse uses to create the network
  of lines between jobs.
* Combines many short lines and curves into a network of splines.

If there are no additional notes necessary you may remove this entire section.
-->

* Fix: Corrected CSRF token header format for proper validation.

[imperative mood]: https://chris.beams.io/posts/git-commit/#imperative
