### PR TITLE
fix(runtime): optimize rootfs_manager SetupCwd to reduce unnecessary syscall

### DIFF
--- a/worker/runtime/rootfs_manager.go
+++ b/worker/runtime/rootfs_manager.go
@@ -81,13 +81,8 @@ func NewRootfsManager(opts ...RootfsManagerOpt) *rootfsManager {
 func (r rootfsManager) SetupCwd(rootfsPath string, cwd string) error {
 	abs := filepath.Join(rootfsPath, cwd)
 
-	_, err := os.Stat(abs)
-	if err == nil { // exists
-		return nil
-	}
-
-	err = r.mkdirall(abs, 0777)
-	if err != nil {
+	err := r.mkdirall(abs, 0777)
+	if err != nil && !os.IsExist(err) {
 		return fmt.Errorf("mkdir: %w", err)
 	}
 


### PR DESCRIPTION
Removes redundant os.Stat call in SetupCwd by directly attempting directory creation with MkdirAll and handling the "already exists" error. This eliminates an extra syscall.
