### PR TITLE
Remove 'set_pipeline' experimental warnings

### DIFF
--- a/atc/exec/set_pipeline_step.go
+++ b/atc/exec/set_pipeline_step.go
@@ -84,11 +84,6 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState, delegate S
 	stderr := delegate.Stderr()
 
 	if step.plan.Name == "self" {
-		fmt.Fprintln(stderr, "\x1b[1;33mWARNING: 'set_pipeline: self' is experimental and may be removed in the future!\x1b[0m")
-		fmt.Fprintln(stderr, "")
-		fmt.Fprintln(stderr, "\x1b[33mcontribute to discussion #5732 with feedback: https://github.com/concourse/concourse/discussions/5732\x1b[0m")
-		fmt.Fprintln(stderr, "")
-
 		step.plan.Name = step.metadata.PipelineName
 		step.plan.InstanceVars = step.metadata.PipelineInstanceVars
 		// self must be set to current team, thus ignore team.
@@ -135,11 +130,6 @@ func (step *SetPipelineStep) run(ctx context.Context, state RunState, delegate S
 	if step.plan.Team == "" {
 		team = step.teamFactory.GetByID(step.metadata.TeamID)
 	} else {
-		fmt.Fprintln(stderr, "\x1b[1;33mWARNING: specifying the team in a set_pipeline step is experimental and may be removed in the future!\x1b[0m")
-		fmt.Fprintln(stderr, "")
-		fmt.Fprintln(stderr, "\x1b[33mcontribute to discussion #5731 with feedback: https://github.com/concourse/concourse/discussions/5731\x1b[0m")
-		fmt.Fprintln(stderr, "")
-
 		currentTeam, found, err := step.teamFactory.FindTeam(step.metadata.TeamName)
 		if err != nil {
 			return false, err

--- a/atc/exec/set_pipeline_step_test.go
+++ b/atc/exec/set_pipeline_step_test.go
@@ -438,12 +438,6 @@ jobs:
 					_, teamId, _, _, _ := fakeBuild.SavePipelineArgsForCall(0)
 					Expect(teamId).To(Equal(fakeTeam.ID()))
 				})
-
-				It("should print an experimental message", func() {
-					Expect(stderr).To(gbytes.Say("WARNING: 'set_pipeline: self' is experimental"))
-					Expect(stderr).To(gbytes.Say("contribute to discussion #5732"))
-					Expect(stderr).To(gbytes.Say("discussions/5732"))
-				})
 			})
 
 			Context("when team is configured", func() {
@@ -513,12 +507,6 @@ jobs:
 							Expect(fakeDelegate.FinishedCallCount()).To(Equal(1))
 							_, succeeded := fakeDelegate.FinishedArgsForCall(0)
 							Expect(succeeded).To(BeTrue())
-						})
-
-						It("should print an experimental message", func() {
-							Expect(stderr).To(gbytes.Say("WARNING: specifying the team"))
-							Expect(stderr).To(gbytes.Say("contribute to discussion #5731"))
-							Expect(stderr).To(gbytes.Say("discussions/5731"))
 						})
 					})
 


### PR DESCRIPTION
The set_pipeline feature is now considered stable and widely used, so remove the warning messages that marked it as experimental. This affects both the self-referential pipeline syntax and team specification warnings.

# Release Note

* Removed "experimental" warnings from the `set_pipeline` step