### PR TITLE
perf: optimize metrics map allocation in emit.go

### DIFF
--- a/atc/metric/emit.go
+++ b/atc/metric/emit.go
@@ -170,7 +170,12 @@ func (m *Monitor) emit(logger lager.Logger, event Event) {
 	event.Host = m.eventHost
 	event.Time = time.Now()
 
-	mergedAttributes := map[string]string{}
+	attrCount := len(m.eventAttributes)
+	if event.Attributes != nil {
+		attrCount += len(event.Attributes)
+	}
+
+	mergedAttributes := make(map[string]string, attrCount)
 	for k, v := range m.eventAttributes {
 		mergedAttributes[k] = v
 	}


### PR DESCRIPTION
- Pre-allocate attribute maps with exact capacity to avoid resizing
- Improve memory efficiency during high-volume metric collection
- Reduce garbage collection pressure from repeated map allocations