### PR TITLE
atc: allow identifiers to start with numbers

### DIFF
--- a/atc/api/config_test.go
+++ b/atc/api/config_test.go
@@ -376,11 +376,11 @@ var _ = Describe("Config API", func() {
 								"warnings": [
 									{
 										"type": "invalid_identifier",
-										"message": "pipeline: '_pipeline' is not a valid identifier: must start with a lowercase letter"
+										"message": "pipeline: '_pipeline' is not a valid identifier: must start with a lowercase letter or a number"
 									},
 									{
 										"type": "invalid_identifier",
-										"message": "team: '_team' is not a valid identifier: must start with a lowercase letter"
+										"message": "team: '_team' is not a valid identifier: must start with a lowercase letter or a number"
 									}
 								]
 							}`))

--- a/atc/api/pipelines_test.go
+++ b/atc/api/pipelines_test.go
@@ -1727,7 +1727,7 @@ var _ = Describe("Pipelines API", func() {
 								"warnings": [
 									{
 										"type": "invalid_identifier",
-										"message": "pipeline: '_some-new-name' is not a valid identifier: must start with a lowercase letter"
+										"message": "pipeline: '_some-new-name' is not a valid identifier: must start with a lowercase letter or a number"
 									}
 								]
 							}`))

--- a/atc/api/teams_test.go
+++ b/atc/api/teams_test.go
@@ -361,7 +361,7 @@ var _ = Describe("Teams API", func() {
 									"warnings": [
 										{
 											"type": "invalid_identifier",
-											"message": "team: '_some-team' is not a valid identifier: must start with a lowercase letter"
+											"message": "team: '_some-team' is not a valid identifier: must start with a lowercase letter or a number"
 										}
 									],
 									"team": {
@@ -576,7 +576,7 @@ var _ = Describe("Teams API", func() {
 								"warnings": [
 									{
 										"type": "invalid_identifier",
-										"message": "team: '_some-new-name' is not a valid identifier: must start with a lowercase letter"
+										"message": "team: '_some-new-name' is not a valid identifier: must start with a lowercase letter or a number"
 									}
 								]
 							}`))

--- a/atc/configwarning.go
+++ b/atc/configwarning.go
@@ -11,8 +11,9 @@ type ConfigWarning struct {
 	Message string `json:"message"`
 }
 
-var validIdentifiers = regexp.MustCompile(`^[\p{Ll}\p{Lt}\p{Lm}\p{Lo}][\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-_.]*$`)
-var startsWithLetter = regexp.MustCompile(`^[^\p{Ll}\p{Lt}\p{Lm}\p{Lo}]`)
+var validIdentifiers = regexp.MustCompile(`^[\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d][\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-_.]*$`)
+var startsWithLetterOrNumber = regexp.MustCompile(`^[^\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d]`)
+var justNumbers = regexp.MustCompile(`^\d+$`)
 var invalidCharacter = regexp.MustCompile(`([^\p{Ll}\p{Lt}\p{Lm}\p{Lo}\d\-_.])`)
 
 func ValidateIdentifier(identifier string, context ...string) (*ConfigWarning, error) {
@@ -20,23 +21,35 @@ func ValidateIdentifier(identifier string, context ...string) (*ConfigWarning, e
 		return nil, fmt.Errorf("%s: identifier cannot be an empty string", strings.Join(context, ""))
 	}
 
+	// Skip validation for specific contexts
 	contextLen := len(context)
 	if contextLen >= 2 && (strings.Contains(context[contextLen-1], "set_pipeline") || strings.Contains(context[contextLen-1], "task")) && context[contextLen-2] == ".across" {
 		return nil, nil
 	}
 
+	// Check if identifier is just numbers (still not allowed)
+	if justNumbers.MatchString(identifier) {
+		return &ConfigWarning{
+			Type:    "invalid_identifier",
+			Message: fmt.Sprintf("%s: '%s' is not a valid identifier: cannot be just numbers", strings.Join(context, ""), identifier),
+		}, nil
+	}
+
+	// Standard identifier validation
 	if !validIdentifiers.MatchString(identifier) {
 		var reason string
 
-		if startsWithLetter.MatchString(identifier) {
-			reason = "must start with a lowercase letter"
+		if startsWithLetterOrNumber.MatchString(identifier) {
+			reason = "must start with a lowercase letter or a number"
 		} else if invalidChar := invalidCharacter.Find([]byte(identifier[1:])); invalidChar != nil {
 			reason = fmt.Sprintf("illegal character '%s'", invalidChar)
 		}
+
 		return &ConfigWarning{
 			Type:    "invalid_identifier",
-			Message: fmt.Sprintf("%s: %s", strings.Join(context, ""), fmt.Sprintf("'%s' is not a valid identifier: %s", identifier, reason)),
+			Message: fmt.Sprintf("%s: '%s' is not a valid identifier: %s", strings.Join(context, ""), identifier, reason),
 		}, nil
 	}
+
 	return nil, nil
 }

--- a/atc/configwarning_test.go
+++ b/atc/configwarning_test.go
@@ -36,25 +36,29 @@ var _ = Describe("ValidateIdentifier", func() {
 		{
 			description: "starts with a number",
 			identifier:  "1something",
-			warningMsg:  "must start with a lowercase letter",
-			warning:     true,
+			warning:     false,
+		},
+		{
+			description: "starts with a number",
+			identifier:  "1_min",
+			warning:     false,
 		},
 		{
 			description: "starts with hyphen",
 			identifier:  "-something",
-			warningMsg:  "must start with a lowercase letter",
+			warningMsg:  "must start with a lowercase letter or a number",
 			warning:     true,
 		},
 		{
 			description: "starts with period",
 			identifier:  ".something",
-			warningMsg:  "must start with a lowercase letter",
+			warningMsg:  "must start with a lowercase letter or a number",
 			warning:     true,
 		},
 		{
 			description: "starts with an uppercase letter",
 			identifier:  "Something",
-			warningMsg:  "must start with a lowercase letter",
+			warningMsg:  "must start with a lowercase letter or a number",
 			warning:     true,
 		},
 		{


### PR DESCRIPTION
This change updates the identifier validation to permit identifiers that start with
numbers (e.g., "1pipeline") while keeping other validation rules intact. All identifiers
must now start with either a lowercase letter or a number, and the error messages have
been updated accordingly.

# Release Note

* Identifiers (names of pipelines/jobs/resources/steps/etc.) can start with numbers. Previously they could only start with `a-z`, otherwise Concourse would warn you that the identifier is invalid. An identifier cannot be only numbers though. `543` is invalid, but `2-days` is valid.