### PR TITLE
Use math/rand/v2

### DIFF
--- a/atc/atccmd/command.go
+++ b/atc/atccmd/command.go
@@ -7,7 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -2103,6 +2103,6 @@ func (cmd *RunCommand) isMTLSEnabled() bool {
 type rander struct{}
 
 func (r rander) Int() int {
-	// The global rand is thread-safe.
+	// math/rand/v2 uses per-goroutine generators, avoiding lock contention
 	return rand.Int()
 }

--- a/atc/db/migration/migration_test.go
+++ b/atc/db/migration/migration_test.go
@@ -3,7 +3,7 @@ package migration_test
 import (
 	"database/sql"
 	"io/fs"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -576,17 +576,15 @@ func ExpectDatabaseMigrationVersionToEqual(migrator migration.Migrator, expected
 }
 
 func ExpectToBeAbleToInsertData(dbConn *sql.DB) {
-	rand.Seed(time.Now().UnixNano())
-
-	teamID := rand.Intn(10000)
+	teamID := rand.IntN(10000)
 	_, err := dbConn.Exec("INSERT INTO teams(id, name) VALUES ($1, $2)", teamID, strconv.Itoa(teamID))
 	Expect(err).NotTo(HaveOccurred())
 
-	pipelineID := rand.Intn(10000)
+	pipelineID := rand.IntN(10000)
 	_, err = dbConn.Exec("INSERT INTO pipelines(id, team_id, name) VALUES ($1, $2, $3)", pipelineID, teamID, strconv.Itoa(pipelineID))
 	Expect(err).NotTo(HaveOccurred())
 
-	jobID := rand.Intn(10000)
+	jobID := rand.IntN(10000)
 	_, err = dbConn.Exec("INSERT INTO jobs(id, pipeline_id, name, config) VALUES ($1, $2, $3, '{}')", jobID, pipelineID, strconv.Itoa(jobID))
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/atc/integration/team_migration_test.go
+++ b/atc/integration/team_migration_test.go
@@ -2,7 +2,7 @@ package integration_test
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"time"
@@ -88,7 +88,7 @@ var characterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXY
 func randomString() string {
 	b := make([]rune, 50)
 	for i := range b {
-		b[i] = characterRunes[rand.Intn(len(characterRunes))]
+		b[i] = characterRunes[rand.IntN(len(characterRunes))]
 	}
 	return string(b)
 }

--- a/atc/worker/placement.go
+++ b/atc/worker/placement.go
@@ -3,7 +3,7 @@ package worker
 import (
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"strings"
 

--- a/atc/worker/pool.go
+++ b/atc/worker/pool.go
@@ -3,7 +3,7 @@ package worker
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"strings"
 	"time"
@@ -349,7 +349,7 @@ func (pool Pool) CreateVolumeForArtifact(ctx context.Context, spec Spec) (runtim
 		return nil, nil, err
 	}
 
-	worker := pool.factory.NewWorker(logger, compatibleWorkers[rand.Intn(len(compatibleWorkers))])
+	worker := pool.factory.NewWorker(logger, compatibleWorkers[rand.IntN(len(compatibleWorkers))])
 	return worker.CreateVolumeForArtifact(ctx, spec.TeamID)
 }
 

--- a/topgun/k8s/k8s_suite_test.go
+++ b/topgun/k8s/k8s_suite_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -122,7 +122,7 @@ var _ = AfterSuite(func() {
 })
 
 func setReleaseNameAndNamespace(description string) {
-	releaseName = fmt.Sprintf("topgun-"+description+"-%d", rand.Int63n(100000000))
+	releaseName = fmt.Sprintf("topgun-"+description+"-%d", rand.Int64N(100000000))
 	namespace = releaseName
 }
 

--- a/tsa/client.go
+++ b/tsa/client.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"strings"

--- a/tsa/random_atc_endpoint_picker.go
+++ b/tsa/random_atc_endpoint_picker.go
@@ -1,7 +1,7 @@
 package tsa
 
 import (
-	"math/rand"
+	"math/rand/v2"
 
 	"github.com/concourse/concourse/atc"
 	"github.com/concourse/flag/v2"
@@ -24,5 +24,5 @@ func NewRandomATCEndpointPicker(atcURLFlags []flag.URL) EndpointPicker {
 }
 
 func (p *randomATCEndpointPicker) Pick() *rata.RequestGenerator {
-	return p.ATCEndpoints[rand.Intn(len(p.ATCEndpoints))]
+	return p.ATCEndpoints[rand.IntN(len(p.ATCEndpoints))]
 }

--- a/worker/baggageclaim/integration/baggageclaim/suite_test.go
+++ b/worker/baggageclaim/integration/baggageclaim/suite_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"os/exec"
@@ -162,7 +162,7 @@ func randSeq(n int) string {
 
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[rand.IntN(len(letters))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
This commit updates the rander.Int() implementation to use Go 1.22's math/rand/v2 package. The new rand package provides per-goroutine random generators, eliminating lock contention that existed with the previous global random source.
