### PR TITLE
fix: add O_TRUNC flag when writing volume metadata file

### DIFF
--- a/worker/baggageclaim/volume/metadata.go
+++ b/worker/baggageclaim/volume/metadata.go
@@ -101,7 +101,7 @@ func readMetadataFile(path string, properties any) error {
 func writeMetadataFile(path string, properties any) error {
 	file, err := os.OpenFile(
 		path,
-		os.O_WRONLY|os.O_CREATE,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 		0644,
 	)
 	if err != nil {


### PR DESCRIPTION
When writing metadata files, the code was using O_WRONLY|O_CREATE flags without O_TRUNC. This could cause file corruption when writing shorter content than what existed previously, as the remaining bytes from the old content would persist in the file.

The fix adds O_TRUNC to ensure clean overwrites and maintain data integrity.
