### PR TITLE
Improve error handling in DestroyVolume unmount operation

### DIFF
--- a/worker/baggageclaim/volume/driver/overlay_linux.go
+++ b/worker/baggageclaim/volume/driver/overlay_linux.go
@@ -59,7 +59,7 @@ func (driver *OverlayDriver) DestroyVolume(vol volume.FilesystemVolume) error {
 	// when a path is already unmounted, and unmount is called
 	// on it, syscall.EINVAL is returned as an error
 	// ignore this error and continue to clean up
-	if err != nil && err != os.ErrInvalid {
+	if err != nil && !errors.Is(err, syscall.EINVAL) {
 		return err
 	}
 


### PR DESCRIPTION
Replace os.ErrInvalid check with syscall.EINVAL when handling unmount errors. This is more precise as syscall.EINVAL is the actual error returned when attempting to unmount an already unmounted path. The functionality remains the same, but the code now more clearly indicates which error is being handled.
