### PR TITLE
Replace urljoiner dependency with standard library URL handling

### DIFF
--- a/fly/integration/set_pipeline_test.go
+++ b/fly/integration/set_pipeline_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"code.cloudfoundry.org/urljoiner"
 	"github.com/mgutz/ansi"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
@@ -1367,7 +1366,7 @@ this is super secure
 							yes(stdin)
 
 							if expectCreationMessage {
-								pipelineURL := urljoiner.Join(atcServer.URL(), "teams/main/pipelines", "awesome-pipeline")
+								pipelineURL := atcServer.URL() + "/teams/main/pipelines/awesome-pipeline"
 
 								Eventually(sess).Should(gbytes.Say("pipeline created!"))
 								Eventually(sess).Should(gbytes.Say(fmt.Sprintf("you can view your pipeline here: %s", pipelineURL)))

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	code.cloudfoundry.org/garden v0.0.0-20250319022510-05a9be852e89
 	code.cloudfoundry.org/lager/v3 v3.30.0
 	code.cloudfoundry.org/localip v0.34.0
-	code.cloudfoundry.org/urljoiner v0.0.0-20170223060717-5cabba6c0a50
 	dario.cat/mergo v1.0.1
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -619,8 +619,6 @@ code.cloudfoundry.org/lager/v3 v3.30.0 h1:doVyqsEPz+SnM2DgOfKGcNXEvYbjKr6PrR88iv
 code.cloudfoundry.org/lager/v3 v3.30.0/go.mod h1:3nPT1LzO+fPChWArPw1gzHB2F7CY9snqMKNIKAnt+r4=
 code.cloudfoundry.org/localip v0.34.0 h1:q9+fmeWamEALp33cGfkMF/NzgQ4zErzl4Fv2Ac9az18=
 code.cloudfoundry.org/localip v0.34.0/go.mod h1:8914yKYzBAXSMpBA2tEw7o8WtwW2Cb3jFJUZnFKfhDk=
-code.cloudfoundry.org/urljoiner v0.0.0-20170223060717-5cabba6c0a50 h1:y+DtLO/eX/9NZjGGHntWs1bNG6uxdql8SqrHzu6VH3Q=
-code.cloudfoundry.org/urljoiner v0.0.0-20170223060717-5cabba6c0a50/go.mod h1:GyubIUn2eHGSlpIqJhGKBKicAe6CUV/pQJosfNEHdo4=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=


### PR DESCRIPTION
Removed the external code.cloudfoundry.org/urljoiner dependency in favor of a more direct string concatenation approach for URL construction.