### PR TITLE
kernel: Use unix.ByteSliceToString for safe release string handling

### DIFF
--- a/worker/baggageclaim/kernel/kernel_unix.go
+++ b/worker/baggageclaim/kernel/kernel_unix.go
@@ -5,7 +5,9 @@
 // versions for different platforms.
 package kernel
 
-import "bytes"
+import (
+	"golang.org/x/sys/unix"
+)
 
 // GetKernelVersion gets the current kernel version.
 func GetKernelVersion() (*VersionInfo, error) {
@@ -14,18 +16,8 @@ func GetKernelVersion() (*VersionInfo, error) {
 		return nil, err
 	}
 
-	release := make([]byte, len(uts.Release))
-
-	i := 0
-	for _, c := range uts.Release {
-		release[i] = byte(c)
-		i++
-	}
-
 	// Remove the \x00 from the release for Atoi to parse correctly
-	release = release[:bytes.IndexByte(release, 0)]
-
-	return ParseRelease(string(release))
+	return ParseRelease(unix.ByteSliceToString(uts.Release[:]))
 }
 
 // CheckKernelVersion checks if current kernel is newer than (or equal to)


### PR DESCRIPTION
Replace manual byte conversion and null terminator handling with the
standard unix.ByteSliceToString function from golang.org/x/sys/unix.
This improves cross-platform compatibility and eliminates potential
panic conditions when processing kernel release strings.

The previous implementation manually converted syscall.Utsname.Release
byte-by-byte and required explicit null terminator handling, which
could fail on certain platforms due to type differences or if the
string filled the entire buffer.

See https://github.com/moby/moby/blob/master/pkg/parsers/kernel/kernel_unix.go