### PR TITLE
Support custom pipeline background image styling

### DIFF
--- a/atc/config.go
+++ b/atc/config.go
@@ -213,7 +213,8 @@ type Prototype struct {
 }
 
 type DisplayConfig struct {
-	BackgroundImage string `json:"background_image,omitempty"`
+	BackgroundImage  string `json:"background_image,omitempty"`
+	BackgroundFilter string `json:"background_filter,omitempty"`
 }
 
 type CheckEvery struct {

--- a/web/elm/src/Concourse.elm
+++ b/web/elm/src/Concourse.elm
@@ -1117,6 +1117,7 @@ type alias Pipeline =
     , teamName : TeamName
     , groups : List PipelineGroup
     , backgroundImage : Maybe String
+    , backgroundFilter : Maybe String
     }
 
 
@@ -1139,6 +1140,7 @@ encodePipeline pipeline =
         , ( "team_name", pipeline.teamName |> Json.Encode.string )
         , ( "groups", pipeline.groups |> Json.Encode.list encodePipelineGroup )
         , ( "display", Json.Encode.object [ ( "background_image", pipeline.backgroundImage |> Json.Encode.Extra.maybe Json.Encode.string ) ] )
+        , ( "display", Json.Encode.object [ ( "background_filter", pipeline.backgroundFilter |> Json.Encode.Extra.maybe Json.Encode.string ) ] )
         ]
 
 
@@ -1156,6 +1158,7 @@ decodePipeline =
         |> andMap (Json.Decode.field "team_name" Json.Decode.string)
         |> andMap (defaultTo [] <| Json.Decode.field "groups" (Json.Decode.list decodePipelineGroup))
         |> andMap (Json.Decode.maybe (Json.Decode.at [ "display", "background_image" ] Json.Decode.string))
+        |> andMap (Json.Decode.maybe (Json.Decode.at [ "display", "background_filter" ] Json.Decode.string))
 
 
 encodePipelineGroup : PipelineGroup -> Json.Encode.Value

--- a/web/elm/src/Dashboard/Dashboard.elm
+++ b/web/elm/src/Dashboard/Dashboard.elm
@@ -618,6 +618,7 @@ toConcoursePipeline p =
     , archived = p.archived
     , groups = []
     , backgroundImage = Maybe.Nothing
+    , backgroundFilter = Maybe.Nothing
     }
 
 

--- a/web/elm/src/Pipeline/Pipeline.elm
+++ b/web/elm/src/Pipeline/Pipeline.elm
@@ -532,7 +532,13 @@ backgroundImage pipeline =
     case pipeline of
         RemoteData.Success p ->
             p.backgroundImage
-                |> Maybe.map Styles.pipelineBackground
+                |> Maybe.map
+                    (\img ->
+                        Styles.pipelineBackground
+                            { image = img
+                            , filter = p.backgroundFilter
+                            }
+                    )
                 |> Maybe.withDefault []
 
         _ ->

--- a/web/elm/src/Pipeline/Styles.elm
+++ b/web/elm/src/Pipeline/Styles.elm
@@ -80,17 +80,16 @@ cliIcon cli =
     ]
 
 
-pipelineBackground : String -> List (Html.Attribute msg)
-pipelineBackground bg =
+pipelineBackground : { image : String, filter : Maybe String } -> List (Html.Attribute msg)
+pipelineBackground { image, filter } =
     [ style "background-image" <|
         "url(\""
-            ++ bg
+            ++ image
             ++ "\")"
     , style "background-repeat" "no-repeat"
     , style "background-size" "cover"
     , style "background-position" "center"
-    , style "opacity" "30%"
-    , style "filter" "grayscale(1)"
+    , style "filter" (Maybe.withDefault "grayscale(100%) opacity(30%)" filter)
     , style "width" "100%"
     , style "height" "100%"
     , style "position" "absolute"

--- a/web/elm/tests/Data.elm
+++ b/web/elm/tests/Data.elm
@@ -189,6 +189,7 @@ pipeline team id =
     , teamName = team
     , groups = []
     , backgroundImage = Maybe.Nothing
+    , backgroundFilter = Maybe.Nothing
     }
 
 

--- a/web/elm/tests/PipelineTests.elm
+++ b/web/elm/tests/PipelineTests.elm
@@ -314,8 +314,7 @@ all =
                         , style "background-repeat" "no-repeat"
                         , style "background-size" "cover"
                         , style "background-position" "center"
-                        , style "opacity" "30%"
-                        , style "filter" "grayscale(1)"
+                        , style "filter" "grayscale(100%) opacity(30%)"
                         ]
         , describe "update" <|
             let


### PR DESCRIPTION
Add support for configurable filter setting for pipeline background images. This enhances the visual customization options for pipelines by allowing users to set:

- Custom filter effects (defaults to grayscale(100%) opacity(30%) as before)

# Release Note

* Add `background_filter` option for pipeline background images which takes in string of [CSS filters](https://developer.mozilla.org/en-US/docs/Web/CSS/filter). Defaults to the current filters `opacity(30%) grayscale(100%)`