### PR TITLE
Migrate from mitchellh/mapstructure to go-viper/mapstructure/v2

### DIFF
--- a/atc/creds/secretsmanager/manager_factory.go
+++ b/atc/creds/secretsmanager/manager_factory.go
@@ -2,8 +2,8 @@ package secretsmanager
 
 import (
 	"github.com/concourse/concourse/atc/creds"
+	"github.com/go-viper/mapstructure/v2"
 	flags "github.com/jessevdk/go-flags"
-	"github.com/mitchellh/mapstructure"
 )
 
 type managerFactory struct{}

--- a/atc/creds/ssm/manager_factory.go
+++ b/atc/creds/ssm/manager_factory.go
@@ -2,8 +2,8 @@ package ssm
 
 import (
 	"github.com/concourse/concourse/atc/creds"
+	"github.com/go-viper/mapstructure/v2"
 	flags "github.com/jessevdk/go-flags"
-	"github.com/mitchellh/mapstructure"
 )
 
 type ssmManagerFactory struct{}

--- a/atc/creds/vault/manager.go
+++ b/atc/creds/vault/manager.go
@@ -11,7 +11,7 @@ import (
 	"code.cloudfoundry.org/lager/v3"
 
 	"github.com/concourse/concourse/atc/creds"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 type VaultManager struct {

--- a/atc/db/migration/migrations/1528470872_add_global_users.up.go
+++ b/atc/db/migration/migrations/1528470872_add_global_users.up.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 func (m *migrations) Up_1528470872() error {

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-jose/go-jose/v3 v3.0.4
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/gobwas/glob v0.2.3
 	github.com/goccy/go-yaml v1.16.0
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
@@ -62,7 +63,6 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.11.2
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/miekg/dns v1.1.64
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.36.3
 	github.com/opencontainers/runc v1.2.6
@@ -244,6 +244,7 @@ require (
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.3.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -902,6 +902,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
+github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=

--- a/skymarshal/skycmd/flags.go
+++ b/skymarshal/skycmd/flags.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	flags "github.com/jessevdk/go-flags"
-	"github.com/mitchellh/mapstructure"
 	"sigs.k8s.io/yaml"
 
 	"github.com/concourse/concourse/atc"


### PR DESCRIPTION
Updated the mapstructure implementation to use github.com/go-viper/mapstructure/v2 instead of the deprecated github.com/mitchellh/mapstructure package. The go-viper/mapstructure package is a maintained fork of mitchellh/mapstructure with the same API, ensuring compatibility while providing ongoing maintenance and improvements.

This change only updates the import path with no functional changes.
