### PR TITLE
Replace standard gzip with klauspost/compress/gzip for fly downloads

### DIFF
--- a/atc/api/cliserver/download.go
+++ b/atc/api/cliserver/download.go
@@ -3,7 +3,6 @@ package cliserver
 import (
 	"archive/tar"
 	"archive/zip"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +10,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/klauspost/compress/gzip"
 )
 
 var whitelist = regexp.MustCompile(`^[a-z0-9]+$`)


### PR DESCRIPTION
Switch from Go's standard library compress/gzip to github.com/klauspost/compress/gzip for improved performance when handling tgz downloads. This drop-in replacement offers 3-7x faster decompression speeds and better memory usage while maintaining the same API, requiring no changes to existing code logic.