### PR TITLE
refactor: optimize Counter and Gauge with atomic.Int64

### DIFF
--- a/atc/metric/counter.go
+++ b/atc/metric/counter.go
@@ -3,18 +3,18 @@ package metric
 import "sync/atomic"
 
 type Counter struct {
-	cur int64
+	cur atomic.Int64
 }
 
 func (m *Counter) Inc() {
-	atomic.AddInt64((*int64)(&m.cur), 1)
+	m.cur.Add(1)
 }
 
 func (m *Counter) IncDelta(delta int) {
-	atomic.AddInt64((*int64)(&m.cur), int64(delta))
+	m.cur.Add(int64(delta))
 }
 
 func (m *Counter) Delta() float64 {
-	cur := atomic.SwapInt64((*int64)(&m.cur), 0)
+	cur := m.cur.Swap(0)
 	return float64(cur)
 }

--- a/atc/metric/gauge.go
+++ b/atc/metric/gauge.go
@@ -3,51 +3,48 @@ package metric
 import "sync/atomic"
 
 type Gauge struct {
-	cur int64
-	max int64
+	cur atomic.Int64
+	max atomic.Int64
 }
 
 func (c *Gauge) Inc() {
-	cur := atomic.AddInt64(&c.cur, 1)
-
-	for {
-		max := atomic.LoadInt64(&c.max)
-		if cur > max {
-			if atomic.CompareAndSwapInt64(&c.max, max, cur) {
-				break
-			}
-		} else {
-			break
-		}
-	}
+	cur := c.cur.Add(1)
+	c.updateMaxIfGreater(cur)
 }
 
 func (c *Gauge) Set(val int64) {
-	for {
-		max := atomic.LoadInt64(&c.max)
-		if val > max {
-			if atomic.CompareAndSwapInt64(&c.max, max, val) {
-				break
-			}
-		} else {
-			break
-		}
-	}
+	c.updateMaxIfGreater(val)
 }
 
 func (c *Gauge) Dec() {
-	atomic.AddInt64(&c.cur, -1)
+	c.cur.Add(-1)
 }
 
 func (c *Gauge) Max() float64 {
-	cur := atomic.LoadInt64(&c.cur)
-	max := atomic.SwapInt64(&c.max, -1)
+	cur := c.cur.Load()
+	max := c.max.Swap(-1)
 
 	if max == -1 {
-		// no call to .Inc has occurred since last call to .Max;
-		// highest value must be the current value
+		// max is -1, indicating no maximum value has been recorded
+		// since the last call to Max(); in this case, return the
+		// current counter value as it's the best available gauge
 		return float64(cur)
 	}
 
 	return float64(max)
+}
+
+// Helper method to update max value if the provided value is greater
+func (c *Gauge) updateMaxIfGreater(val int64) {
+	for {
+		max := c.max.Load()
+		if val <= max {
+			return // No need to update
+		}
+
+		if c.max.CompareAndSwap(max, val) {
+			return // Successfully updated
+		}
+		// If CompareAndSwap failed, loop and try again
+	}
 }


### PR DESCRIPTION
- Update to use atomic.Int64 instead of function-based atomic operations
- Maintain backward compatibility with existing behavior

This change modernizes the code to use Go 1.19+ atomic types while improving 
performance in high-concurrency scenarios.
