### PR TITLE
Add ESC key shortcut to hide keyboard help

### DIFF
--- a/web/elm/src/Build/Shortcuts.elm
+++ b/web/elm/src/Build/Shortcuts.elm
@@ -157,6 +157,13 @@ handleKeyPressed keyEvent ( model, effects ) =
             ( Keyboard.Slash, True ) ->
                 ( { newModel | showHelp = not newModel.showHelp }, effects )
 
+            ( Keyboard.Escape, False ) ->
+                if model.showHelp then
+                    ( { newModel | showHelp = False }, effects )
+
+                else
+                    ( newModel, effects )
+
             ( Keyboard.H, False ) ->
                 case nextHistoryItem model.history (historyItem model) of
                     Just item ->


### PR DESCRIPTION
- Modified handleKeyPressed function to detect Escape key presses
- Added conditional logic to hide help panel when ESC is pressed and help is visible
- Follows common UI patterns where ESC dismisses overlays rather than toggling them

# Release Note

* Can use the Escape key to close the Help menu in the Web UI
